### PR TITLE
Start moving parameter utils to infrastructure.

### DIFF
--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/SingleQueryParameterUtils.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/SingleQueryParameterUtils.java
@@ -13,90 +13,18 @@
 
 package tech.pegasys.teku.beaconrestapi;
 
+import static tech.pegasys.teku.infrastructure.restapi.endpoints.SingleQueryParameterUtils.validateQueryParameter;
+
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.api.exceptions.BadRequestException;
 import tech.pegasys.teku.api.schema.BLSSignature;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 public class SingleQueryParameterUtils {
-
-  public static final String INVALID_BYTES32_DATA =
-      "Unable to read Bytes32 data from query parameter.";
   public static final String INVALID_BYTES96_DATA =
       "Unable to read Bytes96 data from query parameter.";
-  public static final String INVALID_NUMERIC_VALUE =
-      "Unable to read a numeric value from query parameter.";
-  public static final String NULL_OR_EMPTY_FORMAT = "'%s' cannot be null or empty.";
-  public static final String MUST_SPECIFY_ONLY_ONCE = "'%s' must have a single value in the query.";
-
-  /**
-   * Checks that a parameter exists, has a single entry, and is not an empty string
-   *
-   * @param parameterMap the parameter map
-   * @param key the name of the param to get and validate
-   * @return returns the Value from the key, or throws IllegalArgumentException
-   */
-  public static String validateQueryParameter(
-      final Map<String, List<String>> parameterMap, final String key)
-      throws IllegalArgumentException {
-    if (parameterMap.containsKey(key)) {
-      if (parameterMap.get(key).size() != 1) {
-        throw new IllegalArgumentException(String.format(MUST_SPECIFY_ONLY_ONCE, key));
-      }
-      if (!StringUtils.isEmpty(parameterMap.get(key).get(0))) {
-        return parameterMap.get(key).get(0);
-      }
-    }
-    throw new IllegalArgumentException(String.format(NULL_OR_EMPTY_FORMAT, key));
-  }
-
-  public static int getParameterValueAsInt(
-      final Map<String, List<String>> parameterMap, final String key)
-      throws IllegalArgumentException {
-    String stringValue = validateQueryParameter(parameterMap, key);
-    try {
-      return Integer.parseInt(stringValue);
-    } catch (IllegalArgumentException ex) {
-      throw new IllegalArgumentException(INVALID_NUMERIC_VALUE);
-    }
-  }
-
-  public static UInt64 getParameterValueAsUInt64(
-      final Map<String, List<String>> parameterMap, final String key)
-      throws IllegalArgumentException {
-    String stringValue = validateQueryParameter(parameterMap, key);
-    try {
-      return UInt64.valueOf(stringValue);
-    } catch (IllegalArgumentException ex) {
-      throw new IllegalArgumentException(INVALID_NUMERIC_VALUE);
-    }
-  }
-
-  public static long getParameterValueAsLong(
-      final Map<String, List<String>> parameterMap, final String key)
-      throws IllegalArgumentException {
-    String stringValue = validateQueryParameter(parameterMap, key);
-    try {
-      return Long.parseLong(stringValue);
-    } catch (IllegalArgumentException ex) {
-      throw new IllegalArgumentException(INVALID_NUMERIC_VALUE);
-    }
-  }
-
-  public static Bytes32 getParameterValueAsBytes32(
-      final Map<String, List<String>> parameterMap, final String key)
-      throws IllegalArgumentException {
-    String stringValue = validateQueryParameter(parameterMap, key);
-    try {
-      return Bytes32.fromHexString(stringValue);
-    } catch (IllegalArgumentException ex) {
-      throw new IllegalArgumentException(INVALID_BYTES32_DATA);
-    }
-  }
 
   public static BLSSignature getParameterValueAsBLSSignature(
       final Map<String, List<String>> parameterMap, final String key)
@@ -109,18 +37,13 @@ public class SingleQueryParameterUtils {
     }
   }
 
