### PR TITLE
Migrate database command should migrate to leveldb2 by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,3 +22,4 @@ For information on changes in released versions of Teku, see the [releases page]
 ### Bug Fixes
 - Fixed performance issue when processing blocks containing deposits.
 - Make performance degradation more graceful when there is insufficient CPU for the beacon node to keep up with the chain. Reduces regularity of "Cannot create attestation for future slot" errors.
+- Fixed the target database format for the `migrate-database` command.

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/MigrateDatabaseCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/MigrateDatabaseCommand.java
@@ -89,7 +89,7 @@ public class MigrateDatabaseCommand implements Runnable {
       description =
           "The file to export the slashing protection database to. (rocksdb: 4,5,6), leveldb1, leveldb2",
       arity = "1")
-  private String toDbVersion = DatabaseVersion.DEFAULT_VERSION.getValue();
+  private String toDbVersion = DatabaseVersion.LEVELDB2.getValue();
 
   // batch size param
   @CommandLine.Option(


### PR DESCRIPTION
When the leveldb-tree version became default, it changed the default 'to' database type, and that won't be very successful given the storage structures.

workaround: specify `--Xto leveldb2` in the CLI, and this will override the default using the development 'to' flag.

fixes #5198

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
