### PR TITLE
Add labelled gauge showing the number of items in pending pools

### DIFF
--- a/beacon/sync/src/testFixtures/java/tech/pegasys/teku/beacon/sync/SyncingNodeManager.java
+++ b/beacon/sync/src/testFixtures/java/tech/pegasys/teku/beacon/sync/SyncingNodeManager.java
@@ -51,6 +51,7 @@ import tech.pegasys.teku.statetransition.forkchoice.MergeTransitionBlockValidato
 import tech.pegasys.teku.statetransition.forkchoice.StubForkChoiceNotifier;
 import tech.pegasys.teku.statetransition.util.FutureItems;
 import tech.pegasys.teku.statetransition.util.PendingPool;
+import tech.pegasys.teku.statetransition.util.PendingPoolFactory;
 import tech.pegasys.teku.statetransition.validation.BlockValidator;
 import tech.pegasys.teku.storage.api.FinalizedCheckpointChannel;
 import tech.pegasys.teku.storage.client.MemoryOnlyRecentChainData;
@@ -113,7 +114,8 @@ public class SyncingNodeManager {
             new StubExecutionEngineChannel(spec));
 
     BlockValidator blockValidator = new BlockValidator(spec, recentChainData);
-    final PendingPool<SignedBeaconBlock> pendingBlocks = PendingPool.createForBlocks(spec);
+    final PendingPool<SignedBeaconBlock> pendingBlocks =
+        new PendingPoolFactory(new NoOpMetricsSystem()).createForBlocks(spec);
     final FutureItems<SignedBeaconBlock> futureBlocks =
         FutureItems.create(SignedBeaconBlock::getSlot);
     BlockManager blockManager =

--- a/ethereum/statetransition/src/integration-test/java/tech/pegasys/teku/statetransition/attestation/AttestationManagerIntegrationTest.java
+++ b/ethereum/statetransition/src/integration-test/java/tech/pegasys/teku/statetransition/attestation/AttestationManagerIntegrationTest.java
@@ -42,6 +42,7 @@ import tech.pegasys.teku.statetransition.forkchoice.MergeTransitionBlockValidato
 import tech.pegasys.teku.statetransition.forkchoice.StubForkChoiceNotifier;
 import tech.pegasys.teku.statetransition.util.FutureItems;
 import tech.pegasys.teku.statetransition.util.PendingPool;
+import tech.pegasys.teku.statetransition.util.PendingPoolFactory;
 import tech.pegasys.teku.statetransition.validation.AggregateAttestationValidator;
 import tech.pegasys.teku.statetransition.validation.AttestationValidator;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
@@ -75,7 +76,7 @@ class AttestationManagerIntegrationTest {
           transitionBlockValidator);
 
   private final PendingPool<ValidateableAttestation> pendingAttestations =
-      PendingPool.createForAttestations(spec);
+      new PendingPoolFactory(storageSystem.getMetricsSystem()).createForAttestations(spec);
   private final FutureItems<ValidateableAttestation> futureAttestations =
       FutureItems.create(ValidateableAttestation::getEarliestSlotForForkChoiceProcessing);
   private final SignatureVerificationService signatureVerificationService =

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/PendingPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/PendingPool.java
@@ -91,6 +91,7 @@ public class PendingPool<T> implements SlotEventsChannel, FinalizedCheckpointCha
     this.requiredBlockRootsFunction = requiredBlockRootsFunction;
     this.targetSlotFunction = targetSlotFunction;
     this.sizeGauge = sizeGauge;
+    sizeGauge.set(0, itemType); // Init the label so it appears in metrics immediately
   }
 
   public synchronized void add(T item) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/PendingPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/PendingPool.java
@@ -35,11 +35,10 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.ethereum.events.SlotEventsChannel;
+import tech.pegasys.teku.infrastructure.metrics.SettableLabelledGauge;
 import tech.pegasys.teku.infrastructure.subscribers.Subscribers;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.datastructures.attestation.ValidateableAttestation;
-import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.storage.api.FinalizedCheckpointChannel;
 
@@ -48,9 +47,8 @@ public class PendingPool<T> implements SlotEventsChannel, FinalizedCheckpointCha
 
   private static final Comparator<SlotAndRoot> SLOT_AND_ROOT_COMPARATOR =
       Comparator.comparing(SlotAndRoot::getSlot).thenComparing(SlotAndRoot::getRoot);
