### PR TITLE
Skip state root checks when regenerating blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ For information on changes in released versions of Teku, see the [releases page]
 
 
 ### Additions and Improvements
-
+- Improved performance when regenerating non-finalized states that had to be dropped from memory.
 
 ### Bug Fixes
 - Added stricter limits on attestation pool size. 

--- a/ethereum/dataproviders/src/main/java/tech/pegasys/teku/dataproviders/generators/BlockProcessor.java
+++ b/ethereum/dataproviders/src/main/java/tech/pegasys/teku/dataproviders/generators/BlockProcessor.java
@@ -26,23 +26,10 @@ class BlockProcessor {
   }
 
   public BeaconState process(final BeaconState preState, final SignedBeaconBlock block) {
-
     try {
-      final BeaconState postState = spec.replayValidatedBlock(preState, block);
-      assertBlockAndStateMatch(block, postState);
-      return postState;
+      return spec.replayValidatedBlock(preState, block);
     } catch (StateTransitionException e) {
       throw new IllegalStateException(getFailedStateGenerationError(block), e);
-    }
-  }
-
-  public void assertBlockAndStateMatch(final SignedBeaconBlock block, final BeaconState state) {
-    if (!block.getStateRoot().equals(state.hashTreeRoot())) {
-      final String msg =
-          String.format(
-              "Failed to regenerate state for block root %s.  Generated state root %s does not match expected state root %s",
-              block.getRoot(), state.hashTreeRoot(), block.getStateRoot());
-      throw new IllegalStateException(msg);
     }
   }
 


### PR DESCRIPTION
## PR Description
Avoid checking the state hash tree root when reapplying blocks to regenerate the state.

We were already skipping the check as part of the actual state transition (same as we skip checking the block signatures) but then had a separate sanity check as part of the regeneration pipeline which was run for every applied block.

## Fixed Issue(s)
fixes #5242 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
