### PR TITLE
Use lowercase names for SSZ fields

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/BeaconState.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/BeaconState.java
@@ -40,26 +40,26 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.phase0.B
 
 public interface BeaconState extends SszContainer, ValidatorStats {
 
-  BeaconStateSchema<?, ?> getBeaconStateSchema();
+  BeaconStateSchema<? extends BeaconState, ? extends MutableBeaconState> getBeaconStateSchema();
 
   default UInt64 getGenesis_time() {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.GENESIS_TIME.name());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.GENESIS_TIME.getFieldName());
     return ((SszUInt64) get(fieldIndex)).get();
   }
 
   default Bytes32 getGenesis_validators_root() {
     final int fieldIndex =
-        getSchema().getFieldIndex(BeaconStateFields.GENESIS_VALIDATORS_ROOT.name());
+        getSchema().getFieldIndex(BeaconStateFields.GENESIS_VALIDATORS_ROOT.getFieldName());
     return ((SszBytes32) get(fieldIndex)).get();
   }
 
   default UInt64 getSlot() {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.SLOT.name());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.SLOT.getFieldName());
     return ((SszUInt64) get(fieldIndex)).get();
   }
 
   default Fork getFork() {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.FORK.name());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.FORK.getFieldName());
     return getAny(fieldIndex);
   }
 
@@ -69,83 +69,89 @@ public interface BeaconState extends SszContainer, ValidatorStats {
 
   // History
   default BeaconBlockHeader getLatest_block_header() {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.LATEST_BLOCK_HEADER.name());
+    final int fieldIndex =
+        getSchema().getFieldIndex(BeaconStateFields.LATEST_BLOCK_HEADER.getFieldName());
     return getAny(fieldIndex);
   }
 
   default SszBytes32Vector getBlock_roots() {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.BLOCK_ROOTS.name());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.BLOCK_ROOTS.getFieldName());
     return getAny(fieldIndex);
   }
 
   default SszBytes32Vector getState_roots() {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.STATE_ROOTS.name());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.STATE_ROOTS.getFieldName());
     return getAny(fieldIndex);
   }
 
   default SszPrimitiveList<Bytes32, SszBytes32> getHistorical_roots() {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.HISTORICAL_ROOTS.name());
+    final int fieldIndex =
+        getSchema().getFieldIndex(BeaconStateFields.HISTORICAL_ROOTS.getFieldName());
     return getAny(fieldIndex);
   }
 
   // Eth1
   default Eth1Data getEth1_data() {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.ETH1_DATA.name());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.ETH1_DATA.getFieldName());
     return getAny(fieldIndex);
   }
 
   default SszList<Eth1Data> getEth1_data_votes() {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.ETH1_DATA_VOTES.name());
+    final int fieldIndex =
+        getSchema().getFieldIndex(BeaconStateFields.ETH1_DATA_VOTES.getFieldName());
     return getAny(fieldIndex);
   }
 
   default UInt64 getEth1_deposit_index() {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.ETH1_DEPOSIT_INDEX.name());
+    final int fieldIndex =
+        getSchema().getFieldIndex(BeaconStateFields.ETH1_DEPOSIT_INDEX.getFieldName());
     return ((SszUInt64) get(fieldIndex)).get();
   }
 
   // Registry
   default SszList<Validator> getValidators() {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.VALIDATORS.name());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.VALIDATORS.getFieldName());
     return getAny(fieldIndex);
   }
 
   default SszUInt64List getBalances() {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.BALANCES.name());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.BALANCES.getFieldName());
     return getAny(fieldIndex);
   }
 
   default SszBytes32Vector getRandao_mixes() {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.RANDAO_MIXES.name());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.RANDAO_MIXES.getFieldName());
     return getAny(fieldIndex);
   }
 
   // Slashings
   default SszPrimitiveVector<UInt64, SszUInt64> getSlashings() {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.SLASHINGS.name());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.SLASHINGS.getFieldName());
     return getAny(fieldIndex);
   }
 
   // Finality
   default SszBitvector getJustification_bits() {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.JUSTIFICATION_BITS.name());
+    final int fieldIndex =
+        getSchema().getFieldIndex(BeaconStateFields.JUSTIFICATION_BITS.getFieldName());
     return getAny(fieldIndex);
   }
 
   default Checkpoint getPrevious_justified_checkpoint() {
     final int fieldIndex =
-        getSchema().getFieldIndex(BeaconStateFields.PREVIOUS_JUSTIFIED_CHECKPOINT.name());
+        getSchema().getFieldIndex(BeaconStateFields.PREVIOUS_JUSTIFIED_CHECKPOINT.getFieldName());
     return getAny(fieldIndex);
   }
 
   default Checkpoint getCurrent_justified_checkpoint() {
     final int fieldIndex =
-        getSchema().getFieldIndex(BeaconStateFields.CURRENT_JUSTIFIED_CHECKPOINT.name());
+        getSchema().getFieldIndex(BeaconStateFields.CURRENT_JUSTIFIED_CHECKPOINT.getFieldName());
     return getAny(fieldIndex);
   }
 
   default Checkpoint getFinalized_checkpoint() {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.FINALIZED_CHECKPOINT.name());
