### PR TITLE
Apply execution engine timeouts

### DIFF
--- a/ethereum/executionlayer/build.gradle
+++ b/ethereum/executionlayer/build.gradle
@@ -17,6 +17,7 @@ dependencies {
   runtimeOnly 'io.jsonwebtoken:jjwt-jackson'
 
   testImplementation testFixtures(project(':ethereum:spec'))
+  testImplementation testFixtures(project(':infrastructure:async'))
   testImplementation testFixtures(project(':infrastructure:time'))
 
   integrationTestImplementation testFixtures(project(':infrastructure:json'))

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/Web3JExecutionEngineClient.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/Web3JExecutionEngineClient.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.ethereum.executionlayer.client;
 
 import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -43,6 +44,9 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.execution.PowBlock;
 
 public class Web3JExecutionEngineClient implements ExecutionEngineClient {
+  public static final Duration EXECUTION_TIMEOUT = Duration.ofMinutes(2);
+  private static final Duration NON_EXECUTION_TIMEOUT = Duration.ofSeconds(12);
+
   private final Web3JClient web3JClient;
 
   static {
@@ -107,7 +111,7 @@ public class Web3JExecutionEngineClient implements ExecutionEngineClient {
             Collections.singletonList(payloadId.toHexString()),
             web3JClient.getWeb3jService(),
             ExecutionPayloadV1Web3jResponse.class);
-    return web3JClient.doRequest(web3jRequest);
+    return web3JClient.doRequest(web3jRequest, NON_EXECUTION_TIMEOUT);
   }
 
   @Override
@@ -118,7 +122,7 @@ public class Web3JExecutionEngineClient implements ExecutionEngineClient {
             Collections.singletonList(executionPayload),
             web3JClient.getWeb3jService(),
             PayloadStatusV1Web3jResponse.class);
-    return web3JClient.doRequest(web3jRequest);
+    return web3JClient.doRequest(web3jRequest, EXECUTION_TIMEOUT);
   }
 
   @Override
@@ -130,7 +134,7 @@ public class Web3JExecutionEngineClient implements ExecutionEngineClient {
             list(forkChoiceState, payloadAttributes.orElse(null)),
             web3JClient.getWeb3jService(),
             ForkChoiceUpdatedResultWeb3jResponse.class);
-    return web3JClient.doRequest(web3jRequest);
+    return web3JClient.doRequest(web3jRequest, EXECUTION_TIMEOUT);
   }
 
   @Override
@@ -142,7 +146,7 @@ public class Web3JExecutionEngineClient implements ExecutionEngineClient {
             Collections.singletonList(transitionConfiguration),
             web3JClient.getWeb3jService(),
             TransitionConfigurationV1Web3jResponse.class);
-    return web3JClient.doRequest(web3jRequest);
+    return web3JClient.doRequest(web3jRequest, NON_EXECUTION_TIMEOUT);
   }
 
   @Override
@@ -153,7 +157,7 @@ public class Web3JExecutionEngineClient implements ExecutionEngineClient {
             Collections.singletonList(payloadId.toHexString()),
             web3JClient.getWeb3jService(),
             ExecutionPayloadHeaderV1Web3jResponse.class);
-    return web3JClient.doRequest(web3jRequest);
+    return web3JClient.doRequest(web3jRequest, NON_EXECUTION_TIMEOUT);
   }
 
   @Override
@@ -165,7 +169,7 @@ public class Web3JExecutionEngineClient implements ExecutionEngineClient {
             Collections.singletonList(signedBlindedBeaconBlock),
             web3JClient.getWeb3jService(),
             ExecutionPayloadV1Web3jResponse.class);
