### PR TITLE
Add time based tolerance before disconnecting event streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,3 +29,4 @@ For information on changes in released versions of Teku, see the [releases page]
 - Fixed issue with loading the optimised BLST library on Windows.
 - Reduced log level for notifications that the eth1 chain head could not be retrieved because no endpoints were available.
 - Fixed issue where logging options were not recognised if specified after the `validator-client` subcommand.
+- Avoid disconnecting event stream connections subscribed to attestation events for briefly exceeding the maximum pending event queue size. A very large number of attestations are received all at once on MainNet making it almost impossible for a consumer to stay below the queue size limit at all times.

--- a/data/beaconrestapi/build.gradle
+++ b/data/beaconrestapi/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     testImplementation testFixtures(project(':infrastructure:async'))
     testImplementation testFixtures(project(':infrastructure:bls'))
     testImplementation testFixtures(project(':infrastructure:restapi'))
+    testImplementation testFixtures(project(':infrastructure:time'))
 
     testImplementation testFixtures(project(':infrastructure:json'))
 

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/AbstractDataBackedRestAPIIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/AbstractDataBackedRestAPIIntegrationTest.java
@@ -42,6 +42,7 @@ import tech.pegasys.teku.core.ChainBuilder;
 import tech.pegasys.teku.infrastructure.async.SyncAsyncRunner;
 import tech.pegasys.teku.infrastructure.async.eventthread.InlineEventThread;
 import tech.pegasys.teku.infrastructure.events.EventChannels;
+import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.Eth2P2PNetwork;
 import tech.pegasys.teku.provider.JsonProvider;
