### PR TITLE
Use lower-case for beacon block fields

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/altair/BeaconBlockBodySchemaAltairImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/altair/BeaconBlockBodySchemaAltairImpl.java
@@ -75,29 +75,29 @@ public class BeaconBlockBodySchemaAltairImpl
   public static BeaconBlockBodySchemaAltair<? extends BeaconBlockBodyAltair> create(
       final SpecConfig specConfig, final AttesterSlashingSchema attesterSlashingSchema) {
     return new BeaconBlockBodySchemaAltairImpl(
-        namedSchema(BlockBodyFields.RANDAO_REVEAL.name(), SszSignatureSchema.INSTANCE),
-        namedSchema(BlockBodyFields.ETH1_DATA.name(), Eth1Data.SSZ_SCHEMA),
-        namedSchema(BlockBodyFields.GRAFFITI.name(), SszPrimitiveSchemas.BYTES32_SCHEMA),
+        namedSchema(BlockBodyFields.RANDAO_REVEAL, SszSignatureSchema.INSTANCE),
+        namedSchema(BlockBodyFields.ETH1_DATA, Eth1Data.SSZ_SCHEMA),
+        namedSchema(BlockBodyFields.GRAFFITI, SszPrimitiveSchemas.BYTES32_SCHEMA),
         namedSchema(
-            BlockBodyFields.PROPOSER_SLASHINGS.name(),
+            BlockBodyFields.PROPOSER_SLASHINGS,
             SszListSchema.create(
                 ProposerSlashing.SSZ_SCHEMA, specConfig.getMaxProposerSlashings())),
         namedSchema(
-            BlockBodyFields.ATTESTER_SLASHINGS.name(),
+            BlockBodyFields.ATTESTER_SLASHINGS,
             SszListSchema.create(attesterSlashingSchema, specConfig.getMaxAttesterSlashings())),
         namedSchema(
-            BlockBodyFields.ATTESTATIONS.name(),
+            BlockBodyFields.ATTESTATIONS,
             SszListSchema.create(
                 new AttestationSchema(specConfig), specConfig.getMaxAttestations())),
         namedSchema(
-            BlockBodyFields.DEPOSITS.name(),
+            BlockBodyFields.DEPOSITS,
             SszListSchema.create(Deposit.SSZ_SCHEMA, specConfig.getMaxDeposits())),
         namedSchema(
-            BlockBodyFields.VOLUNTARY_EXITS.name(),
+            BlockBodyFields.VOLUNTARY_EXITS,
             SszListSchema.create(
                 SignedVoluntaryExit.SSZ_SCHEMA, specConfig.getMaxVoluntaryExits())),
         namedSchema(
-            BlockBodyFields.SYNC_AGGREGATE.name(),
+            BlockBodyFields.SYNC_AGGREGATE,
             SyncAggregateSchema.create(
                 specConfig.toVersionAltair().orElseThrow().getSyncCommitteeSize())));
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BeaconBlockBodySchemaBellatrixImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BeaconBlockBodySchemaBellatrixImpl.java
@@ -83,32 +83,31 @@ public class BeaconBlockBodySchemaBellatrixImpl
   public static BeaconBlockBodySchemaBellatrixImpl create(
       final SpecConfigBellatrix specConfig, final AttesterSlashingSchema attesterSlashingSchema) {
     return new BeaconBlockBodySchemaBellatrixImpl(
-        namedSchema(BlockBodyFields.RANDAO_REVEAL.name(), SszSignatureSchema.INSTANCE),
-        namedSchema(BlockBodyFields.ETH1_DATA.name(), Eth1Data.SSZ_SCHEMA),
-        namedSchema(BlockBodyFields.GRAFFITI.name(), SszPrimitiveSchemas.BYTES32_SCHEMA),
+        namedSchema(BlockBodyFields.RANDAO_REVEAL, SszSignatureSchema.INSTANCE),
+        namedSchema(BlockBodyFields.ETH1_DATA, Eth1Data.SSZ_SCHEMA),
+        namedSchema(BlockBodyFields.GRAFFITI, SszPrimitiveSchemas.BYTES32_SCHEMA),
         namedSchema(
-            BlockBodyFields.PROPOSER_SLASHINGS.name(),
+            BlockBodyFields.PROPOSER_SLASHINGS,
             SszListSchema.create(
                 ProposerSlashing.SSZ_SCHEMA, specConfig.getMaxProposerSlashings())),
         namedSchema(
-            BlockBodyFields.ATTESTER_SLASHINGS.name(),
+            BlockBodyFields.ATTESTER_SLASHINGS,
             SszListSchema.create(attesterSlashingSchema, specConfig.getMaxAttesterSlashings())),
         namedSchema(
-            BlockBodyFields.ATTESTATIONS.name(),
+            BlockBodyFields.ATTESTATIONS,
             SszListSchema.create(
                 new AttestationSchema(specConfig), specConfig.getMaxAttestations())),
         namedSchema(
-            BlockBodyFields.DEPOSITS.name(),
+            BlockBodyFields.DEPOSITS,
             SszListSchema.create(Deposit.SSZ_SCHEMA, specConfig.getMaxDeposits())),
         namedSchema(
-            BlockBodyFields.VOLUNTARY_EXITS.name(),
+            BlockBodyFields.VOLUNTARY_EXITS,
             SszListSchema.create(
                 SignedVoluntaryExit.SSZ_SCHEMA, specConfig.getMaxVoluntaryExits())),
         namedSchema(
-            BlockBodyFields.SYNC_AGGREGATE.name(),
+            BlockBodyFields.SYNC_AGGREGATE,
             SyncAggregateSchema.create(specConfig.getSyncCommitteeSize())),
-        namedSchema(
-            BlockBodyFields.EXECUTION_PAYLOAD.name(), new ExecutionPayloadSchema(specConfig)));
+        namedSchema(BlockBodyFields.EXECUTION_PAYLOAD, new ExecutionPayloadSchema(specConfig)));
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/phase0/BeaconBlockBodySchemaPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/phase0/BeaconBlockBodySchemaPhase0.java
@@ -73,25 +73,25 @@ public class BeaconBlockBodySchemaPhase0
   public static BeaconBlockBodySchemaPhase0 create(
       final SpecConfig specConfig, final AttesterSlashingSchema attesterSlashingSchema) {
     return new BeaconBlockBodySchemaPhase0(
-        namedSchema(BlockBodyFields.RANDAO_REVEAL.name(), SszSignatureSchema.INSTANCE),
-        namedSchema(BlockBodyFields.ETH1_DATA.name(), Eth1Data.SSZ_SCHEMA),
-        namedSchema(BlockBodyFields.GRAFFITI.name(), SszPrimitiveSchemas.BYTES32_SCHEMA),
+        namedSchema(BlockBodyFields.RANDAO_REVEAL, SszSignatureSchema.INSTANCE),
+        namedSchema(BlockBodyFields.ETH1_DATA, Eth1Data.SSZ_SCHEMA),
+        namedSchema(BlockBodyFields.GRAFFITI, SszPrimitiveSchemas.BYTES32_SCHEMA),
         namedSchema(
-            BlockBodyFields.PROPOSER_SLASHINGS.name(),
+            BlockBodyFields.PROPOSER_SLASHINGS,
             SszListSchema.create(
                 ProposerSlashing.SSZ_SCHEMA, specConfig.getMaxProposerSlashings())),
         namedSchema(
-            BlockBodyFields.ATTESTER_SLASHINGS.name(),
+            BlockBodyFields.ATTESTER_SLASHINGS,
             SszListSchema.create(attesterSlashingSchema, specConfig.getMaxAttesterSlashings())),
         namedSchema(
-            BlockBodyFields.ATTESTATIONS.name(),
+            BlockBodyFields.ATTESTATIONS,
             SszListSchema.create(
                 new AttestationSchema(specConfig), specConfig.getMaxAttestations())),
         namedSchema(
-            BlockBodyFields.DEPOSITS.name(),
+            BlockBodyFields.DEPOSITS,
             SszListSchema.create(Deposit.SSZ_SCHEMA, specConfig.getMaxDeposits())),
         namedSchema(
-            BlockBodyFields.VOLUNTARY_EXITS.name(),
+            BlockBodyFields.VOLUNTARY_EXITS,
             SszListSchema.create(
                 SignedVoluntaryExit.SSZ_SCHEMA, specConfig.getMaxVoluntaryExits())));
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/BeaconState.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/BeaconState.java
@@ -43,23 +43,22 @@ public interface BeaconState extends SszContainer, ValidatorStats {
   BeaconStateSchema<? extends BeaconState, ? extends MutableBeaconState> getBeaconStateSchema();
 
   default UInt64 getGenesis_time() {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.GENESIS_TIME.getFieldName());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.GENESIS_TIME);
     return ((SszUInt64) get(fieldIndex)).get();
   }
 
   default Bytes32 getGenesis_validators_root() {
-    final int fieldIndex =
-        getSchema().getFieldIndex(BeaconStateFields.GENESIS_VALIDATORS_ROOT.getFieldName());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.GENESIS_VALIDATORS_ROOT);
     return ((SszBytes32) get(fieldIndex)).get();
   }
 
   default UInt64 getSlot() {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.SLOT.getFieldName());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.SLOT);
     return ((SszUInt64) get(fieldIndex)).get();
   }
 
   default Fork getFork() {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.FORK.getFieldName());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.FORK);
     return getAny(fieldIndex);
   }
 
