### PR TITLE
Make TerminalPowBlockMonitor less noisy

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/TerminalPowBlockMonitor.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/TerminalPowBlockMonitor.java
@@ -135,7 +135,7 @@ public class TerminalPowBlockMonitor {
     }
 
     if (!inSync) {
-      LOG.info("Node is syncing, skipping check.");
+      LOG.debug("Node is syncing, skipping check.");
       return;
     }
 


### PR DESCRIPTION
## PR Description
Reduce log level of the syncing message from TerminalPowBlockMonitor.  We already have `Syncing` log messages making it clear the node is syncing so don't need an extra info message every slot

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
