### PR TITLE
Recognise logging options before or after the validator-client subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,3 +28,4 @@ For information on changes in released versions of Teku, see the [releases page]
 - Added stricter limits on attestation pool size. 
 - Fixed issue with loading the optimised BLST library on Windows.
 - Reduced log level for notifications that the eth1 chain head could not be retrieved because no endpoints were available.
+- Fixed issue where logging options were not recognised if specified after the `validator-client` subcommand.

--- a/teku/src/main/java/tech/pegasys/teku/cli/BeaconNodeCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/BeaconNodeCommand.java
@@ -344,10 +344,6 @@ public class BeaconNodeCommand implements Callable<Integer> {
     return loggingOptions.applyLoggingConfiguration(logDirectoryPath, logFilePrefix);
   }
 
-  public LoggingOptions getLoggingOptions() {
-    return loggingOptions;
-  }
-
   public StartAction getStartAction() {
     return startAction;
   }

--- a/teku/src/main/java/tech/pegasys/teku/cli/BeaconNodeCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/BeaconNodeCommand.java
@@ -331,15 +331,22 @@ public class BeaconNodeCommand implements Callable<Integer> {
   }
 
   private void startLogging() {
-    LoggingConfig loggingConfig = buildLoggingConfig(dataOptions.getDataPath(), LOG_FILE_PREFIX);
+    LoggingConfig loggingConfig =
+        buildLoggingConfig(loggingOptions, dataOptions.getDataPath(), LOG_FILE_PREFIX);
     loggingConfigurator.startLogging(loggingConfig);
     // jupnp logs a lot of context to level WARN, and it is quite verbose.
     LoggingConfigurator.setAllLevelsSilently("org.jupnp", Level.ERROR);
   }
 
   public LoggingConfig buildLoggingConfig(
-      final String logDirectoryPath, final String logFilePrefix) {
+      final LoggingOptions loggingOptions,
+      final String logDirectoryPath,
+      final String logFilePrefix) {
     return loggingOptions.applyLoggingConfiguration(logDirectoryPath, logFilePrefix);
+  }
+
+  public LoggingOptions getLoggingOptions() {
+    return loggingOptions;
   }
 
   public StartAction getStartAction() {

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/ValidatorClientCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/ValidatorClientCommand.java
@@ -73,7 +73,6 @@ public class ValidatorClientCommand implements Callable<Integer> {
   private InteropOptions interopOptions;
 
   @Mixin(name = "Logging")
-  @SuppressWarnings("unused")
   private final LoggingOptions loggingOptions;
 
   @Mixin(name = "Metrics")

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/ValidatorClientCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/ValidatorClientCommand.java
@@ -172,7 +172,7 @@ public class ValidatorClientCommand implements Callable<Integer> {
     validatorClientOptions.configure(builder);
     dataOptions.configure(builder);
     validatorRestApiOptions.configure(builder);
-    parentCommand.getLoggingOptions().configureWireLogs(builder);
+    loggingOptions.configureWireLogs(builder);
     interopOptions.configure(builder);
     metricsOptions.configure(builder);
     return builder.build();

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/ValidatorClientCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/ValidatorClientCommand.java
@@ -73,8 +73,7 @@ public class ValidatorClientCommand implements Callable<Integer> {
   private InteropOptions interopOptions;
 
   @Mixin(name = "Logging")
-  @SuppressWarnings("FieldMayBeFinal")
-  private LoggingOptions loggingOptions = new LoggingOptions();
+  private LoggingOptions loggingOptions;
 
   @Mixin(name = "Metrics")
   private MetricsOptions metricsOptions;
@@ -119,7 +118,8 @@ public class ValidatorClientCommand implements Callable<Integer> {
 
   private void startLogging() {
     LoggingConfig loggingConfig =
-        parentCommand.buildLoggingConfig(dataOptions.getDataPath(), LOG_FILE_PREFIX);
+        parentCommand.buildLoggingConfig(
+            loggingOptions, dataOptions.getDataPath(), LOG_FILE_PREFIX);
     parentCommand.getLoggingConfigurator().startLogging(loggingConfig);
     // jupnp logs a lot of context to level WARN, and it is quite verbose.
     LoggingConfigurator.setAllLevelsSilently("org.jupnp", Level.ERROR);
@@ -168,7 +168,7 @@ public class ValidatorClientCommand implements Callable<Integer> {
     validatorClientOptions.configure(builder);
     dataOptions.configure(builder);
     validatorRestApiOptions.configure(builder);
-    loggingOptions.configureWireLogs(builder);
+    parentCommand.getLoggingOptions().configureWireLogs(builder);
     interopOptions.configure(builder);
     metricsOptions.configure(builder);
     return builder.build();

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/ValidatorClientCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/ValidatorClientCommand.java
@@ -73,7 +73,8 @@ public class ValidatorClientCommand implements Callable<Integer> {
   private InteropOptions interopOptions;
 
   @Mixin(name = "Logging")
-  private LoggingOptions loggingOptions;
+  @SuppressWarnings("unused")
+  private final LoggingOptions loggingOptions;
 
   @Mixin(name = "Metrics")
   private MetricsOptions metricsOptions;
@@ -94,6 +95,10 @@ public class ValidatorClientCommand implements Callable<Integer> {
   @ParentCommand private BeaconNodeCommand parentCommand;
 
   private static final String AUTO_NETWORK_OPTION = "auto";
+
+  public ValidatorClientCommand(final LoggingOptions sharedLoggingOptions) {
+    this.loggingOptions = sharedLoggingOptions;
+  }
 
   @Override
   public Integer call() {
@@ -118,8 +123,7 @@ public class ValidatorClientCommand implements Callable<Integer> {
 
   private void startLogging() {
     LoggingConfig loggingConfig =
-        parentCommand.buildLoggingConfig(
-            loggingOptions, dataOptions.getDataPath(), LOG_FILE_PREFIX);
+        parentCommand.buildLoggingConfig(dataOptions.getDataPath(), LOG_FILE_PREFIX);
     parentCommand.getLoggingConfigurator().startLogging(loggingConfig);
     // jupnp logs a lot of context to level WARN, and it is quite verbose.
     LoggingConfigurator.setAllLevelsSilently("org.jupnp", Level.ERROR);

--- a/teku/src/test/java/tech/pegasys/teku/cli/AbstractBeaconNodeCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/AbstractBeaconNodeCommandTest.java
@@ -42,6 +42,7 @@ public abstract class AbstractBeaconNodeCommandTest {
   protected final PrintWriter outputWriter = new PrintWriter(stringWriter, true);
   protected final PrintWriter errorWriter = new PrintWriter(stringWriter, true);
   protected final LoggingConfigurator loggingConfigurator = mock(LoggingConfigurator.class);
+  protected boolean expectValidatorClient = false;
 
   final StartAction startAction = mock(StartAction.class);
 
@@ -66,7 +67,7 @@ public abstract class AbstractBeaconNodeCommandTest {
       final ArgumentCaptor<TekuConfiguration> configCaptor =
           ArgumentCaptor.forClass(TekuConfiguration.class);
       assertThat(stringWriter.toString()).isEmpty();
-      verify(startAction).start(configCaptor.capture(), eq(false));
+      verify(startAction).start(configCaptor.capture(), eq(expectValidatorClient));
 
       return configCaptor.getValue();
     } catch (Throwable t) {
@@ -79,7 +80,6 @@ public abstract class AbstractBeaconNodeCommandTest {
 
   public LoggingConfig getResultingLoggingConfiguration() {
     return beaconNodeCommand.buildLoggingConfig(
-        beaconNodeCommand.getLoggingOptions(),
         getResultingTekuConfiguration().dataConfig().getDataBasePath().toString(),
         BeaconNodeCommand.LOG_FILE_PREFIX);
   }

--- a/teku/src/test/java/tech/pegasys/teku/cli/AbstractBeaconNodeCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/AbstractBeaconNodeCommandTest.java
@@ -79,6 +79,7 @@ public abstract class AbstractBeaconNodeCommandTest {
 
   public LoggingConfig getResultingLoggingConfiguration() {
     return beaconNodeCommand.buildLoggingConfig(
+        beaconNodeCommand.getLoggingOptions(),
         getResultingTekuConfiguration().dataConfig().getDataBasePath().toString(),
         BeaconNodeCommand.LOG_FILE_PREFIX);
   }

--- a/teku/src/test/java/tech/pegasys/teku/cli/subcommand/ValidatorClientCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/subcommand/ValidatorClientCommandTest.java
@@ -15,14 +15,22 @@ package tech.pegasys.teku.cli.subcommand;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.cli.AbstractBeaconNodeCommandTest;
+import tech.pegasys.teku.infrastructure.logging.LoggingConfig;
+import tech.pegasys.teku.infrastructure.logging.LoggingDestination;
 
 public class ValidatorClientCommandTest extends AbstractBeaconNodeCommandTest {
   private final String[] argsNetworkOptOnParent =
       new String[] {
         "--network", "auto", "vc",
       };
+
+  @BeforeEach
+  void setUp() {
+    expectValidatorClient = true;
+  }
 
   @Test
   public void networkOption_ShouldFail_IfSpecifiedOnParentCommand() {
@@ -31,5 +39,21 @@ public class ValidatorClientCommandTest extends AbstractBeaconNodeCommandTest {
     String cmdOutput = getCommandLineOutput();
     assertThat(cmdOutput)
         .contains("--network option should not be specified before the validator-client command");
+  }
+
+  @Test
+  void loggingOptions_shouldUseLoggingOptionsFromBeforeSubcommand() {
+    final LoggingConfig config =
+        getLoggingConfigurationFromArguments(
+            "--log-destination=console", "vc", "--network=mainnet");
+    assertThat(config.getDestination()).isEqualTo(LoggingDestination.CONSOLE);
+  }
+
+  @Test
+  void loggingOptions_shouldUseLoggingOptionsFromAfterSubcommand() {
+    final LoggingConfig config =
+        getLoggingConfigurationFromArguments(
+            "vc", "--network=mainnet", "--log-destination=console");
+    assertThat(config.getDestination()).isEqualTo(LoggingDestination.CONSOLE);
   }
 }


### PR DESCRIPTION
## PR Description
Previously the logging options like `--log-destination` were only recognised if they were specified prior to the `validator-client` subcommand.  This change ensures the same `LoggingOptions` instance is used for both the parent and subcommand so that the option works either before or after the subcommand.

We can't just use scope = INHERIT here because not all subcommands support the logging options.

## Fixed Issue(s)
Found as part of #5388 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
