### PR TITLE
Add execution_optimistic to getBlock v2

### DIFF
--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetBlock.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetBlock.java
@@ -36,6 +36,7 @@ import java.util.Optional;
 import org.jetbrains.annotations.NotNull;
 import tech.pegasys.teku.api.ChainDataProvider;
 import tech.pegasys.teku.api.DataProvider;
+import tech.pegasys.teku.api.ObjectAndMetaData;
 import tech.pegasys.teku.api.response.v1.beacon.GetBlockResponse;
 import tech.pegasys.teku.api.schema.SignedBeaconBlock;
 import tech.pegasys.teku.beaconrestapi.handlers.AbstractHandler;
@@ -77,15 +78,16 @@ public class GetBlock extends AbstractHandler implements Handler {
   @Override
   public void handle(@NotNull final Context ctx) throws Exception {
     final Map<String, String> pathParams = ctx.pathParamMap();
-    final SafeFuture<Optional<SignedBeaconBlock>> future =
+    final SafeFuture<Optional<ObjectAndMetaData<SignedBeaconBlock>>> future =
         chainDataProvider.getBlock(pathParams.get(PARAM_BLOCK_ID));
     handleOptionalResult(ctx, future, this::handleResult, SC_NOT_FOUND);
   }
 
-  private Optional<String> handleResult(Context ctx, final SignedBeaconBlock response)
+  private Optional<String> handleResult(
+      final Context ctx, final ObjectAndMetaData<SignedBeaconBlock> response)
       throws JsonProcessingException {
     if (!chainDataProvider
-        .getMilestoneAtSlot(response.getMessage().slot)
+        .getMilestoneAtSlot(response.getData().getMessage().slot)
         .equals(SpecMilestone.PHASE0)) {
       ctx.status(SC_BAD_REQUEST);
       return Optional.of(
@@ -93,8 +95,8 @@ public class GetBlock extends AbstractHandler implements Handler {
               jsonProvider,
               String.format(
                   "Slot %s is not a phase0 slot, please fetch via /eth/v2/beacon/blocks",
-                  response.getMessage().slot)));
+                  response.getData().getMessage().slot)));
     }
-    return Optional.of(jsonProvider.objectToJSON(new GetBlockResponse(response)));
+    return Optional.of(jsonProvider.objectToJSON(new GetBlockResponse(response.getData())));
   }
 }

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.function.IntPredicate;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -120,20 +121,9 @@ public class ChainDataProvider {
         .thenApply(maybeBlock -> maybeBlock.map(block -> new BlockHeader(block, true)));
   }
 
-  public SafeFuture<Optional<SignedBeaconBlock>> getBlock(final String slotParameter) {
-    return defaultBlockSelectorFactory
-        .defaultBlockSelector(slotParameter)
-        .getSingleBlock()
-        .thenApply(this::discardBlockMetaData)
-        .thenApply(maybeBlock -> maybeBlock.map(schemaObjectProvider::getSignedBeaconBlock));
-  }
-
-  public SafeFuture<Optional<SignedBeaconBlock>> getBlockV2(final String slotParameter) {
-    return defaultBlockSelectorFactory
-        .defaultBlockSelector(slotParameter)
-        .getSingleBlock()
-        .thenApply(this::discardBlockMetaData)
-        .thenApply(maybeBlock -> maybeBlock.map(schemaObjectProvider::getSignedBeaconBlock));
+  public SafeFuture<Optional<ObjectAndMetaData<SignedBeaconBlock>>> getBlock(
+      final String slotParameter) {
+    return fromBlock(slotParameter, schemaObjectProvider::getSignedBeaconBlock);
   }
 
   public SafeFuture<Optional<SszResponse>> getBlockSsz(final String slotParameter) {
@@ -152,12 +142,7 @@ public class ChainDataProvider {
   }
 
   public SafeFuture<Optional<ObjectAndMetaData<Root>>> getBlockRoot(final String slotParameter) {
-    return defaultBlockSelectorFactory
-        .defaultBlockSelector(slotParameter)
-        .getSingleBlock()
-        .thenApply(
-            maybeBlock ->
-                maybeBlock.map(blockData -> blockData.map(block -> new Root(block.getRoot()))));
+    return fromBlock(slotParameter, block -> new Root(block.getRoot()));
   }
 
   public SafeFuture<Optional<List<Attestation>>> getBlockAttestations(final String slotParameter) {
@@ -492,6 +477,7 @@ public class ChainDataProvider {
   //  - if Altair milestone is not supported,
   //  - if a slot is specified and that slot is a phase 0 slot
   // otherwise true will be returned
+
   public boolean stateParameterMaySupportAltair(final String epochParam) {
     if (!spec.isMilestoneSupported(SpecMilestone.ALTAIR)) {
       return false;
@@ -566,5 +552,14 @@ public class ChainDataProvider {
   private tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock discardBlockMetaData(
       final BlockAndMetaData blockAndMetaData) {
     return blockAndMetaData.getData();
+  }
+
+  private <T> SafeFuture<Optional<ObjectAndMetaData<T>>> fromBlock(
+      final String slotParameter,
+      final Function<tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock, T> mapper) {
+    return defaultBlockSelectorFactory
+        .defaultBlockSelector(slotParameter)
+        .getSingleBlock()
+        .thenApply(maybeBlockData -> maybeBlockData.map(blockData -> blockData.map(mapper)));
   }
 }

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/response/v2/beacon/GetBlockResponseV2.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/response/v2/beacon/GetBlockResponseV2.java
@@ -14,9 +14,12 @@
 package tech.pegasys.teku.api.response.v2.beacon;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.swagger.v3.oas.annotations.media.Schema;
 import tech.pegasys.teku.api.schema.SignedBeaconBlock;
 import tech.pegasys.teku.api.schema.Version;
 import tech.pegasys.teku.api.schema.altair.SignedBeaconBlockAltair;
@@ -26,6 +29,11 @@ import tech.pegasys.teku.api.schema.phase0.SignedBeaconBlockPhase0;
 
 public class GetBlockResponseV2 {
   private final Version version;
+
+  @JsonProperty("execution_optimistic")
+  @JsonInclude(Include.NON_NULL)
+  @Schema(hidden = true)
+  public final Boolean execution_optimistic;
 
   @JsonTypeInfo(
       use = JsonTypeInfo.Id.NAME,
@@ -49,8 +57,10 @@ public class GetBlockResponseV2 {
   @JsonCreator
   public GetBlockResponseV2(
       @JsonProperty("version") final Version version,
+      @JsonProperty("execution_optimistic") final Boolean executionOptimistic,
       @JsonProperty("data") final SignedBeaconBlock data) {
     this.version = version;
+    this.execution_optimistic = executionOptimistic;
     this.data = data;
   }
 }


### PR DESCRIPTION
## PR Description
Add `execution_optimistic` flag to getBlock v2.  Also collapse the `getBlock` and `getBlockV2` methods into one since they were exact duplicates of each other.  The v1 getBlock method doesn't get `execution_optimistic` added but the implementation of it is updated to extract the block from the metadata wrapper for consistency.

## Fixed Issue(s)
#5068 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
