### PR TITLE
Ensure gossip subscription is started when we begin waiting for EL to sync

### DIFF
--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/events/SyncState.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/events/SyncState.java
@@ -17,6 +17,7 @@ public enum SyncState {
   START_UP,
   SYNCING,
   OPTIMISTIC_SYNCING,
+  AWAITING_EL, // Beacon chain has completed optimistic sync but waiting for the EL
   IN_SYNC;
 
   public boolean isInSync() {
@@ -28,10 +29,10 @@ public enum SyncState {
   }
 
   public boolean isSyncing() {
-    return this == SYNCING || this == OPTIMISTIC_SYNCING;
+    return this == SYNCING || this == OPTIMISTIC_SYNCING || this == AWAITING_EL;
   }
 
   public boolean isOptimistic() {
-    return this == OPTIMISTIC_SYNCING;
+    return this == OPTIMISTIC_SYNCING || this == AWAITING_EL;
   }
 }

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/events/SyncStateTracker.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/events/SyncStateTracker.java
@@ -131,7 +131,7 @@ public class SyncStateTracker extends Service
   private void updateCurrentState() {
     final SyncState previousState = currentState;
     if (headIsOptimistic) {
-      currentState = SyncState.OPTIMISTIC_SYNCING;
+      currentState = syncActive ? SyncState.OPTIMISTIC_SYNCING : SyncState.AWAITING_EL;
     } else if (syncActive) {
       currentState = SyncState.SYNCING;
     } else if (startingUp) {

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/events/SyncStateTrackerTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/events/SyncStateTrackerTest.java
@@ -143,9 +143,9 @@ class SyncStateTrackerTest {
     verify(eventLogger).syncCompleted();
     assertSyncState(SyncState.START_UP);
 
-    // turn head optimistic
+    // turn head optimistic. No blocks to sync so enter awaiting EL state.
     tracker.onOptimisticHeadChanged(true);
-    assertSyncState(SyncState.OPTIMISTIC_SYNCING);
+    assertSyncState(SyncState.AWAITING_EL);
 
     verifyNoMoreInteractions(eventLogger);
   }


### PR DESCRIPTION
## PR Description
Previously if the optimistic sync started far enough back that we didn't subscribe to or unsubscribed from gossip, the sync state wouldn't change when the optimistic sync completed until the EL also completed sync. Since the P2P network listens for sync state changes to decide when to subscribe to gossip, Teku didn't subscribe to gossip while waiting for the EL causing to fall behind until long sync kicked in again.

Introducing a new AWAITING_EL sync state ensures a sync state change happens and provides more accurate sync state information for the node to work with.

## Fixed Issue(s)
fixes #5323 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
