### PR TITLE
[Merge] Run fork choice if head block is found to be invalid

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -403,7 +403,8 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
             }
           }
 
-          final Bytes32 validatedBlockRoot = result.getInvalidTransitionBlockRoot().orElse(blockRoot);
+          final Bytes32 validatedBlockRoot =
+              result.getInvalidTransitionBlockRoot().orElse(blockRoot);
 
           getForkChoiceStrategy().onExecutionPayloadResult(validatedBlockRoot, resultStatus);
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -391,7 +391,7 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
     }
     transitionValidatedStatus.finishAsync(
         result -> {
-          PayloadStatus resultStatus = result.getStatus();
+          final PayloadStatus resultStatus = result.getStatus();
 
           if (resultStatus.hasValidStatus()) {
             UInt64 latestValidFinalizedSlotInStore = recentChainData.getLatestValidFinalizedSlot();
@@ -403,7 +403,7 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
             }
           }
 
-          Bytes32 validatedBlockRoot = result.getInvalidTransitionBlockRoot().orElse(blockRoot);
+          final Bytes32 validatedBlockRoot = result.getInvalidTransitionBlockRoot().orElse(blockRoot);
 
           getForkChoiceStrategy().onExecutionPayloadResult(validatedBlockRoot, resultStatus);
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
@@ -711,7 +711,7 @@ class ForkChoiceTest {
 
     // first time, fork choice update block will be invalid and after that it will be valid
     setForkChoiceNotifierConsecutiveForkChoiceUpdatedResults(
-        invalidWithLastValidBlockHash, PayloadStatus.VALID);
+        List.of(invalidWithLastValidBlockHash, PayloadStatus.VALID));
 
     storageSystem.chainUpdater().setCurrentSlot(nextBlockSlot.increment());
     final SignedBlockAndState blockAndStatePlus1 =
@@ -981,19 +981,22 @@ class ForkChoiceTest {
   }
 
   private void setForkChoiceNotifierForkChoiceUpdatedResult(final PayloadStatus status) {
-    setForkChoiceNotifierConsecutiveForkChoiceUpdatedResults(status);
+    setForkChoiceNotifierConsecutiveForkChoiceUpdatedResults(List.of(status));
   }
 
   private void setForkChoiceNotifierConsecutiveForkChoiceUpdatedResults(
-      final PayloadStatus... statuses) {
-    if (statuses.length == 0) {
+      final List<PayloadStatus> statuses) {
+    if (statuses.isEmpty()) {
       return;
     }
     Stubber stubber = null;
-    for (int i = 0; i < statuses.length; i++) {
-      ForkChoiceUpdatedResult result = new ForkChoiceUpdatedResult(statuses[i], Optional.empty());
+    for (PayloadStatus status : statuses) {
+      ForkChoiceUpdatedResult result =
+          Optional.ofNullable(status)
+              .map(payloadStatus -> new ForkChoiceUpdatedResult(payloadStatus, Optional.empty()))
+              .orElse(null);
       Answer<Void> onForkChoiceUpdatedResultAnswer = getOnForkChoiceUpdatedResultAnswer(result);
-      if (i == 0) {
+      if (stubber == null) {
         stubber = doAnswer(onForkChoiceUpdatedResultAnswer);
       } else {
         stubber.doAnswer(onForkChoiceUpdatedResultAnswer);


### PR DESCRIPTION
## PR Description
[Merge] Run fork choice if head block is found to be invalid

- Extended `onExecutionPayloadResult` to run fork choice if execution payload is invalid
- Modified tests accordingly

## Fixed Issue(s)
related to #5371 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
