### PR TITLE
[Bellatrix] add `--Xee-version` param to change engine api version

### DIFF
--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionEngineChannelImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionEngineChannelImpl.java
@@ -22,6 +22,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.ethereum.executionlayer.client.ExecutionEngineClient;
 import tech.pegasys.teku.ethereum.executionlayer.client.KintsugiWeb3JExecutionEngineClient;
+import tech.pegasys.teku.ethereum.executionlayer.client.Web3JExecutionEngineClient;
 import tech.pegasys.teku.ethereum.executionlayer.client.schema.ExecutionPayloadV1;
 import tech.pegasys.teku.ethereum.executionlayer.client.schema.ForkChoiceStateV1;
 import tech.pegasys.teku.ethereum.executionlayer.client.schema.ForkChoiceUpdatedResult;
@@ -48,10 +49,26 @@ public class ExecutionEngineChannelImpl implements ExecutionEngineChannel {
   private final Spec spec;
 
   public static ExecutionEngineChannelImpl create(
-      String eeEndpoint, Spec spec, TimeProvider timeProvider) {
+      final String eeEndpoint,
+      final Spec spec,
+      final TimeProvider timeProvider,
+      final Version version) {
     checkNotNull(eeEndpoint);
+    checkNotNull(version);
     return new ExecutionEngineChannelImpl(
-        new KintsugiWeb3JExecutionEngineClient(eeEndpoint, timeProvider), spec);
+        createEngineClient(eeEndpoint, timeProvider, version), spec);
+  }
+
+  private static ExecutionEngineClient createEngineClient(
+      final String eeEndpoint, final TimeProvider timeProvider, final Version version) {
+    LOG.info("Execution Engine version: {}", version);
+    switch (version) {
+      case kiln:
+        return new Web3JExecutionEngineClient(eeEndpoint, timeProvider);
+      case kintsugi:
+      default:
+        return new KintsugiWeb3JExecutionEngineClient(eeEndpoint, timeProvider);
+    }
   }
 
   private ExecutionEngineChannelImpl(ExecutionEngineClient executionEngineClient, Spec spec) {

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionEngineChannelImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionEngineChannelImpl.java
@@ -52,7 +52,7 @@ public class ExecutionEngineChannelImpl implements ExecutionEngineChannel {
       final String eeEndpoint,
       final Spec spec,
       final TimeProvider timeProvider,
-      final Version version) {
+      final Optional<Version> version) {
     checkNotNull(eeEndpoint);
     checkNotNull(version);
     return new ExecutionEngineChannelImpl(
@@ -60,9 +60,10 @@ public class ExecutionEngineChannelImpl implements ExecutionEngineChannel {
   }
 
   private static ExecutionEngineClient createEngineClient(
-      final String eeEndpoint, final TimeProvider timeProvider, final Version version) {
-    LOG.info("Execution Engine version: {}", version);
-    switch (version) {
+      final String eeEndpoint, final TimeProvider timeProvider, final Optional<Version> version) {
+    final Version actualVersion = version.orElse(Version.kintsugi);
+    LOG.info("Execution Engine version: {}", actualVersion);
+    switch (actualVersion) {
       case kiln:
         return new Web3JExecutionEngineClient(eeEndpoint, timeProvider);
       case kintsugi:

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionEngineChannelImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionEngineChannelImpl.java
@@ -52,7 +52,7 @@ public class ExecutionEngineChannelImpl implements ExecutionEngineChannel {
       final String eeEndpoint,
       final Spec spec,
       final TimeProvider timeProvider,
-      final Optional<Version> version) {
+      final Version version) {
     checkNotNull(eeEndpoint);
     checkNotNull(version);
     return new ExecutionEngineChannelImpl(
@@ -60,13 +60,12 @@ public class ExecutionEngineChannelImpl implements ExecutionEngineChannel {
   }
 
   private static ExecutionEngineClient createEngineClient(
-      final String eeEndpoint, final TimeProvider timeProvider, final Optional<Version> version) {
-    final Version actualVersion = version.orElse(Version.kintsugi);
-    LOG.info("Execution Engine version: {}", actualVersion);
-    switch (actualVersion) {
-      case kiln:
+      final String eeEndpoint, final TimeProvider timeProvider, final Version version) {
+    LOG.info("Execution Engine version: {}", version);
+    switch (version) {
+      case KILN:
         return new Web3JExecutionEngineClient(eeEndpoint, timeProvider);
-      case kintsugi:
+      case KINTSUGI:
       default:
         return new KintsugiWeb3JExecutionEngineClient(eeEndpoint, timeProvider);
     }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionengine/ExecutionEngineChannel.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionengine/ExecutionEngineChannel.java
@@ -66,7 +66,9 @@ public interface ExecutionEngineChannel extends ChannelInterface {
   SafeFuture<PayloadStatus> newPayload(final ExecutionPayload executionPayload);
 
   enum Version {
-    kintsugi,
-    kiln
+    KINTSUGI,
+    KILN;
+
+    public static Version DEFAULT_VERSION = KINTSUGI;
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionengine/ExecutionEngineChannel.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionengine/ExecutionEngineChannel.java
@@ -64,4 +64,9 @@ public interface ExecutionEngineChannel extends ChannelInterface {
   SafeFuture<ExecutionPayload> getPayload(final Bytes8 payloadId, final UInt64 slot);
 
   SafeFuture<PayloadStatus> newPayload(final ExecutionPayload executionPayload);
+
+  enum Version {
+    kintsugi,
+    kiln
+  }
 }

--- a/services/executionengine/src/main/java/tech/pegasys/teku/services/executionengine/ExecutionEngineConfiguration.java
+++ b/services/executionengine/src/main/java/tech/pegasys/teku/services/executionengine/ExecutionEngineConfiguration.java
@@ -24,10 +24,10 @@ public class ExecutionEngineConfiguration {
 
   private final Spec spec;
   private final Optional<String> endpoint;
-  private final Version version;
+  private final Optional<Version> version;
 
   private ExecutionEngineConfiguration(
-      final Spec spec, final Optional<String> endpoint, final Version version) {
+      final Spec spec, final Optional<String> endpoint, final Optional<Version> version) {
     this.spec = spec;
     this.endpoint = endpoint;
     this.version = version;
@@ -52,14 +52,14 @@ public class ExecutionEngineConfiguration {
                 "Invalid configuration. --Xee-endpoint parameter is mandatory when Bellatrix milestone is enabled"));
   }
 
-  public Version getVersion() {
+  public Optional<Version> getVersion() {
     return version;
   }
 
   public static class Builder {
     private Spec spec;
     private Optional<String> endpoint = Optional.empty();
-    private Version version;
+    private Optional<Version> version = Optional.empty();
 
     private Builder() {}
 
@@ -74,8 +74,11 @@ public class ExecutionEngineConfiguration {
     }
 
     public Builder version(final String version) {
+      if (version == null) {
+        return this;
+      }
       try {
-        this.version = Version.valueOf(version);
+        this.version = Optional.of(Version.valueOf(version));
         return this;
       } catch (IllegalArgumentException e) {
         throw new IllegalArgumentException(

--- a/services/executionengine/src/main/java/tech/pegasys/teku/services/executionengine/ExecutionEngineConfiguration.java
+++ b/services/executionengine/src/main/java/tech/pegasys/teku/services/executionengine/ExecutionEngineConfiguration.java
@@ -13,19 +13,24 @@
 
 package tech.pegasys.teku.services.executionengine;
 
+import java.util.Arrays;
 import java.util.Optional;
 import tech.pegasys.teku.infrastructure.exceptions.InvalidConfigurationException;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannel.Version;
 
 public class ExecutionEngineConfiguration {
 
   private final Spec spec;
   private final Optional<String> endpoint;
+  private final Version version;
 
-  private ExecutionEngineConfiguration(final Spec spec, final Optional<String> endpoint) {
+  private ExecutionEngineConfiguration(
+      final Spec spec, final Optional<String> endpoint, final Version version) {
     this.spec = spec;
     this.endpoint = endpoint;
+    this.version = version;
   }
 
   public static Builder builder() {
@@ -47,19 +52,35 @@ public class ExecutionEngineConfiguration {
                 "Invalid configuration. --Xee-endpoint parameter is mandatory when Bellatrix milestone is enabled"));
   }
 
+  public Version getVersion() {
+    return version;
+  }
+
   public static class Builder {
     private Spec spec;
     private Optional<String> endpoint = Optional.empty();
+    private Version version;
 
     private Builder() {}
 
     public ExecutionEngineConfiguration build() {
-      return new ExecutionEngineConfiguration(spec, endpoint);
+
+      return new ExecutionEngineConfiguration(spec, endpoint, version);
     }
 
     public Builder endpoint(final String endpoint) {
       this.endpoint = Optional.ofNullable(endpoint);
       return this;
+    }
+
+    public Builder version(final String version) {
+      try {
+        this.version = Version.valueOf(version);
+        return this;
+      } catch (IllegalArgumentException e) {
+        throw new IllegalArgumentException(
+            "Invalid \"--Xee-version\". Allowed values are: " + Arrays.toString(Version.values()));
+      }
     }
 
     public Builder specProvider(final Spec spec) {

--- a/services/executionengine/src/main/java/tech/pegasys/teku/services/executionengine/ExecutionEngineConfiguration.java
+++ b/services/executionengine/src/main/java/tech/pegasys/teku/services/executionengine/ExecutionEngineConfiguration.java
@@ -13,7 +13,6 @@
 
 package tech.pegasys.teku.services.executionengine;
 
-import java.util.Arrays;
 import java.util.Optional;
 import tech.pegasys.teku.infrastructure.exceptions.InvalidConfigurationException;
 import tech.pegasys.teku.spec.Spec;
@@ -24,10 +23,10 @@ public class ExecutionEngineConfiguration {
 
   private final Spec spec;
   private final Optional<String> endpoint;
-  private final Optional<Version> version;
+  private final Version version;
 
   private ExecutionEngineConfiguration(
-      final Spec spec, final Optional<String> endpoint, final Optional<Version> version) {
+      final Spec spec, final Optional<String> endpoint, final Version version) {
     this.spec = spec;
     this.endpoint = endpoint;
     this.version = version;
@@ -52,14 +51,14 @@ public class ExecutionEngineConfiguration {
                 "Invalid configuration. --Xee-endpoint parameter is mandatory when Bellatrix milestone is enabled"));
   }
 
-  public Optional<Version> getVersion() {
+  public Version getVersion() {
     return version;
   }
 
   public static class Builder {
     private Spec spec;
     private Optional<String> endpoint = Optional.empty();
-    private Optional<Version> version = Optional.empty();
+    private Version version = Version.DEFAULT_VERSION;
 
     private Builder() {}
 
@@ -73,17 +72,9 @@ public class ExecutionEngineConfiguration {
       return this;
     }
 
-    public Builder version(final String version) {
-      if (version == null) {
-        return this;
-      }
-      try {
-        this.version = Optional.of(Version.valueOf(version));
-        return this;
-      } catch (IllegalArgumentException e) {
-        throw new IllegalArgumentException(
-            "Invalid \"--Xee-version\". Allowed values are: " + Arrays.toString(Version.values()));
-      }
+    public Builder version(final Version version) {
+      this.version = version;
+      return this;
     }
 
     public Builder specProvider(final Spec spec) {

--- a/services/executionengine/src/main/java/tech/pegasys/teku/services/executionengine/ExecutionEngineService.java
+++ b/services/executionengine/src/main/java/tech/pegasys/teku/services/executionengine/ExecutionEngineService.java
@@ -49,7 +49,8 @@ public class ExecutionEngineService extends Service {
     LOG.info("Using execution engine at {}", endpoint);
     final ExecutionEngineChannel executionEngine =
         new ThrottlingExecutionEngineChannel(
-            ExecutionEngineChannelImpl.create(endpoint, config.getSpec(), timeProvider),
+            ExecutionEngineChannelImpl.create(
+                endpoint, config.getSpec(), timeProvider, config.getVersion()),
             MAXIMUM_CONCURRENT_EE_REQUESTS,
             metricsSystem);
     eventChannels.subscribe(ExecutionEngineChannel.class, executionEngine);

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ExecutionEngineOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ExecutionEngineOptions.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.cli.options;
 import static tech.pegasys.teku.config.TekuConfiguration.Builder;
 
 import picocli.CommandLine.Option;
+import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannel.Version;
 
 public class ExecutionEngineOptions {
 
@@ -29,11 +30,11 @@ public class ExecutionEngineOptions {
 
   @Option(
       names = {"--Xee-version"},
-      paramLabel = "<STRING>",
+      paramLabel = "<EXECUTION_ENGINE_VERSION>",
       description = "Execution Engine API version. Possible values are: kintsugi (default) or kiln",
       arity = "1",
       hidden = true)
-  private String executionEngineVersion = null;
+  private Version executionEngineVersion = Version.DEFAULT_VERSION;
 
   public void configure(final Builder builder) {
     builder.executionEngine(

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ExecutionEngineOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ExecutionEngineOptions.java
@@ -27,7 +27,16 @@ public class ExecutionEngineOptions {
       hidden = true)
   private String executionEngineEndpoint = null;
 
+  @Option(
+      names = {"--Xee-version"},
+      paramLabel = "<STRING>",
+      description = "Execution Engine API version. Possible values are: kintsugi (default) or kiln",
+      arity = "1",
+      hidden = true)
+  private String executionEngineVersion = "kintsugi";
+
   public void configure(final Builder builder) {
-    builder.executionEngine(b -> b.endpoint(executionEngineEndpoint));
+    builder.executionEngine(
+        b -> b.endpoint(executionEngineEndpoint).version(executionEngineVersion));
   }
 }

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ExecutionEngineOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ExecutionEngineOptions.java
@@ -33,7 +33,7 @@ public class ExecutionEngineOptions {
       description = "Execution Engine API version. Possible values are: kintsugi (default) or kiln",
       arity = "1",
       hidden = true)
-  private String executionEngineVersion = "kintsugi";
+  private String executionEngineVersion = null;
 
   public void configure(final Builder builder) {
     builder.executionEngine(


### PR DESCRIPTION
## PR Description
Adds a new hidden CLI param `--Xee-version` that allows to change engine API dialect.
Possible values `kintsugi` (default) and `kiln`.

`kintsugi` is based on spec `v1.0.0-alpha.5`
`kiln` is based on spec `v1.0.0-alpha.6`

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
