### PR TITLE
Use entrySet instead of keySet when iterating over the whole map

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/performance/DefaultPerformanceTracker.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/performance/DefaultPerformanceTracker.java
@@ -271,14 +271,15 @@ public class DefaultPerformanceTracker implements PerformanceTracker {
               // data hash to inclusion slot to aggregation bitlist
               Map<Bytes32, NavigableMap<UInt64, SszBitlist>> slotAndBitlistsByAttestationDataHash =
                   new HashMap<>();
-              for (UInt64 slot : attestationsIncludedOnChain.keySet()) {
-                for (Attestation attestation : attestationsIncludedOnChain.get(slot)) {
+              for (Map.Entry<UInt64, List<Attestation>> entry :
+                  attestationsIncludedOnChain.entrySet()) {
+                for (Attestation attestation : entry.getValue()) {
                   Bytes32 attestationDataHash = attestation.getData().hashTreeRoot();
                   NavigableMap<UInt64, SszBitlist> slotToBitlists =
                       slotAndBitlistsByAttestationDataHash.computeIfAbsent(
                           attestationDataHash, __ -> new TreeMap<>());
                   slotToBitlists.merge(
-                      slot, attestation.getAggregationBits(), SszBitlist::nullableOr);
+                      entry.getKey(), attestation.getAggregationBits(), SszBitlist::nullableOr);
                 }
               }
 

--- a/infrastructure/ssz/generator/src/main/java/tech/pegasys/teku/infrastructure/ssz/ContainersGenerator.java
+++ b/infrastructure/ssz/generator/src/main/java/tech/pegasys/teku/infrastructure/ssz/ContainersGenerator.java
@@ -163,8 +163,10 @@ public class ContainersGenerator {
 
   public String replacePlaceholders(String src, Map<String, String> varToVal) {
     String res = src;
-    for (String var : varToVal.keySet()) {
-      res = res.replaceAll("/\\*\\$\\$" + var + "\\*/[^$]+/\\*\\$\\$\\*/", varToVal.get(var));
+    for (Map.Entry<String, String> entry : varToVal.entrySet()) {
+      res =
+          res.replaceAll(
+              "/\\*\\$\\$" + entry.getKey() + "\\*/[^$]+/\\*\\$\\$\\*/", entry.getValue());
     }
     if (res.contains("/*$$")) {
       throw new RuntimeException("Non substituted placeholders found: " + res);

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/DefaultValidatorStatusLogger.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/DefaultValidatorStatusLogger.java
@@ -163,9 +163,12 @@ public class DefaultValidatorStatusLogger implements ValidatorStatusLogger {
                 return;
               }
 
-              for (BLSPublicKey key : newValidatorStatuses.keySet()) {
+              for (Map.Entry<BLSPublicKey, ValidatorStatus> entry :
+                  newValidatorStatuses.entrySet()) {
+                BLSPublicKey key = entry.getKey();
+                ValidatorStatus newStatus = entry.getValue();
                 ValidatorStatus oldStatus = oldValidatorStatuses.get(key);
-                ValidatorStatus newStatus = newValidatorStatuses.get(key);
+
                 // report the status of a new validator
                 if (oldStatus == null) {
                   STATUS_LOG.validatorStatus(key.toAbbreviatedString(), newStatus.name());


### PR DESCRIPTION
## PR Description

This replaces `keySet` with `entrySet` for loops that iterate over the whole map.

It is more efficient to use an iterator on the `entrySet` of the map, avoiding the extra `HashMap.get(key)` lookup.

See: https://stackoverflow.com/a/3870093 & https://stackoverflow.com/a/38116169

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
