### PR TITLE
Serialize events to bytes instead of String

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@ For information on changes in released versions of Teku, see the [releases page]
 ### Additions and Improvements
 - Check `Eth1Address` checksum ([EIP-55](https://eips.ethereum.org/EIPS/eip-55)) if address is mixed-case.
 - Ignore aggregate attestation and sync contribution gossip that does not include any new validators.
-- Optimised BLS batch validation
-- Optimised message ID calculation in jvm-libp2p
+- Optimised BLS batch validation.
+- Optimised message ID calculation in jvm-libp2p.
+- Reduced memory requirements when sending events on the REST API to many clients.
 
 ### Bug Fixes

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriber.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriber.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.beaconrestapi.handlers.v1.events;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.javalin.http.sse.SseClient;
+import java.io.ByteArrayInputStream;
 import java.time.Duration;
 import java.util.List;
 import java.util.Queue;
@@ -113,7 +114,9 @@ public class EventSubscriber {
                   sseClient.hashCode());
               QueuedEvent event = queuedEvents.poll();
               while (event != null && !stopped.get()) {
-                sseClient.sendEvent(event.getEventType().name(), event.getMessageData());
+                sseClient.sendEvent(
+                    event.getEventType().name(),
+                    new ByteArrayInputStream(event.getMessageData().toArrayUnsafe()));
                 event = queuedEvents.poll();
               }
             })

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManager.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManager.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.beaconrestapi.handlers.v1.events;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.TOPICS;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -23,6 +24,7 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.api.ChainDataProvider;
 import tech.pegasys.teku.api.ConfigProvider;
@@ -203,15 +205,17 @@ public class EventSubscriptionManager implements ChainHeadChannel, FinalizedChec
 
   public static class EventSource<T> {
     private final Event<T> event;
-    private String value;
+    private Bytes value;
 
     public EventSource(final Event<T> event) {
       this.event = event;
     }
 
-    public String get() throws JsonProcessingException {
+    public Bytes get() throws JsonProcessingException {
       if (value == null) {
-        value = JsonUtil.serialize(event.getData(), event.getJsonTypeDefinition());
+        value =
+            Bytes.wrap(
+                JsonUtil.serialize(event.getData(), event.getJsonTypeDefinition()).getBytes(UTF_8));
       }
       return value;
     }

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/QueuedEvent.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/QueuedEvent.java
@@ -14,18 +14,19 @@
 package tech.pegasys.teku.beaconrestapi.handlers.v1.events;
 
 import java.util.Objects;
+import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.api.response.v1.EventType;
 
 public class QueuedEvent {
   private final EventType eventType;
-  private final String messageData;
+  private final Bytes messageData;
 
-  private QueuedEvent(final EventType eventType, final String messageData) {
+  private QueuedEvent(final EventType eventType, final Bytes messageData) {
     this.eventType = eventType;
     this.messageData = messageData;
   }
 
-  public static QueuedEvent of(final EventType eventType, final String messageData) {
+  public static QueuedEvent of(final EventType eventType, final Bytes messageData) {
     return new QueuedEvent(eventType, messageData);
   }
 
@@ -50,7 +51,7 @@ public class QueuedEvent {
     return eventType;
   }
 
-  public String getMessageData() {
+  public Bytes getMessageData() {
     return messageData;
   }
 }


### PR DESCRIPTION
## PR Description
Previously a single String instance was stored and a new byte[] created for every subscriber. Now a single byte[] is stored and reused for every subscriber.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
