### PR TITLE
implement CreateBlockRequest with typedefs

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionCache.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionCache.java
@@ -32,6 +32,10 @@ public class SchemaDefinitionCache {
     return schemas.computeIfAbsent(milestone, this::createSchemaDefinition);
   }
 
+  public SchemaDefinitions atSlot(final UInt64 slot) {
+    return getSchemaDefinition(milestoneAtSlot(slot));
+  }
+
   public final SpecMilestone milestoneAtSlot(final UInt64 slot) {
     return spec.atSlot(slot).getMilestone();
   }

--- a/validator/remote/build.gradle
+++ b/validator/remote/build.gradle
@@ -5,6 +5,7 @@ dependencies {
   implementation project(':infrastructure:bls')
   implementation project(':infrastructure:events')
   implementation project(':infrastructure:http')
+  implementation project(':infrastructure:json')
   implementation project(':infrastructure:logging')
   implementation project(':infrastructure:metrics')
   implementation project(':infrastructure:serviceutils')

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
@@ -259,14 +259,7 @@ public class RemoteValidatorApiHandler implements ValidatorApiChannel {
       final Optional<Bytes32> graffiti,
       final boolean blinded) {
     return sendRequest(
-        () -> {
-          final tech.pegasys.teku.api.schema.BLSSignature schemaBLSSignature =
-              new tech.pegasys.teku.api.schema.BLSSignature(randaoReveal);
-
-          return apiClient
-              .createUnsignedBlock(slot, schemaBLSSignature, graffiti, blinded)
-              .map(block -> block.asInternalBeaconBlock(spec));
-        });
+        () -> typeDefClient.createUnsignedBlock(slot, randaoReveal, graffiti, blinded));
   }
 
   @Override

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/OkHttpValidatorTypeDefClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/OkHttpValidatorTypeDefClient.java
@@ -22,7 +22,6 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.genesis.GenesisData;
-import tech.pegasys.teku.spec.schemas.SchemaDefinitionCache;
 import tech.pegasys.teku.validator.remote.typedef.handlers.CreateBlockRequest;
 import tech.pegasys.teku.validator.remote.typedef.handlers.GetGenesisRequest;
 
