### PR TITLE
forkChoiceUpdated test with MockWebServer

### DIFF
--- a/ethereum/executionlayer/build.gradle
+++ b/ethereum/executionlayer/build.gradle
@@ -16,5 +16,7 @@ dependencies {
   runtimeOnly 'io.jsonwebtoken:jjwt-impl'
   runtimeOnly 'io.jsonwebtoken:jjwt-jackson'
 
+  testImplementation 'com.squareup.okhttp3:mockwebserver'
   testImplementation testFixtures(project(':ethereum:spec'))
+  testImplementation testFixtures(project(':infrastructure:time'))
 }

--- a/ethereum/executionlayer/build.gradle
+++ b/ethereum/executionlayer/build.gradle
@@ -16,7 +16,8 @@ dependencies {
   runtimeOnly 'io.jsonwebtoken:jjwt-impl'
   runtimeOnly 'io.jsonwebtoken:jjwt-jackson'
 
-  testImplementation 'com.squareup.okhttp3:mockwebserver'
   testImplementation testFixtures(project(':ethereum:spec'))
   testImplementation testFixtures(project(':infrastructure:time'))
+
+  integrationTestImplementation 'com.squareup.okhttp3:mockwebserver'
 }

--- a/ethereum/executionlayer/build.gradle
+++ b/ethereum/executionlayer/build.gradle
@@ -19,5 +19,6 @@ dependencies {
   testImplementation testFixtures(project(':ethereum:spec'))
   testImplementation testFixtures(project(':infrastructure:time'))
 
+  integrationTestImplementation testFixtures(project(':infrastructure:json'))
   integrationTestImplementation 'com.squareup.okhttp3:mockwebserver'
 }

