### PR TITLE
remove memoize hashRoot from `SszSuperNode` and `LazyBranchNode`

### DIFF
--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/SszSuperNode.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/SszSuperNode.java
@@ -15,8 +15,6 @@ package tech.pegasys.teku.infrastructure.ssz.tree;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import com.google.common.base.Suppliers;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.tuweni.bytes.Bytes;
@@ -49,7 +47,7 @@ public class SszSuperNode implements TreeNode, LeafDataNode {
   private final int depth;
   private final SszNodeTemplate elementTemplate;
   private final Bytes ssz;
-  private final Supplier<Bytes32> hashTreeRoot = Suppliers.memoize(this::calcHashTreeRoot);
+  private volatile Bytes32 cachedHash;
 
   public SszSuperNode(int depth, SszNodeTemplate elementTemplate, Bytes ssz) {
     this.depth = depth;
@@ -69,7 +67,12 @@ public class SszSuperNode implements TreeNode, LeafDataNode {
 
   @Override
   public Bytes32 hashTreeRoot() {
-    return hashTreeRoot.get();
+    Bytes32 cachedHash = this.cachedHash;
+    if (cachedHash == null) {
+      cachedHash = calcHashTreeRoot();
+      this.cachedHash = cachedHash;
+    }
+    return cachedHash;
   }
 
   private Bytes32 calcHashTreeRoot() {


### PR DESCRIPTION
## PR Description
Substitutes the memoization of `hashTreeRoot` with a simple `volatile` variable.

Profiling by applying state transition on mainnet state at 3378209, to 3378508 (about 300 blocks)

CPU benefits:

<img width="1679" alt="image" src="https://user-images.githubusercontent.com/15999009/160615366-bce00670-d417-4894-8758-5bc4e04e1e8b.png">

Memory benefits:

<img width="1638" alt="image" src="https://user-images.githubusercontent.com/15999009/160615642-0ff5fbde-90ef-468d-899a-046297b45918.png">


fixes #5246

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
