### PR TITLE
Don't log warning when block slashing protection is old

### DIFF
--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/SlashingProtectionLogger.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/SlashingProtectionLogger.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.teku.validator.client.loader;
 
+import static tech.pegasys.teku.data.signingrecord.ValidatorSigningRecord.NEVER_SIGNED;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -71,7 +73,7 @@ public class SlashingProtectionLogger implements ValidatorTimingChannel {
     this.activeValidators = Optional.empty();
   }
 
-  private void logSlashingProtection(final List<Validator> validators, final UInt64 curSlot) {
+  private void logSlashingProtection(final List<Validator> validators, final UInt64 currentSlot) {
     final List<Pair<Validator, Optional<ValidatorSigningRecord>>> validatorRecords =
         getValidatorSigningRecords(validators);
     final List<Pair<Validator, ValidatorSigningRecord>> protectedList =
@@ -82,7 +84,7 @@ public class SlashingProtectionLogger implements ValidatorTimingChannel {
     logLoadedProtectionValidators(protectedList);
     filterAndLogNotLoadedProtectionValidators(validatorRecords);
     Function<ValidatorSigningRecord, Boolean> outdatedSigningRecordClassifier =
-        createOutdatedSigningRecordClassifier(curSlot, SAFE_PROTECTION_EPOCHS_DELTA);
+        createOutdatedSigningRecordClassifier(currentSlot);
     final List<Pair<Validator, ValidatorSigningRecord>> outdatedProtectionList =
         protectedList.stream()
             .filter(pair -> outdatedSigningRecordClassifier.apply(pair.getRight()))
@@ -142,17 +144,14 @@ public class SlashingProtectionLogger implements ValidatorTimingChannel {
   }
 
   private Function<ValidatorSigningRecord, Boolean> createOutdatedSigningRecordClassifier(
-      final UInt64 curSlot, final UInt64 outdatedEpochsDelta) {
+      final UInt64 currentSlot) {
     return signingRecord ->
-        spec.computeEpochAtSlot(curSlot)
-                .minusMinZero(spec.computeEpochAtSlot(signingRecord.getBlockSlot()))
-                .isGreaterThan(outdatedEpochsDelta)
-            || spec.computeEpochAtSlot(curSlot)
-                .minusMinZero(
-                    signingRecord.getAttestationTargetEpoch() == null
-                        ? UInt64.ZERO
-                        : signingRecord.getAttestationTargetEpoch())
-                .isGreaterThan(outdatedEpochsDelta);
+        spec.computeEpochAtSlot(currentSlot)
+            .minusMinZero(
+                signingRecord.getAttestationTargetEpoch() == NEVER_SIGNED
+                    ? UInt64.ZERO
+                    : signingRecord.getAttestationTargetEpoch())
+            .isGreaterThan(SAFE_PROTECTION_EPOCHS_DELTA);
   }
 
   @Override


### PR DESCRIPTION
## PR Description
Blocks aren't expected to be produced very often so don't consider the slashing protection records out of date based on the last block slot. If the attestation data is up to date then the slashing protection record is up to date.

Also simplified the tests a bit.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
