### PR TITLE
Allow fork choice store to save and retrieve time in milliseconds

### DIFF
--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
@@ -256,7 +256,7 @@ public class ForkChoiceTestExecutor implements TestExecutor {
 
         case "time":
           final UInt64 expectedTime = getUInt64(checks, checkType);
-          assertThat(store.getTime()).isEqualTo(expectedTime);
+          assertThat(store.getTimeSeconds()).isEqualTo(expectedTime);
           break;
 
         case "justified_checkpoint_root":

--- a/ethereum/spec/build.gradle
+++ b/ethereum/spec/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     implementation project(':infrastructure:events')
     implementation project(':infrastructure:io')
     implementation project(':infrastructure:logging')
+    implementation project(':infrastructure:time')
     implementation project(':ethereum:pow:api')
 
     implementation 'com.google.code.gson:gson'

--- a/ethereum/spec/build.gradle
+++ b/ethereum/spec/build.gradle
@@ -65,4 +65,5 @@ dependencies {
     testFixturesImplementation project(':infrastructure:bytes')
     testFixturesImplementation testFixtures(project(':infrastructure:bls'))
     testFixturesImplementation project(':infrastructure:events')
+    testFixturesImplementation project(':infrastructure:time')
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -392,7 +392,7 @@ public class Spec {
   }
 
   public UInt64 getCurrentSlot(ReadOnlyStore store) {
-    return atTime(store.getGenesisTime(), store.getTime())
+    return atTime(store.getGenesisTime(), store.getTimeSeconds())
         .getForkChoiceUtil()
         .getCurrentSlot(store);
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/MutableStore.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/MutableStore.java
@@ -33,6 +33,8 @@ public interface MutableStore extends ReadOnlyStore {
 
   void setTime(UInt64 time);
 
+  void setTimeMillis(UInt64 timeMillis);
+
   void setGenesisTime(UInt64 genesisTime);
 
   void setJustifiedCheckpoint(Checkpoint justifiedCheckpoint);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/MutableStore.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/MutableStore.java
@@ -31,7 +31,7 @@ public interface MutableStore extends ReadOnlyStore {
 
   void putStateRoot(Bytes32 stateRoot, SlotAndBlockRoot slotAndBlockRoot);
 
-  void setTime(UInt64 time);
+  void setTimeSeconds(UInt64 timeSeconds);
 
   void setTimeMillis(UInt64 timeMillis);
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ReadOnlyStore.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ReadOnlyStore.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.teku.spec.datastructures.forkchoice;
 
+import static tech.pegasys.teku.infrastructure.time.TimeUtilities.millisToSeconds;
+
 import java.util.Collection;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
@@ -31,7 +33,9 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 
 public interface ReadOnlyStore {
 
-  UInt64 getTime();
+  default UInt64 getTimeSeconds() {
+    return millisToSeconds(getTimeMillis());
+  }
 
   /**
    * Returns time in milliseconds to allow for more fine-grained time calculations

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ReadOnlyStore.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ReadOnlyStore.java
@@ -33,6 +33,13 @@ public interface ReadOnlyStore {
 
   UInt64 getTime();
 
+  /**
+   * Returns time in milliseconds to allow for more fine-grained time calculations
+   *
+   * @return the time in milliseconds
+   */
+  UInt64 getTimeMillis();
+
   UInt64 getGenesisTime();
 
   /**

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
@@ -57,7 +57,8 @@ public class ForkChoiceUtil {
   }
 
   public UInt64 getSlotsSinceGenesis(ReadOnlyStore store, boolean useUnixTime) {
-    UInt64 time = useUnixTime ? UInt64.valueOf(Instant.now().getEpochSecond()) : store.getTime();
+    UInt64 time =
+        useUnixTime ? UInt64.valueOf(Instant.now().getEpochSecond()) : store.getTimeSeconds();
     return getCurrentSlot(time, store.getGenesisTime());
   }
 
@@ -169,13 +170,13 @@ public class ForkChoiceUtil {
   public void onTick(MutableStore store, UInt64 time) {
     // To be extra safe check both time and genesisTime, although time should always be >=
     // genesisTime
-    if (store.getTime().isGreaterThan(time) || store.getGenesisTime().isGreaterThan(time)) {
+    if (store.getTimeSeconds().isGreaterThan(time) || store.getGenesisTime().isGreaterThan(time)) {
       return;
     }
     UInt64 previousSlot = getCurrentSlot(store);
 
     // Update store time
-    store.setTime(time);
+    store.setTimeSeconds(time);
 
     UInt64 currentSlot = getCurrentSlot(store);
 

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtilTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtilTest.java
@@ -184,20 +184,20 @@ class ForkChoiceUtilTest {
   void onTick_shouldExitImmediatelyWhenCurrentTimeIsBeforeGenesisTime() {
     final MutableStore store = mock(MutableStore.class);
     when(store.getGenesisTime()).thenReturn(UInt64.valueOf(3000));
-    when(store.getTime()).thenReturn(UInt64.ZERO);
+    when(store.getTimeSeconds()).thenReturn(UInt64.ZERO);
     forkChoiceUtil.onTick(store, UInt64.valueOf(2000));
 
-    verify(store, never()).setTime(any());
+    verify(store, never()).setTimeSeconds(any());
   }
 
   @Test
   void onTick_shouldExitImmediatelyWhenCurrentTimeIsBeforeStoreTime() {
     final MutableStore store = mock(MutableStore.class);
     when(store.getGenesisTime()).thenReturn(UInt64.valueOf(3000));
-    when(store.getTime()).thenReturn(UInt64.valueOf(5000));
+    when(store.getTimeSeconds()).thenReturn(UInt64.valueOf(5000));
     forkChoiceUtil.onTick(store, UInt64.valueOf(4000));
 
-    verify(store, never()).setTime(any());
+    verify(store, never()).setTimeSeconds(any());
   }
 
   @Test
@@ -249,7 +249,7 @@ class ForkChoiceUtilTest {
     }
 
     final UInt64 genesisTime = UInt64.valueOf(1982239L);
-    when(store.getTime())
+    when(store.getTimeSeconds())
         .thenReturn(spec.getSlotStartTime(UInt64.valueOf(currentSlot), genesisTime));
     when(store.getGenesisTime()).thenReturn(genesisTime);
     return store;

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
@@ -36,7 +36,6 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 
 public class TestStoreImpl implements MutableStore, VoteUpdater {
   private final Spec spec;
-  protected UInt64 time;
   protected UInt64 timeMillis;
   protected UInt64 genesisTime;
   protected final Optional<Checkpoint> initialCheckpoint;
@@ -63,7 +62,6 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
       final Map<Checkpoint, BeaconState> checkpointStates,
       final Map<UInt64, VoteTracker> votes) {
     this.spec = spec;
-    this.time = time;
     this.timeMillis = secondsToMillis(time);
     this.genesisTime = genesisTime;
     this.initialCheckpoint = initialCheckpoint;
@@ -77,11 +75,6 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
   }
 
   // Readonly methods
-  @Override
-  public UInt64 getTime() {
-    return time;
-  }
-
   @Override
   public UInt64 getTimeMillis() {
     return timeMillis;
@@ -262,8 +255,8 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
   }
 
   @Override
-  public void setTime(final UInt64 time) {
-    this.time = time;
+  public void setTimeSeconds(final UInt64 timeSeconds) {
+    setTimeMillis(secondsToMillis(timeSeconds));
   }
 
   @Override

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.teku.spec.datastructures.forkchoice;
 
+import static tech.pegasys.teku.infrastructure.time.TimeUtilities.secondsToMillis;
+
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -35,6 +37,7 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 public class TestStoreImpl implements MutableStore, VoteUpdater {
   private final Spec spec;
   protected UInt64 time;
+  protected UInt64 timeMillis;
   protected UInt64 genesisTime;
   protected final Optional<Checkpoint> initialCheckpoint;
   protected Checkpoint justifiedCheckpoint;
@@ -61,6 +64,7 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
       final Map<UInt64, VoteTracker> votes) {
     this.spec = spec;
     this.time = time;
+    this.timeMillis = secondsToMillis(time);
     this.genesisTime = genesisTime;
     this.initialCheckpoint = initialCheckpoint;
     this.justifiedCheckpoint = justifiedCheckpoint;
@@ -76,6 +80,11 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
   @Override
   public UInt64 getTime() {
     return time;
+  }
+
+  @Override
+  public UInt64 getTimeMillis() {
+    return timeMillis;
   }
 
   @Override
@@ -255,6 +264,11 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
   @Override
   public void setTime(final UInt64 time) {
     this.time = time;
+  }
+
+  @Override
+  public void setTimeMillis(final UInt64 time) {
+    this.timeMillis = time;
   }
 
   @Override

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -327,7 +327,7 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
     if (proposerBoostEnabled && spec.getCurrentSlot(transaction).equals(block.getSlot())) {
       final int secondsPerSlot = spec.getSecondsPerSlot(block.getSlot());
       final UInt64 timeIntoSlot =
-          transaction.getTime().minus(transaction.getGenesisTime()).mod(secondsPerSlot);
+          transaction.getTimeSeconds().minus(transaction.getGenesisTime()).mod(secondsPerSlot);
 
       if (isBeforeAttestingInterval(secondsPerSlot, timeIntoSlot)) {
         transaction.setProposerBoostRoot(block.getRoot());

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AttestationValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AttestationValidator.java
@@ -97,7 +97,7 @@ public class AttestationValidator {
     // MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance) -- i.e. attestation.data.slot +
     // ATTESTATION_PROPAGATION_SLOT_RANGE >= current_slot >= attestation.data.slot (a client MAY
     // queue future attestations for processing at the appropriate slot).
-    final UInt64 currentTimeMillis = secondsToMillis(recentChainData.getStore().getTime());
+    final UInt64 currentTimeMillis = recentChainData.getStore().getTimeMillis();
     if (isCurrentTimeAfterAttestationPropagationSlotRange(currentTimeMillis, attestation)
         || isFromFarFuture(attestation, currentTimeMillis)) {
       return completedFuture(InternalValidationResultWithState.ignore());

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlockValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlockValidator.java
@@ -150,7 +150,7 @@ public class BlockValidator {
     ReadOnlyStore store = recentChainData.getStore();
     final long disparityInSeconds = Math.round((float) MAXIMUM_GOSSIP_CLOCK_DISPARITY / 1000.0);
     final UInt64 maxOffset = UInt64.valueOf(disparityInSeconds);
-    final UInt64 maxTime = store.getTime().plus(maxOffset);
+    final UInt64 maxTime = store.getTimeSeconds().plus(maxOffset);
     UInt64 maxCurrSlot = spec.getCurrentSlot(maxTime, store.getGenesisTime());
     return block.getSlot().compareTo(maxCurrSlot) > 0;
   }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/AttestationValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/AttestationValidatorTest.java
@@ -165,7 +165,7 @@ class AttestationValidatorTest {
     final UInt64 slot = ATTESTATION_PROPAGATION_SLOT_RANGE.plus(ONE);
     chainUpdater.setCurrentSlot(slot);
     // Add one more second to get past the MAXIMUM_GOSSIP_CLOCK_DISPARITY
-    chainUpdater.setTime(recentChainData.getStore().getTime().plus(ONE));
+    chainUpdater.setTime(recentChainData.getStore().getTimeSeconds().plus(ONE));
 
     assertThat(validate(attestation).code()).isEqualTo(IGNORE);
   }

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/BeaconChainUtil.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/BeaconChainUtil.java
@@ -192,7 +192,7 @@ public class BeaconChainUtil {
   public void setTime(final UInt64 time) {
     checkState(!recentChainData.isPreGenesis(), "Cannot set time before genesis");
     final StoreTransaction tx = recentChainData.startStoreTransaction();
-    tx.setTime(time);
+    tx.setTimeSeconds(time);
     tx.commit().join();
   }
 

--- a/fork-choice-tests/src/integration-test/java/tech/pegasys/teku/forkChoiceTests/ForkChoiceIntegrationTest.java
+++ b/fork-choice-tests/src/integration-test/java/tech/pegasys/teku/forkChoiceTests/ForkChoiceIntegrationTest.java
@@ -197,7 +197,7 @@ public class ForkChoiceIntegrationTest {
       if (step instanceof UInt64) {
         UpdatableStore.StoreTransaction transaction = storageClient.startStoreTransaction();
         while (SPEC.getCurrentSlot(transaction).compareTo((UInt64) step) < 0) {
-          SPEC.onTick(transaction, transaction.getTime().plus(UInt64.ONE));
+          SPEC.onTick(transaction, transaction.getTimeSeconds().plus(UInt64.ONE));
         }
         assertEquals(step, SPEC.getCurrentSlot(transaction));
         transaction.commit().join();

--- a/storage/build.gradle
+++ b/storage/build.gradle
@@ -14,6 +14,7 @@ dependencies {
   implementation project(':infrastructure:logging')
   implementation project(':infrastructure:metrics')
   implementation project(':infrastructure:ssz')
+  implementation project(':infrastructure:time')
   implementation project(':pow')
   implementation project(':storage:api')
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
@@ -84,7 +84,6 @@ class Store implements UpdatableStore {
   final ForkChoiceStrategy forkChoiceStrategy;
 
   private final Optional<Checkpoint> initialCheckpoint;
-  UInt64 time;
   UInt64 timeMillis;
   UInt64 genesisTime;
   AnchorPoint finalizedAnchor;
@@ -135,7 +134,6 @@ class Store implements UpdatableStore {
     // Store instance variables
     this.initialCheckpoint = initialCheckpoint;
     this.hotStatePersistenceFrequencyInEpochs = hotStatePersistenceFrequencyInEpochs;
-    this.time = time;
     this.timeMillis = secondsToMillis(time);
     this.genesisTime = genesisTime;
     this.justifiedCheckpoint = justifiedCheckpoint;
@@ -296,16 +294,6 @@ class Store implements UpdatableStore {
   @Override
   public VoteUpdater startVoteUpdate(final VoteUpdateChannel voteUpdateChannel) {
     return new StoreVoteUpdater(this, lock, voteUpdateChannel);
-  }
-
-  @Override
-  public UInt64 getTime() {
-    readLock.lock();
-    try {
-      return time;
-    } finally {
-      readLock.unlock();
-    }
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
@@ -17,6 +17,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static tech.pegasys.teku.dataproviders.generators.StateAtSlotTask.AsyncStateProvider.fromAnchor;
 import static tech.pegasys.teku.dataproviders.lookup.BlockProvider.fromDynamicMap;
 import static tech.pegasys.teku.dataproviders.lookup.BlockProvider.fromMap;
+import static tech.pegasys.teku.infrastructure.time.TimeUtilities.secondsToMillis;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -84,6 +85,7 @@ class Store implements UpdatableStore {
 
   private final Optional<Checkpoint> initialCheckpoint;
   UInt64 time;
+  UInt64 timeMillis;
   UInt64 genesisTime;
   AnchorPoint finalizedAnchor;
   Checkpoint justifiedCheckpoint;
@@ -134,6 +136,7 @@ class Store implements UpdatableStore {
     this.initialCheckpoint = initialCheckpoint;
     this.hotStatePersistenceFrequencyInEpochs = hotStatePersistenceFrequencyInEpochs;
     this.time = time;
+    this.timeMillis = secondsToMillis(time);
     this.genesisTime = genesisTime;
     this.justifiedCheckpoint = justifiedCheckpoint;
     this.bestJustifiedCheckpoint = bestJustifiedCheckpoint;
@@ -300,6 +303,16 @@ class Store implements UpdatableStore {
     readLock.lock();
     try {
       return time;
+    } finally {
+      readLock.unlock();
+    }
+  }
+
+  @Override
+  public UInt64 getTimeMillis() {
+    readLock.lock();
+    try {
+      return timeMillis;
     } finally {
       readLock.unlock();
     }

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransaction.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransaction.java
@@ -53,6 +53,7 @@ class StoreTransaction implements UpdatableStore.StoreTransaction {
   private final StorageUpdateChannel storageUpdateChannel;
 
   Optional<UInt64> time = Optional.empty();
+  Optional<UInt64> timeMillis = Optional.empty();
   Optional<UInt64> genesisTime = Optional.empty();
   Optional<Checkpoint> justifiedCheckpoint = Optional.empty();
   Optional<Checkpoint> finalizedCheckpoint = Optional.empty();
@@ -106,6 +107,17 @@ class StoreTransaction implements UpdatableStore.StoreTransaction {
         storeTime,
         time);
     this.time = Optional.of(time);
+  }
+
+  @Override
+  public void setTimeMillis(UInt64 timeMillis) {
+    final UInt64 storeTimeMillis = store.getTimeMillis();
+    checkArgument(
+        timeMillis.isGreaterThanOrEqualTo(storeTimeMillis),
+        "Cannot revert time millis from %s to %s",
+        storeTimeMillis,
+        timeMillis);
+    this.timeMillis = Optional.of(timeMillis);
   }
 
   @Override
@@ -197,6 +209,11 @@ class StoreTransaction implements UpdatableStore.StoreTransaction {
   @Override
   public UInt64 getTime() {
     return time.orElseGet(store::getTime);
+  }
+
+  @Override
+  public UInt64 getTimeMillis() {
+    return timeMillis.orElseGet(store::getTimeMillis);
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransaction.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransaction.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.storage.store;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static tech.pegasys.teku.dataproviders.generators.StateAtSlotTask.AsyncStateProvider.fromBlockAndState;
+import static tech.pegasys.teku.infrastructure.time.TimeUtilities.secondsToMillis;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -52,7 +53,6 @@ class StoreTransaction implements UpdatableStore.StoreTransaction {
   private final ReadWriteLock lock;
   private final StorageUpdateChannel storageUpdateChannel;
 
-  Optional<UInt64> time = Optional.empty();
   Optional<UInt64> timeMillis = Optional.empty();
   Optional<UInt64> genesisTime = Optional.empty();
   Optional<Checkpoint> justifiedCheckpoint = Optional.empty();
@@ -99,14 +99,21 @@ class StoreTransaction implements UpdatableStore.StoreTransaction {
   }
 
   @Override
-  public void setTime(UInt64 time) {
-    final UInt64 storeTime = store.getTime();
+  public void setTimeSeconds(UInt64 timeSeconds) {
+    final UInt64 storeTime = store.getTimeSeconds();
     checkArgument(
-        time.isGreaterThanOrEqualTo(storeTime),
-        "Cannot revert time from %s to %s",
+        timeSeconds.isGreaterThanOrEqualTo(storeTime),
+        "Cannot revert time (seconds) from %s to %s",
         storeTime,
-        time);
-    this.time = Optional.of(time);
+        timeSeconds);
+    UInt64 timeMillis = secondsToMillis(timeSeconds);
+    if (updatingMillisIsRequired(timeMillis)) {
+      setTimeMillis(timeMillis);
+    }
+  }
+
+  private boolean updatingMillisIsRequired(UInt64 timeMillis) {
+    return timeMillis.isGreaterThan(store.getTimeMillis());
   }
 
   @Override
@@ -114,7 +121,7 @@ class StoreTransaction implements UpdatableStore.StoreTransaction {
     final UInt64 storeTimeMillis = store.getTimeMillis();
     checkArgument(
         timeMillis.isGreaterThanOrEqualTo(storeTimeMillis),
-        "Cannot revert time millis from %s to %s",
+        "Cannot revert time (millis) from %s to %s",
         storeTimeMillis,
         timeMillis);
     this.timeMillis = Optional.of(timeMillis);
@@ -204,11 +211,6 @@ class StoreTransaction implements UpdatableStore.StoreTransaction {
   @Override
   public void commit(final Runnable onSuccess, final String errorMessage) {
     commit(onSuccess, err -> LOG.error(errorMessage, err));
-  }
-
-  @Override
-  public UInt64 getTime() {
-    return time.orElseGet(store::getTime);
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransactionUpdates.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransactionUpdates.java
@@ -89,6 +89,9 @@ class StoreTransactionUpdates {
   public void applyToStore(final Store store, final UpdateResult updateResult) {
     // Add new data
     tx.time.filter(t -> t.isGreaterThan(store.getTime())).ifPresent(value -> store.time = value);
+    tx.timeMillis
+        .filter(t -> t.isGreaterThan(store.getTimeMillis()))
+        .ifPresent(value -> store.timeMillis = value);
     tx.genesisTime.ifPresent(value -> store.genesisTime = value);
     tx.justifiedCheckpoint.ifPresent(value -> store.justifiedCheckpoint = value);
     tx.bestJustifiedCheckpoint.ifPresent(value -> store.bestJustifiedCheckpoint = value);

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransactionUpdates.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransactionUpdates.java
@@ -88,7 +88,6 @@ class StoreTransactionUpdates {
 
   public void applyToStore(final Store store, final UpdateResult updateResult) {
     // Add new data
-    tx.time.filter(t -> t.isGreaterThan(store.getTime())).ifPresent(value -> store.time = value);
     tx.timeMillis
         .filter(t -> t.isGreaterThan(store.getTimeMillis()))
         .ifPresent(value -> store.timeMillis = value);

--- a/storage/src/test/java/tech/pegasys/teku/storage/client/RecentChainDataTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/client/RecentChainDataTest.java
@@ -125,7 +125,7 @@ class RecentChainDataTest {
     final UInt64 genesisTime = UInt64.valueOf(5000);
     final SignedBlockAndState genesis = chainBuilder.generateGenesis(genesisTime, false);
     recentChainData.initializeFromGenesis(genesis.getState(), UInt64.valueOf(100));
-    assertThat(recentChainData.getStore().getTime()).isEqualTo(genesisTime);
+    assertThat(recentChainData.getStore().getTimeSeconds()).isEqualTo(genesisTime);
   }
 
   @Test
@@ -136,7 +136,7 @@ class RecentChainDataTest {
     final UInt64 time = genesisTime.plus(100);
     final SignedBlockAndState genesis = chainBuilder.generateGenesis(genesisTime, false);
     recentChainData.initializeFromGenesis(genesis.getState(), time);
-    assertThat(recentChainData.getStore().getTime()).isEqualTo(time);
+    assertThat(recentChainData.getStore().getTimeSeconds()).isEqualTo(time);
   }
 
   @Test
@@ -153,7 +153,7 @@ class RecentChainDataTest {
     final UInt64 anchorBlockTime =
         anchorPoint.getBlockSlot().times(genesisSpecConfig.getSecondsPerSlot()).plus(genesisTime);
     recentChainData.initializeFromAnchorPoint(anchorPoint, UInt64.valueOf(100));
-    assertThat(recentChainData.getStore().getTime()).isEqualTo(anchorBlockTime);
+    assertThat(recentChainData.getStore().getTimeSeconds()).isEqualTo(anchorBlockTime);
   }
 
   @Test
@@ -172,7 +172,7 @@ class RecentChainDataTest {
     final UInt64 time = genesisTime.plus(1);
     assertThat(time).isLessThan(anchorBlockTime);
     recentChainData.initializeFromAnchorPoint(anchorPoint, time);
-    assertThat(recentChainData.getStore().getTime()).isEqualTo(anchorBlockTime);
+    assertThat(recentChainData.getStore().getTimeSeconds()).isEqualTo(anchorBlockTime);
   }
 
   @Test
@@ -190,7 +190,7 @@ class RecentChainDataTest {
         anchorPoint.getBlockSlot().times(genesisSpecConfig.getSecondsPerSlot()).plus(genesisTime);
     final UInt64 time = anchorBlockTime.plus(100);
     recentChainData.initializeFromAnchorPoint(anchorPoint, time);
-    assertThat(recentChainData.getStore().getTime()).isEqualTo(time);
+    assertThat(recentChainData.getStore().getTimeSeconds()).isEqualTo(time);
   }
 
   @Test
@@ -309,7 +309,7 @@ class RecentChainDataTest {
     final Checkpoint originalCheckpoint = recentChainData.getStore().getFinalizedCheckpoint();
 
     final StoreTransaction tx = recentChainData.startStoreTransaction();
-    tx.setTime(UInt64.valueOf(11L));
+    tx.setTimeSeconds(UInt64.valueOf(11L));
     tx.commit().reportExceptions();
 
     final Checkpoint currentCheckpoint = recentChainData.getStore().getFinalizedCheckpoint();

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/kvstore/AbstractKvStoreDatabaseTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/kvstore/AbstractKvStoreDatabaseTest.java
@@ -92,7 +92,7 @@ public abstract class AbstractKvStoreDatabaseTest extends AbstractStorageBackedD
             .stateProvider(mock(StateAndBlockSummaryProvider.class))
             .build();
 
-    assertThat(store.getTime()).isEqualTo(genesisTime);
+    assertThat(store.getTimeSeconds()).isEqualTo(genesisTime);
   }
 
   @Test

--- a/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTest.java
@@ -251,6 +251,7 @@ class StoreTest extends AbstractStoreTest {
 
     final Checkpoint genesisCheckpoint = store.getFinalizedCheckpoint();
     final UInt64 initialTime = store.getTime();
+    final UInt64 initialTimeMillis = store.getTimeMillis();
     final UInt64 genesisTime = store.getGenesisTime();
 
     final Checkpoint checkpoint1 = chainBuilder.getCurrentCheckpointForEpoch(UInt64.valueOf(1));
@@ -268,7 +269,10 @@ class StoreTest extends AbstractStoreTest {
     tx.setJustifiedCheckpoint(checkpoint2);
     tx.setBestJustifiedCheckpoint(checkpoint3);
     // Update time
-    tx.setTime(initialTime.plus(UInt64.ONE));
+    UInt64 updatedTime = initialTime.plus(UInt64.ONE);
+    tx.setTime(updatedTime);
+    UInt64 updatedTimeMillis = initialTimeMillis.plus(1300);
+    tx.setTimeMillis(updatedTimeMillis);
     tx.setGenesisTime(genesisTime.plus(UInt64.ONE));
 
     // Check that store is not yet updated
@@ -282,6 +286,7 @@ class StoreTest extends AbstractStoreTest {
     assertThat(store.getFinalizedCheckpoint()).isEqualTo(genesisCheckpoint);
     // Check time
     assertThat(store.getTime()).isEqualTo(initialTime);
+    assertThat(store.getTimeMillis()).isEqualTo(initialTimeMillis);
     assertThat(store.getGenesisTime()).isEqualTo(genesisTime);
 
     // Check that transaction is updated
@@ -296,7 +301,8 @@ class StoreTest extends AbstractStoreTest {
     assertThat(tx.getJustifiedCheckpoint()).isEqualTo(checkpoint2);
     assertThat(tx.getBestJustifiedCheckpoint()).isEqualTo(checkpoint3);
     // Check time
-    assertThat(tx.getTime()).isEqualTo(initialTime.plus(UInt64.ONE));
+    assertThat(tx.getTime()).isEqualTo(updatedTime);
+    assertThat(tx.getTimeMillis()).isEqualTo(updatedTimeMillis);
     assertThat(tx.getGenesisTime()).isEqualTo(genesisTime.plus(UInt64.ONE));
 
     // Commit transaction
@@ -305,8 +311,10 @@ class StoreTest extends AbstractStoreTest {
     final SafeFuture<Void> txResult2;
     if (withInterleavedTransaction) {
       UInt64 time = store.getTime().plus(UInt64.ONE);
+      UInt64 timeMillis = store.getTimeMillis().plus(1300);
       StoreTransaction tx2 = store.startTransaction(updateChannel);
       tx2.setTime(time);
+      tx2.setTimeMillis(timeMillis);
       txResult2 = tx2.commit();
     } else {
       txResult2 = SafeFuture.COMPLETE;
@@ -335,7 +343,8 @@ class StoreTest extends AbstractStoreTest {
     assertThat(finalizedCheckpointState).isCompleted();
     assertThat(finalizedCheckpointState.join().getCheckpoint()).isEqualTo(checkpoint1);
     // Check time
-    assertThat(store.getTime()).isEqualTo(initialTime.plus(UInt64.ONE));
+    assertThat(store.getTime()).isEqualTo(updatedTime);
+    assertThat(store.getTimeMillis()).isEqualTo(updatedTimeMillis);
     assertThat(store.getGenesisTime()).isEqualTo(genesisTime.plus(UInt64.ONE));
 
     // Check store was pruned as expected

--- a/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTest.java
@@ -309,10 +309,8 @@ class StoreTest extends AbstractStoreTest {
 
     final SafeFuture<Void> txResult2;
     if (withInterleavedTransaction) {
-      UInt64 time = store.getTimeSeconds().plus(UInt64.ONE);
       UInt64 timeMillis = store.getTimeMillis().plus(1300);
       StoreTransaction tx2 = store.startTransaction(updateChannel);
-      tx2.setTimeSeconds(time);
       tx2.setTimeMillis(timeMillis);
       txResult2 = tx2.commit();
     } else {

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/client/ChainUpdater.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/client/ChainUpdater.java
@@ -64,7 +64,7 @@ public class ChainUpdater {
   public void setTime(final UInt64 time) {
     checkState(!recentChainData.isPreGenesis(), "Cannot set time before genesis");
     final StoreTransaction tx = recentChainData.startStoreTransaction();
-    tx.setTime(time);
+    tx.setTimeSeconds(time);
     tx.commit().join();
   }
 
@@ -259,7 +259,7 @@ public class ChainUpdater {
   public void saveBlockTime(final SignedBlockAndState block) {
     // Make sure time is consistent with block
     final UInt64 blockTime = getSlotTime(block.getSlot());
-    if (blockTime.compareTo(recentChainData.getStore().getTime()) > 0) {
+    if (blockTime.compareTo(recentChainData.getStore().getTimeSeconds()) > 0) {
       setTime(blockTime);
     }
   }

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/store/StoreAssertions.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/store/StoreAssertions.java
@@ -23,6 +23,7 @@ public class StoreAssertions {
         .isEqualToIgnoringGivenFields(
             expectedState,
             "time",
+            "timeMillis",
             "stateCountGauge",
             "blockCountGauge",
             "checkpointCountGauge",

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/store/StoreAssertions.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/store/StoreAssertions.java
@@ -22,7 +22,6 @@ public class StoreAssertions {
     assertThat(actualState)
         .isEqualToIgnoringGivenFields(
             expectedState,
-            "time",
             "timeMillis",
             "stateCountGauge",
             "blockCountGauge",


### PR DESCRIPTION
## PR Description
Modified `ReadOnlyStore` and `MutableStore` to allow to store and retrieve time in milliseconds.

## Fixed Issue(s)
will help to resolve #5297 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
