### PR TITLE
[Bellatrix] implements `engine_exchangeTransitionConfiguration`

### DIFF
--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionEngineChannelImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionEngineChannelImpl.java
@@ -29,6 +29,7 @@ import tech.pegasys.teku.ethereum.executionlayer.client.schema.ForkChoiceUpdated
 import tech.pegasys.teku.ethereum.executionlayer.client.schema.PayloadAttributesV1;
 import tech.pegasys.teku.ethereum.executionlayer.client.schema.PayloadStatusV1;
 import tech.pegasys.teku.ethereum.executionlayer.client.schema.Response;
+import tech.pegasys.teku.ethereum.executionlayer.client.schema.TransitionConfigurationV1;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.ssz.type.Bytes8;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
@@ -40,6 +41,7 @@ import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannel;
 import tech.pegasys.teku.spec.executionengine.ForkChoiceState;
 import tech.pegasys.teku.spec.executionengine.PayloadAttributes;
 import tech.pegasys.teku.spec.executionengine.PayloadStatus;
+import tech.pegasys.teku.spec.executionengine.TransitionConfiguration;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsBellatrix;
 
 public class ExecutionEngineChannelImpl implements ExecutionEngineChannel {
@@ -159,5 +161,25 @@ public class ExecutionEngineChannelImpl implements ExecutionEngineChannel {
             payloadStatus ->
                 LOG.trace("newPayload(executionPayload={}) -> {}", executionPayload, payloadStatus))
         .exceptionally(PayloadStatus::failedExecution);
+  }
+
+  @Override
+  public SafeFuture<TransitionConfiguration> exchangeTransitionConfiguration(
+      TransitionConfiguration transitionConfiguration) {
+    LOG.trace(
+        "calling exchangeTransitionConfiguration(transitionConfiguration={})",
+        transitionConfiguration);
+
+    return executionEngineClient
+        .exchangeTransitionConfiguration(
+            TransitionConfigurationV1.fromInternalTransitionConfiguration(transitionConfiguration))
+        .thenApply(ExecutionEngineChannelImpl::unwrapResponseOrThrow)
+        .thenApply(TransitionConfigurationV1::asInternalTransitionConfiguration)
+        .thenPeek(
+            remoteTransitionConfiguration ->
+                LOG.trace(
+                    "exchangeTransitionConfiguration(transitionConfiguration={}) -> {}",
+                    transitionConfiguration,
+                    remoteTransitionConfiguration));
   }
 }

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ThrottlingExecutionEngineChannel.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ThrottlingExecutionEngineChannel.java
@@ -28,6 +28,7 @@ import tech.pegasys.teku.spec.executionengine.ForkChoiceState;
 import tech.pegasys.teku.spec.executionengine.ForkChoiceUpdatedResult;
 import tech.pegasys.teku.spec.executionengine.PayloadAttributes;
 import tech.pegasys.teku.spec.executionengine.PayloadStatus;
+import tech.pegasys.teku.spec.executionengine.TransitionConfiguration;
 
 public class ThrottlingExecutionEngineChannel implements ExecutionEngineChannel {
   private final ExecutionEngineChannel delegate;
@@ -71,5 +72,12 @@ public class ThrottlingExecutionEngineChannel implements ExecutionEngineChannel 
   @Override
   public SafeFuture<PayloadStatus> newPayload(ExecutionPayload executionPayload) {
     return taskQueue.queueTask(() -> delegate.newPayload(executionPayload));
+  }
+
+  @Override
+  public SafeFuture<TransitionConfiguration> exchangeTransitionConfiguration(
+      TransitionConfiguration transitionConfiguration) {
+    return taskQueue.queueTask(
+        () -> delegate.exchangeTransitionConfiguration(transitionConfiguration));
   }
 }

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/ExecutionEngineClient.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/ExecutionEngineClient.java
@@ -21,6 +21,7 @@ import tech.pegasys.teku.ethereum.executionlayer.client.schema.ForkChoiceUpdated
 import tech.pegasys.teku.ethereum.executionlayer.client.schema.PayloadAttributesV1;
 import tech.pegasys.teku.ethereum.executionlayer.client.schema.PayloadStatusV1;
 import tech.pegasys.teku.ethereum.executionlayer.client.schema.Response;
+import tech.pegasys.teku.ethereum.executionlayer.client.schema.TransitionConfigurationV1;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.ssz.type.Bytes8;
 import tech.pegasys.teku.spec.datastructures.execution.PowBlock;
