### PR TITLE
Add missing final to SafeFuture.COMPLETE constant.

### DIFF
--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
@@ -31,7 +31,7 @@ import java.util.stream.Stream;
 
 public class SafeFuture<T> extends CompletableFuture<T> {
 
-  public static SafeFuture<Void> COMPLETE = SafeFuture.completedFuture(null);
+  public static final SafeFuture<Void> COMPLETE = SafeFuture.completedFuture(null);
 
   public static void reportExceptions(final CompletionStage<?> future) {
     future.exceptionally(


### PR DESCRIPTION
## PR Description
The `SafeFuture.COMPLETE` constant was missing the `final` keyword.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
