### PR TITLE
Disable layer caching for dockerScan

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -232,7 +232,7 @@ jobs:
     steps:
       - prepare
       - setup_remote_docker:
-          docker_layer_caching: true
+          docker_layer_caching: false
       - run:
           name: Install trivy
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -501,6 +501,7 @@ jobs:
 workflows:
   circleci:
     jobs:
+      - dockerScan
       - assemble:
           filters:
             tags: &filters-release-tags

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -501,7 +501,6 @@ jobs:
 workflows:
   circleci:
     jobs:
-      - dockerScan
       - assemble:
           filters:
             tags: &filters-release-tags


### PR DESCRIPTION
## PR Description
Disable the docker layer caching when running dockerScan to reduce likelihood of running against a cached version.


## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
