### PR TITLE
Invalid blocks should not be considered viable for head

### DIFF
--- a/ethereum/forkchoice/src/main/java/tech/pegasys/teku/ethereum/forkchoice/ProtoArray.java
+++ b/ethereum/forkchoice/src/main/java/tech/pegasys/teku/ethereum/forkchoice/ProtoArray.java
@@ -569,7 +569,8 @@ public class ProtoArray {
    * @return
    */
   public boolean nodeIsViableForHead(ProtoNode node) {
-    return (node.getJustifiedEpoch().equals(justifiedEpoch) || justifiedEpoch.equals(initialEpoch))
+    return !node.isInvalid()
+        && (node.getJustifiedEpoch().equals(justifiedEpoch) || justifiedEpoch.equals(initialEpoch))
         && (node.getFinalizedEpoch().equals(finalizedEpoch) || finalizedEpoch.equals(initialEpoch));
   }
 

--- a/ethereum/forkchoice/src/test/java/tech/pegasys/teku/ethereum/forkchoice/ProtoArrayTest.java
+++ b/ethereum/forkchoice/src/test/java/tech/pegasys/teku/ethereum/forkchoice/ProtoArrayTest.java
@@ -451,9 +451,13 @@ class ProtoArrayTest {
   }
 
   private void assertHead(final Bytes32 expectedBlockHash) {
+    final ProtoNode node = protoArray.getProtoNode(expectedBlockHash).orElseThrow();
     assertThat(
             protoArray.findOptimisticHead(GENESIS_CHECKPOINT.getRoot(), UInt64.ZERO, UInt64.ZERO))
-        .isEqualTo(protoArray.getProtoNode(expectedBlockHash).orElseThrow());
+        .isEqualTo(node);
+
+    assertThat(node.getBestDescendantIndex()).isEmpty();
+    assertThat(node.getBestChildIndex()).isEmpty();
   }
 
   private void addValidBlock(final long slot, final Bytes32 blockRoot, final Bytes32 parentRoot) {


### PR DESCRIPTION
## PR Description
This ensures ProtoArray always updates the best child/descendant links correctly when marking a node as invalid. With thanks to Paul Hauner.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
