### PR TITLE
[MEV Boost\Builder] Create REST api client abstraction in `executionclient` module

### DIFF
--- a/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/rest/OkHttpRestClientTest.java
+++ b/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/rest/OkHttpRestClientTest.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionclient.rest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.List;
+import java.util.function.Consumer;
+import okhttp3.OkHttpClient;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.ethereum.executionclient.schema.Response;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.json.types.CoreTypes;
+import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
+import tech.pegasys.teku.infrastructure.json.types.SerializableTypeDefinition;
+
+class OkHttpRestClientTest {
+
+  private static final String TEST_PATH = "v1/test";
+  private static final Bytes32 TEST_BLOCK_HASH =
+      Bytes32.fromHexString("0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2");
+
+  private final MockWebServer mockWebServer = new MockWebServer();
+  private final OkHttpClient okHttpClient = new OkHttpClient.Builder().build();
+
+  private DeserializableTypeDefinition<TestObject> responseTypeDefinition;
+  private SerializableTypeDefinition<TestObject2> requestTypeDefinition;
+
+  private OkHttpRestClient underTest;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    mockWebServer.start();
+    String endpoint = "http://localhost:" + mockWebServer.getPort();
+    this.responseTypeDefinition =
+        DeserializableTypeDefinition.object(TestObject.class)
+            .initializer(TestObject::new)
+            .withField("foo", CoreTypes.STRING_TYPE, TestObject::getFoo, TestObject::setFoo)
+            .build();
+    this.requestTypeDefinition =
+        SerializableTypeDefinition.object(TestObject2.class)
+            .withField("block_hash", CoreTypes.BYTES32_TYPE, TestObject2::getBlockHash)
+            .build();
+    this.underTest = new OkHttpRestClient(okHttpClient, endpoint);
+  }
+
+  @AfterEach
+  public void afterEach() throws Exception {
+    mockWebServer.shutdown();
+  }
+
+  @Test
+  void getsResponseAsync() throws InterruptedException {
+    mockWebServer.enqueue(
+        new MockResponse()
+            .setBody("{\"foo\" : \"bar\"}")
+            .setResponseCode(200)
+            .addHeader("Content-Type", "application/json"));
+
+    SafeFuture<Response<TestObject>> responseFuture =
+        underTest.getAsync(TEST_PATH, responseTypeDefinition);
+
+    assertThat(responseFuture)
+        .succeedsWithin(Duration.ofSeconds(10))
+        .satisfies(
+            response -> {
+              assertThat(response.getErrorMessage()).isNull();
+              assertThat(response.getPayload())
+                  .satisfies(testObject -> assertThat(testObject.getFoo()).isEqualTo("bar"));
+            });
+
+    RecordedRequest request = mockWebServer.takeRequest();
+
+    assertThat(request.getPath()).isEqualTo("/" + TEST_PATH);
+    assertThat(request.getMethod()).isEqualTo("GET");
+  }
+
+  @Test
+  void getsResponseAsyncIgnoringResponseBody() throws InterruptedException {
+    mockWebServer.enqueue(new MockResponse().setResponseCode(200));
+
+    SafeFuture<Response<Void>> responseFuture = underTest.getAsync(TEST_PATH);
+
+    assertThat(responseFuture)
+        .succeedsWithin(Duration.ofSeconds(5))
+        .satisfies(
+            response -> {
+              assertThat(response.getErrorMessage()).isNull();
+              assertThat(response.getPayload()).isNull();
+            });
+
+    RecordedRequest request = mockWebServer.takeRequest();
+
+    assertThat(request.getPath()).isEqualTo("/" + TEST_PATH);
+    assertThat(request.getMethod()).isEqualTo("GET");
+  }
+
+  @Test
+  void getAsyncHandlesFailures() throws InterruptedException {
+    String errorBody = "{\"code\":400,\"message\":\"Invalid block: missing signature\"}";
+    mockWebServer.enqueue(new MockResponse().setResponseCode(400).setBody(errorBody));
+
+    SafeFuture<Response<TestObject>> responseFuture =
+        underTest.getAsync(TEST_PATH, responseTypeDefinition);
+
+    assertThat(responseFuture)
+        .succeedsWithin(Duration.ofSeconds(5))
+        .satisfies(
+            response -> {
+              assertThat(response.getErrorMessage()).isEqualTo(errorBody);
+              assertThat(response.getPayload()).isNull();
+            });
+
+    // error without a body
+    mockWebServer.enqueue(new MockResponse().setResponseCode(500));
+
+    SafeFuture<Response<TestObject>> secondResponseFuture =
+        underTest.getAsync(TEST_PATH, responseTypeDefinition);
+
+    assertThat(secondResponseFuture)
+        .succeedsWithin(Duration.ofSeconds(5))
+        .satisfies(
+            response -> {
+              assertThat(response.getErrorMessage()).isEqualTo("500: Server Error");
+              assertThat(response.getPayload()).isNull();
+            });
+
+    assertThat(mockWebServer.getRequestCount()).isEqualTo(2);
+
+    RecordedRequest request = mockWebServer.takeRequest();
+    RecordedRequest secondRequest = mockWebServer.takeRequest();
+
+    Consumer<RecordedRequest> requestsAssertions =
+        (req) -> {
+          assertThat(req.getPath()).isEqualTo("/" + TEST_PATH);
+          assertThat(req.getMethod()).isEqualTo("GET");
+        };
+
+    assertThat(List.of(request, secondRequest)).allSatisfy(requestsAssertions);
+  }
+
+  @Test
+  void postsAsync() throws InterruptedException {
+    mockWebServer.enqueue(
+        new MockResponse()
+            .setBody("{\"foo\" : \"bar\"}")
+            .setResponseCode(200)
+            .addHeader("Content-Type", "application/json"));
+
+    TestObject2 requestBodyObject = new TestObject2(TEST_BLOCK_HASH);
+    SafeFuture<Response<TestObject>> responseFuture =
+        underTest.postAsync(
+            TEST_PATH, requestBodyObject, requestTypeDefinition, responseTypeDefinition);
+
+    assertThat(responseFuture)
+        .succeedsWithin(Duration.ofSeconds(10))
+        .satisfies(
+            response -> {
+              assertThat(response.getErrorMessage()).isNull();
+              assertThat(response.getPayload())
+                  .satisfies(testObject -> assertThat(testObject.getFoo()).isEqualTo("bar"));
+            });
+
+    RecordedRequest request = mockWebServer.takeRequest();
+
+    assertThat(request.getPath()).isEqualTo("/" + TEST_PATH);
+    assertThat(request.getBody().readUtf8())
+        .isEqualTo(
+            "{\"block_hash\":\"0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2\"}");
+    assertThat(request.getMethod()).isEqualTo("POST");
+  }
+
+  @Test
+  void postsAsyncIgnoringResponseBody() throws InterruptedException {
+    mockWebServer.enqueue(
+        new MockResponse()
+            .setBody("{\"foo\" : \"bar\"}")
+            .setResponseCode(200)
+            .addHeader("Content-Type", "application/json"));
+
+    TestObject2 requestBodyObject = new TestObject2(TEST_BLOCK_HASH);
+    SafeFuture<Response<Void>> responseFuture =
+        underTest.postAsync(TEST_PATH, requestBodyObject, requestTypeDefinition);
+
+    assertThat(responseFuture)
+        .succeedsWithin(Duration.ofSeconds(10))
+        .satisfies(
+            response -> {
+              assertThat(response.getErrorMessage()).isNull();
+              assertThat(response.getPayload()).isNull();
+            });
+
+    RecordedRequest request = mockWebServer.takeRequest();
+
+    assertThat(request.getPath()).isEqualTo("/" + TEST_PATH);
+    assertThat(request.getBody().readUtf8())
+        .isEqualTo(
+            "{\"block_hash\":\"0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2\"}");
+    assertThat(request.getMethod()).isEqualTo("POST");
+  }
+
+  private static class TestObject {
+    private String foo;
+
+    public String getFoo() {
+      return foo;
+    }
+
+    public void setFoo(String foo) {
+      this.foo = foo;
+    }
+  }
+
+  private static class TestObject2 {
+    private final Bytes32 blockHash;
+
+    public TestObject2(Bytes32 blockHash) {
+      this.blockHash = blockHash;
+    }
+
+    public Bytes32 getBlockHash() {
+      return blockHash;
+    }
+  }
+}

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/BuilderApiMethod.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/BuilderApiMethod.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionclient;
+
+import static java.net.URLEncoder.encode;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.util.Map;
+import tech.pegasys.teku.ethereum.executionclient.rest.RestExecutionBuilderClient;
+
+public enum BuilderApiMethod {
+  REGISTER_VALIDATOR("eth/v1/builder/validators"),
+  GET_EXECUTION_PAYLOAD_HEADER("eth/v1/builder/header/:slot/:parent_hash/:pubkey"),
+  SEND_SIGNED_BLINDED_BLOCK("eth/v1/builder/blinded_blocks"),
+  GET_STATUS("eth1/v1/builder/status");
+
+  private final String path;
+
+  BuilderApiMethod(final String path) {
+    this.path = path;
+  }
+
+  public String getPath() {
+    return path;
+  }
+
+  /** Will be used when {@link RestExecutionBuilderClient} is implemented * */
+  @SuppressWarnings("UnusedMethod")
+  public String resolvePath(final Map<String, String> urlParams) {
+    String result = path;
+    for (final Map.Entry<String, String> param : urlParams.entrySet()) {
+      result = result.replace(":" + param.getKey(), encode(param.getValue(), UTF_8));
+    }
+    return result;
+  }
+}

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ExecutionBuilderClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ExecutionBuilderClient.java
@@ -18,7 +18,6 @@ import org.apache.tuweni.bytes.Bytes48;
 import tech.pegasys.teku.ethereum.executionclient.schema.BlindedBeaconBlockV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.BuilderBidV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV1;
