### PR TITLE
Log error when latestValidHash cannot be found

### DIFF
--- a/ethereum/forkchoice/build.gradle
+++ b/ethereum/forkchoice/build.gradle
@@ -4,6 +4,7 @@ dependencies {
     implementation project(':infrastructure:async')
     implementation project(':infrastructure:events')
     implementation project(':infrastructure:exceptions')
+    implementation project(':infrastructure:logging')
 
     testImplementation project(':infrastructure:crypto')
     testImplementation testFixtures(project(':ethereum:core'))

--- a/ethereum/forkchoice/src/main/java/tech/pegasys/teku/ethereum/forkchoice/ProtoArray.java
+++ b/ethereum/forkchoice/src/main/java/tech/pegasys/teku/ethereum/forkchoice/ProtoArray.java
@@ -19,6 +19,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static tech.pegasys.teku.ethereum.forkchoice.ProtoNodeValidationStatus.INVALID;
 import static tech.pegasys.teku.ethereum.forkchoice.ProtoNodeValidationStatus.OPTIMISTIC;
 import static tech.pegasys.teku.ethereum.forkchoice.ProtoNodeValidationStatus.VALID;
+import static tech.pegasys.teku.infrastructure.logging.StatusLogger.STATUS_LOG;
 
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import it.unimi.dsi.fastutil.ints.IntSet;
@@ -313,7 +314,9 @@ public class ProtoArray {
       parentIndex = parentNode.getParentIndex();
     }
     // Couldn't find the last valid hash - so can't take advantage of it.
-    LOG.debug("Failed to find block for latestValidHash {}", latestValidHash);
+    // Alert this user as it may indicate that invalid payloads have been finalized
+    // (or the EL client is malfunctioning somehow).
+    STATUS_LOG.unknownLatestValidHash(latestValidHash);
     return Optional.empty();
   }
 

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
@@ -365,6 +365,15 @@ public class StatusLogger {
         error);
   }
 
+  public void unknownLatestValidHash(final Bytes32 latestValidHash) {
+    log.error(
+        print(
+            "Could not find latest valid execution payload hash ("
+                + latestValidHash
+                + ") in the non-finalized chain. Optimistic sync may have finalized an invalid transition block.",
+            Color.RED));
+  }
+
   private void logWithColorIfLevelGreaterThanInfo(
       final Level level, final String msg, final ColorConsolePrinter.Color color) {
     final boolean useColor = level.compareTo(Level.INFO) < 0;


### PR DESCRIPTION
## PR Description
Print an error to the console when the EL returns a latestValidHash that can't be found in protoarray. Either the EL is malfunctioning or optimistic sync has finalised invalid blocks.

## Fixed Issue(s)
fixes #4964 

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
