### PR TITLE
Improve error message when SSL keystore not provided for validator API.

### DIFF
--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/ValidatorRestApiConfig.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/ValidatorRestApiConfig.java
@@ -194,7 +194,8 @@ public class ValidatorRestApiConfig {
               },
               () -> {
                 throw new InvalidConfigurationException(
-                    "Validator api requires ssl keystore to be defined.");
+                    "Could not start the validator API as no SSL keystore was provided. "
+                        + "Please specify one via the --validator-api-keystore-file and --validator-api-keystore-password-file options.");
               });
         } else {
           restApiKeystoreFile = Optional.empty();

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/restapi/ValidatorRestApiConfigTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/restapi/ValidatorRestApiConfigTest.java
@@ -35,7 +35,7 @@ class ValidatorRestApiConfigTest {
   void validatorApiRequiresSsl() {
     assertThatThrownBy(() -> ValidatorRestApiConfig.builder().restApiEnabled(true).build())
         .isInstanceOf(InvalidConfigurationException.class)
-        .hasMessageContaining("requires ssl keystore");
+        .hasMessageContaining("no SSL keystore was provided");
   }
 
   @Test


### PR DESCRIPTION
## PR Description
Improve error message when the validator API can't start because no SSL key is provided.

## Fixed Issue(s)
fixes #5386 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
