### PR TITLE
Add method to find the transition block to protoarray.

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ReadOnlyForkChoiceStrategy.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ReadOnlyForkChoiceStrategy.java
@@ -37,6 +37,8 @@ public interface ReadOnlyForkChoiceStrategy {
 
   Map<Bytes32, UInt64> getOptimisticChainHeads();
 
+  Optional<Bytes32> getOptimisticallySyncedTransitionBlockRoot(Bytes32 head);
+
   List<Map<String, Object>> getNodeData();
 
   boolean contains(Bytes32 blockRoot);

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/RandomChainBuilderForkChoiceStrategy.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/RandomChainBuilderForkChoiceStrategy.java
@@ -99,6 +99,11 @@ public class RandomChainBuilderForkChoiceStrategy implements ReadOnlyForkChoiceS
   }
 
   @Override
+  public Optional<Bytes32> getOptimisticallySyncedTransitionBlockRoot(final Bytes32 head) {
+    return Optional.empty();
+  }
+
+  @Override
   public List<Map<String, Object>> getNodeData() {
     return Collections.emptyList();
   }

--- a/protoarray/src/main/java/tech/pegasys/teku/protoarray/ForkChoiceStrategy.java
+++ b/protoarray/src/main/java/tech/pegasys/teku/protoarray/ForkChoiceStrategy.java
@@ -207,6 +207,7 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
     }
   }
 
+  @Override
   public Optional<Bytes32> getOptimisticallySyncedTransitionBlockRoot(final Bytes32 head) {
     protoArrayLock.readLock().lock();
     try {

--- a/protoarray/src/main/java/tech/pegasys/teku/protoarray/ForkChoiceStrategy.java
+++ b/protoarray/src/main/java/tech/pegasys/teku/protoarray/ForkChoiceStrategy.java
@@ -207,6 +207,15 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
     }
   }
 
+  public Optional<Bytes32> getOptimisticallySyncedTransitionBlockRoot(final Bytes32 head) {
+    protoArrayLock.readLock().lock();
+    try {
+      return protoArray.findMergeTransitionBlock(head).map(ProtoNode::getBlockRoot);
+    } finally {
+      protoArrayLock.readLock().unlock();
+    }
+  }
+
   void processAttestation(
       VoteUpdater voteUpdater, UInt64 validatorIndex, Bytes32 blockRoot, UInt64 targetEpoch) {
     VoteTracker vote = voteUpdater.getVote(validatorIndex);

--- a/protoarray/src/test/java/tech/pegasys/teku/protoarray/ProtoArrayTest.java
+++ b/protoarray/src/test/java/tech/pegasys/teku/protoarray/ProtoArrayTest.java
@@ -493,7 +493,7 @@ class ProtoArrayTest {
     addOptimisticBlock(1, block1a, GENESIS_CHECKPOINT.getRoot(), Bytes32.ZERO);
     addOptimisticBlock(2, block2a, block1a, Bytes32.ZERO);
     addOptimisticBlock(3, block3a, block2a, Bytes32.ZERO);
-    addOptimisticBlock(3, block4a, block3a);
+    addOptimisticBlock(4, block4a, block3a);
     assertThat(protoArray.findMergeTransitionBlock(block3a)).isEmpty();
   }
 


### PR DESCRIPTION
## PR Description
In order to ensure we validate the merge transition block we need to be able to find it in the non-finalised data so add a method to protoarray to support that.

## Fixed Issue(s)
#4671 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
