### PR TITLE
Fix configuration for boolean cli options

### DIFF
--- a/ethereum/networks/src/main/java/tech/pegasys/teku/networks/Eth2NetworkConfiguration.java
+++ b/ethereum/networks/src/main/java/tech/pegasys/teku/networks/Eth2NetworkConfiguration.java
@@ -44,6 +44,7 @@ public class Eth2NetworkConfiguration {
   private static final int DEFAULT_STARTUP_TIMEOUT_SECONDS = 30;
   public static final boolean DEFAULT_PROPOSER_BOOST_ENABLED = true;
   public static final boolean DEFAULT_EQUIVOCATING_INDICES_ENABLED = false;
+  public static final boolean DEFAULT_FORK_CHOICE_BEFORE_PROPOSING_ENABLED = false;
 
   private final Spec spec;
   private final String constants;
@@ -58,6 +59,7 @@ public class Eth2NetworkConfiguration {
   private final Optional<UInt64> eth1DepositContractDeployBlock;
   private final boolean proposerBoostEnabled;
   private final boolean equivocatingIndicesEnabled;
+  private final boolean forkChoiceBeforeProposingEnabled;
   private final Optional<Bytes32> terminalBlockHashOverride;
   private final Optional<UInt256> totalTerminalDifficultyOverride;
   private final Optional<UInt64> terminalBlockHashEpochOverride;
@@ -74,6 +76,7 @@ public class Eth2NetworkConfiguration {
       final Optional<UInt64> eth1DepositContractDeployBlock,
       final boolean proposerBoostEnabled,
       final boolean equivocatingIndicesEnabled,
+      final boolean forkChoiceBeforeProposingEnabled,
       final Optional<UInt64> altairForkEpoch,
       final Optional<UInt64> bellatrixForkEpoch,
       final Optional<Bytes32> terminalBlockHashOverride,
@@ -86,6 +89,7 @@ public class Eth2NetworkConfiguration {
     this.startupTargetPeerCount = startupTargetPeerCount;
     this.startupTimeoutSeconds = startupTimeoutSeconds;
     this.discoveryBootnodes = discoveryBootnodes;
+    this.forkChoiceBeforeProposingEnabled = forkChoiceBeforeProposingEnabled;
     this.altairForkEpoch = altairForkEpoch;
     this.bellatrixForkEpoch = bellatrixForkEpoch;
     this.eth1DepositContractAddress =
@@ -161,6 +165,10 @@ public class Eth2NetworkConfiguration {
     return equivocatingIndicesEnabled;
   }
 
+  public boolean isForkChoiceBeforeProposingEnabled() {
+    return forkChoiceBeforeProposingEnabled;
+  }
+
   public Optional<UInt64> getAltairForkEpoch() {
     return altairForkEpoch;
   }
@@ -197,6 +205,7 @@ public class Eth2NetworkConfiguration {
     private Optional<UInt64> eth1DepositContractDeployBlock = Optional.empty();
     private boolean proposerBoostEnabled = DEFAULT_PROPOSER_BOOST_ENABLED;
     private boolean equivocatingIndicesEnabled = DEFAULT_EQUIVOCATING_INDICES_ENABLED;
+    private boolean forkChoiceBeforeProposingEnabled = DEFAULT_FORK_CHOICE_BEFORE_PROPOSING_ENABLED;
     private Optional<UInt64> altairForkEpoch = Optional.empty();
     private Optional<UInt64> bellatrixForkEpoch = Optional.empty();
     private Optional<Bytes32> terminalBlockHashOverride = Optional.empty();
@@ -251,6 +260,7 @@ public class Eth2NetworkConfiguration {
           eth1DepositContractDeployBlock,
           proposerBoostEnabled,
           equivocatingIndicesEnabled,
+          forkChoiceBeforeProposingEnabled,
           altairForkEpoch,
           bellatrixForkEpoch,
           terminalBlockHashOverride,
@@ -328,6 +338,12 @@ public class Eth2NetworkConfiguration {
 
     public Builder equivocatingIndicesEnabled(final boolean equivocatingIndicesEnabled) {
       this.equivocatingIndicesEnabled = equivocatingIndicesEnabled;
+      return this;
+    }
+
+    public Builder forkChoiceBeforeProposingEnabled(
+        final boolean forkChoiceBeforeProposingEnabled) {
+      this.forkChoiceBeforeProposingEnabled = forkChoiceBeforeProposingEnabled;
       return this;
     }
 

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/DepositOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/DepositOptions.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.cli.options;
 
 import java.util.ArrayList;
 import java.util.List;
+import picocli.CommandLine.Help.Visibility;
 import picocli.CommandLine.Option;
 import tech.pegasys.teku.config.TekuConfiguration;
 import tech.pegasys.teku.services.powchain.PowchainConfiguration;
@@ -42,6 +43,7 @@ public class DepositOptions {
       paramLabel = "<BOOLEAN>",
       description = "Enable experimental time based Eth1 head tracking",
       hidden = true,
+      showDefaultValue = Visibility.ALWAYS,
       arity = "0..1",
       fallbackValue = "true")
   private boolean useTimeBasedHeadTracking =
@@ -52,6 +54,7 @@ public class DepositOptions {
       paramLabel = "<BOOLEAN>",
       description = "Enable logging an event on each slot whenever deposits are missing",
       hidden = true,
+      showDefaultValue = Visibility.ALWAYS,
       arity = "0..1",
       fallbackValue = "true")
   private boolean useMissingDepositEventLogging =

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/Eth2NetworkOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/Eth2NetworkOptions.java
@@ -19,6 +19,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
 import picocli.CommandLine;
+import picocli.CommandLine.Help.Visibility;
 import picocli.CommandLine.Option;
 import tech.pegasys.teku.cli.converter.Bytes32Converter;
 import tech.pegasys.teku.cli.converter.UInt256Converter;
@@ -124,7 +125,8 @@ public class Eth2NetworkOptions {
       paramLabel = "<BOOLEAN>",
       description = "Whether to enable the fork choice proposer boost feature.",
       arity = "0..1",
-      fallbackValue = "false",
+      fallbackValue = "true",
+      showDefaultValue = Visibility.ALWAYS,
       hidden = true)
   private Boolean proposerBoostEnabled = Eth2NetworkConfiguration.DEFAULT_PROPOSER_BOOST_ENABLED;
 
@@ -133,10 +135,22 @@ public class Eth2NetworkOptions {
       paramLabel = "<BOOLEAN>",
       description = "Whether to enable the fork choice equivocating indices feature.",
       arity = "0..1",
-      fallbackValue = "false",
+      fallbackValue = "true",
+      showDefaultValue = Visibility.ALWAYS,
       hidden = true)
   private Boolean equivocatingIndicesEnabled =
       Eth2NetworkConfiguration.DEFAULT_EQUIVOCATING_INDICES_ENABLED;
+
+  @Option(
+      names = {"--Xfork-choice-before-proposing-enabled"},
+      paramLabel = "<BOOLEAN>",
+      description = "Whether to enable run fork choice before creating block proposals.",
+      arity = "0..1",
+      fallbackValue = "true",
+      showDefaultValue = Visibility.ALWAYS,
+      hidden = true)
+  private Boolean forkChoiceBeforeProposingEnabled =
+      Eth2NetworkConfiguration.DEFAULT_FORK_CHOICE_BEFORE_PROPOSING_ENABLED;
 
   public Eth2NetworkConfiguration getNetworkConfiguration() {
     return createEth2NetworkConfig();
@@ -166,12 +180,6 @@ public class Eth2NetworkOptions {
     if (StringUtils.isNotBlank(initialState)) {
       builder.customInitialState(initialState);
     }
-    if (proposerBoostEnabled != null) {
-      builder.proposerBoostEnabled(proposerBoostEnabled);
-    }
-    if (equivocatingIndicesEnabled != null) {
-      builder.equivocatingIndicesEnabled(equivocatingIndicesEnabled);
-    }
     if (altairForkEpoch != null) {
       builder.altairForkEpoch(altairForkEpoch);
     }
@@ -187,7 +195,11 @@ public class Eth2NetworkOptions {
     if (terminalBlockHashEpochOverride != null) {
       builder.terminalBlockHashEpochOverride(terminalBlockHashEpochOverride);
     }
-    builder.safeSlotsToImportOptimistically(safeSlotsToImportOptimistically);
+    builder
+        .safeSlotsToImportOptimistically(safeSlotsToImportOptimistically)
+        .equivocatingIndicesEnabled(equivocatingIndicesEnabled)
+        .forkChoiceBeforeProposingEnabled(forkChoiceBeforeProposingEnabled)
+        .proposerBoostEnabled(proposerBoostEnabled);
   }
 
   public String getNetwork() {

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/InteropOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/InteropOptions.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.cli.options;
 
+import picocli.CommandLine.Help.Visibility;
 import picocli.CommandLine.Option;
 import tech.pegasys.teku.config.TekuConfiguration;
 import tech.pegasys.teku.validator.api.InteropConfig;
@@ -55,6 +56,7 @@ public class InteropOptions {
       names = {"--Xinterop-enabled"},
       paramLabel = "<BOOLEAN>",
       fallbackValue = "true",
+      showDefaultValue = Visibility.ALWAYS,
       description = "Enables developer options for testing",
       arity = "0..1")
   private boolean interopEnabled = false;

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
@@ -150,6 +150,7 @@ public class P2POptions {
       paramLabel = "<BOOLEAN>",
       showDefaultValue = Visibility.ALWAYS,
       description = "Enables experimental multipeer sync",
+      fallbackValue = "true",
       hidden = true,
       arity = "1")
   private boolean multiPeerSyncEnabled = SyncConfig.DEFAULT_MULTI_PEER_SYNC_ENABLED;
@@ -178,6 +179,7 @@ public class P2POptions {
       paramLabel = "<BOOLEAN>",
       showDefaultValue = Visibility.ALWAYS,
       description = "If true, turn on batch verification for gossiped attestation signatures",
+      fallbackValue = "true",
       hidden = true,
       arity = "0..1")
   private boolean batchVerifyAttestationSignatures =

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
@@ -75,6 +75,7 @@ public class ValidatorOptions {
       names = {"--validators-keystore-locking-enabled"},
       paramLabel = "<BOOLEAN>",
       showDefaultValue = Visibility.ALWAYS,
+      fallbackValue = "true",
       description = "Enable locking validator keystore files",
       arity = "1")
   private boolean validatorKeystoreLockingEnabled =

--- a/teku/src/main/java/tech/pegasys/teku/cli/slashingprotection/RepairCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/slashingprotection/RepairCommand.java
@@ -56,6 +56,7 @@ public class RepairCommand implements Runnable {
       names = {"--check-only-enabled"},
       paramLabel = "<BOOLEAN>",
       showDefaultValue = Visibility.ALWAYS,
+      fallbackValue = "true",
       description = "Read and report potential problems, but don't update anything.",
       arity = "0..1")
   private boolean checkOnlyEnabled = false;
@@ -64,6 +65,7 @@ public class RepairCommand implements Runnable {
       names = {"--update-all-enabled"},
       paramLabel = "<BOOLEAN>",
       showDefaultValue = Visibility.ALWAYS,
+      fallbackValue = "true",
       description = "All validator slashing protection records should be updated.",
       arity = "0..1")
   private boolean updateAllEnabled = false;

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/TransitionCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/TransitionCommand.java
@@ -28,6 +28,7 @@ import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.ssz.SSZException;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
+import picocli.CommandLine.Help.Visibility;
 import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
@@ -102,6 +103,8 @@ public class TransitionCommand implements Runnable {
       @Mixin InAndOutParams params,
       @Option(
               names = {"--delta", "-d"},
+              showDefaultValue = Visibility.ALWAYS,
+              fallbackValue = "true",
               description = "to interpret the slot number as a delta from the pre-state")
           boolean delta,
       @Parameters(paramLabel = "<number>", description = "Number of slots to process")

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/VoluntaryExitCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/VoluntaryExitCommand.java
@@ -99,6 +99,7 @@ public class VoluntaryExitCommand implements Runnable {
       description = "Request confirmation before submitting voluntary exits.",
       paramLabel = "<BOOLEAN>",
       showDefaultValue = Visibility.ALWAYS,
+      fallbackValue = "true",
       arity = "1")
   private boolean confirmationEnabled = true;
 

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/internal/validator/options/VerbosityOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/internal/validator/options/VerbosityOptions.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.cli.subcommand.internal.validator.options;
 
 import com.google.common.annotations.VisibleForTesting;
+import picocli.CommandLine.Help.Visibility;
 import picocli.CommandLine.Option;
 
 public class VerbosityOptions {
@@ -23,6 +24,8 @@ public class VerbosityOptions {
       paramLabel = "<true|false>",
       description = "Controls verbose status output. (default: ${DEFAULT-VALUE})",
       arity = "1",
+      showDefaultValue = Visibility.ALWAYS,
+      fallbackValue = "true",
       defaultValue = "true")
   private boolean verboseOutputEnabled = true;
 

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/Eth2NetworkOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/Eth2NetworkOptionsTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.cli.AbstractBeaconNodeCommandTest;
 import tech.pegasys.teku.config.TekuConfiguration;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.networks.Eth2NetworkConfiguration;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 
@@ -162,20 +163,66 @@ class Eth2NetworkOptionsTest extends AbstractBeaconNodeCommandTest {
   void shouldFailLoadingInvalidTransitionOverrides() {
     assertThrows(
         AssertionError.class,
-        () -> {
-          getTekuConfigurationFromArguments("--Xnetwork-total-terminal-difficulty-override", "asd");
-        });
+        () ->
+            getTekuConfigurationFromArguments(
+                "--Xnetwork-total-terminal-difficulty-override", "asd"));
 
     assertThrows(
         AssertionError.class,
-        () -> {
-          getTekuConfigurationFromArguments("--Xnetwork-terminal-block-hash-override", "756");
-        });
+        () -> getTekuConfigurationFromArguments("--Xnetwork-terminal-block-hash-override", "756"));
 
     assertThrows(
         AssertionError.class,
-        () -> {
-          getTekuConfigurationFromArguments("--Xnetwork-terminal-block-hash-epoch-override", "asd");
-        });
+        () ->
+            getTekuConfigurationFromArguments(
+                "--Xnetwork-terminal-block-hash-epoch-override", "asd"));
+  }
+
+  @Test
+  void shouldEnableEquivocatingIndices() {
+    final Eth2NetworkConfiguration networkConfig =
+        getTekuConfigurationFromArguments("--Xfork-choice-equivocating-indices-enabled")
+            .eth2NetworkConfiguration();
+    assertThat(networkConfig.isEquivocatingIndicesEnabled()).isTrue();
+  }
+
+  @Test
+  void shouldDisableEquivocatingIndices() {
+    final Eth2NetworkConfiguration networkConfig =
+        getTekuConfigurationFromArguments("--Xfork-choice-equivocating-indices-enabled=false")
+            .eth2NetworkConfiguration();
+    assertThat(networkConfig.isEquivocatingIndicesEnabled()).isFalse();
+  }
+
+  @Test
+  void shouldEnableProposerBoost() {
+    final Eth2NetworkConfiguration networkConfig =
+        getTekuConfigurationFromArguments("--Xfork-choice-proposer-boost-enabled")
+            .eth2NetworkConfiguration();
+    assertThat(networkConfig.isProposerBoostEnabled()).isTrue();
+  }
+
+  @Test
+  void shouldDisableProposerBoost() {
+    final Eth2NetworkConfiguration networkConfig =
+        getTekuConfigurationFromArguments("--Xfork-choice-proposer-boost-enabled=false")
+            .eth2NetworkConfiguration();
+    assertThat(networkConfig.isProposerBoostEnabled()).isFalse();
+  }
+
+  @Test
+  void shouldEnableForkChoiceBeforeProposing() {
+    final Eth2NetworkConfiguration networkConfig =
+        getTekuConfigurationFromArguments("--Xfork-choice-before-proposing-enabled")
+            .eth2NetworkConfiguration();
+    assertThat(networkConfig.isForkChoiceBeforeProposingEnabled()).isTrue();
+  }
+
+  @Test
+  void shouldDisableForkChoiceBeforeProposing() {
+    final Eth2NetworkConfiguration networkConfig =
+        getTekuConfigurationFromArguments("--Xfork-choice-before-proposing-enabled=false")
+            .eth2NetworkConfiguration();
+    assertThat(networkConfig.isForkChoiceBeforeProposingEnabled()).isFalse();
   }
 }


### PR DESCRIPTION
## PR Description
Ensure all boolean CLI options have showDefaultValues = ALWAYS and fallbackValue = "true".

That ensures the default value is shown in help and that `--option-enabled` with no argument always enables the value instead of toggling it from its default.

Also adds the new `--Xfork-choice-before-proposing-enabled` which is what I was working on before discovering the config issues.  A separate PR will make it actually do something (which is fine because it's hidden).

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