@@ -69,89 +68,83 @@ public interface BeaconState extends SszContainer, ValidatorStats {
 
   // History
   default BeaconBlockHeader getLatest_block_header() {
-    final int fieldIndex =
-        getSchema().getFieldIndex(BeaconStateFields.LATEST_BLOCK_HEADER.getFieldName());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.LATEST_BLOCK_HEADER);
     return getAny(fieldIndex);
   }
 
   default SszBytes32Vector getBlock_roots() {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.BLOCK_ROOTS.getFieldName());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.BLOCK_ROOTS);
     return getAny(fieldIndex);
   }
 
   default SszBytes32Vector getState_roots() {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.STATE_ROOTS.getFieldName());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.STATE_ROOTS);
     return getAny(fieldIndex);
   }
 
   default SszPrimitiveList<Bytes32, SszBytes32> getHistorical_roots() {
-    final int fieldIndex =
-        getSchema().getFieldIndex(BeaconStateFields.HISTORICAL_ROOTS.getFieldName());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.HISTORICAL_ROOTS);
     return getAny(fieldIndex);
   }
 
   // Eth1
   default Eth1Data getEth1_data() {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.ETH1_DATA.getFieldName());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.ETH1_DATA);
     return getAny(fieldIndex);
   }
 
   default SszList<Eth1Data> getEth1_data_votes() {
-    final int fieldIndex =
-        getSchema().getFieldIndex(BeaconStateFields.ETH1_DATA_VOTES.getFieldName());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.ETH1_DATA_VOTES);
     return getAny(fieldIndex);
   }
 
   default UInt64 getEth1_deposit_index() {
-    final int fieldIndex =
-        getSchema().getFieldIndex(BeaconStateFields.ETH1_DEPOSIT_INDEX.getFieldName());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.ETH1_DEPOSIT_INDEX);
     return ((SszUInt64) get(fieldIndex)).get();
   }
 
   // Registry
   default SszList<Validator> getValidators() {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.VALIDATORS.getFieldName());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.VALIDATORS);
     return getAny(fieldIndex);
   }
 
   default SszUInt64List getBalances() {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.BALANCES.getFieldName());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.BALANCES);
     return getAny(fieldIndex);
   }
 
   default SszBytes32Vector getRandao_mixes() {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.RANDAO_MIXES.getFieldName());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.RANDAO_MIXES);
     return getAny(fieldIndex);
   }
 
   // Slashings
   default SszPrimitiveVector<UInt64, SszUInt64> getSlashings() {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.SLASHINGS.getFieldName());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.SLASHINGS);
     return getAny(fieldIndex);
   }
 
   // Finality
   default SszBitvector getJustification_bits() {
-    final int fieldIndex =
-        getSchema().getFieldIndex(BeaconStateFields.JUSTIFICATION_BITS.getFieldName());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.JUSTIFICATION_BITS);
     return getAny(fieldIndex);
   }
 
   default Checkpoint getPrevious_justified_checkpoint() {
     final int fieldIndex =
-        getSchema().getFieldIndex(BeaconStateFields.PREVIOUS_JUSTIFIED_CHECKPOINT.getFieldName());
+        getSchema().getFieldIndex(BeaconStateFields.PREVIOUS_JUSTIFIED_CHECKPOINT);
     return getAny(fieldIndex);
   }
 
   default Checkpoint getCurrent_justified_checkpoint() {
     final int fieldIndex =
-        getSchema().getFieldIndex(BeaconStateFields.CURRENT_JUSTIFIED_CHECKPOINT.getFieldName());
+        getSchema().getFieldIndex(BeaconStateFields.CURRENT_JUSTIFIED_CHECKPOINT);
     return getAny(fieldIndex);
   }
 
   default Checkpoint getFinalized_checkpoint() {
-    final int fieldIndex =
-        getSchema().getFieldIndex(BeaconStateFields.FINALIZED_CHECKPOINT.getFieldName());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.FINALIZED_CHECKPOINT);
     return getAny(fieldIndex);
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/BeaconStateSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/BeaconStateSchema.java
@@ -19,6 +19,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszBytes32;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszContainerSchema;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszFieldName;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszListSchema;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszSchema;
 import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszBitvectorSchema;
