### PR TITLE
Avoid unnecessary boxing

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -639,8 +639,9 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
             : spec.atEpoch(epoch).getBeaconStateUtil().getPreviousDutyDependentRoot(state);
     return new AttesterDuties(
         dependentRoot,
-        validatorIndices.stream()
-            .map(index -> createAttesterDuties(state, epoch, index))
+        validatorIndices
+            .intStream()
+            .mapToObj(index -> createAttesterDuties(state, epoch, index))
             .filter(Optional::isPresent)
             .map(Optional::get)
             .collect(toList()));


### PR DESCRIPTION
## PR Description
Avoid unnecessary boxing of int when streaming validator indices.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
