### PR TITLE
Add Bearer prefix to jwt token

### DIFF
--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/auth/JwtAuthInterceptor.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/auth/JwtAuthInterceptor.java
@@ -37,7 +37,7 @@ public class JwtAuthInterceptor implements Interceptor {
       return chain.proceed(chain.request());
     }
     final Token token = optionalToken.get();
-    final String authHeader = token.getJwtToken();
+    final String authHeader = "Bearer " + token.getJwtToken();
     return chain.proceed(
         chain.request().newBuilder().header(HttpHeaders.AUTHORIZATION, authHeader).build());
   }

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/auth/TokenProvider.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/auth/TokenProvider.java
@@ -34,7 +34,7 @@ public class TokenProvider {
     final String jwtToken =
         Jwts.builder()
             .setIssuedAt(Date.from(Instant.ofEpochMilli(expiry.longValue())))
-            .signWith(SignatureAlgorithm.HS256, jwtConfig.getKey())
+            .signWith(jwtConfig.getKey(), SignatureAlgorithm.HS256)
             .compact();
     return Optional.of(new Token(jwtToken, expiry));
   }


### PR DESCRIPTION
## PR Description
Add the "Bearer" prefix in the jwt authorisation header.

Switch order of args to use the non-deprecated version of `signWith`.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
