### PR TITLE
ForkChoiceUpdated messages were sending the head as the finalized hash.

### DIFF
--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/schema/ForkChoiceStateV1.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/schema/ForkChoiceStateV1.java
@@ -54,7 +54,7 @@ public class ForkChoiceStateV1 {
     return new ForkChoiceStateV1(
         forkChoiceState.getHeadExecutionBlockHash(),
         forkChoiceState.getSafeExecutionBlockHash(),
-        forkChoiceState.getHeadExecutionBlockHash());
+        forkChoiceState.getFinalizedExecutionBlockHash());
   }
 
   @Override


### PR DESCRIPTION
## PR Description
Fixes `forkChoiceUpdated` messages to send the correct finalised hash instead of the head hash.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
