### PR TITLE
Add metadata to StateSelector info

### DIFF
--- a/data/provider/src/main/java/tech/pegasys/teku/api/stateselector/StateAndMetaData.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/stateselector/StateAndMetaData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ConsenSys AG.
+ * Copyright 2022 ConsenSys AG.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -13,9 +13,17 @@
 
 package tech.pegasys.teku.api.stateselector;
 
-import java.util.Optional;
-import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.api.ObjectAndMetaData;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 
-public interface StateSelector {
-  SafeFuture<Optional<StateAndMetaData>> getState();
+public class StateAndMetaData extends ObjectAndMetaData<BeaconState> {
+
+  public StateAndMetaData(
+      final BeaconState data,
+      final SpecMilestone milestone,
+      final boolean executionOptimistic,
+      final boolean bellatrixEnabled) {
+    super(data, milestone, executionOptimistic, bellatrixEnabled);
+  }
 }

--- a/data/provider/src/main/java/tech/pegasys/teku/api/stateselector/StateSelectorFactory.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/stateselector/StateSelectorFactory.java
@@ -20,13 +20,20 @@ import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.api.exceptions.BadRequestException;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockHeader;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.storage.client.ChainHead;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 
 public class StateSelectorFactory {
+
+  private final Spec spec;
   private final CombinedChainDataClient client;
 
-  public StateSelectorFactory(final CombinedChainDataClient client) {
+  public StateSelectorFactory(final Spec spec, final CombinedChainDataClient client) {
+    this.spec = spec;
     this.client = client;
   }
 
@@ -72,35 +79,98 @@ public class StateSelectorFactory {
 
   public StateSelector headSelector() {
     return () -> {
-      final Optional<SafeFuture<BeaconState>> maybeFuture = client.getBestState();
-      if (maybeFuture.isEmpty()) {
+      final Optional<ChainHead> maybeChainHead = client.getChainHead();
+      if (maybeChainHead.isEmpty()) {
         return SafeFuture.completedFuture(Optional.empty());
       }
-      return maybeFuture.get().thenApply(Optional::of);
+      final ChainHead chainHead = maybeChainHead.get();
+      return chainHead
+          .getState()
+          .thenApply(state -> Optional.of(addMetaData(state, chainHead.isOptimistic())));
     };
   }
 
   public StateSelector finalizedSelector() {
-    return () -> SafeFuture.completedFuture(client.getFinalizedState());
+    // TODO: May need to check if chain head is optimistic as well
+    return () ->
+        SafeFuture.completedFuture(
+            client
+                .getLatestFinalized()
+                .map(
+                    finalized ->
+                        addMetaData(
+                            finalized.getState(),
+                            isCheckpointOptimistic(finalized.getCheckpoint().getRoot()))));
   }
 
   public StateSelector justifiedSelector() {
-    return client::getJustifiedState;
+    return () ->
+        client
+            .getJustifiedState()
+            .thenApply(
+                maybeState ->
+                    maybeState.map(
+                        state ->
+                            addMetaData(
+                                state,
+                                isCheckpointOptimistic(
+                                    BeaconBlockHeader.fromState(state).getRoot()))));
   }
 
   public StateSelector genesisSelector() {
-    return () -> client.getStateAtSlotExact(GENESIS_SLOT);
+    return () ->
+        client
+            .getStateAtSlotExact(GENESIS_SLOT)
+            .thenApply(maybeState -> maybeState.map(state -> addMetaData(state, false)));
   }
 
   public StateSelector forSlot(final UInt64 slot) {
-    return () -> client.getStateAtSlotExact(slot);
+    return () ->
+        client
+            .getChainHead()
+            .map(
+                head ->
+                    client
+                        .getStateAtSlotExact(slot, head.getRoot())
+                        .thenApply(
+                            maybeState ->
+                                maybeState.map(state -> addMetaData(state, head.isOptimistic()))))
+            .orElse(SafeFuture.completedFuture(Optional.empty()));
   }
 
   public StateSelector forStateRoot(final Bytes32 stateRoot) {
-    return () -> client.getStateByStateRoot(stateRoot);
+    return () ->
+        client
+            .getStateByStateRoot(stateRoot)
+            .thenApply(
+                maybeState ->
+                    maybeState.map(
+                        state ->
+                            addMetaData(
+                                state,
+                                client.isOptimisticBlock(
+                                    BeaconBlockHeader.fromState(state).getRoot()))));
   }
 
   public StateSelector forBlockRoot(final Bytes32 blockRoot) {
-    return () -> client.getStateByBlockRoot(blockRoot);
+    return () ->
+        client
+            .getStateByBlockRoot(blockRoot)
+            .thenApply(
+                maybeState ->
+                    maybeState.map(
+                        state -> addMetaData(state, client.isOptimisticBlock(blockRoot))));
+  }
+
+  private StateAndMetaData addMetaData(final BeaconState state, final boolean executionOptimistic) {
+    return new StateAndMetaData(
+        state,
+        spec.atSlot(state.getSlot()).getMilestone(),
+        executionOptimistic,
+        spec.isMilestoneSupported(SpecMilestone.BELLATRIX));
+  }
+
+  private boolean isCheckpointOptimistic(final Bytes32 root) {
+    return client.isOptimisticBlock(root);
   }
 }

--- a/data/provider/src/test/java/tech/pegasys/teku/api/stateselector/StateSelectorFactoryTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/stateselector/StateSelectorFactoryTest.java
@@ -18,6 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThatSafeFuture;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 
 import java.util.Optional;
@@ -26,10 +27,14 @@ import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.api.exceptions.BadRequestException;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
+import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.storage.api.StorageQueryChannel;
+import tech.pegasys.teku.storage.client.ChainHead;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
@@ -38,33 +43,35 @@ public class StateSelectorFactoryTest {
   private final CombinedChainDataClient client = mock(CombinedChainDataClient.class);
   private final Spec spec = TestSpecFactory.createMinimalPhase0();
   private final DataStructureUtil data = new DataStructureUtil(spec);
+  private final SpecMilestone milestone = spec.getGenesisSpec().getMilestone();
   private final BeaconState state = data.randomBeaconState();
 
-  private final StateSelectorFactory factory = new StateSelectorFactory(client);
+  private final StateSelectorFactory factory = new StateSelectorFactory(spec, client);
 
   @Test
   public void headSelector_shouldGetBestState() throws ExecutionException, InterruptedException {
-    when(client.getBestState()).thenReturn(Optional.of(SafeFuture.completedFuture(state)));
-    Optional<BeaconState> result = factory.headSelector().getState().get();
-    assertThat(result).isEqualTo(Optional.of(state));
-    verify(client).getBestState();
+    final SignedBlockAndState blockAndState = data.randomSignedBlockAndState(10);
+    final ChainHead chainHead = ChainHead.create(blockAndState);
+    when(client.getChainHead()).thenReturn(Optional.of(chainHead));
+    Optional<StateAndMetaData> result = factory.headSelector().getState().get();
+    assertThat(result).contains(withMetaData(blockAndState.getState()));
   }
 
   @Test
   public void finalizedSelector_shouldGetFinalizedState()
       throws ExecutionException, InterruptedException {
-    when(client.getFinalizedState()).thenReturn(Optional.of(state));
-    Optional<BeaconState> result = factory.finalizedSelector().getState().get();
-    assertThat(result).isEqualTo(Optional.of(state));
-    verify(client).getFinalizedState();
+    when(client.getLatestFinalized())
+        .thenReturn(Optional.of(AnchorPoint.fromInitialState(spec, state)));
+    Optional<StateAndMetaData> result = factory.finalizedSelector().getState().get();
+    assertThat(result).contains(withMetaData(state));
   }
 
   @Test
   public void justifiedSelector_shouldGetJustifiedState()
       throws ExecutionException, InterruptedException {
     when(client.getJustifiedState()).thenReturn(SafeFuture.completedFuture(Optional.of(state)));
-    Optional<BeaconState> result = factory.justifiedSelector().getState().get();
-    assertThat(result).isEqualTo(Optional.of(state));
+    Optional<StateAndMetaData> result = factory.justifiedSelector().getState().get();
+    assertThat(result).contains(withMetaData(state));
     verify(client).getJustifiedState();
   }
 
@@ -73,18 +80,20 @@ public class StateSelectorFactoryTest {
       throws ExecutionException, InterruptedException {
     when(client.getStateAtSlotExact(ZERO))
         .thenReturn(SafeFuture.completedFuture(Optional.of(state)));
-    Optional<BeaconState> result = factory.genesisSelector().getState().get();
-    assertThat(result).isEqualTo(Optional.of(state));
+    Optional<StateAndMetaData> result = factory.genesisSelector().getState().get();
+    assertThat(result).contains(withMetaData(state));
     verify(client).getStateAtSlotExact(ZERO);
   }
 
   @Test
   public void forSlot_shouldGetStateAtSlotExact() throws ExecutionException, InterruptedException {
-    when(client.getStateAtSlotExact(state.getSlot()))
+    final SignedBlockAndState blockAndState = data.randomSignedBlockAndState(15);
+    final ChainHead chainHead = ChainHead.create(blockAndState);
+    when(client.getChainHead()).thenReturn(Optional.of(chainHead));
+    when(client.getStateAtSlotExact(state.getSlot(), chainHead.getRoot()))
         .thenReturn(SafeFuture.completedFuture(Optional.of(state)));
-    Optional<BeaconState> result = factory.forSlot(state.getSlot()).getState().get();
-    assertThat(result).isEqualTo(Optional.of(state));
-    verify(client).getStateAtSlotExact(state.getSlot());
+    Optional<StateAndMetaData> result = factory.forSlot(state.getSlot()).getState().get();
+    assertThat(result).contains(withMetaData(state));
   }
 
   @Test
@@ -92,8 +101,8 @@ public class StateSelectorFactoryTest {
       throws ExecutionException, InterruptedException {
     when(client.getStateByStateRoot(state.hashTreeRoot()))
         .thenReturn(SafeFuture.completedFuture(Optional.of(state)));
-    Optional<BeaconState> result = factory.forStateRoot(state.hashTreeRoot()).getState().get();
-    assertThat(result).isEqualTo(Optional.of(state));
+    Optional<StateAndMetaData> result = factory.forStateRoot(state.hashTreeRoot()).getState().get();
+    assertThat(result).contains(withMetaData(state));
     verify(client).getStateByStateRoot(state.hashTreeRoot());
   }
 
@@ -108,22 +117,26 @@ public class StateSelectorFactoryTest {
   }
 
   @Test
-  public void stateSelector_shouldReturnEmptyWhenPreForkChoice()
-      throws ExecutionException, InterruptedException {
+  public void stateSelector_shouldReturnEmptyWhenPreForkChoice() {
     final StorageQueryChannel historicalChainData = mock(StorageQueryChannel.class);
     final RecentChainData recentChainData = mock(RecentChainData.class);
     final CombinedChainDataClient client1 =
         new CombinedChainDataClient(recentChainData, historicalChainData, spec);
-    final StateSelectorFactory factory = new StateSelectorFactory(client1);
+    final StateSelectorFactory factory = new StateSelectorFactory(spec, client1);
     when(recentChainData.isPreGenesis()).thenReturn(false);
     when(recentChainData.isPreForkChoice()).thenReturn(true);
-    final SafeFuture<Optional<BeaconState>> future =
+    final SafeFuture<Optional<StateAndMetaData>> future =
         factory.defaultStateSelector(ZERO.toString()).getState();
-    assertThat(future.get()).isEmpty();
+    assertThatSafeFuture(future).isCompletedWithEmptyOptional();
   }
 
   @Test
   public void defaultBlockSelector_shouldThrowBadRequestForBadHexState() {
     assertThrows(BadRequestException.class, () -> factory.defaultStateSelector("0xzz"));
+  }
+
+  private StateAndMetaData withMetaData(final BeaconState state) {
+    return new StateAndMetaData(
+        state, milestone, false, spec.isMilestoneSupported(SpecMilestone.BELLATRIX));
   }
 }


### PR DESCRIPTION
## PR Description
Updates `StateSelector` to return `StateAndMetaData` so that APIs can be updated to include `execution_optimistic`.

## Fixed Issue(s)
#5081 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
