### PR TITLE
Verify ancestor transition blocks as part of forkChoiceUpdated response handling

### DIFF
--- a/beacon/sync/src/testFixtures/java/tech/pegasys/teku/beacon/sync/SyncingNodeManager.java
+++ b/beacon/sync/src/testFixtures/java/tech/pegasys/teku/beacon/sync/SyncingNodeManager.java
@@ -39,6 +39,7 @@ import tech.pegasys.teku.networking.p2p.peer.Peer;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannel;
 import tech.pegasys.teku.spec.executionengine.StubExecutionEngineChannel;
 import tech.pegasys.teku.statetransition.BeaconChainUtil;
 import tech.pegasys.teku.statetransition.block.BlockImportChannel;
@@ -46,6 +47,7 @@ import tech.pegasys.teku.statetransition.block.BlockImportNotifications;
 import tech.pegasys.teku.statetransition.block.BlockImporter;
 import tech.pegasys.teku.statetransition.block.BlockManager;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
+import tech.pegasys.teku.statetransition.forkchoice.MergeTransitionBlockValidator;
 import tech.pegasys.teku.statetransition.forkchoice.StubForkChoiceNotifier;
 import tech.pegasys.teku.statetransition.util.FutureItems;
 import tech.pegasys.teku.statetransition.util.PendingPool;
