### PR TITLE
Update to jvm-lip2p 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,5 +20,6 @@ For information on changes in released versions of Teku, see the [releases page]
 - Check `Eth1Address` checksum ([EIP-55](https://eips.ethereum.org/EIPS/eip-55)) if address is mixed-case.
 - Ignore aggregate attestation and sync contribution gossip that does not include any new validators.
 - Optimised BLS batch validation
+- Optimised message ID calculation in jvm-libp2p
 
 ### Bug Fixes

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -46,7 +46,7 @@ dependencyManagement {
     dependency 'io.protostuff:protostuff-core:1.6.2'
     dependency 'io.protostuff:protostuff-runtime:1.6.2'
 
-    dependency 'io.libp2p:jvm-libp2p-minimal:0.8.9-RELEASE'
+    dependency 'io.libp2p:jvm-libp2p-minimal:0.9.0-RELEASE'
     dependency 'tech.pegasys:jblst:0.3.7-1'
 
     dependency 'org.hdrhistogram:HdrHistogram:2.1.12'

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/gossip/LibP2PGossipNetworkBuilder.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/gossip/LibP2PGossipNetworkBuilder.java
@@ -39,7 +39,6 @@ import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.jetbrains.annotations.NotNull;
-import tech.pegasys.teku.infrastructure.crypto.Hash;
 import tech.pegasys.teku.networking.p2p.gossip.PreparedGossipMessage;
 import tech.pegasys.teku.networking.p2p.gossip.PreparedGossipMessageFactory;
 import tech.pegasys.teku.networking.p2p.gossip.config.GossipConfig;
@@ -99,10 +98,7 @@ public class LibP2PGossipNetworkBuilder {
 
           final SeenCache<Optional<ValidationResult>> seenCache =
               new TTLSeenCache<>(
-                  new FastIdSeenCache<>(
-                      msg ->
-                          Bytes.wrap(
-                              Hash.sha256(msg.getProtobufMessage().getData().toByteArray()))),
+                  new FastIdSeenCache<>(msg -> Bytes.wrap(msg.messageSha256())),
                   gossipParams.getSeenTTL(),
                   getCurTimeMillis());
 


### PR DESCRIPTION
## PR Description
Take advantage of cached sha256 value when calculating the ID for the fast seen message cache.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
