### PR TITLE
Use respondAsync functionality rather than the handleOptionalResult

### DIFF
--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/paths/_eth_v1_beacon_states_{state_id}_fork.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/paths/_eth_v1_beacon_states_{state_id}_fork.json
@@ -30,7 +30,7 @@
         "content" : {
           "application/json" : {
             "schema" : {
-              "$ref" : "#/components/schemas/BadRequest"
+              "$ref" : "#/components/schemas/HttpErrorResponse"
             }
           }
         }

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/schema/HttpErrorResponse.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/schema/HttpErrorResponse.json
@@ -1,9 +1,9 @@
 {
   "title" : "HttpErrorResponse",
   "type" : "object",
-  "required" : [ "status", "message" ],
+  "required" : [ "code", "message" ],
   "properties" : {
-    "status" : {
+    "code" : {
       "type" : "number"
     },
     "message" : {

--- a/infrastructure/http/src/main/java/tech/pegasys/teku/infrastructure/http/HttpErrorResponse.java
+++ b/infrastructure/http/src/main/java/tech/pegasys/teku/infrastructure/http/HttpErrorResponse.java
@@ -19,15 +19,15 @@ import java.util.Objects;
 
 public class HttpErrorResponse {
 
-  private final Integer status;
+  private final int code;
   private final String message;
 
   public static HttpErrorResponse badRequest(String message) {
     return new HttpErrorResponse(SC_BAD_REQUEST, message);
   }
 
-  public HttpErrorResponse(final Integer status, final String message) {
-    this.status = status;
+  public HttpErrorResponse(final int code, final String message) {
+    this.code = code;
     this.message = message;
   }
 
@@ -35,8 +35,8 @@ public class HttpErrorResponse {
     return message;
   }
 
-  public Integer getStatus() {
-    return status;
+  public int getCode() {
+    return code;
   }
 
   @Override
@@ -48,11 +48,11 @@ public class HttpErrorResponse {
       return false;
     }
     final HttpErrorResponse that = (HttpErrorResponse) o;
-    return Objects.equals(status, that.status) && Objects.equals(message, that.message);
+    return code == that.code && Objects.equals(message, that.message);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(status, message);
+    return Objects.hash(code, message);
   }
 }

--- a/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/CoreTypes.java
+++ b/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/CoreTypes.java
@@ -70,7 +70,7 @@ public class CoreTypes {
   public static final SerializableTypeDefinition<HttpErrorResponse> HTTP_ERROR_RESPONSE_TYPE =
       SerializableTypeDefinition.object(HttpErrorResponse.class)
           .name("HttpErrorResponse")
-          .withField("code", INTEGER_TYPE, HttpErrorResponse::getStatus)
+          .withField("code", INTEGER_TYPE, HttpErrorResponse::getCode)
           .withField("message", STRING_TYPE, HttpErrorResponse::getMessage)
           .build();
 

--- a/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/CoreTypes.java
+++ b/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/CoreTypes.java
@@ -70,7 +70,7 @@ public class CoreTypes {
   public static final SerializableTypeDefinition<HttpErrorResponse> HTTP_ERROR_RESPONSE_TYPE =
       SerializableTypeDefinition.object(HttpErrorResponse.class)
           .name("HttpErrorResponse")
-          .withField("status", INTEGER_TYPE, HttpErrorResponse::getStatus)
+          .withField("code", INTEGER_TYPE, HttpErrorResponse::getStatus)
           .withField("message", STRING_TYPE, HttpErrorResponse::getMessage)
           .build();
 

--- a/infrastructure/json/src/test/java/tech/pegasys/teku/infrastructure/json/types/CoreTypesTest.java
+++ b/infrastructure/json/src/test/java/tech/pegasys/teku/infrastructure/json/types/CoreTypesTest.java
@@ -46,6 +46,6 @@ class CoreTypesTest {
     final Map<String, Object> result =
         JsonTestUtil.parse(serialize(value, CoreTypes.HTTP_ERROR_RESPONSE_TYPE));
 
-    assertThat(result).containsOnly(entry("status", 442), entry("message", "No good"));
+    assertThat(result).containsOnly(entry("code", 442), entry("message", "No good"));
   }
 }

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/RestApiBuilder.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/RestApiBuilder.java
@@ -171,7 +171,7 @@ public class RestApiBuilder {
           try {
             final HttpErrorResponse response =
                 ((RestApiExceptionHandler) handler).handleException(exception, ctx.url());
-            ctx.status(response.getStatus());
+            ctx.status(response.getCode());
             ctx.json(JsonUtil.serialize(response, HTTP_ERROR_RESPONSE_TYPE));
           } catch (final Throwable t) {
             ctx.status(SC_INTERNAL_SERVER_ERROR);

--- a/validator/client/src/test/resources/tech/pegasys/teku/validator/client/restapi/schema/HttpErrorResponse.json
+++ b/validator/client/src/test/resources/tech/pegasys/teku/validator/client/restapi/schema/HttpErrorResponse.json
@@ -1,9 +1,9 @@
 {
   "title" : "HttpErrorResponse",
   "type" : "object",
-  "required" : [ "status", "message" ],
+  "required" : [ "code", "message" ],
   "properties" : {
-    "status" : {
+    "code" : {
       "type" : "number"
     },
     "message" : {


### PR DESCRIPTION
pushing towards standardising future processing on the new implementation of the api.

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
