### PR TITLE
Add option to toggle block performance metrics

### DIFF
--- a/beacon/sync/src/testFixtures/java/tech/pegasys/teku/beacon/sync/SyncingNodeManager.java
+++ b/beacon/sync/src/testFixtures/java/tech/pegasys/teku/beacon/sync/SyncingNodeManager.java
@@ -128,7 +128,8 @@ public class SyncingNodeManager {
             futureBlocks,
             blockValidator,
             new SystemTimeProvider(),
-            EVENT_LOG);
+            EVENT_LOG,
+            false);
 
     eventChannels
         .subscribe(SlotEventsChannel.class, blockManager)

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
@@ -215,7 +215,8 @@ public class ForkChoiceTestExecutor implements TestExecutor {
         block.getRoot(),
         block.getSlot(),
         block.getParentRoot());
-    final SafeFuture<BlockImportResult> result = forkChoice.onBlock(block, executionEngine);
+    final SafeFuture<BlockImportResult> result =
+        forkChoice.onBlock(block, Optional.empty(), executionEngine);
     assertThat(result).isCompleted();
     final BlockImportResult importResult = result.join();
     assertThat(importResult)

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/BlockImporter.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/BlockImporter.java
@@ -77,7 +77,14 @@ public class BlockImporter {
   }
 
   @CheckReturnValue