@@ -39,52 +40,49 @@ public interface BeaconStateSchema<T extends BeaconState, TMutable extends Mutab
   T createEmpty();
 
   default SszBytes32VectorSchema<?> getBlockRootsSchema() {
-    return (SszBytes32VectorSchema<?>)
-        getChildSchema(getFieldIndex(BeaconStateFields.BLOCK_ROOTS.getFieldName()));
+    return (SszBytes32VectorSchema<?>) getChildSchema(getFieldIndex(BeaconStateFields.BLOCK_ROOTS));
   }
 
   default SszBytes32VectorSchema<?> getStateRootsSchema() {
-    return (SszBytes32VectorSchema<?>)
-        getChildSchema(getFieldIndex(BeaconStateFields.STATE_ROOTS.getFieldName()));
+    return (SszBytes32VectorSchema<?>) getChildSchema(getFieldIndex(BeaconStateFields.STATE_ROOTS));
   }
 
   @SuppressWarnings("unchecked")
   default SszPrimitiveListSchema<Bytes32, SszBytes32, ?> getHistoricalRootsSchema() {
     return (SszPrimitiveListSchema<Bytes32, SszBytes32, ?>)
-        getChildSchema(getFieldIndex(BeaconStateFields.HISTORICAL_ROOTS.getFieldName()));
+        getChildSchema(getFieldIndex(BeaconStateFields.HISTORICAL_ROOTS));
   }
 
   @SuppressWarnings("unchecked")
   default SszListSchema<Eth1Data, ?> getEth1DataVotesSchema() {
     return (SszListSchema<Eth1Data, ?>)
-        getChildSchema(getFieldIndex(BeaconStateFields.ETH1_DATA_VOTES.getFieldName()));
+        getChildSchema(getFieldIndex(BeaconStateFields.ETH1_DATA_VOTES));
   }
 
   @SuppressWarnings("unchecked")
   default SszListSchema<Validator, ?> getValidatorsSchema() {
     return (SszListSchema<Validator, ?>)
-        getChildSchema(getFieldIndex(BeaconStateFields.VALIDATORS.getFieldName()));
+        getChildSchema(getFieldIndex(BeaconStateFields.VALIDATORS));
   }
 
   default SszUInt64ListSchema<?> getBalancesSchema() {
-    return (SszUInt64ListSchema<?>)
-        getChildSchema(getFieldIndex(BeaconStateFields.BALANCES.getFieldName()));
+    return (SszUInt64ListSchema<?>) getChildSchema(getFieldIndex(BeaconStateFields.BALANCES));
   }
 
   default SszBytes32VectorSchema<?> getRandaoMixesSchema() {
     return (SszBytes32VectorSchema<?>)
-        getChildSchema(getFieldIndex(BeaconStateFields.RANDAO_MIXES.getFieldName()));
+        getChildSchema(getFieldIndex(BeaconStateFields.RANDAO_MIXES));
   }
 
   @SuppressWarnings("unchecked")
   default SszPrimitiveVectorSchema<UInt64, SszUInt64, ?> getSlashingsSchema() {
     return (SszPrimitiveVectorSchema<UInt64, SszUInt64, ?>)
-        getChildSchema(getFieldIndex(BeaconStateFields.SLASHINGS.getFieldName()));
+        getChildSchema(getFieldIndex(BeaconStateFields.SLASHINGS));
   }
 
   default SszBitvectorSchema<?> getJustificationBitsSchema() {
     return (SszBitvectorSchema<?>)
-        getChildSchema(getFieldIndex(BeaconStateFields.JUSTIFICATION_BITS.getFieldName()));
+        getChildSchema(getFieldIndex(BeaconStateFields.JUSTIFICATION_BITS));
   }
 
   default SyncCommitteeSchema getCurrentSyncCommitteeSchemaOrThrow() {
@@ -95,14 +93,10 @@ public interface BeaconStateSchema<T extends BeaconState, TMutable extends Mutab
     return (SyncCommitteeSchema) getSchemaOrThrow(BeaconStateFields.NEXT_SYNC_COMMITTEE);
   }
 
