### PR TITLE
SSZ improvements in `MessageDigest` handling

### DIFF
--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/BranchNode.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/BranchNode.java
@@ -63,14 +63,14 @@ public interface BranchNode extends TreeNode {
   @Override
   default Bytes32 hashTreeRoot() {
     final MessageDigest messageDigest = left().hashTreeRootDigest();
-    right().updateDigest(messageDigest);
+    right().updateDigestWithHashTreeRoot(messageDigest);
     return Bytes32.wrap(messageDigest.digest());
   }
 
   @Override
   default MessageDigest hashTreeRootDigest() {
     final MessageDigest messageDigest = left().hashTreeRootDigest();
-    right().updateDigest(messageDigest);
+    right().updateDigestWithHashTreeRoot(messageDigest);
     final Bytes32 hashTreeRoot = Bytes32.wrap(messageDigest.digest());
     messageDigest.reset();
     hashTreeRoot.update(messageDigest);

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/BranchNode.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/BranchNode.java
@@ -61,20 +61,12 @@ public interface BranchNode extends TreeNode {
   BranchNode rebind(boolean left, TreeNode newNode);
 
   @Override
-  default Bytes32 hashTreeRoot() {
-    final MessageDigest messageDigest = left().hashTreeRootDigest();
-    right().updateDigestWithHashTreeRoot(messageDigest);
+  default Bytes32 hashTreeRoot(MessageDigest messageDigest) {
+    final Bytes32 leftRoot = left().hashTreeRoot(messageDigest);
+    final Bytes32 rightRoot = right().hashTreeRoot(messageDigest);
+    leftRoot.update(messageDigest);
+    rightRoot.update(messageDigest);
     return Bytes32.wrap(messageDigest.digest());
-  }
-
-  @Override
-  default MessageDigest hashTreeRootDigest() {
-    final MessageDigest messageDigest = left().hashTreeRootDigest();
-    right().updateDigestWithHashTreeRoot(messageDigest);
-    final Bytes32 hashTreeRoot = Bytes32.wrap(messageDigest.digest());
-    messageDigest.reset();
-    hashTreeRoot.update(messageDigest);
-    return messageDigest;
   }
 
   @NotNull

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/LazyBranchNode.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/LazyBranchNode.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.infrastructure.ssz.tree;
 
 import com.google.common.base.Suppliers;
+import java.security.MessageDigest;
 import java.util.function.Supplier;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.tuweni.bytes.Bytes32;
@@ -95,6 +96,18 @@ public class LazyBranchNode implements BranchNode {
     Bytes32 cachedHash = this.cachedHash;
     if (cachedHash == null) {
       cachedHash = Hash.sha256(leftRoot, rightRoot);
+      this.cachedHash = cachedHash;
+    }
+    return cachedHash;
+  }
+
+  @Override
+  public Bytes32 hashTreeRoot(MessageDigest messageDigest) {
+    Bytes32 cachedHash = this.cachedHash;
+    if (cachedHash == null) {
+      leftRoot.update(messageDigest);
+      rightRoot.update(messageDigest);
+      cachedHash = Bytes32.wrap(messageDigest.digest());
       this.cachedHash = cachedHash;
     }
     return cachedHash;

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/SimpleBranchNode.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/SimpleBranchNode.java
@@ -13,10 +13,12 @@
 
 package tech.pegasys.teku.infrastructure.ssz.tree;
 
+import java.security.MessageDigest;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.crypto.MessageDigestFactory;
 
-class SimpleBranchNode implements BranchNode, TreeNode {
+class SimpleBranchNode implements BranchNode {
 
   private final TreeNode left;
   private final TreeNode right;
@@ -63,6 +65,17 @@ class SimpleBranchNode implements BranchNode, TreeNode {
       this.cachedHash = cachedHash;
     }
     return cachedHash;
+  }
+
+  @Override
+  public MessageDigest hashTreeRootDigest() {
+    Bytes32 cachedHash = this.cachedHash;
+    if (cachedHash == null) {
+      return BranchNode.super.hashTreeRootDigest();
+    }
+    final MessageDigest digest = MessageDigestFactory.createSha256();
+    cachedHash.update(digest);
+    return digest;
   }
 
   @Override

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/SimpleBranchNode.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/SimpleBranchNode.java
@@ -16,9 +16,8 @@ package tech.pegasys.teku.infrastructure.ssz.tree;
 import java.security.MessageDigest;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.tuweni.bytes.Bytes32;
-import tech.pegasys.teku.infrastructure.crypto.MessageDigestFactory;
 
-class SimpleBranchNode implements BranchNode {
+class SimpleBranchNode implements BranchNode, TreeNode {
 
   private final TreeNode left;
   private final TreeNode right;
@@ -68,14 +67,13 @@ class SimpleBranchNode implements BranchNode {
   }
 
   @Override
-  public MessageDigest hashTreeRootDigest() {
+  public Bytes32 hashTreeRoot(MessageDigest messageDigest) {
     Bytes32 cachedHash = this.cachedHash;
     if (cachedHash == null) {
-      return BranchNode.super.hashTreeRootDigest();
+      cachedHash = BranchNode.super.hashTreeRoot(messageDigest);
+      this.cachedHash = cachedHash;
     }
-    final MessageDigest digest = MessageDigestFactory.createSha256();
-    cachedHash.update(digest);
-    return digest;
+    return cachedHash;
   }
 
   @Override

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/SimpleLeafNode.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/SimpleLeafNode.java
@@ -59,7 +59,7 @@ class SimpleLeafNode implements LeafNode, TreeNode {
   }
 
   @Override
-  public void updateDigest(MessageDigest messageDigest) {
+  public void updateDigestWithHashTreeRoot(MessageDigest messageDigest) {
     Bytes32 cachedHash = this.cachedHash;
     if (cachedHash != null) {
       cachedHash.update(messageDigest);

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/SimpleLeafNode.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/SimpleLeafNode.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.infrastructure.ssz.tree;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import java.security.MessageDigest;
 import java.util.Arrays;
 import java.util.Objects;
 import org.apache.tuweni.bytes.Bytes;
@@ -55,6 +56,19 @@ class SimpleLeafNode implements LeafNode, TreeNode {
       this.cachedHash = cachedHash;
     }
     return cachedHash;
+  }
+
+  @Override
+  public void updateDigest(MessageDigest messageDigest) {
+    Bytes32 cachedHash = this.cachedHash;
+    if (cachedHash != null) {
+      cachedHash.update(messageDigest);
+      return;
+    }
+    data.update(messageDigest);
+    if (data.size() < MAX_BYTE_SIZE) {
+      ZERO_LEAVES[MAX_BYTE_SIZE - data.size()].getData().update(messageDigest);
+    }
   }
 
   @Override

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/SimpleLeafNode.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/SimpleLeafNode.java
@@ -51,24 +51,19 @@ class SimpleLeafNode implements LeafNode, TreeNode {
   @Override
   public Bytes32 hashTreeRoot() {
     Bytes32 cachedHash = this.cachedHash;
-    if (cachedHash == null) {
-      cachedHash = Bytes32.wrap(Arrays.copyOf(data.toArrayUnsafe(), MAX_BYTE_SIZE));
-      this.cachedHash = cachedHash;
+    if (cachedHash != null) {
+      return cachedHash;
     }
-    return cachedHash;
+    return Bytes32.wrap(Arrays.copyOf(data.toArrayUnsafe(), MAX_BYTE_SIZE));
   }
 
   @Override
-  public void updateDigestWithHashTreeRoot(MessageDigest messageDigest) {
+  public Bytes32 hashTreeRoot(MessageDigest messageDigest) {
     Bytes32 cachedHash = this.cachedHash;
     if (cachedHash != null) {
-      cachedHash.update(messageDigest);
-      return;
+      return cachedHash;
     }
-    data.update(messageDigest);
-    if (data.size() < MAX_BYTE_SIZE) {
-      ZERO_LEAVES[MAX_BYTE_SIZE - data.size()].getData().update(messageDigest);
-    }
+    return Bytes32.wrap(Arrays.copyOf(data.toArrayUnsafe(), MAX_BYTE_SIZE));
   }
 
   @Override

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/TreeNode.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/TreeNode.java
@@ -35,19 +35,12 @@ public interface TreeNode {
    * Calculates (if necessary) and returns `hash_tree_root` of this tree node. Worth to mention that
    * `hash_tree_root` of a {@link LeafNode} is the node {@link Bytes32} content
    */
-  Bytes32 hashTreeRoot();
-
-  /** Provide a MessageDigest and updates it with the node `hash_tree_root` */
-  default MessageDigest hashTreeRootDigest() {
+  default Bytes32 hashTreeRoot() {
     final MessageDigest digest = MessageDigestFactory.createSha256();
-    hashTreeRoot().update(digest);
-    return digest;
+    return hashTreeRoot(digest);
   }
 
-  /** update a given digest with `hash_tree_root` */
-  default void updateDigestWithHashTreeRoot(MessageDigest messageDigest) {
-    hashTreeRoot().update(messageDigest);
-  }
+  Bytes32 hashTreeRoot(MessageDigest messageDigest);
 
   /**
    * Gets this node descendant by its 'generalized index'

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/TreeNode.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/TreeNode.java
@@ -44,7 +44,8 @@ public interface TreeNode {
     return digest;
   }
 
-  default void updateDigest(MessageDigest messageDigest) {
+  /** update a given digest with `hash_tree_root` */
+  default void updateDigestWithHashTreeRoot(MessageDigest messageDigest) {
     hashTreeRoot().update(messageDigest);
   }
 

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/TreeNode.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/TreeNode.java
@@ -15,10 +15,12 @@ package tech.pegasys.teku.infrastructure.ssz.tree;
 
 import static java.util.Collections.singletonList;
 
+import java.security.MessageDigest;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import org.apache.tuweni.bytes.Bytes32;
 import org.jetbrains.annotations.NotNull;
+import tech.pegasys.teku.infrastructure.crypto.MessageDigestFactory;
 
 /**
  * Basic interface for Backing Tree node Backing Binary Tree concept for SSZ structures is described
@@ -34,6 +36,17 @@ public interface TreeNode {
    * `hash_tree_root` of a {@link LeafNode} is the node {@link Bytes32} content
    */
   Bytes32 hashTreeRoot();
+
+  /** Provide a MessageDigest and updates it with the node `hash_tree_root` */
+  default MessageDigest hashTreeRootDigest() {
+    final MessageDigest digest = MessageDigestFactory.createSha256();
+    hashTreeRoot().update(digest);
+    return digest;
+  }
+
+  default void updateDigest(MessageDigest messageDigest) {
+    hashTreeRoot().update(messageDigest);
+  }
 
   /**
    * Gets this node descendant by its 'generalized index'


### PR DESCRIPTION
This pr improves `MessageDigest` handling in 2 ways
- by reusing it when possible (which avoids several objects creations) and passing around between nodes.
- leveraging "delegation" feature above, in `SimpleLeafNode`, to avoid allocating new trailing zeros. Receiving the MessageDigest from the branch node we can update it in 2 steps: adding Data and static zeros borrowed from `ZERO_LEAVES` to reach the needed 32 bytes.

New version:
Reuse `MessageDigest` almost everywhere

## BeaconStateBenchmark

Test case I used to compare profiles (from `BeaconStateBenchmark`):

```java
private static final BLSPublicKey pubkey = BLSTestUtil.randomPublicKey(0);
private static final DataStructureUtil dataStructureUtil =
    new DataStructureUtil(0).withPubKeyGenerator(() -> pubkey);
private static final BeaconState beaconState = dataStructureUtil.randomBeaconState(32 * 1024);

public static void main(String[] args) {
  IntStream.range(0, 2000)
      .forEach(
          __ -> {
            BeaconState stateW =
                beaconState.updated(
                    state -> {
                      int size = state.getBalances().size();
                      UInt64 balance = UInt64.valueOf(777);
                      for (int i = 0; i < size; i++) {
                        state.getBalances().setElement(i, balance);
                      }
                    });
            stateW.hashTreeRoot();
          });
}
```
### CPU usage reduction

initial version: 4%
<img width="1188" alt="image" src="https://user-images.githubusercontent.com/15999009/161120382-2370e8fe-3004-4697-bef1-ef7374d8e6ee.png">

-->> new version: 7.5%
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/15999009/161272339-bdf23016-0766-495f-b738-c7fc157caad5.png">


###  Memory allocation reduction

initial version: 46%
<img width="1189" alt="image" src="https://user-images.githubusercontent.com/15999009/161120512-45b373e8-4284-471d-913b-fcf2c2ae0682.png">

-->> new version: 85%
<img width="1783" alt="image" src="https://user-images.githubusercontent.com/15999009/161271818-fa6fef3a-d612-40b3-be3c-89fe88a0b3ae.png">

due to:

initial version:
<img width="1219" alt="image" src="https://user-images.githubusercontent.com/15999009/161120679-d44cdf57-ceb2-483b-9e2b-173ee0833e3a.png">

-->> new version: (not even detected)

<img width="1810" alt="image" src="https://user-images.githubusercontent.com/15999009/161272753-1d973582-2957-4164-aafe-cc1f83089dca.png">

initial version:
<img width="1222" alt="image" src="https://user-images.githubusercontent.com/15999009/161121495-8c867011-9335-4ebb-a588-a70f49ff1a79.png">

-->> new version: 
<img width="1805" alt="image" src="https://user-images.githubusercontent.com/15999009/161273538-30c047de-8123-49fb-b500-3dea72956188.png">

-->> new version (more pressure on Bytes32 as expected)
![image](https://user-images.githubusercontent.com/15999009/161274264-79b94866-6613-4646-937e-bf148819e637.png)


## Mainnet state transition
but in a real world scenario, profiling by applying state transition on mainnet state at 3378209, to 3378508 (about 300 blocks)

### CPU usage increase

initial version: -1.6% (worse)
<img width="1785" alt="image" src="https://user-images.githubusercontent.com/15999009/161129049-8ee28853-c9a1-4bad-a77f-8c6990925ace.png">

-->> new version: 0.5%
<img width="1115" alt="image" src="https://user-images.githubusercontent.com/15999009/161276224-6ef62202-9aac-4a25-b0b8-d3be83a98d55.png">


###  Memory allocation reduction

initial version: 12%
<img width="1787" alt="image" src="https://user-images.githubusercontent.com/15999009/161128591-0a6bfc9d-6312-4b87-bd7f-c6467ddd9f1c.png">

-->> new version: 23%
<img width="1426" alt="image" src="https://user-images.githubusercontent.com/15999009/161276382-e96efbfa-140a-4cbd-a5d4-19b84576157f.png">

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