-  private static final UInt64 DEFAULT_HISTORICAL_SLOT_TOLERANCE = UInt64.valueOf(320);
-  private static final int DEFAULT_MAX_ITEMS = 5000;
 
+  private final String itemType;
   private final Spec spec;
   private final Subscribers<RequiredBlockRootSubscriber> requiredBlockRootSubscribers =
       Subscribers.create(true);
@@ -69,11 +67,14 @@ public class PendingPool<T> implements SlotEventsChannel, FinalizedCheckpointCha
   private final Function<T, Bytes32> hashTreeRootFunction;
   private final Function<T, Collection<Bytes32>> requiredBlockRootsFunction;
   private final Function<T, UInt64> targetSlotFunction;
+  private final SettableLabelledGauge sizeGauge;
 
   private volatile UInt64 currentSlot = UInt64.ZERO;
   private volatile UInt64 latestFinalizedSlot = GENESIS_SLOT;
 
   PendingPool(
+      final SettableLabelledGauge sizeGauge,
+      final String itemType,
       final Spec spec,
       final UInt64 historicalSlotTolerance,
       final UInt64 futureSlotTolerance,
@@ -81,6 +82,7 @@ public class PendingPool<T> implements SlotEventsChannel, FinalizedCheckpointCha
       final Function<T, Bytes32> hashTreeRootFunction,
       final Function<T, Collection<Bytes32>> requiredBlockRootsFunction,
       final Function<T, UInt64> targetSlotFunction) {
+    this.itemType = itemType;
     this.spec = spec;
     this.historicalSlotTolerance = historicalSlotTolerance;
     this.futureSlotTolerance = futureSlotTolerance;
@@ -88,40 +90,7 @@ public class PendingPool<T> implements SlotEventsChannel, FinalizedCheckpointCha
     this.hashTreeRootFunction = hashTreeRootFunction;
     this.requiredBlockRootsFunction = requiredBlockRootsFunction;
     this.targetSlotFunction = targetSlotFunction;
-  }
-
-  public static PendingPool<SignedBeaconBlock> createForBlocks(final Spec spec) {
-    return createForBlocks(
-        spec,
-        DEFAULT_HISTORICAL_SLOT_TOLERANCE,
-        FutureItems.DEFAULT_FUTURE_SLOT_TOLERANCE,
-        DEFAULT_MAX_ITEMS);
-  }
-
-  public static PendingPool<SignedBeaconBlock> createForBlocks(
-      final Spec spec,
-      final UInt64 historicalBlockTolerance,
-      final UInt64 futureBlockTolerance,
-      final int maxItems) {
-    return new PendingPool<>(
-        spec,
-        historicalBlockTolerance,
-        futureBlockTolerance,
-        maxItems,
-        block -> block.getMessage().hashTreeRoot(),
-        block -> Collections.singleton(block.getParentRoot()),
-        SignedBeaconBlock::getSlot);
-  }
-
-  public static PendingPool<ValidateableAttestation> createForAttestations(final Spec spec) {
-    return new PendingPool<>(
-        spec,
-        DEFAULT_HISTORICAL_SLOT_TOLERANCE,
-        FutureItems.DEFAULT_FUTURE_SLOT_TOLERANCE,
-        DEFAULT_MAX_ITEMS,
-        ValidateableAttestation::hash_tree_root,
-        ValidateableAttestation::getDependentBlockRoots,
-        ValidateableAttestation::getEarliestSlotForForkChoiceProcessing);
+    this.sizeGauge = sizeGauge;
   }
 
   public synchronized void add(T item) {
@@ -162,6 +131,7 @@ public class PendingPool<T> implements SlotEventsChannel, FinalizedCheckpointCha
           "Save unattached item at slot {} for future import: {}",
           targetSlotFunction.apply(item),
           item);
+      sizeGauge.set(pendingItems.size(), itemType);
     }
 
     orderedPendingItems.add(toSlotAndRoot(item));
@@ -185,6 +155,7 @@ public class PendingPool<T> implements SlotEventsChannel, FinalizedCheckpointCha
                 s -> s.onRequiredBlockRootDropped(requiredRoot));
           }
         });
