### PR TITLE
Mark blocks with default payload as VALID

### DIFF
--- a/ethereum/forkchoice/src/main/java/tech/pegasys/teku/ethereum/forkchoice/ProtoArray.java
+++ b/ethereum/forkchoice/src/main/java/tech/pegasys/teku/ethereum/forkchoice/ProtoArray.java
@@ -136,7 +136,7 @@ public class ProtoArray {
             UInt64.ZERO,
             Optional.empty(),
             Optional.empty(),
-            optimisticallyProcessed ? OPTIMISTIC : VALID);
+            optimisticallyProcessed && !executionBlockHash.isZero() ? OPTIMISTIC : VALID);
 
     indices.add(blockRoot, nodeIndex);
     nodes.add(node);

--- a/ethereum/forkchoice/src/test/java/tech/pegasys/teku/ethereum/forkchoice/ProtoArrayTest.java
+++ b/ethereum/forkchoice/src/test/java/tech/pegasys/teku/ethereum/forkchoice/ProtoArrayTest.java
@@ -440,6 +440,15 @@ class ProtoArrayTest {
     assertThat(protoArray.findOptimisticallySyncedMergeTransitionBlock(block4a)).isEmpty();
   }
 
+  @Test
+  void onBlock_shouldNotMarkDefaultPayloadAsOptimistic() {
+    addOptimisticBlock(1, block1a, GENESIS_CHECKPOINT.getRoot(), Bytes32.ZERO);
+    addOptimisticBlock(1, block1b, GENESIS_CHECKPOINT.getRoot(), dataStructureUtil.randomBytes32());
+
+    assertThat(protoArray.getProtoNode(block1a).orElseThrow().isOptimistic()).isFalse();
+    assertThat(protoArray.getProtoNode(block1b).orElseThrow().isOptimistic()).isTrue();
+  }
+
   private void assertHead(final Bytes32 expectedBlockHash) {
     assertThat(
             protoArray.findOptimisticHead(GENESIS_CHECKPOINT.getRoot(), UInt64.ZERO, UInt64.ZERO))

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
@@ -125,8 +125,6 @@ class ForkChoiceTest {
         .setTime(genesis.getState().getGenesis_time().plus(10L * spec.getSecondsPerSlot(ZERO)));
 
     forkChoice.subscribeToOptimisticHeadChangesAndUpdate(optimisticSyncStateTracker);
-    verify(optimisticSyncStateTracker).onOptimisticHeadChanged(true);
-    reset(optimisticSyncStateTracker);
   }
 
   @Test

--- a/storage/src/test/java/tech/pegasys/teku/storage/client/RecentChainDataTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/client/RecentChainDataTest.java
@@ -221,7 +221,7 @@ class RecentChainDataTest {
                 bestBlock.getStateRoot(),
                 bestBlock.getRoot(),
                 true,
-                true,
+                false, // Default execution payload so not optimistic
                 spec.getBeaconStateUtil(bestBlock.getSlot())
                     .getPreviousDutyDependentRoot(bestBlock.getState()),
                 spec.getBeaconStateUtil(bestBlock.getSlot())


### PR DESCRIPTION
## PR Description
When importing blocks to protoarray, mark any block with a default execution payload as fully validated even if the block processor may optimistically execute them.

## Fixed Issue(s)
fixes #5082

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
