### PR TITLE
Migrate the publish blinded block intereface to new api.

### DIFF
--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/paths/_eth_v1_beacon_blinded_blocks.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/paths/_eth_v1_beacon_blinded_blocks.json
@@ -1,0 +1,59 @@
+{
+  "post" : {
+    "tags" : [ "Validator", "Validator Required Api", "Experimental" ],
+    "operationId" : "publishBlindedBlock",
+    "summary" : "Publish a signed blinded block",
+    "description" : "Submit a signed blinded beacon block to the beacon node to be imported. The beacon node performs the required validation.",
+    "requestBody" : {
+      "content" : {
+        "application/json" : {
+          "schema" : {
+            "title" : "SignedBlindedBlock",
+            "type" : "object",
+            "oneOf" : [ {
+              "$ref" : "#/components/schemas/SignedBeaconBlockPhase0"
+            }, {
+              "$ref" : "#/components/schemas/SignedBeaconBlockAltair"
+            }, {
+              "$ref" : "#/components/schemas/SignedBlindedBlockBellatrix"
+            } ]
+          }
+        }
+      }
+    },
+    "responses" : {
+      "200" : {
+        "description" : "Block has been successfully broadcast, validated and imported.",
+        "content" : { }
+      },
+      "202" : {
+        "description" : "Block has been successfully broadcast, but failed validation and has not been imported.",
+        "content" : { }
+      },
+      "400" : {
+        "description" : "Unable to parse request body.",
+        "content" : {
+          "application/json" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/HttpErrorResponse"
+            }
+          }
+        }
+      },
+      "503" : {
+        "description" : "Beacon node is currently syncing.",
+        "content" : { }
+      },
+      "500" : {
+        "description" : "Internal server error",
+        "content" : {
+          "application/json" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/HttpErrorResponse"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/schema/SignedBeaconBlockAltair.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/schema/SignedBeaconBlockAltair.json
@@ -1,0 +1,16 @@
+{
+  "title" : "SignedBeaconBlockAltair",
+  "type" : "object",
+  "required" : [ "message", "signature" ],
+  "properties" : {
+    "message" : {
+      "$ref" : "#/components/schemas/BeaconBlockAltair"
+    },
+    "signature" : {
+      "type" : "string",
+      "pattern" : "^0x[a-fA-F0-9]{2,}$",
+      "description" : "SSZ hexadecimal",
+      "format" : "bytes"
+    }
+  }
+}

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/schema/SignedBeaconBlockPhase0.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/schema/SignedBeaconBlockPhase0.json
@@ -1,0 +1,16 @@
+{
+  "title" : "SignedBeaconBlockPhase0",
+  "type" : "object",
+  "required" : [ "message", "signature" ],
+  "properties" : {
+    "message" : {
+      "$ref" : "#/components/schemas/BeaconBlockPhase0"
+    },
+    "signature" : {
+      "type" : "string",
+      "pattern" : "^0x[a-fA-F0-9]{2,}$",
+      "description" : "SSZ hexadecimal",
+      "format" : "bytes"
+    }
+  }
+}

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/schema/SignedBlindedBlockBellatrix.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/schema/SignedBlindedBlockBellatrix.json
@@ -1,0 +1,16 @@
+{
+  "title" : "SignedBlindedBlockBellatrix",
+  "type" : "object",
+  "required" : [ "message", "signature" ],
+  "properties" : {
+    "message" : {
+      "$ref" : "#/components/schemas/BlindedBlockBellatrix"
+    },
+    "signature" : {
+      "type" : "string",
+      "pattern" : "^0x[a-fA-F0-9]{2,}$",
+      "description" : "SSZ hexadecimal",
+      "format" : "bytes"
+    }
+  }
+}

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApi.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApi.java
@@ -403,7 +403,7 @@ public class BeaconRestApi {
     app.get(GetBlockHeader.ROUTE, new GetBlockHeader(dataProvider, jsonProvider));
 
     app.post(PostBlock.ROUTE, new PostBlock(dataProvider, jsonProvider));
-    app.post(PostBlindedBlock.ROUTE, new PostBlindedBlock(dataProvider, jsonProvider));
+    addMigratedEndpoint(new PostBlindedBlock(dataProvider, schemaCache));
 
     app.get(GetBlock.ROUTE, new GetBlock(dataProvider, jsonProvider));
     app.get(

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostBlindedBlock.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostBlindedBlock.java
@@ -128,7 +128,9 @@ public class PostBlindedBlock extends MigratingEndpointAdapter {
                   .getRejectionReason()
                   .get()
                   .equals(BlockImportResult.FailureReason.INTERNAL_ERROR.name())) {
-                return AsyncApiResponse.respondWithCode(SC_INTERNAL_SERVER_ERROR);
+                return AsyncApiResponse.respondWithError(
+                    SC_INTERNAL_SERVER_ERROR,
+                    "An internal error occurred, check the server logs for more details.");
               } else {
                 return AsyncApiResponse.respondWithCode(SC_ACCEPTED);
               }

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostBlindedBlock.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostBlindedBlock.java
@@ -14,8 +14,9 @@
 package tech.pegasys.teku.beaconrestapi.handlers.v1.beacon;
 
 import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
-import static javax.servlet.http.HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
 import static javax.servlet.http.HttpServletResponse.SC_SERVICE_UNAVAILABLE;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_ACCEPTED;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.RES_ACCEPTED;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.RES_BAD_REQUEST;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.RES_INTERNAL_ERROR;
@@ -23,47 +24,57 @@ import static tech.pegasys.teku.infrastructure.http.RestApiConstants.RES_OK;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.RES_SERVICE_UNAVAILABLE;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.TAG_BEACON;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.TAG_EXPERIMENTAL;
+import static tech.pegasys.teku.infrastructure.http.RestApiConstants.TAG_VALIDATOR;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.TAG_VALIDATOR_REQUIRED;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.javalin.http.Context;
-import io.javalin.http.Handler;
 import io.javalin.plugin.openapi.annotations.HttpMethod;
 import io.javalin.plugin.openapi.annotations.OpenApi;
 import io.javalin.plugin.openapi.annotations.OpenApiContent;
 import io.javalin.plugin.openapi.annotations.OpenApiRequestBody;
 import io.javalin.plugin.openapi.annotations.OpenApiResponse;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import java.util.Optional;
 import org.jetbrains.annotations.NotNull;
 import tech.pegasys.teku.api.DataProvider;
 import tech.pegasys.teku.api.SyncDataProvider;
 import tech.pegasys.teku.api.ValidatorDataProvider;
-import tech.pegasys.teku.api.schema.SignedBeaconBlock;
+import tech.pegasys.teku.api.schema.ValidatorBlockResult;
 import tech.pegasys.teku.api.schema.interfaces.SignedBlindedBlock;
-import tech.pegasys.teku.beaconrestapi.schema.BadRequest;
-import tech.pegasys.teku.infrastructure.http.HttpStatusCodes;
-import tech.pegasys.teku.provider.JsonProvider;
+import tech.pegasys.teku.beaconrestapi.MigratingEndpointAdapter;
+import tech.pegasys.teku.beaconrestapi.SchemaDefinitionCache;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.json.JsonUtil;
+import tech.pegasys.teku.infrastructure.json.types.CoreTypes;
+import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
+import tech.pegasys.teku.infrastructure.json.types.SerializableOneOfTypeDefinition;
+import tech.pegasys.teku.infrastructure.json.types.SerializableOneOfTypeDefinitionBuilder;
+import tech.pegasys.teku.infrastructure.restapi.endpoints.AsyncApiResponse;
+import tech.pegasys.teku.infrastructure.restapi.endpoints.EndpointMetadata;
+import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiRequest;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 
-public class PostBlindedBlock implements Handler {
-  private static final Logger LOG = LogManager.getLogger();
+public class PostBlindedBlock extends MigratingEndpointAdapter {
   public static final String ROUTE = "/eth/v1/beacon/blinded_blocks";
 
-  private final JsonProvider jsonProvider;
   private final ValidatorDataProvider validatorDataProvider;
   private final SyncDataProvider syncDataProvider;
 
-  public PostBlindedBlock(final DataProvider dataProvider, final JsonProvider jsonProvider) {
-    this.validatorDataProvider = dataProvider.getValidatorDataProvider();
-    this.syncDataProvider = dataProvider.getSyncDataProvider();
-    this.jsonProvider = jsonProvider;
+  public PostBlindedBlock(
+      final DataProvider dataProvider, final SchemaDefinitionCache schemaDefinitionCache) {
+    this(
+        dataProvider.getValidatorDataProvider(),
+        dataProvider.getSyncDataProvider(),
+        schemaDefinitionCache);
   }
 
   PostBlindedBlock(
       final ValidatorDataProvider validatorDataProvider,
       final SyncDataProvider syncDataProvider,
-      final JsonProvider jsonProvider) {
-    this.jsonProvider = jsonProvider;
+      final SchemaDefinitionCache schemaDefinitionCache) {
+    super(getEndpointMetaData(schemaDefinitionCache));
     this.validatorDataProvider = validatorDataProvider;
     this.syncDataProvider = syncDataProvider;
   }
@@ -96,28 +107,72 @@ public class PostBlindedBlock implements Handler {
       })
   @Override
   public void handle(@NotNull final Context ctx) throws Exception {
-    try {
-      if (syncDataProvider.isSyncing()) {
-        ctx.status(SC_SERVICE_UNAVAILABLE);
-        ctx.json(BadRequest.serviceUnavailable(jsonProvider));
-        return;
-      }
+    adapt(ctx);
+  }
 
-      final SignedBeaconBlock signedBlindedBlock =
-          validatorDataProvider.parseBlindedBlock(jsonProvider, ctx.body());
-
-      LOG.debug("parsed block is from slot: {}", signedBlindedBlock.getMessage().slot);
-
-      ctx.status(HttpStatusCodes.SC_BAD_REQUEST);
-      ctx.json(BadRequest.badRequest(jsonProvider, "Blinded blocks not implemented"));
-
-    } catch (final JsonProcessingException ex) {
-      ctx.status(SC_BAD_REQUEST);
-      ctx.json(BadRequest.badRequest(jsonProvider, ex.getMessage()));
-    } catch (final Exception ex) {
-      LOG.error("Failed to post blinded block due to internal error", ex);
-      ctx.status(SC_INTERNAL_SERVER_ERROR);
-      ctx.json(BadRequest.internalError(jsonProvider, ex.getMessage()));
+  @Override
+  public void handleRequest(final RestApiRequest request) throws JsonProcessingException {
+    if (syncDataProvider.isSyncing()) {
+      request.respondError(SC_SERVICE_UNAVAILABLE, "Beacon node is currently syncing.");
     }
+
+    final SafeFuture<ValidatorBlockResult> result =
+        validatorDataProvider.submitSignedBlindedBlock(request.getRequestBody());
+    request.respondAsync(
+        result.thenApply(
+            blockResult -> {
+              if (blockResult.getResponseCode() < SC_BAD_REQUEST) {
+                return AsyncApiResponse.respondWithCode(blockResult.getResponseCode());
+              }
+              return AsyncApiResponse.respondWithError(
+                  blockResult.getResponseCode(), blockResult.getFailureReason().orElse(""));
+            }));
+  }
+
+  private static EndpointMetadata getEndpointMetaData(
+      final SchemaDefinitionCache schemaDefinitionCache) {
+    return EndpointMetadata.post(ROUTE)
+        .operationId("publishBlindedBlock")
+        .summary("Publish a signed blinded block")
+        .description(
+            "Submit a signed blinded beacon block to the beacon node to be imported."
+                + " The beacon node performs the required validation.")
+        .tags(TAG_VALIDATOR, TAG_VALIDATOR_REQUIRED, TAG_EXPERIMENTAL)
+        .requestBodyType(
+            getSignedBlindedBlockSchemaDefinition(schemaDefinitionCache),
+            (json) -> signedBlockTypeSelector(json, schemaDefinitionCache))
+        .response(SC_OK, "Block has been successfully broadcast, validated and imported.")
+        .response(
+            SC_ACCEPTED,
+            "Block has been successfully broadcast, but failed validation and has not been imported.")
+        .withBadRequestResponse(Optional.of("Unable to parse request body."))
+        .response(SC_SERVICE_UNAVAILABLE, "Beacon node is currently syncing.")
+        .build();
+  }
+
+  private static SerializableOneOfTypeDefinition<SignedBeaconBlock>
+      getSignedBlindedBlockSchemaDefinition(final SchemaDefinitionCache schemaDefinitionCache) {
+    final SerializableOneOfTypeDefinitionBuilder<SignedBeaconBlock> builder =
+        new SerializableOneOfTypeDefinitionBuilder<SignedBeaconBlock>().title("SignedBlindedBlock");
+    for (SpecMilestone milestone : SpecMilestone.values()) {
+      builder.withType(
+          block -> schemaDefinitionCache.milestoneAtSlot(block.getSlot()).equals(milestone),
+          schemaDefinitionCache
+              .getSchemaDefinition(milestone)
+              .getSignedBlindedBeaconBlockSchema()
+              .getJsonTypeDefinition());
+    }
+    return builder.build();
+  }
+
+  private static DeserializableTypeDefinition<SignedBeaconBlock> signedBlockTypeSelector(
+      final String json, final SchemaDefinitionCache schemaDefinitionCache) {
+    final Optional<UInt64> slot =
+        JsonUtil.getAttribute(json, CoreTypes.UINT64_TYPE, "message", "slot");
+    final SpecMilestone milestone = schemaDefinitionCache.milestoneAtSlot(slot.orElseThrow());
+    return schemaDefinitionCache
+        .getSchemaDefinition(milestone)
+        .getSignedBlindedBeaconBlockSchema()
+        .getJsonTypeDefinition();
   }
 }

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/SchemaDefinitionCacheTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/SchemaDefinitionCacheTest.java
@@ -20,15 +20,24 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszSchema;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
 
 public class SchemaDefinitionCacheTest {
+  private static final Logger LOG = LogManager.getLogger();
 
   @ParameterizedTest
   @EnumSource(SpecMilestone.class)
@@ -67,5 +76,31 @@ public class SchemaDefinitionCacheTest {
     final SchemaDefinitionCache cache = new SchemaDefinitionCache(spec);
     assertThat(spec.forMilestone(SpecMilestone.BELLATRIX)).isNull();
     assertThat(cache.getSchemaDefinition(SpecMilestone.BELLATRIX)).isNotNull();
+  }
+
+  @ParameterizedTest
+  @EnumSource(SpecMilestone.class)
+  void subsequentCallsShouldGetTheSameSchemaObject(final SpecMilestone specMilestone) {
+    final Spec spec = TestSpecFactory.createMinimal(specMilestone);
+    final SchemaDefinitionCache cache = new SchemaDefinitionCache(spec);
+
+    final List<Method> methods = Arrays.asList(SchemaDefinitions.class.getMethods());
+    // all the get methods should return the same object on subsequent calls,
+    // as creation of the schema objects is relatively expensive
+    methods.stream()
+        .filter(method -> method.getName().startsWith("get"))
+        .forEach(
+            method -> {
+              try {
+                LOG.info(method.getName());
+                final SszSchema<?> first =
+                    (SszSchema<?>) method.invoke(cache.getSchemaDefinition(specMilestone));
+                final SszSchema<?> second =
+                    (SszSchema<?>) method.invoke(cache.getSchemaDefinition(specMilestone));
+                assertThat(first.getJsonTypeDefinition()).isEqualTo(second.getJsonTypeDefinition());
+              } catch (IllegalAccessException | InvocationTargetException e) {
+                LOG.error(e);
+              }
+            });
   }
 }

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/SchemaDefinitionCacheTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/SchemaDefinitionCacheTest.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -99,7 +100,7 @@ public class SchemaDefinitionCacheTest {
                     (SszSchema<?>) method.invoke(cache.getSchemaDefinition(specMilestone));
                 assertThat(first.getJsonTypeDefinition()).isEqualTo(second.getJsonTypeDefinition());
               } catch (IllegalAccessException | InvocationTargetException e) {
-                LOG.error(e);
+                Assertions.fail(e);
               }
             });
   }

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
@@ -220,16 +220,10 @@ public class ValidatorDataProvider {
         .thenApply(ValidatorDataProvider::generateSubmitSignedBlockResponse);
   }
 
-  public SafeFuture<ValidatorBlockResult> submitSignedBlindedBlock(
+  public SafeFuture<SendSignedBlockResult> submitSignedBlindedBlock(
       final tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock signedBeaconBlock) {
     LOG.debug("parsed block is from slot: {}", signedBeaconBlock.getMessage().getSlot());
-    final SpecMilestone milestone = spec.atSlot(signedBeaconBlock.getSlot()).getMilestone();
-    if (milestone == SpecMilestone.PHASE0 || milestone == SpecMilestone.ALTAIR) {
-      return validatorApiChannel
-          .sendSignedBlock(signedBeaconBlock)
-          .thenApply(ValidatorDataProvider::generateSubmitSignedBlockResponse);
-    }
-    return SafeFuture.failedFuture(new IllegalStateException("Not implemented"));
+    return validatorApiChannel.sendSignedBlock(signedBeaconBlock);
   }
 
   public SafeFuture<Optional<PostDataFailureResponse>> submitCommitteeSignatures(

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
@@ -27,6 +27,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.api.exceptions.BadRequestException;
@@ -69,11 +71,13 @@ import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 import tech.pegasys.teku.validator.api.AttesterDuty;
 import tech.pegasys.teku.validator.api.CommitteeSubscriptionRequest;
 import tech.pegasys.teku.validator.api.ProposerDuty;
+import tech.pegasys.teku.validator.api.SendSignedBlockResult;
 import tech.pegasys.teku.validator.api.SubmitDataError;
 import tech.pegasys.teku.validator.api.SyncCommitteeDuty;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 
 public class ValidatorDataProvider {
+  private static final Logger LOG = LogManager.getLogger();
 
   public static final String CANNOT_PRODUCE_HISTORIC_BLOCK =
       "Cannot produce a block for a historic slot.";
@@ -213,23 +217,19 @@ public class ValidatorDataProvider {
       final SignedBeaconBlock signedBeaconBlock) {
     return validatorApiChannel
         .sendSignedBlock(signedBeaconBlock.asInternalSignedBeaconBlock(spec))
-        .thenApply(
-            result -> {
-              int responseCode;
-              Optional<Bytes32> hashRoot = result.getBlockRoot();
-              if (result.getRejectionReason().isEmpty()) {
-                responseCode = SC_OK;
-              } else if (result
-                  .getRejectionReason()
-                  .get()
-                  .equals(FailureReason.INTERNAL_ERROR.name())) {
-                responseCode = SC_INTERNAL_ERROR;
-              } else {
-                responseCode = SC_ACCEPTED;
-              }
+        .thenApply(ValidatorDataProvider::generateSubmitSignedBlockResponse);
+  }
 
-              return new ValidatorBlockResult(responseCode, result.getRejectionReason(), hashRoot);
-            });
+  public SafeFuture<ValidatorBlockResult> submitSignedBlindedBlock(
+      final tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock signedBeaconBlock) {
+    LOG.debug("parsed block is from slot: {}", signedBeaconBlock.getMessage().getSlot());
+    final SpecMilestone milestone = spec.atSlot(signedBeaconBlock.getSlot()).getMilestone();
+    if (milestone == SpecMilestone.PHASE0 || milestone == SpecMilestone.ALTAIR) {
+      return validatorApiChannel
+          .sendSignedBlock(signedBeaconBlock)
+          .thenApply(ValidatorDataProvider::generateSubmitSignedBlockResponse);
+    }
+    return SafeFuture.failedFuture(new IllegalStateException("Not implemented"));
   }
 
   public SafeFuture<Optional<PostDataFailureResponse>> submitCommitteeSignatures(
@@ -451,5 +451,20 @@ public class ValidatorDataProvider {
         syncCommitteeContributionSchema.getAggregationBitsSchema().fromBytes(aggregationBits);
 
     return aggregationBitsVector.getAllSetBits();
+  }
+
+  private static ValidatorBlockResult generateSubmitSignedBlockResponse(
+      SendSignedBlockResult result) {
+    int responseCode;
+    Optional<Bytes32> hashRoot = result.getBlockRoot();
+    if (result.getRejectionReason().isEmpty()) {
+      responseCode = SC_OK;
+    } else if (result.getRejectionReason().get().equals(FailureReason.INTERNAL_ERROR.name())) {
+      responseCode = SC_INTERNAL_ERROR;
+    } else {
+      responseCode = SC_ACCEPTED;
+    }
+
+    return new ValidatorBlockResult(responseCode, result.getRejectionReason(), hashRoot);
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBeaconBlockSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBeaconBlockSchema.java
@@ -22,9 +22,10 @@ import tech.pegasys.teku.spec.datastructures.type.SszSignatureSchema;
 public class SignedBeaconBlockSchema
     extends ContainerSchema2<SignedBeaconBlock, BeaconBlock, SszSignature> {
 
-  public SignedBeaconBlockSchema(final BeaconBlockSchema beaconBlockSchema) {
+  public SignedBeaconBlockSchema(
+      final BeaconBlockSchema beaconBlockSchema, final String containerName) {
     super(
-        "SignedBeaconBlock",
+        containerName,
         namedSchema("message", beaconBlockSchema),
         namedSchema("signature", SszSignatureSchema.INSTANCE));
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsAltair.java
@@ -49,7 +49,8 @@ public class SchemaDefinitionsAltair extends AbstractSchemaDefinitions {
         BeaconBlockBodySchemaAltairImpl.create(
             specConfig, getAttesterSlashingSchema(), "BeaconBlockBodyAltair");
     this.beaconBlockSchema = new BeaconBlockSchema(beaconBlockBodySchema, "BeaconBlockAltair");
-    this.signedBeaconBlockSchema = new SignedBeaconBlockSchema(beaconBlockSchema);
+    this.signedBeaconBlockSchema =
+        new SignedBeaconBlockSchema(beaconBlockSchema, "SignedBeaconBlockAltair");
     this.syncCommitteeContributionSchema = SyncCommitteeContributionSchema.create(specConfig);
     this.contributionAndProofSchema =
         ContributionAndProofSchema.create(syncCommitteeContributionSchema);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsBellatrix.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsBellatrix.java
@@ -53,8 +53,10 @@ public class SchemaDefinitionsBellatrix extends SchemaDefinitionsAltair {
     this.beaconBlockSchema = new BeaconBlockSchema(beaconBlockBodySchema, "BeaconBlockBellatrix");
     this.blindedBeaconBlockSchema =
         new BeaconBlockSchema(blindedBeaconBlockBodySchema, "BlindedBlockBellatrix");
-    this.signedBeaconBlockSchema = new SignedBeaconBlockSchema(beaconBlockSchema);
-    this.signedBlindedBeaconBlockSchema = new SignedBeaconBlockSchema(blindedBeaconBlockSchema);
+    this.signedBeaconBlockSchema =
+        new SignedBeaconBlockSchema(beaconBlockSchema, "SignedBeaconBlockBellatrix");
+    this.signedBlindedBeaconBlockSchema =
+        new SignedBeaconBlockSchema(blindedBeaconBlockSchema, "SignedBlindedBlockBellatrix");
     this.executionPayloadHeaderSchema = new ExecutionPayloadHeaderSchema(specConfig);
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsPhase0.java
@@ -27,6 +27,8 @@ public class SchemaDefinitionsPhase0 extends AbstractSchemaDefinitions {
   private final BeaconStateSchemaPhase0 beaconStateSchema;
   private final BeaconBlockBodySchema<?> beaconBlockBodySchema;
   private final MetadataMessageSchemaPhase0 metadataMessageSchema;
+  private final BeaconBlockSchema beaconBlockSchema;
+  private final SignedBeaconBlockSchema signedBeaconBlockSchema;
 
   public SchemaDefinitionsPhase0(final SpecConfig specConfig) {
     super(specConfig);
@@ -35,6 +37,9 @@ public class SchemaDefinitionsPhase0 extends AbstractSchemaDefinitions {
         BeaconBlockBodySchemaPhase0.create(
             specConfig, getAttesterSlashingSchema(), "BeaconBlockBodyPhase0");
     this.metadataMessageSchema = new MetadataMessageSchemaPhase0();
+    beaconBlockSchema = new BeaconBlockSchema(beaconBlockBodySchema, "BeaconBlockPhase0");
+    signedBeaconBlockSchema =
+        new SignedBeaconBlockSchema(beaconBlockSchema, "SignedBeaconBlockPhase0");
   }
 
   @Override
@@ -44,12 +49,12 @@ public class SchemaDefinitionsPhase0 extends AbstractSchemaDefinitions {
 
   @Override
   public SignedBeaconBlockSchema getSignedBeaconBlockSchema() {
-    return new SignedBeaconBlockSchema(getBeaconBlockSchema());
+    return signedBeaconBlockSchema;
   }
 
   @Override
   public BeaconBlockSchema getBeaconBlockSchema() {
-    return new BeaconBlockSchema(getBeaconBlockBodySchema(), "BeaconBlockPhase0");
+    return beaconBlockSchema;
   }
 
   @Override

--- a/infrastructure/http/src/main/java/tech/pegasys/teku/infrastructure/http/HttpErrorResponse.java
+++ b/infrastructure/http/src/main/java/tech/pegasys/teku/infrastructure/http/HttpErrorResponse.java
@@ -15,6 +15,8 @@ package tech.pegasys.teku.infrastructure.http;
 
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_BAD_REQUEST;
 
+import java.util.Objects;
+
 public class HttpErrorResponse {
 
   private final Integer status;
@@ -35,5 +37,22 @@ public class HttpErrorResponse {
 
   public Integer getStatus() {
     return status;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final HttpErrorResponse that = (HttpErrorResponse) o;
+    return Objects.equals(status, that.status) && Objects.equals(message, that.message);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(status, message);
   }
 }

--- a/infrastructure/json/src/test/java/tech/pegasys/teku/infrastructure/json/JsonUtilTest.java
+++ b/infrastructure/json/src/test/java/tech/pegasys/teku/infrastructure/json/JsonUtilTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.json;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.UncheckedIOException;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.json.types.CoreTypes;
+import tech.pegasys.teku.infrastructure.json.types.OneOfTypeTestTypeDefinition;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+class JsonUtilTest {
+
+  @Test
+  void getAttribute() {
+    final Optional<String> result =
+        JsonUtil.getAttribute("{\"slot\": \"1234567\"}", CoreTypes.STRING_TYPE, "slot");
+    assertThat(result).contains("1234567");
+  }
+
+  @Test
+  void getAttribute_notFirstField() {
+    final Optional<String> result =
+        JsonUtil.getAttribute(
+            "{\"a\":\"zzz\", \"slot\": \"1234567\"}", CoreTypes.STRING_TYPE, "slot");
+    assertThat(result).contains("1234567");
+  }
+
+  @Test
+  void getAttribute_missing() {
+    final Optional<String> result = JsonUtil.getAttribute("{}", CoreTypes.STRING_TYPE, "slot");
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void getAttribute_missingOnlyInChildObject() {
+    final Optional<String> result =
+        JsonUtil.getAttribute("{\"data\": { \"slot\": \"1\"}}", CoreTypes.STRING_TYPE, "slot");
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void getAttribute_deepSearch() {
+    final Optional<String> result =
+        JsonUtil.getAttribute(
+            "{\"data\": { \"slot\": \"1\"}}", CoreTypes.STRING_TYPE, "data", "slot");
+    assertThat(result).contains("1");
+  }
+
+  @Test
+  void getAttribute_getsAttributeAtParent() {
+    final Optional<UInt64> result =
+        JsonUtil.getAttribute(
+            "{\"data\": { \"slot\": \"1\"},"
+                + "\"meta\": [ {\"slot\": \"2\"}, {\"slot\": \"3\"}],"
+                + " \"slot\":\"1234\"}",
+            CoreTypes.UINT64_TYPE,
+            "slot");
+    assertThat(result).contains(UInt64.valueOf(1234));
+  }
+
+  @Test
+  void getAttribute_throwsUncheckedIoException() {
+    assertThatThrownBy(() -> JsonUtil.getAttribute("{", CoreTypes.STRING_TYPE, "slot"))
+        .isInstanceOf(UncheckedIOException.class);
+  }
+
+  @Test
+  void getAttribute_shouldReadObject() {
+    final Optional<OneOfTypeTestTypeDefinition.TestObjA> result =
+        JsonUtil.getAttribute(
+            "{\"data\": " + "{\"value1\":\"FOO\"}}", OneOfTypeTestTypeDefinition.TYPE_A, "data");
+    assertThat(result).contains(new OneOfTypeTestTypeDefinition.TestObjA("FOO"));
+  }
+}

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/AsyncApiResponse.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/AsyncApiResponse.java
@@ -15,37 +15,35 @@ package tech.pegasys.teku.infrastructure.restapi.endpoints;
 
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
 
+import java.util.Optional;
+
 public class AsyncApiResponse {
   final int responseCode;
-  final String responseBody;
+  final Optional<Object> responseBody;
 
-  private AsyncApiResponse(final int responseCode, final String responseBody) {
+  private AsyncApiResponse(final int responseCode, final Object responseBody) {
     this.responseCode = responseCode;
-    this.responseBody = responseBody;
+    this.responseBody = Optional.ofNullable(responseBody);
   }
 
   public int getResponseCode() {
     return responseCode;
   }
 
-  public boolean hasResponseBody() {
-    return !responseBody.isEmpty();
-  }
-
-  public String getResponseBody() {
+  public Optional<Object> getResponseBody() {
     return responseBody;
   }
 
   public static AsyncApiResponse respondWithError(
-      final int responseCode, final String responseBody) {
+      final int responseCode, final Object responseBody) {
     return new AsyncApiResponse(responseCode, responseBody);
   }
 
   public static AsyncApiResponse respondWithCode(final int responseCode) {
-    return new AsyncApiResponse(responseCode, "");
+    return new AsyncApiResponse(responseCode, null);
   }
 
-  public static AsyncApiResponse respondOk(final String responseBody) {
+  public static AsyncApiResponse respondOk(final Object responseBody) {
     return new AsyncApiResponse(SC_OK, responseBody);
   }
 }

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/AsyncApiResponse.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/AsyncApiResponse.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.teku.infrastructure.restapi.endpoints;
 
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
+
 public class AsyncApiResponse {
   final int responseCode;
   final String responseBody;
@@ -23,7 +25,7 @@ public class AsyncApiResponse {
   }
 
   public int getResponseCode() {
-    return 0;
+    return responseCode;
   }
 
   public boolean hasResponseBody() {
@@ -31,7 +33,7 @@ public class AsyncApiResponse {
   }
 
   public String getResponseBody() {
-    return null;
+    return responseBody;
   }
 
   public static AsyncApiResponse respondWithError(
@@ -41,5 +43,9 @@ public class AsyncApiResponse {
 
   public static AsyncApiResponse respondWithCode(final int responseCode) {
     return new AsyncApiResponse(responseCode, "");
+  }
+
+  public static AsyncApiResponse respondOk(final String responseBody) {
+    return new AsyncApiResponse(SC_OK, responseBody);
   }
 }

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/AsyncApiResponse.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/AsyncApiResponse.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.restapi.endpoints;
+
+public class AsyncApiResponse {
+  final int responseCode;
+  final String responseBody;
+
+  private AsyncApiResponse(final int responseCode, final String responseBody) {
+    this.responseCode = responseCode;
+    this.responseBody = responseBody;
+  }
+
+  public int getResponseCode() {
+    return 0;
+  }
+
+  public boolean hasResponseBody() {
+    return !responseBody.isEmpty();
+  }
+
+  public String getResponseBody() {
+    return null;
+  }
+
+  public static AsyncApiResponse respondWithError(
+      final int responseCode, final String responseBody) {
+    return new AsyncApiResponse(responseCode, responseBody);
+  }
+
+  public static AsyncApiResponse respondWithCode(final int responseCode) {
+    return new AsyncApiResponse(responseCode, "");
+  }
+}

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/AsyncApiResponse.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/AsyncApiResponse.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.infrastructure.restapi.endpoints;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
 
 import java.util.Optional;
+import tech.pegasys.teku.infrastructure.http.HttpErrorResponse;
 
 public class AsyncApiResponse {
   final int responseCode;
@@ -34,9 +35,18 @@ public class AsyncApiResponse {
     return responseBody;
   }
 
+  /**
+   * Respond with error.
+   *
+   * <p>Errors must be defined with `CoreTypes.HTTP_ERROR_RESPONSE_TYPE`
+   *
+   * @param responseCode HTTP error code
+   * @param errorMessage Message text for response to user
+   * @return AsyncApiResponse with a HttpErrorResponse as the responseBody
+   */
   public static AsyncApiResponse respondWithError(
-      final int responseCode, final Object responseBody) {
-    return new AsyncApiResponse(responseCode, responseBody);
+      final int responseCode, final String errorMessage) {
+    return new AsyncApiResponse(responseCode, new HttpErrorResponse(responseCode, errorMessage));
   }
 
   public static AsyncApiResponse respondWithCode(final int responseCode) {

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/RestApiRequest.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/RestApiRequest.java
@@ -50,6 +50,17 @@ public class RestApiRequest {
     respond(HttpStatusCodes.SC_OK, JSON_CONTENT_TYPE, response);
   }
 
+  public void respondAsync(final SafeFuture<AsyncApiResponse> futureResponse) {
+    context.future(
+        futureResponse.thenAccept(
+            result -> {
+              context.status(result.getResponseCode());
+              if (result.hasResponseBody()) {
+                context.json(result.getResponseBody());
+              }
+            }));
+  }
+
   public void respondOk(final Object response, final CacheLength cacheLength)
       throws JsonProcessingException {
     context.header(Header.CACHE_CONTROL, cacheLength.getHttpHeaderValue());

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/RestApiRequest.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/RestApiRequest.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.infrastructure.restapi.endpoints;
 
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_INTERNAL_SERVER_ERROR;
 import static tech.pegasys.teku.infrastructure.json.JsonUtil.JSON_CONTENT_TYPE;
 import static tech.pegasys.teku.infrastructure.restapi.endpoints.BadRequest.BAD_REQUEST_TYPE;
 
@@ -22,6 +23,8 @@ import io.javalin.http.Context;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.http.HttpErrorResponse;
 import tech.pegasys.teku.infrastructure.http.HttpStatusCodes;
@@ -29,6 +32,7 @@ import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.SerializableTypeDefinition;
 
 public class RestApiRequest {
+  private static final Logger LOG = LogManager.getLogger();
   private final Context context;
   private final EndpointMetadata metadata;
   private final Map<String, String> pathParamMap;
@@ -54,9 +58,11 @@ public class RestApiRequest {
     context.future(
         futureResponse.thenAccept(
             result -> {
-              context.status(result.getResponseCode());
-              if (result.hasResponseBody()) {
-                context.json(result.getResponseBody());
+              try {
+                respond(result.getResponseCode(), JSON_CONTENT_TYPE, result.getResponseBody());
+              } catch (JsonProcessingException e) {
+                LOG.trace("Failed to generate API response", e);
+                context.status(SC_INTERNAL_SERVER_ERROR);
               }
             }));
   }
@@ -70,6 +76,17 @@ public class RestApiRequest {
   public void respondError(final int statusCode, final String message)
       throws JsonProcessingException {
     respond(statusCode, JSON_CONTENT_TYPE, new HttpErrorResponse(statusCode, message));
+  }
+
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  private void respond(
+      final int statusCode, final String contentType, final Optional<Object> response)
+      throws JsonProcessingException {
+    context.status(statusCode);
+    if (response.isPresent()) {
+      final SerializableTypeDefinition type = metadata.getResponseType(statusCode, contentType);
+      context.result(JsonUtil.serialize(response, type));
+    }
   }
 
   @SuppressWarnings({"rawtypes", "unchecked"})

--- a/infrastructure/restapi/src/test/java/tech/pegasys/teku/infrastructure/restapi/endpoints/AsyncApiResponseTest.java
+++ b/infrastructure/restapi/src/test/java/tech/pegasys/teku/infrastructure/restapi/endpoints/AsyncApiResponseTest.java
@@ -26,7 +26,6 @@ public class AsyncApiResponseTest {
   void shouldGetCode() {
     final AsyncApiResponse response = AsyncApiResponse.respondWithCode(SC_OK);
     assertThat(response.getResponseCode()).isEqualTo(SC_OK);
-    assertThat(response.hasResponseBody()).isFalse();
     assertThat(response.getResponseBody()).isEmpty();
   }
 
@@ -34,15 +33,13 @@ public class AsyncApiResponseTest {
   void shouldRespondWithError() {
     final AsyncApiResponse response = AsyncApiResponse.respondWithError(SC_BAD_REQUEST, BODY);
     assertThat(response.getResponseCode()).isEqualTo(SC_BAD_REQUEST);
-    assertThat(response.hasResponseBody()).isTrue();
-    assertThat(response.getResponseBody()).isEqualTo(BODY);
+    assertThat(response.getResponseBody().orElseThrow()).isEqualTo(BODY);
   }
 
   @Test
   void shouldRespondOk() {
     final AsyncApiResponse response = AsyncApiResponse.respondOk(BODY);
     assertThat(response.getResponseCode()).isEqualTo(SC_OK);
-    assertThat(response.hasResponseBody()).isTrue();
-    assertThat(response.getResponseBody()).isEqualTo(BODY);
+    assertThat(response.getResponseBody().orElseThrow()).isEqualTo(BODY);
   }
 }

--- a/infrastructure/restapi/src/test/java/tech/pegasys/teku/infrastructure/restapi/endpoints/AsyncApiResponseTest.java
+++ b/infrastructure/restapi/src/test/java/tech/pegasys/teku/infrastructure/restapi/endpoints/AsyncApiResponseTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.restapi.endpoints;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_BAD_REQUEST;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
+
+import org.junit.jupiter.api.Test;
+
+public class AsyncApiResponseTest {
+  private static final String BODY = "{\"slot\":\"1\"}";
+
+  @Test
+  void shouldGetCode() {
+    final AsyncApiResponse response = AsyncApiResponse.respondWithCode(SC_OK);
+    assertThat(response.getResponseCode()).isEqualTo(SC_OK);
+    assertThat(response.hasResponseBody()).isFalse();
+    assertThat(response.getResponseBody()).isEmpty();
+  }
+
+  @Test
+  void shouldRespondWithError() {
+    final AsyncApiResponse response = AsyncApiResponse.respondWithError(SC_BAD_REQUEST, BODY);
+    assertThat(response.getResponseCode()).isEqualTo(SC_BAD_REQUEST);
+    assertThat(response.hasResponseBody()).isTrue();
+    assertThat(response.getResponseBody()).isEqualTo(BODY);
+  }
+
+  @Test
+  void shouldRespondOk() {
+    final AsyncApiResponse response = AsyncApiResponse.respondOk(BODY);
+    assertThat(response.getResponseCode()).isEqualTo(SC_OK);
+    assertThat(response.hasResponseBody()).isTrue();
+    assertThat(response.getResponseBody()).isEqualTo(BODY);
+  }
+}

--- a/infrastructure/restapi/src/test/java/tech/pegasys/teku/infrastructure/restapi/endpoints/AsyncApiResponseTest.java
+++ b/infrastructure/restapi/src/test/java/tech/pegasys/teku/infrastructure/restapi/endpoints/AsyncApiResponseTest.java
@@ -18,6 +18,7 @@ import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_BAD_REQUE
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
 
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.http.HttpErrorResponse;
 
 public class AsyncApiResponseTest {
   private static final String BODY = "{\"slot\":\"1\"}";
@@ -31,9 +32,11 @@ public class AsyncApiResponseTest {
 
   @Test
   void shouldRespondWithError() {
-    final AsyncApiResponse response = AsyncApiResponse.respondWithError(SC_BAD_REQUEST, BODY);
+    final AsyncApiResponse response =
+        AsyncApiResponse.respondWithError(SC_BAD_REQUEST, "bad request");
     assertThat(response.getResponseCode()).isEqualTo(SC_BAD_REQUEST);
-    assertThat(response.getResponseBody().orElseThrow()).isEqualTo(BODY);
+    assertThat(response.getResponseBody().orElseThrow())
+        .isEqualTo(new HttpErrorResponse(SC_BAD_REQUEST, "bad request"));
   }
 
   @Test


### PR DESCRIPTION
 - started building out async handling for responding to a request
 - built out parser to determine the type of object based on an attribute of that object
 - publish blinded block will now actually publish phase0 or altair blocks via existing channel interface.
 - new SchemaDefinitionCacheTest to ensure that schemas aren't being recreated, but rather re-used.

 For validation, changed the block publishing api used by the VC to use this one temporarily and it is working cleanly (validation activity only).

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