-  public SafeFuture<BlockImportResult> importBlock(SignedBeaconBlock block) {
+  public SafeFuture<BlockImportResult> importBlock(final SignedBeaconBlock block) {
+    return importBlock(block, Optional.empty());
+  }
+
+  @CheckReturnValue
+  public SafeFuture<BlockImportResult> importBlock(
+      final SignedBeaconBlock block,
+      final Optional<BlockImportPerformance> blockImportPerformance) {
     final Optional<Boolean> knownOptimistic = recentChainData.isBlockOptimistic(block.getRoot());
     if (knownOptimistic.isPresent()) {
       LOG.trace(
@@ -92,7 +99,7 @@ public class BlockImporter {
     }
 
     return validateWeakSubjectivityPeriod()
-        .thenCompose(__ -> forkChoice.onBlock(block, executionEngine))
+        .thenCompose(__ -> forkChoice.onBlock(block, blockImportPerformance, executionEngine))
         .thenApply(
             result -> {
               if (!result.isSuccessful()) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/ReexecutingExecutionPayloadBlockManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/ReexecutingExecutionPayloadBlockManager.java
@@ -52,7 +52,8 @@ public class ReexecutingExecutionPayloadBlockManager extends BlockManager {
       final BlockValidator validator,
       final TimeProvider timeProvider,
       final EventLogger eventLogger,
-      final AsyncRunner asyncRunner) {
+      final AsyncRunner asyncRunner,
+      final boolean blockImportPerformanceEnabled) {
     super(
         recentChainData,
         blockImporter,
@@ -60,7 +61,8 @@ public class ReexecutingExecutionPayloadBlockManager extends BlockManager {
         futureBlocks,
         validator,
         timeProvider,
-        eventLogger);
+        eventLogger,
+        blockImportPerformanceEnabled);
     this.asyncRunner = asyncRunner;
   }
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockManagerTest.java
@@ -29,6 +29,7 @@ import static tech.pegasys.teku.spec.config.SpecConfig.GENESIS_SLOT;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -272,21 +273,21 @@ public class BlockManagerTest {
         localChain.chainBuilder().generateBlockAtSlot(nextNextSlot).getBlock();
 
     final SafeFuture<BlockImportResult> blockImportResult = new SafeFuture<>();
-    when(blockImporter.importBlock(nextNextBlock))
+    when(blockImporter.importBlock(nextNextBlock, Optional.empty()))
         .thenReturn(blockImportResult)
         .thenReturn(new SafeFuture<>());
 
     incrementSlot();
     incrementSlot();
     blockManager.importBlock(nextNextBlock);
-    ignoreFuture(verify(blockImporter).importBlock(nextNextBlock));
+    ignoreFuture(verify(blockImporter).importBlock(nextNextBlock, Optional.empty()));
 
     // Before nextNextBlock imports, it's parent becomes available
     when(localRecentChainData.containsBlock(nextNextBlock.getParentRoot())).thenReturn(true);
 
     // So when the block import completes, it should be retried
     blockImportResult.complete(BlockImportResult.FAILED_UNKNOWN_PARENT);
-    ignoreFuture(verify(blockImporter, times(2)).importBlock(nextNextBlock));
+    ignoreFuture(verify(blockImporter, times(2)).importBlock(nextNextBlock, Optional.empty()));
 
     assertThat(pendingBlocks.contains(nextNextBlock)).isFalse();
   }
@@ -569,7 +570,9 @@ public class BlockManagerTest {
         .isCompletedWithValueMatching(InternalValidationResult::isAccept);
     verify(eventLogger)
         .lateBlockImport(
-            block.getRoot(), block.getSlot(), UInt64.valueOf(1_000), UInt64.valueOf(3_000));
+            block.getRoot(),
+            block.getSlot(),
+            "Received 1000ms, Pre-state retrieved +3000ms, Block processed +0ms, Transaction prepared +0ms, Transaction committed +0ms, Import complete +0ms");
   }
 
   @Test

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockManagerTest.java
@@ -118,7 +118,8 @@ public class BlockManagerTest {
           futureBlocks,
           blockValidator,
           timeProvider,
-          eventLogger);
+          eventLogger,
+          true);
 
   private UInt64 currentSlot = GENESIS_SLOT;
 
@@ -258,7 +259,8 @@ public class BlockManagerTest {
             futureBlocks,
             mock(BlockValidator.class),
             timeProvider,
-            eventLogger);
+            eventLogger,
+            false);
     forwardBlockImportedNotificationsTo(blockManager);
     assertThat(blockManager.start()).isCompleted();
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/ReexecutingExecutionPayloadBlockManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/ReexecutingExecutionPayloadBlockManagerTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.spec.config.SpecConfig.GENESIS_SLOT;
 
+import java.util.Optional;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -90,7 +91,7 @@ public class ReexecutingExecutionPayloadBlockManagerTest {
           timeProvider,
           eventLogger,
           asyncRunner,
-          true);
+          false);
 
   @BeforeAll
   public static void initSession() {
@@ -120,7 +121,7 @@ public class ReexecutingExecutionPayloadBlockManagerTest {
         remoteStorageSystem.chainUpdater().chainBuilder.generateNextBlock().getBlock();
 
     // syncing
-    when(blockImporter.importBlock(nextBlock))
+    when(blockImporter.importBlock(nextBlock, Optional.empty()))
         .thenReturn(
             SafeFuture.completedFuture(
                 BlockImportResult.FAILED_EXECUTION_PAYLOAD_EXECUTION_SYNCING));
@@ -128,7 +129,7 @@ public class ReexecutingExecutionPayloadBlockManagerTest {
     assertThat(blockManager.importBlock(nextBlock)).isCompleted();
 
     // communication error
-    when(blockImporter.importBlock(nextBlock))
+    when(blockImporter.importBlock(nextBlock, Optional.empty()))
         .thenReturn(
             SafeFuture.completedFuture(
                 BlockImportResult.failedExecutionPayloadExecution(new RuntimeException("error"))));
@@ -136,12 +137,12 @@ public class ReexecutingExecutionPayloadBlockManagerTest {
     asyncRunner.executeQueuedActions();
 
     // successful imported now
-    when(blockImporter.importBlock(nextBlock))
+    when(blockImporter.importBlock(nextBlock, Optional.empty()))
         .thenReturn(SafeFuture.completedFuture(BlockImportResult.successful(nextBlock)));
 
     asyncRunner.executeQueuedActions();
 
-    verify(blockImporter, times(3)).importBlock(nextBlock);
+    verify(blockImporter, times(3)).importBlock(nextBlock, Optional.empty());
 
     // should be dequeued now, so no more interactions
     asyncRunner.executeQueuedActions();
@@ -154,14 +155,14 @@ public class ReexecutingExecutionPayloadBlockManagerTest {
         remoteStorageSystem.chainUpdater().chainBuilder.generateNextBlock().getBlock();
 
     // invalid
-    when(blockImporter.importBlock(nextBlock))
+    when(blockImporter.importBlock(nextBlock, Optional.empty()))
         .thenReturn(
             SafeFuture.completedFuture(
                 BlockImportResult.failedStateTransition(new IllegalStateException("invalid"))));
 
     assertThat(blockManager.importBlock(nextBlock)).isCompleted();
 
-    verify(blockImporter, times(1)).importBlock(nextBlock);
+    verify(blockImporter, times(1)).importBlock(nextBlock, Optional.empty());
 
     // should not bw queued
     asyncRunner.executeQueuedActions();
@@ -174,14 +175,14 @@ public class ReexecutingExecutionPayloadBlockManagerTest {
         remoteStorageSystem.chainUpdater().chainBuilder.generateNextBlock().getBlock();
 
     // syncing
-    when(blockImporter.importBlock(nextBlock))
+    when(blockImporter.importBlock(nextBlock, Optional.empty()))
         .thenReturn(
             SafeFuture.completedFuture(
                 BlockImportResult.FAILED_EXECUTION_PAYLOAD_EXECUTION_SYNCING));
 
     assertThat(blockManager.importBlock(nextBlock)).isCompleted();
 
-    verify(blockImporter, times(1)).importBlock(nextBlock);
+    verify(blockImporter, times(1)).importBlock(nextBlock, Optional.empty());
 
     blockManager.onSlot(currentSlot.plus(3));
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/ReexecutingExecutionPayloadBlockManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/ReexecutingExecutionPayloadBlockManagerTest.java
@@ -89,7 +89,8 @@ public class ReexecutingExecutionPayloadBlockManagerTest {
           mock(BlockValidator.class),
           timeProvider,
           eventLogger,
-          asyncRunner);
+          asyncRunner,
+          true);
 
   @BeforeAll
   public static void initSession() {

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
@@ -146,7 +146,7 @@ class ForkChoiceTest {
   void onBlock_shouldImmediatelyMakeChildOfCurrentHeadTheNewHead() {
     final SignedBlockAndState blockAndState = chainBuilder.generateBlockAtSlot(ONE);
     final SafeFuture<BlockImportResult> importResult =
-        forkChoice.onBlock(blockAndState.getBlock(), executionEngine);
+        forkChoice.onBlock(blockAndState.getBlock(), Optional.empty(), executionEngine);
     assertBlockImportedSuccessfully(importResult, false);
 
     assertThat(recentChainData.getHeadBlock().map(MinimalBeaconBlockSummary::getRoot))
@@ -162,7 +162,7 @@ class ForkChoiceTest {
 
     final SignedBlockAndState blockAndState = chainBuilder.generateBlockAtSlot(ONE);
     final SafeFuture<BlockImportResult> importResult =
-        forkChoice.onBlock(blockAndState.getBlock(), executionEngine);
+        forkChoice.onBlock(blockAndState.getBlock(), Optional.empty(), executionEngine);
     assertBlockImportedSuccessfully(importResult, false);
 
     assertThat(recentChainData.getHeadBlock().map(MinimalBeaconBlockSummary::getRoot))
@@ -370,7 +370,7 @@ class ForkChoiceTest {
   void onBlock_shouldSendForkChoiceUpdatedNotification() {
     final SignedBlockAndState blockAndState = chainBuilder.generateBlockAtSlot(ONE);
     final SafeFuture<BlockImportResult> importResult =
-        forkChoice.onBlock(blockAndState.getBlock(), executionEngine);
+        forkChoice.onBlock(blockAndState.getBlock(), Optional.empty(), executionEngine);
     assertBlockImportedSuccessfully(importResult, false);
 
     assertForkChoiceUpdateNotification(blockAndState, false);
@@ -632,7 +632,7 @@ class ForkChoiceTest {
     executionEngine.setPayloadStatus(PayloadStatus.SYNCING);
     setForkChoiceNotifierForkChoiceUpdatedResult(PayloadStatus.SYNCING);
     final SafeFuture<BlockImportResult> result =
-        forkChoice.onBlock(blockAndState.getBlock(), executionEngine);
+        forkChoice.onBlock(blockAndState.getBlock(), Optional.empty(), executionEngine);
     assertBlockImportedSuccessfully(result, true);
 
     assertForkChoiceUpdateNotification(blockAndState, true);
@@ -884,13 +884,13 @@ class ForkChoiceTest {
 
   private void importBlock(final SignedBlockAndState block) {
     final SafeFuture<BlockImportResult> result =
-        forkChoice.onBlock(block.getBlock(), executionEngine);
+        forkChoice.onBlock(block.getBlock(), Optional.empty(), executionEngine);
     assertBlockImportedSuccessfully(result, false);
   }
 
   private void importBlockOptimistically(final SignedBlockAndState block) {
     final SafeFuture<BlockImportResult> result =
-        forkChoice.onBlock(block.getBlock(), executionEngine);
+        forkChoice.onBlock(block.getBlock(), Optional.empty(), executionEngine);
     assertBlockImportedSuccessfully(result, true);
   }
 
@@ -903,7 +903,7 @@ class ForkChoiceTest {
 
   private void importBlockWithError(final SignedBlockAndState block, FailureReason failureReason) {
     final SafeFuture<BlockImportResult> result =
-        forkChoice.onBlock(block.getBlock(), executionEngine);
+        forkChoice.onBlock(block.getBlock(), Optional.empty(), executionEngine);
     assertBlockImportFailure(result, failureReason);
   }
 

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/BeaconChainUtil.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/BeaconChainUtil.java
@@ -250,7 +250,7 @@ public class BeaconChainUtil {
         createBlockAndStateAtSlot(slot, true, attestations, deposits, exits, eth1Data).getBlock();
     setSlot(slot);
     final BlockImportResult importResult =
-        forkChoice.onBlock(block, new StubExecutionEngineChannel(spec)).join();
+        forkChoice.onBlock(block, Optional.empty(), new StubExecutionEngineChannel(spec)).join();
     if (!importResult.isSuccessful()) {
       throw new IllegalStateException(
           "Produced an invalid block ( reason "

--- a/fork-choice-tests/src/integration-test/java/tech/pegasys/teku/forkChoiceTests/ForkChoiceTestExecutor.java
+++ b/fork-choice-tests/src/integration-test/java/tech/pegasys/teku/forkChoiceTests/ForkChoiceTestExecutor.java
@@ -280,7 +280,7 @@ public class ForkChoiceTestExecutor {
 
   private boolean processBlock(ForkChoice fc, SignedBeaconBlock block) {
     BlockImportResult blockImportResult =
-        fc.onBlock(block, new StubExecutionEngineChannel(SPEC)).join();
+        fc.onBlock(block, Optional.empty(), new StubExecutionEngineChannel(SPEC)).join();
     return blockImportResult.isSuccessful();
   }
 

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java
@@ -197,15 +197,10 @@ public class EventLogger {
     error(configurationErrorEventLog, Color.RED);
   }
 
-  public void lateBlockImport(
-      final Bytes32 root,
-      final UInt64 slot,
-      final UInt64 arrivalDelayMs,
-      final UInt64 processingTimeMs) {
+  public void lateBlockImport(final Bytes32 root, final UInt64 slot, final String timings) {
     String reorgEventLog =
         String.format(
-            "Late Block Import *** Arrival Delay: %sms, Processing Time: %sms: Block: %s",
-            arrivalDelayMs, processingTimeMs, LogFormatter.formatBlock(slot, root));
+            "Late Block Import *** Block: %s %s", LogFormatter.formatBlock(slot, root), timings);
     warn(reorgEventLog, Color.YELLOW);
   }
 

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java
@@ -204,7 +204,7 @@ public class EventLogger {
       final UInt64 processingTimeMs) {
     String reorgEventLog =
         String.format(
-            "Late Block Import *** Arrival Delay: %s, Processing Time: %s: Block: %s",
+            "Late Block Import *** Arrival Delay: %sms, Processing Time: %sms: Block: %s",
             arrivalDelayMs, processingTimeMs, LogFormatter.formatBlock(slot, root));
     warn(reorgEventLog, Color.YELLOW);
   }

--- a/infrastructure/metrics/src/main/java/tech/pegasys/teku/infrastructure/metrics/MetricsConfig.java
+++ b/infrastructure/metrics/src/main/java/tech/pegasys/teku/infrastructure/metrics/MetricsConfig.java
@@ -38,6 +38,7 @@ public class MetricsConfig {
       Arrays.asList("127.0.0.1", "localhost");
   public static final int DEFAULT_IDLE_TIMEOUT_SECONDS = 60;
   public static final int DEFAULT_METRICS_PUBLICATION_INTERVAL = 60;
+  public static final boolean DEFAULT_BLOCK_PERFORMANCE_ENABLED = false;
 
   private final boolean metricsEnabled;
   private final int metricsPort;
@@ -47,6 +48,7 @@ public class MetricsConfig {
   private final Optional<URL> metricsEndpoint;
   private final int publicationInterval;
   private final int idleTimeoutSeconds;
+  private final boolean blockPerformanceEnabled;
 
   private MetricsConfig(
       final boolean metricsEnabled,
@@ -56,7 +58,8 @@ public class MetricsConfig {
       final List<String> metricsHostAllowlist,
       final URL metricsEndpoint,
       final int publicationInterval,
-      final int idleTimeoutSeconds) {
+      final int idleTimeoutSeconds,
+      final boolean blockPerformanceEnabled) {
     this.metricsEnabled = metricsEnabled;
     this.metricsPort = metricsPort;
     this.metricsInterface = metricsInterface;
@@ -65,6 +68,7 @@ public class MetricsConfig {
     this.metricsEndpoint = Optional.ofNullable(metricsEndpoint);
     this.publicationInterval = publicationInterval;
     this.idleTimeoutSeconds = idleTimeoutSeconds;
+    this.blockPerformanceEnabled = blockPerformanceEnabled;
   }
 
   public static MetricsConfigBuilder builder() {
@@ -103,6 +107,10 @@ public class MetricsConfig {
     return idleTimeoutSeconds;
   }
 
+  public boolean isBlockPerformanceEnabled() {
+    return blockPerformanceEnabled;
+  }
+
   public static final class MetricsConfigBuilder {
 
     private boolean metricsEnabled = false;
@@ -113,6 +121,7 @@ public class MetricsConfig {
     private URL metricsPublishEndpoint = null;
     private int metricsPublishInterval = DEFAULT_METRICS_PUBLICATION_INTERVAL;
     private int idleTimeoutSeconds = DEFAULT_IDLE_TIMEOUT_SECONDS;
+    private boolean blockPerformanceEnabled = DEFAULT_BLOCK_PERFORMANCE_ENABLED;
 
     private MetricsConfigBuilder() {}
 
@@ -168,6 +177,11 @@ public class MetricsConfig {
       return this;
     }
 
+    public MetricsConfigBuilder blockPerformanceEnabled(final boolean blockPerformanceEnabled) {
+      this.blockPerformanceEnabled = blockPerformanceEnabled;
+      return this;
+    }
+
     public MetricsConfig build() {
       return new MetricsConfig(
           metricsEnabled,
@@ -177,7 +191,8 @@ public class MetricsConfig {
           metricsHostAllowlist,
           metricsPublishEndpoint,
           metricsPublishInterval,
-          idleTimeoutSeconds);
+          idleTimeoutSeconds,
+          blockPerformanceEnabled);
     }
   }
 }

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainConfiguration.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainConfiguration.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.services.beaconchain;
 
 import tech.pegasys.teku.beacon.sync.SyncConfig;
 import tech.pegasys.teku.beaconrestapi.BeaconRestApiConfig;
+import tech.pegasys.teku.infrastructure.metrics.MetricsConfig;
 import tech.pegasys.teku.networking.eth2.P2PConfig;
 import tech.pegasys.teku.networks.Eth2NetworkConfiguration;
 import tech.pegasys.teku.services.powchain.PowchainConfiguration;
@@ -37,6 +38,7 @@ public class BeaconChainConfiguration {
   private final Spec spec;
 
   private final BeaconChainControllerFactory beaconChainControllerFactory;
+  private final MetricsConfig metricsConfig;
 
   public BeaconChainConfiguration(
       final Eth2NetworkConfiguration eth2NetworkConfiguration,
@@ -49,7 +51,8 @@ public class BeaconChainConfiguration {
       final PowchainConfiguration powchainConfiguration,
       final StoreConfig storeConfig,
       final Spec spec,
-      final BeaconChainControllerFactory beaconChainControllerFactory) {
+      final BeaconChainControllerFactory beaconChainControllerFactory,
+      final MetricsConfig metricsConfig) {
     this.eth2NetworkConfiguration = eth2NetworkConfiguration;
     this.weakSubjectivityConfig = weakSubjectivityConfig;
     this.validatorConfig = validatorConfig;
@@ -61,6 +64,7 @@ public class BeaconChainConfiguration {
     this.storeConfig = storeConfig;
     this.spec = spec;
     this.beaconChainControllerFactory = beaconChainControllerFactory;
+    this.metricsConfig = metricsConfig;
   }
 
   public Spec getSpec() {
@@ -101,6 +105,10 @@ public class BeaconChainConfiguration {
 
   public StoreConfig storeConfig() {
     return storeConfig;
+  }
+
+  public MetricsConfig getMetricsConfig() {
+    return metricsConfig;
   }
 
   public BeaconChainControllerFactory getBeaconChainControllerFactory() {

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -824,7 +824,8 @@ public class BeaconChainController extends Service implements BeaconChainControl
               blockValidator,
               timeProvider,
               EVENT_LOG,
-              beaconAsyncRunner);
+              beaconAsyncRunner,
+              beaconConfig.getMetricsConfig().isBlockPerformanceEnabled());
     } else {
       blockManager =
           new BlockManager(
@@ -834,7 +835,8 @@ public class BeaconChainController extends Service implements BeaconChainControl
               futureBlocks,
               blockValidator,
               timeProvider,
-              EVENT_LOG);
+              EVENT_LOG,
+              beaconConfig.getMetricsConfig().isBlockPerformanceEnabled());
     }
     eventChannels
         .subscribe(SlotEventsChannel.class, blockManager)

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/MetricsOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/MetricsOptions.java
@@ -89,6 +89,16 @@ public class MetricsOptions {
       arity = "1")
   private int metricsPublicationInterval = MetricsConfig.DEFAULT_METRICS_PUBLICATION_INTERVAL;
 
+  @Option(
+      names = {"--Xmetrics-block-timing-tracking-enabled"},
+      hidden = true,
+      showDefaultValue = Visibility.ALWAYS,
+      paramLabel = "<BOOLEAN>",
+      description = "Whether block timing metrics are tracked and reported",
+      fallbackValue = "true",
+      arity = "0..1")
+  private boolean blockPerformanceEnabled = MetricsConfig.DEFAULT_BLOCK_PERFORMANCE_ENABLED;
+
   public void configure(TekuConfiguration.Builder builder) {
     builder.metrics(
         b ->
@@ -99,7 +109,8 @@ public class MetricsOptions {
                 .metricsHostAllowlist(metricsHostAllowlist)
                 .metricsPublishEndpoint(parseMetricsEndpointUrl())
                 .metricsPublishInterval(metricsPublicationInterval)
-                .idleTimeoutSeconds(idleTimeoutSeconds));
+                .idleTimeoutSeconds(idleTimeoutSeconds)
+                .blockPerformanceEnabled(blockPerformanceEnabled));
   }
 
   private URL parseMetricsEndpointUrl() {

--- a/teku/src/main/java/tech/pegasys/teku/config/TekuConfiguration.java
+++ b/teku/src/main/java/tech/pegasys/teku/config/TekuConfiguration.java
@@ -92,7 +92,8 @@ public class TekuConfiguration {
             powchainConfiguration,
             storeConfig,
             spec,
-            beaconChainControllerFactory);
+            beaconChainControllerFactory,
+            metricsConfig);
     this.validatorClientConfig =
         new ValidatorClientConfiguration(
             validatorConfig, interopConfig, validatorRestApiConfig, spec);


### PR DESCRIPTION
## PR Description
Add a hidden option to toggle block performance metric tracking on or off.  Defaults to off at least for now.

Capture more detailed timing events as the block goes through the import process.

Also adds units to the late block warning message.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
