### PR TITLE
Use milliseconds for calculating slot intervals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ For information on changes in released versions of Teku, see the [releases page]
 
 ### Additions and Improvements
 - Improved performance when regenerating non-finalized states that had to be dropped from memory.
+- Performance optimizations for Gnosis beacon chain
 
 ### Bug Fixes
 - Added stricter limits on attestation pool size. 

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/DutyMetrics.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/DutyMetrics.java
@@ -13,6 +13,9 @@
 
 package tech.pegasys.teku.validator.coordinator;
 
+import static tech.pegasys.teku.infrastructure.time.TimeUtilities.secondsToMillis;
+import static tech.pegasys.teku.spec.constants.NetworkConstants.INTERVALS_PER_SLOT;
+
 import com.google.common.annotations.VisibleForTesting;
 import java.util.List;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
@@ -71,9 +74,9 @@ public class DutyMetrics {
 
   private UInt64 calculateExpectedAttestationTimeInMillis(final UInt64 slot) {
     final UInt64 genesisTime = recentChainData.getGenesisTime();
-    return genesisTime
-        .plus(slot.times(spec.getSecondsPerSlot(slot)))
-        .plus(spec.getSecondsPerSlot(slot) / 3)
-        .times(1000);
+    UInt64 millisPerSlot = secondsToMillis(spec.getSecondsPerSlot(slot));
+    return secondsToMillis(genesisTime)
+        .plus(slot.times(millisPerSlot))
+        .plus(millisPerSlot.dividedBy(INTERVALS_PER_SLOT));
   }
 }

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/DutyMetricsTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/DutyMetricsTest.java
@@ -16,36 +16,47 @@ package tech.pegasys.teku.validator.coordinator;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.infrastructure.time.TimeUtilities.secondsToMillis;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import tech.pegasys.teku.infrastructure.metrics.MetricsHistogram;
 import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.networks.Eth2Network;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
 class DutyMetricsTest {
 
   private static final UInt64 GENESIS_TIME = UInt64.valueOf(100_000);
-  private final Spec spec = TestSpecFactory.createMinimalPhase0();
   private final StubTimeProvider timeProvider =
       StubTimeProvider.withTimeInSeconds(GENESIS_TIME.longValue());
   private final RecentChainData recentChainData = mock(RecentChainData.class);
   private final MetricsHistogram attestationHistogram = mock(MetricsHistogram.class);
-  private final DutyMetrics metrics =
-      new DutyMetrics(timeProvider, recentChainData, attestationHistogram, spec);
+
+  private DutyMetrics createMetrics(Spec spec) {
+    return new DutyMetrics(timeProvider, recentChainData, attestationHistogram, spec);
+  }
 
   @BeforeEach
   void setUp() {
     when(recentChainData.getGenesisTime()).thenReturn(GENESIS_TIME);
   }
 
-  @Test
-  void shouldRecordDelayWhenAttestationIsPublishedLate() {
+  @ParameterizedTest
+  @EnumSource(
+      value = Eth2Network.class,
+      names = {"MAINNET", "MINIMAL", "GNOSIS"})
+  void shouldRecordDelayWhenAttestationIsPublishedLate(Eth2Network eth2Network) {
+    Spec spec = getSpec(eth2Network);
+    DutyMetrics metrics = createMetrics(spec);
+
     final UInt64 slotNumber = UInt64.valueOf(30);
-    final UInt64 expectedAttestationTime = expectedAttestationTime(slotNumber);
+    final UInt64 expectedAttestationTime = expectedAttestationTime(slotNumber, spec);
     final int publicationDelay = 575;
     timeProvider.advanceTimeByMillis(expectedAttestationTime.plus(publicationDelay).longValue());
 
@@ -54,10 +65,16 @@ class DutyMetricsTest {
     verify(attestationHistogram).recordValue(publicationDelay);
   }
 
-  @Test
-  void shouldRecordZeroDelayWhenAttestationIsPublishedEarly() {
+  @ParameterizedTest
+  @EnumSource(
+      value = Eth2Network.class,
+      names = {"MAINNET", "MINIMAL", "GNOSIS"})
+  void shouldRecordZeroDelayWhenAttestationIsPublishedEarly(Eth2Network eth2Network) {
+    Spec spec = getSpec(eth2Network);
+    DutyMetrics metrics = createMetrics(spec);
+
     final UInt64 slotNumber = UInt64.valueOf(30);
-    final UInt64 expectedAttestationTime = expectedAttestationTime(slotNumber);
+    final UInt64 expectedAttestationTime = expectedAttestationTime(slotNumber, spec);
     timeProvider.advanceTimeByMillis(expectedAttestationTime.minus(50).longValue());
 
     metrics.onAttestationPublished(UInt64.valueOf(30));
@@ -65,9 +82,12 @@ class DutyMetricsTest {
     verify(attestationHistogram).recordValue(0);
   }
 
-  private UInt64 expectedAttestationTime(final UInt64 slot) {
-    return slot.times(spec.getSecondsPerSlot(slot))
-        .plus(spec.getSecondsPerSlot(slot) / 3)
-        .times(1000);
+  private Spec getSpec(Eth2Network eth2Network) {
+    return TestSpecFactory.create(SpecMilestone.PHASE0, eth2Network);
+  }
+
+  private UInt64 expectedAttestationTime(final UInt64 slot, final Spec spec) {
+    UInt64 millisPerSlot = secondsToMillis(spec.getSecondsPerSlot(slot));
+    return slot.times(millisPerSlot).plus(millisPerSlot.dividedBy(3));
   }
 }

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/AbstractBeaconStateBuilder.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/AbstractBeaconStateBuilder.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.spec.util;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static java.time.Instant.now;
 import static java.util.stream.Collectors.toList;
 
 import java.util.List;
@@ -112,8 +113,8 @@ abstract class AbstractBeaconStateBuilder<
   }
 
   protected void initDefaults() {
-
-    genesisTime = dataStructureUtil.randomUInt64();
+    // limit genesis time to current time
+    genesisTime = dataStructureUtil.randomUInt64(now().getEpochSecond());
     genesisValidatorsRoot = dataStructureUtil.randomBytes32();
     slot = dataStructureUtil.randomUInt64();
     fork = dataStructureUtil.randomFork();

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -154,6 +154,10 @@ public final class DataStructureUtil {
     return new Random(nextSeed()).nextLong();
   }
 
+  public long randomLong(final long bound) {
+    return new Random(nextSeed()).longs(0, bound).findFirst().orElse(0L);
+  }
+
   public int randomPositiveInt() {
     return randomInt(Integer.MAX_VALUE);
   }
@@ -166,6 +170,10 @@ public final class DataStructureUtil {
 
   public UInt64 randomUInt64() {
     return UInt64.fromLongBits(randomLong());
+  }
+
+  public UInt64 randomUInt64(final long bound) {
+    return UInt64.fromLongBits(randomLong(bound));
   }
 
   public UInt256 randomUInt256() {

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -154,7 +154,7 @@ public final class DataStructureUtil {
     return new Random(nextSeed()).nextLong();
   }
 
-  public long randomLong(final long bound) {
+  public long randomPositiveLong(final long bound) {
     return new Random(nextSeed()).longs(0, bound).findFirst().orElse(0L);
   }
 
@@ -173,7 +173,7 @@ public final class DataStructureUtil {
   }
 
   public UInt64 randomUInt64(final long bound) {
-    return UInt64.fromLongBits(randomLong(bound));
+    return UInt64.fromLongBits(randomPositiveLong(bound));
   }
 
   public UInt256 randomUInt256() {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.statetransition.forkchoice;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static tech.pegasys.teku.infrastructure.logging.P2PLogger.P2P_LOG;
+import static tech.pegasys.teku.infrastructure.time.TimeUtilities.secondsToMillis;
 import static tech.pegasys.teku.spec.constants.NetworkConstants.INTERVALS_PER_SLOT;
 import static tech.pegasys.teku.statetransition.forkchoice.StateRootCollector.addParentStateRoots;
 
@@ -306,9 +307,8 @@ public class ForkChoice {
       final int secondsPerSlot = spec.getSecondsPerSlot(block.getSlot());
       final UInt64 timeIntoSlot =
           transaction.getTime().minus(transaction.getGenesisTime()).mod(secondsPerSlot);
-      final boolean isBeforeAttestingInterval =
-          timeIntoSlot.isLessThan(secondsPerSlot / INTERVALS_PER_SLOT);
-      if (isBeforeAttestingInterval) {
+
+      if (isBeforeAttestingInterval(secondsPerSlot, timeIntoSlot)) {
         transaction.setProposerBoostRoot(block.getRoot());
       }
     }
@@ -344,6 +344,11 @@ public class ForkChoice {
     updateForkChoiceForImportedBlock(block, result, forkChoiceStrategy);
     notifyForkChoiceUpdatedAndOptimisticSyncingChanged();
     return result;
+  }
+
+  private boolean isBeforeAttestingInterval(int secondsPerSlot, UInt64 timeIntoSlot) {
+    UInt64 oneThirdSlot = secondsToMillis(secondsPerSlot).dividedBy(INTERVALS_PER_SLOT);
+    return secondsToMillis(timeIntoSlot).isLessThan(oneThirdSlot);
   }
 
   private void onExecutionPayloadResult(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -346,7 +346,7 @@ public class ForkChoice {
     return result;
   }
 
-  private boolean isBeforeAttestingInterval(int secondsPerSlot, UInt64 timeIntoSlot) {
+  private boolean isBeforeAttestingInterval(final int secondsPerSlot, final UInt64 timeIntoSlot) {
     UInt64 oneThirdSlot = secondsToMillis(secondsPerSlot).dividedBy(INTERVALS_PER_SLOT);
     return secondsToMillis(timeIntoSlot).isLessThan(oneThirdSlot);
   }

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/timed/RepeatingTaskScheduler.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/timed/RepeatingTaskScheduler.java
@@ -51,7 +51,7 @@ public class RepeatingTaskScheduler {
    * @param task the task to execute. If useMillis is true, then {@link RepeatingTask#execute} will
    *     use epoch millis instead of epoch seconds.
    */
-  public void scheduleRepeatingEvent(
+  private void scheduleRepeatingEvent(
       final UInt64 initialInvocationTime,
       final UInt64 repeatingPeriod,
       final boolean useMillis,

--- a/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/SlotProcessorTest.java
+++ b/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/SlotProcessorTest.java
@@ -370,7 +370,7 @@ public class SlotProcessorTest {
     verify(recentChainData, never()).retrieveStateAtSlot(any());
 
     // But just before the last slot of the epoch ends, we should precompute the next epoch
-    slotProcessor.onTick(nextEpochSlotMinusOne.plus((secondsPerSlot / 3) * 2));
+    slotProcessor.onTick(nextEpochSlotMinusOne.plus((secondsPerSlot / 3) * 2L));
     if (isNotDivisibleBy3(secondsPerSlot)) {
       // 2/3 is not due yet, will be on the next second
       verify(epochCachePrimer, never()).primeCacheForEpoch(ONE);

--- a/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/SlotProcessorTest.java
+++ b/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/SlotProcessorTest.java
@@ -20,12 +20,15 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.infrastructure.time.TimeUtilities.secondsToMillis;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.ArgumentCaptor;
 import tech.pegasys.teku.beacon.sync.events.SyncState;
 import tech.pegasys.teku.beacon.sync.events.SyncStateProvider;
@@ -35,10 +38,12 @@ import tech.pegasys.teku.infrastructure.logging.EventLogger;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.Eth2P2PNetwork;
 import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.MinimalBeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.networks.Eth2Network;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.EpochCachePrimer;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceNotifier;
@@ -68,19 +73,22 @@ public class SlotProcessorTest {
   private final Eth2P2PNetwork p2pNetwork = mock(Eth2P2PNetwork.class);
   private final SlotEventsChannel slotEventsChannel = mock(SlotEventsChannel.class);
   private final EpochCachePrimer epochCachePrimer = mock(EpochCachePrimer.class);
-  private final SlotProcessor slotProcessor =
-      new SlotProcessor(
-          spec,
-          recentChainData,
-          syncStateProvider,
-          forkChoiceTrigger,
-          forkChoiceNotifier,
-          p2pNetwork,
-          slotEventsChannel,
-          epochCachePrimer,
-          eventLogger);
+  private final SlotProcessor slotProcessor = createSlotProcessor(spec);
   private final UInt64 genesisTime = beaconState.getGenesisTime();
   private final UInt64 desiredSlot = UInt64.valueOf(100L);
+
+  private SlotProcessor createSlotProcessor(Spec spec) {
+    return new SlotProcessor(
+        spec,
+        recentChainData,
+        syncStateProvider,
+        forkChoiceTrigger,
+        forkChoiceNotifier,
+        p2pNetwork,
+        slotEventsChannel,
+        epochCachePrimer,
+        eventLogger);
+  }
 
   @BeforeEach
   public void setup() {
@@ -127,17 +135,19 @@ public class SlotProcessorTest {
 
   @Test
   public void isTimeReached_shouldReturnFalseIfTimeNotReached() {
-    assertThat(slotProcessor.isTimeReached(genesisTime, genesisTime.plus(ONE))).isFalse();
+    assertThat(slotProcessor.isTimeReached(genesisTime, secondsToMillis(genesisTime).plus(ONE)))
+        .isFalse();
   }
 
   @Test
   public void isTimeReached_shouldReturnTrueIfTimeMatches() {
-    assertThat(slotProcessor.isTimeReached(genesisTime, genesisTime)).isTrue();
+    assertThat(slotProcessor.isTimeReached(genesisTime, secondsToMillis(genesisTime))).isTrue();
   }
 
   @Test
   public void isTimeReached_shouldReturnTrueIfBeyondEarliestTime() {
-    assertThat(slotProcessor.isTimeReached(genesisTime, genesisTime.minus(ONE))).isTrue();
+    assertThat(slotProcessor.isTimeReached(genesisTime, secondsToMillis(genesisTime).minus(ONE)))
+        .isTrue();
   }
 
   @Test
@@ -228,16 +238,29 @@ public class SlotProcessorTest {
     verify(eventLogger).nodeSlotsMissed(ZERO, slot);
   }
 
-  @Test
-  public void onTick_shouldRunAttestationsDuringProcessing() {
+  @ParameterizedTest
+  @EnumSource(
+      value = Eth2Network.class,
+      names = {"MAINNET", "MINIMAL", "GNOSIS"})
+  public void onTick_shouldRunAttestationsDuringProcessing(Eth2Network eth2Network) {
+    Spec spec = TestSpecFactory.create(SpecMilestone.PHASE0, eth2Network);
+    int secondsPerSlot = spec.getGenesisSpecConfig().getSecondsPerSlot();
+
+    SlotProcessor slotProcessor = createSlotProcessor(spec);
+
     // skip the slot start
     final UInt64 slot = slotProcessor.getNodeSlot().getValue();
     slotProcessor.setOnTickSlotStart(slot);
-    when(syncStateProvider.getCurrentSyncState()).thenReturn(SyncState.IN_SYNC);
 
+    when(syncStateProvider.getCurrentSyncState()).thenReturn(SyncState.IN_SYNC);
     when(p2pNetwork.getPeerCount()).thenReturn(1);
 
     slotProcessor.onTick(beaconState.getGenesisTime().plus(secondsPerSlot / 3));
+    if (isNotDivisibleBy3(secondsPerSlot)) {
+      // attestation is not due yet, will be on the next second
+      verify(forkChoiceTrigger, never()).onAttestationsDueForSlot(slot);
+      slotProcessor.onTick(beaconState.getGenesisTime().plus(oneThirdSeconds(secondsPerSlot) + 1));
+    }
     final Checkpoint justifiedCheckpoint = recentChainData.getStore().getJustifiedCheckpoint();
     final Checkpoint finalizedCheckpoint = recentChainData.getStore().getFinalizedCheckpoint();
     verify(eventLogger)
@@ -272,16 +295,24 @@ public class SlotProcessorTest {
     assertThat(slotProcessor.getNodeSlot().getValue()).isEqualTo(desiredSlot);
   }
 
-  @Test
-  void shouldProgressThroughMultipleSlots() {
+  @ParameterizedTest
+  @EnumSource(
+      value = Eth2Network.class,
+      names = {"MAINNET", "MINIMAL", "GNOSIS"})
+  void shouldProgressThroughMultipleSlots(Eth2Network eth2Network) {
     when(syncStateProvider.getCurrentSyncState()).thenReturn(SyncState.IN_SYNC);
     when(p2pNetwork.getPeerCount()).thenReturn(1);
+
+    Spec spec = TestSpecFactory.create(SpecMilestone.PHASE0, eth2Network);
+    int secondsPerSlot = spec.getGenesisSpecConfig().getSecondsPerSlot();
+
+    SlotProcessor slotProcessor = createSlotProcessor(spec);
 
     // Slot 0 start
     slotProcessor.onTick(beaconState.getGenesisTime());
     verify(slotEventsChannel).onSlot(ZERO);
     // Attestation due
-    slotProcessor.onTick(beaconState.getGenesisTime().plus(secondsPerSlot / 3));
+    slotProcessor.onTick(beaconState.getGenesisTime().plus(oneThirdSeconds(secondsPerSlot)));
     verify(forkChoiceTrigger).onAttestationsDueForSlot(ZERO);
 
     // Slot 2 start
@@ -289,12 +320,15 @@ public class SlotProcessorTest {
     slotProcessor.onTick(slot1Start);
     verify(slotEventsChannel).onSlot(ONE);
     // Attestation due
-    slotProcessor.onTick(slot1Start.plus(secondsPerSlot / 3));
+    slotProcessor.onTick(slot1Start.plus(oneThirdSeconds(secondsPerSlot)));
     verify(forkChoiceTrigger).onAttestationsDueForSlot(ONE);
   }
 
-  @Test
-  void shouldPrecomputeEpochTransitionJustBeforeFirstSlotOfNextEpoch() {
+  @ParameterizedTest
+  @EnumSource(
+      value = Eth2Network.class,
+      names = {"MAINNET", "MINIMAL", "GNOSIS"})
+  void shouldPrecomputeEpochTransitionJustBeforeFirstSlotOfNextEpoch(Eth2Network eth2Network) {
     final RecentChainData recentChainData = mock(RecentChainData.class);
     when(recentChainData.getGenesisTime()).thenReturn(genesisTime);
     final Optional<MinimalBeaconBlockSummary> headBlock =
@@ -302,6 +336,9 @@ public class SlotProcessorTest {
     when(recentChainData.getHeadBlock()).thenReturn(headBlock);
     when(recentChainData.retrieveStateAtSlot(any())).thenReturn(new SafeFuture<>());
     when(syncStateProvider.getCurrentSyncState()).thenReturn(SyncState.IN_SYNC);
+
+    Spec spec = TestSpecFactory.create(SpecMilestone.PHASE0, eth2Network);
+    int secondsPerSlot = spec.getGenesisSpecConfig().getSecondsPerSlot();
 
     final SlotProcessor slotProcessor =
         new SlotProcessor(
@@ -314,27 +351,44 @@ public class SlotProcessorTest {
             slotEventsChannel,
             epochCachePrimer,
             eventLogger);
-    slotProcessor.setCurrentSlot(UInt64.valueOf(6));
-    final UInt64 slot6StartTime = spec.getSlotStartTime(UInt64.valueOf(6), genesisTime);
-    final UInt64 slot7StartTime = spec.getSlotStartTime(UInt64.valueOf(7), genesisTime);
+
+    int slotsPerEpoch = spec.getGenesisSpecConfig().getSlotsPerEpoch();
+
+    UInt64 currentSlot = UInt64.valueOf(slotsPerEpoch - 2);
+    slotProcessor.setCurrentSlot(currentSlot);
+    final UInt64 nextEpochSlotMinusTwo = spec.getSlotStartTime(currentSlot, genesisTime);
+    final UInt64 nextEpochSlotMinusOne = spec.getSlotStartTime(currentSlot.plus(1), genesisTime);
 
     // Progress through to end of initial epoch
-    slotProcessor.onTick(slot6StartTime);
-    slotProcessor.onTick(slot6StartTime.plus(secondsPerSlot / 3));
-    slotProcessor.onTick(slot6StartTime.plus(secondsPerSlot / 3 * 2));
-    slotProcessor.onTick(slot7StartTime);
-    slotProcessor.onTick(slot7StartTime.plus(secondsPerSlot / 3));
+    slotProcessor.onTick(nextEpochSlotMinusTwo);
+    slotProcessor.onTick(nextEpochSlotMinusTwo.plus(oneThirdSeconds(secondsPerSlot)));
+    slotProcessor.onTick(nextEpochSlotMinusTwo.plus(oneThirdSeconds(secondsPerSlot) * 2));
+    slotProcessor.onTick(nextEpochSlotMinusOne);
+    slotProcessor.onTick(nextEpochSlotMinusOne.plus(oneThirdSeconds(secondsPerSlot)));
 
     // Shouldn't have precomputed epoch transition yet.
     verify(recentChainData, never()).retrieveStateAtSlot(any());
 
     // But just before the last slot of the epoch ends, we should precompute the next epoch
-    slotProcessor.onTick(slot7StartTime.plus(secondsPerSlot / 3 * 2));
+    slotProcessor.onTick(nextEpochSlotMinusOne.plus((secondsPerSlot / 3) * 2));
+    if (isNotDivisibleBy3(secondsPerSlot)) {
+      // 2/3 is not due yet, will be on the next second
+      verify(epochCachePrimer, never()).primeCacheForEpoch(ONE);
+      slotProcessor.onTick(nextEpochSlotMinusOne.plus(oneThirdSeconds(secondsPerSlot) * 2));
+    }
     verify(epochCachePrimer).primeCacheForEpoch(ONE);
 
     // Should not repeat computation
-    slotProcessor.onTick(slot7StartTime.plus(secondsPerSlot / 3 * 2 + 1));
-    slotProcessor.onTick(slot7StartTime.plus(secondsPerSlot / 3 * 2 + 2));
+    slotProcessor.onTick(nextEpochSlotMinusOne.plus(oneThirdSeconds(secondsPerSlot) * 2 + 1));
+    slotProcessor.onTick(nextEpochSlotMinusOne.plus(oneThirdSeconds(secondsPerSlot) * 2 + 2));
     verify(recentChainData, atMostOnce()).retrieveStateAtSlot(any());
+  }
+
+  private long oneThirdSeconds(int seconds) {
+    return seconds / 3 + (isNotDivisibleBy3(seconds) ? 1L : 0L);
+  }
+
+  private boolean isNotDivisibleBy3(int seconds) {
+    return seconds % 3 != 0;
   }
 }


### PR DESCRIPTION
## PR Description
Modified `DutyMetrics` to calculate the expected attestation time in milliseconds correctly
Modified `ForkChoice` to use milliseconds instead of seconds when checking if the current time into the slot is before the attesting interval.
Modified `SlotProcessor` to use milliseconds instead of seconds when calculating 1/3 and 2/3 of slot.
Changed visibility of the main `RepeatingTaskScheduler` constructor to private

## Fixed Issue(s)
fixes #5297 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
