### PR TITLE
Fix empty block messages to align with the longer block hash

### DIFF
--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java
@@ -152,7 +152,7 @@ public class EventLogger {
       final UInt64 justifiedCheckpoint,
       final UInt64 finalizedCheckpoint,
       final int numPeers) {
-    String blockRoot = "   ... empty";
+    String blockRoot = "                                                       ... empty";
     if (nodeSlot.equals(headSlot)) {
       blockRoot = LogFormatter.formatHashRoot(bestBlockRoot);
     }


### PR DESCRIPTION
## PR Description
Fix alignment of empty `Slot Event` messages with the longer block hash we now print:

```
Slot Event  *** Slot: 4544, Block: 5559c5dff45886420718f3b1e7b082df0ce437bf881a91c765c4db5bea8e628e, Justified: 141, Finalized: 140, Peers: 2
Slot Event  *** Slot: 4545, Block:                                                        ... empty, Justified: 141, Finalized: 140, Peers: 2
Slot Event  *** Slot: 4546, Block:                                                        ... empty, Justified: 141, Finalized: 140, Peers: 3
Slot Event  *** Slot: 4547, Block: aad9da69138161eeb2d1684caa780abd5649d7bd0cb5d0991d375c99ac5c208b, Justified: 141, Finalized: 140, Peers: 3
```

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
