### PR TITLE
Remove deprecated ChainBuilder.create constructor

### DIFF
--- a/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/ChainBuilder.java
+++ b/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/ChainBuilder.java
@@ -41,7 +41,6 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.Eth1Data;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
@@ -96,11 +95,6 @@ public class ChainBuilder {
 
   public static ChainBuilder create(final Spec spec) {
     return ChainBuilder.create(spec, DEFAULT_VALIDATOR_KEYS);
-  }
-
-  @Deprecated
-  public static ChainBuilder create(final List<BLSKeyPair> validatorKeys) {
-    return create(TestSpecFactory.createMinimalPhase0(), validatorKeys);
   }
 
   public static ChainBuilder create(final Spec spec, final List<BLSKeyPair> validatorKeys) {

--- a/ethereum/dataproviders/src/test/java/tech/pegasys/teku/dataproviders/generators/StateGeneratorTest.java
+++ b/ethereum/dataproviders/src/test/java/tech/pegasys/teku/dataproviders/generators/StateGeneratorTest.java
@@ -42,7 +42,7 @@ import tech.pegasys.teku.spec.datastructures.hashtree.HashTree;
 public class StateGeneratorTest {
   protected static final List<BLSKeyPair> VALIDATOR_KEYS = BLSKeyGenerator.generateKeyPairs(3);
   private final Spec spec = TestSpecFactory.createMinimalPhase0();
-  private final ChainBuilder chainBuilder = ChainBuilder.create(VALIDATOR_KEYS);
+  private final ChainBuilder chainBuilder = ChainBuilder.create(spec, VALIDATOR_KEYS);
 
   @Test
   public void regenerateStateForBlock_missingBaseBlock() {

--- a/ethereum/dataproviders/src/test/java/tech/pegasys/teku/dataproviders/generators/StreamingStateRegeneratorTest.java
+++ b/ethereum/dataproviders/src/test/java/tech/pegasys/teku/dataproviders/generators/StreamingStateRegeneratorTest.java
@@ -31,7 +31,7 @@ class StreamingStateRegeneratorTest {
 
   private static final List<BLSKeyPair> VALIDATOR_KEYS = BLSKeyGenerator.generateKeyPairs(3);
   private final Spec spec = TestSpecFactory.createMinimalPhase0();
-  private final ChainBuilder chainBuilder = ChainBuilder.create(VALIDATOR_KEYS);
+  private final ChainBuilder chainBuilder = ChainBuilder.create(spec, VALIDATOR_KEYS);
 
   @Test
   void shouldHandleValidChainFromGenesis() throws Exception {

--- a/storage/src/integration-test/java/tech/pegasys/teku/storage/client/AbstractCombinedChainDataClientTest.java
+++ b/storage/src/integration-test/java/tech/pegasys/teku/storage/client/AbstractCombinedChainDataClientTest.java
@@ -49,7 +49,7 @@ public abstract class AbstractCombinedChainDataClientTest {
 
   protected final Spec spec = TestSpecFactory.createMinimalPhase0();
   protected StorageSystem storageSystem;
-  protected ChainBuilder chainBuilder = ChainBuilder.create(VALIDATOR_KEYS);
+  protected ChainBuilder chainBuilder = ChainBuilder.create(spec, VALIDATOR_KEYS);
   protected ChainUpdater chainUpdater;
   protected CombinedChainDataClient client;
 

--- a/storage/src/test/java/tech/pegasys/teku/storage/client/RecentChainDataTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/client/RecentChainDataTest.java
@@ -798,7 +798,8 @@ class RecentChainDataTest {
   @Test
   public void getAncestorsOnFork() {
     initPreGenesis();
-    final ChainBuilder chainBuilder = ChainBuilder.create(BLSKeyGenerator.generateKeyPairs(16));
+    final ChainBuilder chainBuilder =
+        ChainBuilder.create(spec, BLSKeyGenerator.generateKeyPairs(16));
     final SignedBlockAndState genesis = chainBuilder.generateGenesis();
     recentChainData.initializeFromGenesis(genesis.getState(), UInt64.ZERO);
 
@@ -839,7 +840,8 @@ class RecentChainDataTest {
   @Test
   public void getAncestorsOnFork_unknownRoot() {
     initPreGenesis();
-    final ChainBuilder chainBuilder = ChainBuilder.create(BLSKeyGenerator.generateKeyPairs(16));
+    final ChainBuilder chainBuilder =
+        ChainBuilder.create(spec, BLSKeyGenerator.generateKeyPairs(16));
     final SignedBlockAndState genesis = chainBuilder.generateGenesis();
     recentChainData.initializeFromGenesis(genesis.getState(), UInt64.ZERO);
     assertThat(recentChainData.getAncestorsOnFork(UInt64.valueOf(1), Bytes32.ZERO)).isEmpty();

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/state/FinalizedStateCacheTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/state/FinalizedStateCacheTest.java
@@ -40,7 +40,7 @@ class FinalizedStateCacheTest {
   private static final int MAXIMUM_CACHE_SIZE = 3;
   protected static final List<BLSKeyPair> VALIDATOR_KEYS = BLSKeyGenerator.generateKeyPairs(3);
   private final Spec spec = TestSpecFactory.createMinimalPhase0();
-  private final ChainBuilder chainBuilder = ChainBuilder.create(VALIDATOR_KEYS);
+  private final ChainBuilder chainBuilder = ChainBuilder.create(spec, VALIDATOR_KEYS);
   private final Database database = mock(Database.class);
   // We don't use soft references in unit tests to avoid intermittency
   private final FinalizedStateCache cache =


### PR DESCRIPTION
## PR Description

This PR removes the deprecated constructor and updates old instances. New constructor needs a spec.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
