### PR TITLE
Fix `Ssz*ListSchemaImpl` inheritance

### DIFF
--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/impl/SszBitlistSchemaImpl.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/impl/SszBitlistSchemaImpl.java
@@ -26,7 +26,6 @@ import tech.pegasys.teku.infrastructure.ssz.collections.impl.SszBitlistImpl;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszBit;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
 import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszBitlistSchema;
-import tech.pegasys.teku.infrastructure.ssz.schema.impl.AbstractSszListSchema;
 import tech.pegasys.teku.infrastructure.ssz.schema.json.SszPrimitiveTypeDefinitions;
 import tech.pegasys.teku.infrastructure.ssz.sos.SszDeserializeException;
 import tech.pegasys.teku.infrastructure.ssz.sos.SszReader;
@@ -34,7 +33,7 @@ import tech.pegasys.teku.infrastructure.ssz.sos.SszWriter;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeUtil;
 
-public class SszBitlistSchemaImpl extends AbstractSszListSchema<SszBit, SszBitlist>
+public class SszBitlistSchemaImpl extends SszPrimitiveListSchemaImpl<Boolean, SszBit, SszBitlist>
     implements SszBitlistSchema<SszBitlist> {
 
   public SszBitlistSchemaImpl(long maxLength) {

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/impl/SszByteListSchemaImpl.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/impl/SszByteListSchemaImpl.java
@@ -23,12 +23,12 @@ import tech.pegasys.teku.infrastructure.ssz.collections.impl.SszByteListImpl;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszByte;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
 import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszByteListSchema;
-import tech.pegasys.teku.infrastructure.ssz.schema.impl.AbstractSszListSchema;
 import tech.pegasys.teku.infrastructure.ssz.schema.json.SszPrimitiveTypeDefinitions;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 
 public class SszByteListSchemaImpl<SszListT extends SszByteList>
-    extends AbstractSszListSchema<SszByte, SszListT> implements SszByteListSchema<SszListT> {
+    extends SszPrimitiveListSchemaImpl<Byte, SszByte, SszListT>
+    implements SszByteListSchema<SszListT> {
 
   public SszByteListSchemaImpl(long maxLength) {
     super(SszPrimitiveSchemas.BYTE_SCHEMA, maxLength);

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/impl/SszUInt64ListSchemaImpl.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/impl/SszUInt64ListSchemaImpl.java
@@ -18,11 +18,12 @@ import tech.pegasys.teku.infrastructure.ssz.collections.impl.SszUInt64ListImpl;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
 import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszUInt64ListSchema;
-import tech.pegasys.teku.infrastructure.ssz.schema.impl.AbstractSszListSchema;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 public class SszUInt64ListSchemaImpl<SszListT extends SszUInt64List>
-    extends AbstractSszListSchema<SszUInt64, SszListT> implements SszUInt64ListSchema<SszListT> {
+    extends SszPrimitiveListSchemaImpl<UInt64, SszUInt64, SszListT>
+    implements SszUInt64ListSchema<SszListT> {
 
   public SszUInt64ListSchemaImpl(long maxLength) {
     super(SszPrimitiveSchemas.UINT64_SCHEMA, maxLength);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

Extend primitive `Ssz*ListSchemaImpl` from `SszPrimitiveListSchemaImpl` rather than `AbstractSszListSchema`

Relates to #5349 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