@@ -92,9 +94,15 @@ public class SyncingNodeManager {
     final BeaconChainUtil chainUtil = BeaconChainUtil.create(spec, recentChainData, validatorKeys);
     chainUtil.initializeStorage();
 
+    final MergeTransitionBlockValidator transitionBlockValidator =
+        new MergeTransitionBlockValidator(spec, recentChainData, ExecutionEngineChannel.NOOP);
     ForkChoice forkChoice =
         new ForkChoice(
-            spec, new InlineEventThread(), recentChainData, new StubForkChoiceNotifier());
+            spec,
+            new InlineEventThread(),
+            recentChainData,
+            new StubForkChoiceNotifier(),
+            transitionBlockValidator);
     BlockImporter blockImporter =
         new BlockImporter(
             spec,

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/AbstractDataBackedRestAPIIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/AbstractDataBackedRestAPIIntegrationTest.java
@@ -56,12 +56,14 @@ import tech.pegasys.teku.spec.datastructures.eth1.Eth1Address;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
+import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannel;
 import tech.pegasys.teku.statetransition.BeaconChainUtil;
 import tech.pegasys.teku.statetransition.OperationPool;
 import tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPool;
 import tech.pegasys.teku.statetransition.attestation.AttestationManager;
 import tech.pegasys.teku.statetransition.block.BlockManager;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
+import tech.pegasys.teku.statetransition.forkchoice.MergeTransitionBlockValidator;
 import tech.pegasys.teku.statetransition.forkchoice.StubForkChoiceNotifier;
 import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeContributionPool;
 import tech.pegasys.teku.statetransition.validatorcache.ActiveValidatorCache;
@@ -147,7 +149,12 @@ public abstract class AbstractDataBackedRestAPIIntegrationTest {
         useMockForkChoice
             ? mock(ForkChoice.class)
             : new ForkChoice(
-                spec, new InlineEventThread(), recentChainData, new StubForkChoiceNotifier());
+                spec,
+                new InlineEventThread(),
+                recentChainData,
+                new StubForkChoiceNotifier(),
+                new MergeTransitionBlockValidator(
+                    spec, recentChainData, ExecutionEngineChannel.NOOP));
     beaconChainUtil =
         BeaconChainUtil.create(
             spec, recentChainData, chainBuilder.getValidatorKeys(), forkChoice, true);

--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/EpochTransitionBenchmark.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/EpochTransitionBenchmark.java
@@ -53,6 +53,7 @@ import tech.pegasys.teku.statetransition.BeaconChainUtil;
 import tech.pegasys.teku.statetransition.block.BlockImportNotifications;
 import tech.pegasys.teku.statetransition.block.BlockImporter;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
+import tech.pegasys.teku.statetransition.forkchoice.MergeTransitionBlockValidator;
 import tech.pegasys.teku.statetransition.forkchoice.StubForkChoiceNotifier;
 import tech.pegasys.teku.storage.client.MemoryOnlyRecentChainData;
 import tech.pegasys.teku.storage.client.RecentChainData;
@@ -105,9 +106,15 @@ public class EpochTransitionBenchmark {
     wsValidator = WeakSubjectivityFactory.lenientValidator();
 
     recentChainData = MemoryOnlyRecentChainData.create(spec);
+    final MergeTransitionBlockValidator transitionBlockValidator =
+        new MergeTransitionBlockValidator(spec, recentChainData, ExecutionEngineChannel.NOOP);
     ForkChoice forkChoice =
         new ForkChoice(
-            spec, new InlineEventThread(), recentChainData, new StubForkChoiceNotifier());
+            spec,
+            new InlineEventThread(),
+            recentChainData,
+            new StubForkChoiceNotifier(),
+            transitionBlockValidator);
     localChain = BeaconChainUtil.create(spec, recentChainData, validatorKeys, false);
     localChain.initializeStorage();
 

--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/ProfilingRun.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/ProfilingRun.java
@@ -46,6 +46,7 @@ import tech.pegasys.teku.statetransition.BeaconChainUtil;
 import tech.pegasys.teku.statetransition.block.BlockImportNotifications;
 import tech.pegasys.teku.statetransition.block.BlockImporter;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
+import tech.pegasys.teku.statetransition.forkchoice.MergeTransitionBlockValidator;
 import tech.pegasys.teku.statetransition.forkchoice.StubForkChoiceNotifier;
 import tech.pegasys.teku.storage.client.MemoryOnlyRecentChainData;
 import tech.pegasys.teku.storage.client.RecentChainData;
@@ -88,9 +89,15 @@ public class ProfilingRun {
           mock(BlockImportNotifications.class);
       RecentChainData recentChainData = MemoryOnlyRecentChainData.create(spec);
       recentChainData.initializeFromGenesis(initialState, UInt64.ZERO);
+      final MergeTransitionBlockValidator transitionBlockValidator =
+          new MergeTransitionBlockValidator(spec, recentChainData, ExecutionEngineChannel.NOOP);
       ForkChoice forkChoice =
           new ForkChoice(
-              spec, new InlineEventThread(), recentChainData, new StubForkChoiceNotifier());
+              spec,
+              new InlineEventThread(),
+              recentChainData,
+              new StubForkChoiceNotifier(),
+              transitionBlockValidator);
       BeaconChainUtil localChain =
           BeaconChainUtil.create(spec, recentChainData, validatorKeys, false);
       BlockImporter blockImporter =
@@ -170,9 +177,15 @@ public class ProfilingRun {
       BeaconChainUtil localChain = BeaconChainUtil.create(recentChainData, validatorKeys, false);
       recentChainData.initializeFromGenesis(initialState, UInt64.ZERO);
       initialState = null;
+      final MergeTransitionBlockValidator transitionBlockValidator =
+          new MergeTransitionBlockValidator(spec, recentChainData, ExecutionEngineChannel.NOOP);
       ForkChoice forkChoice =
           new ForkChoice(
-              spec, new InlineEventThread(), recentChainData, new StubForkChoiceNotifier());
+              spec,
+              new InlineEventThread(),
+              recentChainData,
+              new StubForkChoiceNotifier(),
+              transitionBlockValidator);
       BlockImporter blockImporter =
           new BlockImporter(
               spec,

--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/TransitionBenchmark.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/TransitionBenchmark.java
@@ -44,6 +44,7 @@ import tech.pegasys.teku.statetransition.BeaconChainUtil;
 import tech.pegasys.teku.statetransition.block.BlockImportNotifications;
 import tech.pegasys.teku.statetransition.block.BlockImporter;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
+import tech.pegasys.teku.statetransition.forkchoice.MergeTransitionBlockValidator;
 import tech.pegasys.teku.statetransition.forkchoice.StubForkChoiceNotifier;
 import tech.pegasys.teku.storage.client.MemoryOnlyRecentChainData;
 import tech.pegasys.teku.storage.client.RecentChainData;
@@ -87,9 +88,15 @@ public abstract class TransitionBenchmark {
     spec = TestSpecFactory.createMainnetAltair();
     wsValidator = WeakSubjectivityFactory.lenientValidator();
     recentChainData = MemoryOnlyRecentChainData.create(spec);
+    final MergeTransitionBlockValidator transitionBlockValidator =
+        new MergeTransitionBlockValidator(spec, recentChainData, ExecutionEngineChannel.NOOP);
     ForkChoice forkChoice =
         new ForkChoice(
-            spec, new InlineEventThread(), recentChainData, new StubForkChoiceNotifier());
+            spec,
+            new InlineEventThread(),
+            recentChainData,
+            new StubForkChoiceNotifier(),
+            transitionBlockValidator);
     localChain = BeaconChainUtil.create(spec, recentChainData, validatorKeys, false);
     localChain.initializeStorage();
 

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
@@ -45,9 +45,11 @@ import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannel;
 import tech.pegasys.teku.spec.executionengine.StubExecutionEngineChannel;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
+import tech.pegasys.teku.statetransition.forkchoice.MergeTransitionBlockValidator;
 import tech.pegasys.teku.statetransition.forkchoice.StubForkChoiceNotifier;
 import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystemBuilder;
@@ -94,9 +96,16 @@ public class ForkChoiceTestExecutor implements TestExecutor {
             spec, new SignedBlockAndState(anchorBlock, anchorState)),
         spec.getSlotStartTime(anchorBlock.getSlot(), anchorState.getGenesis_time()));
 
+    final MergeTransitionBlockValidator transitionBlockValidator =
+        new MergeTransitionBlockValidator(spec, recentChainData, ExecutionEngineChannel.NOOP);
     final ForkChoice forkChoice =
         new ForkChoice(
-            spec, new InlineEventThread(), recentChainData, new StubForkChoiceNotifier(), true);
+            spec,
+            new InlineEventThread(),
+            recentChainData,
+            new StubForkChoiceNotifier(),
+            transitionBlockValidator,
+            true);
     final StubExecutionEngineChannel executionEngine = new StubExecutionEngineChannel(spec);
 
     runSteps(testDefinition, spec, recentChainData, forkChoice, executionEngine);

