### PR TITLE
Print Syncing messages during optimistic sync and initial startup

### DIFF
--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -723,7 +723,7 @@ public class BeaconChainController extends Service
         new SlotProcessor(
             spec,
             recentChainData,
-            syncService.getForwardSync(),
+            syncService,
             forkChoiceTrigger,
             forkChoiceNotifier,
             p2pNetwork,


### PR DESCRIPTION
## PR Description
Change `SlotProcessor` to use a `SyncStateProvider` (which is ultimately backed by `SyncStateTracker`) to determine if the node is syncing or not.  This means that it will stay in syncing mode while waiting for the EL to finish validating blocks after optimistic sync reaches the beacon chain head.

It will also now be in syncing mode immediately after startup until either sufficient peers are reached or the timeout is reached (ie while the node is in the initial startup mode).  Other components like the REST API and `ValidatorApiHandler` always used this sync state so their behaviour is unchanged, but now the console messages accurately reflect the sync state.

Also fixed a minor oversight where the p2p network wasn't informed of epoch changes during sync. It uses those events to ensure it subscribes to the right fork gossip topics. Mostly gossip is disabled during sync anyway but with some particularly unlucky timings Teku may have wound up not subscribed to the right fork gossip until the epoch after sync completed.


## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
