### PR TITLE
[Merge] provide a mocked execution engine able to emulate transition via TTD or TBH and supporting standard and mev_boost flow

### DIFF
--- a/beacon/sync/src/testFixtures/java/tech/pegasys/teku/beacon/sync/SyncingNodeManager.java
+++ b/beacon/sync/src/testFixtures/java/tech/pegasys/teku/beacon/sync/SyncingNodeManager.java
@@ -45,7 +45,7 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannel;
-import tech.pegasys.teku.spec.executionengine.StubExecutionEngineChannel;
+import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannelMock;
 import tech.pegasys.teku.statetransition.BeaconChainUtil;
 import tech.pegasys.teku.statetransition.block.BlockImportChannel;
 import tech.pegasys.teku.statetransition.block.BlockImportNotifications;
@@ -116,7 +116,7 @@ public class SyncingNodeManager {
             recentChainData,
             forkChoice,
             WeakSubjectivityFactory.lenientValidator(),
-            new StubExecutionEngineChannel(spec));
+            new ExecutionEngineChannelMock(spec, false));
 
     BlockValidator blockValidator = new BlockValidator(spec, recentChainData);
     final PendingPool<SignedBeaconBlock> pendingBlocks =

--- a/beacon/sync/src/testFixtures/java/tech/pegasys/teku/beacon/sync/SyncingNodeManager.java
+++ b/beacon/sync/src/testFixtures/java/tech/pegasys/teku/beacon/sync/SyncingNodeManager.java
@@ -45,7 +45,7 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannel;
-import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannelMock;
+import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannelStub;
 import tech.pegasys.teku.statetransition.BeaconChainUtil;
 import tech.pegasys.teku.statetransition.block.BlockImportChannel;
 import tech.pegasys.teku.statetransition.block.BlockImportNotifications;
@@ -116,7 +116,7 @@ public class SyncingNodeManager {
             recentChainData,
             forkChoice,
             WeakSubjectivityFactory.lenientValidator(),
-            new ExecutionEngineChannelMock(spec, false));
+            new ExecutionEngineChannelStub(spec, false));
 
     BlockValidator blockValidator = new BlockValidator(spec, recentChainData);
     final PendingPool<SignedBeaconBlock> pendingBlocks =

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
@@ -46,7 +46,7 @@ import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannel;
-import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannelMock;
+import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannelStub;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
 import tech.pegasys.teku.statetransition.forkchoice.MergeTransitionBlockValidator;
@@ -106,7 +106,7 @@ public class ForkChoiceTestExecutor implements TestExecutor {
             new StubForkChoiceNotifier(),
             transitionBlockValidator,
             true);
-    final ExecutionEngineChannelMock executionEngine = new ExecutionEngineChannelMock(spec, false);
+    final ExecutionEngineChannelStub executionEngine = new ExecutionEngineChannelStub(spec, false);
 
     runSteps(testDefinition, spec, recentChainData, forkChoice, executionEngine);
   }
