### PR TITLE
Find common ancestor using protoarray rather than chain head state

### DIFF
--- a/ethereum/forkchoice/src/main/java/tech/pegasys/teku/ethereum/forkchoice/BlockMetadataStore.java
+++ b/ethereum/forkchoice/src/main/java/tech/pegasys/teku/ethereum/forkchoice/BlockMetadataStore.java
@@ -19,6 +19,7 @@ import java.util.Set;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockAndCheckpointEpochs;
+import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 
 public interface BlockMetadataStore {
@@ -34,6 +35,8 @@ public interface BlockMetadataStore {
   Optional<UInt64> blockSlot(Bytes32 blockRoot);
 
   Optional<Bytes32> executionBlockHash(Bytes32 beaconBlockRoot);
+
+  Optional<SlotAndBlockRoot> findCommonAncestor(Bytes32 root1, Bytes32 root2);
 
   void applyUpdate(
       Collection<BlockAndCheckpointEpochs> addedBlocks,

--- a/ethereum/forkchoice/src/main/java/tech/pegasys/teku/ethereum/forkchoice/ProtoArray.java
+++ b/ethereum/forkchoice/src/main/java/tech/pegasys/teku/ethereum/forkchoice/ProtoArray.java
@@ -649,7 +649,7 @@ public class ProtoArray {
     return indices.getRootIndices();
   }
 
-  private ProtoNode getNodeByIndex(final int index) {
+  ProtoNode getNodeByIndex(final int index) {
     return checkNotNull(nodes.get(index), "Missing node %s", index);
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/ChainHead.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/ChainHead.java
@@ -14,13 +14,10 @@
 package tech.pegasys.teku.storage.client;
 
 import java.util.Objects;
-import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSummary;
-import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
-import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 
 class ChainHead extends StateAndBlockSummary {
@@ -47,48 +44,6 @@ class ChainHead extends StateAndBlockSummary {
 
   public UInt64 getForkChoiceEpoch() {
     return spec.computeEpochAtSlot(forkChoiceSlot);
-  }
-
-  public SlotAndBlockRoot findCommonAncestor(final ChainHead other) {
-    if (getSlot().isZero() || other.getSlot().isZero()) {
-      // One fork has no blocks so the only possible common ancestor is genesis.
-      if (getSlot().isZero()) {
-        return new SlotAndBlockRoot(UInt64.ZERO, getRoot());
-      } else if (other.getSlot().isZero()) {
-        return new SlotAndBlockRoot(UInt64.ZERO, other.getRoot());
-      }
-    }
-    UInt64 slot = getSlot().min(other.getSlot());
-    final UInt64 longestChainSlot = getSlot().max(other.getSlot());
-    UInt64 minSlotWithHistoricRoot =
-        longestChainSlot
-            .max(spec.getSlotsPerHistoricalRoot(slot)) // Avoid underflow
-            .minus(spec.getSlotsPerHistoricalRoot(slot));
-    while (slot.isGreaterThan(minSlotWithHistoricRoot)) {
-      final Bytes32 blockRootAtSlot = getBlockRootAtSlot(slot);
-      if (blockRootAtSlot.equals(other.getBlockRootAtSlot(slot))) {
-        return new SlotAndBlockRoot(slot, blockRootAtSlot);
-      }
-      slot = slot.minus(1);
-    }
-    // Couldn't find a common ancestor in the available block roots so fallback to finalized
-    final Checkpoint earliestFinalizedCheckpoint =
-        getState()
-                .getFinalized_checkpoint()
-                .getEpoch()
-                .isLessThanOrEqualTo(other.getState().getFinalized_checkpoint().getEpoch())
-            ? getState().getFinalized_checkpoint()
-            : other.getState().getFinalized_checkpoint();
-    return new SlotAndBlockRoot(
-        earliestFinalizedCheckpoint.getEpochStartSlot(spec), earliestFinalizedCheckpoint.getRoot());
-  }
-
-  private Bytes32 getBlockRootAtSlot(final UInt64 slot) {
-    // The block root for the state's own slot is not included in the state so any slot greater than
-    // or equal to slot must have the head block root.
-    return slot.isGreaterThanOrEqualTo(getSlot())
-        ? getRoot()
-        : spec.getBlockRootAtSlot(getState(), slot);
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
@@ -296,7 +296,10 @@ public abstract class RecentChainData implements StoreUpdateHandler {
         final ChainHead previousChainHead = originalHead.get();
 
         final SlotAndBlockRoot commonAncestorSlotAndBlockRoot =
-            previousChainHead.findCommonAncestor(newChainHead);
+            store
+                .getForkChoiceStrategy()
+                .findCommonAncestor(previousChainHead.getRoot(), newChainHead.getRoot())
+                .orElseGet(() -> store.getFinalizedCheckpoint().toSlotAndBlockRoot(spec));
 
         reorgCounter.inc();
         optionalReorgContext =

--- a/storage/src/test/java/tech/pegasys/teku/storage/client/ChainHeadTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/client/ChainHeadTest.java
@@ -16,9 +16,7 @@ package tech.pegasys.teku.storage.client;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.tuweni.bytes.Bytes;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import tech.pegasys.teku.core.ChainBuilder;
 import tech.pegasys.teku.infrastructure.ssz.SszData;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszSchema;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -26,20 +24,12 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
-import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class ChainHeadTest {
   private final Spec spec = TestSpecFactory.createMinimalPhase0();
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
-  private final ChainBuilder chainBuilder = ChainBuilder.create(spec);
-  private SignedBlockAndState genesis;
-
-  @BeforeEach
-  public void setup() {
-    genesis = chainBuilder.generateGenesis();
-  }
 
   @Test
   public void equals_shouldBeEqualToCopy() {
@@ -72,81 +62,6 @@ public class ChainHeadTest {
     final ChainHead otherChainHead = ChainHead.create(otherBlock, forkChoiceSlot, spec);
 
     assertThat(chainHead).isNotEqualTo(otherChainHead);
-  }
-
-  @Test
-  void findCommonAncestor_atGenesisBlock() {
-    final SignedBlockAndState block2 = chainBuilder.generateBlockAtSlot(2);
-    final ChainHead chainHeadA = ChainHead.create(genesis, UInt64.valueOf(10), spec);
-    final ChainHead chainHeadB = ChainHead.create(block2, UInt64.valueOf(12), spec);
-    final SlotAndBlockRoot slotAndBlockRootChainA = chainHeadA.findCommonAncestor(chainHeadB);
-    final SlotAndBlockRoot slotAndBlockRootChainB = chainHeadB.findCommonAncestor(chainHeadA);
-    assertThat(slotAndBlockRootChainA.getSlot()).isEqualTo(UInt64.ZERO);
-    assertThat(slotAndBlockRootChainB.getSlot()).isEqualTo(UInt64.ZERO);
-    assertThat(slotAndBlockRootChainB.getBlockRoot()).isEqualTo(genesis.getRoot());
-    assertThat(slotAndBlockRootChainB.getBlockRoot()).isEqualTo(genesis.getRoot());
-  }
-
-  @Test
-  void findCommonAncestor_headBlockEmptyVsFull() {
-    final SignedBlockAndState block1 = chainBuilder.generateBlockAtSlot(1);
-    final SignedBlockAndState block2 = chainBuilder.generateBlockAtSlot(2);
-    final ChainHead chainHeadA = ChainHead.create(block1, UInt64.valueOf(2), spec);
-    final ChainHead chainHeadB = ChainHead.create(block2, UInt64.valueOf(2), spec);
-    final SlotAndBlockRoot slotAndBlockRootChainA = chainHeadA.findCommonAncestor(chainHeadB);
-    final SlotAndBlockRoot slotAndBlockRootChainB = chainHeadB.findCommonAncestor(chainHeadA);
-    assertThat(slotAndBlockRootChainA.getSlot()).isEqualTo(UInt64.ONE);
-    assertThat(slotAndBlockRootChainB.getSlot()).isEqualTo(UInt64.ONE);
-    assertThat(slotAndBlockRootChainA.getBlockRoot()).isEqualTo(block1.getRoot());
-    assertThat(slotAndBlockRootChainB.getBlockRoot()).isEqualTo(block1.getRoot());
-  }
-
-  @Test
-  void findCommonAncestor_differingChains() {
-    chainBuilder.generateBlockAtSlot(2);
-    final ChainBuilder fork = chainBuilder.fork();
-    chainBuilder.generateBlocksUpToSlot(4);
-    final SignedBlockAndState chainHead = chainBuilder.generateBlockAtSlot(5);
-
-    // Fork skips slot 3 so the chains are different
-    fork.generateBlockAtSlot(4);
-    fork.generateBlocksUpToSlot(6);
-    final SignedBlockAndState forkHead = fork.generateBlockAtSlot(7);
-
-    final ChainHead chainHeadA = ChainHead.create(chainHead, UInt64.valueOf(8), spec);
-    final ChainHead chainHeadB = ChainHead.create(forkHead, UInt64.valueOf(9), spec);
-    final SlotAndBlockRoot slotAndBlockRootChainA = chainHeadA.findCommonAncestor(chainHeadB);
-    final SlotAndBlockRoot slotAndBlockRootChainB = chainHeadB.findCommonAncestor(chainHeadA);
-    final SignedBeaconBlock commonBlock = chainBuilder.getBlockAtSlot(UInt64.valueOf(2));
-    assertThat(slotAndBlockRootChainA.getSlot()).isEqualTo(UInt64.valueOf(2));
-    assertThat(slotAndBlockRootChainB.getSlot()).isEqualTo(UInt64.valueOf(2));
-    assertThat(slotAndBlockRootChainA.getBlockRoot()).isEqualTo(commonBlock.getRoot());
-    assertThat(slotAndBlockRootChainB.getBlockRoot()).isEqualTo(commonBlock.getRoot());
-  }
-
-  @Test
-  void findCommonAncestor_differingBeyondHistoricRoots() {
-    final ChainBuilder fork = chainBuilder.fork();
-
-    final SignedBlockAndState chainHead =
-        chainBuilder.generateBlockAtSlot(spec.getSlotsPerHistoricalRoot(fork.getLatestSlot()) + 2);
-
-    // Fork skips slot 1 so the chains are different
-    fork.generateBlockAtSlot(1);
-    final SignedBlockAndState forkHead =
-        fork.generateBlockAtSlot(spec.getSlotsPerHistoricalRoot(fork.getLatestSlot()) + 2);
-
-    final ChainHead chainHeadA = ChainHead.create(chainHead, chainHead.getSlot(), spec);
-    final ChainHead chainHeadB = ChainHead.create(forkHead, forkHead.getSlot(), spec);
-    final SlotAndBlockRoot slotAndBlockRootChainA = chainHeadA.findCommonAncestor(chainHeadB);
-    final SlotAndBlockRoot slotAndBlockRootChainB = chainHeadB.findCommonAncestor(chainHeadA);
-    assertThat(slotAndBlockRootChainA.getSlot()).isEqualTo(UInt64.ZERO);
-    assertThat(slotAndBlockRootChainB.getSlot()).isEqualTo(UInt64.ZERO);
-
-    assertThat(slotAndBlockRootChainA.getBlockRoot())
-        .isEqualTo(chainHeadA.getState().getFinalized_checkpoint().getRoot());
-    assertThat(slotAndBlockRootChainB.getBlockRoot())
-        .isEqualTo(chainHeadB.getState().getFinalized_checkpoint().getRoot());
   }
 
   @SuppressWarnings("unchecked")


### PR DESCRIPTION
## PR Description
To avoid needing the chain head state to be loaded prior to setting the new head, find common ancestors using the information in protoarray rather than the historical block info in the head state.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
