### PR TITLE
Use new RequestBody.create() method

### DIFF
--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/AbstractDataBackedRestAPIIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/AbstractDataBackedRestAPIIntegrationTest.java
@@ -300,7 +300,7 @@ public abstract class AbstractDataBackedRestAPIIntegrationTest {
   }
 
   protected Response post(final String route, final String postData) throws IOException {
-    final RequestBody body = RequestBody.create(JSON, postData);
+    final RequestBody body = RequestBody.create(postData, JSON);
     final Request request = new Request.Builder().url(getUrl() + route).post(body).build();
     return client.newCall(request).execute();
   }


### PR DESCRIPTION
## PR Description

The `RequestBody.create(MediaType, String)` version is deprecated.

The new version is `RequestBody.create(String, MediaType)`.

See: https://stackoverflow.com/a/57495696

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
