### PR TITLE
Do not send old PayloadAttributes in ForkChoiceUpdate

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceUpdateData.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceUpdateData.java
@@ -72,7 +72,7 @@ public class ForkChoiceUpdateData {
     if (this.forkChoiceState.equals(forkChoiceState)) {
       return this;
     }
-    return new ForkChoiceUpdateData(forkChoiceState, payloadAttributes, terminalBlockHash);
+    return new ForkChoiceUpdateData(forkChoiceState, Optional.empty(), terminalBlockHash);
   }
 
   public ForkChoiceUpdateData withPayloadAttributes(


### PR DESCRIPTION
Since we are always calling `withPayloadAttributesAsync` after `withForkChoiceState`, should be safe to cleanup attributes when updating `ForkChoiceState` because:
- if Attributes are retrieved asynchronously: we know that we will execute another fcu later when they will be available
- if Attributes are retrieved synchronously: we will overwrite the empty Optional with retrieved Attributes immediately and we will do a single fcu call.

## Fixed Issue(s)
fixes #5318 

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
