### PR TITLE
Optimise epoch transition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@ For information on changes in released versions of Teku, see the [releases page]
 
 ### Additions and Improvements
 - Improved performance when regenerating non-finalized states that had to be dropped from memory.
-- Performance optimizations for Gnosis beacon chain
+- Performance optimizations for Gnosis beacon chain.
+- Improved performance when processing epoch transitions.
 
 ### Bug Fixes
 - Added stricter limits on attestation pool size. 

--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/EpochTransitionBenchmark.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/EpochTransitionBenchmark.java
@@ -143,8 +143,8 @@ public class EpochTransitionBenchmark {
             .getValidatorStatusFactory()
             .createValidatorStatuses(preEpochTransitionState);
     preEpochTransitionState.hashTreeRoot();
-        attestationDeltas =
-            epochProcessor.getRewardAndPenaltyDeltas(preEpochTransitionState, validatorStatuses);
+    attestationDeltas =
+        epochProcessor.getRewardAndPenaltyDeltas(preEpochTransitionState, validatorStatuses);
 
     System.out.println("Done!");
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/BeaconState.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/BeaconState.java
@@ -33,6 +33,7 @@ import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
 import tech.pegasys.teku.spec.datastructures.state.Validator;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.BeaconStateFields;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.BeaconStateInvariants;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.analysis.ValidatorStats;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.altair.BeaconStateAltair;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.bellatrix.BeaconStateBellatrix;
@@ -43,17 +44,17 @@ public interface BeaconState extends SszContainer, ValidatorStats {
   BeaconStateSchema<? extends BeaconState, ? extends MutableBeaconState> getBeaconStateSchema();
 
   default UInt64 getGenesisTime() {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.GENESIS_TIME);
+    final int fieldIndex = BeaconStateInvariants.GENESIS_TIME_FIELD.getIndex();
     return ((SszUInt64) get(fieldIndex)).get();
   }
 
   default Bytes32 getGenesisValidatorsRoot() {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.GENESIS_VALIDATORS_ROOT);
+    final int fieldIndex = BeaconStateInvariants.GENESIS_VALIDATORS_ROOT_FIELD.getIndex();
     return ((SszBytes32) get(fieldIndex)).get();
   }
 
   default UInt64 getSlot() {
-    final int fieldIndex = getSchema().getFieldIndex(BeaconStateFields.SLOT);
+    final int fieldIndex = BeaconStateInvariants.SLOT_FIELD.getIndex();
     return ((SszUInt64) get(fieldIndex)).get();
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/BeaconStateInvariants.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/BeaconStateInvariants.java
@@ -37,11 +37,11 @@ public class BeaconStateInvariants {
   static final SszSchema<SszUInt64> SLOT_SCHEMA = SszPrimitiveSchemas.UINT64_SCHEMA;
 
   // Fields
-  static final SszField GENESIS_TIME_FIELD =
+  public static final SszField GENESIS_TIME_FIELD =
       new SszField(0, BeaconStateFields.GENESIS_TIME, GENESIS_TIME_SCHEMA);
-  static final SszField GENESIS_VALIDATORS_ROOT_FIELD =
+  public static final SszField GENESIS_VALIDATORS_ROOT_FIELD =
       new SszField(1, BeaconStateFields.GENESIS_VALIDATORS_ROOT, GENESIS_VALIDATORS_ROOT_SCHEMA);
-  static final SszField SLOT_FIELD = new SszField(2, BeaconStateFields.SLOT, SLOT_SCHEMA);
+  public static final SszField SLOT_FIELD = new SszField(2, BeaconStateFields.SLOT, SLOT_SCHEMA);
 
   // Return list of invariant fields
   static List<SszField> getInvariantFields() {


### PR DESCRIPTION
## PR Description
Few optimisations in this:

* Fix the EpochTransitionBenchmark and include calculating the hashTreeRoot of the resulting state since that's a fairly big part of the cost
* Use the BeaconState invariant fields to get the field index for slot (and genesis validator root and genesis time). Avoids a map lookup to find the index which is a big win when accessing the state slot in a loop
* Compute baseReward from the validator statuses instead of state. Avoids a bunch of SSZ field accesses for each validator and caches some values that are used for each calculation more efficiently.
* Avoid temporary list creation when updating primitive collections. Avoids needing to iterate through the Stream to create the list, then iterating again to actually do the processing.


Before changes:
EpochTransitionBenchmark.epochTransition              32768  thrpt   10  21.627 ± 0.875  ops/s

After changes:
EpochTransitionBenchmark.epochTransition              32768  thrpt   10  26.840 ± 0.720  ops/s


Before:
![image](https://user-images.githubusercontent.com/72675/163299476-42c7ef58-d858-4e80-a57e-77f68e36c8e7.png)


After:
![image](https://user-images.githubusercontent.com/72675/163299513-cd4eb099-9d07-4488-9e0b-d6305055b1c0.png)


## Fixed Issue(s)
#5243 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