@@ -31,13 +30,13 @@ public class OkHttpValidatorTypeDefClient {
   private final OkHttpClient okHttpClient;
   private final HttpUrl baseEndpoint;
 
-  private final SchemaDefinitionCache schemaDefinitionCache;
+  private final Spec spec;
 
   public OkHttpValidatorTypeDefClient(
       final OkHttpClient okHttpClient, final HttpUrl baseEndpoint, final Spec spec) {
     this.okHttpClient = okHttpClient;
     this.baseEndpoint = baseEndpoint;
-    this.schemaDefinitionCache = new SchemaDefinitionCache(spec);
+    this.spec = spec;
   }
 
   public Optional<GenesisData> getGenesis() {
@@ -51,7 +50,7 @@ public class OkHttpValidatorTypeDefClient {
       final Optional<Bytes32> graffiti,
       final boolean blinded) {
     final CreateBlockRequest createBlockRequest =
-        new CreateBlockRequest(baseEndpoint, okHttpClient, schemaDefinitionCache, slot, blinded);
+        new CreateBlockRequest(baseEndpoint, okHttpClient, spec, slot, blinded);
     return createBlockRequest.createUnsignedBlock(randaoReveal, graffiti);
   }
 }

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/OkHttpValidatorTypeDefClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/OkHttpValidatorTypeDefClient.java
@@ -16,8 +16,14 @@ package tech.pegasys.teku.validator.remote.typedef;
 import java.util.Optional;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.genesis.GenesisData;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionCache;
+import tech.pegasys.teku.validator.remote.typedef.handlers.CreateBlockRequest;
 import tech.pegasys.teku.validator.remote.typedef.handlers.GetGenesisRequest;
 
 public class OkHttpValidatorTypeDefClient {
@@ -25,14 +31,27 @@ public class OkHttpValidatorTypeDefClient {
   private final OkHttpClient okHttpClient;
   private final HttpUrl baseEndpoint;
 
+  private final SchemaDefinitionCache schemaDefinitionCache;
+
   public OkHttpValidatorTypeDefClient(
       final OkHttpClient okHttpClient, final HttpUrl baseEndpoint, final Spec spec) {
     this.okHttpClient = okHttpClient;
     this.baseEndpoint = baseEndpoint;
+    this.schemaDefinitionCache = new SchemaDefinitionCache(spec);
   }
 
   public Optional<GenesisData> getGenesis() {
     final GetGenesisRequest request = new GetGenesisRequest(okHttpClient, baseEndpoint);
     return request.getGenesisData();
+  }
+
+  public Optional<BeaconBlock> createUnsignedBlock(
+      final UInt64 slot,
+      final BLSSignature randaoReveal,
+      final Optional<Bytes32> graffiti,
+      final boolean blinded) {
+    final CreateBlockRequest createBlockRequest =
+        new CreateBlockRequest(baseEndpoint, okHttpClient, schemaDefinitionCache, slot, blinded);
+    return createBlockRequest.createUnsignedBlock(randaoReveal, graffiti);
   }
 }

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/handlers/CreateBlockRequest.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/handlers/CreateBlockRequest.java
@@ -33,9 +33,9 @@ import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
-import tech.pegasys.teku.spec.schemas.SchemaDefinitionCache;
 import tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod;
 import tech.pegasys.teku.validator.remote.typedef.ResponseHandler;
 
@@ -49,7 +49,7 @@ public class CreateBlockRequest extends AbstractTypeDefRequest {
   public CreateBlockRequest(
       final HttpUrl baseEndpoint,
       final OkHttpClient okHttpClient,
-      final SchemaDefinitionCache schemaDefinitionCache,
+      final Spec spec,
       final UInt64 slot,
       final boolean blinded) {
     super(baseEndpoint, okHttpClient);
@@ -57,11 +57,14 @@ public class CreateBlockRequest extends AbstractTypeDefRequest {
     this.slot = slot;
     this.unsignedBlockDefinition =
         blinded
-            ? schemaDefinitionCache
-                .atSlot(slot)
+            ? spec.atSlot(slot)
+                .getSchemaDefinitions()
                 .getBlindedBeaconBlockSchema()
                 .getJsonTypeDefinition()
-            : schemaDefinitionCache.atSlot(slot).getBeaconBlockSchema().getJsonTypeDefinition();
+            : spec.atSlot(slot)
+                .getSchemaDefinitions()
+                .getBeaconBlockSchema()
+                .getJsonTypeDefinition();
     this.getBlockResponseDefinition =
         DeserializableTypeDefinition.object(GetBlockResponse.class)
             .initializer(GetBlockResponse::new)

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/handlers/CreateBlockRequest.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/handlers/CreateBlockRequest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.remote.typedef.handlers;
+
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
+import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_UNSIGNED_BLINDED_BLOCK;
+import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_UNSIGNED_BLOCK_V2;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.api.response.v1.beacon.GetBlockResponse;
+import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.infrastructure.json.JsonUtil;
+import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionCache;
+import tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod;
+import tech.pegasys.teku.validator.remote.typedef.ResponseHandler;
+
+public class CreateBlockRequest extends AbstractTypeDefRequest {
+  private static final Logger LOG = LogManager.getLogger();
+  private final UInt64 slot;
+  private DeserializableTypeDefinition<GetBlockResponse> getBlockResponseDefinition;
+  private final DeserializableTypeDefinition<BeaconBlock> unsignedBlockDefinition;
+  private final ValidatorApiMethod apiMethod;
+
+  public CreateBlockRequest(
+      final HttpUrl baseEndpoint,
+      final OkHttpClient okHttpClient,
+      final SchemaDefinitionCache schemaDefinitionCache,
+      final UInt64 slot,
+      final boolean blinded) {
+    super(baseEndpoint, okHttpClient);
+    apiMethod = blinded ? GET_UNSIGNED_BLINDED_BLOCK : GET_UNSIGNED_BLOCK_V2;
+    this.slot = slot;
+    this.unsignedBlockDefinition =
+        blinded
+            ? schemaDefinitionCache
+                .atSlot(slot)
+                .getBlindedBeaconBlockSchema()
+                .getJsonTypeDefinition()
+            : schemaDefinitionCache.atSlot(slot).getBeaconBlockSchema().getJsonTypeDefinition();
+    this.getBlockResponseDefinition =
+        DeserializableTypeDefinition.object(GetBlockResponse.class)
+            .initializer(GetBlockResponse::new)
+            .withField(
+                "data",
+                unsignedBlockDefinition,
+                GetBlockResponse::getData,
+                GetBlockResponse::setData)
+            .withField(
+                "version",
+                DeserializableTypeDefinition.enumOf(SpecMilestone.class),
+                GetBlockResponse::getSpecMilestone,
+                GetBlockResponse::setSpecMilestone)
+            .build();
+  }
+
+  public Optional<BeaconBlock> createUnsignedBlock(
+      final BLSSignature randaoReveal, final Optional<Bytes32> graffiti) {
+    final Map<String, String> queryParams = new HashMap<>();
+    queryParams.put("randao_reveal", randaoReveal.toString());
+    graffiti.ifPresent(bytes32 -> queryParams.put("graffiti", bytes32.toHexString()));
+
+    return get(
+            apiMethod,
+            Map.of("slot", slot.toString()),
+            queryParams,
+            new ResponseHandler<>(getBlockResponseDefinition)
+                .withHandler(SC_OK, this::handleBeaconBlockResult))
+        .map(GetBlockResponse::getData);
+  }
+
+  private Optional<GetBlockResponse> handleBeaconBlockResult(
+      final Request request, final Response response) {
+    try {
+      return Optional.of(JsonUtil.parse(response.body().string(), getBlockResponseDefinition));
+    } catch (IOException e) {
+      LOG.trace("Failed to parse response object creating block");
+    }
+    return Optional.empty();
+  }
+
+  static class GetBlockResponse {
+    private BeaconBlock data;
+    private SpecMilestone specMilestone;
+
+    public GetBlockResponse() {}
+
+    public BeaconBlock getData() {
+      return data;
+    }
+
+    public void setData(final BeaconBlock data) {
+      this.data = data;
+    }
+
+    public SpecMilestone getSpecMilestone() {
+      return specMilestone;
+    }
+
+    public void setSpecMilestone(final SpecMilestone specMilestone) {
+      this.specMilestone = specMilestone;
+    }
+  }
+}

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
@@ -21,7 +21,6 @@ import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.refEq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -379,14 +378,9 @@ class RemoteValidatorApiHandlerTest {
     final BLSSignature blsSignature = dataStructureUtil.randomSignature();
     final Optional<Bytes32> graffiti = Optional.of(Bytes32.random());
 
-    final tech.pegasys.teku.api.schema.BLSSignature schemaBlsSignature =
-        new tech.pegasys.teku.api.schema.BLSSignature(blsSignature);
-    final tech.pegasys.teku.api.schema.BeaconBlock schemaBeaconBlock =
-        new tech.pegasys.teku.api.schema.phase0.BeaconBlockPhase0(beaconBlock);
-
-    when(apiClient.createUnsignedBlock(
-            eq(beaconBlock.getSlot()), refEq(schemaBlsSignature), eq(graffiti), eq(false)))
-        .thenReturn(Optional.of(schemaBeaconBlock));
+    when(typeDefClient.createUnsignedBlock(
+            eq(beaconBlock.getSlot()), eq(blsSignature), eq(graffiti), eq(false)))
+        .thenReturn(Optional.of(beaconBlock));
 
     SafeFuture<Optional<BeaconBlock>> future =
         apiHandler.createUnsignedBlock(UInt64.ONE, blsSignature, graffiti, false);


### PR DESCRIPTION
 - currently only returning JSON which is consistent with existing API.

 - we're back to using JsonUtil to decode, which required pulling in the infrastructure:json package.

 Continues to support blinded block requests.

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
