### PR TITLE
Fix resource inconsistencies in API testing

### DIFF
--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetBlockHeadersTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetBlockHeadersTest.java
@@ -78,7 +78,7 @@ class GetBlockHeadersTest extends AbstractMigratedBeaconHandlerWithChainDataProv
     final String data = getResponseStringFromMetadata(handler, SC_OK, responseData);
     final String expected =
         Resources.toString(
-            Resources.getResource(GetBlockAttestationsTest.class, "getBlockHeaders.json"), UTF_8);
+            Resources.getResource(GetBlockHeadersTest.class, "getBlockHeaders.json"), UTF_8);
     assertThat(data).isEqualTo(expected);
   }
 

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetBlockRootTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetBlockRootTest.java
@@ -83,7 +83,7 @@ class GetBlockRootTest extends AbstractMigratedBeaconHandlerWithChainDataProvide
     final String data = getResponseStringFromMetadata(handler, SC_OK, responseData);
     final String expected =
         Resources.toString(
-            Resources.getResource(GetBlockHeaderTest.class, "getBlockRoot.json"), UTF_8);
+            Resources.getResource(GetBlockRootTest.class, "getBlockRoot.json"), UTF_8);
     assertThat(data).isEqualTo(expected);
   }
 }

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetProposerSlashingsTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetProposerSlashingsTest.java
@@ -65,7 +65,7 @@ class GetProposerSlashingsTest extends AbstractMigratedBeaconHandlerTest {
     final String data = getResponseStringFromMetadata(handler, SC_OK, responseData);
     final String expected =
         Resources.toString(
-            Resources.getResource(GetBlockAttestationsTest.class, "getProposerSlashings.json"),
+            Resources.getResource(GetProposerSlashingsTest.class, "getProposerSlashings.json"),
             UTF_8);
     assertThat(data).isEqualTo(expected);
   }


### PR DESCRIPTION
## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
