### PR TITLE
Use more generic types

### DIFF
--- a/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/ChainBuilder.java
+++ b/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/ChainBuilder.java
@@ -46,6 +46,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.Eth1Data;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
+import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
 import tech.pegasys.teku.spec.datastructures.interop.MockStartBeaconStateGenerator;
@@ -371,9 +372,8 @@ public class ChainBuilder {
    * @return a stream of valid attestations voting for the specified block
    */
   public Stream<Attestation> streamValidAttestationsWithTargetBlock(
-      final SignedBlockAndState attestedHead) {
-    return attestationGenerator.streamAttestations(
-        attestedHead.toUnsigned(), attestedHead.getSlot());
+      final StateAndBlockSummary attestedHead) {
+    return attestationGenerator.streamAttestations(attestedHead, attestedHead.getSlot());
   }
 
   private void assertChainIsNotEmpty() {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandler.java
@@ -37,8 +37,8 @@ import tech.pegasys.teku.networking.eth2.rpc.core.RpcException.InvalidRpcMethodV
 import tech.pegasys.teku.networking.p2p.rpc.StreamClosedException;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
-import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BeaconBlocksByRangeRequestMessage;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 
@@ -146,7 +146,7 @@ public class BeaconBlocksByRangeMessageHandler
               final UInt64 headBlockSlot =
                   combinedChainDataClient
                       .getChainHead()
-                      .map(StateAndBlockSummary::getSlot)
+                      .map(BeaconBlockSummary::getSlot)
                       .orElse(ZERO);
               final NavigableMap<UInt64, Bytes32> hotRoots;
               if (combinedChainDataClient.isFinalized(endSlot)) {

--- a/storage/src/test/java/tech/pegasys/teku/storage/client/RecentChainDataTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/client/RecentChainDataTest.java
@@ -45,6 +45,7 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
+import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
@@ -211,10 +212,12 @@ class RecentChainDataTest {
     chainBuilder.generateBlockAtSlot(genesisSpecConfig.getSlotsPerEpoch() - 1);
     chainBuilder.generateBlockAtSlot(genesisSpecConfig.getSlotsPerEpoch() * 2L - 1);
     final SignedBlockAndState bestBlock = chainBuilder.generateNextBlock();
-    saveBlock(recentChainData, bestBlock);
+    chainBuilder
+        .streamBlocksAndStates()
+        .forEach(blockAndState -> saveBlock(recentChainData, blockAndState));
 
     recentChainData.updateHead(bestBlock.getRoot(), bestBlock.getSlot());
-    assertThat(recentChainData.getChainHead().map(StateAndBlockSummary::getRoot))
+    assertThat(recentChainData.getChainHead().map(BeaconBlockSummary::getRoot))
         .contains(bestBlock.getRoot());
     assertThat(this.storageSystem.reorgEventChannel().getHeadEvents())
         .contains(
@@ -235,7 +238,7 @@ class RecentChainDataTest {
     final SignedBlockAndState bestBlock = chainBuilder.generateNextBlock();
 
     recentChainData.updateHead(bestBlock.getRoot(), bestBlock.getSlot());
-    assertThat(recentChainData.getChainHead().map(StateAndBlockSummary::getRoot))
+    assertThat(recentChainData.getChainHead().map(BeaconBlockSummary::getRoot))
         .contains(genesis.getRoot());
   }
 


### PR DESCRIPTION
## PR Description
Use more generic types in method references when referring to the chain head. Also fixes an odd quirk in `RecentChainDataTest` where it wasn't importing all blocks.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
