### PR TITLE
Align `SimpleLeafNode` to `SimpleBranchNode`: make cached hash `volatile`

### DIFF
--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/SimpleBranchNode.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/SimpleBranchNode.java
@@ -57,8 +57,10 @@ class SimpleBranchNode implements BranchNode, TreeNode {
 
   @Override
   public Bytes32 hashTreeRoot() {
+    Bytes32 cachedHash = this.cachedHash;
     if (cachedHash == null) {
       cachedHash = BranchNode.super.hashTreeRoot();
+      this.cachedHash = cachedHash;
     }
     return cachedHash;
   }

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/SimpleLeafNode.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/SimpleLeafNode.java
@@ -23,15 +23,15 @@ import org.apache.tuweni.bytes.Bytes32;
 class SimpleLeafNode implements LeafNode, TreeNode {
 
   private final Bytes data;
-  private Bytes32 hashTreeRoot;
+  private volatile Bytes32 cachedHash;
 
   public SimpleLeafNode(Bytes data) {
     checkArgument(data.size() <= MAX_BYTE_SIZE);
     if (data.size() == MAX_BYTE_SIZE) {
       // if data is Bytes32, it will pass throw with no object creation
       // otherwise translate types to Bytes32
-      this.hashTreeRoot = Bytes32.wrap(data.copy());
-      this.data = hashTreeRoot;
+      this.cachedHash = Bytes32.wrap(data.copy());
+      this.data = cachedHash;
       return;
     }
     // If we store data as is, some Bytes instances (ie ConcatenatedBytes) will
@@ -49,12 +49,10 @@ class SimpleLeafNode implements LeafNode, TreeNode {
 
   @Override
   public Bytes32 hashTreeRoot() {
-    if (hashTreeRoot != null) {
-      return hashTreeRoot;
+    if (cachedHash == null) {
+      cachedHash = Bytes32.wrap(Arrays.copyOf(data.toArrayUnsafe(), MAX_BYTE_SIZE));
     }
-
-    hashTreeRoot = Bytes32.wrap(Arrays.copyOf(data.toArrayUnsafe(), MAX_BYTE_SIZE));
-    return hashTreeRoot;
+    return cachedHash;
   }
 
   @Override

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/SimpleLeafNode.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/SimpleLeafNode.java
@@ -49,8 +49,10 @@ class SimpleLeafNode implements LeafNode, TreeNode {
 
   @Override
   public Bytes32 hashTreeRoot() {
+    Bytes32 cachedHash = this.cachedHash;
     if (cachedHash == null) {
       cachedHash = Bytes32.wrap(Arrays.copyOf(data.toArrayUnsafe(), MAX_BYTE_SIZE));
+      this.cachedHash = cachedHash;
     }
     return cachedHash;
   }

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/TreeUtil.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/TreeUtil.java
@@ -100,7 +100,7 @@ public class TreeUtil {
       checkArgument(defaultNodesCount == 1);
       return defaultNode;
     } else {
-      long leftNodesCount = Math.min(defaultNodesCount, 1 << (depth - 1));
+      long leftNodesCount = Math.min(defaultNodesCount, 1L << (depth - 1));
       long rightNodesCount = defaultNodesCount - leftNodesCount;
       TreeNode lTree = createTree(defaultNode, leftNodesCount, depth - 1);
       TreeNode rTree =


### PR DESCRIPTION
## PR Description

`SimpleLeafNode` was caching the hashtree in a non-volatile variable.

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
