### PR TITLE
Continue polling engine_exchangeConfiguration after the merge completes

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/MergeTransitionConfigCheck.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/MergeTransitionConfigCheck.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.forkchoice;
+
+import java.time.Duration;
+import java.util.Optional;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import tech.pegasys.teku.infrastructure.async.AsyncRunner;
+import tech.pegasys.teku.infrastructure.async.Cancellable;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.logging.EventLogger;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.service.serviceutils.Service;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.SpecVersion;
+import tech.pegasys.teku.spec.config.SpecConfigBellatrix;
+import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannel;
+import tech.pegasys.teku.spec.executionengine.TransitionConfiguration;
+
+public class MergeTransitionConfigCheck extends Service {
+
+  /**
+   * From the execution engine spec:
+   *
+   * <blockquote>
+   *
+   * Consensus Layer client software SHOULD poll this endpoint every 60 seconds
+   *
+   * </blockquote>
+   */
+  private static final Duration POLLING_PERIOD = Duration.ofSeconds(60);
+
+  private static final Logger LOG = LogManager.getLogger();
+
+  private final EventLogger eventLogger;
+  private final Spec spec;
+  private final ExecutionEngineChannel executionEngine;
+  private final AsyncRunner asyncRunner;
+
+  private Optional<Cancellable> timer = Optional.empty();
+  private TransitionConfiguration localTransitionConfiguration;
+
+  public MergeTransitionConfigCheck(
+      final EventLogger eventLogger,
+      final Spec spec,
+      final ExecutionEngineChannel executionEngine,
+      final AsyncRunner asyncRunner) {
+    this.eventLogger = eventLogger;
+    this.spec = spec;
+    this.executionEngine = executionEngine;
+    this.asyncRunner = asyncRunner;
+  }
+
+  @Override
+  protected synchronized SafeFuture<?> doStart() {
+    final SpecVersion bellatrixMilestone = spec.forMilestone(SpecMilestone.BELLATRIX);
+    if (bellatrixMilestone == null) {
+      LOG.debug("Bellatrix is not scheduled. Not checking transition configuration.");
+      return SafeFuture.COMPLETE;
+    }
+    final SpecConfigBellatrix specConfigBellatrix =
+        bellatrixMilestone.getConfig().toVersionBellatrix().orElseThrow();
+
+    localTransitionConfiguration =
+        new TransitionConfiguration(
+            specConfigBellatrix.getTerminalTotalDifficulty(),
+            specConfigBellatrix.getTerminalBlockHash(),
+            UInt64.ZERO);
+
+    timer =
+        Optional.of(
+            asyncRunner.runWithFixedDelay(
+                this::verifyTransitionConfiguration,
+                POLLING_PERIOD,
+                (error) -> LOG.error("An error occurred while executing the monitor task", error)));
+    return SafeFuture.COMPLETE;
+  }
+
+  @Override
+  protected synchronized SafeFuture<?> doStop() {
+    timer.ifPresent(Cancellable::cancel);
+    timer = Optional.empty();
+    return SafeFuture.COMPLETE;
+  }
+
+  private synchronized void verifyTransitionConfiguration() {
+    executionEngine
+        .exchangeTransitionConfiguration(localTransitionConfiguration)
+        .thenAccept(
+            remoteTransitionConfiguration -> {
+              if (!localTransitionConfiguration
+                      .getTerminalTotalDifficulty()
+                      .equals(remoteTransitionConfiguration.getTerminalTotalDifficulty())
+                  || !localTransitionConfiguration
+                      .getTerminalBlockHash()
+                      .equals(remoteTransitionConfiguration.getTerminalBlockHash())) {
+
+                eventLogger.transitionConfigurationTtdTbhMismatch(
+                    localTransitionConfiguration.toString(),
+                    remoteTransitionConfiguration.toString());
+              } else if (remoteTransitionConfiguration.getTerminalBlockHash().isZero()
+                  != remoteTransitionConfiguration.getTerminalBlockNumber().isZero()) {
+
+                eventLogger.transitionConfigurationRemoteTbhTbnInconsistency(
+                    remoteTransitionConfiguration.toString());
+              }
+            })
+        .finish(
+            error ->
+                LOG.error(
+                    "An error occurred while querying remote transition configuration", error));
+  }
+}

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/MergeTransitionConfigCheckTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/MergeTransitionConfigCheckTest.java
@@ -94,7 +94,6 @@ class MergeTransitionConfigCheckTest {
 
   @Test
   void shouldReportWrongTotalTerminalDifficulty() {
-    // wrong terminal total difficulty
     final TransitionConfiguration wrongRemoteConfig =
         new TransitionConfiguration(
             wrongRemoteTTD, localTransitionConfiguration.getTerminalBlockHash(), UInt64.ZERO);
@@ -110,7 +109,6 @@ class MergeTransitionConfigCheckTest {
 
   @Test
   void shouldDetectWrongTerminalBlockHash() {
-    // wrong terminal block hash
     final TransitionConfiguration wrongRemoteConfig =
         new TransitionConfiguration(
             localTransitionConfiguration.getTerminalTotalDifficulty(), wrongRemoteTBH, UInt64.ZERO);
@@ -126,7 +124,6 @@ class MergeTransitionConfigCheckTest {
 
   @Test
   void shouldReportInconsistencyReportedByRemote() {
-    // remote terminal block hash / terminal block number inconsistency
     final TransitionConfiguration wrongRemoteConfig =
         new TransitionConfiguration(
             localTransitionConfiguration.getTerminalTotalDifficulty(),

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/MergeTransitionConfigCheckTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/MergeTransitionConfigCheckTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.forkchoice;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.function.Consumer;
+import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.units.bigints.UInt256;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
+import tech.pegasys.teku.infrastructure.logging.EventLogger;
+import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.config.SpecConfigBuilder.BellatrixBuilder;
+import tech.pegasys.teku.spec.config.SpecConfigLoader;
+import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannel;
+import tech.pegasys.teku.spec.executionengine.TransitionConfiguration;
+import tech.pegasys.teku.spec.logic.common.block.AbstractBlockProcessor;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+class MergeTransitionConfigCheckTest {
+
+  private static final UInt64 BELLATRIX_FORK_EPOCH = UInt64.ONE;
+  private static final Bytes32 TERMINAL_BLOCK_HASH = Bytes32.random();
+  private static final UInt64 TERMINAL_BLOCK_EPOCH = UInt64.valueOf(2);
+
+  private final ExecutionEngineChannel executionEngine = mock(ExecutionEngineChannel.class);
+  private final StubTimeProvider timeProvider = StubTimeProvider.withTimeInSeconds(10_000);
+  private final StubAsyncRunner asyncRunner = new StubAsyncRunner(timeProvider);
+  private final EventLogger eventLogger = Mockito.mock(EventLogger.class);
+
+  private DataStructureUtil dataStructureUtil;
+  private MergeTransitionConfigCheck mergeTransitionConfigCheck;
+  private TransitionConfiguration localTransitionConfiguration;
+
+  @BeforeAll
+  public static void initSession() {
+    AbstractBlockProcessor.blsVerifyDeposit = false;
+  }
+
+  @AfterAll
+  public static void resetSession() {
+    AbstractBlockProcessor.blsVerifyDeposit = true;
+  }
+
+  @Test
+  void shouldDetectTerminalConfigProblems() {
+    setUpTerminalBlockHashConfig();
+    final UInt256 wrongRemoteTTD = dataStructureUtil.randomUInt256();
+    final Bytes32 wrongRemoteTBH = dataStructureUtil.randomBytes32();
+
+    TransitionConfiguration wrongRemoteConfig;
+
+    assertThat(mergeTransitionConfigCheck.start()).isCompleted();
+
+    // wrong TTD
+    wrongRemoteConfig =
+        new TransitionConfiguration(
+            wrongRemoteTTD, localTransitionConfiguration.getTerminalBlockHash(), UInt64.ZERO);
+    when(executionEngine.exchangeTransitionConfiguration(localTransitionConfiguration))
+        .thenReturn(SafeFuture.completedFuture(wrongRemoteConfig));
+
+    asyncRunner.executeQueuedActions();
+
+    verify(eventLogger)
+        .transitionConfigurationTtdTbhMismatch(
+            localTransitionConfiguration.toString(), wrongRemoteConfig.toString());
+
+    // wrong TBH
+    wrongRemoteConfig =
+        new TransitionConfiguration(
+            localTransitionConfiguration.getTerminalTotalDifficulty(), wrongRemoteTBH, UInt64.ZERO);
+    when(executionEngine.exchangeTransitionConfiguration(localTransitionConfiguration))
+        .thenReturn(SafeFuture.completedFuture(wrongRemoteConfig));
+
+    asyncRunner.executeQueuedActions();
+
+    verify(eventLogger)
+        .transitionConfigurationTtdTbhMismatch(
+            localTransitionConfiguration.toString(), wrongRemoteConfig.toString());
+
+    // remote TBH TBN inconsistency
+    wrongRemoteConfig =
+        new TransitionConfiguration(
+            localTransitionConfiguration.getTerminalTotalDifficulty(),
+            localTransitionConfiguration.getTerminalBlockHash(),
+            UInt64.ZERO);
+    when(executionEngine.exchangeTransitionConfiguration(localTransitionConfiguration))
+        .thenReturn(SafeFuture.completedFuture(wrongRemoteConfig));
+
+    asyncRunner.executeQueuedActions();
+
+    verify(eventLogger)
+        .transitionConfigurationRemoteTbhTbnInconsistency(wrongRemoteConfig.toString());
+
+    verifyNoMoreInteractions(eventLogger);
+  }
+
+  private void setUpTerminalBlockHashConfig() {
+    setUpCommon(
+        bellatrixBuilder ->
+            bellatrixBuilder
+                .bellatrixForkEpoch(BELLATRIX_FORK_EPOCH)
+                .terminalBlockHash(TERMINAL_BLOCK_HASH)
+                .terminalBlockHashActivationEpoch(TERMINAL_BLOCK_EPOCH));
+
+    when(executionEngine.exchangeTransitionConfiguration(localTransitionConfiguration))
+        .thenReturn(
+            SafeFuture.completedFuture(
+                new TransitionConfiguration(
+                    localTransitionConfiguration.getTerminalTotalDifficulty(),
+                    localTransitionConfiguration.getTerminalBlockHash(),
+                    dataStructureUtil.randomUInt64())));
+  }
+
+  private void setUpCommon(Consumer<BellatrixBuilder> bellatrixBuilder) {
+    Spec spec =
+        TestSpecFactory.createBellatrix(
+            SpecConfigLoader.loadConfig(
+                "minimal",
+                phase0Builder ->
+                    phase0Builder
+                        .altairBuilder(altairBuilder -> altairBuilder.altairForkEpoch(UInt64.ZERO))
+                        .bellatrixBuilder(bellatrixBuilder)));
+    dataStructureUtil = new DataStructureUtil(spec);
+
+    localTransitionConfiguration =
+        new TransitionConfiguration(
+            spec.getGenesisSpecConfig()
+                .toVersionBellatrix()
+                .orElseThrow()
+                .getTerminalTotalDifficulty(),
+            spec.getGenesisSpecConfig().toVersionBellatrix().orElseThrow().getTerminalBlockHash(),
+            UInt64.ZERO);
+
+    mergeTransitionConfigCheck =
+        new MergeTransitionConfigCheck(eventLogger, spec, executionEngine, asyncRunner);
+  }
+}

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/MergeTransitionConfigCheckTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/MergeTransitionConfigCheckTest.java
@@ -21,8 +21,6 @@ import static org.mockito.Mockito.when;
 
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -36,7 +34,6 @@ import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.config.SpecConfigLoader;
 import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannel;
 import tech.pegasys.teku.spec.executionengine.TransitionConfiguration;
-import tech.pegasys.teku.spec.logic.common.block.AbstractBlockProcessor;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 class MergeTransitionConfigCheckTest {
@@ -69,16 +66,6 @@ class MergeTransitionConfigCheckTest {
 
   private final UInt256 wrongRemoteTTD = dataStructureUtil.randomUInt256();
   private final Bytes32 wrongRemoteTBH = dataStructureUtil.randomBytes32();
-
-  @BeforeAll
-  public static void initSession() {
-    AbstractBlockProcessor.blsVerifyDeposit = false;
-  }
-
-  @AfterAll
-  public static void resetSession() {
-    AbstractBlockProcessor.blsVerifyDeposit = true;
-  }
 
   @BeforeEach
   void setUp() {

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/MergeTransitionConfigCheckTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/MergeTransitionConfigCheckTest.java
@@ -75,7 +75,7 @@ class MergeTransitionConfigCheckTest {
 
     assertThat(mergeTransitionConfigCheck.start()).isCompleted();
 
-    // wrong TTD
+    // wrong terminal total difficulty
     wrongRemoteConfig =
         new TransitionConfiguration(
             wrongRemoteTTD, localTransitionConfiguration.getTerminalBlockHash(), UInt64.ZERO);
@@ -88,7 +88,7 @@ class MergeTransitionConfigCheckTest {
         .transitionConfigurationTtdTbhMismatch(
             localTransitionConfiguration.toString(), wrongRemoteConfig.toString());
 
-    // wrong TBH
+    // wrong terminal block hash
     wrongRemoteConfig =
         new TransitionConfiguration(
             localTransitionConfiguration.getTerminalTotalDifficulty(), wrongRemoteTBH, UInt64.ZERO);
@@ -101,7 +101,7 @@ class MergeTransitionConfigCheckTest {
         .transitionConfigurationTtdTbhMismatch(
             localTransitionConfiguration.toString(), wrongRemoteConfig.toString());
 
-    // remote TBH TBN inconsistency
+    // remote terminal block hash / terminal block number inconsistency
     wrongRemoteConfig =
         new TransitionConfiguration(
             localTransitionConfiguration.getTerminalTotalDifficulty(),

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -95,6 +95,7 @@ import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceNotifier;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceNotifierImpl;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceTrigger;
 import tech.pegasys.teku.statetransition.forkchoice.MergeTransitionBlockValidator;
+import tech.pegasys.teku.statetransition.forkchoice.MergeTransitionConfigCheck;
 import tech.pegasys.teku.statetransition.forkchoice.TerminalPowBlockMonitor;
 import tech.pegasys.teku.statetransition.genesis.GenesisHandler;
 import tech.pegasys.teku.statetransition.synccommittee.SignedContributionAndProofValidator;
@@ -200,6 +201,8 @@ public class BeaconChainController extends Service implements BeaconChainControl
   protected volatile ForkChoiceNotifier forkChoiceNotifier;
   protected volatile ExecutionEngineChannel executionEngine;
   protected volatile Optional<TerminalPowBlockMonitor> terminalPowBlockMonitor = Optional.empty();
+  protected volatile Optional<MergeTransitionConfigCheck> mergeTransitionConfigCheck =
+      Optional.empty();
 
   protected UInt64 genesisTimeTracker = ZERO;
   protected BlockManager blockManager;
@@ -258,7 +261,10 @@ public class BeaconChainController extends Service implements BeaconChainControl
             blockManager.start(),
             syncService.start(),
             SafeFuture.fromRunnable(
-                () -> terminalPowBlockMonitor.ifPresent(TerminalPowBlockMonitor::start)))
+                () -> terminalPowBlockMonitor.ifPresent(TerminalPowBlockMonitor::start)),
+            mergeTransitionConfigCheck
+                .map(MergeTransitionConfigCheck::start)
+                .orElse(SafeFuture.completedFuture(null)))
         .finish(
             error -> {
               Throwable rootCause = Throwables.getRootCause(error);
@@ -286,7 +292,10 @@ public class BeaconChainController extends Service implements BeaconChainControl
             p2pNetwork.stop(),
             timerService.stop(),
             SafeFuture.fromRunnable(
-                () -> terminalPowBlockMonitor.ifPresent(TerminalPowBlockMonitor::stop)))
+                () -> terminalPowBlockMonitor.ifPresent(TerminalPowBlockMonitor::stop)),
+            mergeTransitionConfigCheck
+                .map(MergeTransitionConfigCheck::stop)
+                .orElse(SafeFuture.completedFuture(null)))
         .thenRun(forkChoiceExecutor::stop);
   }
 
@@ -340,7 +349,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
   public void initAll() {
     initExecutionEngine();
     initForkChoiceNotifier();
-    initTerminalPowBlockMonitor();
+    initMergeMonitors();
     initForkChoice();
     initBlockImporter();
     initCombinedChainDataClient();
@@ -372,7 +381,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
     executionEngine = eventChannels.getPublisher(ExecutionEngineChannel.class, beaconAsyncRunner);
   }
 
-  protected void initTerminalPowBlockMonitor() {
+  protected void initMergeMonitors() {
     if (spec.isMilestoneSupported(SpecMilestone.BELLATRIX)) {
       terminalPowBlockMonitor =
           Optional.of(
@@ -384,6 +393,10 @@ public class BeaconChainController extends Service implements BeaconChainControl
                   beaconAsyncRunner,
                   EVENT_LOG,
                   timeProvider));
+
+      mergeTransitionConfigCheck =
+          Optional.of(
+              new MergeTransitionConfigCheck(EVENT_LOG, spec, executionEngine, beaconAsyncRunner));
     }
   }
 


### PR DESCRIPTION
## PR Description
From the execution engine spec: EL clients SHOULD log an error if they don't receive a call to engine_exchangeConfiguration at least once every 120 seconds. This doesn't include a provision for stopping polling after the merge completes, and the EL may not have the same view of the merge status as we do due to different syncing stages.  So we need to keep polling even after we see the merge as complete.

## Fixed Issue(s)
fixes #5324 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
