### PR TITLE
Show default values for hidden options

### DIFF
--- a/teku/src/main/java/tech/pegasys/teku/cli/options/BeaconRestApiOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/BeaconRestApiOptions.java
@@ -104,6 +104,7 @@ public class BeaconRestApiOptions {
   @Option(
       names = {"--Xbeacon-liveness-tracking-enabled"},
       paramLabel = "<BOOLEAN>",
+      showDefaultValue = Visibility.ALWAYS,
       description = "Track validator liveness and enable requests to the liveness rest api.",
       arity = "0..1",
       fallbackValue = "true",

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ExecutionEngineOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ExecutionEngineOptions.java
@@ -36,8 +36,7 @@ public class ExecutionEngineOptions {
   @Option(
       names = {"--Xee-version"},
       paramLabel = "<EXECUTION_ENGINE_VERSION>",
-      description =
-          "Execution Engine API version. Possible values are: kintsugi (default), kiln or kilnV2",
+      description = "Execution Engine API version. " + "Valid values: ${COMPLETION-CANDIDATES}",
       arity = "1",
       hidden = true)
   private Version executionEngineVersion = Version.DEFAULT_VERSION;

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/LoggingOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/LoggingOptions.java
@@ -68,6 +68,7 @@ public class LoggingOptions {
       paramLabel = "<BOOLEAN>",
       description = "Whether warnings are logged for invalid P2P messages",
       hidden = true,
+      showDefaultValue = Visibility.ALWAYS,
       fallbackValue = "true",
       arity = "0..1")
   private boolean logIncludeP2pWarningsEnabled = false;
@@ -103,6 +104,7 @@ public class LoggingOptions {
   @Option(
       names = {"--Xlog-wire-cipher-enabled"},
       hidden = true,
+      showDefaultValue = Visibility.ALWAYS,
       paramLabel = "<BOOLEAN>",
       description = "Whether raw encrypted wire packets are logged",
       fallbackValue = "true",
@@ -112,6 +114,7 @@ public class LoggingOptions {
   @Option(
       names = {"--Xlog-wire-plain-enabled"},
       hidden = true,
+      showDefaultValue = Visibility.ALWAYS,
       paramLabel = "<BOOLEAN>",
       description = "Whether raw decrypted wire packets are logged",
       fallbackValue = "true",
@@ -121,6 +124,7 @@ public class LoggingOptions {
   @Option(
       names = {"--Xlog-wire-mux-enabled"},
       hidden = true,
+      showDefaultValue = Visibility.ALWAYS,
       paramLabel = "<BOOLEAN>",
       description = "Whether multiplexer wire packets (aka Libp2p stream frames) are logged",
       fallbackValue = "true",
@@ -130,6 +134,7 @@ public class LoggingOptions {
   @Option(
       names = {"--Xlog-wire-gossip-enabled"},
       hidden = true,
+      showDefaultValue = Visibility.ALWAYS,
       paramLabel = "<BOOLEAN>",
       description = "Whether gossip messages are logged",
       fallbackValue = "true",

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
@@ -56,6 +56,7 @@ public class ValidatorOptions {
   @Option(
       names = {"--validators-performance-tracking-enabled"},
       paramLabel = "<BOOLEAN>",
+      showDefaultValue = Visibility.ALWAYS,
       description = "Enable validator performance tracking",
       fallbackValue = "true",
       arity = "0..1",

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/UnstableOptionsCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/UnstableOptionsCommand.java
@@ -65,6 +65,7 @@ public class UnstableOptionsCommand implements Runnable, CommandLine.IHelpComman
       final String mixinName, final CommandLine.Model.CommandSpec commandSpec) {
     // Recreate the options but flip hidden to false.
     final CommandLine.Model.CommandSpec cs = CommandLine.Model.CommandSpec.create();
+    cs.usageMessage().showDefaultValues(true);
     commandSpec.options().stream()
         .filter(option -> option.hidden() && option.names()[0].startsWith("--X"))
         .forEach(option -> cs.addOption(option.toBuilder().hidden(false).build()));


### PR DESCRIPTION
## PR Description
Ensure that default values are shown for hidden options when using teku -X.

Also automatically list the possible options for execution engine version instead of hard coding.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
