### PR TITLE
Improve sync message when waiting for EL sync to complete

### DIFF
--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java
@@ -87,6 +87,15 @@ public class EventLogger {
     info(syncEventLog, Color.WHITE);
   }
 
+  public void syncEventAwaitingEL(
+      final UInt64 nodeSlot, final UInt64 headSlot, final int numPeers) {
+    final String syncEventLog =
+        String.format(
+            "Syncing     *** Target slot: %s, Head slot: %s, Waiting for execution layer sync, Connected peers: %s",
+            nodeSlot, headSlot, numPeers);
+    info(syncEventLog, Color.WHITE);
+  }
+
   public void syncCompleted() {
     info("Syncing completed", Color.GREEN);
   }

--- a/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/SlotProcessorTest.java
+++ b/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/SlotProcessorTest.java
@@ -191,6 +191,22 @@ public class SlotProcessorTest {
   }
 
   @Test
+  public void onTick_shouldChangeSyncingMessageWhenWaitingForExecutionSync() {
+    ArgumentCaptor<UInt64> captor = ArgumentCaptor.forClass(UInt64.class);
+    when(syncStateProvider.getCurrentSyncState()).thenReturn(SyncState.AWAITING_EL);
+    when(p2pNetwork.getPeerCount()).thenReturn(1);
+
+    slotProcessor.onTick(genesisTimeMillis);
+    assertThat(slotProcessor.getNodeSlot().getValue()).isEqualTo(ONE);
+
+    verify(slotEventsChannel).onSlot(captor.capture());
+    assertThat(captor.getValue()).isEqualTo(ZERO);
+
+    verify(syncStateProvider).getCurrentSyncState();
+    verify(eventLogger).syncEventAwaitingEL(ZERO, ZERO, 1);
+  }
+
+  @Test
   public void onTick_shouldRunStartSlotAtGenesis() {
     ArgumentCaptor<UInt64> captor = ArgumentCaptor.forClass(UInt64.class);
     when(syncStateProvider.getCurrentSyncState()).thenReturn(SyncState.IN_SYNC);


### PR DESCRIPTION
## PR Description
Improve syncing message when waiting for the EL sync to complete. Previously it would always report 1 remaining slot, now it explicitly states that teku is waiting for the EL sync to complete:

```
Syncing     *** Target slot: 378413, Head slot: 378405, Waiting for execution layer sync, Connected peers: 10
```

## Fixed Issue(s)
fixes #5330 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
