### PR TITLE
Record when the finalized optimistic transition payload is validated

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/MutableStore.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/MutableStore.java
@@ -46,4 +46,6 @@ public interface MutableStore extends ReadOnlyStore {
   void removeProposerBoostRoot();
 
   void setLatestValidFinalizedSlot(UInt64 slot);
+
+  void removeFinalizedOptimisticTransitionPayload();
 }

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
@@ -288,6 +288,9 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
   }
 
   @Override
+  public void removeFinalizedOptimisticTransitionPayload() {}
+
+  @Override
   public void removeProposerBoostRoot() {
     proposerBoostRoot = Optional.empty();
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/events/FinalizedChainData.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/events/FinalizedChainData.java
@@ -19,7 +19,6 @@ import static com.google.common.base.Preconditions.checkState;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
@@ -31,22 +30,16 @@ public class FinalizedChainData {
   private final Map<Bytes32, Bytes32> finalizedChildToParentMap;
   private final Map<Bytes32, SignedBeaconBlock> finalizedBlocks;
   private final Map<Bytes32, BeaconState> finalizedStates;
-  private final boolean optimisticTransitionBlockRootSet;
-  private final Optional<Bytes32> optimisticTransitionBlockRoot;
 
   private FinalizedChainData(
       final AnchorPoint latestFinalized,
       final Map<Bytes32, Bytes32> finalizedChildToParentMap,
       final Map<Bytes32, SignedBeaconBlock> finalizedBlocks,
-      final Map<Bytes32, BeaconState> finalizedStates,
-      final boolean optimisticTransitionBlockRootSet,
-      final Optional<Bytes32> optimisticTransitionBlockRoot) {
+      final Map<Bytes32, BeaconState> finalizedStates) {
     this.latestFinalized = latestFinalized;
     this.finalizedChildToParentMap = finalizedChildToParentMap;
     this.finalizedBlocks = finalizedBlocks;
     this.finalizedStates = finalizedStates;
-    this.optimisticTransitionBlockRootSet = optimisticTransitionBlockRootSet;
-    this.optimisticTransitionBlockRoot = optimisticTransitionBlockRoot;
   }
 
   public static Builder builder() {
@@ -77,31 +70,16 @@ public class FinalizedChainData {
     return latestFinalized;
   }
 
-  public boolean isOptimisticTransitionBlockRootSet() {
-    return optimisticTransitionBlockRootSet;
-  }
-
-  public Optional<Bytes32> getOptimisticTransitionBlockRoot() {
-    return optimisticTransitionBlockRoot;
-  }
-
   public static class Builder {
     private AnchorPoint latestFinalized;
     private final Map<Bytes32, Bytes32> finalizedChildToParentMap = new HashMap<>();
     private final Map<Bytes32, SignedBeaconBlock> finalizedBlocks = new HashMap<>();
     private final Map<Bytes32, BeaconState> finalizedStates = new HashMap<>();
-    private boolean optimisticTransitionBlockRootSet = false;
-    private Optional<Bytes32> optimisticTransitionBlockRoot = Optional.empty();
 
     public FinalizedChainData build() {
       assertValid();
       return new FinalizedChainData(
-          latestFinalized,
-          finalizedChildToParentMap,
-          finalizedBlocks,
-          finalizedStates,
-          optimisticTransitionBlockRootSet,
-          optimisticTransitionBlockRoot);
+          latestFinalized, finalizedChildToParentMap, finalizedBlocks, finalizedStates);
     }
 
     private void assertValid() {
@@ -161,14 +139,6 @@ public class FinalizedChainData {
       checkNotNull(child);
       checkNotNull(parent);
       this.finalizedChildToParentMap.put(child, parent);
-      return this;
-    }
-
-    public Builder optimisticTransitionBlockRoot(
-        final Optional<Bytes32> optimisticTransitionBlockRoot) {
-      checkNotNull(optimisticTransitionBlockRoot);
-      this.optimisticTransitionBlockRootSet = true;
-      this.optimisticTransitionBlockRoot = optimisticTransitionBlockRoot;
       return this;
     }
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/events/StorageUpdate.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/events/StorageUpdate.java
@@ -36,6 +36,8 @@ public class StorageUpdate {
   private final Map<Bytes32, BlockAndCheckpointEpochs> hotBlocks;
   private final Map<Bytes32, BeaconState> hotStates;
   private final Set<Bytes32> deletedHotBlocks;
+  private final boolean optimisticTransitionBlockRootSet;
+  private final Optional<Bytes32> optimisticTransitionBlockRoot;
 
   public StorageUpdate(
       final Optional<UInt64> genesisTime,
@@ -46,7 +48,9 @@ public class StorageUpdate {
       final Map<Bytes32, BlockAndCheckpointEpochs> hotBlocks,
       final Map<Bytes32, BeaconState> hotStates,
       final Set<Bytes32> deletedHotBlocks,
-      final Map<Bytes32, SlotAndBlockRoot> stateRoots) {
+      final Map<Bytes32, SlotAndBlockRoot> stateRoots,
+      final boolean optimisticTransitionBlockRootSet,
+      final Optional<Bytes32> optimisticTransitionBlockRoot) {
     this.genesisTime = genesisTime;
     this.finalizedChainData = finalizedChainData;
     this.lastValidFinalizedSlot = lastValidFinalizedSlot;
@@ -56,6 +60,8 @@ public class StorageUpdate {
     this.hotStates = hotStates;
     this.deletedHotBlocks = deletedHotBlocks;
     this.stateRoots = stateRoots;
+    this.optimisticTransitionBlockRootSet = optimisticTransitionBlockRootSet;
+    this.optimisticTransitionBlockRoot = optimisticTransitionBlockRoot;
   }
 
   public boolean isEmpty() {
@@ -118,14 +124,12 @@ public class StorageUpdate {
     return finalizedChainData.map(FinalizedChainData::getLatestFinalizedState);
   }
 
-  public boolean isFinalizedOptimisticBlockRootSet() {
-    return finalizedChainData
-        .map(FinalizedChainData::isOptimisticTransitionBlockRootSet)
-        .orElse(false);
+  public boolean isFinalizedOptimisticTransitionBlockRootSet() {
+    return optimisticTransitionBlockRootSet;
   }
 
   public Optional<Bytes32> getOptimisticTransitionBlockRoot() {
-    return finalizedChainData.flatMap(FinalizedChainData::getOptimisticTransitionBlockRoot);
+    return optimisticTransitionBlockRoot;
   }
 
   public Map<Bytes32, SlotAndBlockRoot> getStateRoots() {

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
@@ -552,7 +552,7 @@ public class KvStoreDatabase implements Database {
             update.getFinalizedBlocks(),
             update.getFinalizedStates(),
             update.getDeletedHotBlocks(),
-            update.isFinalizedOptimisticBlockRootSet(),
+            update.isFinalizedOptimisticTransitionBlockRootSet(),
             update.getOptimisticTransitionBlockRoot());
     LOG.trace("Applying hot updates");
     try (final HotUpdater updater = hotDao.hotUpdater()) {

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransaction.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransaction.java
@@ -60,6 +60,7 @@ class StoreTransaction implements UpdatableStore.StoreTransaction {
   Optional<Bytes32> proposerBoostRoot = Optional.empty();
   boolean proposerBoostRootSet = false;
   Optional<UInt64> latestValidFinalizedSlot = Optional.empty();
+  boolean clearFinalizedOptimisticTransitionPayload = false;
   Map<Bytes32, SlotAndBlockRoot> stateRoots = new HashMap<>();
   Map<Bytes32, SignedBlockAndState> blockAndStates = new HashMap<>();
   private final UpdatableStore.StoreUpdateHandler updateHandler;
@@ -141,6 +142,11 @@ class StoreTransaction implements UpdatableStore.StoreTransaction {
   @Override
   public void setLatestValidFinalizedSlot(UInt64 slot) {
     this.latestValidFinalizedSlot = Optional.of(slot);
+  }
+
+  @Override
+  public void removeFinalizedOptimisticTransitionPayload() {
+    this.clearFinalizedOptimisticTransitionPayload = true;
   }
 
   @CheckReturnValue


### PR DESCRIPTION
## PR Description
When the finalised transition payload is eventually checked and found to be valid, update the database and Store so that we don't keep revalidating it forever.

## Fixed Issue(s)
fixes #4671 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
