### PR TITLE
Add parameter support to migrated rest api endpoint

### DIFF
--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/paths/_eth_v1_beacon_states_{state_id}_fork.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/paths/_eth_v1_beacon_states_{state_id}_fork.json
@@ -4,6 +4,16 @@
     "operationId" : "getSateFork",
     "summary" : "Get state fork",
     "description" : "Returns Fork object for state with given 'state_id'.",
+    "parameters" : [ {
+      "name" : "state_id",
+      "required" : true,
+      "in" : "path",
+      "schema" : {
+        "type" : "string",
+        "description" : "State identifier. Can be one of: \"head\" (canonical head in node's view), \"genesis\", \"finalized\", \"justified\", &lt;slot&gt;, &lt;hex encoded stateRoot with 0x prefix&gt;.",
+        "example" : "head"
+      }
+    } ],
     "responses" : {
       "200" : {
         "description" : "Request successful",

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/paths/_eth_v1_node_health.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/paths/_eth_v1_node_health.json
@@ -4,6 +4,14 @@
     "operationId" : "getNodePeers",
     "summary" : "Get node peers",
     "description" : "Retrieves data about the node's network peers.",
+    "parameters" : [ {
+      "name" : "syncing_status",
+      "in" : "query",
+      "schema" : {
+        "type" : "string",
+        "description" : "Customize syncing status instead of default status code (206)"
+      }
+    } ],
     "responses" : {
       "200" : {
         "description" : "Node is ready",

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/paths/_eth_v1_node_peers_{peer_id}.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/paths/_eth_v1_node_peers_{peer_id}.json
@@ -4,6 +4,16 @@
     "operationId" : "getNodePeer",
     "summary" : "Get node peer",
     "description" : "Retrieves data about the given peer.",
+    "parameters" : [ {
+      "name" : "peer_id",
+      "required" : true,
+      "in" : "path",
+      "schema" : {
+        "type" : "string",
+        "description" : "Cryptographic hash of a peer’s public key. [Read more](https://docs.libp2p.io/concepts/peer-id/)",
+        "example" : "QmYyQSo1c1Ym7orWxLYvCrM2EmxFTANf8wXmmE7DWjhx5N"
+      }
+    } ],
     "responses" : {
       "200" : {
         "description" : "Request successful",

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_node_peers_{peer_id}.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_node_peers_{peer_id}.json
@@ -7,6 +7,7 @@
     "parameters" : [ {
       "name" : "peer_id",
       "in" : "path",
+      "description" : "Cryptographic hash of a peer’s public key. [Read more](https://docs.libp2p.io/concepts/peer-id/)",
       "required" : true,
       "schema" : {
         "type" : "string"

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateFork.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateFork.java
@@ -43,6 +43,7 @@ import tech.pegasys.teku.beaconrestapi.MigratingEndpointAdapter;
 import tech.pegasys.teku.beaconrestapi.handlers.AbstractHandler;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
+import tech.pegasys.teku.infrastructure.json.types.CoreTypes;
 import tech.pegasys.teku.infrastructure.json.types.SerializableTypeDefinition;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.EndpointMetadata;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiRequest;
@@ -81,6 +82,7 @@ public class GetStateFork extends MigratingEndpointAdapter {
             .summary("Get state fork")
             .description("Returns Fork object for state with given 'state_id'.")
             .tags(TAG_BEACON, TAG_VALIDATOR_REQUIRED)
+            .pathParam(PARAM_STATE_ID, CoreTypes.string(PARAM_STATE_ID_DESCRIPTION, "head"))
             .response(SC_OK, "Request successful", RESPONSE_TYPE)
             .response(SC_NOT_FOUND, "Not found", BAD_REQUEST_TYPE)
             .build());

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetHealth.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetHealth.java
@@ -41,6 +41,7 @@ import tech.pegasys.teku.api.ChainDataProvider;
 import tech.pegasys.teku.api.DataProvider;
 import tech.pegasys.teku.api.SyncDataProvider;
 import tech.pegasys.teku.beaconrestapi.MigratingEndpointAdapter;
+import tech.pegasys.teku.infrastructure.json.types.CoreTypes;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.EndpointMetadata;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiRequest;
 
@@ -60,6 +61,7 @@ public class GetHealth extends MigratingEndpointAdapter {
             .operationId("getNodePeers")
             .summary("Get node peers")
             .description("Retrieves data about the node's network peers.")
+            .queryParam(SYNCING_STATUS, CoreTypes.string(SYNCING_STATUS_DESCRIPTION))
             .tags(TAG_NODE)
             .response(SC_OK, "Node is ready")
             .response(SC_PARTIAL_CONTENT, "Node is syncing but can serve incomplete data")

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetPeerById.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetPeerById.java
@@ -18,6 +18,8 @@ import static tech.pegasys.teku.beaconrestapi.handlers.AbstractHandler.routeWith
 import static tech.pegasys.teku.beaconrestapi.handlers.v1.node.GetPeers.PEER_DATA_TYPE;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.CACHE_NONE;
+import static tech.pegasys.teku.infrastructure.http.RestApiConstants.PARAM_PEER_ID;
+import static tech.pegasys.teku.infrastructure.http.RestApiConstants.PARAM_PEER_ID_DESCRIPTION;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.RES_INTERNAL_ERROR;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.RES_NOT_FOUND;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.RES_OK;
@@ -29,6 +31,7 @@ import io.javalin.http.Context;
 import io.javalin.plugin.openapi.annotations.HttpMethod;
 import io.javalin.plugin.openapi.annotations.OpenApi;
 import io.javalin.plugin.openapi.annotations.OpenApiContent;
+import io.javalin.plugin.openapi.annotations.OpenApiParam;
 import io.javalin.plugin.openapi.annotations.OpenApiResponse;
 import java.util.Optional;
 import java.util.function.Function;
@@ -37,6 +40,7 @@ import tech.pegasys.teku.api.DataProvider;
 import tech.pegasys.teku.api.NetworkDataProvider;
 import tech.pegasys.teku.api.response.v1.node.PeerResponse;
 import tech.pegasys.teku.beaconrestapi.MigratingEndpointAdapter;
+import tech.pegasys.teku.infrastructure.json.types.CoreTypes;
 import tech.pegasys.teku.infrastructure.json.types.SerializableTypeDefinition;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.EndpointMetadata;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiRequest;
@@ -64,6 +68,10 @@ public class GetPeerById extends MigratingEndpointAdapter {
             .operationId("getNodePeer")
             .summary("Get node peer")
             .description("Retrieves data about the given peer.")
+            .pathParam(
+                PARAM_PEER_ID,
+                CoreTypes.string(
+                    PARAM_PEER_ID_DESCRIPTION, "QmYyQSo1c1Ym7orWxLYvCrM2EmxFTANf8wXmmE7DWjhx5N"))
             .tags(TAG_NODE)
             .response(SC_OK, "Request successful", PEERS_BY_ID_RESPONSE_TYPE)
             .response(SC_NOT_FOUND, "Peer not found")
@@ -77,6 +85,7 @@ public class GetPeerById extends MigratingEndpointAdapter {
       summary = "Get node peer",
       tags = {TAG_NODE},
       description = "Retrieves data about the given peer.",
+      pathParams = {@OpenApiParam(name = PARAM_PEER_ID, description = PARAM_PEER_ID_DESCRIPTION)},
       responses = {
         @OpenApiResponse(status = RES_OK, content = @OpenApiContent(from = PeerResponse.class)),
         @OpenApiResponse(status = RES_NOT_FOUND, description = "Peer not found"),

--- a/infrastructure/http/src/main/java/tech/pegasys/teku/infrastructure/http/RestApiConstants.java
+++ b/infrastructure/http/src/main/java/tech/pegasys/teku/infrastructure/http/RestApiConstants.java
@@ -71,6 +71,10 @@ public class RestApiConstants {
   public static final String COMMITTEE_INDEX_QUERY_DESCRIPTION =
       "`uint64` Committee index to query.";
 
+  public static final String PARAM_PEER_ID = "peer_id";
+  public static final String PARAM_PEER_ID_DESCRIPTION =
+      "Cryptographic hash of a peer’s public key. [Read more](https://docs.libp2p.io/concepts/peer-id/)";
+
   public static final String PARAM_BLOCK_ID = "block_id";
   public static final String PARAM_BLOCK_ID_DESCRIPTION =
       "Block identifier. Can be one of: "


### PR DESCRIPTION
GetStateFork had a path parameter that was required, but we weren't listing it in documentation.

Added the ability to build path parameters and query parameters with the EndpointMetaData.

It'd be nice to be able to specify mandatory query parameters, but currently this is a gap.

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