+    sizeGauge.set(pendingItems.size(), itemType);
   }
 
   public synchronized int size() {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/PendingPoolFactory.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/PendingPoolFactory.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.util;
+
+import java.util.Collections;
+import org.hyperledger.besu.plugin.services.MetricsSystem;
+import tech.pegasys.teku.infrastructure.metrics.SettableLabelledGauge;
+import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.datastructures.attestation.ValidateableAttestation;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+
+public class PendingPoolFactory {
+
+  private static final UInt64 DEFAULT_HISTORICAL_SLOT_TOLERANCE = UInt64.valueOf(320);
+  private static final int DEFAULT_MAX_ITEMS = 5000;
+  private final SettableLabelledGauge sizeGauge;
+
+  public PendingPoolFactory(final MetricsSystem metricsSystem) {
+    this.sizeGauge =
+        SettableLabelledGauge.create(
+            metricsSystem,
+            TekuMetricCategory.BEACON,
+            "pending_pool_size",
+            "Number of items in pending pool",
+            "type");
+  }
+
+  public PendingPool<SignedBeaconBlock> createForBlocks(final Spec spec) {
+    return createForBlocks(
+        spec,
+        DEFAULT_HISTORICAL_SLOT_TOLERANCE,
+        FutureItems.DEFAULT_FUTURE_SLOT_TOLERANCE,
+        DEFAULT_MAX_ITEMS);
+  }
+
+  public PendingPool<SignedBeaconBlock> createForBlocks(
+      final Spec spec,
+      final UInt64 historicalBlockTolerance,
+      final UInt64 futureBlockTolerance,
+      final int maxItems) {
+    return new PendingPool<>(
+        sizeGauge,
+        "blocks",
+        spec,
+        historicalBlockTolerance,
+        futureBlockTolerance,
+        maxItems,
+        block -> block.getMessage().hashTreeRoot(),
+        block -> Collections.singleton(block.getParentRoot()),
+        SignedBeaconBlock::getSlot);
+  }
+
+  public PendingPool<ValidateableAttestation> createForAttestations(final Spec spec) {
+    return new PendingPool<>(
+        sizeGauge,
+        "attestations",
+        spec,
+        DEFAULT_HISTORICAL_SLOT_TOLERANCE,
+        FutureItems.DEFAULT_FUTURE_SLOT_TOLERANCE,
+        DEFAULT_MAX_ITEMS,
+        ValidateableAttestation::hash_tree_root,
+        ValidateableAttestation::getDependentBlockRoots,
+        ValidateableAttestation::getEarliestSlotForForkChoiceProcessing);
+  }
+}

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AttestationManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AttestationManagerTest.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
@@ -50,6 +51,7 @@ import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
 import tech.pegasys.teku.statetransition.util.FutureItems;
 import tech.pegasys.teku.statetransition.util.PendingPool;
+import tech.pegasys.teku.statetransition.util.PendingPoolFactory;
 import tech.pegasys.teku.statetransition.validation.AggregateAttestationValidator;
 import tech.pegasys.teku.statetransition.validation.AttestationValidator;
 import tech.pegasys.teku.statetransition.validation.signatures.SignatureVerificationService;
@@ -63,8 +65,9 @@ class AttestationManagerTest {
 
   private final AggregatingAttestationPool attestationPool = mock(AggregatingAttestationPool.class);
   private final ForkChoice forkChoice = mock(ForkChoice.class);
+  private final StubMetricsSystem metricsSystem = new StubMetricsSystem();
   private final PendingPool<ValidateableAttestation> pendingAttestations =
-      PendingPool.createForAttestations(spec);
+      new PendingPoolFactory(metricsSystem).createForAttestations(spec);
   private final FutureItems<ValidateableAttestation> futureAttestations =
       FutureItems.create(ValidateableAttestation::getEarliestSlotForForkChoiceProcessing);
   private final SignatureVerificationService signatureVerificationService =

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockManagerTest.java
@@ -38,6 +38,7 @@ import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.core.ChainBuilder.BlockOptions;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.eventthread.InlineEventThread;
+import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
@@ -56,6 +57,7 @@ import tech.pegasys.teku.statetransition.forkchoice.MergeTransitionBlockValidato
 import tech.pegasys.teku.statetransition.forkchoice.StubForkChoiceNotifier;
 import tech.pegasys.teku.statetransition.util.FutureItems;
 import tech.pegasys.teku.statetransition.util.PendingPool;
+import tech.pegasys.teku.statetransition.util.PendingPoolFactory;
 import tech.pegasys.teku.statetransition.validation.BlockValidator;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
 import tech.pegasys.teku.storage.client.RecentChainData;
@@ -72,9 +74,10 @@ public class BlockManagerTest {
   private final UInt64 historicalBlockTolerance = UInt64.valueOf(5);
   private final UInt64 futureBlockTolerance = UInt64.valueOf(2);
   private final int maxPendingBlocks = 10;
+  private final StubMetricsSystem metricsSystem = new StubMetricsSystem();
   private final PendingPool<SignedBeaconBlock> pendingBlocks =
-      PendingPool.createForBlocks(
-          spec, historicalBlockTolerance, futureBlockTolerance, maxPendingBlocks);
+      new PendingPoolFactory(metricsSystem)
+          .createForBlocks(spec, historicalBlockTolerance, futureBlockTolerance, maxPendingBlocks);
   private final FutureItems<SignedBeaconBlock> futureBlocks =
       FutureItems.create(SignedBeaconBlock::getSlot);
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/ReexecutingExecutionPayloadBlockManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/ReexecutingExecutionPayloadBlockManagerTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
+import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
@@ -38,6 +39,7 @@ import tech.pegasys.teku.spec.logic.common.block.AbstractBlockProcessor;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
 import tech.pegasys.teku.statetransition.util.FutureItems;
 import tech.pegasys.teku.statetransition.util.PendingPool;
+import tech.pegasys.teku.statetransition.util.PendingPoolFactory;
 import tech.pegasys.teku.statetransition.validation.BlockValidator;
 import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystemBuilder;
@@ -51,9 +53,10 @@ public class ReexecutingExecutionPayloadBlockManagerTest {
   private final UInt64 historicalBlockTolerance = UInt64.valueOf(5);
   private final UInt64 futureBlockTolerance = UInt64.valueOf(2);
   private final int maxPendingBlocks = 10;
+  private final StubMetricsSystem metricsSystem = new StubMetricsSystem();
   private final PendingPool<SignedBeaconBlock> pendingBlocks =
-      PendingPool.createForBlocks(
-          spec, historicalBlockTolerance, futureBlockTolerance, maxPendingBlocks);
+      new PendingPoolFactory(metricsSystem)
+          .createForBlocks(spec, historicalBlockTolerance, futureBlockTolerance, maxPendingBlocks);
   private final FutureItems<SignedBeaconBlock> futureBlocks =
       FutureItems.create(SignedBeaconBlock::getSlot);
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/PendingPoolTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/PendingPoolTest.java
@@ -20,6 +20,7 @@ import java.util.List;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
@@ -32,9 +33,11 @@ public class PendingPoolTest {
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
   private final UInt64 historicalTolerance = UInt64.valueOf(5);
   private final UInt64 futureTolerance = UInt64.valueOf(2);
+  private final StubMetricsSystem metricsSystem = new StubMetricsSystem();
   private final int maxItems = 15;
   private final PendingPool<SignedBeaconBlock> pendingPool =
-      PendingPool.createForBlocks(spec, historicalTolerance, futureTolerance, maxItems);
+      new PendingPoolFactory(metricsSystem)
+          .createForBlocks(spec, historicalTolerance, futureTolerance, maxItems);
   private UInt64 currentSlot = historicalTolerance.times(2);
   private final List<Bytes32> requiredRootEvents = new ArrayList<>();
   private final List<Bytes32> requiredRootDroppedEvents = new ArrayList<>();


### PR DESCRIPTION
## PR Description
Adds a `beacon_pending_pool_size` gauge to report the number of items in the pending block and attestations pool.

Note this is somewhat complicated by the fact that the `MetricsSystem` doesn't just return the same labelled gauge if the same name is specified like it does for counters so we have to introduce `PendingPoolFactory` to hold the single instance of the labelled gauge.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
