### PR TITLE
Update GetNewBlindedBlock to use MigratingAdapter

### DIFF
--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/AbstractDataBackedRestAPIIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/AbstractDataBackedRestAPIIntegrationTest.java
@@ -186,7 +186,7 @@ public abstract class AbstractDataBackedRestAPIIntegrationTest {
             .build();
 
     beaconRestApi =
-        new BeaconRestApi(dataProvider, config, eventChannels, SyncAsyncRunner.SYNC_RUNNER);
+        new BeaconRestApi(dataProvider, config, eventChannels, SyncAsyncRunner.SYNC_RUNNER, spec);
     beaconRestApi.start();
     client = new OkHttpClient.Builder().readTimeout(0, TimeUnit.SECONDS).build();
   }

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/beacon/migrated/MigratedOpenApiIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/beacon/migrated/MigratedOpenApiIntegrationTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import tech.pegasys.teku.beaconrestapi.AbstractDataBackedRestAPIIntegrationTest;
 import tech.pegasys.teku.infrastructure.restapi.OpenApiTestUtil;
+import tech.pegasys.teku.spec.SpecMilestone;
 
 public class MigratedOpenApiIntegrationTest extends AbstractDataBackedRestAPIIntegrationTest {
   private JsonNode currentJsonNodes;
@@ -29,7 +30,7 @@ public class MigratedOpenApiIntegrationTest extends AbstractDataBackedRestAPIInt
 
   @BeforeEach
   public void setup() throws IOException {
-    startRestAPIAtGenesis();
+    startRestAPIAtGenesis(SpecMilestone.BELLATRIX);
     currentJsonNodes = util.parseSwagger(beaconRestApi.getMigratedOpenApi());
   }
 

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/beacon/migrated/MigratedOpenApiIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/beacon/migrated/MigratedOpenApiIntegrationTest.java
@@ -21,7 +21,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import tech.pegasys.teku.beaconrestapi.AbstractDataBackedRestAPIIntegrationTest;
 import tech.pegasys.teku.infrastructure.restapi.OpenApiTestUtil;
-import tech.pegasys.teku.spec.SpecMilestone;
 
 public class MigratedOpenApiIntegrationTest extends AbstractDataBackedRestAPIIntegrationTest {
   private JsonNode currentJsonNodes;
@@ -30,7 +29,7 @@ public class MigratedOpenApiIntegrationTest extends AbstractDataBackedRestAPIInt
 
   @BeforeEach
   public void setup() throws IOException {
-    startRestAPIAtGenesis(SpecMilestone.BELLATRIX);
+    startRestAPIAtGenesis();
     currentJsonNodes = util.parseSwagger(beaconRestApi.getMigratedOpenApi());
   }
 

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/paths/_eth_v1_validator_blinded_blocks_{slot}.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/paths/_eth_v1_validator_blinded_blocks_{slot}.json
@@ -1,0 +1,68 @@
+{
+  "get" : {
+    "tags" : [ "Validator", "Validator Required Api", "Experimental" ],
+    "operationId" : "getNewBlindedBlock",
+    "summary" : "Produce unsigned blinded block",
+    "description" : "Requests a beacon node to produce a valid blinded block, which can then be signed by a validator. A blinded block is a block with only a transactions root, rather than a full transactions list.\n\nMetadata in the response indicates the type of block produced, and the supported types of block will be added to as forks progress.\n\nPre-Bellatrix, this endpoint will return a `BeaconBlock`.",
+    "parameters" : [ {
+      "name" : "slot",
+      "required" : true,
+      "in" : "path",
+      "schema" : {
+        "type" : "string",
+        "description" : "The slot for which the block should be proposed.",
+        "example" : "1",
+        "format" : "uint64"
+      }
+    }, {
+      "name" : "randao_reveal",
+      "required" : true,
+      "in" : "query",
+      "schema" : {
+        "type" : "string",
+        "description" : "`BLSSignature Hex` BLS12-381 signature for the current epoch."
+      }
+    }, {
+      "name" : "graffiti",
+      "in" : "query",
+      "schema" : {
+        "type" : "string",
+        "description" : "`Bytes32 Hex` Graffiti.",
+        "example" : "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+        "format" : "byte"
+      }
+    } ],
+    "responses" : {
+      "200" : {
+        "description" : "Request successful",
+        "content" : {
+          "application/json" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/GetNewBlindedBlockResponse"
+            }
+          }
+        }
+      },
+      "400" : {
+        "description" : "The request could not be processed, check the response for more information.",
+        "content" : {
+          "application/json" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/HttpErrorResponse"
+            }
+          }
+        }
+      },
+      "500" : {
+        "description" : "Internal server error",
+        "content" : {
+          "application/json" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/HttpErrorResponse"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/paths/_eth_v1_validator_blinded_blocks_{slot}.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/paths/_eth_v1_validator_blinded_blocks_{slot}.json
@@ -20,7 +20,9 @@
       "in" : "query",
       "schema" : {
         "type" : "string",
-        "description" : "`BLSSignature Hex` BLS12-381 signature for the current epoch."
+        "description" : "`BLSSignature Hex` BLS12-381 signature for the current epoch.",
+        "example" : "0x1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505cc411d61252fb6cb3fa0017b679f8bb2305b26a285fa2737f175668d0dff91cc1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505",
+        "format" : "byte"
       }
     }, {
       "name" : "graffiti",

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/schema/Attestation.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/schema/Attestation.json
@@ -1,0 +1,22 @@
+{
+  "title" : "Attestation",
+  "type" : "object",
+  "required" : [ "aggregation_bits", "data", "signature" ],
+  "properties" : {
+    "aggregation_bits" : {
+      "type" : "string",
+      "pattern" : "^0x[a-fA-F0-9]{2,}$",
+      "description" : "SSZ hexadecimal",
+      "format" : "bytes"
+    },
+    "data" : {
+      "$ref" : "#/components/schemas/AttestationData"
+    },
+    "signature" : {
+      "type" : "string",
+      "pattern" : "^0x[a-fA-F0-9]{2,}$",
+      "description" : "SSZ hexadecimal",
+      "format" : "bytes"
+    }
+  }
+}

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/schema/AttestationData.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/schema/AttestationData.json
@@ -1,0 +1,31 @@
+{
+  "title" : "AttestationData",
+  "type" : "object",
+  "required" : [ "slot", "index", "beacon_block_root", "source", "target" ],
+  "properties" : {
+    "slot" : {
+      "type" : "string",
+      "description" : "unsigned 64 bit integer",
+      "example" : "1",
+      "format" : "uint64"
+    },
+    "index" : {
+      "type" : "string",
+      "description" : "unsigned 64 bit integer",
+      "example" : "1",
+      "format" : "uint64"
+    },
+    "beacon_block_root" : {
+      "type" : "string",
+      "description" : "Bytes32 hexadecimal",
+      "example" : "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+      "format" : "byte"
+    },
+    "source" : {
+      "$ref" : "#/components/schemas/Checkpoint"
+    },
+    "target" : {
+      "$ref" : "#/components/schemas/Checkpoint"
+    }
+  }
+}

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/schema/AttesterSlashing.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/schema/AttesterSlashing.json
@@ -1,0 +1,13 @@
+{
+  "title" : "AttesterSlashing",
+  "type" : "object",
+  "required" : [ "attestation_1", "attestation_2" ],
+  "properties" : {
+    "attestation_1" : {
+      "$ref" : "#/components/schemas/IndexedAttestation"
+    },
+    "attestation_2" : {
+      "$ref" : "#/components/schemas/IndexedAttestation"
+    }
+  }
+}

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/schema/BeaconBlockAltair.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/schema/BeaconBlockAltair.json
@@ -1,0 +1,34 @@
+{
+  "title" : "BeaconBlockAltair",
+  "type" : "object",
+  "required" : [ "slot", "proposer_index", "parent_root", "state_root", "body" ],
+  "properties" : {
+    "slot" : {
+      "type" : "string",
+      "description" : "unsigned 64 bit integer",
+      "example" : "1",
+      "format" : "uint64"
+    },
+    "proposer_index" : {
+      "type" : "string",
+      "description" : "unsigned 64 bit integer",
+      "example" : "1",
+      "format" : "uint64"
+    },
+    "parent_root" : {
+      "type" : "string",
+      "description" : "Bytes32 hexadecimal",
+      "example" : "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+      "format" : "byte"
+    },
+    "state_root" : {
+      "type" : "string",
+      "description" : "Bytes32 hexadecimal",
+      "example" : "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+      "format" : "byte"
+    },
+    "body" : {
+      "$ref" : "#/components/schemas/BeaconBlockBodyAltair"
+    }
+  }
+}

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/schema/BeaconBlockBodyAltair.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/schema/BeaconBlockBodyAltair.json
@@ -1,0 +1,55 @@
+{
+  "title" : "BeaconBlockBodyAltair",
+  "type" : "object",
+  "required" : [ "randao_reveal", "eth1_data", "graffiti", "proposer_slashings", "attester_slashings", "attestations", "deposits", "voluntary_exits", "sync_aggregate" ],
+  "properties" : {
+    "randao_reveal" : {
+      "type" : "string",
+      "pattern" : "^0x[a-fA-F0-9]{2,}$",
+      "description" : "SSZ hexadecimal",
+      "format" : "bytes"
+    },
+    "eth1_data" : {
+      "$ref" : "#/components/schemas/Eth1Data"
+    },
+    "graffiti" : {
+      "type" : "string",
+      "description" : "Bytes32 hexadecimal",
+      "example" : "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+      "format" : "byte"
+    },
+    "proposer_slashings" : {
+      "type" : "array",
+      "items" : {
+        "$ref" : "#/components/schemas/ProposerSlashing"
+      }
+    },
+    "attester_slashings" : {
+      "type" : "array",
+      "items" : {
+        "$ref" : "#/components/schemas/AttesterSlashing"
+      }
+    },
+    "attestations" : {
+      "type" : "array",
+      "items" : {
+        "$ref" : "#/components/schemas/Attestation"
+      }
+    },
+    "deposits" : {
+      "type" : "array",
+      "items" : {
+        "$ref" : "#/components/schemas/Deposit"
+      }
+    },
+    "voluntary_exits" : {
+      "type" : "array",
+      "items" : {
+        "$ref" : "#/components/schemas/SignedVoluntaryExit"
+      }
+    },
+    "sync_aggregate" : {
+      "$ref" : "#/components/schemas/SyncAggregate"
+    }
+  }
+}

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/schema/BeaconBlockBodyPhase0.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/schema/BeaconBlockBodyPhase0.json
@@ -1,0 +1,52 @@
+{
+  "title" : "BeaconBlockBodyPhase0",
+  "type" : "object",
+  "required" : [ "randao_reveal", "eth1_data", "graffiti", "proposer_slashings", "attester_slashings", "attestations", "deposits", "voluntary_exits" ],
+  "properties" : {
+    "randao_reveal" : {
+      "type" : "string",
+      "pattern" : "^0x[a-fA-F0-9]{2,}$",
+      "description" : "SSZ hexadecimal",
+      "format" : "bytes"
+    },
+    "eth1_data" : {
+      "$ref" : "#/components/schemas/Eth1Data"
+    },
+    "graffiti" : {
+      "type" : "string",
+      "description" : "Bytes32 hexadecimal",
+      "example" : "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+      "format" : "byte"
+    },
+    "proposer_slashings" : {
+      "type" : "array",
+      "items" : {
+        "$ref" : "#/components/schemas/ProposerSlashing"
+      }
+    },
+    "attester_slashings" : {
+      "type" : "array",
+      "items" : {
+        "$ref" : "#/components/schemas/AttesterSlashing"
+      }
+    },
+    "attestations" : {
+      "type" : "array",
+      "items" : {
+        "$ref" : "#/components/schemas/Attestation"
+      }
+    },
+    "deposits" : {
+      "type" : "array",
+      "items" : {
+        "$ref" : "#/components/schemas/Deposit"
+      }
+    },
+    "voluntary_exits" : {
+      "type" : "array",
+      "items" : {
+        "$ref" : "#/components/schemas/SignedVoluntaryExit"
+      }
+    }
+  }
+}

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/schema/BeaconBlockHeader.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/schema/BeaconBlockHeader.json
@@ -1,0 +1,37 @@
+{
+  "title" : "BeaconBlockHeader",
+  "type" : "object",
+  "required" : [ "slot", "proposer_index", "parent_root", "state_root", "body_root" ],
+  "properties" : {
+    "slot" : {
+      "type" : "string",
+      "description" : "unsigned 64 bit integer",
+      "example" : "1",
+      "format" : "uint64"
+    },
+    "proposer_index" : {
+      "type" : "string",
+      "description" : "unsigned 64 bit integer",
+      "example" : "1",
+      "format" : "uint64"
+    },
+    "parent_root" : {
+      "type" : "string",
+      "description" : "Bytes32 hexadecimal",
+      "example" : "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+      "format" : "byte"
+    },
+    "state_root" : {
+      "type" : "string",
+      "description" : "Bytes32 hexadecimal",
+      "example" : "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+      "format" : "byte"
+    },
+    "body_root" : {
+      "type" : "string",
+      "description" : "Bytes32 hexadecimal",
+      "example" : "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+      "format" : "byte"
+    }
+  }
+}

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/schema/BeaconBlockPhase0.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/schema/BeaconBlockPhase0.json
@@ -1,0 +1,34 @@
+{
+  "title" : "BeaconBlockPhase0",
+  "type" : "object",
+  "required" : [ "slot", "proposer_index", "parent_root", "state_root", "body" ],
+  "properties" : {
+    "slot" : {
+      "type" : "string",
+      "description" : "unsigned 64 bit integer",
+      "example" : "1",
+      "format" : "uint64"
+    },
+    "proposer_index" : {
+      "type" : "string",
+      "description" : "unsigned 64 bit integer",
+      "example" : "1",
+      "format" : "uint64"
+    },
+    "parent_root" : {
+      "type" : "string",
+      "description" : "Bytes32 hexadecimal",
+      "example" : "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+      "format" : "byte"
+    },
+    "state_root" : {
+      "type" : "string",
+      "description" : "Bytes32 hexadecimal",
+      "example" : "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+      "format" : "byte"
+    },
+    "body" : {
+      "$ref" : "#/components/schemas/BeaconBlockBodyPhase0"
+    }
+  }
+}

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/schema/BlindedBlockBellatrix.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/schema/BlindedBlockBellatrix.json
@@ -1,0 +1,34 @@
+{
+  "title" : "BlindedBlockBellatrix",
+  "type" : "object",
+  "required" : [ "slot", "proposer_index", "parent_root", "state_root", "body" ],
+  "properties" : {
+    "slot" : {
+      "type" : "string",
+      "description" : "unsigned 64 bit integer",
+      "example" : "1",
+      "format" : "uint64"
+    },
+    "proposer_index" : {
+      "type" : "string",
+      "description" : "unsigned 64 bit integer",
+      "example" : "1",
+      "format" : "uint64"
+    },
+    "parent_root" : {
+      "type" : "string",
+      "description" : "Bytes32 hexadecimal",
+      "example" : "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+      "format" : "byte"
+    },
+    "state_root" : {
+      "type" : "string",
+      "description" : "Bytes32 hexadecimal",
+      "example" : "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+      "format" : "byte"
+    },
+    "body" : {
+      "$ref" : "#/components/schemas/BlindedBlockBodyBellatrix"
+    }
+  }
+}

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/schema/BlindedBlockBodyBellatrix.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/schema/BlindedBlockBodyBellatrix.json
@@ -1,0 +1,58 @@
+{
+  "title" : "BlindedBlockBodyBellatrix",
+  "type" : "object",
+  "required" : [ "randao_reveal", "eth1_data", "graffiti", "proposer_slashings", "attester_slashings", "attestations", "deposits", "voluntary_exits", "sync_aggregate", "execution_payload_header" ],
+  "properties" : {
+    "randao_reveal" : {
+      "type" : "string",
+      "pattern" : "^0x[a-fA-F0-9]{2,}$",
+      "description" : "SSZ hexadecimal",
+      "format" : "bytes"
+    },
+    "eth1_data" : {
+      "$ref" : "#/components/schemas/Eth1Data"
+    },
+    "graffiti" : {
+      "type" : "string",
+      "description" : "Bytes32 hexadecimal",
+      "example" : "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+      "format" : "byte"
+    },
+    "proposer_slashings" : {
+      "type" : "array",
+      "items" : {
+        "$ref" : "#/components/schemas/ProposerSlashing"
+      }
+    },
+    "attester_slashings" : {
+      "type" : "array",
+      "items" : {
+        "$ref" : "#/components/schemas/AttesterSlashing"
+      }
+    },
+    "attestations" : {
+      "type" : "array",
+      "items" : {
+        "$ref" : "#/components/schemas/Attestation"
+      }
+    },
+    "deposits" : {
+      "type" : "array",
+      "items" : {
+        "$ref" : "#/components/schemas/Deposit"
+      }
+    },
+    "voluntary_exits" : {
+      "type" : "array",
+      "items" : {
+        "$ref" : "#/components/schemas/SignedVoluntaryExit"
+      }
+    },
+    "sync_aggregate" : {
+      "$ref" : "#/components/schemas/SyncAggregate"
+    },
+    "execution_payload_header" : {
+      "$ref" : "#/components/schemas/ExecutionPayloadHeader"
+    }
+  }
+}

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/schema/Checkpoint.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/schema/Checkpoint.json
@@ -1,0 +1,19 @@
+{
+  "title" : "Checkpoint",
+  "type" : "object",
+  "required" : [ "epoch", "root" ],
+  "properties" : {
+    "epoch" : {
+      "type" : "string",
+      "description" : "unsigned 64 bit integer",
+      "example" : "1",
+      "format" : "uint64"
+    },
+    "root" : {
+      "type" : "string",
+      "description" : "Bytes32 hexadecimal",
+      "example" : "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+      "format" : "byte"
+    }
+  }
+}

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/schema/Deposit.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/schema/Deposit.json
@@ -1,0 +1,19 @@
+{
+  "title" : "Deposit",
+  "type" : "object",
+  "required" : [ "proof", "data" ],
+  "properties" : {
+    "proof" : {
+      "type" : "array",
+      "items" : {
+        "type" : "string",
+        "description" : "Bytes32 hexadecimal",
+        "example" : "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+        "format" : "byte"
+      }
+    },
+    "data" : {
+      "$ref" : "#/components/schemas/DepositData"
+    }
+  }
+}

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/schema/DepositData.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/schema/DepositData.json
@@ -1,0 +1,31 @@
+{
+  "title" : "DepositData",
+  "type" : "object",
+  "required" : [ "pubkey", "withdrawal_credentials", "amount", "signature" ],
+  "properties" : {
+    "pubkey" : {
+      "type" : "string",
+      "pattern" : "^0x[a-fA-F0-9]{2,}$",
+      "description" : "Bytes48 hexadecimal",
+      "format" : "bytes"
+    },
+    "withdrawal_credentials" : {
+      "type" : "string",
+      "description" : "Bytes32 hexadecimal",
+      "example" : "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+      "format" : "byte"
+    },
+    "amount" : {
+      "type" : "string",
+      "description" : "unsigned 64 bit integer",
+      "example" : "1",
+      "format" : "uint64"
+    },
+    "signature" : {
+      "type" : "string",
+      "pattern" : "^0x[a-fA-F0-9]{2,}$",
+      "description" : "SSZ hexadecimal",
+      "format" : "bytes"
+    }
+  }
+}

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/schema/Eth1Data.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/schema/Eth1Data.json
@@ -1,0 +1,25 @@
+{
+  "title" : "Eth1Data",
+  "type" : "object",
+  "required" : [ "deposit_root", "deposit_count", "block_hash" ],
+  "properties" : {
+    "deposit_root" : {
+      "type" : "string",
+      "description" : "Bytes32 hexadecimal",
+      "example" : "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+      "format" : "byte"
+    },
+    "deposit_count" : {
+      "type" : "string",
+      "description" : "unsigned 64 bit integer",
+      "example" : "1",
+      "format" : "uint64"
+    },
+    "block_hash" : {
+      "type" : "string",
+      "description" : "Bytes32 hexadecimal",
+      "example" : "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+      "format" : "byte"
+    }
+  }
+}

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/schema/ExecutionPayloadHeader.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/schema/ExecutionPayloadHeader.json
@@ -1,0 +1,91 @@
+{
+  "title" : "ExecutionPayloadHeader",
+  "type" : "object",
+  "required" : [ "parent_hash", "fee_recipient", "state_root", "receipts_root", "logs_bloom", "prev_randao", "block_number", "gas_limit", "gas_used", "timestamp", "extra_data", "base_fee_per_gas", "block_hash", "transactions_root" ],
+  "properties" : {
+    "parent_hash" : {
+      "type" : "string",
+      "description" : "Bytes32 hexadecimal",
+      "example" : "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+      "format" : "byte"
+    },
+    "fee_recipient" : {
+      "type" : "string",
+      "pattern" : "^0x[a-fA-F0-9]{2,}$",
+      "description" : "SSZ hexadecimal",
+      "format" : "bytes"
+    },
+    "state_root" : {
+      "type" : "string",
+      "description" : "Bytes32 hexadecimal",
+      "example" : "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+      "format" : "byte"
+    },
+    "receipts_root" : {
+      "type" : "string",
+      "description" : "Bytes32 hexadecimal",
+      "example" : "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+      "format" : "byte"
+    },
+    "logs_bloom" : {
+      "type" : "string",
+      "pattern" : "^0x[a-fA-F0-9]{2,}$",
+      "description" : "SSZ hexadecimal",
+      "format" : "bytes"
+    },
+    "prev_randao" : {
+      "type" : "string",
+      "description" : "Bytes32 hexadecimal",
+      "example" : "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+      "format" : "byte"
+    },
+    "block_number" : {
+      "type" : "string",
+      "description" : "unsigned 64 bit integer",
+      "example" : "1",
+      "format" : "uint64"
+    },
+    "gas_limit" : {
+      "type" : "string",
+      "description" : "unsigned 64 bit integer",
+      "example" : "1",
+      "format" : "uint64"
+    },
+    "gas_used" : {
+      "type" : "string",
+      "description" : "unsigned 64 bit integer",
+      "example" : "1",
+      "format" : "uint64"
+    },
+    "timestamp" : {
+      "type" : "string",
+      "description" : "unsigned 64 bit integer",
+      "example" : "1",
+      "format" : "uint64"
+    },
+    "extra_data" : {
+      "type" : "string",
+      "pattern" : "^0x[a-fA-F0-9]{2,}$",
+      "description" : "SSZ encoded byte list",
+      "format" : "bytes"
+    },
+    "base_fee_per_gas" : {
+      "type" : "string",
+      "description" : "unsigned 256 bit integer",
+      "example" : "1",
+      "format" : "uint256"
+    },
+    "block_hash" : {
+      "type" : "string",
+      "description" : "Bytes32 hexadecimal",
+      "example" : "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+      "format" : "byte"
+    },
+    "transactions_root" : {
+      "type" : "string",
+      "description" : "Bytes32 hexadecimal",
+      "example" : "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+      "format" : "byte"
+    }
+  }
+}

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/schema/GetNewBlindedBlockResponse.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/schema/GetNewBlindedBlockResponse.json
@@ -1,0 +1,22 @@
+{
+  "title" : "GetNewBlindedBlockResponse",
+  "type" : "object",
+  "required" : [ "data", "version" ],
+  "properties" : {
+    "data" : {
+      "title" : "BlindedBlock",
+      "type" : "object",
+      "oneOf" : [ {
+        "$ref" : "#/components/schemas/BeaconBlockPhase0"
+      }, {
+        "$ref" : "#/components/schemas/BeaconBlockAltair"
+      }, {
+        "$ref" : "#/components/schemas/BlindedBlockBellatrix"
+      } ]
+    },
+    "version" : {
+      "type" : "string",
+      "enum" : [ "PHASE0", "ALTAIR", "BELLATRIX" ]
+    }
+  }
+}

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/schema/IndexedAttestation.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/schema/IndexedAttestation.json
@@ -1,0 +1,25 @@
+{
+  "title" : "IndexedAttestation",
+  "type" : "object",
+  "required" : [ "attesting_indices", "data", "signature" ],
+  "properties" : {
+    "attesting_indices" : {
+      "type" : "array",
+      "items" : {
+        "type" : "string",
+        "description" : "unsigned 64 bit integer",
+        "example" : "1",
+        "format" : "uint64"
+      }
+    },
+    "data" : {
+      "$ref" : "#/components/schemas/AttestationData"
+    },
+    "signature" : {
+      "type" : "string",
+      "pattern" : "^0x[a-fA-F0-9]{2,}$",
+      "description" : "SSZ hexadecimal",
+      "format" : "bytes"
+    }
+  }
+}

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/schema/ProposerSlashing.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/schema/ProposerSlashing.json
@@ -1,0 +1,13 @@
+{
+  "title" : "ProposerSlashing",
+  "type" : "object",
+  "required" : [ "signed_header_1", "signed_header_2" ],
+  "properties" : {
+    "signed_header_1" : {
+      "$ref" : "#/components/schemas/SignedBeaconBlockHeader"
+    },
+    "signed_header_2" : {
+      "$ref" : "#/components/schemas/SignedBeaconBlockHeader"
+    }
+  }
+}

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/schema/SignedBeaconBlockHeader.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/schema/SignedBeaconBlockHeader.json
@@ -1,0 +1,16 @@
+{
+  "title" : "SignedBeaconBlockHeader",
+  "type" : "object",
+  "required" : [ "message", "signature" ],
+  "properties" : {
+    "message" : {
+      "$ref" : "#/components/schemas/BeaconBlockHeader"
+    },
+    "signature" : {
+      "type" : "string",
+      "pattern" : "^0x[a-fA-F0-9]{2,}$",
+      "description" : "SSZ hexadecimal",
+      "format" : "bytes"
+    }
+  }
+}

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/schema/SignedVoluntaryExit.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/schema/SignedVoluntaryExit.json
@@ -1,0 +1,16 @@
+{
+  "title" : "SignedVoluntaryExit",
+  "type" : "object",
+  "required" : [ "message", "signature" ],
+  "properties" : {
+    "message" : {
+      "$ref" : "#/components/schemas/VoluntaryExit"
+    },
+    "signature" : {
+      "type" : "string",
+      "pattern" : "^0x[a-fA-F0-9]{2,}$",
+      "description" : "SSZ hexadecimal",
+      "format" : "bytes"
+    }
+  }
+}

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/schema/SyncAggregate.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/schema/SyncAggregate.json
@@ -1,0 +1,19 @@
+{
+  "title" : "SyncAggregate",
+  "type" : "object",
+  "required" : [ "sync_committee_bits", "sync_committee_signature" ],
+  "properties" : {
+    "sync_committee_bits" : {
+      "type" : "string",
+      "pattern" : "^0x[a-fA-F0-9]{2,}$",
+      "description" : "SSZ hexadecimal",
+      "format" : "bytes"
+    },
+    "sync_committee_signature" : {
+      "type" : "string",
+      "pattern" : "^0x[a-fA-F0-9]{2,}$",
+      "description" : "SSZ hexadecimal",
+      "format" : "bytes"
+    }
+  }
+}

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/schema/VoluntaryExit.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/schema/VoluntaryExit.json
@@ -1,0 +1,19 @@
+{
+  "title" : "VoluntaryExit",
+  "type" : "object",
+  "required" : [ "epoch", "validator_index" ],
+  "properties" : {
+    "epoch" : {
+      "type" : "string",
+      "description" : "unsigned 64 bit integer",
+      "example" : "1",
+      "format" : "uint64"
+    },
+    "validator_index" : {
+      "type" : "string",
+      "description" : "unsigned 64 bit integer",
+      "example" : "1",
+      "format" : "uint64"
+    }
+  }
+}

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/EthereumTypes.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/EthereumTypes.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.beaconrestapi;
+
+import org.apache.tuweni.bytes.Bytes;
+import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
+import tech.pegasys.teku.infrastructure.json.types.StringValueTypeDefinition;
+
+public class EthereumTypes {
+
+  public static final StringValueTypeDefinition<BLSSignature> SIGNATURE_TYPE =
+      DeserializableTypeDefinition.string(BLSSignature.class)
+          .formatter(BLSSignature::toString)
+          .parser(value -> BLSSignature.fromBytesCompressed(Bytes.fromHexString(value)))
+          .example(
+              "0x1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505"
+                  + "cc411d61252fb6cb3fa0017b679f8bb2305b26a285fa2737f175668d0dff91cc"
+                  + "1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505")
+          .description("`BLSSignature Hex` BLS12-381 signature for the current epoch.")
+          .format("byte")
+          .build();
+}

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/SchemaDefinitionCache.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/SchemaDefinitionCache.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.beaconrestapi;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.SpecVersion;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
+
+public class SchemaDefinitionCache {
+  private final Spec spec;
+  private final Map<SpecMilestone, SchemaDefinitions> schemas = new ConcurrentHashMap<>();
+
+  public SchemaDefinitionCache(final Spec spec) {
+    this.spec = spec;
+  }
+
+  public SchemaDefinitions getSchemaDefinition(final SpecMilestone milestone) {
+    return schemas.computeIfAbsent(milestone, this::createSchemaDefinition);
+  }
+
+  public final SpecMilestone milestoneAtSlot(final UInt64 slot) {
+    return spec.atSlot(slot).getMilestone();
+  }
+
+  private SchemaDefinitions createSchemaDefinition(final SpecMilestone milestone) {
+    final SpecVersion specVersion = spec.forMilestone(milestone);
+    if (specVersion != null) {
+      return specVersion.getSchemaDefinitions();
+    }
+    return SpecVersion.create(milestone, spec.getGenesisSpecConfig())
+        .orElseThrow()
+        .getSchemaDefinitions();
+  }
+}

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetNewBlindedBlock.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetNewBlindedBlock.java
@@ -49,6 +49,7 @@ import tech.pegasys.teku.infrastructure.json.types.CoreTypes;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 import tech.pegasys.teku.infrastructure.json.types.SerializableOneOfTypeDefinitionBuilder;
 import tech.pegasys.teku.infrastructure.json.types.SerializableTypeDefinition;
+import tech.pegasys.teku.infrastructure.json.types.StringValueTypeDefinition;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.EndpointMetadata;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.ParameterMetadata;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiRequest;
@@ -68,11 +69,22 @@ public class GetNewBlindedBlock extends MigratingEndpointAdapter {
           CoreTypes.UINT64_TYPE.withDescription(
               "The slot for which the block should be proposed."));
 
-  // todo would be nice to not have to get this from string
-  private static final ParameterMetadata<String> PARAM_RANDAO =
+  private static final StringValueTypeDefinition<BLSSignature> SIGNATURE_TYPE =
+      DeserializableTypeDefinition.string(BLSSignature.class)
+          .formatter(BLSSignature::toString)
+          .parser(value -> BLSSignature.fromBytesCompressed(Bytes.fromHexString(value)))
+          .example(
+              "0x1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505"
+                  + "cc411d61252fb6cb3fa0017b679f8bb2305b26a285fa2737f175668d0dff91cc"
+                  + "1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505")
+          .description("`BLSSignature Hex` BLS12-381 signature for the current epoch.")
+          .format("byte")
+          .build();
+
+  private static final ParameterMetadata<BLSSignature> PARAM_RANDAO =
       new ParameterMetadata<>(
           RestApiConstants.RANDAO_REVEAL,
-          CoreTypes.STRING_TYPE.withDescription(
+          SIGNATURE_TYPE.withDescription(
               "`BLSSignature Hex` BLS12-381 signature for the current epoch."));
 
   private static final ParameterMetadata<Bytes32> PARAM_GRAFFITI =
@@ -138,9 +150,7 @@ public class GetNewBlindedBlock extends MigratingEndpointAdapter {
   @Override
   public void handleRequest(final RestApiRequest request) throws JsonProcessingException {
     final UInt64 slot = request.getPathParameter(PARAM_SLOT);
-    final BLSSignature signature =
-        BLSSignature.fromBytesCompressed(
-            Bytes.fromHexString(request.getQueryParameter(PARAM_RANDAO)));
+    final BLSSignature signature = request.getQueryParameter(PARAM_RANDAO);
     final Optional<Bytes32> grafitti = request.getOptionalQueryParameter(PARAM_GRAFFITI);
     throw new IllegalArgumentException("Not implemented");
   }

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetNewBlindedBlock.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetNewBlindedBlock.java
@@ -186,7 +186,7 @@ public class GetNewBlindedBlock extends MigratingEndpointAdapter {
                                     .equals(SpecMilestone.PHASE0),
                             schemaDefinitionCache
                                 .getSchemaDefinition(SpecMilestone.PHASE0)
-                                .getBlindedBlockSchema()
+                                .getBlindedBeaconBlockSchema()
                                 .getJsonTypeDefinition())
                         .withType(
                             block ->
@@ -195,7 +195,7 @@ public class GetNewBlindedBlock extends MigratingEndpointAdapter {
                                     .equals(SpecMilestone.ALTAIR),
                             schemaDefinitionCache
                                 .getSchemaDefinition(SpecMilestone.ALTAIR)
-                                .getBlindedBlockSchema()
+                                .getBlindedBeaconBlockSchema()
                                 .getJsonTypeDefinition())
                         .withType(
                             block ->
@@ -204,7 +204,7 @@ public class GetNewBlindedBlock extends MigratingEndpointAdapter {
                                     .equals(SpecMilestone.BELLATRIX),
                             schemaDefinitionCache
                                 .getSchemaDefinition(SpecMilestone.BELLATRIX)
-                                .getBlindedBlockSchema()
+                                .getBlindedBeaconBlockSchema()
                                 .getJsonTypeDefinition())
                         .build(),
                     Function.identity())

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/BeaconRestApiTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/BeaconRestApiTest.java
@@ -29,7 +29,6 @@ import tech.pegasys.teku.api.DataProvider;
 import tech.pegasys.teku.beacon.sync.SyncService;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
 import tech.pegasys.teku.infrastructure.events.EventChannels;
-import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.eth1.Eth1Address;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
@@ -47,8 +46,7 @@ import tech.pegasys.teku.storage.client.RecentChainData;
 
 @SuppressWarnings("unchecked")
 class BeaconRestApiTest {
-  private final Spec spec = TestSpecFactory.createMinimalBellatrix();
-  private final RecentChainData storageClient = MemoryOnlyRecentChainData.create(spec);
+  private final RecentChainData storageClient = MemoryOnlyRecentChainData.create();
   private final CombinedChainDataClient combinedChainDataClient =
       mock(CombinedChainDataClient.class);
   private final JettyServer server = mock(JettyServer.class);

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/BeaconRestApiTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/BeaconRestApiTest.java
@@ -29,6 +29,7 @@ import tech.pegasys.teku.api.DataProvider;
 import tech.pegasys.teku.beacon.sync.SyncService;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
 import tech.pegasys.teku.infrastructure.events.EventChannels;
+import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.eth1.Eth1Address;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
@@ -46,8 +47,8 @@ import tech.pegasys.teku.storage.client.RecentChainData;
 
 @SuppressWarnings("unchecked")
 class BeaconRestApiTest {
-
-  private final RecentChainData storageClient = MemoryOnlyRecentChainData.create();
+  private final Spec spec = TestSpecFactory.createMinimalBellatrix();
+  private final RecentChainData storageClient = MemoryOnlyRecentChainData.create(spec);
   private final CombinedChainDataClient combinedChainDataClient =
       mock(CombinedChainDataClient.class);
   private final JettyServer server = mock(JettyServer.class);
@@ -93,7 +94,13 @@ class BeaconRestApiTest {
             .voluntaryExitPool(voluntaryExitPool)
             .syncCommitteeContributionPool(syncCommitteeContributionPool)
             .build();
-    new BeaconRestApi(dataProvider, beaconRestApiConfig, eventChannels, new StubAsyncRunner(), app);
+    new BeaconRestApi(
+        dataProvider,
+        beaconRestApiConfig,
+        eventChannels,
+        new StubAsyncRunner(),
+        app,
+        storageClient.getSpec());
   }
 
   @Test

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/BeaconRestApiV1Test.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/BeaconRestApiV1Test.java
@@ -86,7 +86,6 @@ import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.PostSyncCommitteeSu
 import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.PostValidatorLiveness;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
 import tech.pegasys.teku.infrastructure.events.EventChannels;
-import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.eth1.Eth1Address;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
@@ -104,8 +103,7 @@ import tech.pegasys.teku.storage.client.RecentChainData;
 
 @SuppressWarnings("unchecked")
 public class BeaconRestApiV1Test {
-  private final Spec spec = TestSpecFactory.createMinimalBellatrix();
-  private final RecentChainData storageClient = MemoryOnlyRecentChainData.create(spec);
+  private final RecentChainData storageClient = MemoryOnlyRecentChainData.create();
   private final CombinedChainDataClient combinedChainDataClient =
       mock(CombinedChainDataClient.class);
   private final JettyServer server = mock(JettyServer.class);

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/BeaconRestApiV1Test.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/BeaconRestApiV1Test.java
@@ -86,6 +86,7 @@ import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.PostSyncCommitteeSu
 import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.PostValidatorLiveness;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
 import tech.pegasys.teku.infrastructure.events.EventChannels;
+import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.eth1.Eth1Address;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
@@ -103,7 +104,8 @@ import tech.pegasys.teku.storage.client.RecentChainData;
 
 @SuppressWarnings("unchecked")
 public class BeaconRestApiV1Test {
-  private final RecentChainData storageClient = MemoryOnlyRecentChainData.create();
+  private final Spec spec = TestSpecFactory.createMinimalBellatrix();
+  private final RecentChainData storageClient = MemoryOnlyRecentChainData.create(spec);
   private final CombinedChainDataClient combinedChainDataClient =
       mock(CombinedChainDataClient.class);
   private final JettyServer server = mock(JettyServer.class);
@@ -150,7 +152,13 @@ public class BeaconRestApiV1Test {
             .voluntaryExitPool(voluntaryExitPool)
             .syncCommitteeContributionPool(syncCommitteeContributionPool)
             .build();
-    new BeaconRestApi(dataProvider, beaconRestApiConfig, eventChannels, new StubAsyncRunner(), app);
+    new BeaconRestApi(
+        dataProvider,
+        beaconRestApiConfig,
+        eventChannels,
+        new StubAsyncRunner(),
+        app,
+        storageClient.getSpec());
   }
 
   @ParameterizedTest(name = "{0}")

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/EthereumTypesTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/EthereumTypesTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.beaconrestapi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class EthereumTypesTest {
+  private final Spec spec = TestSpecFactory.createMinimalBellatrix();
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+
+  @Test
+  void shouldDeserializeBLSSignatureFromString() {
+    final BLSSignature signature = dataStructureUtil.randomSignature();
+    final String serialized = signature.toString();
+    assertThat(EthereumTypes.SIGNATURE_TYPE.deserializeFromString(serialized)).isEqualTo(signature);
+  }
+}

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/SchemaDefinitionCacheTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/SchemaDefinitionCacheTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.beaconrestapi;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecFactory;
+
+public class SchemaDefinitionCacheTest {
+
+  @Test
+  void shouldGetSchemasForAllMilestones() {
+    final Spec spec = TestSpecFactory.createMinimalPhase0();
+    final SchemaDefinitionCache cache = new SchemaDefinitionCache(spec);
+    assertThat(cache.getSchemaDefinition(SpecMilestone.PHASE0)).isNotNull();
+    assertThat(cache.getSchemaDefinition(SpecMilestone.ALTAIR)).isNotNull();
+    assertThat(cache.getSchemaDefinition(SpecMilestone.BELLATRIX)).isNotNull();
+  }
+
+  @Test
+  void shouldUseExistingSchemaDefinitionIfPossible() {
+    final Spec spec = mock(Spec.class);
+    when(spec.forMilestone(SpecMilestone.ALTAIR))
+        .thenReturn(TestSpecFactory.createMinimalAltair().forMilestone(SpecMilestone.ALTAIR));
+    final SchemaDefinitionCache cache = new SchemaDefinitionCache(spec);
+    assertThat(cache.getSchemaDefinition(SpecMilestone.ALTAIR)).isNotNull();
+    verify(spec).forMilestone(eq(SpecMilestone.ALTAIR));
+
+    assertThat(cache.getSchemaDefinition(SpecMilestone.ALTAIR)).isNotNull();
+    verifyNoMoreInteractions(spec);
+  }
+
+  @Test
+  void shouldGetSpecMilestoneFromSpecObject() {
+    final Spec spec = mock(Spec.class);
+    when(spec.atSlot(any()))
+        .thenReturn(TestSpecFactory.createMinimalAltair().forMilestone(SpecMilestone.ALTAIR));
+    final SchemaDefinitionCache cache = new SchemaDefinitionCache(spec);
+    assertThat(cache.milestoneAtSlot(UInt64.ONE)).isEqualTo(SpecMilestone.ALTAIR);
+    verify(spec).atSlot(any());
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -111,6 +111,14 @@ public class Spec {
     return specVersions.get(milestone);
   }
 
+  public SpecVersion forMilestoneOrDefault(final SpecMilestone milestone) {
+    SpecVersion specVersion = specVersions.get(milestone);
+    if (specVersion != null) {
+      return specVersion;
+    }
+    return SpecVersion.create(milestone, getGenesisSpecConfig()).orElseThrow();
+  }
+
   public SpecVersion atEpoch(final UInt64 epoch) {
     return specVersions.get(forkSchedule.getSpecMilestoneAtEpoch(epoch));
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -111,14 +111,6 @@ public class Spec {
     return specVersions.get(milestone);
   }
 
-  public SpecVersion forMilestoneOrDefault(final SpecMilestone milestone) {
-    SpecVersion specVersion = specVersions.get(milestone);
-    if (specVersion != null) {
-      return specVersion;
-    }
-    return SpecVersion.create(milestone, getGenesisSpecConfig()).orElseThrow();
-  }
-
   public SpecVersion atEpoch(final UInt64 epoch) {
     return specVersions.get(forkSchedule.getSpecMilestoneAtEpoch(epoch));
   }

--- a/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/CoreTypes.java
+++ b/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/CoreTypes.java
@@ -29,7 +29,7 @@ public class CoreTypes {
 
   public static final StringValueTypeDefinition<Byte> BYTE_TYPE = new ByteTypeDefinition();
 
-  public static final DeserializableTypeDefinition<Bytes32> BYTES32_TYPE =
+  public static final StringValueTypeDefinition<Bytes32> BYTES32_TYPE =
       DeserializableTypeDefinition.string(Bytes32.class)
           .formatter(Bytes32::toHexString)
           .parser(Bytes32::fromHexString)
@@ -47,7 +47,7 @@ public class CoreTypes {
           .format("byte")
           .build();
 
-  public static final DeserializableTypeDefinition<UInt64> UINT64_TYPE =
+  public static final StringValueTypeDefinition<UInt64> UINT64_TYPE =
       DeserializableTypeDefinition.string(UInt64.class)
           .formatter(UInt64::toString)
           .parser(UInt64::valueOf)

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -794,7 +794,8 @@ public class BeaconChainController extends Service implements BeaconChainControl
                   dataProvider,
                   beaconConfig.beaconRestApiConfig(),
                   eventChannels,
-                  eventAsyncRunner));
+                  eventAsyncRunner,
+                  spec));
 
       if (beaconConfig.beaconRestApiConfig().isBeaconLivenessTrackingEnabled()) {
         final int initialValidatorsCount =


### PR DESCRIPTION
We now need the spec passed in so that we can get a definition, and we needed to make sure we had a spec for documentation to work without breaking the api when spec instances aren't defined.

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
