### PR TITLE
Reduce CircleCI storage requirements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,6 @@ commands:
           keys:
             - deps-{{ checksum "build.gradle" }}-{{ checksum "gradle/versions.gradle" }}-{{ .Branch }}-{{ .Revision }}
             - deps-{{ checksum "build.gradle" }}-{{ checksum "gradle/versions.gradle" }}
-            - deps-
   capture_test_results:
     description: "Capture test results"
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,7 +168,7 @@ jobs:
           name: Prep Artifacts
           command: |
             mkdir /tmp/teku-distributions
-            cp build/distributions/*.tar.gz
+            cp build/distributions/*.tar.gz /tmp/teku-distributions/
       - notify
       - save_cache:
           name: Caching gradle dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,6 +164,11 @@ jobs:
           name: Assemble
           command: |
             ./gradlew --no-daemon --parallel clean compileJava compileTestJava compileJmhJava compileIntegrationTestJava compileAcceptanceTestJava assemble
+      - run:
+          name: Prep Artifacts
+          command: |
+            mkdir /tmp/teku-distributions
+            cp build/distributions/*.tar.gz
       - notify
       - save_cache:
           name: Caching gradle dependencies
@@ -177,7 +182,7 @@ jobs:
             - ./
       - store_artifacts:
           name: Distribution artifacts
-          path:  build/distributions
+          path:  /tmp/teku-distributions
           destination: distributions
           when: always
 

--- a/build.gradle
+++ b/build.gradle
@@ -244,7 +244,7 @@ allprojects {
   }
 }
 
-def refTestVersion = 'v1.1.9' // Arbitrary change to refresh cache number: 0
+def refTestVersion = 'v1.1.9' // Arbitrary change to refresh cache number: 1
 def blsRefTestVersion = 'v0.1.0'
 def refTestBaseUrl = 'https://github.com/ethereum/eth2.0-spec-tests/releases/download'
 def blsRefTestBaseUrl = 'https://github.com/ethereum/bls12-381-tests/releases/download'


### PR DESCRIPTION
## PR Description
Only capture .tar.gz distribution as a CircleCI artefact. Reduces the amount of storage space we need to use on CircleCI.

Also ensures the gradle dependencies cache starts from scratch when dependencies change to ensure we aren't keeping old versions of dependencies in the cache unnecessarily.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
