### PR TITLE
Use milliseconds for ForkChoice onTick

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/DutyMetrics.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/DutyMetrics.java
@@ -74,7 +74,7 @@ public class DutyMetrics {
 
   private UInt64 calculateExpectedAttestationTimeInMillis(final UInt64 slot) {
     final UInt64 genesisTime = recentChainData.getGenesisTime();
-    UInt64 millisPerSlot = secondsToMillis(spec.getSecondsPerSlot(slot));
+    UInt64 millisPerSlot = spec.getMillisPerSlot(slot);
     return secondsToMillis(genesisTime)
         .plus(slot.times(millisPerSlot))
         .plus(millisPerSlot.dividedBy(INTERVALS_PER_SLOT));

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/DutyMetricsTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/DutyMetricsTest.java
@@ -16,7 +16,6 @@ package tech.pegasys.teku.validator.coordinator;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static tech.pegasys.teku.infrastructure.time.TimeUtilities.secondsToMillis;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -87,7 +86,7 @@ class DutyMetricsTest {
   }
 
   private UInt64 expectedAttestationTime(final UInt64 slot, final Spec spec) {
-    UInt64 millisPerSlot = secondsToMillis(spec.getSecondsPerSlot(slot));
+    UInt64 millisPerSlot = spec.getMillisPerSlot(slot);
     return slot.times(millisPerSlot).plus(millisPerSlot.dividedBy(3));
   }
 }

--- a/eth-reference-tests/build.gradle
+++ b/eth-reference-tests/build.gradle
@@ -15,6 +15,7 @@ dependencies {
   referenceTestImplementation testFixtures(project(':storage'))
   referenceTestImplementation project(':infrastructure:async')
   referenceTestImplementation testFixtures(project(':infrastructure:async'))
+  referenceTestImplementation project(':infrastructure:time')
 
   referenceTestImplementation 'com.fasterxml.jackson.core:jackson-databind'
   referenceTestImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.reference.phase0.forkchoice;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.infrastructure.time.TimeUtilities.secondsToMillis;
 
 import com.google.common.collect.ImmutableMap;
 import java.nio.ByteOrder;
@@ -141,7 +142,7 @@ public class ForkChoiceTestExecutor implements TestExecutor {
         applyChecks(recentChainData, forkChoice, step);
 
       } else if (step.containsKey("tick")) {
-        forkChoice.onTick(getUInt64(step, "tick"));
+        forkChoice.onTick(secondsToMillis(getUInt64(step, "tick")));
 
       } else if (step.containsKey("block")) {
         applyBlock(testDefinition, spec, forkChoice, step, executionEngine);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -14,6 +14,8 @@
 package tech.pegasys.teku.spec;
 
 import static com.google.common.base.Preconditions.checkState;
+import static tech.pegasys.teku.infrastructure.time.TimeUtilities.millisToSeconds;
+import static tech.pegasys.teku.infrastructure.time.TimeUtilities.secondsToMillis;
 
 import com.google.common.base.Preconditions;
 import it.unimi.dsi.fastutil.ints.IntList;
@@ -195,6 +197,10 @@ public class Spec {
 
   public int getSecondsPerSlot(final UInt64 slot) {
     return atSlot(slot).getConfig().getSecondsPerSlot();
+  }
+
+  public UInt64 getMillisPerSlot(final UInt64 slot) {
+    return secondsToMillis(getSecondsPerSlot(slot));
   }
 
   public long getMaxDeposits(final BeaconState state) {
@@ -433,8 +439,9 @@ public class Spec {
     return atSlot(forkChoiceStrategy.blockSlot(root).orElse(startSlot));
   }
 
-  public void onTick(MutableStore store, UInt64 time) {
-    atTime(store.getGenesisTime(), time).getForkChoiceUtil().onTick(store, time);
+  public void onTick(MutableStore store, UInt64 timeMillis) {
+    UInt64 timeSeconds = millisToSeconds(timeMillis);
+    atTime(store.getGenesisTime(), timeSeconds).getForkChoiceUtil().onTick(store, timeMillis);
   }
 
   public AttestationProcessingResult validateAttestation(

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtilTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtilTest.java
@@ -17,6 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -182,22 +183,32 @@ class ForkChoiceUtilTest {
 
   @Test
   void onTick_shouldExitImmediatelyWhenCurrentTimeIsBeforeGenesisTime() {
-    final MutableStore store = mock(MutableStore.class);
+    final MutableStore store = spy(MutableStore.class);
     when(store.getGenesisTime()).thenReturn(UInt64.valueOf(3000));
-    when(store.getTimeSeconds()).thenReturn(UInt64.ZERO);
-    forkChoiceUtil.onTick(store, UInt64.valueOf(2000));
+    when(store.getTimeMillis()).thenReturn(UInt64.ZERO);
+    forkChoiceUtil.onTick(store, UInt64.valueOf(2000000));
 
-    verify(store, never()).setTimeSeconds(any());
+    verify(store, never()).setTimeMillis(any());
   }
 
   @Test
   void onTick_shouldExitImmediatelyWhenCurrentTimeIsBeforeStoreTime() {
-    final MutableStore store = mock(MutableStore.class);
+    final MutableStore store = spy(MutableStore.class);
     when(store.getGenesisTime()).thenReturn(UInt64.valueOf(3000));
-    when(store.getTimeSeconds()).thenReturn(UInt64.valueOf(5000));
-    forkChoiceUtil.onTick(store, UInt64.valueOf(4000));
+    when(store.getTimeMillis()).thenReturn(UInt64.valueOf(5000000));
+    forkChoiceUtil.onTick(store, UInt64.valueOf(4000000));
 
-    verify(store, never()).setTimeSeconds(any());
+    verify(store, never()).setTimeMillis(any());
+  }
+
+  @Test
+  void onTick_setsStoreTimeAndStoreTimeMillis() {
+    final MutableStore store = spy(MutableStore.class);
+    when(store.getGenesisTime()).thenReturn(UInt64.valueOf(3000));
+    when(store.getTimeMillis()).thenReturn(UInt64.valueOf(4000000));
+    forkChoiceUtil.onTick(store, UInt64.valueOf(5000678));
+
+    verify(store).setTimeMillis(UInt64.valueOf(5000678));
   }
 
   @Test

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtilTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtilTest.java
@@ -36,6 +36,8 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.forkchoice.MutableStore;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyStore;
+import tech.pegasys.teku.spec.datastructures.forkchoice.TestStoreFactory;
+import tech.pegasys.teku.spec.datastructures.forkchoice.TestStoreImpl;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.spec.util.RandomChainBuilder;
 import tech.pegasys.teku.spec.util.RandomChainBuilderForkChoiceStrategy;
@@ -183,7 +185,7 @@ class ForkChoiceUtilTest {
 
   @Test
   void onTick_shouldExitImmediatelyWhenCurrentTimeIsBeforeGenesisTime() {
-    final MutableStore store = spy(MutableStore.class);
+    final MutableStore store = mock(MutableStore.class);
     when(store.getGenesisTime()).thenReturn(UInt64.valueOf(3000));
     when(store.getTimeMillis()).thenReturn(UInt64.ZERO);
     forkChoiceUtil.onTick(store, UInt64.valueOf(2000000));
@@ -193,7 +195,7 @@ class ForkChoiceUtilTest {
 
   @Test
   void onTick_shouldExitImmediatelyWhenCurrentTimeIsBeforeStoreTime() {
-    final MutableStore store = spy(MutableStore.class);
+    final MutableStore store = mock(MutableStore.class);
     when(store.getGenesisTime()).thenReturn(UInt64.valueOf(3000));
     when(store.getTimeMillis()).thenReturn(UInt64.valueOf(5000000));
     forkChoiceUtil.onTick(store, UInt64.valueOf(4000000));
@@ -202,13 +204,11 @@ class ForkChoiceUtilTest {
   }
 
   @Test
-  void onTick_setsStoreTimeAndStoreTimeMillis() {
-    final MutableStore store = spy(MutableStore.class);
-    when(store.getGenesisTime()).thenReturn(UInt64.valueOf(3000));
-    when(store.getTimeMillis()).thenReturn(UInt64.valueOf(4000000));
-    forkChoiceUtil.onTick(store, UInt64.valueOf(5000678));
-
-    verify(store).setTimeMillis(UInt64.valueOf(5000678));
+  void onTick_setsStoreTimeMillis() {
+    final TestStoreImpl store = new TestStoreFactory(spec).createGenesisStore();
+    final UInt64 expectedMillis = store.getTimeMillis().plus(123456);
+    forkChoiceUtil.onTick(store, expectedMillis);
+    assertThat(store.getTimeMillis()).isEqualTo(expectedMillis);
   }
 
   @Test

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtilTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtilTest.java
@@ -17,7 +17,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -325,11 +325,10 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
         transaction, block, postState, payloadResult.hasNotValidatedStatus());
 
     if (proposerBoostEnabled && spec.getCurrentSlot(transaction).equals(block.getSlot())) {
-      final int secondsPerSlot = spec.getSecondsPerSlot(block.getSlot());
-      final UInt64 timeIntoSlot =
-          transaction.getTimeSeconds().minus(transaction.getGenesisTime()).mod(secondsPerSlot);
+      final UInt64 millisPerSlot = spec.getMillisPerSlot(block.getSlot());
+      final UInt64 timeIntoSlotMillis = getMillisIntoSlot(transaction, millisPerSlot);
 
-      if (isBeforeAttestingInterval(secondsPerSlot, timeIntoSlot)) {
+      if (isBeforeAttestingInterval(millisPerSlot, timeIntoSlotMillis)) {
         transaction.setProposerBoostRoot(block.getRoot());
       }
     }
@@ -367,9 +366,17 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
     return result;
   }
 
-  private boolean isBeforeAttestingInterval(final int secondsPerSlot, final UInt64 timeIntoSlot) {
-    UInt64 oneThirdSlot = secondsToMillis(secondsPerSlot).dividedBy(INTERVALS_PER_SLOT);
-    return secondsToMillis(timeIntoSlot).isLessThan(oneThirdSlot);
+  private UInt64 getMillisIntoSlot(StoreTransaction transaction, UInt64 millisPerSlot) {
+    return transaction
+        .getTimeMillis()
+        .minus(secondsToMillis(transaction.getGenesisTime()))
+        .mod(millisPerSlot);
+  }
+
+  private boolean isBeforeAttestingInterval(
+      final UInt64 millisPerSlot, final UInt64 timeIntoSlotMillis) {
+    UInt64 oneThirdSlot = millisPerSlot.dividedBy(INTERVALS_PER_SLOT);
+    return timeIntoSlotMillis.isLessThan(oneThirdSlot);
   }
 
   private void onExecutionPayloadResult(
@@ -552,10 +559,10 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
         .reportExceptions();
   }
 
-  public void onTick(final UInt64 currentTime) {
+  public void onTick(final UInt64 currentTimeMillis) {
     final StoreTransaction transaction = recentChainData.startStoreTransaction();
     final UInt64 previousSlot = spec.getCurrentSlot(transaction);
-    spec.onTick(transaction, currentTime);
+    spec.onTick(transaction, currentTimeMillis);
     if (spec.getCurrentSlot(transaction).isGreaterThan(previousSlot)) {
       transaction.removeProposerBoostRoot();
     }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeCurrentSlotUtil.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeCurrentSlotUtil.java
@@ -38,7 +38,7 @@ public class SyncCommitteeCurrentSlotUtil {
       return false;
     }
 
-    final UInt64 slotMillis = secondsToMillis(spec.atSlot(slot).getConfig().getSecondsPerSlot());
+    final UInt64 slotMillis = spec.getMillisPerSlot(slot);
     final UInt64 slotStartTimeMillis =
         secondsToMillis(spec.getSlotStartTime(slot, recentChainData.getGenesisTime()));
     final UInt64 slotEndTimeMillis = slotStartTimeMillis.plus(slotMillis);

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
@@ -45,6 +45,7 @@ import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.core.ChainBuilder;
 import tech.pegasys.teku.core.ChainBuilder.BlockOptions;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.async.SafeFutureAssert;
 import tech.pegasys.teku.infrastructure.async.eventthread.InlineEventThread;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
@@ -232,7 +233,7 @@ class ForkChoiceTest {
       UInt64 timeIntoSlotMillis =
           recentChainData.getStore().getTimeMillis().plus(advanceTimeSlotMillis);
       transaction.setTimeMillis(timeIntoSlotMillis);
-      transaction.commit().join();
+      SafeFutureAssert.safeJoin(transaction.commit());
     }
 
     importBlock(expectedChainHead);

--- a/fork-choice-tests/src/integration-test/java/tech/pegasys/teku/forkChoiceTests/ForkChoiceIntegrationTest.java
+++ b/fork-choice-tests/src/integration-test/java/tech/pegasys/teku/forkChoiceTests/ForkChoiceIntegrationTest.java
@@ -197,7 +197,7 @@ public class ForkChoiceIntegrationTest {
       if (step instanceof UInt64) {
         UpdatableStore.StoreTransaction transaction = storageClient.startStoreTransaction();
         while (SPEC.getCurrentSlot(transaction).compareTo((UInt64) step) < 0) {
-          SPEC.onTick(transaction, transaction.getTimeSeconds().plus(UInt64.ONE));
+          SPEC.onTick(transaction, transaction.getTimeMillis().plus(1000));
         }
         assertEquals(step, SPEC.getCurrentSlot(transaction));
         transaction.commit().join();

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/SlotProcessor.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/SlotProcessor.java
@@ -198,7 +198,7 @@ public class SlotProcessor {
   }
 
   private UInt64 oneThirdSlotMillis(final UInt64 slot) {
-    return secondsToMillis(spec.getSecondsPerSlot(slot)).dividedBy(INTERVALS_PER_SLOT);
+    return spec.getMillisPerSlot(slot).dividedBy(INTERVALS_PER_SLOT);
   }
 
   private void processSlotStart(final UInt64 nodeEpoch) {

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransaction.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransaction.java
@@ -108,7 +108,7 @@ class StoreTransaction implements UpdatableStore.StoreTransaction {
         timeSeconds);
     UInt64 timeMillis = secondsToMillis(timeSeconds);
     if (updatingMillisIsRequired(timeMillis)) {
-      setTimeMillis(timeMillis);
+      this.timeMillis = Optional.of(timeMillis);
     }
   }
 


### PR DESCRIPTION
## PR Description
Modified `forkChoice.onTick` method to use milliseconds
Added `spec.getMillisPerSlot` config helper method

## Fixed Issue(s)
related to #5297 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
