### PR TITLE
Use spec for correct slot when verifying finalized transition block

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/SlotAndExecutionPayload.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/SlotAndExecutionPayload.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.execution;
+
+import com.google.common.base.MoreObjects;
+import java.util.Objects;
+import java.util.Optional;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+
+public class SlotAndExecutionPayload {
+  private final UInt64 slot;
+  private final ExecutionPayload executionPayload;
+
+  public SlotAndExecutionPayload(final UInt64 slot, final ExecutionPayload executionPayload) {
+    this.slot = slot;
+    this.executionPayload = executionPayload;
+  }
+
+  public static Optional<SlotAndExecutionPayload> fromBlock(final SignedBeaconBlock block) {
+    return block
+        .getMessage()
+        .getBody()
+        .getOptionalExecutionPayload()
+        .map(payload -> new SlotAndExecutionPayload(block.getSlot(), payload));
+  }
+
+  public UInt64 getSlot() {
+    return slot;
+  }
+
+  public ExecutionPayload getExecutionPayload() {
+    return executionPayload;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final SlotAndExecutionPayload that = (SlotAndExecutionPayload) o;
+    return Objects.equals(slot, that.slot)
+        && Objects.equals(executionPayload, that.executionPayload);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(slot, executionPayload);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("slot", slot)
+        .add("executionPayload", executionPayload)
+        .toString();
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ReadOnlyStore.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ReadOnlyStore.java
@@ -23,7 +23,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
-import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
+import tech.pegasys.teku.spec.datastructures.execution.SlotAndExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.CheckpointState;
@@ -57,7 +57,7 @@ public interface ReadOnlyStore {
 
   AnchorPoint getLatestFinalized();
 
-  Optional<ExecutionPayload> getFinalizedOptimisticTransitionPayload();
+  Optional<SlotAndExecutionPayload> getFinalizedOptimisticTransitionPayload();
 
   Checkpoint getBestJustifiedCheckpoint();
 

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
@@ -26,7 +26,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
-import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
+import tech.pegasys.teku.spec.datastructures.execution.SlotAndExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.CheckpointState;
@@ -111,7 +111,7 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
   }
 
   @Override
-  public Optional<ExecutionPayload> getFinalizedOptimisticTransitionPayload() {
+  public Optional<SlotAndExecutionPayload> getFinalizedOptimisticTransitionPayload() {
     return Optional.empty();
   }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoicePayloadExecutor.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoicePayloadExecutor.java
@@ -30,12 +30,15 @@ class ForkChoicePayloadExecutor implements OptimisticExecutionPayloadExecutor {
   private static final Logger LOG = LogManager.getLogger();
 
   private final ExecutionEngineChannel executionEngine;
+  private final SignedBeaconBlock block;
   private final MergeTransitionBlockValidator transitionBlockValidator;
   private Optional<SafeFuture<PayloadStatus>> result = Optional.empty();
 
   ForkChoicePayloadExecutor(
+      final SignedBeaconBlock block,
       final ExecutionEngineChannel executionEngine,
       final MergeTransitionBlockValidator transitionBlockValidator) {
+    this.block = block;
     this.transitionBlockValidator = transitionBlockValidator;
     this.executionEngine = executionEngine;
   }
@@ -46,8 +49,9 @@ class ForkChoicePayloadExecutor implements OptimisticExecutionPayloadExecutor {
       final SignedBeaconBlock block,
       final ExecutionEngineChannel executionEngine) {
     return new ForkChoicePayloadExecutor(
+        block,
         executionEngine,
-        new MergeTransitionBlockValidator(spec, recentChainData, executionEngine, block));
+        new MergeTransitionBlockValidator(spec, recentChainData, executionEngine));
   }
 
   public SafeFuture<PayloadStatus> getExecutionResult() {
@@ -73,7 +77,7 @@ class ForkChoicePayloadExecutor implements OptimisticExecutionPayloadExecutor {
                     result -> {
                       if (result.hasValidStatus()) {
                         return transitionBlockValidator.verifyTransitionBlock(
-                            latestExecutionPayloadHeader, executionPayload);
+                            latestExecutionPayloadHeader, block);
                       } else {
                         return SafeFuture.completedFuture(result);
                       }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/MergeTransitionBlockValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/MergeTransitionBlockValidatorTest.java
@@ -29,7 +29,6 @@ import tech.pegasys.teku.core.ChainBuilder.BlockOptions;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.bellatrix.BeaconStateBellatrix;
@@ -78,9 +77,7 @@ class MergeTransitionBlockValidatorTest {
     storageSystem.chainUpdater().saveBlock(chainHead);
     final SignedBlockAndState blockToVerify = storageSystem.chainBuilder().generateNextBlock();
 
-    final MergeTransitionBlockValidator transitionVerifier =
-        createTransitionValidator(blockToVerify.getBlock());
-    final ExecutionPayload newExecutionPayload = getExecutionPayload(blockToVerify);
+    final MergeTransitionBlockValidator transitionVerifier = createTransitionValidator();
 
     assertThat(
             storageSystem
@@ -97,7 +94,7 @@ class MergeTransitionBlockValidatorTest {
                 .toVersionBellatrix()
                 .orElseThrow()
                 .getLatestExecutionPayloadHeader(),
-            newExecutionPayload);
+            blockToVerify.getBlock());
 
     verifyNoInteractions(executionEngine);
     assertThat(result).isCompletedWithValue(PayloadStatus.VALID);
@@ -109,9 +106,7 @@ class MergeTransitionBlockValidatorTest {
     final SignedBlockAndState chainHead = storageSystem.chainBuilder().getLatestBlockAndState();
     final SignedBlockAndState blockToVerify = storageSystem.chainBuilder().generateNextBlock();
 
-    final MergeTransitionBlockValidator transitionVerifier =
-        createTransitionValidator(blockToVerify.getBlock());
-    final ExecutionPayload newExecutionPayload = getExecutionPayload(blockToVerify);
+    final MergeTransitionBlockValidator transitionVerifier = createTransitionValidator();
 
     assertThat(
             storageSystem
@@ -128,7 +123,7 @@ class MergeTransitionBlockValidatorTest {
                 .toVersionBellatrix()
                 .orElseThrow()
                 .getLatestExecutionPayloadHeader(),
-            newExecutionPayload);
+            blockToVerify.getBlock());
 
     verify(executionEngine).getPowBlock(getExecutionPayload(transitionBlock).getParentHash());
     assertThat(result).isNotCompleted();
@@ -147,16 +142,14 @@ class MergeTransitionBlockValidatorTest {
 
     final SignedBlockAndState blockToVerify = storageSystem.chainBuilder().generateNextBlock();
 
-    final MergeTransitionBlockValidator transitionVerifier =
-        createTransitionValidator(blockToVerify.getBlock());
-    final ExecutionPayload newExecutionPayload = getExecutionPayload(blockToVerify);
+    final MergeTransitionBlockValidator transitionVerifier = createTransitionValidator();
 
     assertThat(storageSystem.recentChainData().getStore().getFinalizedOptimisticTransitionPayload())
         .isPresent();
 
     final SafeFuture<PayloadStatus> result =
         transitionVerifier.verifyTransitionBlock(
-            chainHeadState.getLatestExecutionPayloadHeader(), newExecutionPayload);
+            chainHeadState.getLatestExecutionPayloadHeader(), blockToVerify.getBlock());
 
     verify(executionEngine).getPowBlock(getExecutionPayload(transitionBlock).getParentHash());
     assertThat(result).isNotCompleted();
@@ -200,8 +193,8 @@ class MergeTransitionBlockValidatorTest {
         .orElseThrow();
   }
 
-  private MergeTransitionBlockValidator createTransitionValidator(final SignedBeaconBlock block) {
+  private MergeTransitionBlockValidator createTransitionValidator() {
     return new MergeTransitionBlockValidator(
-        spec, storageSystem.recentChainData(), executionEngine, block);
+        spec, storageSystem.recentChainData(), executionEngine);
   }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/api/UpdateResult.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/api/UpdateResult.java
@@ -14,25 +14,26 @@
 package tech.pegasys.teku.storage.api;
 
 import java.util.Optional;
-import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
+import tech.pegasys.teku.spec.datastructures.execution.SlotAndExecutionPayload;
 import tech.pegasys.teku.storage.events.FinalizedChainData;
 
 public class UpdateResult {
 
   public static final UpdateResult EMPTY = new UpdateResult(Optional.empty());
 
-  private final Optional<ExecutionPayload> finalizedOptimisticTransitionPayload;
+  private final Optional<SlotAndExecutionPayload> finalizedOptimisticTransitionPayload;
 
-  public UpdateResult(final Optional<ExecutionPayload> finalizedOptimisticTransitionPayload) {
+  public UpdateResult(
+      final Optional<SlotAndExecutionPayload> finalizedOptimisticTransitionPayload) {
     this.finalizedOptimisticTransitionPayload = finalizedOptimisticTransitionPayload;
   }
 
   /**
-   * Get the execution payload from the block specified in {@link
+   * Get the slot and execution payload from the block specified in {@link
    * FinalizedChainData#getOptimisticTransitionBlockRoot()}. If no transition block root is
    * specified this will always be empty.
    */
-  public Optional<ExecutionPayload> getFinalizedOptimisticTransitionPayload() {
+  public Optional<SlotAndExecutionPayload> getFinalizedOptimisticTransitionPayload() {
     return finalizedOptimisticTransitionPayload;
   }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
@@ -53,7 +53,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
-import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
+import tech.pegasys.teku.spec.datastructures.execution.SlotAndExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteUpdater;
 import tech.pegasys.teku.spec.datastructures.hashtree.HashTree;
@@ -89,7 +89,7 @@ class Store implements UpdatableStore {
   Checkpoint justifiedCheckpoint;
   Checkpoint bestJustifiedCheckpoint;
   UInt64 latestValidFinalizedSlot = UInt64.ZERO;
-  Optional<ExecutionPayload> finalizedOptimisticTransitionPayload;
+  Optional<SlotAndExecutionPayload> finalizedOptimisticTransitionPayload;
   Optional<Bytes32> proposerBoostRoot = Optional.empty();
   final CachingTaskQueue<Bytes32, StateAndBlockSummary> states;
   final Map<Bytes32, SignedBeaconBlock> blocks;
@@ -108,7 +108,7 @@ class Store implements UpdatableStore {
       final UInt64 time,
       final UInt64 genesisTime,
       final AnchorPoint finalizedAnchor,
-      final Optional<ExecutionPayload> finalizedOptimisticTransitionPayload,
+      final Optional<SlotAndExecutionPayload> finalizedOptimisticTransitionPayload,
       final Checkpoint justifiedCheckpoint,
       final Checkpoint bestJustifiedCheckpoint,
       final ForkChoiceStrategy forkChoiceStrategy,
@@ -172,7 +172,7 @@ class Store implements UpdatableStore {
       final UInt64 time,
       final UInt64 genesisTime,
       final AnchorPoint finalizedAnchor,
-      final Optional<ExecutionPayload> finalizedOptimisticTransitionPayload,
+      final Optional<SlotAndExecutionPayload> finalizedOptimisticTransitionPayload,
       final Checkpoint justifiedCheckpoint,
       final Checkpoint bestJustifiedCheckpoint,
       final Map<Bytes32, StoredBlockMetadata> blockInfoByRoot,
@@ -351,7 +351,7 @@ class Store implements UpdatableStore {
   }
 
   @Override
-  public Optional<ExecutionPayload> getFinalizedOptimisticTransitionPayload() {
+  public Optional<SlotAndExecutionPayload> getFinalizedOptimisticTransitionPayload() {
     readLock.lock();
     try {
       return finalizedOptimisticTransitionPayload;

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreBuilder.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreBuilder.java
@@ -28,7 +28,7 @@ import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.CheckpointEpochs;
-import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
+import tech.pegasys.teku.spec.datastructures.execution.SlotAndExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
@@ -49,7 +49,7 @@ public class StoreBuilder {
   private Checkpoint justifiedCheckpoint;
   private Checkpoint bestJustifiedCheckpoint;
   private Map<UInt64, VoteTracker> votes;
-  private Optional<ExecutionPayload> finalizedOptimisticTransitionPayload = Optional.empty();
+  private Optional<SlotAndExecutionPayload> finalizedOptimisticTransitionPayload = Optional.empty();
 
   private StoreBuilder() {}
 
@@ -205,7 +205,7 @@ public class StoreBuilder {
   }
 
   public StoreBuilder finalizedOptimisticTransitionPayload(
-      final Optional<ExecutionPayload> finalizedOptimisticTransitionPayload) {
+      final Optional<SlotAndExecutionPayload> finalizedOptimisticTransitionPayload) {
     checkNotNull(finalizedOptimisticTransitionPayload);
     this.finalizedOptimisticTransitionPayload = finalizedOptimisticTransitionPayload;
     return this;

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransaction.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransaction.java
@@ -36,7 +36,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
-import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
+import tech.pegasys.teku.spec.datastructures.execution.SlotAndExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
@@ -226,7 +226,7 @@ class StoreTransaction implements UpdatableStore.StoreTransaction {
   }
 
   @Override
-  public Optional<ExecutionPayload> getFinalizedOptimisticTransitionPayload() {
+  public Optional<SlotAndExecutionPayload> getFinalizedOptimisticTransitionPayload() {
     return store.getFinalizedOptimisticTransitionPayload();
   }
 

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/AbstractDatabaseTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/AbstractDatabaseTest.java
@@ -53,6 +53,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
+import tech.pegasys.teku.spec.datastructures.execution.SlotAndExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
@@ -592,10 +593,10 @@ public abstract class AbstractDatabaseTest {
     tx.setFinalizedCheckpoint(finalizedCheckpoint);
     assertThat(tx.commit()).isCompleted();
 
-    final Optional<ExecutionPayload> transitionPayload =
-        transitionBlock.getBlock().getMessage().getBody().getOptionalExecutionPayload();
+    final Optional<SlotAndExecutionPayload> transitionPayload =
+        SlotAndExecutionPayload.fromBlock(transitionBlock.getBlock());
     assertThat(transitionPayload).isPresent();
-    assertThat(transitionPayload.get().isDefault()).isFalse();
+    assertThat(transitionPayload.get().getExecutionPayload().isDefault()).isFalse();
     assertThat(recentChainData.getStore().getFinalizedOptimisticTransitionPayload())
         .isEqualTo(transitionPayload);
   }
@@ -649,10 +650,10 @@ public abstract class AbstractDatabaseTest {
     tx.setFinalizedCheckpoint(finalizedCheckpoint);
     assertThat(tx.commit()).isCompleted();
 
-    final Optional<ExecutionPayload> transitionPayload =
-        transitionBlock.getBlock().getMessage().getBody().getOptionalExecutionPayload();
+    final Optional<SlotAndExecutionPayload> transitionPayload =
+        SlotAndExecutionPayload.fromBlock(transitionBlock.getBlock());
     assertThat(transitionPayload).isPresent();
-    assertThat(transitionPayload.get().isDefault()).isFalse();
+    assertThat(transitionPayload.get().getExecutionPayload().isDefault()).isFalse();
     assertThat(recentChainData.getStore().getFinalizedOptimisticTransitionPayload())
         .isEqualTo(transitionPayload);
   }
@@ -673,8 +674,8 @@ public abstract class AbstractDatabaseTest {
     tx.setFinalizedCheckpoint(finalizedCheckpoint);
     assertThat(tx.commit()).isCompleted();
 
-    final Optional<ExecutionPayload> transitionPayload =
-        transitionBlock.getBlock().getMessage().getBody().getOptionalExecutionPayload();
+    final Optional<SlotAndExecutionPayload> transitionPayload =
+        SlotAndExecutionPayload.fromBlock(transitionBlock.getBlock());
     assertThat(transitionPayload).isPresent();
     assertThat(recentChainData.getStore().getFinalizedOptimisticTransitionPayload())
         .isEqualTo(transitionPayload);
@@ -712,10 +713,10 @@ public abstract class AbstractDatabaseTest {
     tx2.setFinalizedCheckpoint(finalizedCheckpoint2);
     assertThat(tx2.commit()).isCompleted();
 
-    final Optional<ExecutionPayload> transitionPayload =
-        transitionBlock.getBlock().getMessage().getBody().getOptionalExecutionPayload();
+    final Optional<SlotAndExecutionPayload> transitionPayload =
+        SlotAndExecutionPayload.fromBlock(transitionBlock.getBlock());
     assertThat(transitionPayload).isPresent();
-    assertThat(transitionPayload.get().isDefault()).isFalse();
+    assertThat(transitionPayload.get().getExecutionPayload().isDefault()).isFalse();
     assertThat(recentChainData.getStore().getFinalizedOptimisticTransitionPayload())
         .isEqualTo(transitionPayload);
   }


### PR DESCRIPTION
## PR Description
Previously the spec was selected based on the slot of the block being imported, even if the transition block being verified was actually an ancestor of that block.  Now we get the slot and execution payload of the transition block so that we can use the correct slot even if the transition block has been finalised.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