+    final int fieldIndex =
+        getSchema().getFieldIndex(BeaconStateFields.FINALIZED_CHECKPOINT.getFieldName());
     return getAny(fieldIndex);
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/BeaconStateSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/BeaconStateSchema.java
@@ -40,51 +40,51 @@ public interface BeaconStateSchema<T extends BeaconState, TMutable extends Mutab
 
   default SszBytes32VectorSchema<?> getBlockRootsSchema() {
     return (SszBytes32VectorSchema<?>)
-        getChildSchema(getFieldIndex(BeaconStateFields.BLOCK_ROOTS.name()));
+        getChildSchema(getFieldIndex(BeaconStateFields.BLOCK_ROOTS.getFieldName()));
   }
 
   default SszBytes32VectorSchema<?> getStateRootsSchema() {
     return (SszBytes32VectorSchema<?>)
-        getChildSchema(getFieldIndex(BeaconStateFields.STATE_ROOTS.name()));
+        getChildSchema(getFieldIndex(BeaconStateFields.STATE_ROOTS.getFieldName()));
   }
 
   @SuppressWarnings("unchecked")
   default SszPrimitiveListSchema<Bytes32, SszBytes32, ?> getHistoricalRootsSchema() {
     return (SszPrimitiveListSchema<Bytes32, SszBytes32, ?>)
-        getChildSchema(getFieldIndex(BeaconStateFields.HISTORICAL_ROOTS.name()));
+        getChildSchema(getFieldIndex(BeaconStateFields.HISTORICAL_ROOTS.getFieldName()));
   }
 
   @SuppressWarnings("unchecked")
   default SszListSchema<Eth1Data, ?> getEth1DataVotesSchema() {
     return (SszListSchema<Eth1Data, ?>)
-        getChildSchema(getFieldIndex(BeaconStateFields.ETH1_DATA_VOTES.name()));
+        getChildSchema(getFieldIndex(BeaconStateFields.ETH1_DATA_VOTES.getFieldName()));
   }
 
   @SuppressWarnings("unchecked")
   default SszListSchema<Validator, ?> getValidatorsSchema() {
     return (SszListSchema<Validator, ?>)
-        getChildSchema(getFieldIndex(BeaconStateFields.VALIDATORS.name()));
+        getChildSchema(getFieldIndex(BeaconStateFields.VALIDATORS.getFieldName()));
   }
 
   default SszUInt64ListSchema<?> getBalancesSchema() {
     return (SszUInt64ListSchema<?>)
-        getChildSchema(getFieldIndex(BeaconStateFields.BALANCES.name()));
+        getChildSchema(getFieldIndex(BeaconStateFields.BALANCES.getFieldName()));
   }
 
   default SszBytes32VectorSchema<?> getRandaoMixesSchema() {
     return (SszBytes32VectorSchema<?>)
-        getChildSchema(getFieldIndex(BeaconStateFields.RANDAO_MIXES.name()));
+        getChildSchema(getFieldIndex(BeaconStateFields.RANDAO_MIXES.getFieldName()));
   }
 
   @SuppressWarnings("unchecked")
   default SszPrimitiveVectorSchema<UInt64, SszUInt64, ?> getSlashingsSchema() {
     return (SszPrimitiveVectorSchema<UInt64, SszUInt64, ?>)
-        getChildSchema(getFieldIndex(BeaconStateFields.SLASHINGS.name()));
+        getChildSchema(getFieldIndex(BeaconStateFields.SLASHINGS.getFieldName()));
   }
 
   default SszBitvectorSchema<?> getJustificationBitsSchema() {
     return (SszBitvectorSchema<?>)
-        getChildSchema(getFieldIndex(BeaconStateFields.JUSTIFICATION_BITS.name()));
+        getChildSchema(getFieldIndex(BeaconStateFields.JUSTIFICATION_BITS.getFieldName()));
   }
 
   default SyncCommitteeSchema getCurrentSyncCommitteeSchemaOrThrow() {
@@ -96,7 +96,7 @@ public interface BeaconStateSchema<T extends BeaconState, TMutable extends Mutab
   }
 
   private SszSchema<?> getSchemaOrThrow(final BeaconStateFields field) {
-    final String fieldName = field.name();
+    final String fieldName = field.getFieldName();
     final int fieldIndex = getFieldIndex(fieldName);
     checkArgument(
         fieldIndex >= 0,

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/MutableBeaconState.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/MutableBeaconState.java
@@ -45,153 +45,161 @@ public interface MutableBeaconState extends BeaconState, SszMutableRefContainer 
   // Versioning
 
   default void setGenesis_time(UInt64 genesis_time) {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.GENESIS_TIME.name());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.GENESIS_TIME.getFieldName());
     set(fieldIndex, SszUInt64.of(genesis_time));
   }
 
   default void setGenesis_validators_root(Bytes32 genesis_validators_root) {
     final int fieldIndex =
-        getSchema().getFieldIndex(BeaconStateFields.GENESIS_VALIDATORS_ROOT.name());
+        getSchema().getFieldIndex(BeaconStateFields.GENESIS_VALIDATORS_ROOT.getFieldName());
     set(fieldIndex, SszBytes32.of(genesis_validators_root));
   }
 
   default void setSlot(UInt64 slot) {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.SLOT.name());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.SLOT.getFieldName());
     set(fieldIndex, SszUInt64.of(slot));
   }
 
   default void setFork(Fork fork) {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.FORK.name());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.FORK.getFieldName());
     set(fieldIndex, fork);
   }
 
   // History
   default void setLatest_block_header(BeaconBlockHeader latest_block_header) {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.LATEST_BLOCK_HEADER.name());
