### PR TITLE
Remove MAX_VALIDATORS_PER_COMMITTEE and Constants.setConstants

### DIFF
--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/EpochTransitionBenchmark.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/EpochTransitionBenchmark.java
@@ -38,7 +38,6 @@ import tech.pegasys.teku.infrastructure.ssz.collections.SszMutableUInt64List;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.config.Constants;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
@@ -86,7 +85,6 @@ public class EpochTransitionBenchmark {
 
   @Setup(Level.Trial)
   public void init() throws Exception {
-    Constants.setConstants(TestSpecFactory.createMainnetPhase0());
     AbstractBlockProcessor.BLS_VERIFY_DEPOSIT = false;
 
     String blocksFile =

--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/ProfilingRun.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/ProfilingRun.java
@@ -33,7 +33,6 @@ import tech.pegasys.teku.infrastructure.async.eventthread.InlineEventThread;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.config.Constants;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.interop.InteropStartupUtil;
 import tech.pegasys.teku.spec.datastructures.state.Validator;
@@ -62,7 +61,6 @@ public class ProfilingRun {
   @Test
   public void importBlocks() throws Exception {
 
-    Constants.setConstants(TestSpecFactory.createMainnetPhase0());
     AbstractBlockProcessor.BLS_VERIFY_DEPOSIT = false;
 
     int validatorsCount = 32 * 1024;
@@ -144,7 +142,6 @@ public class ProfilingRun {
   @Test
   public void importBlocksMemProfiling() throws Exception {
 
-    Constants.setConstants(TestSpecFactory.createMainnetPhase0());
     AbstractBlockProcessor.BLS_VERIFY_DEPOSIT = false;
 
     int validatorsCount = 32 * 1024;

--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/ShuffleBenchmark.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/ShuffleBenchmark.java
@@ -28,7 +28,6 @@ import org.openjdk.jmh.infra.Blackhole;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.config.Constants;
 import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
 
 @Fork(3)
@@ -42,10 +41,6 @@ public class ShuffleBenchmark {
   Bytes32 seed = Bytes32.ZERO;
   private final Spec spec = TestSpecFactory.createMainnetPhase0();
   private final MiscHelpers miscHelpers = spec.atSlot(UInt64.ZERO).miscHelpers();
-
-  public ShuffleBenchmark() {
-    Constants.setConstants(spec);
-  }
 
   @Benchmark
   @Warmup(iterations = 2)

--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/TransitionBenchmark.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/TransitionBenchmark.java
@@ -36,7 +36,6 @@ import tech.pegasys.teku.infrastructure.async.eventthread.InlineEventThread;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.config.Constants;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannel;
 import tech.pegasys.teku.spec.logic.common.block.AbstractBlockProcessor;
@@ -70,7 +69,6 @@ public abstract class TransitionBenchmark {
 
   @Setup(Level.Trial)
   public void init() throws Exception {
-    Constants.setConstants(TestSpecFactory.createMainnetPhase0());
     AbstractBlockProcessor.BLS_VERIFY_DEPOSIT = false;
 
     String blocksFile =

--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/gen/Generator.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/gen/Generator.java
@@ -30,7 +30,6 @@ import tech.pegasys.teku.core.AttestationGenerator;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.config.Constants;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
@@ -49,7 +48,6 @@ public class Generator {
   @Test
   public void generateBlocks() throws Exception {
     final Spec spec = TestSpecFactory.createMainnetAltair();
-    Constants.setConstants(spec);
 
     AbstractBlockProcessor.BLS_VERIFY_DEPOSIT = false;
 

--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/util/backing/BeaconStateBenchmark.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/util/backing/BeaconStateBenchmark.java
@@ -23,8 +23,6 @@ import org.openjdk.jmh.infra.Blackhole;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.bls.BLSTestUtil;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.config.Constants;
 import tech.pegasys.teku.spec.datastructures.state.Validator;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
@@ -36,10 +34,6 @@ public class BeaconStateBenchmark {
   private static final DataStructureUtil dataStructureUtil =
       new DataStructureUtil(0).withPubKeyGenerator(() -> pubkey);
   private static final BeaconState beaconState = dataStructureUtil.randomBeaconState(32 * 1024);
-
-  public BeaconStateBenchmark() {
-    Constants.setConstants(TestSpecFactory.createMainnetPhase0());
-  }
 
   @Benchmark
   @Warmup(iterations = 5, time = 1000, timeUnit = TimeUnit.MILLISECONDS)

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/Eth2ReferenceTestCase.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/Eth2ReferenceTestCase.java
@@ -32,7 +32,6 @@ import tech.pegasys.teku.reference.phase0.shuffling.ShufflingTestExecutor;
 import tech.pegasys.teku.reference.phase0.ssz_generic.SszGenericTests;
 import tech.pegasys.teku.reference.phase0.ssz_static.SszTestExecutor;
 import tech.pegasys.teku.reference.phase0.ssz_static.SszTestExecutorDeprecated;
-import tech.pegasys.teku.spec.config.Constants;
 
 public abstract class Eth2ReferenceTestCase {
 
@@ -71,7 +70,6 @@ public abstract class Eth2ReferenceTestCase {
           .build();
 
   protected void runReferenceTest(final TestDefinition testDefinition) throws Throwable {
-    Constants.setConstants(testDefinition.getSpec());
     getExecutorFor(testDefinition).runTest(testDefinition);
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/Constants.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/Constants.java
@@ -15,11 +15,8 @@ package tech.pegasys.teku.spec.config;
 
 import java.time.Duration;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.Spec;
 
 public class Constants {
-
-  @Deprecated public static int MAX_VALIDATORS_PER_COMMITTEE;
 
   // Networking
   public static final int GOSSIP_MAX_SIZE = 1048576; // bytes
@@ -62,26 +59,4 @@ public class Constants {
 
   // Teku Validator Client Specific
   public static final Duration GENESIS_DATA_RETRY_DELAY = Duration.ofSeconds(10);
-
-  static {
-    setConstants(SpecConfigLoader.loadConfig("minimal"));
-  }
-
-  /**
-   * @deprecated Use tech.pegasys.teku.spec.constants.SpecConfig
-   * @param spec The spec from which to load constants
-   */
-  @Deprecated
-  public static void setConstants(final Spec spec) {
-    setConstants(spec.getGenesisSpecConfig());
-  }
-
-  /**
-   * @deprecated Use tech.pegasys.teku.spec.constants.SpecConfig
-   * @param config The config from which to load constants
-   */
-  @Deprecated
-  public static void setConstants(final SpecConfig config) {
-    MAX_VALIDATORS_PER_COMMITTEE = config.getMaxValidatorsPerCommittee();
-  }
 }

--- a/fuzz/src/main/java/tech/pegasys/teku/fuzz/FuzzUtil.java
+++ b/fuzz/src/main/java/tech/pegasys/teku/fuzz/FuzzUtil.java
@@ -35,7 +35,6 @@ import tech.pegasys.teku.infrastructure.ssz.schema.SszSchema;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.config.Constants;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodySchema;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
@@ -66,18 +65,11 @@ public class FuzzUtil {
             ? TestSpecFactory.createMainnetPhase0()
             : TestSpecFactory.createMinimalPhase0();
     beaconBlockBodySchema = spec.getGenesisSpec().getSchemaDefinitions().getBeaconBlockBodySchema();
-    initialize(useMainnetConfig, disable_bls);
+    initialize(disable_bls);
     this.signatureVerifier = disable_bls ? BLSSignatureVerifier.NO_OP : BLSSignatureVerifier.SIMPLE;
   }
 
-  public static void initialize(final boolean useMainnetConfig, final boolean disable_bls) {
-    // NOTE: makes global Constants/config changes
-    if (useMainnetConfig) {
-      Constants.setConstants(TestSpecFactory.createMainnetPhase0());
-    } else {
-      Constants.setConstants(TestSpecFactory.createMinimalPhase0());
-    }
-
+  public static void initialize(final boolean disable_bls) {
     if (disable_bls) {
       BLSConstants.disableBLSVerification();
     }

--- a/fuzz/src/test/java/tech/pegasys/teku/fuzz/FuzzUtilTest.java
+++ b/fuzz/src/test/java/tech/pegasys/teku/fuzz/FuzzUtilTest.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.junit.BouncyCastleExtension;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tech.pegasys.teku.fuzz.input.AttestationFuzzInput;
@@ -36,7 +35,6 @@ import tech.pegasys.teku.infrastructure.ssz.SszData;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszSchema;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.config.Constants;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSchema;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
@@ -70,11 +68,6 @@ class FuzzUtilTest {
   // uses process_deposits.
 
   // *************** START Deposit Tests *****************
-
-  @AfterEach
-  public void cleanup() {
-    Constants.setConstants(TestSpecFactory.createMinimalPhase0());
-  }
 
   @Test
   public void fuzzAttestation_minimal() {

--- a/fuzz/src/test/java/tech/pegasys/teku/fuzz/input/AbstractFuzzInputTest.java
+++ b/fuzz/src/test/java/tech/pegasys/teku/fuzz/input/AbstractFuzzInputTest.java
@@ -32,7 +32,7 @@ public abstract class AbstractFuzzInputTest<T extends SszData> {
 
   @BeforeEach
   public void setup() {
-    FuzzUtil.initialize(false, true);
+    FuzzUtil.initialize(true);
   }
 
   @Test

--- a/teku/src/main/java/tech/pegasys/teku/AbstractNode.java
+++ b/teku/src/main/java/tech/pegasys/teku/AbstractNode.java
@@ -37,7 +37,6 @@ import tech.pegasys.teku.service.serviceutils.ServiceConfig;
 import tech.pegasys.teku.service.serviceutils.layout.DataDirLayout;
 import tech.pegasys.teku.services.ServiceController;
 import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.config.Constants;
 
 public abstract class AbstractNode implements Node {
   private static final Logger LOG = LogManager.getLogger();
@@ -76,7 +75,6 @@ public abstract class AbstractNode implements Node {
     this.metricsPublisher =
         new MetricsPublisherManager(
             asyncRunnerFactory, serviceConfig.getTimeProvider(), metricsEndpoint);
-    Constants.setConstants(tekuConfig.eth2NetworkConfiguration().getSpec());
   }
 
   private void reportOverrides(final TekuConfiguration tekuConfig) {

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/TransitionCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/TransitionCommand.java
@@ -35,7 +35,6 @@ import tech.pegasys.teku.cli.converter.PicoCliVersionProvider;
 import tech.pegasys.teku.cli.options.Eth2NetworkOptions;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.config.Constants;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.EpochProcessingException;
@@ -125,7 +124,6 @@ public class TransitionCommand implements Runnable {
   private int processStateTransition(
       final InAndOutParams params, final StateTransitionFunction transition) {
     final Spec spec = params.eth2NetworkOptions.getNetworkConfiguration().getSpec();
-    Constants.setConstants(params.eth2NetworkOptions.getNetworkConfiguration().getSpec());
     try (final InputStream in = selectInputStream(params);
         final OutputStream out = selectOutputStream(params)) {
       final Bytes inData = Bytes.wrap(ByteStreams.toByteArray(in));

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugDbCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugDbCommand.java
@@ -34,7 +34,6 @@ import tech.pegasys.teku.infrastructure.async.ScheduledExecutorAsyncRunner;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.service.serviceutils.layout.DataDirLayout;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.config.Constants;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
@@ -115,7 +114,6 @@ public class DebugDbCommand implements Runnable {
                   "The slot to retrieve the state for. If unavailable the closest available state will be returned")
           final long slot)
       throws Exception {
-    setConstants(eth2NetworkOptions);
     try (final Database database =
         createDatabase(dataOptions, dataStorageOptions, eth2NetworkOptions)) {
       return writeState(
@@ -149,7 +147,6 @@ public class DebugDbCommand implements Runnable {
               description = "File to write the block matching the latest finalized state to")
           final Path blockOutputFile)
       throws Exception {
-    setConstants(eth2NetworkOptions);
     final AsyncRunner asyncRunner =
         ScheduledExecutorAsyncRunner.create(
             "async", 1, new MetricTrackingExecutorFactory(new NoOpMetricsSystem()));
@@ -176,10 +173,6 @@ public class DebugDbCommand implements Runnable {
     } finally {
       asyncRunner.shutdown();
     }
-  }
-
-  private void setConstants(@Mixin final Eth2NetworkOptions eth2NetworkOptions) {
-    Constants.setConstants(eth2NetworkOptions.getNetworkConfiguration().getSpec());
   }
 
   private Database createDatabase(

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/internal/validator/options/DepositOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/internal/validator/options/DepositOptions.java
@@ -33,7 +33,6 @@ import tech.pegasys.teku.cli.subcommand.internal.validator.tools.ConsoleAdapter;
 import tech.pegasys.teku.cli.subcommand.internal.validator.tools.DepositSender;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networks.Eth2NetworkConfiguration;
-import tech.pegasys.teku.spec.config.Constants;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.datastructures.eth1.Eth1Address;
 
@@ -98,7 +97,6 @@ public class DepositOptions {
     final Eth2NetworkConfiguration networkConfig =
         Eth2NetworkConfiguration.builder(network).build();
     final tech.pegasys.teku.spec.Spec spec = networkConfig.getSpec();
-    Constants.setConstants(networkConfig.getSpec());
     return new DepositSender(
         spec,
         eth1NodeUrl,


### PR DESCRIPTION
## PR Description
Remove the last variable constant from `Constants` and the `setConstants` method. All spec config is now accessed via the `SpecConfig` class. 🎉 

The `Constants` still exists for now but only contains actual constants. Some of those could potentially be moved to better places but that's just routine refactoring.

## Fixed Issue(s)
fixes #3394

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