-import tech.pegasys.teku.ethereum.executionclient.schema.GenericBuilderStatus;
 import tech.pegasys.teku.ethereum.executionclient.schema.Response;
 import tech.pegasys.teku.ethereum.executionclient.schema.SignedMessage;
 import tech.pegasys.teku.ethereum.executionclient.schema.ValidatorRegistrationV1;
@@ -27,9 +26,9 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 public interface ExecutionBuilderClient {
 
-  SafeFuture<Response<GenericBuilderStatus>> status();
+  SafeFuture<Response<Void>> status();
 
-  SafeFuture<Response<GenericBuilderStatus>> registerValidator(
+  SafeFuture<Response<Void>> registerValidator(
       SignedMessage<ValidatorRegistrationV1> signedValidatorRegistrationV1);
 
   SafeFuture<Response<SignedMessage<BuilderBidV1>>> getHeader(

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/OkHttpRestClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/OkHttpRestClient.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionclient.rest;
+
+import static java.util.Collections.emptyMap;
+import static java.util.Objects.requireNonNull;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.base.Strings;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Optional;
+import okhttp3.Call;
+import okhttp3.Callback;
+import okhttp3.HttpUrl;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.ResponseBody;
+import okio.BufferedSink;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import tech.pegasys.teku.ethereum.executionclient.schema.Response;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.json.JsonUtil;
+import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
+import tech.pegasys.teku.infrastructure.json.types.SerializableTypeDefinition;
+
+public class OkHttpRestClient implements RestClient {
+
+  private static final Logger LOG = LogManager.getLogger();
+
+  private static final MediaType JSON_MEDIA_TYPE = MediaType.parse("application/json");
+
+  private static final Map<String, String> EMPTY_QUERY_PARAMS = emptyMap();
+
+  private final OkHttpClient httpClient;
+  private final HttpUrl baseEndpoint;
+
+  public OkHttpRestClient(final OkHttpClient httpClient, final String baseEndpoint) {
+    this.httpClient = httpClient;
+    this.baseEndpoint = HttpUrl.get(baseEndpoint);
+  }
+
+  @Override
+  public SafeFuture<Response<Void>> getAsync(final String apiPath) {
+    return getAsync(apiPath, EMPTY_QUERY_PARAMS, Optional.empty());
+  }
+
+  @Override
+  public <T> SafeFuture<Response<T>> getAsync(
+      final String apiPath, final DeserializableTypeDefinition<T> responseTypeDefinition) {
+    return getAsync(apiPath, EMPTY_QUERY_PARAMS, Optional.of(responseTypeDefinition));
+  }
+
+  @Override
+  public <S> SafeFuture<Response<Void>> postAsync(
+      final String apiPath,
+      final S requestBodyObject,
+      final SerializableTypeDefinition<S> requestTypeDefinition) {
+    return postAsync(
+        apiPath, EMPTY_QUERY_PARAMS, requestBodyObject, requestTypeDefinition, Optional.empty());
+  }
+
+  @Override
+  public <T, S> SafeFuture<Response<T>> postAsync(
+      final String apiPath,
+      final S requestBodyObject,
+      final SerializableTypeDefinition<S> requestTypeDefinition,
+      final DeserializableTypeDefinition<T> responseTypeDefinition) {
+    return postAsync(
+        apiPath,
+        EMPTY_QUERY_PARAMS,
+        requestBodyObject,
+        requestTypeDefinition,
+        Optional.of(responseTypeDefinition));
+  }
+
+  private <T> SafeFuture<Response<T>> getAsync(
+      final String apiPath,
+      final Map<String, String> queryParams,
+      final Optional<DeserializableTypeDefinition<T>> responseTypeDefinitionMaybe) {
+    final Request request = createGetRequest(apiPath, queryParams);
+    return makeAsyncRequest(request, responseTypeDefinitionMaybe);
+  }
+
+  private <T, S> SafeFuture<Response<T>> postAsync(
+      final String apiPath,
+      final Map<String, String> queryParams,
+      final S requestBodyObject,
+      final SerializableTypeDefinition<S> requestTypeDefinition,
+      final Optional<DeserializableTypeDefinition<T>> responseTypeDefinitionMaybe) {
+    final RequestBody requestBody = createRequestBody(requestBodyObject, requestTypeDefinition);
+    final Request request = createPostRequest(apiPath, queryParams, requestBody);
+    return makeAsyncRequest(request, responseTypeDefinitionMaybe);
+  }
+
+  private Request createGetRequest(final String apiPath, final Map<String, String> queryParams) {
+    final HttpUrl httpUrl = createHttpUrl(apiPath, queryParams);
+    return new Request.Builder().url(httpUrl).build();
+  }
+
+  private <S> RequestBody createRequestBody(
+      final S requestBodyObject, final SerializableTypeDefinition<S> requestTypeDefinition) {
+    return new RequestBody() {
+
+      @Override
+      public void writeTo(@NotNull BufferedSink bufferedSink) throws JsonProcessingException {
+        JsonUtil.serializeToBytes(
+            requestBodyObject, requestTypeDefinition, bufferedSink.outputStream());
+      }
+
+      @Nullable
+      @Override
+      public MediaType contentType() {
+        return JSON_MEDIA_TYPE;
+      }
+    };
+  }
+
+  private Request createPostRequest(
+      final String apiPath, final Map<String, String> queryParams, RequestBody requestBody) {
+    final HttpUrl httpUrl = createHttpUrl(apiPath, queryParams);
+    return new Request.Builder().url(httpUrl).post(requestBody).build();
+  }
+
+  private HttpUrl createHttpUrl(final String apiPath, final Map<String, String> queryParams) {
+    final HttpUrl.Builder urlBuilder = baseEndpoint.newBuilder(apiPath);
+    queryParams.forEach(requireNonNull(urlBuilder)::addQueryParameter);
+    return urlBuilder.build();
+  }
+
+  private <T> SafeFuture<Response<T>> makeAsyncRequest(
+      final Request request,
+      final Optional<DeserializableTypeDefinition<T>> responseTypeDefinitionMaybe) {
+    final SafeFuture<Response<T>> futureResponse = new SafeFuture<>();
+    final Callback responseCallback =
+        new Callback() {
+          @Override
+          public void onFailure(@NotNull final Call call, @NotNull final IOException ex) {
+            futureResponse.completeExceptionally(ex);
+          }
+
+          @Override
+          public void onResponse(
+              @NotNull final Call call, @NotNull final okhttp3.Response response) {
+            HttpUrl requestUrl = response.request().url();
+            LOG.trace("{} {} {}", response.request().method(), requestUrl, response.code());
+            if (!response.isSuccessful()) {
+              handleFailure(response, futureResponse);
+              return;
+            }
+            final ResponseBody responseBody = response.body();
+            if (responseBody == null || responseTypeDefinitionMaybe.isEmpty()) {
+              futureResponse.complete(Response.withNullPayload());
+              return;
+            }
+            try {
+              final T payload =
+                  JsonUtil.parse(responseBody.byteStream(), responseTypeDefinitionMaybe.get());
+              futureResponse.complete(new Response<>(payload));
+            } catch (Throwable ex) {
+              futureResponse.completeExceptionally(ex);
+            }
+          }
+        };
+    httpClient.newCall(request).enqueue(responseCallback);
+    return futureResponse;
+  }
+
+  private <T> void handleFailure(
+      final okhttp3.Response response, final SafeFuture<Response<T>> futureResponse) {
+    try {
+      final String errorMessage = getErrorMessageForFailedResponse(response);
+      futureResponse.complete(new Response<>(errorMessage));
+    } catch (Throwable ex) {
+      futureResponse.completeExceptionally(ex);
+    }
+  }
+
+  private String getErrorMessageForFailedResponse(final okhttp3.Response response)
+      throws IOException {
+    final String errorCodeAndStatusMessage = response.code() + ": " + response.message();
+    final ResponseBody responseBody = response.body();
+    if (responseBody == null) {
+      return errorCodeAndStatusMessage;
+    }
+    final String failureBody = responseBody.string();
+    if (Strings.nullToEmpty(failureBody).isBlank()) {
+      return errorCodeAndStatusMessage;
+    } else {
+      return failureBody;
+    }
+  }
+}

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/RestClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/RestClient.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionclient.rest;
+
+import tech.pegasys.teku.ethereum.executionclient.schema.Response;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
+import tech.pegasys.teku.infrastructure.json.types.SerializableTypeDefinition;
+
+public interface RestClient {
+
+  SafeFuture<Response<Void>> getAsync(final String apiPath);
+
+  <T> SafeFuture<Response<T>> getAsync(
+      final String apiPath, final DeserializableTypeDefinition<T> responseTypeDefinition);
+
+  <S> SafeFuture<Response<Void>> postAsync(
+      final String apiPath,
+      final S requestBodyObject,
+      final SerializableTypeDefinition<S> requestTypeDefinition);
+
+  <T, S> SafeFuture<Response<T>> postAsync(
+      final String apiPath,
+      final S requestBodyObject,
+      final SerializableTypeDefinition<S> requestTypeDefinition,
+      final DeserializableTypeDefinition<T> responseTypeDefinition);
+}

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/Response.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/Response.java
@@ -34,12 +34,24 @@ public class Response<T> {
     this.errorMessage = null;
   }
 
+  public static <T> Response<T> withNullPayload() {
+    return new Response<>(null, null);
+  }
+
   public T getPayload() {
     return payload;
   }
 
   public String getErrorMessage() {
     return errorMessage;
+  }
+
+  public boolean isSuccess() {
+    return errorMessage == null;
+  }
+
+  public boolean isFailure() {
+    return errorMessage != null;
   }
 
   @Override

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JExecutionBuilderClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JExecutionBuilderClient.java
@@ -43,18 +43,20 @@ public class Web3JExecutionBuilderClient implements ExecutionBuilderClient {
   }
 
   @Override
-  public SafeFuture<Response<GenericBuilderStatus>> status() {
+  public SafeFuture<Response<Void>> status() {
     Request<?, GenericBuilderStatusWeb3jResponse> web3jRequest =
         new Request<>(
             "builder_status",
             List.of(),
             web3JClient.getWeb3jService(),
             GenericBuilderStatusWeb3jResponse.class);
-    return web3JClient.doRequest(web3jRequest, EL_BUILDER_STATUS_TIMEOUT);
+    return web3JClient
+        .doRequest(web3jRequest, EL_BUILDER_STATUS_TIMEOUT)
+        .thenApply(statusResponse -> new Response<>(statusResponse.getErrorMessage()));
   }
 
   @Override
-  public SafeFuture<Response<GenericBuilderStatus>> registerValidator(
+  public SafeFuture<Response<Void>> registerValidator(
       final SignedMessage<ValidatorRegistrationV1> signedValidatorRegistrationV1) {
     Request<?, GenericBuilderStatusWeb3jResponse> web3jRequest =
         new Request<>(
@@ -62,7 +64,9 @@ public class Web3JExecutionBuilderClient implements ExecutionBuilderClient {
             Collections.singletonList(signedValidatorRegistrationV1),
             web3JClient.getWeb3jService(),
             GenericBuilderStatusWeb3jResponse.class);
-    return web3JClient.doRequest(web3jRequest, EL_BUILDER_REGISTER_VALIDATOR_TIMEOUT);
+    return web3JClient
+        .doRequest(web3jRequest, EL_BUILDER_REGISTER_VALIDATOR_TIMEOUT)
+        .thenApply(statusResponse -> new Response<>(statusResponse.getErrorMessage()));
   }
 
   @Override

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
@@ -405,10 +405,7 @@ public class ExecutionLayerManagerImpl implements ExecutionLayerManager {
   }
 
   private static <K> K unwrapResponseOrThrow(Response<K> response) {
-    checkArgument(
-        response.getErrorMessage() == null,
-        "Invalid remote response: %s",
-        response.getErrorMessage());
+    checkArgument(response.isSuccess(), "Invalid remote response: %s", response.getErrorMessage());
     return checkNotNull(response.getPayload(), "No payload content found");
   }
 
@@ -421,7 +418,7 @@ public class ExecutionLayerManagerImpl implements ExecutionLayerManager {
         .status()
         .finish(
             statusResponse -> {
-              if (statusResponse.getErrorMessage() != null) {
+              if (statusResponse.isFailure()) {
                 markBuilderAsNotAvailable(statusResponse.getErrorMessage());
               } else {
                 if (latestBuilderAvailability.compareAndSet(false, true)) {

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImplTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImplTest.java
@@ -33,7 +33,6 @@ import tech.pegasys.teku.ethereum.executionclient.schema.BlindedBeaconBlockV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.BuilderBidV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadHeaderV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV1;
-import tech.pegasys.teku.ethereum.executionclient.schema.GenericBuilderStatus;
 import tech.pegasys.teku.ethereum.executionclient.schema.Response;
 import tech.pegasys.teku.ethereum.executionclient.schema.SignedMessage;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -77,8 +76,8 @@ class ExecutionLayerManagerImplTest {
 
   @Test
   public void builderShouldBeAvailableWhenBuilderIsOperatingNormally() {
-    SafeFuture<Response<GenericBuilderStatus>> builderClientResponse =
-        SafeFuture.completedFuture(new Response<>(GenericBuilderStatus.OK));
+    SafeFuture<Response<Void>> builderClientResponse =
+        SafeFuture.completedFuture(Response.withNullPayload());
 
     updateBuilderStatus(builderClientResponse);
 
@@ -88,7 +87,7 @@ class ExecutionLayerManagerImplTest {
 
   @Test
   public void builderShouldNotBeAvailableWhenBuilderIsNotOperatingNormally() {
-    SafeFuture<Response<GenericBuilderStatus>> builderClientResponse =
+    SafeFuture<Response<Void>> builderClientResponse =
         SafeFuture.completedFuture(new Response<>("oops"));
 
     updateBuilderStatus(builderClientResponse);
@@ -99,7 +98,7 @@ class ExecutionLayerManagerImplTest {
 
   @Test
   public void builderShouldNotBeAvailableWhenBuilderStatusCallFails() {
-    SafeFuture<Response<GenericBuilderStatus>> builderClientResponse =
+    SafeFuture<Response<Void>> builderClientResponse =
         SafeFuture.failedFuture(new Throwable("oops"));
 
     updateBuilderStatus(builderClientResponse);
@@ -114,7 +113,7 @@ class ExecutionLayerManagerImplTest {
     assertThat(executionLayerManager.isBuilderAvailable()).isTrue();
 
     // Given builder status is ok
-    updateBuilderStatus(SafeFuture.completedFuture(new Response<>(GenericBuilderStatus.OK)));
+    updateBuilderStatus(SafeFuture.completedFuture(Response.withNullPayload()));
 
     // Then
     assertThat(executionLayerManager.isBuilderAvailable()).isTrue();
@@ -128,7 +127,7 @@ class ExecutionLayerManagerImplTest {
     verify(eventLogger).executionBuilderIsOffline("oops");
 
     // Given builder status is back to being ok
-    updateBuilderStatus(SafeFuture.completedFuture(new Response<>(GenericBuilderStatus.OK)));
+    updateBuilderStatus(SafeFuture.completedFuture(Response.withNullPayload()));
 
     // Then
     assertThat(executionLayerManager.isBuilderAvailable()).isTrue();
@@ -360,13 +359,11 @@ class ExecutionLayerManagerImplTest {
         eventLogger);
   }
 
-  private void updateBuilderStatus(
-      SafeFuture<Response<GenericBuilderStatus>> builderClientResponse) {
+  private void updateBuilderStatus(SafeFuture<Response<Void>> builderClientResponse) {
     updateBuilderStatus(builderClientResponse, UInt64.ONE);
   }
 
-  private void updateBuilderStatus(
-      SafeFuture<Response<GenericBuilderStatus>> builderClientResponse, UInt64 slot) {
+  private void updateBuilderStatus(SafeFuture<Response<Void>> builderClientResponse, UInt64 slot) {
     when(executionBuilderClient.status()).thenReturn(builderClientResponse);
     // trigger update of the builder status
     executionLayerManager.onSlot(slot);
@@ -387,7 +384,7 @@ class ExecutionLayerManagerImplTest {
   }
 
   private void setBuilderOnline(UInt64 slot) {
-    updateBuilderStatus(SafeFuture.completedFuture(new Response<>(GenericBuilderStatus.OK)), slot);
+    updateBuilderStatus(SafeFuture.completedFuture(Response.withNullPayload()), slot);
     reset(executionBuilderClient);
     assertThat(executionLayerManager.isBuilderAvailable()).isTrue();
   }


### PR DESCRIPTION
## PR Description

- Introduce a `RestClient` abstraction and an okhttp implementation`
- Created `RestExecutionBuilderClient` skeleton which will be implemented later
- Changed `GenericBuilderStatus` response to `Void` since it no longer applies

## Fixed Issue(s)
related to #5396 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
