### PR TITLE
Enforce terminal block hash configuration

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/bellatrix/SpecLogicBellatrix.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/bellatrix/SpecLogicBellatrix.java
@@ -161,7 +161,7 @@ public class SpecLogicBellatrix extends AbstractSpecLogic {
         new BellatrixStateUpgrade(config, schemaDefinitions, beaconStateAccessors);
 
     final BellatrixTransitionHelpers bellatrixTransitionHelpers =
-        new BellatrixTransitionHelpers(config);
+        new BellatrixTransitionHelpers(config, miscHelpers);
 
     final ExecutionPayloadUtil executionPayloadUtil = new ExecutionPayloadUtil();
 

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/TestSpecFactory.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/TestSpecFactory.java
@@ -65,6 +65,12 @@ public class TestSpecFactory {
     return create(specConfig, SpecMilestone.BELLATRIX);
   }
 
+  public static Spec createMinimalBellatrix(final Consumer<SpecConfigBuilder> configAdapter) {
+    final SpecConfigBellatrix specConfig =
+        getBellatrixSpecConfig(Eth2Network.MINIMAL, configAdapter);
+    return create(specConfig, SpecMilestone.BELLATRIX);
+  }
+
   public static Spec createMinimalAltair() {
     final SpecConfigAltair specConfig = getAltairSpecConfig(Eth2Network.MINIMAL);
     return create(specConfig, SpecMilestone.ALTAIR);
@@ -165,11 +171,23 @@ public class TestSpecFactory {
 
   private static SpecConfigBellatrix getBellatrixSpecConfig(
       final Eth2Network network, final UInt64 altairForkEpoch, UInt64 bellatrixForkEpoch) {
+    return getBellatrixSpecConfig(
+        network,
+        c ->
+            c.altairBuilder(a -> a.altairForkEpoch(altairForkEpoch))
+                .bellatrixBuilder(m -> m.bellatrixForkEpoch(bellatrixForkEpoch)));
+  }
+
+  private static SpecConfigBellatrix getBellatrixSpecConfig(
+      final Eth2Network network, final Consumer<SpecConfigBuilder> configAdapter) {
     return SpecConfigBellatrix.required(
         SpecConfigLoader.loadConfig(
             network.configName(),
-            c ->
-                c.altairBuilder(a -> a.altairForkEpoch(altairForkEpoch))
-                    .bellatrixBuilder(m -> m.bellatrixForkEpoch(bellatrixForkEpoch))));
+            builder -> {
+              builder
+                  .altairBuilder(a -> a.altairForkEpoch(UInt64.ZERO))
+                  .bellatrixBuilder(b -> b.bellatrixForkEpoch(UInt64.ZERO));
+              configAdapter.accept(builder);
+            }));
   }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/MergeTransitionBlockValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/MergeTransitionBlockValidator.java
@@ -143,7 +143,7 @@ public class MergeTransitionBlockValidator {
                     new IllegalStateException(
                         "Attempting to validate a bellatrix block when spec does not have bellatrix transition helpers"));
     return bellatrixTransitionHelpers
-        .validateMergeBlock(executionEngine, executionPayload)
+        .validateMergeBlock(executionEngine, executionPayload, slot)
         .exceptionally(
             error -> {
               LOG.error("Error while validating merge block", error);


### PR DESCRIPTION
## PR Description
implements the validation of `TERMINAL_BLOCK_HASH` and `TERMINAL_BLOCK_HAS_ACTIVATION_EPOCH` to allow setting a fixed terminal PoW block.

## Fixed Issue(s)
fixes #4957 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
