### PR TITLE
Support new blinded block creation

### DIFF
--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetNewBlindedBlock.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetNewBlindedBlock.java
@@ -44,18 +44,21 @@ import tech.pegasys.teku.api.response.v1.validator.GetNewBlindedBlockResponse;
 import tech.pegasys.teku.beaconrestapi.MigratingEndpointAdapter;
 import tech.pegasys.teku.beaconrestapi.SchemaDefinitionCache;
 import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.http.RestApiConstants;
 import tech.pegasys.teku.infrastructure.json.types.CoreTypes;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 import tech.pegasys.teku.infrastructure.json.types.SerializableOneOfTypeDefinition;
 import tech.pegasys.teku.infrastructure.json.types.SerializableOneOfTypeDefinitionBuilder;
 import tech.pegasys.teku.infrastructure.json.types.SerializableTypeDefinition;
+import tech.pegasys.teku.infrastructure.restapi.endpoints.AsyncApiResponse;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.EndpointMetadata;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.ParameterMetadata;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiRequest;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
+import tech.pegasys.teku.storage.client.ChainDataUnavailableException;
 
 @SuppressWarnings("unused")
 public class GetNewBlindedBlock extends MigratingEndpointAdapter {
@@ -131,9 +134,18 @@ public class GetNewBlindedBlock extends MigratingEndpointAdapter {
   @Override
   public void handleRequest(final RestApiRequest request) throws JsonProcessingException {
     final UInt64 slot = request.getPathParameter(PARAM_SLOT);
-    final BLSSignature signature = request.getQueryParameter(PARAM_RANDAO);
-    final Optional<Bytes32> grafitti = request.getOptionalQueryParameter(PARAM_GRAFFITI);
-    throw new IllegalArgumentException("Not implemented");
+    final BLSSignature randao = request.getQueryParameter(PARAM_RANDAO);
+    final Optional<Bytes32> graffiti = request.getOptionalQueryParameter(PARAM_GRAFFITI);
+    final SafeFuture<Optional<tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock>> result =
+        provider.getUnsignedBeaconBlockAtSlot(slot, randao, graffiti, true);
+    request.respondAsync(
+        result.thenApplyChecked(
+            maybeBlock -> {
+              if (maybeBlock.isEmpty()) {
+                throw new ChainDataUnavailableException();
+              }
+              return AsyncApiResponse.respondOk(maybeBlock.get());
+            }));
   }
 
   private static EndpointMetadata getEndpointMetaData(

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
@@ -108,8 +108,12 @@ public class ValidatorDataProvider {
     return combinedChainDataClient.isStoreAvailable();
   }
 
-  public SafeFuture<Optional<BeaconBlock>> getUnsignedBeaconBlockAtSlot(
-      UInt64 slot, BLSSignature randao, Optional<Bytes32> graffiti) {
+  public SafeFuture<Optional<tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock>>
+      getUnsignedBeaconBlockAtSlot(
+          final UInt64 slot,
+          final tech.pegasys.teku.bls.BLSSignature randao,
+          final Optional<Bytes32> graffiti,
+          final boolean isBlinded) {
     if (slot == null) {
       throw new IllegalArgumentException(NO_SLOT_PROVIDED);
     }
@@ -125,9 +129,15 @@ public class ValidatorDataProvider {
     if (currentSlot.isGreaterThan(slot)) {
       throw new IllegalArgumentException(CANNOT_PRODUCE_HISTORIC_BLOCK);
     }
+    return validatorApiChannel.createUnsignedBlock(slot, randao, graffiti, false);
+  }
 
-    return validatorApiChannel
-        .createUnsignedBlock(
+  public SafeFuture<Optional<BeaconBlock>> getUnsignedBeaconBlockAtSlot(
+      UInt64 slot, BLSSignature randao, Optional<Bytes32> graffiti) {
+    if (randao == null) {
+      throw new IllegalArgumentException(NO_RANDAO_PROVIDED);
+    }
+    return getUnsignedBeaconBlockAtSlot(
             slot,
             tech.pegasys.teku.bls.BLSSignature.fromBytesCompressed(randao.getBytes()),
             graffiti,

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
@@ -129,7 +129,7 @@ public class ValidatorDataProvider {
     if (currentSlot.isGreaterThan(slot)) {
       throw new IllegalArgumentException(CANNOT_PRODUCE_HISTORIC_BLOCK);
     }
-    return validatorApiChannel.createUnsignedBlock(slot, randao, graffiti, false);
+    return validatorApiChannel.createUnsignedBlock(slot, randao, graffiti, isBlinded);
   }
 
   public SafeFuture<Optional<BeaconBlock>> getUnsignedBeaconBlockAtSlot(

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/RestApiRequest.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/RestApiRequest.java
@@ -85,7 +85,7 @@ public class RestApiRequest {
     context.status(statusCode);
     if (response.isPresent()) {
       final SerializableTypeDefinition type = metadata.getResponseType(statusCode, contentType);
-      context.result(JsonUtil.serialize(response, type));
+      context.result(JsonUtil.serialize(response.get(), type));
     }
   }
 


### PR DESCRIPTION
As part of this, the async handler had to be fixed to return a body, it was previously trying to serialize its own optional.

Reworked the old block creation so that we don't have 2 sets of code.

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
