### PR TITLE
Additional logging eth1 syncing status

### DIFF
--- a/pow/src/main/java/tech/pegasys/teku/pow/Web3jInSyncCheck.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/Web3jInSyncCheck.java
@@ -38,12 +38,17 @@ public class Web3jInSyncCheck {
         // If we're close to the chain head, consider the node in sync
         // Avoids marking the node as invalid while it imports the latest block
         LOG.debug(
-            "Eth1 endpiont {} syncing but close to head so considering it valid. Current block {} Highest block: {}",
+            "Eth1 endpiont {} syncing but close to head so considering it valid. Current block: {} Highest block: {}",
             id,
             currentBlock,
             highestBlock);
         return false;
       }
+      LOG.info(
+          "Eth1 endpoint {} syncing. Current block: {} Highest block: {}",
+          id,
+          currentBlock,
+          highestBlock);
       return true;
     } catch (final NumberFormatException | NullPointerException e) {
       LOG.error("Failed to parse syncing details from eth1 endpoint {}", id, e);


### PR DESCRIPTION
Signed-off-by: Frank Li <b439988l@gmail.com>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
In running my validator I found myself frequently sending curl requests to my Besu node for block number and checking Teku logs, if we log the eth1 block number when it's still syncing I think a lot of operators will only need to check Teku logs when their eth1 client is still syncing.

Two things I'm not sure:
- Is this gonna add too many logs (i don't think so based on the frequency the check is done)
- Is info appropriate? (i think so because I want to see it without going into debug logs)

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.
None required

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
None required
