### PR TITLE
Retrieve IndexedAttestation and AttesterSlashing schemas from SchemaDefinitions

### DIFF
--- a/data/provider/src/main/java/tech/pegasys/teku/api/DataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/DataProvider.java
@@ -191,6 +191,7 @@ public class DataProvider {
       final NetworkDataProvider networkDataProvider = new NetworkDataProvider(p2pNetwork);
       final NodeDataProvider nodeDataProvider =
           new NodeDataProvider(
+              spec,
               attestationPool,
               attesterSlashingPool,
               proposerSlashingPool,

--- a/data/provider/src/main/java/tech/pegasys/teku/api/NodeDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/NodeDataProvider.java
@@ -31,6 +31,7 @@ import tech.pegasys.teku.api.schema.ProposerSlashing;
 import tech.pegasys.teku.api.schema.SignedVoluntaryExit;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.attestation.ProcessedAttestationListener;
 import tech.pegasys.teku.spec.datastructures.blocks.ReceivedBlockListener;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SignedContributionAndProof;
@@ -45,6 +46,7 @@ import tech.pegasys.teku.statetransition.validatorcache.ActiveValidatorChannel;
 
 public class NodeDataProvider {
 
+  private final Spec spec;
   private final AggregatingAttestationPool attestationPool;
   private final OperationPool<tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing>
       attesterSlashingPool;
@@ -60,6 +62,7 @@ public class NodeDataProvider {
   private final PayloadAttributesCalculator payloadAttributesCalculator;
 
   public NodeDataProvider(
+      final Spec spec,
       final AggregatingAttestationPool attestationPool,
       final OperationPool<tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing>
           attesterSlashingsPool,
@@ -73,6 +76,7 @@ public class NodeDataProvider {
       final boolean isLivenessTrackingEnabled,
       final ActiveValidatorChannel activeValidatorChannel,
       final PayloadAttributesCalculator payloadAttributesCalculator) {
+    this.spec = spec;
     this.attestationPool = attestationPool;
     this.attesterSlashingPool = attesterSlashingsPool;
     this.proposerSlashingPool = proposerSlashingPool;
@@ -116,7 +120,7 @@ public class NodeDataProvider {
   }
 
   public SafeFuture<InternalValidationResult> postAttesterSlashing(AttesterSlashing slashing) {
-    return attesterSlashingPool.add(slashing.asInternalAttesterSlashing());
+    return attesterSlashingPool.add(slashing.asInternalAttesterSlashing(spec));
   }
 
   public SafeFuture<InternalValidationResult> postProposerSlashing(ProposerSlashing slashing) {

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/AttesterSlashing.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/AttesterSlashing.java
@@ -16,6 +16,9 @@ package tech.pegasys.teku.api.schema;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecVersion;
+import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing.AttesterSlashingSchema;
 
 public class AttesterSlashing {
   public final IndexedAttestation attestation_1;
@@ -36,9 +39,17 @@ public class AttesterSlashing {
   }
 
   public tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing
-      asInternalAttesterSlashing() {
-    return new tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing(
-        attestation_1.asInternalIndexedAttestation(), attestation_2.asInternalIndexedAttestation());
+      asInternalAttesterSlashing(final Spec spec) {
+    return asInternalAttesterSlashing(spec.atSlot(attestation_1.data.slot));
+  }
+
+  public tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing
+      asInternalAttesterSlashing(final SpecVersion spec) {
+    final AttesterSlashingSchema attesterSlashingSchema =
+        spec.getSchemaDefinitions().getAttesterSlashingSchema();
+    return attesterSlashingSchema.create(
+        attestation_1.asInternalIndexedAttestation(spec),
+        attestation_2.asInternalIndexedAttestation(spec));
   }
 
   @Override

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/BeaconBlockBody.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/BeaconBlockBody.java
@@ -108,7 +108,7 @@ public class BeaconBlockBody {
                       .collect(schema.getProposerSlashingsSchema().collector()))
               .attesterSlashings(
                   attester_slashings.stream()
-                      .map(AttesterSlashing::asInternalAttesterSlashing)
+                      .map(slashing -> slashing.asInternalAttesterSlashing(spec))
                       .collect(schema.getAttesterSlashingsSchema().collector()))
               .deposits(
                   deposits.stream()

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/IndexedAttestation.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/IndexedAttestation.java
@@ -23,6 +23,9 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecVersion;
+import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestation.IndexedAttestationSchema;
 
 public class IndexedAttestation {
   @ArraySchema(schema = @Schema(type = "string", format = "uint64"))
@@ -52,11 +55,16 @@ public class IndexedAttestation {
   }
 
   public tech.pegasys.teku.spec.datastructures.operations.IndexedAttestation
-      asInternalIndexedAttestation() {
-    return new tech.pegasys.teku.spec.datastructures.operations.IndexedAttestation(
-        tech.pegasys.teku.spec.datastructures.operations.IndexedAttestation.SSZ_SCHEMA
-            .getAttestingIndicesSchema()
-            .of(attesting_indices),
+      asInternalIndexedAttestation(final Spec spec) {
+    return asInternalIndexedAttestation(spec.atSlot(data.slot));
+  }
+
+  public tech.pegasys.teku.spec.datastructures.operations.IndexedAttestation
+      asInternalIndexedAttestation(final SpecVersion spec) {
+    final IndexedAttestationSchema indexedAttestationSchema =
+        spec.getSchemaDefinitions().getIndexedAttestationSchema();
+    return indexedAttestationSchema.create(
+        indexedAttestationSchema.getAttestingIndicesSchema().of(attesting_indices),
         data.asInternalAttestationData(),
         signature.asInternalBLSSignature());
   }

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/operations/OperationsTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/operations/OperationsTestExecutor.java
@@ -149,7 +149,10 @@ public class OperationsTestExecutor<T extends SszData> implements TestExecutor {
     switch (operation) {
       case ATTESTER_SLASHING:
         final AttesterSlashing attesterSlashing =
-            loadSsz(testDefinition, dataFileName, AttesterSlashing.SSZ_SCHEMA);
+            loadSsz(
+                testDefinition,
+                dataFileName,
+                testDefinition.getSpec().getGenesisSchemaDefinitions().getAttesterSlashingSchema());
         processor.processAttesterSlashing(state, attesterSlashing);
         break;
       case PROPOSER_SLASHING:

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_static/SszTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_static/SszTestExecutor.java
@@ -43,6 +43,9 @@ public class SszTestExecutor<T extends SszData> implements TestExecutor {
               "ssz_static/Attestation",
               new SszTestExecutor<>(SchemaDefinitions::getAttestationSchema))
           .put(
+              "ssz_static/AttesterSlashing",
+              new SszTestExecutor<>(SchemaDefinitions::getAttesterSlashingSchema))
+          .put(
               "ssz_static/SignedAggregateAndProof",
               new SszTestExecutor<>(SchemaDefinitions::getSignedAggregateAndProofSchema))
           .put(
@@ -60,6 +63,9 @@ public class SszTestExecutor<T extends SszData> implements TestExecutor {
           .put(
               "ssz_static/HistoricalBatch",
               new SszTestExecutor<>(SchemaDefinitions::getHistoricalBatchSchema))
+          .put(
+              "ssz_static/IndexedAttestation",
+              new SszTestExecutor<>(SchemaDefinitions::getIndexedAttestationSchema))
           .put(
               "ssz_static/PendingAttestation",
               new SszTestExecutor<>(

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_static/SszTestExecutorDeprecated.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_static/SszTestExecutorDeprecated.java
@@ -28,11 +28,9 @@ import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockHeader;
 import tech.pegasys.teku.spec.datastructures.blocks.Eth1Data;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlockHeader;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
-import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.Deposit;
 import tech.pegasys.teku.spec.datastructures.operations.DepositData;
 import tech.pegasys.teku.spec.datastructures.operations.DepositMessage;
-import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestation;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.operations.VoluntaryExit;
@@ -52,9 +50,6 @@ public class SszTestExecutorDeprecated<T extends SszData> implements TestExecuto
               "ssz_static/AttestationData",
               new SszTestExecutorDeprecated<>(AttestationData.SSZ_SCHEMA))
           .put(
-              "ssz_static/AttesterSlashing",
-              new SszTestExecutorDeprecated<>(AttesterSlashing.SSZ_SCHEMA))
-          .put(
               "ssz_static/BeaconBlockHeader",
               new SszTestExecutorDeprecated<>(BeaconBlockHeader.SSZ_SCHEMA))
           .put("ssz_static/Checkpoint", new SszTestExecutorDeprecated<>(Checkpoint.SSZ_SCHEMA))
@@ -67,9 +62,6 @@ public class SszTestExecutorDeprecated<T extends SszData> implements TestExecuto
           .put("ssz_static/Eth1Data", new SszTestExecutorDeprecated<>(Eth1Data.SSZ_SCHEMA))
           .put("ssz_static/Fork", new SszTestExecutorDeprecated<>(Fork.SSZ_SCHEMA))
           .put("ssz_static/ForkData", new SszTestExecutorDeprecated<>(ForkData.SSZ_SCHEMA))
-          .put(
-              "ssz_static/IndexedAttestation",
-              new SszTestExecutorDeprecated<>(IndexedAttestation.SSZ_SCHEMA))
           .put(
               "ssz_static/ProposerSlashing",
               new SszTestExecutorDeprecated<>(ProposerSlashing.SSZ_SCHEMA))

--- a/ethereum/core/src/test/java/tech/pegasys/teku/core/fuzz/FuzzRegressionTest.java
+++ b/ethereum/core/src/test/java/tech/pegasys/teku/core/fuzz/FuzzRegressionTest.java
@@ -37,7 +37,9 @@ public class FuzzRegressionTest {
     final BeaconState state =
         load("issue2345/state.ssz", spec.getGenesisSchemaDefinitions().getBeaconStateSchema());
     final AttesterSlashing slashing =
-        load("issue2345/attester_slashing.ssz", AttesterSlashing.SSZ_SCHEMA);
+        load(
+            "issue2345/attester_slashing.ssz",
+            spec.getGenesisSchemaDefinitions().getAttesterSlashingSchema());
     SszList<AttesterSlashing> slashings =
         BeaconBlockBodyLists.ofSpec(spec).createAttesterSlashings(slashing);
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/altair/BeaconBlockBodySchemaAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/altair/BeaconBlockBodySchemaAltair.java
@@ -16,17 +16,10 @@ package tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import java.util.Optional;
-import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodySchema;
 
 public interface BeaconBlockBodySchemaAltair<T extends BeaconBlockBodyAltair>
     extends BeaconBlockBodySchema<T> {
-
-  static BeaconBlockBodySchemaAltair<? extends BeaconBlockBodyAltair> create(
-      final SpecConfig specConfig) {
-
-    return BeaconBlockBodySchemaAltairImpl.create(specConfig);
-  }
 
   static BeaconBlockBodySchemaAltair<?> required(final BeaconBlockBodySchema<?> schema) {
     checkArgument(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/altair/BeaconBlockBodySchemaAltairImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/altair/BeaconBlockBodySchemaAltairImpl.java
@@ -28,6 +28,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.blockbody.common.BlockBodyFi
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation.AttestationSchema;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
+import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing.AttesterSlashingSchema;
 import tech.pegasys.teku.spec.datastructures.operations.Deposit;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
@@ -72,7 +73,7 @@ public class BeaconBlockBodySchemaAltairImpl
   }
 
   public static BeaconBlockBodySchemaAltair<? extends BeaconBlockBodyAltair> create(
-      final SpecConfig specConfig) {
+      final SpecConfig specConfig, final AttesterSlashingSchema attesterSlashingSchema) {
     return new BeaconBlockBodySchemaAltairImpl(
         namedSchema(BlockBodyFields.RANDAO_REVEAL.name(), SszSignatureSchema.INSTANCE),
         namedSchema(BlockBodyFields.ETH1_DATA.name(), Eth1Data.SSZ_SCHEMA),
@@ -83,8 +84,7 @@ public class BeaconBlockBodySchemaAltairImpl
                 ProposerSlashing.SSZ_SCHEMA, specConfig.getMaxProposerSlashings())),
         namedSchema(
             BlockBodyFields.ATTESTER_SLASHINGS.name(),
-            SszListSchema.create(
-                AttesterSlashing.SSZ_SCHEMA, specConfig.getMaxAttesterSlashings())),
+            SszListSchema.create(attesterSlashingSchema, specConfig.getMaxAttesterSlashings())),
         namedSchema(
             BlockBodyFields.ATTESTATIONS.name(),
             SszListSchema.create(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BeaconBlockBodySchemaBellatrix.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BeaconBlockBodySchemaBellatrix.java
@@ -14,16 +14,11 @@
 package tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.bellatrix;
 
 import java.util.Optional;
-import tech.pegasys.teku.spec.config.SpecConfigBellatrix;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.BeaconBlockBodySchemaAltair;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSchema;
 
 public interface BeaconBlockBodySchemaBellatrix<T extends BeaconBlockBodyBellatrix>
     extends BeaconBlockBodySchemaAltair<T> {
-
-  static BeaconBlockBodySchemaBellatrix<?> create(final SpecConfigBellatrix specConfig) {
-    return BeaconBlockBodySchemaBellatrixImpl.create(specConfig);
-  }
 
   ExecutionPayloadSchema getExecutionPayloadSchema();
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BeaconBlockBodySchemaBellatrixImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BeaconBlockBodySchemaBellatrixImpl.java
@@ -33,13 +33,14 @@ import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSchema;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation.AttestationSchema;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
+import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing.AttesterSlashingSchema;
 import tech.pegasys.teku.spec.datastructures.operations.Deposit;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.type.SszSignature;
 import tech.pegasys.teku.spec.datastructures.type.SszSignatureSchema;
 
-class BeaconBlockBodySchemaBellatrixImpl
+public class BeaconBlockBodySchemaBellatrixImpl
     extends ContainerSchema10<
         BeaconBlockBodyBellatrixImpl,
         SszSignature,
@@ -79,7 +80,8 @@ class BeaconBlockBodySchemaBellatrixImpl
         executionPayloadSchema);
   }
 
-  static BeaconBlockBodySchemaBellatrixImpl create(final SpecConfigBellatrix specConfig) {
+  public static BeaconBlockBodySchemaBellatrixImpl create(
+      final SpecConfigBellatrix specConfig, final AttesterSlashingSchema attesterSlashingSchema) {
     return new BeaconBlockBodySchemaBellatrixImpl(
         namedSchema(BlockBodyFields.RANDAO_REVEAL.name(), SszSignatureSchema.INSTANCE),
         namedSchema(BlockBodyFields.ETH1_DATA.name(), Eth1Data.SSZ_SCHEMA),
@@ -90,8 +92,7 @@ class BeaconBlockBodySchemaBellatrixImpl
                 ProposerSlashing.SSZ_SCHEMA, specConfig.getMaxProposerSlashings())),
         namedSchema(
             BlockBodyFields.ATTESTER_SLASHINGS.name(),
-            SszListSchema.create(
-                AttesterSlashing.SSZ_SCHEMA, specConfig.getMaxAttesterSlashings())),
+            SszListSchema.create(attesterSlashingSchema, specConfig.getMaxAttesterSlashings())),
         namedSchema(
             BlockBodyFields.ATTESTATIONS.name(),
             SszListSchema.create(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/phase0/BeaconBlockBodySchemaPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/phase0/BeaconBlockBodySchemaPhase0.java
@@ -29,6 +29,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.blockbody.common.BlockBodyFi
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation.AttestationSchema;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
+import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing.AttesterSlashingSchema;
 import tech.pegasys.teku.spec.datastructures.operations.Deposit;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
@@ -69,7 +70,8 @@ public class BeaconBlockBodySchemaPhase0
         voluntaryExitsSchema);
   }
 
-  public static BeaconBlockBodySchemaPhase0 create(final SpecConfig specConfig) {
+  public static BeaconBlockBodySchemaPhase0 create(
+      final SpecConfig specConfig, final AttesterSlashingSchema attesterSlashingSchema) {
     return new BeaconBlockBodySchemaPhase0(
         namedSchema(BlockBodyFields.RANDAO_REVEAL.name(), SszSignatureSchema.INSTANCE),
         namedSchema(BlockBodyFields.ETH1_DATA.name(), Eth1Data.SSZ_SCHEMA),
@@ -80,8 +82,7 @@ public class BeaconBlockBodySchemaPhase0
                 ProposerSlashing.SSZ_SCHEMA, specConfig.getMaxProposerSlashings())),
         namedSchema(
             BlockBodyFields.ATTESTER_SLASHINGS.name(),
-            SszListSchema.create(
-                AttesterSlashing.SSZ_SCHEMA, specConfig.getMaxAttesterSlashings())),
+            SszListSchema.create(attesterSlashingSchema, specConfig.getMaxAttesterSlashings())),
         namedSchema(
             BlockBodyFields.ATTESTATIONS.name(),
             SszListSchema.create(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/AttesterSlashing.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/AttesterSlashing.java
@@ -23,6 +23,7 @@ import tech.pegasys.teku.infrastructure.ssz.containers.Container2;
 import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema2;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestation.IndexedAttestationSchema;
 
 public class AttesterSlashing
     extends Container2<AttesterSlashing, IndexedAttestation, IndexedAttestation> {
@@ -30,20 +31,23 @@ public class AttesterSlashing
   public static class AttesterSlashingSchema
       extends ContainerSchema2<AttesterSlashing, IndexedAttestation, IndexedAttestation> {
 
-    public AttesterSlashingSchema() {
+    public AttesterSlashingSchema(final IndexedAttestationSchema indexedAttestationSchema) {
       super(
           "AttesterSlashing",
-          namedSchema("attestation_1", IndexedAttestation.SSZ_SCHEMA),
-          namedSchema("attestation_2", IndexedAttestation.SSZ_SCHEMA));
+          namedSchema("attestation_1", indexedAttestationSchema),
+          namedSchema("attestation_2", indexedAttestationSchema));
     }
 
     @Override
     public AttesterSlashing createFromBackingNode(TreeNode node) {
       return new AttesterSlashing(this, node);
     }
-  }
 
-  public static final AttesterSlashingSchema SSZ_SCHEMA = new AttesterSlashingSchema();
+    public AttesterSlashing create(
+        final IndexedAttestation attestation1, final IndexedAttestation attestation2) {
+      return new AttesterSlashing(this, attestation1, attestation2);
+    }
+  }
 
   private final Supplier<Set<UInt64>> intersectingIndices =
       Suppliers.memoize(
@@ -59,8 +63,16 @@ public class AttesterSlashing
     super(type, backingNode);
   }
 
-  public AttesterSlashing(IndexedAttestation attestation_1, IndexedAttestation attestation_2) {
-    super(SSZ_SCHEMA, attestation_1, attestation_2);
+  private AttesterSlashing(
+      final AttesterSlashingSchema schema,
+      final IndexedAttestation attestation1,
+      final IndexedAttestation attestation2) {
+    super(schema, attestation1, attestation2);
+  }
+
+  @Override
+  public AttesterSlashingSchema getSchema() {
+    return (AttesterSlashingSchema) super.getSchema();
   }
 
   public Set<UInt64> getIntersectingValidatorIndices() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/IndexedAttestation.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/IndexedAttestation.java
@@ -19,7 +19,7 @@ import tech.pegasys.teku.infrastructure.ssz.containers.Container3;
 import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema3;
 import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszUInt64ListSchema;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
-import tech.pegasys.teku.spec.config.Constants;
+import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.datastructures.type.SszSignature;
 import tech.pegasys.teku.spec.datastructures.type.SszSignatureSchema;
 
@@ -29,12 +29,12 @@ public class IndexedAttestation
   public static class IndexedAttestationSchema
       extends ContainerSchema3<IndexedAttestation, SszUInt64List, AttestationData, SszSignature> {
 
-    public IndexedAttestationSchema() {
+    public IndexedAttestationSchema(final SpecConfig config) {
       super(
           "IndexedAttestation",
           namedSchema(
               "attesting_indices",
-              SszUInt64ListSchema.create(Constants.MAX_VALIDATORS_PER_COMMITTEE)),
+              SszUInt64ListSchema.create(config.getMaxValidatorsPerCommittee())),
           namedSchema("data", AttestationData.SSZ_SCHEMA),
           namedSchema("signature", SszSignatureSchema.INSTANCE));
     }
@@ -47,17 +47,30 @@ public class IndexedAttestation
     public IndexedAttestation createFromBackingNode(TreeNode node) {
       return new IndexedAttestation(this, node);
     }
-  }
 
-  public static final IndexedAttestationSchema SSZ_SCHEMA = new IndexedAttestationSchema();
+    public IndexedAttestation create(
+        final SszUInt64List attestingIndices,
+        final AttestationData data,
+        final BLSSignature signature) {
+      return new IndexedAttestation(this, attestingIndices, data, signature);
+    }
+  }
 
   private IndexedAttestation(IndexedAttestationSchema type, TreeNode backingNode) {
     super(type, backingNode);
   }
 
-  public IndexedAttestation(
-      SszUInt64List attesting_indices, AttestationData data, BLSSignature signature) {
-    super(SSZ_SCHEMA, attesting_indices, data, new SszSignature(signature));
+  private IndexedAttestation(
+      final IndexedAttestationSchema schema,
+      final SszUInt64List attestingIndices,
+      final AttestationData data,
+      final BLSSignature signature) {
+    super(schema, attestingIndices, data, new SszSignature(signature));
+  }
+
+  @Override
+  public IndexedAttestationSchema getSchema() {
+    return (IndexedAttestationSchema) super.getSchema();
   }
 
   public SszUInt64List getAttesting_indices() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/AttestationUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/AttestationUtil.java
@@ -39,22 +39,28 @@ import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestation;
+import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestation.IndexedAttestationSchema;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.util.AttestationProcessingResult;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
 import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
 
 public class AttestationUtil {
 
   private static final Logger LOG = LogManager.getLogger();
 
+  private final SchemaDefinitions schemaDefinitions;
   private final BeaconStateAccessors beaconStateAccessors;
   private final MiscHelpers miscHelpers;
 
   public AttestationUtil(
-      final BeaconStateAccessors beaconStateAccessors, final MiscHelpers miscHelpers) {
+      final SchemaDefinitions schemaDefinitions,
+      final BeaconStateAccessors beaconStateAccessors,
+      final MiscHelpers miscHelpers) {
+    this.schemaDefinitions = schemaDefinitions;
     this.beaconStateAccessors = beaconStateAccessors;
     this.miscHelpers = miscHelpers;
   }
@@ -89,11 +95,13 @@ public class AttestationUtil {
     List<Integer> attesting_indices =
         getAttestingIndices(state, attestation.getData(), attestation.getAggregationBits());
 
-    return new IndexedAttestation(
+    final IndexedAttestationSchema indexedAttestationSchema =
+        schemaDefinitions.getIndexedAttestationSchema();
+    return indexedAttestationSchema.create(
         attesting_indices.stream()
             .sorted()
             .map(UInt64::valueOf)
-            .collect(IndexedAttestation.SSZ_SCHEMA.getAttestingIndicesSchema().collectorUnboxed()),
+            .collect(indexedAttestationSchema.getAttestingIndicesSchema().collectorUnboxed()),
         attestation.getData(),
         attestation.getAggregateSignature());
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/SpecLogicAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/SpecLogicAltair.java
@@ -105,7 +105,8 @@ public class SpecLogicAltair extends AbstractSpecLogic {
     final BeaconStateUtil beaconStateUtil =
         new BeaconStateUtil(
             config, schemaDefinitions, predicates, miscHelpers, beaconStateAccessors);
-    final AttestationUtil attestationUtil = new AttestationUtil(beaconStateAccessors, miscHelpers);
+    final AttestationUtil attestationUtil =
+        new AttestationUtil(schemaDefinitions, beaconStateAccessors, miscHelpers);
     final OperationValidator operationValidator =
         OperationValidator.create(
             config, predicates, miscHelpers, beaconStateAccessors, attestationUtil);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/bellatrix/SpecLogicBellatrix.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/bellatrix/SpecLogicBellatrix.java
@@ -111,7 +111,8 @@ public class SpecLogicBellatrix extends AbstractSpecLogic {
     final BeaconStateUtil beaconStateUtil =
         new BeaconStateUtil(
             config, schemaDefinitions, predicates, miscHelpers, beaconStateAccessors);
-    final AttestationUtil attestationUtil = new AttestationUtil(beaconStateAccessors, miscHelpers);
+    final AttestationUtil attestationUtil =
+        new AttestationUtil(schemaDefinitions, beaconStateAccessors, miscHelpers);
     final OperationValidator operationValidator =
         OperationValidator.create(
             config, predicates, miscHelpers, beaconStateAccessors, attestationUtil);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/SpecLogicPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/SpecLogicPhase0.java
@@ -93,7 +93,8 @@ public class SpecLogicPhase0 extends AbstractSpecLogic {
     final BeaconStateUtil beaconStateUtil =
         new BeaconStateUtil(
             config, schemaDefinitions, predicates, miscHelpers, beaconStateAccessors);
-    final AttestationUtil attestationUtil = new AttestationUtil(beaconStateAccessors, miscHelpers);
+    final AttestationUtil attestationUtil =
+        new AttestationUtil(schemaDefinitions, beaconStateAccessors, miscHelpers);
     final OperationValidator operationValidator =
         OperationValidator.create(
             config, predicates, miscHelpers, beaconStateAccessors, attestationUtil);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/AbstractSchemaDefinitions.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/AbstractSchemaDefinitions.java
@@ -18,6 +18,8 @@ import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszBitvectorSchem
 import tech.pegasys.teku.spec.config.Constants;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.constants.NetworkConstants;
+import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing.AttesterSlashingSchema;
+import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestation.IndexedAttestationSchema;
 import tech.pegasys.teku.spec.datastructures.operations.SignedAggregateAndProof.SignedAggregateAndProofSchema;
 import tech.pegasys.teku.spec.datastructures.state.HistoricalBatch.HistoricalBatchSchema;
 
@@ -29,10 +31,14 @@ public abstract class AbstractSchemaDefinitions implements SchemaDefinitions {
       SszBitvectorSchema.create(NetworkConstants.SYNC_COMMITTEE_SUBNET_COUNT);
   private final HistoricalBatchSchema historicalBatchSchema;
   private final SignedAggregateAndProofSchema signedAggregateAndProofSchema;
+  private final IndexedAttestationSchema indexedAttestationSchema;
+  private final AttesterSlashingSchema attesterSlashingSchema;
 
   public AbstractSchemaDefinitions(final SpecConfig specConfig) {
     this.historicalBatchSchema = new HistoricalBatchSchema(specConfig.getSlotsPerHistoricalRoot());
     this.signedAggregateAndProofSchema = new SignedAggregateAndProofSchema(specConfig);
+    this.indexedAttestationSchema = new IndexedAttestationSchema(specConfig);
+    this.attesterSlashingSchema = new AttesterSlashingSchema(indexedAttestationSchema);
   }
 
   @Override
@@ -53,5 +59,15 @@ public abstract class AbstractSchemaDefinitions implements SchemaDefinitions {
   @Override
   public SignedAggregateAndProofSchema getSignedAggregateAndProofSchema() {
     return signedAggregateAndProofSchema;
+  }
+
+  @Override
+  public IndexedAttestationSchema getIndexedAttestationSchema() {
+    return indexedAttestationSchema;
+  }
+
+  @Override
+  public AttesterSlashingSchema getAttesterSlashingSchema() {
+    return attesterSlashingSchema;
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitions.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitions.java
@@ -22,6 +22,8 @@ import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodySch
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.metadata.MetadataMessageSchema;
 import tech.pegasys.teku.spec.datastructures.operations.AggregateAndProof.AggregateAndProofSchema;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation.AttestationSchema;
+import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing.AttesterSlashingSchema;
+import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestation.IndexedAttestationSchema;
 import tech.pegasys.teku.spec.datastructures.operations.SignedAggregateAndProof.SignedAggregateAndProofSchema;
 import tech.pegasys.teku.spec.datastructures.state.HistoricalBatch.HistoricalBatchSchema;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchema;
@@ -53,6 +55,10 @@ public interface SchemaDefinitions {
   default AttestationSchema getAttestationSchema() {
     return getAggregateAndProofSchema().getAttestationSchema();
   }
+
+  IndexedAttestationSchema getIndexedAttestationSchema();
+
+  AttesterSlashingSchema getAttesterSlashingSchema();
 
   default Optional<SchemaDefinitionsAltair> toVersionAltair() {
     return Optional.empty();

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsAltair.java
@@ -20,6 +20,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSchema;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlockSchema;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodySchema;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.BeaconBlockBodySchemaAltair;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.BeaconBlockBodySchemaAltairImpl;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.metadata.versions.altair.MetadataMessageSchemaAltair;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.ContributionAndProofSchema;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SignedContributionAndProofSchema;
@@ -44,7 +45,8 @@ public class SchemaDefinitionsAltair extends AbstractSchemaDefinitions {
   public SchemaDefinitionsAltair(final SpecConfigAltair specConfig) {
     super(specConfig);
     this.beaconStateSchema = BeaconStateSchemaAltair.create(specConfig);
-    this.beaconBlockBodySchema = BeaconBlockBodySchemaAltair.create(specConfig);
+    this.beaconBlockBodySchema =
+        BeaconBlockBodySchemaAltairImpl.create(specConfig, getAttesterSlashingSchema());
     this.beaconBlockSchema = new BeaconBlockSchema(beaconBlockBodySchema);
     this.signedBeaconBlockSchema = new SignedBeaconBlockSchema(beaconBlockSchema);
     this.syncCommitteeContributionSchema = SyncCommitteeContributionSchema.create(specConfig);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsBellatrix.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsBellatrix.java
@@ -21,6 +21,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSchema;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlockSchema;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodySchema;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.bellatrix.BeaconBlockBodySchemaBellatrix;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.bellatrix.BeaconBlockBodySchemaBellatrixImpl;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeaderSchema;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSchema;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchema;
@@ -38,7 +39,8 @@ public class SchemaDefinitionsBellatrix extends SchemaDefinitionsAltair {
   public SchemaDefinitionsBellatrix(final SpecConfigBellatrix specConfig) {
     super(specConfig.toVersionAltair().orElseThrow());
     this.beaconStateSchema = BeaconStateSchemaBellatrix.create(specConfig);
-    this.beaconBlockBodySchema = BeaconBlockBodySchemaBellatrix.create(specConfig);
+    this.beaconBlockBodySchema =
+        BeaconBlockBodySchemaBellatrixImpl.create(specConfig, getAttesterSlashingSchema());
     this.beaconBlockSchema = new BeaconBlockSchema(beaconBlockBodySchema);
     this.signedBeaconBlockSchema = new SignedBeaconBlockSchema(beaconBlockSchema);
     this.executionPayloadHeaderSchema = new ExecutionPayloadHeaderSchema(specConfig);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsPhase0.java
@@ -31,7 +31,8 @@ public class SchemaDefinitionsPhase0 extends AbstractSchemaDefinitions {
   public SchemaDefinitionsPhase0(final SpecConfig specConfig) {
     super(specConfig);
     this.beaconStateSchema = BeaconStateSchemaPhase0.create(specConfig);
-    this.beaconBlockBodySchema = BeaconBlockBodySchemaPhase0.create(specConfig);
+    this.beaconBlockBodySchema =
+        BeaconBlockBodySchemaPhase0.create(specConfig, getAttesterSlashingSchema());
     this.metadataMessageSchema = new MetadataMessageSchemaPhase0();
   }
 

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/common/AbstractBeaconBlockBodyTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/common/AbstractBeaconBlockBodyTest.java
@@ -97,7 +97,11 @@ public abstract class AbstractBeaconBlockBodyTest<T extends BeaconBlockBody> {
 
   protected abstract T createBlockBody(final Consumer<BeaconBlockBodyBuilder> contentProvider);
 
-  protected abstract BeaconBlockBodySchema<? extends T> getBlockBodySchema();
+  @SuppressWarnings("unchecked")
+  protected BeaconBlockBodySchema<? extends T> getBlockBodySchema() {
+    return (BeaconBlockBodySchema<? extends T>)
+        spec.getGenesisSchemaDefinitions().getBeaconBlockBodySchema();
+  }
 
   protected T createDefaultBlockBody() {
     return createBlockBody();

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/altair/BeaconBlockBodyAltairTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/altair/BeaconBlockBodyAltairTest.java
@@ -20,7 +20,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodyBuilder;
-import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodySchema;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.common.AbstractBeaconBlockBodyTest;
 
 class BeaconBlockBodyAltairTest extends AbstractBeaconBlockBodyTest<BeaconBlockBodyAltair> {
@@ -45,11 +44,6 @@ class BeaconBlockBodyAltairTest extends AbstractBeaconBlockBodyTest<BeaconBlockB
   protected BeaconBlockBodyAltair createBlockBody(
       final Consumer<BeaconBlockBodyBuilder> contentProvider) {
     return (BeaconBlockBodyAltair) getBlockBodySchema().createBlockBody(contentProvider);
-  }
-
-  @Override
-  protected BeaconBlockBodySchema<? extends BeaconBlockBodyAltair> getBlockBodySchema() {
-    return BeaconBlockBodySchemaAltair.create(spec.getGenesisSpecConfig());
   }
 
   @Override

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BeaconBlockBodyBellatrixTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BeaconBlockBodyBellatrixTest.java
@@ -20,7 +20,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodyBuilder;
-import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodySchema;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.common.AbstractBeaconBlockBodyTest;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregate;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
@@ -52,12 +51,6 @@ class BeaconBlockBodyBellatrixTest extends AbstractBeaconBlockBodyTest<BeaconBlo
   protected BeaconBlockBodyBellatrix createBlockBody(
       final Consumer<BeaconBlockBodyBuilder> contentProvider) {
     return (BeaconBlockBodyBellatrix) getBlockBodySchema().createBlockBody(contentProvider);
-  }
-
-  @Override
-  protected BeaconBlockBodySchema<? extends BeaconBlockBodyBellatrix> getBlockBodySchema() {
-    return (BeaconBlockBodySchemaBellatrix<?>)
-        spec.getGenesisSchemaDefinitions().getBeaconBlockBodySchema();
   }
 
   @Override

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/phase0/BeaconBlockBodyPhase0Test.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/phase0/BeaconBlockBodyPhase0Test.java
@@ -17,7 +17,6 @@ import java.util.function.Consumer;
 import org.junit.jupiter.api.BeforeEach;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodyBuilder;
-import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodySchema;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.common.AbstractBeaconBlockBodyTest;
 
 public class BeaconBlockBodyPhase0Test extends AbstractBeaconBlockBodyTest<BeaconBlockBodyPhase0> {
@@ -31,10 +30,5 @@ public class BeaconBlockBodyPhase0Test extends AbstractBeaconBlockBodyTest<Beaco
   protected BeaconBlockBodyPhase0 createBlockBody(
       final Consumer<BeaconBlockBodyBuilder> contentProvider) {
     return (BeaconBlockBodyPhase0) getBlockBodySchema().createBlockBody(contentProvider);
-  }
-
-  @Override
-  protected BeaconBlockBodySchema<BeaconBlockBodyPhase0> getBlockBodySchema() {
-    return BeaconBlockBodySchemaPhase0.create(spec.getGenesisSpecConfig());
   }
 }

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/phase0/BeaconBlockBodySchemaPhase0Test.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/phase0/BeaconBlockBodySchemaPhase0Test.java
@@ -19,6 +19,8 @@ import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.config.SpecConfig;
+import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing.AttesterSlashingSchema;
+import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestation.IndexedAttestationSchema;
 
 public class BeaconBlockBodySchemaPhase0Test {
 
@@ -26,8 +28,12 @@ public class BeaconBlockBodySchemaPhase0Test {
   public void create_minimal() {
     final Spec spec = TestSpecFactory.createMinimalPhase0();
     final SpecConfig specConfig = spec.getGenesisSpecConfig();
-    final BeaconBlockBodySchemaPhase0 specA = BeaconBlockBodySchemaPhase0.create(specConfig);
-    final BeaconBlockBodySchemaPhase0 specB = BeaconBlockBodySchemaPhase0.create(specConfig);
+    final BeaconBlockBodySchemaPhase0 specA =
+        BeaconBlockBodySchemaPhase0.create(
+            specConfig, new AttesterSlashingSchema(new IndexedAttestationSchema(specConfig)));
+    final BeaconBlockBodySchemaPhase0 specB =
+        BeaconBlockBodySchemaPhase0.create(
+            specConfig, new AttesterSlashingSchema(new IndexedAttestationSchema(specConfig)));
 
     assertThat(specA).isEqualTo(specB);
   }
@@ -36,8 +42,12 @@ public class BeaconBlockBodySchemaPhase0Test {
   public void create_mainnet() {
     final Spec spec = TestSpecFactory.createMainnetPhase0();
     final SpecConfig specConfig = spec.getGenesisSpecConfig();
-    final BeaconBlockBodySchemaPhase0 specA = BeaconBlockBodySchemaPhase0.create(specConfig);
-    final BeaconBlockBodySchemaPhase0 specB = BeaconBlockBodySchemaPhase0.create(specConfig);
+    final BeaconBlockBodySchemaPhase0 specA =
+        BeaconBlockBodySchemaPhase0.create(
+            specConfig, new AttesterSlashingSchema(new IndexedAttestationSchema(specConfig)));
+    final BeaconBlockBodySchemaPhase0 specB =
+        BeaconBlockBodySchemaPhase0.create(
+            specConfig, new AttesterSlashingSchema(new IndexedAttestationSchema(specConfig)));
 
     assertThat(specA).isEqualTo(specB);
   }

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/operations/AttesterSlashingTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/operations/AttesterSlashingTest.java
@@ -18,16 +18,24 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import java.util.Objects;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing.AttesterSlashingSchema;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 class AttesterSlashingTest {
 
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
-  private IndexedAttestation indexedAttestation1 = dataStructureUtil.randomIndexedAttestation();
-  private IndexedAttestation indexedAttestation2 = dataStructureUtil.randomIndexedAttestation();
+  private final Spec spec = TestSpecFactory.createDefault();
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+  private final AttesterSlashingSchema attesterSlashingSchema =
+      spec.getGenesisSchemaDefinitions().getAttesterSlashingSchema();
+  private final IndexedAttestation indexedAttestation1 =
+      dataStructureUtil.randomIndexedAttestation();
+  private final IndexedAttestation indexedAttestation2 =
+      dataStructureUtil.randomIndexedAttestation();
 
   private AttesterSlashing attesterSlashing =
-      new AttesterSlashing(indexedAttestation1, indexedAttestation2);
+      attesterSlashingSchema.create(indexedAttestation1, indexedAttestation2);
 
   @Test
   void equalsReturnsTrueWhenObjectsAreSame() {
@@ -39,7 +47,7 @@ class AttesterSlashingTest {
   @Test
   void equalsReturnsTrueWhenObjectFieldsAreEqual() {
     AttesterSlashing testAttesterSlashing =
-        new AttesterSlashing(indexedAttestation1, indexedAttestation2);
+        attesterSlashingSchema.create(indexedAttestation1, indexedAttestation2);
 
     assertEquals(attesterSlashing, testAttesterSlashing);
   }
@@ -54,7 +62,7 @@ class AttesterSlashingTest {
     }
 
     AttesterSlashing testAttesterSlashing =
-        new AttesterSlashing(otherIndexedAttestation1, indexedAttestation2);
+        attesterSlashingSchema.create(otherIndexedAttestation1, indexedAttestation2);
 
     assertNotEquals(attesterSlashing, testAttesterSlashing);
   }
@@ -69,7 +77,7 @@ class AttesterSlashingTest {
     }
 
     AttesterSlashing testAttesterSlashing =
-        new AttesterSlashing(indexedAttestation1, otherIndexedAttestation2);
+        attesterSlashingSchema.create(indexedAttestation1, otherIndexedAttestation2);
 
     assertNotEquals(attesterSlashing, testAttesterSlashing);
   }
@@ -78,7 +86,7 @@ class AttesterSlashingTest {
   void roundtripSsz() {
     AttesterSlashing attesterSlashing = dataStructureUtil.randomAttesterSlashing();
     AttesterSlashing newAttesterSlashing =
-        AttesterSlashing.SSZ_SCHEMA.sszDeserialize(attesterSlashing.sszSerialize());
+        attesterSlashingSchema.sszDeserialize(attesterSlashing.sszSerialize());
     assertEquals(attesterSlashing, newAttesterSlashing);
   }
 }

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/operations/IndexedAttestationTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/operations/IndexedAttestationTest.java
@@ -16,17 +16,20 @@ package tech.pegasys.teku.spec.datastructures.operations;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 class IndexedAttestationTest {
 
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final Spec spec = TestSpecFactory.createDefault();
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
 
   @Test
   void roundTripViaSsz() {
     IndexedAttestation indexedAttestation = dataStructureUtil.randomIndexedAttestation();
     IndexedAttestation newIndexedAttestation =
-        IndexedAttestation.SSZ_SCHEMA.sszDeserialize(indexedAttestation.sszSerialize());
+        indexedAttestation.getSchema().sszDeserialize(indexedAttestation.sszSerialize());
     assertEquals(indexedAttestation, newIndexedAttestation);
   }
 }

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/sostests/IsVariableTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/sostests/IsVariableTest.java
@@ -26,10 +26,8 @@ import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockHeader;
 import tech.pegasys.teku.spec.datastructures.blocks.Eth1Data;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
-import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.Deposit;
 import tech.pegasys.teku.spec.datastructures.operations.DepositData;
-import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestation;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.VoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
@@ -47,8 +45,8 @@ public class IsVariableTest {
         Arguments.of(SCHEMA_DEFINITIONS.getBeaconBlockBodySchema()),
         Arguments.of(SCHEMA_DEFINITIONS.getBeaconBlockSchema()),
         Arguments.of(SCHEMA_DEFINITIONS.getAttestationSchema()),
-        Arguments.of(AttesterSlashing.SSZ_SCHEMA),
-        Arguments.of(IndexedAttestation.SSZ_SCHEMA),
+        Arguments.of(SCHEMA_DEFINITIONS.getAttesterSlashingSchema()),
+        Arguments.of(SCHEMA_DEFINITIONS.getIndexedAttestationSchema()),
         Arguments.of(SCHEMA_DEFINITIONS.getBeaconStateSchema()),
         Arguments.of(
             BeaconStateSchemaPhase0.required(SCHEMA_DEFINITIONS.getBeaconStateSchema())

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/util/LengthBoundsCalculatorTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/util/LengthBoundsCalculatorTest.java
@@ -30,11 +30,9 @@ import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BeaconBlocksB
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.GoodbyeMessage;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.StatusMessage;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
-import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.Deposit;
 import tech.pegasys.teku.spec.datastructures.operations.DepositData;
 import tech.pegasys.teku.spec.datastructures.operations.DepositMessage;
-import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestation;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.operations.VoluntaryExit;
@@ -71,7 +69,9 @@ public class LengthBoundsCalculatorTest {
             (SchemaProvider) SchemaDefinitions::getAttestationSchema,
             SszLengthBounds.ofBytes(229, 485)),
         Arguments.of(getProvider(AttestationData.SSZ_SCHEMA), SszLengthBounds.ofBytes(128, 128)),
-        Arguments.of(getProvider(AttesterSlashing.SSZ_SCHEMA), SszLengthBounds.ofBytes(464, 33232)),
+        Arguments.of(
+            (SchemaProvider) SchemaDefinitions::getAttesterSlashingSchema,
+            SszLengthBounds.ofBytes(464, 33232)),
         Arguments.of(
             (SchemaProvider) SchemaDefinitions::getBeaconBlockSchema,
             SszLengthBounds.ofBytes(304, 157656)),
@@ -93,7 +93,8 @@ public class LengthBoundsCalculatorTest {
             (SchemaProvider) SchemaDefinitions::getHistoricalBatchSchema,
             SszLengthBounds.ofBytes(524288, 524288)),
         Arguments.of(
-            getProvider(IndexedAttestation.SSZ_SCHEMA), SszLengthBounds.ofBytes(228, 16612)),
+            (SchemaProvider) SchemaDefinitions::getIndexedAttestationSchema,
+            SszLengthBounds.ofBytes(228, 16612)),
         Arguments.of(
             (SchemaProvider)
                 definitions ->

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -94,6 +94,7 @@ import tech.pegasys.teku.spec.datastructures.operations.DepositData;
 import tech.pegasys.teku.spec.datastructures.operations.DepositMessage;
 import tech.pegasys.teku.spec.datastructures.operations.DepositWithIndex;
 import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestation;
+import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestation.IndexedAttestationSchema;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.SignedAggregateAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
@@ -569,7 +570,9 @@ public final class DataStructureUtil {
   public AttesterSlashing randomAttesterSlashing(final UInt64... attestingIndices) {
     IndexedAttestation attestation1 = randomIndexedAttestation(attestingIndices);
     IndexedAttestation attestation2 = randomIndexedAttestation(attestingIndices);
-    return new AttesterSlashing(attestation1, attestation2);
+    return spec.getGenesisSchemaDefinitions()
+        .getAttesterSlashingSchema()
+        .create(attestation1, attestation2);
   }
 
   public List<SignedBeaconBlock> randomSignedBeaconBlockSequence(
@@ -841,9 +844,12 @@ public final class DataStructureUtil {
   }
 
   public IndexedAttestation randomIndexedAttestation(final UInt64... attestingIndices) {
+    final IndexedAttestationSchema indexedAttestationSchema =
+        spec.getGenesisSchemaDefinitions().getIndexedAttestationSchema();
     SszUInt64List attesting_indices =
-        IndexedAttestation.SSZ_SCHEMA.getAttestingIndicesSchema().of(attestingIndices);
-    return new IndexedAttestation(attesting_indices, randomAttestationData(), randomSignature());
+        indexedAttestationSchema.getAttestingIndicesSchema().of(attestingIndices);
+    return indexedAttestationSchema.create(
+        attesting_indices, randomAttestationData(), randomSignature());
   }
 
   public DepositData randomDepositData() {

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
@@ -46,7 +46,7 @@ import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrate
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation.AttestationSchema;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
-import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestation;
+import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestation.IndexedAttestationSchema;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.util.AttestationProcessingResult;
 import tech.pegasys.teku.spec.executionengine.ExecutePayloadResult;
@@ -680,9 +680,11 @@ class ForkChoiceTest {
                     new Checkpoint(
                         spec.computeEpochAtSlot(updatedAttestationSlot), targetBlock.getRoot())),
                 dataStructureUtil.randomSignature()));
+    final IndexedAttestationSchema indexedAttestationSchema =
+        spec.atSlot(updatedAttestationSlot).getSchemaDefinitions().getIndexedAttestationSchema();
     updatedVote.setIndexedAttestation(
-        new IndexedAttestation(
-            IndexedAttestation.SSZ_SCHEMA.getAttestingIndicesSchema().of(validatorIndex),
+        indexedAttestationSchema.create(
+            indexedAttestationSchema.getAttestingIndicesSchema().of(validatorIndex),
             updatedVote.getData(),
             updatedVote.getAttestation().getAggregateSignature()));
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/AttesterSlashingValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/AttesterSlashingValidatorTest.java
@@ -63,7 +63,7 @@ public class AttesterSlashingValidatorTest {
   public void shouldIgnoreAttesterSlashingForTheSameAttesters() {
     AttesterSlashing slashing1 = dataStructureUtil.randomAttesterSlashing();
     AttesterSlashing slashing2 =
-        new AttesterSlashing(slashing1.getAttestation_1(), slashing1.getAttestation_2());
+        slashing1.getSchema().create(slashing1.getAttestation_1(), slashing1.getAttestation_2());
     when(mockSpec.validateAttesterSlashing(eq(recentChainData.getBestState().orElseThrow()), any()))
         .thenReturn(Optional.empty());
     assertTrue(attesterSlashingValidator.validateFully(slashing1).isAccept());

--- a/fuzz/src/main/java/tech/pegasys/teku/fuzz/input/AttesterSlashingFuzzInput.java
+++ b/fuzz/src/main/java/tech/pegasys/teku/fuzz/input/AttesterSlashingFuzzInput.java
@@ -29,7 +29,7 @@ public class AttesterSlashingFuzzInput
       createType(final SpecVersion spec) {
     return ContainerSchema2.create(
         SszSchema.as(BeaconState.class, spec.getSchemaDefinitions().getBeaconStateSchema()),
-        AttesterSlashing.SSZ_SCHEMA,
+        spec.getSchemaDefinitions().getAttesterSlashingSchema(),
         AttesterSlashingFuzzInput::new);
   }
 

--- a/fuzz/src/test/java/tech/pegasys/teku/fuzz/FuzzUtilTest.java
+++ b/fuzz/src/test/java/tech/pegasys/teku/fuzz/FuzzUtilTest.java
@@ -105,7 +105,9 @@ class FuzzUtilTest {
     final Path testCaseDir =
         Path.of("minimal/operations/attester_slashing/pyspec_tests/success_surround");
     final AttesterSlashing data =
-        loadSsz(testCaseDir.resolve("attester_slashing.ssz"), AttesterSlashing.SSZ_SCHEMA);
+        loadSsz(
+            testCaseDir.resolve("attester_slashing.ssz"),
+            spec.getGenesisSchemaDefinitions().getAttesterSlashingSchema());
     final BeaconState preState = loadSsz(testCaseDir.resolve("pre.ssz"), genesisBeaconStateSchema);
     final BeaconState postState =
         loadSsz(testCaseDir.resolve("post.ssz"), genesisBeaconStateSchema);

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/AttesterSlashingGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/AttesterSlashingGossipManager.java
@@ -18,6 +18,7 @@ import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
 import tech.pegasys.teku.networking.eth2.gossip.topics.GossipTopicName;
 import tech.pegasys.teku.networking.eth2.gossip.topics.OperationProcessor;
 import tech.pegasys.teku.networking.p2p.gossip.GossipNetwork;
+import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
 import tech.pegasys.teku.storage.client.RecentChainData;
@@ -25,6 +26,7 @@ import tech.pegasys.teku.storage.client.RecentChainData;
 public class AttesterSlashingGossipManager extends AbstractGossipManager<AttesterSlashing> {
 
   public AttesterSlashingGossipManager(
+      final Spec spec,
       final RecentChainData recentChainData,
       final AsyncRunner asyncRunner,
       final GossipNetwork gossipNetwork,
@@ -40,7 +42,9 @@ public class AttesterSlashingGossipManager extends AbstractGossipManager<Atteste
         gossipEncoding,
         forkInfo,
         processor,
-        AttesterSlashing.SSZ_SCHEMA,
+        spec.atEpoch(forkInfo.getFork().getEpoch())
+            .getSchemaDefinitions()
+            .getAttesterSlashingSchema(),
         maxMessageSize);
   }
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/forks/versions/GossipForkSubscriptionsPhase0.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/forks/versions/GossipForkSubscriptionsPhase0.java
@@ -181,6 +181,7 @@ public class GossipForkSubscriptionsPhase0 implements GossipForkSubscriptions {
 
     attesterSlashingGossipManager =
         new AttesterSlashingGossipManager(
+            spec,
             recentChainData,
             asyncRunner,
             discoveryNetwork,

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/AttesterSlashingTopicHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/AttesterSlashingTopicHandlerTest.java
@@ -37,7 +37,7 @@ public class AttesterSlashingTopicHandlerTest extends AbstractTopicHandlerTest<A
         gossipEncoding,
         forkDigest,
         GossipTopicName.ATTESTER_SLASHING,
-        AttesterSlashing.SSZ_SCHEMA,
+        spec.getGenesisSchemaDefinitions().getAttesterSlashingSchema(),
         GOSSIP_MAX_SIZE);
   }
 
@@ -98,7 +98,7 @@ public class AttesterSlashingTopicHandlerTest extends AbstractTopicHandlerTest<A
             gossipEncoding,
             forkDigest,
             GossipTopicName.ATTESTER_SLASHING,
-            AttesterSlashing.SSZ_SCHEMA,
+            spec.getGenesisSchemaDefinitions().getAttesterSlashingSchema(),
             GOSSIP_MAX_SIZE);
     assertThat(topicHandler.getTopic()).isEqualTo("/eth2/11223344/attester_slashing/ssz_snappy");
   }


### PR DESCRIPTION
## PR Description
Retrieve `IndexedAttestation` into `SchemaDefinitions` so it can access `MAX_VALIDATORS_PER_COMMITTEE` from `SpecConfig` instead of `Constants.  `AttesterSlashing` also needs to move because it includes `IndexedAttestation`.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
