### PR TITLE
Change attestation publication errors log level

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/AttestationGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/AttestationGossipManager.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.teku.networking.eth2.gossip;
 
+import io.libp2p.pubsub.NoPeersForOutboundMessageException;
+import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
@@ -60,7 +62,8 @@ public class AttestationGossipManager implements GossipManager {
               attestationPublishSuccessCounter.inc();
             },
             error -> {
-              LOG.trace(
+              LOG.log(
+                  error instanceof NoPeersForOutboundMessageException ? Level.DEBUG : Level.WARN,
                   "Failed to publish attestation for slot {}",
                   attestation.getData().getSlot(),
                   error);


### PR DESCRIPTION
## PR Description

Changes logging to DEBUG when we have no peers for the topic.
In all other cases (when no succeeded submission to at least one peer) we log a WARN.


## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
