### PR TITLE
Include execution_optimistic in finalized checkpoint events

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/DepositProvider.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/DepositProvider.java
@@ -98,7 +98,8 @@ public class DepositProvider implements Eth1EventsChannel, FinalizedCheckpointCh
   }
 
   @Override
-  public void onNewFinalizedCheckpoint(final Checkpoint checkpoint) {
+  public void onNewFinalizedCheckpoint(
+      final Checkpoint checkpoint, final boolean fromOptimisticBlock) {
     recentChainData
         .retrieveBlockState(checkpoint.getRoot())
         .thenAccept(

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/DepositProviderTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/DepositProviderTest.java
@@ -154,7 +154,7 @@ public class DepositProviderTest {
 
     assertThat(depositProvider.getDepositMapSize()).isEqualTo(20);
 
-    depositProvider.onNewFinalizedCheckpoint(new Checkpoint(UInt64.ONE, finalizedBlockRoot));
+    depositProvider.onNewFinalizedCheckpoint(new Checkpoint(UInt64.ONE, finalizedBlockRoot), false);
 
     assertThat(depositProvider.getDepositMapSize()).isEqualTo(10);
   }

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManager.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManager.java
@@ -176,12 +176,16 @@ public class EventSubscriptionManager implements ChainHeadChannel, FinalizedChec
   }
 
   @Override
-  public void onNewFinalizedCheckpoint(final Checkpoint checkpoint) {
+  public void onNewFinalizedCheckpoint(
+      final Checkpoint checkpoint, final boolean fromOptimisticBlock) {
     Optional<Bytes32> stateRoot = provider.getStateRootFromBlockRoot(checkpoint.getRoot());
-    final FinalizedCheckpointEvent checkpointString =
+    final FinalizedCheckpointEvent event =
         new FinalizedCheckpointEvent(
-            checkpoint.getRoot(), stateRoot.orElse(Bytes32.ZERO), checkpoint.getEpoch());
-    notifySubscribersOfEvent(EventType.finalized_checkpoint, checkpointString);
+            checkpoint.getRoot(),
+            stateRoot.orElse(Bytes32.ZERO),
+            checkpoint.getEpoch(),
+            getExecutionOptimisticForApi(fromOptimisticBlock));
+    notifySubscribersOfEvent(EventType.finalized_checkpoint, event);
   }
 
   protected void onSyncStateChange(final SyncState syncState) {

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManagerTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManagerTest.java
@@ -94,7 +94,7 @@ public class EventSubscriptionManagerTest {
       data.randomSignedContributionAndProof(0L);
 
   private final FinalizedCheckpointEvent sampleCheckpointEvent =
-      new FinalizedCheckpointEvent(data.randomBytes32(), data.randomBytes32(), epoch);
+      new FinalizedCheckpointEvent(data.randomBytes32(), data.randomBytes32(), epoch, null);
 
   private final SyncState sampleSyncState = SyncState.IN_SYNC;
   private final SignedBeaconBlock sampleBlock =
@@ -351,7 +351,7 @@ public class EventSubscriptionManagerTest {
 
   private void triggerFinalizedCheckpointEvent() {
     manager.onNewFinalizedCheckpoint(
-        new Checkpoint(sampleCheckpointEvent.epoch, sampleCheckpointEvent.block));
+        new Checkpoint(sampleCheckpointEvent.epoch, sampleCheckpointEvent.block), false);
     asyncRunner.executeQueuedActions();
   }
 

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/FinalizedCheckpointEvent.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/FinalizedCheckpointEvent.java
@@ -14,8 +14,11 @@
 package tech.pegasys.teku.api.response.v1;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.Objects;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -30,29 +33,41 @@ public class FinalizedCheckpointEvent {
   @JsonProperty("epoch")
   public final UInt64 epoch;
 
+  @JsonProperty("execution_optimistic")
+  @JsonInclude(Include.NON_NULL)
+  @Schema(hidden = true)
+  public final Boolean executionOptimistic;
+
   @JsonCreator
   public FinalizedCheckpointEvent(
       @JsonProperty("block") final Bytes32 block,
       @JsonProperty("state") final Bytes32 state,
-      @JsonProperty("epoch") final UInt64 epoch) {
+      @JsonProperty("epoch") final UInt64 epoch,
+      @JsonProperty("execution_optimistic") final Boolean executionOptimistic) {
     this.block = block;
     this.state = state;
     this.epoch = epoch;
+    this.executionOptimistic = executionOptimistic;
   }
 
   @Override
   public boolean equals(final Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
     final FinalizedCheckpointEvent that = (FinalizedCheckpointEvent) o;
     return Objects.equals(block, that.block)
         && Objects.equals(state, that.state)
-        && Objects.equals(epoch, that.epoch);
+        && Objects.equals(epoch, that.epoch)
+        && Objects.equals(executionOptimistic, that.executionOptimistic);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(block, state, epoch);
+    return Objects.hash(block, state, epoch, executionOptimistic);
   }
 
   @Override
@@ -61,6 +76,7 @@ public class FinalizedCheckpointEvent {
         .add("block", block)
         .add("state", state)
         .add("epoch", epoch)
+        .add("executionOptimistic", executionOptimistic)
         .toString();
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/MutableStore.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/MutableStore.java
@@ -37,7 +37,7 @@ public interface MutableStore extends ReadOnlyStore {
 
   void setJustifiedCheckpoint(Checkpoint justified_checkpoint);
 
-  void setFinalizedCheckpoint(Checkpoint finalized_checkpoint);
+  void setFinalizedCheckpoint(Checkpoint finalized_checkpoint, boolean fromOptimisticBlock);
 
   void setBestJustifiedCheckpoint(Checkpoint best_justified_checkpoint);
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
@@ -299,7 +299,10 @@ public class ForkChoiceUtil {
   }
 
   public void applyBlockToStore(
-      final MutableStore store, final SignedBeaconBlock signedBlock, final BeaconState postState) {
+      final MutableStore store,
+      final SignedBeaconBlock signedBlock,
+      final BeaconState postState,
+      final boolean isBlockOptimistic) {
     // Add new block to store
     store.putBlockAndState(signedBlock, postState);
 
@@ -319,7 +322,7 @@ public class ForkChoiceUtil {
     // Update finalized checkpoint
     final Checkpoint finalizedCheckpoint = postState.getFinalized_checkpoint();
     if (finalizedCheckpoint.getEpoch().compareTo(store.getFinalizedCheckpoint().getEpoch()) > 0) {
-      store.setFinalizedCheckpoint(finalizedCheckpoint);
+      store.setFinalizedCheckpoint(finalizedCheckpoint, isBlockOptimistic);
 
       // Potentially update justified if different from store
       if (!store.getJustifiedCheckpoint().equals(postState.getCurrent_justified_checkpoint())) {

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
@@ -268,7 +268,8 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
   }
 
   @Override
-  public void setFinalizedCheckpoint(final Checkpoint finalized_checkpoint) {
+  public void setFinalizedCheckpoint(
+      final Checkpoint finalized_checkpoint, final boolean fromOptimisticBlock) {
     this.finalized_checkpoint = finalized_checkpoint;
   }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -284,7 +284,8 @@ public class ForkChoice {
 
     final StoreTransaction transaction = recentChainData.startStoreTransaction();
     addParentStateRoots(spec, blockSlotState, transaction);
-    forkChoiceUtil.applyBlockToStore(transaction, block, postState);
+    forkChoiceUtil.applyBlockToStore(
+        transaction, block, postState, payloadResult.hasNotValidatedStatus());
 
     if (proposerBoostEnabled && spec.getCurrentSlot(transaction).equals(block.getSlot())) {
       final int secondsPerSlot = spec.getSecondsPerSlot(block.getSlot());

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/PendingPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/PendingPool.java
@@ -304,7 +304,8 @@ public class PendingPool<T> implements SlotEventsChannel, FinalizedCheckpointCha
   }
 
   @Override
-  public void onNewFinalizedCheckpoint(final Checkpoint checkpoint) {
+  public void onNewFinalizedCheckpoint(
+      final Checkpoint checkpoint, final boolean fromOptimisticBlock) {
     this.latestFinalizedSlot = checkpoint.getEpochStartSlot(spec);
   }
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockImporterTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockImporterTest.java
@@ -232,7 +232,7 @@ public class BlockImporterTest {
     final UInt64 bestEpoch = spec.computeEpochAtSlot(recentChainData.getHeadSlot());
     assertThat(bestEpoch).isEqualTo(SpecConfig.GENESIS_EPOCH.plus(1));
     final Checkpoint finalized = new Checkpoint(bestEpoch, bestRoot);
-    tx.setFinalizedCheckpoint(finalized);
+    tx.setFinalizedCheckpoint(finalized, false);
     tx.commit().join();
 
     // Known blocks should report as successfully imported
@@ -256,7 +256,7 @@ public class BlockImporterTest {
     final UInt64 bestEpoch = spec.computeEpochAtSlot(recentChainData.getHeadSlot());
     assertThat(bestEpoch).isEqualTo(SpecConfig.GENESIS_EPOCH.plus(1));
     final Checkpoint finalized = new Checkpoint(bestEpoch, bestRoot);
-    tx.setFinalizedCheckpoint(finalized);
+    tx.setFinalizedCheckpoint(finalized, false);
     tx.commit().join();
 
     // Import a block prior to the latest finalized block
@@ -332,7 +332,7 @@ public class BlockImporterTest {
     final Bytes32 finalizedRoot = recentChainData.getBestBlockRoot().orElseThrow();
     final UInt64 finalizedEpoch = UInt64.ONE;
     final Checkpoint finalized = new Checkpoint(finalizedEpoch, finalizedRoot);
-    tx.setFinalizedCheckpoint(finalized);
+    tx.setFinalizedCheckpoint(finalized, false);
     tx.commit().join();
 
     // Now create a new block that is not descendant from the finalized block

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/PendingPoolTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/PendingPoolTest.java
@@ -36,8 +36,8 @@ public class PendingPoolTest {
   private final PendingPool<SignedBeaconBlock> pendingPool =
       PendingPool.createForBlocks(spec, historicalTolerance, futureTolerance, maxItems);
   private UInt64 currentSlot = historicalTolerance.times(2);
-  private List<Bytes32> requiredRootEvents = new ArrayList<>();
-  private List<Bytes32> requiredRootDroppedEvents = new ArrayList<>();
+  private final List<Bytes32> requiredRootEvents = new ArrayList<>();
+  private final List<Bytes32> requiredRootDroppedEvents = new ArrayList<>();
 
   @BeforeEach
   public void setup() {
@@ -128,7 +128,7 @@ public class PendingPoolTest {
   public void add_nonFinalizedBlock() {
     final SignedBeaconBlock finalizedBlock = dataStructureUtil.randomSignedBeaconBlock(10);
     final Checkpoint checkpoint = finalizedCheckpoint(finalizedBlock);
-    pendingPool.onNewFinalizedCheckpoint(checkpoint);
+    pendingPool.onNewFinalizedCheckpoint(checkpoint, false);
 
     final UInt64 slot = checkpoint.getEpochStartSlot(spec).plus(UInt64.ONE);
     setSlot(slot);
@@ -147,7 +147,7 @@ public class PendingPoolTest {
   public void add_finalizedBlock() {
     final SignedBeaconBlock finalizedBlock = dataStructureUtil.randomSignedBeaconBlock(10);
     final Checkpoint checkpoint = finalizedCheckpoint(finalizedBlock);
-    pendingPool.onNewFinalizedCheckpoint(checkpoint);
+    pendingPool.onNewFinalizedCheckpoint(checkpoint, false);
     final long slot = checkpoint.getEpochStartSlot(spec).longValue() + 10;
     setSlot(slot);
 
@@ -442,7 +442,7 @@ public class PendingPoolTest {
     }
 
     // Update finalized checkpoint and prune
-    pendingPool.onNewFinalizedCheckpoint(checkpoint);
+    pendingPool.onNewFinalizedCheckpoint(checkpoint, false);
     pendingPool.prune();
 
     // Check that all final blocks have been pruned

--- a/storage/src/main/java/tech/pegasys/teku/storage/api/FinalizedCheckpointChannel.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/api/FinalizedCheckpointChannel.java
@@ -17,5 +17,5 @@ import tech.pegasys.teku.infrastructure.events.VoidReturningChannelInterface;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 
 public interface FinalizedCheckpointChannel extends VoidReturningChannelInterface {
-  void onNewFinalizedCheckpoint(final Checkpoint checkpoint);
+  void onNewFinalizedCheckpoint(Checkpoint checkpoint, boolean fromOptimisticBlock);
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
@@ -571,8 +571,9 @@ public abstract class RecentChainData implements StoreUpdateHandler {
   }
 
   @Override
-  public void onNewFinalizedCheckpoint(Checkpoint finalizedCheckpoint) {
-    finalizedCheckpointChannel.onNewFinalizedCheckpoint(finalizedCheckpoint);
+  public void onNewFinalizedCheckpoint(
+      final Checkpoint finalizedCheckpoint, final boolean fromOptimisticBlock) {
+    finalizedCheckpointChannel.onNewFinalizedCheckpoint(finalizedCheckpoint, fromOptimisticBlock);
   }
 
   public SafeFuture<Optional<BeaconState>> retrieveCheckpointState(final Checkpoint checkpoint) {

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransaction.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransaction.java
@@ -56,6 +56,7 @@ class StoreTransaction implements UpdatableStore.StoreTransaction {
   Optional<UInt64> genesisTime = Optional.empty();
   Optional<Checkpoint> justifiedCheckpoint = Optional.empty();
   Optional<Checkpoint> finalizedCheckpoint = Optional.empty();
+  boolean finalizedCheckpointOptimistic = false;
   Optional<Checkpoint> bestJustifiedCheckpoint = Optional.empty();
   Optional<Bytes32> proposerBoostRoot = Optional.empty();
   boolean proposerBoostRootSet = false;
@@ -118,8 +119,9 @@ class StoreTransaction implements UpdatableStore.StoreTransaction {
   }
 
   @Override
-  public void setFinalizedCheckpoint(Checkpoint finalized_checkpoint) {
+  public void setFinalizedCheckpoint(Checkpoint finalized_checkpoint, boolean fromOptimisticBlock) {
     this.finalizedCheckpoint = Optional.of(finalized_checkpoint);
+    this.finalizedCheckpointOptimistic = fromOptimisticBlock;
   }
 
   @Override
@@ -179,7 +181,10 @@ class StoreTransaction implements UpdatableStore.StoreTransaction {
                         }
 
                         // Signal back changes to the handler
-                        finalizedCheckpoint.ifPresent(updateHandler::onNewFinalizedCheckpoint);
+                        finalizedCheckpoint.ifPresent(
+                            checkpoint ->
+                                updateHandler.onNewFinalizedCheckpoint(
+                                    checkpoint, finalizedCheckpointOptimistic));
                       });
             });
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/UpdatableStore.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/UpdatableStore.java
@@ -48,8 +48,8 @@ public interface UpdatableStore extends ReadOnlyStore {
   }
 
   interface StoreUpdateHandler {
-    StoreUpdateHandler NOOP = finalizedCheckpoint -> {};
+    StoreUpdateHandler NOOP = (finalizedCheckpoint, fromOptimisticBlock) -> {};
 
-    void onNewFinalizedCheckpoint(Checkpoint finalizedCheckpoint);
+    void onNewFinalizedCheckpoint(Checkpoint finalizedCheckpoint, boolean fromOptimisticBlock);
   }
 }

--- a/storage/src/test/java/tech/pegasys/teku/storage/client/RecentChainDataTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/client/RecentChainDataTest.java
@@ -294,7 +294,7 @@ class RecentChainDataTest {
     assertThat(originalCheckpoint).isNotEqualTo(newCheckpoint); // Sanity check
 
     final StoreTransaction tx = recentChainData.startStoreTransaction();
-    tx.setFinalizedCheckpoint(newCheckpoint);
+    tx.setFinalizedCheckpoint(newCheckpoint, false);
 
     tx.commit().reportExceptions();
 
@@ -557,7 +557,7 @@ class RecentChainDataTest {
     // Initially finalized slot should match store
     assertThat(tx.getLatestFinalizedBlockSlot()).isEqualTo(genesis.getSlot());
     // Update checkpoint and check finalized slot accessors
-    tx.setFinalizedCheckpoint(new Checkpoint(epoch, finalizedBlock.getRoot()));
+    tx.setFinalizedCheckpoint(new Checkpoint(epoch, finalizedBlock.getRoot()), false);
     assertThat(tx.getLatestFinalizedBlockSlot()).isEqualTo(finalizedBlockSlot);
     assertThat(recentChainData.getStore().getLatestFinalizedBlockSlot())
         .isEqualTo(genesis.getSlot());
@@ -975,7 +975,7 @@ class RecentChainDataTest {
     // Add blocks and finalize epoch 1, so that blocks will be pruned
     final StoreTransaction tx = recentChainData.startStoreTransaction();
     final Checkpoint finalizedCheckpoint = chainBuilder.getCurrentCheckpointForEpoch(1);
-    tx.setFinalizedCheckpoint(finalizedCheckpoint);
+    tx.setFinalizedCheckpoint(finalizedCheckpoint, false);
     newBlocks.forEach(tx::putBlockAndState);
     tx.commit().reportExceptions();
 
@@ -1046,7 +1046,7 @@ class RecentChainDataTest {
     saveBlock(recentChainData, finalizedBlock);
 
     final StoreTransaction tx = recentChainData.startStoreTransaction();
-    tx.setFinalizedCheckpoint(new Checkpoint(epoch, finalizedBlock.getRoot()));
+    tx.setFinalizedCheckpoint(new Checkpoint(epoch, finalizedBlock.getRoot()), false);
     assertThat(tx.commit()).isCompleted();
   }
 

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/AbstractDatabaseTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/AbstractDatabaseTest.java
@@ -334,7 +334,7 @@ public abstract class AbstractDatabaseTest {
 
     // Finalize block2
     final StoreTransaction transaction = recentChainData.startStoreTransaction();
-    transaction.setFinalizedCheckpoint(finalizedCheckpoint);
+    transaction.setFinalizedCheckpoint(finalizedCheckpoint, false);
     commit(transaction);
 
     assertThat(database.getLatestAvailableFinalizedState(block2.getSlot()))
@@ -355,7 +355,7 @@ public abstract class AbstractDatabaseTest {
 
     final StoreTransaction transaction = recentChainData.startStoreTransaction();
     transaction.setGenesisTime(UInt64.valueOf(3));
-    transaction.setFinalizedCheckpoint(checkpoint1);
+    transaction.setFinalizedCheckpoint(checkpoint1, false);
     transaction.setJustifiedCheckpoint(checkpoint2);
     transaction.setBestJustifiedCheckpoint(checkpoint3);
 
@@ -554,7 +554,7 @@ public abstract class AbstractDatabaseTest {
     add(newBlocks);
     // Then finalize
     final StoreTransaction tx = recentChainData.startStoreTransaction();
-    tx.setFinalizedCheckpoint(finalizedCheckpoint);
+    tx.setFinalizedCheckpoint(finalizedCheckpoint, false);
     assertThat(tx.commit()).isCompleted();
 
     // All finalized blocks and states should be available
@@ -590,7 +590,7 @@ public abstract class AbstractDatabaseTest {
     final Checkpoint finalizedCheckpoint =
         chainBuilder.getCurrentCheckpointForEpoch(chainBuilder.getLatestEpoch());
     final StoreTransaction tx = recentChainData.startStoreTransaction();
-    tx.setFinalizedCheckpoint(finalizedCheckpoint);
+    tx.setFinalizedCheckpoint(finalizedCheckpoint, false);
     assertThat(tx.commit()).isCompleted();
 
     final Optional<SlotAndExecutionPayload> transitionPayload =
@@ -620,7 +620,7 @@ public abstract class AbstractDatabaseTest {
     final Checkpoint finalizedCheckpoint =
         chainBuilder.getCurrentCheckpointForEpoch(chainBuilder.getLatestEpoch());
     final StoreTransaction tx = recentChainData.startStoreTransaction();
-    tx.setFinalizedCheckpoint(finalizedCheckpoint);
+    tx.setFinalizedCheckpoint(finalizedCheckpoint, false);
     assertThat(tx.commit()).isCompleted();
 
     final Optional<ExecutionPayload> transitionPayload =
@@ -647,7 +647,7 @@ public abstract class AbstractDatabaseTest {
     final Checkpoint finalizedCheckpoint =
         chainBuilder.getCurrentCheckpointForEpoch(chainBuilder.getLatestEpoch());
     final StoreTransaction tx = recentChainData.startStoreTransaction();
-    tx.setFinalizedCheckpoint(finalizedCheckpoint);
+    tx.setFinalizedCheckpoint(finalizedCheckpoint, false);
     assertThat(tx.commit()).isCompleted();
 
     final Optional<SlotAndExecutionPayload> transitionPayload =
@@ -671,7 +671,7 @@ public abstract class AbstractDatabaseTest {
     final Checkpoint finalizedCheckpoint =
         chainBuilder.getCurrentCheckpointForEpoch(chainBuilder.getLatestEpoch());
     final StoreTransaction tx = recentChainData.startStoreTransaction();
-    tx.setFinalizedCheckpoint(finalizedCheckpoint);
+    tx.setFinalizedCheckpoint(finalizedCheckpoint, false);
     assertThat(tx.commit()).isCompleted();
 
     final Optional<SlotAndExecutionPayload> transitionPayload =
@@ -697,7 +697,7 @@ public abstract class AbstractDatabaseTest {
     final Checkpoint finalizedCheckpoint =
         chainBuilder.getCurrentCheckpointForEpoch(chainBuilder.getLatestEpoch());
     final StoreTransaction tx = recentChainData.startStoreTransaction();
-    tx.setFinalizedCheckpoint(finalizedCheckpoint);
+    tx.setFinalizedCheckpoint(finalizedCheckpoint, false);
     assertThat(tx.commit()).isCompleted();
     final Optional<SlotAndExecutionPayload> transitionPayload =
         SlotAndExecutionPayload.fromBlock(transitionBlock.getBlock());
@@ -730,7 +730,7 @@ public abstract class AbstractDatabaseTest {
     final Checkpoint finalizedCheckpoint =
         chainBuilder.getCurrentCheckpointForEpoch(chainBuilder.getLatestEpoch());
     final StoreTransaction tx = recentChainData.startStoreTransaction();
-    tx.setFinalizedCheckpoint(finalizedCheckpoint);
+    tx.setFinalizedCheckpoint(finalizedCheckpoint, false);
     assertThat(tx.commit()).isCompleted();
 
     // Finalize the next epoch
@@ -741,7 +741,7 @@ public abstract class AbstractDatabaseTest {
     final Checkpoint finalizedCheckpoint2 =
         chainBuilder.getCurrentCheckpointForEpoch(chainBuilder.getLatestEpoch());
     final StoreTransaction tx2 = recentChainData.startStoreTransaction();
-    tx2.setFinalizedCheckpoint(finalizedCheckpoint2);
+    tx2.setFinalizedCheckpoint(finalizedCheckpoint2, false);
     assertThat(tx2.commit()).isCompleted();
 
     final Optional<SlotAndExecutionPayload> transitionPayload =
@@ -1396,7 +1396,7 @@ public abstract class AbstractDatabaseTest {
   protected void finalizeEpoch(
       final UInt64 epoch, final SignedBlockAndState block, final StoreTransaction transaction) {
     final Checkpoint checkpoint = new Checkpoint(epoch, block.getRoot());
-    transaction.setFinalizedCheckpoint(checkpoint);
+    transaction.setFinalizedCheckpoint(checkpoint, false);
   }
 
   protected void justifyEpoch(

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/kvstore/AbstractKvStoreDatabaseTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/kvstore/AbstractKvStoreDatabaseTest.java
@@ -194,7 +194,7 @@ public abstract class AbstractKvStoreDatabaseTest extends AbstractStorageBackedD
     final Checkpoint newCheckpoint = getCheckpointForBlock(newBlock.getBlock());
     final StoreTransaction transaction = recentChainData.startStoreTransaction();
     transaction.putBlockAndState(newBlock);
-    transaction.setFinalizedCheckpoint(newCheckpoint);
+    transaction.setFinalizedCheckpoint(newCheckpoint, false);
     transaction.commit().reportExceptions();
     // Close db
     database.close();

--- a/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTest.java
@@ -212,7 +212,7 @@ class StoreTest extends AbstractStoreTest {
 
     final StoreTransaction tx = store.startTransaction(new StubStorageUpdateChannel());
     tx.putBlockAndState(finalizedBlockAndState);
-    tx.setFinalizedCheckpoint(finalizedCheckpoint);
+    tx.setFinalizedCheckpoint(finalizedCheckpoint, false);
     assertThat(tx.commit()).isCompleted();
 
     final SafeFuture<CheckpointState> result = store.retrieveFinalizedCheckpointAndState();
@@ -264,7 +264,7 @@ class StoreTest extends AbstractStoreTest {
     // Add blocks
     chainBuilder.streamBlocksAndStates().forEach(tx::putBlockAndState);
     // Update checkpoints
-    tx.setFinalizedCheckpoint(checkpoint1);
+    tx.setFinalizedCheckpoint(checkpoint1, false);
     tx.setJustifiedCheckpoint(checkpoint2);
     tx.setBestJustifiedCheckpoint(checkpoint3);
     // Update time

--- a/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTransactionTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTransactionTest.java
@@ -100,7 +100,7 @@ public class StoreTransactionTest extends AbstractStoreTest {
     addBlock(store, finalizedBlock);
 
     final StoreTransaction tx = store.startTransaction(storageUpdateChannel);
-    tx.setFinalizedCheckpoint(finalizedCheckpoint);
+    tx.setFinalizedCheckpoint(finalizedCheckpoint, false);
     assertThat(tx.getLatestFinalized().getRoot()).isEqualTo(finalizedBlock.getRoot());
   }
 
@@ -116,7 +116,7 @@ public class StoreTransactionTest extends AbstractStoreTest {
 
     final StoreTransaction tx = store.startTransaction(storageUpdateChannel);
     tx.putBlockAndState(finalizedBlock);
-    tx.setFinalizedCheckpoint(finalizedCheckpoint);
+    tx.setFinalizedCheckpoint(finalizedCheckpoint, false);
     assertThat(tx.getLatestFinalized().getRoot()).isEqualTo(finalizedBlock.getRoot());
   }
 
@@ -264,7 +264,7 @@ public class StoreTransactionTest extends AbstractStoreTest {
 
     final StoreTransaction tx = store.startTransaction(new StubStorageUpdateChannel());
     tx.putBlockAndState(finalizedBlockAndState);
-    tx.setFinalizedCheckpoint(finalizedCheckpoint);
+    tx.setFinalizedCheckpoint(finalizedCheckpoint, false);
 
     final SafeFuture<CheckpointState> result = tx.retrieveFinalizedCheckpointAndState();
     assertThat(result).isCompleted();
@@ -288,7 +288,7 @@ public class StoreTransactionTest extends AbstractStoreTest {
     assertThat(blockTx.commit()).isCompleted();
 
     final StoreTransaction tx = store.startTransaction(new StubStorageUpdateChannel());
-    tx.setFinalizedCheckpoint(finalizedCheckpoint);
+    tx.setFinalizedCheckpoint(finalizedCheckpoint, false);
 
     final SafeFuture<CheckpointState> result = tx.retrieveFinalizedCheckpointAndState();
     assertThat(result).isCompleted();
@@ -308,7 +308,7 @@ public class StoreTransactionTest extends AbstractStoreTest {
         new Checkpoint(UInt64.ONE, finalizedBlockAndState.getRoot());
 
     final StoreTransaction finalizingTx = store.startTransaction(new StubStorageUpdateChannel());
-    finalizingTx.setFinalizedCheckpoint(finalizedCheckpoint);
+    finalizingTx.setFinalizedCheckpoint(finalizedCheckpoint, false);
     finalizingTx.putBlockAndState(finalizedBlockAndState);
     assertThat(finalizingTx.commit()).isCompleted();
 
@@ -332,7 +332,7 @@ public class StoreTransactionTest extends AbstractStoreTest {
         new Checkpoint(UInt64.ONE, finalizedBlockAndState.getRoot());
 
     final SignedBlockAndState newerFinalizedBlockAndState =
-        chainBuilder.generateBlockAtSlot(spec.slotsPerEpoch(ZERO) * 2);
+        chainBuilder.generateBlockAtSlot(spec.slotsPerEpoch(ZERO) * 2L);
     final Checkpoint newerFinalizedCheckpoint =
         new Checkpoint(UInt64.valueOf(2), newerFinalizedBlockAndState.getRoot());
 
@@ -344,12 +344,12 @@ public class StoreTransactionTest extends AbstractStoreTest {
 
     // Start tx finalizing epoch 1
     final StoreTransaction tx = store.startTransaction(new StubStorageUpdateChannel());
-    tx.setFinalizedCheckpoint(finalizedCheckpoint);
+    tx.setFinalizedCheckpoint(finalizedCheckpoint, false);
 
     // Finalize epoch 2
     final StoreTransaction otherTx = store.startTransaction(new StubStorageUpdateChannel());
     otherTx.putBlockAndState(newerFinalizedBlockAndState);
-    otherTx.setFinalizedCheckpoint(newerFinalizedCheckpoint);
+    otherTx.setFinalizedCheckpoint(newerFinalizedCheckpoint, false);
     assertThat(otherTx.commit()).isCompleted();
 
     // Check response from tx1 for finalized value

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubFinalizedCheckpointChannel.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubFinalizedCheckpointChannel.java
@@ -18,5 +18,6 @@ import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 public class StubFinalizedCheckpointChannel implements FinalizedCheckpointChannel {
 
   @Override
-  public void onNewFinalizedCheckpoint(final Checkpoint checkpoint) {}
+  public void onNewFinalizedCheckpoint(
+      final Checkpoint checkpoint, final boolean fromOptimisticBlock) {}
 }

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/client/ChainUpdater.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/client/ChainUpdater.java
@@ -128,7 +128,7 @@ public class ChainUpdater {
     final Checkpoint checkpoint = new Checkpoint(epoch, blockAndState.getRoot());
 
     final StoreTransaction tx = recentChainData.startStoreTransaction();
-    tx.setFinalizedCheckpoint(checkpoint);
+    tx.setFinalizedCheckpoint(checkpoint, false);
     assertThat(tx.commit()).isDone();
 
     return blockAndState;
@@ -200,7 +200,7 @@ public class ChainUpdater {
     }
     final Checkpoint finalizedCheckpoint = bestBlock.getState().getFinalized_checkpoint();
     if (finalizedCheckpoint.getEpoch().isGreaterThan(recentChainData.getFinalizedEpoch())) {
-      tx.setFinalizedCheckpoint(finalizedCheckpoint);
+      tx.setFinalizedCheckpoint(finalizedCheckpoint, false);
     }
     assertThat(tx.commit()).isCompleted();
   }


### PR DESCRIPTION
## PR Description
Add `execution_optimistic` to new finalized checkpoint events. Set to true when the block that triggers finalization is optimistically imported.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
