### PR TITLE
Reduce attestation retention period

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ For information on changes in released versions of Teku, see the [releases page]
 ### Breaking Changes
 
 ### Additions and Improvements
+- Reduced attestation pool memory usage.
 
 ### Bug Fixes
 - Fixed performance issue when processing blocks containing deposits.

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolTest.java
@@ -19,7 +19,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
-import static tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPool.ATTESTATION_RETENTION_EPOCHS;
+import static tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPool.ATTESTATION_RETENTION_SLOTS;
 import static tech.pegasys.teku.statetransition.attestation.AggregatorUtil.aggregateAttestations;
 
 import java.util.ArrayList;
@@ -295,12 +295,7 @@ class AggregatingAttestationPoolTest {
 
     assertThat(aggregatingPool.getSize()).isEqualTo(2);
     aggregatingPool.onSlot(
-        pruneAttestationData
-            .getSlot()
-            .plus(
-                spec.getSlotsPerEpoch(pruneAttestationData.getSlot())
-                    * ATTESTATION_RETENTION_EPOCHS)
-            .plus(ONE));
+        pruneAttestationData.getSlot().plus(ATTESTATION_RETENTION_SLOTS).plus(ONE));
 
     assertThat(
             aggregatingPool.getAttestationsForBlock(


### PR DESCRIPTION
## PR Description
Drop attestations from the AggregatingAttestationPool after 32 slots when they become worthless to include.

## Fixed Issue(s)
Quick win to start #5196.  Potentially we should have further controls on the size but this halves the size of the pool quickly and easily.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
