### PR TITLE
Increase timeout for ATs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -294,7 +294,7 @@ jobs:
           path: build/test-results
 
   acceptanceTests:
-    parallelism: 3
+    parallelism: 4
     executor: machine_executor_amd64
     steps:
       - prepare
@@ -302,6 +302,7 @@ jobs:
           at: ~/project
       - run:
           name: AcceptanceTests
+          no_output_timeout: 20m
           command: |
             CLASSNAMES=$(circleci tests glob "**/src/acceptance-test/java/**/*.java" \
               | sed 's@.*/src/acceptance-test/java/@@' \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -294,7 +294,7 @@ jobs:
           path: build/test-results
 
   acceptanceTests:
-    parallelism: 4
+    parallelism: 5
     executor: machine_executor_amd64
     steps:
       - prepare


### PR DESCRIPTION
## PR Description
Increases timeout for ATs where no output is expected (gradle is silent during test execution).

Also add an additional parallel executor to see if it reduces execution time.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
