### PR TITLE
Provide clearer messages when execution engine payloads are missing content

### DIFF
--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionEngineChannelImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionEngineChannelImpl.java
@@ -81,7 +81,7 @@ public class ExecutionEngineChannelImpl implements ExecutionEngineChannel {
         response.getErrorMessage() == null,
         "Invalid remote response: %s",
         response.getErrorMessage());
-    return response.getPayload();
+    return checkNotNull(response.getPayload(), "No payload content found");
   }
 
   @Override

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierImpl.java
@@ -233,7 +233,9 @@ public class ForkChoiceNotifierImpl implements ForkChoiceNotifier {
   }
 
   private void sendForkChoiceUpdated() {
-    forkChoiceUpdateData.send(executionEngineChannel).reportExceptions();
+    forkChoiceUpdateData
+        .send(executionEngineChannel)
+        .finish(error -> LOG.error("forkChoiceUpdated notification failed", error));
   }
 
   private void updatePayloadAttributes(final UInt64 blockSlot) {


### PR DESCRIPTION
## PR Description
Improve the error messages we get when the EL returns something stupid - in this case `null` response to `forkChoiceUpdated`.  Previously it was an almost entirely incomprehensible exception in `CompletableFuture` due to the way futures and method references work.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
