### PR TITLE
Use Ubuntu 20.04 explicitly

### DIFF
--- a/docker/jdk16/Dockerfile
+++ b/docker/jdk16/Dockerfile
@@ -9,7 +9,7 @@ RUN JAVA_TOOL_OPTIONS="-Djdk.lang.Process.launchMechanism=vfork" $JAVA_HOME/bin/
          --compress=2 \
          --output /javaruntime
 
-FROM ubuntu:latest
+FROM ubuntu:20.04
 ENV JAVA_HOME=/opt/java/openjdk
 ENV PATH "${JAVA_HOME}/bin:${PATH}"
 COPY --from=jre-build /javaruntime $JAVA_HOME

--- a/docker/jdk17/Dockerfile
+++ b/docker/jdk17/Dockerfile
@@ -9,7 +9,7 @@ RUN JAVA_TOOL_OPTIONS="-Djdk.lang.Process.launchMechanism=vfork" $JAVA_HOME/bin/
          --compress=2 \
          --output /javaruntime
 
-FROM ubuntu:latest
+FROM ubuntu:20.04
 ENV JAVA_HOME=/opt/java/openjdk
 ENV PATH "${JAVA_HOME}/bin:${PATH}"
 COPY --from=jre-build /javaruntime $JAVA_HOME


### PR DESCRIPTION
## PR Description
The new jammy ubuntu release is having issues so stick with the previously LTS for now.

Note that our current releases are using 20.04 already so this is maintaining the status quo, and it's still fully supported for some time yet. Logged #5377 to remind us to upgrade again in the future when the CI caching issues are sorted.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
