### PR TITLE
Remove empty NodeContainer constructor

### DIFF
--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/NodeContainer.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/NodeContainer.java
@@ -26,8 +26,6 @@ public class NodeContainer extends GenericContainer<NodeContainer> {
 
   private final Map<File, String> tarballToExpand = new HashMap<>();
 
-  public NodeContainer() {}
-
   public NodeContainer(final String dockerImageName) {
     super(dockerImageName);
   }


### PR DESCRIPTION
## PR Description

Removes the empty `NodeContainer` constructor that is never used.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
