### PR TITLE
Change default execution engine version to kilnv2

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionengine/ExecutionEngineChannel.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionengine/ExecutionEngineChannel.java
@@ -91,6 +91,6 @@ public interface ExecutionEngineChannel extends ChannelInterface {
     KILN,
     KILNV2;
 
-    public static Version DEFAULT_VERSION = KINTSUGI;
+    public static Version DEFAULT_VERSION = KILNV2;
   }
 }


### PR DESCRIPTION
## PR Description
Switch default execution engine version to kilnv2 in preparation for kiln testnet launch. Kintsugi is well on the way out.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
