### PR TITLE
Support custom descriptions on type definitions

### DIFF
--- a/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/BooleanTypeDefinition.java
+++ b/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/BooleanTypeDefinition.java
@@ -16,17 +16,36 @@ package tech.pegasys.teku.infrastructure.json.types;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import java.io.IOException;
+import java.util.Optional;
 
 public class BooleanTypeDefinition implements DeserializableTypeDefinition<Boolean> {
+  private final Optional<String> description;
+
+  public BooleanTypeDefinition() {
+    this.description = Optional.empty();
+  }
+
+  public BooleanTypeDefinition(final String description) {
+    this.description = Optional.of(description);
+  }
+
   @Override
   public Boolean deserialize(final JsonParser parser) throws IOException {
     return parser.getBooleanValue();
   }
 
   @Override
+  public DeserializableTypeDefinition<Boolean> withDescription(final String description) {
+    return new BooleanTypeDefinition(description);
+  }
+
+  @Override
   public void serializeOpenApiType(final JsonGenerator gen) throws IOException {
     gen.writeStartObject();
     gen.writeStringField("type", "boolean");
+    if (description.isPresent()) {
+      gen.writeStringField("description", description.get());
+    }
     gen.writeEndObject();
   }
 

--- a/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/ByteTypeDefinition.java
+++ b/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/ByteTypeDefinition.java
@@ -19,14 +19,12 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import java.io.IOException;
 
-class ByteTypeDefinition implements DeserializableTypeDefinition<Byte> {
+class ByteTypeDefinition extends PrimitiveTypeDefinition<Byte> {
 
   @Override
-  public void serializeOpenApiType(final JsonGenerator gen) throws IOException {
-    gen.writeStartObject();
+  public void serializeOpenApiTypeFields(final JsonGenerator gen) throws IOException {
     gen.writeStringField("type", "string");
     gen.writeStringField("format", "byte");
-    gen.writeEndObject();
   }
 
   @Override

--- a/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/DescribedPrimitiveTypeDefinition.java
+++ b/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/DescribedPrimitiveTypeDefinition.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.json.types;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Optional;
+
+class DescribedPrimitiveTypeDefinition<T> implements DeserializableTypeDefinition<T> {
+
+  private final PrimitiveTypeDefinition<T> delegate;
+  private final String description;
+
+  DescribedPrimitiveTypeDefinition(
+      final PrimitiveTypeDefinition<T> delegate, final String description) {
+    this.delegate = delegate;
+    this.description = description;
+  }
+
+  @Override
+  public T deserialize(final JsonParser parser) throws IOException {
+    return delegate.deserialize(parser);
+  }
+
+  @Override
+  public Optional<String> getTypeName() {
+    // Clear name to ensure customised type is inlined
+    return Optional.empty();
+  }
+
+  @Override
+  public void serializeOpenApiType(final JsonGenerator gen) throws IOException {
+    gen.writeStartObject();
+    delegate.serializeOpenApiTypeFields(gen);
+    gen.writeStringField("description", description);
+    gen.writeEndObject();
+  }
+
+  @Override
+  public Collection<OpenApiTypeDefinition> getReferencedTypeDefinitions() {
+    return delegate.getReferencedTypeDefinitions();
+  }
+
+  @Override
+  public DeserializableTypeDefinition<T> withDescription(final String description) {
+    return delegate.withDescription(description);
+  }
+
+  @Override
+  public void serialize(final T value, final JsonGenerator gen) throws IOException {
+    delegate.serialize(value, gen);
+  }
+}

--- a/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/DeserializableArrayTypeDefinition.java
+++ b/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/DeserializableArrayTypeDefinition.java
@@ -36,6 +36,15 @@ public class DeserializableArrayTypeDefinition<ItemT, CollectionT extends Iterab
     this.createFromList = createFromList;
   }
 
+  public DeserializableArrayTypeDefinition(
+      final DeserializableTypeDefinition<ItemT> itemType,
+      final Function<List<ItemT>, CollectionT> createFromList,
+      final String description) {
+    super(itemType, description);
+    this.itemType = itemType;
+    this.createFromList = createFromList;
+  }
+
   @Override
   public CollectionT deserialize(final JsonParser parser) throws IOException {
     if (!parser.isExpectedStartArrayToken()) {
@@ -47,5 +56,10 @@ public class DeserializableArrayTypeDefinition<ItemT, CollectionT extends Iterab
       result.add(itemType.deserialize(parser));
     }
     return createFromList.apply(result);
+  }
+
+  @Override
+  public DeserializableTypeDefinition<CollectionT> withDescription(final String description) {
+    return new DeserializableArrayTypeDefinition<>(itemType, createFromList, description);
   }
 }

--- a/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/DeserializableObjectTypeDefinition.java
+++ b/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/DeserializableObjectTypeDefinition.java
@@ -41,10 +41,12 @@ class DeserializableObjectTypeDefinition<TObject, TBuilder>
 
   DeserializableObjectTypeDefinition(
       final Optional<String> name,
+      final Optional<String> title,
+      final Optional<String> description,
       final Supplier<TBuilder> initializer,
       final Function<TBuilder, TObject> finisher,
       final Map<String, DeserializableFieldDefinition<TObject, TBuilder>> fields) {
-    super(name, fields);
+    super(name, title, description, fields);
     this.initializer = initializer;
     this.finisher = finisher;
     this.deserializableFields = fields;
@@ -85,6 +87,17 @@ class DeserializableObjectTypeDefinition<TObject, TBuilder>
     }
 
     return finisher.apply(builder);
+  }
+
+  @Override
+  public DeserializableTypeDefinition<TObject> withDescription(final String description) {
+    return new DeserializableObjectTypeDefinition<>(
+        Optional.empty(), // Clear name to ensure customised type is inlined
+        getTitle(),
+        Optional.of(description),
+        initializer,
+        finisher,
+        deserializableFields);
   }
 
   @Override

--- a/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/DeserializableObjectTypeDefinitionBuilder.java
+++ b/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/DeserializableObjectTypeDefinitionBuilder.java
@@ -26,6 +26,8 @@ public class DeserializableObjectTypeDefinitionBuilder<TObject, TBuilder> {
   private final Map<String, DeserializableFieldDefinition<TObject, TBuilder>> fields =
       new LinkedHashMap<>();
   private Optional<String> name = Optional.empty();
+  private Optional<String> title = Optional.empty();
+  private Optional<String> description = Optional.empty();
   private Supplier<TBuilder> initializer;
   private Function<TBuilder, TObject> finisher;
 
@@ -33,6 +35,17 @@ public class DeserializableObjectTypeDefinitionBuilder<TObject, TBuilder> {
 
   public DeserializableObjectTypeDefinitionBuilder<TObject, TBuilder> name(final String name) {
     this.name = Optional.of(name);
+    return this;
+  }
+
+  public DeserializableObjectTypeDefinitionBuilder<TObject, TBuilder> title(final String title) {
+    this.title = Optional.of(title);
+    return this;
+  }
+
+  public DeserializableObjectTypeDefinitionBuilder<TObject, TBuilder> description(
+      final String description) {
+    this.description = Optional.of(description);
     return this;
   }
 
@@ -69,6 +82,7 @@ public class DeserializableObjectTypeDefinitionBuilder<TObject, TBuilder> {
   public DeserializableTypeDefinition<TObject> build() {
     checkNotNull(initializer, "Must specify an initializer");
     checkNotNull(finisher, "Must specify a finisher");
-    return new DeserializableObjectTypeDefinition<>(name, initializer, finisher, fields);
+    return new DeserializableObjectTypeDefinition<>(
+        name, title.or(() -> name), description, initializer, finisher, fields);
   }
 }

--- a/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/DeserializableTypeDefinition.java
+++ b/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/DeserializableTypeDefinition.java
@@ -23,6 +23,9 @@ public interface DeserializableTypeDefinition<TObject> extends SerializableTypeD
 
   TObject deserialize(JsonParser parser) throws IOException;
 
+  @Override
+  DeserializableTypeDefinition<TObject> withDescription(final String description);
+
   static <TObject> StringTypeBuilder<TObject> string(
       @SuppressWarnings("unused") final Class<TObject> clazz) {
     return new StringTypeBuilder<>();

--- a/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/EnumTypeDefinition.java
+++ b/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/EnumTypeDefinition.java
@@ -17,7 +17,7 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import java.io.IOException;
 
-public class EnumTypeDefinition<T extends Enum<T>> implements DeserializableTypeDefinition<T> {
+public class EnumTypeDefinition<T extends Enum<T>> extends PrimitiveTypeDefinition<T> {
   final Class<T> itemType;
 
   public EnumTypeDefinition(final Class<T> itemType) {
@@ -36,8 +36,7 @@ public class EnumTypeDefinition<T extends Enum<T>> implements DeserializableType
   }
 
   @Override
-  public void serializeOpenApiType(final JsonGenerator gen) throws IOException {
-    gen.writeStartObject();
+  public void serializeOpenApiTypeFields(final JsonGenerator gen) throws IOException {
     gen.writeStringField("type", "string");
     gen.writeArrayFieldStart("enum");
 
@@ -45,7 +44,6 @@ public class EnumTypeDefinition<T extends Enum<T>> implements DeserializableType
       gen.writeString(value.toString());
     }
     gen.writeEndArray();
-    gen.writeEndObject();
   }
 
   @Override

--- a/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/OpenApiTypeDefinition.java
+++ b/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/OpenApiTypeDefinition.java
@@ -27,6 +27,8 @@ public interface OpenApiTypeDefinition {
     return Optional.empty();
   }
 
+  OpenApiTypeDefinition withDescription(final String description);
+
   void serializeOpenApiType(JsonGenerator gen) throws IOException;
 
   default Collection<OpenApiTypeDefinition> getReferencedTypeDefinitions() {

--- a/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/PrimitiveTypeDefinition.java
+++ b/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/PrimitiveTypeDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 ConsenSys AG.
+ * Copyright 2022 ConsenSys AG.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -14,23 +14,23 @@
 package tech.pegasys.teku.infrastructure.json.types;
 
 import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonParser;
 import java.io.IOException;
 
-class IntegerTypeDefinition extends PrimitiveTypeDefinition<Integer> {
+public abstract class PrimitiveTypeDefinition<T> implements DeserializableTypeDefinition<T> {
 
   @Override
-  public void serializeOpenApiTypeFields(final JsonGenerator gen) throws IOException {
+  public final void serializeOpenApiType(final JsonGenerator gen) throws IOException {
+    gen.writeStartObject();
+    serializeOpenApiTypeFields(gen);
+    gen.writeEndObject();
+  }
+
+  protected void serializeOpenApiTypeFields(final JsonGenerator gen) throws IOException {
     gen.writeStringField("type", "number");
   }
 
   @Override
-  public void serialize(final Integer value, final JsonGenerator gen) throws IOException {
-    gen.writeNumber(value);
-  }
-
-  @Override
-  public Integer deserialize(final JsonParser parser) throws IOException {
-    return parser.getIntValue();
+  public DeserializableTypeDefinition<T> withDescription(final String description) {
+    return new DescribedPrimitiveTypeDefinition<>(this, description);
   }
 }

--- a/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/SerializableArrayTypeDefinition.java
+++ b/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/SerializableArrayTypeDefinition.java
@@ -16,13 +16,22 @@ package tech.pegasys.teku.infrastructure.json.types;
 import com.fasterxml.jackson.core.JsonGenerator;
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Optional;
 
 public class SerializableArrayTypeDefinition<ItemT, CollectionT extends Iterable<ItemT>>
     implements SerializableTypeDefinition<CollectionT> {
   private final SerializableTypeDefinition<ItemT> itemType;
+  private final Optional<String> description;
 
   public SerializableArrayTypeDefinition(final SerializableTypeDefinition<ItemT> itemType) {
     this.itemType = itemType;
+    this.description = Optional.empty();
+  }
+
+  public SerializableArrayTypeDefinition(
+      final SerializableTypeDefinition<ItemT> itemType, final String description) {
+    this.itemType = itemType;
+    this.description = Optional.of(description);
   }
 
   @Override
@@ -35,9 +44,17 @@ public class SerializableArrayTypeDefinition<ItemT, CollectionT extends Iterable
   }
 
   @Override
+  public SerializableTypeDefinition<CollectionT> withDescription(final String description) {
+    return new SerializableArrayTypeDefinition<>(itemType, description);
+  }
+
+  @Override
   public void serializeOpenApiType(final JsonGenerator gen) throws IOException {
     gen.writeStartObject();
     gen.writeStringField("type", "array");
+    if (description.isPresent()) {
+      gen.writeStringField("description", description.get());
+    }
     gen.writeFieldName("items");
     itemType.serializeOpenApiTypeOrReference(gen);
     gen.writeEndObject();

--- a/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/SerializableObjectTypeDefinition.java
+++ b/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/SerializableObjectTypeDefinition.java
@@ -25,18 +25,28 @@ import java.util.Optional;
 class SerializableObjectTypeDefinition<TObject> implements SerializableTypeDefinition<TObject> {
 
   private final Optional<String> name;
+  private final Optional<String> title;
+  private final Optional<String> description;
   private final Map<String, ? extends SerializableFieldDefinition<TObject>> fields;
 
   SerializableObjectTypeDefinition(
       final Optional<String> name,
+      final Optional<String> title,
+      final Optional<String> description,
       final Map<String, ? extends SerializableFieldDefinition<TObject>> fields) {
     this.name = name;
+    this.title = title;
+    this.description = description;
     this.fields = fields;
   }
 
   @Override
   public Optional<String> getTypeName() {
     return name;
+  }
+
+  public Optional<String> getTitle() {
+    return title;
   }
 
   @Override
@@ -49,10 +59,22 @@ class SerializableObjectTypeDefinition<TObject> implements SerializableTypeDefin
   }
 
   @Override
+  public SerializableTypeDefinition<TObject> withDescription(final String description) {
+    return new SerializableObjectTypeDefinition<>(
+        Optional.empty(), // Clear name to ensure customised type is inlined
+        title,
+        Optional.of(description),
+        fields);
+  }
+
+  @Override
   public void serializeOpenApiType(final JsonGenerator gen) throws IOException {
     gen.writeStartObject();
-    if (name.isPresent()) {
-      gen.writeStringField("title", name.get());
+    if (title.isPresent()) {
+      gen.writeStringField("title", title.get());
+    }
+    if (description.isPresent()) {
+      gen.writeStringField("description", description.get());
     }
     gen.writeStringField("type", "object");
     writeRequiredFields(gen);

--- a/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/SerializableObjectTypeDefinitionBuilder.java
+++ b/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/SerializableObjectTypeDefinitionBuilder.java
@@ -22,11 +22,23 @@ public class SerializableObjectTypeDefinitionBuilder<TObject> {
 
   private final Map<String, SerializableFieldDefinition<TObject>> fields = new LinkedHashMap<>();
   private Optional<String> name = Optional.empty();
+  private Optional<String> title = Optional.empty();
+  private Optional<String> description = Optional.empty();
 
   SerializableObjectTypeDefinitionBuilder() {}
 
   public SerializableObjectTypeDefinitionBuilder<TObject> name(final String name) {
     this.name = Optional.of(name);
+    return this;
+  }
+
+  public SerializableObjectTypeDefinitionBuilder<TObject> title(final String title) {
+    this.title = Optional.of(title);
+    return this;
+  }
+
+  public SerializableObjectTypeDefinitionBuilder<TObject> description(final String description) {
+    this.description = Optional.of(description);
     return this;
   }
 
@@ -47,6 +59,6 @@ public class SerializableObjectTypeDefinitionBuilder<TObject> {
   }
 
   public SerializableTypeDefinition<TObject> build() {
-    return new SerializableObjectTypeDefinition<>(name, fields);
+    return new SerializableObjectTypeDefinition<>(name, title.or(() -> name), description, fields);
   }
 }

--- a/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/SerializableTypeDefinition.java
+++ b/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/SerializableTypeDefinition.java
@@ -20,6 +20,9 @@ import java.util.List;
 public interface SerializableTypeDefinition<T> extends OpenApiTypeDefinition {
   void serialize(T value, JsonGenerator gen) throws IOException;
 
+  @Override
+  SerializableTypeDefinition<T> withDescription(final String description);
+
   static <T> SerializableObjectTypeDefinitionBuilder<T> object(
       @SuppressWarnings("unused") final Class<T> type) {
     return object();

--- a/infrastructure/json/src/test/java/tech/pegasys/teku/infrastructure/json/types/OpenApiTypeDefinitionTest.java
+++ b/infrastructure/json/src/test/java/tech/pegasys/teku/infrastructure/json/types/OpenApiTypeDefinitionTest.java
@@ -80,6 +80,11 @@ class OpenApiTypeDefinitionTest {
     }
 
     @Override
+    public OpenApiTypeDefinition withDescription(final String description) {
+      throw new UnsupportedOperationException("Not implemented");
+    }
+
+    @Override
     public void serializeOpenApiType(final JsonGenerator gen) throws IOException {
       gen.writeStartObject();
       gen.writeStringField("type", "custom");

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/json/SszTypeDefinitionWrapper.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/json/SszTypeDefinitionWrapper.java
@@ -42,6 +42,12 @@ public class SszTypeDefinitionWrapper<DataT, SszDataT extends SszPrimitive<DataT
   }
 
   @Override
+  public DeserializableTypeDefinition<SszDataT> withDescription(final String description) {
+    return new SszTypeDefinitionWrapper<>(
+        schema, primitiveTypeDefinition.withDescription(description));
+  }
+
+  @Override
   public void serializeOpenApiType(final JsonGenerator gen) throws IOException {
     primitiveTypeDefinition.serializeOpenApiType(gen);
   }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/ValidatorTypes.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/ValidatorTypes.java
@@ -95,7 +95,10 @@ public class ValidatorTypes {
               "derivation_path",
               CoreTypes.string("The derivation path (if present in the imported keystore)."),
               __ -> Optional.empty())
-          .withField("readonly", BOOLEAN_TYPE, Validator::isReadOnly)
+          .withField(
+              "readonly",
+              BOOLEAN_TYPE.withDescription("Whether the validator can be modified"),
+              Validator::isReadOnly)
           .build();
 
   public static SerializableTypeDefinition<List<Validator>> LIST_KEYS_RESPONSE_TYPE =
@@ -107,6 +110,7 @@ public class ValidatorTypes {
   public static DeserializableTypeDefinition<URL> URL_TYPE =
       DeserializableTypeDefinition.string(URL.class)
           .name("Signer")
+          .description("URL of the remote signer to use for this validator")
           .formatter(URL::toString)
           .parser(
               url -> {
@@ -142,7 +146,7 @@ public class ValidatorTypes {
           .withOptionalField("url", URL_TYPE, ExternalValidator::getUrl, ExternalValidator::setUrl)
           .withField(
               "readonly",
-              BOOLEAN_TYPE,
+              BOOLEAN_TYPE.withDescription("Whether the validator can be modified"),
               ExternalValidator::isReadOnly,
               ExternalValidator::setReadOnly)
           .build();

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/restapi/ValidatorOpenApiTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/restapi/ValidatorOpenApiTest.java
@@ -33,10 +33,8 @@ import tech.pegasys.teku.validator.client.ActiveKeyManager;
 class ValidatorOpenApiTest {
   private final ValidatorRestApiConfig config = mock(ValidatorRestApiConfig.class);
   private final ActiveKeyManager keyManager = mock(ActiveKeyManager.class);
-  private RestApi restApi;
   private final OpenApiTestUtil<ValidatorOpenApiTest> util =
       new OpenApiTestUtil<>(ValidatorOpenApiTest.class);
-  private Optional<String> maybeJson;
   private JsonNode jsonNode;
 
   @BeforeEach
@@ -49,8 +47,8 @@ class ValidatorOpenApiTest {
     when(config.getRestApiKeystoreFile()).thenReturn(Optional.of(Path.of("keystore")));
     when(config.getRestApiKeystorePasswordFile()).thenReturn(Optional.of(Path.of("pass")));
     when(dataDirLayout.getValidatorDataDirectory()).thenReturn(validatorDataDirectory);
-    restApi = ValidatorRestApi.create(config, keyManager, dataDirLayout);
-    maybeJson = restApi.getRestApiDocs();
+    final RestApi restApi = ValidatorRestApi.create(config, keyManager, dataDirLayout);
+    final Optional<String> maybeJson = restApi.getRestApiDocs();
     assertThat(maybeJson).isPresent();
     jsonNode = util.parseSwagger(maybeJson.orElseThrow());
   }

--- a/validator/client/src/test/resources/tech/pegasys/teku/validator/client/restapi/schema/ListKeysResponse.json
+++ b/validator/client/src/test/resources/tech/pegasys/teku/validator/client/restapi/schema/ListKeysResponse.json
@@ -17,7 +17,8 @@
             "description" : "The derivation path (if present in the imported keystore)."
           },
           "readonly" : {
-            "type" : "boolean"
+            "type" : "boolean",
+            "description" : "Whether the validator can be modified"
           }
         }
       }

--- a/validator/client/src/test/resources/tech/pegasys/teku/validator/client/restapi/schema/Signer.json
+++ b/validator/client/src/test/resources/tech/pegasys/teku/validator/client/restapi/schema/Signer.json
@@ -1,4 +1,5 @@
 {
   "type" : "string",
-  "title" : "Signer"
+  "title" : "Signer",
+  "description" : "URL of the remote signer to use for this validator"
 }

--- a/validator/client/src/test/resources/tech/pegasys/teku/validator/client/restapi/schema/SignerDefinition.json
+++ b/validator/client/src/test/resources/tech/pegasys/teku/validator/client/restapi/schema/SignerDefinition.json
@@ -10,7 +10,8 @@
       "$ref" : "#/components/schemas/Signer"
     },
     "readonly" : {
-      "type" : "boolean"
+      "type" : "boolean",
+      "description" : "Whether the validator can be modified"
     }
   }
 }


### PR DESCRIPTION
## PR Description
Support adding custom definitions to type definitions so we can provide more information even when re-using common types (especially useful for SSZ and primitive types).

Unfortunately the swagger-ui doesn't support overriding the description when using references that the OpenAPI spec allows so we have to ensure we inline the type when a custom description is used.  Hence `name` and `title` have been separated so we can separately control whether the type is referenced or included inline and what the name of that type is.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