--- a/ethereum/statetransition/src/integration-test/java/tech/pegasys/teku/statetransition/attestation/AttestationManagerIntegrationTest.java
+++ b/ethereum/statetransition/src/integration-test/java/tech/pegasys/teku/statetransition/attestation/AttestationManagerIntegrationTest.java
@@ -36,7 +36,9 @@ import tech.pegasys.teku.spec.datastructures.operations.Attestation.AttestationS
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
+import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannel;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
+import tech.pegasys.teku.statetransition.forkchoice.MergeTransitionBlockValidator;
 import tech.pegasys.teku.statetransition.forkchoice.StubForkChoiceNotifier;
 import tech.pegasys.teku.statetransition.util.FutureItems;
 import tech.pegasys.teku.statetransition.util.PendingPool;
@@ -62,8 +64,15 @@ class AttestationManagerIntegrationTest {
 
   private final AggregatingAttestationPool attestationPool =
       new AggregatingAttestationPool(spec, new NoOpMetricsSystem());
+  private final MergeTransitionBlockValidator transitionBlockValidator =
+      new MergeTransitionBlockValidator(spec, recentChainData, ExecutionEngineChannel.NOOP);
   private final ForkChoice forkChoice =
-      new ForkChoice(spec, new InlineEventThread(), recentChainData, new StubForkChoiceNotifier());
+      new ForkChoice(
+          spec,
+          new InlineEventThread(),
+          recentChainData,
+          new StubForkChoiceNotifier(),
+          transitionBlockValidator);
 
   private final PendingPool<ValidateableAttestation> pendingAttestations =
       PendingPool.createForAttestations(spec);

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/MergeTransitionBlockValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/MergeTransitionBlockValidator.java
@@ -57,6 +57,10 @@ public class MergeTransitionBlockValidator {
           BeaconBlockBodyBellatrix.required(block.getMessage().getBody()).getExecutionPayload());
     }
 
