### PR TITLE
Fix BlockHeader to use the body root not block root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,3 +21,4 @@ For information on changes in released versions of Teku, see the [releases page]
  - Updated discovery library with improved performance.
  - Updated libp2p library to respect message list limits when sending messages.
  - Fixed issue on custom testnets with two forks in sequential epochs where the maximum gossip topic subscription limits were exceeded.
+ - Fixed issue where `/eth/v1/beacon/headers` and `/eth/v1/beacon/headers/:block_id` would incorrectly return the block root in the `body_root` field.

--- a/data/provider/src/test/java/tech/pegasys/teku/api/ChainDataProviderTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/ChainDataProviderTest.java
@@ -181,7 +181,7 @@ public class ChainDataProviderTest {
             block.getMessage().getProposerIndex(),
             block.getParentRoot(),
             block.getStateRoot(),
-            block.getRoot());
+            block.getBodyRoot());
     final BlockHeader expected =
         new BlockHeader(
             block.getRoot(),

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/beacon/BlockHeader.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/beacon/BlockHeader.java
@@ -54,7 +54,7 @@ public class BlockHeader {
                 signedBeaconBlock.getMessage().getProposerIndex(),
                 signedBeaconBlock.getParentRoot(),
                 signedBeaconBlock.getStateRoot(),
-                signedBeaconBlock.getRoot()),
+                signedBeaconBlock.getBodyRoot()),
             new BLSSignature(signedBeaconBlock.getSignature()));
   }
 


### PR DESCRIPTION
## PR Description
Fix `BlockHeader` to assign the body root to `body_root` instead of the block root.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
