### PR TITLE
Opt-in panda emoji for merge blocks

### DIFF
--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java
@@ -134,15 +134,20 @@ public class EventLogger {
       final Bytes32 bestBlockRoot,
       final UInt64 justifiedCheckpoint,
       final UInt64 finalizedCheckpoint,
+      final boolean mergeComplete,
       final int numPeers) {
     String blockRoot = "                                                       ... empty";
     if (nodeSlot.equals(headSlot)) {
       blockRoot = LogFormatter.formatHashRoot(bestBlockRoot);
     }
+    final String panda =
+        mergeComplete && System.getProperty("teku.pandas", "false").equalsIgnoreCase("true")
+            ? "🐼 "
+            : "";
     final String slotEventLog =
         String.format(
-            "Slot Event  *** Slot: %s, Block: %s, Justified: %s, Finalized: %s, Peers: %d",
-            nodeSlot, blockRoot, justifiedCheckpoint, finalizedCheckpoint, numPeers);
+            "Slot Event  *** Slot: %s, %sBlock: %s, Justified: %s, Finalized: %s, Peers: %d",
+            nodeSlot, panda, blockRoot, justifiedCheckpoint, finalizedCheckpoint, numPeers);
     info(slotEventLog, Color.WHITE);
   }
 

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/SlotProcessor.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/SlotProcessor.java
@@ -242,6 +242,7 @@ public class SlotProcessor {
                     head.getRoot(),
                     recentChainData.getJustifiedCheckpoint().map(Checkpoint::getEpoch).orElse(ZERO),
                     recentChainData.getFinalizedCheckpoint().map(Checkpoint::getEpoch).orElse(ZERO),
+                    !head.getExecutionBlockHash().isZero(),
                     p2pNetwork.getPeerCount()));
   }
 

--- a/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/SlotProcessorTest.java
+++ b/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/SlotProcessorTest.java
@@ -269,6 +269,7 @@ public class SlotProcessorTest {
             recentChainData.getBestBlockRoot().orElseThrow(),
             justifiedCheckpoint.getEpoch(),
             finalizedCheckpoint.getEpoch(),
+            false,
             1);
     verify(forkChoiceTrigger).onAttestationsDueForSlot(slot);
   }


### PR DESCRIPTION
## PR Description
When the system property `teku.panda` is set to `true`, mark merge blocks with a panda in the slot event log.

Leaving this as defaulting to off in case someone is parsing the Slot Event line.  We should still add a separate log line when the merge first happens but don't want to risk breakage by defaulting this to on.

## Fixed Issue(s)
#5231 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
