### PR TITLE
Fix Web3Signer AT Docker failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ executors:
 
   machine_executor_amd64:
     machine:
-      image: ubuntu-2004:202008-01 #Ubuntu 20.04, docker 19.03, docker-compose 1.27.4
+      image: ubuntu-2004:202201-02 # Ubuntu 20.04, Docker v20.10.12, Docker Compose v1.29.2
       docker_layer_caching: true
     working_directory: ~/project
     environment:
@@ -67,7 +67,7 @@ executors:
 
   machine_executor_arm64:
     machine:
-      image: ubuntu-2004:202101-01
+      image: ubuntu-2004:202201-02 # Ubuntu 20.04, Docker v20.10.12, Docker Compose v1.29.2
     resource_class: arm.medium
     environment:
       architecture: "arm64"

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/Web3SignerNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/Web3SignerNode.java
@@ -48,6 +48,7 @@ public class Web3SignerNode extends Node {
         .withLogConsumer(frame -> LOG.debug(frame.getUtf8String().trim()))
         .waitingFor(new HttpWaitStrategy().forPort(HTTP_API_PORT).forPath("/upcheck"))
         .withCommand("--config-file=" + CONFIG_FILE_PATH, "eth2");
+    container.followOutput(outputFrame -> LOG.debug(outputFrame.getUtf8String().trim()));
     this.config = config;
   }
 

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/Web3SignerNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/Web3SignerNode.java
@@ -48,7 +48,6 @@ public class Web3SignerNode extends Node {
         .withLogConsumer(frame -> LOG.debug(frame.getUtf8String().trim()))
         .waitingFor(new HttpWaitStrategy().forPort(HTTP_API_PORT).forPath("/upcheck"))
         .withCommand("--config-file=" + CONFIG_FILE_PATH, "eth2");
-    container.followOutput(outputFrame -> LOG.debug(outputFrame.getUtf8String().trim()));
     this.config = config;
   }
 
@@ -90,6 +89,13 @@ public class Web3SignerNode extends Node {
         });
     Thread.sleep(100);
     container.start();
+
+    LOG.info(
+        "Started Web3Signer container {} with imageId {}",
+        container.getDockerImageName(),
+        container.getContainerInfo().getImageId());
+
+    container.followOutput(outputFrame -> LOG.debug("{}", outputFrame.getUtf8String().trim()));
   }
 
   @Override

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/Web3SignerNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/Web3SignerNode.java
@@ -89,13 +89,6 @@ public class Web3SignerNode extends Node {
         });
     Thread.sleep(100);
     container.start();
-
-    LOG.info(
-        "Started Web3Signer container {} with imageId {}",
-        container.getDockerImageName(),
-        container.getContainerInfo().getImageId());
-
-    container.followOutput(outputFrame -> LOG.debug("{}", outputFrame.getUtf8String().trim()));
   }
 
   @Override


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Fix the Web3Signer AT docker failure by updating the machine executors so that a newer docker version can be used. Web3Signer was updated to use the latest ubuntu and due some changes in glibc the docker image requires an updated runtime https://discourse.ubuntu.com/t/hirsute-hippo-release-notes/19221 see the "Container images" section.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
