### PR TITLE
[MEV boost] improve blinded block validator options and flow handling

### DIFF
--- a/ethereum/core/src/test/java/tech/pegasys/teku/core/signatures/LocalSignerTest.java
+++ b/ethereum/core/src/test/java/tech/pegasys/teku/core/signatures/LocalSignerTest.java
@@ -57,6 +57,20 @@ class LocalSignerTest {
   }
 
   @Test
+  public void shouldSignBlindedBlock() {
+    final BeaconBlock block = dataStructureUtil.randomBlindedBeaconBlock(10);
+    final BLSSignature expectedSignature =
+        BLSSignature.fromBytesCompressed(
+            Bytes.fromBase64String(
+                "pbSSuf7h70JkzI/U157flTWPZDuaBXgRLj1HLMoCwjA4Xd0hMdGewn7G2HLZiQcNC9G6FSd1+0BT5PwknYez4ya6TccwpaGnsvWYLPf3SNIX5Ug7Yi1CF1fvEr3x9sZ0"));
+
+    final SafeFuture<BLSSignature> result = signer.signBlock(block, fork);
+    asyncRunner.executeQueuedActions();
+
+    assertThat(result).isCompletedWithValue(expectedSignature);
+  }
+
+  @Test
   public void shouldCreateRandaoReveal() {
     final BLSSignature expectedSignature =
         BLSSignature.fromBytesCompressed(

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -708,6 +708,10 @@ public final class DataStructureUtil {
         body);
   }
 
+  public BeaconBlock randomBlindedBeaconBlock(long slotNum) {
+    return randomBlindedBeaconBlock(UInt64.valueOf(slotNum));
+  }
+
   public BeaconBlock randomBlindedBeaconBlock(UInt64 slotNum) {
     final UInt64 proposerIndex = randomUInt64();
     Bytes32 previousRoot = randomBytes32();

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
@@ -13,8 +13,6 @@
 
 package tech.pegasys.teku.cli.options;
 
-import static tech.pegasys.teku.validator.api.ValidatorConfig.DEFAULT_VALIDATOR_BLINDED_BLOCKS_ENABLED;
-
 import java.nio.file.Path;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
@@ -102,16 +100,6 @@ public class ValidatorOptions {
       arity = "0..1")
   private boolean generateEarlyAttestations = ValidatorConfig.DEFAULT_GENERATE_EARLY_ATTESTATIONS;
 
-  @Option(
-      names = {"--Xvalidators-blinded-blocks-api-enabled"},
-      paramLabel = "<BOOLEAN>",
-      showDefaultValue = Visibility.ALWAYS,
-      description = "Use blinded block api calls",
-      fallbackValue = "true",
-      hidden = true,
-      arity = "0..1")
-  private boolean blindedBlocksApiEnabled = DEFAULT_VALIDATOR_BLINDED_BLOCKS_ENABLED;
-
   public void configure(TekuConfiguration.Builder builder) {
     if (validatorPerformanceTrackingEnabled != null) {
       if (validatorPerformanceTrackingEnabled) {
@@ -125,7 +113,6 @@ public class ValidatorOptions {
         config ->
             config
                 .validatorKeystoreLockingEnabled(validatorKeystoreLockingEnabled)
-                .blindedBeaconBlocksApiEnabled(blindedBlocksApiEnabled)
                 .validatorPerformanceTrackingMode(validatorPerformanceTrackingMode)
                 .validatorExternalSignerSlashingProtectionEnabled(
                     validatorExternalSignerSlashingProtectionEnabled)

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorProposerOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorProposerOptions.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.teku.cli.options;
 
+import static tech.pegasys.teku.validator.api.ValidatorConfig.DEFAULT_VALIDATOR_BLINDED_BLOCKS_ENABLED;
+
 import picocli.CommandLine.Help.Visibility;
 import picocli.CommandLine.Option;
 import tech.pegasys.teku.config.TekuConfiguration;
@@ -56,6 +58,16 @@ public class ValidatorProposerOptions {
   private boolean proposerMevBoostEnabled =
       ValidatorConfig.DEFAULT_VALIDATOR_PROPOSER_MEV_BOOST_ENABLED;
 
+  @Option(
+      names = {"--Xvalidators-proposer-blinded-blocks-enabled"},
+      paramLabel = "<BOOLEAN>",
+      showDefaultValue = Visibility.ALWAYS,
+      description = "Use blinded blocks when in block production duties",
+      fallbackValue = "true",
+      hidden = true,
+      arity = "0..1")
+  private boolean blindedBlocksEnabled = DEFAULT_VALIDATOR_BLINDED_BLOCKS_ENABLED;
+
   public void configure(TekuConfiguration.Builder builder) {
     builder.validator(
         config ->
@@ -63,6 +75,7 @@ public class ValidatorProposerOptions {
                 .proposerDefaultFeeRecipient(proposerDefaultFeeRecipient)
                 .proposerConfigSource(proposerConfig)
                 .refreshProposerConfigFromSource(proposerConfigRefreshEnabled)
-                .proposerMevBoostEnabled(proposerMevBoostEnabled));
+                .proposerMevBoostEnabled(proposerMevBoostEnabled)
+                .blindedBeaconBlocksEnabled(blindedBlocksEnabled));
   }
 }

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/RemoteSpecLoader.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/RemoteSpecLoader.java
@@ -13,8 +13,6 @@
 
 package tech.pegasys.teku.cli.subcommand;
 
-import static tech.pegasys.teku.validator.api.ValidatorConfig.DEFAULT_VALIDATOR_BLINDED_BLOCKS_ENABLED;
-
 import java.net.URI;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
@@ -91,7 +89,6 @@ class RemoteSpecLoader {
     // Strip any authentication info from the URL to ensure it doesn't get logged.
     apiEndpoint = apiEndpoint.newBuilder().username("").password("").build();
     final OkHttpClient okHttpClient = httpClientBuilder.build();
-    return new OkHttpValidatorRestApiClient(
-        apiEndpoint, okHttpClient, DEFAULT_VALIDATOR_BLINDED_BLOCKS_ENABLED);
+    return new OkHttpValidatorRestApiClient(apiEndpoint, okHttpClient);
   }
 }

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/ValidatorOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/ValidatorOptionsTest.java
@@ -119,9 +119,9 @@ public class ValidatorOptionsTest extends AbstractBeaconNodeCommandTest {
 
   @Test
   public void shouldEnableBlindedBeaconBlocks() {
-    final String[] args = {"--Xvalidators-blinded-blocks-api-enabled", "true"};
+    final String[] args = {"--Xvalidators-proposer-blinded-blocks-enabled", "true"};
     final TekuConfiguration config = getTekuConfigurationFromArguments(args);
-    assertThat(config.validatorClient().getValidatorConfig().isBlindedBeaconBlocksApiEnabled())
+    assertThat(config.validatorClient().getValidatorConfig().isBlindedBeaconBlocksEnabled())
         .isTrue();
   }
 
@@ -129,7 +129,26 @@ public class ValidatorOptionsTest extends AbstractBeaconNodeCommandTest {
   public void shouldNotUseBlindedBeaconBlocksByDefault() {
     final String[] args = {};
     final TekuConfiguration config = getTekuConfigurationFromArguments(args);
-    assertThat(config.validatorClient().getValidatorConfig().isBlindedBeaconBlocksApiEnabled())
+    assertThat(config.validatorClient().getValidatorConfig().isBlindedBeaconBlocksEnabled())
         .isFalse();
+  }
+
+  @Test
+  public void shouldEnableMevBoost() {
+    final String[] args = {
+      "--Xvalidators-proposer-mev-boost-enabled",
+      "true",
+      "--Xvalidators-proposer-blinded-blocks-enabled",
+      "true"
+    };
+    final TekuConfiguration config = getTekuConfigurationFromArguments(args);
+    assertThat(config.validatorClient().getValidatorConfig().isProposerMevBoostEnabled()).isTrue();
+  }
+
+  @Test
+  public void shouldNotUseMevBoostByDefault() {
+    final String[] args = {};
+    final TekuConfiguration config = getTekuConfigurationFromArguments(args);
+    assertThat(config.validatorClient().getValidatorConfig().isProposerMevBoostEnabled()).isFalse();
   }
 }

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/ValidatorOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/ValidatorOptionsTest.java
@@ -134,15 +134,12 @@ public class ValidatorOptionsTest extends AbstractBeaconNodeCommandTest {
   }
 
   @Test
-  public void shouldEnableMevBoost() {
-    final String[] args = {
-      "--Xvalidators-proposer-mev-boost-enabled",
-      "true",
-      "--Xvalidators-proposer-blinded-blocks-enabled",
-      "true"
-    };
+  public void shouldEnableMevBoostWithBlindedBlocks() {
+    final String[] args = {"--Xvalidators-proposer-mev-boost-enabled", "true"};
     final TekuConfiguration config = getTekuConfigurationFromArguments(args);
     assertThat(config.validatorClient().getValidatorConfig().isProposerMevBoostEnabled()).isTrue();
+    assertThat(config.validatorClient().getValidatorConfig().isBlindedBeaconBlocksEnabled())
+        .isTrue();
   }
 
   @Test

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
@@ -60,7 +60,7 @@ public class ValidatorConfig {
   private final Optional<Eth1Address> proposerDefaultFeeRecipient;
   private final Optional<String> proposerConfigSource;
   private final boolean refreshProposerConfigFromSource;
-  private final boolean blindedBeaconBlocksApiEnabled;
+  private final boolean blindedBeaconBlocksEnabled;
   private final boolean proposerMevBoostEnabled;
 
   private ValidatorConfig(
@@ -83,7 +83,7 @@ public class ValidatorConfig {
       final Optional<String> proposerConfigSource,
       final boolean refreshProposerConfigFromSource,
       final boolean proposerMevBoostEnabled,
-      final boolean blindedBeaconBlocksApiEnabled) {
+      final boolean blindedBeaconBlocksEnabled) {
     this.validatorKeys = validatorKeys;
     this.validatorExternalSignerPublicKeySources = validatorExternalSignerPublicKeySources;
     this.validatorExternalSignerUrl = validatorExternalSignerUrl;
@@ -105,7 +105,7 @@ public class ValidatorConfig {
     this.proposerDefaultFeeRecipient = proposerDefaultFeeRecipient;
     this.proposerConfigSource = proposerConfigSource;
     this.refreshProposerConfigFromSource = refreshProposerConfigFromSource;
-    this.blindedBeaconBlocksApiEnabled = blindedBeaconBlocksApiEnabled;
+    this.blindedBeaconBlocksEnabled = blindedBeaconBlocksEnabled;
     this.proposerMevBoostEnabled = proposerMevBoostEnabled;
   }
 
@@ -180,8 +180,8 @@ public class ValidatorConfig {
     return refreshProposerConfigFromSource;
   }
 
-  public boolean isBlindedBeaconBlocksApiEnabled() {
-    return blindedBeaconBlocksApiEnabled;
+  public boolean isBlindedBeaconBlocksEnabled() {
+    return blindedBeaconBlocksEnabled;
   }
 
   public boolean isProposerMevBoostEnabled() {
@@ -222,7 +222,7 @@ public class ValidatorConfig {
     private boolean refreshProposerConfigFromSource =
         DEFAULT_VALIDATOR_PROPOSER_CONFIG_REFRESH_ENABLED;
     private boolean proposerMevBoostEnabled = DEFAULT_VALIDATOR_PROPOSER_MEV_BOOST_ENABLED;
-    private boolean blindedBlocksApiEnabled = DEFAULT_VALIDATOR_BLINDED_BLOCKS_ENABLED;
+    private boolean blindedBlocksEnabled = DEFAULT_VALIDATOR_BLINDED_BLOCKS_ENABLED;
 
     private Builder() {}
 
@@ -353,8 +353,8 @@ public class ValidatorConfig {
       return this;
     }
 
-    public Builder blindedBeaconBlocksApiEnabled(final boolean blindedBeaconBlockEnabled) {
-      this.blindedBlocksApiEnabled = blindedBeaconBlockEnabled;
+    public Builder blindedBeaconBlocksEnabled(final boolean blindedBeaconBlockEnabled) {
+      this.blindedBlocksEnabled = blindedBeaconBlockEnabled;
       return this;
     }
 
@@ -363,6 +363,7 @@ public class ValidatorConfig {
       validateExternalSignerKeystoreAndPasswordFileConfig();
       validateExternalSignerTruststoreAndPasswordFileConfig();
       validateExternalSignerURLScheme();
+      validateMevBoostAndBlindedBlocks();
       return new ValidatorConfig(
           validatorKeys,
           validatorExternalSignerPublicKeySources,
@@ -383,7 +384,7 @@ public class ValidatorConfig {
           proposerConfigSource,
           refreshProposerConfigFromSource,
           proposerMevBoostEnabled,
-          blindedBlocksApiEnabled);
+          blindedBlocksEnabled);
     }
 
     private void validateExternalSignerUrlAndPublicKeys() {
@@ -429,6 +430,14 @@ public class ValidatorConfig {
                   validatorExternalSignerUrl);
           throw new InvalidConfigurationException(errorMessage);
         }
+      }
+    }
+
+    private void validateMevBoostAndBlindedBlocks() {
+      if (proposerMevBoostEnabled && !blindedBlocksEnabled) {
+        final String errorMessage =
+            "Invalid configuration. '--Xvalidators-proposer-mev-boost-enabled' requires '--Xvalidators-proposer-blinded-blocks-enabled' to be enabled as well.";
+        throw new InvalidConfigurationException(errorMessage);
       }
     }
 

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
@@ -23,11 +23,14 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.exceptions.InvalidConfigurationException;
 import tech.pegasys.teku.spec.datastructures.eth1.Eth1Address;
 
 public class ValidatorConfig {
+  private static final Logger LOG = LogManager.getLogger();
 
   private static final int DEFAULT_REST_API_PORT = 5051;
   public static final String DEFAULT_BEACON_NODE_API_ENDPOINT =
@@ -435,9 +438,9 @@ public class ValidatorConfig {
 
     private void validateMevBoostAndBlindedBlocks() {
       if (proposerMevBoostEnabled && !blindedBlocksEnabled) {
-        final String errorMessage =
-            "Invalid configuration. '--Xvalidators-proposer-mev-boost-enabled' requires '--Xvalidators-proposer-blinded-blocks-enabled' to be enabled as well.";
-        throw new InvalidConfigurationException(errorMessage);
+        LOG.info(
+            "'--Xvalidators-proposer-mev-boost-enabled' requires '--Xvalidators-proposer-blinded-blocks-enabled', enabling it");
+        blindedBlocksEnabled = true;
       }
     }
 

--- a/validator/api/src/test/java/tech/pegasys/teku/validator/api/ValidatorConfigTest.java
+++ b/validator/api/src/test/java/tech/pegasys/teku/validator/api/ValidatorConfigTest.java
@@ -13,8 +13,6 @@
 
 package tech.pegasys.teku.validator.api;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.nio.file.Path;
@@ -165,12 +163,6 @@ class ValidatorConfigTest {
             .build();
 
     verifyProposerConfigOrProposerDefaultFeeRecipientNotThrow(config);
-  }
-
-  @Test
-  public void shouldThrowIfMevBoostIsWithoutBlindedBeaconBlocks() {
-    assertThatThrownBy(() -> configBuilder.proposerMevBoostEnabled(true).build())
-        .isInstanceOf(InvalidConfigurationException.class);
   }
 
   void verifyProposerConfigOrProposerDefaultFeeRecipientNotThrow(final ValidatorConfig config) {

--- a/validator/api/src/test/java/tech/pegasys/teku/validator/api/ValidatorConfigTest.java
+++ b/validator/api/src/test/java/tech/pegasys/teku/validator/api/ValidatorConfigTest.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.teku.validator.api;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.nio.file.Path;
@@ -163,6 +165,12 @@ class ValidatorConfigTest {
             .build();
 
     verifyProposerConfigOrProposerDefaultFeeRecipientNotThrow(config);
+  }
+
+  @Test
+  public void shouldThrowIfMevBoostIsWithoutBlindedBeaconBlocks() {
+    assertThatThrownBy(() -> configBuilder.proposerMevBoostEnabled(true).build())
+        .isInstanceOf(InvalidConfigurationException.class);
   }
 
   void verifyProposerConfigOrProposerDefaultFeeRecipientNotThrow(final ValidatorConfig config) {

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
@@ -99,8 +99,6 @@ public class ValidatorClientService extends Service {
     final AsyncRunner asyncRunner = services.createAsyncRunner("validator");
     final boolean generateEarlyAttestations =
         config.getValidatorConfig().generateEarlyAttestations();
-    final boolean blindedBlocksEnabled =
-        config.getValidatorConfig().isBlindedBeaconBlocksApiEnabled();
     final BeaconNodeApi beaconNodeApi =
         config
             .getValidatorConfig()
@@ -112,8 +110,7 @@ public class ValidatorClientService extends Service {
                         asyncRunner,
                         endpoint,
                         config.getSpec(),
-                        generateEarlyAttestations,
-                        blindedBlocksEnabled))
+                        generateEarlyAttestations))
             .orElseGet(
                 () ->
                     InProcessBeaconNodeApi.create(
@@ -194,7 +191,11 @@ public class ValidatorClientService extends Service {
     this.validatorIndexProvider =
         new ValidatorIndexProvider(validators, validatorApiChannel, asyncRunner);
     final BlockDutyFactory blockDutyFactory =
-        new BlockDutyFactory(forkProvider, validatorApiChannel, spec);
+        new BlockDutyFactory(
+            forkProvider,
+            validatorApiChannel,
+            config.getValidatorConfig().isBlindedBeaconBlocksEnabled(),
+            spec);
     final AttestationDutyFactory attestationDutyFactory =
         new AttestationDutyFactory(spec, forkProvider, validatorApiChannel);
     final BeaconCommitteeSubscriptions beaconCommitteeSubscriptions =

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/BlockDutyFactory.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/BlockDutyFactory.java
@@ -24,20 +24,23 @@ public class BlockDutyFactory implements DutyFactory<BlockProductionDuty, Duty> 
   private final ForkProvider forkProvider;
   private final ValidatorApiChannel validatorApiChannel;
   private final Spec spec;
+  private final boolean useBlindedBlock;
 
   public BlockDutyFactory(
       final ForkProvider forkProvider,
       final ValidatorApiChannel validatorApiChannel,
+      final boolean useBlindedBlock,
       final Spec spec) {
     this.forkProvider = forkProvider;
-
+    this.useBlindedBlock = useBlindedBlock;
     this.validatorApiChannel = validatorApiChannel;
     this.spec = spec;
   }
 
   @Override
   public BlockProductionDuty createProductionDuty(final UInt64 slot, final Validator validator) {
-    return new BlockProductionDuty(validator, slot, forkProvider, validatorApiChannel, spec);
+    return new BlockProductionDuty(
+        validator, slot, forkProvider, validatorApiChannel, useBlindedBlock, spec);
   }
 
   @Override

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/BlockProductionDuty.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/BlockProductionDuty.java
@@ -35,6 +35,7 @@ public class BlockProductionDuty implements Duty {
   private final UInt64 slot;
   private final ForkProvider forkProvider;
   private final ValidatorApiChannel validatorApiChannel;
+  private final boolean useBlindedBlock;
   private final Spec spec;
 
   public BlockProductionDuty(
@@ -42,11 +43,13 @@ public class BlockProductionDuty implements Duty {
       final UInt64 slot,
       final ForkProvider forkProvider,
       final ValidatorApiChannel validatorApiChannel,
+      final boolean useBlindedBlock,
       final Spec spec) {
     this.validator = validator;
     this.slot = slot;
     this.forkProvider = forkProvider;
     this.validatorApiChannel = validatorApiChannel;
+    this.useBlindedBlock = useBlindedBlock;
     this.spec = spec;
   }
 
@@ -82,7 +85,7 @@ public class BlockProductionDuty implements Duty {
 
   public SafeFuture<Optional<BeaconBlock>> createUnsignedBlock(final BLSSignature randaoReveal) {
     return validatorApiChannel.createUnsignedBlock(
-        slot, randaoReveal, validator.getGraffiti(), false);
+        slot, randaoReveal, validator.getGraffiti(), useBlindedBlock);
   }
 
   public SafeFuture<BLSSignature> createRandaoReveal(final ForkInfo forkInfo) {

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApi.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApi.java
@@ -54,8 +54,7 @@ public class RemoteBeaconNodeApi implements BeaconNodeApi {
       final AsyncRunner asyncRunner,
       final URI beaconNodeApiEndpoint,
       final Spec spec,
-      final boolean generateEarlyAttestations,
-      final boolean blindedBlocksEnabled) {
+      final boolean generateEarlyAttestations) {
 
     final OkHttpClient.Builder httpClientBuilder =
         new OkHttpClient.Builder().readTimeout(READ_TIMEOUT);
@@ -70,7 +69,7 @@ public class RemoteBeaconNodeApi implements BeaconNodeApi {
     apiEndpoint = apiEndpoint.newBuilder().username("").password("").build();
     final OkHttpClient okHttpClient = httpClientBuilder.build();
     final OkHttpValidatorRestApiClient apiClient =
-        new OkHttpValidatorRestApiClient(apiEndpoint, okHttpClient, blindedBlocksEnabled);
+        new OkHttpValidatorRestApiClient(apiEndpoint, okHttpClient);
 
     final ValidatorApiChannel validatorApiChannel =
         new MetricRecordingValidatorApiChannel(

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
@@ -104,15 +104,10 @@ public class OkHttpValidatorRestApiClient implements ValidatorRestApiClient {
   private final JsonProvider jsonProvider = new JsonProvider();
   private final OkHttpClient httpClient;
   private final HttpUrl baseEndpoint;
-  private final boolean blindedBlocksEnabled;
 
-  public OkHttpValidatorRestApiClient(
-      final HttpUrl baseEndpoint,
-      final OkHttpClient okHttpClient,
-      final boolean blindedBlocksEnabled) {
+  public OkHttpValidatorRestApiClient(final HttpUrl baseEndpoint, final OkHttpClient okHttpClient) {
     this.baseEndpoint = baseEndpoint;
     this.httpClient = okHttpClient;
-    this.blindedBlocksEnabled = blindedBlocksEnabled;
   }
 
   public Optional<GetSpecResponse> getConfigSpec() {
@@ -174,7 +169,7 @@ public class OkHttpValidatorRestApiClient implements ValidatorRestApiClient {
     queryParams.put("randao_reveal", encodeQueryParam(randaoReveal));
     graffiti.ifPresent(bytes32 -> queryParams.put("graffiti", encodeQueryParam(bytes32)));
 
-    if (blindedBlocksEnabled || blinded) {
+    if (blinded) {
       return createUnsignedBlindedBlock(pathParams, queryParams);
     }
 

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApiTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApiTest.java
@@ -34,7 +34,7 @@ class RemoteBeaconNodeApiTest {
     assertThatThrownBy(
             () ->
                 RemoteBeaconNodeApi.create(
-                    serviceConfig, asyncRunner, new URI("notvalid"), spec, false, false))
+                    serviceConfig, asyncRunner, new URI("notvalid"), spec, false))
         .hasMessageContaining("Failed to convert remote api endpoint");
   }
 }

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClientTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClientTest.java
@@ -84,7 +84,7 @@ class OkHttpValidatorRestApiClientTest {
   public void beforeEach() throws Exception {
     mockWebServer.start();
     okHttpClient = new OkHttpClient();
-    apiClient = new OkHttpValidatorRestApiClient(mockWebServer.url("/"), okHttpClient, false);
+    apiClient = new OkHttpValidatorRestApiClient(mockWebServer.url("/"), okHttpClient);
   }
 
   @AfterEach
@@ -256,7 +256,7 @@ class OkHttpValidatorRestApiClientTest {
                 asJson(
                     new GetNewBlindedBlockResponse(
                         SpecMilestone.BELLATRIX, new BlindedBlockBellatrix(expectedBeaconBlock)))));
-    apiClient = new OkHttpValidatorRestApiClient(mockWebServer.url("/"), okHttpClient, true);
+    apiClient = new OkHttpValidatorRestApiClient(mockWebServer.url("/"), okHttpClient);
     Optional<BeaconBlock> maybeBlock =
         apiClient.createUnsignedBlock(slot, blsSignature, graffiti, true);
     assertThat(maybeBlock).isPresent();
@@ -298,9 +298,7 @@ class OkHttpValidatorRestApiClientTest {
         isBlindedBlocksEnabled
             ? schemaObjectsBellatrix.signedBlindedBlock()
             : schemaObjectsBellatrix.signedBeaconBlock();
-    apiClient =
-        new OkHttpValidatorRestApiClient(
-            mockWebServer.url("/"), okHttpClient, isBlindedBlocksEnabled);
+    apiClient = new OkHttpValidatorRestApiClient(mockWebServer.url("/"), okHttpClient);
 
     // Block has been successfully broadcast, validated and imported
     mockWebServer.enqueue(new MockResponse().setResponseCode(SC_OK).setBody(asJson(blockRoot)));
@@ -731,7 +729,7 @@ class OkHttpValidatorRestApiClientTest {
       throws Exception {
     final HttpUrl url =
         mockWebServer.url("/").newBuilder().username("user").password("password").build();
-    apiClient = new OkHttpValidatorRestApiClient(url, okHttpClient, false);
+    apiClient = new OkHttpValidatorRestApiClient(url, okHttpClient);
     mockWebServer.enqueue(new MockResponse().setResponseCode(SC_NO_CONTENT));
 
     apiClient.getGenesis();


### PR DESCRIPTION
## PR Description

I renamed `--Xvalidators-blinded-blocks-api-enabled` to `--Xvalidators-proposer-blinded-blocks-enabled` and moved in `ValidatorProposerOptions`

The flag now is used in `BlockDutyFactory` and `BlockProductionDuty`, no more in the `OkHttpValidatorRestApiClient` which now choose the right endpoint based on blinded flag at runtime.

Enabling `--Xvalidators-proposer-mev-boost-enabled` automatically enables `--Xvalidators-proposer-blinded-blocks-enabled`

Add a signer test for blinded block

## Fixed Issue(s)
fixes #5260

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
