### PR TITLE
Batch verify deposit signatures

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/genesis/GenesisGenerator.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/genesis/GenesisGenerator.java
@@ -95,7 +95,7 @@ public class GenesisGenerator {
           // We do still verify the signature
           genesisSpec
               .getBlockProcessor()
-              .processDepositWithoutCheckingMerkleProof(state, deposit, keyCache);
+              .processDepositWithoutCheckingMerkleProof(state, deposit, keyCache, false);
 
           processActivation(deposit);
         });

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/BlockProcessor.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/BlockProcessor.java
@@ -106,7 +106,8 @@ public interface BlockProcessor {
   void processDepositWithoutCheckingMerkleProof(
       final MutableBeaconState state,
       final Deposit deposit,
-      final Object2IntMap<BLSPublicKey> pubKeyToIndexMap);
+      final Object2IntMap<BLSPublicKey> pubKeyToIndexMap,
+      final boolean signatureCheckIsDone);
 
   void processVoluntaryExits(
       MutableBeaconState state,


### PR DESCRIPTION
This processes a full set of 16 deposits in around 4ms rather than 22ms - over 5x speedup.

Logic:
  - We check signatures of all the block's deposits in a batch.
      - Almost always this will succeed and we can then process all the deposits without checking any individual signatures.
  - If the batch check fails then we fall back to normal deposit processing
     -  This verifies signatures for new validators and ignores the signatures for existing validators as usual.

Resolves #5254.