+    final int fieldIndex =
+        getSchema().getFieldIndex(BeaconStateFields.LATEST_BLOCK_HEADER.getFieldName());
     set(fieldIndex, latest_block_header);
   }
 
   @Override
   default SszMutableBytes32Vector getBlock_roots() {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.BLOCK_ROOTS.name());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.BLOCK_ROOTS.getFieldName());
     return getAnyByRef(fieldIndex);
   }
 
   default void setBlock_roots(SszBytes32Vector block_roots) {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.BLOCK_ROOTS.name());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.BLOCK_ROOTS.getFieldName());
     set(fieldIndex, block_roots);
   }
 
   @Override
   default SszMutableBytes32Vector getState_roots() {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.STATE_ROOTS.name());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.STATE_ROOTS.getFieldName());
     return getAnyByRef(fieldIndex);
   }
 
   default void setState_roots(SszBytes32Vector state_roots) {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.STATE_ROOTS.name());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.STATE_ROOTS.getFieldName());
     set(fieldIndex, state_roots);
   }
 
   @Override
   default SszMutablePrimitiveList<Bytes32, SszBytes32> getHistorical_roots() {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.HISTORICAL_ROOTS.name());
+    final int fieldIndex =
+        getSchema().getFieldIndex(BeaconStateFields.HISTORICAL_ROOTS.getFieldName());
     return getAnyByRef(fieldIndex);
   }
 
   default void setHistorical_roots(SszPrimitiveList<Bytes32, SszBytes32> historical_roots) {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.HISTORICAL_ROOTS.name());
+    final int fieldIndex =
+        getSchema().getFieldIndex(BeaconStateFields.HISTORICAL_ROOTS.getFieldName());
     set(fieldIndex, historical_roots);
   }
 
   // Eth1
   default void setEth1_data(Eth1Data eth1_data) {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.ETH1_DATA.name());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.ETH1_DATA.getFieldName());
     set(fieldIndex, eth1_data);
   }
 
   @Override
   default SszMutableList<Eth1Data> getEth1_data_votes() {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.ETH1_DATA_VOTES.name());
+    final int fieldIndex =
+        getSchema().getFieldIndex(BeaconStateFields.ETH1_DATA_VOTES.getFieldName());
     return getAnyByRef(fieldIndex);
   }
 
   default void setEth1_data_votes(SszList<Eth1Data> eth1DataList) {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.ETH1_DATA_VOTES.name());
+    final int fieldIndex =
+        getSchema().getFieldIndex(BeaconStateFields.ETH1_DATA_VOTES.getFieldName());
     set(fieldIndex, eth1DataList);
   }
 
   default void setEth1_deposit_index(UInt64 eth1_deposit_index) {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.ETH1_DEPOSIT_INDEX.name());
+    final int fieldIndex =
+        getSchema().getFieldIndex(BeaconStateFields.ETH1_DEPOSIT_INDEX.getFieldName());
     set(fieldIndex, SszUInt64.of(eth1_deposit_index));
   }
 
   // Registry
   @Override
   default SszMutableList<Validator> getValidators() {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.VALIDATORS.name());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.VALIDATORS.getFieldName());
     return getAnyByRef(fieldIndex);
   }
 
   default void setValidators(SszList<Validator> validators) {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.VALIDATORS.name());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.VALIDATORS.getFieldName());
     set(fieldIndex, validators);
   }
 
   @Override
   default SszMutableUInt64List getBalances() {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.BALANCES.name());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.BALANCES.getFieldName());
     return getAnyByRef(fieldIndex);
   }
 
   default void setBalances(SszUInt64List balances) {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.BALANCES.name());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.BALANCES.getFieldName());
     set(fieldIndex, balances);
   }
 
   @Override
   default SszMutableBytes32Vector getRandao_mixes() {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.RANDAO_MIXES.name());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.RANDAO_MIXES.getFieldName());
     return getAnyByRef(fieldIndex);
   }
 
   default void setRandao_mixes(SszBytes32Vector randao_mixes) {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.RANDAO_MIXES.name());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.RANDAO_MIXES.getFieldName());
     set(fieldIndex, randao_mixes);
   }
 
   // Slashings
   @Override
   default SszMutablePrimitiveVector<UInt64, SszUInt64> getSlashings() {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.SLASHINGS.name());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.SLASHINGS.getFieldName());
     return getAnyByRef(fieldIndex);
   }
 
   default void setSlashings(SszPrimitiveVector<UInt64, SszUInt64> slashings) {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.SLASHINGS.name());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.SLASHINGS.getFieldName());
     set(fieldIndex, slashings);
   }
 
   // Finality
   default void setJustification_bits(SszBitvector justification_bits) {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.JUSTIFICATION_BITS.name());
+    final int fieldIndex =
+        getSchema().getFieldIndex(BeaconStateFields.JUSTIFICATION_BITS.getFieldName());
     set(fieldIndex, justification_bits);
   }
 
   default void setPrevious_justified_checkpoint(Checkpoint previous_justified_checkpoint) {
     final int fieldIndex =
-        getSchema().getFieldIndex(BeaconStateFields.PREVIOUS_JUSTIFIED_CHECKPOINT.name());
+        getSchema().getFieldIndex(BeaconStateFields.PREVIOUS_JUSTIFIED_CHECKPOINT.getFieldName());
     set(fieldIndex, previous_justified_checkpoint);
   }
 
   default void setCurrent_justified_checkpoint(Checkpoint current_justified_checkpoint) {
     final int fieldIndex =
-        getSchema().getFieldIndex(BeaconStateFields.CURRENT_JUSTIFIED_CHECKPOINT.name());
+        getSchema().getFieldIndex(BeaconStateFields.CURRENT_JUSTIFIED_CHECKPOINT.getFieldName());
     set(fieldIndex, current_justified_checkpoint);
   }
 
   default void setFinalized_checkpoint(Checkpoint finalized_checkpoint) {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.FINALIZED_CHECKPOINT.name());
