### PR TITLE
add onSlot eth1 deposit availability check and some other nits

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/DepositProvider.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/DepositProvider.java
@@ -163,7 +163,6 @@ public class DepositProvider
               }
             })
         .reportExceptions();
-    ;
   }
 
   public synchronized SszList<Deposit> getDeposits(BeaconState state, Eth1Data eth1Data) {

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/DepositProvider.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/DepositProvider.java
@@ -163,7 +163,9 @@ public class DepositProvider
                 eventLogger.eth1DepositDataNotAvailable(
                     maxPossibleResultingDepositIndex.plus(UInt64.ONE), eth1DepositCount);
               }
-            });
+            })
+        .reportExceptions();
+    ;
   }
 
   public synchronized SszList<Deposit> getDeposits(BeaconState state, Eth1Data eth1Data) {

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/DepositProvider.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/DepositProvider.java
@@ -62,13 +62,15 @@ public class DepositProvider
   private final Spec spec;
   private final DepositsSchemaCache depositsSchemaCache = new DepositsSchemaCache();
   private final DepositUtil depositUtil;
+  private final boolean useMissingDepositEventLogging;
 
   public DepositProvider(
       MetricsSystem metricsSystem,
       RecentChainData recentChainData,
       final Eth1DataCache eth1DataCache,
       final Spec spec,
-      final EventLogger eventLogger) {
+      final EventLogger eventLogger,
+      final boolean useMissingDepositEventLogging) {
     this.eventLogger = eventLogger;
     this.recentChainData = recentChainData;
     this.eth1DataCache = eth1DataCache;
@@ -81,6 +83,7 @@ public class DepositProvider
             TekuMetricCategory.BEACON,
             "eth1_deposit_total",
             "Total number of received ETH1 deposits");
+    this.useMissingDepositEventLogging = useMissingDepositEventLogging;
   }
 
   @Override
