### PR TITLE
Make execution_optimistic and canonical flags consistent

### DIFF
--- a/data/provider/src/main/java/tech/pegasys/teku/api/blockselector/BlockSelectorFactory.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/blockselector/BlockSelectorFactory.java
@@ -83,20 +83,37 @@ public class BlockSelectorFactory {
 
   private SafeFuture<Optional<BlockAndMetaData>> fromChainHead(final ChainHead head) {
     return head.getBlock()
-        .thenApply(maybeBlock -> lookupBlockData(maybeBlock, head.isOptimistic(), true));
+        .thenApply(maybeBlock -> lookupCanonicalBlockData(maybeBlock, head.isOptimistic()));
   }
 
   public BlockSelector nonCanonicalBlocksSelector(final UInt64 slot) {
-    return () ->
-        client.GetAllBlocksAtSlot(slot)
-            .thenApply(
-                blocks -> blocks.stream().map(this::lookupBlockData).collect(Collectors.toList()));
+    return () -> {
+      final Optional<ChainHead> maybeChainHead = client.getChainHead();
+      if (maybeChainHead.isEmpty()) {
+        return SafeFuture.completedFuture(Collections.emptyList());
+      }
+      final ChainHead chainHead = maybeChainHead.get();
+      return client
+          .getAllBlocksAtSlot(slot)
+          .thenApply(
+              blocks ->
+                  blocks.stream()
+                      .map(block -> lookupBlockData(block, chainHead))
+                      .collect(Collectors.toList()));
+    };
   }
 
   public BlockSelector finalizedSelector() {
     return () ->
         optionalToList(
-            SafeFuture.completedFuture(lookupBlockData(client.getFinalizedBlock(), true)));
+            SafeFuture.completedFuture(
+                // Finalized checkpoint is always canonical
+                lookupCanonicalBlockData(
+                    client.getFinalizedBlock(),
+                    // The finalized checkpoint may change because of optimistically imported blocks
+                    // at the head and if the head isn't optimistic, the finalized block can't be
+                    // optimistic.
+                    client.isChainHeadOptimistic())));
   }
 
   public BlockSelector genesisSelector() {
@@ -104,7 +121,7 @@ public class BlockSelectorFactory {
         optionalToList(
             client
                 .getBlockAtSlotExact(GENESIS_SLOT)
-                .thenApply(maybeBlock -> lookupBlockData(maybeBlock, false, true)));
+                .thenApply(maybeBlock -> lookupCanonicalBlockData(maybeBlock, false)));
   }
 
   public BlockSelector forSlot(final UInt64 slot) {
@@ -121,7 +138,7 @@ public class BlockSelectorFactory {
   private SafeFuture<Optional<BlockAndMetaData>> forSlot(final ChainHead head, final UInt64 slot) {
     return client
         .getBlockAtSlotExact(slot, head.getRoot())
-        .thenApply(maybeBlock -> lookupBlockData(maybeBlock, head.isOptimistic(), true));
+        .thenApply(maybeBlock -> lookupCanonicalBlockData(maybeBlock, head.isOptimistic()));
   }
 
   public BlockSelector forBlockRoot(final Bytes32 blockRoot) {
@@ -135,32 +152,27 @@ public class BlockSelectorFactory {
         maybeBlock -> maybeBlock.map(List::of).orElseGet(Collections::emptyList));
   }
 
-  private Optional<BlockAndMetaData> lookupBlockData(
-      final Optional<SignedBeaconBlock> maybeBlock, final boolean isCanonical) {
-    return maybeBlock.map(block -> lookupBlockData(block, isCanonical));
-  }
-
   private Optional<BlockAndMetaData> lookupBlockData(final Optional<SignedBeaconBlock> maybeBlock) {
-    return maybeBlock.map(this::lookupBlockData);
+    // Ensure we use the same chain head when calculating metadata to ensure a consistent view.
+    final Optional<ChainHead> chainHead = client.getChainHead();
+    if (maybeBlock.isEmpty() || chainHead.isEmpty()) {
+      return Optional.empty();
+    }
+    return Optional.of(lookupBlockData(maybeBlock.get(), chainHead.get()));
   }
 
-  private Optional<BlockAndMetaData> lookupBlockData(
-      final Optional<SignedBeaconBlock> maybeBlock,
-      final boolean isOptimistic,
-      final boolean isCanonical) {
-    return maybeBlock.map(block -> lookupBlockData(block, isOptimistic, isCanonical));
-  }
-
-  private BlockAndMetaData lookupBlockData(final SignedBeaconBlock block) {
-    return lookupBlockData(
-        block,
-        client.isOptimisticBlock(block.getRoot()),
-        client.isCanonicalBlock(block.getSlot(), block.getRoot()));
+  private Optional<BlockAndMetaData> lookupCanonicalBlockData(
+      final Optional<SignedBeaconBlock> maybeBlock, final boolean isOptimistic) {
+    return maybeBlock.map(block -> lookupBlockData(block, isOptimistic, true));
   }
 
   private BlockAndMetaData lookupBlockData(
-      final SignedBeaconBlock block, final boolean isCanonical) {
-    return lookupBlockData(block, client.isOptimisticBlock(block.getRoot()), isCanonical);
+      final SignedBeaconBlock block, final ChainHead chainHead) {
+    return lookupBlockData(
+        block,
+        // If the chain head is optimistic that will "taint" whether the block is canonical
+        chainHead.isOptimistic() || client.isOptimisticBlock(block.getRoot()),
+        client.isCanonicalBlock(block.getSlot(), block.getRoot(), chainHead.getRoot()));
   }
 
   private BlockAndMetaData lookupBlockData(

--- a/data/provider/src/main/java/tech/pegasys/teku/api/stateselector/StateSelectorFactory.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/stateselector/StateSelectorFactory.java
@@ -174,8 +174,4 @@ public class StateSelectorFactory {
         spec.isMilestoneSupported(SpecMilestone.BELLATRIX),
         canonical);
   }
-
-  private boolean isCheckpointOptimistic(final Bytes32 root) {
-    return client.isOptimisticBlock(root);
-  }
 }

--- a/data/provider/src/main/java/tech/pegasys/teku/api/stateselector/StateSelectorFactory.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/stateselector/StateSelectorFactory.java
@@ -100,10 +100,8 @@ public class StateSelectorFactory {
                         addMetaData(
                             finalized.getState(),
                             // The finalized checkpoint may change because of optimistically
-                            // imported blocks
-                            // at the head and if the head isn't optimistic, the finalized block
-                            // can't be
-                            // optimistic.
+                            // imported blocks at the head and if the head isn't optimistic, the
+                            // finalized block can't be optimistic.
                             client.isChainHeadOptimistic(),
                             true)));
   }