-    return web3JClient.doRequest(web3jRequest);
+    return web3JClient.doRequest(web3jRequest, NON_EXECUTION_TIMEOUT);
   }
 
   protected Web3JClient getWeb3JClient() {

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/Web3jHttpClient.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/Web3jHttpClient.java
@@ -38,7 +38,10 @@ public class Web3jHttpClient extends Web3JClient {
 
   private OkHttpClient createOkHttpClient(
       final Optional<JwtConfig> jwtConfig, final TimeProvider timeProvider) {
-    final OkHttpClient.Builder builder = new OkHttpClient.Builder();
+    final OkHttpClient.Builder builder =
+        new OkHttpClient.Builder()
+            // Set read timeout to longest request timeout
+            .readTimeout(Web3JExecutionEngineClient.EXECUTION_TIMEOUT);
     if (LOG.isTraceEnabled()) {
       HttpLoggingInterceptor logging = new HttpLoggingInterceptor(LOG::trace);
       logging.setLevel(HttpLoggingInterceptor.Level.BODY);

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/Web3jWebsocketClient.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/Web3jWebsocketClient.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.ethereum.executionlayer.client;
 
 import java.net.ConnectException;
 import java.net.URI;
+import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -74,10 +75,11 @@ public class Web3jWebsocketClient extends Web3JClient {
   }
 
   @Override
-  protected <T> SafeFuture<Response<T>> doRequest(
-      Request<?, ? extends org.web3j.protocol.core.Response<T>> web3jRequest) {
+  public <T> SafeFuture<Response<T>> doRequest(
+      Request<?, ? extends org.web3j.protocol.core.Response<T>> web3jRequest,
+      final Duration timeout) {
     return tryToConnect()
         .<SafeFuture<Response<T>>>map(SafeFuture::failedFuture)
-        .orElseGet(() -> super.doRequest(web3jRequest));
+        .orElseGet(() -> super.doRequest(web3jRequest, timeout));
   }
 }

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/client/Web3JClientTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/client/Web3JClientTest.java
@@ -18,11 +18,16 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThatSafeFuture;
+import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
+import static tech.pegasys.teku.infrastructure.async.Waiter.waitFor;
 
 import java.net.URI;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -33,10 +38,13 @@ import org.web3j.protocol.Web3jService;
 import org.web3j.protocol.core.Request;
 import org.web3j.protocol.core.methods.response.VoidResponse;
 import org.web3j.protocol.websocket.WebSocketService;
+import tech.pegasys.teku.ethereum.executionlayer.client.schema.Response;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 
 public class Web3JClientTest {
-  private static final TimeProvider TIME_PROVIDER = mock(TimeProvider.class);
+  private static final TimeProvider TIME_PROVIDER = StubTimeProvider.withTimeInSeconds(1000);
   private static final Web3jService WEB3J_SERVICE = mock(Web3jService.class);
   private static final Web3JClient WEB3J_CLIENT = new Web3JClientImpl(TIME_PROVIDER);
   private static final URI ENDPOINT = URI.create("");
@@ -47,6 +55,7 @@ public class Web3JClientTest {
       new Web3jWebsocketClient(ENDPOINT, TIME_PROVIDER, Optional.empty());
   private static final Web3jIpcClient WEB3J_IPC_CLIENT =
       new Web3jIpcClient(URI.create("file:/a"), TIME_PROVIDER, Optional.empty());
+  private static final Duration TIMEOUT = Duration.ofSeconds(10000000);
 
   static class Web3JClientImpl extends Web3JClient {
     protected Web3JClientImpl(TimeProvider timeProvider) {
@@ -83,7 +92,7 @@ public class Web3JClientTest {
 
   @ParameterizedTest
   @MethodSource("getClientInstances")
-  public void shouldModifyRequestWhenDoRequestCalled(Web3JClient client) {
+  public void shouldModifyRequestWhenDoRequestCalled(final Web3JClient client) {
     client.addRequestAdapter(
         request -> {
           request.setId(123);
@@ -94,8 +103,24 @@ public class Web3JClientTest {
     request.setId(1);
     when(WEB3J_SERVICE.sendAsync(request, VoidResponse.class))
         .thenReturn(CompletableFuture.completedFuture(new VoidResponse()));
-    client.doRequest(request).finish(ex -> {});
+    assertThat(client.doRequest(request, TIMEOUT)).isCompleted();
     verify(WEB3J_SERVICE, times(1)).sendAsync(request, VoidResponse.class);
     assertThat(request.getId()).isEqualTo(123);
+  }
+
+  @ParameterizedTest
+  @MethodSource("getClientInstances")
+  void shouldTimeoutIfResponseNotReceived(final Web3JClient client) throws Exception {
+    Request<Void, VoidResponse> request =
+        new Request<>("test", new ArrayList<>(), WEB3J_SERVICE, VoidResponse.class);
+    when(WEB3J_SERVICE.sendAsync(request, VoidResponse.class))
+        .thenReturn(new CompletableFuture<>());
+
+    final Duration crazyShortTimeout = Duration.ofMillis(0);
+    final SafeFuture<Response<Void>> result = client.doRequest(request, crazyShortTimeout);
+    waitFor(result);
+    assertThatSafeFuture(result).isCompleted();
+    final Response<Void> response = safeJoin(result);
+    assertThat(response.getErrorMessage()).isEqualTo(TimeoutException.class.getSimpleName());
   }
 }


### PR DESCRIPTION
## PR Description
Apply timeouts to execution engine requests as per the latest spec.

Web3j doesn't allow setting the actual http timeout separate for different request types and web sockets and IPC don't have any concept of request timeouts at all. So we handle the timeout via the future and set the HTTP read timeout to the longest timeout we need to ensure it doesn't abort the connection before the timeout is reached.

## Fixed Issue(s)
fixes #5302 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
