### PR TITLE
Terminal blocks must not be in the future

### DIFF
--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/BellatrixMergeTransitionAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/BellatrixMergeTransitionAcceptanceTest.java
@@ -14,7 +14,6 @@
 package tech.pegasys.teku.test.acceptance;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.time.SystemTimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -23,7 +22,6 @@ import tech.pegasys.teku.test.acceptance.dsl.BesuNode;
 import tech.pegasys.teku.test.acceptance.dsl.TekuNode;
 import tech.pegasys.teku.test.acceptance.dsl.tools.deposits.ValidatorKeystores;
 
-@Disabled("While investigating flakiness")
 public class BellatrixMergeTransitionAcceptanceTest extends AcceptanceTestBase {
   private static final String NETWORK_NAME = "less-swift";
 

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
@@ -180,7 +180,9 @@ public class ForkChoiceTestExecutor implements TestExecutor {
                       .readFixedBytes(Bytes32.SIZE)
                       .toUnsignedBigInteger(ByteOrder.LITTLE_ENDIAN));
           reader.readFixedBytes(Bytes32.SIZE); // Read difficulty even though we don't use it.
-          return new PowBlock(blockHash, parentHash, totalDifficulty);
+          // We don't get a timestamp but as long as it's in the past that's fine
+          final UInt64 timestamp = UInt64.ZERO;
+          return new PowBlock(blockHash, parentHash, totalDifficulty, timestamp);
         });
   }
 

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/Web3JExecutionEngineClient.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/Web3JExecutionEngineClient.java
@@ -38,6 +38,7 @@ import tech.pegasys.teku.ethereum.executionlayer.client.serialization.SignedBeac
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.bytes.Bytes8;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.execution.PowBlock;
 
@@ -94,7 +95,8 @@ public class Web3JExecutionEngineClient implements ExecutionEngineClient {
         : new PowBlock(
             Bytes32.fromHexStringStrict(eth1Block.getHash()),
             Bytes32.fromHexStringStrict(eth1Block.getParentHash()),
-            UInt256.valueOf(eth1Block.getTotalDifficulty()));
+            UInt256.valueOf(eth1Block.getTotalDifficulty()),
+            UInt64.valueOf(eth1Block.getTimestamp()));
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/PowBlock.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/PowBlock.java
@@ -16,17 +16,21 @@ package tech.pegasys.teku.spec.datastructures.execution;
 import com.google.common.base.MoreObjects;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 public class PowBlock {
 
   private final Bytes32 blockHash;
   private final Bytes32 parentHash;
   private final UInt256 totalDifficulty;
+  private final UInt64 blockTimestamp;
 
-  public PowBlock(Bytes32 blockHash, Bytes32 parentHash, UInt256 totalDifficulty) {
+  public PowBlock(
+      Bytes32 blockHash, Bytes32 parentHash, UInt256 totalDifficulty, UInt64 blockTimestamp) {
     this.blockHash = blockHash;
     this.parentHash = parentHash;
     this.totalDifficulty = totalDifficulty;
+    this.blockTimestamp = blockTimestamp;
   }
 
   public Bytes32 getBlockHash() {
@@ -41,12 +45,17 @@ public class PowBlock {
     return totalDifficulty;
   }
 
+  public UInt64 getBlockTimestamp() {
+    return blockTimestamp;
+  }
+
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
         .add("blockHash", blockHash)
         .add("parentHash", parentHash)
         .add("totalDifficulty", totalDifficulty)
+        .add("blockTimestamp", blockTimestamp)
         .toString();
   }
 }

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/bellatrix/helpers/BellatrixTransitionHelpersTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/bellatrix/helpers/BellatrixTransitionHelpersTest.java
@@ -151,7 +151,7 @@ class BellatrixTransitionHelpersTest {
 
   private PowBlock withPowBlock(final Bytes32 hash, final UInt256 totalDifficulty) {
     final PowBlock powBlock =
-        new PowBlock(hash, dataStructureUtil.randomBytes32(), totalDifficulty);
+        new PowBlock(hash, dataStructureUtil.randomBytes32(), totalDifficulty, UInt64.ZERO);
     when(executionEngine.getPowBlock(powBlock.getBlockHash()))
         .thenReturn(completedFuture(Optional.of(powBlock)));
     return powBlock;

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
@@ -801,12 +801,14 @@ class ForkChoiceTest {
     final Bytes32 terminalBlockHash = dataStructureUtil.randomBytes32();
     final Bytes32 terminalBlockParentHash = dataStructureUtil.randomBytes32();
     final PowBlock terminalBlock =
-        new PowBlock(terminalBlockHash, terminalBlockParentHash, terminalTotalDifficulty.plus(1));
+        new PowBlock(
+            terminalBlockHash, terminalBlockParentHash, terminalTotalDifficulty.plus(1), ZERO);
     final PowBlock terminalParentBlock =
         new PowBlock(
             terminalBlockParentHash,
             dataStructureUtil.randomBytes32(),
-            terminalTotalDifficulty.subtract(1));
+            terminalTotalDifficulty.subtract(1),
+            ZERO);
     executionEngine.addPowBlock(terminalBlock);
     executionEngine.addPowBlock(terminalParentBlock);
     final SignedBlockAndState epoch4Block =

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/MergeTransitionBlockValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/MergeTransitionBlockValidatorTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.core.ChainBuilder.BlockOptions;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.exceptions.FatalServiceFailureException;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
@@ -252,10 +253,14 @@ class MergeTransitionBlockValidatorTest {
         new PowBlock(
             getExecutionPayload(transitionBlock).getParentHash(),
             terminalBlockParentHash,
-            terminalBlockDifficulty));
+            terminalBlockDifficulty,
+            UInt64.ZERO));
     executionEngine.addPowBlock(
         new PowBlock(
-            terminalBlockParentHash, dataStructureUtil.randomBytes32(), ttdBlockParentDifficulty));
+            terminalBlockParentHash,
+            dataStructureUtil.randomBytes32(),
+            ttdBlockParentDifficulty,
+            UInt64.ZERO));
   }
 
   private SignedBlockAndState generateNonfinalizedTransition() {

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -381,7 +381,8 @@ public class BeaconChainController extends Service implements BeaconChainControl
                   recentChainData,
                   forkChoiceNotifier,
                   beaconAsyncRunner,
-                  EVENT_LOG));
+                  EVENT_LOG,
+                  timeProvider));
     }
   }
 


### PR DESCRIPTION
## PR Description
When selecting the terminal block, ensure that it's timestamp is in the past. Otherwise a block built on it may be invalid because it's timestamp (the slot start time) is before the parent block timestamp.

This is extremely unlikely to occur in normal PoW networks but regularly happens when using low fixed difficulty mining in local test networks.

## Fixed Issue(s)
fixes #5284 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
