### PR TITLE
[Bellatrix] Apply bellatrix transition overrides to `SpecConfig`

### DIFF
--- a/ethereum/networks/src/main/java/tech/pegasys/teku/networks/Eth2NetworkConfiguration.java
+++ b/ethereum/networks/src/main/java/tech/pegasys/teku/networks/Eth2NetworkConfiguration.java
@@ -217,8 +217,10 @@ public class Eth2NetworkConfiguration {
                         bellatrixBuilder.safeSlotsToImportOptimistically(
                             safeSlotsToImportOptimistically);
                         bellatrixForkEpoch.ifPresent(bellatrixBuilder::bellatrixForkEpoch);
-                        totalTerminalDifficultyOverride.ifPresent(bellatrixBuilder::terminalTotalDifficulty);
-                        terminalBlockHashEpochOverride.ifPresent(bellatrixBuilder::terminalBlockHashActivationEpoch);
+                        totalTerminalDifficultyOverride.ifPresent(
+                            bellatrixBuilder::terminalTotalDifficulty);
+                        terminalBlockHashEpochOverride.ifPresent(
+                            bellatrixBuilder::terminalBlockHashActivationEpoch);
                         terminalBlockHashOverride.ifPresent(bellatrixBuilder::terminalBlockHash);
                       });
                 });

--- a/ethereum/networks/src/main/java/tech/pegasys/teku/networks/Eth2NetworkConfiguration.java
+++ b/ethereum/networks/src/main/java/tech/pegasys/teku/networks/Eth2NetworkConfiguration.java
@@ -217,6 +217,9 @@ public class Eth2NetworkConfiguration {
                         bellatrixBuilder.safeSlotsToImportOptimistically(
                             safeSlotsToImportOptimistically);
                         bellatrixForkEpoch.ifPresent(bellatrixBuilder::bellatrixForkEpoch);
+                        totalTerminalDifficultyOverride.ifPresent(bellatrixBuilder::terminalTotalDifficulty);
+                        terminalBlockHashEpochOverride.ifPresent(bellatrixBuilder::terminalBlockHashActivationEpoch);
+                        terminalBlockHashOverride.ifPresent(bellatrixBuilder::terminalBlockHash);
                       });
                 });
       }


### PR DESCRIPTION
## PR Description
We were loading the transition overrides from CLI but never apply them to the actual `SpecConfig`

fixes:
`--Xnetwork-total-terminal-difficulty-override`
`--Xnetwork-terminal-block-hash-override`
`--Xnetwork-terminal-block-hash-epoch-override`

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
