### PR TITLE
Convert PeerStatusIntegrationTest to using StorageSystem

### DIFF
--- a/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/PeerStatusIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/PeerStatusIntegrationTest.java
@@ -19,13 +19,11 @@ import static tech.pegasys.teku.infrastructure.async.Waiter.waitFor;
 import static tech.pegasys.teku.spec.config.Constants.MAX_CHUNK_SIZE;
 
 import java.time.Duration;
-import java.util.List;
 import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import tech.pegasys.teku.bls.BLSKeyGenerator;
-import tech.pegasys.teku.bls.BLSKeyPair;
 import tech.pegasys.teku.infrastructure.ssz.type.Bytes4;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
@@ -34,23 +32,29 @@ import tech.pegasys.teku.networking.eth2.rpc.core.encodings.RpcEncoding;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
-import tech.pegasys.teku.statetransition.BeaconChainUtil;
-import tech.pegasys.teku.storage.client.MemoryOnlyRecentChainData;
+import tech.pegasys.teku.spec.logic.common.block.AbstractBlockProcessor;
 import tech.pegasys.teku.storage.client.RecentChainData;
+import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystemBuilder;
+import tech.pegasys.teku.storage.storageSystem.StorageSystem;
 
 public class PeerStatusIntegrationTest {
 
-  private static final List<BLSKeyPair> VALIDATOR_KEYS = BLSKeyGenerator.generateKeyPairs(1);
+  private static final int VALIDATOR_COUNT = 16;
   private final Spec spec = TestSpecFactory.createMinimalPhase0();
   private final Eth2P2PNetworkFactory networkFactory = new Eth2P2PNetworkFactory();
   private final RpcEncoding rpcEncoding = RpcEncoding.createSszSnappyEncoding(MAX_CHUNK_SIZE);
-  private final RecentChainData recentChainData1 = MemoryOnlyRecentChainData.create(spec);
-  private final BeaconChainUtil beaconChainUtil1 =
-      BeaconChainUtil.create(spec, recentChainData1, VALIDATOR_KEYS);
+  private final StorageSystem storageSystem = createStorageSystem();
 
-  @BeforeEach
-  public void setUp() {
-    beaconChainUtil1.initializeStorage();
+  private final RecentChainData recentChainData1 = storageSystem.recentChainData();
+
+  @BeforeAll
+  public static void initSession() {
+    AbstractBlockProcessor.BLS_VERIFY_DEPOSIT = false;
+  }
+
+  @AfterAll
+  public static void resetSession() {
+    AbstractBlockProcessor.BLS_VERIFY_DEPOSIT = true;
   }
 
   @AfterEach
@@ -60,8 +64,59 @@ public class PeerStatusIntegrationTest {
 
   @Test
   public void shouldExchangeStatusMessagesOnConnection() throws Exception {
-    final RecentChainData recentChainData2 = MemoryOnlyRecentChainData.create();
-    BeaconChainUtil.create(recentChainData2, VALIDATOR_KEYS).initializeStorage();
+    final StorageSystem system2 = createStorageSystem();
+    final RecentChainData recentChainData2 = system2.recentChainData();
+    assertThat(recentChainData1.getBestBlockRoot()).isEqualTo(recentChainData2.getBestBlockRoot());
+
+    final Eth2P2PNetwork network1 =
+        networkFactory
+            .builder()
+            .spec(spec)
+            .rpcEncoding(rpcEncoding)
+            .recentChainData(recentChainData1)
+            .startNetwork();
+    final Eth2P2PNetwork network2 =
+        networkFactory
+            .builder()
+            .spec(spec)
+            .rpcEncoding(rpcEncoding)
+            .recentChainData(recentChainData2)
+            .startNetwork();
+
+    waitFor(network1.connect(network1.createPeerAddress(network2.getNodeAddress())));
+    waitFor(
+        () -> {
+          assertThat(network1.getPeerCount()).isEqualTo(1);
+          assertThat(network2.getPeerCount()).isEqualTo(1);
+        });
+
+    final Eth2Peer network2ViewOfPeer1 = network2.getPeer(network1.getNodeId()).orElseThrow();
+
+    assertStatusMatchesStorage(recentChainData1, network2ViewOfPeer1.getStatus());
+
+    final Eth2Peer network1ViewOfPeer2 = network1.getPeer(network2.getNodeId()).orElseThrow();
+    assertStatusMatchesStorage(recentChainData2, network1ViewOfPeer2.getStatus());
+    // When the finalized epoch is genesis we should use a zero finalized root (from the state)
+    // This differs from what recentChainData.getFinalizedCheckpoint will have at genesis
+    assertThat(network1ViewOfPeer2.getStatus().getFinalizedRoot()).isEqualTo(Bytes32.ZERO);
+  }
+
+  @Test
+  public void shouldExchangeStatusMessagesOnConnectionAfterFinalization() throws Exception {
+    final StorageSystem system2 = createStorageSystem();
+    final RecentChainData recentChainData2 = system2.recentChainData();
+    assertThat(recentChainData1.getBestBlockRoot()).isEqualTo(recentChainData2.getBestBlockRoot());
+
+    storageSystem.chainUpdater().finalizeCurrentChain();
+    system2.chainUpdater().syncWith(storageSystem.chainBuilder());
+
+    assertThat(recentChainData1.getBestBlockRoot()).isEqualTo(recentChainData2.getBestBlockRoot());
+    assertThat(recentChainData1.getFinalizedCheckpoint())
+        .isEqualTo(recentChainData2.getFinalizedCheckpoint());
+
+    assertThat(recentChainData1.getFinalizedCheckpoint())
+        .contains(
+            safeJoin(recentChainData1.getBestState().orElseThrow()).getFinalized_checkpoint());
 
     final Eth2P2PNetwork network1 =
         networkFactory
@@ -103,8 +158,8 @@ public class PeerStatusIntegrationTest {
             .recentChainData(recentChainData1)
             .startNetwork();
 
-    final RecentChainData recentChainData2 = MemoryOnlyRecentChainData.create();
-    BeaconChainUtil.create(recentChainData2, VALIDATOR_KEYS).initializeStorage();
+    final StorageSystem storageSystem2 = createStorageSystem();
+    final RecentChainData recentChainData2 = storageSystem2.recentChainData();
     final Eth2P2PNetwork network2 =
         networkFactory
             .builder()
@@ -119,7 +174,7 @@ public class PeerStatusIntegrationTest {
     assertStatusMatchesStorage(recentChainData1, network2ViewOfPeer1.getStatus());
 
     // Peer 1 advances
-    beaconChainUtil1.createAndImportBlockAtSlot(10);
+    this.storageSystem.chainUpdater().advanceChain(10);
 
     final PeerStatus updatedStatusData = waitFor(network2ViewOfPeer1.sendStatus());
     assertStatusMatchesStorage(recentChainData1, updatedStatusData);
@@ -138,8 +193,8 @@ public class PeerStatusIntegrationTest {
             .recentChainData(recentChainData1)
             .startNetwork();
 
-    final RecentChainData recentChainData2 = MemoryOnlyRecentChainData.create();
-    BeaconChainUtil.create(recentChainData2, VALIDATOR_KEYS).initializeStorage();
+    final StorageSystem storageSystem2 = createStorageSystem();
+    final RecentChainData recentChainData2 = storageSystem2.recentChainData();
     final Eth2P2PNetwork network2 =
         networkFactory
             .builder()
@@ -155,7 +210,7 @@ public class PeerStatusIntegrationTest {
     assertStatusMatchesStorage(recentChainData1, network2ViewOfPeer1.getStatus());
 
     // Peer 1 advances
-    beaconChainUtil1.createAndImportBlockAtSlot(10);
+    this.storageSystem.chainUpdater().advanceChain(10);
 
     waitFor(() -> assertStatusMatchesStorage(recentChainData1, network2ViewOfPeer1.getStatus()));
   }
@@ -184,5 +239,15 @@ public class PeerStatusIntegrationTest {
     assertThat(status.getFinalizedEpoch()).isEqualTo(finalizedEpoch);
     assertThat(status.getHeadRoot()).isEqualTo(headRoot);
     assertThat(status.getHeadSlot()).isEqualTo(headSlot);
+  }
+
+  private StorageSystem createStorageSystem() {
+    final StorageSystem system =
+        InMemoryStorageSystemBuilder.create()
+            .specProvider(spec)
+            .numberOfValidators(VALIDATOR_COUNT)
+            .build();
+    system.chainUpdater().initializeGenesis(false);
+    return system;
   }
 }


### PR DESCRIPTION
## PR Description
Convert PeerStatusIntegrationTest to use StorageSystem instead of BeaconChainUtil and add a test for the status after finalisation has progressed past genesis.

Adds a method to "properly" finalize the current chain head in ChainUpdater by adding real attestations to the chain.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
