### PR TITLE
Make chain head update synchronous

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,3 +22,4 @@ For information on changes in released versions of Teku, see the [releases page]
  - Updated libp2p library to respect message list limits when sending messages.
  - Fixed issue on custom testnets with two forks in sequential epochs where the maximum gossip topic subscription limits were exceeded.
  - Fixed issue where `/eth/v1/beacon/headers` and `/eth/v1/beacon/headers/:block_id` would incorrectly return the block root in the `body_root` field.
+ - Simplified chain head updates to resolve `Skipping head block update to avoid potential rollback of the chain head` warnings. 

--- a/ethereum/forkchoice/src/main/java/tech/pegasys/teku/ethereum/forkchoice/ForkChoiceStrategy.java
+++ b/ethereum/forkchoice/src/main/java/tech/pegasys/teku/ethereum/forkchoice/ForkChoiceStrategy.java
@@ -33,6 +33,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockAndCheckpointEpochs;
+import tech.pegasys.teku.spec.datastructures.blocks.MinimalBeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
@@ -282,6 +283,16 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
     protoArrayLock.readLock().lock();
     try {
       return getProtoNode(blockRoot).map(ProtoNode::isFullyValidated).orElse(false);
+    } finally {
+      protoArrayLock.readLock().unlock();
+    }
+  }
+
+  @Override
+  public Optional<MinimalBeaconBlockSummary> getMinimalBlockSummary(final Bytes32 blockRoot) {
+    protoArrayLock.readLock().lock();
+    try {
+      return getProtoNode(blockRoot).map(ProtoNode::toMinimalBlockSummary);
     } finally {
       protoArrayLock.readLock().unlock();
     }

--- a/ethereum/forkchoice/src/main/java/tech/pegasys/teku/ethereum/forkchoice/ProtoNode.java
+++ b/ethereum/forkchoice/src/main/java/tech/pegasys/teku/ethereum/forkchoice/ProtoNode.java
@@ -22,6 +22,7 @@ import java.util.Objects;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.blocks.MinimalBeaconBlockSummary;
 
 public class ProtoNode {
 
@@ -174,6 +175,10 @@ public class ProtoNode {
         this.validationStatus,
         validationStatus);
     this.validationStatus = validationStatus;
+  }
+
+  public MinimalBeaconBlockSummary toMinimalBlockSummary() {
+    return new ProtoNodeData(blockSlot, blockRoot, parentRoot, stateRoot);
   }
 
   public Map<String, Object> getData() {

--- a/ethereum/forkchoice/src/main/java/tech/pegasys/teku/ethereum/forkchoice/ProtoNodeData.java
+++ b/ethereum/forkchoice/src/main/java/tech/pegasys/teku/ethereum/forkchoice/ProtoNodeData.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.forkchoice;
+
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.blocks.MinimalBeaconBlockSummary;
+
+public class ProtoNodeData implements MinimalBeaconBlockSummary {
+
+  private final UInt64 slot;
+  private final Bytes32 root;
+  private final Bytes32 parentRoot;
+  private final Bytes32 stateRoot;
+
+  public ProtoNodeData(
+      final UInt64 slot, final Bytes32 root, final Bytes32 parentRoot, final Bytes32 stateRoot) {
+    this.slot = slot;
+    this.root = root;
+    this.parentRoot = parentRoot;
+    this.stateRoot = stateRoot;
+  }
+
+  @Override
+  public UInt64 getSlot() {
+    return slot;
+  }
+
+  @Override
+  public Bytes32 getRoot() {
+    return root;
+  }
+
+  @Override
+  public Bytes32 getParentRoot() {
+    return parentRoot;
+  }
+
+  @Override
+  public Bytes32 getStateRoot() {
+    return stateRoot;
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ReadOnlyForkChoiceStrategy.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ReadOnlyForkChoiceStrategy.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 import java.util.Set;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.blocks.MinimalBeaconBlockSummary;
 
 public interface ReadOnlyForkChoiceStrategy {
 
@@ -44,4 +45,6 @@ public interface ReadOnlyForkChoiceStrategy {
   boolean isOptimistic(Bytes32 blockRoot);
 
   boolean isFullyValidated(final Bytes32 blockRoot);
+
+  Optional<MinimalBeaconBlockSummary> getMinimalBlockSummary(Bytes32 blockRoot);
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ReadOnlyForkChoiceStrategy.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ReadOnlyForkChoiceStrategy.java
@@ -20,6 +20,7 @@ import java.util.Set;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.MinimalBeaconBlockSummary;
+import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 
 public interface ReadOnlyForkChoiceStrategy {
 
@@ -30,6 +31,8 @@ public interface ReadOnlyForkChoiceStrategy {
   Optional<Bytes32> executionBlockHash(Bytes32 blockRoot);
 
   Optional<Bytes32> getAncestor(Bytes32 blockRoot, UInt64 slot);
+
+  Optional<SlotAndBlockRoot> findCommonAncestor(Bytes32 blockRoot1, Bytes32 blockRoot2);
 
   Set<Bytes32> getBlockRootsAtSlot(UInt64 slot);
 

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/RandomChainBuilderForkChoiceStrategy.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/RandomChainBuilderForkChoiceStrategy.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 import java.util.Set;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.blocks.MinimalBeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.bellatrix.BeaconBlockBodyBellatrix;
@@ -116,6 +117,11 @@ public class RandomChainBuilderForkChoiceStrategy implements ReadOnlyForkChoiceS
   @Override
   public boolean isFullyValidated(Bytes32 blockRoot) {
     return true;
+  }
+
+  @Override
+  public Optional<MinimalBeaconBlockSummary> getMinimalBlockSummary(final Bytes32 blockRoot) {
+    return getBlock(blockRoot).map(a -> a);
   }
 
   private Optional<SignedBeaconBlock> getBlock(final Bytes32 root) {

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/RandomChainBuilderForkChoiceStrategy.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/RandomChainBuilderForkChoiceStrategy.java
@@ -23,6 +23,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.MinimalBeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.bellatrix.BeaconBlockBodyBellatrix;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
@@ -73,6 +74,12 @@ public class RandomChainBuilderForkChoiceStrategy implements ReadOnlyForkChoiceS
       return Optional.empty();
     }
     return getBlock(slot).map(SignedBeaconBlock::getRoot);
+  }
+
+  @Override
+  public Optional<SlotAndBlockRoot> findCommonAncestor(
+      final Bytes32 blockRoot1, final Bytes32 blockRoot2) {
+    return Optional.empty();
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/ChainHead.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/ChainHead.java
@@ -60,6 +60,13 @@ public class ChainHead implements MinimalBeaconBlockSummary {
         SafeFuture.completedFuture(blockAndState));
   }
 
+  public static ChainHead create(
+      final MinimalBeaconBlockSummary blockData,
+      final Bytes32 executionPayloadBlockHash,
+      final SafeFuture<StateAndBlockSummary> stateAndBlockSummaryFuture) {
+    return new ChainHead(blockData, executionPayloadBlockHash, stateAndBlockSummaryFuture);
+  }
+
   public SafeFuture<BeaconState> getState() {
     return stateAndBlockSummaryFuture.thenApply(StateAndBlockSummary::getState);
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
@@ -256,72 +256,28 @@ public abstract class RecentChainData implements StoreUpdateHandler {
    * @param currentSlot The current slot - the slot at which the new head was selected
    */
   public void updateHead(Bytes32 root, UInt64 currentSlot) {
-    final Optional<ChainHead> originalChainHead = chainHead;
-
-    final ReadOnlyForkChoiceStrategy forkChoiceStrategy = store.getForkChoiceStrategy();
-    final Optional<MinimalBeaconBlockSummary> maybeBlockData =
-        forkChoiceStrategy.getMinimalBlockSummary(root);
-    if (maybeBlockData.isEmpty()) {
-      LOG.error("Unable to update head block as of slot {}. Unknown block: {}", currentSlot, root);
-      return;
-    }
-    final Bytes32 executionBlockHash =
-        forkChoiceStrategy.executionBlockHash(root).orElse(Bytes32.ZERO);
-    final MinimalBeaconBlockSummary blockData = maybeBlockData.get();
-
-    final SafeFuture<StateAndBlockSummary> chainHeadStateFuture =
-        store
-            .retrieveStateAndBlockSummary(root)
-            .thenApply(
-                maybeHead ->
-                    maybeHead.orElseThrow(
-                        () ->
-                            new IllegalStateException(
-                                String.format(
-                                    "Unable to update head block as of slot %s.  Block is unavailable: %s.",
-                                    currentSlot, root))));
-    updateChainHead(
-        originalChainHead, ChainHead.create(blockData, executionBlockHash, chainHeadStateFuture));
-  }
-
-  private void updateChainHead(
-      final Optional<ChainHead> originalHead, final ChainHead newChainHead) {
     synchronized (this) {
-      if (!chainHead.equals(originalHead)) {
-        // The chain head has been updated while we were waiting for the newChainHead
-        // Skip this update to avoid accidentally regressing the chain head
-        LOG.info("Skipping head block update to avoid potential rollback of the chain head.");
-        return;
-      }
-      if (originalHead.isPresent() && isNewHeadSameAsOld(originalHead.get(), newChainHead)) {
+      if (chainHead.map(head -> head.getRoot().equals(root)).orElse(false)) {
         LOG.trace("Skipping head update because new head is same as previous head");
         return;
       }
-      this.chainHead = Optional.of(newChainHead);
-      final Optional<ReorgContext> optionalReorgContext;
-      final ForkChoiceStrategy forkChoiceStrategy = store.getForkChoiceStrategy();
-      if (originalHead.map(head -> hasReorgedFrom(head.getRoot(), head.getSlot())).orElse(false)) {
+      final Optional<ChainHead> originalChainHead = chainHead;
 
-        final ChainHead previousChainHead = originalHead.get();
-
-        final SlotAndBlockRoot commonAncestorSlotAndBlockRoot =
-            forkChoiceStrategy
-                .findCommonAncestor(previousChainHead.getRoot(), newChainHead.getRoot())
-                .orElseGet(() -> store.getFinalizedCheckpoint().toSlotAndBlockRoot(spec));
-
-        reorgCounter.inc();
-        optionalReorgContext =
-            ReorgContext.of(
-                previousChainHead.getRoot(),
-                previousChainHead.getSlot(),
-                previousChainHead.getStateRoot(),
-                commonAncestorSlotAndBlockRoot.getSlot(),
-                commonAncestorSlotAndBlockRoot.getBlockRoot());
-      } else {
-        optionalReorgContext = ReorgContext.empty();
+      final ReadOnlyForkChoiceStrategy forkChoiceStrategy = store.getForkChoiceStrategy();
+      final Optional<MinimalBeaconBlockSummary> maybeBlockData =
+          forkChoiceStrategy.getMinimalBlockSummary(root);
+      if (maybeBlockData.isEmpty()) {
+        LOG.error(
+            "Unable to update head block as of slot {}. Unknown block: {}", currentSlot, root);
+        return;
       }
+      final ChainHead newChainHead =
+          createNewChainHead(root, currentSlot, forkChoiceStrategy, maybeBlockData.get());
+      this.chainHead = Optional.of(newChainHead);
+      final Optional<ReorgContext> optionalReorgContext =
+          computeReorgContext(forkChoiceStrategy, originalChainHead, newChainHead);
       final boolean epochTransition =
-          originalHead
+          originalChainHead
               .map(
                   previousChainHead ->
                       spec.computeEpochAtSlot(previousChainHead.getSlot())
@@ -354,6 +310,57 @@ public abstract class RecentChainData implements StoreUpdateHandler {
     bestBlockInitialized.complete(null);
   }
 
+  private Optional<ReorgContext> computeReorgContext(
+      final ReadOnlyForkChoiceStrategy forkChoiceStrategy,
+      final Optional<ChainHead> originalChainHead,
+      final ChainHead newChainHead) {
+    final Optional<ReorgContext> optionalReorgContext;
+    if (originalChainHead
+        .map(head -> hasReorgedFrom(head.getRoot(), head.getSlot()))
+        .orElse(false)) {
+      final ChainHead previousChainHead = originalChainHead.get();
+
+      final SlotAndBlockRoot commonAncestorSlotAndBlockRoot =
+          forkChoiceStrategy
+              .findCommonAncestor(previousChainHead.getRoot(), newChainHead.getRoot())
+              .orElseGet(() -> store.getFinalizedCheckpoint().toSlotAndBlockRoot(spec));
+
+      reorgCounter.inc();
+      optionalReorgContext =
+          ReorgContext.of(
+              previousChainHead.getRoot(),
+              previousChainHead.getSlot(),
+              previousChainHead.getStateRoot(),
+              commonAncestorSlotAndBlockRoot.getSlot(),
+              commonAncestorSlotAndBlockRoot.getBlockRoot());
+    } else {
+      optionalReorgContext = ReorgContext.empty();
+    }
+    return optionalReorgContext;
+  }
+
+  private ChainHead createNewChainHead(
+      final Bytes32 root,
+      final UInt64 currentSlot,
+      final ReadOnlyForkChoiceStrategy forkChoiceStrategy,
+      final MinimalBeaconBlockSummary blockData) {
+    final Bytes32 executionBlockHash =
+        forkChoiceStrategy.executionBlockHash(root).orElse(Bytes32.ZERO);
+
+    final SafeFuture<StateAndBlockSummary> chainHeadStateFuture =
+        store
+            .retrieveStateAndBlockSummary(root)
+            .thenApply(
+                maybeHead ->
+                    maybeHead.orElseThrow(
+                        () ->
+                            new IllegalStateException(
+                                String.format(
+                                    "Unable to update head block as of slot %s.  Block is unavailable: %s.",
+                                    currentSlot, root))));
+    return ChainHead.create(blockData, executionBlockHash, chainHeadStateFuture);
+  }
+
   private Bytes32 getFinalizedBlockParentRoot() {
     return getForkChoiceStrategy()
         .orElseThrow()
@@ -372,10 +379,6 @@ public abstract class RecentChainData implements StoreUpdateHandler {
 
   public Optional<UInt64> getOptimisticHeadSlot() {
     return optimisticHead.map(ForkChoiceState::getHeadBlockSlot);
-  }
-
-  private boolean isNewHeadSameAsOld(final ChainHead originalHead, final ChainHead newChainHead) {
-    return originalHead.getRoot().equals(newChainHead.getRoot());
   }
 
   private boolean hasReorgedFrom(


### PR DESCRIPTION
## PR Description
Basic block data is taken synchronously from protoarray with the actual block and state being loaded async. This allows the new chain head to be set synchronously, avoiding reordering issues that previously needed to be handled.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
