### PR TITLE
`SimpleLeafNode` remove `Bytes32` objects creations and cache `hashTreeRoot`

### DIFF
--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/SSZBenchmark.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/SSZBenchmark.java
@@ -23,8 +23,9 @@ import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class SSZBenchmark {
-
-  private static SimpleOffsetSerializable state = new DataStructureUtil().randomBeaconState();
+  private static DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(TestSpecFactory.createMinimalBellatrix());
+  private static SimpleOffsetSerializable state = dataStructureUtil.randomBeaconState();
 
   @Benchmark
   @Warmup(iterations = 2, time = 100, timeUnit = TimeUnit.MILLISECONDS)
@@ -33,8 +34,7 @@ public class SSZBenchmark {
     state.sszSerialize();
   }
 
-  private static ExecutionPayload executionPayload =
-      new DataStructureUtil(TestSpecFactory.createMainnetBellatrix()).randomExecutionPayload();
+  private static ExecutionPayload executionPayload = dataStructureUtil.randomExecutionPayload();
 
   @Benchmark
   @Warmup(iterations = 2, time = 100, timeUnit = TimeUnit.MILLISECONDS)


### PR DESCRIPTION
SSZ optimizations in `SimpleLeafNode` by storing data in `Bytes` and cache `hashTreeRoot`.

The drawback is that, in the current form, this PR is going to use more memory

### CPU

bellatrix state serialization
OLD
SSZBenchmark.BeaconStateSerialization  thrpt   25  42454.753 ± 726.571  ops/s

NEW
SSZBenchmark.BeaconStateSerialization  thrpt   25  47264.855 ± 595.956  ops/s

-> **11% perf increase**

### Memory

#### bellatrix state generation
```Java
// bellatrix dataStructureUtil
IntStream.range(0, 1000).forEach(__ -> dataStructureUtil.randomBeaconState());
```

OLD
<img width="744" alt="image" src="https://user-images.githubusercontent.com/15999009/159169718-7e2ed180-1915-431f-ad94-5b2f60781d5c.png">

NEW
generation only
<img width="843" alt="image" src="https://user-images.githubusercontent.com/15999009/159169609-955ff8a0-4eb7-4b4f-88dd-3ef31d98121a.png">

-> **2.6% less memory pressure**

#### bellatrix state serialization
```Java
IntStream.range(0, 1000).forEach(__ -> bellatrixState.sszSerialize());
```

OLD
<img width="792" alt="image" src="https://user-images.githubusercontent.com/15999009/159169289-db6be5d3-7ddf-4910-8afc-7e9a76657911.png">

NEW
<img width="789" alt="image" src="https://user-images.githubusercontent.com/15999009/159169345-a9297c27-dd50-48de-8e32-3f0b3f6e9010.png">

-> **68% less memory pressure**

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
