### PR TITLE
Support repeating async task with fixed delay

### DIFF
--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/AsyncRunner.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/AsyncRunner.java
@@ -63,6 +63,31 @@ public interface AsyncRunner {
   }
 
   /**
+   * Schedules the recurrent task which will be repeatedly executed with the specified delay.
+   *
+   * <p>The recurrent task may perform actions async and the delay between executions will only
+   * begin when the returned future is completed.
+   *
+   * <p>The returned instance can be used to cancel the task. Note that {@link Cancellable#cancel()}
+   * doesn't interrupt already running task.
+   *
+   * <p>Whenever the {@code runnable} throws exception it is notified to the {@code
+   * exceptionHandler} and the task recurring executions are not interrupted
+   */
+  default <T> Cancellable runWithFixedDelay(
+      final ExceptionThrowingFutureSupplier<T> runnable,
+      final Duration initialDelay,
+      final Duration delay,
+      final Consumer<Throwable> exceptionHandler) {
+    Preconditions.checkNotNull(exceptionHandler);
+
+    Cancellable cancellable = FutureUtil.createCancellable();
+    FutureUtil.runWithFixedDelay(
+        this, runnable, cancellable, initialDelay, delay, exceptionHandler);
+    return cancellable;
+  }
+
+  /**
    * Execute the future supplier until it completes normally up to some maximum number of retries.
    *
    * @param action The action to run


### PR DESCRIPTION
## PR Description
Adds a method to `AsyncRunner` to repeatedly run a task with async elements with a fixed delay between when one task ends and the next starts.  Currently this is unused but will be required as part of calculating our peer status once the chain head is accessed via a future.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
