### PR TITLE
Make BeaconChainMetricsTest use consistent block and state combinations

### DIFF
--- a/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/BeaconChainMetricsTest.java
+++ b/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/BeaconChainMetricsTest.java
@@ -36,16 +36,17 @@ import tech.pegasys.teku.networking.eth2.Eth2P2PNetwork;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.NodeSlot;
-import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
-import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.PendingAttestation;
 import tech.pegasys.teku.spec.datastructures.state.Validator;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.phase0.BeaconStatePhase0;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState.Mutator;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.phase0.BeaconStateSchemaPhase0;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.phase0.MutableBeaconStatePhase0;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.storage.client.ChainHead;
 import tech.pegasys.teku.storage.client.MemoryOnlyRecentChainData;
 import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.validator.coordinator.Eth1DataCache;
@@ -63,9 +64,7 @@ class BeaconChainMetricsTest {
       Bytes32.fromHexString("0x760aa80a2c5cc1452a5301ecb176b366372d5f2218e0c24eFFFFFFFFFFFFFF7F");
   private final Bytes32 root3 =
       Bytes32.fromHexString("0x760aa80a2c5cc1452a5301ecb176b366372d5f2218e0c24e0000000000000080");
-  private BeaconStatePhase0 state =
-      dataStructureUtil.stateBuilderPhase0().slot(NODE_SLOT_VALUE).build();
-  private StateAndBlockSummary chainHead;
+  private SignedBlockAndState chainHead;
 
   private final NodeSlot nodeSlot = new NodeSlot(NODE_SLOT_VALUE);
 
@@ -84,36 +83,36 @@ class BeaconChainMetricsTest {
 
   @BeforeEach
   void setUp() {
-    final SignedBeaconBlock block = dataStructureUtil.randomSignedBlockAndState(state).getBlock();
-    chainHead = mock(SignedBlockAndState.class);
-    when(chainHead.getBeaconBlock()).thenReturn(block.getBeaconBlock());
-    when(chainHead.getRoot()).thenReturn(block.getRoot());
-    when(chainHead.getSlot()).thenAnswer(__ -> state.getSlot());
-    when(chainHead.getState()).thenAnswer(__ -> state);
-    when(recentChainData.getChainHead()).thenReturn(Optional.of(chainHead));
-
     // Update state
     List<Bytes32> blockRootsList =
         new ArrayList<>(Collections.nCopies(1000, dataStructureUtil.randomBytes32()));
-    state =
-        state
+
+    final BeaconState state =
+        dataStructureUtil
+            .stateBuilderPhase0()
+            .slot(NODE_SLOT_VALUE)
+            .build()
             .updated(
                 s -> {
                   s.setFinalized_checkpoint(finalizedCheckpoint);
                   s.setCurrent_justified_checkpoint(currentJustifiedCheckpoint);
                   s.setPrevious_justified_checkpoint(previousJustifiedCheckpoint);
                   s.getBlock_roots().setAllElements(blockRootsList);
-                })
-            .toVersionPhase0()
-            .orElseThrow();
+                });
+    chainHead = dataStructureUtil.randomSignedBlockAndState(state);
+
+    when(recentChainData.getChainHead()).thenAnswer(__ -> Optional.of(ChainHead.create(chainHead)));
+  }
+
+  private <E extends RuntimeException> void updateState(
+      final Mutator<MutableBeaconStatePhase0, E, E, E> mutator) {
+    final BeaconState updatedState =
+        chainHead.getState().toVersionPhase0().orElseThrow().updatedPhase0(mutator);
+    chainHead = dataStructureUtil.randomSignedBlockAndState(updatedState);
   }
 
   private void setBlockRoots(List<Bytes32> newBlockRoots) {
-    state =
-        state
-            .updated(s -> s.getBlock_roots().setAllElements(newBlockRoots))
-            .toVersionPhase0()
-            .orElseThrow();
+    updateState(s -> s.getBlock_roots().setAllElements(newBlockRoots));
   }
 
   @Test
@@ -164,7 +163,7 @@ class BeaconChainMetricsTest {
     when(recentChainData.isPreGenesis()).thenReturn(false);
     beaconChainMetrics.onSlot(NODE_SLOT_VALUE);
     assertThat(metricsSystem.getGauge(BEACON, "finalized_epoch").getValue())
-        .isEqualTo(state.getFinalized_checkpoint().getEpoch().longValue());
+        .isEqualTo(chainHead.getState().getFinalized_checkpoint().getEpoch().longValue());
   }
 
   @Test
