### PR TITLE
Update to jvm-libp2p 0.8.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,3 +19,4 @@ For information on changes in released versions of Teku, see the [releases page]
 ### Bug Fixes
  - Improved handling of the http accept header used to determine whether to send SSZ data or json for states and blocks.
  - Updated discovery library with improved performance.
+ - Updated libp2p library to respect message list limits when sending messages.

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -41,7 +41,7 @@ dependencyManagement {
     dependency 'io.protostuff:protostuff-core:1.6.2'
     dependency 'io.protostuff:protostuff-runtime:1.6.2'
 
-    dependency 'io.libp2p:jvm-libp2p-minimal:0.8.8-RELEASE'
+    dependency 'io.libp2p:jvm-libp2p-minimal:0.8.9-RELEASE'
     dependency 'tech.pegasys:jblst:0.3.6-4'
 
     dependency 'org.hdrhistogram:HdrHistogram:2.1.12'

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetworkBuilder.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/LibP2PNetworkBuilder.java
@@ -168,8 +168,8 @@ public class LibP2PNetworkBuilder {
             .setProtocolVersion("ipfs/0.1.0")
             .setAgentVersion(VersionProvider.CLIENT_IDENTITY + "/" + VersionProvider.VERSION)
             .setPublicKey(ByteArrayExtKt.toProtobuf(nodePubKey.bytes()))
-            .addListenAddrs(ByteArrayExtKt.toProtobuf(advertisedAddr.getBytes()))
-            .setObservedAddr(ByteArrayExtKt.toProtobuf(advertisedAddr.getBytes()))
+            .addListenAddrs(ByteArrayExtKt.toProtobuf(advertisedAddr.serialize()))
+            .setObservedAddr(ByteArrayExtKt.toProtobuf(advertisedAddr.serialize()))
             .addAllProtocols(ping.getProtocolDescriptor().getAnnounceProtocols())
             .addAllProtocols(
                 gossipNetwork.getGossip().getProtocolDescriptor().getAnnounceProtocols())

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/MultiaddrPeerAddress.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/MultiaddrPeerAddress.java
@@ -48,7 +48,7 @@ public class MultiaddrPeerAddress extends PeerAddress {
 
   private static MultiaddrPeerAddress fromMultiaddr(final Multiaddr multiaddr) {
     final MultiaddrComponent p2pComponent = multiaddr.getFirstComponent(Protocol.P2P);
-    if (p2pComponent == null || p2pComponent.getStringValue() != null) {
+    if (p2pComponent == null || p2pComponent.getStringValue() == null) {
       throw new IllegalArgumentException("No peer ID present in multiaddr: " + multiaddr);
     }
     final LibP2PNodeId nodeId = new LibP2PNodeId(PeerId.fromBase58(p2pComponent.getStringValue()));

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/MultiaddrPeerAddress.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/MultiaddrPeerAddress.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.networking.p2p.libp2p;
 
 import io.libp2p.core.PeerId;
 import io.libp2p.core.multiformats.Multiaddr;
+import io.libp2p.core.multiformats.MultiaddrComponent;
 import io.libp2p.core.multiformats.Protocol;
 import java.util.Objects;
 import tech.pegasys.teku.networking.p2p.discovery.DiscoveryPeer;
@@ -46,11 +47,11 @@ public class MultiaddrPeerAddress extends PeerAddress {
   }
 
   private static MultiaddrPeerAddress fromMultiaddr(final Multiaddr multiaddr) {
-    final String p2pComponent = multiaddr.getStringComponent(Protocol.P2P);
-    if (p2pComponent == null) {
+    final MultiaddrComponent p2pComponent = multiaddr.getFirstComponent(Protocol.P2P);
+    if (p2pComponent == null || p2pComponent.getStringValue() != null) {
       throw new IllegalArgumentException("No peer ID present in multiaddr: " + multiaddr);
     }
-    final LibP2PNodeId nodeId = new LibP2PNodeId(PeerId.fromBase58(p2pComponent));
+    final LibP2PNodeId nodeId = new LibP2PNodeId(PeerId.fromBase58(p2pComponent.getStringValue()));
     return new MultiaddrPeerAddress(nodeId, multiaddr);
   }
 

--- a/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/libp2p/MultiaddrUtilTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/libp2p/MultiaddrUtilTest.java
@@ -17,11 +17,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.libp2p.core.PeerId;
 import io.libp2p.core.multiformats.Multiaddr;
+import io.libp2p.core.multiformats.MultiaddrComponent;
 import io.libp2p.core.multiformats.Protocol;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes;
+import org.assertj.core.api.AbstractObjectAssert;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszBitvector;
 import tech.pegasys.teku.networking.p2p.discovery.DiscoveryPeer;
@@ -52,9 +54,9 @@ class MultiaddrUtilTest {
         new InetSocketAddress(InetAddress.getByAddress(ipAddress), port);
     final Multiaddr result = MultiaddrUtil.fromInetSocketAddress(address);
     assertThat(result).isEqualTo(Multiaddr.fromString("/ip4/123.34.58.22/tcp/5883/"));
-    assertThat(result.getComponent(Protocol.IP4)).isEqualTo(ipAddress);
-    assertThat(result.getComponent(Protocol.TCP)).isEqualTo(Protocol.TCP.addressToBytes("5883"));
-    assertThat(result.getComponent(Protocol.P2P)).isNull();
+    assertThatComponent(result, Protocol.IP4).isEqualTo(ipAddress);
+    assertThatComponent(result, Protocol.TCP).isEqualTo(Protocol.TCP.addressToBytes("5883"));
+    assertThat(result.getFirstComponent(Protocol.P2P)).isNull();
   }
 
   @Test
@@ -65,9 +67,9 @@ class MultiaddrUtilTest {
         new InetSocketAddress(InetAddress.getByAddress(ipAddress), port);
     final Multiaddr result = MultiaddrUtil.fromInetSocketAddress(address);
     assertThat(result).isEqualTo(Multiaddr.fromString("/ip6/3300:4:5000:780:0:12:0:1/tcp/5883/"));
-    assertThat(result.getComponent(Protocol.IP6)).isEqualTo(ipAddress);
-    assertThat(result.getComponent(Protocol.TCP)).isEqualTo(Protocol.TCP.addressToBytes("5883"));
-    assertThat(result.getComponent(Protocol.P2P)).isNull();
+    assertThatComponent(result, Protocol.IP6).isEqualTo(ipAddress);
+    assertThatComponent(result, Protocol.TCP).isEqualTo(Protocol.TCP.addressToBytes("5883"));
+    assertThat(result.getFirstComponent(Protocol.P2P)).isNull();
   }
 
   @Test
@@ -83,9 +85,9 @@ class MultiaddrUtilTest {
             SYNC_COMMITTEE_SUBNETS);
     final Multiaddr result = MultiaddrUtil.fromDiscoveryPeer(peer);
     assertThat(result).isEqualTo(Multiaddr.fromString("/ip4/123.34.58.22/tcp/5883/p2p/" + PEER_ID));
-    assertThat(result.getComponent(Protocol.IP4)).isEqualTo(ipAddress);
-    assertThat(result.getComponent(Protocol.TCP)).isEqualTo(Protocol.TCP.addressToBytes("5883"));
-    assertThat(result.getComponent(Protocol.P2P)).isEqualTo(NODE_ID.toBytes().toArrayUnsafe());
+    assertThatComponent(result, Protocol.IP4).isEqualTo(ipAddress);
+    assertThatComponent(result, Protocol.TCP).isEqualTo(Protocol.TCP.addressToBytes("5883"));
+    assertThatComponent(result, Protocol.P2P).isEqualTo(NODE_ID.toBytes().toArrayUnsafe());
   }
 
   @Test
@@ -102,9 +104,9 @@ class MultiaddrUtilTest {
     final Multiaddr result = MultiaddrUtil.fromDiscoveryPeer(peer);
     assertThat(result)
         .isEqualTo(Multiaddr.fromString("/ip6/3300:4:5000:780:0:12:0:1/tcp/5883/p2p/" + PEER_ID));
-    assertThat(result.getComponent(Protocol.IP6)).isEqualTo(ipAddress);
-    assertThat(result.getComponent(Protocol.TCP)).isEqualTo(Protocol.TCP.addressToBytes("5883"));
-    assertThat(result.getComponent(Protocol.P2P)).isEqualTo(NODE_ID.toBytes().toArrayUnsafe());
+    assertThatComponent(result, Protocol.IP6).isEqualTo(ipAddress);
+    assertThatComponent(result, Protocol.TCP).isEqualTo(Protocol.TCP.addressToBytes("5883"));
+    assertThatComponent(result, Protocol.P2P).isEqualTo(NODE_ID.toBytes().toArrayUnsafe());
   }
 
   @Test
@@ -137,5 +139,10 @@ class MultiaddrUtilTest {
         Multiaddr.fromString(
             "/ip4/127.0.0.1/udp/9000/p2p/16Uiu2HAmR4wQRGWgCNy5uzx7HfuV59Q6X1MVzBRmvreuHgEQcCnF");
     assertThat(MultiaddrUtil.fromDiscoveryPeerAsUdp(peer)).isEqualTo(expectedMultiAddr);
+  }
+
+  private AbstractObjectAssert<?, byte[]> assertThatComponent(
+      final Multiaddr result, final Protocol p2p) {
+    return assertThat(result.getFirstComponent(p2p)).extracting(MultiaddrComponent::getValue);
   }
 }


### PR DESCRIPTION
## PR Description
Updates jvm-libp2p to 0.8.9. Few APIs changed requiring minor tweaks.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
