### PR TITLE
[Merge] implement TTD ETA

### DIFF
--- a/infrastructure/logging/build.gradle
+++ b/infrastructure/logging/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
     api 'org.apache.tuweni:tuweni-bytes'
+    api 'org.apache.tuweni:tuweni-units'
 
     implementation 'org.apache.logging.log4j:log4j-core'
 }

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java
@@ -15,12 +15,15 @@ package tech.pegasys.teku.infrastructure.logging;
 
 import static tech.pegasys.teku.infrastructure.logging.ColorConsolePrinter.print;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.units.bigints.UInt256;
 import tech.pegasys.teku.infrastructure.logging.ColorConsolePrinter.Color;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
@@ -180,6 +183,19 @@ public class EventLogger {
             "Merge       *** Terminal Block detected: %s",
             LogFormatter.formatHashRoot(terminalBlockHash)),
         Color.GREEN);
+  }
+
+  public void terminalPowBlockTtdEta(final UInt256 ttd, final Duration eta) {
+
+    final String etaString =
+        String.format(
+            "%s days and %sh %sm %ss",
+            eta.toDays(),
+            eta.toHours() - TimeUnit.DAYS.toHours(eta.toDays()),
+            eta.toMinutes() - TimeUnit.HOURS.toMinutes(eta.toHours()),
+            eta.getSeconds() - TimeUnit.MINUTES.toSeconds(eta.toMinutes()));
+
+    log.info(String.format("TTD (%s) ETA: %s", ttd, etaString));
   }
 
   public void transitionConfigurationTtdTbhMismatch(


### PR DESCRIPTION
## PR Description

Calculates an ETA for TTD based on the last 5 `totalDifficulty` received from the EL.
Prints the ETA every 5 polls, which will be around every minute giving the 14 second polling.

## Fixed Issue(s)
fixes #5191

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
