### PR TITLE
Add stricter limits to attestation pool size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,3 +27,4 @@ For information on changes in released versions of Teku, see the [releases page]
 
 ### Bug Fixes
 - Fixed the target database format for the `migrate-database` command.
+- Added stricter limits on attestation pool size. 

--- a/ethereum/statetransition/src/integration-test/java/tech/pegasys/teku/statetransition/attestation/AttestationManagerIntegrationTest.java
+++ b/ethereum/statetransition/src/integration-test/java/tech/pegasys/teku/statetransition/attestation/AttestationManagerIntegrationTest.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.statetransition.attestation;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPool.DEFAULT_MAXIMUM_ATTESTATION_COUNT;
 
 import it.unimi.dsi.fastutil.ints.IntList;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
@@ -65,7 +66,8 @@ class AttestationManagerIntegrationTest {
   private final RecentChainData recentChainData = storageSystem.recentChainData();
 
   private final AggregatingAttestationPool attestationPool =
-      new AggregatingAttestationPool(spec, new NoOpMetricsSystem());
+      new AggregatingAttestationPool(
+          spec, new NoOpMetricsSystem(), DEFAULT_MAXIMUM_ATTESTATION_COUNT);
   private final MergeTransitionBlockValidator transitionBlockValidator =
       new MergeTransitionBlockValidator(spec, recentChainData, ExecutionEngineChannel.NOOP);
   private final ForkChoice forkChoice =

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -17,6 +17,7 @@ import static tech.pegasys.teku.infrastructure.logging.EventLogger.EVENT_LOG;
 import static tech.pegasys.teku.infrastructure.logging.StatusLogger.STATUS_LOG;
 import static tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory.BEACON;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
+import static tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPool.DEFAULT_MAXIMUM_ATTESTATION_COUNT;
 
 import com.google.common.base.Throwables;
 import java.net.BindException;
@@ -757,7 +758,8 @@ public class BeaconChainController extends Service implements BeaconChainControl
 
   public void initAttestationPool() {
     LOG.debug("BeaconChainController.initAttestationPool()");
-    attestationPool = new AggregatingAttestationPool(spec, metricsSystem);
+    attestationPool =
+        new AggregatingAttestationPool(spec, metricsSystem, DEFAULT_MAXIMUM_ATTESTATION_COUNT);
     eventChannels.subscribe(SlotEventsChannel.class, attestationPool);
     blockImporter.subscribeToVerifiedBlockAttestations(
         attestationPool::onAttestationsIncludedInBlock);


### PR DESCRIPTION
## PR Description
When the total number of attestations in the pool grows too large, start dropping attestations from older slots.  It's expensive to determine exactly how many attestations we could include in a block because that depends on how well they aggregate, but we can set an approximate maximum number that are ever likely to be useful and ensure the pool size stays below that.  For efficiency and simplicity we drop all attestations from the oldest slot we have when the limit is exceeded which is cheap and the oldest attestations are likely to be the least valuable.

## Fixed Issue(s)
fixes #5196 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
