### PR TITLE
Be more flexible when selecting state to validate attestation with

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -469,12 +469,12 @@ public class Spec {
   public AttestationProcessingResult validateAttestation(
       final ReadOnlyStore store,
       final ValidateableAttestation validateableAttestation,
-      final Optional<BeaconState> maybeTargetState) {
+      final Optional<BeaconState> maybeState) {
     final UInt64 slot = validateableAttestation.getAttestation().getData().getSlot();
     final Fork fork = forkSchedule.getFork(computeEpochAtSlot(slot));
     return atSlot(slot)
         .getForkChoiceUtil()
-        .validate(fork, store, validateableAttestation, maybeTargetState);
+        .validate(fork, store, validateableAttestation, maybeState);
   }
 
   public Optional<OperationInvalidReason> validateAttesterSlashing(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
@@ -221,16 +221,16 @@ public class ForkChoiceUtil {
       final Fork fork,
       final ReadOnlyStore store,
       final ValidateableAttestation validateableAttestation,
-      final Optional<BeaconState> maybeTargetState) {
+      final Optional<BeaconState> maybeState) {
     Attestation attestation = validateableAttestation.getAttestation();
     return validateOnAttestation(store, attestation.getData())
         .ifSuccessful(
             () -> {
-              if (maybeTargetState.isEmpty()) {
+              if (maybeState.isEmpty()) {
                 return AttestationProcessingResult.UNKNOWN_BLOCK;
               } else {
                 return attestationUtil.isValidIndexedAttestation(
-                    fork, maybeTargetState.get(), validateableAttestation);
+                    fork, maybeState.get(), validateableAttestation);
               }
             })
         .ifSuccessful(() -> checkIfAttestationShouldBeSavedForFuture(store, attestation));

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
@@ -838,9 +838,7 @@ class ForkChoiceTest {
     assertThat(result)
         .isCompletedWithValue(
             AttestationProcessingResult.invalid(
-                String.format(
-                    "Checkpoint state (%s) must be at or prior to checkpoint slot boundary (%s)",
-                    targetBlock.getSlot(), targetCheckpoint.getEpochStartSlot(spec))));
+                "LMD vote must be consistent with FFG vote target"));
   }
 
   private UInt64 applyAttestationFromValidator(

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
@@ -817,7 +817,7 @@ class ForkChoiceTest {
   }
 
   @Test
-  void onAttestation_shouldBeInvalidWhenInvalidCheckpointThrown() {
+  void onAttestation_shouldBeInvalidWhenTargetRefersToBlockAfterTargetEpochStart() {
     final SignedBlockAndState targetBlock = chainBuilder.generateBlockAtSlot(5);
     importBlock(targetBlock);
 


### PR DESCRIPTION
## PR Description
Update `ForkChoice.onAttestation` to use `AttestationStateSelector` to select the state to validate with. This lets it optimise for picking a state that is already available whenever possible.

## Fixed Issue(s)
fixes #5477 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
