### PR TITLE
Enable gossip scoring by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,5 +22,6 @@ For information on changes in released versions of Teku, see the [releases page]
 - Optimised BLS batch validation.
 - Optimised message ID calculation in jvm-libp2p.
 - Reduced memory requirements when sending events on the REST API to many clients.
+- Gossip scoring is enabled by default. It can be disabled with --Xp2p-gossip-scoring-enabled=false
 
 ### Bug Fixes

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/P2PConfig.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/P2PConfig.java
@@ -31,7 +31,7 @@ public class P2PConfig {
   public static final int DEFAULT_PEER_REQUEST_LIMIT = 50;
   public static final int DEFAULT_P2P_TARGET_SUBNET_SUBSCRIBER_COUNT = 2;
   public static final boolean DEFAULT_SUBSCRIBE_ALL_SUBNETS_ENABLED = false;
-  public static final boolean DEFAULT_GOSSIP_SCORING_ENABLED = false;
+  public static final boolean DEFAULT_GOSSIP_SCORING_ENABLED = true;
   public static final boolean DEFAULT_BATCH_VERIFY_ATTESTATION_SIGNATURES = true;
   public static final int DEFAULT_BATCH_VERIFY_MAX_THREADS = 2;
   public static final int DEFAULT_BATCH_VERIFY_QUEUE_CAPACITY = 15_000;


### PR DESCRIPTION
## PR Description
Enable gossip scoring by default. We've seen this running well across all our test nodes (on prater and mainnet) for some time now.

## Fixed Issue(s)
fixes #4264 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
