### PR TITLE
Optimise BlockValidator

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlockValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlockValidator.java
@@ -81,66 +81,69 @@ public class BlockValidator {
       return completedFuture(reject("Block does not descend from finalized checkpoint"));
     }
 
-    return recentChainData
-        .retrieveBlockByRoot(block.getMessage().getParentRoot())
-        .thenCompose(
-            parentBlock -> {
-              if (parentBlock.isEmpty()) {
+    final Optional<UInt64> maybeParentBlockSlot =
+        recentChainData.getSlotForBlockRoot(block.getParentRoot());
+    if (maybeParentBlockSlot.isEmpty()) {
+      LOG.trace(
+          "BlockValidator: Parent block does not exist. It will be saved for future processing");
+      return completedFuture(InternalValidationResult.SAVE_FOR_FUTURE);
+    }
+    final UInt64 parentBlockSlot = maybeParentBlockSlot.get();
+
+    if (parentBlockSlot.isGreaterThanOrEqualTo(block.getSlot())) {
+      return completedFuture(reject("Parent block is after child block."));
+    }
+
+    return getParentStateInBlockEpoch(block, parentBlockSlot)
+        .thenApply(
+            maybePostState -> {
+              if (maybePostState.isEmpty()) {
                 LOG.trace(
-                    "BlockValidator: Parent block does not exist. It will be saved for future processing");
-                return completedFuture(InternalValidationResult.SAVE_FOR_FUTURE);
+                    "Block was available but state wasn't. Must have been pruned by finalized.");
+                return InternalValidationResult.IGNORE;
               }
+              final BeaconState postState = maybePostState.get();
 
-              if (parentBlock.get().getSlot().isGreaterThanOrEqualTo(block.getSlot())) {
-                return completedFuture(reject("Parent block is after child block."));
+              if (!blockIsProposedByTheExpectedProposer(block, postState)) {
+                return reject(
+                    "Block proposed by incorrect proposer (%s)", block.getProposerIndex());
               }
+              if (spec.atSlot(block.getSlot()).miscHelpers().isMergeTransitionComplete(postState)) {
+                Optional<ExecutionPayload> executionPayload =
+                    block.getMessage().getBody().getOptionalExecutionPayload();
 
-              final UInt64 firstSlotInBlockEpoch =
-                  spec.computeStartSlotAtEpoch(spec.computeEpochAtSlot(block.getSlot()));
-              return recentChainData
-                  .retrieveStateAtSlot(
-                      new SlotAndBlockRoot(
-                          parentBlock.get().getSlot().max(firstSlotInBlockEpoch),
-                          block.getParentRoot()))
-                  .thenApply(
-                      maybePostState -> {
-                        if (maybePostState.isEmpty()) {
-                          LOG.trace(
-                              "Block was available but state wasn't. Must have been pruned by finalized.");
-                          return InternalValidationResult.IGNORE;
-                        }
-                        final BeaconState postState = maybePostState.get();
+                if (executionPayload.isEmpty()) {
+                  return reject("Missing execution payload");
+                }
 
-                        if (!blockIsProposedByTheExpectedProposer(block, postState)) {
-                          return reject(
-                              "Block proposed by incorrect proposer (%s)",
-                              block.getProposerIndex());
-                        }
-                        if (spec.atSlot(block.getSlot())
-                            .miscHelpers()
-                            .isMergeTransitionComplete(postState)) {
-                          Optional<ExecutionPayload> executionPayload =
-                              block.getMessage().getBody().getOptionalExecutionPayload();
-
-                          if (executionPayload.isEmpty()) {
-                            return reject("Missing execution payload");
-                          }
-
-                          if (executionPayload
-                                  .get()
-                                  .getTimestamp()
-                                  .compareTo(spec.computeTimeAtSlot(postState, block.getSlot()))
-                              != 0) {
-                            return reject(
-                                "Execution Payload timestamp is not consistence with and block slot time");
-                          }
-                        }
-                        if (!blockSignatureIsValidWithRespectToProposerIndex(block, postState)) {
-                          return reject("Block signature is invalid");
-                        }
-                        return InternalValidationResult.ACCEPT;
-                      });
+                if (executionPayload
+                        .get()
+                        .getTimestamp()
+                        .compareTo(spec.computeTimeAtSlot(postState, block.getSlot()))
+                    != 0) {
+                  return reject(
+                      "Execution Payload timestamp is not consistence with and block slot time");
+                }
+              }
+              if (!blockSignatureIsValidWithRespectToProposerIndex(block, postState)) {
+                return reject("Block signature is invalid");
+              }
+              return InternalValidationResult.ACCEPT;
             });
+  }
+
+  /**
+   * Retrieve the state for the parent block, applying the epoch transition if required to be able
+   * to calculate the expected proposer for block.
+   */
+  private SafeFuture<Optional<BeaconState>> getParentStateInBlockEpoch(
+      final SignedBeaconBlock block, final UInt64 parentBlockSlot) {
+    final UInt64 firstSlotInBlockEpoch =
+        spec.computeStartSlotAtEpoch(spec.computeEpochAtSlot(block.getSlot()));
+    return parentBlockSlot.isLessThan(firstSlotInBlockEpoch)
+        ? recentChainData.retrieveStateAtSlot(
+            new SlotAndBlockRoot(firstSlotInBlockEpoch, block.getParentRoot()))
+        : recentChainData.retrieveBlockState(block.getParentRoot());
   }
 
   private boolean blockIsFromFutureSlot(SignedBeaconBlock block) {

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransactionUpdates.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransactionUpdates.java
@@ -108,9 +108,10 @@ class StoreTransactionUpdates {
         (root) -> {
           store.blocks.remove(root);
           store.states.remove(root);
-          store.checkpointStates.removeIf(
-              slotAndBlockRoot -> slotAndBlockRoot.getBlockRoot().equals(root));
         });
+
+    store.checkpointStates.removeIf(
+        slotAndBlockRoot -> prunedHotBlockRoots.contains(slotAndBlockRoot.getBlockRoot()));
     tx.latestValidFinalizedSlot.ifPresent(value -> store.latestValidFinalizedSlot = value);
 
     if (tx.proposerBoostRootSet) {


### PR DESCRIPTION
## PR Description
Only retrieve the parent block slot instead of the entire block.
Only request the state at a specific slot if the parent block is from a prior epoch. This avoids unnecessarily adding to the checkpoint state cache if the state doesn't need to have any slots applied.

Combines well with #5205 to require fewer states in the caches.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
