### PR TITLE
Use more fastutil collections

### DIFF
--- a/beacon/validator/build.gradle
+++ b/beacon/validator/build.gradle
@@ -21,6 +21,7 @@ dependencies {
   implementation project(':infrastructure:events')
   implementation project(':infrastructure:metrics')
 
+  implementation 'it.unimi.dsi:fastutil'
   implementation 'org.apache.tuweni:tuweni-bytes'
   implementation 'org.apache.tuweni:tuweni-ssz'
 

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -20,9 +20,11 @@ import static tech.pegasys.teku.infrastructure.logging.ValidatorLogger.VALIDATOR
 import static tech.pegasys.teku.spec.config.SpecConfig.GENESIS_SLOT;
 
 import com.google.common.annotations.VisibleForTesting;
+import it.unimi.dsi.fastutil.ints.IntCollection;
+import it.unimi.dsi.fastutil.ints.IntSet;
+import it.unimi.dsi.fastutil.ints.IntSets;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -182,7 +184,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
 
   @Override
   public SafeFuture<Optional<AttesterDuties>> getAttestationDuties(
-      final UInt64 epoch, final Collection<Integer> validatorIndexes) {
+      final UInt64 epoch, final IntCollection validatorIndexes) {
     if (isSyncActive()) {
       return NodeSyncingException.failedFuture();
     }
@@ -208,7 +210,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
 
   @Override
   public SafeFuture<Optional<SyncCommitteeDuties>> getSyncCommitteeDuties(
-      final UInt64 epoch, final Collection<Integer> validatorIndices) {
+      final UInt64 epoch, final IntCollection validatorIndices) {
     if (isSyncActive()) {
       return NodeSyncingException.failedFuture();
     }
@@ -435,7 +437,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
       final UInt64 unsubscribeSlot = spec.computeStartSlotAtEpoch(untilEpoch);
       final SyncCommitteeUtil syncCommitteeUtil =
           spec.getSyncCommitteeUtilRequired(spec.computeStartSlotAtEpoch(untilEpoch));
-      final Set<Integer> syncCommitteeIndices = subscription.getSyncCommitteeIndices();
+      final IntSet syncCommitteeIndices = subscription.getSyncCommitteeIndices();
       performanceTracker.saveExpectedSyncCommitteeParticipant(
           subscription.getValidatorIndex(), syncCommitteeIndices, untilEpoch.decrement());
       syncCommitteeUtil
@@ -629,7 +631,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
   }
 
   private AttesterDuties getAttesterDutiesFromIndexesAndState(
-      final BeaconState state, final UInt64 epoch, final Collection<Integer> validatorIndexes) {
+      final BeaconState state, final UInt64 epoch, final IntCollection validatorIndexes) {
     final Bytes32 dependentRoot =
         epoch.isGreaterThan(spec.getCurrentEpoch(state))
             ? spec.atEpoch(epoch).getBeaconStateUtil().getCurrentDutyDependentRoot(state)
@@ -704,7 +706,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
   private SyncCommitteeDuties getSyncCommitteeDutiesFromIndexesAndState(
       final Optional<BeaconState> maybeState,
       final UInt64 epoch,
-      final Collection<Integer> validatorIndices) {
+      final IntCollection validatorIndices) {
     if (maybeState.isEmpty()) {
       return new SyncCommitteeDuties(List.of());
     }
@@ -716,13 +718,13 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
   }
 
   private Optional<SyncCommitteeDuty> getSyncCommitteeDuty(
-      final BeaconState state, final UInt64 epoch, final Integer validatorIndex) {
+      final BeaconState state, final UInt64 epoch, final int validatorIndex) {
     final Optional<SyncCommitteeUtil> syncCommitteeUtil =
         spec.atEpoch(epoch).getSyncCommitteeUtil();
-    final Set<Integer> duties =
+    final IntSet duties =
         syncCommitteeUtil
             .map(util -> util.getCommitteeIndices(state, epoch, UInt64.valueOf(validatorIndex)))
-            .orElse(Collections.emptySet());
+            .orElse(IntSets.emptySet());
 
     if (duties.isEmpty()) {
       return Optional.empty();

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/performance/DefaultPerformanceTracker.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/performance/DefaultPerformanceTracker.java
@@ -16,7 +16,9 @@ package tech.pegasys.teku.validator.coordinator.performance;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.common.annotations.VisibleForTesting;
-import java.util.ArrayList;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntList;
+import it.unimi.dsi.fastutil.ints.IntSet;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -227,7 +229,7 @@ public class DefaultPerformanceTracker implements PerformanceTracker {
 
     int correctTargetCount = 0;
     int correctHeadBlockCount = 0;
-    List<Integer> inclusionDistances = new ArrayList<>();
+    IntList inclusionDistances = new IntArrayList();
 
     // Pre-process attestations included on chain to group them by
     // data hash to inclusion slot to aggregation bitlist
@@ -347,7 +349,7 @@ public class DefaultPerformanceTracker implements PerformanceTracker {
   @Override
   public void saveExpectedSyncCommitteeParticipant(
       final int validatorIndex,
-      final Set<Integer> syncCommitteeIndices,
+      final IntSet syncCommitteeIndices,
       final UInt64 subscribeUntilEpoch) {
     syncCommitteePerformanceTracker.saveExpectedSyncCommitteeParticipant(
         validatorIndex, syncCommitteeIndices, subscribeUntilEpoch);

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/performance/NoOpPerformanceTracker.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/performance/NoOpPerformanceTracker.java
@@ -13,7 +13,7 @@
 
 package tech.pegasys.teku.validator.coordinator.performance;
 
-import java.util.Set;
+import it.unimi.dsi.fastutil.ints.IntSet;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
@@ -35,9 +35,7 @@ public class NoOpPerformanceTracker implements PerformanceTracker {
 
   @Override
   public void saveExpectedSyncCommitteeParticipant(
-      final int validatorIndex,
-      final Set<Integer> syncCommitteeIndices,
-      final UInt64 periodEndEpoch) {}
+      final int validatorIndex, final IntSet syncCommitteeIndices, final UInt64 periodEndEpoch) {}
 
   @Override
   public void saveProducedSyncCommitteeMessage(final SyncCommitteeMessage message) {}

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/performance/PerformanceTracker.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/performance/PerformanceTracker.java
@@ -13,7 +13,7 @@
 
 package tech.pegasys.teku.validator.coordinator.performance;
 
-import java.util.Set;
+import it.unimi.dsi.fastutil.ints.IntSet;
 import tech.pegasys.teku.ethereum.events.SlotEventsChannel;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
@@ -31,7 +31,7 @@ public interface PerformanceTracker extends SlotEventsChannel {
   void reportBlockProductionAttempt(UInt64 epoch);
 
   void saveExpectedSyncCommitteeParticipant(
-      int validatorIndex, Set<Integer> syncCommitteeIndices, UInt64 periodEndEpoch);
+      int validatorIndex, IntSet syncCommitteeIndices, UInt64 periodEndEpoch);
 
   void saveProducedSyncCommitteeMessage(SyncCommitteeMessage message);
 }

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/performance/SyncCommitteePerformanceTracker.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/performance/SyncCommitteePerformanceTracker.java
@@ -202,11 +202,8 @@ public class SyncCommitteePerformanceTracker {
             slot);
         continue;
       }
-      for (int committeeIndex : committeeIndices) {
-        if (syncCommitteeBits.getBit(committeeIndex)) {
-          numberOfIncludedMessages++;
-        }
-      }
+      numberOfIncludedMessages +=
+          (int) committeeIndices.intStream().filter(syncCommitteeBits::getBit).count();
     }
     return numberOfIncludedMessages;
   }

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -33,8 +33,8 @@ import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 import static tech.pegasys.teku.spec.datastructures.util.AttestationProcessingResult.SUCCESSFUL;
 import static tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult.FailureReason.DOES_NOT_DESCEND_FROM_LATEST_FINALIZED;
 
-import it.unimi.dsi.fastutil.ints.IntArrayList;
-import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import it.unimi.dsi.fastutil.ints.IntList;
+import it.unimi.dsi.fastutil.ints.IntSet;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -221,7 +221,7 @@ class ValidatorApiHandlerTest {
   public void getAttestationDuties_shouldFailWhenNodeIsSyncing() {
     nodeIsSyncing();
     final SafeFuture<Optional<AttesterDuties>> duties =
-        validatorApiHandler.getAttestationDuties(EPOCH, IntArrayList.of(1));
+        validatorApiHandler.getAttestationDuties(EPOCH, IntList.of(1));
     assertThat(duties).isCompletedExceptionally();
     assertThatThrownBy(duties::get).hasRootCauseInstanceOf(NodeSyncingException.class);
   }
@@ -234,7 +234,7 @@ class ValidatorApiHandlerTest {
     when(chainDataClient.getCurrentEpoch()).thenReturn(EPOCH.minus(ONE));
 
     final SafeFuture<Optional<AttesterDuties>> result =
-        validatorApiHandler.getAttestationDuties(EPOCH, IntArrayList.of());
+        validatorApiHandler.getAttestationDuties(EPOCH, IntList.of());
     final AttesterDuties duties = assertCompletedSuccessfully(result).orElseThrow();
     assertThat(duties.getDuties()).isEmpty();
     assertThat(duties.getDependentRoot()).isEqualTo(spec.getCurrentDutyDependentRoot(state));
@@ -248,7 +248,7 @@ class ValidatorApiHandlerTest {
     when(chainDataClient.getCurrentEpoch()).thenReturn(EPOCH.minus(ONE));
 
     final SafeFuture<Optional<AttesterDuties>> result =
-        validatorApiHandler.getAttestationDuties(EPOCH, IntArrayList.of());
+        validatorApiHandler.getAttestationDuties(EPOCH, IntList.of());
     final AttesterDuties duties = assertCompletedSuccessfully(result).orElseThrow();
     assertThat(duties.getDependentRoot()).isEqualTo(spec.getPreviousDutyDependentRoot(state));
   }
@@ -258,7 +258,7 @@ class ValidatorApiHandlerTest {
     when(chainDataClient.getCurrentEpoch()).thenReturn(EPOCH.minus(3));
 
     final SafeFuture<Optional<AttesterDuties>> result =
-        validatorApiHandler.getAttestationDuties(EPOCH, IntArrayList.of(1));
+        validatorApiHandler.getAttestationDuties(EPOCH, IntList.of(1));
     assertThat(result).isCompletedExceptionally();
     assertThatThrownBy(result::get).hasRootCauseInstanceOf(IllegalArgumentException.class);
   }
@@ -273,7 +273,7 @@ class ValidatorApiHandlerTest {
     when(chainDataClient.getCurrentEpoch()).thenReturn(EPOCH.minus(ONE));
 
     final SafeFuture<Optional<AttesterDuties>> result =
-        validatorApiHandler.getAttestationDuties(EPOCH, IntArrayList.of(1, 32));
+        validatorApiHandler.getAttestationDuties(EPOCH, IntList.of(1, 32));
     final Optional<AttesterDuties> duties = assertCompletedSuccessfully(result);
     assertThat(duties.orElseThrow().getDuties())
         .containsExactly(new AttesterDuty(validator1Key, 1, 4, 0, 1, 1, UInt64.valueOf(108)));
@@ -289,7 +289,7 @@ class ValidatorApiHandlerTest {
     when(chainDataClient.getCurrentEpoch()).thenReturn(EPOCH.minus(2));
 
     final SafeFuture<Optional<AttesterDuties>> result =
-        validatorApiHandler.getAttestationDuties(EPOCH, IntArrayList.of(1, 32));
+        validatorApiHandler.getAttestationDuties(EPOCH, IntList.of(1, 32));
     final Optional<AttesterDuties> duties = assertCompletedSuccessfully(result);
     assertThat(duties.orElseThrow().getDuties())
         .containsExactly(new AttesterDuty(validator1Key, 1, 4, 0, 1, 1, UInt64.valueOf(108)));
@@ -369,7 +369,7 @@ class ValidatorApiHandlerTest {
             .plus(epochsPerSyncCommitteePeriod * 2L);
     assertThatSafeFuture(
             validatorApiHandler.getSyncCommitteeDuties(
-                firstSlotAfterNextSyncCommitteePeriod, IntArrayList.of(1)))
+                firstSlotAfterNextSyncCommitteePeriod, IntList.of(1)))
         .isCompletedExceptionallyWith(IllegalArgumentException.class)
         .hasMessageContaining("not within the current or next sync committee periods");
   }
@@ -405,7 +405,7 @@ class ValidatorApiHandlerTest {
     when(chainDataClient.getStateAtSlotExact(any())).thenReturn(new SafeFuture<>());
 
     final SafeFuture<Optional<SyncCommitteeDuties>> result =
-        validatorApiHandler.getSyncCommitteeDuties(EPOCH, IntArrayList.of(1));
+        validatorApiHandler.getSyncCommitteeDuties(EPOCH, IntList.of(1));
     assertThat(result).isNotDone();
 
     // The start of the sync committee period is prior to the fork block so we should use the
@@ -644,9 +644,9 @@ class ValidatorApiHandlerTest {
   @Test
   void subscribeToSyncCommitteeSubnets_shouldConvertCommitteeIndexToSubnetId() {
     final SyncCommitteeSubnetSubscription subscription1 =
-        new SyncCommitteeSubnetSubscription(1, IntOpenHashSet.of(1, 2, 15, 30), UInt64.valueOf(44));
+        new SyncCommitteeSubnetSubscription(1, IntSet.of(1, 2, 15, 30), UInt64.valueOf(44));
     final SyncCommitteeSubnetSubscription subscription2 =
-        new SyncCommitteeSubnetSubscription(1, IntOpenHashSet.of(5, 10), UInt64.valueOf(35));
+        new SyncCommitteeSubnetSubscription(1, IntSet.of(5, 10), UInt64.valueOf(35));
     validatorApiHandler.subscribeToSyncCommitteeSubnets(List.of(subscription1, subscription2));
     final UInt64 unsubscribeSlotSubscription1 = spec.computeStartSlotAtEpoch(UInt64.valueOf(44));
     final UInt64 unsubscribeSlotSubscription2 = spec.computeStartSlotAtEpoch(UInt64.valueOf(35));

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/performance/SyncCommitteePerformanceTrackerTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/performance/SyncCommitteePerformanceTrackerTest.java
@@ -22,9 +22,9 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import it.unimi.dsi.fastutil.ints.IntSet;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -77,7 +77,7 @@ class SyncCommitteePerformanceTrackerTest {
 
   @Test
   void shouldExpectMessagesForEachPositionInCommitteeAtEachSlot() {
-    tracker.saveExpectedSyncCommitteeParticipant(1, Set.of(2, 5, 6), UInt64.valueOf(3));
+    tracker.saveExpectedSyncCommitteeParticipant(1, IntSet.of(2, 5, 6), UInt64.valueOf(3));
 
     final int expected = 3 * spec.getSlotsPerEpoch(UInt64.ZERO);
     assertThat(calculatePerformance(UInt64.ONE).getNumberOfExpectedMessages()).isEqualTo(expected);
@@ -85,7 +85,7 @@ class SyncCommitteePerformanceTrackerTest {
 
   @Test
   void shouldCountNumberOfProducedMessages() {
-    tracker.saveExpectedSyncCommitteeParticipant(1, Set.of(2, 7, 8), UInt64.valueOf(3));
+    tracker.saveExpectedSyncCommitteeParticipant(1, IntSet.of(2, 7, 8), UInt64.valueOf(3));
     tracker.saveProducedSyncCommitteeMessage(createMessage(1, 1));
     tracker.saveProducedSyncCommitteeMessage(createMessage(1, 3));
 
@@ -106,7 +106,7 @@ class SyncCommitteePerformanceTrackerTest {
         .getBlockRootAtSlot(eq(chainHead.getState()), any());
     doReturn(slot1Hash).when(specSpy).getBlockRootAtSlot(chainHead.getState(), UInt64.ONE);
 
-    tracker.saveExpectedSyncCommitteeParticipant(1, Set.of(2, 7, 8), UInt64.valueOf(3));
+    tracker.saveExpectedSyncCommitteeParticipant(1, IntSet.of(2, 7, 8), UInt64.valueOf(3));
     tracker.saveProducedSyncCommitteeMessage(createMessage(1, 1, slot1Hash));
     tracker.saveProducedSyncCommitteeMessage(createMessage(1, 2, wrongBlockRoot));
     tracker.saveProducedSyncCommitteeMessage(createMessage(1, 3, wrongBlockRoot));
@@ -118,7 +118,7 @@ class SyncCommitteePerformanceTrackerTest {
 
   @Test
   void shouldCountNumberOfIncludedMessages() {
-    tracker.saveExpectedSyncCommitteeParticipant(1, Set.of(2, 7, 8), UInt64.valueOf(3));
+    tracker.saveExpectedSyncCommitteeParticipant(1, IntSet.of(2, 7, 8), UInt64.valueOf(3));
 
     // Not included as no block was present
     tracker.saveProducedSyncCommitteeMessage(createMessage(1, 1));

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/validator/GetSyncCommitteeContributionIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/validator/GetSyncCommitteeContributionIntegrationTest.java
@@ -21,8 +21,8 @@ import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_NOT_FOUND
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 
+import it.unimi.dsi.fastutil.ints.IntList;
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import okhttp3.Response;
@@ -83,7 +83,7 @@ public class GetSyncCommitteeContributionIntegrationTest
             Optional.of(
                 spec.getSyncCommitteeUtilRequired(ONE)
                     .createSyncCommitteeContribution(
-                        ONE, blockRoot, ONE, List.of(1), sig.asInternalBLSSignature())));
+                        ONE, blockRoot, ONE, IntList.of(1), sig.asInternalBLSSignature())));
 
     when(validatorApiChannel.createSyncCommitteeContribution(eq(ONE), eq(1), eq(blockRoot)))
         .thenReturn(future);

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/validator/PostSyncDutiesIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/validator/PostSyncDutiesIntegrationTest.java
@@ -20,10 +20,10 @@ import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 
 import it.unimi.dsi.fastutil.ints.IntList;
+import it.unimi.dsi.fastutil.ints.IntSet;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import okhttp3.Response;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -59,7 +59,7 @@ public class PostSyncDutiesIntegrationTest extends AbstractDataBackedRestAPIInte
                 new SyncCommitteeDuties(
                     List.of(
                         new SyncCommitteeDuty(
-                            VALIDATOR_KEYS.get(1).getPublicKey(), 1, Set.of(11))))));
+                            VALIDATOR_KEYS.get(1).getPublicKey(), 1, IntSet.of(11))))));
     when(syncService.getCurrentSyncState()).thenReturn(SyncState.IN_SYNC);
     when(validatorApiChannel.getSyncCommitteeDuties(ONE, validators)).thenReturn(out);
 
@@ -72,6 +72,6 @@ public class PostSyncDutiesIntegrationTest extends AbstractDataBackedRestAPIInte
     assertThat(dutiesResponse.data.get(0))
         .isEqualTo(
             new tech.pegasys.teku.api.response.v1.validator.SyncCommitteeDuty(
-                new BLSPubKey(VALIDATOR_KEYS.get(1).getPublicKey()), ONE, Set.of(11)));
+                new BLSPubKey(VALIDATOR_KEYS.get(1).getPublicKey()), ONE, IntSet.of(11)));
   }
 }

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/validator/PostSyncDutiesIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/validator/PostSyncDutiesIntegrationTest.java
@@ -19,6 +19,7 @@ import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_BAD_REQUE
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 
+import it.unimi.dsi.fastutil.ints.IntList;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
@@ -37,7 +38,7 @@ import tech.pegasys.teku.validator.api.SyncCommitteeDuties;
 import tech.pegasys.teku.validator.api.SyncCommitteeDuty;
 
 public class PostSyncDutiesIntegrationTest extends AbstractDataBackedRestAPIIntegrationTest {
-  final List<Integer> validators = List.of(1);
+  final IntList validators = IntList.of(1);
 
   @Test
   public void shouldReturnBadRequestWhenRequestBodyIsEmpty() throws Exception {

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostAttesterDuties.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostAttesterDuties.java
@@ -34,10 +34,10 @@ import io.javalin.plugin.openapi.annotations.OpenApi;
 import io.javalin.plugin.openapi.annotations.OpenApiContent;
 import io.javalin.plugin.openapi.annotations.OpenApiRequestBody;
 import io.javalin.plugin.openapi.annotations.OpenApiResponse;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.api.DataProvider;
@@ -118,7 +118,9 @@ public class PostAttesterDuties extends AbstractHandler implements Handler {
 
       SafeFuture<Optional<PostAttesterDutiesResponse>> future =
           validatorDataProvider.getAttesterDuties(
-              epoch, Arrays.stream(indexes).map(UInt64::intValue).collect(Collectors.toList()));
+              epoch,
+              IntArrayList.toList(
+                  Arrays.stream(indexes).map(UInt64::intValue).mapToInt(Integer::intValue)));
 
       handleOptionalResult(
           ctx, future, this::handleResult, this::handleError, SC_SERVICE_UNAVAILABLE);

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostAttesterDuties.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostAttesterDuties.java
@@ -118,9 +118,7 @@ public class PostAttesterDuties extends AbstractHandler implements Handler {
 
       SafeFuture<Optional<PostAttesterDutiesResponse>> future =
           validatorDataProvider.getAttesterDuties(
-              epoch,
-              IntArrayList.toList(
-                  Arrays.stream(indexes).map(UInt64::intValue).mapToInt(Integer::intValue)));
+              epoch, IntArrayList.toList(Arrays.stream(indexes).mapToInt(UInt64::intValue)));
 
       handleOptionalResult(
           ctx, future, this::handleResult, this::handleError, SC_SERVICE_UNAVAILABLE);

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostSyncDuties.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostSyncDuties.java
@@ -34,8 +34,8 @@ import io.javalin.plugin.openapi.annotations.OpenApi;
 import io.javalin.plugin.openapi.annotations.OpenApiContent;
 import io.javalin.plugin.openapi.annotations.OpenApiRequestBody;
 import io.javalin.plugin.openapi.annotations.OpenApiResponse;
-import java.util.Arrays;
-import java.util.List;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntList;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.logging.log4j.LogManager;
@@ -101,7 +101,7 @@ public class PostSyncDuties extends AbstractHandler implements Handler {
     final Map<String, String> parameters = ctx.pathParamMap();
     try {
       final UInt64 epoch = UInt64.valueOf(parameters.get(EPOCH));
-      final List<Integer> indexes = Arrays.asList(parseRequestBody(ctx.body(), Integer[].class));
+      final IntList indexes = IntArrayList.of(parseRequestBody(ctx.body(), int[].class));
 
       SafeFuture<Optional<PostSyncDutiesResponse>> future =
           validatorDataProvider.getSyncDuties(epoch, indexes);

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostSyncDuties.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostSyncDuties.java
@@ -34,7 +34,6 @@ import io.javalin.plugin.openapi.annotations.OpenApi;
 import io.javalin.plugin.openapi.annotations.OpenApiContent;
 import io.javalin.plugin.openapi.annotations.OpenApiRequestBody;
 import io.javalin.plugin.openapi.annotations.OpenApiResponse;
-import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntList;
 import java.util.Map;
 import java.util.Optional;
@@ -101,7 +100,7 @@ public class PostSyncDuties extends AbstractHandler implements Handler {
     final Map<String, String> parameters = ctx.pathParamMap();
     try {
       final UInt64 epoch = UInt64.valueOf(parameters.get(EPOCH));
-      final IntList indexes = IntArrayList.of(parseRequestBody(ctx.body(), int[].class));
+      final IntList indexes = IntList.of(parseRequestBody(ctx.body(), int[].class));
 
       SafeFuture<Optional<PostSyncDutiesResponse>> future =
           validatorDataProvider.getSyncDuties(epoch, indexes);

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostAttesterDutiesTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostAttesterDutiesTest.java
@@ -20,6 +20,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
+import it.unimi.dsi.fastutil.ints.IntList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -82,7 +83,7 @@ public class PostAttesterDutiesTest extends AbstractValidatorApiTest {
     when(syncService.getCurrentSyncState()).thenReturn(SyncState.IN_SYNC);
     when(context.pathParamMap()).thenReturn(Map.of("epoch", "100"));
     when(context.body()).thenReturn("[\"2\"]");
-    when(validatorDataProvider.getAttesterDuties(UInt64.valueOf(100), List.of(2)))
+    when(validatorDataProvider.getAttesterDuties(UInt64.valueOf(100), IntList.of(2)))
         .thenReturn(SafeFuture.failedFuture(new IllegalArgumentException("Bad epoch")));
 
     handler.handle(context);

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
@@ -271,9 +271,7 @@ public class ValidatorDataProvider {
                     new tech.pegasys.teku.validator.api.SyncCommitteeSubnetSubscription(
                         subscription.validatorIndex.intValue(),
                         IntOpenHashSet.toSet(
-                            subscription.syncCommitteeIndices.stream()
-                                .map(UInt64::intValue)
-                                .mapToInt(Integer::intValue)),
+                            subscription.syncCommitteeIndices.stream().mapToInt(UInt64::intValue)),
                         subscription.untilEpoch))
             .collect(toList()));
   }

--- a/data/provider/src/test/java/tech/pegasys/teku/api/ValidatorDataProviderTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/ValidatorDataProviderTest.java
@@ -32,6 +32,7 @@ import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 import static tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult.FailureReason;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
@@ -340,7 +341,7 @@ public class ValidatorDataProviderTest {
                     new tech.pegasys.teku.validator.api.AttesterDuties(
                         previousTargetRoot, emptyList()))));
     final SafeFuture<Optional<PostAttesterDutiesResponse>> future =
-        provider.getAttesterDuties(UInt64.ONE, List.of());
+        provider.getAttesterDuties(UInt64.ONE, IntArrayList.of());
     assertThat(future).isCompleted();
     Optional<PostAttesterDutiesResponse> maybeData = future.join();
     assertThat(maybeData.isPresent()).isTrue();
@@ -358,7 +359,7 @@ public class ValidatorDataProviderTest {
                     new AttesterDuties(dataStructureUtil.randomBytes32(), List.of(v1, v2)))));
 
     final SafeFuture<Optional<PostAttesterDutiesResponse>> future =
-        provider.getAttesterDuties(ONE, List.of(1, 11));
+        provider.getAttesterDuties(ONE, IntArrayList.of(1, 11));
     assertThat(future).isCompleted();
     final Optional<PostAttesterDutiesResponse> maybeList = future.join();
     final PostAttesterDutiesResponse list = maybeList.orElseThrow();

--- a/data/provider/src/test/java/tech/pegasys/teku/api/ValidatorDataProviderTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/ValidatorDataProviderTest.java
@@ -32,7 +32,7 @@ import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 import static tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult.FailureReason;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
@@ -341,7 +341,7 @@ public class ValidatorDataProviderTest {
                     new tech.pegasys.teku.validator.api.AttesterDuties(
                         previousTargetRoot, emptyList()))));
     final SafeFuture<Optional<PostAttesterDutiesResponse>> future =