@@ -136,6 +139,9 @@ public class DepositProvider
 
   @Override
   public void onSlot(final UInt64 slot) {
+    if (!useMissingDepositEventLogging) {
+      return;
+    }
     // We want to verify our Beacon Node view of the eth1 deposits.
     // So we want to check if it has the necessary deposit data to propose a block
     if (recentChainData.getBestState().isEmpty()) {

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/DepositProvider.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/DepositProvider.java
@@ -139,14 +139,12 @@ public class DepositProvider
 
   @Override
   public void onSlot(final UInt64 slot) {
-    if (!useMissingDepositEventLogging) {
+    if (!useMissingDepositEventLogging || recentChainData.getBestState().isEmpty()) {
       return;
     }
+
     // We want to verify our Beacon Node view of the eth1 deposits.
     // So we want to check if it has the necessary deposit data to propose a block
-    if (recentChainData.getBestState().isEmpty()) {
-      return;
-    }
 
     recentChainData
         .getBestState()

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/DepositProvider.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/DepositProvider.java
@@ -148,11 +148,10 @@ public class DepositProvider
         .thenAccept(
             state -> {
               final UInt64 eth1DepositCount = state.getEth1Data().getDepositCount();
-              final UInt64 eth1DepositIndex = state.getEth1DepositIndex();
 
               final UInt64 maxPossibleResultingDepositIndex =
                   depositNavigableMap.isEmpty()
-                      ? eth1DepositIndex
+                      ? UInt64.ZERO
                       : depositNavigableMap.lastKey().plus(ONE);
               if (maxPossibleResultingDepositIndex.isLessThan(eth1DepositCount)) {
                 eventLogger.eth1DepositDataNotAvailable(

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/DepositProviderTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/DepositProviderTest.java
@@ -75,7 +75,7 @@ public class DepositProviderTest {
     dataStructureUtil = new DataStructureUtil(spec);
     depositProvider =
         new DepositProvider(
-            new StubMetricsSystem(), recentChainData, eth1DataCache, spec, eventLogger);
+            new StubMetricsSystem(), recentChainData, eth1DataCache, spec, eventLogger, true);
     depositMerkleTree =
         new OptimizedMerkleTree(spec.getGenesisSpecConfig().getDepositContractTreeDepth());
     mockStateEth1DataVotes();

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/DepositProviderTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/DepositProviderTest.java
@@ -29,6 +29,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.ethereum.pow.api.DepositsFromBlockEvent;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.logging.EventLogger;
 import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszListSchema;
@@ -57,6 +58,7 @@ public class DepositProviderTest {
   private final RecentChainData recentChainData = mock(RecentChainData.class);
   private final BeaconState state = mock(BeaconState.class);
   private final Eth1DataCache eth1DataCache = mock(Eth1DataCache.class);
+  private final EventLogger eventLogger = mock(EventLogger.class);
   private List<tech.pegasys.teku.ethereum.pow.api.Deposit> allSeenDepositsList;
   private DepositProvider depositProvider;
   private Eth1Data randomEth1Data;
@@ -72,7 +74,8 @@ public class DepositProviderTest {
     depositUtil = new DepositUtil(spec);
     dataStructureUtil = new DataStructureUtil(spec);
     depositProvider =
-        new DepositProvider(new StubMetricsSystem(), recentChainData, eth1DataCache, spec);
+        new DepositProvider(
+            new StubMetricsSystem(), recentChainData, eth1DataCache, spec, eventLogger);
     depositMerkleTree =
         new OptimizedMerkleTree(spec.getGenesisSpecConfig().getDepositContractTreeDepth());
     mockStateEth1DataVotes();
@@ -220,6 +223,21 @@ public class DepositProviderTest {
     assertThatThrownBy(() -> depositProvider.getDeposits(state, randomEth1Data))
         .isInstanceOf(MissingDepositsException.class)
         .hasMessageContaining("9 to 10");
+  }
+
+  @Test
+  void shouldLogAnEventOnSlotWhenAllDepositsRequiredForStateNotAvailable() {
+    setup(1);
+    // To generate a valid proof we need the deposits up to state deposit count
+    // So we want to check if on each slot our node has necessary deposit data
+    mockDepositsFromEth1Block(0, 8);
+    mockStateEth1DepositIndex(5);
+    mockEth1DataDepositCount(10);
+    when(recentChainData.getBestState()).thenReturn(Optional.of(SafeFuture.completedFuture(state)));
+
+    depositProvider.onSlot(UInt64.ONE);
+
+    verify(eventLogger).eth1DepositDataNotAvailable(UInt64.valueOf(9), UInt64.valueOf(10));
   }
 
   @Test

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/util/MerkleTree.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/util/MerkleTree.java
@@ -140,7 +140,7 @@ public abstract class MerkleTree {
         // Return the tree node as-is without modifications
         proof.add(tree.get(i).get(siblingIndex));
       }
-      itemIndex /= 2;
+      itemIndex >>>= 1;
     }
     proof.add(calcMixInValue(viewLimit));
     return proof;

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java
@@ -118,6 +118,13 @@ public class EventLogger {
         Color.YELLOW);
   }
 
+  public void eth1DepositDataNotAvailable(final UInt64 fromIndex, final UInt64 toIndex) {
+    final String eth1DepositDataNotAvailableEventLog =
+        String.format(
+            "Some ETH1 deposits are not available. Missing deposits %s to %s", fromIndex, toIndex);
+    warn(eth1DepositDataNotAvailableEventLog, Color.YELLOW);
+  }
+
   public void syncCompletedWhileHeadIsOptimistic() {
     info("Beacon chain syncing complete, waiting for Execution Client", Color.YELLOW);
   }

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -519,7 +519,13 @@ public class BeaconChainController extends Service implements BeaconChainControl
   public void initDepositProvider() {
     LOG.debug("BeaconChainController.initDepositProvider()");
     depositProvider =
-        new DepositProvider(metricsSystem, recentChainData, eth1DataCache, spec, EVENT_LOG);
+        new DepositProvider(
+            metricsSystem,
+            recentChainData,
+            eth1DataCache,
+            spec,
+            EVENT_LOG,
+            beaconConfig.powchainConfig().useMissingDepositEventLogging());
     eventChannels
         .subscribe(Eth1EventsChannel.class, depositProvider)
         .subscribe(FinalizedCheckpointChannel.class, depositProvider)

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -518,10 +518,12 @@ public class BeaconChainController extends Service implements BeaconChainControl
 
   public void initDepositProvider() {
     LOG.debug("BeaconChainController.initDepositProvider()");
-    depositProvider = new DepositProvider(metricsSystem, recentChainData, eth1DataCache, spec);
+    depositProvider =
+        new DepositProvider(metricsSystem, recentChainData, eth1DataCache, spec, EVENT_LOG);
     eventChannels
         .subscribe(Eth1EventsChannel.class, depositProvider)
-        .subscribe(FinalizedCheckpointChannel.class, depositProvider);
+        .subscribe(FinalizedCheckpointChannel.class, depositProvider)
+        .subscribe(SlotEventsChannel.class, depositProvider);
   }
 
   protected void initEth1DataCache() {

--- a/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/PowchainConfiguration.java
+++ b/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/PowchainConfiguration.java
@@ -27,6 +27,7 @@ import tech.pegasys.teku.spec.datastructures.eth1.Eth1Address;
 public class PowchainConfiguration {
   public static final int DEFAULT_ETH1_LOGS_MAX_BLOCK_RANGE = 10_000;
   public static final boolean DEFAULT_USE_TIME_BASED_HEAD_TRACKING = true;
+  public static final boolean DEFAULT_USE_MISSING_DEPOSIT_EVENT_LOGGING = false;
 
   private final Spec spec;
   private final List<String> eth1Endpoints;
@@ -34,6 +35,7 @@ public class PowchainConfiguration {
   private final Optional<UInt64> depositContractDeployBlock;
   private final int eth1LogsMaxBlockRange;
   private final boolean useTimeBasedHeadTracking;
+  private final boolean useMissingDepositEventLogging;
 
   private PowchainConfiguration(
       final Spec spec,
@@ -41,13 +43,15 @@ public class PowchainConfiguration {
       final Eth1Address depositContract,
       final Optional<UInt64> depositContractDeployBlock,
       final int eth1LogsMaxBlockRange,
-      final boolean useTimeBasedHeadTracking) {
+      final boolean useTimeBasedHeadTracking,
+      final boolean useMissingDepositEventLogging) {
     this.spec = spec;
     this.eth1Endpoints = eth1Endpoints;
     this.depositContract = depositContract;
     this.depositContractDeployBlock = depositContractDeployBlock;
     this.eth1LogsMaxBlockRange = eth1LogsMaxBlockRange;
     this.useTimeBasedHeadTracking = useTimeBasedHeadTracking;
+    this.useMissingDepositEventLogging = useMissingDepositEventLogging;
   }
 
   public static Builder builder() {
@@ -82,6 +86,10 @@ public class PowchainConfiguration {
     return useTimeBasedHeadTracking;
   }
 
+  public boolean useMissingDepositEventLogging() {
+    return useMissingDepositEventLogging;
+  }
+
   public static class Builder {
     private Spec spec;
     private List<String> eth1Endpoints = new ArrayList<>();
@@ -89,6 +97,7 @@ public class PowchainConfiguration {
     private Optional<UInt64> depositContractDeployBlock = Optional.empty();
     private int eth1LogsMaxBlockRange = DEFAULT_ETH1_LOGS_MAX_BLOCK_RANGE;
     private boolean useTimeBasedHeadTracking = DEFAULT_USE_TIME_BASED_HEAD_TRACKING;
+    private boolean useMissingDepositEventLogging = DEFAULT_USE_MISSING_DEPOSIT_EVENT_LOGGING;
 
     private Builder() {}
 
@@ -100,7 +109,8 @@ public class PowchainConfiguration {
           depositContract,
           depositContractDeployBlock,
           eth1LogsMaxBlockRange,
-          useTimeBasedHeadTracking);
+          useTimeBasedHeadTracking,
+          useMissingDepositEventLogging);
     }
 
     private void validate() {
@@ -169,6 +179,11 @@ public class PowchainConfiguration {
 
     public Builder useTimeBasedHeadTracking(final boolean useTimeBasedHeadTracking) {
       this.useTimeBasedHeadTracking = useTimeBasedHeadTracking;
+      return this;
+    }
+
+    public Builder useMissingDepositEventLogging(final boolean useMissingDepositEventLogging) {
+      this.useMissingDepositEventLogging = useMissingDepositEventLogging;
       return this;
     }
   }

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/DepositOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/DepositOptions.java
@@ -47,11 +47,22 @@ public class DepositOptions {
   private boolean useTimeBasedHeadTracking =
       PowchainConfiguration.DEFAULT_USE_TIME_BASED_HEAD_TRACKING;
 
+  @Option(
+      names = {"--Xeth1-missing-deposits-event-logging-enabled"},
+      paramLabel = "<BOOLEAN>",
+      description = "Enable logging an event on each slot whenever deposits are missing",
+      hidden = true,
+      arity = "0..1",
+      fallbackValue = "true")
+  private boolean useMissingDepositEventLogging =
+      PowchainConfiguration.DEFAULT_USE_MISSING_DEPOSIT_EVENT_LOGGING;
+
   public void configure(final TekuConfiguration.Builder builder) {
     builder.powchain(
         b ->
             b.eth1Endpoints(eth1Endpoints)
                 .eth1LogsMaxBlockRange(eth1LogsMaxBlockRange)
-                .useTimeBasedHeadTracking(useTimeBasedHeadTracking));
+                .useTimeBasedHeadTracking(useTimeBasedHeadTracking)
+                .useMissingDepositEventLogging(useMissingDepositEventLogging));
   }
 }


### PR DESCRIPTION
## PR Description
adds a check wrt eth1 deposit availability and other little nits.

the check can be activated using a new `--Xeth1-missing-deposits-event-logging-enabled`

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
