### PR TITLE
Only send block event after import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,12 @@
 For information on changes in released versions of Teku, see the [releases page](https://github.com/ConsenSys/teku/releases).
 
 ## Unreleased Changes
+
+### Breaking Changes
 - Support for the Pyrmont testnet has been removed. The Prater testnet should be used instead.
+- `block` events are now published on the beacon rest API after the block is imported, instead of after it had passed gossip validation rules.
+     Blocks that pass the gossip validation rules but fail state transition will no longer emit a `block` event.
+
 ### Additions and Improvements
 - Added support for exporting metrics to an external consumer with `--metrics-publish-endpoint`.
 

--- a/data/provider/src/main/java/tech/pegasys/teku/api/NodeDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/NodeDataProvider.java
@@ -33,7 +33,7 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.attestation.ProcessedAttestationListener;
-import tech.pegasys.teku.spec.datastructures.blocks.ReceivedBlockListener;
+import tech.pegasys.teku.spec.datastructures.blocks.ImportedBlockListener;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SignedContributionAndProof;
 import tech.pegasys.teku.statetransition.OperationPool;
 import tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPool;
@@ -127,7 +127,7 @@ public class NodeDataProvider {
     return proposerSlashingPool.add(slashing.asInternalProposerSlashing());
   }
 
-  public void subscribeToReceivedBlocks(ReceivedBlockListener listener) {
+  public void subscribeToReceivedBlocks(ImportedBlockListener listener) {
     blockManager.subscribeToReceivedBlocks(listener);
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/ImportedBlockListener.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/ImportedBlockListener.java
@@ -13,6 +13,6 @@
 
 package tech.pegasys.teku.spec.datastructures.blocks;
 
-public interface ReceivedBlockListener {
-  void accept(SignedBeaconBlock block);
+public interface ImportedBlockListener {
+  void onBlockImported(SignedBeaconBlock block);
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBeaconBlock.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBeaconBlock.java
@@ -29,7 +29,7 @@ public class SignedBeaconBlock extends Container2<SignedBeaconBlock, BeaconBlock
     super(type, backingNode);
   }
 
-  private SignedBeaconBlock(
+  SignedBeaconBlock(
       final SignedBeaconBlockSchema type, final BeaconBlock message, final BLSSignature signature) {
     super(type, message, new SszSignature(signature));
   }
@@ -40,6 +40,11 @@ public class SignedBeaconBlock extends Container2<SignedBeaconBlock, BeaconBlock
         spec.atSlot(message.getSlot()).getSchemaDefinitions().getSignedBeaconBlockSchema(),
         message,
         signature);
+  }
+
+  @Override
+  public SignedBeaconBlockSchema getSchema() {
+    return (SignedBeaconBlockSchema) super.getSchema();
   }
 
   public BeaconBlock getMessage() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBeaconBlockSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBeaconBlockSchema.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.datastructures.blocks;
 
+import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema2;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.spec.datastructures.type.SszSignature;
@@ -26,6 +27,10 @@ public class SignedBeaconBlockSchema
         "SignedBeaconBlock",
         namedSchema("message", beaconBlockSchema),
         namedSchema("signature", SszSignatureSchema.INSTANCE));
+  }
+
+  public SignedBeaconBlock create(final BeaconBlock message, final BLSSignature signature) {
+    return new SignedBeaconBlock(this, message, signature);
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/results/SuccessfulBlockImportResult.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/results/SuccessfulBlockImportResult.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.spec.logic.common.statetransition.results;
 
 import com.google.common.base.MoreObjects;
+import java.util.Objects;
 import java.util.Optional;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 
@@ -54,6 +55,23 @@ public class SuccessfulBlockImportResult implements BlockImportResult {
   @Override
   public Optional<Throwable> getFailureCause() {
     return Optional.empty();
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final SuccessfulBlockImportResult that = (SuccessfulBlockImportResult) o;
+    return blockOnCanonicalChain == that.blockOnCanonicalChain && Objects.equals(block, that.block);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(block, blockOnCanonicalChain);
   }
 
   @Override

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/BlockManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/BlockManager.java
@@ -27,7 +27,7 @@ import tech.pegasys.teku.infrastructure.collections.LimitedMap;
 import tech.pegasys.teku.infrastructure.subscribers.Subscribers;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.service.serviceutils.Service;
-import tech.pegasys.teku.spec.datastructures.blocks.ReceivedBlockListener;
+import tech.pegasys.teku.spec.datastructures.blocks.ImportedBlockListener;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.FailedBlockImportResult;
@@ -52,7 +52,7 @@ public class BlockManager extends Service
   // and will not require any further retry. Descendants of these blocks will be considered invalid
   // as well.
   private final Map<Bytes32, BlockImportResult> invalidBlockRoots = LimitedMap.create(500);
-  private final Subscribers<ReceivedBlockListener> receivedBlockSubscribers =
+  private final Subscribers<ImportedBlockListener> receivedBlockSubscribers =
       Subscribers.create(true);
 
   public BlockManager(
@@ -109,12 +109,12 @@ public class BlockManager extends Service
     futureBlocks.prune(slot).forEach(this::importBlockIgnoringResult);
   }
 
-  public void subscribeToReceivedBlocks(ReceivedBlockListener receivedBlockListener) {
-    receivedBlockSubscribers.subscribe(receivedBlockListener);
+  public void subscribeToReceivedBlocks(ImportedBlockListener importedBlockListener) {
+    receivedBlockSubscribers.subscribe(importedBlockListener);
   }
 
   private void notifyReceivedBlockSubscribers(SignedBeaconBlock signedBeaconBlock) {
-    receivedBlockSubscribers.forEach(s -> s.accept(signedBeaconBlock));
+    receivedBlockSubscribers.forEach(s -> s.onBlockImported(signedBeaconBlock));
   }
 
   @Override
@@ -133,12 +133,14 @@ public class BlockManager extends Service
 
   private SafeFuture<BlockImportResult> doImportBlock(final SignedBeaconBlock block) {
     return handleInvalidBlock(block)
-        .or(
-            () -> {
-              notifyReceivedBlockSubscribers(block);
-              return handleKnownBlock(block);
-            })
-        .orElseGet(() -> handleBlockImport(block));
+        .or(() -> handleKnownBlock(block))
+        .orElseGet(() -> handleBlockImport(block))
+        .thenPeek(
+            result -> {
+              if (result.isSuccessful()) {
+                notifyReceivedBlockSubscribers(block);
+              }
+            });
   }
 
   private Optional<BlockImportResult> propagateInvalidity(final SignedBeaconBlock block) {

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockManagerTest.java
@@ -20,8 +20,11 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.async.FutureUtil.ignoreFuture;
+import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThatSafeFuture;
+import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 import static tech.pegasys.teku.spec.config.SpecConfig.GENESIS_SLOT;
 
 import java.util.ArrayList;
@@ -38,6 +41,7 @@ import tech.pegasys.teku.infrastructure.async.eventthread.InlineEventThread;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.blocks.ImportedBlockListener;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannel;
 import tech.pegasys.teku.spec.executionengine.PayloadStatus;
@@ -144,8 +148,54 @@ public class BlockManagerTest {
         localChain.chainBuilder().generateBlockAtSlot(nextSlot).getBlock();
     incrementSlot();
 
-    blockManager.importBlock(nextBlock).join();
+    safeJoin(blockManager.importBlock(nextBlock));
     assertThat(pendingBlocks.size()).isEqualTo(0);
+  }
+
+  @Test
+  public void shouldNotifySubscribersOnImport() {
+    final ImportedBlockListener subscriber = mock(ImportedBlockListener.class);
+    blockManager.subscribeToReceivedBlocks(subscriber);
+    final UInt64 nextSlot = GENESIS_SLOT.plus(UInt64.ONE);
+    final SignedBeaconBlock nextBlock =
+        localChain.chainBuilder().generateBlockAtSlot(nextSlot).getBlock();
+    incrementSlot();
+
+    safeJoin(blockManager.importBlock(nextBlock));
+    verify(subscriber).onBlockImported(nextBlock);
+  }
+
+  @Test
+  public void shouldNotifySubscribersOnKnownBlock() {
+    final ImportedBlockListener subscriber = mock(ImportedBlockListener.class);
+    blockManager.subscribeToReceivedBlocks(subscriber);
+    final UInt64 nextSlot = GENESIS_SLOT.plus(UInt64.ONE);
+    final SignedBeaconBlock nextBlock =
+        localChain.chainBuilder().generateBlockAtSlot(nextSlot).getBlock();
+    incrementSlot();
+
+    safeJoin(blockManager.importBlock(nextBlock));
+    verify(subscriber).onBlockImported(nextBlock);
+
+    assertThatSafeFuture(blockManager.importBlock(nextBlock))
+        .isCompletedWithValue(BlockImportResult.knownBlock(nextBlock));
+    verify(subscriber, times(2)).onBlockImported(nextBlock);
+  }
+
+  @Test
+  public void shouldNotNotifySubscribersOnInvalidBlock() {
+    final ImportedBlockListener subscriber = mock(ImportedBlockListener.class);
+    blockManager.subscribeToReceivedBlocks(subscriber);
+    final UInt64 nextSlot = GENESIS_SLOT.plus(UInt64.ONE);
+    final SignedBeaconBlock validBlock =
+        localChain.chainBuilder().generateBlockAtSlot(nextSlot).getBlock();
+    final SignedBeaconBlock invalidBlock =
+        validBlock.getSchema().create(validBlock.getMessage(), dataStructureUtil.randomSignature());
+    incrementSlot();
+
+    assertThatSafeFuture(blockManager.importBlock(invalidBlock))
+        .isCompletedWithValueMatching(result -> !result.isSuccessful());
+    verifyNoInteractions(subscriber);
   }
 
   @Test
@@ -159,7 +209,7 @@ public class BlockManagerTest {
 
     incrementSlot();
     incrementSlot();
-    blockManager.importBlock(nextNextBlock).join();
+    safeJoin(blockManager.importBlock(nextNextBlock));
     assertThat(pendingBlocks.size()).isEqualTo(1);
     assertThat(futureBlocks.size()).isEqualTo(0);
     assertThat(pendingBlocks.contains(nextNextBlock)).isTrue();
@@ -212,7 +262,7 @@ public class BlockManagerTest {
     final SignedBeaconBlock nextBlock =
         localChain.chainBuilder().generateBlockAtSlot(nextSlot).getBlock();
 
-    blockManager.importBlock(nextBlock).join();
+    safeJoin(blockManager.importBlock(nextBlock));
     assertThat(pendingBlocks.size()).isEqualTo(0);
     assertThat(futureBlocks.size()).isEqualTo(1);
     assertThat(futureBlocks.contains(nextBlock)).isTrue();
@@ -228,7 +278,7 @@ public class BlockManagerTest {
         localChain.chainBuilder().generateBlockAtSlot(nextNextSlot).getBlock();
 
     incrementSlot();
-    blockManager.importBlock(nextNextBlock).join();
+    safeJoin(blockManager.importBlock(nextNextBlock));
     assertThat(pendingBlocks.size()).isEqualTo(1);
     assertThat(futureBlocks.size()).isEqualTo(0);
     assertThat(pendingBlocks.contains(nextNextBlock)).isTrue();


### PR DESCRIPTION
## PR Description
Send `block` events only after the block is imported.

Previously events were sent once the block passed the gossip validation rules but with the need to include the execution_optimistic flag the event now needs to be sent after import. Blocks which pass the gossip validation checks but fail state transition will no longer generate an event.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
