### PR TITLE
Update deprecated gradle methods/props to work with v8.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -350,7 +350,7 @@ check.dependsOn('checkMavenCoordinateCollisions')
 
 application {
   applicationName = "teku"
-  mainClassName = "tech.pegasys.teku.Teku"
+  getMainClass().set("tech.pegasys.teku.Teku")
   applicationDefaultJvmArgs = [
       "-Dvertx.disableFileCPResolving=true",
       "-Dteku.home=TEKU_HOME",
@@ -369,7 +369,7 @@ task autocomplete(type: JavaExec) {
   dependsOn compileJava
   outputs.file "build/teku.autocomplete.sh"
 
-  main = application.mainClassName
+  mainClass = application.getMainClass()
   args "debug-tools", "generate-autocomplete", "--output", "build/teku.autocomplete.sh"
   classpath sourceSets.main.runtimeClasspath
 }
@@ -382,7 +382,7 @@ distTar {
     delete fileTree(dir: 'build/distributions', include: '*.tar.gz')
   }
   compression = Compression.GZIP
-  extension = 'tar.gz'
+  archiveExtension = 'tar.gz'
 }
 
 distZip {
@@ -551,7 +551,7 @@ subprojects {
    maxParallelForks = (System.getenv('GRADLE_MAX_TEST_FORKS') ?: (Runtime.runtime.availableProcessors().intdiv(2) ?: 1)).toInteger()
     useJUnitPlatform()
     reports {
-      junitXml.enabled = true
+      junitXml.required = true
     }
     filter {
       // Support filtering tests with the --tests option to gradle
@@ -712,7 +712,7 @@ subprojects {
   }
 
   jar {
-    baseName jarName
+    archiveBaseName = jarName
     manifest {
       attributes(
           'Specification-Title': jarName,

--- a/eth-reference-tests/build.gradle
+++ b/eth-reference-tests/build.gradle
@@ -34,7 +34,7 @@ task generateReferenceTestClasses(type: JavaExec) {
   group = "Execution"
   description = "Generate reference test classes"
   classpath = project.project(':eth-tests').sourceSets.referenceTest.runtimeClasspath
-  main = 'tech.pegasys.teku.ethtests.ReferenceTestGenerator'
+  mainClass = 'tech.pegasys.teku.ethtests.ReferenceTestGenerator'
   args = [project.file('src/referenceTest/generated_tests').absolutePath]
   systemProperty("teku.ref-test-module.path", project.file("../eth-reference-tests").absolutePath)
 }

--- a/infrastructure/ssz/generator/build.gradle
+++ b/infrastructure/ssz/generator/build.gradle
@@ -6,7 +6,7 @@ dependencies {
 task generateContainers(type: JavaExec) {
     dependsOn compileJava
 
-    main = 'tech.pegasys.teku.ssz.backing.ContainersGenerator'
+    mainClass = 'tech.pegasys.teku.ssz.backing.ContainersGenerator'
     args project.sourceSets.main.java.srcDirs.join(" "),
             project.parent.sourceSets.main.java.srcDirs.join(" ")
     classpath sourceSets.main.runtimeClasspath


### PR DESCRIPTION
## PR Description

Gradle was complaining about some deprecated methods/properties being used:

```
Deprecated Gradle features were used in this build, making it incompatible with Gradle 8.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

See https://docs.gradle.org/7.4.1/userguide/command_line_interface.html#sec:command_line_warnings
```

Here are the warnings when you give the `--warning-mode all` flag:

```
> Configure project :
The JavaApplication.setMainClassName(String) method has been deprecated. This is scheduled to be removed in Gradle 8.0. Use #getMainClass().set(...) instead. See https://docs.gradle.org/7.4.1/dsl/org.gradle.api.plugins.JavaApplication.html#org.gradle.api.plugins.JavaApplication:mainClass for more details.
        at build_6fmn1m0wpovw4z1jolq1ueoh8$_run_closure17.doCall(/Users/jtraglia/Projects/jtraglia/teku/build.gradle:353)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
The JavaApplication.getMainClassName() method has been deprecated. This is scheduled to be removed in Gradle 8.0. Use #getMainClass() instead. See https://docs.gradle.org/7.4.1/dsl/org.gradle.api.plugins.JavaApplication.html#org.gradle.api.plugins.JavaApplication:mainClass for more details.
        at build_6fmn1m0wpovw4z1jolq1ueoh8$_run_closure18.doCall(/Users/jtraglia/Projects/jtraglia/teku/build.gradle:372)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
The JavaExec.main property has been deprecated. This is scheduled to be removed in Gradle 8.0. Please use the mainClass property instead. See https://docs.gradle.org/7.4.1/dsl/org.gradle.api.tasks.JavaExec.html#org.gradle.api.tasks.JavaExec:main for more details.
        at build_6fmn1m0wpovw4z1jolq1ueoh8$_run_closure18.doCall(/Users/jtraglia/Projects/jtraglia/teku/build.gradle:372)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
The AbstractArchiveTask.extension property has been deprecated. This is scheduled to be removed in Gradle 8.0. Please use the archiveExtension property instead. See https://docs.gradle.org/7.4.1/dsl/org.gradle.api.tasks.bundling.AbstractArchiveTask.html#org.gradle.api.tasks.bundling.AbstractArchiveTask:extension for more details.
        at build_6fmn1m0wpovw4z1jolq1ueoh8$_run_closure20.doCall(/Users/jtraglia/Projects/jtraglia/teku/build.gradle:385)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
The Report.enabled property has been deprecated. This is scheduled to be removed in Gradle 8.0. Please use the required property instead. See https://docs.gradle.org/7.4.1/dsl/org.gradle.api.reporting.Report.html#org.gradle.api.reporting.Report:enabled for more details.
        at build_6fmn1m0wpovw4z1jolq1ueoh8$_run_closure27$_closure75$_closure91.doCall(/Users/jtraglia/Projects/jtraglia/teku/build.gradle:554)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
The AbstractArchiveTask.baseName property has been deprecated. This is scheduled to be removed in Gradle 8.0. Please use the archiveBaseName property instead. See https://docs.gradle.org/7.4.1/dsl/org.gradle.api.tasks.bundling.AbstractArchiveTask.html#org.gradle.api.tasks.bundling.AbstractArchiveTask:baseName for more details.
        at build_6fmn1m0wpovw4z1jolq1ueoh8$_run_closure27$_closure86.doCall(/Users/jtraglia/Projects/jtraglia/teku/build.gradle:715)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)

> Configure project :eth-reference-tests
The JavaExec.main property has been deprecated. This is scheduled to be removed in Gradle 8.0. Please use the mainClass property instead. See https://docs.gradle.org/7.4.1/dsl/org.gradle.api.tasks.JavaExec.html#org.gradle.api.tasks.JavaExec:main for more details.
        at build_3vmb747xqfixglqdhfkv9ivld$_run_closure4.doCall(/Users/jtraglia/Projects/jtraglia/teku/eth-reference-tests/build.gradle:37)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)

> Configure project :infrastructure:ssz:generator
The JavaExec.main property has been deprecated. This is scheduled to be removed in Gradle 8.0. Please use the mainClass property instead. See https://docs.gradle.org/7.4.1/dsl/org.gradle.api.tasks.JavaExec.html#org.gradle.api.tasks.JavaExec:main for more details.
        at build_br5h0gxxfbc4cffukb0s6b5te$_run_closure2.doCall(/Users/jtraglia/Projects/jtraglia/teku/infrastructure/ssz/generator/build.gradle:9)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
```

This PR makes all of the recommended changes. We can safely update to Gradle 8.0 whenever we want to now.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
