### PR TITLE
Avoid spamming logs when no eth1 endpoints available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,3 +27,4 @@ For information on changes in released versions of Teku, see the [releases page]
 ### Bug Fixes
 - Added stricter limits on attestation pool size. 
 - Fixed issue with loading the optimised BLST library on Windows.
+- Reduced log level for notifications that the eth1 chain head could not be retrieved because no endpoints were available.

--- a/pow/src/main/java/tech/pegasys/teku/pow/TimeBasedEth1HeadTracker.java
+++ b/pow/src/main/java/tech/pegasys/teku/pow/TimeBasedEth1HeadTracker.java
@@ -28,6 +28,7 @@ import tech.pegasys.teku.infrastructure.async.runloop.RunLoopLogic;
 import tech.pegasys.teku.infrastructure.subscribers.Subscribers;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.pow.exception.Eth1RequestException;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.config.Constants;
 
@@ -171,6 +172,8 @@ public class TimeBasedEth1HeadTracker implements Eth1HeadTracker, RunLoopLogic {
       LOG.error(
           "Block number {} not yet available. Retrying after delay.",
           ((BlockUnavailableException) rootCause).getBlockNumber());
+    } else if (rootCause instanceof Eth1RequestException && rootCause.getSuppressed().length == 0) {
+      LOG.debug("Failed to update eth1 chain head - no endpoints available");
     } else {
       LOG.error("Failed to update eth1 chain head", t);
     }


### PR DESCRIPTION
## PR Description
Reduce log level to debug when we fail to update eth1 chain head because all endpoints are unsuitable.

## Fixed Issue(s)

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
