### PR TITLE
Set the optimistic flag for known blocks correctly

### DIFF
--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -753,7 +753,7 @@ class ValidatorApiHandlerTest {
   public void sendSignedBlock_shouldConvertKnownBlockResult() {
     final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(5);
     when(blockImportChannel.importBlock(block))
-        .thenReturn(SafeFuture.completedFuture(BlockImportResult.knownBlock(block)));
+        .thenReturn(SafeFuture.completedFuture(BlockImportResult.knownBlock(block, false)));
     final SafeFuture<SendSignedBlockResult> result = validatorApiHandler.sendSignedBlock(block);
 
     verify(blockGossipChannel).publishBlock(block);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/results/BlockImportResult.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/results/BlockImportResult.java
@@ -55,8 +55,10 @@ public interface BlockImportResult {
     return new OptimisticSuccessfulBlockImportResult(block);
   }
 
-  static BlockImportResult knownBlock(final SignedBeaconBlock block) {
-    return new SuccessfulBlockImportResult(block);
+  static BlockImportResult knownBlock(final SignedBeaconBlock block, final boolean isOptimistic) {
+    return isOptimistic
+        ? new OptimisticSuccessfulBlockImportResult(block)
+        : new SuccessfulBlockImportResult(block);
   }
 
   enum FailureReason {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/BlockImporter.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/BlockImporter.java
@@ -78,11 +78,12 @@ public class BlockImporter {
 
   @CheckReturnValue
   public SafeFuture<BlockImportResult> importBlock(SignedBeaconBlock block) {
-    if (recentChainData.containsBlock(block.getMessage().hashTreeRoot())) {
+    final Optional<Boolean> knownOptimistic = recentChainData.isBlockOptimistic(block.getRoot());
+    if (knownOptimistic.isPresent()) {
       LOG.trace(
           "Importing known block {}.  Return successful result without re-processing.",
           () -> formatBlock(block));
-      return SafeFuture.completedFuture(BlockImportResult.knownBlock(block));
+      return SafeFuture.completedFuture(BlockImportResult.knownBlock(block, knownOptimistic.get()));
     }
 
     if (!weakSubjectivityValidator.isBlockValid(block, getForkChoiceStrategy())) {

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
@@ -570,6 +570,18 @@ public abstract class RecentChainData implements StoreUpdateHandler {
         .orElse(true);
   }
 
+  /**
+   * Returns empty if the block is unknown, or an optional indicating whether the block is
+   * optimistically imported or not.
+   *
+   * @param blockRoot the block to check
+   * @return empty if the block is unknown, Optional(true) when the block is optimistically imported
+   *     and Optional(false) when imported and fully validated.
+   */
+  public Optional<Boolean> isBlockOptimistic(final Bytes32 blockRoot) {
+    return getForkChoiceStrategy().flatMap(forkChoice -> forkChoice.isOptimistic(blockRoot));
+  }
+
   @Override
   public void onNewFinalizedCheckpoint(
       final Checkpoint finalizedCheckpoint, final boolean fromOptimisticBlock) {


### PR DESCRIPTION
## PR Description
Ensure the execution_optimistic value is set correctly for known blocks.

## Fixed Issue(s)
fixes #5109 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
