### PR TITLE
Remove deprecated `DataStructureUtil` constructors

### DIFF
--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/events/CoalescingChainHeadChannelTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/events/CoalescingChainHeadChannelTest.java
@@ -24,12 +24,14 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import tech.pegasys.teku.infrastructure.logging.EventLogger;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.storage.api.ChainHeadChannel;
 import tech.pegasys.teku.storage.api.ReorgContext;
 
 class CoalescingChainHeadChannelTest {
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(TestSpecFactory.createDefault());
 
   private final ChainHeadChannel delegate = Mockito.mock(ChainHeadChannel.class);
 

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/BatchDataRequesterTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/BatchDataRequesterTest.java
@@ -29,13 +29,15 @@ import tech.pegasys.teku.beacon.sync.forward.multipeer.chains.TargetChain;
 import tech.pegasys.teku.beacon.sync.forward.multipeer.chains.TargetChainTestUtil;
 import tech.pegasys.teku.infrastructure.async.eventthread.InlineEventThread;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 class BatchDataRequesterTest {
   private static final UInt64 BATCH_SIZE = UInt64.valueOf(50);
   private static final int MAX_PENDING_BATCHES = 5;
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(TestSpecFactory.createDefault());
   private final InlineEventThread eventThread = new InlineEventThread();
   private final BatchChain batchChain = new BatchChain();
   private final StubBatchFactory batchFactory = new StubBatchFactory(eventThread, false);

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/BatchImporterTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/BatchImporterTest.java
@@ -34,13 +34,15 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
 import tech.pegasys.teku.networking.eth2.peers.SyncSource;
 import tech.pegasys.teku.networking.p2p.peer.DisconnectReason;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.block.BlockImporter;
 
 class BatchImporterTest {
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(TestSpecFactory.createDefault());
   private final BlockImporter blockImporter = mock(BlockImporter.class);
   private final StubAsyncRunner asyncRunner = new StubAsyncRunner();
   private final Batch batch = mock(Batch.class);

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/MultipeerCommonAncestorFinderTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/MultipeerCommonAncestorFinderTest.java
@@ -39,7 +39,7 @@ class MultipeerCommonAncestorFinderTest {
 
   private static final UInt64 FINALIZED_EPOCH = UInt64.valueOf(10);
   final Spec spec = TestSpecFactory.createMinimalPhase0();
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
   private final CommonAncestor commonAncestor = mock(CommonAncestor.class);
   private final RecentChainData recentChainData = mock(RecentChainData.class);
   private final InlineEventThread eventThread = new InlineEventThread();

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/SyncControllerTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/SyncControllerTest.java
@@ -36,11 +36,13 @@ import tech.pegasys.teku.beacon.sync.forward.multipeer.chains.TargetChain;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.eventthread.InlineEventThread;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
 class SyncControllerTest {
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(TestSpecFactory.createDefault());
   private final InlineEventThread eventThread = new InlineEventThread();
   private final Sync sync = mock(Sync.class);
   private final SyncTargetSelector syncTargetSelector = mock(SyncTargetSelector.class);

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/SyncTargetSelectorTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/SyncTargetSelectorTest.java
@@ -26,6 +26,7 @@ import tech.pegasys.teku.beacon.sync.forward.multipeer.chains.TargetChain;
 import tech.pegasys.teku.beacon.sync.forward.multipeer.chains.TargetChains;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.peers.SyncSource;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
@@ -35,7 +36,8 @@ import tech.pegasys.teku.storage.client.RecentChainData;
 class SyncTargetSelectorTest {
 
   private static final int SYNC_THRESHOLD = 40;
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(TestSpecFactory.createDefault());
   private final RecentChainData recentChainData = mock(RecentChainData.class);
   private UInt64 suitableSyncTargetSlot;
 

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/BatchChainTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/BatchChainTest.java
@@ -21,11 +21,13 @@ import tech.pegasys.teku.beacon.sync.forward.multipeer.chains.TargetChain;
 import tech.pegasys.teku.beacon.sync.forward.multipeer.chains.TargetChainTestUtil;
 import tech.pegasys.teku.infrastructure.async.eventthread.InlineEventThread;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 class BatchChainTest {
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(TestSpecFactory.createDefault());
   private final TargetChain targetChain =
       TargetChainTestUtil.chainWith(new SlotAndBlockRoot(UInt64.MAX_VALUE, Bytes32.ZERO));
   private final StubBatchFactory batchFactory =

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/SyncSourceBatchTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/SyncSourceBatchTest.java
@@ -37,13 +37,15 @@ import tech.pegasys.teku.networking.eth2.peers.StubSyncSource;
 import tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.BlocksByRangeResponseInvalidResponseException;
 import tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.BlocksByRangeResponseInvalidResponseException.InvalidResponseType;
 import tech.pegasys.teku.networking.p2p.peer.PeerDisconnectedException;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class SyncSourceBatchTest {
 
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(TestSpecFactory.createDefault());
   private final TargetChain targetChain =
       chainWith(new SlotAndBlockRoot(UInt64.valueOf(1000), Bytes32.ZERO));
   private final InlineEventThread eventThread = new InlineEventThread();

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/chains/TargetChainsTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/chains/TargetChainsTest.java
@@ -20,11 +20,13 @@ import static tech.pegasys.teku.beacon.sync.forward.multipeer.chains.TargetChain
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.peers.SyncSource;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 class TargetChainsTest {
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(TestSpecFactory.createDefault());
   private final TargetChains targetChains = new TargetChains();
   private final SyncSource peer1 = mock(SyncSource.class);
   private final SyncSource peer2 = mock(SyncSource.class);

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/gossip/FetchBlockTaskTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/gossip/FetchBlockTaskTest.java
@@ -29,12 +29,14 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.networking.eth2.Eth2P2PNetwork;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.teku.networking.p2p.mock.MockNodeId;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class FetchBlockTaskTest {
 
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(TestSpecFactory.createDefault());
   final Eth2P2PNetwork eth2P2PNetwork = mock(Eth2P2PNetwork.class);
   final List<Eth2Peer> peers = new ArrayList<>();
 

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/gossip/FetchRecentBlocksServiceTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/gossip/FetchRecentBlocksServiceTest.java
@@ -38,13 +38,15 @@ import tech.pegasys.teku.beacon.sync.gossip.FetchRecentBlocksService.FetchBlockT
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
 import tech.pegasys.teku.networking.eth2.Eth2P2PNetwork;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.util.PendingPool;
 
 public class FetchRecentBlocksServiceTest {
 
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(TestSpecFactory.createDefault());
   private final Eth2P2PNetwork eth2P2PNetwork = mock(Eth2P2PNetwork.class);
 
   @SuppressWarnings("unchecked")

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/PostAttesterSlashingIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/PostAttesterSlashingIntegrationTest.java
@@ -27,12 +27,14 @@ import tech.pegasys.teku.api.schema.AttesterSlashing;
 import tech.pegasys.teku.beaconrestapi.AbstractDataBackedRestAPIIntegrationTest;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.PostAttesterSlashing;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
 
 public class PostAttesterSlashingIntegrationTest extends AbstractDataBackedRestAPIIntegrationTest {
 
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(TestSpecFactory.createDefault());
 
   @BeforeEach
   public void setup() {

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/PostProposerSlashingIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/PostProposerSlashingIntegrationTest.java
@@ -27,12 +27,14 @@ import tech.pegasys.teku.api.schema.ProposerSlashing;
 import tech.pegasys.teku.beaconrestapi.AbstractDataBackedRestAPIIntegrationTest;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.PostProposerSlashing;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
 
 public class PostProposerSlashingIntegrationTest extends AbstractDataBackedRestAPIIntegrationTest {
 
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(TestSpecFactory.createDefault());
 
   @BeforeEach
   public void setup() {

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/PostVoluntaryExitIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/PostVoluntaryExitIntegrationTest.java
@@ -28,12 +28,14 @@ import tech.pegasys.teku.api.schema.SignedVoluntaryExit;
 import tech.pegasys.teku.beaconrestapi.AbstractDataBackedRestAPIIntegrationTest;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.PostVoluntaryExit;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
 
 public class PostVoluntaryExitIntegrationTest extends AbstractDataBackedRestAPIIntegrationTest {
 
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(TestSpecFactory.createDefault());
 
   @BeforeEach
   public void setup() {

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetGenesisTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetGenesisTest.java
@@ -21,10 +21,12 @@ import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.api.response.v1.beacon.GenesisData;
 import tech.pegasys.teku.api.response.v1.beacon.GetGenesisResponse;
 import tech.pegasys.teku.beaconrestapi.AbstractBeaconHandlerTest;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class GetGenesisTest extends AbstractBeaconHandlerTest {
-  final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(TestSpecFactory.createDefault());
 
   @Test
   public void shouldReturnUnavailableWhenStoreNotAvailable() throws Exception {

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostAttestationTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostAttestationTest.java
@@ -35,10 +35,12 @@ import tech.pegasys.teku.api.schema.Attestation;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.provider.JsonProvider;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class PostAttestationTest {
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(TestSpecFactory.createDefault());
   private Context context = mock(Context.class);
   private ValidatorDataProvider provider = mock(ValidatorDataProvider.class);
   private final JsonProvider jsonProvider = new JsonProvider();

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostAttesterSlashingTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostAttesterSlashingTest.java
@@ -28,11 +28,13 @@ import tech.pegasys.teku.api.NodeDataProvider;
 import tech.pegasys.teku.api.schema.AttesterSlashing;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.provider.JsonProvider;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
 
 public class PostAttesterSlashingTest {
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(TestSpecFactory.createDefault());
   private Context context = mock(Context.class);
   private NodeDataProvider provider = mock(NodeDataProvider.class);
   private final JsonProvider jsonProvider = new JsonProvider();

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostProposerSlashingTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostProposerSlashingTest.java
@@ -28,11 +28,13 @@ import tech.pegasys.teku.api.NodeDataProvider;
 import tech.pegasys.teku.api.schema.ProposerSlashing;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.provider.JsonProvider;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
 
 public class PostProposerSlashingTest {
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(TestSpecFactory.createDefault());
   private Context context = mock(Context.class);
   private NodeDataProvider provider = mock(NodeDataProvider.class);
   private final JsonProvider jsonProvider = new JsonProvider();

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostVoluntaryExitTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostVoluntaryExitTest.java
@@ -28,11 +28,13 @@ import tech.pegasys.teku.api.NodeDataProvider;
 import tech.pegasys.teku.api.schema.SignedVoluntaryExit;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.provider.JsonProvider;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
 
 public class PostVoluntaryExitTest {
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(TestSpecFactory.createDefault());
   private Context context = mock(Context.class);
   private NodeDataProvider provider = mock(NodeDataProvider.class);
   private final JsonProvider jsonProvider = new JsonProvider();

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetAttestationDataTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetAttestationDataTest.java
@@ -37,12 +37,14 @@ import tech.pegasys.teku.beaconrestapi.schema.BadRequest;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.provider.JsonProvider;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.storage.client.ChainDataUnavailableException;
 
 class GetAttestationDataTest {
 
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(TestSpecFactory.createDefault());
   private Context context = mock(Context.class);
   private ValidatorDataProvider provider = mock(ValidatorDataProvider.class);
   private final JsonProvider jsonProvider = new JsonProvider();

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetNewBlockTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetNewBlockTest.java
@@ -48,6 +48,7 @@ import tech.pegasys.teku.infrastructure.http.RestApiConstants;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.provider.JsonProvider;
 import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class GetNewBlockTest {
@@ -58,7 +59,8 @@ public class GetNewBlockTest {
   protected final ValidatorDataProvider provider = mock(ValidatorDataProvider.class);
   protected final JsonProvider jsonProvider = new JsonProvider();
   private GetNewBlock handler;
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(TestSpecFactory.createDefault());
   private final Bytes32 graffiti = dataStructureUtil.randomBytes32();
 
   @SuppressWarnings("unchecked")

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostAggregateAndProofsTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostAggregateAndProofsTest.java
@@ -30,6 +30,7 @@ import org.mockito.ArgumentCaptor;
 import tech.pegasys.teku.api.ValidatorDataProvider;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.provider.JsonProvider;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.operations.SignedAggregateAndProof;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
@@ -39,7 +40,8 @@ class PostAggregateAndProofsTest {
   private final ArgumentCaptor<SafeFuture<String>> args = ArgumentCaptor.forClass(SafeFuture.class);
 
   @SuppressWarnings("unused")
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(TestSpecFactory.createDefault());
 
   private final Context context = mock(Context.class);
   private final ValidatorDataProvider provider = mock(ValidatorDataProvider.class);

--- a/data/serializer/src/test/java/tech/pegasys/teku/api/response/v1/HeadEventTest.java
+++ b/data/serializer/src/test/java/tech/pegasys/teku/api/response/v1/HeadEventTest.java
@@ -19,11 +19,13 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.provider.JsonProvider;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 class HeadEventTest {
 
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(TestSpecFactory.createDefault());
 
   private final JsonProvider jsonProvider = new JsonProvider();
 

--- a/data/serializer/src/test/java/tech/pegasys/teku/api/schema/BLSPubKeyTest.java
+++ b/data/serializer/src/test/java/tech/pegasys/teku/api/schema/BLSPubKeyTest.java
@@ -17,10 +17,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class BLSPubKeyTest {
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(TestSpecFactory.createDefault());
   private final BLSPublicKey blsPublicKey = dataStructureUtil.randomPublicKey();
 
   @Test

--- a/data/serializer/src/test/java/tech/pegasys/teku/api/schema/Eth1DataTest.java
+++ b/data/serializer/src/test/java/tech/pegasys/teku/api/schema/Eth1DataTest.java
@@ -16,10 +16,12 @@ package tech.pegasys.teku.api.schema;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class Eth1DataTest {
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(TestSpecFactory.createDefault());
   private final tech.pegasys.teku.spec.datastructures.blocks.Eth1Data eth1DataInternal =
       dataStructureUtil.randomEth1Data();
 

--- a/data/serializer/src/test/java/tech/pegasys/teku/api/schema/ForkTest.java
+++ b/data/serializer/src/test/java/tech/pegasys/teku/api/schema/ForkTest.java
@@ -16,10 +16,12 @@ package tech.pegasys.teku.api.schema;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class ForkTest {
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(TestSpecFactory.createDefault());
   private final tech.pegasys.teku.spec.datastructures.state.Fork forkInternal =
       dataStructureUtil.randomFork();
 

--- a/data/serializer/src/test/java/tech/pegasys/teku/api/schema/ValidatorTest.java
+++ b/data/serializer/src/test/java/tech/pegasys/teku/api/schema/ValidatorTest.java
@@ -16,10 +16,12 @@ package tech.pegasys.teku.api.schema;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class ValidatorTest {
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(TestSpecFactory.createDefault());
   private final tech.pegasys.teku.spec.datastructures.state.Validator validatorInternal =
       dataStructureUtil.randomValidator();
 

--- a/data/serializer/src/test/java/tech/pegasys/teku/provider/JsonProviderTest.java
+++ b/data/serializer/src/test/java/tech/pegasys/teku/provider/JsonProviderTest.java
@@ -27,11 +27,13 @@ import tech.pegasys.teku.api.schema.BeaconState;
 import tech.pegasys.teku.api.schema.phase0.BeaconStatePhase0;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszBitvector;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 class JsonProviderTest {
   private static final String Q = "\"";
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(TestSpecFactory.createDefault());
   private final JsonProvider jsonProvider = new JsonProvider();
 
   @Test

--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/VoteTrackerSerialize.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/VoteTrackerSerialize.java
@@ -19,13 +19,15 @@ import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Warmup;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.storage.server.kvstore.serialization.KvStoreSerializer;
 
 public class VoteTrackerSerialize {
 
-  private static VoteTracker votes = new DataStructureUtil().randomVoteTracker();
+  private static VoteTracker votes =
+      new DataStructureUtil(TestSpecFactory.createDefault()).randomVoteTracker();
   private static KvStoreSerializer<VoteTracker> serializer = KvStoreSerializer.VOTES_SERIALIZER;
   private static Bytes votesSerialized = Bytes.wrap(serializer.serialize(votes));
 

--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/util/backing/BeaconStateBenchmark.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/util/backing/BeaconStateBenchmark.java
@@ -23,6 +23,7 @@ import org.openjdk.jmh.infra.Blackhole;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.bls.BLSTestUtil;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.state.Validator;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
@@ -32,7 +33,7 @@ public class BeaconStateBenchmark {
 
   private static final BLSPublicKey pubkey = BLSTestUtil.randomPublicKey(0);
   private static final DataStructureUtil dataStructureUtil =
-      new DataStructureUtil(0).withPubKeyGenerator(() -> pubkey);
+      new DataStructureUtil(0, TestSpecFactory.createDefault()).withPubKeyGenerator(() -> pubkey);
   private static final BeaconState beaconState = dataStructureUtil.randomBeaconState(32 * 1024);
 
   @Benchmark

--- a/ethereum/core/src/test/java/tech/pegasys/teku/core/signatures/LocalSlashingProtectorTest.java
+++ b/ethereum/core/src/test/java/tech/pegasys/teku/core/signatures/LocalSlashingProtectorTest.java
@@ -33,6 +33,7 @@ import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.data.signingrecord.ValidatorSigningRecord;
 import tech.pegasys.teku.infrastructure.io.SyncDataAccessor;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 class LocalSlashingProtectorTest {
@@ -40,7 +41,8 @@ class LocalSlashingProtectorTest {
   private static final UInt64 ATTESTATION_TEST_BLOCK_SLOT = UInt64.valueOf(3);
   private static final UInt64 BLOCK_TEST_SOURCE_EPOCH = UInt64.valueOf(12);
   private static final UInt64 BLOCK_TEST_TARGET_EPOCH = UInt64.valueOf(15);
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(TestSpecFactory.createDefault());
 
   private final BLSPublicKey validator = dataStructureUtil.randomPublicKey();
   private final SyncDataAccessor dataWriter = mock(SyncDataAccessor.class);

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/config/SpecConfigBuilderTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/config/SpecConfigBuilderTest.java
@@ -22,11 +22,13 @@ import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecFactory;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 class SpecConfigBuilderTest {
 
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(TestSpecFactory.createDefault());
 
   @Test
   public void shouldLoadAltairForkEpoch() {

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/BeaconBlockHeaderTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/BeaconBlockHeaderTest.java
@@ -20,10 +20,12 @@ import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 class BeaconBlockHeaderTest {
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(TestSpecFactory.createDefault());
   private final UInt64 slot = dataStructureUtil.randomUInt64();
   private final UInt64 proposerIndex = dataStructureUtil.randomUInt64();
   private final Bytes32 previousBlockRoot = dataStructureUtil.randomBytes32();

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBeaconBlockHeaderTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBeaconBlockHeaderTest.java
@@ -20,10 +20,12 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 class SignedBeaconBlockHeaderTest {
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(TestSpecFactory.createDefault());
   private final UInt64 slot = dataStructureUtil.randomUInt64();
   private final UInt64 proposerIndex = dataStructureUtil.randomUInt64();
   private final Bytes32 previousBlockRoot = dataStructureUtil.randomBytes32();

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBeaconBlockTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBeaconBlockTest.java
@@ -27,7 +27,7 @@ class SignedBeaconBlockTest {
   public void shouldRoundTripViaSsz() {
     final Spec spec = TestSpecFactory.createMinimalPhase0();
     final SchemaDefinitions schemaDefinitions = spec.getGenesisSchemaDefinitions();
-    final SignedBeaconBlock block = new DataStructureUtil().randomSignedBeaconBlock(1);
+    final SignedBeaconBlock block = new DataStructureUtil(spec).randomSignedBeaconBlock(1);
     final Bytes ssz = block.sszSerialize();
     final SignedBeaconBlock result =
         schemaDefinitions.getSignedBeaconBlockSchema().sszDeserialize(ssz);

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/hashtree/HashTreeTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/hashtree/HashTreeTest.java
@@ -21,12 +21,14 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class HashTreeTest {
 
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(TestSpecFactory.createDefault());
 
   @Test
   public void build_singleChain() {

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/networking/libp2p/rpc/EnrForkIdTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/networking/libp2p/rpc/EnrForkIdTest.java
@@ -17,10 +17,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 class EnrForkIdTest {
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(TestSpecFactory.createDefault());
 
   @Test
   public void shouldRoundTripViaSsz() {

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/operations/DepositDataTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/operations/DepositDataTest.java
@@ -21,10 +21,12 @@ import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 class DepositDataTest {
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(TestSpecFactory.createDefault());
   private BLSPublicKey pubkey = dataStructureUtil.randomPublicKey();
   private Bytes32 withdrawalCredentials = dataStructureUtil.randomBytes32();
   private UInt64 amount = dataStructureUtil.randomUInt64();

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/operations/DepositMessageTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/operations/DepositMessageTest.java
@@ -20,10 +20,12 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 class DepositMessageTest {
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(TestSpecFactory.createDefault());
   private BLSPublicKey pubkey = dataStructureUtil.randomPublicKey();
   private Bytes32 withdrawalCredentials = dataStructureUtil.randomBytes32();
   private UInt64 amount = dataStructureUtil.randomUInt64();

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/operations/DepositTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/operations/DepositTest.java
@@ -30,11 +30,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tech.pegasys.teku.infrastructure.ssz.SszTestUtils;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszBytes32Vector;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 @ExtendWith(BouncyCastleExtension.class)
 class DepositTest {
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(TestSpecFactory.createDefault());
   private SszBytes32Vector branch = setupMerkleBranch();
   private DepositData depositData = dataStructureUtil.randomDepositData();
 
@@ -96,8 +98,7 @@ class DepositTest {
   }
 
   private SszBytes32Vector setupMerkleBranch() {
-    return new DataStructureUtil()
-        .randomSszBytes32Vector(
-            Deposit.SSZ_SCHEMA.getProofSchema(), (Supplier<Bytes32>) Bytes32::random);
+    return dataStructureUtil.randomSszBytes32Vector(
+        Deposit.SSZ_SCHEMA.getProofSchema(), (Supplier<Bytes32>) Bytes32::random);
   }
 }

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/operations/ProposerSlashingTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/operations/ProposerSlashingTest.java
@@ -19,11 +19,13 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import java.util.Objects;
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlockHeader;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 class ProposerSlashingTest {
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(TestSpecFactory.createDefault());
   private SignedBeaconBlockHeader proposal1 = dataStructureUtil.randomSignedBeaconBlockHeader();
   private SignedBeaconBlockHeader proposal2 = dataStructureUtil.randomSignedBeaconBlockHeader();
 

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/operations/VoluntaryExitTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/operations/VoluntaryExitTest.java
@@ -19,10 +19,12 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 class VoluntaryExitTest {
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(TestSpecFactory.createDefault());
   private UInt64 epoch = dataStructureUtil.randomUInt64();
   private UInt64 validatorIndex = dataStructureUtil.randomUInt64();
 

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/state/CheckpointTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/state/CheckpointTest.java
@@ -17,10 +17,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 class CheckpointTest {
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(TestSpecFactory.createDefault());
 
   @Test
   void roundTripViaSsz() {

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/state/ForkTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/state/ForkTest.java
@@ -20,10 +20,12 @@ import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.bytes.Bytes4;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 class ForkTest {
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(TestSpecFactory.createDefault());
   private Bytes4 previousVersion = new Bytes4(Bytes.of(1, 2, 3, 4));
   private Bytes4 currentVersion = new Bytes4(Bytes.of(5, 6, 7, 8));
   private UInt64 epoch = dataStructureUtil.randomUInt64();

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/state/ValidatorTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/state/ValidatorTest.java
@@ -22,10 +22,12 @@ import org.apache.tuweni.bytes.Bytes48;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.bls.BLSTestUtil;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 class ValidatorTest {
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(TestSpecFactory.createDefault());
 
   private int seed = 100;
   private Bytes48 pubkey = BLSTestUtil.randomPublicKey(seed).toBytesCompressed();

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/ValidatorIndexCacheTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/ValidatorIndexCacheTest.java
@@ -25,11 +25,13 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.infrastructure.collections.cache.Cache;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class ValidatorIndexCacheTest {
-  final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(TestSpecFactory.createDefault());
   final BeaconState state = dataStructureUtil.randomBeaconState();
   final BLSPublicKey missingPublicKey = dataStructureUtil.randomPublicKey();
 

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -64,7 +64,6 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.SpecVersion;
-import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.config.SpecConfigBellatrix;
 import tech.pegasys.teku.spec.constants.Domain;
@@ -125,7 +124,6 @@ import tech.pegasys.teku.spec.schemas.SchemaDefinitionsAltair;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsBellatrix;
 
 public final class DataStructureUtil {
-  private static final Supplier<Spec> DEFAULT_SPEC_PROVIDER = TestSpecFactory::createMinimalPhase0;
   private static final int MAX_EP_RANDOM_TRANSACTIONS = 10;
   private static final int MAX_EP_RANDOM_TRANSACTIONS_SIZE = 32;
 
@@ -133,16 +131,6 @@ public final class DataStructureUtil {
 
   private int seed;
   private Supplier<BLSPublicKey> pubKeyGenerator = () -> BLSTestUtil.randomPublicKey(nextSeed());
-
-  @Deprecated
-  public DataStructureUtil() {
-    this(92892824, DEFAULT_SPEC_PROVIDER.get());
-  }
-
-  @Deprecated
-  public DataStructureUtil(final int seed) {
-    this(seed, DEFAULT_SPEC_PROVIDER.get());
-  }
 
   public DataStructureUtil(final Spec spec) {
     this(92892824, spec);

--- a/ethereum/weaksubjectivity/src/test/java/tech/pegasys/teku/weaksubjectivity/config/WeakSubjectivityConfigTest.java
+++ b/ethereum/weaksubjectivity/src/test/java/tech/pegasys/teku/weaksubjectivity/config/WeakSubjectivityConfigTest.java
@@ -27,7 +27,7 @@ public class WeakSubjectivityConfigTest {
   private final Spec spec = TestSpecFactory.createMinimalPhase0();
   private final WeakSubjectivityConfig config =
       WeakSubjectivityConfig.builder().specProvider(spec).build();
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
   private final Checkpoint checkpoint = dataStructureUtil.randomCheckpoint();
 
   @Test

--- a/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/AttesterSlashingGossipIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/AttesterSlashingGossipIntegrationTest.java
@@ -29,6 +29,7 @@ import tech.pegasys.teku.infrastructure.async.Waiter;
 import tech.pegasys.teku.networking.eth2.Eth2P2PNetworkFactory.Eth2P2PNetworkBuilder;
 import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
 import tech.pegasys.teku.networking.eth2.gossip.topics.OperationProcessor;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
@@ -37,7 +38,8 @@ public class AttesterSlashingGossipIntegrationTest {
 
   private final List<BLSKeyPair> validatorKeys = BLSKeyGenerator.generateKeyPairs(3);
   private final Eth2P2PNetworkFactory networkFactory = new Eth2P2PNetworkFactory();
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(TestSpecFactory.createDefault());
 
   @AfterEach
   public void tearDown() throws Exception {

--- a/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/BeaconBlocksByRootIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/BeaconBlocksByRootIntegrationTest.java
@@ -40,6 +40,7 @@ import tech.pegasys.teku.networking.eth2.rpc.core.RpcException.DeserializationFa
 import tech.pegasys.teku.networking.p2p.peer.DisconnectReason;
 import tech.pegasys.teku.networking.p2p.peer.PeerDisconnectedException;
 import tech.pegasys.teku.networking.p2p.rpc.RpcResponseListener;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
@@ -253,7 +254,7 @@ public class BeaconBlocksByRootIntegrationTest extends AbstractRpcMethodIntegrat
   }
 
   private List<SignedBeaconBlock> largeBlockSequence(final int count) {
-    DataStructureUtil dataStructureUtil = new DataStructureUtil();
+    DataStructureUtil dataStructureUtil = new DataStructureUtil(TestSpecFactory.createDefault());
     final SignedBeaconBlock parent = peerStorage.chainBuilder().getLatestBlockAndState().getBlock();
     List<SignedBlockAndState> newBlocks =
         dataStructureUtil.randomSignedBlockAndStateSequence(parent, count, true);

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlocksByRangeListenerWrapperTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlocksByRangeListenerWrapperTest.java
@@ -26,11 +26,13 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.teku.networking.p2p.rpc.RpcResponseListener;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class BlocksByRangeListenerWrapperTest {
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(TestSpecFactory.createDefault());
   private BlocksByRangeListenerWrapper listenerWrapper;
   private final Eth2Peer peer = mock(Eth2Peer.class);
 

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/encodings/compression/NoopCompressorTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/encodings/compression/NoopCompressorTest.java
@@ -22,11 +22,13 @@ import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.networking.eth2.rpc.core.encodings.compression.Compressor.Decompressor;
 import tech.pegasys.teku.networking.eth2.rpc.core.encodings.compression.noop.NoopCompressor;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class NoopCompressorTest {
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(TestSpecFactory.createDefault());
   private final Compressor compressor = new NoopCompressor();
 
   @Test

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/encodings/compression/SnappyCompressorTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/encodings/compression/SnappyCompressorTest.java
@@ -27,6 +27,7 @@ import tech.pegasys.teku.networking.eth2.rpc.core.encodings.compression.Compress
 import tech.pegasys.teku.networking.eth2.rpc.core.encodings.compression.exceptions.CompressionException;
 import tech.pegasys.teku.networking.eth2.rpc.core.encodings.compression.exceptions.PayloadSmallerThanExpectedException;
 import tech.pegasys.teku.networking.eth2.rpc.core.encodings.compression.snappy.SnappyFramedCompressor;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
@@ -41,7 +42,8 @@ public class SnappyCompressorTest {
   private static final Bytes SNAPPY_HEADER =
       Bytes.wrap(new byte[] {(byte) 0xff, 0x06, 0x00, 0x00, 0x73, 0x4e, 0x61, 0x50, 0x70, 0x59});
 
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(TestSpecFactory.createDefault());
   private final Compressor compressor = new SnappyFramedCompressor();
 
   @Test

--- a/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/discovery/discv5/NodeRecordConverterTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/discovery/discv5/NodeRecordConverterTest.java
@@ -220,7 +220,7 @@ class NodeRecordConverterTest {
 
   @Test
   public void shouldConvertEnrForkId() {
-    EnrForkId enrForkId = new DataStructureUtil().randomEnrForkId();
+    EnrForkId enrForkId = new DataStructureUtil(SPEC).randomEnrForkId();
     Bytes encodedForkId = enrForkId.sszSerialize();
     final Optional<DiscoveryPeer> result =
         convertNodeRecordWithFields(

--- a/pow/src/test/java/tech/pegasys/teku/pow/ValidatingEth1EventsPublisherTest.java
+++ b/pow/src/test/java/tech/pegasys/teku/pow/ValidatingEth1EventsPublisherTest.java
@@ -22,10 +22,12 @@ import tech.pegasys.teku.ethereum.pow.api.DepositsFromBlockEvent;
 import tech.pegasys.teku.ethereum.pow.api.InvalidDepositEventsException;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.pow.api.Eth1EventsChannel;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class ValidatingEth1EventsPublisherTest {
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(TestSpecFactory.createDefault());
   private final Eth1EventsChannel delegate = mock(Eth1EventsChannel.class);
   private final ValidatingEth1EventsPublisher publisher =
       new ValidatingEth1EventsPublisher(delegate);

--- a/pow/src/test/java/tech/pegasys/teku/pow/event/DepositsFromBlockEventTest.java
+++ b/pow/src/test/java/tech/pegasys/teku/pow/event/DepositsFromBlockEventTest.java
@@ -22,10 +22,12 @@ import tech.pegasys.teku.ethereum.pow.api.Deposit;
 import tech.pegasys.teku.ethereum.pow.api.DepositsFromBlockEvent;
 import tech.pegasys.teku.ethereum.pow.api.InvalidDepositEventsException;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class DepositsFromBlockEventTest {
-  final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(TestSpecFactory.createDefault());
 
   @Test
   public void create_withOutOfOrderDeposits() {

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/kvstore/AbstractKvStoreDatabaseTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/kvstore/AbstractKvStoreDatabaseTest.java
@@ -34,6 +34,7 @@ import tech.pegasys.teku.ethereum.pow.api.MinGenesisTimeBlockEvent;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockAndCheckpointEpochs;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
@@ -174,7 +175,8 @@ public abstract class AbstractKvStoreDatabaseTest extends AbstractStorageBackedD
       throws Exception {
     database.storeInitialAnchor(genesisAnchor);
 
-    final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+    final DataStructureUtil dataStructureUtil =
+        new DataStructureUtil(TestSpecFactory.createDefault());
     try (final KvStoreEth1Dao.Eth1Updater updater =
         ((KvStoreDatabase) database).eth1Dao.eth1Updater()) {
       final MinGenesisTimeBlockEvent genesisTimeBlockEvent =

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/kvstore/serialization/DepositsFromBlockSerializerTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/kvstore/serialization/DepositsFromBlockSerializerTest.java
@@ -18,12 +18,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.ethereum.pow.api.DepositsFromBlockEvent;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class DepositsFromBlockSerializerTest {
   private final DepositsFromBlockEventSerializer serializer =
       new DepositsFromBlockEventSerializer();
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(TestSpecFactory.createDefault());
 
   @Test
   public void shouldEncodeAndDecodeWithMultipleDeposits() {

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/kvstore/serialization/MinGenesisTimeBlockEventSerializerTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/kvstore/serialization/MinGenesisTimeBlockEventSerializerTest.java
@@ -17,10 +17,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.ethereum.pow.api.MinGenesisTimeBlockEvent;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class MinGenesisTimeBlockEventSerializerTest {
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(TestSpecFactory.createDefault());
   private final MinGenesisTimeBlockEventSerializer serializer =
       new MinGenesisTimeBlockEventSerializer();
 

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/kvstore/serialization/SlotAndBlockRootSerializerTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/kvstore/serialization/SlotAndBlockRootSerializerTest.java
@@ -16,12 +16,14 @@ package tech.pegasys.teku.storage.server.kvstore.serialization;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class SlotAndBlockRootSerializerTest {
   private final SlotAndBlockRootSerializer serializer = new SlotAndBlockRootSerializer();
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(TestSpecFactory.createDefault());
 
   @Test
   public void roundTrip() {

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/network/DatabaseNetworkTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/network/DatabaseNetworkTest.java
@@ -22,12 +22,13 @@ import java.io.IOException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import tech.pegasys.teku.infrastructure.bytes.Bytes4;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.eth1.Eth1Address;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.storage.server.DatabaseStorageException;
 
 public class DatabaseNetworkTest {
-  DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  DataStructureUtil dataStructureUtil = new DataStructureUtil(TestSpecFactory.createDefault());
 
   @Test
   public void shouldCreateNetworkFile(@TempDir final File tempDir) throws IOException {

--- a/storage/src/test/java/tech/pegasys/teku/storage/store/StoreVoteUpdaterTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/store/StoreVoteUpdaterTest.java
@@ -21,13 +21,15 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteUpdater;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.storage.api.VoteUpdateChannel;
 
 class StoreVoteUpdaterTest extends AbstractStoreTest {
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(TestSpecFactory.createDefault());
   final VoteUpdateChannel voteUpdateChannel = mock(VoteUpdateChannel.class);
 
   private final UpdatableStore store = createGenesisStore();

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/WeakSubjectivityOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/WeakSubjectivityOptionsTest.java
@@ -21,13 +21,16 @@ import tech.pegasys.teku.cli.AbstractBeaconNodeCommandTest;
 import tech.pegasys.teku.cli.converter.CheckpointConverter;
 import tech.pegasys.teku.config.TekuConfiguration;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class WeakSubjectivityOptionsTest extends AbstractBeaconNodeCommandTest {
+  private final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(TestSpecFactory.createDefault());
+
   @Test
   public void weakSubjectivityCheckpoint_shouldAcceptValue() {
-    final DataStructureUtil dataStructureUtil = new DataStructureUtil();
     final Checkpoint checkpoint = dataStructureUtil.randomCheckpoint();
     final String checkpointParam = checkpoint.getRoot().toHexString() + ":" + checkpoint.getEpoch();
 
@@ -77,7 +80,6 @@ public class WeakSubjectivityOptionsTest extends AbstractBeaconNodeCommandTest {
 
   @Test
   public void weakSubjectivityCheckpoint_handleBadValue() {
-    final DataStructureUtil dataStructureUtil = new DataStructureUtil();
     final Checkpoint checkpoint = dataStructureUtil.randomCheckpoint();
     final String checkpointParam = checkpoint.getRoot().toHexString() + ":";
     final String[] args = {"--ws-checkpoint", checkpointParam};

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/AbstractDutySchedulerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/AbstractDutySchedulerTest.java
@@ -30,6 +30,7 @@ import tech.pegasys.teku.core.signatures.Signer;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
 import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
@@ -50,7 +51,8 @@ public abstract class AbstractDutySchedulerTest {
   final ForkProvider forkProvider = mock(ForkProvider.class);
   final StubAsyncRunner asyncRunner = new StubAsyncRunner();
 
-  final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(TestSpecFactory.createDefault());
   final ForkInfo fork = dataStructureUtil.randomForkInfo();
   final StubMetricsSystem metricsSystem = new StubMetricsSystem();
 

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/DutyResultTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/DutyResultTest.java
@@ -26,6 +26,7 @@ import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.logging.ValidatorLogger;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.validator.api.NodeSyncingException;
 
@@ -33,7 +34,8 @@ class DutyResultTest {
 
   private static final UInt64 SLOT = UInt64.valueOf(323);
   private static final String TYPE = "type";
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(TestSpecFactory.createDefault());
   private final ValidatorLogger validatorLogger = mock(ValidatorLogger.class);
   private final BLSPublicKey validatorKey = dataStructureUtil.randomPublicKey();
   private final Set<String> validatorId = Set.of(validatorKey.toAbbreviatedString());

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/PublicKeyLoaderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/PublicKeyLoaderTest.java
@@ -27,10 +27,12 @@ import org.apache.tuweni.bytes.Bytes48;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.infrastructure.exceptions.InvalidConfigurationException;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class PublicKeyLoaderTest {
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(TestSpecFactory.createDefault());
   private final String firstKeyStr =
       dataStructureUtil.randomPublicKey().toBytesCompressed().toHexString();
   private final String secondKeyStr =

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/EventSourceHandlerTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/EventSourceHandlerTest.java
@@ -28,11 +28,13 @@ import tech.pegasys.teku.api.response.v1.HeadEvent;
 import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.provider.JsonProvider;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.validator.api.ValidatorTimingChannel;
 
 class EventSourceHandlerTest {
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil();
+  private final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(TestSpecFactory.createDefault());
   private final JsonProvider jsonProvider = new JsonProvider();
   private final ValidatorTimingChannel validatorTimingChannel = mock(ValidatorTimingChannel.class);
   final StubMetricsSystem metricsSystem = new StubMetricsSystem();


### PR DESCRIPTION
## PR Description

This PR removes the deprecated `DataStructureUtil` constructors and updates the remaining instances to use the newer constructors that require a specification. In most cases:

* `DataStructureUtil()` -> `DataStructureUtil(TestSpecFactory.createDefault())`

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