@@ -115,10 +113,10 @@ public class StateSelectorFactory {
             .thenApply(
                 maybeState ->
                     maybeState.map(
-                        state -> {
-                          BeaconBlockHeader header = BeaconBlockHeader.fromState(state);
-                          return addMetaData(state, isCheckpointOptimistic(header.getRoot()), true);
-                        }));
+                        // The justified checkpoint may change because of optimistically
+                        // imported blocks at the head and if the head isn't optimistic, the
+                        // justified block can't be optimistic.
+                        state -> addMetaData(state, client.isChainHeadOptimistic(), true)));
   }
 
   public StateSelector genesisSelector() {

--- a/data/provider/src/test/java/tech/pegasys/teku/api/blockselector/BlockSelectorFactoryTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/blockselector/BlockSelectorFactoryTest.java
@@ -75,9 +75,14 @@ public class BlockSelectorFactoryTest {
   @Test
   public void blockRootSelector_shouldGetBlockByBlockRoot()
       throws ExecutionException, InterruptedException {
+    final SignedBlockAndState head =
+        data.randomSignedBlockAndState(block.getSlot().plus(3), block.getRoot());
+    final ChainHead chainHead = ChainHead.create(head);
+    when(client.getChainHead()).thenReturn(Optional.of(chainHead));
+    when(client.isCanonicalBlock(block.getSlot(), block.getRoot(), chainHead.getRoot()))
+        .thenReturn(true);
     when(client.getBlockByBlockRoot(any()))
         .thenReturn(SafeFuture.completedFuture(Optional.of(block)));
-    when(client.isCanonicalBlock(any(), any())).thenReturn(true);
     List<BlockAndMetaData> blockList =
         blockSelectorFactory.forBlockRoot(block.getRoot()).getBlock().get();
     verify(client).getBlockByBlockRoot(block.getRoot());

--- a/data/provider/src/test/java/tech/pegasys/teku/api/stateselector/StateSelectorFactoryTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/stateselector/StateSelectorFactoryTest.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.api.stateselector;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -24,12 +23,14 @@ import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
+import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.api.exceptions.BadRequestException;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockHeader;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
@@ -71,7 +72,6 @@ public class StateSelectorFactoryTest {
   public void justifiedSelector_shouldGetJustifiedState()
       throws ExecutionException, InterruptedException {
     when(client.getJustifiedState()).thenReturn(SafeFuture.completedFuture(Optional.of(state)));
-    when(client.isCanonicalBlock(any(), any())).thenReturn(true);
     Optional<StateAndMetaData> result = factory.justifiedSelector().getState().get();
     assertThat(result).contains(withMetaData(state));
     verify(client).getJustifiedState();
@@ -101,9 +101,14 @@ public class StateSelectorFactoryTest {
   @Test
   public void forStateRoot_shouldGetStateAtSlotExact()
       throws ExecutionException, InterruptedException {
+    final Bytes32 blockRoot = BeaconBlockHeader.fromState(state).getRoot();
+    final SignedBlockAndState head =
+        data.randomSignedBlockAndState(state.getSlot().plus(3), blockRoot);
+    final ChainHead chainHead = ChainHead.create(head);
+    when(client.getChainHead()).thenReturn(Optional.of(chainHead));
+    when(client.isCanonicalBlock(state.getSlot(), blockRoot, chainHead.getRoot())).thenReturn(true);
     when(client.getStateByStateRoot(state.hashTreeRoot()))
         .thenReturn(SafeFuture.completedFuture(Optional.of(state)));
-    when(client.isCanonicalBlock(any(), any())).thenReturn(true);
     Optional<StateAndMetaData> result = factory.forStateRoot(state.hashTreeRoot()).getState().get();
     assertThat(result).contains(withMetaData(state));
     verify(client).getStateByStateRoot(state.hashTreeRoot());

--- a/storage/src/integration-test/java/tech/pegasys/teku/storage/client/AbstractCombinedChainDataClientTest.java
+++ b/storage/src/integration-test/java/tech/pegasys/teku/storage/client/AbstractCombinedChainDataClientTest.java
@@ -284,7 +284,12 @@ public abstract class AbstractCombinedChainDataClientTest {
         chainUpdater.advanceChain(targetBlock.getSlot().plus(UInt64.ONE));
     chainUpdater.updateBestBlock(bestBlock);
 
-    assertThat(client.isCanonicalBlock(targetBlock.getSlot(), targetBlock.getRoot())).isTrue();
+    assertThat(
+            client.isCanonicalBlock(
+                targetBlock.getSlot(),
+                targetBlock.getRoot(),
+                client.getChainHead().orElseThrow().getRoot()))
+        .isTrue();
   }
 
   @Test
@@ -294,7 +299,12 @@ public abstract class AbstractCombinedChainDataClientTest {
     final SignedBlockAndState bestBlock = chainUpdater.advanceChain(UInt64.ONE);
     chainUpdater.updateBestBlock(bestBlock);
 
-    assertThat(client.isCanonicalBlock(bestBlock.getSlot(), bestBlock.getRoot())).isTrue();
+    assertThat(
+            client.isCanonicalBlock(
+                bestBlock.getSlot(),
+                bestBlock.getRoot(),
+                client.getChainHead().orElseThrow().getRoot()))
+        .isTrue();
   }
 
   @Test
@@ -305,7 +315,12 @@ public abstract class AbstractCombinedChainDataClientTest {
     chainUpdater.updateBestBlock(bestBlock);
     final SignedBlockAndState targetBlock = chainBuilder.generateNextBlock();
 
-    assertThat(client.isCanonicalBlock(targetBlock.getSlot(), targetBlock.getRoot())).isFalse();
+    assertThat(
+            client.isCanonicalBlock(
+                targetBlock.getSlot(),
+                targetBlock.getRoot(),
+                client.getChainHead().orElseThrow().getRoot()))
+        .isFalse();
   }
 
   @Test
@@ -319,7 +334,12 @@ public abstract class AbstractCombinedChainDataClientTest {
     final SignedBlockAndState bestBlock = chainUpdater.advanceChain(parentBlock.getSlot().plus(2));
     chainUpdater.updateBestBlock(bestBlock);
 
-    assertThat(client.isCanonicalBlock(orphanBlock.getSlot(), orphanBlock.getRoot())).isFalse();
+    assertThat(
+            client.isCanonicalBlock(
+                orphanBlock.getSlot(),
+                orphanBlock.getRoot(),
+                client.getChainHead().orElseThrow().getRoot()))
+        .isFalse();
   }
 
   @Test


### PR DESCRIPTION
## PR Description
If the chain head is optimistically executed, that "taints" whether a block is canonical or not and so the `execution_optimistic` flag needs to be set.  Similarly the finalised and justified checkpoints may have been set based on later imported blocks so should be marked optimistic whenever the head is optimistic (and because they must be ancestors of the head, can't be optimistic unless the chain head is).

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
