### PR TITLE
add support to `klinV2` in `--Xee-version`. `kiln` option will run kilnV1 spec

### DIFF
--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionEngineChannelImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionEngineChannelImpl.java
@@ -68,7 +68,7 @@ public class ExecutionEngineChannelImpl implements ExecutionEngineChannel {
     switch (version) {
       case KILNV2:
         return new Web3JExecutionEngineClient(eeEndpoint, timeProvider);
-      case KILNV1:
+      case KILN:
         return new KilnV1Web3JExecutionEngineClient(eeEndpoint, timeProvider);
       case KINTSUGI:
       default:

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionEngineChannelImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionEngineChannelImpl.java
@@ -21,6 +21,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.ethereum.executionlayer.client.ExecutionEngineClient;
+import tech.pegasys.teku.ethereum.executionlayer.client.KilnV1Web3JExecutionEngineClient;
 import tech.pegasys.teku.ethereum.executionlayer.client.KintsugiWeb3JExecutionEngineClient;
 import tech.pegasys.teku.ethereum.executionlayer.client.Web3JExecutionEngineClient;
 import tech.pegasys.teku.ethereum.executionlayer.client.schema.ExecutionPayloadV1;
@@ -65,8 +66,10 @@ public class ExecutionEngineChannelImpl implements ExecutionEngineChannel {
       final String eeEndpoint, final TimeProvider timeProvider, final Version version) {
     LOG.info("Execution Engine version: {}", version);
     switch (version) {
-      case KILN:
+      case KILNV2:
         return new Web3JExecutionEngineClient(eeEndpoint, timeProvider);
+      case KILNV1:
+        return new KilnV1Web3JExecutionEngineClient(eeEndpoint, timeProvider);
       case KINTSUGI:
       default:
         return new KintsugiWeb3JExecutionEngineClient(eeEndpoint, timeProvider);

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/KilnV1Web3JExecutionEngineClient.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/KilnV1Web3JExecutionEngineClient.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionlayer.client;
+
+import tech.pegasys.teku.ethereum.executionlayer.client.schema.Response;
+import tech.pegasys.teku.ethereum.executionlayer.client.schema.TransitionConfigurationV1;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.time.TimeProvider;
+
+public class KilnV1Web3JExecutionEngineClient extends Web3JExecutionEngineClient {
+
+  public KilnV1Web3JExecutionEngineClient(String eeEndpoint, TimeProvider timeProvider) {
+    super(eeEndpoint, timeProvider);
+  }
+
+  @Override
+  public SafeFuture<Response<TransitionConfigurationV1>> exchangeTransitionConfiguration(
+      TransitionConfigurationV1 transitionConfiguration) {
+    return SafeFuture.completedFuture(new Response<>(transitionConfiguration));
+  }
+}

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/KintsugiWeb3JExecutionEngineClient.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/KintsugiWeb3JExecutionEngineClient.java
@@ -29,14 +29,13 @@ import tech.pegasys.teku.ethereum.executionlayer.client.schema.ForkChoiceUpdated
 import tech.pegasys.teku.ethereum.executionlayer.client.schema.PayloadAttributesV1;
 import tech.pegasys.teku.ethereum.executionlayer.client.schema.PayloadStatusV1;
 import tech.pegasys.teku.ethereum.executionlayer.client.schema.Response;
-import tech.pegasys.teku.ethereum.executionlayer.client.schema.TransitionConfigurationV1;
 import tech.pegasys.teku.ethereum.executionlayer.client.serialization.Bytes8Deserializer;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.ssz.type.Bytes8;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.spec.executionengine.ExecutionPayloadStatus;
 
-public class KintsugiWeb3JExecutionEngineClient extends Web3JExecutionEngineClient {
+public class KintsugiWeb3JExecutionEngineClient extends KilnV1Web3JExecutionEngineClient {
 
   private final AtomicLong nextId = new AtomicLong(0);
 
@@ -65,12 +64,6 @@ public class KintsugiWeb3JExecutionEngineClient extends Web3JExecutionEngineClie
             eeWeb3jService,
             KintsugiForkChoiceUpdatedWeb3jResponse.class);
     return doRequest(web3jRequest).thenApply(this::fromKintsugiForkChoiceUpdatedResultResponse);
-  }
-
-  @Override
-  public SafeFuture<Response<TransitionConfigurationV1>> exchangeTransitionConfiguration(
-      TransitionConfigurationV1 transitionConfiguration) {
-    return SafeFuture.completedFuture(new Response<>(transitionConfiguration));
   }
 
   private Response<ForkChoiceUpdatedResult> fromKintsugiForkChoiceUpdatedResultResponse(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionengine/ExecutionEngineChannel.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionengine/ExecutionEngineChannel.java
@@ -76,7 +76,7 @@ public interface ExecutionEngineChannel extends ChannelInterface {
 
   enum Version {
     KINTSUGI,
-    KILNV1,
+    KILN,
     KILNV2;
 
     public static Version DEFAULT_VERSION = KINTSUGI;

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionengine/ExecutionEngineChannel.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionengine/ExecutionEngineChannel.java
@@ -76,7 +76,8 @@ public interface ExecutionEngineChannel extends ChannelInterface {
 
   enum Version {
     KINTSUGI,
-    KILN;
+    KILNV1,
+    KILNV2;
 
     public static Version DEFAULT_VERSION = KINTSUGI;
   }

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ExecutionEngineOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ExecutionEngineOptions.java
@@ -32,7 +32,7 @@ public class ExecutionEngineOptions {
       names = {"--Xee-version"},
       paramLabel = "<EXECUTION_ENGINE_VERSION>",
       description =
-          "Execution Engine API version. Possible values are: kintsugi (default), kilnV1 or kilnV2",
+          "Execution Engine API version. Possible values are: kintsugi (default), kiln or kilnV2",
       arity = "1",
       hidden = true)
   private Version executionEngineVersion = Version.DEFAULT_VERSION;

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ExecutionEngineOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ExecutionEngineOptions.java
@@ -31,7 +31,8 @@ public class ExecutionEngineOptions {
   @Option(
       names = {"--Xee-version"},
       paramLabel = "<EXECUTION_ENGINE_VERSION>",
-      description = "Execution Engine API version. Possible values are: kintsugi (default) or kiln",
+      description =
+          "Execution Engine API version. Possible values are: kintsugi (default), kilnV1 or kilnV2",
       arity = "1",
       hidden = true)
   private Version executionEngineVersion = Version.DEFAULT_VERSION;


### PR DESCRIPTION
## PR Description

- adds`klinV2` version in  `--Xee-version`
- `klin` option will run `kilnV1` specs, hiding the `engine_exchangeTransitionConfigurationV1` and must hide JWT authentication #4980 

## Documentation

- [ ] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
