### PR TITLE
Fix PicoCLI warning because of unescaped % character

### DIFF
--- a/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
@@ -132,7 +132,7 @@ public class P2POptions {
       names = {"--Xp2p-minimum-randomly-selected-peer-count"},
       paramLabel = "<INTEGER>",
       description =
-          "Number of peers that should be selected randomly (default 20% of lower-bound target)",
+          "Number of peers that should be selected randomly (default 20%% of lower-bound target)",
       arity = "1",
       hidden = true)
   private Integer minimumRandomlySelectedPeerCount;


### PR DESCRIPTION
## PR Description
Fix PicoCLI warning:
```
[picocli WARN] Could not format 'Number of peers that should be selected randomly (default 20% of lower-bound target)' (Underlying error: Format specifier '% o'). Using raw String: '%n' format strings have not been replaced with newlines. Please ensure to escape '%' characters with another '%'.
```

It's only on a hidden option so doesn't apply to normal `teku --help` but just `teku -X`.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