-  public static Optional<Bytes32> getParameterValueAsBytes32IfPresent(
-      final Map<String, List<String>> parameterMap, final String key) {
-    return parameterMap.containsKey(key)
-        ? Optional.of(SingleQueryParameterUtils.getParameterValueAsBytes32(parameterMap, key))
-        : Optional.empty();
-  }
-
   public static Optional<UInt64> getParameterValueAsUInt64IfPresent(
       final Map<String, List<String>> parameterMap, final String key) {
     try {
       return parameterMap.containsKey(key)
-          ? Optional.of(SingleQueryParameterUtils.getParameterValueAsUInt64(parameterMap, key))
+          ? Optional.of(
+              tech.pegasys.teku.infrastructure.restapi.endpoints.SingleQueryParameterUtils
+                  .getParameterValueAsUInt64(parameterMap, key))
           : Optional.empty();
     } catch (IllegalArgumentException ex) {
       throw new BadRequestException(

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/admin/Readiness.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/admin/Readiness.java
@@ -16,7 +16,6 @@ package tech.pegasys.teku.beaconrestapi.handlers.tekuv1.admin;
 import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
 import static javax.servlet.http.HttpServletResponse.SC_OK;
 import static javax.servlet.http.HttpServletResponse.SC_SERVICE_UNAVAILABLE;
-import static tech.pegasys.teku.beaconrestapi.SingleQueryParameterUtils.getParameterValueAsLong;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.CACHE_NONE;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.RES_BAD_REQUEST;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.RES_OK;
@@ -24,6 +23,7 @@ import static tech.pegasys.teku.infrastructure.http.RestApiConstants.RES_SERVICE
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.TAG_TEKU;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.TARGET_PEER_COUNT;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.TARGET_PEER_COUNT_DESCRIPTION;
+import static tech.pegasys.teku.infrastructure.restapi.endpoints.SingleQueryParameterUtils.getParameterValueAsLong;
 
 import io.javalin.core.util.Header;
 import io.javalin.http.Context;

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetBlockHeaders.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetBlockHeaders.java
@@ -20,6 +20,8 @@ import static tech.pegasys.teku.infrastructure.http.RestApiConstants.RES_INTERNA
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.RES_OK;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.SLOT;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.TAG_BEACON;
+import static tech.pegasys.teku.infrastructure.restapi.endpoints.SingleQueryParameterUtils.getParameterValueAsBytes32IfPresent;
+import static tech.pegasys.teku.infrastructure.restapi.endpoints.SingleQueryParameterUtils.getParameterValueAsUInt64IfPresent;
 
 import com.google.common.base.Throwables;
 import io.javalin.http.Context;
@@ -37,7 +39,6 @@ import org.jetbrains.annotations.NotNull;
 import tech.pegasys.teku.api.ChainDataProvider;
 import tech.pegasys.teku.api.DataProvider;
 import tech.pegasys.teku.api.response.v1.beacon.GetBlockHeadersResponse;
-import tech.pegasys.teku.beaconrestapi.SingleQueryParameterUtils;
 import tech.pegasys.teku.beaconrestapi.handlers.AbstractHandler;
 import tech.pegasys.teku.beaconrestapi.schema.BadRequest;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -81,9 +82,8 @@ public class GetBlockHeaders extends AbstractHandler implements Handler {
     final Map<String, List<String>> queryParameters = ctx.queryParamMap();
 
     final Optional<Bytes32> parentRoot =
-        SingleQueryParameterUtils.getParameterValueAsBytes32IfPresent(queryParameters, PARENT_ROOT);
-    final Optional<UInt64> slot =
-        SingleQueryParameterUtils.getParameterValueAsUInt64IfPresent(queryParameters, SLOT);
+        getParameterValueAsBytes32IfPresent(queryParameters, PARENT_ROOT);
+    final Optional<UInt64> slot = getParameterValueAsUInt64IfPresent(queryParameters, SLOT);
     try {
       ctx.future(
           chainDataProvider

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetHealth.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetHealth.java
@@ -16,7 +16,6 @@ package tech.pegasys.teku.beaconrestapi.handlers.v1.node;
 import static javax.servlet.http.HttpServletResponse.SC_OK;
 import static javax.servlet.http.HttpServletResponse.SC_PARTIAL_CONTENT;
 import static javax.servlet.http.HttpServletResponse.SC_SERVICE_UNAVAILABLE;
-import static tech.pegasys.teku.beaconrestapi.SingleQueryParameterUtils.getParameterValueAsInt;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.CACHE_NONE;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.RES_OK;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.RES_PARTIAL_CONTENT;
@@ -32,8 +31,6 @@ import io.javalin.plugin.openapi.annotations.HttpMethod;
 import io.javalin.plugin.openapi.annotations.OpenApi;
 import io.javalin.plugin.openapi.annotations.OpenApiParam;
 import io.javalin.plugin.openapi.annotations.OpenApiResponse;
-import java.util.List;
-import java.util.Map;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
@@ -98,18 +95,18 @@ public class GetHealth extends MigratingEndpointAdapter {
     if (!chainDataProvider.isStoreAvailable()) {
       request.respondWithCode(SC_SERVICE_UNAVAILABLE);
     } else if (syncProvider.isSyncing()) {
-      int syncingStatus = SC_PARTIAL_CONTENT;
-      try {
-        final Map<String, List<String>> parameters = request.getQueryParamMap();
-        if (!parameters.isEmpty()) {
-          syncingStatus = getParameterValueAsInt(parameters, SYNCING_STATUS);
-        }
-      } catch (final IllegalArgumentException ex) {
-        LOG.trace("Illegal parameter in GetHealth", ex);
-      }
-      request.respondWithCode(syncingStatus);
+      request.respondWithCode(getResponseCodeFromQueryParams(request));
     } else {
       request.respondWithCode(SC_OK);
     }
+  }
+
+  private int getResponseCodeFromQueryParams(final RestApiRequest request) {
+    try {
+      return request.getQueryParamAsOptionalInteger(SYNCING_STATUS).orElse(SC_PARTIAL_CONTENT);
+    } catch (IllegalArgumentException ex) {
+      LOG.trace("Illegal parameter in GetHealth", ex);
+    }
+    return SC_PARTIAL_CONTENT;
   }
 }

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetAggregateAttestation.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetAggregateAttestation.java
@@ -17,8 +17,6 @@ import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
 import static javax.servlet.http.HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
 import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
 import static javax.servlet.http.HttpServletResponse.SC_OK;
-import static tech.pegasys.teku.beaconrestapi.SingleQueryParameterUtils.getParameterValueAsBytes32;
-import static tech.pegasys.teku.beaconrestapi.SingleQueryParameterUtils.getParameterValueAsUInt64;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.ATTESTATION_DATA_ROOT;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.RES_BAD_REQUEST;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.RES_FORBIDDEN;
@@ -28,6 +26,8 @@ import static tech.pegasys.teku.infrastructure.http.RestApiConstants.RES_OK;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.SLOT;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.TAG_VALIDATOR;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.TAG_VALIDATOR_REQUIRED;
+import static tech.pegasys.teku.infrastructure.restapi.endpoints.SingleQueryParameterUtils.getParameterValueAsBytes32;
+import static tech.pegasys.teku.infrastructure.restapi.endpoints.SingleQueryParameterUtils.getParameterValueAsUInt64;
 
 import com.google.common.base.Throwables;
 import io.javalin.http.Context;

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetAttestationData.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetAttestationData.java
@@ -14,8 +14,6 @@
 package tech.pegasys.teku.beaconrestapi.handlers.v1.validator;
 
 import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
-import static tech.pegasys.teku.beaconrestapi.SingleQueryParameterUtils.getParameterValueAsInt;
-import static tech.pegasys.teku.beaconrestapi.SingleQueryParameterUtils.getParameterValueAsUInt64;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.COMMITTEE_INDEX;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.RES_BAD_REQUEST;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.RES_INTERNAL_ERROR;
@@ -25,6 +23,8 @@ import static tech.pegasys.teku.infrastructure.http.RestApiConstants.SERVICE_UNA
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.SLOT;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.TAG_VALIDATOR;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.TAG_VALIDATOR_REQUIRED;
+import static tech.pegasys.teku.infrastructure.restapi.endpoints.SingleQueryParameterUtils.getParameterValueAsInt;
+import static tech.pegasys.teku.infrastructure.restapi.endpoints.SingleQueryParameterUtils.getParameterValueAsUInt64;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.javalin.http.Context;

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetNewBlock.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetNewBlock.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.beaconrestapi.handlers.v1.validator;
 
 import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
 import static tech.pegasys.teku.beaconrestapi.SingleQueryParameterUtils.getParameterValueAsBLSSignature;
-import static tech.pegasys.teku.beaconrestapi.SingleQueryParameterUtils.getParameterValueAsBytes32;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.GRAFFITI;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.RANDAO_REVEAL;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.RES_BAD_REQUEST;
@@ -26,6 +25,7 @@ import static tech.pegasys.teku.infrastructure.http.RestApiConstants.SERVICE_UNA
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.SLOT;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.TAG_VALIDATOR;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.TAG_VALIDATOR_REQUIRED;
+import static tech.pegasys.teku.infrastructure.restapi.endpoints.SingleQueryParameterUtils.getParameterValueAsBytes32IfPresent;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.base.Throwables;
@@ -105,7 +105,7 @@ public class GetNewBlock extends AbstractHandler implements Handler {
       final UInt64 slot = UInt64.valueOf(pathParamMap.get(SLOT));
       final BLSSignature randao = getParameterValueAsBLSSignature(queryParamMap, RANDAO_REVEAL);
       final Optional<Bytes32> graffiti =
-          getOptionalParameterValueAsBytes32(queryParamMap, GRAFFITI);
+          getParameterValueAsBytes32IfPresent(queryParamMap, GRAFFITI);
       ctx.future(
           provider
               .getUnsignedBeaconBlockAtSlot(slot, randao, graffiti)
@@ -125,15 +125,6 @@ public class GetNewBlock extends AbstractHandler implements Handler {
 
   protected String produceResultString(final BeaconBlock block) throws JsonProcessingException {
     return jsonProvider.objectToJSON(new GetNewBlockResponse(block));
-  }
-
-  private Optional<Bytes32> getOptionalParameterValueAsBytes32(
-      Map<String, List<String>> queryParamMap, final String key) {
-    if (queryParamMap.containsKey(key)) {
-      return Optional.of(getParameterValueAsBytes32(queryParamMap, key));
-    } else {
-      return Optional.empty();
-    }
   }
 
   private SafeFuture<String> handleError(final Context ctx, final Throwable error) {

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetSyncCommitteeContribution.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetSyncCommitteeContribution.java
@@ -15,9 +15,6 @@ package tech.pegasys.teku.beaconrestapi.handlers.v1.validator;
 
 import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
 import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
-import static tech.pegasys.teku.beaconrestapi.SingleQueryParameterUtils.getParameterValueAsBytes32;
-import static tech.pegasys.teku.beaconrestapi.SingleQueryParameterUtils.getParameterValueAsInt;
-import static tech.pegasys.teku.beaconrestapi.SingleQueryParameterUtils.getParameterValueAsUInt64;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.BEACON_BLOCK_ROOT;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.RES_BAD_REQUEST;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.RES_INTERNAL_ERROR;
@@ -27,6 +24,9 @@ import static tech.pegasys.teku.infrastructure.http.RestApiConstants.SLOT;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.SUBCOMMITTEE_INDEX;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.TAG_VALIDATOR;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.TAG_VALIDATOR_REQUIRED;
+import static tech.pegasys.teku.infrastructure.restapi.endpoints.SingleQueryParameterUtils.getParameterValueAsBytes32;
+import static tech.pegasys.teku.infrastructure.restapi.endpoints.SingleQueryParameterUtils.getParameterValueAsInt;
+import static tech.pegasys.teku.infrastructure.restapi.endpoints.SingleQueryParameterUtils.getParameterValueAsUInt64;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.javalin.http.Context;

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/SingleQueryParameterUtilsTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/SingleQueryParameterUtilsTest.java
@@ -17,17 +17,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static tech.pegasys.teku.beaconrestapi.SingleQueryParameterUtils.getParameterValueAsBLSSignature;
-import static tech.pegasys.teku.beaconrestapi.SingleQueryParameterUtils.getParameterValueAsBytes32;
-import static tech.pegasys.teku.beaconrestapi.SingleQueryParameterUtils.getParameterValueAsInt;
-import static tech.pegasys.teku.beaconrestapi.SingleQueryParameterUtils.getParameterValueAsLong;
-import static tech.pegasys.teku.beaconrestapi.SingleQueryParameterUtils.getParameterValueAsUInt64;
-import static tech.pegasys.teku.beaconrestapi.SingleQueryParameterUtils.validateQueryParameter;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes;
-import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.api.schema.BLSSignature;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -37,90 +31,6 @@ public class SingleQueryParameterUtilsTest {
   public static final String KEY = "any";
   public static final String VALUE = "1";
   public static final Map<String, List<String>> INVALID_DATA = Map.of(KEY, List.of("1.5"));
-
-  @Test
-  public void validateParameters_shouldDetectMissingKey() {
-    Map<String, List<String>> data = Map.of();
-
-    assertThrows(IllegalArgumentException.class, () -> validateQueryParameter(data, KEY));
-  }
-
-  @Test
-  public void validateParameters_shouldDetectEmptyString() {
-    Map<String, List<String>> data = Map.of(KEY, List.of());
-
-    assertThrows(IllegalArgumentException.class, () -> validateQueryParameter(data, KEY));
-  }
-
-  @Test
-  public void validateParameters_shouldDetectMultipleEntries() {
-    Map<String, List<String>> data = Map.of(KEY, List.of("1", "2"));
-
-    assertThrows(IllegalArgumentException.class, () -> validateQueryParameter(data, KEY));
-  }
-
-  @Test
-  public void validateParameters_shouldReturnValue() {
-    Map<String, List<String>> data = Map.of(KEY, List.of(VALUE));
-
-    assertEquals(VALUE, validateQueryParameter(data, KEY));
-  }
-
-  @Test
-  public void getParameterValueAsInt_shouldReturnValue() {
-    Map<String, List<String>> data = Map.of(KEY, List.of(VALUE));
-    assertEquals(1, getParameterValueAsInt(data, KEY));
-  }
-
-  @Test
-  public void getParameterValueAsInt_shouldThrowIllegalArgIfNotIntValue_String() {
-    Map<String, List<String>> data = Map.of(KEY, List.of("not-an-int"));
-    assertThrows(IllegalArgumentException.class, () -> getParameterValueAsInt(data, KEY));
-  }
-
-  @Test
-  public void getParameterValueAsInt_shouldThrowIllegalArgIfNotIntValue_Decimal() {
-    assertThrows(IllegalArgumentException.class, () -> getParameterValueAsInt(INVALID_DATA, KEY));
-  }
-
-  @Test
-  public void getParameterAsUInt64_shouldReturnValue() {
-    Map<String, List<String>> data = Map.of(KEY, List.of("1"));
-    UInt64 result = getParameterValueAsUInt64(data, KEY);
-    assertEquals(UInt64.ONE, result);
-  }
-
-  @Test
-  public void getParameterAsUInt64_shouldThrowIfCannotParse() {
-    assertThrows(
-        IllegalArgumentException.class, () -> getParameterValueAsUInt64(INVALID_DATA, KEY));
-  }
-
-  @Test
-  public void getParameterAsLong_shouldReturnValue() {
-    Map<String, List<String>> data = Map.of(KEY, List.of("1"));
-    long result = getParameterValueAsLong(data, KEY);
-    assertEquals(1L, result);
-  }
-
-  @Test
-  public void getParameterAsLong_shouldThrowIfCannotParse() {
-    assertThrows(IllegalArgumentException.class, () -> getParameterValueAsLong(INVALID_DATA, KEY));
-  }
-
-  @Test
-  public void getParameterAsBytes32_shouldThrowIfCannotParse() {
-    assertThrows(
-        IllegalArgumentException.class, () -> getParameterValueAsBytes32(INVALID_DATA, KEY));
-  }
-
-  @Test
-  public void getParameterAsBytes32_shouldParseHex32String() {
-    Bytes32 bytes32 = Bytes32.random();
-    Map<String, List<String>> data = Map.of(KEY, List.of(bytes32.toHexString()));
-    Bytes32 result = getParameterValueAsBytes32(data, KEY);
-    assertEquals(bytes32, result);
-  }
 
   @Test
   public void getParameterAsBLSSignature_shouldThrowIfCannotParse() {
@@ -134,21 +44,6 @@ public class SingleQueryParameterUtilsTest {
     Map<String, List<String>> data = Map.of(KEY, List.of(signature.toHexString()));
     BLSSignature result = getParameterValueAsBLSSignature(data, KEY);
     assertEquals(signature, result);
-  }
-
-  @Test
-  public void getParameterAsBytes32IfPresent_houldReturnEmptyIfNotPresent() {
-    assertThat(SingleQueryParameterUtils.getParameterValueAsBytes32IfPresent(Map.of(), "t"))
-        .isEmpty();
-  }
-
-  @Test
-  public void getParameterAsBytes32IfPresent_shouldReturnData() {
-    Bytes32 bytes32 = Bytes32.random();
-    assertThat(
-            SingleQueryParameterUtils.getParameterValueAsBytes32IfPresent(
-                Map.of("t", List.of(bytes32.toHexString())), "t"))
-        .isEqualTo(Optional.of(bytes32));
   }
 
   @Test

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/RestApiRequest.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/RestApiRequest.java
@@ -84,12 +84,17 @@ public class RestApiRequest {
     context.status(statusCode);
   }
 
-  public String getPathParam(String pathParameter) {
+  public String getPathParam(final String pathParameter) {
     return pathParamMap.get(pathParameter);
   }
 
-  public Map<String, List<String>> getQueryParamMap() {
-    return queryParamMap;
+  public int getQueryParamAsInt(final String queryParameter) {
+    return SingleQueryParameterUtils.getParameterValueAsInt(queryParamMap, queryParameter);
+  }
+
+  public Optional<Integer> getQueryParamAsOptionalInteger(final String queryParameter) {
+    return SingleQueryParameterUtils.getParameterValueAsIntegerIfPresent(
+        queryParamMap, queryParameter);
   }
 
   public <T> void handleOptionalResult(

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/SingleQueryParameterUtils.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/SingleQueryParameterUtils.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.restapi.endpoints;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+public class SingleQueryParameterUtils {
+  public static final String INVALID_BYTES32_DATA =
+      "Unable to read Bytes32 data from query parameter.";
+  public static final String INVALID_BYTES96_DATA =
+      "Unable to read Bytes96 data from query parameter.";
+  public static final String INVALID_NUMERIC_VALUE =
+      "Unable to read a numeric value from query parameter.";
+  /**
+   * Checks that a parameter exists, has a single entry, and is not an empty string
+   *
+   * @param parameterMap the parameter map
+   * @param key the name of the param to get and validate
+   * @return returns the Value from the key, or throws IllegalArgumentException
+   */
+  public static String validateQueryParameter(
+      final Map<String, List<String>> parameterMap, final String key)
+      throws IllegalArgumentException {
+    if (parameterMap.containsKey(key)) {
+      if (parameterMap.get(key).size() != 1) {
+        throw new IllegalArgumentException(
+            String.format("'%s' must have a single value in the query.", key));
+      }
+      if (!StringUtils.isEmpty(parameterMap.get(key).get(0))) {
+        return parameterMap.get(key).get(0);
+      }
+    }
+    throw new IllegalArgumentException(String.format("'%s' cannot be null or empty.", key));
+  }
+
+  public static int getParameterValueAsInt(
+      final Map<String, List<String>> parameterMap, final String key)
+      throws IllegalArgumentException {
+    String stringValue = validateQueryParameter(parameterMap, key);
+    try {
+      return Integer.parseInt(stringValue);
+    } catch (IllegalArgumentException ex) {
+      throw new IllegalArgumentException(INVALID_NUMERIC_VALUE);
+    }
+  }
+
+  public static UInt64 getParameterValueAsUInt64(
+      final Map<String, List<String>> parameterMap, final String key)
+      throws IllegalArgumentException {
+    String stringValue = validateQueryParameter(parameterMap, key);
+    try {
+      return UInt64.valueOf(stringValue);
+    } catch (IllegalArgumentException ex) {
+      throw new IllegalArgumentException(INVALID_NUMERIC_VALUE);
+    }
+  }
+
+  public static long getParameterValueAsLong(
+      final Map<String, List<String>> parameterMap, final String key)
+      throws IllegalArgumentException {
+    String stringValue = validateQueryParameter(parameterMap, key);
+    try {
+      return Long.parseLong(stringValue);
+    } catch (IllegalArgumentException ex) {
+      throw new IllegalArgumentException(INVALID_NUMERIC_VALUE);
+    }
+  }
+
+  public static Bytes32 getParameterValueAsBytes32(
+      final Map<String, List<String>> parameterMap, final String key)
+      throws IllegalArgumentException {
+    String stringValue = validateQueryParameter(parameterMap, key);
+    try {
+      return Bytes32.fromHexString(stringValue);
+    } catch (IllegalArgumentException ex) {
+      throw new IllegalArgumentException(INVALID_BYTES32_DATA);
+    }
+  }
+
+  public static Optional<Bytes32> getParameterValueAsBytes32IfPresent(
+      final Map<String, List<String>> parameterMap, final String key) {
+    return parameterMap.containsKey(key)
+        ? Optional.of(SingleQueryParameterUtils.getParameterValueAsBytes32(parameterMap, key))
+        : Optional.empty();
+  }
+
+  public static Optional<UInt64> getParameterValueAsUInt64IfPresent(
+      final Map<String, List<String>> parameterMap, final String key) {
+    return parameterMap.containsKey(key)
+        ? Optional.of(getParameterValueAsUInt64(parameterMap, key))
+        : Optional.empty();
+  }
+
+  public static Optional<Integer> getParameterValueAsIntegerIfPresent(
+      final Map<String, List<String>> parameterMap, final String key) {
+    return parameterMap.containsKey(key)
+        ? Optional.of(getParameterValueAsInt(parameterMap, key))
+        : Optional.empty();
+  }
+}

--- a/infrastructure/restapi/src/test/java/tech/pegasys/teku/infrastructure/restapi/endpoints/SingleQueryParameterUtilsTest.java
+++ b/infrastructure/restapi/src/test/java/tech/pegasys/teku/infrastructure/restapi/endpoints/SingleQueryParameterUtilsTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.restapi.endpoints;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static tech.pegasys.teku.infrastructure.restapi.endpoints.SingleQueryParameterUtils.getParameterValueAsBytes32;
+import static tech.pegasys.teku.infrastructure.restapi.endpoints.SingleQueryParameterUtils.getParameterValueAsBytes32IfPresent;
+import static tech.pegasys.teku.infrastructure.restapi.endpoints.SingleQueryParameterUtils.getParameterValueAsInt;
+import static tech.pegasys.teku.infrastructure.restapi.endpoints.SingleQueryParameterUtils.getParameterValueAsIntegerIfPresent;
+import static tech.pegasys.teku.infrastructure.restapi.endpoints.SingleQueryParameterUtils.getParameterValueAsLong;
+import static tech.pegasys.teku.infrastructure.restapi.endpoints.SingleQueryParameterUtils.getParameterValueAsUInt64;
+import static tech.pegasys.teku.infrastructure.restapi.endpoints.SingleQueryParameterUtils.getParameterValueAsUInt64IfPresent;
+import static tech.pegasys.teku.infrastructure.restapi.endpoints.SingleQueryParameterUtils.validateQueryParameter;
+import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+public class SingleQueryParameterUtilsTest {
+  public static final String KEY = "any";
+  public static final String VALUE = "1";
+
+  public static final Map<String, List<String>> INVALID_DATA = Map.of(KEY, List.of("1.5"));
+
+  @Test
+  public void validateParameters_shouldDetectMissingKey() {
+    final Map<String, List<String>> data = Map.of();
+    assertThrows(IllegalArgumentException.class, () -> validateQueryParameter(data, KEY));
+  }
+
+  @Test
+  public void validateParameters_shouldDetectEmptyString() {
+    final Map<String, List<String>> data = Map.of(KEY, List.of());
+    assertThrows(IllegalArgumentException.class, () -> validateQueryParameter(data, KEY));
+  }
+
+  @Test
+  public void validateParameters_shouldDetectMultipleEntries() {
+    final Map<String, List<String>> data = Map.of(KEY, List.of("1", "2"));
+    assertThrows(IllegalArgumentException.class, () -> validateQueryParameter(data, KEY));
+  }
+
+  @Test
+  public void validateParameters_shouldReturnValue() {
+    final Map<String, List<String>> data = Map.of(KEY, List.of(VALUE));
+    assertThat(validateQueryParameter(data, KEY)).isEqualTo(VALUE);
+  }
+
+  @Test
+  public void getParameterValueAsInt_shouldReturnValue() {
+    final Map<String, List<String>> data = Map.of(KEY, List.of(VALUE));
+    assertThat(getParameterValueAsInt(data, KEY)).isEqualTo(1);
+  }
+
+  @Test
+  public void getParameterValueAsInt_shouldThrowIllegalArgIfNotIntValue_String() {
+    final Map<String, List<String>> data = Map.of(KEY, List.of("not-an-int"));
+    assertThatThrownBy(() -> getParameterValueAsInt(data, KEY))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void getParameterValueAsInt_shouldThrowIllegalArgIfNotIntValue_Decimal() {
+    assertThatThrownBy(() -> getParameterValueAsInt(INVALID_DATA, KEY))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void getParameterAsUInt64_shouldReturnValue() {
+    final Map<String, List<String>> data = Map.of(KEY, List.of("1"));
+    assertThat(getParameterValueAsUInt64(data, KEY)).isEqualTo(ONE);
+  }
+
+  @Test
+  public void getParameterAsUInt64_shouldThrowIfCannotParse() {
+    assertThrows(
+        IllegalArgumentException.class, () -> getParameterValueAsUInt64(INVALID_DATA, KEY));
+  }
+
+  @Test
+  public void getParameterAsLong_shouldReturnValue() {
+    Map<String, List<String>> data = Map.of(KEY, List.of("1"));
+    assertThat(getParameterValueAsLong(data, KEY)).isEqualTo(1L);
+  }
+
+  @Test
+  public void getParameterAsLong_shouldThrowIfCannotParse() {
+    assertThatThrownBy(() -> getParameterValueAsLong(INVALID_DATA, KEY))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void getParameterAsBytes32_shouldThrowIfCannotParse() {
+    assertThatThrownBy(() -> getParameterValueAsBytes32(INVALID_DATA, KEY))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void getParameterAsBytes32_shouldParseHex32String() {
+    final Bytes32 bytes32 = Bytes32.random();
+    final Map<String, List<String>> data = Map.of(KEY, List.of(bytes32.toHexString()));
+    assertThat(getParameterValueAsBytes32(data, KEY)).isEqualTo(bytes32);
+  }
+
+  @Test
+  public void getParameterAsBytes32IfPresent_houldReturnEmptyIfNotPresent() {
+    assertThat(getParameterValueAsBytes32IfPresent(Map.of(), "t")).isEmpty();
+  }
+
+  @Test
+  public void getParameterAsBytes32IfPresent_shouldReturnData() {
+    final Bytes32 bytes32 = Bytes32.random();
+    final Map<String, List<String>> data = Map.of("t", List.of(bytes32.toHexString()));
+    assertThat(getParameterValueAsBytes32IfPresent(data, "t")).isEqualTo(Optional.of(bytes32));
+  }
+
+  @Test
+  public void getParameterAsUInt64IfPresent_shouldReturnEmptyIfNotPresent() {
+    assertThat(getParameterValueAsUInt64IfPresent(Map.of(), "t")).isEmpty();
+  }
+
+  @Test
+  public void getParameterAsUInt64IfPresent_shouldReturnData() {
+    final UInt64 value = UInt64.valueOf("123456");
+    final Map<String, List<String>> data = Map.of("t", List.of(value.toString()));
+    assertThat(getParameterValueAsUInt64IfPresent(data, "t")).isEqualTo(Optional.of(value));
+  }
+
+  @Test
+  public void getParameterAsIntegerIfPresent_shouldReturnEmptyIfNotPresent() {
+    assertThat(getParameterValueAsIntegerIfPresent(Map.of(), "t")).isEmpty();
+  }
+
+  @Test
+  public void getParameterAsIntegerIfPresent_shouldReturnData() {
+    final Integer value = 123456;
+    final Map<String, List<String>> data = Map.of("t", List.of(value.toString()));
+    assertThat(getParameterValueAsIntegerIfPresent(data, "t")).isEqualTo(Optional.of(value));
+  }
+}

--- a/infrastructure/restapi/src/test/java/tech/pegasys/teku/infrastructure/restapi/endpoints/SingleQueryParameterUtilsTest.java
+++ b/infrastructure/restapi/src/test/java/tech/pegasys/teku/infrastructure/restapi/endpoints/SingleQueryParameterUtilsTest.java
@@ -150,8 +150,7 @@ public class SingleQueryParameterUtilsTest {
 
   @Test
   public void getParameterAsIntegerIfPresent_shouldReturnData() {
-    final Integer value = 123456;
-    final Map<String, List<String>> data = Map.of("t", List.of(value.toString()));
-    assertThat(getParameterValueAsIntegerIfPresent(data, "t")).isEqualTo(Optional.of(value));
+    final Map<String, List<String>> data = Map.of("t", List.of("123456"));
+    assertThat(getParameterValueAsIntegerIfPresent(data, "t")).isEqualTo(Optional.of(123456));
   }
 }


### PR DESCRIPTION
We don't want individual handlers to have to handle all of the complexity of dealing with query parameters, so it makes sense to use parameterUtils, but currently they're not accessible.

Also removed the `getQueryParamMap` function, as ideally we won't need to have direct access to the query or path paramter maps from the context.

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