-  private SszSchema<?> getSchemaOrThrow(final BeaconStateFields field) {
-    final String fieldName = field.getFieldName();
-    final int fieldIndex = getFieldIndex(fieldName);
+  private SszSchema<?> getSchemaOrThrow(final SszFieldName field) {
+    final int fieldIndex = getFieldIndex(field);
     checkArgument(
-        fieldIndex >= 0,
-        "Expected a %s field in schema %s but was not found",
-        fieldName,
-        getClass());
+        fieldIndex >= 0, "Expected a %s field in schema %s but was not found", field, getClass());
     return getChildSchema(fieldIndex);
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/MutableBeaconState.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/MutableBeaconState.java
@@ -45,161 +45,152 @@ public interface MutableBeaconState extends BeaconState, SszMutableRefContainer 
   // Versioning
 
   default void setGenesis_time(UInt64 genesis_time) {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.GENESIS_TIME.getFieldName());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.GENESIS_TIME);
     set(fieldIndex, SszUInt64.of(genesis_time));
   }
 
   default void setGenesis_validators_root(Bytes32 genesis_validators_root) {
-    final int fieldIndex =
-        getSchema().getFieldIndex(BeaconStateFields.GENESIS_VALIDATORS_ROOT.getFieldName());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.GENESIS_VALIDATORS_ROOT);
     set(fieldIndex, SszBytes32.of(genesis_validators_root));
   }
 
   default void setSlot(UInt64 slot) {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.SLOT.getFieldName());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.SLOT);
     set(fieldIndex, SszUInt64.of(slot));
   }
 
   default void setFork(Fork fork) {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.FORK.getFieldName());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.FORK);
     set(fieldIndex, fork);
   }
 
   // History
   default void setLatest_block_header(BeaconBlockHeader latest_block_header) {
-    final int fieldIndex =
-        getSchema().getFieldIndex(BeaconStateFields.LATEST_BLOCK_HEADER.getFieldName());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.LATEST_BLOCK_HEADER);
     set(fieldIndex, latest_block_header);
   }
 
   @Override
   default SszMutableBytes32Vector getBlock_roots() {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.BLOCK_ROOTS.getFieldName());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.BLOCK_ROOTS);
     return getAnyByRef(fieldIndex);
   }
 
   default void setBlock_roots(SszBytes32Vector block_roots) {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.BLOCK_ROOTS.getFieldName());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.BLOCK_ROOTS);
     set(fieldIndex, block_roots);
   }
 
   @Override
   default SszMutableBytes32Vector getState_roots() {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.STATE_ROOTS.getFieldName());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.STATE_ROOTS);
     return getAnyByRef(fieldIndex);
   }
 
   default void setState_roots(SszBytes32Vector state_roots) {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.STATE_ROOTS.getFieldName());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.STATE_ROOTS);
     set(fieldIndex, state_roots);
   }
 
   @Override
   default SszMutablePrimitiveList<Bytes32, SszBytes32> getHistorical_roots() {
-    final int fieldIndex =
-        getSchema().getFieldIndex(BeaconStateFields.HISTORICAL_ROOTS.getFieldName());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.HISTORICAL_ROOTS);
     return getAnyByRef(fieldIndex);
   }
 
   default void setHistorical_roots(SszPrimitiveList<Bytes32, SszBytes32> historical_roots) {
-    final int fieldIndex =
-        getSchema().getFieldIndex(BeaconStateFields.HISTORICAL_ROOTS.getFieldName());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.HISTORICAL_ROOTS);
     set(fieldIndex, historical_roots);
   }
 
   // Eth1
   default void setEth1_data(Eth1Data eth1_data) {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.ETH1_DATA.getFieldName());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.ETH1_DATA);
     set(fieldIndex, eth1_data);
   }
 
   @Override
   default SszMutableList<Eth1Data> getEth1_data_votes() {
-    final int fieldIndex =
-        getSchema().getFieldIndex(BeaconStateFields.ETH1_DATA_VOTES.getFieldName());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.ETH1_DATA_VOTES);
     return getAnyByRef(fieldIndex);
   }
 
   default void setEth1_data_votes(SszList<Eth1Data> eth1DataList) {
-    final int fieldIndex =
-        getSchema().getFieldIndex(BeaconStateFields.ETH1_DATA_VOTES.getFieldName());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.ETH1_DATA_VOTES);
     set(fieldIndex, eth1DataList);
   }
 
   default void setEth1_deposit_index(UInt64 eth1_deposit_index) {
-    final int fieldIndex =
-        getSchema().getFieldIndex(BeaconStateFields.ETH1_DEPOSIT_INDEX.getFieldName());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.ETH1_DEPOSIT_INDEX);
     set(fieldIndex, SszUInt64.of(eth1_deposit_index));
   }
 
   // Registry
   @Override
   default SszMutableList<Validator> getValidators() {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.VALIDATORS.getFieldName());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.VALIDATORS);
     return getAnyByRef(fieldIndex);
   }
 
   default void setValidators(SszList<Validator> validators) {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.VALIDATORS.getFieldName());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.VALIDATORS);
     set(fieldIndex, validators);
   }
 
   @Override
   default SszMutableUInt64List getBalances() {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.BALANCES.getFieldName());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.BALANCES);
     return getAnyByRef(fieldIndex);
   }
 
   default void setBalances(SszUInt64List balances) {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.BALANCES.getFieldName());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.BALANCES);
     set(fieldIndex, balances);
   }
 
   @Override
   default SszMutableBytes32Vector getRandao_mixes() {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.RANDAO_MIXES.getFieldName());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.RANDAO_MIXES);
     return getAnyByRef(fieldIndex);
   }
 
   default void setRandao_mixes(SszBytes32Vector randao_mixes) {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.RANDAO_MIXES.getFieldName());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.RANDAO_MIXES);
     set(fieldIndex, randao_mixes);
   }
 
   // Slashings
   @Override
   default SszMutablePrimitiveVector<UInt64, SszUInt64> getSlashings() {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.SLASHINGS.getFieldName());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.SLASHINGS);
     return getAnyByRef(fieldIndex);
   }
 
   default void setSlashings(SszPrimitiveVector<UInt64, SszUInt64> slashings) {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.SLASHINGS.getFieldName());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.SLASHINGS);
     set(fieldIndex, slashings);
   }
 
   // Finality
   default void setJustification_bits(SszBitvector justification_bits) {
-    final int fieldIndex =
-        getSchema().getFieldIndex(BeaconStateFields.JUSTIFICATION_BITS.getFieldName());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.JUSTIFICATION_BITS);
     set(fieldIndex, justification_bits);
   }
 
   default void setPrevious_justified_checkpoint(Checkpoint previous_justified_checkpoint) {
     final int fieldIndex =
-        getSchema().getFieldIndex(BeaconStateFields.PREVIOUS_JUSTIFIED_CHECKPOINT.getFieldName());
+        getSchema().getFieldIndex(BeaconStateFields.PREVIOUS_JUSTIFIED_CHECKPOINT);
     set(fieldIndex, previous_justified_checkpoint);
   }
 
   default void setCurrent_justified_checkpoint(Checkpoint current_justified_checkpoint) {
     final int fieldIndex =
-        getSchema().getFieldIndex(BeaconStateFields.CURRENT_JUSTIFIED_CHECKPOINT.getFieldName());
+        getSchema().getFieldIndex(BeaconStateFields.CURRENT_JUSTIFIED_CHECKPOINT);
     set(fieldIndex, current_justified_checkpoint);
   }
 
   default void setFinalized_checkpoint(Checkpoint finalized_checkpoint) {
-    final int fieldIndex =
-        getSchema().getFieldIndex(BeaconStateFields.FINALIZED_CHECKPOINT.getFieldName());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.FINALIZED_CHECKPOINT);
     set(fieldIndex, finalized_checkpoint);
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/BeaconStateFields.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/BeaconStateFields.java
@@ -19,6 +19,7 @@ import static tech.pegasys.teku.spec.datastructures.state.beaconstate.common.Bea
 
 import java.util.List;
 import java.util.Locale;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszFieldName;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszListSchema;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszSchemaHints;
@@ -34,7 +35,7 @@ import tech.pegasys.teku.spec.datastructures.state.Validator;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
 
