### PR TITLE
[MEV Boost] PostBlindedBlock REST API

### DIFF
--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_beacon_blinded_blocks.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_beacon_blinded_blocks.json
@@ -1,0 +1,34 @@
+{
+  "post" : {
+    "tags" : [ "Beacon", "Validator Required Api", "Experimental" ],
+    "summary" : "Publish a signed blinded block",
+    "description" : "Submit a signed blinded beacon block to the beacon node to be imported. The beacon node performs the required validation.",
+    "operationId" : "postEthV1BeaconBlinded_blocks",
+    "requestBody" : {
+      "content" : {
+        "application/json" : {
+          "schema" : {
+            "$ref" : "#/components/schemas/SignedBlindedBlock"
+          }
+        }
+      }
+    },
+    "responses" : {
+      "200" : {
+        "description" : "Block has been successfully broadcast, validated and imported."
+      },
+      "202" : {
+        "description" : "Block has been successfully broadcast, but failed validation and has not been imported."
+      },
+      "400" : {
+        "description" : "Unable to parse request body."
+      },
+      "500" : {
+        "description" : "Beacon node experienced an internal error."
+      },
+      "503" : {
+        "description" : "Beacon node is currently syncing."
+      }
+    }
+  }
+}

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/SignedBlindedBeaconBlockBellatrix.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/SignedBlindedBeaconBlockBellatrix.json
@@ -1,0 +1,13 @@
+{
+  "type" : "object",
+  "properties" : {
+    "message" : {
+      "$ref" : "#/components/schemas/BlindedBlockBellatrix"
+    },
+    "signature" : {
+      "type" : "string",
+      "description" : "Bytes96 hexadecimal",
+      "format" : "byte"
+    }
+  }
+}

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/SignedBlindedBlock.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/SignedBlindedBlock.json
@@ -1,0 +1,10 @@
+{
+  "type" : "object",
+  "oneOf" : [ {
+    "$ref" : "#/components/schemas/SignedBeaconBlockPhase0"
+  }, {
+    "$ref" : "#/components/schemas/SignedBeaconBlockAltair"
+  }, {
+    "$ref" : "#/components/schemas/SignedBlindedBeaconBlockBellatrix"
+  } ]
+}

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApi.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApi.java
@@ -69,6 +69,7 @@ import tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.GetStateValidators;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.GetVoluntaryExits;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.PostAttestation;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.PostAttesterSlashing;
+import tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.PostBlindedBlock;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.PostBlock;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.PostProposerSlashing;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.PostSyncCommittees;
@@ -396,6 +397,7 @@ public class BeaconRestApi {
     app.get(GetBlockHeader.ROUTE, new GetBlockHeader(dataProvider, jsonProvider));
 
     app.post(PostBlock.ROUTE, new PostBlock(dataProvider, jsonProvider));
+    app.post(PostBlindedBlock.ROUTE, new PostBlindedBlock(dataProvider, jsonProvider));
 
     app.get(GetBlock.ROUTE, new GetBlock(dataProvider, jsonProvider));
     app.get(

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostBlindedBlock.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostBlindedBlock.java
@@ -115,7 +115,7 @@ public class PostBlindedBlock implements Handler {
       ctx.status(SC_BAD_REQUEST);
       ctx.json(BadRequest.badRequest(jsonProvider, ex.getMessage()));
     } catch (final Exception ex) {
-      LOG.error("Failed to post block due to internal error", ex);
+      LOG.error("Failed to post blinded block due to internal error", ex);
       ctx.status(SC_INTERNAL_SERVER_ERROR);
       ctx.json(BadRequest.internalError(jsonProvider, ex.getMessage()));
     }

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostBlindedBlock.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostBlindedBlock.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.beaconrestapi.handlers.v1.beacon;
+
+import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
+import static javax.servlet.http.HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
+import static javax.servlet.http.HttpServletResponse.SC_SERVICE_UNAVAILABLE;
+import static tech.pegasys.teku.infrastructure.http.RestApiConstants.RES_ACCEPTED;
+import static tech.pegasys.teku.infrastructure.http.RestApiConstants.RES_BAD_REQUEST;
+import static tech.pegasys.teku.infrastructure.http.RestApiConstants.RES_INTERNAL_ERROR;
+import static tech.pegasys.teku.infrastructure.http.RestApiConstants.RES_OK;
+import static tech.pegasys.teku.infrastructure.http.RestApiConstants.RES_SERVICE_UNAVAILABLE;
+import static tech.pegasys.teku.infrastructure.http.RestApiConstants.TAG_BEACON;
+import static tech.pegasys.teku.infrastructure.http.RestApiConstants.TAG_EXPERIMENTAL;
+import static tech.pegasys.teku.infrastructure.http.RestApiConstants.TAG_VALIDATOR_REQUIRED;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.javalin.http.Context;
+import io.javalin.http.Handler;
+import io.javalin.plugin.openapi.annotations.HttpMethod;
+import io.javalin.plugin.openapi.annotations.OpenApi;
+import io.javalin.plugin.openapi.annotations.OpenApiContent;
+import io.javalin.plugin.openapi.annotations.OpenApiRequestBody;
+import io.javalin.plugin.openapi.annotations.OpenApiResponse;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.NotNull;
+import tech.pegasys.teku.api.DataProvider;
+import tech.pegasys.teku.api.SyncDataProvider;
+import tech.pegasys.teku.api.ValidatorDataProvider;
+import tech.pegasys.teku.api.schema.SignedBeaconBlock;
+import tech.pegasys.teku.api.schema.interfaces.SignedBlindedBlock;
+import tech.pegasys.teku.beaconrestapi.schema.BadRequest;
+import tech.pegasys.teku.infrastructure.http.HttpStatusCodes;
+import tech.pegasys.teku.provider.JsonProvider;
+
+public class PostBlindedBlock implements Handler {
+  private static final Logger LOG = LogManager.getLogger();
+  public static final String ROUTE = "/eth/v1/beacon/blinded_blocks";
+
+  private final JsonProvider jsonProvider;
+  private final ValidatorDataProvider validatorDataProvider;
+  private final SyncDataProvider syncDataProvider;
+
+  public PostBlindedBlock(final DataProvider dataProvider, final JsonProvider jsonProvider) {
+    this.validatorDataProvider = dataProvider.getValidatorDataProvider();
+    this.syncDataProvider = dataProvider.getSyncDataProvider();
+    this.jsonProvider = jsonProvider;
+  }
+
+  PostBlindedBlock(
+      final ValidatorDataProvider validatorDataProvider,
+      final SyncDataProvider syncDataProvider,
+      final JsonProvider jsonProvider) {
+    this.jsonProvider = jsonProvider;
+    this.validatorDataProvider = validatorDataProvider;
+    this.syncDataProvider = syncDataProvider;
+  }
+
+  @OpenApi(
+      path = ROUTE,
+      method = HttpMethod.POST,
+      summary = "Publish a signed blinded block",
+      tags = {TAG_BEACON, TAG_VALIDATOR_REQUIRED, TAG_EXPERIMENTAL},
+      requestBody =
+          @OpenApiRequestBody(content = {@OpenApiContent(from = SignedBlindedBlock.class)}),
+      description =
+          "Submit a signed blinded beacon block to the beacon node to be imported."
+              + " The beacon node performs the required validation.",
+      responses = {
+        @OpenApiResponse(
+            status = RES_OK,
+            description = "Block has been successfully broadcast, validated and imported."),
+        @OpenApiResponse(
+            status = RES_ACCEPTED,
+            description =
+                "Block has been successfully broadcast, but failed validation and has not been imported."),
+        @OpenApiResponse(status = RES_BAD_REQUEST, description = "Unable to parse request body."),
+        @OpenApiResponse(
+            status = RES_INTERNAL_ERROR,
+            description = "Beacon node experienced an internal error."),
+        @OpenApiResponse(
+            status = RES_SERVICE_UNAVAILABLE,
+            description = "Beacon node is currently syncing.")
+      })
+  @Override
+  public void handle(@NotNull final Context ctx) throws Exception {
+    try {
+      if (syncDataProvider.isSyncing()) {
+        ctx.status(SC_SERVICE_UNAVAILABLE);
+        ctx.json(BadRequest.serviceUnavailable(jsonProvider));
+        return;
+      }
+
+      final SignedBeaconBlock signedBlindedBlock =
+          validatorDataProvider.parseBlindedBlock(jsonProvider, ctx.body());
+
+      LOG.debug("parsed block is from slot: " + signedBlindedBlock.getMessage().slot);
+
+      ctx.status(HttpStatusCodes.SC_BAD_REQUEST);
+      ctx.json(BadRequest.badRequest(jsonProvider, "Blinded blocks not implemented"));
+
+    } catch (final JsonProcessingException ex) {
+      ctx.status(SC_BAD_REQUEST);
+      ctx.json(BadRequest.badRequest(jsonProvider, ex.getMessage()));
+    } catch (final Exception ex) {
+      LOG.error("Failed to post block due to internal error", ex);
+      ctx.status(SC_INTERNAL_SERVER_ERROR);
+      ctx.json(BadRequest.internalError(jsonProvider, ex.getMessage()));
+    }
+  }
+}

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostBlindedBlock.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostBlindedBlock.java
@@ -106,7 +106,7 @@ public class PostBlindedBlock implements Handler {
       final SignedBeaconBlock signedBlindedBlock =
           validatorDataProvider.parseBlindedBlock(jsonProvider, ctx.body());
 
-      LOG.debug("parsed block is from slot: " + signedBlindedBlock.getMessage().slot);
+      LOG.debug("parsed block is from slot: {}", signedBlindedBlock.getMessage().slot);
 
       ctx.status(HttpStatusCodes.SC_BAD_REQUEST);
       ctx.json(BadRequest.badRequest(jsonProvider, "Blinded blocks not implemented"));

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/BeaconRestApiV1Test.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/BeaconRestApiV1Test.java
@@ -57,6 +57,7 @@ import tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.GetStateValidators;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.GetVoluntaryExits;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.PostAttestation;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.PostAttesterSlashing;
+import tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.PostBlindedBlock;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.PostBlock;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.PostProposerSlashing;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.PostVoluntaryExit;
@@ -265,6 +266,7 @@ public class BeaconRestApiV1Test {
         .add(Arguments.of(PostProposerSlashing.ROUTE, PostProposerSlashing.class))
         .add(Arguments.of(PostVoluntaryExit.ROUTE, PostVoluntaryExit.class))
         .add(Arguments.of(PostBlock.ROUTE, PostBlock.class))
+        .add(Arguments.of(PostBlindedBlock.ROUTE, PostBlindedBlock.class))
         .add(Arguments.of(PostValidatorLiveness.ROUTE, PostValidatorLiveness.class));
 
     // validator

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/schema/OneOfTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/schema/OneOfTest.java
@@ -88,19 +88,19 @@ public class OneOfTest {
                 isPhase0,
                 spec.forMilestone(SpecMilestone.PHASE0)
                     .getSchemaDefinitions()
-                    .getBlindedBlockSchema()
+                    .getBlindedBeaconBlockSchema()
                     .getJsonTypeDefinition())
             .withType(
                 isAltair,
                 spec.forMilestone(SpecMilestone.ALTAIR)
                     .getSchemaDefinitions()
-                    .getBlindedBlockSchema()
+                    .getBlindedBeaconBlockSchema()
                     .getJsonTypeDefinition())
             .withType(
                 isBellatrix,
                 spec.forMilestone(SpecMilestone.BELLATRIX)
                     .getSchemaDefinitions()
-                    .getBlindedBlockSchema()
+                    .getBlindedBeaconBlockSchema()
                     .getJsonTypeDefinition())
             .build();
 

--- a/data/provider/src/main/java/tech/pegasys/teku/api/SchemaObjectProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/SchemaObjectProvider.java
@@ -51,6 +51,14 @@ public class SchemaObjectProvider {
         getBeaconBlock(internalBlock.getMessage()), new BLSSignature(internalBlock.getSignature()));
   }
 
+  public SignedBeaconBlock getSignedBlindedBeaconBlock(
+      final tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock internalBlock) {
+
+    return new SignedBeaconBlock(
+        getBlindedBlock(internalBlock.getMessage()),
+        new BLSSignature(internalBlock.getSignature()));
+  }
+
   public BeaconBlock getBeaconBlock(
       final tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock block) {
     return getBeaconBlock(block, spec.atSlot(block.getSlot()).getMilestone());

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
@@ -50,6 +50,7 @@ import tech.pegasys.teku.api.schema.altair.SyncCommitteeMessage;
 import tech.pegasys.teku.api.schema.altair.SyncCommitteeSubnetSubscription;
 import tech.pegasys.teku.api.schema.bellatrix.BeaconPreparableProposer;
 import tech.pegasys.teku.api.schema.bellatrix.SignedBeaconBlockBellatrix;
+import tech.pegasys.teku.api.schema.bellatrix.SignedBlindedBeaconBlockBellatrix;
 import tech.pegasys.teku.api.schema.phase0.SignedBeaconBlockPhase0;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.http.HttpStatusCodes;
@@ -182,6 +183,29 @@ public class ValidatorDataProvider {
         throw new IllegalArgumentException("Could not determine milestone for slot " + slot);
     }
     return signedBeaconBlock;
+  }
+
+  public SignedBeaconBlock parseBlindedBlock(
+      final JsonProvider jsonProvider, final String jsonBlock) throws JsonProcessingException {
+    final ObjectMapper mapper = jsonProvider.getObjectMapper();
+    final JsonNode jsonNode = mapper.readTree(jsonBlock);
+    final UInt64 slot = mapper.treeToValue(jsonNode.findValue("slot"), UInt64.class);
+    final SignedBeaconBlock signedBlindedBlock;
+    checkNotNull(slot, "Slot was not found in json block");
+    switch (spec.atSlot(slot).getMilestone()) {
+      case PHASE0:
+        signedBlindedBlock = mapper.treeToValue(jsonNode, SignedBeaconBlockPhase0.class);
+        break;
+      case ALTAIR:
+        signedBlindedBlock = mapper.treeToValue(jsonNode, SignedBeaconBlockAltair.class);
+        break;
+      case BELLATRIX:
+        signedBlindedBlock = mapper.treeToValue(jsonNode, SignedBlindedBeaconBlockBellatrix.class);
+        break;
+      default:
+        throw new IllegalArgumentException("Could not determine milestone for slot " + slot);
+    }
+    return signedBlindedBlock;
   }
 
   public SafeFuture<ValidatorBlockResult> submitSignedBlock(

--- a/data/provider/src/test/java/tech/pegasys/teku/api/ValidatorDataProviderTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/ValidatorDataProviderTest.java
@@ -197,6 +197,21 @@ public class ValidatorDataProviderTest {
   }
 
   @TestTemplate
+  void parseBlock_shouldParseBlindedBlocks() throws JsonProcessingException {
+    final SignedBeaconBlock internalSignedBlock =
+        dataStructureUtil.randomSignedBlindedBeaconBlock(ONE);
+    final tech.pegasys.teku.api.schema.SignedBeaconBlock signedBlock =
+        schemaProvider.getSignedBlindedBeaconBlock(internalSignedBlock);
+    final String signedBlockJson = jsonProvider.objectToJSON(signedBlock);
+
+    final tech.pegasys.teku.api.schema.SignedBeaconBlock parsedBlock =
+        provider.parseBlindedBlock(jsonProvider, signedBlockJson);
+
+    assertThat(parsedBlock).isEqualTo(signedBlock);
+    assertThat(parsedBlock).isInstanceOf(tech.pegasys.teku.api.schema.SignedBeaconBlock.class);
+  }
+
+  @TestTemplate
   void parseBlock_shouldParseMilestoneSpecificBlocks(SpecContext specContext)
       throws JsonProcessingException {
     final SignedBeaconBlock internalSignedBlock = dataStructureUtil.randomSignedBeaconBlock(ONE);

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/bellatrix/SignedBlindedBeaconBlockBellatrix.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/bellatrix/SignedBlindedBeaconBlockBellatrix.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.api.schema.bellatrix;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import tech.pegasys.teku.api.schema.BLSSignature;
+import tech.pegasys.teku.api.schema.SignedBeaconBlock;
+import tech.pegasys.teku.api.schema.interfaces.SignedBlock;
+
+public class SignedBlindedBeaconBlockBellatrix extends SignedBeaconBlock implements SignedBlock {
+  private final BlindedBlockBellatrix message;
+
+  public SignedBlindedBeaconBlockBellatrix(
+      tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock internalBlock) {
+    super(internalBlock);
+    checkArgument(
+        internalBlock.getMessage().getBody().isBlinded(), "requires a signed blinded beacon block");
+    this.message = new BlindedBlockBellatrix(internalBlock.getMessage());
+  }
+
+  @Override
+  public BlindedBlockBellatrix getMessage() {
+    return message;
+  }
+
+  @JsonCreator
+  public SignedBlindedBeaconBlockBellatrix(
+      @JsonProperty("message") final BlindedBlockBellatrix message,
+      @JsonProperty("signature") final BLSSignature signature) {
+    super(message, signature);
+    this.message = message;
+  }
+}

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/interfaces/SignedBlindedBlock.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/interfaces/SignedBlindedBlock.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.api.schema.interfaces;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import tech.pegasys.teku.api.schema.altair.SignedBeaconBlockAltair;
+import tech.pegasys.teku.api.schema.bellatrix.SignedBlindedBeaconBlockBellatrix;
+import tech.pegasys.teku.api.schema.phase0.SignedBeaconBlockPhase0;
+
+@Schema(
+    oneOf = {
+      SignedBeaconBlockPhase0.class,
+      SignedBeaconBlockAltair.class,
+      SignedBlindedBeaconBlockBellatrix.class
+    })
+public interface SignedBlindedBlock {}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBeaconBlock.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBeaconBlock.java
@@ -40,9 +40,7 @@ public class SignedBeaconBlock extends Container2<SignedBeaconBlock, BeaconBlock
         message.getBody().isBlinded()
             ? spec.atSlot(message.getSlot())
                 .getSchemaDefinitions()
-                .toVersionBellatrix()
-                .orElseThrow()
-                .getSignedBlindedBeaconBlockBodySchema()
+                .getSignedBlindedBeaconBlockSchema()
             : spec.atSlot(message.getSlot()).getSchemaDefinitions().getSignedBeaconBlockSchema();
     return new SignedBeaconBlock(signedBeaconBlockSchema, message, signature);
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BeaconBlockBodyBellatrix.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BeaconBlockBodyBellatrix.java
@@ -13,8 +13,6 @@
 
 package tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.bellatrix;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 import java.util.Optional;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.BeaconBlockBodyAltair;
@@ -24,11 +22,11 @@ import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 public interface BeaconBlockBodyBellatrix extends BeaconBlockBodyAltair {
 
   static BeaconBlockBodyBellatrix required(final BeaconBlockBody body) {
-    checkArgument(
-        body instanceof BeaconBlockBodyBellatrix,
-        "Expected bellatrix block body but got %s",
-        body.getClass());
-    return (BeaconBlockBodyBellatrix) body;
+    return body.toVersionBellatrix()
+        .orElseThrow(
+            () ->
+                new IllegalArgumentException(
+                    "Expected bellatrix block body but got " + body.getClass().getSimpleName()));
   }
 
   ExecutionPayload getExecutionPayload();

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitions.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitions.java
@@ -42,6 +42,8 @@ public interface SchemaDefinitions {
 
   BeaconBlockBodySchema<?> getBlindedBlockBodySchema();
 
+  SignedBeaconBlockSchema getSignedBlindedBeaconBlockSchema();
+
   MetadataMessageSchema<?> getMetadataMessageSchema();
 
   SszBitvectorSchema<SszBitvector> getAttnetsENRFieldSchema();

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitions.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitions.java
@@ -38,9 +38,9 @@ public interface SchemaDefinitions {
 
   BeaconBlockBodySchema<?> getBeaconBlockBodySchema();
 
-  BeaconBlockSchema getBlindedBlockSchema();
+  BeaconBlockSchema getBlindedBeaconBlockSchema();
 
-  BeaconBlockBodySchema<?> getBlindedBlockBodySchema();
+  BeaconBlockBodySchema<?> getBlindedBeaconBlockBodySchema();
 
   SignedBeaconBlockSchema getSignedBlindedBeaconBlockSchema();
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsAltair.java
@@ -99,6 +99,11 @@ public class SchemaDefinitionsAltair extends AbstractSchemaDefinitions {
   }
 
   @Override
+  public SignedBeaconBlockSchema getSignedBlindedBeaconBlockSchema() {
+    return getSignedBeaconBlockSchema();
+  }
+
+  @Override
   public MetadataMessageSchemaAltair getMetadataMessageSchema() {
     return metadataMessageSchema;
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsAltair.java
@@ -89,12 +89,12 @@ public class SchemaDefinitionsAltair extends AbstractSchemaDefinitions {
   }
 
   @Override
-  public BeaconBlockSchema getBlindedBlockSchema() {
+  public BeaconBlockSchema getBlindedBeaconBlockSchema() {
     return getBeaconBlockSchema();
   }
 
   @Override
-  public BeaconBlockBodySchema<?> getBlindedBlockBodySchema() {
+  public BeaconBlockBodySchema<?> getBlindedBeaconBlockBodySchema() {
     return getBeaconBlockBodySchema();
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsBellatrix.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsBellatrix.java
@@ -84,12 +84,12 @@ public class SchemaDefinitionsBellatrix extends SchemaDefinitionsAltair {
   }
 
   @Override
-  public BeaconBlockSchema getBlindedBlockSchema() {
+  public BeaconBlockSchema getBlindedBeaconBlockSchema() {
     return blindedBeaconBlockSchema;
   }
 
   @Override
-  public BeaconBlockBodySchema<?> getBlindedBlockBodySchema() {
+  public BeaconBlockBodySchema<?> getBlindedBeaconBlockBodySchema() {
     return blindedBeaconBlockBodySchema;
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsBellatrix.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsBellatrix.java
@@ -98,15 +98,8 @@ public class SchemaDefinitionsBellatrix extends SchemaDefinitionsAltair {
     return beaconBlockBodySchema;
   }
 
-  public BeaconBlockBodySchema<?> getBlindedBeaconBlockBodySchema() {
-    return blindedBeaconBlockBodySchema;
-  }
-
-  public BeaconBlockSchema getBlindedBeaconBlockSchema() {
-    return blindedBeaconBlockSchema;
-  }
-
-  public SignedBeaconBlockSchema getSignedBlindedBeaconBlockBodySchema() {
+  @Override
+  public SignedBeaconBlockSchema getSignedBlindedBeaconBlockSchema() {
     return signedBlindedBeaconBlockSchema;
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsPhase0.java
@@ -68,6 +68,11 @@ public class SchemaDefinitionsPhase0 extends AbstractSchemaDefinitions {
   }
 
   @Override
+  public SignedBeaconBlockSchema getSignedBlindedBeaconBlockSchema() {
+    return getSignedBeaconBlockSchema();
+  }
+
+  @Override
   public MetadataMessageSchemaPhase0 getMetadataMessageSchema() {
     return metadataMessageSchema;
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsPhase0.java
@@ -58,12 +58,12 @@ public class SchemaDefinitionsPhase0 extends AbstractSchemaDefinitions {
   }
 
   @Override
-  public BeaconBlockSchema getBlindedBlockSchema() {
+  public BeaconBlockSchema getBlindedBeaconBlockSchema() {
     return getBeaconBlockSchema();
   }
 
   @Override
-  public BeaconBlockBodySchema<?> getBlindedBlockBodySchema() {
+  public BeaconBlockBodySchema<?> getBlindedBeaconBlockBodySchema() {
     return getBeaconBlockBodySchema();
   }
 

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -719,7 +719,7 @@ public final class DataStructureUtil {
     BeaconBlockBody body = randomBlindedBeaconBlockBody(slotNum);
 
     return new BeaconBlock(
-        spec.atSlot(slotNum).getSchemaDefinitions().getBlindedBlockSchema(),
+        spec.atSlot(slotNum).getSchemaDefinitions().getBlindedBeaconBlockSchema(),
         slotNum,
         proposer_index,
         previous_root,
@@ -832,7 +832,7 @@ public final class DataStructureUtil {
 
   public BeaconBlockBody randomBlindedBeaconBlockBody(UInt64 slotNum) {
     BeaconBlockBodySchema<?> schema =
-        spec.atSlot(slotNum).getSchemaDefinitions().getBlindedBlockBodySchema();
+        spec.atSlot(slotNum).getSchemaDefinitions().getBlindedBeaconBlockBodySchema();
 
     return schema.createBlockBody(
         builder ->

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -637,6 +637,16 @@ public final class DataStructureUtil {
     return signedBlock(beaconBlock);
   }
 
+  public SignedBeaconBlock randomSignedBlindedBeaconBlock(long slotNum) {
+    final BeaconBlock beaconBlock = randomBlindedBeaconBlock(UInt64.valueOf(slotNum));
+    return signedBlock(beaconBlock);
+  }
+
+  public SignedBeaconBlock randomSignedBlindedBeaconBlock(UInt64 slotNum) {
+    final BeaconBlock beaconBlock = randomBlindedBeaconBlock(slotNum);
+    return signedBlock(beaconBlock);
+  }
+
   public SignedBeaconBlock randomSignedBeaconBlock(long slotNum) {
     return randomSignedBeaconBlock(UInt64.valueOf(slotNum));
   }
@@ -709,11 +719,7 @@ public final class DataStructureUtil {
     BeaconBlockBody body = randomBlindedBeaconBlockBody(slotNum);
 
     return new BeaconBlock(
-        spec.atSlot(slotNum)
-            .getSchemaDefinitions()
-            .toVersionBellatrix()
-            .orElseThrow()
-            .getBlindedBeaconBlockSchema(),
+        spec.atSlot(slotNum).getSchemaDefinitions().getBlindedBlockSchema(),
         slotNum,
         proposer_index,
         previous_root,
@@ -826,11 +832,7 @@ public final class DataStructureUtil {
 
   public BeaconBlockBody randomBlindedBeaconBlockBody(UInt64 slotNum) {
     BeaconBlockBodySchema<?> schema =
-        spec.atSlot(slotNum)
-            .getSchemaDefinitions()
-            .toVersionBellatrix()
-            .orElseThrow()
-            .getBlindedBeaconBlockBodySchema();
+        spec.atSlot(slotNum).getSchemaDefinitions().getBlindedBlockBodySchema();
 
     return schema.createBlockBody(
         builder ->


### PR DESCRIPTION
Prepares `PostBlindedBlock` in the old framework.
The backend implementation will follow-up.

I'd suggest to move it to the new framework together with `GetNewBlindedBlock`

Make `BlindedBeaconBlock` parsing work.

Fixes `SchemaDefinitions` method names.

## PR Description

#5097

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
