### PR TITLE
Use fixed version for web3signer

### DIFF
--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/Web3SignerNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/Web3SignerNode.java
@@ -42,7 +42,7 @@ public class Web3SignerNode extends Node {
   private Set<File> configFiles;
 
   private Web3SignerNode(final Network network, final Web3SignerNode.Config config) {
-    super(network, "consensys/web3signer:develop", LOG);
+    super(network, "consensys/web3signer:21.10.6", LOG);
     container
         .withExposedPorts(HTTP_API_PORT)
         .withLogConsumer(frame -> LOG.debug(frame.getUtf8String().trim()))


### PR DESCRIPTION
## PR Description
To make builds predictable, fix the version of web3signer used in acceptance tests to the latest release.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
