### PR TITLE
Simplify selection of spec version for getAncestor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,5 +18,6 @@ For information on changes in released versions of Teku, see the [releases page]
      Blocks that pass the gossip validation rules but fail state transition will no longer emit a `block` event.
 
 ### Additions and Improvements
+- Reduced CPU usage when finding ancestor block roots.
 
 ### Bug Fixes

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -400,7 +400,7 @@ public class Spec {
 
   public Optional<Bytes32> getAncestor(
       ReadOnlyForkChoiceStrategy forkChoiceStrategy, Bytes32 root, UInt64 slot) {
-    return atSlot(forkChoiceStrategy.blockSlot(root).orElse(slot))
+    return forGetAncestor(forkChoiceStrategy, root, slot)
         .getForkChoiceUtil()
         .getAncestor(forkChoiceStrategy, root, slot);
   }
@@ -411,16 +411,23 @@ public class Spec {
       UInt64 startSlot,
       UInt64 step,
       UInt64 count) {
-    return atSlot(forkChoiceStrategy.blockSlot(root).orElse(startSlot))
+    return forGetAncestor(forkChoiceStrategy, root, startSlot)
         .getForkChoiceUtil()
         .getAncestors(forkChoiceStrategy, root, startSlot, step, count);
   }
 
   public NavigableMap<UInt64, Bytes32> getAncestorsOnFork(
       ReadOnlyForkChoiceStrategy forkChoiceStrategy, Bytes32 root, UInt64 startSlot) {
-    return atSlot(forkChoiceStrategy.blockSlot(root).orElse(startSlot))
+    return forGetAncestor(forkChoiceStrategy, root, startSlot)
         .getForkChoiceUtil()
         .getAncestorsOnFork(forkChoiceStrategy, root, startSlot);
+  }
+
+  private SpecVersion forGetAncestor(
+      final ReadOnlyForkChoiceStrategy forkChoiceStrategy,
+      final Bytes32 root,
+      final UInt64 startSlot) {
+    return atSlot(forkChoiceStrategy.blockSlot(root).orElse(startSlot));
   }
 
   public void onTick(MutableStore store, UInt64 time) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -123,14 +123,6 @@ public class Spec {
     return specVersions.get(forkSchedule.getSpecMilestoneAtTime(genesisTime, currentTime));
   }
 
-  private SpecVersion specVersionFromForkChoice(ReadOnlyForkChoiceStrategy forkChoiceStrategy) {
-    final UInt64 latestSlot =
-        forkChoiceStrategy.getChainHeads().values().stream()
-            .max(UInt64::compareTo)
-            .orElse(UInt64.MAX_VALUE);
-    return atSlot(latestSlot);
-  }
-
   public SpecConfig getSpecConfig(final UInt64 epoch) {
     return atEpoch(epoch).getConfig();
   }
@@ -408,7 +400,7 @@ public class Spec {
 
   public Optional<Bytes32> getAncestor(
       ReadOnlyForkChoiceStrategy forkChoiceStrategy, Bytes32 root, UInt64 slot) {
-    return specVersionFromForkChoice(forkChoiceStrategy)
+    return atSlot(forkChoiceStrategy.blockSlot(root).orElse(slot))
         .getForkChoiceUtil()
         .getAncestor(forkChoiceStrategy, root, slot);
   }
@@ -419,14 +411,14 @@ public class Spec {
       UInt64 startSlot,
       UInt64 step,
       UInt64 count) {
-    return specVersionFromForkChoice(forkChoiceStrategy)
+    return atSlot(forkChoiceStrategy.blockSlot(root).orElse(startSlot))
         .getForkChoiceUtil()
         .getAncestors(forkChoiceStrategy, root, startSlot, step, count);
   }
 
   public NavigableMap<UInt64, Bytes32> getAncestorsOnFork(
       ReadOnlyForkChoiceStrategy forkChoiceStrategy, Bytes32 root, UInt64 startSlot) {
-    return specVersionFromForkChoice(forkChoiceStrategy)
+    return atSlot(forkChoiceStrategy.blockSlot(root).orElse(startSlot))
         .getForkChoiceUtil()
         .getAncestorsOnFork(forkChoiceStrategy, root, startSlot);
   }
@@ -635,10 +627,6 @@ public class Spec {
 
   public boolean isMergeTransitionComplete(final BeaconState state) {
     return atState(state).miscHelpers().isMergeTransitionComplete(state);
-  }
-
-  public boolean isMergeTransitionComplete(final SignedBeaconBlock block) {
-    return atBlock(block).miscHelpers().isMergeTransitionComplete(block);
   }
 
   // Private helpers

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
@@ -29,7 +29,6 @@ import tech.pegasys.teku.infrastructure.ssz.collections.SszByteVector;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.config.SpecConfig;
-import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.state.ForkData;
 import tech.pegasys.teku.spec.datastructures.state.SigningData;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
@@ -243,10 +242,6 @@ public class MiscHelpers {
   }
 
   public boolean isMergeTransitionComplete(final BeaconState state) {
-    return false;
-  }
-
-  public boolean isMergeTransitionComplete(final SignedBeaconBlock block) {
     return false;
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/bellatrix/helpers/MiscHelpersBellatrix.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/bellatrix/helpers/MiscHelpersBellatrix.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.spec.logic.versions.bellatrix.helpers;
 
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
-import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.bellatrix.BeaconBlockBodyBellatrix;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.bellatrix.BeaconStateBellatrix;
@@ -31,13 +30,6 @@ public class MiscHelpersBellatrix extends MiscHelpersAltair {
   public boolean isMergeTransitionComplete(final BeaconState genericState) {
     final BeaconStateBellatrix state = BeaconStateBellatrix.required(genericState);
     return !state.getLatestExecutionPayloadHeader().isDefault();
-  }
-
-  @Override
-  public boolean isMergeTransitionComplete(final SignedBeaconBlock block) {
-    return !BeaconBlockBodyBellatrix.required(block.getMessage().getBody())
-        .getExecutionPayload()
-        .isDefault();
   }
 
   public boolean isMergeTransitionBlock(final BeaconState genericState, final BeaconBlock block) {


### PR DESCRIPTION
## PR Description
Previously the highest chain head slot was used which required searching the entire protoarray which is expensive. Instead we can use the slot of the head block. If that's unavailable the response will be empty anyway as the chain is unknown but can safely fall back to using the ancestor slot requested.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