@@ -36,4 +37,7 @@ public interface ExecutionEngineClient {
 
   SafeFuture<Response<ForkChoiceUpdatedResult>> forkChoiceUpdated(
       ForkChoiceStateV1 forkChoiceState, Optional<PayloadAttributesV1> payloadAttributes);
+
+  SafeFuture<Response<TransitionConfigurationV1>> exchangeTransitionConfiguration(
+      TransitionConfigurationV1 transitionConfiguration);
 }

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/KintsugiWeb3JExecutionEngineClient.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/KintsugiWeb3JExecutionEngineClient.java
@@ -70,8 +70,7 @@ public class KintsugiWeb3JExecutionEngineClient extends Web3JExecutionEngineClie
   @Override
   public SafeFuture<Response<TransitionConfigurationV1>> exchangeTransitionConfiguration(
       TransitionConfigurationV1 transitionConfiguration) {
-    return SafeFuture.failedFuture(
-        new UnsupportedOperationException("Not Implemented in Kintsugi version"));
+    return SafeFuture.completedFuture(new Response<>(transitionConfiguration));
   }
 
   private Response<ForkChoiceUpdatedResult> fromKintsugiForkChoiceUpdatedResultResponse(

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/KintsugiWeb3JExecutionEngineClient.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/KintsugiWeb3JExecutionEngineClient.java
@@ -29,6 +29,7 @@ import tech.pegasys.teku.ethereum.executionlayer.client.schema.ForkChoiceUpdated
 import tech.pegasys.teku.ethereum.executionlayer.client.schema.PayloadAttributesV1;
 import tech.pegasys.teku.ethereum.executionlayer.client.schema.PayloadStatusV1;
 import tech.pegasys.teku.ethereum.executionlayer.client.schema.Response;
+import tech.pegasys.teku.ethereum.executionlayer.client.schema.TransitionConfigurationV1;
 import tech.pegasys.teku.ethereum.executionlayer.client.serialization.Bytes8Deserializer;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.ssz.type.Bytes8;
@@ -64,6 +65,13 @@ public class KintsugiWeb3JExecutionEngineClient extends Web3JExecutionEngineClie
             eeWeb3jService,
             KintsugiForkChoiceUpdatedWeb3jResponse.class);
     return doRequest(web3jRequest).thenApply(this::fromKintsugiForkChoiceUpdatedResultResponse);