--- a/ethereum/executionlayer/src/integration-test/java/tech/pegasys/teku/ethereum/executionlayer/client/Web3JExecutionEngineClientTest.java
+++ b/ethereum/executionlayer/src/integration-test/java/tech/pegasys/teku/ethereum/executionlayer/client/Web3JExecutionEngineClientTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionlayer.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.type.MapType;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.ethereum.executionlayer.client.schema.ForkChoiceStateV1;
+import tech.pegasys.teku.ethereum.executionlayer.client.schema.ForkChoiceUpdatedResult;
+import tech.pegasys.teku.ethereum.executionlayer.client.schema.PayloadAttributesV1;
+import tech.pegasys.teku.ethereum.executionlayer.client.schema.Response;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.bytes.Bytes20;
+import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.executionengine.PayloadStatus;
+
+public class Web3JExecutionEngineClientTest {
+  private final MockWebServer mockWebServer = new MockWebServer();
+  private final StubTimeProvider timeProvider = StubTimeProvider.withTimeInSeconds(0);
+
+  @BeforeEach
+  public void beforeEach() throws Exception {
+    mockWebServer.shutdown();
+  }
+
+  @AfterEach
+  public void afterEach() throws Exception {
+    mockWebServer.shutdown();
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void shouldRoundtripWithMockedWebServer() throws InterruptedException, IOException {
+    final Web3JExecutionEngineClient eeClient =
+        new Web3JExecutionEngineClient(
+            "http://localhost:" + mockWebServer.getPort(), timeProvider, Optional.empty());
+
+    final Bytes32 latestValidHash =
+        Bytes32.fromHexString("0x135bc3400c2839fd856a524871200bd5e362db615fc4565e1870ed9a2a936464");
+    final String validationError = "error";
+    final PayloadStatus payloadStatusResponse =
+        PayloadStatus.invalid(Optional.of(latestValidHash), Optional.of(validationError));
+
+    final String bodyResponse =
+        "{\"jsonrpc\": \"2.0\", \"id\": 0, \"result\":"
+            + "{\"payloadStatus\" : { \"status\": \"INVALID\", \"latestValidHash\": \""
+            + latestValidHash
+            + "\", \"validationError\": \""
+            + validationError
+            + "\"}}}";
+
+    mockWebServer.enqueue(
+        new MockResponse()
+            .setResponseCode(200)
+            .setBody(bodyResponse)
+            .addHeader("Content-Type", "application/json"));
+
+    final ForkChoiceStateV1 forkChoiceStateV1Orig =
+        new ForkChoiceStateV1(
+            Bytes32.fromHexString(
+                "0x235bc3400c2839fd856a524871200bd5e362db615fc4565e1870ed9a2a936464"),
+            Bytes32.fromHexString(
+                "0x367cbd40ac7318427aadb97345a91fa2e965daf3158d7f1846f1306305f41bef"),
+            Bytes32.fromHexString(
+                "0xfd18cf40cc907a739be483f1ca0ee23ad65cdd3df23205eabc6d660a75d1f54e"));
+
+    final PayloadAttributesV1 payloadAttributesV1Request =
+        new PayloadAttributesV1(
+            UInt64.valueOf(10),
+            Bytes32.fromHexString(
+                "0x367cbd40ac7318427aadb97345a91fa2e965daf3158d7f1846f1306305f41bef"),
+            Bytes20.fromHexString("0xfd18cf40cc907a739be483f1ca0ee23ad65cdd3d"));
+
+    final SafeFuture<Response<ForkChoiceUpdatedResult>> futureResponseForkChoiceUpdatedResult =
+        eeClient.forkChoiceUpdated(forkChoiceStateV1Orig, Optional.of(payloadAttributesV1Request));
+
+    final RecordedRequest request = mockWebServer.takeRequest();
+
+    final Map<String, Object> data =
+        parseGenericJson(request.getBody().readString(StandardCharsets.UTF_8));
+
+    final Map<String, Object> forkChoiceState =
+        (Map<String, Object>) ((List<Object>) data.get("params")).get(0);
+    final Map<String, Object> payloadAttributes =
+        (Map<String, Object>) ((List<Object>) data.get("params")).get(1);
+
+    assertThat(data.get("method")).isEqualTo("engine_forkchoiceUpdatedV1");
+    assertThat(data.get("id")).isEqualTo(0);
+
+    assertThat(forkChoiceState.get("headBlockHash"))
+        .isEqualTo("0x235bc3400c2839fd856a524871200bd5e362db615fc4565e1870ed9a2a936464");
+    assertThat(forkChoiceState.get("safeBlockHash"))
+        .isEqualTo("0x367cbd40ac7318427aadb97345a91fa2e965daf3158d7f1846f1306305f41bef");
+    assertThat(forkChoiceState.get("finalizedBlockHash"))
+        .isEqualTo("0xfd18cf40cc907a739be483f1ca0ee23ad65cdd3df23205eabc6d660a75d1f54e");
+
+    assertThat(payloadAttributes.get("timestamp")).isEqualTo("0xa");
+    assertThat(payloadAttributes.get("prevRandao"))
+        .isEqualTo("0x367cbd40ac7318427aadb97345a91fa2e965daf3158d7f1846f1306305f41bef");
+    assertThat(payloadAttributes.get("suggestedFeeRecipient"))
+        .isEqualTo("0xfd18cf40cc907a739be483f1ca0ee23ad65cdd3d");
+
+    assertThat(futureResponseForkChoiceUpdatedResult.join())
+        .matches(
+            forkChoiceUpdatedResultResponse ->
+                forkChoiceUpdatedResultResponse
+                    .getPayload()
+                    .asInternalExecutionPayload()
+                    .getPayloadStatus()
+                    .equals(payloadStatusResponse));
+  }
+
+  private Map<String, Object> parseGenericJson(final String json) throws JsonProcessingException {
+    final ObjectMapper mapper = new ObjectMapper();
+    final MapType type =
+        mapper.getTypeFactory().constructMapType(Map.class, String.class, Object.class);
+    return mapper.readValue(json, type);
+  }
+}

--- a/ethereum/executionlayer/src/integration-test/java/tech/pegasys/teku/ethereum/executionlayer/client/Web3JExecutionEngineClientTest.java
+++ b/ethereum/executionlayer/src/integration-test/java/tech/pegasys/teku/ethereum/executionlayer/client/Web3JExecutionEngineClientTest.java
@@ -15,10 +15,6 @@ package tech.pegasys.teku.ethereum.executionlayer.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.type.MapType;
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
@@ -36,6 +32,7 @@ import tech.pegasys.teku.ethereum.executionlayer.client.schema.PayloadAttributes
 import tech.pegasys.teku.ethereum.executionlayer.client.schema.Response;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.bytes.Bytes20;
+import tech.pegasys.teku.infrastructure.json.JsonTestUtil;
 import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.executionengine.PayloadStatus;
@@ -56,7 +53,7 @@ public class Web3JExecutionEngineClientTest {
 
   @Test
   @SuppressWarnings("unchecked")
-  void shouldRoundtripWithMockedWebServer() throws InterruptedException, IOException {
+  void shouldRoundtripWithMockedWebServer() throws Exception {
     final Web3JExecutionEngineClient eeClient =
         new Web3JExecutionEngineClient(
             "http://localhost:" + mockWebServer.getPort(), timeProvider, Optional.empty());
@@ -103,7 +100,7 @@ public class Web3JExecutionEngineClientTest {
     final RecordedRequest request = mockWebServer.takeRequest();
 
     final Map<String, Object> data =
-        parseGenericJson(request.getBody().readString(StandardCharsets.UTF_8));
+        JsonTestUtil.parse(request.getBody().readString(StandardCharsets.UTF_8));
 
     final Map<String, Object> forkChoiceState =
         (Map<String, Object>) ((List<Object>) data.get("params")).get(0);
@@ -134,12 +131,5 @@ public class Web3JExecutionEngineClientTest {
                     .asInternalExecutionPayload()
                     .getPayloadStatus()
                     .equals(payloadStatusResponse));
-  }
-
-  private Map<String, Object> parseGenericJson(final String json) throws JsonProcessingException {
-    final ObjectMapper mapper = new ObjectMapper();
-    final MapType type =
-        mapper.getTypeFactory().constructMapType(Map.class, String.class, Object.class);
-    return mapper.readValue(json, type);
   }
 }

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/client/Web3JExecutionEngineClientTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/client/Web3JExecutionEngineClientTest.java
@@ -528,11 +528,11 @@ public class Web3JExecutionEngineClientTest {
 
     final String bodyResponse =
         "{\"jsonrpc\": \"2.0\", \"id\": 0, \"result\":"
-            + "{\"payloadStatus\" : { \"status\": \"INVALID\", \"latestValidHash\": "
+            + "{\"payloadStatus\" : { \"status\": \"INVALID\", \"latestValidHash\": \""
             + latestValidHash
-            + ", \"validationError\": "
+            + "\", \"validationError\": \""
             + validationError
-            + "}}}";
+            + "\"}}}";
 
     mockWebServer.enqueue(
         new MockResponse()

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/client/Web3JExecutionEngineClientTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/client/Web3JExecutionEngineClientTest.java
@@ -28,10 +28,15 @@ import com.fasterxml.jackson.databind.exc.ValueInstantiationException;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.util.Optional;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import tech.pegasys.teku.ethereum.executionlayer.client.schema.ExecutionPayloadHeaderV1;
@@ -40,6 +45,7 @@ import tech.pegasys.teku.ethereum.executionlayer.client.schema.ForkChoiceStateV1
 import tech.pegasys.teku.ethereum.executionlayer.client.schema.ForkChoiceUpdatedResult;
 import tech.pegasys.teku.ethereum.executionlayer.client.schema.PayloadAttributesV1;
 import tech.pegasys.teku.ethereum.executionlayer.client.schema.PayloadStatusV1;
+import tech.pegasys.teku.ethereum.executionlayer.client.schema.Response;
 import tech.pegasys.teku.ethereum.executionlayer.client.schema.TransitionConfigurationV1;
 import tech.pegasys.teku.ethereum.executionlayer.client.serialization.Bytes20Deserializer;
 import tech.pegasys.teku.ethereum.executionlayer.client.serialization.Bytes20Serializer;
@@ -50,8 +56,10 @@ import tech.pegasys.teku.ethereum.executionlayer.client.serialization.UInt256AsH
 import tech.pegasys.teku.ethereum.executionlayer.client.serialization.UInt256AsHexSerializer;
 import tech.pegasys.teku.ethereum.executionlayer.client.serialization.UInt64AsHexDeserializer;
 import tech.pegasys.teku.ethereum.executionlayer.client.serialization.UInt64AsHexSerializer;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.bytes.Bytes20;
 import tech.pegasys.teku.infrastructure.bytes.Bytes8;
+import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecContext;
@@ -70,6 +78,13 @@ public class Web3JExecutionEngineClientTest {
   ObjectMapper objectMapper;
   SerializerProvider serializerProvider;
   DataStructureUtil dataStructureUtil;
+  private final MockWebServer mockWebServer = new MockWebServer();
+  private final StubTimeProvider timeProvider = StubTimeProvider.withTimeInSeconds(0);
+
+  @AfterEach
+  public void stopMWS() throws Exception {
+    mockWebServer.shutdown();
+  }
 
   @BeforeEach
   @TestTemplate
@@ -494,6 +509,77 @@ public class Web3JExecutionEngineClientTest {
             internalTransitionConfiguration);
 
     assertThat(externalTransitionConfiguration2).isEqualTo(externalTransitionConfiguration);
+  }
+
+  @TestTemplate
+  void shouldRoundtripWithMockedWebServer() throws InterruptedException, IOException {
+
+    mockWebServer.start();
+
+    final Web3JExecutionEngineClient eeClient =
+        new Web3JExecutionEngineClient(
+            "http://localhost:" + mockWebServer.getPort(), timeProvider, Optional.empty());
+
+    final Bytes32 latestValidHash =
+        Bytes32.fromHexString("0x135bc3400c2839fd856a524871200bd5e362db615fc4565e1870ed9a2a936464");
+    final String validationError = "error";
+    final PayloadStatus payloadStatusResponse =
+        PayloadStatus.invalid(Optional.of(latestValidHash), Optional.of(validationError));
+
+    final String bodyResponse =
+        "{\"jsonrpc\": \"2.0\", \"id\": 0, \"result\":"
+            + "{\"payloadStatus\" : { \"status\": \"INVALID\", \"latestValidHash\": "
+            + latestValidHash
+            + ", \"validationError\": "
+            + validationError
+            + "}}}";
+
+    mockWebServer.enqueue(
+        new MockResponse()
+            .setResponseCode(200)
+            .setBody(bodyResponse)
+            .addHeader("Content-Type", "application/json"));
+
+    final ForkChoiceStateV1 forkChoiceStateV1Orig =
+        new ForkChoiceStateV1(
+            Bytes32.fromHexString(
+                "0x235bc3400c2839fd856a524871200bd5e362db615fc4565e1870ed9a2a936464"),
+            Bytes32.fromHexString(
+                "0x367cbd40ac7318427aadb97345a91fa2e965daf3158d7f1846f1306305f41bef"),
+            Bytes32.fromHexString(
+                "0xfd18cf40cc907a739be483f1ca0ee23ad65cdd3df23205eabc6d660a75d1f54e"));
+
+    final PayloadAttributesV1 payloadAttributesV1Request =
+        new PayloadAttributesV1(
+            UInt64.valueOf(10),
+            Bytes32.fromHexString(
+                "0x367cbd40ac7318427aadb97345a91fa2e965daf3158d7f1846f1306305f41bef"),
+            Bytes20.fromHexString("0xfd18cf40cc907a739be483f1ca0ee23ad65cdd3d"));
+
+    final SafeFuture<Response<ForkChoiceUpdatedResult>> futureResponseForkChoiceUpdatedResult =
+        eeClient.forkChoiceUpdated(forkChoiceStateV1Orig, Optional.of(payloadAttributesV1Request));
+
+    final RecordedRequest request = mockWebServer.takeRequest();
+
+    assertThat(request.getBody().readString(StandardCharsets.UTF_8))
+        .isEqualTo(
+            "{\"jsonrpc\":\"2.0\",\"method\":\"engine_forkchoiceUpdatedV1\",\"params\":["
+                + "{\"headBlockHash\":\"0x235bc3400c2839fd856a524871200bd5e362db615fc4565e1870ed9a2a936464\","
+                + "\"safeBlockHash\":\"0x367cbd40ac7318427aadb97345a91fa2e965daf3158d7f1846f1306305f41bef\","
+                + "\"finalizedBlockHash\":\"0xfd18cf40cc907a739be483f1ca0ee23ad65cdd3df23205eabc6d660a75d1f54e\"},"
+                + "{\"timestamp\":\"0xa\","
+                + "\"prevRandao\":\"0x367cbd40ac7318427aadb97345a91fa2e965daf3158d7f1846f1306305f41bef\","
+                + "\"suggestedFeeRecipient\":\"0xfd18cf40cc907a739be483f1ca0ee23ad65cdd3d\"}],"
+                + "\"id\":0}");
+
+    assertThat(futureResponseForkChoiceUpdatedResult.join())
+        .matches(
+            forkChoiceUpdatedResultResponse ->
+                forkChoiceUpdatedResultResponse
+                    .getPayload()
+                    .asInternalExecutionPayload()
+                    .getPayloadStatus()
+                    .equals(payloadStatusResponse));
   }
 
   private ForkChoiceUpdatedResult createExternalForkChoiceUpdatedResult(

--- a/validator/client/build.gradle
+++ b/validator/client/build.gradle
@@ -44,7 +44,6 @@ dependencies {
   testImplementation testFixtures(project(':infrastructure:json'))
   testImplementation testFixtures(project(':infrastructure:time'))
   testImplementation testFixtures(project(':infrastructure:serviceutils'))
-  testImplementation testFixtures(project(':infrastructure:json'))
   testImplementation testFixtures(project(':infrastructure:restapi'))
 
 }


### PR DESCRIPTION
## PR Description

Introduce the usage of `MockWebServer` to test `Web3JExecutionEngineClient`

Currently used only to forkChoiceUpdated

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
