### PR TITLE
Calculate the proposer again when validators added or for missed events.

### DIFF
--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/BeaconProposerPreparer.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/BeaconProposerPreparer.java
@@ -62,11 +62,11 @@ public class BeaconProposerPreparer implements ValidatorTimingChannel {
     if (slot.mod(spec.getSlotsPerEpoch(slot)).isZero() || !firstCallDone) {
       firstCallDone = true;
 
-      calculateProposer();
+      sendPreparableProposerList();
     }
   }
 
-  private void calculateProposer() {
+  private void sendPreparableProposerList() {
     SafeFuture<Optional<ProposerConfig>> proposerConfigFuture =
         proposerConfigProvider.getProposerConfig();
 
@@ -132,12 +132,12 @@ public class BeaconProposerPreparer implements ValidatorTimingChannel {
 
   @Override
   public void onPossibleMissedEvents() {
-    calculateProposer();
+    sendPreparableProposerList();
   }
 
   @Override
   public void onValidatorsAdded() {
-    calculateProposer();
+    sendPreparableProposerList();
   }
 
   @Override

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/BeaconProposerPreparer.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/BeaconProposerPreparer.java
@@ -62,27 +62,30 @@ public class BeaconProposerPreparer implements ValidatorTimingChannel {
     if (slot.mod(spec.getSlotsPerEpoch(slot)).isZero() || !firstCallDone) {
       firstCallDone = true;
 
-      SafeFuture<Optional<ProposerConfig>> proposerConfigFuture =
-          proposerConfigProvider.getProposerConfig();
-
-      validatorIndexProvider
-          .getValidatorIndexesByPublicKey()
-          .thenCompose(
-              publicKeyToIndex ->
-                  proposerConfigFuture
-                      .thenApply(
-                          proposerConfig ->
-                              buildBeaconPreparableProposerList(proposerConfig, publicKeyToIndex))
-                      .exceptionally(
-                          throwable -> {
-                            LOG.warn(
-                                "An error occurred while obtaining proposer config", throwable);
-                            return buildBeaconPreparableProposerList(
-                                Optional.empty(), publicKeyToIndex);
-                          }))
-          .thenAccept(validatorApiChannel::prepareBeaconProposer)
-          .finish(VALIDATOR_LOGGER::beaconProposerPreparationFailed);
+      calculateProposer();
     }
+  }
+
+  private void calculateProposer() {
+    SafeFuture<Optional<ProposerConfig>> proposerConfigFuture =
+        proposerConfigProvider.getProposerConfig();
+
+    validatorIndexProvider
+        .getValidatorIndexesByPublicKey()
+        .thenCompose(
+            publicKeyToIndex ->
+                proposerConfigFuture
+                    .thenApply(
+                        proposerConfig ->
+                            buildBeaconPreparableProposerList(proposerConfig, publicKeyToIndex))
+                    .exceptionally(
+                        throwable -> {
+                          LOG.warn("An error occurred while obtaining proposer config", throwable);
+                          return buildBeaconPreparableProposerList(
+                              Optional.empty(), publicKeyToIndex);
+                        }))
+        .thenAccept(validatorApiChannel::prepareBeaconProposer)
+        .finish(VALIDATOR_LOGGER::beaconProposerPreparationFailed);
   }
 
   private List<BeaconPreparableProposer> buildBeaconPreparableProposerList(
@@ -128,10 +131,14 @@ public class BeaconProposerPreparer implements ValidatorTimingChannel {
   public void onChainReorg(UInt64 newSlot, UInt64 commonAncestorSlot) {}
 
   @Override
-  public void onPossibleMissedEvents() {}
+  public void onPossibleMissedEvents() {
+    calculateProposer();
+  }
 
   @Override
-  public void onValidatorsAdded() {}
+  public void onValidatorsAdded() {
+    calculateProposer();
+  }
 
   @Override
   public void onBlockProductionDue(UInt64 slot) {}

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/BeaconProposerPreparerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/BeaconProposerPreparerTest.java
@@ -156,6 +156,17 @@ public class BeaconProposerPreparerTest {
   }
 
   @TestTemplate
+  void should_callPrepareBeaconProposerAfterOnPossibleMissedEvents() {
+    beaconProposerPreparer.onPossibleMissedEvents();
+    verify(validatorApiChannel).prepareBeaconProposer(any());
+  }
+
+  void should_callPrepareBeaconProposerAfterOnValidatorsAdded() {
+    beaconProposerPreparer.onValidatorsAdded();
+    verify(validatorApiChannel).prepareBeaconProposer(any());
+  }
+
+  @TestTemplate
   void should_catchApiExceptions() {
     doThrow(new RuntimeException("error")).when(validatorApiChannel).prepareBeaconProposer(any());
 


### PR DESCRIPTION
It is possible that adding validators will add proposals that we need to be aware of, so we should recalculate when validators are added, to give ourselves the best chance at not missing a block proposal. Similarly for possible missed events, its possible that proposers have been changed.

Fixes #4992

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
