### PR TITLE
Improved debug messages

### DIFF
--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AbstractDutyScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AbstractDutyScheduler.java
@@ -149,7 +149,7 @@ public abstract class AbstractDutyScheduler implements ValidatorTimingChannel {
     // Check slot being null for the edge case of genesis slot (i.e. slot 0)
     if (lastProductionSlot != null && slot.compareTo(lastProductionSlot) <= 0) {
       LOG.debug(
-          "Not performing {} duties for slot {} because last production slot {} is beyond that.",
+          "Not performing {} duties for slot {} because last production slot {} is equal or beyond that.",
           dutyType,
           slot,
           lastProductionSlot);
@@ -164,6 +164,12 @@ public abstract class AbstractDutyScheduler implements ValidatorTimingChannel {
           getCurrentEpoch().map(UInt64::toString).orElse("UNDEFINED"));
       return;
     }
+
+    LOG.debug(
+        "Performing {} duties for slot {}, last production slot {}",
+        dutyType,
+        slot,
+        lastProductionSlot);
 
     lastProductionSlot = slot;
     notifyEpochDuties(PendingDuties::onProductionDue, slot);


### PR DESCRIPTION
## PR Description

This is a smaller version of PR #4271. In this PR I fixed a message and I introduced a log for the current performed activity.

During a debug session with the validator, I enabled the `DEBUG` log level and I found this kind of message:

```log
2021-08-21 01:14:58.706+02:00 | ValidatorTimingChannel-0 | INFO  | AbstractDutyScheduler | Not performing attestation duties for slot 1889773 because it is too far ahead of the current slot UNDEFINED
2021-08-21 01:15:15.003+02:00 | ValidatorTimingChannel-0 | DEBUG | AbstractDutyScheduler | Not performing attestation duties for slot 1889774 because last production slot 1889774 is beyond that.
2021-08-21 01:15:27.002+02:00 | ValidatorTimingChannel-0 | DEBUG | AbstractDutyScheduler | Not performing attestation duties for slot 1889775 because last production slot 1889775 is beyond that.
2021-08-21 01:15:39.003+02:00 | ValidatorTimingChannel-0 | DEBUG | AbstractDutyScheduler | Not performing attestation duties for slot 1889776 because last production slot 1889776 is beyond that.
2021-08-21 01:15:51.003+02:00 | ValidatorTimingChannel-0 | DEBUG | AbstractDutyScheduler | Not performing attestation duties for slot 1889777 because last production slot 1889777 is beyond that.
2021-08-21 01:16:03.003+02:00 | ValidatorTimingChannel-0 | DEBUG | AbstractDutyScheduler | Not performing attestation duties for slot 1889778 because last production slot 1889778 is beyond that.
2021-08-21 01:16:15.002+02:00 | ValidatorTimingChannel-0 | DEBUG | AbstractDutyScheduler | Not performing attestation duties for slot 1889779 because last production slot 1889779 is beyond that.
2021-08-21 01:16:27.007+02:00 | ValidatorTimingChannel-0 | DEBUG | AbstractDutyScheduler | Not performing attestation duties for slot 1889780 because last production slot 1889780 is beyond that.
2021-08-21 01:16:34.989+02:00 | validator-async-0 | INFO  | teku-validator-log | Validator   *** Published attestation        Count: 1, Slot: 1889781, Root: 15b158..6304
2021-08-21 01:16:39.002+02:00 | ValidatorTimingChannel-0 | DEBUG | AbstractDutyScheduler | Not performing attestation duties for slot 1889781 because last production slot 1889781 is beyond that.
2021-08-21 01:16:51.001+02:00 | ValidatorTimingChannel-0 | DEBUG | AbstractDutyScheduler | Not performing attestation duties for slot 1889782 because last production slot 1889782 is beyond that.
2021-08-21 01:17:03.001+02:00 | ValidatorTimingChannel-0 | DEBUG | AbstractDutyScheduler | Not performing attestation duties for slot 1889783 because last production slot 1889783 is beyond that.
```

I found these messages a bit misleading, especially when they say *not performing attestation duties...* just after publishing one correctly. And also, the current slot is almost always equal to the last production slot, so again the message is not very clear, I never saw it *beyond that*.

Merging this PR the log will look like this:

```log
2021-08-21 04:50:35.087+02:00 | ValidatorTimingChannel-0 | DEBUG | AbstractDutyScheduler | Performing block duties for slot 1890851, last production slot null
2021-08-21 04:50:35.422+02:00 | ValidatorTimingChannel-0 | DEBUG | AbstractDutyScheduler | Performing attestation duties for slot 1890851, last production slot null
2021-08-21 04:50:39.003+02:00 | ValidatorTimingChannel-0 | DEBUG | AbstractDutyScheduler | Not performing attestation duties for slot 1890851 because last production slot 1890851 is equal beyond that
[...]
2021-08-21 04:51:31.706+02:00 | ValidatorTimingChannel-0 | INFO  | AbstractDutyScheduler | Not performing attestation duties for slot 1890856 because last production slot 1890856 is equal beyond that
2021-08-21 04:51:47.150+02:00 | ValidatorTimingChannel-0 | DEBUG | AbstractDutyScheduler | Performing attestation duties for slot 1890857, last production slot 1890856
2021-08-21 04:51:59.004+02:00 | ValidatorTimingChannel-0 | DEBUG | AbstractDutyScheduler | Performing block duties for slot 1890858, last production slot 1890857
```

## Fixed Issue(s)

None.

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.