### PR TITLE
Don't use a separate windows cache for dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -193,9 +193,8 @@ jobs:
       - restore_cache:
           name: Restore cached gradle dependencies
           keys:
-            - windows-{{ checksum "build.gradle" }}-{{ checksum "gradle/versions.gradle" }}-{{ .Branch }}-{{ .Revision }}
-            - windows-{{ checksum "build.gradle" }}-{{ checksum "gradle/versions.gradle" }}
-            - windows-
+            - deps-{{ checksum "build.gradle" }}-{{ checksum "gradle/versions.gradle" }}-{{ .Branch }}-{{ .Revision }}
+            - deps-{{ checksum "build.gradle" }}-{{ checksum "gradle/versions.gradle" }}
       - run:
           name: Build
           command: |
@@ -210,12 +209,6 @@ jobs:
             Get-ChildItem -Recurse | Where-Object {$_.FullName -match "test-results\\.*\\.*.xml"} | Copy-Item -Destination build\test-results\
       - store_test_results:
           path: build/test-results
-      - save_cache:
-          name: Caching gradle dependencies
-          key: windows-{{ checksum "build.gradle" }}-{{ .Branch }}-{{ .Revision }}
-          paths:
-            - .gradle
-            - ~/.gradle
 
   spotless:
     executor: small_executor


### PR DESCRIPTION
## PR Description
Use the same gradle cache from assemble for the windows build and don't update the cache from windows.

Hopefully will save a little time on the windows build.


## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