-        provider.getAttesterDuties(UInt64.ONE, IntArrayList.of());
+        provider.getAttesterDuties(UInt64.ONE, IntList.of());
     assertThat(future).isCompleted();
     Optional<PostAttesterDutiesResponse> maybeData = future.join();
     assertThat(maybeData.isPresent()).isTrue();
@@ -359,7 +359,7 @@ public class ValidatorDataProviderTest {
                     new AttesterDuties(dataStructureUtil.randomBytes32(), List.of(v1, v2)))));
 
     final SafeFuture<Optional<PostAttesterDutiesResponse>> future =
-        provider.getAttesterDuties(ONE, IntArrayList.of(1, 11));
+        provider.getAttesterDuties(ONE, IntList.of(1, 11));
     assertThat(future).isCompleted();
     final Optional<PostAttesterDutiesResponse> maybeList = future.join();
     final PostAttesterDutiesResponse list = maybeList.orElseThrow();

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/validator/SyncCommitteeDuty.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/validator/SyncCommitteeDuty.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
+import it.unimi.dsi.fastutil.ints.IntSet;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -55,7 +56,7 @@ public class SyncCommitteeDuty {
   public SyncCommitteeDuty(
       @JsonProperty("pubkey") final BLSPubKey pubkey,
       @JsonProperty("validator_index") final UInt64 validatorIndex,
-      @JsonProperty("validator_sync_committee_indices") final Set<Integer> committeeIndices) {
+      @JsonProperty("validator_sync_committee_indices") final IntSet committeeIndices) {
     this.pubkey = pubkey;
     this.validatorIndex = validatorIndex;
     this.committeeIndices =

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/validator/SyncCommitteeDuty.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/validator/SyncCommitteeDuty.java
@@ -21,7 +21,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
-import it.unimi.dsi.fastutil.ints.IntSet;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -56,7 +55,7 @@ public class SyncCommitteeDuty {
   public SyncCommitteeDuty(
       @JsonProperty("pubkey") final BLSPubKey pubkey,
       @JsonProperty("validator_index") final UInt64 validatorIndex,
-      @JsonProperty("validator_sync_committee_indices") final IntSet committeeIndices) {
+      @JsonProperty("validator_sync_committee_indices") final Set<Integer> committeeIndices) {
     this.pubkey = pubkey;
     this.validatorIndex = validatorIndex;
     this.committeeIndices =

--- a/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/synccomittee/SignedContributionAndProofTestBuilder.java
+++ b/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/synccomittee/SignedContributionAndProofTestBuilder.java
@@ -17,12 +17,12 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntList;
+import it.unimi.dsi.fastutil.ints.IntSet;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.function.IntFunction;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.bls.BLS;
@@ -160,8 +160,7 @@ public class SignedContributionAndProofTestBuilder {
         subcommitteeIndex);
     final BLSSignature syncSignature =
         signer.signSyncCommitteeMessage(slot, beaconBlockRoot, state.getForkInfo()).join();
-    final Set<Integer> participationIndices =
-        assignments.getParticipationBitIndices(subcommitteeIndex);
+    final IntSet participationIndices = assignments.getParticipationBitIndices(subcommitteeIndex);
     // Have to add signature once for each time the validator appears in the subcommittee
     syncSignatures.addAll(Collections.nCopies(participationIndices.size(), syncSignature));
     subcommitteeParticipationIndices.addAll(participationIndices);

--- a/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/synccomittee/SignedContributionAndProofTestBuilder.java
+++ b/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/synccomittee/SignedContributionAndProofTestBuilder.java
@@ -15,6 +15,8 @@ package tech.pegasys.teku.core.synccomittee;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntList;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -47,7 +49,7 @@ public class SignedContributionAndProofTestBuilder {
   private Optional<BLSSignature> signedContributionAndProofSignature = Optional.empty();
   private Bytes32 beaconBlockRoot;
   private UInt64 slot;
-  private final List<Integer> subcommitteeParticipationIndices = new ArrayList<>();
+  private final IntList subcommitteeParticipationIndices = new IntArrayList();
   private final List<BLSSignature> syncSignatures = new ArrayList<>();
   private int subcommitteeIndex;
   private BeaconStateAltair state;

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/SyncCommitteeUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/SyncCommitteeUtil.java
@@ -220,9 +220,7 @@ public class SyncCommitteeUtil {
   public IntSet getSyncSubcommittees(final IntSet committeeIndices) {
     final int subcommitteeSize = getSubcommitteeSize();
     return IntOpenHashSet.toSet(
-        committeeIndices.stream()
-            .map(index -> index / subcommitteeSize)
-            .mapToInt(Integer::intValue));
+        committeeIndices.intStream().map(index -> index / subcommitteeSize));
   }
 
   public Bytes32 getSyncCommitteeMessageSigningRoot(

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/SyncCommitteeUtilTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/SyncCommitteeUtilTest.java
@@ -17,10 +17,10 @@ import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static tech.pegasys.teku.spec.constants.NetworkConstants.SYNC_COMMITTEE_SUBNET_COUNT;
 
+import it.unimi.dsi.fastutil.ints.IntSet;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.bls.BLSPublicKey;
@@ -127,7 +127,7 @@ class SyncCommitteeUtilTest {
   @Test
   void getCommitteeIndices() {
     final BeaconState state = createStateWithCurrentSyncCommittee(validatorPublicKeys);
-    final Set<Integer> indices =
+    final IntSet indices =
         syncCommitteeUtil.getCommitteeIndices(
             state, spec.computeEpochAtSlot(state.getSlot()), UInt64.valueOf(12));
     assertThat(indices).containsExactly(12);

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/altair/SyncAggregateAssert.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/altair/SyncAggregateAssert.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import it.unimi.dsi.fastutil.ints.IntIterable;
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.error.BasicErrorMessageFactory;
 import tech.pegasys.teku.bls.BLSSignature;
@@ -34,11 +35,11 @@ public class SyncAggregateAssert extends AbstractAssert<SyncAggregateAssert, Syn
     return hasSyncCommitteeBits().hasInfiniteSignature();
   }
 
-  public SyncAggregateAssert hasSyncCommitteeBits(final Iterable<Integer> bits) {
+  public SyncAggregateAssert hasSyncCommitteeBits(final IntIterable bits) {
     final SszBitvector actualBits = actual.getSyncCommitteeBits();
-    assertThat(actualBits.getAllSetBits())
-        .describedAs("sync committee bits %s", actualBits)
-        .containsExactlyInAnyOrderElementsOf(bits);
+    for (int bit : bits) {
+      assertThat(actualBits.getAllSetBits().contains(bit)).isTrue();
+    }
     return this;
   }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeMessagePool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeMessagePool.java
@@ -13,16 +13,16 @@
 
 package tech.pegasys.teku.statetransition.synccommittee;
 
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import it.unimi.dsi.fastutil.ints.IntSet;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 import java.util.TreeMap;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.bls.BLS;
@@ -154,11 +154,11 @@ public class SyncCommitteeMessagePool implements SlotEventsChannel {
   }
 
   private static class ContributionData {
-    private final Set<Integer> participationIndices = new HashSet<>();
+    private final IntSet participationIndices = new IntOpenHashSet();
     private final List<BLSSignature> signatures = new ArrayList<>();
 
-    public void add(final Set<Integer> participationIndices, final BLSSignature signature) {
-      for (Integer index : participationIndices) {
+    public void add(final IntSet participationIndices, final BLSSignature signature) {
+      for (int index : participationIndices) {
         if (!this.participationIndices.add(index)) {
           throw new IllegalStateException("Already added " + index);
         }
@@ -170,7 +170,7 @@ public class SyncCommitteeMessagePool implements SlotEventsChannel {
       return signatures.isEmpty();
     }
 
-    public Set<Integer> getParticipationIndices() {
+    public IntSet getParticipationIndices() {
       return participationIndices;
     }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeMessagePool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeMessagePool.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.statetransition.synccommittee;
 
+import it.unimi.dsi.fastutil.ints.IntIterator;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import it.unimi.dsi.fastutil.ints.IntSet;
 import java.util.ArrayList;
@@ -158,7 +159,9 @@ public class SyncCommitteeMessagePool implements SlotEventsChannel {
     private final List<BLSSignature> signatures = new ArrayList<>();
 
     public void add(final IntSet participationIndices, final BLSSignature signature) {
-      for (int index : participationIndices) {
+      IntIterator iterator = participationIndices.iterator();
+      while (iterator.hasNext()) {
+        int index = iterator.nextInt();
         if (!this.participationIndices.add(index)) {
           throw new IllegalStateException("Already added " + index);
         }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeContributionPoolTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeContributionPoolTest.java
@@ -204,9 +204,11 @@ class SyncCommitteeContributionPoolTest {
             * contribution.getSubcommitteeIndex().intValue();
     final IntList expectedParticipants =
         IntArrayList.toList(
-            contribution.getAggregationBits().getAllSetBits().stream()
-                .map(index -> subcommitteeIndexOffset + index)
-                .mapToInt(Integer::intValue));
+            contribution
+                .getAggregationBits()
+                .getAllSetBits()
+                .intStream()
+                .map(index -> subcommitteeIndexOffset + index));
     assertThatSyncAggregate(result)
         .hasSyncCommitteeBits(expectedParticipants)
         .hasSignature(contribution.getSignature());

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeContributionPoolTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeContributionPoolTest.java
@@ -221,7 +221,7 @@ class SyncCommitteeContributionPoolTest {
             contribution.getSlot(),
             contribution.getBeaconBlockRoot(),
             contribution.getSubcommitteeIndex(),
-            IntArrayList.of(participationBits),
+            IntList.of(participationBits),
             contribution.getSignature());
 
     return syncCommitteeUtil.createSignedContributionAndProof(

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeContributionPoolTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeContributionPoolTest.java
@@ -24,8 +24,8 @@ import static tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.al
 import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.ACCEPT;
 import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.reject;
 
-import java.util.List;
-import java.util.stream.Collectors;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntList;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -202,17 +202,18 @@ class SyncCommitteeContributionPoolTest {
         config.getSyncCommitteeSize()
             / SYNC_COMMITTEE_SUBNET_COUNT
             * contribution.getSubcommitteeIndex().intValue();
-    final List<Integer> expectedParticipants =
-        contribution.getAggregationBits().getAllSetBits().stream()
-            .map(index -> subcommitteeIndexOffset + index)
-            .collect(Collectors.toList());
+    final IntList expectedParticipants =
+        IntArrayList.toList(
+            contribution.getAggregationBits().getAllSetBits().stream()
+                .map(index -> subcommitteeIndexOffset + index)
+                .mapToInt(Integer::intValue));
     assertThatSyncAggregate(result)
         .hasSyncCommitteeBits(expectedParticipants)
         .hasSignature(contribution.getSignature());
   }
 
   private SignedContributionAndProof withParticipationBits(
-      final SignedContributionAndProof proof, final Integer... participationBits) {
+      final SignedContributionAndProof proof, final int... participationBits) {
     final SyncCommitteeContribution contribution = proof.getMessage().getContribution();
     final SyncCommitteeUtil syncCommitteeUtil = spec.getSyncCommitteeUtilRequired(altairSlot);
     final SyncCommitteeContribution newContribution =
@@ -220,7 +221,7 @@ class SyncCommitteeContributionPoolTest {
             contribution.getSlot(),
             contribution.getBeaconBlockRoot(),
             contribution.getSubcommitteeIndex(),
-            List.of(participationBits),
+            IntArrayList.of(participationBits),
             contribution.getSignature());
 
     return syncCommitteeUtil.createSignedContributionAndProof(

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeMessagePoolTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeMessagePoolTest.java
@@ -24,11 +24,11 @@ import static tech.pegasys.teku.statetransition.validation.InternalValidationRes
 import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.IGNORE;
 import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.reject;
 
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import it.unimi.dsi.fastutil.ints.IntSet;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.IntStream;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
@@ -327,7 +327,7 @@ class SyncCommitteeMessagePoolTest {
       final int subnetId, final ValidateableSyncCommitteeMessage... messages) {
     checkArgument(messages.length > 0, "Must specify at least one message");
     final ValidateableSyncCommitteeMessage template = messages[0];
-    final Set<Integer> participantIds = new HashSet<>();
+    final IntSet participantIds = new IntOpenHashSet();
     final List<BLSSignature> blsSignatures = new ArrayList<>();
     for (ValidateableSyncCommitteeMessage message : messages) {
       participantIds.addAll(

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeMessageValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeMessageValidatorTest.java
@@ -23,7 +23,6 @@ import static tech.pegasys.teku.statetransition.validation.InternalValidationRes
 import it.unimi.dsi.fastutil.ints.IntSet;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.bls.BLSKeyPair;
@@ -285,23 +284,21 @@ class SyncCommitteeMessageValidatorTest {
   }
 
   private ValidateableSyncCommitteeMessage fromValidatorSpy(
-      SyncCommitteeMessage message, final Set<Integer> subcommitteeIds) {
+      SyncCommitteeMessage message, final IntSet subcommitteeIds) {
     final ValidateableSyncCommitteeMessage validateableMessage =
         ValidateableSyncCommitteeMessage.fromValidator(message);
     return createSpy(validateableMessage, subcommitteeIds);
   }
 
   private ValidateableSyncCommitteeMessage fromNetworkSpy(
-      SyncCommitteeMessage message,
-      final int receivedSubnetId,
-      final Set<Integer> subcommitteeIds) {
+      SyncCommitteeMessage message, final int receivedSubnetId, final IntSet subcommitteeIds) {
     final ValidateableSyncCommitteeMessage validateableMessage =
         ValidateableSyncCommitteeMessage.fromNetwork(message, receivedSubnetId);
     return createSpy(validateableMessage, subcommitteeIds);
   }
 
   private ValidateableSyncCommitteeMessage createSpy(
-      ValidateableSyncCommitteeMessage validateableMessage, final Set<Integer> subcommitteeIds) {
+      ValidateableSyncCommitteeMessage validateableMessage, final IntSet subcommitteeIds) {
     // Create spies
     final ValidateableSyncCommitteeMessage validateableMessageSpy = spy(validateableMessage);
     validateableMessage.calculateAssignments(

--- a/infrastructure/collections/build.gradle
+++ b/infrastructure/collections/build.gradle
@@ -1,3 +1,5 @@
 dependencies {
   implementation 'com.google.guava:guava'
+
+  testFixturesImplementation 'it.unimi.dsi:fastutil'
 }

--- a/infrastructure/collections/src/testFixtures/java/tech/pegasys/teku/infrastructure/collections/PrimitiveCollectionAssert.java
+++ b/infrastructure/collections/src/testFixtures/java/tech/pegasys/teku/infrastructure/collections/PrimitiveCollectionAssert.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.collections;
+
+import it.unimi.dsi.fastutil.ints.IntCollection;
+import it.unimi.dsi.fastutil.ints.IntList;
+import java.util.Collection;
+import java.util.List;
+import org.assertj.core.api.AbstractCollectionAssert;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.ListAssert;
+import org.assertj.core.api.ObjectAssert;
+
+public class PrimitiveCollectionAssert {
+  public static ListAssert<Integer> assertThatIntCollection(final IntList collection) {
+    return Assertions.assertThat((List<Integer>) collection);
+  }
+
+  public static AbstractCollectionAssert<
+          ?, Collection<? extends Integer>, Integer, ObjectAssert<Integer>>
+      assertThatIntCollection(final IntCollection collection) {
+    return Assertions.assertThat(collection);
+  }
+}

--- a/infrastructure/ssz/build.gradle
+++ b/infrastructure/ssz/build.gradle
@@ -1,9 +1,11 @@
 dependencies {
   implementation project(':infrastructure:crypto')
+
+  implementation 'it.unimi.dsi:fastutil'
   implementation 'org.apache.commons:commons-lang3'
   implementation 'org.apache.tuweni:tuweni-bytes'
-  implementation 'org.apache.tuweni:tuweni-units'
   implementation 'org.apache.tuweni:tuweni-ssz'
+  implementation 'org.apache.tuweni:tuweni-units'
 
   testFixturesApi 'org.apache.tuweni:tuweni-bytes'
   testFixturesApi 'org.apache.tuweni:tuweni-units'

--- a/infrastructure/ssz/build.gradle
+++ b/infrastructure/ssz/build.gradle
@@ -7,6 +7,8 @@ dependencies {
   implementation 'org.apache.tuweni:tuweni-ssz'
   implementation 'org.apache.tuweni:tuweni-units'
 
+  testImplementation testFixtures(project(':infrastructure:collections'))
+
   testFixturesApi 'org.apache.tuweni:tuweni-bytes'
   testFixturesApi 'org.apache.tuweni:tuweni-units'
   testFixturesApi project(':infrastructure:unsigned')

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/SszBitlist.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/SszBitlist.java
@@ -13,7 +13,7 @@
 
 package tech.pegasys.teku.infrastructure.ssz.collections;
 
-import java.util.List;
+import it.unimi.dsi.fastutil.ints.IntList;
 import java.util.stream.IntStream;
 import javax.annotation.Nullable;
 import tech.pegasys.teku.infrastructure.ssz.collections.impl.SszBitlistImpl;
@@ -69,7 +69,7 @@ public interface SszBitlist extends SszPrimitiveList<Boolean, SszBit> {
   boolean isSuperSetOf(SszBitlist other);
 
   /** Returns indexes of all bits set in this {@link SszBitlist} */
-  List<Integer> getAllSetBits();
+  IntList getAllSetBits();
 
   /** Streams indexes of all bits set in this {@link SszBitlist} */
   default IntStream streamAllSetBits() {

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/SszBitvector.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/SszBitvector.java
@@ -13,7 +13,7 @@
 
 package tech.pegasys.teku.infrastructure.ssz.collections;
 
-import java.util.List;
+import it.unimi.dsi.fastutil.ints.IntList;
 import java.util.stream.IntStream;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszBit;
 import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszBitvectorSchema;
@@ -48,7 +48,7 @@ public interface SszBitvector extends SszPrimitiveVector<Boolean, SszBit> {
   SszBitvector rightShift(int n);
 
   /** Returns indexes of all bits set in this {@link SszBitvector} */
-  List<Integer> getAllSetBits();
+  IntList getAllSetBits();
 
   /** Streams indexes of all bits set in this {@link SszBitvector} */
   default IntStream streamAllSetBits() {

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/BitlistImpl.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/BitlistImpl.java
@@ -16,9 +16,9 @@ package tech.pegasys.teku.infrastructure.ssz.collections.impl;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkElementIndex;
 
-import java.util.ArrayList;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntList;
 import java.util.BitSet;
-import java.util.List;
 import java.util.Objects;
 import java.util.stream.IntStream;
 import org.apache.tuweni.bytes.Bytes;
@@ -93,8 +93,8 @@ class BitlistImpl {
     return other.streamAllSetBits().allMatch(idx -> idx < getCurrentSize() && getBit(idx));
   }
 
-  public List<Integer> getAllSetBits() {
-    final List<Integer> setBits = new ArrayList<>();
+  public IntList getAllSetBits() {
+    final IntList setBits = new IntArrayList();
     for (int i = data.nextSetBit(0); i >= 0; i = data.nextSetBit(i + 1)) {
       setBits.add(i);
     }

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/SszBitlistImpl.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/SszBitlistImpl.java
@@ -15,7 +15,7 @@ package tech.pegasys.teku.infrastructure.ssz.collections.impl;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import java.util.List;
+import it.unimi.dsi.fastutil.ints.IntList;
 import javax.annotation.Nullable;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
@@ -128,7 +128,7 @@ public class SszBitlistImpl extends SszListImpl<SszBit> implements SszBitlist {
   }
 
   @Override
-  public List<Integer> getAllSetBits() {
+  public IntList getAllSetBits() {
     return value.getAllSetBits();
   }
 

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/SszBitvectorImpl.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/SszBitvectorImpl.java
@@ -15,8 +15,8 @@ package tech.pegasys.teku.infrastructure.ssz.collections.impl;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import java.util.List;
-import java.util.stream.Collectors;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntList;
 import tech.pegasys.teku.infrastructure.ssz.cache.IntCache;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszBitvector;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszMutablePrimitiveVector;
@@ -74,8 +74,8 @@ public class SszBitvectorImpl extends SszVectorImpl<SszBit> implements SszBitvec
   }
 
   @Override
-  public List<Integer> getAllSetBits() {
-    return value.streamAllSetBits().boxed().collect(Collectors.toList());
+  public IntList getAllSetBits() {
+    return IntArrayList.toList(value.streamAllSetBits().boxed().mapToInt(Integer::intValue));
   }
 
   @Override

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/SszBitvectorImpl.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/SszBitvectorImpl.java
@@ -75,7 +75,7 @@ public class SszBitvectorImpl extends SszVectorImpl<SszBit> implements SszBitvec
 
   @Override
   public IntList getAllSetBits() {
-    return IntArrayList.toList(value.streamAllSetBits().boxed().mapToInt(Integer::intValue));
+    return IntArrayList.toList(value.streamAllSetBits());
   }
 
   @Override

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/collections/SszBitlistTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/collections/SszBitlistTest.java
@@ -99,7 +99,7 @@ public class SszBitlistTest implements SszPrimitiveListTestBase {
     Bytes ssz1 = bitlist1.sszSerialize();
     SszBitlist bitlist2 = bitlist1.getSchema().sszDeserialize(ssz1);
 
-    assertThat(bitlist2.getAllSetBits()).isEqualTo(bitlist1.getAllSetBits());
+    assertThat(bitlist2.getAllSetBits().equals(bitlist1.getAllSetBits())).isTrue();
     assertThat(bitlist2.size()).isEqualTo(bitlist1.size());
     for (int i = 0; i < bitlist1.size(); i++) {
       assertThat(bitlist2.getBit(i)).isEqualTo(bitlist1.getBit(i));
@@ -119,7 +119,7 @@ public class SszBitlistTest implements SszPrimitiveListTestBase {
     TreeNode tree = bitlist1.getBackingNode();
     SszBitlist bitlist2 = bitlist1.getSchema().createFromBackingNode(tree);
 
-    assertThat(bitlist2.getAllSetBits()).isEqualTo(bitlist1.getAllSetBits());
+    assertThat(bitlist2.getAllSetBits().equals(bitlist1.getAllSetBits())).isTrue();
     assertThat(bitlist2.size()).isEqualTo(bitlist1.size());
     for (int i = 0; i < bitlist1.size(); i++) {
       assertThat(bitlist2.getBit(i)).isEqualTo(bitlist1.getBit(i));

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/collections/SszBitlistTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/collections/SszBitlistTest.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.infrastructure.ssz.collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static tech.pegasys.teku.infrastructure.collections.PrimitiveCollectionAssert.assertThatIntCollection;
 
 import java.util.OptionalInt;
 import java.util.Random;
@@ -99,7 +100,7 @@ public class SszBitlistTest implements SszPrimitiveListTestBase {
     Bytes ssz1 = bitlist1.sszSerialize();
     SszBitlist bitlist2 = bitlist1.getSchema().sszDeserialize(ssz1);
 
-    assertThat(bitlist2.getAllSetBits().equals(bitlist1.getAllSetBits())).isTrue();
+    assertThatIntCollection(bitlist2.getAllSetBits()).isEqualTo(bitlist1.getAllSetBits());
     assertThat(bitlist2.size()).isEqualTo(bitlist1.size());
     for (int i = 0; i < bitlist1.size(); i++) {
       assertThat(bitlist2.getBit(i)).isEqualTo(bitlist1.getBit(i));
@@ -119,7 +120,7 @@ public class SszBitlistTest implements SszPrimitiveListTestBase {
     TreeNode tree = bitlist1.getBackingNode();
     SszBitlist bitlist2 = bitlist1.getSchema().createFromBackingNode(tree);
 
-    assertThat(bitlist2.getAllSetBits().equals(bitlist1.getAllSetBits())).isTrue();
+    assertThatIntCollection(bitlist2.getAllSetBits()).isEqualTo(bitlist1.getAllSetBits());
     assertThat(bitlist2.size()).isEqualTo(bitlist1.size());
     for (int i = 0; i < bitlist1.size(); i++) {
       assertThat(bitlist2.getBit(i)).isEqualTo(bitlist1.getBit(i));

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/collections/SszBitvectorTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/collections/SszBitvectorTest.java
@@ -72,7 +72,7 @@ public class SszBitvectorTest implements SszPrimitiveCollectionTestBase, SszVect
     Bytes ssz1 = bitvector1.sszSerialize();
     SszBitvector bitvector2 = bitvector1.getSchema().sszDeserialize(ssz1);
 
-    assertThat(bitvector2.getAllSetBits()).isEqualTo(bitvector1.getAllSetBits());
+    assertThat(bitvector2.getAllSetBits().equals(bitvector1.getAllSetBits())).isTrue();
     Assertions.assertThat(bitvector2.size()).isEqualTo(bitvector1.size());
     for (int i = 0; i < bitvector1.size(); i++) {
       assertThat(bitvector2.getBit(i)).isEqualTo(bitvector1.getBit(i));
@@ -87,7 +87,7 @@ public class SszBitvectorTest implements SszPrimitiveCollectionTestBase, SszVect
     TreeNode tree = bitvector1.getBackingNode();
     SszBitvector bitvector2 = bitvector1.getSchema().createFromBackingNode(tree);
 
-    assertThat(bitvector2.getAllSetBits()).isEqualTo(bitvector1.getAllSetBits());
+    assertThat(bitvector2.getAllSetBits().equals(bitvector1.getAllSetBits())).isTrue();
     Assertions.assertThat(bitvector2.size()).isEqualTo(bitvector1.size());
     for (int i = 0; i < bitvector1.size(); i++) {
       assertThat(bitvector2.getBit(i)).isEqualTo(bitvector1.getBit(i));

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/collections/SszBitvectorTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/collections/SszBitvectorTest.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.infrastructure.ssz.collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static tech.pegasys.teku.infrastructure.collections.PrimitiveCollectionAssert.assertThatIntCollection;
 
 import java.util.List;
 import java.util.Random;
@@ -72,7 +73,7 @@ public class SszBitvectorTest implements SszPrimitiveCollectionTestBase, SszVect
     Bytes ssz1 = bitvector1.sszSerialize();
     SszBitvector bitvector2 = bitvector1.getSchema().sszDeserialize(ssz1);
 
-    assertThat(bitvector2.getAllSetBits().equals(bitvector1.getAllSetBits())).isTrue();
+    assertThatIntCollection(bitvector2.getAllSetBits()).isEqualTo(bitvector1.getAllSetBits());
     Assertions.assertThat(bitvector2.size()).isEqualTo(bitvector1.size());
     for (int i = 0; i < bitvector1.size(); i++) {
       assertThat(bitvector2.getBit(i)).isEqualTo(bitvector1.getBit(i));
@@ -87,7 +88,7 @@ public class SszBitvectorTest implements SszPrimitiveCollectionTestBase, SszVect
     TreeNode tree = bitvector1.getBackingNode();
     SszBitvector bitvector2 = bitvector1.getSchema().createFromBackingNode(tree);
 
-    assertThat(bitvector2.getAllSetBits().equals(bitvector1.getAllSetBits())).isTrue();
+    assertThatIntCollection(bitvector2.getAllSetBits()).isEqualTo(bitvector1.getAllSetBits());
     Assertions.assertThat(bitvector2.size()).isEqualTo(bitvector1.size());
     for (int i = 0; i < bitvector1.size(); i++) {
       assertThat(bitvector2.getBit(i)).isEqualTo(bitvector1.getBit(i));

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/BitlistImplTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/BitlistImplTest.java
@@ -18,8 +18,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static tech.pegasys.teku.infrastructure.collections.PrimitiveCollectionAssert.assertThatIntCollection;
 
-import it.unimi.dsi.fastutil.ints.IntList;
 import java.util.stream.Stream;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.MutableBytes;
@@ -54,14 +54,14 @@ class BitlistImplTest {
   void getAllSetBits() {
     BitlistImpl bitlist = create(0, 1, 3, 8, 9);
 
-    assertThat(bitlist.getAllSetBits().equals(IntList.of(0, 1, 3, 8, 9))).isTrue();
+    assertThatIntCollection(bitlist.getAllSetBits()).containsExactly(0, 1, 3, 8, 9);
   }
 
   @Test
   void getAllSetBits_noSetBits() {
     BitlistImpl bitlist = create();
 
-    assertThat(bitlist.getAllSetBits().isEmpty()).isTrue();
+    assertThatIntCollection(bitlist.getAllSetBits()).isEmpty();
   }
 
   @Test

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/BitlistImplTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/BitlistImplTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import it.unimi.dsi.fastutil.ints.IntArrayList;
 import java.util.stream.Stream;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.MutableBytes;
@@ -53,14 +54,14 @@ class BitlistImplTest {
   void getAllSetBits() {
     BitlistImpl bitlist = create(0, 1, 3, 8, 9);
 
-    assertThat(bitlist.getAllSetBits()).containsExactly(0, 1, 3, 8, 9);
+    assertThat(bitlist.getAllSetBits().equals(IntArrayList.of(0, 1, 3, 8, 9))).isTrue();
   }
 
   @Test
   void getAllSetBits_noSetBits() {
     BitlistImpl bitlist = create();
 
-    assertThat(bitlist.getAllSetBits()).isEmpty();
+    assertThat(bitlist.getAllSetBits().isEmpty()).isTrue();
   }
 
   @Test

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/BitlistImplTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/BitlistImplTest.java
@@ -19,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntList;
 import java.util.stream.Stream;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.MutableBytes;
@@ -54,7 +54,7 @@ class BitlistImplTest {
   void getAllSetBits() {
     BitlistImpl bitlist = create(0, 1, 3, 8, 9);
 
-    assertThat(bitlist.getAllSetBits().equals(IntArrayList.of(0, 1, 3, 8, 9))).isTrue();
+    assertThat(bitlist.getAllSetBits().equals(IntList.of(0, 1, 3, 8, 9))).isTrue();
   }
 
   @Test

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/SszBitlistSchemaTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/SszBitlistSchemaTest.java
@@ -17,7 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntList;
 import java.util.List;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -102,7 +102,7 @@ public class SszBitlistSchemaTest extends SszListSchemaTestBase {
     assertThat(schema.ofBits(2, 0, 1).sszSerialize()).isEqualTo(Bytes.of(0b111));
     assertThat(schema.ofBits(300).size()).isEqualTo(300);
     assertThat(schema.ofBits(300).getAllSetBits().isEmpty()).isTrue();
-    assertThat(schema.ofBits(300, 299).getAllSetBits().equals(IntArrayList.of(299))).isTrue();
+    assertThat(schema.ofBits(300, 299).getAllSetBits().equals(IntList.of(299))).isTrue();
     assertThat(schema.ofBits(300, IntStream.range(0, 300).toArray()).streamAllSetBits().distinct())
         .isSorted()
         .hasSize(300);

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/SszBitlistSchemaTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/SszBitlistSchemaTest.java
@@ -17,6 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import it.unimi.dsi.fastutil.ints.IntArrayList;
 import java.util.List;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -100,8 +101,8 @@ public class SszBitlistSchemaTest extends SszListSchemaTestBase {
     assertThat(schema.ofBits(2, 1).sszSerialize()).isEqualTo(Bytes.of(0b110));
     assertThat(schema.ofBits(2, 0, 1).sszSerialize()).isEqualTo(Bytes.of(0b111));
     assertThat(schema.ofBits(300).size()).isEqualTo(300);
-    assertThat(schema.ofBits(300).getAllSetBits()).isEmpty();
-    assertThat(schema.ofBits(300, 299).getAllSetBits()).containsExactly(299);
+    assertThat(schema.ofBits(300).getAllSetBits().isEmpty()).isTrue();
+    assertThat(schema.ofBits(300, 299).getAllSetBits().equals(IntArrayList.of(299))).isTrue();
     assertThat(schema.ofBits(300, IntStream.range(0, 300).toArray()).streamAllSetBits().distinct())
         .isSorted()
         .hasSize(300);

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/SszBitlistSchemaTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/SszBitlistSchemaTest.java
@@ -16,8 +16,8 @@ package tech.pegasys.teku.infrastructure.ssz.schema.collections;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static tech.pegasys.teku.infrastructure.collections.PrimitiveCollectionAssert.assertThatIntCollection;
 
-import it.unimi.dsi.fastutil.ints.IntList;
 import java.util.List;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -101,8 +101,8 @@ public class SszBitlistSchemaTest extends SszListSchemaTestBase {
     assertThat(schema.ofBits(2, 1).sszSerialize()).isEqualTo(Bytes.of(0b110));
     assertThat(schema.ofBits(2, 0, 1).sszSerialize()).isEqualTo(Bytes.of(0b111));
     assertThat(schema.ofBits(300).size()).isEqualTo(300);
-    assertThat(schema.ofBits(300).getAllSetBits().isEmpty()).isTrue();
-    assertThat(schema.ofBits(300, 299).getAllSetBits().equals(IntList.of(299))).isTrue();
+    assertThatIntCollection(schema.ofBits(300).getAllSetBits()).isEmpty();
+    assertThatIntCollection(schema.ofBits(300, 299).getAllSetBits()).containsExactly(299);
     assertThat(schema.ofBits(300, IntStream.range(0, 300).toArray()).streamAllSetBits().distinct())
         .isSorted()
         .hasSize(300);

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/SszBitvectorSchemaTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/SszBitvectorSchemaTest.java
@@ -16,7 +16,7 @@ package tech.pegasys.teku.infrastructure.ssz.schema.collections;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntList;
 import java.util.List;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -77,7 +77,7 @@ public class SszBitvectorSchemaTest extends SszVectorSchemaTestBase {
     assertThat(schema.ofBits(0, 1).sszSerialize()).isEqualTo(rightPad(Bytes.of(0b11), 13));
     assertThat(schema.ofBits().size()).isEqualTo(100);
     assertThat(schema.ofBits().getAllSetBits().isEmpty()).isTrue();
-    assertThat(schema.ofBits(99).getAllSetBits().equals(IntArrayList.of(99))).isTrue();
+    assertThat(schema.ofBits(99).getAllSetBits().equals(IntList.of(99))).isTrue();
     assertThat(schema.ofBits(IntStream.range(0, 100).toArray()).streamAllSetBits().distinct())
         .isSorted()
         .hasSize(100);

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/SszBitvectorSchemaTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/SszBitvectorSchemaTest.java
@@ -15,8 +15,8 @@ package tech.pegasys.teku.infrastructure.ssz.schema.collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static tech.pegasys.teku.infrastructure.collections.PrimitiveCollectionAssert.assertThatIntCollection;
 
-import it.unimi.dsi.fastutil.ints.IntList;
 import java.util.List;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -76,8 +76,8 @@ public class SszBitvectorSchemaTest extends SszVectorSchemaTestBase {
     assertThat(schema.ofBits(1).sszSerialize()).isEqualTo(rightPad(Bytes.of(0b10), 13));
     assertThat(schema.ofBits(0, 1).sszSerialize()).isEqualTo(rightPad(Bytes.of(0b11), 13));
     assertThat(schema.ofBits().size()).isEqualTo(100);
-    assertThat(schema.ofBits().getAllSetBits().isEmpty()).isTrue();
-    assertThat(schema.ofBits(99).getAllSetBits().equals(IntList.of(99))).isTrue();
+    assertThatIntCollection(schema.ofBits().getAllSetBits()).isEmpty();
+    assertThatIntCollection(schema.ofBits(99).getAllSetBits()).containsExactly(99);
     assertThat(schema.ofBits(IntStream.range(0, 100).toArray()).streamAllSetBits().distinct())
         .isSorted()
         .hasSize(100);

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/SszBitvectorSchemaTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/SszBitvectorSchemaTest.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.infrastructure.ssz.schema.collections;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import it.unimi.dsi.fastutil.ints.IntArrayList;
 import java.util.List;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -75,8 +76,8 @@ public class SszBitvectorSchemaTest extends SszVectorSchemaTestBase {
     assertThat(schema.ofBits(1).sszSerialize()).isEqualTo(rightPad(Bytes.of(0b10), 13));
     assertThat(schema.ofBits(0, 1).sszSerialize()).isEqualTo(rightPad(Bytes.of(0b11), 13));
     assertThat(schema.ofBits().size()).isEqualTo(100);
-    assertThat(schema.ofBits().getAllSetBits()).isEmpty();
-    assertThat(schema.ofBits(99).getAllSetBits()).containsExactly(99);
+    assertThat(schema.ofBits().getAllSetBits().isEmpty()).isTrue();
+    assertThat(schema.ofBits(99).getAllSetBits().equals(IntArrayList.of(99))).isTrue();
     assertThat(schema.ofBits(IntStream.range(0, 100).toArray()).streamAllSetBits().distinct())
         .isSorted()
         .hasSize(100);

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/schema/impl/StoringUtilTest.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/schema/impl/StoringUtilTest.java
@@ -25,11 +25,11 @@ import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.ssz.tree.GIndexUtil.RIGHTMOST_G_INDEX;
 import static tech.pegasys.teku.infrastructure.ssz.tree.GIndexUtil.SELF_G_INDEX;
 
+import it.unimi.dsi.fastutil.ints.IntSet;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Stream;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
@@ -213,7 +213,7 @@ class StoringUtilTest {
     final List<TreeNode> children = createChildrenForDepth(depth);
     final TreeNode rootNode = TreeUtil.createTree(children, depth);
     final List<TreeNode> branchNodes = getNodesAtDepth(rootNode, maxBranchLevelsSkipped);
-    final Set<Integer> skippableBranchIndices = Set.of(0, 2);
+    final IntSet skippableBranchIndices = IntSet.of(0, 2);
     // Can skip intermediate branches 0 and 2, but should store the others
     skippableBranchIndices.forEach(
         index ->

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/subnets/StableSubnetSubscriberTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/subnets/StableSubnetSubscriberTest.java
@@ -22,9 +22,10 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import it.unimi.dsi.fastutil.ints.IntSet;
 import java.util.Random;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -181,10 +182,11 @@ public class StableSubnetSubscriberTest {
   }
 
   private void assertSubnetsAreDistinct(Set<SubnetSubscription> subnetSubscriptions) {
-    Set<Integer> subnetIds =
-        subnetSubscriptions.stream()
-            .map(SubnetSubscription::getSubnetId)
-            .collect(Collectors.toSet());
+    IntSet subnetIds =
+        IntOpenHashSet.toSet(
+            subnetSubscriptions.stream()
+                .map(SubnetSubscription::getSubnetId)
+                .mapToInt(Integer::intValue));
     assertThat(subnetSubscriptions).hasSameSizeAs(subnetIds);
   }
 

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/SyncCommitteeDuty.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/SyncCommitteeDuty.java
@@ -14,20 +14,20 @@
 package tech.pegasys.teku.validator.api;
 
 import com.google.common.base.MoreObjects;
+import it.unimi.dsi.fastutil.ints.IntSet;
 import java.util.Objects;
-import java.util.Set;
 import tech.pegasys.teku.bls.BLSPublicKey;
 
 public class SyncCommitteeDuty {
 
   private final BLSPublicKey publicKey;
   private final int validatorIndex;
-  private final Set<Integer> validatorSyncCommitteeIndices;
+  private final IntSet validatorSyncCommitteeIndices;
 
   public SyncCommitteeDuty(
       final BLSPublicKey publicKey,
       final int validatorIndex,
-      final Set<Integer> validatorSyncCommitteeIndices) {
+      final IntSet validatorSyncCommitteeIndices) {
     this.publicKey = publicKey;
     this.validatorIndex = validatorIndex;
     this.validatorSyncCommitteeIndices = validatorSyncCommitteeIndices;
@@ -41,7 +41,7 @@ public class SyncCommitteeDuty {
     return validatorIndex;
   }
 
-  public Set<Integer> getValidatorSyncCommitteeIndices() {
+  public IntSet getValidatorSyncCommitteeIndices() {
     return validatorSyncCommitteeIndices;
   }
 

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/SyncCommitteeSubnetSubscription.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/SyncCommitteeSubnetSubscription.java
@@ -13,17 +13,17 @@
 
 package tech.pegasys.teku.validator.api;
 
+import it.unimi.dsi.fastutil.ints.IntSet;
 import java.util.Objects;
-import java.util.Set;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 public class SyncCommitteeSubnetSubscription {
   private final int validatorIndex;
-  private final Set<Integer> syncCommitteeIndices;
+  private final IntSet syncCommitteeIndices;
   private final UInt64 untilEpoch;
 
   public SyncCommitteeSubnetSubscription(
-      final int validatorIndex, final Set<Integer> syncCommitteeIndices, final UInt64 untilEpoch) {
+      final int validatorIndex, final IntSet syncCommitteeIndices, final UInt64 untilEpoch) {
     this.validatorIndex = validatorIndex;
     this.syncCommitteeIndices = syncCommitteeIndices;
     this.untilEpoch = untilEpoch;
@@ -33,7 +33,7 @@ public class SyncCommitteeSubnetSubscription {
     return validatorIndex;
   }
 
-  public Set<Integer> getSyncCommitteeIndices() {
+  public IntSet getSyncCommitteeIndices() {
     return syncCommitteeIndices;
   }
 

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.validator.api;
 
+import it.unimi.dsi.fastutil.ints.IntCollection;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -49,10 +50,10 @@ public interface ValidatorApiChannel extends ChannelInterface {
       final Collection<BLSPublicKey> validatorIdentifiers);
 
   SafeFuture<Optional<AttesterDuties>> getAttestationDuties(
-      final UInt64 epoch, final Collection<Integer> validatorIndices);
+      final UInt64 epoch, final IntCollection validatorIndices);
 
   SafeFuture<Optional<SyncCommitteeDuties>> getSyncCommitteeDuties(
-      final UInt64 epoch, final Collection<Integer> validatorIndices);
+      final UInt64 epoch, final IntCollection validatorIndices);
 
   SafeFuture<Optional<ProposerDuties>> getProposerDuties(final UInt64 epoch);
 

--- a/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
+++ b/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.validator.beaconnode.metrics;
 
+import it.unimi.dsi.fastutil.ints.IntCollection;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -220,14 +221,14 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
 
   @Override
   public SafeFuture<Optional<AttesterDuties>> getAttestationDuties(
-      final UInt64 epoch, final Collection<Integer> validatorIndexes) {
+      final UInt64 epoch, final IntCollection validatorIndexes) {
     return countDataRequest(
         delegate.getAttestationDuties(epoch, validatorIndexes), attestationDutiesRequestCounter);
   }
 
   @Override
   public SafeFuture<Optional<SyncCommitteeDuties>> getSyncCommitteeDuties(
-      final UInt64 epoch, final Collection<Integer> validatorIndices) {
+      final UInt64 epoch, final IntCollection validatorIndices) {
     return countDataRequest(
         delegate.getSyncCommitteeDuties(epoch, validatorIndices),
         syncCommitteeDutiesRequestCounter);

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AbstractDutyLoader.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AbstractDutyLoader.java
@@ -13,7 +13,7 @@
 
 package tech.pegasys.teku.validator.client;
 
-import java.util.Collection;
+import it.unimi.dsi.fastutil.ints.IntCollection;
 import java.util.Optional;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -58,7 +58,7 @@ public abstract class AbstractDutyLoader<D, S extends ScheduledDuties> implement
   }
 
   protected abstract SafeFuture<Optional<D>> requestDuties(
-      final UInt64 epoch, final Collection<Integer> validatorIndices);
+      final UInt64 epoch, final IntCollection validatorIndices);
 
   protected abstract SafeFuture<S> scheduleAllDuties(UInt64 epoch, D duties);
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyLoader.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyLoader.java
@@ -13,7 +13,7 @@
 
 package tech.pegasys.teku.validator.client;
 
-import java.util.Collection;
+import it.unimi.dsi.fastutil.ints.IntCollection;
 import java.util.Optional;
 import java.util.function.Function;
 import org.apache.logging.log4j.LogManager;
@@ -65,7 +65,7 @@ public class AttestationDutyLoader
 
   @Override
   protected SafeFuture<Optional<AttesterDuties>> requestDuties(
-      final UInt64 epoch, final Collection<Integer> validatorIndices) {
+      final UInt64 epoch, final IntCollection validatorIndices) {
     if (validatorIndices.isEmpty()) {
       return SafeFuture.completedFuture(Optional.empty());
     }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/BlockProductionDutyLoader.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/BlockProductionDutyLoader.java
@@ -13,7 +13,7 @@
 
 package tech.pegasys.teku.validator.client;
 
-import java.util.Collection;
+import it.unimi.dsi.fastutil.ints.IntCollection;
 import java.util.Optional;
 import java.util.function.Function;
 import org.apache.tuweni.bytes.Bytes32;
@@ -47,7 +47,7 @@ public class BlockProductionDutyLoader
 
   @Override
   protected SafeFuture<Optional<ProposerDuties>> requestDuties(
-      final UInt64 epoch, final Collection<Integer> validatorIndices) {
+      final UInt64 epoch, final IntCollection validatorIndices) {
     if (validatorIndices.isEmpty()) {
       return SafeFuture.completedFuture(Optional.empty());
     }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/SyncCommitteeDutyLoader.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/SyncCommitteeDutyLoader.java
@@ -13,7 +13,7 @@
 
 package tech.pegasys.teku.validator.client;
 
-import java.util.Collection;
+import it.unimi.dsi.fastutil.ints.IntCollection;
 import java.util.Optional;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -48,7 +48,7 @@ public class SyncCommitteeDutyLoader
 
   @Override
   protected SafeFuture<Optional<SyncCommitteeDuties>> requestDuties(
-      final UInt64 epoch, final Collection<Integer> validatorIndices) {
+      final UInt64 epoch, final IntCollection validatorIndices) {
     return validatorApiChannel.getSyncCommitteeDuties(epoch, validatorIndices);
   }
 

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorIndexProvider.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorIndexProvider.java
@@ -14,9 +14,10 @@
 package tech.pegasys.teku.validator.client;
 
 import static java.util.stream.Collectors.joining;
-import static java.util.stream.Collectors.toList;
 
 import com.google.common.collect.Sets;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntCollection;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.Map;
@@ -101,13 +102,14 @@ public class ValidatorIndexProvider {
     return Optional.ofNullable(validatorIndexesByPublicKey.get(publicKey));
   }
 
-  public SafeFuture<Collection<Integer>> getValidatorIndices() {
+  public SafeFuture<IntCollection> getValidatorIndices() {
     // Wait for at least one successful load of validator indices before attempting to read
     return firstSuccessfulRequest.thenApply(
         __ ->
-            ownedValidators.getActiveValidators().stream()
-                .flatMap(validator -> getValidatorIndex(validator.getPublicKey()).stream())
-                .collect(toList()));
+            IntArrayList.toList(
+                ownedValidators.getActiveValidators().stream()
+                    .flatMap(validator -> getValidatorIndex(validator.getPublicKey()).stream())
+                    .mapToInt(Integer::intValue)));
   }
 
   public SafeFuture<Map<BLSPublicKey, Optional<Integer>>> getValidatorIndexesByPublicKey() {

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeScheduledDuties.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeScheduledDuties.java
@@ -18,6 +18,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.common.annotations.VisibleForTesting;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.ints.IntCollection;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.Set;
@@ -196,9 +197,7 @@ public class SyncCommitteeScheduledDuties implements ScheduledDuties {
     }
 
     public Builder committeeAssignments(
-        final Validator validator,
-        final int validatorIndex,
-        final Collection<Integer> committeeIndices) {
+        final Validator validator, final int validatorIndex, final IntCollection committeeIndices) {
       assignments
           .computeIfAbsent(
               validatorIndex, __ -> new ValidatorAndCommitteeIndices(validator, validatorIndex))

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/synccommittee/ValidatorAndCommitteeIndices.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/synccommittee/ValidatorAndCommitteeIndices.java
@@ -13,16 +13,16 @@
 
 package tech.pegasys.teku.validator.client.duties.synccommittee;
 
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Set;
+import it.unimi.dsi.fastutil.ints.IntCollection;
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import it.unimi.dsi.fastutil.ints.IntSet;
 import tech.pegasys.teku.validator.client.Validator;
 
 class ValidatorAndCommitteeIndices {
 
   private final Validator validator;
   private final int validatorIndex;
-  private final Set<Integer> committeeIndices = new HashSet<>();
+  private final IntSet committeeIndices = new IntOpenHashSet();
 
   ValidatorAndCommitteeIndices(final Validator validator, final int validatorIndex) {
     this.validator = validator;
@@ -33,7 +33,7 @@ class ValidatorAndCommitteeIndices {
     committeeIndices.add(subcommitteeIndex);
   }
 
-  public void addCommitteeIndices(final Collection<Integer> subcommitteeIndex) {
+  public void addCommitteeIndices(final IntCollection subcommitteeIndex) {
     committeeIndices.addAll(subcommitteeIndex);
   }
 
@@ -45,7 +45,7 @@ class ValidatorAndCommitteeIndices {
     return validatorIndex;
   }
 
-  public Set<Integer> getCommitteeIndices() {
+  public IntSet getCommitteeIndices() {
     return committeeIndices;
   }
 }

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/AbstractDutySchedulerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/AbstractDutySchedulerTest.java
@@ -18,7 +18,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.async.SafeFuture.completedFuture;
 
-import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntList;
 import java.util.Collection;
 import java.util.Optional;
@@ -40,7 +39,7 @@ public abstract class AbstractDutySchedulerTest {
   static final BLSPublicKey VALIDATOR1_KEY = BLSTestUtil.randomPublicKey(100);
   static final BLSPublicKey VALIDATOR2_KEY = BLSTestUtil.randomPublicKey(200);
   static final Collection<BLSPublicKey> VALIDATOR_KEYS = Set.of(VALIDATOR1_KEY, VALIDATOR2_KEY);
-  static final IntList VALIDATOR_INDICES = IntArrayList.of(123, 559);
+  static final IntList VALIDATOR_INDICES = IntList.of(123, 559);
   final ValidatorIndexProvider validatorIndexProvider = mock(ValidatorIndexProvider.class);
   final Signer validator1Signer = mock(Signer.class);
   final Signer validator2Signer = mock(Signer.class);

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/AbstractDutySchedulerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/AbstractDutySchedulerTest.java
@@ -18,8 +18,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.async.SafeFuture.completedFuture;
 
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntList;
 import java.util.Collection;
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
@@ -39,7 +40,7 @@ public abstract class AbstractDutySchedulerTest {
   static final BLSPublicKey VALIDATOR1_KEY = BLSTestUtil.randomPublicKey(100);
   static final BLSPublicKey VALIDATOR2_KEY = BLSTestUtil.randomPublicKey(200);
   static final Collection<BLSPublicKey> VALIDATOR_KEYS = Set.of(VALIDATOR1_KEY, VALIDATOR2_KEY);
-  static final List<Integer> VALIDATOR_INDICES = List.of(123, 559);
+  static final IntList VALIDATOR_INDICES = IntArrayList.of(123, 559);
   final ValidatorIndexProvider validatorIndexProvider = mock(ValidatorIndexProvider.class);
   final Signer validator1Signer = mock(Signer.class);
   final Signer validator2Signer = mock(Signer.class);

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutyLoaderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutyLoaderTest.java
@@ -20,7 +20,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntList;
 import java.util.List;
 import java.util.Map;
@@ -48,7 +47,7 @@ import tech.pegasys.teku.validator.client.loader.OwnedValidators;
 
 class AttestationDutyLoaderTest {
 
-  private static final IntList VALIDATOR_INDICES = IntArrayList.of(1);
+  private static final IntList VALIDATOR_INDICES = IntList.of(1);
 
   private final Spec spec = TestSpecFactory.createMinimalPhase0();
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutyLoaderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutyLoaderTest.java
@@ -20,6 +20,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -46,7 +48,7 @@ import tech.pegasys.teku.validator.client.loader.OwnedValidators;
 
 class AttestationDutyLoaderTest {
 
-  private static final List<Integer> VALIDATOR_INDICES = List.of(1);
+  private static final IntList VALIDATOR_INDICES = IntArrayList.of(1);
 
   private final Spec spec = TestSpecFactory.createMinimalPhase0();
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/SyncCommitteeDutyLoaderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/SyncCommitteeDutyLoaderTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThatSafeFuture;
 
+import it.unimi.dsi.fastutil.ints.IntSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -49,7 +50,7 @@ class SyncCommitteeDutyLoaderTest {
       new Validator(dataStructureUtil.randomPublicKey(), mock(Signer.class), Optional::empty);
   private final int validator1Index = 19;
   private final int validator2Index = 23;
-  private final Set<Integer> validatorIndices = Set.of(validator1Index, validator2Index);
+  private final IntSet validatorIndices = IntSet.of(validator1Index, validator2Index);
   private final OwnedValidators validators =
       new OwnedValidators(
           Map.of(validator1.getPublicKey(), validator1, validator2.getPublicKey(), validator2));
@@ -88,9 +89,11 @@ class SyncCommitteeDutyLoaderTest {
                     new SyncCommitteeDuties(
                         List.of(
                             new SyncCommitteeDuty(
-                                validator1.getPublicKey(), validator1Index, Set.of(1, 6, 25)),
+                                validator1.getPublicKey(), validator1Index, IntSet.of(1, 6, 25)),
                             new SyncCommitteeDuty(
-                                validator2.getPublicKey(), validator2Index, Set.of(7, 50, 38)))))));
+                                validator2.getPublicKey(),
+                                validator2Index,
+                                IntSet.of(7, 50, 38)))))));
 
     final SyncCommitteeScheduledDuties duties = loadDuties(epoch);
     assertThat(duties.countDuties()).isEqualTo(2);
@@ -99,9 +102,9 @@ class SyncCommitteeDutyLoaderTest {
         .subscribeToSyncCommitteeSubnets(
             Set.of(
                 new SyncCommitteeSubnetSubscription(
-                    validator1Index, Set.of(1, 6, 25), untilEpoch.increment()),
+                    validator1Index, IntSet.of(1, 6, 25), untilEpoch.increment()),
                 new SyncCommitteeSubnetSubscription(
-                    validator2Index, Set.of(7, 50, 38), untilEpoch.increment())));
+                    validator2Index, IntSet.of(7, 50, 38), untilEpoch.increment())));
   }
 
   private SyncCommitteeScheduledDuties loadDuties(final UInt64 epoch) {

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorIndexProviderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorIndexProviderTest.java
@@ -22,11 +22,11 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.core.signatures.NoOpLocalSigner.NO_OP_SIGNER;
 
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntCollection;
 import java.io.IOException;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -161,14 +161,14 @@ class ValidatorIndexProviderTest {
     final SafeFuture<Map<BLSPublicKey, Integer>> requestResult = new SafeFuture<>();
     when(validatorApiChannel.getValidatorIndices(Set.of(key1))).thenReturn(requestResult);
 
-    final SafeFuture<Collection<Integer>> result = provider.getValidatorIndices();
+    final SafeFuture<IntCollection> result = provider.getValidatorIndices();
     assertThat(result).isNotDone();
 
     provider.lookupValidators();
     assertThat(result).isNotDone();
 
     requestResult.complete(Map.of(key1, 1));
-    assertThat(result).isCompletedWithValue(List.of(1));
+    assertThat(result).isCompletedWithValue(IntArrayList.of(1));
   }
 
   private OwnedValidators ownedValidatorsWithKeys(final BLSPublicKey... keys) {

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorIndexProviderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorIndexProviderTest.java
@@ -22,8 +22,8 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.core.signatures.NoOpLocalSigner.NO_OP_SIGNER;
 
-import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntCollection;
+import it.unimi.dsi.fastutil.ints.IntList;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
@@ -168,7 +168,7 @@ class ValidatorIndexProviderTest {
     assertThat(result).isNotDone();
 
     requestResult.complete(Map.of(key1, 1));
-    assertThat(result).isCompletedWithValue(IntArrayList.of(1));
+    assertThat(result).isCompletedWithValue(IntList.of(1));
   }
 
   private OwnedValidators ownedValidatorsWithKeys(final BLSPublicKey... keys) {

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeAggregationDutyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeAggregationDutyTest.java
@@ -20,7 +20,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -274,7 +274,7 @@ class SyncCommitteeAggregationDutyTest {
       final Validator validator, final int validatorIndex, final int... committeeIndices) {
     final ValidatorAndCommitteeIndices assignment =
         new ValidatorAndCommitteeIndices(validator, validatorIndex);
-    assignment.addCommitteeIndices(IntArrayList.of(committeeIndices));
+    assignment.addCommitteeIndices(IntList.of(committeeIndices));
     return assignment;
   }
 

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeAggregationDutyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeAggregationDutyTest.java
@@ -13,7 +13,6 @@
 
 package tech.pegasys.teku.validator.client.duties.synccommittee;
 
-import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -21,6 +20,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import it.unimi.dsi.fastutil.ints.IntArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -271,10 +271,10 @@ class SyncCommitteeAggregationDutyTest {
   }
 
   private ValidatorAndCommitteeIndices committeeAssignment(
-      final Validator validator, final int validatorIndex, final Integer... committeeIndices) {
+      final Validator validator, final int validatorIndex, final int... committeeIndices) {
     final ValidatorAndCommitteeIndices assignment =
         new ValidatorAndCommitteeIndices(validator, validatorIndex);
-    assignment.addCommitteeIndices(asList(committeeIndices));
+    assignment.addCommitteeIndices(IntArrayList.of(committeeIndices));
     return assignment;
   }
 

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeProductionDutyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeProductionDutyTest.java
@@ -24,6 +24,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -237,10 +239,10 @@ class SyncCommitteeProductionDutyTest {
   }
 
   private ValidatorAndCommitteeIndices committeeAssignment(
-      final Validator validator, final int validatorIndex, final Integer... committeeIndices) {
+      final Validator validator, final int validatorIndex, final int... committeeIndices) {
     final ValidatorAndCommitteeIndices assignment =
         new ValidatorAndCommitteeIndices(validator, validatorIndex);
-    assignment.addCommitteeIndices(asList(committeeIndices));
+    assignment.addCommitteeIndices(IntOpenHashSet.toSet(Arrays.stream(committeeIndices)));
     return assignment;
   }
 }

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeScheduledDutiesTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeScheduledDutiesTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import it.unimi.dsi.fastutil.ints.IntSet;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -77,9 +78,9 @@ class SyncCommitteeScheduledDutiesTest {
         .subscribeToSyncCommitteeSubnets(
             Set.of(
                 new SyncCommitteeSubnetSubscription(
-                    50, Set.of(1, 2, 3), PERIOD_END_EPOCH.increment()),
+                    50, IntSet.of(1, 2, 3), PERIOD_END_EPOCH.increment()),
                 new SyncCommitteeSubnetSubscription(
-                    70, Set.of(2, 6), PERIOD_END_EPOCH.increment())));
+                    70, IntSet.of(2, 6), PERIOD_END_EPOCH.increment())));
   }
 
   @Test

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
@@ -190,9 +190,7 @@ public class RemoteValidatorApiHandler implements ValidatorApiChannel {
                         duty.pubkey.asBLSPublicKey(),
                         duty.validatorIndex.intValue(),
                         IntOpenHashSet.toSet(
-                            duty.committeeIndices.stream()
-                                .map(UInt64::intValue)
-                                .mapToInt(Integer::intValue))))
+                            duty.committeeIndices.stream().mapToInt(UInt64::intValue))))
             .collect(toList()));
   }
 

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
@@ -19,6 +19,8 @@ import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 
 import com.google.common.base.Throwables;
+import it.unimi.dsi.fastutil.ints.IntCollection;
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -155,7 +157,7 @@ public class RemoteValidatorApiHandler implements ValidatorApiChannel {
 
   @Override
   public SafeFuture<Optional<AttesterDuties>> getAttestationDuties(
-      final UInt64 epoch, final Collection<Integer> validatorIndexes) {
+      final UInt64 epoch, final IntCollection validatorIndexes) {
     return sendRequest(
         () ->
             apiClient
@@ -171,7 +173,7 @@ public class RemoteValidatorApiHandler implements ValidatorApiChannel {
 
   @Override
   public SafeFuture<Optional<SyncCommitteeDuties>> getSyncCommitteeDuties(
-      final UInt64 epoch, final Collection<Integer> validatorIndices) {
+      final UInt64 epoch, final IntCollection validatorIndices) {
     return sendRequest(
         () ->
             apiClient
@@ -187,9 +189,10 @@ public class RemoteValidatorApiHandler implements ValidatorApiChannel {
                     new SyncCommitteeDuty(
                         duty.pubkey.asBLSPublicKey(),
                         duty.validatorIndex.intValue(),
-                        duty.committeeIndices.stream()
-                            .map(UInt64::intValue)
-                            .collect(Collectors.toSet())))
+                        IntOpenHashSet.toSet(
+                            duty.committeeIndices.stream()
+                                .map(UInt64::intValue)
+                                .mapToInt(Integer::intValue))))
             .collect(toList()));
   }
 

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
@@ -32,6 +32,7 @@ import static tech.pegasys.teku.infrastructure.ssz.SszDataAssert.assertThatSszDa
 import static tech.pegasys.teku.validator.remote.RemoteValidatorApiHandler.MAX_PUBLIC_KEY_BATCH_SIZE;
 import static tech.pegasys.teku.validator.remote.RemoteValidatorApiHandler.MAX_RATE_LIMITING_RETRIES;
 
+import it.unimi.dsi.fastutil.ints.IntArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -211,7 +212,7 @@ class RemoteValidatorApiHandlerTest {
   @Test
   public void getAttestationDuties_WithEmptyPublicKeys_ReturnsEmpty() {
     SafeFuture<Optional<AttesterDuties>> future =
-        apiHandler.getAttestationDuties(UInt64.ONE, emptyList());
+        apiHandler.getAttestationDuties(UInt64.ONE, IntArrayList.of());
 
     assertThat(unwrapToOptional(future)).isEmpty();
   }
@@ -225,7 +226,7 @@ class RemoteValidatorApiHandlerTest {
                     dataStructureUtil.randomBytes32(), Collections.emptyList())));
 
     SafeFuture<Optional<AttesterDuties>> future =
-        apiHandler.getAttestationDuties(UInt64.ONE, List.of(1234));
+        apiHandler.getAttestationDuties(UInt64.ONE, IntArrayList.of(1234));
 
     assertThat(unwrapToValue(future).getDuties()).isEmpty();
   }
@@ -257,14 +258,14 @@ class RemoteValidatorApiHandlerTest {
             validatorCommitteeIndex,
             UInt64.ZERO);
 
-    when(apiClient.getAttestationDuties(UInt64.ONE, List.of(validatorIndex)))
+    when(apiClient.getAttestationDuties(UInt64.ONE, IntArrayList.of(validatorIndex)))
         .thenReturn(
             Optional.of(
                 new PostAttesterDutiesResponse(
                     dataStructureUtil.randomBytes32(), List.of(schemaValidatorDuties))));
 
     SafeFuture<Optional<AttesterDuties>> future =
-        apiHandler.getAttestationDuties(UInt64.ONE, List.of(validatorIndex));
+        apiHandler.getAttestationDuties(UInt64.ONE, IntArrayList.of(validatorIndex));
 
     AttesterDuties validatorDuties = unwrapToValue(future);
 

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
@@ -32,7 +32,7 @@ import static tech.pegasys.teku.infrastructure.ssz.SszDataAssert.assertThatSszDa
 import static tech.pegasys.teku.validator.remote.RemoteValidatorApiHandler.MAX_PUBLIC_KEY_BATCH_SIZE;
 import static tech.pegasys.teku.validator.remote.RemoteValidatorApiHandler.MAX_RATE_LIMITING_RETRIES;
 
-import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -212,7 +212,7 @@ class RemoteValidatorApiHandlerTest {
   @Test
   public void getAttestationDuties_WithEmptyPublicKeys_ReturnsEmpty() {
     SafeFuture<Optional<AttesterDuties>> future =
-        apiHandler.getAttestationDuties(UInt64.ONE, IntArrayList.of());
+        apiHandler.getAttestationDuties(UInt64.ONE, IntList.of());
 
     assertThat(unwrapToOptional(future)).isEmpty();
   }
@@ -226,7 +226,7 @@ class RemoteValidatorApiHandlerTest {
                     dataStructureUtil.randomBytes32(), Collections.emptyList())));
 
     SafeFuture<Optional<AttesterDuties>> future =
-        apiHandler.getAttestationDuties(UInt64.ONE, IntArrayList.of(1234));
+        apiHandler.getAttestationDuties(UInt64.ONE, IntList.of(1234));
 
     assertThat(unwrapToValue(future).getDuties()).isEmpty();
   }
@@ -258,14 +258,14 @@ class RemoteValidatorApiHandlerTest {
             validatorCommitteeIndex,
             UInt64.ZERO);
 
-    when(apiClient.getAttestationDuties(UInt64.ONE, IntArrayList.of(validatorIndex)))
+    when(apiClient.getAttestationDuties(UInt64.ONE, IntList.of(validatorIndex)))
         .thenReturn(
             Optional.of(
                 new PostAttesterDutiesResponse(
                     dataStructureUtil.randomBytes32(), List.of(schemaValidatorDuties))));
 
     SafeFuture<Optional<AttesterDuties>> future =
-        apiHandler.getAttestationDuties(UInt64.ONE, IntArrayList.of(validatorIndex));
+        apiHandler.getAttestationDuties(UInt64.ONE, IntList.of(validatorIndex));
 
     AttesterDuties validatorDuties = unwrapToValue(future);
 


### PR DESCRIPTION
This is an extension of #4984. It converts the following collections:

* `Set<Integer>` -> `IntSet`
* `List<Integer>` -> `IntList`
* `Collection<Integer>` -> `IntCollection`
* `Iterable<Integer>` -> `IntIterable`

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