-public enum BeaconStateFields {
+public enum BeaconStateFields implements SszFieldName {
   GENESIS_TIME,
   GENESIS_VALIDATORS_ROOT,
   SLOT,
@@ -65,7 +66,8 @@ public enum BeaconStateFields {
   // Bellatrix fields
   LATEST_EXECUTION_PAYLOAD_HEADER;
 
-  public String getFieldName() {
+  @Override
+  public String getSszFieldName() {
     return name().toLowerCase(Locale.ROOT);
   }
 
@@ -100,52 +102,48 @@ public enum BeaconStateFields {
   }
 
   static List<SszField> getCommonFields(final SpecConfig specConfig) {
-    SszField fork_field = new SszField(3, BeaconStateFields.FORK.getFieldName(), Fork.SSZ_SCHEMA);
+    SszField fork_field = new SszField(3, BeaconStateFields.FORK, Fork.SSZ_SCHEMA);
     final BeaconBlockHeader.BeaconBlockHeaderSchema blockHeaderSchema =
         BeaconBlockHeader.SSZ_SCHEMA;
     SszField latestBlockHeaderField =
-        new SszField(4, BeaconStateFields.LATEST_BLOCK_HEADER.getFieldName(), blockHeaderSchema);
+        new SszField(4, BeaconStateFields.LATEST_BLOCK_HEADER, blockHeaderSchema);
     SszField blockRootsField =
         new SszField(
             5,
-            BeaconStateFields.BLOCK_ROOTS.getFieldName(),
+            BeaconStateFields.BLOCK_ROOTS,
             () ->
                 SszVectorSchema.create(
                     SszPrimitiveSchemas.BYTES32_SCHEMA, specConfig.getSlotsPerHistoricalRoot()));
     SszField stateRootsField =
         new SszField(
             6,
-            BeaconStateFields.STATE_ROOTS.getFieldName(),
+            BeaconStateFields.STATE_ROOTS,
             () ->
                 SszVectorSchema.create(
                     SszPrimitiveSchemas.BYTES32_SCHEMA, specConfig.getSlotsPerHistoricalRoot()));
     SszField historicalRootsField =
         new SszField(
             7,
-            BeaconStateFields.HISTORICAL_ROOTS.getFieldName(),
+            BeaconStateFields.HISTORICAL_ROOTS,
             () ->
                 SszListSchema.create(
                     SszPrimitiveSchemas.BYTES32_SCHEMA, specConfig.getHistoricalRootsLimit()));
-    SszField eth1DataField =
-        new SszField(8, BeaconStateFields.ETH1_DATA.getFieldName(), Eth1Data.SSZ_SCHEMA);
+    SszField eth1DataField = new SszField(8, BeaconStateFields.ETH1_DATA, Eth1Data.SSZ_SCHEMA);
     SszField eth1DataVotesField =
         new SszField(
             9,
-            BeaconStateFields.ETH1_DATA_VOTES.getFieldName(),
+            BeaconStateFields.ETH1_DATA_VOTES,
             () ->
                 SszListSchema.create(
                     Eth1Data.SSZ_SCHEMA,
                     (long) specConfig.getEpochsPerEth1VotingPeriod()
                         * specConfig.getSlotsPerEpoch()));
     SszField eth1DepositIndexField =
-        new SszField(
-            10,
-            BeaconStateFields.ETH1_DEPOSIT_INDEX.getFieldName(),
-            SszPrimitiveSchemas.UINT64_SCHEMA);
+        new SszField(10, BeaconStateFields.ETH1_DEPOSIT_INDEX, SszPrimitiveSchemas.UINT64_SCHEMA);
     SszField validatorsField =
         new SszField(
             11,
-            BeaconStateFields.VALIDATORS.getFieldName(),
+            BeaconStateFields.VALIDATORS,
             () ->
                 SszListSchema.create(
                     Validator.SSZ_SCHEMA,
@@ -154,42 +152,35 @@ public enum BeaconStateFields {
     SszField balancesField =
         new SszField(
             12,
-            BeaconStateFields.BALANCES.getFieldName(),
+            BeaconStateFields.BALANCES,
             () ->
                 SszListSchema.create(
                     SszPrimitiveSchemas.UINT64_SCHEMA, specConfig.getValidatorRegistryLimit()));
     SszField randaoMixesField =
         new SszField(
             13,
-            BeaconStateFields.RANDAO_MIXES.getFieldName(),
+            BeaconStateFields.RANDAO_MIXES,
             () ->
                 SszVectorSchema.create(
                     SszPrimitiveSchemas.BYTES32_SCHEMA, specConfig.getEpochsPerHistoricalVector()));
     SszField slashingsField =
         new SszField(
             14,
-            BeaconStateFields.SLASHINGS.getFieldName(),
+            BeaconStateFields.SLASHINGS,
             () ->
                 SszVectorSchema.create(
                     SszPrimitiveSchemas.UINT64_SCHEMA, specConfig.getEpochsPerSlashingsVector()));
     SszField justificationBitsField =
         new SszField(
             17,
-            BeaconStateFields.JUSTIFICATION_BITS.getFieldName(),
+            BeaconStateFields.JUSTIFICATION_BITS,
             () -> SszBitvectorSchema.create(specConfig.getJustificationBitsLength()));
     SszField previousJustifiedCheckpointField =
-        new SszField(
-            18,
-            BeaconStateFields.PREVIOUS_JUSTIFIED_CHECKPOINT.getFieldName(),
-            Checkpoint.SSZ_SCHEMA);
+        new SszField(18, BeaconStateFields.PREVIOUS_JUSTIFIED_CHECKPOINT, Checkpoint.SSZ_SCHEMA);
     SszField currentJustifiedCheckpointField =
-        new SszField(
-            19,
-            BeaconStateFields.CURRENT_JUSTIFIED_CHECKPOINT.getFieldName(),
-            Checkpoint.SSZ_SCHEMA);
+        new SszField(19, BeaconStateFields.CURRENT_JUSTIFIED_CHECKPOINT, Checkpoint.SSZ_SCHEMA);
     SszField finalizedCheckpointField =
-        new SszField(
-            20, BeaconStateFields.FINALIZED_CHECKPOINT.getFieldName(), Checkpoint.SSZ_SCHEMA);
+        new SszField(20, BeaconStateFields.FINALIZED_CHECKPOINT, Checkpoint.SSZ_SCHEMA);
 
     return List.of(
         GENESIS_TIME_FIELD,
@@ -211,5 +202,10 @@ public enum BeaconStateFields {
         previousJustifiedCheckpointField,
         currentJustifiedCheckpointField,
         finalizedCheckpointField);
+  }
+
+  @Override
+  public String toString() {
+    return getSszFieldName();
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/BeaconStateInvariants.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/BeaconStateInvariants.java
@@ -38,13 +38,10 @@ public class BeaconStateInvariants {
 
   // Fields
   static SszField GENESIS_TIME_FIELD =
-      new SszField(0, BeaconStateFields.GENESIS_TIME.getFieldName(), GENESIS_TIME_SCHEMA);
+      new SszField(0, BeaconStateFields.GENESIS_TIME, GENESIS_TIME_SCHEMA);
   static SszField GENESIS_VALIDATORS_ROOT_FIELD =
-      new SszField(
-          1,
-          BeaconStateFields.GENESIS_VALIDATORS_ROOT.getFieldName(),
-          GENESIS_VALIDATORS_ROOT_SCHEMA);
-  static SszField SLOT_FIELD = new SszField(2, BeaconStateFields.SLOT.getFieldName(), SLOT_SCHEMA);
+      new SszField(1, BeaconStateFields.GENESIS_VALIDATORS_ROOT, GENESIS_VALIDATORS_ROOT_SCHEMA);
+  static SszField SLOT_FIELD = new SszField(2, BeaconStateFields.SLOT, SLOT_SCHEMA);
 
   // Return list of invariant fields
   static List<SszField> getInvariantFields() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/altair/BeaconStateAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/altair/BeaconStateAltair.java
@@ -35,31 +35,27 @@ public interface BeaconStateAltair extends BeaconState {
   // Participation
   default SszList<SszByte> getPreviousEpochParticipation() {
     final int fieldIndex =
-        getSchema().getFieldIndex(BeaconStateFields.PREVIOUS_EPOCH_PARTICIPATION.getFieldName());
+        getSchema().getFieldIndex(BeaconStateFields.PREVIOUS_EPOCH_PARTICIPATION);
     return getAny(fieldIndex);
   }
 
   default SszList<SszByte> getCurrentEpochParticipation() {
-    final int fieldIndex =
-        getSchema().getFieldIndex(BeaconStateFields.CURRENT_EPOCH_PARTICIPATION.getFieldName());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.CURRENT_EPOCH_PARTICIPATION);
     return getAny(fieldIndex);
   }
 
   default SszUInt64List getInactivityScores() {
-    final int fieldIndex =
-        getSchema().getFieldIndex(BeaconStateFields.INACTIVITY_SCORES.getFieldName());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.INACTIVITY_SCORES);
     return getAny(fieldIndex);
   }
 
   default SyncCommittee getCurrentSyncCommittee() {
-    final int fieldIndex =
-        getSchema().getFieldIndex(BeaconStateFields.CURRENT_SYNC_COMMITTEE.getFieldName());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.CURRENT_SYNC_COMMITTEE);
     return getAny(fieldIndex);
   }
 
   default SyncCommittee getNextSyncCommittee() {
-    final int fieldIndex =
-        getSchema().getFieldIndex(BeaconStateFields.NEXT_SYNC_COMMITTEE.getFieldName());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.NEXT_SYNC_COMMITTEE);
     return getAny(fieldIndex);
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/altair/BeaconStateSchemaAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/altair/BeaconStateSchemaAltair.java
@@ -53,14 +53,14 @@ public class BeaconStateSchemaAltair
     final SszField previousEpochAttestationsField =
         new SszField(
             PREVIOUS_EPOCH_PARTICIPATION_FIELD_INDEX,
-            BeaconStateFields.PREVIOUS_EPOCH_PARTICIPATION.getFieldName(),
+            BeaconStateFields.PREVIOUS_EPOCH_PARTICIPATION,
             () ->
                 SszListSchema.create(
                     SszPrimitiveSchemas.BYTE_SCHEMA, specConfig.getValidatorRegistryLimit()));
     final SszField currentEpochAttestationsField =
         new SszField(
             CURRENT_EPOCH_PARTICIPATION_FIELD_INDEX,
-            BeaconStateFields.CURRENT_EPOCH_PARTICIPATION.getFieldName(),
+            BeaconStateFields.CURRENT_EPOCH_PARTICIPATION,
             () ->
                 SszListSchema.create(
                     SszPrimitiveSchemas.BYTE_SCHEMA, specConfig.getValidatorRegistryLimit()));
@@ -68,17 +68,17 @@ public class BeaconStateSchemaAltair
     final SszField inactivityScores =
         new SszField(
             INACTIVITY_SCORES_FIELD_INDEX,
-            BeaconStateFields.INACTIVITY_SCORES.getFieldName(),
+            BeaconStateFields.INACTIVITY_SCORES,
             SszUInt64ListSchema.create(specConfig.getValidatorRegistryLimit()));
     final SszField currentSyncCommitteeField =
         new SszField(
             CURRENT_SYNC_COMMITTEE_FIELD_INDEX,
-            BeaconStateFields.CURRENT_SYNC_COMMITTEE.getFieldName(),
+            BeaconStateFields.CURRENT_SYNC_COMMITTEE,
             () -> new SyncCommitteeSchema(SpecConfigAltair.required(specConfig)));
     final SszField nextSyncCommitteeField =
         new SszField(
             NEXT_SYNC_COMMITTEE_FIELD_INDEX,
-            BeaconStateFields.NEXT_SYNC_COMMITTEE.getFieldName(),
+            BeaconStateFields.NEXT_SYNC_COMMITTEE,
             () -> new SyncCommitteeSchema(SpecConfigAltair.required(specConfig)));
     return List.of(
         previousEpochAttestationsField,
@@ -99,29 +99,28 @@ public class BeaconStateSchemaAltair
   @SuppressWarnings("unchecked")
   public SszPrimitiveListSchema<Byte, SszByte, ?> getPreviousEpochParticipationSchema() {
     return (SszPrimitiveListSchema<Byte, SszByte, ?>)
-        getChildSchema(
-            getFieldIndex(BeaconStateFields.PREVIOUS_EPOCH_PARTICIPATION.getFieldName()));
+        getChildSchema(getFieldIndex(BeaconStateFields.PREVIOUS_EPOCH_PARTICIPATION));
   }
 
   @SuppressWarnings("unchecked")
   public SszPrimitiveListSchema<Byte, SszByte, ?> getCurrentEpochParticipationSchema() {
     return (SszPrimitiveListSchema<Byte, SszByte, ?>)
-        getChildSchema(getFieldIndex(BeaconStateFields.CURRENT_EPOCH_PARTICIPATION.getFieldName()));
+        getChildSchema(getFieldIndex(BeaconStateFields.CURRENT_EPOCH_PARTICIPATION));
   }
 
   public SszUInt64ListSchema<?> getInactivityScoresSchema() {
     return (SszUInt64ListSchema<?>)
-        getChildSchema(getFieldIndex(BeaconStateFields.INACTIVITY_SCORES.getFieldName()));
+        getChildSchema(getFieldIndex(BeaconStateFields.INACTIVITY_SCORES));
   }
 
   public SyncCommitteeSchema getCurrentSyncCommitteeSchema() {
     return (SyncCommitteeSchema)
-        getChildSchema(getFieldIndex(BeaconStateFields.CURRENT_SYNC_COMMITTEE.getFieldName()));
+        getChildSchema(getFieldIndex(BeaconStateFields.CURRENT_SYNC_COMMITTEE));
   }
 
   public SyncCommitteeSchema getNextSyncCommitteeSchema() {
     return (SyncCommitteeSchema)
-        getChildSchema(getFieldIndex(BeaconStateFields.NEXT_SYNC_COMMITTEE.getFieldName()));
+        getChildSchema(getFieldIndex(BeaconStateFields.NEXT_SYNC_COMMITTEE));
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/altair/MutableBeaconStateAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/altair/MutableBeaconStateAltair.java
@@ -37,51 +37,45 @@ public interface MutableBeaconStateAltair extends MutableBeaconState, BeaconStat
   @Override
   default SszMutableList<SszByte> getPreviousEpochParticipation() {
     final int fieldIndex =
-        getSchema().getFieldIndex(BeaconStateFields.PREVIOUS_EPOCH_PARTICIPATION.getFieldName());
+        getSchema().getFieldIndex(BeaconStateFields.PREVIOUS_EPOCH_PARTICIPATION);
     return getAnyByRef(fieldIndex);
   }
 
   default void setPreviousEpochParticipation(final SszList<SszByte> newValue) {
     final int fieldIndex =
-        getSchema().getFieldIndex(BeaconStateFields.PREVIOUS_EPOCH_PARTICIPATION.getFieldName());
+        getSchema().getFieldIndex(BeaconStateFields.PREVIOUS_EPOCH_PARTICIPATION);
     set(fieldIndex, newValue);
   }
 
   @Override
   default SszMutableList<SszByte> getCurrentEpochParticipation() {
-    final int fieldIndex =
-        getSchema().getFieldIndex(BeaconStateFields.CURRENT_EPOCH_PARTICIPATION.getFieldName());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.CURRENT_EPOCH_PARTICIPATION);
     return getAnyByRef(fieldIndex);
   }
 
   default void setCurrentEpochParticipation(final SszList<SszByte> newValue) {
-    final int fieldIndex =
-        getSchema().getFieldIndex(BeaconStateFields.CURRENT_EPOCH_PARTICIPATION.getFieldName());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.CURRENT_EPOCH_PARTICIPATION);
     set(fieldIndex, newValue);
   }
 
   @Override
   default SszMutableUInt64List getInactivityScores() {
-    final int fieldIndex =
-        getSchema().getFieldIndex(BeaconStateFields.INACTIVITY_SCORES.getFieldName());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.INACTIVITY_SCORES);
     return getAnyByRef(fieldIndex);
   }
 
   default void setInactivityScores(SszUInt64List newValue) {
-    final int fieldIndex =
-        getSchema().getFieldIndex(BeaconStateFields.INACTIVITY_SCORES.getFieldName());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.INACTIVITY_SCORES);
     set(fieldIndex, newValue);
   }
 
   default void setCurrentSyncCommittee(SyncCommittee currentSyncCommittee) {
-    final int fieldIndex =
-        getSchema().getFieldIndex(BeaconStateFields.CURRENT_SYNC_COMMITTEE.getFieldName());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.CURRENT_SYNC_COMMITTEE);
     set(fieldIndex, currentSyncCommittee);
   }
 
   default void setNextSyncCommittee(SyncCommittee nextSyncCommittee) {
-    final int fieldIndex =
-        getSchema().getFieldIndex(BeaconStateFields.NEXT_SYNC_COMMITTEE.getFieldName());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.NEXT_SYNC_COMMITTEE);
     set(fieldIndex, nextSyncCommittee);
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/bellatrix/BeaconStateBellatrix.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/bellatrix/BeaconStateBellatrix.java
@@ -32,7 +32,7 @@ public interface BeaconStateBellatrix extends BeaconStateAltair {
 
   default ExecutionPayloadHeader getLatestExecutionPayloadHeader() {
     final int fieldIndex =
-        getSchema().getFieldIndex(BeaconStateFields.LATEST_EXECUTION_PAYLOAD_HEADER.getFieldName());
+        getSchema().getFieldIndex(BeaconStateFields.LATEST_EXECUTION_PAYLOAD_HEADER);
     return getAny(fieldIndex);
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/bellatrix/BeaconStateSchemaBellatrix.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/bellatrix/BeaconStateSchemaBellatrix.java
@@ -51,7 +51,7 @@ public class BeaconStateSchemaBellatrix
     final SszField latestExecutionPayloadHeaderField =
         new SszField(
             LATEST_EXECUTION_PAYLOAD_HEADER_FIELD_INDEX,
-            BeaconStateFields.LATEST_EXECUTION_PAYLOAD_HEADER.getFieldName(),
+            BeaconStateFields.LATEST_EXECUTION_PAYLOAD_HEADER,
             () -> new ExecutionPayloadHeaderSchema(SpecConfigBellatrix.required(specConfig)));
     return Stream.concat(
             BeaconStateSchemaAltair.getUniqueFields(specConfig).stream(),
@@ -70,35 +70,33 @@ public class BeaconStateSchemaBellatrix
   @SuppressWarnings("unchecked")
   public SszPrimitiveListSchema<Byte, SszByte, ?> getPreviousEpochParticipationSchema() {
     return (SszPrimitiveListSchema<Byte, SszByte, ?>)
-        getChildSchema(
-            getFieldIndex(BeaconStateFields.PREVIOUS_EPOCH_PARTICIPATION.getFieldName()));
+        getChildSchema(getFieldIndex(BeaconStateFields.PREVIOUS_EPOCH_PARTICIPATION));
   }
 
   @SuppressWarnings("unchecked")
   public SszPrimitiveListSchema<Byte, SszByte, ?> getCurrentEpochParticipationSchema() {
     return (SszPrimitiveListSchema<Byte, SszByte, ?>)
-        getChildSchema(getFieldIndex(BeaconStateFields.CURRENT_EPOCH_PARTICIPATION.getFieldName()));
+        getChildSchema(getFieldIndex(BeaconStateFields.CURRENT_EPOCH_PARTICIPATION));
   }
 
   public SszUInt64ListSchema<?> getInactivityScoresSchema() {
     return (SszUInt64ListSchema<?>)
-        getChildSchema(getFieldIndex(BeaconStateFields.INACTIVITY_SCORES.getFieldName()));
+        getChildSchema(getFieldIndex(BeaconStateFields.INACTIVITY_SCORES));
   }
 
   public SyncCommitteeSchema getCurrentSyncCommitteeSchema() {
     return (SyncCommitteeSchema)
-        getChildSchema(getFieldIndex(BeaconStateFields.CURRENT_SYNC_COMMITTEE.getFieldName()));
+        getChildSchema(getFieldIndex(BeaconStateFields.CURRENT_SYNC_COMMITTEE));
   }
 
   public SyncCommitteeSchema getNextSyncCommitteeSchema() {
     return (SyncCommitteeSchema)
-        getChildSchema(getFieldIndex(BeaconStateFields.NEXT_SYNC_COMMITTEE.getFieldName()));
+        getChildSchema(getFieldIndex(BeaconStateFields.NEXT_SYNC_COMMITTEE));
   }
 
   public ExecutionPayloadHeaderSchema getLastExecutionPayloadHeaderSchema() {
     return (ExecutionPayloadHeaderSchema)
-        getChildSchema(
-            getFieldIndex(BeaconStateFields.LATEST_EXECUTION_PAYLOAD_HEADER.getFieldName()));
+        getChildSchema(getFieldIndex(BeaconStateFields.LATEST_EXECUTION_PAYLOAD_HEADER));
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/bellatrix/MutableBeaconStateBellatrix.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/bellatrix/MutableBeaconStateBellatrix.java
@@ -33,7 +33,7 @@ public interface MutableBeaconStateBellatrix
 
   default void setLatestExecutionPayloadHeader(ExecutionPayloadHeader executionPayloadHeader) {
     final int fieldIndex =
-        getSchema().getFieldIndex(BeaconStateFields.LATEST_EXECUTION_PAYLOAD_HEADER.getFieldName());
+        getSchema().getFieldIndex(BeaconStateFields.LATEST_EXECUTION_PAYLOAD_HEADER);
     set(fieldIndex, executionPayloadHeader);
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/phase0/BeaconStatePhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/phase0/BeaconStatePhase0.java
@@ -37,14 +37,12 @@ public interface BeaconStatePhase0 extends BeaconState {
 
   // Attestations
   default SszList<PendingAttestation> getPrevious_epoch_attestations() {
-    final int fieldIndex =
-        getSchema().getFieldIndex(BeaconStateFields.PREVIOUS_EPOCH_ATTESTATIONS.getFieldName());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.PREVIOUS_EPOCH_ATTESTATIONS);
     return getAny(fieldIndex);
   }
 
   default SszList<PendingAttestation> getCurrent_epoch_attestations() {
-    final int fieldIndex =
-        getSchema().getFieldIndex(BeaconStateFields.CURRENT_EPOCH_ATTESTATIONS.getFieldName());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.CURRENT_EPOCH_ATTESTATIONS);
     return getAny(fieldIndex);
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/phase0/BeaconStateSchemaPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/phase0/BeaconStateSchemaPhase0.java
@@ -54,7 +54,7 @@ public class BeaconStateSchemaPhase0
     final SszField previousEpochAttestationsField =
         new SszField(
             15,
-            BeaconStateFields.PREVIOUS_EPOCH_ATTESTATIONS.getFieldName(),
+            BeaconStateFields.PREVIOUS_EPOCH_ATTESTATIONS,
             () ->
                 SszListSchema.create(
                     pendingAttestationSchema,
@@ -62,7 +62,7 @@ public class BeaconStateSchemaPhase0
     final SszField currentEpochAttestationsField =
         new SszField(
             16,
-            BeaconStateFields.CURRENT_EPOCH_ATTESTATIONS.getFieldName(),
+            BeaconStateFields.CURRENT_EPOCH_ATTESTATIONS,
             () ->
                 SszListSchema.create(
                     pendingAttestationSchema,
@@ -74,13 +74,13 @@ public class BeaconStateSchemaPhase0
   @SuppressWarnings("unchecked")
   public SszListSchema<PendingAttestation, ?> getPreviousEpochAttestationsSchema() {
     return (SszListSchema<PendingAttestation, ?>)
-        getChildSchema(getFieldIndex(BeaconStateFields.PREVIOUS_EPOCH_ATTESTATIONS.getFieldName()));
+        getChildSchema(getFieldIndex(BeaconStateFields.PREVIOUS_EPOCH_ATTESTATIONS));
   }
 
   @SuppressWarnings("unchecked")
   public SszListSchema<PendingAttestation, ?> getCurrentEpochAttestationsSchema() {
     return (SszListSchema<PendingAttestation, ?>)
-        getChildSchema(getFieldIndex(BeaconStateFields.CURRENT_EPOCH_ATTESTATIONS.getFieldName()));
+        getChildSchema(getFieldIndex(BeaconStateFields.CURRENT_EPOCH_ATTESTATIONS));
   }
 
   public PendingAttestationSchema getPendingAttestationSchema() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/phase0/MutableBeaconStatePhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/phase0/MutableBeaconStatePhase0.java
@@ -33,15 +33,13 @@ public interface MutableBeaconStatePhase0 extends MutableBeaconState, BeaconStat
   // Attestations
   @Override
   default SszMutableList<PendingAttestation> getPrevious_epoch_attestations() {
-    final int fieldIndex =
-        getSchema().getFieldIndex(BeaconStateFields.PREVIOUS_EPOCH_ATTESTATIONS.getFieldName());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.PREVIOUS_EPOCH_ATTESTATIONS);
     return getAnyByRef(fieldIndex);
   }
 
   @Override
   default SszMutableList<PendingAttestation> getCurrent_epoch_attestations() {
-    final int fieldIndex =
-        getSchema().getFieldIndex(BeaconStateFields.CURRENT_EPOCH_ATTESTATIONS.getFieldName());
+    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.CURRENT_EPOCH_ATTESTATIONS);
     return getAnyByRef(fieldIndex);
   }
 

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/SszContainerSchema.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/SszContainerSchema.java
@@ -69,6 +69,16 @@ public interface SszContainerSchema<C extends SszContainer> extends SszComposite
   int getFieldIndex(String fieldName);
 
   /**
+   * Get the index of a field by name
+   *
+   * @param fieldName
+   * @return The index if it exists, otherwise -1
+   */
+  default int getFieldIndex(SszFieldName fieldName) {
+    return getFieldIndex(fieldName.getSszFieldName());
+  }
+
+  /**
    * Creates the backing tree from container field values
    *
    * @throws IllegalArgumentException if value types doesn't match this scheme field types

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/SszFieldName.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/SszFieldName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 ConsenSys AG.
+ * Copyright 2022 ConsenSys AG.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -11,25 +11,8 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.spec.datastructures.blocks.blockbody.common;
+package tech.pegasys.teku.infrastructure.ssz.schema;
 
-import java.util.Locale;
-import tech.pegasys.teku.infrastructure.ssz.schema.SszFieldName;
-
-public enum BlockBodyFields implements SszFieldName {
-  RANDAO_REVEAL,
-  ETH1_DATA,
-  GRAFFITI,
-  PROPOSER_SLASHINGS,
-  ATTESTER_SLASHINGS,
-  ATTESTATIONS,
-  DEPOSITS,
-  VOLUNTARY_EXITS,
-  SYNC_AGGREGATE,
-  EXECUTION_PAYLOAD;
-
-  @Override
-  public String getSszFieldName() {
-    return name().toLowerCase(Locale.ROOT);
-  }
+public interface SszFieldName {
+  String getSszFieldName();
 }

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/impl/AbstractSszContainerSchema.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/impl/AbstractSszContainerSchema.java
@@ -29,6 +29,7 @@ import java.util.stream.IntStream;
 import tech.pegasys.teku.infrastructure.ssz.SszContainer;
 import tech.pegasys.teku.infrastructure.ssz.SszData;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszContainerSchema;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszFieldName;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszSchema;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszType;
 import tech.pegasys.teku.infrastructure.ssz.sos.SszDeserializeException;
@@ -61,6 +62,11 @@ public abstract class AbstractSszContainerSchema<C extends SszContainer>
     public SszSchema<T> getSchema() {
       return schema;
     }
+  }
+
+  protected static <T extends SszData> NamedSchema<T> namedSchema(
+      SszFieldName fieldName, SszSchema<T> schema) {
+    return namedSchema(fieldName.getSszFieldName(), schema);
   }
 
   protected static <T extends SszData> NamedSchema<T> namedSchema(

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/sos/SszField.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/sos/SszField.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.infrastructure.ssz.sos;
 
 import java.util.function.Supplier;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszFieldName;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszSchema;
 
 public class SszField {
@@ -29,8 +30,16 @@ public class SszField {
     this(index, "field-" + index, viewType);
   }
 
+  public SszField(int index, SszFieldName name, SszSchema<?> sszSchema) {
+    this(index, name.getSszFieldName(), sszSchema);
+  }
+
   public SszField(int index, String name, SszSchema<?> sszSchema) {
     this(index, name, () -> sszSchema);
+  }
+
+  public SszField(int index, SszFieldName name, Supplier<SszSchema<?>> viewType) {
+    this(index, name.getSszFieldName(), viewType);
   }
 
   public SszField(int index, String name, Supplier<SszSchema<?>> viewType) {


### PR DESCRIPTION
## PR Description
Use lower-case for beacon block field names in preparation for JSON serialization.

Allow enums to be used as field names directly and apply this to the state field names as well.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
