### PR TITLE
Ignore aggregate attestations that are a subset of aggregates we've already seen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ For information on changes in released versions of Teku, see the [releases page]
 - Added `is_optimistic` field to `/eth/v1/node/syncing` response.
 - Using execution engine endpoint as Eth1 endpoint when latter is not provided.
 - Check `Eth1Address` checksum ([EIP-55](https://eips.ethereum.org/EIPS/eip-55)) if address is mixed-case.
+- Ignore aggregate attestation gossip that does not include any new validators.
 
 ### Bug Fixes
 - Added stricter limits on attestation pool size. 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/Constants.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/Constants.java
@@ -32,6 +32,8 @@ public class Constants {
   public static final int VALID_BLOCK_SET_SIZE = 1000;
   // Target holding two slots worth of aggregators (16 aggregators, 64 committees and 2 slots)
   public static final int VALID_AGGREGATE_SET_SIZE = 16 * 64 * 2;
+  // Target 2 different attestation data (aggregators normally agree) for two slots
+  public static final int VALID_ATTESTATION_DATA_SET_SIZE = 2 * 64 * 2;
   public static final int VALID_VALIDATOR_SET_SIZE = 10000;
   public static final int VALID_CONTRIBUTION_AND_PROOF_SET_SIZE = 10000;
   public static final int VALID_SYNC_COMMITTEE_MESSAGE_SET_SIZE = 10000;

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/SeenAggregatesCache.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/SeenAggregatesCache.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.util;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.collections.LimitedMap;
+import tech.pegasys.teku.infrastructure.collections.LimitedSet;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszBitlist;
+
+public class SeenAggregatesCache {
+
+  private final Map<Bytes32, Set<SszBitlist>> seenAggregationBitsByDataRoot;
+  private final int aggregateSetSize;
+
+  public SeenAggregatesCache(final int rootCacheSize, final int aggregateSetSize) {
+    this.seenAggregationBitsByDataRoot = LimitedMap.create(rootCacheSize);
+    this.aggregateSetSize = aggregateSetSize;
+  }
+
+  public boolean add(final Bytes32 root, final SszBitlist aggregationBits) {
+    final Set<SszBitlist> seenBitlists =
+        seenAggregationBitsByDataRoot.computeIfAbsent(
+            root,
+            // Aim to hold all aggregation bits but have a limit for safety.
+            // Normally we'd have far fewer as we avoid adding subsets.
+            key -> LimitedSet.create(aggregateSetSize));
+    if (isAlreadySeen(seenBitlists, aggregationBits)) {
+      return false;
+    }
+    return seenBitlists.add(aggregationBits);
+  }
+
+  public boolean isAlreadySeen(final Bytes32 root, final SszBitlist aggregationBits) {
+    final Set<SszBitlist> seenAggregates =
+        seenAggregationBitsByDataRoot.getOrDefault(root, Collections.emptySet());
+    return isAlreadySeen(seenAggregates, aggregationBits);
+  }
+
+  private boolean isAlreadySeen(
+      final Set<SszBitlist> seenAggregates, final SszBitlist aggregationBits) {
+    return seenAggregates.stream().anyMatch(seen -> seen.isSuperSetOf(aggregationBits));
+  }
+}

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/SeenAggregatesCacheTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/SeenAggregatesCacheTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszBitlist;
+import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszBitlistSchema;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+class SeenAggregatesCacheTest {
+
+  private final Spec spec = TestSpecFactory.createDefault();
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+  private final SszBitlistSchema<SszBitlist> bitlistSchema = SszBitlistSchema.create(10);
+  private final SeenAggregatesCache cache = new SeenAggregatesCache(3, 4);
+
+  @Test
+  void isAlreadySeen_shouldBeTrueWhenValueIsEqual() {
+    final Bytes32 root = dataStructureUtil.randomBytes32();
+    assertThat(cache.add(root, bitlist(true, false, true, false))).isTrue();
+
+    assertThat(cache.isAlreadySeen(root, bitlist(true, false, true, false))).isTrue();
+  }
+
+  @Test
+  void isAlreadySeen_shouldBeTrueWhenValueIsSubset() {
+    final Bytes32 root = dataStructureUtil.randomBytes32();
+    assertThat(cache.add(root, bitlist(true, false, true, false))).isTrue();
+
+    assertThat(cache.isAlreadySeen(root, bitlist(true, false, false, false))).isTrue();
+  }
+
+  @Test
+  void isAlreadySeen_shouldBeFalseWhenSuperset() {
+    final Bytes32 root = dataStructureUtil.randomBytes32();
+    assertThat(cache.add(root, bitlist(true, false, true, false))).isTrue();
+
+    assertThat(cache.isAlreadySeen(root, bitlist(true, true, false, false))).isFalse();
+  }
+
+  @Test
+  void isAlreadySeen_shouldBeFalseWhenNoIndividualSeenValueIsASuperset() {
+    final Bytes32 root = dataStructureUtil.randomBytes32();
+    // Combined we've seen all validators
+    assertThat(cache.add(root, bitlist(true, false, true, false))).isTrue();
+    assertThat(cache.add(root, bitlist(false, true, false, true))).isTrue();
+
+    // But this aggregate isn't a subset of either previously seen value
+    assertThat(cache.isAlreadySeen(root, bitlist(true, true, false, false))).isFalse();
+  }
+
+  @Test
+  void isAlreadySeen_shouldBeFalseWhenRootIsDifferent() {
+    final Bytes32 root = dataStructureUtil.randomBytes32();
+    // Combined we've seen all validators
+    assertThat(cache.add(root, bitlist(true, false, true, false))).isTrue();
+
+    // But this aggregate isn't a subset of either previously seen value
+    assertThat(
+            cache.isAlreadySeen(
+                dataStructureUtil.randomBytes32(), bitlist(true, false, true, false)))
+        .isFalse();
+  }
+
+  @Test
+  void add_shouldBeFalseWhenValueIsEqual() {
+    final Bytes32 root = dataStructureUtil.randomBytes32();
+    assertThat(cache.add(root, bitlist(true, false, true, false))).isTrue();
+
+    assertThat(cache.add(root, bitlist(true, false, true, false))).isFalse();
+  }
+
+  @Test
+  void add_shouldBeFalseWhenValueIsSubset() {
+    final Bytes32 root = dataStructureUtil.randomBytes32();
+    assertThat(cache.add(root, bitlist(true, false, true, false))).isTrue();
+
+    assertThat(cache.add(root, bitlist(true, false, false, false))).isFalse();
+  }
+
+  @Test
+  void add_shouldBeTrueWhenSuperset() {
+    final Bytes32 root = dataStructureUtil.randomBytes32();
+    assertThat(cache.add(root, bitlist(true, false, true, false))).isTrue();
+
+    assertThat(cache.add(root, bitlist(true, true, false, false))).isTrue();
+  }
+
+  @Test
+  void add_shouldBeTrueWhenNoIndividualSeenValueIsASuperset() {
+    final Bytes32 root = dataStructureUtil.randomBytes32();
+    // Combined we've seen all validators
+    assertThat(cache.add(root, bitlist(true, false, true, false))).isTrue();
+    assertThat(cache.add(root, bitlist(false, true, false, true))).isTrue();
+
+    // But this aggregate isn't a subset of either previously seen value
+    assertThat(cache.add(root, bitlist(true, true, false, false))).isTrue();
+  }
+
+  private SszBitlist bitlist(final Boolean... values) {
+    return bitlistSchema.of(values);
+  }
+}


### PR DESCRIPTION
## PR Description
Change the aggregate attestation validation rules to ignore any aggregate that we've seen a non-strict superset for already. This avoids reprocessing and gossiping aggregates that add no new value.

The set of received aggregate hashes is removed because they will be caught by this new check (ie an aggregate is always a non-strict superset of itself).

## Fixed Issue(s)
#5304  (need to apply to sync committee aggregates as well before it's complete)

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
