### PR TITLE
Add CLI argument for using blinded beacon blocks for the validator-client

### DIFF
--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.teku.cli.options;
 
+import static tech.pegasys.teku.validator.api.ValidatorConfig.DEFAULT_VALIDATOR_BLINDED_BLOCKS_ENABLED;
+
 import java.nio.file.Path;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
@@ -107,7 +109,7 @@ public class ValidatorOptions {
       fallbackValue = "true",
       hidden = true,
       arity = "0..1")
-  private boolean blindedBlocksApiEnabled = false;
+  private boolean blindedBlocksApiEnabled = DEFAULT_VALIDATOR_BLINDED_BLOCKS_ENABLED;
 
   public void configure(TekuConfiguration.Builder builder) {
     if (validatorPerformanceTrackingEnabled != null) {

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
@@ -99,6 +99,16 @@ public class ValidatorOptions {
       arity = "0..1")
   private boolean generateEarlyAttestations = ValidatorConfig.DEFAULT_GENERATE_EARLY_ATTESTATIONS;
 
+  @Option(
+      names = {"--Xvalidators-blinded-blocks-api-enabled"},
+      paramLabel = "<BOOLEAN>",
+      showDefaultValue = Visibility.ALWAYS,
+      description = "Use blinded block api calls",
+      fallbackValue = "true",
+      hidden = true,
+      arity = "0..1")
+  private boolean blindedBlocksApiEnabled = false;
+
   public void configure(TekuConfiguration.Builder builder) {
     if (validatorPerformanceTrackingEnabled != null) {
       if (validatorPerformanceTrackingEnabled) {
@@ -112,6 +122,7 @@ public class ValidatorOptions {
         config ->
             config
                 .validatorKeystoreLockingEnabled(validatorKeystoreLockingEnabled)
+                .blindedBeaconBlocksApiEnabled(blindedBlocksApiEnabled)
                 .validatorPerformanceTrackingMode(validatorPerformanceTrackingMode)
                 .validatorExternalSignerSlashingProtectionEnabled(
                     validatorExternalSignerSlashingProtectionEnabled)

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/ValidatorOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/ValidatorOptionsTest.java
@@ -116,4 +116,20 @@ public class ValidatorOptionsTest extends AbstractBeaconNodeCommandTest {
         .isEqualTo(
             Optional.of(Eth1Address.fromHexString("0xfe3b557e8fb62b89f4916b721be55ceb828dbd73")));
   }
+
+  @Test
+  public void shouldEnableBlindedBeaconBlocks() {
+    final String[] args = {"--Xvalidators-blinded-blocks-api-enabled", "true"};
+    final TekuConfiguration config = getTekuConfigurationFromArguments(args);
+    assertThat(config.validatorClient().getValidatorConfig().isBlindedBeaconBlocksApiEnabled())
+        .isTrue();
+  }
+
+  @Test
+  public void shouldNotUseBlindedBeaconBlocksByDefault() {
+    final String[] args = {};
+    final TekuConfiguration config = getTekuConfigurationFromArguments(args);
+    assertThat(config.validatorClient().getValidatorConfig().isBlindedBeaconBlocksApiEnabled())
+        .isFalse();
+  }
 }

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
@@ -58,6 +58,7 @@ public class ValidatorConfig {
   private final Optional<Eth1Address> proposerDefaultFeeRecipient;
   private final Optional<String> proposerConfigSource;
   private final boolean refreshProposerConfigFromSource;
+  private final boolean blindedBeaconBlocksApiEnabled;
 
   private ValidatorConfig(
       final List<String> validatorKeys,
@@ -77,7 +78,8 @@ public class ValidatorConfig {
       final boolean generateEarlyAttestations,
       final Optional<Eth1Address> proposerDefaultFeeRecipient,
       final Optional<String> proposerConfigSource,
-      final boolean refreshProposerConfigFromSource) {
+      final boolean refreshProposerConfigFromSource,
+      final boolean blindedBeaconBlocksApiEnabled) {
     this.validatorKeys = validatorKeys;
     this.validatorExternalSignerPublicKeySources = validatorExternalSignerPublicKeySources;
     this.validatorExternalSignerUrl = validatorExternalSignerUrl;
@@ -99,6 +101,7 @@ public class ValidatorConfig {
     this.proposerDefaultFeeRecipient = proposerDefaultFeeRecipient;
     this.proposerConfigSource = proposerConfigSource;
     this.refreshProposerConfigFromSource = refreshProposerConfigFromSource;
+    this.blindedBeaconBlocksApiEnabled = blindedBeaconBlocksApiEnabled;
   }
 
   public static Builder builder() {
@@ -172,6 +175,10 @@ public class ValidatorConfig {
     return refreshProposerConfigFromSource;
   }
 
+  public boolean isBlindedBeaconBlocksApiEnabled() {
+    return blindedBeaconBlocksApiEnabled;
+  }
+
   private void validateProposerDefaultFeeRecipientOrProposerConfigSource() {
     if (proposerDefaultFeeRecipient.isEmpty()
         && proposerConfigSource.isEmpty()
@@ -205,6 +212,7 @@ public class ValidatorConfig {
     private Optional<String> proposerConfigSource = Optional.empty();
     private boolean refreshProposerConfigFromSource =
         DEFAULT_VALIDATOR_PROPOSER_CONFIG_REFRESH_ENABLED;
+    private boolean blindedBlocksApiEnabled = false;
 
     private Builder() {}
 
@@ -330,6 +338,11 @@ public class ValidatorConfig {
       return this;
     }
 
+    public Builder blindedBeaconBlocksApiEnabled(final boolean blindedBeaconBlockEnabled) {
+      this.blindedBlocksApiEnabled = blindedBeaconBlockEnabled;
+      return this;
+    }
+
     public ValidatorConfig build() {
       validateExternalSignerUrlAndPublicKeys();
       validateExternalSignerKeystoreAndPasswordFileConfig();
@@ -353,7 +366,8 @@ public class ValidatorConfig {
           generateEarlyAttestations,
           proposerDefaultFeeRecipient,
           proposerConfigSource,
-          refreshProposerConfigFromSource);
+          refreshProposerConfigFromSource,
+          blindedBlocksApiEnabled);
     }
 
     private void validateExternalSignerUrlAndPublicKeys() {

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
@@ -39,6 +39,7 @@ public class ValidatorConfig {
   public static final boolean DEFAULT_GENERATE_EARLY_ATTESTATIONS = true;
   public static final Optional<Bytes32> DEFAULT_GRAFFITI = Optional.empty();
   public static final boolean DEFAULT_VALIDATOR_PROPOSER_CONFIG_REFRESH_ENABLED = false;
+  public static final boolean DEFAULT_VALIDATOR_BLINDED_BLOCKS_ENABLED = false;
 
   private final List<String> validatorKeys;
   private final List<String> validatorExternalSignerPublicKeySources;
@@ -212,7 +213,7 @@ public class ValidatorConfig {
     private Optional<String> proposerConfigSource = Optional.empty();
     private boolean refreshProposerConfigFromSource =
         DEFAULT_VALIDATOR_PROPOSER_CONFIG_REFRESH_ENABLED;
-    private boolean blindedBlocksApiEnabled = false;
+    private boolean blindedBlocksApiEnabled = DEFAULT_VALIDATOR_BLINDED_BLOCKS_ENABLED;
 
     private Builder() {}
 


### PR DESCRIPTION

This will be needed for MEV boost, but is also likely to be used post merge to reduce block data sent to the BN.

fixes #5022

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
