### PR TITLE
[MEV-Boost\builder] implement execution builder api client

### DIFF
--- a/ethereum/executionlayer/src/integration-test/java/tech/pegasys/teku/ethereum/executionlayer/client/Web3JExecutionBuilderClientTest.java
+++ b/ethereum/executionlayer/src/integration-test/java/tech/pegasys/teku/ethereum/executionlayer/client/Web3JExecutionBuilderClientTest.java
@@ -17,16 +17,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.InstanceOfAssertFactories.INTEGER;
 import static org.assertj.core.api.InstanceOfAssertFactories.STRING;
 
-import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializerProvider;
 import com.google.common.io.Resources;
 import java.io.IOException;
-import java.io.StringWriter;
-import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Optional;
@@ -48,7 +43,6 @@ import tech.pegasys.teku.ethereum.executionlayer.client.schema.SignedMessage;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecContext;
 import tech.pegasys.teku.spec.TestSpecInvocationContextProvider.SpecContext;
@@ -60,23 +54,15 @@ public class Web3JExecutionBuilderClientTest {
   private final MockWebServer mockWebServer = new MockWebServer();
   private final StubTimeProvider timeProvider = StubTimeProvider.withTimeInSeconds(0);
 
-  Writer jsonWriter;
-  JsonGenerator jsonGenerator;
   ObjectMapper objectMapper;
-  SerializerProvider serializerProvider;
   DataStructureUtil dataStructureUtil;
-  Spec spec;
 
   Web3JExecutionBuilderClient ebClient;
 
   @BeforeEach
   void setUp(SpecContext specContext) throws IOException {
-    jsonWriter = new StringWriter();
-    jsonGenerator = new JsonFactory().createGenerator(jsonWriter);
     objectMapper = new ObjectMapper();
-    serializerProvider = objectMapper.getSerializerProvider();
     dataStructureUtil = specContext.getDataStructureUtil();
-    spec = specContext.getSpec();
     mockWebServer.start();
     Web3jClientBuilder web3JClientBuilder = new Web3jClientBuilder();
     Web3JClient web3JClient =

--- a/ethereum/executionlayer/src/integration-test/java/tech/pegasys/teku/ethereum/executionlayer/client/Web3JExecutionBuilderClientTest.java
+++ b/ethereum/executionlayer/src/integration-test/java/tech/pegasys/teku/ethereum/executionlayer/client/Web3JExecutionBuilderClientTest.java
@@ -33,7 +33,6 @@ import java.util.Optional;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
-import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.bytes.Bytes48;
 import org.junit.jupiter.api.AfterEach;
@@ -96,7 +95,6 @@ public class Web3JExecutionBuilderClientTest {
   }
 
   @TestTemplate
-  @SuppressWarnings("unchecked")
   void getPayload_shouldRoundtripWithMockedWebServer() throws Exception {
     final String jsonGetPayloadResponse =
         Resources.toString(
@@ -209,13 +207,5 @@ public class Web3JExecutionBuilderClientTest {
         .asInstanceOf(INTEGER)
         .isGreaterThanOrEqualTo(0);
     assertThat(requestBodyJsonNode.get("jsonrpc").asText()).asInstanceOf(STRING).isEqualTo("2.0");
-  }
-
-  private UInt64 deserializeToUInt64(final String value) {
-    return UInt64.valueOf(Bytes.fromHexStringLenient(value).toUnsignedBigInteger());
-  }
-
-  private Bytes32 deserializeToBytes32(final String value) {
-    return Bytes32.fromHexStringStrict(value);
   }
 }

--- a/ethereum/executionlayer/src/integration-test/java/tech/pegasys/teku/ethereum/executionlayer/client/Web3JExecutionBuilderClientTest.java
+++ b/ethereum/executionlayer/src/integration-test/java/tech/pegasys/teku/ethereum/executionlayer/client/Web3JExecutionBuilderClientTest.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionlayer.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.INTEGER;
+import static org.assertj.core.api.InstanceOfAssertFactories.STRING;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.google.common.io.Resources;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Optional;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.bytes.Bytes48;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import tech.pegasys.teku.ethereum.executionengine.Web3JClient;
+import tech.pegasys.teku.ethereum.executionengine.Web3jClientBuilder;
+import tech.pegasys.teku.ethereum.executionengine.schema.Response;
+import tech.pegasys.teku.ethereum.executionlayer.client.schema.BlindedBeaconBlockV1;
+import tech.pegasys.teku.ethereum.executionlayer.client.schema.BuilderBidV1;
+import tech.pegasys.teku.ethereum.executionlayer.client.schema.ExecutionPayloadV1;
+import tech.pegasys.teku.ethereum.executionlayer.client.schema.SignedMessage;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecContext;
+import tech.pegasys.teku.spec.TestSpecInvocationContextProvider.SpecContext;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+@TestSpecContext(milestone = SpecMilestone.BELLATRIX)
+public class Web3JExecutionBuilderClientTest {
+  private static final Duration DEFAULT_TIMEOUT = Duration.ofMinutes(1);
+  private final MockWebServer mockWebServer = new MockWebServer();
+  private final StubTimeProvider timeProvider = StubTimeProvider.withTimeInSeconds(0);
+
+  Writer jsonWriter;
+  JsonGenerator jsonGenerator;
+  ObjectMapper objectMapper;
+  SerializerProvider serializerProvider;
+  DataStructureUtil dataStructureUtil;
+  Spec spec;
+
+  Web3JExecutionBuilderClient ebClient;
+
+  @BeforeEach
+  void setUp(SpecContext specContext) throws IOException {
+    jsonWriter = new StringWriter();
+    jsonGenerator = new JsonFactory().createGenerator(jsonWriter);
+    objectMapper = new ObjectMapper();
+    serializerProvider = objectMapper.getSerializerProvider();
+    dataStructureUtil = specContext.getDataStructureUtil();
+    spec = specContext.getSpec();
+    mockWebServer.start();
+    Web3jClientBuilder web3JClientBuilder = new Web3jClientBuilder();
+    Web3JClient web3JClient =
+        web3JClientBuilder
+            .endpoint("http://localhost:" + mockWebServer.getPort())
+            .timeout(DEFAULT_TIMEOUT)
+            .jwtConfigOpt(Optional.empty())
+            .timeProvider(timeProvider)
+            .build();
+    ebClient = new Web3JExecutionBuilderClient(web3JClient);
+  }
+
+  @AfterEach
+  public void afterEach() throws Exception {
+    mockWebServer.shutdown();
+  }
+
+  @TestTemplate
+  @SuppressWarnings("unchecked")
+  void getPayload_shouldRoundtripWithMockedWebServer() throws Exception {
+    final String jsonGetPayloadResponse =
+        Resources.toString(
+            Resources.getResource("builder_getPayloadResponse.json"), StandardCharsets.UTF_8);
+
+    final String bodyResponse =
+        "{\"jsonrpc\": \"2.0\", \"id\": 0, \"result\":" + jsonGetPayloadResponse + "}";
+
+    final ExecutionPayloadV1 executionPayloadResponse =
+        objectMapper.readValue(jsonGetPayloadResponse, ExecutionPayloadV1.class);
+
+    // double-check that what we are going to respond corresponds to the json data
+    final String serializedExecutionPayloadResponse =
+        objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(executionPayloadResponse);
+    assertThat(serializedExecutionPayloadResponse).isEqualTo(jsonGetPayloadResponse);
+
+    mockWebServer.enqueue(
+        new MockResponse()
+            .setBody(bodyResponse)
+            .setResponseCode(200)
+            .addHeader("Content-Type", "application/json"));
+
+    final String jsonGetPayloadRequest =
+        Resources.toString(
+            Resources.getResource("builder_getPayloadRequest.json"), StandardCharsets.UTF_8);
+
+    final SignedMessage<BlindedBeaconBlockV1> signedBlindedBeaconBlockRequest =
+        objectMapper.readValue(jsonGetPayloadRequest, new TypeReference<>() {});
+
+    SafeFuture<Response<ExecutionPayloadV1>> futureResponseProposeBlindedBlock =
+        ebClient.getPayload(signedBlindedBeaconBlockRequest);
+
+    final RecordedRequest request = mockWebServer.takeRequest();
+
+    final JsonNode requestBodyJsonNode =
+        objectMapper.readTree(request.getBody().readString(StandardCharsets.UTF_8));
+
+    // check that sent blinded block match as per sent object as well as received object from the
+    // mock
+    final String serializedSignedBlindedBeaconBlockRequest =
+        objectMapper
+            .writerWithDefaultPrettyPrinter()
+            .writeValueAsString(signedBlindedBeaconBlockRequest);
+    assertThat(serializedSignedBlindedBeaconBlockRequest).isEqualTo(jsonGetPayloadRequest);
+    assertThat(serializedSignedBlindedBeaconBlockRequest)
+        .isEqualTo(requestBodyJsonNode.get("params").get(0).toPrettyString());
+
+    verifyJsonRpcMethodCall(requestBodyJsonNode, "builder_getPayloadV1");
+
+    assertThat(futureResponseProposeBlindedBlock.join())
+        .matches(
+            executionPayloadV1Response1 ->
+                executionPayloadV1Response1.getPayload().equals(executionPayloadResponse));
+  }
+
+  @TestTemplate
+  void getHeader_shouldRoundtripWithMockedWebServer() throws Exception {
+    final String jsonSignedBuilderBidResponse =
+        Resources.toString(
+            Resources.getResource("builder_getHeaderResponse.json"), StandardCharsets.UTF_8);
+
+    final String bodyResponse =
+        "{\"jsonrpc\": \"2.0\", \"id\": 0, \"result\":" + jsonSignedBuilderBidResponse + "}";
+
+    final SignedMessage<BuilderBidV1> signedBuilderBidV1 =
+        objectMapper.readValue(jsonSignedBuilderBidResponse, new TypeReference<>() {});
+
+    // double-check that what we are going to respond corresponds to the json data
+    final String serializedSignedBuilderBidResponse =
+        objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(signedBuilderBidV1);
+    assertThat(serializedSignedBuilderBidResponse).isEqualTo(jsonSignedBuilderBidResponse);
+
+    mockWebServer.enqueue(
+        new MockResponse()
+            .setBody(bodyResponse)
+            .setResponseCode(200)
+            .addHeader("Content-Type", "application/json"));
+
+    final UInt64 slotRequest = dataStructureUtil.randomUInt64();
+    final Bytes48 pubKeyRequest = dataStructureUtil.randomPublicKeyBytes();
+    final Bytes32 parentHashRequest = dataStructureUtil.randomBytes32();
+
+    SafeFuture<Response<SignedMessage<BuilderBidV1>>> futureResponseExecutionHeader =
+        ebClient.getHeader(slotRequest, pubKeyRequest, parentHashRequest);
+
+    final RecordedRequest request = mockWebServer.takeRequest();
+
+    final JsonNode requestBodyJsonNode =
+        objectMapper.readTree(request.getBody().readString(StandardCharsets.UTF_8));
+
+    final String slot = requestBodyJsonNode.get("params").get(0).asText();
+    final String pubKey = requestBodyJsonNode.get("params").get(1).asText();
+    final String parentHash = requestBodyJsonNode.get("params").get(2).asText();
+
+    verifyJsonRpcMethodCall(requestBodyJsonNode, "builder_getHeaderV1");
+
+    assertThat(slotRequest).isEqualTo(UInt64.valueOf(slot));
+    assertThat(pubKeyRequest).isEqualTo(Bytes48.fromHexString(pubKey));
+    assertThat(parentHashRequest).isEqualTo(Bytes32.fromHexString(parentHash));
+
+    assertThat(futureResponseExecutionHeader.join())
+        .matches(
+            signedBuilderBidV1Response ->
+                signedBuilderBidV1Response.getPayload().equals(signedBuilderBidV1));
+  }
+
+  private void verifyJsonRpcMethodCall(final JsonNode requestBodyJsonNode, final String method) {
+    assertThat(requestBodyJsonNode.get("method").asText()).asInstanceOf(STRING).isEqualTo(method);
+    assertThat(requestBodyJsonNode.get("id").asInt())
+        .asInstanceOf(INTEGER)
+        .isGreaterThanOrEqualTo(0);
+    assertThat(requestBodyJsonNode.get("jsonrpc").asText()).asInstanceOf(STRING).isEqualTo("2.0");
+  }
+
+  private UInt64 deserializeToUInt64(final String value) {
+    return UInt64.valueOf(Bytes.fromHexStringLenient(value).toUnsignedBigInteger());
+  }
+
+  private Bytes32 deserializeToBytes32(final String value) {
+    return Bytes32.fromHexStringStrict(value);
+  }
+}

--- a/ethereum/executionlayer/src/integration-test/java/tech/pegasys/teku/ethereum/executionlayer/client/Web3JExecutionEngineClientTest.java
+++ b/ethereum/executionlayer/src/integration-test/java/tech/pegasys/teku/ethereum/executionlayer/client/Web3JExecutionEngineClientTest.java
@@ -20,7 +20,6 @@ import static org.assertj.core.api.InstanceOfAssertFactories.STRING;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.io.Resources;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
@@ -32,23 +31,18 @@ import java.util.Optional;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
-import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
-import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.ethereum.executionengine.Web3JClient;
 import tech.pegasys.teku.ethereum.executionengine.Web3jClientBuilder;
 import tech.pegasys.teku.ethereum.executionengine.schema.Response;
-import tech.pegasys.teku.ethereum.executionlayer.client.schema.ExecutionPayloadHeaderV1;
-import tech.pegasys.teku.ethereum.executionlayer.client.schema.ExecutionPayloadV1;
 import tech.pegasys.teku.ethereum.executionlayer.client.schema.ForkChoiceStateV1;
 import tech.pegasys.teku.ethereum.executionlayer.client.schema.ForkChoiceUpdatedResult;
 import tech.pegasys.teku.ethereum.executionlayer.client.schema.PayloadAttributesV1;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.bytes.Bytes20;
-import tech.pegasys.teku.infrastructure.bytes.Bytes8;
 import tech.pegasys.teku.infrastructure.json.JsonTestUtil;
 import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -56,11 +50,6 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecContext;
 import tech.pegasys.teku.spec.TestSpecInvocationContextProvider.SpecContext;
-import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
-import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
-import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
-import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeaderSchema;
-import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSchema;
 import tech.pegasys.teku.spec.executionengine.PayloadStatus;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
@@ -178,142 +167,6 @@ public class Web3JExecutionEngineClientTest {
                     .asInternalExecutionPayload()
                     .getPayloadStatus()
                     .equals(payloadStatusResponse));
-  }
-
-  @TestTemplate
-  @SuppressWarnings("unchecked")
-  void proposeBlindedBlock_shouldRoundtripWithMockedWebServer() throws Exception {
-    final String jsonExecutionPayloadResponse =
-        Resources.toString(
-            Resources.getResource("proposeBlindedBlockResponse.json"), StandardCharsets.UTF_8);
-
-    final String bodyResponse =
-        "{\"jsonrpc\": \"2.0\", \"id\": 0, \"result\":" + jsonExecutionPayloadResponse + "}";
-
-    final ExecutionPayloadSchema executionPayloadSchema =
-        spec.getGenesisSchemaDefinitions()
-            .toVersionBellatrix()
-            .orElseThrow()
-            .getExecutionPayloadSchema();
-
-    final ExecutionPayload executionPayloadResponse =
-        objectMapper
-            .readValue(jsonExecutionPayloadResponse, ExecutionPayloadV1.class)
-            .asInternalExecutionPayload(executionPayloadSchema);
-
-    mockWebServer.enqueue(
-        new MockResponse()
-            .setBody(bodyResponse)
-            .setResponseCode(200)
-            .addHeader("Content-Type", "application/json"));
-
-    final SignedBeaconBlock signedBeaconBlockRequest =
-        dataStructureUtil.randomSignedBlindedBeaconBlock();
-
-    SafeFuture<Response<ExecutionPayloadV1>> futureResponseProposeBlindedBlock =
-        eeClient.proposeBlindedBlock(signedBeaconBlockRequest);
-
-    final RecordedRequest request = mockWebServer.takeRequest();
-
-    final Map<String, Object> data =
-        JsonTestUtil.parse(request.getBody().readString(StandardCharsets.UTF_8));
-
-    final String signedBeaconBlockSignature =
-        (String)
-            ((Map<String, Object>) ((List<Object>) data.get("params")).get(0)).get("signature");
-    final Map<String, Object> beaconBlock =
-        (Map<String, Object>)
-            ((Map<String, Object>) ((List<Object>) data.get("params")).get(0)).get("message");
-
-    verifyJsonRpcMethodCall(data, "builder_proposeBlindedBlockV1");
-
-    assertThat(signedBeaconBlockRequest.getSignature())
-        .isEqualTo(
-            BLSSignature.fromBytesCompressed(Bytes.fromHexString(signedBeaconBlockSignature)));
-
-    assertThat(signedBeaconBlockRequest.getSlot())
-        .isEqualTo(UInt64.valueOf(beaconBlock.get("slot").toString()));
-    assertThat(signedBeaconBlockRequest.getProposerIndex())
-        .isEqualTo(UInt64.valueOf(beaconBlock.get("proposer_index").toString()));
-    assertThat(signedBeaconBlockRequest.getParentRoot())
-        .isEqualTo(Bytes32.fromHexString(beaconBlock.get("parent_root").toString()));
-    assertThat(signedBeaconBlockRequest.getStateRoot())
-        .isEqualTo(Bytes32.fromHexString(beaconBlock.get("state_root").toString()));
-
-    final Map<String, Object> executionPayloadHeader =
-        (Map<String, Object>)
-            ((Map<String, Object>) beaconBlock.get("body")).get("execution_payload_header");
-
-    assertThat(
-            signedBeaconBlockRequest
-                .getBeaconBlock()
-                .orElseThrow()
-                .getBody()
-                .getOptionalExecutionPayloadHeader()
-                .orElseThrow()
-                .getTransactionsRoot())
-        .isEqualTo(
-            Bytes32.fromHexString(executionPayloadHeader.get("transactions_root").toString()));
-
-    assertThat(futureResponseProposeBlindedBlock.join())
-        .matches(
-            executionPayloadV1Response1 ->
-                executionPayloadV1Response1
-                    .getPayload()
-                    .asInternalExecutionPayload(executionPayloadSchema)
-                    .equals(executionPayloadResponse));
-  }
-
-  @TestTemplate
-  @SuppressWarnings("unchecked")
-  void getPayloadHeader_shouldRoundtripWithMockedWebServer() throws Exception {
-    final String jsonExecutionPayloadHeaderResponse =
-        Resources.toString(
-            Resources.getResource("getPayloadHeaderResponse.json"), StandardCharsets.UTF_8);
-
-    final String bodyResponse =
-        "{\"jsonrpc\": \"2.0\", \"id\": 0, \"result\":" + jsonExecutionPayloadHeaderResponse + "}";
-
-    final ExecutionPayloadHeaderSchema executionPayloadHeaderSchema =
-        spec.getGenesisSchemaDefinitions()
-            .toVersionBellatrix()
-            .orElseThrow()
-            .getExecutionPayloadHeaderSchema();
-
-    final ExecutionPayloadHeader executionPayloadHeaderResponse =
-        objectMapper
-            .readValue(jsonExecutionPayloadHeaderResponse, ExecutionPayloadHeaderV1.class)
-            .asInternalExecutionPayloadHeader(executionPayloadHeaderSchema);
-
-    mockWebServer.enqueue(
-        new MockResponse()
-            .setBody(bodyResponse)
-            .setResponseCode(200)
-            .addHeader("Content-Type", "application/json"));
-
-    final Bytes8 payloadIdRequest = dataStructureUtil.randomBytes8();
-
-    SafeFuture<Response<ExecutionPayloadHeaderV1>> futureResponseExecutionPayloadHeader =
-        eeClient.getPayloadHeader(payloadIdRequest);
-
-    final RecordedRequest request = mockWebServer.takeRequest();
-
-    final Map<String, Object> data =
-        JsonTestUtil.parse(request.getBody().readString(StandardCharsets.UTF_8));
-
-    final String payloadId = (String) ((List<Object>) data.get("params")).get(0);
-
-    verifyJsonRpcMethodCall(data, "builder_getPayloadHeaderV1");
-
-    assertThat(payloadIdRequest).isEqualTo(Bytes8.fromHexString(payloadId));
-
-    assertThat(futureResponseExecutionPayloadHeader.join())
-        .matches(
-            executionPayloadHeaderV1Response1 ->
-                executionPayloadHeaderV1Response1
-                    .getPayload()
-                    .asInternalExecutionPayloadHeader(executionPayloadHeaderSchema)
-                    .equals(executionPayloadHeaderResponse));
   }
 
   private void verifyJsonRpcMethodCall(Map<String, Object> data, final String method) {

--- a/ethereum/executionlayer/src/integration-test/java/tech/pegasys/teku/ethereum/executionlayer/client/Web3JExecutionEngineClientTest.java
+++ b/ethereum/executionlayer/src/integration-test/java/tech/pegasys/teku/ethereum/executionlayer/client/Web3JExecutionEngineClientTest.java
@@ -20,7 +20,6 @@ import static org.assertj.core.api.InstanceOfAssertFactories.STRING;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializerProvider;
 import com.google.common.io.Resources;
 import java.io.IOException;
 import java.io.StringWriter;
@@ -74,7 +73,6 @@ public class Web3JExecutionEngineClientTest {
   Writer jsonWriter;
   JsonGenerator jsonGenerator;
   ObjectMapper objectMapper;
-  SerializerProvider serializerProvider;
   DataStructureUtil dataStructureUtil;
   Spec spec;
 
@@ -85,7 +83,6 @@ public class Web3JExecutionEngineClientTest {
     jsonWriter = new StringWriter();
     jsonGenerator = new JsonFactory().createGenerator(jsonWriter);
     objectMapper = new ObjectMapper();
-    serializerProvider = objectMapper.getSerializerProvider();
     dataStructureUtil = specContext.getDataStructureUtil();
     spec = specContext.getSpec();
     mockWebServer.start();

--- a/ethereum/executionlayer/src/integration-test/resources/builder_getHeaderResponse.json
+++ b/ethereum/executionlayer/src/integration-test/resources/builder_getHeaderResponse.json
@@ -1,0 +1,23 @@
+{
+  "message" : {
+    "header" : {
+      "parentHash" : "0x235bc3400c2839fd856a524871200bd5e362db615fc4565e1870ed9a2a936464",
+      "feeRecipient" : "0x367cbd40ac7318427aadb97345a91fa2e965daf3",
+      "stateRoot" : "0xfd18cf40cc907a739be483f1ca0ee23ad65cdd3df23205eabc6d660a75d1f54e",
+      "receiptsRoot" : "0x103ac9406cdc59b89027eb1c9e97f607dd5fdccfa8fb2da4eaeea9d25032add9",
+      "logsBloom" : "0x6fdfab408c56b6105a76eff5c0435d09fc6ed7a938e7f946cf74fbbb9416428f619b26eab6d66297cbd9dbc84db437c8d36f9b30556f5f8062bbc80a0e3f35fb2f4921ae3f8361dacf697513c2f8aac786dccb24a7ca3eef9743ab9071ee3663dca121493e717c27ee277bf5d484a83c2da75b4bea86c1d15a2b29352abad715b00fa1c4b94733e496720ced4c31ce785ec3e407136f39dcb857d7d9ff590deeb512704b2f0a58ee953d5a85894a9e9ab9528d1fc87daf2064b515ee861e4dd23bb5714c0fb38a36a1da1698fbee3aae5de1b51de39f6e3d3309e338abb70e275410a1b83e9e9d43d051e6a4a9bdbe6d6fb282c4f2463428a0502a0e2e4b71fb",
+      "prevRandao" : "0x8200a6402ca295554fb9562193cc71d60272d63beeaf2201fdf53e846e77f919",
+      "blockNumber" : "0x40b79d4886f7bf4c",
+      "gasLimit" : "0x40b1be5bcbd70aec",
+      "gasUsed" : "0x3fd8861ec01cf90b",
+      "timestamp" : "0x3fd2a73204fc44aa",
+      "extraData" : "0x0c65de3f6bad3d",
+      "baseFeePerGas" : "0x6b0ac13f8a279ad3abec11bed1a49214f6e7af79b643595df6a38706b338e93b",
+      "blockHash" : "0x7e2bbb3f2a737918a12f79e9a52da7e1fceaae0b6c0c82172425cbce8d99a0c6",
+      "transactionsRoot" : "0x9e2bbb3f2a737918a12f79e9a52da7e1fceaae0b6c0c82172425cbce8d99a0c6"
+    },
+    "value" : "0x1020333333220000",
+    "pubkey" : "0xb0861f72583516b17a3fdc33419d5c04c0a4444cc2478136b4935f3148797699e3ef4a4b2227b14876b3d49ff03b796d"
+  },
+  "signature" : "0xddc1ca509e29c6452441069f26da6e073589b3bd1cace50e3427426af5bfdd566d077d4bdf618e249061b9770471e3d515779aa758b8ccb4b06226a8d5ebc99e19d4c3278e5006b837985bec4e0ce39df92c1f88d1afd0f98dbae360024a390d"
+}

--- a/ethereum/executionlayer/src/integration-test/resources/builder_getPayloadRequest.json
+++ b/ethereum/executionlayer/src/integration-test/resources/builder_getPayloadRequest.json
@@ -1,0 +1,161 @@
+{
+  "message" : {
+    "slot" : "0x40c35b22fd39280c",
+    "proposerIndex" : "0x40bd7c36421873ac",
+    "parentRoot" : "0xfd18cf40cc907a739be483f1ca0ee23ad65cdd3df23205eabc6d660a75d1f54e",
+    "stateRoot" : "0x103ac9406cdc59b89027eb1c9e97f607dd5fdccfa8fb2da4eaeea9d25032add9",
+    "body" : {
+      "randaoReveal" : "0x983e008a34dda42f0c8f857f66aa82212aff48250f9ac54b30ae622d0835bdb7609c9cac67e7d19be24ffe5c77d581230e25c0e72fdf4066618bb0df7e09e66562de35b1f751004ad1ec65089c19a56a8b120983c301dbbf03df5ba674712ab4",
+      "eth1Data" : {
+        "depositRoot" : "0x8200a6402ca295554fb9562193cc71d60272d63beeaf2201fdf53e846e77f919",
+        "depositCount" : "0x40b79d4886f7bf4c",
+        "blockHash" : "0x5cbeb140ec0ad7cb653388caecba483cf66bd817821ed18ca1f3b7f3b9b58a04"
+      },
+      "graffiti" : "0x0000000000000000000000000000000000000000000000000000000000000000",
+      "proposerSlashings" : [ {
+        "signedHeader1" : {
+          "message" : {
+            "slot" : "0x3fd8861ec01cf90b",
+            "proposerIndex" : "0x3fd2a73204fc44aa",
+            "parentRoot" : "0xf943e43fcb615e36ec5aa6b9db6f1746d0d5b50d708f6400e39cf25495f39cfb",
+            "stateRoot" : "0x0c65de3f6bad3d7be19d0de5aff82b13d6d8b49f26588dba111e361d6f545486",
+            "bodyRoot" : "0x6b0ac13f8a279ad3abec11bed1a49214f6e7af79b643595df6a38706b338e93b"
+          },
+          "signature" : "0x860cc33a81805835339f1598b95691556b6f4fc5ee6a25bb24d70c658dc69d3d2e5cd62a22e14e7d962a4095e0d93ea41240a49151f9bb2884bdd1cdefcff246969101fe377460d78d58ea47c2f270e9cc8ce4bc4e81e43314bda61076350d4d"
+        },
+        "signedHeader2" : {
+          "message" : {
+            "slot" : "0x3fd8861ec01cf90b",
+            "proposerIndex" : "0x3fd2a73204fc44aa",
+            "parentRoot" : "0x45c8cc3f4a90db49c16643672a93697ae9e1b15549b207e99aa10076fe767a26",
+            "stateRoot" : "0x58e9c63feadbba8eb6a9aa92fd1b7e47efe4b0e7ff7a30a3c822443ed8d731b1",
+            "bodyRoot" : "0xb88ea93f0a5617e780f8ae6b1fc8e4480ff4abc18f66fc45ada895271cbcc666"
+          },
+          "signature" : "0xb8f4f7eb7f1ff3eb3923e6bf36b3a0865c80f47fb8e5dbe8830751f66bd8a06a3a1e06b7b2dec66556b532721018ce940c982953c8c6176125c7dd2ba1e8cb944e10e4a14905f7135a477810872518cbac085dfc69c1759d64dab5e225a5f16c"
+        }
+      } ],
+      "attesterSlashings" : [ {
+        "attestation1" : {
+          "attestingIndices" : [ "0x3fb54c925d58beca", "0x3faf6da4a2380a6a", "0x3f921303fa94848a" ],
+          "data" : {
+            "slot" : "0x3f8c34173f73d02a",
+            "index" : "0x3f9dd0de70d5ed4a",
+            "beaconBlockRoot" : "0xf1f1973fea38b5b560c1e4ed9a6222b021fda877b2c07674362c6080acdeec06",
+            "source" : {
+              "epoch" : "0x201b3a76",
+              "root" : "0x00963040ab8a07b778f467851c7d0cdc7faec2a32d5e528c900d85297e084df0"
+            },
+            "target" : {
+              "epoch" : "0x20211963",
+              "root" : "0xda533c406bf3482d8e6e992e756be34172a8c47fc1cc0018350bfe98c946deda"
+            }
+          },
+          "signature" : "0x8bfc6e1a1c76bdafb4d491ce02a35effde6d7362eb32c03f119c47c12fb2b49e7656bbd4702ba02560fd7fe117f2c74e02142ce46176ebf269d5b34a48a65525e35db6cc446965e86e22e9d8adf5abe92315690b6de5f4591769487539fed52a"
+        },
+        "attestation2" : {
+          "attestingIndices" : [ "0x3fb54c925d58beca", "0x3faf6da4a2380a6a", "0x3f921303fa94848a" ],
+          "data" : {
+            "slot" : "0x40191a4cca84b92b",
+            "index" : "0x402ab713fbe6d64b",
+            "beaconBlockRoot" : "0x27d82440eb21c640637a36dcc38e35768bb4c0c79aefa300ec0f0cba32cabb05",
+            "source" : {
+              "epoch" : "0x2003bec3",
+              "root" : "0x999e0140abe701de220ca2e0b9c3b044b1c6ba33e0a3985dfe16a16b510f0846"
+            },
+            "target" : {
+              "epoch" : "0x20099db0",
+              "root" : "0x735c0d406b5043543786d38912b287aaa4c0bc0f731247e9a3141adb9c4d9930"
+            }
+          },
+          "signature" : "0xb2213ef588828a7c18cdc781d0ed2516fd3e11de625f191aae7ae4be8b1ad2cc217728c65a500aedea276d345f09fd3212b009568a6549f5f40ead6d7ec4d0f3f329c00a1b4bca59068ee0555c94aec91bebc18365ca0b2d6692557b4b0c4267"
+        }
+      } ],
+      "attestations" : [ {
+        "aggregationBits" : "0x46e4e5ccf2f1f586175a551fbef71fe367c10ae7f627b52680c69658efc3b9da2f03cedf49e4513374e10642a1ed264963dc671c03d571d45f02ec63fba7c7cb5897c09c76e4c5236f21c008302634d96493aae59b7960506c097817d713613d4b3e735f49272d0db6c25864be1413035ae25485ce5cb268bd0ec7a76871cc5cc0b3a892d31613f8f58fbcc1c4848be416ec389ac6b0c1e25ee635a1da4e2aeb872b99856e51958cbf99b64db166c7de9cc849fc9ca7e56dda4a7b586db617c6c55fcd252d40b15b9fbdd843a50d56cbd65f7ecffef1b632b74275254a3ee3487a305314041fa888fb642ab9d17e38e5eb338144f383c4ef9cd53141a6c9153001",
+        "data" : {
+          "slot" : "0x3ffbbfac22e1334b",
+          "index" : "0x3ff5e0bf67c07eeb",
+          "beaconBlockRoot" : "0x82a81c3f096d065c7e3f5d7df79bd182a53c9471a737cfb9f7c4e9ed95d0f767",
+          "source" : {
+            "epoch" : "0x1f8b64ca",
+            "root" : "0x5c66283fc9d547d293b98e264f8aa8e89836964d3ba67d459cc2625de10e8952"
+          },
+          "target" : {
+            "epoch" : "0x1f9143b7",
+            "root" : "0xcf2c053f899b836f534bfa2a45bf23b7be4890b9815a72a2aec9f70eff53d592"
+          }
+        },
+        "signature" : "0x90b1100958899f808951acd4cc1d72be010f4b43fdf69587719b141b72d8410d144cac042cec8515ea74c9cbe5150c7e10b02be9ddd07421143b08f67c911f57c4a1544bc7f6a984df017e189f72aff167227b4238b50340311483aa9c843d43"
+      }, {
+        "aggregationBits" : "0x16ffdcef1985b63b0b86daf194945f6e5c79ff31d7f9e08dee15b8fc65e74f6026349b4d5581aed81b7b945f0311e8318ae875d01c887e25386494a4151a7674dc0d279e3a2e2cb766fab0b30149410e81047bf6716e4627426e31ffa8ee22ca74c2a8db72cc801a5e912011916389fe12b8a5aee2441475ce7eb8efed2750b3d42fa1c1160c759ef11a6c999dd4bbc975a5b74a5f235cb575ef86c17418c6573d2699ff130df86057d200f042949e6997925f96fd595654ade0dec66e5b0834fdfd10f4860899ee48b80944cc981f4558aad23743e7b51e9ba22d445a5dc3601569e23e0c2c50ee21f954b0d903c7f8455cc4c66334ffec5d2095a4177766bc01",
+        "data" : {
+          "slot" : "0x3f0b0bbb2aa44fe9",
+          "index" : "0x3eedb11a8300ca09",
+          "beaconBlockRoot" : "0x2ed2e73ea915e0c71d9afe03676b8ab8dd578b9311463e45934f49f843386a48",
+          "source" : {
+            "epoch" : "0x1f7cb77a",
+            "root" : "0x0890f33e697e213e331430adc059611ed0518d6fa4b4ecd0384dc2678e76fb32"
+          },
+          "target" : {
+            "epoch" : "0x1f6b1ab3",
+            "root" : "0x7a56d03e29445ddbf2a59bb1b68edcecf66387dbea68e12d4a545719acbb4773"
+          }
+        },
+        "signature" : "0x8b88a54eb155233ec6d52f2e549cacd5d9bc79e05bf0915d9278a94c9a3c75e0d75167129d10e728550df65875ecef551085599499b226b88d238a71dfdd199be5de9fde058fbaf60cf7765b0e614d3bfa76c1c47281283d7bb2ff9a30247fc5"
+      }, {
+        "aggregationBits" : "0x703ed6e365b5bf731c1f0eb420574e1c82eec772e63229764db7d26d22edd399ebcb9efabf0ffa4739ccd17c80383fbabe45ac79e3bc7343b3d58f63c2e2f60081accefcaf44c38b4166828de77250e91c3277d8659a794cc12fa329122c631c97ca0c49886e0fd2fd661d945dd464b0ef56e83e286cf1a06feaa1ee634f5ff320b2a107ead7e4831d52e9c165b43807060efe5b45a5ed8876bd2b00959c83f37ac0f1d7ecfa7db13dca97b2dc84df4e7346f45d464d7fc8e2b9fa74af320b9d50be3887bb9a4e07a46ee9a32c8d713f85768f525671e924a66020227fbf2fb6de5bcfc9596c1153fe20674dbfd85cdd63a3e73af76327fa8e537ea3019c583601",
+        "data" : {
+          "slot" : "0x3f7a97510e11b30a",
+          "index" : "0x3f74b86452f0feaa",
+          "beaconBlockRoot" : "0x2a55863fca1b5384408a1a7015fd5f173406a62dd51af1a2c0af2ad93b0113a7",
+          "source" : {
+            "epoch" : "0x1fc03b1e",
+            "root" : "0x9d1b633f8ae18e21ff1b86740b32dbe55a18a0991bcfe5ffd2b6bf8a59465fe7"
+          },
+          "target" : {
+            "epoch" : "0x1fae9e58",
+            "root" : "0x77d96e3f4a4ad0971596b71d6420b24b4d12a275af3d948b77b438faa484f0d1"
+          }
+        },
+        "signature" : "0x8c2c3b368bc00b3853e6df352e816dd910016db953ac77cc1565e3c22f1c0b24c59f24ea9e8ca406aa95b23368d163e80baa6de3f8f7ac19ee78c976d2ae5a21c86fa1762cc959bc734379055cb7aa1de36eae00541936b8c2ee908c770d41ff"
+      } ],
+      "deposits" : [ {
+        "proof" : [ "0xe99f4b3f0a100c35d42723225a552d1a73249ce1f5f188e889bbcdabc2c93c12", "0xe99f4b3f0a100c35d42723225a552d1a73249ce1f5f188e889bbcdabc2c93c12", "0xe99f4b3f0a100c35d42723225a552d1a73249ce1f5f188e889bbcdabc2c93c12", "0xe99f4b3f0a100c35d42723225a552d1a73249ce1f5f188e889bbcdabc2c93c12", "0xe99f4b3f0a100c35d42723225a552d1a73249ce1f5f188e889bbcdabc2c93c12", "0xe99f4b3f0a100c35d42723225a552d1a73249ce1f5f188e889bbcdabc2c93c12", "0xe99f4b3f0a100c35d42723225a552d1a73249ce1f5f188e889bbcdabc2c93c12", "0xe99f4b3f0a100c35d42723225a552d1a73249ce1f5f188e889bbcdabc2c93c12", "0xe99f4b3f0a100c35d42723225a552d1a73249ce1f5f188e889bbcdabc2c93c12", "0xe99f4b3f0a100c35d42723225a552d1a73249ce1f5f188e889bbcdabc2c93c12", "0xe99f4b3f0a100c35d42723225a552d1a73249ce1f5f188e889bbcdabc2c93c12", "0xe99f4b3f0a100c35d42723225a552d1a73249ce1f5f188e889bbcdabc2c93c12", "0xe99f4b3f0a100c35d42723225a552d1a73249ce1f5f188e889bbcdabc2c93c12", "0xe99f4b3f0a100c35d42723225a552d1a73249ce1f5f188e889bbcdabc2c93c12", "0xe99f4b3f0a100c35d42723225a552d1a73249ce1f5f188e889bbcdabc2c93c12", "0xe99f4b3f0a100c35d42723225a552d1a73249ce1f5f188e889bbcdabc2c93c12", "0xe99f4b3f0a100c35d42723225a552d1a73249ce1f5f188e889bbcdabc2c93c12", "0xe99f4b3f0a100c35d42723225a552d1a73249ce1f5f188e889bbcdabc2c93c12", "0xe99f4b3f0a100c35d42723225a552d1a73249ce1f5f188e889bbcdabc2c93c12", "0xe99f4b3f0a100c35d42723225a552d1a73249ce1f5f188e889bbcdabc2c93c12", "0xe99f4b3f0a100c35d42723225a552d1a73249ce1f5f188e889bbcdabc2c93c12", "0xe99f4b3f0a100c35d42723225a552d1a73249ce1f5f188e889bbcdabc2c93c12", "0xe99f4b3f0a100c35d42723225a552d1a73249ce1f5f188e889bbcdabc2c93c12", "0xe99f4b3f0a100c35d42723225a552d1a73249ce1f5f188e889bbcdabc2c93c12", "0xe99f4b3f0a100c35d42723225a552d1a73249ce1f5f188e889bbcdabc2c93c12", "0xe99f4b3f0a100c35d42723225a552d1a73249ce1f5f188e889bbcdabc2c93c12", "0xe99f4b3f0a100c35d42723225a552d1a73249ce1f5f188e889bbcdabc2c93c12", "0xe99f4b3f0a100c35d42723225a552d1a73249ce1f5f188e889bbcdabc2c93c12", "0xe99f4b3f0a100c35d42723225a552d1a73249ce1f5f188e889bbcdabc2c93c12", "0xe99f4b3f0a100c35d42723225a552d1a73249ce1f5f188e889bbcdabc2c93c12", "0xe99f4b3f0a100c35d42723225a552d1a73249ce1f5f188e889bbcdabc2c93c12", "0xe99f4b3f0a100c35d42723225a552d1a73249ce1f5f188e889bbcdabc2c93c12", "0xe99f4b3f0a100c35d42723225a552d1a73249ce1f5f188e889bbcdabc2c93c12" ],
+        "data" : {
+          "pubkey" : "0x8394a37cbc9eeea84b75c9f76a70ff76ace5592592024093f471cb0bcc656d1b8ff2f483bce58db6162f8e7c961c5b41",
+          "withdrawalCredentials" : "0xc35d573fca784dabeaa154cbb2430480661e9ebd886037742eb9461b0e08cefc",
+          "amount" : "0x773594000",
+          "signature" : "0xa12ef7e492b6761e5e3db657c6dbfc9221d4407013c7bded7b2c08cc01bc410f9a56a6954002755a97a4e67f60868b751443d66a10e7773ce4d841b90e0ea1972cd25fbb79cd0d452ccf4cd8474f7632d06f70c8b9cdee109e0210ff0618d517"
+        }
+      } ],
+      "voluntaryExits" : [ {
+        "message" : {
+          "epoch" : "0x3f34243648893e89",
+          "validatorIndex" : "0x3f517ed5f02cc46a"
+        },
+        "signature" : "0x8077d47ad0fe431af45ca6ed24efda0fa9c84364ee8af5f9e83f53b3e5934961197cb31b062dcc3d5dc793ec6de565960924b65d0535f3833ecc51567572959e2849e470be8b6a1f21e2c735552595e9765e66a599d645d33fa3746d409fa122"
+      } ],
+      "syncAggregate" : {
+        "syncCommitteeBits" : "0x01000000",
+        "syncCommitteeSignature" : "0xaacffaf60c8253477ecad70de8589f2ef7670d0b0dc446d4baac3b465a901d3e64bb6d2c3d8bdb58aed45ac30466261416d152d5ae242204201bf6decfddde697ae0c5d44cf31ca3d43aa18f2799461fc1ee14dbf905b1e31f242fd31c083c5a"
+      },
+      "executionPayloadHeader" : {
+        "parentHash" : "0xf8eb5a3ea82ccf3c1be1ac153e3f77f273a07343291711b9de6b9dbebc4c9b49",
+        "feeRecipient" : "0xbf886c3ec849316e3b187793c3a4398b6097768d",
+        "stateRoot" : "0xd2a9663e689510b3305bdebe972d4e58669a751fbc85bf448269162e078b2c34",
+        "receiptsRoot" : "0x324f493e880f6d0bfaa9e297b9d9b45986a970f94c718be767ef67174b6fc1e9",
+        "logsBloom" : "0x4570433e285b4c50f0ec49c38d62c9268cac6f8b023ab4a19570abdf25d078748f9069c96e9d6a2801cf607000a52447e46e1bef4e056ee30d4bd3517aaf7bf65ba04dd28c3a4a14b8dc72a300f051722a6814fa3931d90a82d23285d4c1127b6c67bbc4f8682ddbf9b31eb3114c26dccc5330109d6f17799339c2d7ed7e4e3a7de5d515106aaec7be6d78be3e21806d6d30c39b77c75dcf354b63033fb200b3b9dc023d948278f0956c0ee99323da0162f2a84b6a95749d2fa1d4e089af416d412ccd992683f7e41f7b496ca04f9f463806e3643d1c07f39d2a65f84e97b7dfaafac740d1e03f30923a4270fcf651ad2ca3737859a524e86e02229a55abd1a7",
+        "prevRandao" : "0x0c0d553e4878ae811024144112c88bbf79a372d5dfdf39730cede08696ad52d4",
+        "blockNumber" : "0x3e4f2e1ec68dc3e8",
+        "gasLimit" : "0x3e31d37e1eea3e08",
+        "gasUsed" : "0x3e2bf49163c989a8",
+        "timestamp" : "0x3e3d9157952ba6c8",
+        "extraData" : "0xcb571a3e876c67",
+        "baseFeePerGas" : "0xde78143e27b846779904841e2aa96d8fbec4671bb57ffa72037ac721f8d633ca",
+        "blockHash" : "0xa415263e48d5a8a8ba3b4e9caf0e3028abbb6a65922580447af6fcc869b40d2a",
+        "transactionsRoot" : "0xb736203ee72088edaf7eb5c7839744f5b1be69f748eea8fea77740914415c5b4"
+      }
+    }
+  },
+  "signature" : "0x896e97042e9255565a03a997df50fd179a215e566b6f3e6d26079573ddeb571771e55709c1fe02456d74b8fa921045c00cdf09653914c9feb018edbcab2efe7114f4820fe12a98920e54058ea3dee06f00bb2f9ea8bfad95c0056fbd55fac8a4"
+}

--- a/ethereum/executionlayer/src/integration-test/resources/builder_getPayloadResponse.json
+++ b/ethereum/executionlayer/src/integration-test/resources/builder_getPayloadResponse.json
@@ -1,0 +1,16 @@
+{
+  "parentHash" : "0x235bc3400c2839fd856a524871200bd5e362db615fc4565e1870ed9a2a936464",
+  "feeRecipient" : "0x367cbd40ac7318427aadb97345a91fa2e965daf3",
+  "stateRoot" : "0xfd18cf40cc907a739be483f1ca0ee23ad65cdd3df23205eabc6d660a75d1f54e",
+  "receiptsRoot" : "0x103ac9406cdc59b89027eb1c9e97f607dd5fdccfa8fb2da4eaeea9d25032add9",
+  "logsBloom" : "0x6fdfab408c56b6105a76eff5c0435d09fc6ed7a938e7f946cf74fbbb9416428f619b26eab6d66297cbd9dbc84db437c8d36f9b30556f5f8062bbc80a0e3f35fb2f4921ae3f8361dacf697513c2f8aac786dccb24a7ca3eef9743ab9071ee3663dca121493e717c27ee277bf5d484a83c2da75b4bea86c1d15a2b29352abad715b00fa1c4b94733e496720ced4c31ce785ec3e407136f39dcb857d7d9ff590deeb512704b2f0a58ee953d5a85894a9e9ab9528d1fc87daf2064b515ee861e4dd23bb5714c0fb38a36a1da1698fbee3aae5de1b51de39f6e3d3309e338abb70e275410a1b83e9e9d43d051e6a4a9bdbe6d6fb282c4f2463428a0502a0e2e4b71fb",
+  "prevRandao" : "0x8200a6402ca295554fb9562193cc71d60272d63beeaf2201fdf53e846e77f919",
+  "blockNumber" : "0x40b79d4886f7bf4c",
+  "gasLimit" : "0x40b1be5bcbd70aec",
+  "gasUsed" : "0x3fd8861ec01cf90b",
+  "timestamp" : "0x3fd2a73204fc44aa",
+  "extraData" : "0x0c65de3f6bad3d",
+  "baseFeePerGas" : "0x6b0ac13f8a279ad3abec11bed1a49214f6e7af79b643595df6a38706b338e93b",
+  "blockHash" : "0x7e2bbb3f2a737918a12f79e9a52da7e1fceaae0b6c0c82172425cbce8d99a0c6",
+  "transactions" : [ "0xb88ea93f0a5617" ]
+}

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/ExecutionBuilderClient.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/ExecutionBuilderClient.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionlayer.client;
+
+import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.bytes.Bytes48;
+import tech.pegasys.teku.ethereum.executionengine.schema.Response;
+import tech.pegasys.teku.ethereum.executionlayer.client.schema.BlindedBeaconBlockV1;
+import tech.pegasys.teku.ethereum.executionlayer.client.schema.BuilderBidV1;
+import tech.pegasys.teku.ethereum.executionlayer.client.schema.ExecutionPayloadV1;
+import tech.pegasys.teku.ethereum.executionlayer.client.schema.GenericBuilderStatus;
+import tech.pegasys.teku.ethereum.executionlayer.client.schema.SignedMessage;
+import tech.pegasys.teku.ethereum.executionlayer.client.schema.ValidatorRegistrationV1;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+public interface ExecutionBuilderClient {
+
+  SafeFuture<Response<GenericBuilderStatus>> status();
+
+  SafeFuture<Response<GenericBuilderStatus>> registerValidator(
+      SignedMessage<ValidatorRegistrationV1> signedValidatorRegistrationV1);
+
+  SafeFuture<Response<SignedMessage<BuilderBidV1>>> getHeader(
+      UInt64 slot, Bytes48 pubKey, Bytes32 parentHash);
+
+  SafeFuture<Response<ExecutionPayloadV1>> getPayload(
+      SignedMessage<BlindedBeaconBlockV1> signedBlindedBeaconBlock);
+}

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/Web3JExecutionBuilderClient.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/Web3JExecutionBuilderClient.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionlayer.client;
+
+import static tech.pegasys.teku.spec.config.Constants.NON_EXECUTION_TIMEOUT;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.bytes.Bytes48;
+import org.web3j.protocol.core.Request;
+import tech.pegasys.teku.ethereum.executionengine.Web3JClient;
+import tech.pegasys.teku.ethereum.executionengine.schema.Response;
+import tech.pegasys.teku.ethereum.executionlayer.client.schema.BlindedBeaconBlockV1;
+import tech.pegasys.teku.ethereum.executionlayer.client.schema.BuilderBidV1;
+import tech.pegasys.teku.ethereum.executionlayer.client.schema.ExecutionPayloadV1;
+import tech.pegasys.teku.ethereum.executionlayer.client.schema.GenericBuilderStatus;
+import tech.pegasys.teku.ethereum.executionlayer.client.schema.SignedMessage;
+import tech.pegasys.teku.ethereum.executionlayer.client.schema.ValidatorRegistrationV1;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+public class Web3JExecutionBuilderClient implements ExecutionBuilderClient {
+  private final Web3JClient web3JClient;
+
+  public Web3JExecutionBuilderClient(final Web3JClient web3JClient) {
+    this.web3JClient = web3JClient;
+  }
+
+  @Override
+  public SafeFuture<Response<GenericBuilderStatus>> status() {
+    Request<?, GenericBuilderStatusWeb3jResponse> web3jRequest =
+        new Request<>(
+            "builder_status",
+            List.of(),
+            web3JClient.getWeb3jService(),
+            GenericBuilderStatusWeb3jResponse.class);
+    return web3JClient.doRequest(web3jRequest, NON_EXECUTION_TIMEOUT);
+  }
+
+  @Override
+  public SafeFuture<Response<GenericBuilderStatus>> registerValidator(
+      final SignedMessage<ValidatorRegistrationV1> signedValidatorRegistrationV1) {
+    Request<?, GenericBuilderStatusWeb3jResponse> web3jRequest =
+        new Request<>(
+            "builder_registerValidatorV1",
+            Collections.singletonList(signedValidatorRegistrationV1),
+            web3JClient.getWeb3jService(),
+            GenericBuilderStatusWeb3jResponse.class);
+    return web3JClient.doRequest(web3jRequest, NON_EXECUTION_TIMEOUT);
+  }
+
+  @Override
+  public SafeFuture<Response<SignedMessage<BuilderBidV1>>> getHeader(
+      final UInt64 slot, final Bytes48 pubKey, final Bytes32 parentHash) {
+    Request<?, ExecutionPayloadHeaderV1Web3jResponse> web3jRequest =
+        new Request<>(
+            "builder_getHeaderV1",
+            List.of(slot.toString(), pubKey.toHexString(), parentHash.toHexString()),
+            web3JClient.getWeb3jService(),
+            ExecutionPayloadHeaderV1Web3jResponse.class);
+    return web3JClient.doRequest(web3jRequest, NON_EXECUTION_TIMEOUT);
+  }
+
+  @Override
+  public SafeFuture<Response<ExecutionPayloadV1>> getPayload(
+      SignedMessage<BlindedBeaconBlockV1> signedBlindedBeaconBlock) {
+    Request<?, ExecutionPayloadV1Web3jResponse> web3jRequest =
+        new Request<>(
+            "builder_getPayloadV1",
+            Collections.singletonList(signedBlindedBeaconBlock),
+            web3JClient.getWeb3jService(),
+            ExecutionPayloadV1Web3jResponse.class);
+    return web3JClient.doRequest(web3jRequest, NON_EXECUTION_TIMEOUT);
+  }
+
+  protected Web3JClient getWeb3JClient() {
+    return web3JClient;
+  }
+
+  static class ExecutionPayloadV1Web3jResponse
+      extends org.web3j.protocol.core.Response<ExecutionPayloadV1> {}
+
+  static class ExecutionPayloadHeaderV1Web3jResponse
+      extends org.web3j.protocol.core.Response<SignedMessage<BuilderBidV1>> {}
+
+  static class GenericBuilderStatusWeb3jResponse
+      extends org.web3j.protocol.core.Response<GenericBuilderStatus> {}
+
+  /**
+   * Returns a list that supports null items.
+   *
+   * @param items the items to put in a list
+   * @return the list
+   */
+  protected List<Object> list(final Object... items) {
+    final List<Object> list = new ArrayList<>();
+    for (Object item : items) {
+      list.add(item);
+    }
+    return list;
+  }
+}

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/Web3JExecutionEngineClient.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/Web3JExecutionEngineClient.java
@@ -16,15 +16,12 @@ package tech.pegasys.teku.ethereum.executionlayer.client;
 import static tech.pegasys.teku.spec.config.Constants.EXECUTION_TIMEOUT;
 import static tech.pegasys.teku.spec.config.Constants.NON_EXECUTION_TIMEOUT;
 
-import com.fasterxml.jackson.core.Version;
-import com.fasterxml.jackson.databind.module.SimpleModule;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
-import org.web3j.protocol.ObjectMapperFactory;
 import org.web3j.protocol.core.DefaultBlockParameterName;
 import org.web3j.protocol.core.Request;
 import org.web3j.protocol.core.methods.response.EthBlock;
@@ -37,7 +34,6 @@ import tech.pegasys.teku.ethereum.executionlayer.client.schema.ForkChoiceUpdated
 import tech.pegasys.teku.ethereum.executionlayer.client.schema.PayloadAttributesV1;
 import tech.pegasys.teku.ethereum.executionlayer.client.schema.PayloadStatusV1;
 import tech.pegasys.teku.ethereum.executionlayer.client.schema.TransitionConfigurationV1;
-import tech.pegasys.teku.ethereum.executionlayer.client.serialization.SignedBeaconBlockSerializer;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.bytes.Bytes8;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -46,12 +42,6 @@ import tech.pegasys.teku.spec.datastructures.execution.PowBlock;
 
 public class Web3JExecutionEngineClient implements ExecutionEngineClient {
   private final Web3JClient web3JClient;
-
-  static {
-    SimpleModule module = new SimpleModule("TekuEESsz", new Version(1, 0, 0, null, null, null));
-    module.addSerializer(SignedBeaconBlock.class, new SignedBeaconBlockSerializer());
-    ObjectMapperFactory.getObjectMapper().registerModule(module);
-  }
 
   public Web3JExecutionEngineClient(final Web3JClient web3JClient) {
     this.web3JClient = web3JClient;

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/schema/AttestationDataV1.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/schema/AttestationDataV1.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionlayer.client.schema;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.util.Objects;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.ethereum.executionlayer.client.serialization.Bytes32Deserializer;
+import tech.pegasys.teku.ethereum.executionlayer.client.serialization.BytesSerializer;
+import tech.pegasys.teku.ethereum.executionlayer.client.serialization.UInt64AsHexDeserializer;
+import tech.pegasys.teku.ethereum.executionlayer.client.serialization.UInt64AsHexSerializer;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+@SuppressWarnings("JavaCase")
+public class AttestationDataV1 {
+  @JsonSerialize(using = UInt64AsHexSerializer.class)
+  @JsonDeserialize(using = UInt64AsHexDeserializer.class)
+  public final UInt64 slot;
+
+  @JsonSerialize(using = UInt64AsHexSerializer.class)
+  @JsonDeserialize(using = UInt64AsHexDeserializer.class)
+  public final UInt64 index;
+
+  @JsonSerialize(using = BytesSerializer.class)
+  @JsonDeserialize(using = Bytes32Deserializer.class)
+  public final Bytes32 beaconBlockRoot;
+
+  public final CheckpointV1 source;
+  public final CheckpointV1 target;
+
+  @JsonCreator
+  public AttestationDataV1(
+      @JsonProperty("slot") final UInt64 slot,
+      @JsonProperty("index") final UInt64 index,
+      @JsonProperty("beaconBlockRoot") final Bytes32 beaconBlockRoot,
+      @JsonProperty("source") final CheckpointV1 source,
+      @JsonProperty("target") final CheckpointV1 target) {
+    this.slot = slot;
+    this.index = index;
+    this.beaconBlockRoot = beaconBlockRoot;
+    this.source = source;
+    this.target = target;
+  }
+
+  public AttestationDataV1(tech.pegasys.teku.spec.datastructures.operations.AttestationData data) {
+    this.slot = data.getSlot();
+    this.index = data.getIndex();
+    this.beaconBlockRoot = data.getBeaconBlockRoot();
+    this.source = new CheckpointV1(data.getSource());
+    this.target = new CheckpointV1(data.getTarget());
+  }
+
+  public tech.pegasys.teku.spec.datastructures.operations.AttestationData
+      asInternalAttestationData() {
+    tech.pegasys.teku.spec.datastructures.state.Checkpoint src = source.asInternalCheckpoint();
+    tech.pegasys.teku.spec.datastructures.state.Checkpoint tgt = target.asInternalCheckpoint();
+
+    return new tech.pegasys.teku.spec.datastructures.operations.AttestationData(
+        slot, index, beaconBlockRoot, src, tgt);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof AttestationDataV1)) {
+      return false;
+    }
+    AttestationDataV1 that = (AttestationDataV1) o;
+    return Objects.equals(slot, that.slot)
+        && Objects.equals(index, that.index)
+        && Objects.equals(beaconBlockRoot, that.beaconBlockRoot)
+        && Objects.equals(source, that.source)
+        && Objects.equals(target, that.target);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(slot, index, beaconBlockRoot, source, target);
+  }
+}

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/schema/AttestationV1.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/schema/AttestationV1.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionlayer.client.schema;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.util.Objects;
+import org.apache.tuweni.bytes.Bytes;
+import tech.pegasys.teku.ethereum.executionlayer.client.serialization.BLSSignatureDeserializer;
+import tech.pegasys.teku.ethereum.executionlayer.client.serialization.BLSSignatureSerializer;
+import tech.pegasys.teku.ethereum.executionlayer.client.serialization.BytesDeserializer;
+import tech.pegasys.teku.ethereum.executionlayer.client.serialization.BytesSerializer;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecVersion;
+import tech.pegasys.teku.spec.datastructures.operations.Attestation.AttestationSchema;
+
+public class AttestationV1 {
+  @JsonSerialize(using = BytesSerializer.class)
+  @JsonDeserialize(using = BytesDeserializer.class)
+  public final Bytes aggregationBits;
+
+  public final AttestationDataV1 data;
+
+  @JsonSerialize(using = BLSSignatureSerializer.class)
+  @JsonDeserialize(using = BLSSignatureDeserializer.class)
+  public final BLSSignature signature;
+
+  public AttestationV1(tech.pegasys.teku.spec.datastructures.operations.Attestation attestation) {
+    this.aggregationBits = attestation.getAggregationBits().sszSerialize();
+    this.data = new AttestationDataV1(attestation.getData());
+    this.signature = new BLSSignature(attestation.getAggregateSignature());
+  }
+
+  @JsonCreator
+  public AttestationV1(
+      @JsonProperty("aggregationBits") final Bytes aggregationBits,
+      @JsonProperty("data") final AttestationDataV1 data,
+      @JsonProperty("signature") final BLSSignature signature) {
+    this.aggregationBits = aggregationBits;
+    this.data = data;
+    this.signature = signature;
+  }
+
+  public tech.pegasys.teku.spec.datastructures.operations.Attestation asInternalAttestation(
+      final Spec spec) {
+    return asInternalAttestation(spec.atSlot(data.slot));
+  }
+
+  public tech.pegasys.teku.spec.datastructures.operations.Attestation asInternalAttestation(
+      final SpecVersion specVersion) {
+    final AttestationSchema attestationSchema =
+        specVersion.getSchemaDefinitions().getAttestationSchema();
+    return attestationSchema.create(
+        attestationSchema.getAggregationBitsSchema().sszDeserialize(aggregationBits),
+        data.asInternalAttestationData(),
+        signature.asInternalBLSSignature());
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof AttestationV1)) {
+      return false;
+    }
+    AttestationV1 that = (AttestationV1) o;
+    return Objects.equals(aggregationBits, that.aggregationBits)
+        && Objects.equals(data, that.data)
+        && Objects.equals(signature, that.signature);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(aggregationBits, data, signature);
+  }
+}

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/schema/AttesterSlashingV1.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/schema/AttesterSlashingV1.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionlayer.client.schema;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
+import tech.pegasys.teku.spec.SpecVersion;
+import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing.AttesterSlashingSchema;
+
+public class AttesterSlashingV1 {
+  public final IndexedAttestationV1 attestation1;
+  public final IndexedAttestationV1 attestation2;
+
+  @JsonCreator
+  public AttesterSlashingV1(
+      @JsonProperty("attestation1") final IndexedAttestationV1 attestation1,
+      @JsonProperty("attestation2") final IndexedAttestationV1 attestation2) {
+    this.attestation1 = attestation1;
+    this.attestation2 = attestation2;
+  }
+
+  public AttesterSlashingV1(
+      tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing attesterSlashing) {
+    attestation1 = new IndexedAttestationV1(attesterSlashing.getAttestation1());
+    attestation2 = new IndexedAttestationV1(attesterSlashing.getAttestation2());
+  }
+
+  public tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing
+      asInternalAttesterSlashing(final SpecVersion spec) {
+    final AttesterSlashingSchema attesterSlashingSchema =
+        spec.getSchemaDefinitions().getAttesterSlashingSchema();
+    return attesterSlashingSchema.create(
+        attestation1.asInternalIndexedAttestation(spec),
+        attestation2.asInternalIndexedAttestation(spec));
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof AttesterSlashingV1)) {
+      return false;
+    }
+    AttesterSlashingV1 that = (AttesterSlashingV1) o;
+    return Objects.equals(attestation1, that.attestation1)
+        && Objects.equals(attestation2, that.attestation2);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(attestation1, attestation2);
+  }
+}

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/schema/BLSPubKey.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/schema/BLSPubKey.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionlayer.client.schema;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import java.util.Objects;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes48;
+import tech.pegasys.teku.bls.BLSPublicKey;
+
+@SuppressWarnings("JavaCase")
+public class BLSPubKey {
+  /** The number of bytes in this value - i.e. 48 */
+  private static final int SIZE = 48;
+
+  private final Bytes bytes;
+
+  public BLSPubKey(Bytes bytes) {
+    checkArgument(
+        bytes.size() == SIZE,
+        "Bytes%s should be %s bytes, but was %s bytes.",
+        SIZE,
+        SIZE,
+        bytes.size());
+    this.bytes = bytes;
+  }
+
+  public BLSPubKey(BLSPublicKey publicKey) {
+    this(publicKey.toSSZBytes());
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final BLSPubKey BLSSignature = (BLSPubKey) o;
+    return bytes.equals(BLSSignature.bytes);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(bytes);
+  }
+
+  @Override
+  public String toString() {
+    return bytes.toString();
+  }
+
+  public static BLSPubKey fromHexString(String value) {
+    try {
+      return new BLSPubKey(BLSPublicKey.fromBytesCompressedValidate(Bytes48.fromHexString(value)));
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException(
+          "Public key " + value + " is invalid: " + e.getMessage(), e);
+    }
+  }
+
+  public String toHexString() {
+    return bytes.toHexString();
+  }
+
+  public Bytes toBytes() {
+    return bytes;
+  }
+
+  public static BLSPubKey empty() {
+    return new BLSPubKey(Bytes.wrap(new byte[SIZE]));
+  }
+
+  public BLSPublicKey asBLSPublicKey() {
+    return BLSPublicKey.fromSSZBytes(bytes);
+  }
+}

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/schema/BLSSignature.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/schema/BLSSignature.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionlayer.client.schema;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import java.util.Objects;
+import org.apache.tuweni.bytes.Bytes;
+import tech.pegasys.teku.bls.BLSConstants;
+
+public class BLSSignature {
+  /** The number of bytes in this value - i.e. 96 */
+  private static final int SIZE = BLSConstants.BLS_SIGNATURE_SIZE;
+
+  private final Bytes bytes;
+
+  public BLSSignature(Bytes bytes) {
+    checkArgument(
+        bytes.size() == SIZE,
+        "Bytes%s should be %s bytes, but was %s bytes.",
+        SIZE,
+        SIZE,
+        bytes.size());
+    this.bytes = bytes;
+  }
+
+  public BLSSignature(tech.pegasys.teku.bls.BLSSignature signature) {
+    this(signature.toBytesCompressed());
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final BLSSignature blsSignature = (BLSSignature) o;
+    return bytes.equals(blsSignature.bytes);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(bytes);
+  }
+
+  @Override
+  public String toString() {
+    return bytes.toString();
+  }
+
+  public static BLSSignature fromHexString(String value) {
+    return new BLSSignature(Bytes.fromHexString(value));
+  }
+
+  public String toHexString() {
+    return bytes.toHexString();
+  }
+
+  public static BLSSignature empty() {
+    return new BLSSignature(tech.pegasys.teku.bls.BLSSignature.empty());
+  }
+
+  public final Bytes getBytes() {
+    return bytes;
+  }
+
+  public tech.pegasys.teku.bls.BLSSignature asInternalBLSSignature() {
+    return tech.pegasys.teku.bls.BLSSignature.fromBytesCompressed(bytes);
+  }
+}

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/schema/BeaconBlockHeaderV1.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/schema/BeaconBlockHeaderV1.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionlayer.client.schema;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.common.base.MoreObjects;
+import java.util.Objects;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.ethereum.executionlayer.client.serialization.Bytes32Deserializer;
+import tech.pegasys.teku.ethereum.executionlayer.client.serialization.BytesSerializer;
+import tech.pegasys.teku.ethereum.executionlayer.client.serialization.UInt64AsHexDeserializer;
+import tech.pegasys.teku.ethereum.executionlayer.client.serialization.UInt64AsHexSerializer;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+@SuppressWarnings("JavaCase")
+public class BeaconBlockHeaderV1 {
+  @JsonSerialize(using = UInt64AsHexSerializer.class)
+  @JsonDeserialize(using = UInt64AsHexDeserializer.class)
+  public final UInt64 slot;
+
+  @JsonSerialize(using = UInt64AsHexSerializer.class)
+  @JsonDeserialize(using = UInt64AsHexDeserializer.class)
+  public final UInt64 proposerIndex;
+
+  @JsonSerialize(using = BytesSerializer.class)
+  @JsonDeserialize(using = Bytes32Deserializer.class)
+  public final Bytes32 parentRoot;
+
+  @JsonSerialize(using = BytesSerializer.class)
+  @JsonDeserialize(using = Bytes32Deserializer.class)
+  public final Bytes32 stateRoot;
+
+  @JsonSerialize(using = BytesSerializer.class)
+  @JsonDeserialize(using = Bytes32Deserializer.class)
+  public final Bytes32 bodyRoot;
+
+  @JsonCreator
+  public BeaconBlockHeaderV1(
+      @JsonProperty("slot") final UInt64 slot,
+      @JsonProperty("proposerIndex") final UInt64 proposerIndex,
+      @JsonProperty("parentRoot") final Bytes32 parentRoot,
+      @JsonProperty("stateRoot") final Bytes32 stateRoot,
+      @JsonProperty("bodyRoot") final Bytes32 bodyRoot) {
+    this.slot = slot;
+    this.proposerIndex = proposerIndex;
+    this.parentRoot = parentRoot;
+    this.stateRoot = stateRoot;
+    this.bodyRoot = bodyRoot;
+  }
+
+  public BeaconBlockHeaderV1(
+      final tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockHeader header) {
+    this.slot = header.getSlot();
+    this.proposerIndex = header.getProposerIndex();
+    this.parentRoot = header.getParentRoot();
+    this.stateRoot = header.getStateRoot();
+    this.bodyRoot = header.getBodyRoot();
+  }
+
+  public tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockHeader
+      asInternalBeaconBlockHeader() {
+    return new tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockHeader(
+        slot, proposerIndex, parentRoot, stateRoot, bodyRoot);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final BeaconBlockHeaderV1 that = (BeaconBlockHeaderV1) o;
+    return Objects.equals(slot, that.slot)
+        && Objects.equals(proposerIndex, that.proposerIndex)
+        && Objects.equals(parentRoot, that.parentRoot)
+        && Objects.equals(stateRoot, that.stateRoot)
+        && Objects.equals(bodyRoot, that.bodyRoot);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(slot, proposerIndex, parentRoot, stateRoot, bodyRoot);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("slot", slot)
+        .add("proposerIndex", proposerIndex)
+        .add("parentRoot", parentRoot)
+        .add("stateRoot", stateRoot)
+        .add("bodyRoot", bodyRoot)
+        .toString();
+  }
+}

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/schema/BlindedBeaconBlockBodyV1.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/schema/BlindedBeaconBlockBodyV1.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionlayer.client.schema;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.ethereum.executionlayer.client.serialization.BLSSignatureDeserializer;
+import tech.pegasys.teku.ethereum.executionlayer.client.serialization.BLSSignatureSerializer;
+import tech.pegasys.teku.ethereum.executionlayer.client.serialization.Bytes32Deserializer;
+import tech.pegasys.teku.ethereum.executionlayer.client.serialization.BytesSerializer;
+import tech.pegasys.teku.spec.SpecVersion;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodySchema;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregateSchema;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.bellatrix.BlindedBeaconBlockBodySchemaBellatrix;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeaderSchema;
+import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
+
+public class BlindedBeaconBlockBodyV1 {
+  @JsonSerialize(using = BLSSignatureSerializer.class)
+  @JsonDeserialize(using = BLSSignatureDeserializer.class)
+  public final BLSSignature randaoReveal;
+
+  public final Eth1DataV1 eth1Data;
+
+  @JsonSerialize(using = BytesSerializer.class)
+  @JsonDeserialize(using = Bytes32Deserializer.class)
+  public final Bytes32 graffiti;
+
+  public final List<ProposerSlashingV1> proposerSlashings;
+  public final List<AttesterSlashingV1> attesterSlashings;
+  public final List<AttestationV1> attestations;
+  public final List<DepositV1> deposits;
+  public final List<SignedMessage<VoluntaryExitV1>> voluntaryExits;
+  public final SyncAggregateV1 syncAggregate;
+  public final ExecutionPayloadHeaderV1 executionPayloadHeader;
+
+  @JsonCreator
+  public BlindedBeaconBlockBodyV1(
+      @JsonProperty("randaoReveal") final BLSSignature randaoReveal,
+      @JsonProperty("eth1Data") final Eth1DataV1 eth1Data,
+      @JsonProperty("graffiti") final Bytes32 graffiti,
+      @JsonProperty("proposerSlashings") final List<ProposerSlashingV1> proposerSlashings,
+      @JsonProperty("attesterSlashings") final List<AttesterSlashingV1> attesterSlashings,
+      @JsonProperty("attestations") final List<AttestationV1> attestations,
+      @JsonProperty("deposits") final List<DepositV1> deposits,
+      @JsonProperty("voluntaryExits") final List<SignedMessage<VoluntaryExitV1>> voluntaryExits,
+      @JsonProperty("syncAggregate") final SyncAggregateV1 syncAggregate,
+      @JsonProperty("executionPayloadHeader")
+          final ExecutionPayloadHeaderV1 executionPayloadHeader) {
+    this.randaoReveal = randaoReveal;
+    this.eth1Data = eth1Data;
+    this.graffiti = graffiti;
+    this.proposerSlashings = proposerSlashings;
+    this.attesterSlashings = attesterSlashings;
+    this.attestations = attestations;
+    this.deposits = deposits;
+    this.voluntaryExits = voluntaryExits;
+    this.syncAggregate = syncAggregate;
+    this.executionPayloadHeader = executionPayloadHeader;
+  }
+
+  public BlindedBeaconBlockBodySchemaBellatrix<?> getBeaconBlockBodySchema(final SpecVersion spec) {
+    return (BlindedBeaconBlockBodySchemaBellatrix<?>)
+        spec.getSchemaDefinitions().getBlindedBeaconBlockBodySchema();
+  }
+
+  public BlindedBeaconBlockBodyV1(
+      tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody body) {
+    this.randaoReveal = new BLSSignature(body.getRandaoReveal().toSSZBytes());
+    this.eth1Data = new Eth1DataV1(body.getEth1Data());
+    this.graffiti = body.getGraffiti();
+    this.proposerSlashings =
+        body.getProposerSlashings().stream()
+            .map(ProposerSlashingV1::new)
+            .collect(Collectors.toList());
+    this.attesterSlashings =
+        body.getAttesterSlashings().stream()
+            .map(AttesterSlashingV1::new)
+            .collect(Collectors.toList());
+    this.attestations =
+        body.getAttestations().stream().map(AttestationV1::new).collect(Collectors.toList());
+    this.deposits = body.getDeposits().stream().map(DepositV1::new).collect(Collectors.toList());
+    this.voluntaryExits =
+        body.getVoluntaryExits().stream()
+            .map(
+                signedVoluntaryExit ->
+                    new SignedMessage<>(
+                        new VoluntaryExitV1(signedVoluntaryExit.getMessage()),
+                        signedVoluntaryExit.getSignature()))
+            .collect(Collectors.toList());
+    this.syncAggregate = new SyncAggregateV1(body.getOptionalSyncAggregate().orElseThrow());
+    this.executionPayloadHeader =
+        ExecutionPayloadHeaderV1.fromInternalExecutionPayloadHeader(
+            body.getOptionalExecutionPayloadHeader().orElseThrow());
+  }
+
+  public tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody
+      asInternalBeaconBlockBody(final SpecVersion spec) {
+
+    final ExecutionPayloadHeaderSchema executionPayloadHeaderSchema =
+        getBeaconBlockBodySchema(spec).getExecutionPayloadHeaderSchema();
+    final SyncAggregateSchema syncAggregateSchema =
+        getBeaconBlockBodySchema(spec).getSyncAggregateSchema();
+    final BeaconBlockBodySchema<?> schema = getBeaconBlockBodySchema(spec);
+
+    return schema.createBlockBody(
+        builder -> {
+          builder
+              .randaoReveal(randaoReveal.asInternalBLSSignature())
+              .eth1Data(
+                  new tech.pegasys.teku.spec.datastructures.blocks.Eth1Data(
+                      eth1Data.depositRoot, eth1Data.depositCount, eth1Data.blockHash))
+              .graffiti(graffiti)
+              .attestations(
+                  attestations.stream()
+                      .map(attestation -> attestation.asInternalAttestation(spec))
+                      .collect(schema.getAttestationsSchema().collector()))
+              .proposerSlashings(
+                  proposerSlashings.stream()
+                      .map(ProposerSlashingV1::asInternalProposerSlashing)
+                      .collect(schema.getProposerSlashingsSchema().collector()))
+              .attesterSlashings(
+                  attesterSlashings.stream()
+                      .map(slashing -> slashing.asInternalAttesterSlashing(spec))
+                      .collect(schema.getAttesterSlashingsSchema().collector()))
+              .deposits(
+                  deposits.stream()
+                      .map(DepositV1::asInternalDeposit)
+                      .collect(schema.getDepositsSchema().collector()))
+              .voluntaryExits(
+                  voluntaryExits.stream()
+                      .map(
+                          voluntaryExit ->
+                              new SignedVoluntaryExit(
+                                  voluntaryExit.getMessage().asInternalVoluntaryExit(),
+                                  voluntaryExit.getSignature().asInternalBLSSignature()))
+                      .collect(schema.getVoluntaryExitsSchema().collector()))
+              .syncAggregate(
+                  () ->
+                      syncAggregateSchema.create(
+                          syncAggregateSchema
+                              .getSyncCommitteeBitsSchema()
+                              .fromBytes(syncAggregate.syncCommitteeBits)
+                              .getAllSetBits(),
+                          syncAggregate.syncCommitteeSignature.asInternalBLSSignature()))
+              .executionPayloadHeader(
+                  () ->
+                      executionPayloadHeaderSchema.create(
+                          executionPayloadHeader.parentHash,
+                          executionPayloadHeader.feeRecipient,
+                          executionPayloadHeader.stateRoot,
+                          executionPayloadHeader.receiptsRoot,
+                          executionPayloadHeader.logsBloom,
+                          executionPayloadHeader.prevRandao,
+                          executionPayloadHeader.blockNumber,
+                          executionPayloadHeader.gasLimit,
+                          executionPayloadHeader.gasUsed,
+                          executionPayloadHeader.timestamp,
+                          executionPayloadHeader.extraData,
+                          executionPayloadHeader.baseFeePerGas,
+                          executionPayloadHeader.blockHash,
+                          executionPayloadHeader.transactionsRoot));
+        });
+  }
+}

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/schema/BlindedBeaconBlockV1.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/schema/BlindedBeaconBlockV1.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionlayer.client.schema;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.util.Objects;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.ethereum.executionlayer.client.serialization.Bytes32Deserializer;
+import tech.pegasys.teku.ethereum.executionlayer.client.serialization.BytesSerializer;
+import tech.pegasys.teku.ethereum.executionlayer.client.serialization.UInt64AsHexDeserializer;
+import tech.pegasys.teku.ethereum.executionlayer.client.serialization.UInt64AsHexSerializer;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecVersion;
+import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSchema;
+
+public class BlindedBeaconBlockV1 {
+  @JsonSerialize(using = UInt64AsHexSerializer.class)
+  @JsonDeserialize(using = UInt64AsHexDeserializer.class)
+  public final UInt64 slot;
+
+  @JsonSerialize(using = UInt64AsHexSerializer.class)
+  @JsonDeserialize(using = UInt64AsHexDeserializer.class)
+  public final UInt64 proposerIndex;
+
+  @JsonSerialize(using = BytesSerializer.class)
+  @JsonDeserialize(using = Bytes32Deserializer.class)
+  public final Bytes32 parentRoot;
+
+  @JsonSerialize(using = BytesSerializer.class)
+  @JsonDeserialize(using = Bytes32Deserializer.class)
+  public final Bytes32 stateRoot;
+
+  protected final BlindedBeaconBlockBodyV1 body;
+
+  public BlindedBeaconBlockBodyV1 getBody() {
+    return body;
+  }
+
+  @JsonCreator
+  public BlindedBeaconBlockV1(
+      @JsonProperty("slot") final UInt64 slot,
+      @JsonProperty("proposerIndex") final UInt64 proposerIndex,
+      @JsonProperty("parentRoot") final Bytes32 parentRoot,
+      @JsonProperty("stateRoot") final Bytes32 stateRoot,
+      @JsonProperty("body") final BlindedBeaconBlockBodyV1 body) {
+    this.slot = slot;
+    this.proposerIndex = proposerIndex;
+    this.parentRoot = parentRoot;
+    this.stateRoot = stateRoot;
+    this.body = body;
+  }
+
+  public BeaconBlockSchema getBeaconBlockSchema(final SpecVersion spec) {
+    return spec.getSchemaDefinitions().getBeaconBlockSchema();
+  }
+
+  public BlindedBeaconBlockV1(tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock message) {
+    this.slot = message.getSlot();
+    this.proposerIndex = message.getProposerIndex();
+    this.parentRoot = message.getParentRoot();
+    this.stateRoot = message.getStateRoot();
+    this.body =
+        new BlindedBeaconBlockBodyV1(message.getBody().toBlindedVersionBellatrix().orElseThrow());
+  }
+
+  public tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock asInternalBeaconBlock(
+      final Spec spec) {
+    final SpecVersion specVersion = spec.atSlot(slot);
+    return getBeaconBlockSchema(spec.atSlot(slot))
+        .create(
+            slot,
+            proposerIndex,
+            parentRoot,
+            stateRoot,
+            body.asInternalBeaconBlockBody(specVersion));
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof BlindedBeaconBlockV1)) {
+      return false;
+    }
+    BlindedBeaconBlockV1 that = (BlindedBeaconBlockV1) o;
+    return Objects.equals(slot, that.slot)
+        && Objects.equals(proposerIndex, that.proposerIndex)
+        && Objects.equals(parentRoot, that.parentRoot)
+        && Objects.equals(stateRoot, that.stateRoot)
+        && Objects.equals(body, that.body);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(slot, proposerIndex, parentRoot, stateRoot, body);
+  }
+}

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/schema/BuilderBidV1.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/schema/BuilderBidV1.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionlayer.client.schema;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.common.base.MoreObjects;
+import java.util.Objects;
+import org.apache.tuweni.units.bigints.UInt256;
+import tech.pegasys.teku.ethereum.executionlayer.client.serialization.BLSPubKeyDeserializer;
+import tech.pegasys.teku.ethereum.executionlayer.client.serialization.BLSPubKeySerializer;
+import tech.pegasys.teku.ethereum.executionlayer.client.serialization.UInt256AsHexDeserializer;
+import tech.pegasys.teku.ethereum.executionlayer.client.serialization.UInt256AsHexSerializer;
+
+public class BuilderBidV1 {
+  @JsonProperty("header")
+  private final ExecutionPayloadHeaderV1 header;
+
+  @JsonSerialize(using = UInt256AsHexSerializer.class)
+  @JsonDeserialize(using = UInt256AsHexDeserializer.class)
+  private final UInt256 value;
+
+  @JsonSerialize(using = BLSPubKeySerializer.class)
+  @JsonDeserialize(using = BLSPubKeyDeserializer.class)
+  private final BLSPubKey pubkey;
+
+  @JsonCreator
+  public BuilderBidV1(
+      @JsonProperty("header") ExecutionPayloadHeaderV1 header,
+      @JsonProperty("value") UInt256 value,
+      @JsonProperty("pubkey") BLSPubKey pubkey) {
+    checkNotNull(header, "header cannot be null");
+    checkNotNull(value, "value cannot be null");
+    checkNotNull(pubkey, "pubkey cannot be null");
+
+    this.header = header;
+    this.value = value;
+    this.pubkey = pubkey;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final BuilderBidV1 that = (BuilderBidV1) o;
+    return Objects.equals(header, that.header)
+        && Objects.equals(value, that.value)
+        && Objects.equals(pubkey, that.pubkey);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(header, value, pubkey);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("header", header)
+        .add("value", value)
+        .add("pubkey", pubkey)
+        .toString();
+  }
+}

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/schema/CheckpointV1.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/schema/CheckpointV1.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionlayer.client.schema;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.ethereum.executionlayer.client.serialization.Bytes32Deserializer;
+import tech.pegasys.teku.ethereum.executionlayer.client.serialization.BytesSerializer;
+import tech.pegasys.teku.ethereum.executionlayer.client.serialization.UInt64AsHexDeserializer;
+import tech.pegasys.teku.ethereum.executionlayer.client.serialization.UInt64AsHexSerializer;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+public class CheckpointV1 {
+  @JsonSerialize(using = UInt64AsHexSerializer.class)
+  @JsonDeserialize(using = UInt64AsHexDeserializer.class)
+  public final UInt64 epoch;
+
+  @JsonSerialize(using = BytesSerializer.class)
+  @JsonDeserialize(using = Bytes32Deserializer.class)
+  public final Bytes32 root;
+
+  public CheckpointV1(tech.pegasys.teku.spec.datastructures.state.Checkpoint checkpoint) {
+    this.epoch = checkpoint.getEpoch();
+    this.root = checkpoint.getRoot();
+  }
+
+  @JsonCreator
+  public CheckpointV1(
+      @JsonProperty("epoch") final UInt64 epoch, @JsonProperty("root") final Bytes32 root) {
+    this.epoch = epoch;
+    this.root = root;
+  }
+
+  public tech.pegasys.teku.spec.datastructures.state.Checkpoint asInternalCheckpoint() {
+    return new tech.pegasys.teku.spec.datastructures.state.Checkpoint(epoch, root);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof CheckpointV1)) {
+      return false;
+    }
+    CheckpointV1 that = (CheckpointV1) o;
+    return Objects.equal(epoch, that.epoch) && Objects.equal(root, that.root);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(epoch, root);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this).add("epoch", epoch).add("root", root).toString();
+  }
+}

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/schema/DepositDataV1.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/schema/DepositDataV1.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionlayer.client.schema;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.util.Objects;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.ethereum.executionlayer.client.serialization.BLSPubKeyDeserializer;
+import tech.pegasys.teku.ethereum.executionlayer.client.serialization.BLSPubKeySerializer;
+import tech.pegasys.teku.ethereum.executionlayer.client.serialization.BLSSignatureDeserializer;
+import tech.pegasys.teku.ethereum.executionlayer.client.serialization.BLSSignatureSerializer;
+import tech.pegasys.teku.ethereum.executionlayer.client.serialization.Bytes32Deserializer;
+import tech.pegasys.teku.ethereum.executionlayer.client.serialization.BytesSerializer;
+import tech.pegasys.teku.ethereum.executionlayer.client.serialization.UInt64AsHexDeserializer;
+import tech.pegasys.teku.ethereum.executionlayer.client.serialization.UInt64AsHexSerializer;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+public class DepositDataV1 {
+  @JsonSerialize(using = BLSPubKeySerializer.class)
+  @JsonDeserialize(using = BLSPubKeyDeserializer.class)
+  public final BLSPubKey pubkey;
+
+  @JsonSerialize(using = BytesSerializer.class)
+  @JsonDeserialize(using = Bytes32Deserializer.class)
+  public final Bytes32 withdrawalCredentials;
+
+  @JsonSerialize(using = UInt64AsHexSerializer.class)
+  @JsonDeserialize(using = UInt64AsHexDeserializer.class)
+  public final UInt64 amount;
+
+  @JsonSerialize(using = BLSSignatureSerializer.class)
+  @JsonDeserialize(using = BLSSignatureDeserializer.class)
+  public final BLSSignature signature;
+
+  public DepositDataV1(tech.pegasys.teku.spec.datastructures.operations.DepositData depositData) {
+    this.pubkey = new BLSPubKey(depositData.getPubkey().toSSZBytes());
+    this.withdrawalCredentials = depositData.getWithdrawalCredentials();
+    this.amount = depositData.getAmount();
+    this.signature = new BLSSignature(depositData.getSignature());
+  }
+
+  @JsonCreator
+  public DepositDataV1(
+      @JsonProperty("pubkey") final BLSPubKey pubkey,
+      @JsonProperty("withdrawalCredentials") final Bytes32 withdrawalCredentials,
+      @JsonProperty("amount") final UInt64 amount,
+      @JsonProperty("signature") final BLSSignature signature) {
+    this.pubkey = pubkey;
+    this.withdrawalCredentials = withdrawalCredentials;
+    this.amount = amount;
+    this.signature = signature;
+  }
+
+  public tech.pegasys.teku.spec.datastructures.operations.DepositData asInternalDepositData() {
+    return new tech.pegasys.teku.spec.datastructures.operations.DepositData(
+        BLSPublicKey.fromSSZBytes(pubkey.toBytes()),
+        withdrawalCredentials,
+        amount,
+        signature.asInternalBLSSignature());
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof DepositDataV1)) {
+      return false;
+    }
+    DepositDataV1 that = (DepositDataV1) o;
+    return Objects.equals(pubkey, that.pubkey)
+        && Objects.equals(withdrawalCredentials, that.withdrawalCredentials)
+        && Objects.equals(amount, that.amount)
+        && Objects.equals(signature, that.signature);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(pubkey, withdrawalCredentials, amount, signature);
+  }
+}

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/schema/DepositV1.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/schema/DepositV1.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionlayer.client.schema;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.ethereum.executionlayer.client.serialization.Bytes32Deserializer;
+import tech.pegasys.teku.ethereum.executionlayer.client.serialization.BytesSerializer;
+
+public class DepositV1 {
+  @JsonSerialize(contentUsing = BytesSerializer.class)
+  @JsonDeserialize(contentUsing = Bytes32Deserializer.class)
+  public final List<Bytes32> proof;
+
+  public final DepositDataV1 data;
+
+  public DepositV1(tech.pegasys.teku.spec.datastructures.operations.Deposit deposit) {
+    this.proof = deposit.getProof().streamUnboxed().collect(Collectors.toList());
+    this.data = new DepositDataV1(deposit.getData());
+  }
+
+  @JsonCreator
+  public DepositV1(
+      @JsonProperty("proof") final List<Bytes32> proof,
+      @JsonProperty("data") final DepositDataV1 data) {
+    this.proof = proof;
+    this.data = data;
+  }
+
+  public tech.pegasys.teku.spec.datastructures.operations.Deposit asInternalDeposit() {
+    return new tech.pegasys.teku.spec.datastructures.operations.Deposit(
+        tech.pegasys.teku.spec.datastructures.operations.Deposit.SSZ_SCHEMA
+            .getProofSchema()
+            .of(proof),
+        data.asInternalDepositData());
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof DepositV1)) {
+      return false;
+    }
+    DepositV1 deposit = (DepositV1) o;
+    return Objects.equals(proof, deposit.proof) && Objects.equals(data, deposit.data);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(proof, data);
+  }
+}

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/schema/Eth1DataV1.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/schema/Eth1DataV1.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionlayer.client.schema;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.util.Objects;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.ethereum.executionlayer.client.serialization.Bytes32Deserializer;
+import tech.pegasys.teku.ethereum.executionlayer.client.serialization.BytesSerializer;
+import tech.pegasys.teku.ethereum.executionlayer.client.serialization.UInt64AsHexDeserializer;
+import tech.pegasys.teku.ethereum.executionlayer.client.serialization.UInt64AsHexSerializer;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+@SuppressWarnings("JavaCase")
+public class Eth1DataV1 {
+  @JsonSerialize(using = BytesSerializer.class)
+  @JsonDeserialize(using = Bytes32Deserializer.class)
+  public final Bytes32 depositRoot;
+
+  @JsonSerialize(using = UInt64AsHexSerializer.class)
+  @JsonDeserialize(using = UInt64AsHexDeserializer.class)
+  public final UInt64 depositCount;
+
+  @JsonSerialize(using = BytesSerializer.class)
+  @JsonDeserialize(using = Bytes32Deserializer.class)
+  public final Bytes32 blockHash;
+
+  public Eth1DataV1(final tech.pegasys.teku.spec.datastructures.blocks.Eth1Data eth1Data) {
+    depositCount = eth1Data.getDepositCount();
+    depositRoot = eth1Data.getDepositRoot();
+    blockHash = eth1Data.getBlockHash();
+  }
+
+  @JsonCreator
+  public Eth1DataV1(
+      @JsonProperty("depositRoot") final Bytes32 depositRoot,
+      @JsonProperty("depositCount") final UInt64 depositCount,
+      @JsonProperty("blockHash") final Bytes32 blockHash) {
+    this.depositRoot = depositRoot;
+    this.depositCount = depositCount;
+    this.blockHash = blockHash;
+  }
+
+  public tech.pegasys.teku.spec.datastructures.blocks.Eth1Data asInternalEth1Data() {
+    return new tech.pegasys.teku.spec.datastructures.blocks.Eth1Data(
+        depositRoot, depositCount, blockHash);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof Eth1DataV1)) {
+      return false;
+    }
+    Eth1DataV1 eth1Data = (Eth1DataV1) o;
+    return Objects.equals(depositRoot, eth1Data.depositRoot)
+        && Objects.equals(depositCount, eth1Data.depositCount)
+        && Objects.equals(blockHash, eth1Data.blockHash);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(depositRoot, depositCount, blockHash);
+  }
+}

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/schema/ExecutionPayloadHeaderV1.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/schema/ExecutionPayloadHeaderV1.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.ethereum.executionlayer.client.schema;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -35,6 +36,7 @@ public class ExecutionPayloadHeaderV1 extends ExecutionPayloadCommon {
   @JsonDeserialize(using = Bytes32Deserializer.class)
   public final Bytes32 transactionsRoot;
 
+  @JsonCreator
   public ExecutionPayloadHeaderV1(
       @JsonProperty("parentHash") Bytes32 parentHash,
       @JsonProperty("feeRecipient") Bytes20 feeRecipient,

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/schema/GenericBuilderStatus.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/schema/GenericBuilderStatus.java
@@ -13,4 +13,6 @@
 
 package tech.pegasys.teku.ethereum.executionlayer.client.schema;
 
-public class MEVPayloadHeader {}
+public enum GenericBuilderStatus {
+  OK
+}

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/schema/IndexedAttestationV1.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/schema/IndexedAttestationV1.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionlayer.client.schema;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import tech.pegasys.teku.ethereum.executionlayer.client.serialization.BLSSignatureDeserializer;
+import tech.pegasys.teku.ethereum.executionlayer.client.serialization.BLSSignatureSerializer;
+import tech.pegasys.teku.ethereum.executionlayer.client.serialization.UInt64AsHexDeserializer;
+import tech.pegasys.teku.ethereum.executionlayer.client.serialization.UInt64AsHexSerializer;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecVersion;
+import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestation.IndexedAttestationSchema;
+
+@SuppressWarnings("JavaCase")
+public class IndexedAttestationV1 {
+  @JsonSerialize(contentUsing = UInt64AsHexSerializer.class)
+  @JsonDeserialize(contentUsing = UInt64AsHexDeserializer.class)
+  public final List<UInt64> attestingIndices;
+
+  public final AttestationDataV1 data;
+
+  @JsonSerialize(using = BLSSignatureSerializer.class)
+  @JsonDeserialize(using = BLSSignatureDeserializer.class)
+  public final BLSSignature signature;
+
+  public IndexedAttestationV1(
+      tech.pegasys.teku.spec.datastructures.operations.IndexedAttestation indexedAttestation) {
+    this.attestingIndices =
+        indexedAttestation.getAttestingIndices().streamUnboxed().collect(Collectors.toList());
+    this.data = new AttestationDataV1(indexedAttestation.getData());
+    this.signature = new BLSSignature(indexedAttestation.getSignature());
+  }
+
+  @JsonCreator
+  public IndexedAttestationV1(
+      @JsonProperty("attestingIndices") final List<UInt64> attestingIndices,
+      @JsonProperty("data") final AttestationDataV1 data,
+      @JsonProperty("signature") final BLSSignature signature) {
+    this.attestingIndices = attestingIndices;
+    this.data = data;
+    this.signature = signature;
+  }
+
+  public tech.pegasys.teku.spec.datastructures.operations.IndexedAttestation
+      asInternalIndexedAttestation(final Spec spec) {
+    return asInternalIndexedAttestation(spec.atSlot(data.slot));
+  }
+
+  public tech.pegasys.teku.spec.datastructures.operations.IndexedAttestation
+      asInternalIndexedAttestation(final SpecVersion spec) {
+    final IndexedAttestationSchema indexedAttestationSchema =
+        spec.getSchemaDefinitions().getIndexedAttestationSchema();
+    return indexedAttestationSchema.create(
+        indexedAttestationSchema.getAttestingIndicesSchema().of(attestingIndices),
+        data.asInternalAttestationData(),
+        signature.asInternalBLSSignature());
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof IndexedAttestationV1)) {
+      return false;
+    }
+    IndexedAttestationV1 that = (IndexedAttestationV1) o;
+    return Objects.equals(attestingIndices, that.attestingIndices)
+        && Objects.equals(data, that.data)
+        && Objects.equals(signature, that.signature);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(attestingIndices, data, signature);
+  }
+}

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/schema/ProposerSlashingV1.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/schema/ProposerSlashingV1.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionlayer.client.schema;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlockHeader;
+
+public class ProposerSlashingV1 {
+  public final SignedMessage<BeaconBlockHeaderV1> signedHeader1;
+  public final SignedMessage<BeaconBlockHeaderV1> signedHeader2;
+
+  @JsonCreator
+  public ProposerSlashingV1(
+      @JsonProperty("signedHeader1") final SignedMessage<BeaconBlockHeaderV1> header1,
+      @JsonProperty("signedHeader2") final SignedMessage<BeaconBlockHeaderV1> header2) {
+    this.signedHeader1 = header1;
+    this.signedHeader2 = header2;
+  }
+
+  public ProposerSlashingV1(
+      tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing proposerSlashing) {
+    signedHeader1 =
+        new SignedMessage<BeaconBlockHeaderV1>(
+            new BeaconBlockHeaderV1(proposerSlashing.getHeader1().getMessage()),
+            proposerSlashing.getHeader1().getSignature());
+    signedHeader2 =
+        new SignedMessage<BeaconBlockHeaderV1>(
+            new BeaconBlockHeaderV1(proposerSlashing.getHeader2().getMessage()),
+            proposerSlashing.getHeader2().getSignature());
+  }
+
+  public tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing
+      asInternalProposerSlashing() {
+    return new tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing(
+        new SignedBeaconBlockHeader(
+            signedHeader1.getMessage().asInternalBeaconBlockHeader(),
+            signedHeader1.getSignature().asInternalBLSSignature()),
+        new SignedBeaconBlockHeader(
+            signedHeader2.getMessage().asInternalBeaconBlockHeader(),
+            signedHeader2.getSignature().asInternalBLSSignature()));
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof ProposerSlashingV1)) {
+      return false;
+    }
+    ProposerSlashingV1 that = (ProposerSlashingV1) o;
+    return Objects.equals(signedHeader1, that.signedHeader1)
+        && Objects.equals(signedHeader2, that.signedHeader2);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(signedHeader1, signedHeader2);
+  }
+}

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/schema/SignedMessage.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/schema/SignedMessage.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionlayer.client.schema;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.common.base.MoreObjects;
+import java.util.Objects;
+import tech.pegasys.teku.ethereum.executionlayer.client.serialization.BLSSignatureDeserializer;
+import tech.pegasys.teku.ethereum.executionlayer.client.serialization.BLSSignatureSerializer;
+
+public class SignedMessage<T> {
+  private final T message;
+
+  @JsonSerialize(using = BLSSignatureSerializer.class)
+  @JsonDeserialize(using = BLSSignatureDeserializer.class)
+  private final BLSSignature signature;
+
+  @JsonCreator
+  public SignedMessage(
+      @JsonProperty("message") T message, @JsonProperty("signature") BLSSignature signature) {
+    checkNotNull(message, "message cannot be null");
+    checkNotNull(signature, "signature cannot be null");
+    this.message = message;
+    this.signature = signature;
+  }
+
+  public SignedMessage(T message, tech.pegasys.teku.bls.BLSSignature signature) {
+    checkNotNull(message, "message cannot be null");
+    checkNotNull(signature, "signature cannot be null");
+    this.message = message;
+    this.signature = new BLSSignature(signature);
+  }
+
+  public T getMessage() {
+    return message;
+  }
+
+  public BLSSignature getSignature() {
+    return signature;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final SignedMessage<?> that = (SignedMessage<?>) o;
+    return Objects.equals(message, that.message) && Objects.equals(signature, that.signature);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(message, signature);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("message", message)
+        .add("signature", signature)
+        .toString();
+  }
+}

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/schema/SyncAggregateV1.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/schema/SyncAggregateV1.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionlayer.client.schema;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.apache.tuweni.bytes.Bytes;
+import tech.pegasys.teku.ethereum.executionlayer.client.serialization.BLSSignatureDeserializer;
+import tech.pegasys.teku.ethereum.executionlayer.client.serialization.BLSSignatureSerializer;
+import tech.pegasys.teku.ethereum.executionlayer.client.serialization.BytesDeserializer;
+import tech.pegasys.teku.ethereum.executionlayer.client.serialization.BytesSerializer;
+
+public class SyncAggregateV1 {
+  @JsonSerialize(using = BytesSerializer.class)
+  @JsonDeserialize(using = BytesDeserializer.class)
+  public Bytes syncCommitteeBits;
+
+  @JsonSerialize(using = BLSSignatureSerializer.class)
+  @JsonDeserialize(using = BLSSignatureDeserializer.class)
+  public final BLSSignature syncCommitteeSignature;
+
+  @JsonCreator
+  public SyncAggregateV1(
+      @JsonProperty("syncCommitteeBits") final Bytes syncCommitteeBits,
+      @JsonProperty("syncCommitteeSignature") final BLSSignature syncCommitteeSignature) {
+    this.syncCommitteeBits = syncCommitteeBits;
+    this.syncCommitteeSignature = syncCommitteeSignature;
+  }
+
+  public SyncAggregateV1(
+      final tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregate
+          aggregate) {
+    this.syncCommitteeSignature =
+        new BLSSignature(aggregate.getSyncCommitteeSignature().getSignature());
+    this.syncCommitteeBits = aggregate.getSyncCommitteeBits().sszSerialize();
+  }
+}

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/schema/ValidatorRegistrationV1.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/schema/ValidatorRegistrationV1.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionlayer.client.schema;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.common.base.MoreObjects;
+import java.util.Objects;
+import tech.pegasys.teku.ethereum.executionlayer.client.serialization.BLSPubKeyDeserializer;
+import tech.pegasys.teku.ethereum.executionlayer.client.serialization.BLSPubKeySerializer;
+import tech.pegasys.teku.ethereum.executionlayer.client.serialization.Bytes20Deserializer;
+import tech.pegasys.teku.ethereum.executionlayer.client.serialization.Bytes20Serializer;
+import tech.pegasys.teku.ethereum.executionlayer.client.serialization.UInt64AsHexDeserializer;
+import tech.pegasys.teku.ethereum.executionlayer.client.serialization.UInt64AsHexSerializer;
+import tech.pegasys.teku.infrastructure.bytes.Bytes20;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+public class ValidatorRegistrationV1 {
+  @JsonSerialize(using = Bytes20Serializer.class)
+  @JsonDeserialize(using = Bytes20Deserializer.class)
+  private final Bytes20 feeRecipient;
+
+  @JsonSerialize(using = UInt64AsHexSerializer.class)
+  @JsonDeserialize(using = UInt64AsHexDeserializer.class)
+  private final UInt64 gasTarget;
+
+  @JsonSerialize(using = UInt64AsHexSerializer.class)
+  @JsonDeserialize(using = UInt64AsHexDeserializer.class)
+  private final UInt64 timestamp;
+
+  @JsonSerialize(using = BLSPubKeySerializer.class)
+  @JsonDeserialize(using = BLSPubKeyDeserializer.class)
+  private final BLSPubKey pubkey;
+
+  @JsonCreator
+  public ValidatorRegistrationV1(
+      @JsonProperty("feeRecipient") Bytes20 feeRecipient,
+      @JsonProperty("gasTarget") UInt64 gasTarget,
+      @JsonProperty("timestamp") UInt64 timestamp,
+      @JsonProperty("pubkey") BLSPubKey pubkey) {
+    checkNotNull(feeRecipient, "feeRecipient cannot be null");
+    checkNotNull(gasTarget, "gasTarget cannot be null");
+    checkNotNull(timestamp, "timestamp cannot be null");
+    checkNotNull(pubkey, "pubkey cannot be null");
+
+    this.feeRecipient = feeRecipient;
+    this.gasTarget = gasTarget;
+    this.timestamp = timestamp;
+    this.pubkey = pubkey;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ValidatorRegistrationV1 that = (ValidatorRegistrationV1) o;
+    return Objects.equals(feeRecipient, that.feeRecipient)
+        && Objects.equals(gasTarget, that.gasTarget)
+        && Objects.equals(timestamp, that.timestamp)
+        && Objects.equals(pubkey, that.pubkey);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(feeRecipient, gasTarget, timestamp, pubkey);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("feeRecipient", feeRecipient)
+        .add("gasTarget", gasTarget)
+        .add("timestamp", timestamp)
+        .add("pubkey", pubkey)
+        .toString();
+  }
+}

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/schema/VoluntaryExitV1.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/schema/VoluntaryExitV1.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionlayer.client.schema;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.util.Objects;
+import tech.pegasys.teku.ethereum.executionlayer.client.serialization.UInt64AsHexDeserializer;
+import tech.pegasys.teku.ethereum.executionlayer.client.serialization.UInt64AsHexSerializer;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+public class VoluntaryExitV1 {
+  @JsonSerialize(using = UInt64AsHexSerializer.class)
+  @JsonDeserialize(using = UInt64AsHexDeserializer.class)
+  public final UInt64 epoch;
+
+  @JsonSerialize(using = UInt64AsHexSerializer.class)
+  @JsonDeserialize(using = UInt64AsHexDeserializer.class)
+  public final UInt64 validatorIndex;
+
+  public VoluntaryExitV1(
+      tech.pegasys.teku.spec.datastructures.operations.VoluntaryExit voluntaryExit) {
+    this.epoch = voluntaryExit.getEpoch();
+    this.validatorIndex = voluntaryExit.getValidatorIndex();
+  }
+
+  @JsonCreator
+  public VoluntaryExitV1(
+      @JsonProperty("epoch") final UInt64 epoch,
+      @JsonProperty("validatorIndex") final UInt64 validatorIndex) {
+    this.epoch = epoch;
+    this.validatorIndex = validatorIndex;
+  }
+
+  public tech.pegasys.teku.spec.datastructures.operations.VoluntaryExit asInternalVoluntaryExit() {
+    return new tech.pegasys.teku.spec.datastructures.operations.VoluntaryExit(
+        epoch, validatorIndex);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof VoluntaryExitV1)) {
+      return false;
+    }
+    VoluntaryExitV1 that = (VoluntaryExitV1) o;
+    return Objects.equals(epoch, that.epoch) && Objects.equals(validatorIndex, that.validatorIndex);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(epoch, validatorIndex);
+  }
+}

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/serialization/BLSPubKeyDeserializer.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/serialization/BLSPubKeyDeserializer.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionlayer.client.serialization;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import java.io.IOException;
+import tech.pegasys.teku.ethereum.executionlayer.client.schema.BLSPubKey;
+
+public class BLSPubKeyDeserializer extends JsonDeserializer<BLSPubKey> {
+  @Override
+  public BLSPubKey deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+    return BLSPubKey.fromHexString(p.getValueAsString());
+  }
+}

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/serialization/BLSPubKeySerializer.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/serialization/BLSPubKeySerializer.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionlayer.client.serialization;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import java.io.IOException;
+import tech.pegasys.teku.ethereum.executionlayer.client.schema.BLSPubKey;
+
+public class BLSPubKeySerializer extends JsonSerializer<BLSPubKey> {
+  @Override
+  public void serialize(BLSPubKey value, JsonGenerator gen, SerializerProvider serializers)
+      throws IOException {
+    gen.writeString(value.toHexString().toLowerCase());
+  }
+}

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/serialization/BLSSignatureDeserializer.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/serialization/BLSSignatureDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 ConsenSys AG.
+ * Copyright 2020 ConsenSys AG.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -13,16 +13,15 @@
 
 package tech.pegasys.teku.ethereum.executionlayer.client.serialization;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
 import java.io.IOException;
