### PR TITLE
Fix "unknown enum constant" warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -730,7 +730,6 @@ subprojects {
 
     runtimeOnly 'org.apache.logging.log4j:log4j-core'
     runtimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl'
-    runtimeOnly 'org.apiguardian:apiguardian-api'
 
     testImplementation 'org.apache.tuweni:tuweni-junit'
     testImplementation 'org.assertj:assertj-core'
@@ -741,6 +740,8 @@ subprojects {
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
 
     testFixturesImplementation 'org.assertj:assertj-core'
+
+    testFixturesRuntimeOnly 'org.apiguardian:apiguardian-api'
   }
 
   if (!baseInfrastructureProjects.contains(project.path)) {

--- a/build.gradle
+++ b/build.gradle
@@ -730,6 +730,7 @@ subprojects {
 
     runtimeOnly 'org.apache.logging.log4j:log4j-core'
     runtimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl'
+    runtimeOnly 'org.apiguardian:apiguardian-api'
 
     testImplementation 'org.apache.tuweni:tuweni-junit'
     testImplementation 'org.assertj:assertj-core'

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -106,6 +106,8 @@ dependencyManagement {
       entry 'log4j-slf4j-impl'
     }
 
+    dependency 'org.apiguardian:apiguardian-api:1.1.2'
+
     dependency 'org.assertj:assertj-core:3.22.0'
 
     dependency 'org.awaitility:awaitility:4.2.0'


### PR DESCRIPTION
## PR Description

This gets rid of the "unknown enum constant" warning messages in the build:

```
> Task :eth-benchmark-tests:compileJmhJava
warning: unknown enum constant Status.STABLE
  reason: class file for org.apiguardian.api.API$Status not found
warning: unknown enum constant Status.STABLE
warning: unknown enum constant Status.STABLE
  reason: class file for org.apiguardian.api.API$Status not found
warning: unknown enum constant Status.STABLE
warning: unknown enum constant Status.STABLE
  reason: class file for org.apiguardian.api.API$Status not found
warning: unknown enum constant Status.STABLE
warning: unknown enum constant Status.STABLE
  reason: class file for org.apiguardian.api.API$Status not found
warning: unknown enum constant Status.STABLE
```

We needed to add `apiguardian-api` as a `runtimeOnly` dependency.

See: https://stackoverflow.com/a/46950496

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
