### PR TITLE
Support returning GetNewBlindedBlock as SSZ

### DIFF
--- a/data/beaconrestapi/build.gradle
+++ b/data/beaconrestapi/build.gradle
@@ -28,7 +28,6 @@ dependencies {
     implementation 'io.javalin:javalin-openapi'
     implementation 'org.apache.tuweni:tuweni-units'
     implementation 'org.webjars:swagger-ui'
-    implementation 'org.commonjava.mimeparse:mimeparse'
 
     testImplementation testFixtures(project(':storage'))
     testImplementation testFixtures(project(':ethereum:spec'))

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/debug/GetStateIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/debug/GetStateIntegrationTest.java
@@ -16,8 +16,8 @@ package tech.pegasys.teku.beaconrestapi.v1.debug;
 import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
 import static javax.servlet.http.HttpServletResponse.SC_OK;
 import static org.assertj.core.api.Assertions.assertThat;
-import static tech.pegasys.teku.infrastructure.http.RestApiConstants.HEADER_ACCEPT_JSON;
-import static tech.pegasys.teku.infrastructure.http.RestApiConstants.HEADER_ACCEPT_OCTET;
+import static tech.pegasys.teku.infrastructure.http.ContentTypes.APPLICATION_JSON;
+import static tech.pegasys.teku.infrastructure.http.ContentTypes.APPLICATION_OCTET_STREAM;
 
 import java.io.IOException;
 import okhttp3.Response;
@@ -34,7 +34,7 @@ public class GetStateIntegrationTest extends AbstractDataBackedRestAPIIntegratio
   @Test
   public void shouldGetStateAsJson() throws IOException {
     startRestAPIAtGenesis(SpecMilestone.PHASE0);
-    final Response response = get("head", HEADER_ACCEPT_JSON);
+    final Response response = get("head", APPLICATION_JSON);
     assertThat(response.code()).isEqualTo(SC_OK);
     final GetStateResponse stateResponse =
         jsonProvider.jsonToObject(response.body().string(), GetStateResponse.class);
@@ -54,7 +54,7 @@ public class GetStateIntegrationTest extends AbstractDataBackedRestAPIIntegratio
   @Test
   public void shouldGetStateAsOctetStream() throws IOException {
     startRestAPIAtGenesis(SpecMilestone.PHASE0);
-    final Response response = get("head", HEADER_ACCEPT_OCTET);
+    final Response response = get("head", APPLICATION_OCTET_STREAM);
     assertThat(response.code()).isEqualTo(SC_OK);
     final BeaconState state =
         spec.getGenesisSchemaDefinitions()

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/debug/GetStateIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/debug/GetStateIntegrationTest.java
@@ -16,8 +16,7 @@ package tech.pegasys.teku.beaconrestapi.v1.debug;
 import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
 import static javax.servlet.http.HttpServletResponse.SC_OK;
 import static org.assertj.core.api.Assertions.assertThat;
-import static tech.pegasys.teku.infrastructure.http.ContentTypes.APPLICATION_JSON;
-import static tech.pegasys.teku.infrastructure.http.ContentTypes.APPLICATION_OCTET_STREAM;
+import static tech.pegasys.teku.infrastructure.http.ContentTypes.OCTET_STREAM;
 
 import java.io.IOException;
 import okhttp3.Response;
@@ -26,6 +25,7 @@ import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.api.response.v1.debug.GetStateResponse;
 import tech.pegasys.teku.beaconrestapi.AbstractDataBackedRestAPIIntegrationTest;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.debug.GetState;
+import tech.pegasys.teku.infrastructure.http.ContentTypes;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 
@@ -34,7 +34,7 @@ public class GetStateIntegrationTest extends AbstractDataBackedRestAPIIntegratio
   @Test
   public void shouldGetStateAsJson() throws IOException {
     startRestAPIAtGenesis(SpecMilestone.PHASE0);
-    final Response response = get("head", APPLICATION_JSON);
+    final Response response = get("head", ContentTypes.JSON);
     assertThat(response.code()).isEqualTo(SC_OK);
     final GetStateResponse stateResponse =
         jsonProvider.jsonToObject(response.body().string(), GetStateResponse.class);
@@ -54,7 +54,7 @@ public class GetStateIntegrationTest extends AbstractDataBackedRestAPIIntegratio
   @Test
   public void shouldGetStateAsOctetStream() throws IOException {
     startRestAPIAtGenesis(SpecMilestone.PHASE0);
-    final Response response = get("head", APPLICATION_OCTET_STREAM);
+    final Response response = get("head", OCTET_STREAM);
     assertThat(response.code()).isEqualTo(SC_OK);
     final BeaconState state =
         spec.getGenesisSchemaDefinitions()

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v2/beacon/GetBlockV2IntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v2/beacon/GetBlockV2IntegrationTest.java
@@ -15,7 +15,7 @@ package tech.pegasys.teku.beaconrestapi.v2.beacon;
 
 import static javax.servlet.http.HttpServletResponse.SC_OK;
 import static org.assertj.core.api.Assertions.assertThat;
-import static tech.pegasys.teku.infrastructure.http.ContentTypes.APPLICATION_OCTET_STREAM;
+import static tech.pegasys.teku.infrastructure.http.ContentTypes.OCTET_STREAM;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.HEADER_CONSENSUS_VERSION;
 
 import java.io.IOException;
@@ -77,7 +77,7 @@ public class GetBlockV2IntegrationTest extends AbstractDataBackedRestAPIIntegrat
   public void shouldGetAltairBlockAsSsz() throws IOException {
     startRestAPIAtGenesis(SpecMilestone.ALTAIR);
     createBlocksAtSlots(10);
-    final Response response = get("head", APPLICATION_OCTET_STREAM);
+    final Response response = get("head", OCTET_STREAM);
     assertThat(response.code()).isEqualTo(SC_OK);
     assertThat(response.header(HEADER_CONSENSUS_VERSION)).isEqualTo(Version.altair.name());
   }

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v2/beacon/GetBlockV2IntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v2/beacon/GetBlockV2IntegrationTest.java
@@ -15,7 +15,7 @@ package tech.pegasys.teku.beaconrestapi.v2.beacon;
 
 import static javax.servlet.http.HttpServletResponse.SC_OK;
 import static org.assertj.core.api.Assertions.assertThat;
-import static tech.pegasys.teku.infrastructure.http.RestApiConstants.HEADER_ACCEPT_OCTET;
+import static tech.pegasys.teku.infrastructure.http.ContentTypes.APPLICATION_OCTET_STREAM;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.HEADER_CONSENSUS_VERSION;
 
 import java.io.IOException;
@@ -77,7 +77,7 @@ public class GetBlockV2IntegrationTest extends AbstractDataBackedRestAPIIntegrat
   public void shouldGetAltairBlockAsSsz() throws IOException {
     startRestAPIAtGenesis(SpecMilestone.ALTAIR);
     createBlocksAtSlots(10);
-    final Response response = get("head", HEADER_ACCEPT_OCTET);
+    final Response response = get("head", APPLICATION_OCTET_STREAM);
     assertThat(response.code()).isEqualTo(SC_OK);
     assertThat(response.header(HEADER_CONSENSUS_VERSION)).isEqualTo(Version.altair.name());
   }

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v2/debug/GetStateIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v2/debug/GetStateIntegrationTest.java
@@ -15,8 +15,7 @@ package tech.pegasys.teku.beaconrestapi.v2.debug;
 
 import static javax.servlet.http.HttpServletResponse.SC_OK;
 import static org.assertj.core.api.Assertions.assertThat;
-import static tech.pegasys.teku.infrastructure.http.ContentTypes.APPLICATION_JSON;
-import static tech.pegasys.teku.infrastructure.http.ContentTypes.APPLICATION_OCTET_STREAM;
+import static tech.pegasys.teku.infrastructure.http.ContentTypes.OCTET_STREAM;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.HEADER_CONSENSUS_VERSION;
 
 import java.io.IOException;
@@ -28,13 +27,14 @@ import tech.pegasys.teku.api.schema.altair.BeaconStateAltair;
 import tech.pegasys.teku.api.schema.phase0.BeaconStatePhase0;
 import tech.pegasys.teku.beaconrestapi.AbstractDataBackedRestAPIIntegrationTest;
 import tech.pegasys.teku.beaconrestapi.handlers.v2.debug.GetState;
+import tech.pegasys.teku.infrastructure.http.ContentTypes;
 import tech.pegasys.teku.spec.SpecMilestone;
 
 public class GetStateIntegrationTest extends AbstractDataBackedRestAPIIntegrationTest {
   @Test
   public void shouldGetPhase0StateAsJson() throws IOException {
     startRestAPIAtGenesis(SpecMilestone.PHASE0);
-    final Response response = get("head", APPLICATION_JSON);
+    final Response response = get("head", ContentTypes.JSON);
     assertThat(response.code()).isEqualTo(SC_OK);
     final GetStateResponseV2 stateResponse =
         jsonProvider.jsonToObject(response.body().string(), GetStateResponseV2.class);
@@ -47,7 +47,7 @@ public class GetStateIntegrationTest extends AbstractDataBackedRestAPIIntegratio
   @Test
   public void shouldGetAltairStateAsJson() throws IOException {
     startRestAPIAtGenesis(SpecMilestone.ALTAIR);
-    final Response response = get("head", APPLICATION_JSON);
+    final Response response = get("head", ContentTypes.JSON);
     assertThat(response.code()).isEqualTo(SC_OK);
     final GetStateResponseV2 stateResponse =
         jsonProvider.jsonToObject(response.body().string(), GetStateResponseV2.class);
@@ -60,7 +60,7 @@ public class GetStateIntegrationTest extends AbstractDataBackedRestAPIIntegratio
   @Test
   public void shouldGetAltairStateAsSsz() throws IOException {
     startRestAPIAtGenesis(SpecMilestone.ALTAIR);
-    final Response response = get("head", APPLICATION_OCTET_STREAM);
+    final Response response = get("head", OCTET_STREAM);
     assertThat(response.code()).isEqualTo(SC_OK);
     assertThat(response.header(HEADER_CONSENSUS_VERSION)).isEqualTo(Version.altair.name());
   }

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v2/debug/GetStateIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v2/debug/GetStateIntegrationTest.java
@@ -15,8 +15,8 @@ package tech.pegasys.teku.beaconrestapi.v2.debug;
 
 import static javax.servlet.http.HttpServletResponse.SC_OK;
 import static org.assertj.core.api.Assertions.assertThat;
-import static tech.pegasys.teku.infrastructure.http.RestApiConstants.HEADER_ACCEPT_JSON;
-import static tech.pegasys.teku.infrastructure.http.RestApiConstants.HEADER_ACCEPT_OCTET;
+import static tech.pegasys.teku.infrastructure.http.ContentTypes.APPLICATION_JSON;
+import static tech.pegasys.teku.infrastructure.http.ContentTypes.APPLICATION_OCTET_STREAM;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.HEADER_CONSENSUS_VERSION;
 
 import java.io.IOException;
@@ -34,7 +34,7 @@ public class GetStateIntegrationTest extends AbstractDataBackedRestAPIIntegratio
   @Test
   public void shouldGetPhase0StateAsJson() throws IOException {
     startRestAPIAtGenesis(SpecMilestone.PHASE0);
-    final Response response = get("head", HEADER_ACCEPT_JSON);
+    final Response response = get("head", APPLICATION_JSON);
     assertThat(response.code()).isEqualTo(SC_OK);
     final GetStateResponseV2 stateResponse =
         jsonProvider.jsonToObject(response.body().string(), GetStateResponseV2.class);
@@ -47,7 +47,7 @@ public class GetStateIntegrationTest extends AbstractDataBackedRestAPIIntegratio
   @Test
   public void shouldGetAltairStateAsJson() throws IOException {
     startRestAPIAtGenesis(SpecMilestone.ALTAIR);
-    final Response response = get("head", HEADER_ACCEPT_JSON);
+    final Response response = get("head", APPLICATION_JSON);
     assertThat(response.code()).isEqualTo(SC_OK);
     final GetStateResponseV2 stateResponse =
         jsonProvider.jsonToObject(response.body().string(), GetStateResponseV2.class);
@@ -60,7 +60,7 @@ public class GetStateIntegrationTest extends AbstractDataBackedRestAPIIntegratio
   @Test
   public void shouldGetAltairStateAsSsz() throws IOException {
     startRestAPIAtGenesis(SpecMilestone.ALTAIR);
-    final Response response = get("head", HEADER_ACCEPT_OCTET);
+    final Response response = get("head", APPLICATION_OCTET_STREAM);
     assertThat(response.code()).isEqualTo(SC_OK);
     assertThat(response.header(HEADER_CONSENSUS_VERSION)).isEqualTo(Version.altair.name());
   }

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/paths/_eth_v1_validator_blinded_blocks_{slot}.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/paths/_eth_v1_validator_blinded_blocks_{slot}.json
@@ -42,6 +42,12 @@
             "schema" : {
               "$ref" : "#/components/schemas/GetNewBlindedBlockResponse"
             }
+          },
+          "application/octet-stream" : {
+            "schema" : {
+              "type" : "string",
+              "format" : "binary"
+            }
           }
         }
       },

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_validator_blinded_blocks_{slot}.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_validator_blinded_blocks_{slot}.json
@@ -36,6 +36,11 @@
             "schema" : {
               "$ref" : "#/components/schemas/GetNewBlindedBlockResponse"
             }
+          },
+          "application/octet-stream" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/Unit"
+            }
           }
         }
       },

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApi.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApi.java
@@ -216,6 +216,7 @@ public class BeaconRestApi {
     app.exception(NodeSyncingException.class, this::serviceUnavailable);
     app.exception(ServiceUnavailableException.class, this::serviceUnavailable);
     app.exception(BadRequestException.class, this::badRequest);
+    app.exception(IllegalArgumentException.class, this::badRequest);
     // Add catch-all handler
     app.exception(
         Exception.class,

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/AbstractHandler.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/AbstractHandler.java
@@ -15,8 +15,8 @@ package tech.pegasys.teku.beaconrestapi.handlers;
 
 import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
 import static tech.pegasys.teku.infrastructure.async.SafeFuture.failedFuture;
-import static tech.pegasys.teku.infrastructure.http.ContentTypes.APPLICATION_JSON;
-import static tech.pegasys.teku.infrastructure.http.ContentTypes.APPLICATION_OCTET_STREAM;
+import static tech.pegasys.teku.infrastructure.http.ContentTypes.JSON;
+import static tech.pegasys.teku.infrastructure.http.ContentTypes.OCTET_STREAM;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -33,8 +33,7 @@ import tech.pegasys.teku.infrastructure.http.ContentTypes;
 import tech.pegasys.teku.provider.JsonProvider;
 
 public abstract class AbstractHandler implements Handler {
-  public static final List<String> SSZ_OR_JSON_CONTENT_TYPES =
-      List.of(APPLICATION_OCTET_STREAM, APPLICATION_JSON);
+  public static final List<String> SSZ_OR_JSON_CONTENT_TYPES = List.of(OCTET_STREAM, JSON);
   protected final JsonProvider jsonProvider;
 
   protected AbstractHandler(final JsonProvider jsonProvider) {
@@ -192,6 +191,6 @@ public abstract class AbstractHandler implements Handler {
 
   public static String getContentType(
       final List<String> types, final Optional<String> maybeContentType) {
-    return ContentTypes.getContentType(types, maybeContentType).orElse(APPLICATION_JSON);
+    return ContentTypes.getContentType(types, maybeContentType).orElse(JSON);
   }
 }

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/AbstractHandler.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/AbstractHandler.java
@@ -15,9 +15,9 @@ package tech.pegasys.teku.beaconrestapi.handlers;
 
 import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
 import static tech.pegasys.teku.infrastructure.async.SafeFuture.failedFuture;
+import static tech.pegasys.teku.infrastructure.http.ContentTypes.APPLICATION_JSON;
+import static tech.pegasys.teku.infrastructure.http.ContentTypes.APPLICATION_OCTET_STREAM;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
-import static tech.pegasys.teku.infrastructure.http.RestApiConstants.HEADER_ACCEPT_JSON;
-import static tech.pegasys.teku.infrastructure.http.RestApiConstants.HEADER_ACCEPT_OCTET;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.base.Throwables;
@@ -26,17 +26,15 @@ import io.javalin.http.Handler;
 import java.io.ByteArrayInputStream;
 import java.util.List;
 import java.util.Optional;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.commonjava.mimeparse.MIMEParse;
 import tech.pegasys.teku.api.response.v1.beacon.PostDataFailureResponse;
 import tech.pegasys.teku.beaconrestapi.schema.BadRequest;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.http.ContentTypes;
 import tech.pegasys.teku.provider.JsonProvider;
 
 public abstract class AbstractHandler implements Handler {
-  private static final Logger LOG = LogManager.getLogger();
-  public static final List<String> ACCEPT_ALL = List.of(HEADER_ACCEPT_OCTET, HEADER_ACCEPT_JSON);
+  public static final List<String> SSZ_OR_JSON_CONTENT_TYPES =
+      List.of(APPLICATION_OCTET_STREAM, APPLICATION_JSON);
   protected final JsonProvider jsonProvider;
 
   protected AbstractHandler(final JsonProvider jsonProvider) {
@@ -194,16 +192,6 @@ public abstract class AbstractHandler implements Handler {
 
   public static String getContentType(
       final List<String> types, final Optional<String> maybeContentType) {
-    if (maybeContentType.isEmpty()) {
-      return HEADER_ACCEPT_JSON;
-    }
-    try {
-      final String contentType = maybeContentType.get();
-      final String bestMatch = MIMEParse.bestMatch(types, contentType);
-      return bestMatch.isEmpty() ? HEADER_ACCEPT_JSON : bestMatch;
-    } catch (Exception e) {
-      LOG.trace("Failed to parse accept header", e);
-    }
-    return HEADER_ACCEPT_JSON;
+    return ContentTypes.getContentType(types, maybeContentType).orElse(APPLICATION_JSON);
   }
 }

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/debug/GetState.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/debug/GetState.java
@@ -13,11 +13,11 @@
 
 package tech.pegasys.teku.beaconrestapi.handlers.v1.debug;
 
+import static tech.pegasys.teku.infrastructure.http.ContentTypes.APPLICATION_JSON;
+import static tech.pegasys.teku.infrastructure.http.ContentTypes.APPLICATION_OCTET_STREAM;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_BAD_REQUEST;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_NOT_FOUND;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.HEADER_ACCEPT;
-import static tech.pegasys.teku.infrastructure.http.RestApiConstants.HEADER_ACCEPT_JSON;
-import static tech.pegasys.teku.infrastructure.http.RestApiConstants.HEADER_ACCEPT_OCTET;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.PARAM_STATE_ID;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.PARAM_STATE_ID_DESCRIPTION;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.RES_BAD_REQUEST;
@@ -81,8 +81,8 @@ public class GetState extends AbstractHandler implements Handler {
         @OpenApiResponse(
             status = RES_OK,
             content = {
-              @OpenApiContent(type = HEADER_ACCEPT_JSON, from = GetStateResponse.class),
-              @OpenApiContent(type = HEADER_ACCEPT_OCTET)
+              @OpenApiContent(type = APPLICATION_JSON, from = GetStateResponse.class),
+              @OpenApiContent(type = APPLICATION_OCTET_STREAM)
             }),
         @OpenApiResponse(status = RES_BAD_REQUEST),
         @OpenApiResponse(status = RES_NOT_FOUND),
@@ -93,7 +93,8 @@ public class GetState extends AbstractHandler implements Handler {
   public void handle(@NotNull final Context ctx) throws Exception {
     final Optional<String> maybeAcceptHeader = Optional.ofNullable(ctx.header(HEADER_ACCEPT));
     final Map<String, String> pathParamMap = ctx.pathParamMap();
-    if (getContentType(ACCEPT_ALL, maybeAcceptHeader).equalsIgnoreCase(HEADER_ACCEPT_OCTET)) {
+    if (getContentType(SSZ_OR_JSON_CONTENT_TYPES, maybeAcceptHeader)
+        .equalsIgnoreCase(APPLICATION_OCTET_STREAM)) {
       final SafeFuture<Optional<SszResponse>> future =
           chainDataProvider.getBeaconStateSsz(pathParamMap.get(PARAM_STATE_ID));
       handleOptionalSszResult(

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/debug/GetState.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/debug/GetState.java
@@ -13,8 +13,8 @@
 
 package tech.pegasys.teku.beaconrestapi.handlers.v1.debug;
 
-import static tech.pegasys.teku.infrastructure.http.ContentTypes.APPLICATION_JSON;
-import static tech.pegasys.teku.infrastructure.http.ContentTypes.APPLICATION_OCTET_STREAM;
+import static tech.pegasys.teku.infrastructure.http.ContentTypes.JSON;
+import static tech.pegasys.teku.infrastructure.http.ContentTypes.OCTET_STREAM;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_BAD_REQUEST;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_NOT_FOUND;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.HEADER_ACCEPT;
@@ -81,8 +81,8 @@ public class GetState extends AbstractHandler implements Handler {
         @OpenApiResponse(
             status = RES_OK,
             content = {
-              @OpenApiContent(type = APPLICATION_JSON, from = GetStateResponse.class),
-              @OpenApiContent(type = APPLICATION_OCTET_STREAM)
+              @OpenApiContent(type = JSON, from = GetStateResponse.class),
+              @OpenApiContent(type = OCTET_STREAM)
             }),
         @OpenApiResponse(status = RES_BAD_REQUEST),
         @OpenApiResponse(status = RES_NOT_FOUND),
@@ -94,7 +94,7 @@ public class GetState extends AbstractHandler implements Handler {
     final Optional<String> maybeAcceptHeader = Optional.ofNullable(ctx.header(HEADER_ACCEPT));
     final Map<String, String> pathParamMap = ctx.pathParamMap();
     if (getContentType(SSZ_OR_JSON_CONTENT_TYPES, maybeAcceptHeader)
-        .equalsIgnoreCase(APPLICATION_OCTET_STREAM)) {
+        .equalsIgnoreCase(OCTET_STREAM)) {
       final SafeFuture<Optional<SszResponse>> future =
           chainDataProvider.getBeaconStateSsz(pathParamMap.get(PARAM_STATE_ID));
       handleOptionalSszResult(

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetNewBlindedBlock.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetNewBlindedBlock.java
@@ -15,7 +15,7 @@ package tech.pegasys.teku.beaconrestapi.handlers.v1.validator;
 
 import static tech.pegasys.teku.beaconrestapi.EthereumTypes.SIGNATURE_TYPE;
 import static tech.pegasys.teku.beaconrestapi.handlers.AbstractHandler.routeWithBracedParameters;
-import static tech.pegasys.teku.infrastructure.http.ContentTypes.APPLICATION_OCTET_STREAM;
+import static tech.pegasys.teku.infrastructure.http.ContentTypes.OCTET_STREAM;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.GRAFFITI;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.RANDAO_REVEAL;
@@ -125,7 +125,7 @@ public class GetNewBlindedBlock extends MigratingEndpointAdapter {
             status = RES_OK,
             content = {
               @OpenApiContent(from = GetNewBlindedBlockResponse.class),
-              @OpenApiContent(type = APPLICATION_OCTET_STREAM)
+              @OpenApiContent(type = OCTET_STREAM)
             }),
         @OpenApiResponse(status = RES_BAD_REQUEST, description = "Invalid parameter supplied"),
         @OpenApiResponse(status = RES_INTERNAL_ERROR),

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetNewBlindedBlock.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetNewBlindedBlock.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.beaconrestapi.handlers.v1.validator;
 
 import static tech.pegasys.teku.beaconrestapi.EthereumTypes.SIGNATURE_TYPE;
 import static tech.pegasys.teku.beaconrestapi.handlers.AbstractHandler.routeWithBracedParameters;
+import static tech.pegasys.teku.infrastructure.http.ContentTypes.APPLICATION_OCTET_STREAM;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.GRAFFITI;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.RANDAO_REVEAL;
@@ -55,6 +56,7 @@ import tech.pegasys.teku.infrastructure.restapi.endpoints.AsyncApiResponse;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.EndpointMetadata;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.ParameterMetadata;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiRequest;
+import tech.pegasys.teku.infrastructure.ssz.SszData;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
@@ -121,7 +123,10 @@ public class GetNewBlindedBlock extends MigratingEndpointAdapter {
       responses = {
         @OpenApiResponse(
             status = RES_OK,
-            content = @OpenApiContent(from = GetNewBlindedBlockResponse.class)),
+            content = {
+              @OpenApiContent(from = GetNewBlindedBlockResponse.class),
+              @OpenApiContent(type = APPLICATION_OCTET_STREAM)
+            }),
         @OpenApiResponse(status = RES_BAD_REQUEST, description = "Invalid parameter supplied"),
         @OpenApiResponse(status = RES_INTERNAL_ERROR),
         @OpenApiResponse(status = RES_SERVICE_UNAVAILABLE, description = SERVICE_UNAVAILABLE)
@@ -176,7 +181,8 @@ public class GetNewBlindedBlock extends MigratingEndpointAdapter {
                     "version",
                     SPEC_VERSION,
                     block -> schemaDefinitionCache.milestoneAtSlot(block.getSlot()))
-                .build())
+                .build(),
+            SszData::sszSerialize)
         .build();
   }
 

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v2/beacon/GetBlock.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v2/beacon/GetBlock.java
@@ -13,8 +13,8 @@
 
 package tech.pegasys.teku.beaconrestapi.handlers.v2.beacon;
 
-import static tech.pegasys.teku.infrastructure.http.ContentTypes.APPLICATION_JSON;
-import static tech.pegasys.teku.infrastructure.http.ContentTypes.APPLICATION_OCTET_STREAM;
+import static tech.pegasys.teku.infrastructure.http.ContentTypes.JSON;
+import static tech.pegasys.teku.infrastructure.http.ContentTypes.OCTET_STREAM;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_NOT_FOUND;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.HEADER_ACCEPT;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.HEADER_CONSENSUS_VERSION;
@@ -74,8 +74,8 @@ public class GetBlock extends AbstractHandler implements Handler {
         @OpenApiResponse(
             status = RES_OK,
             content = {
-              @OpenApiContent(type = APPLICATION_JSON, from = GetBlockResponseV2.class),
-              @OpenApiContent(type = APPLICATION_OCTET_STREAM)
+              @OpenApiContent(type = JSON, from = GetBlockResponseV2.class),
+              @OpenApiContent(type = OCTET_STREAM)
             }),
         @OpenApiResponse(status = RES_BAD_REQUEST),
         @OpenApiResponse(status = RES_NOT_FOUND),
@@ -88,7 +88,7 @@ public class GetBlock extends AbstractHandler implements Handler {
     final String blockIdentifier = pathParams.get(PARAM_BLOCK_ID);
 
     if (getContentType(SSZ_OR_JSON_CONTENT_TYPES, maybeAcceptHeader)
-        .equalsIgnoreCase(APPLICATION_OCTET_STREAM)) {
+        .equalsIgnoreCase(OCTET_STREAM)) {
       final SafeFuture<Optional<SszResponse>> future =
           chainDataProvider.getBlockSsz(blockIdentifier);
       handleOptionalSszResult(

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v2/beacon/GetBlock.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v2/beacon/GetBlock.java
@@ -13,10 +13,10 @@
 
 package tech.pegasys.teku.beaconrestapi.handlers.v2.beacon;
 
+import static tech.pegasys.teku.infrastructure.http.ContentTypes.APPLICATION_JSON;
+import static tech.pegasys.teku.infrastructure.http.ContentTypes.APPLICATION_OCTET_STREAM;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_NOT_FOUND;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.HEADER_ACCEPT;
-import static tech.pegasys.teku.infrastructure.http.RestApiConstants.HEADER_ACCEPT_JSON;
-import static tech.pegasys.teku.infrastructure.http.RestApiConstants.HEADER_ACCEPT_OCTET;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.HEADER_CONSENSUS_VERSION;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.PARAM_BLOCK_ID;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.PARAM_BLOCK_ID_DESCRIPTION;
@@ -74,8 +74,8 @@ public class GetBlock extends AbstractHandler implements Handler {
         @OpenApiResponse(
             status = RES_OK,
             content = {
-              @OpenApiContent(type = HEADER_ACCEPT_JSON, from = GetBlockResponseV2.class),
-              @OpenApiContent(type = HEADER_ACCEPT_OCTET)
+              @OpenApiContent(type = APPLICATION_JSON, from = GetBlockResponseV2.class),
+              @OpenApiContent(type = APPLICATION_OCTET_STREAM)
             }),
         @OpenApiResponse(status = RES_BAD_REQUEST),
         @OpenApiResponse(status = RES_NOT_FOUND),
@@ -87,7 +87,8 @@ public class GetBlock extends AbstractHandler implements Handler {
     final Optional<String> maybeAcceptHeader = Optional.ofNullable(ctx.header(HEADER_ACCEPT));
     final String blockIdentifier = pathParams.get(PARAM_BLOCK_ID);
 
-    if (getContentType(ACCEPT_ALL, maybeAcceptHeader).equalsIgnoreCase(HEADER_ACCEPT_OCTET)) {
+    if (getContentType(SSZ_OR_JSON_CONTENT_TYPES, maybeAcceptHeader)
+        .equalsIgnoreCase(APPLICATION_OCTET_STREAM)) {
       final SafeFuture<Optional<SszResponse>> future =
           chainDataProvider.getBlockSsz(blockIdentifier);
       handleOptionalSszResult(

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v2/debug/GetState.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v2/debug/GetState.java
@@ -13,8 +13,8 @@
 
 package tech.pegasys.teku.beaconrestapi.handlers.v2.debug;
 
-import static tech.pegasys.teku.infrastructure.http.ContentTypes.APPLICATION_JSON;
-import static tech.pegasys.teku.infrastructure.http.ContentTypes.APPLICATION_OCTET_STREAM;
+import static tech.pegasys.teku.infrastructure.http.ContentTypes.JSON;
+import static tech.pegasys.teku.infrastructure.http.ContentTypes.OCTET_STREAM;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_NOT_FOUND;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.HEADER_ACCEPT;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.HEADER_CONSENSUS_VERSION;
@@ -78,8 +78,8 @@ public class GetState extends AbstractHandler implements Handler {
         @OpenApiResponse(
             status = RES_OK,
             content = {
-              @OpenApiContent(type = APPLICATION_JSON, from = GetStateResponseV2.class),
-              @OpenApiContent(type = APPLICATION_OCTET_STREAM)
+              @OpenApiContent(type = JSON, from = GetStateResponseV2.class),
+              @OpenApiContent(type = OCTET_STREAM)
             }),
         @OpenApiResponse(status = RES_BAD_REQUEST),
         @OpenApiResponse(status = RES_NOT_FOUND),
@@ -91,7 +91,7 @@ public class GetState extends AbstractHandler implements Handler {
     final Optional<String> maybeAcceptHeader = Optional.ofNullable(ctx.header(HEADER_ACCEPT));
     final Map<String, String> pathParamMap = ctx.pathParamMap();
     if (getContentType(SSZ_OR_JSON_CONTENT_TYPES, maybeAcceptHeader)
-        .equalsIgnoreCase(APPLICATION_OCTET_STREAM)) {
+        .equalsIgnoreCase(OCTET_STREAM)) {
       final SafeFuture<Optional<SszResponse>> future =
           chainDataProvider.getBeaconStateSsz(pathParamMap.get(PARAM_STATE_ID));
       handleOptionalSszResult(

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v2/debug/GetState.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v2/debug/GetState.java
@@ -13,10 +13,10 @@
 
 package tech.pegasys.teku.beaconrestapi.handlers.v2.debug;
 
+import static tech.pegasys.teku.infrastructure.http.ContentTypes.APPLICATION_JSON;
+import static tech.pegasys.teku.infrastructure.http.ContentTypes.APPLICATION_OCTET_STREAM;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_NOT_FOUND;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.HEADER_ACCEPT;
-import static tech.pegasys.teku.infrastructure.http.RestApiConstants.HEADER_ACCEPT_JSON;
-import static tech.pegasys.teku.infrastructure.http.RestApiConstants.HEADER_ACCEPT_OCTET;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.HEADER_CONSENSUS_VERSION;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.PARAM_STATE_ID;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.PARAM_STATE_ID_DESCRIPTION;
@@ -78,8 +78,8 @@ public class GetState extends AbstractHandler implements Handler {
         @OpenApiResponse(
             status = RES_OK,
             content = {
-              @OpenApiContent(type = HEADER_ACCEPT_JSON, from = GetStateResponseV2.class),
-              @OpenApiContent(type = HEADER_ACCEPT_OCTET)
+              @OpenApiContent(type = APPLICATION_JSON, from = GetStateResponseV2.class),
+              @OpenApiContent(type = APPLICATION_OCTET_STREAM)
             }),
         @OpenApiResponse(status = RES_BAD_REQUEST),
         @OpenApiResponse(status = RES_NOT_FOUND),
@@ -90,7 +90,8 @@ public class GetState extends AbstractHandler implements Handler {
   public void handle(@NotNull final Context ctx) throws Exception {
     final Optional<String> maybeAcceptHeader = Optional.ofNullable(ctx.header(HEADER_ACCEPT));
     final Map<String, String> pathParamMap = ctx.pathParamMap();
-    if (getContentType(ACCEPT_ALL, maybeAcceptHeader).equalsIgnoreCase(HEADER_ACCEPT_OCTET)) {
+    if (getContentType(SSZ_OR_JSON_CONTENT_TYPES, maybeAcceptHeader)
+        .equalsIgnoreCase(APPLICATION_OCTET_STREAM)) {
       final SafeFuture<Optional<SszResponse>> future =
           chainDataProvider.getBeaconStateSsz(pathParamMap.get(PARAM_STATE_ID));
       handleOptionalSszResult(

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/AbstractHandlerTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/AbstractHandlerTest.java
@@ -15,8 +15,8 @@ package tech.pegasys.teku.beaconrestapi.handlers;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static tech.pegasys.teku.beaconrestapi.handlers.AbstractHandler.SSZ_OR_JSON_CONTENT_TYPES;
-import static tech.pegasys.teku.infrastructure.http.ContentTypes.APPLICATION_JSON;
-import static tech.pegasys.teku.infrastructure.http.ContentTypes.APPLICATION_OCTET_STREAM;
+import static tech.pegasys.teku.infrastructure.http.ContentTypes.JSON;
+import static tech.pegasys.teku.infrastructure.http.ContentTypes.OCTET_STREAM;
 
 import java.util.List;
 import java.util.Optional;
@@ -26,7 +26,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 class AbstractHandlerTest {
 
-  private static final List<String> JSON_ONLY = List.of(APPLICATION_JSON);
+  private static final List<String> JSON_ONLY = List.of(JSON);
 
   @Test
   void shouldHandleParameterAtEnd() {
@@ -58,7 +58,7 @@ class AbstractHandlerTest {
   @Test
   void accept_shouldReturnJsonIfNotSpecified() {
     assertThat(AbstractHandler.getContentType(SSZ_OR_JSON_CONTENT_TYPES, Optional.empty()))
-        .isEqualTo(APPLICATION_JSON);
+        .isEqualTo(JSON);
   }
 
   @ParameterizedTest(name = "{0}")
@@ -76,7 +76,7 @@ class AbstractHandlerTest {
       })
   void accept_errorsAgainstJsonHeaderRequirement(final String invalidMimeString) {
     assertThat(AbstractHandler.getContentType(JSON_ONLY, Optional.of(invalidMimeString)))
-        .isEqualTo(APPLICATION_JSON);
+        .isEqualTo(JSON);
   }
 
   @Test
@@ -85,7 +85,7 @@ class AbstractHandlerTest {
             AbstractHandler.getContentType(
                 SSZ_OR_JSON_CONTENT_TYPES,
                 Optional.of("application/octet-stream,application/json;q=0.9")))
-        .isEqualTo(APPLICATION_OCTET_STREAM);
+        .isEqualTo(OCTET_STREAM);
   }
 
   @Test
@@ -94,7 +94,7 @@ class AbstractHandlerTest {
             AbstractHandler.getContentType(
                 SSZ_OR_JSON_CONTENT_TYPES,
                 Optional.of("application/octet-stream;q=0.1,application/json;q=0.9")))
-        .isEqualTo(APPLICATION_JSON);
+        .isEqualTo(JSON);
   }
 
   @Test
@@ -102,6 +102,6 @@ class AbstractHandlerTest {
     assertThat(
             AbstractHandler.getContentType(
                 SSZ_OR_JSON_CONTENT_TYPES, Optional.of("application/octet-stream;q=1.0")))
-        .isEqualTo(APPLICATION_OCTET_STREAM);
+        .isEqualTo(OCTET_STREAM);
   }
 }

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/AbstractHandlerTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/AbstractHandlerTest.java
@@ -14,9 +14,9 @@
 package tech.pegasys.teku.beaconrestapi.handlers;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static tech.pegasys.teku.beaconrestapi.handlers.AbstractHandler.ACCEPT_ALL;
-import static tech.pegasys.teku.infrastructure.http.RestApiConstants.HEADER_ACCEPT_JSON;
-import static tech.pegasys.teku.infrastructure.http.RestApiConstants.HEADER_ACCEPT_OCTET;
+import static tech.pegasys.teku.beaconrestapi.handlers.AbstractHandler.SSZ_OR_JSON_CONTENT_TYPES;
+import static tech.pegasys.teku.infrastructure.http.ContentTypes.APPLICATION_JSON;
+import static tech.pegasys.teku.infrastructure.http.ContentTypes.APPLICATION_OCTET_STREAM;
 
 import java.util.List;
 import java.util.Optional;
@@ -26,7 +26,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 class AbstractHandlerTest {
 
-  private static final List<String> JSON_ONLY = List.of(HEADER_ACCEPT_JSON);
+  private static final List<String> JSON_ONLY = List.of(APPLICATION_JSON);
 
   @Test
   void shouldHandleParameterAtEnd() {
@@ -57,8 +57,8 @@ class AbstractHandlerTest {
 
   @Test
   void accept_shouldReturnJsonIfNotSpecified() {
-    assertThat(AbstractHandler.getContentType(ACCEPT_ALL, Optional.empty()))
-        .isEqualTo(HEADER_ACCEPT_JSON);
+    assertThat(AbstractHandler.getContentType(SSZ_OR_JSON_CONTENT_TYPES, Optional.empty()))
+        .isEqualTo(APPLICATION_JSON);
   }
 
   @ParameterizedTest(name = "{0}")
@@ -76,30 +76,32 @@ class AbstractHandlerTest {
       })
   void accept_errorsAgainstJsonHeaderRequirement(final String invalidMimeString) {
     assertThat(AbstractHandler.getContentType(JSON_ONLY, Optional.of(invalidMimeString)))
-        .isEqualTo(HEADER_ACCEPT_JSON);
+        .isEqualTo(APPLICATION_JSON);
   }
 
   @Test
   void accept_shouldPreferenceFirstSpecified() {
     assertThat(
             AbstractHandler.getContentType(
-                ACCEPT_ALL, Optional.of("application/octet-stream,application/json;q=0.9")))
-        .isEqualTo(HEADER_ACCEPT_OCTET);
+                SSZ_OR_JSON_CONTENT_TYPES,
+                Optional.of("application/octet-stream,application/json;q=0.9")))
+        .isEqualTo(APPLICATION_OCTET_STREAM);
   }
 
   @Test
   void accept_shouldPreferenceHighestQValue() {
     assertThat(
             AbstractHandler.getContentType(
-                ACCEPT_ALL, Optional.of("application/octet-stream;q=0.1,application/json;q=0.9")))
-        .isEqualTo(HEADER_ACCEPT_JSON);
+                SSZ_OR_JSON_CONTENT_TYPES,
+                Optional.of("application/octet-stream;q=0.1,application/json;q=0.9")))
+        .isEqualTo(APPLICATION_JSON);
   }
 
   @Test
   void accept_shouldHandleSingleArgWithQSet() {
     assertThat(
             AbstractHandler.getContentType(
-                ACCEPT_ALL, Optional.of("application/octet-stream;q=1.0")))
-        .isEqualTo(HEADER_ACCEPT_OCTET);
+                SSZ_OR_JSON_CONTENT_TYPES, Optional.of("application/octet-stream;q=1.0")))
+        .isEqualTo(APPLICATION_OCTET_STREAM);
   }
 }

--- a/infrastructure/http/build.gradle
+++ b/infrastructure/http/build.gradle
@@ -1,2 +1,3 @@
 dependencies {
+  implementation 'org.commonjava.mimeparse:mimeparse'
 }

--- a/infrastructure/http/src/main/java/tech/pegasys/teku/infrastructure/http/ContentTypes.java
+++ b/infrastructure/http/src/main/java/tech/pegasys/teku/infrastructure/http/ContentTypes.java
@@ -21,8 +21,8 @@ import org.commonjava.mimeparse.MIMEParse;
 
 public class ContentTypes {
 
-  public static final String APPLICATION_JSON = "application/json";
-  public static final String APPLICATION_OCTET_STREAM = "application/octet-stream";
+  public static final String JSON = "application/json";
+  public static final String OCTET_STREAM = "application/octet-stream";
   private static final Logger LOG = LogManager.getLogger();
 
   public static Optional<String> getContentType(

--- a/infrastructure/http/src/main/java/tech/pegasys/teku/infrastructure/http/ContentTypes.java
+++ b/infrastructure/http/src/main/java/tech/pegasys/teku/infrastructure/http/ContentTypes.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.http;
+
+import java.util.Collection;
+import java.util.Optional;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.commonjava.mimeparse.MIMEParse;
+
+public class ContentTypes {
+
+  public static final String APPLICATION_JSON = "application/json";
+  public static final String APPLICATION_OCTET_STREAM = "application/octet-stream";
+  private static final Logger LOG = LogManager.getLogger();
+
+  public static Optional<String> getContentType(
+      final Collection<String> types, final Optional<String> maybeContentType) {
+    if (maybeContentType.isEmpty()) {
+      return Optional.empty();
+    }
+    try {
+      final String contentType = maybeContentType.get();
+      final String bestMatch = MIMEParse.bestMatch(types, contentType);
+      return bestMatch.isEmpty() ? Optional.empty() : Optional.of(bestMatch);
+    } catch (Exception e) {
+      LOG.trace("Failed to parse accept header", e);
+    }
+    return Optional.empty();
+  }
+}

--- a/infrastructure/http/src/main/java/tech/pegasys/teku/infrastructure/http/RestApiConstants.java
+++ b/infrastructure/http/src/main/java/tech/pegasys/teku/infrastructure/http/RestApiConstants.java
@@ -109,8 +109,6 @@ public class RestApiConstants {
           + " status code when current peer count is below than target";
 
   public static final String HEADER_ACCEPT = "Accept";
-  public static final String HEADER_ACCEPT_JSON = "application/json";
-  public static final String HEADER_ACCEPT_OCTET = "application/octet-stream";
 
   public static final String HEADER_CONSENSUS_VERSION = "Eth-Consensus-Version";
 

--- a/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/JsonUtil.java
+++ b/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/JsonUtil.java
@@ -18,12 +18,11 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.JsonToken;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.io.StringWriter;
 import java.io.UncheckedIOException;
 import java.util.Optional;
-import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 import tech.pegasys.teku.infrastructure.json.types.SerializableTypeDefinition;
 
@@ -54,22 +53,22 @@ public class JsonUtil {
     return writer.toString();
   }
 
-  public static <T> Bytes serializeToBytes(final T value, final SerializableTypeDefinition<T> type)
+  public static <T> void serializeToBytes(
+      final T value, final SerializableTypeDefinition<T> type, final OutputStream out)
       throws JsonProcessingException {
-    return serializeToBytes(FACTORY, gen -> type.serialize(value, gen));
+    serializeToBytes(FACTORY, gen -> type.serialize(value, gen), out);
   }
 
-  public static Bytes serializeToBytes(final JsonFactory factory, final JsonWriter serializer)
+  public static void serializeToBytes(
+      final JsonFactory factory, final JsonWriter serializer, final OutputStream out)
       throws JsonProcessingException {
-    final ByteArrayOutputStream writer = new ByteArrayOutputStream();
-    try (final JsonGenerator gen = factory.createGenerator(writer)) {
+    try (final JsonGenerator gen = factory.createGenerator(out)) {
       serializer.accept(gen);
     } catch (final JsonProcessingException e) {
       throw e;
     } catch (final IOException e) {
       throw new UncheckedIOException(e);
     }
-    return Bytes.wrap(writer.toByteArray());
   }
 
   public static <T> T parse(final String json, final DeserializableTypeDefinition<T> type)

--- a/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/DelegatingOpenApiTypeDefinition.java
+++ b/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/DelegatingOpenApiTypeDefinition.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.json.types;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Optional;
+
+public class DelegatingOpenApiTypeDefinition implements OpenApiTypeDefinition {
+  private final OpenApiTypeDefinition typeDefinition;
+
+  protected DelegatingOpenApiTypeDefinition(final OpenApiTypeDefinition typeDefinition) {
+    this.typeDefinition = typeDefinition;
+  }
+
+  @Override
+  public Optional<String> getTypeName() {
+    return typeDefinition.getTypeName();
+  }
+
+  @Override
+  public OpenApiTypeDefinition withDescription(final String description) {
+    return typeDefinition.withDescription(description);
+  }
+
+  @Override
+  public void serializeOpenApiType(final JsonGenerator gen) throws IOException {
+    typeDefinition.serializeOpenApiType(gen);
+  }
+
+  @Override
+  public Collection<OpenApiTypeDefinition> getReferencedTypeDefinitions() {
+    return typeDefinition.getReferencedTypeDefinitions();
+  }
+
+  @Override
+  public Collection<OpenApiTypeDefinition> getSelfAndReferencedTypeDefinitions() {
+    return typeDefinition.getSelfAndReferencedTypeDefinitions();
+  }
+
+  @Override
+  public boolean isEquivalentToDeserializableType(final DeserializableTypeDefinition<?> type) {
+    return typeDefinition.isEquivalentToDeserializableType(type);
+  }
+
+  @Override
+  public void serializeOpenApiTypeOrReference(final JsonGenerator gen) throws IOException {
+    typeDefinition.serializeOpenApiTypeOrReference(gen);
+  }
+}

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/EndpointMetadata.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/EndpointMetadata.java
@@ -17,6 +17,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Collections.emptyMap;
+import static java.util.Collections.emptySet;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_BAD_REQUEST;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_FORBIDDEN;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_INTERNAL_SERVER_ERROR;
@@ -181,6 +182,14 @@ public class EndpointMetadata {
         contentType,
         statusCode);
     return responseType;
+  }
+
+  public Collection<String> getSupportedContentTypes(final int statusCode) {
+    final OpenApiResponse openApiResponse = responses.get(Integer.toString(statusCode));
+    if (openApiResponse == null) {
+      return emptySet();
+    }
+    return openApiResponse.getSupportedContentTypes();
   }
 
   @SuppressWarnings("unchecked")

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/EndpointMetadata.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/EndpointMetadata.java
@@ -39,8 +39,10 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.http.ContentTypes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.exceptions.MissingRequestBodyException;
@@ -51,6 +53,7 @@ import tech.pegasys.teku.infrastructure.json.types.SerializableTypeDefinition;
 import tech.pegasys.teku.infrastructure.json.types.StringValueTypeDefinition;
 import tech.pegasys.teku.infrastructure.restapi.openapi.ContentTypeDefinition;
 import tech.pegasys.teku.infrastructure.restapi.openapi.JsonContentTypeDefinition;
+import tech.pegasys.teku.infrastructure.restapi.openapi.OctetStreamContentTypeDefinition;
 import tech.pegasys.teku.infrastructure.restapi.openapi.OpenApiResponse;
 
 public class EndpointMetadata {
@@ -438,6 +441,21 @@ public class EndpointMetadata {
           responseCode,
           description,
           Map.of(JSON_CONTENT_TYPE, new JsonContentTypeDefinition<>(content)));
+    }
+
+    public <T> EndpointMetaDataBuilder response(
+        final int responseCode,
+        final String description,
+        final SerializableTypeDefinition<T> content,
+        final Function<T, Bytes> toOctetStreamBytes) {
+      return response(
+          responseCode,
+          description,
+          Map.of(
+              JSON_CONTENT_TYPE,
+              new JsonContentTypeDefinition<>(content),
+              ContentTypes.APPLICATION_OCTET_STREAM,
+              new OctetStreamContentTypeDefinition<>(toOctetStreamBytes)));
     }
 
     public EndpointMetaDataBuilder withUnauthorizedResponse() {

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/EndpointMetadata.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/EndpointMetadata.java
@@ -338,7 +338,7 @@ public class EndpointMetadata {
     private Optional<BodyTypeSelector<?>> bodyTypeSelector = Optional.empty();
     private final Map<String, OpenApiResponse> responses = new LinkedHashMap<>();
 
-    private String defaultResponseType = ContentTypes.APPLICATION_JSON;
+    private String defaultResponseType = ContentTypes.JSON;
 
     private List<String> tags = Collections.emptyList();
 
@@ -454,7 +454,7 @@ public class EndpointMetadata {
           Map.of(
               JSON_CONTENT_TYPE,
               new JsonContentTypeDefinition<>(content),
-              ContentTypes.APPLICATION_OCTET_STREAM,
+              ContentTypes.OCTET_STREAM,
               new OctetStreamContentTypeDefinition<>(toOctetStreamBytes)));
     }
 

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/RestApiRequest.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/RestApiRequest.java
@@ -21,7 +21,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import io.javalin.core.util.Header;
 import io.javalin.http.Context;
 import java.io.ByteArrayInputStream;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -29,7 +28,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
-import tech.pegasys.teku.infrastructure.http.ContentTypes;
 import tech.pegasys.teku.infrastructure.http.HttpErrorResponse;
 import tech.pegasys.teku.infrastructure.http.HttpStatusCodes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
@@ -103,10 +101,8 @@ public class RestApiRequest {
   }
 
   private String selectContentType(final int statusCode) {
-    final Collection<String> supportedTypes = metadata.getSupportedContentTypes(statusCode);
-    return ContentTypes.getContentType(
-            supportedTypes, Optional.ofNullable(context.header(HEADER_ACCEPT)))
-        .orElse(ContentTypes.APPLICATION_JSON);
+    return metadata.selectContentType(
+        statusCode, Optional.ofNullable(context.header(HEADER_ACCEPT)));
   }
 
   /** This is only used when intending to return status code without a response body */

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/RestApiRequest.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/RestApiRequest.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.infrastructure.restapi.endpoints;
 
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_INTERNAL_SERVER_ERROR;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.HEADER_ACCEPT;
 import static tech.pegasys.teku.infrastructure.restapi.endpoints.BadRequest.BAD_REQUEST_TYPE;
 
@@ -52,7 +53,7 @@ public class RestApiRequest {
   }
 
   public void respondOk(final Object response) throws JsonProcessingException {
-    respond(HttpStatusCodes.SC_OK, response);
+    respond(SC_OK, response);
   }
 
   public void respondAsync(final SafeFuture<AsyncApiResponse> futureResponse) {
@@ -74,7 +75,7 @@ public class RestApiRequest {
   public void respondOk(final Object response, final CacheLength cacheLength)
       throws JsonProcessingException {
     context.header(Header.CACHE_CONTROL, cacheLength.getHttpHeaderValue());
-    respond(HttpStatusCodes.SC_OK, response);
+    respond(SC_OK, response);
   }
 
   public void respondError(final int statusCode, final String message)

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/RestApiRequest.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/RestApiRequest.java
@@ -30,7 +30,6 @@ import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.http.HttpErrorResponse;
-import tech.pegasys.teku.infrastructure.http.HttpStatusCodes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 
 public class RestApiRequest {

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/openapi/ContentTypeDefinition.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/openapi/ContentTypeDefinition.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.restapi.openapi;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import tech.pegasys.teku.infrastructure.json.types.OpenApiTypeDefinition;
+import tech.pegasys.teku.infrastructure.json.types.SerializableTypeDefinition;
+
+public interface ContentTypeDefinition<T> extends OpenApiTypeDefinition {
+
+  static <T> ContentTypeDefinition<T> json(final SerializableTypeDefinition<T> type) {
+    return new JsonContentTypeDefinition<>(type);
+  }
+
+  void serialize(T value, OutputStream out) throws IOException;
+}

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/openapi/JsonContentTypeDefinition.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/openapi/JsonContentTypeDefinition.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.restapi.openapi;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Collection;
+import java.util.Optional;
+import tech.pegasys.teku.infrastructure.json.JsonUtil;
+import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
+import tech.pegasys.teku.infrastructure.json.types.OpenApiTypeDefinition;
+import tech.pegasys.teku.infrastructure.json.types.SerializableTypeDefinition;
+
+public class JsonContentTypeDefinition<T> implements ContentTypeDefinition<T> {
+  private final SerializableTypeDefinition<T> typeDefinition;
+
+  public JsonContentTypeDefinition(final SerializableTypeDefinition<T> typeDefinition) {
+    this.typeDefinition = typeDefinition;
+  }
+
+  @Override
+  public void serialize(final T value, final OutputStream out) throws IOException {
+    JsonUtil.serializeToBytes(value, typeDefinition, out);
+  }
+
+  @Override
+  public SerializableTypeDefinition<T> withDescription(final String description) {
+    return typeDefinition.withDescription(description);
+  }
+
+  @Override
+  public Optional<String> getTypeName() {
+    return typeDefinition.getTypeName();
+  }
+
+  @Override
+  public void serializeOpenApiType(final JsonGenerator gen) throws IOException {
+    typeDefinition.serializeOpenApiType(gen);
+  }
+
+  @Override
+  public Collection<OpenApiTypeDefinition> getReferencedTypeDefinitions() {
+    return typeDefinition.getReferencedTypeDefinitions();
+  }
+
+  @Override
+  public Collection<OpenApiTypeDefinition> getSelfAndReferencedTypeDefinitions() {
+    return typeDefinition.getSelfAndReferencedTypeDefinitions();
+  }
+
+  @Override
+  public boolean isEquivalentToDeserializableType(final DeserializableTypeDefinition<?> type) {
+    return typeDefinition.isEquivalentToDeserializableType(type);
+  }
+
+  @Override
+  public void serializeOpenApiTypeOrReference(final JsonGenerator gen) throws IOException {
+    typeDefinition.serializeOpenApiTypeOrReference(gen);
+  }
+}

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/openapi/OpenApiResponse.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/openapi/OpenApiResponse.java
@@ -57,4 +57,8 @@ public class OpenApiResponse {
         .flatMap(type -> type.getSelfAndReferencedTypeDefinitions().stream())
         .collect(toSet());
   }
+
+  public Collection<String> getSupportedContentTypes() {
+    return content.keySet();
+  }
 }

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/openapi/OpenApiResponse.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/openapi/OpenApiResponse.java
@@ -21,19 +21,18 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Map.Entry;
 import tech.pegasys.teku.infrastructure.json.types.OpenApiTypeDefinition;
-import tech.pegasys.teku.infrastructure.json.types.SerializableTypeDefinition;
 
 public class OpenApiResponse {
   private final String description;
-  private final Map<String, SerializableTypeDefinition<?>> content;
+  private final Map<String, ? extends ContentTypeDefinition<?>> content;
 
   public OpenApiResponse(
-      final String description, final Map<String, SerializableTypeDefinition<?>> content) {
+      final String description, final Map<String, ? extends ContentTypeDefinition<?>> content) {
     this.description = description;
     this.content = content;
   }
 
-  public SerializableTypeDefinition<?> getType(final String contentType) {
+  public ContentTypeDefinition<?> getType(final String contentType) {
     return content.get(contentType);
   }
 
@@ -41,7 +40,7 @@ public class OpenApiResponse {
     gen.writeStartObject();
     gen.writeStringField("description", description);
     gen.writeObjectFieldStart("content");
-    for (Entry<String, SerializableTypeDefinition<?>> contentEntry : content.entrySet()) {
+    for (Entry<String, ? extends OpenApiTypeDefinition> contentEntry : content.entrySet()) {
       gen.writeObjectFieldStart(contentEntry.getKey());
       gen.writeFieldName("schema");
       contentEntry.getValue().serializeOpenApiTypeOrReference(gen);

--- a/infrastructure/restapi/src/test/java/tech/pegasys/teku/infrastructure/restapi/endpoints/EndpointMetadataTest.java
+++ b/infrastructure/restapi/src/test/java/tech/pegasys/teku/infrastructure/restapi/endpoints/EndpointMetadataTest.java
@@ -130,14 +130,13 @@ class EndpointMetadataTest {
                 SC_OK,
                 "Success",
                 Map.of(
-                    ContentTypes.APPLICATION_JSON,
+                    ContentTypes.JSON,
                     ContentTypeDefinition.json(STRING_TYPE),
-                    ContentTypes.APPLICATION_OCTET_STREAM,
+                    ContentTypes.OCTET_STREAM,
                     ContentTypeDefinition.json(STRING_TYPE)))
             .build();
-    assertThat(
-            metadata.selectContentType(SC_OK, Optional.of(ContentTypes.APPLICATION_OCTET_STREAM)))
-        .isEqualTo(ContentTypes.APPLICATION_OCTET_STREAM);
+    assertThat(metadata.selectContentType(SC_OK, Optional.of(ContentTypes.OCTET_STREAM)))
+        .isEqualTo(ContentTypes.OCTET_STREAM);
   }
 
   @Test

--- a/infrastructure/restapi/src/test/java/tech/pegasys/teku/infrastructure/restapi/openapi/OpenApiDocBuilderTest.java
+++ b/infrastructure/restapi/src/test/java/tech/pegasys/teku/infrastructure/restapi/openapi/OpenApiDocBuilderTest.java
@@ -124,7 +124,8 @@ class OpenApiDocBuilderTest {
                     200,
                     "It depends",
                     Map.of(
-                        "application/json", CoreTypes.STRING_TYPE, "uint", CoreTypes.UINT64_TYPE))
+                        "application/json", ContentTypeDefinition.json(CoreTypes.STRING_TYPE),
+                        "uint", ContentTypeDefinition.json(CoreTypes.UINT64_TYPE)))
                 .response(404, "Not 'ere gov", CoreTypes.HTTP_ERROR_RESPONSE_TYPE)
                 .build());
     final Map<String, Object> result = parse(validBuilder().endpoint(endpoint).build());


### PR DESCRIPTION
## PR Description
Update the rest api framework to support serialising data as either JSON or binary types. Take advantage of it by allowing get new blinded block to return data as SSZ.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
