### PR TITLE
Mark transition block as invalid when TTD condition is not met

### DIFF
--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/executionengine/StubExecutionEngineChannel.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/executionengine/StubExecutionEngineChannel.java
@@ -13,9 +13,11 @@
 
 package tech.pegasys.teku.spec.executionengine;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.tuweni.bytes.Bytes;
@@ -35,6 +37,7 @@ public class StubExecutionEngineChannel implements ExecutionEngineChannel {
   private final Map<Bytes32, PowBlock> knownBlocks = new ConcurrentHashMap<>();
   private final LRUCache<Bytes8, HeadAndAttributes> payloadIdToHeadAndAttrsCache;
   private final AtomicLong payloadIdCounter = new AtomicLong(0);
+  private Set<Bytes32> requestedPowBlocks = new HashSet<>();
   private final Spec spec;
 
   private PayloadStatus payloadStatus = PayloadStatus.VALID;
@@ -50,6 +53,7 @@ public class StubExecutionEngineChannel implements ExecutionEngineChannel {
 
   @Override
   public SafeFuture<Optional<PowBlock>> getPowBlock(final Bytes32 blockHash) {
+    requestedPowBlocks.add(blockHash);
     return SafeFuture.completedFuture(Optional.ofNullable(knownBlocks.get(blockHash)));
   }
 
@@ -129,6 +133,10 @@ public class StubExecutionEngineChannel implements ExecutionEngineChannel {
 
   public void setPayloadStatus(PayloadStatus payloadStatus) {
     this.payloadStatus = payloadStatus;
+  }
+
+  public Set<Bytes32> getRequestedPowBlocks() {
+    return requestedPowBlocks;
   }
 
   private static class HeadAndAttributes {

--- a/ethereum/statetransition/build.gradle
+++ b/ethereum/statetransition/build.gradle
@@ -9,6 +9,7 @@ dependencies {
   implementation project(':infrastructure:async')
   implementation project(':infrastructure:bls')
   implementation project(':infrastructure:collections')
+  implementation project(':infrastructure:exceptions')
   implementation project(':infrastructure:logging')
   implementation project(':infrastructure:metrics')
   implementation project(':infrastructure:subscribers')

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/PayloadValidationResult.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/PayloadValidationResult.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.forkchoice;
+
+import com.google.common.base.MoreObjects;
+import java.util.Objects;
+import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.spec.executionengine.PayloadStatus;
+
+public class PayloadValidationResult {
+
+  public static final PayloadValidationResult VALID =
+      new PayloadValidationResult(PayloadStatus.VALID);
+
+  private final Optional<Bytes32> transitionBlockRoot;
+  private final PayloadStatus status;
+
+  public PayloadValidationResult(final Bytes32 transitionBlockRoot, final PayloadStatus status) {
+    this(Optional.of(transitionBlockRoot), status);
+  }
+
+  public PayloadValidationResult(final PayloadStatus status) {
+    this(Optional.empty(), status);
+  }
+
+  private PayloadValidationResult(
+      final Optional<Bytes32> transitionBlockRoot, final PayloadStatus status) {
+    this.transitionBlockRoot = transitionBlockRoot;
+    this.status = status;
+  }
+
+  public Optional<Bytes32> getInvalidTransitionBlockRoot() {
+    return status.hasInvalidStatus() ? transitionBlockRoot : Optional.empty();
+  }
+
+  public PayloadStatus getStatus() {
+    return status;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final PayloadValidationResult that = (PayloadValidationResult) o;
+    return Objects.equals(transitionBlockRoot, that.transitionBlockRoot)
+        && Objects.equals(status, that.status);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(transitionBlockRoot, status);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("transitionBlockRoot", transitionBlockRoot)
+        .add("status", status)
+        .toString();
+  }
+}

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
@@ -106,7 +106,7 @@ class ForkChoiceTest {
   @BeforeEach
   public void setup() {
     when(transitionBlockValidator.verifyAncestorTransitionBlock(any()))
-        .thenReturn(SafeFuture.completedFuture(PayloadStatus.VALID));
+        .thenReturn(SafeFuture.completedFuture(PayloadValidationResult.VALID));
     setForkChoiceNotifierForkChoiceUpdatedResult(PayloadStatus.VALID);
     recentChainData.initializeFromGenesis(genesis.getState(), UInt64.ZERO);
     reset(
@@ -116,7 +116,7 @@ class ForkChoiceTest {
     // by default everything is valid
     setForkChoiceNotifierForkChoiceUpdatedResult(PayloadStatus.VALID);
     when(transitionBlockValidator.verifyAncestorTransitionBlock(any()))
-        .thenReturn(SafeFuture.completedFuture(PayloadStatus.VALID));
+        .thenReturn(SafeFuture.completedFuture(PayloadValidationResult.VALID));
 
     storageSystem
         .chainUpdater()
@@ -603,7 +603,9 @@ class ForkChoiceTest {
     final Bytes32 chainHeadRoot = recentChainData.getOptimisticHead().get().getHeadBlockRoot();
     when(transitionBlockValidator.verifyAncestorTransitionBlock(chainHeadRoot))
         .thenReturn(
-            SafeFuture.completedFuture(PayloadStatus.invalid(Optional.empty(), Optional.empty())));
+            SafeFuture.completedFuture(
+                new PayloadValidationResult(
+                    PayloadStatus.invalid(Optional.empty(), Optional.empty()))));
 
     assertThat(recentChainData.getStore().containsBlock(chainHeadRoot)).isTrue();
     assertThat(forkChoice.processHead(recentChainData.getHeadSlot())).isCompleted();


### PR DESCRIPTION
## PR Description
When the merge transition checks fail, mark the transition block (and everything after it) as invalid rather than just the latest block we're importing.

## Fixed Issue(s)
#4671 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
