### PR TITLE
Make head state access use a SafeFuture

### DIFF
--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryTest.java
@@ -34,7 +34,6 @@ import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.Eth1Data;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
-import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.BeaconBlockBodyAltair;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.BeaconBlockBodySchemaAltair;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregate;
@@ -168,8 +167,7 @@ class BlockFactoryTest {
     beaconChainUtil.initializeStorage();
 
     final BLSSignature randaoReveal = dataStructureUtil.randomSignature();
-    final StateAndBlockSummary bestBlockAndState = recentChainData.getChainHead().orElseThrow();
-    final Bytes32 bestBlockRoot = bestBlockAndState.getRoot();
+    final Bytes32 bestBlockRoot = recentChainData.getBestBlockRoot().orElseThrow();
     final BeaconState blockSlotState =
         recentChainData
             .retrieveStateAtSlot(new SlotAndBlockRoot(UInt64.valueOf(blockSlot), bestBlockRoot))

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/performance/SyncCommitteePerformanceTrackerTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/performance/SyncCommitteePerformanceTrackerTest.java
@@ -36,7 +36,6 @@ import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
-import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.BeaconBlockBodyAltair;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.BeaconBlockBodySchemaAltair;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregate;
@@ -44,6 +43,7 @@ import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncComm
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeMessageSchema;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsAltair;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.storage.client.ChainHead;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 
 class SyncCommitteePerformanceTrackerTest {
@@ -100,7 +100,7 @@ class SyncCommitteePerformanceTrackerTest {
     final Bytes32 wrongBlockRoot = dataStructureUtil.randomBytes32();
     final SignedBlockAndState chainHead = dataStructureUtil.randomSignedBlockAndState(3);
     when(combinedChainDataClient.getChainHead())
-        .thenReturn(Optional.of(StateAndBlockSummary.create(chainHead)));
+        .thenReturn(Optional.of(ChainHead.create(chainHead)));
     doReturn(dataStructureUtil.randomBytes32())
         .when(specSpy)
         .getBlockRootAtSlot(eq(chainHead.getState()), any());

--- a/data/provider/src/main/java/tech/pegasys/teku/api/blockselector/BlockSelectorFactory.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/blockselector/BlockSelectorFactory.java
@@ -24,6 +24,7 @@ import tech.pegasys.teku.api.exceptions.BadRequestException;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.storage.client.ChainHead;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 
 public class BlockSelectorFactory {
@@ -66,7 +67,12 @@ public class BlockSelectorFactory {
   }
 
   public BlockSelector headSelector() {
-    return () -> optionalToList(SafeFuture.completedFuture(client.getBestBlock()));
+    return () ->
+        optionalToList(
+            client
+                .getChainHead()
+                .map(ChainHead::getBlock)
+                .orElse(SafeFuture.completedFuture(Optional.empty())));
   }
 
   public BlockSelector nonCanonicalBlocksSelector(final UInt64 slot) {

--- a/data/provider/src/test/java/tech/pegasys/teku/api/ChainDataProviderTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/ChainDataProviderTest.java
@@ -173,7 +173,7 @@ public class ChainDataProviderTest {
     final ChainDataProvider provider =
         new ChainDataProvider(spec, recentChainData, combinedChainDataClient);
     final tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock block =
-        combinedChainDataClient.getBestBlock().orElseThrow();
+        storageSystem.getChainHead().getSignedBeaconBlock().orElseThrow();
     BlockHeader result = provider.getBlockHeader("head").get().orElseThrow();
     final BeaconBlockHeader beaconBlockHeader =
         new BeaconBlockHeader(
@@ -210,7 +210,7 @@ public class ChainDataProviderTest {
     final ChainDataProvider provider =
         new ChainDataProvider(spec, recentChainData, combinedChainDataClient);
     final tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock block =
-        combinedChainDataClient.getBestBlock().orElseThrow();
+        storageSystem.getChainHead().getSignedBeaconBlock().orElseThrow();
     List<BlockHeader> results = provider.getBlockHeaders(Optional.empty(), Optional.empty()).get();
     assertThat(results.get(0).root).isEqualTo(block.getRoot());
   }

--- a/data/provider/src/test/java/tech/pegasys/teku/api/blockselector/BlockSelectorFactoryTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/blockselector/BlockSelectorFactoryTest.java
@@ -28,7 +28,9 @@ import tech.pegasys.teku.api.exceptions.BadRequestException;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.storage.client.ChainHead;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 
 public class BlockSelectorFactoryTest {
@@ -40,10 +42,11 @@ public class BlockSelectorFactoryTest {
 
   @Test
   public void headSelector_shouldGetBestBlock() throws ExecutionException, InterruptedException {
-    when(client.getBestBlock()).thenReturn(Optional.of(block));
+    final SignedBlockAndState blockAndState = data.randomSignedBlockAndState(100);
+    when(client.getChainHead()).thenReturn(Optional.of(ChainHead.create(blockAndState)));
     List<SignedBeaconBlock> blockList = blockSelectorFactory.headSelector().getBlock().get();
-    verify(client).getBestBlock();
-    assertThat(blockList).containsExactly(block);
+    verify(client).getChainHead();
+    assertThat(blockList).containsExactly(blockAndState.getBlock());
   }
 
   @Test

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/MinimalBeaconBlockSummary.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/MinimalBeaconBlockSummary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ConsenSys AG.
+ * Copyright 2022 ConsenSys AG.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -13,22 +13,17 @@
 
 package tech.pegasys.teku.spec.datastructures.blocks;
 
-import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
-/** An overarching interface for accessing summary fields (header fields) of a beacon block */
-public interface BeaconBlockSummary extends MinimalBeaconBlockSummary {
+public interface MinimalBeaconBlockSummary {
 
-  UInt64 getProposerIndex();
+  UInt64 getSlot();
 
-  Bytes32 getBodyRoot();
+  Bytes32 getParentRoot();
 
-  default Optional<BeaconBlock> getBeaconBlock() {
-    return Optional.empty();
-  }
+  Bytes32 getStateRoot();
 
-  default Optional<SignedBeaconBlock> getSignedBeaconBlock() {
-    return Optional.empty();
-  }
+  /** @return the hash tree root of the block */
+  Bytes32 getRoot();
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/BeaconStateUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/BeaconStateUtil.java
@@ -27,7 +27,7 @@ import tech.pegasys.teku.infrastructure.ssz.collections.SszBitvector;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
-import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSummary;
+import tech.pegasys.teku.spec.datastructures.blocks.MinimalBeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.state.Validator;
@@ -111,7 +111,7 @@ public class BeaconStateUtil {
    * parent must then be the block in effect in the previous slot.
    */
   public Optional<Bytes32> getPreviousDutyDependentRoot(
-      final ReadOnlyForkChoiceStrategy forkChoiceStrategy, final BeaconBlockSummary block) {
+      final ReadOnlyForkChoiceStrategy forkChoiceStrategy, final MinimalBeaconBlockSummary block) {
     return getDutyDependentRoot(
         forkChoiceStrategy,
         block.getRoot(),
@@ -133,7 +133,7 @@ public class BeaconStateUtil {
    * </ul>
    */
   public Optional<Bytes32> getCurrentDutyDependentRoot(
-      final ReadOnlyForkChoiceStrategy forkChoiceStrategy, final BeaconBlockSummary block) {
+      final ReadOnlyForkChoiceStrategy forkChoiceStrategy, final MinimalBeaconBlockSummary block) {
     return getDutyDependentRoot(
         forkChoiceStrategy, block.getRoot(), miscHelpers.computeEpochAtSlot(block.getSlot()));
   }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/EpochCachePrimer.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/EpochCachePrimer.java
@@ -17,7 +17,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.blocks.MinimalBeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.logic.common.util.BeaconStateUtil;
@@ -53,11 +53,12 @@ public class EpochCachePrimer {
   }
 
   private boolean isWithinOneEpochOfHeadBlock(
-      final UInt64 firstSlot, final SignedBeaconBlock block) {
+      final UInt64 firstSlot, final MinimalBeaconBlockSummary block) {
     return block.getSlot().plus(spec.getSlotsPerEpoch(firstSlot)).isGreaterThanOrEqualTo(firstSlot);
   }
 
-  private boolean isAfterHeadBlockEpoch(final UInt64 epoch, final SignedBeaconBlock headBlock) {
+  private boolean isAfterHeadBlockEpoch(
+      final UInt64 epoch, final MinimalBeaconBlockSummary headBlock) {
     return spec.computeEpochAtSlot(headBlock.getSlot()).isLessThan(epoch);
   }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/PayloadAttributesCalculator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/PayloadAttributesCalculator.java
@@ -29,10 +29,10 @@ import tech.pegasys.teku.infrastructure.ssz.type.Bytes20;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
-import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
 import tech.pegasys.teku.spec.datastructures.operations.versions.bellatrix.BeaconPreparableProposer;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.executionengine.PayloadAttributes;
+import tech.pegasys.teku.storage.client.ChainHead;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
 public class PayloadAttributesCalculator {
@@ -133,13 +133,13 @@ public class PayloadAttributesCalculator {
   }
 
   private SafeFuture<Optional<BeaconState>> getStateInEpoch(final UInt64 requiredEpoch) {
-    final Optional<StateAndBlockSummary> chainHead = recentChainData.getChainHead();
+    final Optional<ChainHead> chainHead = recentChainData.getChainHead();
     if (chainHead.isEmpty()) {
       return SafeFuture.completedFuture(Optional.empty());
     }
-    final StateAndBlockSummary head = chainHead.get();
+    final ChainHead head = chainHead.get();
     if (spec.computeEpochAtSlot(head.getSlot()).equals(requiredEpoch)) {
-      return SafeFuture.completedFuture(Optional.of(head.getState()));
+      return head.getState().thenApply(Optional::of);
     } else {
       return recentChainData.retrieveStateAtSlot(
           new SlotAndBlockRoot(spec.computeStartSlotAtEpoch(requiredEpoch), head.getRoot()));

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/EpochCachePrimerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/EpochCachePrimerTest.java
@@ -23,13 +23,13 @@ import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThat
 
 import java.util.Optional;
 import java.util.function.Consumer;
+import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
@@ -145,10 +145,10 @@ class EpochCachePrimerTest {
   }
 
   private BeaconState getStateForEpoch(final UInt64 epoch) {
-    final SignedBeaconBlock headBlock = recentChainData.getHeadBlock().orElseThrow();
+    final Bytes32 headBlock = recentChainData.getBestBlockRoot().orElseThrow();
     final SafeFuture<Optional<BeaconState>> stateFuture =
         recentChainData.retrieveStateAtSlot(
-            new SlotAndBlockRoot(realSpec.computeStartSlotAtEpoch(epoch), headBlock.getRoot()));
+            new SlotAndBlockRoot(realSpec.computeStartSlotAtEpoch(epoch), headBlock));
     assertThatSafeFuture(stateFuture).isCompletedWithNonEmptyOptional();
     return stateFuture.getNow(null).orElseThrow();
   }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockImporterTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockImporterTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -336,7 +337,8 @@ public class BlockImporterTest {
 
     // Now create a new block that is not descendant from the finalized block
     AttestationGenerator attestationGenerator = new AttestationGenerator(spec, validatorKeys);
-    final StateAndBlockSummary blockAndState = otherStorage.getChainHead().orElseThrow();
+    final StateAndBlockSummary blockAndState =
+        safeJoin(otherStorage.getChainHead().orElseThrow().asStateAndBlockSummary());
     final Attestation attestation = attestationGenerator.validAttestation(blockAndState);
     final SignedBeaconBlock block =
         otherChain.createAndImportBlockAtSlotWithAttestations(currentSlot, List.of(attestation));

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
@@ -46,6 +46,7 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidateableAttestation;
 import tech.pegasys.teku.spec.datastructures.blocks.Eth1Data;
+import tech.pegasys.teku.spec.datastructures.blocks.MinimalBeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.PowBlock;
@@ -147,7 +148,8 @@ class ForkChoiceTest {
         forkChoice.onBlock(blockAndState.getBlock(), executionEngine);
     assertBlockImportedSuccessfully(importResult, false);
 
-    assertThat(recentChainData.getHeadBlock()).contains(blockAndState.getBlock());
+    assertThat(recentChainData.getHeadBlock().map(MinimalBeaconBlockSummary::getRoot))
+        .contains(blockAndState.getRoot());
     assertThat(recentChainData.getHeadSlot()).isEqualTo(blockAndState.getSlot());
   }
 
@@ -162,7 +164,8 @@ class ForkChoiceTest {
         forkChoice.onBlock(blockAndState.getBlock(), executionEngine);
     assertBlockImportedSuccessfully(importResult, false);
 
-    assertThat(recentChainData.getHeadBlock()).contains(blockAndState.getBlock());
+    assertThat(recentChainData.getHeadBlock().map(MinimalBeaconBlockSummary::getRoot))
+        .contains(blockAndState.getRoot());
     assertThat(recentChainData.getHeadSlot()).isEqualTo(blockAndState.getSlot());
     assertThat(storageSystem.chainHeadChannel().getReorgEvents()).isEmpty();
   }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeStateUtilsTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeStateUtilsTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThatSafeFuture;
+import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
@@ -35,6 +36,7 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.altair.BeaconStateAltair;
 import tech.pegasys.teku.spec.logic.common.util.SyncCommitteeUtil;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.storage.client.ChainHead;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
 class SyncCommitteeStateUtilsTest {
@@ -118,7 +120,7 @@ class SyncCommitteeStateUtilsTest {
                     Bytes32.ZERO,
                     dataStructureUtil.randomBytes32()))
             .build();
-    final StateAndBlockSummary chainHead = StateAndBlockSummary.create(headState);
+    final ChainHead chainHead = ChainHead.create(StateAndBlockSummary.create(headState));
     when(recentChainData.getChainHead()).thenReturn(Optional.of(chainHead));
 
     final BeaconStateAltair generatedState =
@@ -148,12 +150,12 @@ class SyncCommitteeStateUtilsTest {
   }
 
   private void assertRetrievedStateIsSuitable(final UInt64 slot, final BeaconState state) {
-    final StateAndBlockSummary chainHead = StateAndBlockSummary.create(state);
+    final ChainHead chainHead = ChainHead.create(StateAndBlockSummary.create(state));
     when(recentChainData.getChainHead()).thenReturn(Optional.of(chainHead));
 
     final SafeFuture<Optional<BeaconStateAltair>> result =
         stateUtils.getStateForSyncCommittee(slot);
 
-    assertThatSafeFuture(result).isCompletedWithOptionalContaining(chainHead.getState());
+    assertThatSafeFuture(result).isCompletedWithOptionalContaining(safeJoin(chainHead.getState()));
   }
 }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/AggregateAttestationValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/AggregateAttestationValidatorTest.java
@@ -149,7 +149,7 @@ class AggregateAttestationValidatorTest {
 
   @Test
   public void shouldReturnValidForValidAggregate() {
-    final StateAndBlockSummary chainHead = recentChainData.getChainHead().orElseThrow();
+    final StateAndBlockSummary chainHead = storageSystem.getChainHead();
     final SignedAggregateAndProof aggregate = generator.validAggregateAndProof(chainHead);
     whenAttestationIsValid(aggregate);
     assertThat(validator.validate(ValidateableAttestation.aggregateFromValidator(spec, aggregate)))
@@ -158,7 +158,7 @@ class AggregateAttestationValidatorTest {
 
   @Test
   public void shouldReturnValidForValidAggregate_whenManyBlocksHaveBeenSkipped() {
-    final StateAndBlockSummary chainHead = recentChainData.getChainHead().orElseThrow();
+    final StateAndBlockSummary chainHead = storageSystem.getChainHead();
     final UInt64 currentSlot =
         chainHead.getSlot().plus(spec.getSlotsPerEpoch(chainHead.getSlot()) * 3L);
     storageSystem.chainUpdater().setCurrentSlot(currentSlot);
@@ -173,7 +173,7 @@ class AggregateAttestationValidatorTest {
   @Test
   public void shouldRejectWhenAttestationValidatorRejects() {
     final SignedAggregateAndProof aggregate =
-        generator.validAggregateAndProof(recentChainData.getChainHead().orElseThrow());
+        generator.validAggregateAndProof(storageSystem.getChainHead());
     ValidateableAttestation attestation =
         ValidateableAttestation.aggregateFromValidator(spec, aggregate);
     when(attestationValidator.singleOrAggregateAttestationChecks(
@@ -186,7 +186,7 @@ class AggregateAttestationValidatorTest {
   @Test
   public void shouldIgnoreWhenAttestationValidatorIgnores() {
     final SignedAggregateAndProof aggregate =
-        generator.validAggregateAndProof(recentChainData.getChainHead().orElseThrow());
+        generator.validAggregateAndProof(storageSystem.getChainHead());
     ValidateableAttestation attestation =
         ValidateableAttestation.aggregateFromValidator(spec, aggregate);
     when(attestationValidator.singleOrAggregateAttestationChecks(
@@ -200,7 +200,7 @@ class AggregateAttestationValidatorTest {
   @Test
   public void shouldSaveForFutureWhenAttestationValidatorSavesForFuture() {
     final SignedAggregateAndProof aggregate =
-        generator.validAggregateAndProof(recentChainData.getChainHead().orElseThrow());
+        generator.validAggregateAndProof(storageSystem.getChainHead());
     ValidateableAttestation attestation =
         ValidateableAttestation.aggregateFromValidator(spec, aggregate);
     when(attestationValidator.singleOrAggregateAttestationChecks(
@@ -230,7 +230,7 @@ class AggregateAttestationValidatorTest {
     final SignedAggregateAndProof aggregate =
         generator
             .generator()
-            .blockAndState(recentChainData.getChainHead().orElseThrow())
+            .blockAndState(storageSystem.getChainHead())
             .aggregatorIndex(ONE)
             .selectionProof(dataStructureUtil.randomSignature())
             .generate();
@@ -280,7 +280,7 @@ class AggregateAttestationValidatorTest {
 
   @Test
   public void shouldAcceptAggregateWithSameHashTreeRoot() {
-    final StateAndBlockSummary chainHead = recentChainData.getChainHead().orElseThrow();
+    final StateAndBlockSummary chainHead = storageSystem.getChainHead();
     final SignedAggregateAndProof aggregateAndProof1 = generator.validAggregateAndProof(chainHead);
 
     final Attestation attestation = aggregateAndProof1.getMessage().getAggregate();
@@ -313,7 +313,7 @@ class AggregateAttestationValidatorTest {
 
   @Test
   public void shouldOnlyAcceptFirstAggregateWithSameHashTreeRootWhenPassedSeenAggregates() {
-    final StateAndBlockSummary chainHead = recentChainData.getChainHead().orElseThrow();
+    final StateAndBlockSummary chainHead = storageSystem.getChainHead();
     final SignedAggregateAndProof aggregateAndProof1 = generator.validAggregateAndProof(chainHead);
     final Attestation attestation = aggregateAndProof1.getMessage().getAggregate();
     final SignedAggregateAndProof aggregateAndProof2 =
@@ -343,7 +343,7 @@ class AggregateAttestationValidatorTest {
 
   @Test
   public void shouldAcceptAggregateWithSameSlotAndDifferentAggregatorIndex() {
-    final StateAndBlockSummary chainHead = recentChainData.getChainHead().orElseThrow();
+    final StateAndBlockSummary chainHead = storageSystem.getChainHead();
     final SignedAggregateAndProof aggregateAndProof1 = generator.validAggregateAndProof(chainHead);
 
     final List<Attestation> aggregatesForSlot =
@@ -415,7 +415,7 @@ class AggregateAttestationValidatorTest {
 
   @Test
   public void shouldRejectAggregateWhenSelectionProofDoesNotSelectAsAggregator() {
-    final StateAndBlockSummary chainHead = recentChainData.getChainHead().orElseThrow();
+    final StateAndBlockSummary chainHead = storageSystem.getChainHead();
     int aggregatorIndex = 3;
     final CommitteeAssignment committeeAssignment =
         getCommitteeAssignment(chainHead, aggregatorIndex, ZERO);
@@ -444,7 +444,7 @@ class AggregateAttestationValidatorTest {
 
   @Test
   public void shouldRejectIfAggregatorIndexIsNotWithinTheCommittee() {
-    final StateAndBlockSummary chainHead = recentChainData.getChainHead().orElseThrow();
+    final StateAndBlockSummary chainHead = storageSystem.getChainHead();
     final int aggregatorIndex = 60;
     final SignedAggregateAndProof aggregate =
         generator
@@ -472,7 +472,7 @@ class AggregateAttestationValidatorTest {
     final SignedAggregateAndProof aggregate =
         generator
             .generator()
-            .blockAndState(recentChainData.getChainHead().orElseThrow())
+            .blockAndState(storageSystem.getChainHead())
             .aggregatorIndex(ONE)
             .selectionProof(dataStructureUtil.randomSignature())
             .generate();
@@ -485,7 +485,7 @@ class AggregateAttestationValidatorTest {
   @Test
   public void shouldRejectIfAggregateAndProofSignatureIsNotValid() {
     final SignedAggregateAndProof validAggregate =
-        generator.validAggregateAndProof(recentChainData.getChainHead().orElseThrow());
+        generator.validAggregateAndProof(storageSystem.getChainHead());
     final SignedAggregateAndProof invalidAggregate =
         signedAggregateAndProofSchema.create(
             validAggregate.getMessage(), dataStructureUtil.randomSignature());

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/BeaconChainUtil.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/BeaconChainUtil.java
@@ -340,8 +340,7 @@ public class BeaconChainUtil {
     while (recentChainData.getStore().getFinalizedCheckpoint().getEpoch().compareTo(epoch) < 0) {
 
       ChainHead head = recentChainData.getChainHead().orElseThrow();
-      final StateAndBlockSummary headStateAndBlockSummary =
-          StateAndBlockSummary.create(head, safeJoin(head.getState()));
+      final StateAndBlockSummary headStateAndBlockSummary = safeJoin(head.asStateAndBlockSummary());
       UInt64 slot = recentChainData.getHeadSlot();
       SszList<Attestation> currentSlotAssignments =
           beaconBlockBodySchema

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/BeaconChainUtil.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/BeaconChainUtil.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.statetransition;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
+import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 import static tech.pegasys.teku.infrastructure.async.SyncAsyncRunner.SYNC_RUNNER;
 
 import java.util.List;
@@ -48,6 +49,7 @@ import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportRe
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
 import tech.pegasys.teku.statetransition.forkchoice.MergeTransitionBlockValidator;
 import tech.pegasys.teku.statetransition.forkchoice.StubForkChoiceNotifier;
+import tech.pegasys.teku.storage.client.ChainHead;
 import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.storage.store.UpdatableStore.StoreTransaction;
 
@@ -299,9 +301,9 @@ public class BeaconChainUtil {
     checkState(
         withValidProposer || validatorKeys.size() > 1,
         "Must have >1 validator in order to create a block from an invalid proposer.");
-    final StateAndBlockSummary bestBlockAndState = recentChainData.getChainHead().orElseThrow();
+    final ChainHead bestBlockAndState = recentChainData.getChainHead().orElseThrow();
     final Bytes32 bestBlockRoot = bestBlockAndState.getRoot();
-    final BeaconState preState = bestBlockAndState.getState();
+    final BeaconState preState = safeJoin(bestBlockAndState.getState());
     checkArgument(bestBlockAndState.getSlot().compareTo(slot) < 0, "Slot must be in the future.");
 
     final int correctProposerIndex = blockCreator.getProposerIndexForSlot(preState, slot);
@@ -337,12 +339,15 @@ public class BeaconChainUtil {
 
     while (recentChainData.getStore().getFinalizedCheckpoint().getEpoch().compareTo(epoch) < 0) {
 
-      StateAndBlockSummary head = recentChainData.getChainHead().orElseThrow();
+      ChainHead head = recentChainData.getChainHead().orElseThrow();
+      final StateAndBlockSummary headStateAndBlockSummary =
+          StateAndBlockSummary.create(head, safeJoin(head.getState()));
       UInt64 slot = recentChainData.getHeadSlot();
       SszList<Attestation> currentSlotAssignments =
           beaconBlockBodySchema
               .getAttestationsSchema()
-              .createFromElements(attestationGenerator.getAttestationsForSlot(head, slot));
+              .createFromElements(
+                  attestationGenerator.getAttestationsForSlot(headStateAndBlockSummary, slot));
       createAndImportBlockAtSlot(
           recentChainData.getHeadSlot().plus(UInt64.ONE),
           Optional.of(currentSlotAssignments),

--- a/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/GossipMessageHandlerIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/GossipMessageHandlerIntegrationTest.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.networking.eth2;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 import static tech.pegasys.teku.infrastructure.async.Waiter.ensureConditionRemainsMet;
 import static tech.pegasys.teku.infrastructure.async.Waiter.waitFor;
 
@@ -216,8 +217,7 @@ public class GossipMessageHandlerIntegrationTest {
 
     // Propagate attestation from network 1
     AttestationGenerator attestationGenerator = new AttestationGenerator(spec, validatorKeys);
-    final StateAndBlockSummary bestBlockAndState =
-        node1.storageClient().getChainHead().orElseThrow();
+    final StateAndBlockSummary bestBlockAndState = getChainHead(node1);
     Attestation validAttestation = attestationGenerator.validAttestation(bestBlockAndState);
     processedAttestationSubscribers.forEach(
         s -> s.accept(ValidateableAttestation.from(spec, validAttestation)));
@@ -267,8 +267,7 @@ public class GossipMessageHandlerIntegrationTest {
 
     // Propagate attestation from network 1
     AttestationGenerator attestationGenerator = new AttestationGenerator(spec, validatorKeys);
-    final StateAndBlockSummary bestBlockAndState =
-        node1.storageClient().getChainHead().orElseThrow();
+    final StateAndBlockSummary bestBlockAndState = getChainHead(node1);
     ValidateableAttestation validAttestation =
         ValidateableAttestation.from(
             spec, attestationGenerator.validAttestation(bestBlockAndState));
@@ -334,8 +333,7 @@ public class GossipMessageHandlerIntegrationTest {
 
     // Propagate attestation from network 1
     AttestationGenerator attestationGenerator = new AttestationGenerator(spec, validatorKeys);
-    final StateAndBlockSummary bestBlockAndState =
-        node1.storageClient().getChainHead().orElseThrow();
+    final StateAndBlockSummary bestBlockAndState = getChainHead(node1);
     Attestation attestation = attestationGenerator.validAttestation(bestBlockAndState);
 
     final int subnetId =
@@ -392,5 +390,9 @@ public class GossipMessageHandlerIntegrationTest {
 
   private void waitForMessageToBeDelivered() throws Exception {
     Thread.sleep(1000);
+  }
+
+  private StateAndBlockSummary getChainHead(final NodeManager node1) {
+    return safeJoin(node1.storageClient().getChainHead().orElseThrow().asStateAndBlockSummary());
   }
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandler.java
@@ -37,7 +37,7 @@ import tech.pegasys.teku.networking.eth2.rpc.core.RpcException.InvalidRpcMethodV
 import tech.pegasys.teku.networking.p2p.rpc.StreamClosedException;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSummary;
+import tech.pegasys.teku.spec.datastructures.blocks.MinimalBeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BeaconBlocksByRangeRequestMessage;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
@@ -146,7 +146,7 @@ public class BeaconBlocksByRangeMessageHandler
               final UInt64 headBlockSlot =
                   combinedChainDataClient
                       .getChainHead()
-                      .map(BeaconBlockSummary::getSlot)
+                      .map(MinimalBeaconBlockSummary::getSlot)
                       .orElse(ZERO);
               final NavigableMap<UInt64, Bytes32> hotRoots;
               if (combinedChainDataClient.isFinalized(endSlot)) {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/StatusMessageFactory.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/StatusMessageFactory.java
@@ -15,7 +15,7 @@ package tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods;
 
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
-import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSummary;
+import tech.pegasys.teku.spec.datastructures.blocks.MinimalBeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.StatusMessage;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
@@ -36,7 +36,7 @@ public class StatusMessageFactory {
     }
 
     final Checkpoint finalizedCheckpoint = recentChainData.getFinalizedCheckpoint().orElseThrow();
-    final BeaconBlockSummary chainHead = recentChainData.getChainHead().orElseThrow();
+    final MinimalBeaconBlockSummary chainHead = recentChainData.getChainHead().orElseThrow();
     final ForkInfo forkInfo = recentChainData.getCurrentForkInfo().orElseThrow();
 
     return Optional.of(

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/ActiveEth2P2PNetworkTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/ActiveEth2P2PNetworkTest.java
@@ -28,7 +28,6 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
-import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
 import tech.pegasys.teku.infrastructure.events.EventChannels;
@@ -56,7 +55,7 @@ public class ActiveEth2P2PNetworkTest {
   private final StorageSystem storageSystem = InMemoryStorageSystemBuilder.buildDefault(spec);
 
   // Stubs and mocks
-  private final AsyncRunner asyncRunner = new StubAsyncRunner();
+  private final StubAsyncRunner asyncRunner = new StubAsyncRunner();
   private final DiscoveryNetwork<?> discoveryNetwork = mock(DiscoveryNetwork.class);
   private final Eth2PeerManager peerManager = mock(Eth2PeerManager.class);
   private final GossipForkManager gossipForkManager = mock(GossipForkManager.class);
@@ -111,6 +110,7 @@ public class ActiveEth2P2PNetworkTest {
 
     // Process epoch 1 - we shouldn't update fork info here
     network.onEpoch(UInt64.ONE);
+    asyncRunner.executeDueActions();
     verify(discoveryNetwork).updateGossipTopicScoring(any());
     verifyNoMoreInteractions(discoveryNetwork);
 

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/AbstractTopicHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/AbstractTopicHandlerTest.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.networking.eth2.gossip.topics;
 
 import static org.mockito.Mockito.mock;
+import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 
 import org.junit.jupiter.api.BeforeEach;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
@@ -23,6 +24,7 @@ import tech.pegasys.teku.networking.eth2.gossip.topics.topichandlers.Eth2TopicHa
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.BeaconChainUtil;
 import tech.pegasys.teku.storage.client.MemoryOnlyRecentChainData;
@@ -53,5 +55,9 @@ public abstract class AbstractTopicHandlerTest<T> {
 
   protected BeaconChainUtil createBeaconChainUtil() {
     return BeaconChainUtil.create(spec, 2, recentChainData);
+  }
+
+  protected StateAndBlockSummary getChainHead() {
+    return safeJoin(recentChainData.getChainHead().orElseThrow().asStateAndBlockSummary());
   }
 }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/SingleAttestationTopicHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/topics/SingleAttestationTopicHandlerTest.java
@@ -55,7 +55,7 @@ public class SingleAttestationTopicHandlerTest
   @Test
   public void handleMessage_valid() {
     final AttestationGenerator attestationGenerator = new AttestationGenerator(spec, validatorKeys);
-    final StateAndBlockSummary blockAndState = recentChainData.getChainHead().orElseThrow();
+    final StateAndBlockSummary blockAndState = getChainHead();
     final ValidateableAttestation attestation =
         ValidateableAttestation.fromNetwork(
             spec, attestationGenerator.validAttestation(blockAndState), SUBNET_ID);
@@ -72,7 +72,7 @@ public class SingleAttestationTopicHandlerTest
   @Test
   public void handleMessage_ignored() {
     final AttestationGenerator attestationGenerator = new AttestationGenerator(spec, validatorKeys);
-    final StateAndBlockSummary blockAndState = recentChainData.getChainHead().orElseThrow();
+    final StateAndBlockSummary blockAndState = getChainHead();
     final ValidateableAttestation attestation =
         ValidateableAttestation.fromNetwork(
             spec, attestationGenerator.validAttestation(blockAndState), SUBNET_ID);
@@ -89,7 +89,7 @@ public class SingleAttestationTopicHandlerTest
   @Test
   public void handleMessage_saveForFuture() {
     final AttestationGenerator attestationGenerator = new AttestationGenerator(spec, validatorKeys);
-    final StateAndBlockSummary blockAndState = recentChainData.getChainHead().orElseThrow();
+    final StateAndBlockSummary blockAndState = getChainHead();
     final ValidateableAttestation attestation =
         ValidateableAttestation.fromNetwork(
             spec, attestationGenerator.validAttestation(blockAndState), SUBNET_ID);
@@ -106,7 +106,7 @@ public class SingleAttestationTopicHandlerTest
   @Test
   public void handleMessage_invalid() {
     final AttestationGenerator attestationGenerator = new AttestationGenerator(spec, validatorKeys);
-    final StateAndBlockSummary blockAndState = recentChainData.getChainHead().orElseThrow();
+    final StateAndBlockSummary blockAndState = getChainHead();
     final ValidateableAttestation attestation =
         ValidateableAttestation.fromNetwork(
             spec, attestationGenerator.validAttestation(blockAndState), SUBNET_ID);

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandlerTest.java
@@ -53,6 +53,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BeaconBlocksByRangeRequestMessage;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.storage.client.ChainHead;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 
 class BeaconBlocksByRangeMessageHandlerTest {
@@ -478,6 +479,7 @@ class BeaconBlocksByRangeMessageHandlerTest {
   }
 
   private void withCanonicalHeadBlock(final StateAndBlockSummary chainHead) {
-    when(combinedChainDataClient.getChainHead()).thenReturn(Optional.of(chainHead));
+    when(combinedChainDataClient.getChainHead())
+        .thenReturn(Optional.of(ChainHead.create(chainHead)));
   }
 }

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/SyncCommitteeMetrics.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/SyncCommitteeMetrics.java
@@ -71,12 +71,16 @@ public class SyncCommitteeMetrics implements SlotEventsChannel, ChainHeadChannel
       final Bytes32 currentDutyDependentRoot,
       final Optional<ReorgContext> optionalReorgContext) {
     recentChainData
-        .getHeadBlock()
-        .flatMap(block -> block.getMessage().getBody().toVersionAltair())
-        .ifPresent(
-            body ->
-                headLiveSyncCommittee.set(
-                    body.getSyncAggregate().getSyncCommitteeBits().getBitCount()));
+        .retrieveBlockByRoot(bestBlockRoot)
+        .thenAccept(
+            maybeBlock ->
+                maybeBlock
+                    .flatMap(block -> block.getBody().toVersionAltair())
+                    .ifPresent(
+                        body ->
+                            headLiveSyncCommittee.set(
+                                body.getSyncAggregate().getSyncCommitteeBits().getBitCount())))
+        .reportExceptions();
   }
 
   @Override

--- a/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/BeaconChainMetricsTest.java
+++ b/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/BeaconChainMetricsTest.java
@@ -46,6 +46,7 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState.Mutat
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.phase0.BeaconStateSchemaPhase0;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.phase0.MutableBeaconStatePhase0;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.storage.client.ChainHead;
 import tech.pegasys.teku.storage.client.MemoryOnlyRecentChainData;
 import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.validator.coordinator.Eth1DataCache;
@@ -100,7 +101,7 @@ class BeaconChainMetricsTest {
                 });
     chainHead = dataStructureUtil.randomSignedBlockAndState(state);
 
-    when(recentChainData.getChainHead()).thenAnswer(__ -> Optional.of(chainHead));
+    when(recentChainData.getChainHead()).thenAnswer(__ -> Optional.of(ChainHead.create(chainHead)));
   }
 
   private <E extends RuntimeException> void updateState(

--- a/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/BeaconChainMetricsTest.java
+++ b/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/BeaconChainMetricsTest.java
@@ -161,7 +161,7 @@ class BeaconChainMetricsTest {
   @Test
   void getFinalizedEpochValue_shouldSupplyValueWhenStoreIsPresent() {
     when(recentChainData.isPreGenesis()).thenReturn(false);
-    beaconChainMetrics.onSlot(NODE_SLOT_VALUE);
+    assertThat(beaconChainMetrics.updateMetrics()).isCompleted();
     assertThat(metricsSystem.getGauge(BEACON, "finalized_epoch").getValue())
         .isEqualTo(chainHead.getState().getFinalized_checkpoint().getEpoch().longValue());
   }
@@ -196,7 +196,7 @@ class BeaconChainMetricsTest {
 
   @Test
   void getFinalizedRootValue_shouldReturnValueWhenStoreIsPresent() {
-    beaconChainMetrics.onSlot(NODE_SLOT_VALUE);
+    assertThat(beaconChainMetrics.updateMetrics()).isCompleted();
 
     assertThat(metricsSystem.getGauge(BEACON, "finalized_root").getValue())
         .isEqualTo(
@@ -213,7 +213,7 @@ class BeaconChainMetricsTest {
 
   @Test
   void getPreviousJustifiedEpochValue_shouldSupplyValueWhenStoreIsPresent() {
-    beaconChainMetrics.onSlot(NODE_SLOT_VALUE);
+    assertThat(beaconChainMetrics.updateMetrics()).isCompleted();
 
     assertThat(metricsSystem.getGauge(BEACON, "previous_justified_epoch").getValue())
         .isEqualTo(chainHead.getState().getPrevious_justified_checkpoint().getEpoch().longValue());
@@ -228,7 +228,7 @@ class BeaconChainMetricsTest {
 
   @Test
   void getPreviousJustifiedRootValue_shouldReturnValueWhenStoreIsPresent() {
-    beaconChainMetrics.onSlot(NODE_SLOT_VALUE);
+    assertThat(beaconChainMetrics.updateMetrics()).isCompleted();
 
     assertThat(metricsSystem.getGauge(BEACON, "previous_justified_root").getValue())
         .isEqualTo(
@@ -245,7 +245,7 @@ class BeaconChainMetricsTest {
 
   @Test
   void getJustifiedRootValue_shouldReturnValueWhenStoreIsPresent() {
-    beaconChainMetrics.onSlot(NODE_SLOT_VALUE);
+    assertThat(beaconChainMetrics.updateMetrics()).isCompleted();
     assertThat(metricsSystem.getGauge(BEACON, "current_justified_root").getValue())
         .isEqualTo(
             BeaconChainMetrics.getLongFromRoot(
@@ -261,7 +261,7 @@ class BeaconChainMetricsTest {
 
   @Test
   void getJustifiedEpochValue_shouldReturnValueWhenStoreIsPresent() {
-    beaconChainMetrics.onSlot(NODE_SLOT_VALUE);
+    assertThat(beaconChainMetrics.updateMetrics()).isCompleted();
     assertThat(metricsSystem.getGauge(BEACON, "current_justified_epoch").getValue())
         .isEqualTo(chainHead.getState().getCurrent_justified_checkpoint().getEpoch().longValue());
   }
@@ -275,7 +275,7 @@ class BeaconChainMetricsTest {
 
   @Test
   void onSlot_shouldUpdateEth1DataMetrics() {
-    beaconChainMetrics.onSlot(NODE_SLOT_VALUE);
+    assertThat(beaconChainMetrics.updateMetrics()).isCompleted();
     verify(eth1DataCache).updateMetrics(chainHead.getState());
   }
 
@@ -291,7 +291,7 @@ class BeaconChainMetricsTest {
 
     withSlotCurrentEpochAttestationsAndValidators(slotNumber, Collections.emptyList(), validators);
 
-    beaconChainMetrics.onSlot(slotNumber);
+    assertThat(beaconChainMetrics.updateMetrics()).isCompleted();
     assertThat(metricsSystem.getGauge(BEACON, "current_active_validators").getValue()).isEqualTo(2);
     assertThat(metricsSystem.getGauge(BEACON, "previous_active_validators").getValue())
         .isEqualTo(1);
@@ -305,7 +305,7 @@ class BeaconChainMetricsTest {
             .collect(toList());
     withCurrentEpochAttestations(attestations);
 
-    beaconChainMetrics.onSlot(UInt64.valueOf(100));
+    assertThat(beaconChainMetrics.updateMetrics()).isCompleted();
     assertThat(metricsSystem.getGauge(BEACON, "current_live_validators").getValue()).isEqualTo(8);
   }
 
@@ -317,7 +317,7 @@ class BeaconChainMetricsTest {
             .collect(toList());
     withCurrentEpochAttestations(attestations);
 
-    beaconChainMetrics.onSlot(UInt64.valueOf(100));
+    assertThat(beaconChainMetrics.updateMetrics()).isCompleted();
     assertThat(metricsSystem.getGauge(BEACON, "current_live_validators").getValue()).isEqualTo(8);
   }
 
@@ -327,7 +327,7 @@ class BeaconChainMetricsTest {
     final SszBitlist bitlist2 = bitlistOf(1, 2, 3, 4);
     withCurrentEpochAttestations(createAttestations(13, 1, bitlist1, bitlist2).collect(toList()));
 
-    beaconChainMetrics.onSlot(UInt64.valueOf(100));
+    assertThat(beaconChainMetrics.updateMetrics()).isCompleted();
     assertThat(metricsSystem.getGauge(BEACON, "current_live_validators").getValue()).isEqualTo(6);
   }
 
@@ -339,7 +339,7 @@ class BeaconChainMetricsTest {
             .collect(toList());
     withPreviousEpochAttestations(100, attestations);
 
-    beaconChainMetrics.onSlot(UInt64.valueOf(100));
+    assertThat(beaconChainMetrics.updateMetrics()).isCompleted();
     assertThat(metricsSystem.getGauge(BEACON, "previous_live_validators").getValue()).isEqualTo(8);
   }
 
@@ -351,7 +351,7 @@ class BeaconChainMetricsTest {
             .collect(toList());
     withPreviousEpochAttestations(100, attestations);
 
-    beaconChainMetrics.onSlot(UInt64.valueOf(100));
+    assertThat(beaconChainMetrics.updateMetrics()).isCompleted();
     assertThat(metricsSystem.getGauge(BEACON, "previous_live_validators").getValue()).isEqualTo(8);
   }
 
@@ -362,7 +362,7 @@ class BeaconChainMetricsTest {
     withPreviousEpochAttestations(
         100, createAttestations(13, 1, bitlist1, bitlist2).collect(toList()));
 
-    beaconChainMetrics.onSlot(UInt64.valueOf(100));
+    assertThat(beaconChainMetrics.updateMetrics()).isCompleted();
     assertThat(metricsSystem.getGauge(BEACON, "previous_live_validators").getValue()).isEqualTo(6);
   }
 
@@ -390,7 +390,7 @@ class BeaconChainMetricsTest {
 
     withCurrentEpochAttestations(allAttestations, UInt64.valueOf(15));
 
-    beaconChainMetrics.onSlot(UInt64.valueOf(20));
+    assertThat(beaconChainMetrics.updateMetrics()).isCompleted();
     assertThat(metricsSystem.getGauge(BEACON, "current_correct_validators").getValue())
         .isEqualTo(4);
   }
@@ -421,7 +421,7 @@ class BeaconChainMetricsTest {
 
     // Make sure we don't try to get the block root for the state's own slot from block roots array
     // Otherwise this will fail.
-    beaconChainMetrics.onSlot(UInt64.valueOf(20));
+    assertThat(beaconChainMetrics.updateMetrics()).isCompleted();
   }
 
   @Test
@@ -450,7 +450,7 @@ class BeaconChainMetricsTest {
     final int slotInNextEpoch = spec.computeStartSlotAtEpoch(UInt64.ONE).plus(13).intValue();
     withPreviousEpochAttestations(slotInNextEpoch, allAttestations);
 
-    beaconChainMetrics.onSlot(UInt64.valueOf(20));
+    assertThat(beaconChainMetrics.updateMetrics()).isCompleted();
     assertThat(metricsSystem.getGauge(BEACON, "previous_correct_validators").getValue())
         .isEqualTo(4);
   }

--- a/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/SlotProcessorTest.java
+++ b/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/SlotProcessorTest.java
@@ -36,7 +36,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.Eth2P2PNetwork;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.blocks.MinimalBeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
@@ -297,7 +297,8 @@ public class SlotProcessorTest {
   void shouldPrecomputeEpochTransitionJustBeforeFirstSlotOfNextEpoch() {
     final RecentChainData recentChainData = mock(RecentChainData.class);
     when(recentChainData.getGenesisTime()).thenReturn(genesisTime);
-    final Optional<SignedBeaconBlock> headBlock = storageSystem.recentChainData().getHeadBlock();
+    final Optional<MinimalBeaconBlockSummary> headBlock =
+        storageSystem.recentChainData().getHeadBlock();
     when(recentChainData.getHeadBlock()).thenReturn(headBlock);
     when(recentChainData.retrieveStateAtSlot(any())).thenReturn(new SafeFuture<>());
     when(syncStateProvider.getCurrentSyncState()).thenReturn(SyncState.IN_SYNC);

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/ChainHead.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/ChainHead.java
@@ -13,23 +13,88 @@
 
 package tech.pegasys.teku.storage.client;
 
+import java.util.Objects;
+import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSummary;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 
-class ChainHead extends StateAndBlockSummary {
+public class ChainHead implements BeaconBlockSummary {
 
-  private ChainHead(BeaconBlockSummary block, BeaconState state) {
-    super(block, state);
+  private final BeaconBlockSummary block;
+  private final SafeFuture<BeaconState> state;
+
+  private ChainHead(final BeaconBlockSummary block, final SafeFuture<BeaconState> state) {
+    this.block = block;
+    this.state = state;
+  }
+
+  public static ChainHead create(ChainHead chainHead) {
+    return new ChainHead(chainHead.block, chainHead.getState());
   }
 
   public static ChainHead create(StateAndBlockSummary blockAndState) {
-    return new ChainHead(blockAndState.getBlockSummary(), blockAndState.getState());
+    return new ChainHead(
+        blockAndState.getBlockSummary(), SafeFuture.completedFuture(blockAndState.getState()));
   }
 
   public static ChainHead create(SignedBlockAndState blockAndState) {
-    return new ChainHead(blockAndState.getBlockSummary(), blockAndState.getState());
+    return new ChainHead(
+        blockAndState.getBlockSummary(), SafeFuture.completedFuture(blockAndState.getState()));
+  }
+
+  public SafeFuture<BeaconState> getState() {
+    return state;
+  }
+
+  public SafeFuture<StateAndBlockSummary> asStateAndBlockSummary() {
+    return state.thenApply(state -> StateAndBlockSummary.create(block, state));
+  }
+
+  @Override
+  public UInt64 getSlot() {
+    return block.getSlot();
+  }
+
+  @Override
+  public UInt64 getProposerIndex() {
+    return block.getProposerIndex();
+  }
+
+  @Override
+  public Bytes32 getParentRoot() {
+    return block.getParentRoot();
+  }
+
+  @Override
+  public Bytes32 getStateRoot() {
+    return block.getStateRoot();
+  }
+
+  @Override
+  public Bytes32 getBodyRoot() {
+    return block.getBodyRoot();
+  }
+
+  @Override
+  public Bytes32 getRoot() {
+    return block.getRoot();
+  }
+
+  @Override
+  public Optional<BeaconBlock> getBeaconBlock() {
+    return block.getBeaconBlock();
+  }
+
+  @Override
+  public Optional<SignedBeaconBlock> getSignedBeaconBlock() {
+    return block.getSignedBeaconBlock();
   }
 
   @Override
@@ -40,11 +105,12 @@ class ChainHead extends StateAndBlockSummary {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    return super.equals(o);
+    final ChainHead chainHead = (ChainHead) o;
+    return Objects.equals(block, chainHead.block);
   }
 
   @Override
   public int hashCode() {
-    return super.hashCode();
+    return Objects.hash(block);
   }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
@@ -344,7 +344,7 @@ public class CombinedChainDataClient {
     return recentChainData.getHeadBlock();
   }
 
-  public Optional<StateAndBlockSummary> getChainHead() {
+  public Optional<ChainHead> getChainHead() {
     return recentChainData.getChainHead();
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
@@ -33,6 +33,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSummary;
+import tech.pegasys.teku.spec.datastructures.blocks.MinimalBeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
@@ -340,7 +341,7 @@ public class CombinedChainDataClient {
     return recentChainData.getBestBlockRoot();
   }
 
-  public Optional<SignedBeaconBlock> getBestBlock() {
+  public Optional<MinimalBeaconBlockSummary> getBestBlock() {
     return recentChainData.getHeadBlock();
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
@@ -39,7 +39,7 @@ import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.SpecVersion;
 import tech.pegasys.teku.spec.config.SpecConfigBellatrix;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
-import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSummary;
+import tech.pegasys.teku.spec.datastructures.blocks.MinimalBeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
@@ -403,7 +403,7 @@ public abstract class RecentChainData implements StoreUpdateHandler {
   /** @return The number of slots between our chainhead and the current slot by time */
   public Optional<UInt64> getChainHeadSlotsBehind() {
     return chainHead
-        .map(BeaconBlockSummary::getSlot)
+        .map(MinimalBeaconBlockSummary::getSlot)
         .flatMap(headSlot -> getCurrentSlot().map(s -> s.minusMinZero(headSlot)));
   }
 
@@ -440,7 +440,7 @@ public abstract class RecentChainData implements StoreUpdateHandler {
 
   /** Retrieves the block chosen by fork choice to build and attest on */
   public Optional<Bytes32> getBestBlockRoot() {
-    return chainHead.map(BeaconBlockSummary::getRoot);
+    return chainHead.map(MinimalBeaconBlockSummary::getRoot);
   }
 
   /** @return The head of the chain. */
@@ -449,8 +449,8 @@ public abstract class RecentChainData implements StoreUpdateHandler {
   }
 
   /** @return The block at the head of the chain. */
-  public Optional<SignedBeaconBlock> getHeadBlock() {
-    return chainHead.flatMap(BeaconBlockSummary::getSignedBeaconBlock);
+  public Optional<MinimalBeaconBlockSummary> getHeadBlock() {
+    return chainHead.map(a -> a);
   }
 
   /** Retrieves the state of the block chosen by fork choice to build and attest on */
@@ -460,7 +460,7 @@ public abstract class RecentChainData implements StoreUpdateHandler {
 
   /** Retrieves the slot of the block chosen by fork choice to build and attest on */
   public UInt64 getHeadSlot() {
-    return chainHead.map(BeaconBlockSummary::getSlot).orElse(UInt64.ZERO);
+    return chainHead.map(MinimalBeaconBlockSummary::getSlot).orElse(UInt64.ZERO);
   }
 
   public boolean containsBlock(final Bytes32 root) {

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
@@ -42,7 +42,6 @@ import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
-import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyStore;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteUpdater;
@@ -445,8 +444,8 @@ public abstract class RecentChainData implements StoreUpdateHandler {
   }
 
   /** @return The head of the chain. */
-  public Optional<StateAndBlockSummary> getChainHead() {
-    return chainHead.map(a -> a);
+  public Optional<ChainHead> getChainHead() {
+    return chainHead;
   }
 
   /** @return The block at the head of the chain. */
@@ -456,7 +455,7 @@ public abstract class RecentChainData implements StoreUpdateHandler {
 
   /** Retrieves the state of the block chosen by fork choice to build and attest on */
   public Optional<SafeFuture<BeaconState>> getBestState() {
-    return chainHead.map(StateAndBlockSummary::getState).map(SafeFuture::completedFuture);
+    return chainHead.map(ChainHead::getState);
   }
 
   /** Retrieves the slot of the block chosen by fork choice to build and attest on */

--- a/storage/src/test/java/tech/pegasys/teku/storage/client/ChainHeadTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/client/ChainHeadTest.java
@@ -14,7 +14,6 @@
 package tech.pegasys.teku.storage.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.Test;
@@ -37,7 +36,7 @@ public class ChainHeadTest {
     final SignedBlockAndState block = dataStructureUtil.randomSignedBlockAndState(UInt64.ONE);
     final ChainHead chainHead = ChainHead.create(block);
 
-    final ChainHead otherChainHead = copy(chainHead);
+    final ChainHead otherChainHead = copy(block);
     assertThat(chainHead).isEqualTo(otherChainHead);
   }
 
@@ -54,13 +53,13 @@ public class ChainHeadTest {
   }
 
   @SuppressWarnings("unchecked")
-  private ChainHead copy(ChainHead original) {
+  private ChainHead copy(SignedBlockAndState original) {
     final SignedBeaconBlock originalBlock = original.getSignedBeaconBlock().orElseThrow();
     final SignedBeaconBlock blockCopy =
         copy(originalBlock, (SszSchema<SignedBeaconBlock>) originalBlock.getSchema());
     final BeaconState stateCopy =
         copy(
-            safeJoin(original.getState()),
+            original.getState(),
             SszSchema.as(
                 BeaconState.class, spec.getGenesisSchemaDefinitions().getBeaconStateSchema()));
     final SignedBlockAndState blockAndStateCopy = new SignedBlockAndState(blockCopy, stateCopy);

--- a/storage/src/test/java/tech/pegasys/teku/storage/client/ChainHeadTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/client/ChainHeadTest.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.storage.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.Test;
@@ -59,7 +60,7 @@ public class ChainHeadTest {
         copy(originalBlock, (SszSchema<SignedBeaconBlock>) originalBlock.getSchema());
     final BeaconState stateCopy =
         copy(
-            original.getState(),
+            safeJoin(original.getState()),
             SszSchema.as(
                 BeaconState.class, spec.getGenesisSchemaDefinitions().getBeaconStateSchema()));
     final SignedBlockAndState blockAndStateCopy = new SignedBlockAndState(blockCopy, stateCopy);

--- a/storage/src/test/java/tech/pegasys/teku/storage/client/RecentChainDataTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/client/RecentChainDataTest.java
@@ -45,7 +45,7 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
-import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSummary;
+import tech.pegasys.teku.spec.datastructures.blocks.MinimalBeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
@@ -218,7 +218,7 @@ class RecentChainDataTest {
         .forEach(blockAndState -> saveBlock(recentChainData, blockAndState));
 
     recentChainData.updateHead(bestBlock.getRoot(), bestBlock.getSlot());
-    assertThat(recentChainData.getChainHead().map(BeaconBlockSummary::getRoot))
+    assertThat(recentChainData.getChainHead().map(MinimalBeaconBlockSummary::getRoot))
         .contains(bestBlock.getRoot());
     assertThat(this.storageSystem.chainHeadChannel().getHeadEvents())
         .contains(
@@ -239,7 +239,7 @@ class RecentChainDataTest {
     final SignedBlockAndState bestBlock = chainBuilder.generateNextBlock();
 
     recentChainData.updateHead(bestBlock.getRoot(), bestBlock.getSlot());
-    assertThat(recentChainData.getChainHead().map(BeaconBlockSummary::getRoot))
+    assertThat(recentChainData.getChainHead().map(MinimalBeaconBlockSummary::getRoot))
         .contains(genesis.getRoot());
   }
 

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/storageSystem/StorageSystem.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/storageSystem/StorageSystem.java
@@ -13,12 +13,14 @@
 
 package tech.pegasys.teku.storage.storageSystem;
 
+import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 import static tech.pegasys.teku.infrastructure.async.SyncAsyncRunner.SYNC_RUNNER;
 
 import tech.pegasys.teku.core.ChainBuilder;
 import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.pow.api.TrackingEth1EventsChannel;
 import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
 import tech.pegasys.teku.storage.api.FinalizedCheckpointChannel;
 import tech.pegasys.teku.storage.api.StubFinalizedCheckpointChannel;
 import tech.pegasys.teku.storage.api.TrackingChainHeadChannel;
@@ -114,6 +116,10 @@ public class StorageSystem implements AutoCloseable {
         restartedSupplier,
         chainBuilder,
         spec);
+  }
+
+  public StateAndBlockSummary getChainHead() {
+    return safeJoin(recentChainData.getChainHead().orElseThrow().asStateAndBlockSummary());
   }
 
   public StubMetricsSystem getMetricsSystem() {


### PR DESCRIPTION
## PR Description
Switches `ChainHead` to expose the head state via a future. Currently the state is actually always a completed future but this gets the places that access it ready for it to be async.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
