### PR TITLE
Update ATs to use latest Besu

### DIFF
--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/BellatrixMergeTransitionAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/BellatrixMergeTransitionAcceptanceTest.java
@@ -13,8 +13,6 @@
 
 package tech.pegasys.teku.test.acceptance;
 
-import static tech.pegasys.teku.test.acceptance.dsl.BesuDockerVersion.DEVELOP;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.time.SystemTimeProvider;
@@ -36,7 +34,6 @@ public class BellatrixMergeTransitionAcceptanceTest extends AcceptanceTestBase {
     final int genesisTime = timeProvider.getTimeInSeconds().plus(10).intValue();
     eth1Node =
         createBesuNode(
-            DEVELOP,
             config -> config.withMergeSupport(true).withGenesisFile("besu/preMergeGenesis.json"));
     eth1Node.start();
 

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/AcceptanceTestBase.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/AcceptanceTestBase.java
@@ -94,7 +94,7 @@ public class AcceptanceTestBase {
   }
 
   protected BesuNode createBesuNode(final Consumer<BesuNode.Config> configOptions) {
-    return createBesuNode(BesuDockerVersion.V21_10_9, configOptions);
+    return createBesuNode(BesuDockerVersion.STABLE, configOptions);
   }
 
   protected BesuNode createBesuNode(

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/BesuDockerVersion.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/BesuDockerVersion.java
@@ -14,8 +14,7 @@
 package tech.pegasys.teku.test.acceptance.dsl;
 
 public enum BesuDockerVersion {
-  DEVELOP("develop"),
-  V21_10_9("21.10.9");
+  STABLE("22.1.3");
 
   private final String version;
 


### PR DESCRIPTION
## PR Description
Update version of besu docker image used in ATs to latest release. Switches the BellatrixMergeTransitionAcceptanceTest to use a besu release instead of develop so it's more predictable.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