@@ -200,7 +199,9 @@ class BeaconChainMetricsTest {
     beaconChainMetrics.onSlot(NODE_SLOT_VALUE);
 
     assertThat(metricsSystem.getGauge(BEACON, "finalized_root").getValue())
-        .isEqualTo(BeaconChainMetrics.getLongFromRoot(state.getFinalized_checkpoint().getRoot()));
+        .isEqualTo(
+            BeaconChainMetrics.getLongFromRoot(
+                chainHead.getState().getFinalized_checkpoint().getRoot()));
   }
 
   @Test
@@ -215,7 +216,7 @@ class BeaconChainMetricsTest {
     beaconChainMetrics.onSlot(NODE_SLOT_VALUE);
 
     assertThat(metricsSystem.getGauge(BEACON, "previous_justified_epoch").getValue())
-        .isEqualTo(state.getPrevious_justified_checkpoint().getEpoch().longValue());
+        .isEqualTo(chainHead.getState().getPrevious_justified_checkpoint().getEpoch().longValue());
   }
 
   @Test
@@ -231,7 +232,8 @@ class BeaconChainMetricsTest {
 
     assertThat(metricsSystem.getGauge(BEACON, "previous_justified_root").getValue())
         .isEqualTo(
-            BeaconChainMetrics.getLongFromRoot(state.getPrevious_justified_checkpoint().getRoot()));
+            BeaconChainMetrics.getLongFromRoot(
+                chainHead.getState().getPrevious_justified_checkpoint().getRoot()));
   }
 
   @Test
@@ -246,7 +248,8 @@ class BeaconChainMetricsTest {
     beaconChainMetrics.onSlot(NODE_SLOT_VALUE);
     assertThat(metricsSystem.getGauge(BEACON, "current_justified_root").getValue())
         .isEqualTo(
-            BeaconChainMetrics.getLongFromRoot(state.getCurrent_justified_checkpoint().getRoot()));
+            BeaconChainMetrics.getLongFromRoot(
+                chainHead.getState().getCurrent_justified_checkpoint().getRoot()));
   }
 
   @Test
@@ -260,7 +263,7 @@ class BeaconChainMetricsTest {
   void getJustifiedEpochValue_shouldReturnValueWhenStoreIsPresent() {
     beaconChainMetrics.onSlot(NODE_SLOT_VALUE);
     assertThat(metricsSystem.getGauge(BEACON, "current_justified_epoch").getValue())
-        .isEqualTo(state.getCurrent_justified_checkpoint().getEpoch().longValue());
+        .isEqualTo(chainHead.getState().getCurrent_justified_checkpoint().getEpoch().longValue());
   }
 
   @Test
@@ -273,7 +276,7 @@ class BeaconChainMetricsTest {
   @Test
   void onSlot_shouldUpdateEth1DataMetrics() {
     beaconChainMetrics.onSlot(NODE_SLOT_VALUE);
-    verify(eth1DataCache).updateMetrics(state);
+    verify(eth1DataCache).updateMetrics(chainHead.getState());
   }
 
   @Test
@@ -287,7 +290,6 @@ class BeaconChainMetricsTest {
             validator(10, 15, true));
 
     withSlotCurrentEpochAttestationsAndValidators(slotNumber, Collections.emptyList(), validators);
-    when(chainHead.getSlot()).thenReturn(slotNumber);
 
     beaconChainMetrics.onSlot(slotNumber);
     assertThat(metricsSystem.getGauge(BEACON, "current_active_validators").getValue()).isEqualTo(2);
@@ -386,8 +388,7 @@ class BeaconChainMetricsTest {
                     bitlist2))
             .collect(toList());
 
-    withCurrentEpochAttestations(
-        allAttestations, UInt64.valueOf(15), dataStructureUtil.randomBytes32());
+    withCurrentEpochAttestations(allAttestations, UInt64.valueOf(15));
 
     beaconChainMetrics.onSlot(UInt64.valueOf(20));
     assertThat(metricsSystem.getGauge(BEACON, "current_correct_validators").getValue())
@@ -416,11 +417,11 @@ class BeaconChainMetricsTest {
                     bitlist2))
             .collect(toList());
 
-    withCurrentEpochAttestations(allAttestations, slot, blockRoot);
+    withCurrentEpochAttestations(allAttestations, slot);
 
-    beaconChainMetrics.onSlot(UInt64.valueOf(20));
-    assertThat(metricsSystem.getGauge(BEACON, "current_correct_validators").getValue())
-        .isEqualTo(4);
+    // Make sure we don't try to get the block root for the state's own slot from block roots array
+    // Otherwise this will fail.
+    assertThat(beaconChainMetrics.updateMetrics()).isCompleted();
   }
 
   @Test