@@ -186,7 +187,13 @@ public abstract class AbstractDataBackedRestAPIIntegrationTest {
             .build();
 
     beaconRestApi =
-        new BeaconRestApi(dataProvider, config, eventChannels, SyncAsyncRunner.SYNC_RUNNER, spec);
+        new BeaconRestApi(
+            dataProvider,
+            config,
+            eventChannels,
+            SyncAsyncRunner.SYNC_RUNNER,
+            StubTimeProvider.withTimeInMillis(1000),
+            spec);
     beaconRestApi.start();
     client = new OkHttpClient.Builder().readTimeout(0, TimeUnit.SECONDS).build();
   }

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriber.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriber.java
@@ -82,7 +82,7 @@ public class EventSubscriber {
         closeCallback.run();
       }
     } else {
-      if (now + EXCESSIVE_QUEUING_TOLERANCE_MS < now) {
+      if (now + EXCESSIVE_QUEUING_TOLERANCE_MS < queuingDisconnectTime) {
         excessiveQueueingDisconnectionTime.set(now + EXCESSIVE_QUEUING_TOLERANCE_MS);
       }
       addEventToQueue(eventType, message);

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriber.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriber.java
@@ -20,32 +20,40 @@ import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.api.response.v1.EventType;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.events.EventSubscriptionManager.EventSource;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
+import tech.pegasys.teku.infrastructure.time.TimeProvider;
 
 public class EventSubscriber {
+
   private static final Logger LOG = LogManager.getLogger();
+  static final int EXCESSIVE_QUEUING_TOLERANCE_MS = 1000;
   private final AtomicBoolean stopped = new AtomicBoolean(false);
   private final List<EventType> eventTypes;
   private final SseClient sseClient;
   private final Queue<QueuedEvent> queuedEvents;
   private final Runnable closeCallback;
+  private final TimeProvider timeProvider;
   private final int maxPendingEvents;
   private final AtomicBoolean processingQueue;
-  final AsyncRunner asyncRunner;
+  private final AsyncRunner asyncRunner;
+  private final AtomicLong excessiveQueueingDisconnectionTime = new AtomicLong(Long.MAX_VALUE);
 
   public EventSubscriber(
       final List<String> eventTypes,
       final SseClient sseClient,
       final Runnable closeCallback,
       final AsyncRunner asyncRunner,
+      final TimeProvider timeProvider,
       final int maxPendingEvents) {
     this.eventTypes = EventType.getTopics(eventTypes);
     this.sseClient = sseClient;
     this.closeCallback = closeCallback;
+    this.timeProvider = timeProvider;
     this.maxPendingEvents = maxPendingEvents;
     this.queuedEvents = new ConcurrentLinkedQueue<>();
     this.processingQueue = new AtomicBoolean(false);
@@ -60,15 +68,31 @@ public class EventSubscriber {
     if (!eventTypes.contains(eventType)) {
       return;
     }
-    if (queuedEvents.size() < maxPendingEvents) {
-      queuedEvents.add(QueuedEvent.of(eventType, message.get()));
-      processEventQueue();
+    final boolean queueSizeBelowLimit = queuedEvents.size() < maxPendingEvents;
+    final long now = timeProvider.getTimeInMillis().longValue();
+    final long queuingDisconnectTime = excessiveQueueingDisconnectionTime.get();
+    if (queueSizeBelowLimit) {
+      excessiveQueueingDisconnectionTime.set(Long.MAX_VALUE);
+      addEventToQueue(eventType, message);
+    } else if (queuingDisconnectTime <= now) {
+      // Had excessive queuing for too long, disconnect.
+      if (stopped.compareAndSet(false, true)) {
+        LOG.debug("Closing event connection due to exceeding the pending message limit");
+        sseClient.ctx.req.getAsyncContext().complete();
+        closeCallback.run();
+      }
     } else {
-      LOG.debug("Closing event connection due to exceeding the pending message limit");
-      stopped.set(true);
-      sseClient.ctx.req.getAsyncContext().complete();
-      closeCallback.run();
+      if (now + EXCESSIVE_QUEUING_TOLERANCE_MS < now) {
+        excessiveQueueingDisconnectionTime.set(now + EXCESSIVE_QUEUING_TOLERANCE_MS);
+      }
+      addEventToQueue(eventType, message);
     }
+  }
+
+  private void addEventToQueue(final EventType eventType, final EventSource<?> message)
+      throws JsonProcessingException {
+    queuedEvents.add(QueuedEvent.of(eventType, message.get()));
+    processEventQueue();
   }
 
   public SseClient getSseClient() {
@@ -111,7 +135,8 @@ public class EventSubscriber {
       asyncRunner
           .runAfterDelay(
               () -> {
-                if (!stopped.get()) {
+                // Don't send a keep alive if we already have messages to send
+                if (!stopped.get() && queuedEvents.isEmpty() && !processingQueue.get()) {
                   sseClient.sendComment("");
                 }
               },

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManager.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManager.java
@@ -34,6 +34,7 @@ import tech.pegasys.teku.beaconrestapi.ListQueryParameterUtils;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.events.EventChannels;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
+import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidateableAttestation;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
@@ -48,6 +49,7 @@ public class EventSubscriptionManager implements ChainHeadChannel, FinalizedChec
   private final ConfigProvider configProvider;
   private final ChainDataProvider provider;
   private final AsyncRunner asyncRunner;
+  private final TimeProvider timeProvider;
   private final int maxPendingEvents;
   // collection of subscribers
   private final Collection<EventSubscriber> eventSubscribers;
@@ -59,9 +61,11 @@ public class EventSubscriptionManager implements ChainHeadChannel, FinalizedChec
       final ConfigProvider configProvider,
       final AsyncRunner asyncRunner,
       final EventChannels eventChannels,
+      final TimeProvider timeProvider,
       final int maxPendingEvents) {
     this.provider = chainDataProvider;
     this.asyncRunner = asyncRunner;
+    this.timeProvider = timeProvider;
     this.maxPendingEvents = maxPendingEvents;
     this.eventSubscribers = new ConcurrentLinkedQueue<>();
     this.configProvider = configProvider;
@@ -87,6 +91,7 @@ public class EventSubscriptionManager implements ChainHeadChannel, FinalizedChec
               LOG.trace("disconnected " + sseClient.hashCode());
             },
             asyncRunner,
+            timeProvider,
             maxPendingEvents);
     eventSubscribers.add(subscriber);
   }

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/GetEvents.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/GetEvents.java
@@ -44,6 +44,7 @@ import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.events.EventChannels;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.BadRequest;
+import tech.pegasys.teku.infrastructure.time.TimeProvider;
 
 public class GetEvents implements Handler {
   private static final Logger LOG = LogManager.getLogger();
@@ -54,6 +55,7 @@ public class GetEvents implements Handler {
       final DataProvider dataProvider,
       final EventChannels eventChannels,
       final AsyncRunner asyncRunner,
+      final TimeProvider timeProvider,
       final int maxPendingEvents) {
     this(
         dataProvider.getNodeDataProvider(),
@@ -62,6 +64,7 @@ public class GetEvents implements Handler {
         dataProvider.getConfigProvider(),
         eventChannels,
         asyncRunner,
+        timeProvider,
         maxPendingEvents);
   }
 
@@ -72,6 +75,7 @@ public class GetEvents implements Handler {
       final ConfigProvider configProvider,
       final EventChannels eventChannels,
       final AsyncRunner asyncRunner,
+      final TimeProvider timeProvider,
       final int maxPendingEvents) {
     eventSubscriptionManager =
         new EventSubscriptionManager(
@@ -81,6 +85,7 @@ public class GetEvents implements Handler {
             configProvider,
             asyncRunner,
             eventChannels,
+            timeProvider,
             maxPendingEvents);
   }
 

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/BeaconRestApiTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/BeaconRestApiTest.java
@@ -29,6 +29,7 @@ import tech.pegasys.teku.api.DataProvider;
 import tech.pegasys.teku.beacon.sync.SyncService;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
 import tech.pegasys.teku.infrastructure.events.EventChannels;
+import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.eth1.Eth1Address;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
@@ -97,6 +98,7 @@ class BeaconRestApiTest {
         beaconRestApiConfig,
         eventChannels,
         new StubAsyncRunner(),
+        StubTimeProvider.withTimeInMillis(1000),
         app,
         storageClient.getSpec());
   }

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/BeaconRestApiV1Test.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/BeaconRestApiV1Test.java
@@ -87,6 +87,7 @@ import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.PostSyncCommitteeSu
 import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.PostValidatorLiveness;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
 import tech.pegasys.teku.infrastructure.events.EventChannels;
+import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.eth1.Eth1Address;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
@@ -156,6 +157,7 @@ public class BeaconRestApiV1Test {
         beaconRestApiConfig,
         eventChannels,
         new StubAsyncRunner(),
+        StubTimeProvider.withTimeInMillis(1000),
         app,
         storageClient.getSpec());
   }

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManagerTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManagerTest.java
@@ -40,6 +40,7 @@ import tech.pegasys.teku.beacon.sync.events.SyncState;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
 import tech.pegasys.teku.infrastructure.events.EventChannels;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
+import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
@@ -122,6 +123,7 @@ public class EventSubscriptionManagerTest {
             configProvider,
             asyncRunner,
             channels,
+            StubTimeProvider.withTimeInMillis(1000),
             10);
     client1 = new SseClient(ctx);
   }

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -814,6 +814,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
                   beaconConfig.beaconRestApiConfig(),
                   eventChannels,
                   eventAsyncRunner,
+                  timeProvider,
                   spec));
 
       if (beaconConfig.beaconRestApiConfig().isBeaconLivenessTrackingEnabled()) {


### PR DESCRIPTION
## PR Description
Given that huge numbers of attestations are received at once, a strict queue length based limit on event stream subscribers is too strict as there's no chance to serialize and read all those events. With this change, the event queue can exceed the maximum size for up to one second, ensuring there is time for the messages to be sent if the subscriber is reading. If the subscriber is slow the timeout is still hit quickly without too many events backing up and causing memory issues.

## Fixed Issue(s)
fixes #5399 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