-import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.ethereum.executionlayer.client.schema.BLSSignature;
 
-public class SignedBeaconBlockSerializer extends JsonSerializer<SignedBeaconBlock> {
+public class BLSSignatureDeserializer extends JsonDeserializer<BLSSignature> {
   @Override
-  public void serialize(SignedBeaconBlock value, JsonGenerator gen, SerializerProvider provider)
-      throws IOException {
-    value.getSchema().jsonSerialize(value, gen);
+  public BLSSignature deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+    return BLSSignature.fromHexString(p.getValueAsString());
   }
 }

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/serialization/BLSSignatureSerializer.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/client/serialization/BLSSignatureSerializer.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionlayer.client.serialization;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import java.io.IOException;
+import tech.pegasys.teku.ethereum.executionlayer.client.schema.BLSSignature;
+
+public class BLSSignatureSerializer extends JsonSerializer<BLSSignature> {
+  @Override
+  public void serialize(BLSSignature value, JsonGenerator gen, SerializerProvider serializers)
+      throws IOException {
+    gen.writeString(value.toHexString().toLowerCase());
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/BuilderBidV1.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/BuilderBidV1.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.execution;
+
+import org.apache.tuweni.units.bigints.UInt256;
+import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.infrastructure.ssz.containers.Container3;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt256;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+import tech.pegasys.teku.spec.datastructures.type.SszPublicKey;
+
+public class BuilderBidV1
+    extends Container3<BuilderBidV1, ExecutionPayloadHeader, SszUInt256, SszPublicKey> {
+
+  protected BuilderBidV1(BuilderBidV1Schema schema, TreeNode backingNode) {
+    super(schema, backingNode);
+  }
+
+  protected BuilderBidV1(
+      BuilderBidV1Schema schema,
+      ExecutionPayloadHeader executionPayloadHeader,
+      SszUInt256 value,
+      SszPublicKey publicKey) {
+    super(schema, executionPayloadHeader, value, publicKey);
+  }
+
+  public ExecutionPayloadHeader getExecutionPayloadHeader() {
+    return getField0();
+  }
+
+  public UInt256 getValue() {
+    return getField1().get();
+  }
+
+  public BLSPublicKey getPublicKey() {
+    return getField2().getBLSPublicKey();
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/BuilderBidV1Schema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/BuilderBidV1Schema.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.execution;
+
+import org.apache.tuweni.units.bigints.UInt256;
+import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema3;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt256;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+import tech.pegasys.teku.spec.datastructures.type.SszPublicKey;
+import tech.pegasys.teku.spec.datastructures.type.SszPublicKeySchema;
+
+public class BuilderBidV1Schema
+    extends ContainerSchema3<BuilderBidV1, ExecutionPayloadHeader, SszUInt256, SszPublicKey> {
+  public BuilderBidV1Schema(final ExecutionPayloadHeaderSchema executionPayloadHeaderSchema) {
+    super(
+        "BuilderBidV1",
+        namedSchema("header", executionPayloadHeaderSchema),
+        namedSchema("value", SszPrimitiveSchemas.UINT256_SCHEMA),
+        namedSchema("pubkey", SszPublicKeySchema.INSTANCE));
+  }
+
+  public BuilderBidV1 create(
+      final ExecutionPayloadHeader executionPayloadHeader,
+      final UInt256 value,
+      final BLSPublicKey publicKey) {
+    return new BuilderBidV1(
+        this, executionPayloadHeader, SszUInt256.of(value), new SszPublicKey(publicKey));
+  }
+
+  @Override
+  public BuilderBidV1 createFromBackingNode(TreeNode node) {
+    return new BuilderBidV1(this, node);
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/SignedBuilderBidV1.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/SignedBuilderBidV1.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.execution;
+
+import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.infrastructure.ssz.containers.Container2;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlockSchema;
+import tech.pegasys.teku.spec.datastructures.type.SszSignature;
+
+public class SignedBuilderBidV1 extends Container2<SignedBuilderBidV1, BuilderBidV1, SszSignature> {
+
+  SignedBuilderBidV1(SignedBuilderBidV1Schema type, TreeNode backingNode) {
+    super(type, backingNode);
+  }
+
+  SignedBuilderBidV1(
+      final SignedBuilderBidV1Schema type,
+      final BuilderBidV1 message,
+      final BLSSignature signature) {
+    super(type, message, new SszSignature(signature));
+  }
+
+  @Override
+  public SignedBeaconBlockSchema getSchema() {
+    return (SignedBeaconBlockSchema) super.getSchema();
+  }
+
+  public BuilderBidV1 getMessage() {
+    return getField0();
+  }
+
+  public BLSSignature getSignature() {
+    return getField1().getSignature();
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/SignedBuilderBidV1Schema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/SignedBuilderBidV1Schema.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.execution;
+
+import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema2;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+import tech.pegasys.teku.spec.datastructures.type.SszSignature;
+import tech.pegasys.teku.spec.datastructures.type.SszSignatureSchema;
+
+public class SignedBuilderBidV1Schema
+    extends ContainerSchema2<SignedBuilderBidV1, BuilderBidV1, SszSignature> {
+
+  public SignedBuilderBidV1Schema(final BuilderBidV1Schema builderBidV1Schema) {
+    super(
+        "SignedBuilderBidV1",
+        namedSchema("message", builderBidV1Schema),
+        namedSchema("signature", SszSignatureSchema.INSTANCE));
+  }
+
+  public SignedBuilderBidV1 create(final BuilderBidV1 message, final BLSSignature signature) {
+    return new SignedBuilderBidV1(this, message, signature);
+  }
+
+  @Override
+  public SignedBuilderBidV1 createFromBackingNode(TreeNode node) {
+    return new SignedBuilderBidV1(this, node);
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/SignedValidatorRegistrationV1.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/SignedValidatorRegistrationV1.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.execution;
+
+import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.infrastructure.ssz.containers.Container2;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+import tech.pegasys.teku.spec.datastructures.type.SszSignature;
+
+public class SignedValidatorRegistrationV1
+    extends Container2<SignedValidatorRegistrationV1, ValidatorRegistrationV1, SszSignature> {
+
+  SignedValidatorRegistrationV1(SignedValidatorRegistrationV1Schema type, TreeNode backingNode) {
+    super(type, backingNode);
+  }
+
+  SignedValidatorRegistrationV1(
+      final SignedValidatorRegistrationV1Schema type,
+      final ValidatorRegistrationV1 message,
+      final BLSSignature signature) {
+    super(type, message, new SszSignature(signature));
+  }
+
+  @Override
+  public SignedValidatorRegistrationV1Schema getSchema() {
+    return (SignedValidatorRegistrationV1Schema) super.getSchema();
+  }
+
+  public ValidatorRegistrationV1 getMessage() {
+    return getField0();
+  }
+
+  public BLSSignature getSignature() {
+    return getField1().getSignature();
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/SignedValidatorRegistrationV1Schema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/SignedValidatorRegistrationV1Schema.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.execution;
+
+import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema2;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+import tech.pegasys.teku.spec.datastructures.type.SszSignature;
+import tech.pegasys.teku.spec.datastructures.type.SszSignatureSchema;
+
+public class SignedValidatorRegistrationV1Schema
+    extends ContainerSchema2<SignedValidatorRegistrationV1, ValidatorRegistrationV1, SszSignature> {
+
+  public SignedValidatorRegistrationV1Schema(
+      final ValidatorRegistrationV1Schema validatorRegistrationV1Schema) {
+    super(
+        "SignedValidatorRegistrationV1",
+        namedSchema("message", validatorRegistrationV1Schema),
+        namedSchema("signature", SszSignatureSchema.INSTANCE));
+  }
+
+  public SignedValidatorRegistrationV1 create(
+      final ValidatorRegistrationV1 message, final BLSSignature signature) {
+    return new SignedValidatorRegistrationV1(this, message, signature);
+  }
+
+  @Override
+  public SignedValidatorRegistrationV1 createFromBackingNode(TreeNode node) {
+    return new SignedValidatorRegistrationV1(this, node);
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ValidatorRegistrationV1.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ValidatorRegistrationV1.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.execution;
+
+import tech.pegasys.teku.infrastructure.ssz.collections.SszByteVector;
+import tech.pegasys.teku.infrastructure.ssz.containers.Container4;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+import tech.pegasys.teku.spec.datastructures.type.SszPublicKey;
+
+public class ValidatorRegistrationV1
+    extends Container4<ValidatorRegistrationV1, SszByteVector, SszUInt64, SszUInt64, SszPublicKey> {
+
+  protected ValidatorRegistrationV1(ValidatorRegistrationV1Schema schema, TreeNode backingNode) {
+    super(schema, backingNode);
+  }
+
+  protected ValidatorRegistrationV1(
+      ValidatorRegistrationV1Schema schema,
+      SszByteVector feeRecipient,
+      SszUInt64 gasTarget,
+      SszUInt64 timestamp,
+      SszPublicKey publicKey) {
+    super(schema, feeRecipient, gasTarget, timestamp, publicKey);
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ValidatorRegistrationV1Schema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ValidatorRegistrationV1Schema.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.execution;
+
+import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.infrastructure.bytes.Bytes20;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszByteVector;
+import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema4;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
+import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszByteVectorSchema;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.type.SszPublicKey;
+import tech.pegasys.teku.spec.datastructures.type.SszPublicKeySchema;
+
+public class ValidatorRegistrationV1Schema
+    extends ContainerSchema4<
+        ValidatorRegistrationV1, SszByteVector, SszUInt64, SszUInt64, SszPublicKey> {
+  public ValidatorRegistrationV1Schema() {
+    super(
+        "ValidatorRegistrationV1",
+        namedSchema("feeRecipient", SszByteVectorSchema.create(Bytes20.SIZE)),
+        namedSchema("gasTarget", SszPrimitiveSchemas.UINT64_SCHEMA),
+        namedSchema("timestamp", SszPrimitiveSchemas.UINT64_SCHEMA),
+        namedSchema("pubkey", SszPublicKeySchema.INSTANCE));
+  }
+
+  public ValidatorRegistrationV1 create(
+      final Bytes20 feeRecipient,
+      final UInt64 gasTarget,
+      final UInt64 timestamp,
+      final BLSPublicKey publicKey) {
+    return new ValidatorRegistrationV1(
+        this,
+        SszByteVector.fromBytes(feeRecipient.getWrappedBytes()),
+        SszUInt64.of(gasTarget),
+        SszUInt64.of(timestamp),
+        new SszPublicKey(publicKey));
+  }
+
+  @Override
+  public ValidatorRegistrationV1 createFromBackingNode(TreeNode node) {
+    return new ValidatorRegistrationV1(this, node);
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsBellatrix.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsBellatrix.java
@@ -24,8 +24,10 @@ import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.bellatrix
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.bellatrix.BeaconBlockBodySchemaBellatrixImpl;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.bellatrix.BlindedBeaconBlockBodySchemaBellatrix;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.bellatrix.BlindedBeaconBlockBodySchemaBellatrixImpl;
+import tech.pegasys.teku.spec.datastructures.execution.BuilderBidV1Schema;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeaderSchema;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSchema;
+import tech.pegasys.teku.spec.datastructures.execution.SignedBuilderBidV1Schema;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchema;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.bellatrix.BeaconStateBellatrix;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.bellatrix.BeaconStateSchemaBellatrix;
@@ -40,6 +42,8 @@ public class SchemaDefinitionsBellatrix extends SchemaDefinitionsAltair {
   private final SignedBeaconBlockSchema signedBeaconBlockSchema;
   private final SignedBeaconBlockSchema signedBlindedBeaconBlockSchema;
   private final ExecutionPayloadHeaderSchema executionPayloadHeaderSchema;
+  private final BuilderBidV1Schema builderBidV1Schema;
+  private final SignedBuilderBidV1Schema signedBuilderBidV1Schema;
 
   public SchemaDefinitionsBellatrix(final SpecConfigBellatrix specConfig) {
     super(specConfig.toVersionAltair().orElseThrow());
@@ -58,6 +62,8 @@ public class SchemaDefinitionsBellatrix extends SchemaDefinitionsAltair {
     this.signedBlindedBeaconBlockSchema =
         new SignedBeaconBlockSchema(blindedBeaconBlockSchema, "SignedBlindedBlockBellatrix");
     this.executionPayloadHeaderSchema = new ExecutionPayloadHeaderSchema(specConfig);
+    this.builderBidV1Schema = new BuilderBidV1Schema(executionPayloadHeaderSchema);
+    this.signedBuilderBidV1Schema = new SignedBuilderBidV1Schema(builderBidV1Schema);
   }
 
   public static SchemaDefinitionsBellatrix required(final SchemaDefinitions schemaDefinitions) {
@@ -111,6 +117,14 @@ public class SchemaDefinitionsBellatrix extends SchemaDefinitionsAltair {
 
   public ExecutionPayloadHeaderSchema getExecutionPayloadHeaderSchema() {
     return executionPayloadHeaderSchema;
+  }
+
+  public BuilderBidV1Schema getBuilderBidV1Schema() {
+    return builderBidV1Schema;
+  }
+
+  public SignedBuilderBidV1Schema getSignedBuilderBidV1Schema() {
+    return signedBuilderBidV1Schema;
   }
 
   @Override


### PR DESCRIPTION
## PR Description

- Introduces `Web3JExecutionBuilderClient`
- Introduces all the required execution client schema files to support the new apis
- Introduced required SSZ objects (`SignedValidatorRegistrationV1` and `SignedBuilderBidV1`) to be able to handle the signature (generation\validation).

In upcoming PR I'll remove builder API from `Web3JExecutionEngineClient` and integrate `Web3JExecutionBuilderClient` in `ExecutionEngineChannel`

## Fixed Issue(s)
related to #5396 

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