@@ -455,61 +456,45 @@ class BeaconChainMetricsTest {
   }
 
   private void withCurrentEpochAttestations(final List<PendingAttestation> attestations) {
-    withCurrentEpochAttestations(
-        attestations, UInt64.valueOf(100), dataStructureUtil.randomBytes32());
+    withSlotCurrentEpochAttestationsAndValidators(
+        UInt64.valueOf(100), attestations, Collections.emptyList());
   }
 
   private void withCurrentEpochAttestations(
-      final List<PendingAttestation> attestations,
-      final UInt64 slot,
-      final Bytes32 currentBlockRoot) {
+      final List<PendingAttestation> attestations, final UInt64 slot) {
     withSlotCurrentEpochAttestationsAndValidators(slot, attestations, Collections.emptyList());
-
-    final StateAndBlockSummary stateAndBlock = mock(StateAndBlockSummary.class);
-    when(stateAndBlock.getSlot()).thenReturn(slot);
-    when(stateAndBlock.getState()).thenReturn(state);
-    when(stateAndBlock.getRoot()).thenReturn(currentBlockRoot);
-    when(recentChainData.getChainHead()).thenReturn(Optional.of(stateAndBlock));
   }
 
   private void withPreviousEpochAttestations(
       final int slotAsInt, final List<PendingAttestation> attestations) {
-    state =
-        state
-            .updatedPhase0(
-                s -> {
-                  s.getPrevious_epoch_attestations().setAll(attestations);
+    updateState(
+        s -> {
+          s.getPrevious_epoch_attestations().setAll(attestations);
 
-                  s.getCurrent_epoch_attestations().clear();
-                  s.setSlot(UInt64.valueOf(slotAsInt));
-                })
-            .toVersionPhase0()
-            .orElseThrow();
+          s.getCurrent_epoch_attestations().clear();
+          s.setSlot(UInt64.valueOf(slotAsInt));
+        });
   }
 
   private void withSlotCurrentEpochAttestationsAndValidators(
       final UInt64 slot,
       final List<PendingAttestation> attestations,
       final List<Validator> validatorsList) {
-    state =
-        state
-            .updatedPhase0(
-                s -> {
-                  s.getCurrent_epoch_attestations().clear();
-                  if (attestations.size() > 0) {
-                    s.getCurrent_epoch_attestations().setAll(attestations);
-                  }
+    updateState(
+        s -> {
+          s.getCurrent_epoch_attestations().clear();
+          if (attestations.size() > 0) {
+            s.getCurrent_epoch_attestations().setAll(attestations);
+          }
 
-                  s.getPrevious_epoch_attestations().clear();
-                  s.setSlot(slot);
+          s.getPrevious_epoch_attestations().clear();
+          s.setSlot(slot);
 
-                  s.getValidators().clear();
-                  if (validatorsList.size() > 0) {
-                    s.getValidators().setAll(validatorsList);
-                  }
-                })
-            .toVersionPhase0()
-            .orElseThrow();
+          s.getValidators().clear();
+          if (validatorsList.size() > 0) {
+            s.getValidators().setAll(validatorsList);
+          }
+        });
   }
 
   private Stream<PendingAttestation> createAttestations(

--- a/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/BeaconChainMetricsTest.java
+++ b/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/BeaconChainMetricsTest.java
@@ -46,7 +46,6 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState.Mutat
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.phase0.BeaconStateSchemaPhase0;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.phase0.MutableBeaconStatePhase0;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
-import tech.pegasys.teku.storage.client.ChainHead;
 import tech.pegasys.teku.storage.client.MemoryOnlyRecentChainData;
 import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.validator.coordinator.Eth1DataCache;
@@ -101,7 +100,7 @@ class BeaconChainMetricsTest {
                 });
     chainHead = dataStructureUtil.randomSignedBlockAndState(state);
 
-    when(recentChainData.getChainHead()).thenAnswer(__ -> Optional.of(ChainHead.create(chainHead)));
+    when(recentChainData.getChainHead()).thenAnswer(__ -> Optional.of(chainHead));
   }
 
   private <E extends RuntimeException> void updateState(
@@ -421,7 +420,7 @@ class BeaconChainMetricsTest {
 
     // Make sure we don't try to get the block root for the state's own slot from block roots array
     // Otherwise this will fail.
-    assertThat(beaconChainMetrics.updateMetrics()).isCompleted();
+    beaconChainMetrics.onSlot(UInt64.valueOf(20));
   }
 
   @Test


### PR DESCRIPTION
## PR Description
Reduce the usage of mocks and make the data more realistic in `BeaconChainMetricsTest`.  The state and block now always have consistent hashes.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
