### PR TITLE
Increase gossip subscription limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,3 +19,4 @@ For information on changes in released versions of Teku, see the [releases page]
 ### Bug Fixes
  - Improved handling of the http accept header used to determine whether to send SSZ data or json for states and blocks.
  - Updated discovery library with improved performance.
+ - Fixed issue on custom testnets with two forks in sequential epochs where the maximum gossip topic subscription limits were exceeded.

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/config/LibP2PParamsFactory.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/config/LibP2PParamsFactory.java
@@ -30,6 +30,9 @@ import tech.pegasys.teku.networking.p2p.gossip.config.GossipTopicScoringConfig;
 import tech.pegasys.teku.networking.p2p.libp2p.LibP2PNodeId;
 
 public class LibP2PParamsFactory {
+
+  public static final int MAX_SUBSCIPTIONS_PER_MESSAGE = 200;
+
   public static GossipParams createGossipParams(final GossipConfig gossipConfig) {
     return GossipParams.builder()
         .D(gossipConfig.getD())
@@ -47,7 +50,7 @@ public class LibP2PParamsFactory {
         .seenTTL(gossipConfig.getSeenTTL())
         .maxPublishedMessages(1000)
         .maxTopicsPerPublishedMessage(1)
-        .maxSubscriptions(200)
+        .maxSubscriptions(MAX_SUBSCIPTIONS_PER_MESSAGE)
         .maxGraftMessages(200)
         .maxPruneMessages(200)
         .maxPeersPerPruneMessage(1000)

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/gossip/LibP2PGossipNetworkBuilder.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/gossip/LibP2PGossipNetworkBuilder.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.networking.p2p.libp2p.gossip;
 
+import static tech.pegasys.teku.networking.p2p.libp2p.config.LibP2PParamsFactory.MAX_SUBSCIPTIONS_PER_MESSAGE;
 import static tech.pegasys.teku.networking.p2p.libp2p.gossip.LibP2PGossipNetwork.NULL_SEQNO_GENERATOR;
 import static tech.pegasys.teku.networking.p2p.libp2p.gossip.LibP2PGossipNetwork.STRICT_FIELDS_VALIDATOR;
 
@@ -49,6 +50,10 @@ import tech.pegasys.teku.networking.p2p.libp2p.config.LibP2PParamsFactory;
  * might be changed in any version in backward incompatible way
  */
 public class LibP2PGossipNetworkBuilder {
+
+  // Enough to subscribe to three forks simultaneously so testnets can fork in subsequent epochs
+  public static final int MAX_SUBSCRIBED_TOPICS = 250;
+
   public static LibP2PGossipNetworkBuilder create() {
     return new LibP2PGossipNetworkBuilder();
   }
@@ -84,7 +89,10 @@ public class LibP2PGossipNetworkBuilder {
         LibP2PParamsFactory.createGossipScoreParams(gossipConfig.getScoringConfig());
 
     final TopicSubscriptionFilter subscriptionFilter =
-        new MaxCountTopicSubscriptionFilter(100, 200, gossipTopicFilter::isRelevantTopic);
+        new MaxCountTopicSubscriptionFilter(
+            MAX_SUBSCIPTIONS_PER_MESSAGE,
+            MAX_SUBSCRIBED_TOPICS,
+            gossipTopicFilter::isRelevantTopic);
     GossipRouter router =
         new GossipRouter(
             gossipParams, scoreParams, PubsubProtocol.Gossip_V_1_1, subscriptionFilter) {


### PR DESCRIPTION
## PR Description
Ensures the limits are high enough to not be exceeded even when three forks are subscribed simultaneously as is the case with custom testnets that schedule two forks in subsequent epochs.

## Fixed Issue(s)
fixes #4903 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