+  }
+
+  @Override
+  public SafeFuture<Response<TransitionConfigurationV1>> exchangeTransitionConfiguration(
+      TransitionConfigurationV1 transitionConfiguration) {
+    return SafeFuture.failedFuture(
+        new UnsupportedOperationException("Not Implemented in Kintsugi version"));
   }
 
   private Response<ForkChoiceUpdatedResult> fromKintsugiForkChoiceUpdatedResultResponse(

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/Web3JExecutionEngineClient.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/Web3JExecutionEngineClient.java
@@ -38,6 +38,7 @@ import tech.pegasys.teku.ethereum.executionlayer.client.schema.ForkChoiceUpdated
 import tech.pegasys.teku.ethereum.executionlayer.client.schema.PayloadAttributesV1;
 import tech.pegasys.teku.ethereum.executionlayer.client.schema.PayloadStatusV1;
 import tech.pegasys.teku.ethereum.executionlayer.client.schema.Response;
+import tech.pegasys.teku.ethereum.executionlayer.client.schema.TransitionConfigurationV1;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.ssz.type.Bytes8;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
@@ -128,6 +129,18 @@ public class Web3JExecutionEngineClient implements ExecutionEngineClient {
     return doRequest(web3jRequest);
   }
 
+  @Override
+  public SafeFuture<Response<TransitionConfigurationV1>> exchangeTransitionConfiguration(
+      TransitionConfigurationV1 transitionConfiguration) {
+    Request<?, ExchangeTransitionConfigurationWeb3jResponse> web3jRequest =
+        new Request<>(
+            "engine_exchangeTransitionConfigurationV1",
+            Collections.singletonList(transitionConfiguration),
+            eeWeb3jService,
+            ExchangeTransitionConfigurationWeb3jResponse.class);
+    return doRequest(web3jRequest);
+  }
+
   private void handleError(Throwable error) {
     final long errorTime = lastError.get();
     if (errorTime == NO_ERROR_TIME
@@ -180,6 +193,9 @@ public class Web3JExecutionEngineClient implements ExecutionEngineClient {
 
   static class ForkChoiceUpdatedWeb3jResponse
       extends org.web3j.protocol.core.Response<ForkChoiceUpdatedResult> {}
+
+  static class ExchangeTransitionConfigurationWeb3jResponse
+      extends org.web3j.protocol.core.Response<TransitionConfigurationV1> {}
 
   /**
    * Returns a list that supports null items.

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/schema/TransitionConfigurationV1.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/schema/TransitionConfigurationV1.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionlayer.client.schema;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.common.base.MoreObjects;
+import java.util.Objects;
+import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.units.bigints.UInt256;
+import tech.pegasys.teku.ethereum.executionlayer.client.serialization.Bytes32Deserializer;
+import tech.pegasys.teku.ethereum.executionlayer.client.serialization.BytesSerializer;
+import tech.pegasys.teku.ethereum.executionlayer.client.serialization.UInt256AsHexDeserializer;
+import tech.pegasys.teku.ethereum.executionlayer.client.serialization.UInt256AsHexSerializer;
+import tech.pegasys.teku.ethereum.executionlayer.client.serialization.UInt64AsHexDeserializer;
+import tech.pegasys.teku.ethereum.executionlayer.client.serialization.UInt64AsHexSerializer;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.executionengine.TransitionConfiguration;
+
+public class TransitionConfigurationV1 {
+  @JsonSerialize(using = UInt256AsHexSerializer.class)
+  @JsonDeserialize(using = UInt256AsHexDeserializer.class)
+  public final UInt256 terminalTotalDifficulty;
+
+  @JsonSerialize(using = BytesSerializer.class)
+  @JsonDeserialize(using = Bytes32Deserializer.class)
+  public final Bytes32 terminalBlockHash;
+
+  @JsonSerialize(using = UInt64AsHexSerializer.class)
+  @JsonDeserialize(using = UInt64AsHexDeserializer.class)
+  public final UInt64 terminalBlockNumber;
+
+  @JsonCreator
+  public TransitionConfigurationV1(
+      @JsonProperty("terminalTotalDifficulty") UInt256 terminalTotalDifficulty,
+      @JsonProperty("terminalBlockHash") Bytes32 terminalBlockHash,
+      @JsonProperty("terminalBlockNumber") UInt64 terminalBlockNumber) {
+    checkNotNull(terminalTotalDifficulty, "terminalTotalDifficulty is required");
+    checkNotNull(terminalBlockHash, "terminalBlockHash is required");
+    checkNotNull(terminalBlockNumber, "terminalBlockNumber is required");
+
+    this.terminalTotalDifficulty = terminalTotalDifficulty;
+    this.terminalBlockHash = terminalBlockHash;
+    this.terminalBlockNumber = terminalBlockNumber;
+  }
+
+  public TransitionConfiguration asInternalTransitionConfiguration() {
+    return new TransitionConfiguration(
+        terminalTotalDifficulty, terminalBlockHash, terminalBlockNumber);
+  }
+
+  public static TransitionConfigurationV1 fromInternalTransitionConfiguration(
+      TransitionConfiguration transitionConfiguration) {
+    return new TransitionConfigurationV1(
+        transitionConfiguration.getTerminalTotalDifficulty(),
+        transitionConfiguration.getTerminalBlockHash(),
+        transitionConfiguration.getTerminalBlockNumber());
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    final TransitionConfigurationV1 that = (TransitionConfigurationV1) o;
+    return Objects.equals(terminalTotalDifficulty, that.terminalTotalDifficulty)
+        && Objects.equals(terminalBlockHash, that.terminalBlockHash)
+        && Objects.equals(terminalBlockNumber, that.terminalBlockNumber);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(terminalTotalDifficulty, terminalBlockHash, terminalBlockNumber);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("terminalTotalDifficulty", terminalTotalDifficulty)
+        .add("terminalBlockHash", terminalBlockHash)
+        .add("terminalBlockNumber", terminalBlockNumber)
+        .toString();
+  }
+}

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/serialization/UInt256AsHexDeserializer.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/serialization/UInt256AsHexDeserializer.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.teku.ethereum.executionlayer.client.serialization;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
@@ -23,6 +25,8 @@ public class UInt256AsHexDeserializer extends JsonDeserializer<UInt256> {
 
   @Override
   public UInt256 deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
-    return UInt256.fromHexString(p.getValueAsString());
+    final String hexValue = p.getValueAsString();
+    checkArgument(hexValue.startsWith("0x"), "Hex value must start with 0x");
+    return UInt256.fromHexString(hexValue);
   }
 }

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/serialization/UInt64AsHexDeserializer.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/serialization/UInt64AsHexDeserializer.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.teku.ethereum.executionlayer.client.serialization;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
@@ -24,6 +26,8 @@ public class UInt64AsHexDeserializer extends JsonDeserializer<UInt64> {
 
   @Override
   public UInt64 deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
-    return UInt64.valueOf(Bytes.fromHexStringLenient(p.getValueAsString()).toUnsignedBigInteger());
+    final String hexValue = p.getValueAsString();
+    checkArgument(hexValue.startsWith("0x"), "Hex value must start with 0x");
+    return UInt64.valueOf(Bytes.fromHexStringLenient(hexValue).toUnsignedBigInteger());
   }
 }

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/client/Web3JExecutionEngineClientTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/client/Web3JExecutionEngineClientTest.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
 import org.junit.jupiter.api.BeforeEach;
@@ -38,6 +39,7 @@ import tech.pegasys.teku.ethereum.executionlayer.client.schema.ForkChoiceStateV1
 import tech.pegasys.teku.ethereum.executionlayer.client.schema.ForkChoiceUpdatedResult;
 import tech.pegasys.teku.ethereum.executionlayer.client.schema.PayloadAttributesV1;
 import tech.pegasys.teku.ethereum.executionlayer.client.schema.PayloadStatusV1;
+import tech.pegasys.teku.ethereum.executionlayer.client.schema.TransitionConfigurationV1;
 import tech.pegasys.teku.ethereum.executionlayer.client.serialization.Bytes20Deserializer;
 import tech.pegasys.teku.ethereum.executionlayer.client.serialization.Bytes20Serializer;
 import tech.pegasys.teku.ethereum.executionlayer.client.serialization.Bytes32Deserializer;
@@ -56,6 +58,7 @@ import tech.pegasys.teku.spec.TestSpecInvocationContextProvider.SpecContext;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.executionengine.ExecutionPayloadStatus;
 import tech.pegasys.teku.spec.executionengine.PayloadStatus;
+import tech.pegasys.teku.spec.executionengine.TransitionConfiguration;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 @TestSpecContext(milestone = SpecMilestone.BELLATRIX)
@@ -201,7 +204,7 @@ public class Web3JExecutionEngineClientTest {
   }
 
   @TestTemplate
-  void shouldDeserializeExecutionPayloadResultWithNulls() throws IOException {
+  void shouldDeserializePayloadStatusWithNulls() throws IOException {
     PayloadStatusV1 payloadStatusV1Expected =
         new PayloadStatusV1(ExecutionPayloadStatus.VALID, null, null);
     PayloadStatus internalPayloadStatusExpected = PayloadStatus.VALID;
@@ -216,7 +219,7 @@ public class Web3JExecutionEngineClientTest {
   }
 
   @TestTemplate
-  void shouldDeserializeExecutionPayloadResult() throws IOException {
+  void shouldDeserializePayloadStatus() throws IOException {
     Bytes32 lastValidHash = dataStructureUtil.randomBytes32();
     PayloadStatusV1 payloadStatusV1Expected =
         new PayloadStatusV1(ExecutionPayloadStatus.INVALID, lastValidHash, "test");
@@ -237,7 +240,7 @@ public class Web3JExecutionEngineClientTest {
   }
 
   @TestTemplate
-  void shouldThrowDeserializingInvalidExecutionPayloadResult() {
+  void shouldThrowDeserializingInvalidPayloadStatusV1() {
     assertThrows(
         InvalidFormatException.class,
         () -> {
@@ -372,6 +375,83 @@ public class Web3JExecutionEngineClientTest {
     String serialized = objectMapper.writeValueAsString(payloadAttributes);
 
     assertThat(serialized).isNotEmpty();
+  }
+
+  @TestTemplate
+  void shouldSerializeTransitionConfigurationV1() throws IOException {
+    final TransitionConfigurationV1 externalTransitionConfiguration =
+        new TransitionConfigurationV1(
+            dataStructureUtil.randomUInt256(),
+            dataStructureUtil.randomBytes32(),
+            dataStructureUtil.randomUInt64());
+
+    String serialized = objectMapper.writeValueAsString(externalTransitionConfiguration);
+
+    assertThat(serialized).isNotEmpty();
+  }
+
+  @TestTemplate
+  void shouldDeserializeTransitionConfigurationV1() throws IOException {
+    final String json =
+        "{\"terminalTotalDifficulty\": \"0xF123657934589000000000000000001\", "
+            + "\"terminalBlockHash\": \"0x95b8e2ba063ab62f68ebe7db0a9669ab9e7906aa4e060e1cc0b67b294ce8c5e4\", "
+            + "\"terminalBlockNumber\": \"0xa79345890\" }";
+
+    final TransitionConfigurationV1 externalTransitionConfiguration =
+        objectMapper.readValue(json, TransitionConfigurationV1.class);
+
+    assertThat(externalTransitionConfiguration.terminalTotalDifficulty)
+        .isEqualTo(UInt256.fromHexString("0xF123657934589000000000000000001"));
+    assertThat(externalTransitionConfiguration.terminalBlockHash)
+        .isEqualTo(
+            Bytes32.fromHexString(
+                "0x95b8e2ba063ab62f68ebe7db0a9669ab9e7906aa4e060e1cc0b67b294ce8c5e4"));
+    assertThat(externalTransitionConfiguration.terminalBlockNumber)
+        .isEqualTo(
+            UInt64.valueOf(Bytes.fromHexStringLenient("0xa79345890").toUnsignedBigInteger()));
+  }
+
+  @TestTemplate
+  void shouldSerializeDeserializeTransitionConfigurationV1() throws IOException {
+    final TransitionConfigurationV1 externalTransitionConfiguration =
+        new TransitionConfigurationV1(
+            dataStructureUtil.randomUInt256(),
+            dataStructureUtil.randomBytes32(),
+            dataStructureUtil.randomUInt64());
+
+    String serialized = objectMapper.writeValueAsString(externalTransitionConfiguration);
+
+    assertThat(serialized).isNotEmpty();
+
+    TransitionConfigurationV1 externalTransitionConfiguration2 =
+        objectMapper.readValue(serialized, TransitionConfigurationV1.class);
+
+    assertThat(externalTransitionConfiguration).isEqualTo(externalTransitionConfiguration2);
+  }
+
+  @TestTemplate
+  void shouldTransitionConfigurationRoundtrip() {
+    final TransitionConfigurationV1 externalTransitionConfiguration =
+        new TransitionConfigurationV1(
+            dataStructureUtil.randomUInt256(),
+            dataStructureUtil.randomBytes32(),
+            dataStructureUtil.randomUInt64());
+
+    final TransitionConfiguration internalTransitionConfiguration =
+        externalTransitionConfiguration.asInternalTransitionConfiguration();
+
+    assertThat(internalTransitionConfiguration.getTerminalBlockHash())
+        .isEqualTo(externalTransitionConfiguration.terminalBlockHash);
+    assertThat(internalTransitionConfiguration.getTerminalBlockNumber())
+        .isEqualTo(externalTransitionConfiguration.terminalBlockNumber);
+    assertThat(internalTransitionConfiguration.getTerminalTotalDifficulty())
+        .isEqualTo(externalTransitionConfiguration.terminalTotalDifficulty);
+
+    final TransitionConfigurationV1 externalTransitionConfiguration2 =
+        TransitionConfigurationV1.fromInternalTransitionConfiguration(
+            internalTransitionConfiguration);
+
+    assertThat(externalTransitionConfiguration2).isEqualTo(externalTransitionConfiguration);
   }
 
   private ForkChoiceUpdatedResult createExternalForkChoiceUpdatedResult(

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/client/Web3JExecutionEngineClientTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/client/Web3JExecutionEngineClientTest.java
@@ -146,6 +146,26 @@ public class Web3JExecutionEngineClientTest {
     assertThat(originalUInt256).isEqualTo(result);
   }
 
+  @TestTemplate
+  void shouldThrowDeserializingUIntQuantityNot0xPrefixed() {
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          JsonParser parser = prepareDeserializationContext("123");
+          UInt256AsHexDeserializer deserializer = new UInt256AsHexDeserializer();
+          deserializer.deserialize(parser, objectMapper.getDeserializationContext());
+        });
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          JsonParser parser = prepareDeserializationContext("123");
+          UInt64AsHexDeserializer deserializer = new UInt64AsHexDeserializer();
+          deserializer.deserialize(parser, objectMapper.getDeserializationContext());
+        });
+  }
+
   private JsonParser prepareDeserializationContext(String serializedValue) throws IOException {
     String json = String.format("{\"value\":%s}", serializedValue);
     JsonParser parser = objectMapper.getFactory().createParser(json);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionengine/ExecutionEngineChannel.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionengine/ExecutionEngineChannel.java
@@ -52,6 +52,12 @@ public interface ExecutionEngineChannel extends ChannelInterface {
         public SafeFuture<PayloadStatus> newPayload(final ExecutionPayload executionPayload) {
           return SafeFuture.completedFuture(PayloadStatus.SYNCING);
         }
+
+        @Override
+        public SafeFuture<TransitionConfiguration> exchangeTransitionConfiguration(
+            TransitionConfiguration transitionConfiguration) {
+          return SafeFuture.completedFuture(null);
+        }
       };
 
   SafeFuture<Optional<PowBlock>> getPowBlock(final Bytes32 blockHash);
@@ -64,6 +70,9 @@ public interface ExecutionEngineChannel extends ChannelInterface {
   SafeFuture<ExecutionPayload> getPayload(final Bytes8 payloadId, final UInt64 slot);
 
   SafeFuture<PayloadStatus> newPayload(final ExecutionPayload executionPayload);
+
+  SafeFuture<TransitionConfiguration> exchangeTransitionConfiguration(
+      final TransitionConfiguration transitionConfiguration);
 
   enum Version {
     KINTSUGI,

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionengine/ExecutionEngineChannel.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionengine/ExecutionEngineChannel.java
@@ -56,7 +56,7 @@ public interface ExecutionEngineChannel extends ChannelInterface {
         @Override
         public SafeFuture<TransitionConfiguration> exchangeTransitionConfiguration(
             TransitionConfiguration transitionConfiguration) {
-          return SafeFuture.completedFuture(null);
+          return SafeFuture.completedFuture(transitionConfiguration);
         }
       };
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionengine/TransitionConfiguration.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionengine/TransitionConfiguration.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.executionengine;
+
+import com.google.common.base.MoreObjects;
+import java.util.Objects;
+import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.units.bigints.UInt256;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+public class TransitionConfiguration {
+  private final UInt256 terminalTotalDifficulty;
+  private final Bytes32 terminalBlockHash;
+  private final UInt64 terminalBlockNumber;
+
+  public TransitionConfiguration(
+      final UInt256 terminalTotalDifficulty,
+      final Bytes32 terminalBlockHash,
+      final UInt64 terminalBlockNumber) {
+    this.terminalTotalDifficulty = terminalTotalDifficulty;
+    this.terminalBlockHash = terminalBlockHash;
+    this.terminalBlockNumber = terminalBlockNumber;
+  }
+
+  public UInt256 getTerminalTotalDifficulty() {
+    return terminalTotalDifficulty;
+  }
+
+  public Bytes32 getTerminalBlockHash() {
+    return terminalBlockHash;
+  }
+
+  public UInt64 getTerminalBlockNumber() {
+    return terminalBlockNumber;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final TransitionConfiguration that = (TransitionConfiguration) o;
+    return Objects.equals(terminalTotalDifficulty, that.terminalTotalDifficulty)
+        && Objects.equals(terminalBlockHash, that.terminalBlockHash)
+        && Objects.equals(terminalBlockNumber, that.terminalBlockNumber);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(terminalTotalDifficulty, terminalBlockHash, terminalBlockNumber);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("terminalTotalDifficulty", terminalTotalDifficulty)
+        .add("terminalBlockHash", terminalBlockHash)
+        .add("terminalBlockNumber", terminalBlockNumber)
+        .toString();
+  }
+}

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/executionengine/StubExecutionEngineChannel.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/executionengine/StubExecutionEngineChannel.java
@@ -123,6 +123,13 @@ public class StubExecutionEngineChannel implements ExecutionEngineChannel {
     return SafeFuture.completedFuture(payloadStatus);
   }
 
+  @Override
+  public SafeFuture<TransitionConfiguration> exchangeTransitionConfiguration(
+      TransitionConfiguration transitionConfiguration) {
+    return SafeFuture.failedFuture(
+        new UnsupportedOperationException("exchangeTransitionConfiguration not supported"));
+  }
+
   public PayloadStatus getPayloadStatus() {
     return payloadStatus;
   }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/TerminalPowBlockMonitor.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/TerminalPowBlockMonitor.java
@@ -275,20 +275,20 @@ public class TerminalPowBlockMonitor {
         .thenAccept(
             remoteTransitionConfiguration -> {
               if (!localTransitionConfiguration
-                  .getTerminalTotalDifficulty()
-                  .equals(remoteTransitionConfiguration.getTerminalTotalDifficulty())) {
-                eventLogger.differentTransitionConfigurationDetected(
-                    "TerminalTotalDifficulty",
-                    localTransitionConfiguration.getTerminalTotalDifficulty().toString(),
-                    remoteTransitionConfiguration.getTerminalTotalDifficulty().toString());
-              }
-              if (!localTransitionConfiguration
-                  .getTerminalBlockHash()
-                  .equals(remoteTransitionConfiguration.getTerminalBlockHash())) {
-                eventLogger.differentTransitionConfigurationDetected(
-                    "TerminalBlockHash",
-                    localTransitionConfiguration.getTerminalBlockHash().toString(),
-                    remoteTransitionConfiguration.getTerminalBlockHash().toString());
+                      .getTerminalTotalDifficulty()
+                      .equals(remoteTransitionConfiguration.getTerminalTotalDifficulty())
+                  || !localTransitionConfiguration
+                      .getTerminalBlockHash()
+                      .equals(remoteTransitionConfiguration.getTerminalBlockHash())) {
+
+                eventLogger.transitionConfiguration_TTD_TBH_mismatch(
+                    localTransitionConfiguration.toString(),
+                    remoteTransitionConfiguration.toString());
+              } else if (remoteTransitionConfiguration.getTerminalBlockHash().isZero()
+                  != remoteTransitionConfiguration.getTerminalBlockNumber().isZero()) {
+
+                eventLogger.transitionConfigurationRemote_TBH_TBN_inconsistency(
+                    remoteTransitionConfiguration.toString());
               }
             })
         .finish(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/TerminalPowBlockMonitor.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/TerminalPowBlockMonitor.java
@@ -281,13 +281,13 @@ public class TerminalPowBlockMonitor {
                       .getTerminalBlockHash()
                       .equals(remoteTransitionConfiguration.getTerminalBlockHash())) {
 
-                eventLogger.transitionConfiguration_TTD_TBH_mismatch(
+                eventLogger.transitionConfigurationTtdTbhMismatch(
                     localTransitionConfiguration.toString(),
                     remoteTransitionConfiguration.toString());
               } else if (remoteTransitionConfiguration.getTerminalBlockHash().isZero()
                   != remoteTransitionConfiguration.getTerminalBlockNumber().isZero()) {
 
-                eventLogger.transitionConfigurationRemote_TBH_TBN_inconsistency(
+                eventLogger.transitionConfigurationRemoteTbhTbnInconsistency(
                     remoteTransitionConfiguration.toString());
               }
             })

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/TerminalPowBlockMonitorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/TerminalPowBlockMonitorTest.java
@@ -395,7 +395,7 @@ public class TerminalPowBlockMonitorTest {
     asyncRunner.executeQueuedActions();
 
     verify(eventLogger)
-        .transitionConfiguration_TTD_TBH_mismatch(
+        .transitionConfigurationTtdTbhMismatch(
             localTransitionConfiguration.toString(), wrongRemoteConfig.toString());
 
     // wrong TBH
@@ -408,7 +408,7 @@ public class TerminalPowBlockMonitorTest {
     asyncRunner.executeQueuedActions();
 
     verify(eventLogger)
-        .transitionConfiguration_TTD_TBH_mismatch(
+        .transitionConfigurationTtdTbhMismatch(
             localTransitionConfiguration.toString(), wrongRemoteConfig.toString());
 
     // remote TBH TBN inconsistency
@@ -423,7 +423,7 @@ public class TerminalPowBlockMonitorTest {
     asyncRunner.executeQueuedActions();
 
     verify(eventLogger)
-        .transitionConfigurationRemote_TBH_TBN_inconsistency(wrongRemoteConfig.toString());
+        .transitionConfigurationRemoteTbhTbnInconsistency(wrongRemoteConfig.toString());
 
     verifyNoMoreInteractions(eventLogger);
   }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/TerminalPowBlockMonitorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/TerminalPowBlockMonitorTest.java
@@ -87,12 +87,23 @@ public class TerminalPowBlockMonitorTest {
                 .bellatrixForkEpoch(BELLATRIX_FORK_EPOCH)
                 .terminalBlockHash(TERMINAL_BLOCK_HASH)
                 .terminalBlockHashActivationEpoch(TERMINAL_BLOCK_EPOCH));
+
+    when(executionEngine.exchangeTransitionConfiguration(localTransitionConfiguration))
+        .thenReturn(
+            SafeFuture.completedFuture(
+                new TransitionConfiguration(
+                    localTransitionConfiguration.getTerminalTotalDifficulty(),
+                    localTransitionConfiguration.getTerminalBlockHash(),
+                    dataStructureUtil.randomUInt64())));
   }
 
   private void setUpTTDConfig() {
     setUpCommon(
         bellatrixBuilder ->
             bellatrixBuilder.bellatrixForkEpoch(BELLATRIX_FORK_EPOCH).terminalTotalDifficulty(TTD));
+
+    when(executionEngine.exchangeTransitionConfiguration(localTransitionConfiguration))
+        .thenReturn(SafeFuture.completedFuture(localTransitionConfiguration));
   }
 
   private void setUpCommon(Consumer<BellatrixBuilder> bellatrixBuilder) {
@@ -121,9 +132,6 @@ public class TerminalPowBlockMonitorTest {
     terminalPowBlockMonitor =
         new TerminalPowBlockMonitor(
             executionEngine, spec, recentChainData, forkChoiceNotifier, asyncRunner, eventLogger);
-
-    when(executionEngine.exchangeTransitionConfiguration(localTransitionConfiguration))
-        .thenReturn(SafeFuture.completedFuture(localTransitionConfiguration));
   }
 
   private void goToSlot(UInt64 slot) {

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java
@@ -194,7 +194,7 @@ public class EventLogger {
         Color.GREEN);
   }
 
-  public void transitionConfiguration_TTD_TBH_mismatch(
+  public void transitionConfigurationTtdTbhMismatch(
       final String localConfig, final String remoteConfig) {
     final String configurationErrorEventLog =
         String.format(
@@ -205,7 +205,7 @@ public class EventLogger {
     error(configurationErrorEventLog, Color.RED);
   }
 
-  public void transitionConfigurationRemote_TBH_TBN_inconsistency(final String remoteConfig) {
+  public void transitionConfigurationRemoteTbhTbnInconsistency(final String remoteConfig) {
     final String configurationErrorEventLog =
         String.format(
             "Merge       *** Transition Configuration error: remote Execution Client TerminalBlockHash and TerminalBlockNumber are inconsistent\n"

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java
@@ -194,6 +194,18 @@ public class EventLogger {
         Color.GREEN);
   }
 
+  public void differentTransitionConfigurationDetected(
+      final String parameter, final String localConfig, final String remoteConfig) {
+    final String genesisEventLog =
+        String.format(
+            "Transition Configuration difference detected *** \n"
+                + "local %s:\n%s\n"
+                + "remote %s:\n%s\n"
+                + "Action required.",
+            parameter, localConfig, parameter, remoteConfig);
+    error(genesisEventLog, Color.RED);
+  }
+
   private void info(final String message, final Color color) {
     log.info(print(message, color));
   }
@@ -204,5 +216,9 @@ public class EventLogger {
 
   private void error(final String message, final Color color, final Throwable error) {
     log.error(print(message, color), error);
+  }
+
+  private void error(final String message, final Color color) {
+    log.error(print(message, color));
   }
 }

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java
@@ -194,16 +194,24 @@ public class EventLogger {
         Color.GREEN);
   }
 
-  public void differentTransitionConfigurationDetected(
-      final String parameter, final String localConfig, final String remoteConfig) {
-    final String genesisEventLog =
+  public void transitionConfiguration_TTD_TBH_mismatch(
+      final String localConfig, final String remoteConfig) {
+    final String configurationErrorEventLog =
         String.format(
-            "Transition Configuration difference detected *** \n"
-                + "local %s:\n%s\n"
-                + "remote %s:\n%s\n"
-                + "Action required.",
-            parameter, localConfig, parameter, remoteConfig);
-    error(genesisEventLog, Color.RED);
+            "Merge       *** Transition Configuration error: local TerminalTotalDifficulty and TerminalBlockHash not matching remote Execution Client values\n"
+                + "  local  configuration: %s\n"
+                + "  remote configuration: %s",
+            localConfig, remoteConfig);
+    error(configurationErrorEventLog, Color.RED);
+  }
+
+  public void transitionConfigurationRemote_TBH_TBN_inconsistency(final String remoteConfig) {
+    final String configurationErrorEventLog =
+        String.format(
+            "Merge       *** Transition Configuration error: remote Execution Client TerminalBlockHash and TerminalBlockNumber are inconsistent\n"
+                + "  remote configuration: %s",
+            remoteConfig);
+    error(configurationErrorEventLog, Color.RED);
   }
 
   private void info(final String message, final Color color) {

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -361,7 +361,12 @@ public class BeaconChainController extends Service
       terminalPowBlockMonitor =
           Optional.of(
               new TerminalPowBlockMonitor(
-                  executionEngine, spec, recentChainData, forkChoiceNotifier, beaconAsyncRunner));
+                  executionEngine,
+                  spec,
+                  recentChainData,
+                  forkChoiceNotifier,
+                  beaconAsyncRunner,
+                  EVENT_LOG));
     }
   }
 


### PR DESCRIPTION
## PR Description

call `engine_exchangeTransitionConfiguration` in `TerminalPowBlockMonitor` to verify no differences between teku configuration and current configured execution engine.

Checks are:
- `TerminalTotalDifficulty` and  `TerminalBlockHash` must correspond
- remote `TerminalBlockHash` and `TerminalBlockNumber` must be both Zero or non-Zero

When one of the check fails an error log event is printed out in console.

## Fixed Issue(s)
fixes #4956

## Documentation

- [ ] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
