### PR TITLE
Remove duplicate message handling from GossipHandler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,5 +20,6 @@ For information on changes in released versions of Teku, see the [releases page]
 ### Additions and Improvements
 - Reduced CPU usage when finding ancestor block roots.
 - Updated gossip validation rules to match consensus spec v1.1.0.
+- Reduced memory usage when deduplicating gossip messages.
 
 ### Bug Fixes

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryTest.java
@@ -186,7 +186,7 @@ class BlockOperationSelectorFactoryTest {
     addToPool(voluntaryExitPool, voluntaryExit);
     addToPool(proposerSlashingPool, proposerSlashing);
     addToPool(attesterSlashingPool, attesterSlashing);
-    assertThat(contributionPool.add(contribution)).isCompletedWithValue(ACCEPT);
+    assertThat(contributionPool.addLocal(contribution)).isCompletedWithValue(ACCEPT);
 
     factory
         .createSelector(parentRoot, blockSlotState, randaoReveal, Optional.empty())
@@ -204,7 +204,7 @@ class BlockOperationSelectorFactoryTest {
   }
 
   private <T extends SszData> void addToPool(final OperationPool<T> pool, final T operation) {
-    assertThat(pool.add(operation)).isCompletedWithValue(ACCEPT);
+    assertThat(pool.addRemote(operation)).isCompletedWithValue(ACCEPT);
   }
 
   @Test
@@ -240,7 +240,7 @@ class BlockOperationSelectorFactoryTest {
     addToPool(attesterSlashingPool, attesterSlashing1);
     addToPool(attesterSlashingPool, attesterSlashing2);
     addToPool(attesterSlashingPool, attesterSlashing3);
-    assertThat(contributionPool.add(contribution)).isCompletedWithValue(ACCEPT);
+    assertThat(contributionPool.addRemote(contribution)).isCompletedWithValue(ACCEPT);
 
     when(proposerSlashingValidator.validateForStateTransition(blockSlotState, proposerSlashing2))
         .thenReturn(Optional.of(ProposerSlashingInvalidReason.INVALID_SIGNATURE));

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -841,7 +841,7 @@ class ValidatorApiHandlerTest {
   void sendSyncCommitteeMessages_shouldAddMessagesToPool() {
     final SyncCommitteeMessage message = dataStructureUtil.randomSyncCommitteeMessage();
     final List<SyncCommitteeMessage> messages = List.of(message);
-    when(syncCommitteeMessagePool.add(any()))
+    when(syncCommitteeMessagePool.addLocal(any()))
         .thenReturn(SafeFuture.completedFuture(InternalValidationResult.ACCEPT));
     final SafeFuture<List<SubmitDataError>> result =
         validatorApiHandler.sendSyncCommitteeMessages(messages);
@@ -853,7 +853,7 @@ class ValidatorApiHandlerTest {
   void sendSyncCommitteeMessages_shouldRaiseErrors() {
     final SyncCommitteeMessage message = dataStructureUtil.randomSyncCommitteeMessage();
     final List<SyncCommitteeMessage> messages = List.of(message);
-    when(syncCommitteeMessagePool.add(any()))
+    when(syncCommitteeMessagePool.addLocal(any()))
         .thenReturn(
             SafeFuture.completedFuture(
                 InternalValidationResult.create(ValidationResultCode.REJECT, "Rejected")));
@@ -874,7 +874,7 @@ class ValidatorApiHandlerTest {
   void sendSignedContributionAndProofs_shouldAddContributionsToPool() {
     final SignedContributionAndProof contribution =
         dataStructureUtil.randomSignedContributionAndProof(5);
-    when(syncCommitteeContributionPool.add(any()))
+    when(syncCommitteeContributionPool.addLocal(any()))
         .thenReturn(SafeFuture.completedFuture(InternalValidationResult.ACCEPT));
 
     final SafeFuture<Void> result =
@@ -888,11 +888,11 @@ class ValidatorApiHandlerTest {
         dataStructureUtil.randomSignedContributionAndProof(5);
     final SignedContributionAndProof contribution2 =
         dataStructureUtil.randomSignedContributionAndProof(5);
-    when(syncCommitteeContributionPool.add(contribution1))
+    when(syncCommitteeContributionPool.addLocal(contribution1))
         .thenReturn(
             SafeFuture.completedFuture(
                 InternalValidationResult.create(ValidationResultCode.REJECT, "Bad")));
-    when(syncCommitteeContributionPool.add(contribution2))
+    when(syncCommitteeContributionPool.addLocal(contribution2))
         .thenReturn(
             SafeFuture.completedFuture(
                 InternalValidationResult.create(ValidationResultCode.REJECT, "Worse")));

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/PostAttesterSlashingIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/PostAttesterSlashingIntegrationTest.java
@@ -59,7 +59,7 @@ public class PostAttesterSlashingIntegrationTest extends AbstractDataBackedRestA
 
     final AttesterSlashing schemaSlashing = new AttesterSlashing(slashing);
 
-    doThrow(new RuntimeException()).when(attesterSlashingPool).add(slashing);
+    doThrow(new RuntimeException()).when(attesterSlashingPool).addLocal(slashing);
 
     Response response = post(PostAttesterSlashing.ROUTE, jsonProvider.objectToJSON(schemaSlashing));
     assertThat(response.code()).isEqualTo(500);
@@ -72,12 +72,12 @@ public class PostAttesterSlashingIntegrationTest extends AbstractDataBackedRestA
 
     final AttesterSlashing schemaSlashing = new AttesterSlashing(slashing);
 
-    when(attesterSlashingPool.add(slashing))
+    when(attesterSlashingPool.addLocal(slashing))
         .thenReturn(SafeFuture.completedFuture(InternalValidationResult.ACCEPT));
 
     Response response = post(PostAttesterSlashing.ROUTE, jsonProvider.objectToJSON(schemaSlashing));
 
-    verify(attesterSlashingPool).add(slashing);
+    verify(attesterSlashingPool).addLocal(slashing);
 
     assertThat(response.code()).isEqualTo(200);
   }

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/PostProposerSlashingIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/PostProposerSlashingIntegrationTest.java
@@ -59,7 +59,7 @@ public class PostProposerSlashingIntegrationTest extends AbstractDataBackedRestA
 
     final ProposerSlashing schemaSlashing = new ProposerSlashing(slashing);
 
-    doThrow(new RuntimeException()).when(proposerSlashingPool).add(slashing);
+    doThrow(new RuntimeException()).when(proposerSlashingPool).addLocal(slashing);
 
     Response response = post(PostProposerSlashing.ROUTE, jsonProvider.objectToJSON(schemaSlashing));
     assertThat(response.code()).isEqualTo(500);
@@ -72,12 +72,12 @@ public class PostProposerSlashingIntegrationTest extends AbstractDataBackedRestA
 
     final ProposerSlashing schemaSlashing = new ProposerSlashing(slashing);
 
-    when(proposerSlashingPool.add(slashing))
+    when(proposerSlashingPool.addLocal(slashing))
         .thenReturn(SafeFuture.completedFuture(InternalValidationResult.ACCEPT));
 
     Response response = post(PostProposerSlashing.ROUTE, jsonProvider.objectToJSON(schemaSlashing));
 
-    verify(proposerSlashingPool).add(slashing);
+    verify(proposerSlashingPool).addLocal(slashing);
 
     assertThat(response.code()).isEqualTo(200);
   }

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/PostVoluntaryExitIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/PostVoluntaryExitIntegrationTest.java
@@ -60,7 +60,7 @@ public class PostVoluntaryExitIntegrationTest extends AbstractDataBackedRestAPII
 
     final SignedVoluntaryExit schemaExit = new SignedVoluntaryExit(signedVoluntaryExit);
 
-    doThrow(new RuntimeException()).when(voluntaryExitPool).add(signedVoluntaryExit);
+    doThrow(new RuntimeException()).when(voluntaryExitPool).addLocal(signedVoluntaryExit);
 
     Response response = post(PostVoluntaryExit.ROUTE, jsonProvider.objectToJSON(schemaExit));
     assertThat(response.code()).isEqualTo(SC_INTERNAL_SERVER_ERROR);
@@ -73,12 +73,12 @@ public class PostVoluntaryExitIntegrationTest extends AbstractDataBackedRestAPII
 
     final SignedVoluntaryExit schemaExit = new SignedVoluntaryExit(signedVoluntaryExit);
 
-    when(voluntaryExitPool.add(signedVoluntaryExit))
+    when(voluntaryExitPool.addLocal(signedVoluntaryExit))
         .thenReturn(SafeFuture.completedFuture(InternalValidationResult.ACCEPT));
 
     Response response = post(PostVoluntaryExit.ROUTE, jsonProvider.objectToJSON(schemaExit));
 
-    verify(voluntaryExitPool).add(signedVoluntaryExit);
+    verify(voluntaryExitPool).addLocal(signedVoluntaryExit);
 
     assertThat(response.code()).isEqualTo(SC_OK);
   }

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManager.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManager.java
@@ -143,7 +143,8 @@ public class EventSubscriptionManager implements ChainHeadChannel, FinalizedChec
 
   protected void onNewVoluntaryExit(
       final tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit exit,
-      final InternalValidationResult result) {
+      final InternalValidationResult result,
+      final boolean fromNetwork) {
     final SignedVoluntaryExit voluntaryExitEvent = new SignedVoluntaryExit(exit);
     notifySubscribersOfEvent(EventType.voluntary_exit, voluntaryExitEvent);
   }
@@ -152,7 +153,8 @@ public class EventSubscriptionManager implements ChainHeadChannel, FinalizedChec
       final tech.pegasys.teku.spec.datastructures.operations.versions.altair
               .SignedContributionAndProof
           proof,
-      final InternalValidationResult result) {
+      final InternalValidationResult result,
+      final boolean fromNetwork) {
     if (result.isAccept()) {
       final SignedContributionAndProof signedContributionAndProof =
           new SignedContributionAndProof(proof);

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManagerTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManagerTest.java
@@ -327,7 +327,9 @@ public class EventSubscriptionManagerTest {
 
   private void triggerVoluntaryExitEvent() {
     manager.onNewVoluntaryExit(
-        sampleVoluntaryExit.asInternalSignedVoluntaryExit(), InternalValidationResult.ACCEPT);
+        sampleVoluntaryExit.asInternalSignedVoluntaryExit(),
+        InternalValidationResult.ACCEPT,
+        false);
     asyncRunner.executeQueuedActions();
   }
 
@@ -386,7 +388,8 @@ public class EventSubscriptionManagerTest {
   }
 
   private void triggerContributionEvent() {
-    manager.onSyncCommitteeContribution(contributionAndProof, InternalValidationResult.ACCEPT);
+    manager.onSyncCommitteeContribution(
+        contributionAndProof, InternalValidationResult.ACCEPT, false);
     asyncRunner.executeQueuedActions();
   }
 }

--- a/data/provider/src/main/java/tech/pegasys/teku/api/NodeDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/NodeDataProvider.java
@@ -116,15 +116,15 @@ public class NodeDataProvider {
   }
 
   public SafeFuture<InternalValidationResult> postVoluntaryExit(SignedVoluntaryExit exit) {
-    return voluntaryExitPool.add(exit.asInternalSignedVoluntaryExit());
+    return voluntaryExitPool.addLocal(exit.asInternalSignedVoluntaryExit());
   }
 
   public SafeFuture<InternalValidationResult> postAttesterSlashing(AttesterSlashing slashing) {
-    return attesterSlashingPool.add(slashing.asInternalAttesterSlashing(spec));
+    return attesterSlashingPool.addLocal(slashing.asInternalAttesterSlashing(spec));
   }
 
   public SafeFuture<InternalValidationResult> postProposerSlashing(ProposerSlashing slashing) {
-    return proposerSlashingPool.add(slashing.asInternalProposerSlashing());
+    return proposerSlashingPool.addLocal(slashing.asInternalProposerSlashing());
   }
 
   public void subscribeToReceivedBlocks(ImportedBlockListener listener) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/LocalOperationAcceptedFilter.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/LocalOperationAcceptedFilter.java
@@ -18,17 +18,28 @@ import tech.pegasys.teku.statetransition.OperationPool.OperationAddedSubscriber;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
 import tech.pegasys.teku.statetransition.validation.ValidationResultCode;
 
-public class OperationAcceptedFilter<T> implements OperationAddedSubscriber<T> {
+/**
+ * Filters added operations to just those that need to be published out via gossip.
+ *
+ * <p>Operations received via gossip are automatically forwarded based on the returned validation
+ * result so only operations received from the local API need to be gossiped on.
+ *
+ * @param <T> the type of operation being filtered.
+ */
+public class LocalOperationAcceptedFilter<T> implements OperationAddedSubscriber<T> {
 
   private final Consumer<T> delegate;
 
-  public OperationAcceptedFilter(final Consumer<T> delegate) {
+  public LocalOperationAcceptedFilter(final Consumer<T> delegate) {
     this.delegate = delegate;
   }
 
   @Override
-  public void onOperationAdded(final T operation, final InternalValidationResult validationStatus) {
-    if (validationStatus.code() == ValidationResultCode.ACCEPT) {
+  public void onOperationAdded(
+      final T operation,
+      final InternalValidationResult validationStatus,
+      final boolean fromNetwork) {
+    if (!fromNetwork && validationStatus.code() == ValidationResultCode.ACCEPT) {
       delegate.accept(operation);
     }
   }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeContributionPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeContributionPool.java
@@ -54,8 +54,18 @@ public class SyncCommitteeContributionPool implements SlotEventsChannel {
     subscribers.subscribe(subscriber);
   }
 
-  public SafeFuture<InternalValidationResult> add(
+  public SafeFuture<InternalValidationResult> addLocal(
       final SignedContributionAndProof signedContributionAndProof) {
+    return add(signedContributionAndProof, false);
+  }
+
+  public SafeFuture<InternalValidationResult> addRemote(
+      final SignedContributionAndProof signedContributionAndProof) {
+    return add(signedContributionAndProof, true);
+  }
+
+  private SafeFuture<InternalValidationResult> add(
+      final SignedContributionAndProof signedContributionAndProof, final boolean fromNetwork) {
     return validator
         .validate(signedContributionAndProof)
         .thenPeek(
@@ -63,7 +73,9 @@ public class SyncCommitteeContributionPool implements SlotEventsChannel {
               if (result.isAccept()) {
                 doAdd(signedContributionAndProof.getMessage().getContribution());
                 subscribers.forEach(
-                    subscriber -> subscriber.onOperationAdded(signedContributionAndProof, result));
+                    subscriber ->
+                        subscriber.onOperationAdded(
+                            signedContributionAndProof, result, fromNetwork));
               }
             });
   }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeMessagePool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeMessagePool.java
@@ -63,13 +63,25 @@ public class SyncCommitteeMessagePool implements SlotEventsChannel {
     subscribers.subscribe(subscriber);
   }
 
-  public SafeFuture<InternalValidationResult> add(final ValidateableSyncCommitteeMessage message) {
+  public SafeFuture<InternalValidationResult> addLocal(
+      final ValidateableSyncCommitteeMessage message) {
+    return add(message, false);
+  }
+
+  public SafeFuture<InternalValidationResult> addRemote(
+      final ValidateableSyncCommitteeMessage message) {
+    return add(message, true);
+  }
+
+  private SafeFuture<InternalValidationResult> add(
+      final ValidateableSyncCommitteeMessage message, final boolean fromNetwork) {
     return validator
         .validate(message)
         .thenPeek(
             result -> {
               if (result.isAccept()) {
-                subscribers.forEach(subscriber -> subscriber.onOperationAdded(message, result));
+                subscribers.forEach(
+                    subscriber -> subscriber.onOperationAdded(message, result, fromNetwork));
                 doAdd(message);
               }
             });

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/OperationPoolTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/OperationPoolTest.java
@@ -91,7 +91,7 @@ public class OperationPoolTest {
     when(validator.validateForStateTransition(any(), any())).thenReturn(Optional.empty());
     final int maxVoluntaryExits = spec.getGenesisSpecConfig().getMaxVoluntaryExits();
     for (int i = 0; i < maxVoluntaryExits + 1; i++) {
-      pool.add(dataStructureUtil.randomSignedVoluntaryExit());
+      pool.addLocal(dataStructureUtil.randomSignedVoluntaryExit());
     }
     assertThat(pool.getItemsForBlock(state)).hasSize(maxVoluntaryExits);
   }
@@ -111,7 +111,7 @@ public class OperationPoolTest {
     when(validator.validateForStateTransition(any(), any())).thenReturn(Optional.empty());
     final int maxVoluntaryExits = spec.getGenesisSpecConfig().getMaxVoluntaryExits();
     for (int i = 0; i < maxVoluntaryExits + 10; i++) {
-      pool.add(dataStructureUtil.randomSignedVoluntaryExit());
+      pool.addLocal(dataStructureUtil.randomSignedVoluntaryExit());
     }
     // Didn't find any applicable items but tried them all
     assertThat(pool.getItemsForBlock(state, filter, operation -> {})).isEmpty();
@@ -153,8 +153,8 @@ public class OperationPoolTest {
 
     when(validator.validateFully(any())).thenReturn(completedFuture(ACCEPT));
 
-    pool.add(slashing1);
-    pool.add(slashing2);
+    pool.addLocal(slashing1);
+    pool.addLocal(slashing2);
 
     when(validator.validateForStateTransition(any(), eq(slashing1)))
         .thenReturn(Optional.of(ExitInvalidReason.SUBMITTED_TOO_EARLY));
@@ -175,7 +175,8 @@ public class OperationPoolTest {
 
     // Set up subscriber
     final Map<ProposerSlashing, InternalValidationResult> addedSlashings = new HashMap<>();
-    OperationAddedSubscriber<ProposerSlashing> subscriber = addedSlashings::put;
+    OperationAddedSubscriber<ProposerSlashing> subscriber =
+        (key, value, fromNetwork) -> addedSlashings.put(key, value);
     pool.subscribeOperationAdded(subscriber);
 
     ProposerSlashing slashing1 = dataStructureUtil.randomProposerSlashing();
@@ -189,10 +190,10 @@ public class OperationPoolTest {
         .thenReturn(completedFuture(InternalValidationResult.reject("Nah")));
     when(validator.validateFully(slashing4)).thenReturn(completedFuture(IGNORE));
 
-    pool.add(slashing1);
-    pool.add(slashing2);
-    pool.add(slashing3);
-    pool.add(slashing4);
+    pool.addLocal(slashing1);
+    pool.addLocal(slashing2);
+    pool.addLocal(slashing3);
+    pool.addLocal(slashing4);
 
     assertThat(addedSlashings.size()).isEqualTo(2);
     assertThat(addedSlashings).containsKey(slashing1);

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeMessagePoolTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeMessagePoolTest.java
@@ -68,12 +68,21 @@ class SyncCommitteeMessagePoolTest {
   }
 
   @Test
-  void shouldNotifySubscriberWhenValidMessageAdded() {
+  void shouldNotifySubscriberWhenLocalValidMessageAdded() {
     pool.subscribeOperationAdded(subscriber);
     when(validator.validate(message)).thenReturn(SafeFuture.completedFuture(ACCEPT));
 
-    assertThat(pool.add(message)).isCompletedWithValue(ACCEPT);
-    verify(subscriber).onOperationAdded(message, ACCEPT);
+    assertThat(pool.addLocal(message)).isCompletedWithValue(ACCEPT);
+    verify(subscriber).onOperationAdded(message, ACCEPT, false);
+  }
+
+  @Test
+  void shouldNotifySubscriberWhenRemoteValidMessageAdded() {
+    pool.subscribeOperationAdded(subscriber);
+    when(validator.validate(message)).thenReturn(SafeFuture.completedFuture(ACCEPT));
+
+    assertThat(pool.addRemote(message)).isCompletedWithValue(ACCEPT);
+    verify(subscriber).onOperationAdded(message, ACCEPT, true);
   }
 
   @Test
@@ -81,7 +90,7 @@ class SyncCommitteeMessagePoolTest {
     pool.subscribeOperationAdded(subscriber);
     when(validator.validate(message)).thenReturn(SafeFuture.completedFuture(reject("Bad")));
 
-    assertThat(pool.add(message)).isCompletedWithValue(reject("Bad"));
+    assertThat(pool.addLocal(message)).isCompletedWithValue(reject("Bad"));
     verifyNoInteractions(subscriber);
   }
 
@@ -90,7 +99,7 @@ class SyncCommitteeMessagePoolTest {
     pool.subscribeOperationAdded(subscriber);
     when(validator.validate(message)).thenReturn(SafeFuture.completedFuture(IGNORE));
 
-    assertThat(pool.add(message)).isCompletedWithValue(IGNORE);
+    assertThat(pool.addLocal(message)).isCompletedWithValue(IGNORE);
     verifyNoInteractions(subscriber);
   }
 
@@ -286,7 +295,7 @@ class SyncCommitteeMessagePoolTest {
   }
 
   private void addValid(final ValidateableSyncCommitteeMessage message0) {
-    assertThat(pool.add(message0)).isCompletedWithValue(ACCEPT);
+    assertThat(pool.addLocal(message0)).isCompletedWithValue(ACCEPT);
   }
 
   private void assertMessagesPresentForSlots(

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -76,7 +76,7 @@ import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannel;
 import tech.pegasys.teku.statetransition.EpochCachePrimer;
-import tech.pegasys.teku.statetransition.OperationAcceptedFilter;
+import tech.pegasys.teku.statetransition.LocalOperationAcceptedFilter;
 import tech.pegasys.teku.statetransition.OperationPool;
 import tech.pegasys.teku.statetransition.OperationsReOrgManager;
 import tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPool;
@@ -691,11 +691,11 @@ public class BeaconChainController extends Service
             .gossipedBlockProcessor(blockManager::validateAndImportBlock)
             .gossipedAttestationProcessor(attestationManager::addAttestation)
             .gossipedAggregateProcessor(attestationManager::addAggregate)
-            .gossipedAttesterSlashingProcessor(attesterSlashingPool::add)
-            .gossipedProposerSlashingProcessor(proposerSlashingPool::add)
-            .gossipedVoluntaryExitProcessor(voluntaryExitPool::add)
-            .gossipedSignedContributionAndProofProcessor(syncCommitteeContributionPool::add)
-            .gossipedSyncCommitteeMessageProcessor(syncCommitteeMessagePool::add)
+            .gossipedAttesterSlashingProcessor(attesterSlashingPool::addRemote)
+            .gossipedProposerSlashingProcessor(proposerSlashingPool::addRemote)
+            .gossipedVoluntaryExitProcessor(voluntaryExitPool::addRemote)
+            .gossipedSignedContributionAndProofProcessor(syncCommitteeContributionPool::addRemote)
+            .gossipedSyncCommitteeMessageProcessor(syncCommitteeMessagePool::addRemote)
             .processedAttestationSubscriptionProvider(
                 attestationManager::subscribeToAttestationsToSend)
             .historicalChainData(
@@ -709,15 +709,15 @@ public class BeaconChainController extends Service
             .build();
 
     syncCommitteeMessagePool.subscribeOperationAdded(
-        new OperationAcceptedFilter<>(p2pNetwork::publishSyncCommitteeMessage));
+        new LocalOperationAcceptedFilter<>(p2pNetwork::publishSyncCommitteeMessage));
     syncCommitteeContributionPool.subscribeOperationAdded(
-        new OperationAcceptedFilter<>(p2pNetwork::publishSyncCommitteeContribution));
+        new LocalOperationAcceptedFilter<>(p2pNetwork::publishSyncCommitteeContribution));
     proposerSlashingPool.subscribeOperationAdded(
-        new OperationAcceptedFilter<>(p2pNetwork::publishProposerSlashing));
+        new LocalOperationAcceptedFilter<>(p2pNetwork::publishProposerSlashing));
     attesterSlashingPool.subscribeOperationAdded(
-        new OperationAcceptedFilter<>(p2pNetwork::publishAttesterSlashing));
+        new LocalOperationAcceptedFilter<>(p2pNetwork::publishAttesterSlashing));
     voluntaryExitPool.subscribeOperationAdded(
-        new OperationAcceptedFilter<>(p2pNetwork::publishVoluntaryExit));
+        new LocalOperationAcceptedFilter<>(p2pNetwork::publishVoluntaryExit));
   }
 
   protected Eth2P2PNetworkBuilder createEth2P2PNetworkBuilder() {


### PR DESCRIPTION
## PR Description
libp2p already does duplicate message filtering for any cases where the same operation is sent to the REST API twice.

Avoid the need to serialise things we already know came from the network by only publishing locally received operations (remote ones are forwarded automatically by libp2p).

## Fixed Issue(s)
fixes #5120 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
