### PR TITLE
Fix valid byte range in json deserializer

### DIFF
--- a/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/ByteTypeDefinition.java
+++ b/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/ByteTypeDefinition.java
@@ -36,7 +36,7 @@ class ByteTypeDefinition extends PrimitiveTypeDefinition<Byte> {
   public Byte deserialize(final JsonParser parser) throws IOException {
     final int value = Integer.parseUnsignedInt(parser.getValueAsString(), 10);
     checkArgument(
-        value <= Math.pow(2, Byte.SIZE), "Value %s exceeds maximum for unsigned byte", value);
+        value < Math.pow(2, Byte.SIZE), "Value %s exceeds maximum for unsigned byte", value);
     return (byte) value;
   }
 


### PR DESCRIPTION
## PR Description

The json deserializer was allowing `0 <= b <= 256` when it should only allow `0 <= b < 256`.

When deserializing `"256"` it would result in `0` without error.

<details closed>
<summary>Test Program</summary>

```java
import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.BYTE_TYPE;

import com.fasterxml.jackson.core.JsonParser;
import com.fasterxml.jackson.databind.ObjectMapper;
import java.io.IOException;

public class Test
{
  static JsonParser prepareDeserializationContext(String serializedValue) throws IOException {
    String json = String.format("{\"value\":%s}", serializedValue);
    JsonParser parser = new ObjectMapper().getFactory().createParser(json);
    parser.nextToken();
    parser.nextToken();
    parser.nextToken();
    return parser;
  }

  public static void main(String[] args) throws IOException {
    JsonParser parser = prepareDeserializationContext("256");

    // Results in value of zero.
    System.out.println(BYTE_TYPE.deserialize(parser));
    // java.lang.NumberFormatException: Value 256 out of range from input 256
    System.out.println(BYTE_TYPE.deserializeFromString("256"));
  }
}
```

</details>

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