+    return verifyAncestorTransitionBlock(block.getParentRoot());
+  }
+
+  public SafeFuture<PayloadStatus> verifyAncestorTransitionBlock(final Bytes32 chainHeadRoot) {
     if (transitionBlockNotFinalized()) {
       // The transition block hasn't been finalized yet
       final Optional<Bytes32> maybeTransitionBlockRoot =
@@ -64,7 +68,7 @@ public class MergeTransitionBlockValidator {
               .getForkChoiceStrategy()
               .orElseThrow()
               // Use the parent root because the block itself won't yet be imported
-              .getOptimisticallySyncedTransitionBlockRoot(block.getParentRoot());
+              .getOptimisticallySyncedTransitionBlockRoot(chainHeadRoot);
       if (maybeTransitionBlockRoot.isPresent()) {
         return retrieveAndVerifyNonFinalizedTransitionBlock(maybeTransitionBlockRoot.get());
       }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockImporterTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockImporterTest.java
@@ -56,6 +56,7 @@ import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportRe
 import tech.pegasys.teku.statetransition.BeaconChainUtil;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceNotifier;
+import tech.pegasys.teku.statetransition.forkchoice.MergeTransitionBlockValidator;
 import tech.pegasys.teku.statetransition.forkchoice.StubForkChoiceNotifier;
 import tech.pegasys.teku.storage.client.MemoryOnlyRecentChainData;
 import tech.pegasys.teku.storage.client.RecentChainData;
@@ -78,8 +79,15 @@ public class BlockImporterTest {
   private final WeakSubjectivityValidator weakSubjectivityValidator =
       mock(WeakSubjectivityValidator.class);
   private final ForkChoiceNotifier forkChoiceNotifier = new StubForkChoiceNotifier();
+  private final MergeTransitionBlockValidator transitionBlockValidator =
+      new MergeTransitionBlockValidator(spec, recentChainData, ExecutionEngineChannel.NOOP);
   private final ForkChoice forkChoice =
-      new ForkChoice(spec, new InlineEventThread(), recentChainData, forkChoiceNotifier);
+      new ForkChoice(
+          spec,
+          new InlineEventThread(),
+          recentChainData,
+          forkChoiceNotifier,
+          transitionBlockValidator);
   private final BeaconChainUtil localChain =
       BeaconChainUtil.create(spec, recentChainData, validatorKeys, forkChoice, false);
 
@@ -418,7 +426,11 @@ public class BlockImporterTest {
     final SignedBlockAndState genesis = storageSystem.chainUpdater().initializeGenesis();
     final ForkChoice forkChoice =
         new ForkChoice(
-            spec, new InlineEventThread(), storageSystem.recentChainData(), forkChoiceNotifier);
+            spec,
+            new InlineEventThread(),
+            storageSystem.recentChainData(),
+            forkChoiceNotifier,
+            transitionBlockValidator);
     final BlockImporter blockImporter =
         new BlockImporter(
             spec,
@@ -457,7 +469,11 @@ public class BlockImporterTest {
     final SignedBlockAndState genesis = storageSystem.chainUpdater().initializeGenesis();
     final ForkChoice forkChoice =
         new ForkChoice(
-            spec, new InlineEventThread(), storageSystem.recentChainData(), forkChoiceNotifier);
+            spec,
+            new InlineEventThread(),
+            storageSystem.recentChainData(),
+            forkChoiceNotifier,
+            transitionBlockValidator);
     final BlockImporter blockImporter =
         new BlockImporter(
             spec,
@@ -504,7 +520,11 @@ public class BlockImporterTest {
     storageSystem.chainUpdater().initializeGenesis();
     final ForkChoice forkChoice =
         new ForkChoice(
-            spec, new InlineEventThread(), storageSystem.recentChainData(), forkChoiceNotifier);
+            spec,
+            new InlineEventThread(),
+            storageSystem.recentChainData(),
+            forkChoiceNotifier,
+            transitionBlockValidator);
     final BlockImporter blockImporter =
         new BlockImporter(
             spec,
@@ -543,7 +563,11 @@ public class BlockImporterTest {
     final StorageSystem storageSystem = InMemoryStorageSystemBuilder.buildDefault();
     final ForkChoice forkChoice =
         new ForkChoice(
-            spec, new InlineEventThread(), storageSystem.recentChainData(), forkChoiceNotifier);
+            spec,
+            new InlineEventThread(),
+            storageSystem.recentChainData(),
+            forkChoiceNotifier,
+            transitionBlockValidator);
     final BlockImporter blockImporter =
         new BlockImporter(
             spec,
@@ -570,7 +594,11 @@ public class BlockImporterTest {
     final StorageSystem storageSystem = InMemoryStorageSystemBuilder.buildDefault();
     final ForkChoice forkChoice =
         new ForkChoice(
-            spec, new InlineEventThread(), storageSystem.recentChainData(), forkChoiceNotifier);
+            spec,
+            new InlineEventThread(),
+            storageSystem.recentChainData(),
+            forkChoiceNotifier,
+            transitionBlockValidator);
     final BlockImporter blockImporter =
         new BlockImporter(
             spec,

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockManagerTest.java
@@ -43,6 +43,7 @@ import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.BeaconChainUtil;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceNotifier;
+import tech.pegasys.teku.statetransition.forkchoice.MergeTransitionBlockValidator;
 import tech.pegasys.teku.statetransition.forkchoice.StubForkChoiceNotifier;
 import tech.pegasys.teku.statetransition.util.FutureItems;
 import tech.pegasys.teku.statetransition.util.PendingPool;
@@ -76,8 +77,15 @@ public class BlockManagerTest {
   private final BeaconChainUtil remoteChain =
       BeaconChainUtil.create(remoteRecentChainData, validatorKeys);
   private final ForkChoiceNotifier forkChoiceNotifier = new StubForkChoiceNotifier();
+  private final MergeTransitionBlockValidator transitionBlockValidator =
+      new MergeTransitionBlockValidator(spec, localRecentChainData, ExecutionEngineChannel.NOOP);
   private final ForkChoice forkChoice =
-      new ForkChoice(spec, new InlineEventThread(), localRecentChainData, forkChoiceNotifier);
+      new ForkChoice(
+          spec,
+          new InlineEventThread(),
+          localRecentChainData,
+          forkChoiceNotifier,
+          transitionBlockValidator);
 
   private final BlockImporter blockImporter =
       new BlockImporter(

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/BeaconChainUtil.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/BeaconChainUtil.java
@@ -42,9 +42,11 @@ import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.Deposit;
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannel;
 import tech.pegasys.teku.spec.executionengine.StubExecutionEngineChannel;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
+import tech.pegasys.teku.statetransition.forkchoice.MergeTransitionBlockValidator;
 import tech.pegasys.teku.statetransition.forkchoice.StubForkChoiceNotifier;
 import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.storage.store.UpdatableStore.StoreTransaction;
@@ -108,7 +110,12 @@ public class BeaconChainUtil {
         spec,
         storageClient,
         validatorKeys,
-        new ForkChoice(spec, new InlineEventThread(), storageClient, new StubForkChoiceNotifier()),
+        new ForkChoice(
+            spec,
+            new InlineEventThread(),
+            storageClient,
+            new StubForkChoiceNotifier(),
+            new MergeTransitionBlockValidator(spec, storageClient, ExecutionEngineChannel.NOOP)),
         true);
   }
 
@@ -129,7 +136,12 @@ public class BeaconChainUtil {
         spec,
         validatorKeys,
         storageClient,
-        new ForkChoice(spec, new InlineEventThread(), storageClient, new StubForkChoiceNotifier()),
+        new ForkChoice(
+            spec,
+            new InlineEventThread(),
+            storageClient,
+            new StubForkChoiceNotifier(),
+            new MergeTransitionBlockValidator(spec, storageClient, ExecutionEngineChannel.NOOP)),
         signDeposits);
   }
 
@@ -367,7 +379,13 @@ public class BeaconChainUtil {
       if (forkChoice == null) {
         final InlineEventThread forkChoiceExecutor = new InlineEventThread();
         forkChoice =
-            new ForkChoice(spec, forkChoiceExecutor, recentChainData, new StubForkChoiceNotifier());
+            new ForkChoice(
+                spec,
+                forkChoiceExecutor,
+                recentChainData,
+                new StubForkChoiceNotifier(),
+                new MergeTransitionBlockValidator(
+                    spec, recentChainData, ExecutionEngineChannel.NOOP));
       }
       if (validatorKeys == null) {
         new MockStartValidatorKeyPairFactory().generateKeyPairs(0, validatorCount);

--- a/fork-choice-tests/src/integration-test/java/tech/pegasys/teku/forkChoiceTests/ForkChoiceTestExecutor.java
+++ b/fork-choice-tests/src/integration-test/java/tech/pegasys/teku/forkChoiceTests/ForkChoiceTestExecutor.java
@@ -47,10 +47,12 @@ import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchema;
 import tech.pegasys.teku.spec.datastructures.util.AttestationProcessingResult;
+import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannel;
 import tech.pegasys.teku.spec.executionengine.StubExecutionEngineChannel;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
+import tech.pegasys.teku.statetransition.forkchoice.MergeTransitionBlockValidator;
 import tech.pegasys.teku.statetransition.forkchoice.StubForkChoiceNotifier;
 import tech.pegasys.teku.storage.client.MemoryOnlyRecentChainData;
 import tech.pegasys.teku.storage.client.RecentChainData;
@@ -174,8 +176,15 @@ public class ForkChoiceTestExecutor {
     storageClient.initializeFromGenesis(genesis, UInt64.ZERO);
 
     final InlineEventThread forkChoiceExecutor = new InlineEventThread();
+    final MergeTransitionBlockValidator transitionBlockValidator =
+        new MergeTransitionBlockValidator(SPEC, storageClient, ExecutionEngineChannel.NOOP);
     ForkChoice forkChoice =
-        new ForkChoice(SPEC, forkChoiceExecutor, storageClient, new StubForkChoiceNotifier());
+        new ForkChoice(
+            SPEC,
+            forkChoiceExecutor,
+            storageClient,
+            new StubForkChoiceNotifier(),
+            transitionBlockValidator);
 
     @SuppressWarnings("ModifiedButNotUsed")
     List<SignedBeaconBlock> blockBuffer = new ArrayList<>();

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -90,6 +90,7 @@ import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceNotifier;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceNotifierImpl;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceTrigger;
+import tech.pegasys.teku.statetransition.forkchoice.MergeTransitionBlockValidator;
 import tech.pegasys.teku.statetransition.forkchoice.TerminalPowBlockMonitor;
 import tech.pegasys.teku.statetransition.genesis.GenesisHandler;
 import tech.pegasys.teku.statetransition.synccommittee.SignedContributionAndProofValidator;
@@ -452,7 +453,12 @@ public class BeaconChainController extends Service
     final boolean proposerBoostEnabled = beaconConfig.eth2NetworkConfig().isProposerBoostEnabled();
     forkChoice =
         new ForkChoice(
-            spec, forkChoiceExecutor, recentChainData, forkChoiceNotifier, proposerBoostEnabled);
+            spec,
+            forkChoiceExecutor,
+            recentChainData,
+            forkChoiceNotifier,
+            new MergeTransitionBlockValidator(spec, recentChainData, executionEngine),
+            proposerBoostEnabled);
     forkChoiceTrigger = new ForkChoiceTrigger(forkChoice);
   }
 


### PR DESCRIPTION
## PR Description
Before marking nodes valid as part of a `forkChoiceUpdated` response, ensure that any ancestor transition block has been checked for terminal total difficulty conditions.

## Fixed Issue(s)
#4671 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
