### PR TITLE
Improve accept header parsing for octet-streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,4 @@ For information on changes in released versions of Teku, see the [releases page]
 ### Additions and Improvements
 
 ### Bug Fixes
+ - Improved handling of the http accept header used to determine whether to send SSZ data or json for states and blocks.

--- a/data/beaconrestapi/build.gradle
+++ b/data/beaconrestapi/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation 'io.javalin:javalin-openapi'
     implementation 'org.apache.tuweni:tuweni-units'
     implementation 'org.webjars:swagger-ui'
+    implementation 'org.commonjava.mimeparse:mimeparse'
 
     testImplementation testFixtures(project(':storage'))
     testImplementation testFixtures(project(':ethereum:spec'))

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/debug/GetState.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/debug/GetState.java
@@ -92,7 +92,7 @@ public class GetState extends AbstractHandler implements Handler {
   public void handle(@NotNull final Context ctx) throws Exception {
     final Optional<String> maybeAcceptHeader = Optional.ofNullable(ctx.header(HEADER_ACCEPT));
     final Map<String, String> pathParamMap = ctx.pathParamMap();
-    if (maybeAcceptHeader.orElse("").equalsIgnoreCase(HEADER_ACCEPT_OCTET)) {
+    if (getContentType(ACCEPT_ALL, maybeAcceptHeader).equalsIgnoreCase(HEADER_ACCEPT_OCTET)) {
       final SafeFuture<Optional<SszResponse>> future =
           chainDataProvider.getBeaconStateSsz(pathParamMap.get(PARAM_STATE_ID));
       handleOptionalSszResult(

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v2/beacon/GetBlock.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v2/beacon/GetBlock.java
@@ -85,7 +85,8 @@ public class GetBlock extends AbstractHandler implements Handler {
     final Map<String, String> pathParams = ctx.pathParamMap();
     final Optional<String> maybeAcceptHeader = Optional.ofNullable(ctx.header(HEADER_ACCEPT));
     final String blockIdentifier = pathParams.get(PARAM_BLOCK_ID);
-    if (maybeAcceptHeader.orElse("").equalsIgnoreCase(HEADER_ACCEPT_OCTET)) {
+
+    if (getContentType(ACCEPT_ALL, maybeAcceptHeader).equalsIgnoreCase(HEADER_ACCEPT_OCTET)) {
       final SafeFuture<Optional<SszResponse>> future =
           chainDataProvider.getBlockSsz(blockIdentifier);
       handleOptionalSszResult(

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v2/debug/GetState.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v2/debug/GetState.java
@@ -89,7 +89,7 @@ public class GetState extends AbstractHandler implements Handler {
   public void handle(@NotNull final Context ctx) throws Exception {
     final Optional<String> maybeAcceptHeader = Optional.ofNullable(ctx.header(HEADER_ACCEPT));
     final Map<String, String> pathParamMap = ctx.pathParamMap();
-    if (maybeAcceptHeader.orElse("").equalsIgnoreCase(HEADER_ACCEPT_OCTET)) {
+    if (getContentType(ACCEPT_ALL, maybeAcceptHeader).equalsIgnoreCase(HEADER_ACCEPT_OCTET)) {
       final SafeFuture<Optional<SszResponse>> future =
           chainDataProvider.getBeaconStateSsz(pathParamMap.get(PARAM_STATE_ID));
       handleOptionalSszResult(

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/AbstractHandlerTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/AbstractHandlerTest.java
@@ -14,10 +14,19 @@
 package tech.pegasys.teku.beaconrestapi.handlers;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.beaconrestapi.handlers.AbstractHandler.ACCEPT_ALL;
+import static tech.pegasys.teku.infrastructure.http.RestApiConstants.HEADER_ACCEPT_JSON;
+import static tech.pegasys.teku.infrastructure.http.RestApiConstants.HEADER_ACCEPT_OCTET;
 
+import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class AbstractHandlerTest {
+
+  private static final List<String> JSON_ONLY = List.of(HEADER_ACCEPT_JSON);
 
   @Test
   void shouldHandleParameterAtEnd() {
@@ -44,5 +53,53 @@ class AbstractHandlerTest {
   void shouldHandleMultipleReplacements() {
     assertThat(AbstractHandler.routeWithBracedParameters("/:foo/:bar/:FOO/BAR"))
         .isEqualTo("/{foo}/{bar}/{FOO}/BAR");
+  }
+
+  @Test
+  void accept_shouldReturnJsonIfNotSpecified() {
+    assertThat(AbstractHandler.getContentType(ACCEPT_ALL, Optional.empty()))
+        .isEqualTo(HEADER_ACCEPT_JSON);
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @ValueSource(
+      strings = {
+        "application/octet-stream;q=1",
+        "a/b/c/d;q=1",
+        "application/js;q=abc",
+        ";q=1",
+        "a;q=1234",
+        ";qabc",
+        ",,,",
+        ";q=1;q=1;q=1",
+        ";;;"
+      })
+  void accept_errorsAgainstJsonHeaderRequirement(final String invalidMimeString) {
+    assertThat(AbstractHandler.getContentType(JSON_ONLY, Optional.of(invalidMimeString)))
+        .isEqualTo(HEADER_ACCEPT_JSON);
+  }
+
+  @Test
+  void accept_shouldPreferenceFirstSpecified() {
+    assertThat(
+            AbstractHandler.getContentType(
+                ACCEPT_ALL, Optional.of("application/octet-stream,application/json;q=0.9")))
+        .isEqualTo(HEADER_ACCEPT_OCTET);
+  }
+
+  @Test
+  void accept_shouldPreferenceHighestQValue() {
+    assertThat(
+            AbstractHandler.getContentType(
+                ACCEPT_ALL, Optional.of("application/octet-stream;q=0.1,application/json;q=0.9")))
+        .isEqualTo(HEADER_ACCEPT_JSON);
+  }
+
+  @Test
+  void accept_shouldHandleSingleArgWithQSet() {
+    assertThat(
+            AbstractHandler.getContentType(
+                ACCEPT_ALL, Optional.of("application/octet-stream;q=1.0")))
+        .isEqualTo(HEADER_ACCEPT_OCTET);
   }
 }

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -93,6 +93,7 @@ dependencyManagement {
     dependency 'org.apache.commons:commons-lang3:3.12.0'
     dependency 'commons-io:commons-io:2.11.0'
     dependency 'org.apache.commons:commons-compress:1.21'
+    dependency 'org.commonjava.mimeparse:mimeparse:0.1.3.3'
 
     dependencySet(group: 'org.apache.logging.log4j', version: '2.17.1') {
       entry 'log4j-api'


### PR DESCRIPTION
Any failure will fall back to `application/json`, but it's significantly better at handling accept header strings than simply an exact match on the header.

fixes #4978

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