+    final int fieldIndex =
+        getSchema().getFieldIndex(BeaconStateFields.FINALIZED_CHECKPOINT.getFieldName());
     set(fieldIndex, finalized_checkpoint);
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/BeaconStateFields.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/BeaconStateFields.java
@@ -18,6 +18,7 @@ import static tech.pegasys.teku.spec.datastructures.state.beaconstate.common.Bea
 import static tech.pegasys.teku.spec.datastructures.state.beaconstate.common.BeaconStateInvariants.SLOT_FIELD;
 
 import java.util.List;
+import java.util.Locale;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszListSchema;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszSchemaHints;
@@ -64,6 +65,10 @@ public enum BeaconStateFields {
   // Bellatrix fields
   LATEST_EXECUTION_PAYLOAD_HEADER;
 
+  public String getFieldName() {
+    return name().toLowerCase(Locale.ROOT);
+  }
+
   public static void copyCommonFieldsFromSource(
       final MutableBeaconState state, final BeaconState source) {
     // Version
@@ -95,38 +100,38 @@ public enum BeaconStateFields {
   }
 
   static List<SszField> getCommonFields(final SpecConfig specConfig) {
-    SszField fork_field = new SszField(3, BeaconStateFields.FORK.name(), Fork.SSZ_SCHEMA);
+    SszField fork_field = new SszField(3, BeaconStateFields.FORK.getFieldName(), Fork.SSZ_SCHEMA);
     final BeaconBlockHeader.BeaconBlockHeaderSchema blockHeaderSchema =
         BeaconBlockHeader.SSZ_SCHEMA;
     SszField latestBlockHeaderField =
-        new SszField(4, BeaconStateFields.LATEST_BLOCK_HEADER.name(), blockHeaderSchema);
+        new SszField(4, BeaconStateFields.LATEST_BLOCK_HEADER.getFieldName(), blockHeaderSchema);
     SszField blockRootsField =
         new SszField(
             5,
-            BeaconStateFields.BLOCK_ROOTS.name(),
+            BeaconStateFields.BLOCK_ROOTS.getFieldName(),
             () ->
                 SszVectorSchema.create(
                     SszPrimitiveSchemas.BYTES32_SCHEMA, specConfig.getSlotsPerHistoricalRoot()));
     SszField stateRootsField =
         new SszField(
             6,
-            BeaconStateFields.STATE_ROOTS.name(),
+            BeaconStateFields.STATE_ROOTS.getFieldName(),
             () ->
                 SszVectorSchema.create(
                     SszPrimitiveSchemas.BYTES32_SCHEMA, specConfig.getSlotsPerHistoricalRoot()));
     SszField historicalRootsField =
         new SszField(
             7,
-            BeaconStateFields.HISTORICAL_ROOTS.name(),
+            BeaconStateFields.HISTORICAL_ROOTS.getFieldName(),
             () ->
                 SszListSchema.create(
                     SszPrimitiveSchemas.BYTES32_SCHEMA, specConfig.getHistoricalRootsLimit()));
     SszField eth1DataField =
-        new SszField(8, BeaconStateFields.ETH1_DATA.name(), Eth1Data.SSZ_SCHEMA);
+        new SszField(8, BeaconStateFields.ETH1_DATA.getFieldName(), Eth1Data.SSZ_SCHEMA);
     SszField eth1DataVotesField =
         new SszField(
             9,
-            BeaconStateFields.ETH1_DATA_VOTES.name(),
+            BeaconStateFields.ETH1_DATA_VOTES.getFieldName(),
             () ->
                 SszListSchema.create(
                     Eth1Data.SSZ_SCHEMA,
@@ -134,11 +139,13 @@ public enum BeaconStateFields {
                         * specConfig.getSlotsPerEpoch()));
     SszField eth1DepositIndexField =
         new SszField(
-            10, BeaconStateFields.ETH1_DEPOSIT_INDEX.name(), SszPrimitiveSchemas.UINT64_SCHEMA);
+            10,
+            BeaconStateFields.ETH1_DEPOSIT_INDEX.getFieldName(),
+            SszPrimitiveSchemas.UINT64_SCHEMA);
     SszField validatorsField =
         new SszField(
             11,
-            BeaconStateFields.VALIDATORS.name(),
+            BeaconStateFields.VALIDATORS.getFieldName(),
             () ->
                 SszListSchema.create(
                     Validator.SSZ_SCHEMA,
@@ -147,37 +154,42 @@ public enum BeaconStateFields {
     SszField balancesField =
         new SszField(
             12,
-            BeaconStateFields.BALANCES.name(),
+            BeaconStateFields.BALANCES.getFieldName(),
             () ->
                 SszListSchema.create(
                     SszPrimitiveSchemas.UINT64_SCHEMA, specConfig.getValidatorRegistryLimit()));
     SszField randaoMixesField =
         new SszField(
             13,
-            BeaconStateFields.RANDAO_MIXES.name(),
+            BeaconStateFields.RANDAO_MIXES.getFieldName(),
             () ->
                 SszVectorSchema.create(
                     SszPrimitiveSchemas.BYTES32_SCHEMA, specConfig.getEpochsPerHistoricalVector()));
     SszField slashingsField =
         new SszField(
             14,
-            BeaconStateFields.SLASHINGS.name(),
+            BeaconStateFields.SLASHINGS.getFieldName(),
             () ->
                 SszVectorSchema.create(
                     SszPrimitiveSchemas.UINT64_SCHEMA, specConfig.getEpochsPerSlashingsVector()));
     SszField justificationBitsField =
         new SszField(
             17,
-            BeaconStateFields.JUSTIFICATION_BITS.name(),
+            BeaconStateFields.JUSTIFICATION_BITS.getFieldName(),
             () -> SszBitvectorSchema.create(specConfig.getJustificationBitsLength()));
     SszField previousJustifiedCheckpointField =
         new SszField(
-            18, BeaconStateFields.PREVIOUS_JUSTIFIED_CHECKPOINT.name(), Checkpoint.SSZ_SCHEMA);
+            18,
+            BeaconStateFields.PREVIOUS_JUSTIFIED_CHECKPOINT.getFieldName(),
+            Checkpoint.SSZ_SCHEMA);
     SszField currentJustifiedCheckpointField =
         new SszField(
-            19, BeaconStateFields.CURRENT_JUSTIFIED_CHECKPOINT.name(), Checkpoint.SSZ_SCHEMA);
+            19,
+            BeaconStateFields.CURRENT_JUSTIFIED_CHECKPOINT.getFieldName(),
+            Checkpoint.SSZ_SCHEMA);
     SszField finalizedCheckpointField =
-        new SszField(20, BeaconStateFields.FINALIZED_CHECKPOINT.name(), Checkpoint.SSZ_SCHEMA);
+        new SszField(
+            20, BeaconStateFields.FINALIZED_CHECKPOINT.getFieldName(), Checkpoint.SSZ_SCHEMA);
 
     return List.of(
         GENESIS_TIME_FIELD,

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/BeaconStateInvariants.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/BeaconStateInvariants.java
@@ -38,11 +38,13 @@ public class BeaconStateInvariants {
 
   // Fields
   static SszField GENESIS_TIME_FIELD =
-      new SszField(0, BeaconStateFields.GENESIS_TIME.name(), GENESIS_TIME_SCHEMA);
+      new SszField(0, BeaconStateFields.GENESIS_TIME.getFieldName(), GENESIS_TIME_SCHEMA);
   static SszField GENESIS_VALIDATORS_ROOT_FIELD =
       new SszField(
-          1, BeaconStateFields.GENESIS_VALIDATORS_ROOT.name(), GENESIS_VALIDATORS_ROOT_SCHEMA);
-  static SszField SLOT_FIELD = new SszField(2, BeaconStateFields.SLOT.name(), SLOT_SCHEMA);
+          1,
+          BeaconStateFields.GENESIS_VALIDATORS_ROOT.getFieldName(),
+          GENESIS_VALIDATORS_ROOT_SCHEMA);
+  static SszField SLOT_FIELD = new SszField(2, BeaconStateFields.SLOT.getFieldName(), SLOT_SCHEMA);
 
   // Return list of invariant fields
   static List<SszField> getInvariantFields() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/altair/BeaconStateAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/altair/BeaconStateAltair.java
@@ -35,29 +35,31 @@ public interface BeaconStateAltair extends BeaconState {
   // Participation
   default SszList<SszByte> getPreviousEpochParticipation() {
     final int fieldIndex =
-        getSchema().getFieldIndex(BeaconStateFields.PREVIOUS_EPOCH_PARTICIPATION.name());
+        getSchema().getFieldIndex(BeaconStateFields.PREVIOUS_EPOCH_PARTICIPATION.getFieldName());
     return getAny(fieldIndex);
   }
 
   default SszList<SszByte> getCurrentEpochParticipation() {
     final int fieldIndex =
-        getSchema().getFieldIndex(BeaconStateFields.CURRENT_EPOCH_PARTICIPATION.name());
+        getSchema().getFieldIndex(BeaconStateFields.CURRENT_EPOCH_PARTICIPATION.getFieldName());
     return getAny(fieldIndex);
   }
 
   default SszUInt64List getInactivityScores() {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.INACTIVITY_SCORES.name());
+    final int fieldIndex =
+        getSchema().getFieldIndex(BeaconStateFields.INACTIVITY_SCORES.getFieldName());
     return getAny(fieldIndex);
   }
 
   default SyncCommittee getCurrentSyncCommittee() {
     final int fieldIndex =
-        getSchema().getFieldIndex(BeaconStateFields.CURRENT_SYNC_COMMITTEE.name());
+        getSchema().getFieldIndex(BeaconStateFields.CURRENT_SYNC_COMMITTEE.getFieldName());
     return getAny(fieldIndex);
   }
 
   default SyncCommittee getNextSyncCommittee() {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.NEXT_SYNC_COMMITTEE.name());
+    final int fieldIndex =
+        getSchema().getFieldIndex(BeaconStateFields.NEXT_SYNC_COMMITTEE.getFieldName());
     return getAny(fieldIndex);
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/altair/BeaconStateSchemaAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/altair/BeaconStateSchemaAltair.java
@@ -53,14 +53,14 @@ public class BeaconStateSchemaAltair
     final SszField previousEpochAttestationsField =
         new SszField(
             PREVIOUS_EPOCH_PARTICIPATION_FIELD_INDEX,
-            BeaconStateFields.PREVIOUS_EPOCH_PARTICIPATION.name(),
+            BeaconStateFields.PREVIOUS_EPOCH_PARTICIPATION.getFieldName(),
             () ->
                 SszListSchema.create(
                     SszPrimitiveSchemas.BYTE_SCHEMA, specConfig.getValidatorRegistryLimit()));
     final SszField currentEpochAttestationsField =
         new SszField(
             CURRENT_EPOCH_PARTICIPATION_FIELD_INDEX,
-            BeaconStateFields.CURRENT_EPOCH_PARTICIPATION.name(),
+            BeaconStateFields.CURRENT_EPOCH_PARTICIPATION.getFieldName(),
             () ->
                 SszListSchema.create(
                     SszPrimitiveSchemas.BYTE_SCHEMA, specConfig.getValidatorRegistryLimit()));
@@ -68,17 +68,17 @@ public class BeaconStateSchemaAltair
     final SszField inactivityScores =
         new SszField(
             INACTIVITY_SCORES_FIELD_INDEX,
-            BeaconStateFields.INACTIVITY_SCORES.name(),
+            BeaconStateFields.INACTIVITY_SCORES.getFieldName(),
             SszUInt64ListSchema.create(specConfig.getValidatorRegistryLimit()));
     final SszField currentSyncCommitteeField =
         new SszField(
             CURRENT_SYNC_COMMITTEE_FIELD_INDEX,
-            BeaconStateFields.CURRENT_SYNC_COMMITTEE.name(),
+            BeaconStateFields.CURRENT_SYNC_COMMITTEE.getFieldName(),
             () -> new SyncCommitteeSchema(SpecConfigAltair.required(specConfig)));
     final SszField nextSyncCommitteeField =
         new SszField(
             NEXT_SYNC_COMMITTEE_FIELD_INDEX,
-            BeaconStateFields.NEXT_SYNC_COMMITTEE.name(),
+            BeaconStateFields.NEXT_SYNC_COMMITTEE.getFieldName(),
             () -> new SyncCommitteeSchema(SpecConfigAltair.required(specConfig)));
     return List.of(
         previousEpochAttestationsField,
@@ -99,28 +99,29 @@ public class BeaconStateSchemaAltair
   @SuppressWarnings("unchecked")
   public SszPrimitiveListSchema<Byte, SszByte, ?> getPreviousEpochParticipationSchema() {
     return (SszPrimitiveListSchema<Byte, SszByte, ?>)
-        getChildSchema(getFieldIndex(BeaconStateFields.PREVIOUS_EPOCH_PARTICIPATION.name()));
+        getChildSchema(
+            getFieldIndex(BeaconStateFields.PREVIOUS_EPOCH_PARTICIPATION.getFieldName()));
   }
 
   @SuppressWarnings("unchecked")
   public SszPrimitiveListSchema<Byte, SszByte, ?> getCurrentEpochParticipationSchema() {
     return (SszPrimitiveListSchema<Byte, SszByte, ?>)
-        getChildSchema(getFieldIndex(BeaconStateFields.CURRENT_EPOCH_PARTICIPATION.name()));
+        getChildSchema(getFieldIndex(BeaconStateFields.CURRENT_EPOCH_PARTICIPATION.getFieldName()));
   }
 
   public SszUInt64ListSchema<?> getInactivityScoresSchema() {
     return (SszUInt64ListSchema<?>)
-        getChildSchema(getFieldIndex(BeaconStateFields.INACTIVITY_SCORES.name()));
+        getChildSchema(getFieldIndex(BeaconStateFields.INACTIVITY_SCORES.getFieldName()));
   }
 
   public SyncCommitteeSchema getCurrentSyncCommitteeSchema() {
     return (SyncCommitteeSchema)
-        getChildSchema(getFieldIndex(BeaconStateFields.CURRENT_SYNC_COMMITTEE.name()));
+        getChildSchema(getFieldIndex(BeaconStateFields.CURRENT_SYNC_COMMITTEE.getFieldName()));
   }
 
   public SyncCommitteeSchema getNextSyncCommitteeSchema() {
     return (SyncCommitteeSchema)
-        getChildSchema(getFieldIndex(BeaconStateFields.NEXT_SYNC_COMMITTEE.name()));
+        getChildSchema(getFieldIndex(BeaconStateFields.NEXT_SYNC_COMMITTEE.getFieldName()));
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/altair/MutableBeaconStateAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/altair/MutableBeaconStateAltair.java
@@ -37,48 +37,51 @@ public interface MutableBeaconStateAltair extends MutableBeaconState, BeaconStat
   @Override
   default SszMutableList<SszByte> getPreviousEpochParticipation() {
     final int fieldIndex =
-        getSchema().getFieldIndex(BeaconStateFields.PREVIOUS_EPOCH_PARTICIPATION.name());
+        getSchema().getFieldIndex(BeaconStateFields.PREVIOUS_EPOCH_PARTICIPATION.getFieldName());
     return getAnyByRef(fieldIndex);
   }
 
   default void setPreviousEpochParticipation(final SszList<SszByte> newValue) {
     final int fieldIndex =
-        getSchema().getFieldIndex(BeaconStateFields.PREVIOUS_EPOCH_PARTICIPATION.name());
+        getSchema().getFieldIndex(BeaconStateFields.PREVIOUS_EPOCH_PARTICIPATION.getFieldName());
     set(fieldIndex, newValue);
   }
 
   @Override
   default SszMutableList<SszByte> getCurrentEpochParticipation() {
     final int fieldIndex =
-        getSchema().getFieldIndex(BeaconStateFields.CURRENT_EPOCH_PARTICIPATION.name());
+        getSchema().getFieldIndex(BeaconStateFields.CURRENT_EPOCH_PARTICIPATION.getFieldName());
     return getAnyByRef(fieldIndex);
   }
 
   default void setCurrentEpochParticipation(final SszList<SszByte> newValue) {
     final int fieldIndex =
-        getSchema().getFieldIndex(BeaconStateFields.CURRENT_EPOCH_PARTICIPATION.name());
+        getSchema().getFieldIndex(BeaconStateFields.CURRENT_EPOCH_PARTICIPATION.getFieldName());
     set(fieldIndex, newValue);
   }
 
   @Override
   default SszMutableUInt64List getInactivityScores() {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.INACTIVITY_SCORES.name());
+    final int fieldIndex =
+        getSchema().getFieldIndex(BeaconStateFields.INACTIVITY_SCORES.getFieldName());
     return getAnyByRef(fieldIndex);
   }
 
   default void setInactivityScores(SszUInt64List newValue) {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.INACTIVITY_SCORES.name());
+    final int fieldIndex =
+        getSchema().getFieldIndex(BeaconStateFields.INACTIVITY_SCORES.getFieldName());
     set(fieldIndex, newValue);
   }
 
   default void setCurrentSyncCommittee(SyncCommittee currentSyncCommittee) {
     final int fieldIndex =
-        getSchema().getFieldIndex(BeaconStateFields.CURRENT_SYNC_COMMITTEE.name());
+        getSchema().getFieldIndex(BeaconStateFields.CURRENT_SYNC_COMMITTEE.getFieldName());
     set(fieldIndex, currentSyncCommittee);
   }
 
   default void setNextSyncCommittee(SyncCommittee nextSyncCommittee) {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.NEXT_SYNC_COMMITTEE.name());
+    final int fieldIndex =
+        getSchema().getFieldIndex(BeaconStateFields.NEXT_SYNC_COMMITTEE.getFieldName());
     set(fieldIndex, nextSyncCommittee);
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/bellatrix/BeaconStateBellatrix.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/bellatrix/BeaconStateBellatrix.java
@@ -32,7 +32,7 @@ public interface BeaconStateBellatrix extends BeaconStateAltair {
 
   default ExecutionPayloadHeader getLatestExecutionPayloadHeader() {
     final int fieldIndex =
-        getSchema().getFieldIndex(BeaconStateFields.LATEST_EXECUTION_PAYLOAD_HEADER.name());
+        getSchema().getFieldIndex(BeaconStateFields.LATEST_EXECUTION_PAYLOAD_HEADER.getFieldName());
     return getAny(fieldIndex);
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/bellatrix/BeaconStateSchemaBellatrix.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/bellatrix/BeaconStateSchemaBellatrix.java
@@ -51,7 +51,7 @@ public class BeaconStateSchemaBellatrix
     final SszField latestExecutionPayloadHeaderField =
         new SszField(
             LATEST_EXECUTION_PAYLOAD_HEADER_FIELD_INDEX,
-            BeaconStateFields.LATEST_EXECUTION_PAYLOAD_HEADER.name(),
+            BeaconStateFields.LATEST_EXECUTION_PAYLOAD_HEADER.getFieldName(),
             () -> new ExecutionPayloadHeaderSchema(SpecConfigBellatrix.required(specConfig)));
     return Stream.concat(
             BeaconStateSchemaAltair.getUniqueFields(specConfig).stream(),
@@ -70,33 +70,35 @@ public class BeaconStateSchemaBellatrix
   @SuppressWarnings("unchecked")
   public SszPrimitiveListSchema<Byte, SszByte, ?> getPreviousEpochParticipationSchema() {
     return (SszPrimitiveListSchema<Byte, SszByte, ?>)
-        getChildSchema(getFieldIndex(BeaconStateFields.PREVIOUS_EPOCH_PARTICIPATION.name()));
+        getChildSchema(
+            getFieldIndex(BeaconStateFields.PREVIOUS_EPOCH_PARTICIPATION.getFieldName()));
   }
 
   @SuppressWarnings("unchecked")
   public SszPrimitiveListSchema<Byte, SszByte, ?> getCurrentEpochParticipationSchema() {
     return (SszPrimitiveListSchema<Byte, SszByte, ?>)
-        getChildSchema(getFieldIndex(BeaconStateFields.CURRENT_EPOCH_PARTICIPATION.name()));
+        getChildSchema(getFieldIndex(BeaconStateFields.CURRENT_EPOCH_PARTICIPATION.getFieldName()));
   }
 
   public SszUInt64ListSchema<?> getInactivityScoresSchema() {
     return (SszUInt64ListSchema<?>)
-        getChildSchema(getFieldIndex(BeaconStateFields.INACTIVITY_SCORES.name()));
+        getChildSchema(getFieldIndex(BeaconStateFields.INACTIVITY_SCORES.getFieldName()));
   }
 
   public SyncCommitteeSchema getCurrentSyncCommitteeSchema() {
     return (SyncCommitteeSchema)
-        getChildSchema(getFieldIndex(BeaconStateFields.CURRENT_SYNC_COMMITTEE.name()));
+        getChildSchema(getFieldIndex(BeaconStateFields.CURRENT_SYNC_COMMITTEE.getFieldName()));
   }
 
   public SyncCommitteeSchema getNextSyncCommitteeSchema() {
     return (SyncCommitteeSchema)
-        getChildSchema(getFieldIndex(BeaconStateFields.NEXT_SYNC_COMMITTEE.name()));
+        getChildSchema(getFieldIndex(BeaconStateFields.NEXT_SYNC_COMMITTEE.getFieldName()));
   }
 
   public ExecutionPayloadHeaderSchema getLastExecutionPayloadHeaderSchema() {
     return (ExecutionPayloadHeaderSchema)
-        getChildSchema(getFieldIndex(BeaconStateFields.LATEST_EXECUTION_PAYLOAD_HEADER.name()));
+        getChildSchema(
+            getFieldIndex(BeaconStateFields.LATEST_EXECUTION_PAYLOAD_HEADER.getFieldName()));
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/bellatrix/MutableBeaconStateBellatrix.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/bellatrix/MutableBeaconStateBellatrix.java
@@ -33,7 +33,7 @@ public interface MutableBeaconStateBellatrix
 
   default void setLatestExecutionPayloadHeader(ExecutionPayloadHeader executionPayloadHeader) {
     final int fieldIndex =
-        getSchema().getFieldIndex(BeaconStateFields.LATEST_EXECUTION_PAYLOAD_HEADER.name());
+        getSchema().getFieldIndex(BeaconStateFields.LATEST_EXECUTION_PAYLOAD_HEADER.getFieldName());
     set(fieldIndex, executionPayloadHeader);
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/phase0/BeaconStatePhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/phase0/BeaconStatePhase0.java
@@ -38,13 +38,13 @@ public interface BeaconStatePhase0 extends BeaconState {
   // Attestations
   default SszList<PendingAttestation> getPrevious_epoch_attestations() {
     final int fieldIndex =
-        getSchema().getFieldIndex(BeaconStateFields.PREVIOUS_EPOCH_ATTESTATIONS.name());
+        getSchema().getFieldIndex(BeaconStateFields.PREVIOUS_EPOCH_ATTESTATIONS.getFieldName());
     return getAny(fieldIndex);
   }
 
   default SszList<PendingAttestation> getCurrent_epoch_attestations() {
     final int fieldIndex =
-        getSchema().getFieldIndex(BeaconStateFields.CURRENT_EPOCH_ATTESTATIONS.name());
+        getSchema().getFieldIndex(BeaconStateFields.CURRENT_EPOCH_ATTESTATIONS.getFieldName());
     return getAny(fieldIndex);
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/phase0/BeaconStateSchemaPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/phase0/BeaconStateSchemaPhase0.java
@@ -54,7 +54,7 @@ public class BeaconStateSchemaPhase0
     final SszField previousEpochAttestationsField =
         new SszField(
             15,
-            BeaconStateFields.PREVIOUS_EPOCH_ATTESTATIONS.name(),
+            BeaconStateFields.PREVIOUS_EPOCH_ATTESTATIONS.getFieldName(),
             () ->
                 SszListSchema.create(
                     pendingAttestationSchema,
@@ -62,7 +62,7 @@ public class BeaconStateSchemaPhase0
     final SszField currentEpochAttestationsField =
         new SszField(
             16,
-            BeaconStateFields.CURRENT_EPOCH_ATTESTATIONS.name(),
+            BeaconStateFields.CURRENT_EPOCH_ATTESTATIONS.getFieldName(),
             () ->
                 SszListSchema.create(
                     pendingAttestationSchema,
@@ -74,13 +74,13 @@ public class BeaconStateSchemaPhase0
   @SuppressWarnings("unchecked")
   public SszListSchema<PendingAttestation, ?> getPreviousEpochAttestationsSchema() {
     return (SszListSchema<PendingAttestation, ?>)
-        getChildSchema(getFieldIndex(BeaconStateFields.PREVIOUS_EPOCH_ATTESTATIONS.name()));
+        getChildSchema(getFieldIndex(BeaconStateFields.PREVIOUS_EPOCH_ATTESTATIONS.getFieldName()));
   }
 
   @SuppressWarnings("unchecked")
   public SszListSchema<PendingAttestation, ?> getCurrentEpochAttestationsSchema() {
     return (SszListSchema<PendingAttestation, ?>)
-        getChildSchema(getFieldIndex(BeaconStateFields.CURRENT_EPOCH_ATTESTATIONS.name()));
+        getChildSchema(getFieldIndex(BeaconStateFields.CURRENT_EPOCH_ATTESTATIONS.getFieldName()));
   }
 
   public PendingAttestationSchema getPendingAttestationSchema() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/phase0/MutableBeaconStatePhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/phase0/MutableBeaconStatePhase0.java
@@ -34,14 +34,14 @@ public interface MutableBeaconStatePhase0 extends MutableBeaconState, BeaconStat
   @Override
   default SszMutableList<PendingAttestation> getPrevious_epoch_attestations() {
     final int fieldIndex =
-        getSchema().getFieldIndex(BeaconStateFields.PREVIOUS_EPOCH_ATTESTATIONS.name());
+        getSchema().getFieldIndex(BeaconStateFields.PREVIOUS_EPOCH_ATTESTATIONS.getFieldName());
     return getAnyByRef(fieldIndex);
   }
 
   @Override
   default SszMutableList<PendingAttestation> getCurrent_epoch_attestations() {
     final int fieldIndex =
-        getSchema().getFieldIndex(BeaconStateFields.CURRENT_EPOCH_ATTESTATIONS.name());
+        getSchema().getFieldIndex(BeaconStateFields.CURRENT_EPOCH_ATTESTATIONS.getFieldName());
     return getAnyByRef(fieldIndex);
   }
 

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/AbstractBeaconStateSchemaTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/AbstractBeaconStateSchemaTest.java
@@ -145,7 +145,7 @@ public abstract class AbstractBeaconStateSchemaTest<
                 createSchema(
                     List.of(GENESIS_TIME_FIELD, GENESIS_VALIDATORS_ROOT_FIELD, randomField)))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Expected invariant field 'SLOT' at index 2, but got 'random'");
+        .hasMessageContaining("Expected invariant field 'slot' at index 2, but got 'random'");
   }
 
   private BeaconStateSchema<BeaconState, MutableBeaconState> createSchema(


### PR DESCRIPTION
## PR Description
Extracted out of #5072 - use `getFieldName()` method instead of `name()` so our SSZ fields have lower case names.

Currently those names aren't used anywhere but we need the lowercase for json serialisation.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
