### PR TITLE
`isDefault` optimization for `ExecutionPayload` and `ExecutionPayloadHeader`

### DIFF
--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/SSZBenchmark.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/SSZBenchmark.java
@@ -18,6 +18,8 @@ import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Warmup;
 import tech.pegasys.teku.infrastructure.ssz.SimpleOffsetSerializable;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class SSZBenchmark {
@@ -29,5 +31,15 @@ public class SSZBenchmark {
   @Measurement(iterations = 5, time = 100, timeUnit = TimeUnit.MILLISECONDS)
   public void BeaconStateSerialization() {
     state.sszSerialize();
+  }
+
+  private static ExecutionPayload executionPayload =
+      new DataStructureUtil(TestSpecFactory.createMainnetBellatrix()).randomExecutionPayload();
+
+  @Benchmark
+  @Warmup(iterations = 2, time = 100, timeUnit = TimeUnit.MILLISECONDS)
+  @Measurement(iterations = 5, time = 100, timeUnit = TimeUnit.MILLISECONDS)
+  public void ExecutionPayloadIsDefault() {
+    executionPayload.isDefault();
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadHeaderSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadHeaderSchema.java
@@ -48,6 +48,8 @@ public class ExecutionPayloadHeaderSchema
         SszBytes32,
         SszBytes32> {
 
+  private final ExecutionPayloadHeader defaultExecutionPayloadHeader;
+
   public ExecutionPayloadHeaderSchema(final SpecConfigBellatrix specConfig) {
     super(
         "ExecutionPayloadHeader",
@@ -65,6 +67,8 @@ public class ExecutionPayloadHeaderSchema
         namedSchema("base_fee_per_gas", SszPrimitiveSchemas.UINT256_SCHEMA),
         namedSchema("block_hash", SszPrimitiveSchemas.BYTES32_SCHEMA),
         namedSchema("transactions_root", SszPrimitiveSchemas.BYTES32_SCHEMA));
+
+    this.defaultExecutionPayloadHeader = createFromBackingNode(getDefaultTree());
   }
 
   public SszByteListSchema<?> getExtraDataSchema() {
@@ -107,5 +111,10 @@ public class ExecutionPayloadHeaderSchema
         SszUInt256.of(baseFeePerGas),
         SszBytes32.of(blockHash),
         SszBytes32.of(transactionsRoot));
+  }
+
+  @Override
+  public ExecutionPayloadHeader getDefault() {
+    return defaultExecutionPayloadHeader;
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadSchema.java
@@ -51,6 +51,8 @@ public class ExecutionPayloadSchema
         SszBytes32,
         SszList<Transaction>> {
 
+  private final ExecutionPayload defaultExecutionPayload;
+
   public ExecutionPayloadSchema(final SpecConfigBellatrix specConfig) {
     super(
         "ExecutionPayload",
@@ -71,6 +73,8 @@ public class ExecutionPayloadSchema
             "transactions",
             SszListSchema.create(
                 new TransactionSchema(specConfig), specConfig.getMaxTransactionsPerPayload())));
+
+    this.defaultExecutionPayload = createFromBackingNode(getDefaultTree());
   }
 
   public ExecutionPayload create(
@@ -125,5 +129,10 @@ public class ExecutionPayloadSchema
   @Override
   public ExecutionPayload createFromBackingNode(TreeNode node) {
     return new ExecutionPayload(this, node);
+  }
+
+  @Override
+  public ExecutionPayload getDefault() {
+    return defaultExecutionPayload;
   }
 }

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/impl/AbstractSszContainerSchema.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/impl/AbstractSszContainerSchema.java
@@ -119,7 +119,7 @@ public abstract class AbstractSszContainerSchema<C extends SszContainer>
     this.defaultTree = createDefaultTree();
     this.treeWidth = SszContainerSchema.super.treeWidth();
     this.fixedPartSize = calcSszFixedPartSize();
-    jsonTypeDefinition = SszContainerTypeDefinition.createFor(this);
+    this.jsonTypeDefinition = SszContainerTypeDefinition.createFor(this);
   }
 
   @Override


### PR DESCRIPTION
We are using `isDefault` to check if merge occurred

this is a 2,5x improvement in performance, avoiding an object creation

New:
SSZBenchmark.ExecutionPayloadIsDefault  thrpt   25  137281804.734 ± 1289911.040  ops/s

Old:
SSZBenchmark.ExecutionPayloadIsDefault  thrpt   25  54469544.873 ± 1771319.253  ops/s

I was tempted to add it at `AbstractSszContainerSchema` but its a waste of memory since it is never used for other SSZs

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