@@ -132,7 +132,7 @@ public class ForkChoiceTestExecutor implements TestExecutor {
       final Spec spec,
       final RecentChainData recentChainData,
       final ForkChoice forkChoice,
-      final ExecutionEngineChannelMock executionEngine)
+      final ExecutionEngineChannelStub executionEngine)
       throws java.io.IOException {
     final List<Map<String, Object>> steps = loadSteps(testDefinition);
     for (Map<String, Object> step : steps) {
@@ -161,7 +161,7 @@ public class ForkChoiceTestExecutor implements TestExecutor {
   private void applyPowBlock(
       final TestDefinition testDefinition,
       final Map<String, Object> step,
-      final ExecutionEngineChannelMock executionEngine) {
+      final ExecutionEngineChannelStub executionEngine) {
     final String filename = (String) step.get("pow_block");
     final PowBlock block =
         TestDataUtils.loadSsz(testDefinition, filename + ".ssz_snappy", this::parsePowBlock);
@@ -206,7 +206,7 @@ public class ForkChoiceTestExecutor implements TestExecutor {
       final Spec spec,
       final ForkChoice forkChoice,
       final Map<String, Object> step,
-      final ExecutionEngineChannelMock executionEngine) {
+      final ExecutionEngineChannelStub executionEngine) {
     final String blockName = get(step, "block");
     final boolean valid = !step.containsKey("valid") || (boolean) step.get("valid");
     final SignedBeaconBlock block =

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
@@ -46,7 +46,7 @@ import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannel;
-import tech.pegasys.teku.spec.executionengine.StubExecutionEngineChannel;
+import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannelMock;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
 import tech.pegasys.teku.statetransition.forkchoice.MergeTransitionBlockValidator;
@@ -106,7 +106,7 @@ public class ForkChoiceTestExecutor implements TestExecutor {
             new StubForkChoiceNotifier(),
             transitionBlockValidator,
             true);
-    final StubExecutionEngineChannel executionEngine = new StubExecutionEngineChannel(spec);
+    final ExecutionEngineChannelMock executionEngine = new ExecutionEngineChannelMock(spec, false);
 
     runSteps(testDefinition, spec, recentChainData, forkChoice, executionEngine);
   }
@@ -132,7 +132,7 @@ public class ForkChoiceTestExecutor implements TestExecutor {
       final Spec spec,
       final RecentChainData recentChainData,
       final ForkChoice forkChoice,
-      final StubExecutionEngineChannel executionEngine)
+      final ExecutionEngineChannelMock executionEngine)
       throws java.io.IOException {
     final List<Map<String, Object>> steps = loadSteps(testDefinition);
     for (Map<String, Object> step : steps) {
@@ -161,7 +161,7 @@ public class ForkChoiceTestExecutor implements TestExecutor {
   private void applyPowBlock(
       final TestDefinition testDefinition,
       final Map<String, Object> step,
-      final StubExecutionEngineChannel executionEngine) {
+      final ExecutionEngineChannelMock executionEngine) {
     final String filename = (String) step.get("pow_block");
     final PowBlock block =
         TestDataUtils.loadSsz(testDefinition, filename + ".ssz_snappy", this::parsePowBlock);
@@ -206,7 +206,7 @@ public class ForkChoiceTestExecutor implements TestExecutor {
       final Spec spec,
       final ForkChoice forkChoice,
       final Map<String, Object> step,
-      final StubExecutionEngineChannel executionEngine) {
+      final ExecutionEngineChannelMock executionEngine) {
     final String blockName = get(step, "block");
     final boolean valid = !step.containsKey("valid") || (boolean) step.get("valid");
     final SignedBeaconBlock block =

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionEngineChannelImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionEngineChannelImpl.java
@@ -44,6 +44,7 @@ import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
 import tech.pegasys.teku.spec.datastructures.execution.PowBlock;
 import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannel;
+import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannelMock;
 import tech.pegasys.teku.spec.executionengine.ForkChoiceState;
 import tech.pegasys.teku.spec.executionengine.PayloadAttributes;
 import tech.pegasys.teku.spec.executionengine.PayloadStatus;
@@ -56,7 +57,7 @@ public class ExecutionEngineChannelImpl implements ExecutionEngineChannel {
   private final ExecutionEngineClient executionEngineClient;
   private final Spec spec;
 
-  public static ExecutionEngineChannelImpl create(
+  public static ExecutionEngineChannel create(
       final String eeEndpoint,
       final Spec spec,
       final TimeProvider timeProvider,
@@ -65,6 +66,9 @@ public class ExecutionEngineChannelImpl implements ExecutionEngineChannel {
       final Path beaconDataDirectory) {
     checkNotNull(eeEndpoint);
     checkNotNull(version);
+    if (eeEndpoint.equalsIgnoreCase(MOCK_ENDPOINT_IDENTIFIER)) {
+      return new ExecutionEngineChannelMock(spec, timeProvider, true);
+    }
     return new ExecutionEngineChannelImpl(
         createEngineClient(eeEndpoint, timeProvider, version, jwtSecretFile, beaconDataDirectory),
         spec);

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionEngineChannelImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionEngineChannelImpl.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.ethereum.executionlayer;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static tech.pegasys.teku.infrastructure.logging.EventLogger.EVENT_LOG;
 
 import java.nio.file.Path;
 import java.util.Optional;
@@ -44,7 +45,7 @@ import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
 import tech.pegasys.teku.spec.datastructures.execution.PowBlock;
 import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannel;
-import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannelMock;
+import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannelStub;
 import tech.pegasys.teku.spec.executionengine.ForkChoiceState;
 import tech.pegasys.teku.spec.executionengine.PayloadAttributes;
 import tech.pegasys.teku.spec.executionengine.PayloadStatus;
@@ -66,8 +67,9 @@ public class ExecutionEngineChannelImpl implements ExecutionEngineChannel {
       final Path beaconDataDirectory) {
     checkNotNull(eeEndpoint);
     checkNotNull(version);
-    if (eeEndpoint.equalsIgnoreCase(MOCK_ENDPOINT_IDENTIFIER)) {
-      return new ExecutionEngineChannelMock(spec, timeProvider, true);
+    if (eeEndpoint.equalsIgnoreCase(STUB_ENDPOINT_IDENTIFIER)) {
+      EVENT_LOG.executionEngineStubEnabled();
+      return new ExecutionEngineChannelStub(spec, timeProvider, true);
     }
     return new ExecutionEngineChannelImpl(
         createEngineClient(eeEndpoint, timeProvider, version, jwtSecretFile, beaconDataDirectory),

--- a/ethereum/spec/build.gradle
+++ b/ethereum/spec/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     implementation project(':infrastructure:events')
     implementation project(':infrastructure:io')
     implementation project(':infrastructure:logging')
+    implementation project(':infrastructure:time')
     implementation project(':ethereum:pow:api')
 
     implementation 'com.google.code.gson:gson'

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionengine/ExecutionEngineChannel.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionengine/ExecutionEngineChannel.java
@@ -25,6 +25,7 @@ import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
 import tech.pegasys.teku.spec.datastructures.execution.PowBlock;
 
 public interface ExecutionEngineChannel extends ChannelInterface {
+  String MOCK_ENDPOINT_IDENTIFIER = "mock";
   ExecutionEngineChannel NOOP =
       new ExecutionEngineChannel() {
         @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionengine/ExecutionEngineChannel.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionengine/ExecutionEngineChannel.java
@@ -25,7 +25,7 @@ import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
 import tech.pegasys.teku.spec.datastructures.execution.PowBlock;
 
 public interface ExecutionEngineChannel extends ChannelInterface {
-  String MOCK_ENDPOINT_IDENTIFIER = "mock";
+  String STUB_ENDPOINT_IDENTIFIER = "stub";
   ExecutionEngineChannel NOOP =
       new ExecutionEngineChannel() {
         @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionengine/ExecutionEngineChannelMock.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionengine/ExecutionEngineChannelMock.java
@@ -264,11 +264,11 @@ public class ExecutionEngineChannelMock implements ExecutionEngineChannel {
         spec.computeStartSlotAtEpoch(specConfigBellatrix.getBellatrixForkEpoch());
 
     // assumes genesis happen immediately at min genesis time reached
-    final UInt64 genesisTime =
+    final UInt64 bellatrixActivationTime =
         spec.getSlotStartTime(
             bellatrixActivationSlot, spec.getGenesisSpecConfig().getMinGenesisTime());
 
-    transitionTime = genesisTime.plus(TRANSITION_DELAY_AFTER_BELLATRIX_ACTIVATION);
+    transitionTime = bellatrixActivationTime.plus(TRANSITION_DELAY_AFTER_BELLATRIX_ACTIVATION);
 
     terminalBlockParent =
         new PowBlock(TERMINAL_BLOCK_PARENT_HASH, Bytes32.ZERO, UInt256.ZERO, UInt64.ZERO);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionengine/ExecutionEngineChannelMock.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionengine/ExecutionEngineChannelMock.java
@@ -13,6 +13,9 @@
 
 package tech.pegasys.teku.spec.executionengine;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -20,33 +23,61 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.bytes.Bytes8;
 import tech.pegasys.teku.infrastructure.collections.cache.LRUCache;
+import tech.pegasys.teku.infrastructure.time.SystemTimeProvider;
+import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.SpecVersion;
+import tech.pegasys.teku.spec.config.SpecConfigBellatrix;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
 import tech.pegasys.teku.spec.datastructures.execution.PowBlock;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsBellatrix;
 
-public class StubExecutionEngineChannel implements ExecutionEngineChannel {
-
+public class ExecutionEngineChannelMock implements ExecutionEngineChannel {
+  private static final Logger LOG = LogManager.getLogger();
+  private final TimeProvider timeProvider;
   private final Map<Bytes32, PowBlock> knownBlocks = new ConcurrentHashMap<>();
   private final LRUCache<Bytes8, HeadAndAttributes> payloadIdToHeadAndAttrsCache;
   private final AtomicLong payloadIdCounter = new AtomicLong(0);
   private Set<Bytes32> requestedPowBlocks = new HashSet<>();
   private final Spec spec;
-
   private PayloadStatus payloadStatus = PayloadStatus.VALID;
+  private ExecutionPayload lastPayloadToBeUnblinded;
 
-  public StubExecutionEngineChannel(Spec spec) {
+  // transition emulation
+  private final boolean transitionEmulationEnabled;
+  private static final int TRANSITION_DELAY_AFTER_BELLATRIX_ACTIVATION = 10;
+  private static final Bytes32 TERMINAL_BLOCK_PARENT_HASH = Bytes32.ZERO;
+  private static final Bytes32 TERMINAL_BLOCK_HASH = Bytes32.fromHexStringLenient("0x01");
+  private PowBlock terminalBlockParent;
+  private PowBlock terminalBlock;
+  private boolean terminalBlockSent;
+  private UInt64 transitionTime;
+
+  public ExecutionEngineChannelMock(
+      final Spec spec, final TimeProvider timeProvider, final boolean enableTransitionEmulation) {
     this.payloadIdToHeadAndAttrsCache = LRUCache.create(10);
     this.spec = spec;
+    this.timeProvider = timeProvider;
+    this.transitionEmulationEnabled = enableTransitionEmulation;
+    if (enableTransitionEmulation) {
+      prepareTransitionBlocks();
+    }
+  }
+
+  public ExecutionEngineChannelMock(final Spec spec, final boolean enableTransitionEmulation) {
+    this(spec, new SystemTimeProvider(), enableTransitionEmulation);
   }
 
   public void addPowBlock(final PowBlock block) {
@@ -55,14 +86,32 @@ public class StubExecutionEngineChannel implements ExecutionEngineChannel {
 
   @Override
   public SafeFuture<Optional<PowBlock>> getPowBlock(final Bytes32 blockHash) {
-    requestedPowBlocks.add(blockHash);
-    return SafeFuture.completedFuture(Optional.ofNullable(knownBlocks.get(blockHash)));
+    if (!transitionEmulationEnabled) {
+      requestedPowBlocks.add(blockHash);
+      return SafeFuture.completedFuture(Optional.ofNullable(knownBlocks.get(blockHash)));
+    }
+    if (blockHash.equals(TERMINAL_BLOCK_PARENT_HASH)) {
+      return SafeFuture.completedFuture(Optional.of(terminalBlockParent));
+    }
+    return SafeFuture.failedFuture(
+        new UnsupportedOperationException("getPowBlock supported for terminalBlockParent only"));
   }
 
   @Override
   public SafeFuture<PowBlock> getPowChainHead() {
-    return SafeFuture.failedFuture(
-        new UnsupportedOperationException("getPowChainHead not supported"));
+    if (!transitionEmulationEnabled) {
+      return SafeFuture.failedFuture(
+          new UnsupportedOperationException("getPowChainHead not supported"));
+    }
+    if (terminalBlockSent) {
+      return SafeFuture.failedFuture(
+          new UnsupportedOperationException("getPowChainHead not supported after transition"));
+    }
+    if (timeProvider.getTimeInSeconds().isGreaterThanOrEqualTo(transitionTime)) {
+      terminalBlockSent = true;
+      return SafeFuture.completedFuture(terminalBlock);
+    }
+    return SafeFuture.completedFuture(terminalBlockParent);
   }
 
   @Override
@@ -112,7 +161,7 @@ public class StubExecutionEngineChannel implements ExecutionEngineChannel {
                 payloadAttributes.getFeeRecipient(),
                 Bytes32.ZERO,
                 Bytes32.ZERO,
-                Bytes.EMPTY,
+                Bytes.random(256),
                 payloadAttributes.getPrevRandao(),
                 UInt64.valueOf(payloadIdCounter.get()),
                 UInt64.ONE,
@@ -121,7 +170,7 @@ public class StubExecutionEngineChannel implements ExecutionEngineChannel {
                 Bytes.EMPTY,
                 UInt256.ONE,
                 Bytes32.random(),
-                List.of()));
+                List.of(Bytes.fromHexString("0x0edf"), Bytes.fromHexString("0xedf0"))));
   }
 
   @Override
@@ -132,56 +181,43 @@ public class StubExecutionEngineChannel implements ExecutionEngineChannel {
   @Override
   public SafeFuture<TransitionConfiguration> exchangeTransitionConfiguration(
       TransitionConfiguration transitionConfiguration) {
-    return SafeFuture.failedFuture(
-        new UnsupportedOperationException("exchangeTransitionConfiguration not supported"));
+    return SafeFuture.completedFuture(transitionConfiguration);
   }
 
   @Override
   public SafeFuture<ExecutionPayloadHeader> getPayloadHeader(Bytes8 payloadId, UInt64 slot) {
     return getPayload(payloadId, slot)
         .thenApply(
-            executionPayload ->
-                spec.atSlot(slot)
-                    .getSchemaDefinitions()
-                    .toVersionBellatrix()
-                    .orElseThrow()
-                    .getExecutionPayloadHeaderSchema()
-                    .create(
-                        executionPayload.getParentHash(),
-                        executionPayload.getFeeRecipient(),
-                        executionPayload.getStateRoot(),
-                        executionPayload.getReceiptsRoot(),
-                        executionPayload.getLogsBloom(),
-                        executionPayload.getPrevRandao(),
-                        executionPayload.getBlockNumber(),
-                        executionPayload.getGasLimit(),
-                        executionPayload.getGasUsed(),
-                        executionPayload.getTimestamp(),
-                        executionPayload.getExtraData(),
-                        executionPayload.getBaseFeePerGas(),
-                        executionPayload.getBlockHash(),
-                        executionPayload.getTransactions().hashTreeRoot()));
+            executionPayload -> {
+              lastPayloadToBeUnblinded = executionPayload;
+              return spec.atSlot(slot)
+                  .getSchemaDefinitions()
+                  .toVersionBellatrix()
+                  .orElseThrow()
+                  .getExecutionPayloadHeaderSchema()
+                  .createFromExecutionPayload(executionPayload);
+            });
   }
 
   @Override
   public SafeFuture<ExecutionPayload> proposeBlindedBlock(
       SignedBeaconBlock signedBlindedBeaconBlock) {
-    Optional<SchemaDefinitionsBellatrix> schemaDefinitionsBellatrix =
+    final Optional<SchemaDefinitionsBellatrix> schemaDefinitionsBellatrix =
         spec.atSlot(signedBlindedBeaconBlock.getSlot()).getSchemaDefinitions().toVersionBellatrix();
 
-    if (schemaDefinitionsBellatrix.isEmpty()) {
-      return SafeFuture.failedFuture(
-          new UnsupportedOperationException(
-              "proposeBlindedBlock not supported for non-Bellatrix milestones"));
-    }
+    checkState(
+        schemaDefinitionsBellatrix.isPresent(),
+        "proposeBlindedBlock not supported for non-Bellatrix milestones");
 
-    if (!signedBlindedBeaconBlock.getBeaconBlock().orElseThrow().getBody().isBlinded()) {
-      return SafeFuture.failedFuture(
-          new UnsupportedOperationException(
-              "proposeBlindedBlock requires a signed blinded beacon block"));
-    }
+    checkState(
+        signedBlindedBeaconBlock.getBeaconBlock().orElseThrow().getBody().isBlinded(),
+        "proposeBlindedBlock requires a signed blinded beacon block");
 
-    ExecutionPayloadHeader executionPayloadHeader =
+    checkNotNull(
+        lastPayloadToBeUnblinded,
+        "proposeBlindedBlock requires a previous call to getPayloadHeader");
+
+    final ExecutionPayloadHeader executionPayloadHeader =
         signedBlindedBeaconBlock
             .getBeaconBlock()
             .orElseThrow()
@@ -189,25 +225,11 @@ public class StubExecutionEngineChannel implements ExecutionEngineChannel {
             .getOptionalExecutionPayloadHeader()
             .orElseThrow();
 
-    return SafeFuture.completedFuture(
-        schemaDefinitionsBellatrix
-            .get()
-            .getExecutionPayloadSchema()
-            .create(
-                executionPayloadHeader.getParentHash(),
-                executionPayloadHeader.getFeeRecipient(),
-                Bytes32.ZERO,
-                Bytes32.ZERO,
-                Bytes.EMPTY,
-                executionPayloadHeader.getPrevRandao(),
-                UInt64.valueOf(payloadIdCounter.get()),
-                UInt64.ONE,
-                UInt64.ZERO,
-                executionPayloadHeader.getTimestamp(),
-                Bytes.EMPTY,
-                UInt256.ONE,
-                Bytes32.random(),
-                List.of()));
+    checkState(
+        executionPayloadHeader.hashTreeRoot().equals(lastPayloadToBeUnblinded.hashTreeRoot()),
+        "provided signed blinded block contains an execution payload header not matching the previously retrieved execution payload via getPayloadHeader");
+
+    return SafeFuture.completedFuture(lastPayloadToBeUnblinded);
   }
 
   public PayloadStatus getPayloadStatus() {
@@ -229,6 +251,40 @@ public class StubExecutionEngineChannel implements ExecutionEngineChannel {
     private HeadAndAttributes(Bytes32 head, PayloadAttributes attributes) {
       this.head = head;
       this.attributes = attributes;
+    }
+  }
+
+  private void prepareTransitionBlocks() {
+    final SpecVersion specVersion = spec.forMilestone(SpecMilestone.BELLATRIX);
+    checkNotNull(specVersion, "Bellatrix must be scheduled to for transition emulation");
+    final SpecConfigBellatrix specConfigBellatrix =
+        specVersion.getConfig().toVersionBellatrix().orElseThrow();
+
+    final UInt64 bellatrixActivationSlot =
+        spec.computeStartSlotAtEpoch(specConfigBellatrix.getBellatrixForkEpoch());
+
+    // assumes genesis happen immediately at min genesis time reached
+    final UInt64 genesisTime =
+        spec.getSlotStartTime(
+            bellatrixActivationSlot, spec.getGenesisSpecConfig().getMinGenesisTime());
+
+    transitionTime = genesisTime.plus(TRANSITION_DELAY_AFTER_BELLATRIX_ACTIVATION);
+
+    terminalBlockParent =
+        new PowBlock(TERMINAL_BLOCK_PARENT_HASH, Bytes32.ZERO, UInt256.ZERO, UInt64.ZERO);
+    terminalBlock =
+        new PowBlock(
+            TERMINAL_BLOCK_HASH,
+            TERMINAL_BLOCK_PARENT_HASH,
+            specConfigBellatrix.getTerminalTotalDifficulty(),
+            transitionTime);
+
+    final UInt64 currentTime = timeProvider.getTimeInSeconds();
+
+    // if transition time is passed, we assume terminalBlock already sent
+    terminalBlockSent = currentTime.isGreaterThanOrEqualTo(transitionTime);
+    if (terminalBlockSent) {
+      LOG.info("transition assumed to be already happened.");
     }
   }
 }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockManagerTest.java
@@ -55,8 +55,8 @@ import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.ImportedBlockListener;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannel;
+import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannelMock;
 import tech.pegasys.teku.spec.executionengine.PayloadStatus;
-import tech.pegasys.teku.spec.executionengine.StubExecutionEngineChannel;
 import tech.pegasys.teku.spec.logic.common.block.AbstractBlockProcessor;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult.FailureReason;
@@ -107,7 +107,8 @@ public class BlockManagerTest {
           forkChoiceNotifier,
           transitionBlockValidator);
 
-  private final StubExecutionEngineChannel executionEngine = new StubExecutionEngineChannel(spec);
+  private final ExecutionEngineChannelMock executionEngine =
+      new ExecutionEngineChannelMock(spec, false);
   private final BlockValidator blockValidator = mock(BlockValidator.class);
 
   private final BlockImporter blockImporter =

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockManagerTest.java
@@ -55,7 +55,7 @@ import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.ImportedBlockListener;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannel;
-import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannelMock;
+import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannelStub;
 import tech.pegasys.teku.spec.executionengine.PayloadStatus;
 import tech.pegasys.teku.spec.logic.common.block.AbstractBlockProcessor;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
@@ -107,8 +107,8 @@ public class BlockManagerTest {
           forkChoiceNotifier,
           transitionBlockValidator);
 
-  private final ExecutionEngineChannelMock executionEngine =
-      new ExecutionEngineChannelMock(spec, false);
+  private final ExecutionEngineChannelStub executionEngine =
+      new ExecutionEngineChannelStub(spec, false);
   private final BlockValidator blockValidator = mock(BlockValidator.class);
 
   private final BlockImporter blockImporter =

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
@@ -58,7 +58,7 @@ import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestation.IndexedAttestationSchema;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.util.AttestationProcessingResult;
-import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannelMock;
+import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannelStub;
 import tech.pegasys.teku.spec.executionengine.ExecutionPayloadStatus;
 import tech.pegasys.teku.spec.executionengine.ForkChoiceState;
 import tech.pegasys.teku.spec.executionengine.ForkChoiceUpdatedResult;
@@ -95,8 +95,8 @@ class ForkChoiceTest {
   private final ForkChoiceNotifier forkChoiceNotifier = mock(ForkChoiceNotifier.class);
   private final OptimisticHeadSubscriber optimisticSyncStateTracker =
       mock(OptimisticHeadSubscriber.class);
-  private final ExecutionEngineChannelMock executionEngine =
-      new ExecutionEngineChannelMock(spec, false);
+  private final ExecutionEngineChannelStub executionEngine =
+      new ExecutionEngineChannelStub(spec, false);
   private final MergeTransitionBlockValidator transitionBlockValidator =
       mock(MergeTransitionBlockValidator.class);
   private ForkChoice forkChoice =

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
@@ -58,11 +58,11 @@ import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestation.IndexedAttestationSchema;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.util.AttestationProcessingResult;
+import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannelMock;
 import tech.pegasys.teku.spec.executionengine.ExecutionPayloadStatus;
 import tech.pegasys.teku.spec.executionengine.ForkChoiceState;
 import tech.pegasys.teku.spec.executionengine.ForkChoiceUpdatedResult;
 import tech.pegasys.teku.spec.executionengine.PayloadStatus;
-import tech.pegasys.teku.spec.executionengine.StubExecutionEngineChannel;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult.FailureReason;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
@@ -95,7 +95,8 @@ class ForkChoiceTest {
   private final ForkChoiceNotifier forkChoiceNotifier = mock(ForkChoiceNotifier.class);
   private final OptimisticHeadSubscriber optimisticSyncStateTracker =
       mock(OptimisticHeadSubscriber.class);
-  private final StubExecutionEngineChannel executionEngine = new StubExecutionEngineChannel(spec);
+  private final ExecutionEngineChannelMock executionEngine =
+      new ExecutionEngineChannelMock(spec, false);
   private final MergeTransitionBlockValidator transitionBlockValidator =
       mock(MergeTransitionBlockValidator.class);
   private ForkChoice forkChoice =

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/MergeTransitionBlockValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/MergeTransitionBlockValidatorTest.java
@@ -33,8 +33,8 @@ import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.PowBlock;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.bellatrix.BeaconStateBellatrix;
 import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannel;
+import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannelMock;
 import tech.pegasys.teku.spec.executionengine.PayloadStatus;
-import tech.pegasys.teku.spec.executionengine.StubExecutionEngineChannel;
 import tech.pegasys.teku.spec.logic.common.block.AbstractBlockProcessor;
 import tech.pegasys.teku.spec.logic.versions.bellatrix.helpers.BellatrixTransitionHelpers;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
@@ -45,7 +45,8 @@ class MergeTransitionBlockValidatorTest {
 
   private final Spec spec = TestSpecFactory.createMinimalBellatrix();
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
-  private final StubExecutionEngineChannel executionEngine = new StubExecutionEngineChannel(spec);
+  private final ExecutionEngineChannelMock executionEngine =
+      new ExecutionEngineChannelMock(spec, false);
   private final StorageSystem storageSystem = InMemoryStorageSystemBuilder.buildDefault(spec);
 
   @BeforeAll

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/MergeTransitionBlockValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/MergeTransitionBlockValidatorTest.java
@@ -33,7 +33,7 @@ import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.PowBlock;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.bellatrix.BeaconStateBellatrix;
 import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannel;
-import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannelMock;
+import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannelStub;
 import tech.pegasys.teku.spec.executionengine.PayloadStatus;
 import tech.pegasys.teku.spec.logic.common.block.AbstractBlockProcessor;
 import tech.pegasys.teku.spec.logic.versions.bellatrix.helpers.BellatrixTransitionHelpers;
@@ -45,8 +45,8 @@ class MergeTransitionBlockValidatorTest {
 
   private final Spec spec = TestSpecFactory.createMinimalBellatrix();
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
-  private final ExecutionEngineChannelMock executionEngine =
-      new ExecutionEngineChannelMock(spec, false);
+  private final ExecutionEngineChannelStub executionEngine =
+      new ExecutionEngineChannelStub(spec, false);
   private final StorageSystem storageSystem = InMemoryStorageSystemBuilder.buildDefault(spec);
 
   @BeforeAll

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/BeaconChainUtil.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/BeaconChainUtil.java
@@ -44,7 +44,7 @@ import tech.pegasys.teku.spec.datastructures.operations.Deposit;
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannel;
-import tech.pegasys.teku.spec.executionengine.StubExecutionEngineChannel;
+import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannelMock;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
 import tech.pegasys.teku.statetransition.forkchoice.MergeTransitionBlockValidator;
@@ -250,7 +250,9 @@ public class BeaconChainUtil {
         createBlockAndStateAtSlot(slot, true, attestations, deposits, exits, eth1Data).getBlock();
     setSlot(slot);
     final BlockImportResult importResult =
-        forkChoice.onBlock(block, Optional.empty(), new StubExecutionEngineChannel(spec)).join();
+        forkChoice
+            .onBlock(block, Optional.empty(), new ExecutionEngineChannelMock(spec, false))
+            .join();
     if (!importResult.isSuccessful()) {
       throw new IllegalStateException(
           "Produced an invalid block ( reason "

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/BeaconChainUtil.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/BeaconChainUtil.java
@@ -44,7 +44,7 @@ import tech.pegasys.teku.spec.datastructures.operations.Deposit;
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannel;
-import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannelMock;
+import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannelStub;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
 import tech.pegasys.teku.statetransition.forkchoice.MergeTransitionBlockValidator;
@@ -251,7 +251,7 @@ public class BeaconChainUtil {
     setSlot(slot);
     final BlockImportResult importResult =
         forkChoice
-            .onBlock(block, Optional.empty(), new ExecutionEngineChannelMock(spec, false))
+            .onBlock(block, Optional.empty(), new ExecutionEngineChannelStub(spec, false))
             .join();
     if (!importResult.isSuccessful()) {
       throw new IllegalStateException(

--- a/fork-choice-tests/src/integration-test/java/tech/pegasys/teku/forkChoiceTests/ForkChoiceIntegrationTest.java
+++ b/fork-choice-tests/src/integration-test/java/tech/pegasys/teku/forkChoiceTests/ForkChoiceIntegrationTest.java
@@ -48,7 +48,7 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchema;
 import tech.pegasys.teku.spec.datastructures.util.AttestationProcessingResult;
 import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannel;
-import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannelMock;
+import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannelStub;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
@@ -280,7 +280,7 @@ public class ForkChoiceIntegrationTest {
 
   private boolean processBlock(ForkChoice fc, SignedBeaconBlock block) {
     BlockImportResult blockImportResult =
-        fc.onBlock(block, Optional.empty(), new ExecutionEngineChannelMock(SPEC, false)).join();
+        fc.onBlock(block, Optional.empty(), new ExecutionEngineChannelStub(SPEC, false)).join();
     return blockImportResult.isSuccessful();
   }
 

--- a/fork-choice-tests/src/integration-test/java/tech/pegasys/teku/forkChoiceTests/ForkChoiceIntegrationTest.java
+++ b/fork-choice-tests/src/integration-test/java/tech/pegasys/teku/forkChoiceTests/ForkChoiceIntegrationTest.java
@@ -48,7 +48,7 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchema;
 import tech.pegasys.teku.spec.datastructures.util.AttestationProcessingResult;
 import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannel;
-import tech.pegasys.teku.spec.executionengine.StubExecutionEngineChannel;
+import tech.pegasys.teku.spec.executionengine.ExecutionEngineChannelMock;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
@@ -280,7 +280,7 @@ public class ForkChoiceIntegrationTest {
 
   private boolean processBlock(ForkChoice fc, SignedBeaconBlock block) {
     BlockImportResult blockImportResult =
-        fc.onBlock(block, Optional.empty(), new StubExecutionEngineChannel(SPEC)).join();
+        fc.onBlock(block, Optional.empty(), new ExecutionEngineChannelMock(SPEC, false)).join();
     return blockImportResult.isSuccessful();
   }
 

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java
@@ -204,6 +204,12 @@ public class EventLogger {
     warn(reorgEventLog, Color.YELLOW);
   }
 
+  public void executionEngineStubEnabled() {
+    info(
+        "Execution Engine Stub has been enabled. Please make sure this is intentional.",
+        Color.YELLOW);
+  }
+
   private void info(final String message, final Color color) {
     log.info(print(message, color));
   }


### PR DESCRIPTION
I promoted the textFixture `StubExecutionEngineChannel` to production code as `ExecutionEngineChannelStub`.
Can be activated by providing `--ee-endpoint stub` option

- Detects bellatrix activation by looking at the first call to `getPowBlock` or `getPowChainHead`. If block production APIs are called before, it assumes transition already happened
- Prepares terminal blocks via TTD or TBH, consider values from exchange configuration APIs. if not available will use Spec.
- supports terminal block validation (node restart before terminal block finalized)
- keeps track of payloads to support mev boost flow
- keeps track of payloads to be able to respond to `getPowChainHead`
- all payloads are considered VALID

## Fixed Issue(s)
fixes #5331

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
