### PR TITLE
Avoid overriding custom logging configuration levels

### DIFF
--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/LoggingConfig.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/LoggingConfig.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.infrastructure.logging;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import java.util.Optional;
 import org.apache.logging.log4j.Level;
 
 public class LoggingConfig {
@@ -24,7 +25,7 @@ public class LoggingConfig {
 
   public static final String DATA_LOG_SUBDIRECTORY = "logs";
 
-  private final Level logLevel;
+  private final Optional<Level> logLevel;
   private final boolean colorEnabled;
   private final boolean includeEventsEnabled;
   private final boolean includeValidatorDutiesEnabled;
@@ -34,7 +35,7 @@ public class LoggingConfig {
   private final String logFileNamePattern;
 
   private LoggingConfig(
-      final Level logLevel,
+      final Optional<Level> logLevel,
       final boolean colorEnabled,
       final boolean includeEventsEnabled,
       final boolean includeValidatorDutiesEnabled,
@@ -56,7 +57,7 @@ public class LoggingConfig {
     return new LoggingConfigBuilder();
   }
 
-  public Level getLogLevel() {
+  public Optional<Level> getLogLevel() {
     return logLevel;
   }
 
@@ -91,7 +92,7 @@ public class LoggingConfig {
   public static final class LoggingConfigBuilder {
     public static final String SEP = System.getProperty("file.separator");
 
-    private Level logLevel;
+    private Optional<Level> logLevel = Optional.empty();
     private boolean colorEnabled = true;
     private boolean includeEventsEnabled = true;
     private boolean includeValidatorDutiesEnabled = true;
@@ -110,9 +111,6 @@ public class LoggingConfig {
     private LoggingConfigBuilder() {}
 
     private void initMissingDefaults() {
-      if (logLevel == null) {
-        logLevel = Level.INFO;
-      }
       if (logPath == null || logPathPattern == null) {
         if (logFileName == null) {
           logFileName = logFileNamePrefix + DEFAULT_LOG_FILE_NAME_SUFFIX;
@@ -144,7 +142,7 @@ public class LoggingConfig {
     }
 
     public LoggingConfigBuilder logLevel(Level logLevel) {
-      this.logLevel = logLevel;
+      this.logLevel = Optional.ofNullable(logLevel);
       return this;
     }
 

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/LoggingConfigurator.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/LoggingConfigurator.java
@@ -92,7 +92,7 @@ public class LoggingConfigurator {
   }
 
   public static synchronized void update(final LoggingConfig configuration) {
-    setAllLevels(configuration.getLogLevel());
+    configuration.getLogLevel().ifPresent(LoggingConfigurator::setAllLevels);
     COLOR.set(configuration.isColorEnabled());
     DESTINATION = configuration.getDestination();
     INCLUDE_EVENTS = configuration.isIncludeEventsEnabled();

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/LoggingOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/LoggingOptionsTest.java
@@ -158,7 +158,7 @@ public class LoggingOptionsTest extends AbstractBeaconNodeCommandTest {
   public void loglevel_shouldAcceptValues(String level) {
     final String[] args = {"--logging", level};
     final LoggingConfig config = getLoggingConfigurationFromArguments(args);
-    assertThat(config.getLogLevel().toString()).isEqualToIgnoringCase(level);
+    assertThat(config.getLogLevel().orElseThrow().toString()).isEqualToIgnoringCase(level);
   }
 
   @ParameterizedTest(name = "{0}")
@@ -166,7 +166,7 @@ public class LoggingOptionsTest extends AbstractBeaconNodeCommandTest {
   public void loglevel_shouldAcceptValuesMixedCase(String level) {
     final String[] args = {"--logging", level};
     final LoggingConfig config = getLoggingConfigurationFromArguments(args);
-    assertThat(config.getLogLevel().toString()).isEqualTo(level.toUpperCase());
+    assertThat(config.getLogLevel().orElseThrow().toString()).isEqualTo(level.toUpperCase());
   }
 
   @Test


### PR DESCRIPTION
## PR Description
Only set all log levels if --logging has been explicitly specified. Otherwise, when using a custom log4j config, the log levels will be overridden.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
