### PR TITLE
Improve responsibility separation between `ForkChoiceNotifier` and `ProposerDataManager`

### DIFF
--- a/beacon/validator/src/integrationTest/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerIntegrationTest.java
+++ b/beacon/validator/src/integrationTest/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerIntegrationTest.java
@@ -40,9 +40,8 @@ import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPool;
 import tech.pegasys.teku.statetransition.attestation.AttestationManager;
 import tech.pegasys.teku.statetransition.block.BlockImportChannel;
-import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceNotifier;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceTrigger;
-import tech.pegasys.teku.statetransition.forkchoice.StubForkChoiceNotifier;
+import tech.pegasys.teku.statetransition.forkchoice.ProposersDataManager;
 import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeContributionPool;
 import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeMessagePool;
 import tech.pegasys.teku.storage.client.ChainUpdater;
@@ -75,7 +74,7 @@ public class ValidatorApiHandlerIntegrationTest {
   private final BlockGossipChannel blockGossipChannel = mock(BlockGossipChannel.class);
   private final ChainDataProvider chainDataProvider = mock(ChainDataProvider.class);
   private final ForkChoiceTrigger forkChoiceTrigger = mock(ForkChoiceTrigger.class);
-  private final ForkChoiceNotifier forkChoiceNotifier = new StubForkChoiceNotifier();
+  private final ProposersDataManager proposersDataManager = mock(ProposersDataManager.class);
 
   private final ChainUpdater chainUpdater = storageSystem.chainUpdater();
   private final SyncCommitteeMessagePool syncCommitteeMessagePool =
@@ -100,7 +99,7 @@ public class ValidatorApiHandlerIntegrationTest {
           performanceTracker,
           spec,
           forkChoiceTrigger,
-          forkChoiceNotifier,
+          proposersDataManager,
           syncCommitteeMessagePool,
           syncCommitteeContributionPool,
           syncCommitteeSubscriptionManager);

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -70,8 +70,8 @@ import tech.pegasys.teku.spec.logic.common.util.SyncCommitteeUtil;
 import tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPool;
 import tech.pegasys.teku.statetransition.attestation.AttestationManager;
 import tech.pegasys.teku.statetransition.block.BlockImportChannel;
-import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceNotifier;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceTrigger;
+import tech.pegasys.teku.statetransition.forkchoice.ProposersDataManager;
 import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeContributionPool;
 import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeMessagePool;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
@@ -117,7 +117,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
   private final SyncCommitteeMessagePool syncCommitteeMessagePool;
   private final SyncCommitteeSubscriptionManager syncCommitteeSubscriptionManager;
   private final SyncCommitteeContributionPool syncCommitteeContributionPool;
-  private final ForkChoiceNotifier forkChoiceNotifier;
+  private final ProposersDataManager proposersDataManager;
 
   public ValidatorApiHandler(
       final ChainDataProvider chainDataProvider,
@@ -134,7 +134,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
       final PerformanceTracker performanceTracker,
       final Spec spec,
       final ForkChoiceTrigger forkChoiceTrigger,
-      final ForkChoiceNotifier forkChoiceNotifier,
+      final ProposersDataManager proposersDataManager,
       final SyncCommitteeMessagePool syncCommitteeMessagePool,
       final SyncCommitteeContributionPool syncCommitteeContributionPool,
       final SyncCommitteeSubscriptionManager syncCommitteeSubscriptionManager) {
@@ -155,7 +155,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
     this.syncCommitteeMessagePool = syncCommitteeMessagePool;
     this.syncCommitteeContributionPool = syncCommitteeContributionPool;
     this.syncCommitteeSubscriptionManager = syncCommitteeSubscriptionManager;
-    this.forkChoiceNotifier = forkChoiceNotifier;
+    this.proposersDataManager = proposersDataManager;
   }
 
   @Override
@@ -619,7 +619,8 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
   @Override
   public void prepareBeaconProposer(
       final Collection<BeaconPreparableProposer> beaconPreparableProposers) {
-    forkChoiceNotifier.onUpdatePreparableProposers(beaconPreparableProposers);
+    proposersDataManager.updatePreparedProposers(
+        beaconPreparableProposers, combinedChainDataClient.getCurrentSlot());
   }
 
   private Optional<SubmitDataError> fromInternalValidationResult(

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -79,9 +79,8 @@ import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPool;
 import tech.pegasys.teku.statetransition.attestation.AttestationManager;
 import tech.pegasys.teku.statetransition.block.BlockImportChannel;
-import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceNotifier;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceTrigger;
-import tech.pegasys.teku.statetransition.forkchoice.StubForkChoiceNotifier;
+import tech.pegasys.teku.statetransition.forkchoice.ProposersDataManager;
 import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeContributionPool;
 import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeMessagePool;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
@@ -123,7 +122,7 @@ class ValidatorApiHandlerTest {
   private final ChainDataProvider chainDataProvider = mock(ChainDataProvider.class);
   private final DutyMetrics dutyMetrics = mock(DutyMetrics.class);
   private final ForkChoiceTrigger forkChoiceTrigger = mock(ForkChoiceTrigger.class);
-  private final ForkChoiceNotifier forkChoiceNotifier = new StubForkChoiceNotifier();
+  private final ProposersDataManager proposersDataManager = mock(ProposersDataManager.class);
   private final SyncCommitteeMessagePool syncCommitteeMessagePool =
       mock(SyncCommitteeMessagePool.class);
   private final SyncCommitteeContributionPool syncCommitteeContributionPool =
@@ -147,7 +146,7 @@ class ValidatorApiHandlerTest {
           performanceTracker,
           spec,
           forkChoiceTrigger,
-          forkChoiceNotifier,
+          proposersDataManager,
           syncCommitteeMessagePool,
           syncCommitteeContributionPool,
           syncCommitteeSubscriptionManager);
@@ -397,7 +396,7 @@ class ValidatorApiHandlerTest {
             performanceTracker,
             spec,
             forkChoiceTrigger,
-            forkChoiceNotifier,
+            proposersDataManager,
             syncCommitteeMessagePool,
             syncCommitteeContributionPool,
             syncCommitteeSubscriptionManager);

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/AbstractDataBackedRestAPIIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/AbstractDataBackedRestAPIIntegrationTest.java
@@ -62,6 +62,7 @@ import tech.pegasys.teku.statetransition.attestation.AttestationManager;
 import tech.pegasys.teku.statetransition.block.BlockManager;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
 import tech.pegasys.teku.statetransition.forkchoice.MergeTransitionBlockValidator;
+import tech.pegasys.teku.statetransition.forkchoice.ProposersDataManager;
 import tech.pegasys.teku.statetransition.forkchoice.StubForkChoiceNotifier;
 import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeContributionPool;
 import tech.pegasys.teku.statetransition.validatorcache.ActiveValidatorCache;
@@ -110,6 +111,7 @@ public abstract class AbstractDataBackedRestAPIIntegrationTest {
   protected final OperationPool<SignedVoluntaryExit> voluntaryExitPool = mock(OperationPool.class);
   protected final SyncCommitteeContributionPool syncCommitteeContributionPool =
       mock(SyncCommitteeContributionPool.class);
+  protected final ProposersDataManager proposersDataManager = mock(ProposersDataManager.class);
 
   private StorageSystem storageSystem;
 
@@ -184,6 +186,7 @@ public abstract class AbstractDataBackedRestAPIIntegrationTest {
             .proposerSlashingPool(proposerSlashingPool)
             .voluntaryExitPool(voluntaryExitPool)
             .syncCommitteeContributionPool(syncCommitteeContributionPool)
+            .proposersDataManager(proposersDataManager)
             .build();
 
     beaconRestApi =

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/BeaconRestApiTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/BeaconRestApiTest.java
@@ -39,6 +39,7 @@ import tech.pegasys.teku.statetransition.OperationPool;
 import tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPool;
 import tech.pegasys.teku.statetransition.attestation.AttestationManager;
 import tech.pegasys.teku.statetransition.block.BlockManager;
+import tech.pegasys.teku.statetransition.forkchoice.ProposersDataManager;
 import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeContributionPool;
 import tech.pegasys.teku.statetransition.validatorcache.ActiveValidatorChannel;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
@@ -64,6 +65,7 @@ class BeaconRestApiTest {
   private final SyncCommitteeContributionPool syncCommitteeContributionPool =
       mock(SyncCommitteeContributionPool.class);
   private final ActiveValidatorChannel activeValidatorChannel = mock(ActiveValidatorChannel.class);
+  private final ProposersDataManager proposersDataManager = mock(ProposersDataManager.class);
 
   @BeforeEach
   public void setup() {
@@ -92,6 +94,7 @@ class BeaconRestApiTest {
             .proposerSlashingPool(proposerSlashingPool)
             .voluntaryExitPool(voluntaryExitPool)
             .syncCommitteeContributionPool(syncCommitteeContributionPool)
+            .proposersDataManager(proposersDataManager)
             .build();
     new BeaconRestApi(
         dataProvider,

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/BeaconRestApiV1Test.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/BeaconRestApiV1Test.java
@@ -96,6 +96,7 @@ import tech.pegasys.teku.statetransition.OperationPool;
 import tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPool;
 import tech.pegasys.teku.statetransition.attestation.AttestationManager;
 import tech.pegasys.teku.statetransition.block.BlockManager;
+import tech.pegasys.teku.statetransition.forkchoice.ProposersDataManager;
 import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeContributionPool;
 import tech.pegasys.teku.statetransition.validatorcache.ActiveValidatorChannel;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
@@ -121,6 +122,7 @@ public class BeaconRestApiV1Test {
   private final ActiveValidatorChannel activeValidatorChannel = mock(ActiveValidatorChannel.class);
   private final SyncCommitteeContributionPool syncCommitteeContributionPool =
       mock(SyncCommitteeContributionPool.class);
+  private final ProposersDataManager proposersDataManager = mock(ProposersDataManager.class);
 
   @BeforeEach
   public void setup() {
@@ -150,6 +152,7 @@ public class BeaconRestApiV1Test {
             .proposerSlashingPool(proposerSlashingPool)
             .voluntaryExitPool(voluntaryExitPool)
             .syncCommitteeContributionPool(syncCommitteeContributionPool)
+            .proposersDataManager(proposersDataManager)
             .build();
     new BeaconRestApi(
         dataProvider,

--- a/data/provider/src/main/java/tech/pegasys/teku/api/DataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/DataProvider.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.api;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import java.util.Optional;
 import tech.pegasys.teku.beacon.sync.SyncService;
 import tech.pegasys.teku.networking.eth2.Eth2P2PNetwork;
 import tech.pegasys.teku.spec.Spec;
@@ -99,7 +98,7 @@ public class DataProvider {
     private OperationPool<ProposerSlashing> proposerSlashingPool;
     private OperationPool<SignedVoluntaryExit> voluntaryExitPool;
     private SyncCommitteeContributionPool syncCommitteeContributionPool;
-    private Optional<ProposersDataManager> proposersDataManager = Optional.empty();
+    private ProposersDataManager proposersDataManager;
 
     private boolean isLivenessTrackingEnabled = true;
 
@@ -176,7 +175,7 @@ public class DataProvider {
       return this;
     }
 
-    public Builder proposersDataManager(final Optional<ProposersDataManager> proposersDataManager) {
+    public Builder proposersDataManager(final ProposersDataManager proposersDataManager) {
       this.proposersDataManager = proposersDataManager;
       return this;
     }

--- a/data/provider/src/main/java/tech/pegasys/teku/api/NodeDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/NodeDataProvider.java
@@ -58,7 +58,7 @@ public class NodeDataProvider {
   private final AttestationManager attestationManager;
   private final ActiveValidatorChannel activeValidatorChannel;
   private final boolean isLivenessTrackingEnabled;
-  private final Optional<ProposersDataManager> proposersDataManager;
+  private final ProposersDataManager proposersDataManager;
 
   public NodeDataProvider(
       final Spec spec,
@@ -74,7 +74,7 @@ public class NodeDataProvider {
       final AttestationManager attestationManager,
       final boolean isLivenessTrackingEnabled,
       final ActiveValidatorChannel activeValidatorChannel,
-      final Optional<ProposersDataManager> proposersDataManager) {
+      final ProposersDataManager proposersDataManager) {
     this.spec = spec;
     this.attestationPool = attestationPool;
     this.attesterSlashingPool = attesterSlashingsPool;
@@ -185,12 +185,10 @@ public class NodeDataProvider {
   }
 
   public Map<String, Object> getProposersData() {
-    return proposersDataManager.map(ProposersDataManager::getData).orElse(Map.of());
+    return proposersDataManager.getData();
   }
 
   public boolean isProposerDefaultFeeRecipientDefined() {
-    return proposersDataManager
-        .map(ProposersDataManager::isProposerDefaultFeeRecipientDefined)
-        .orElse(false);
+    return proposersDataManager.isProposerDefaultFeeRecipientDefined();
   }
 }

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -1130,6 +1130,10 @@ public final class DataStructureUtil {
   }
 
   public SignedValidatorRegistrationV1 randomValidatorRegistration() {
+    return randomValidatorRegistration(randomPublicKey());
+  }
+
+  public SignedValidatorRegistrationV1 randomValidatorRegistration(final BLSPublicKey publicKey) {
     SignedValidatorRegistrationV1Schema signedSchema =
         spec.getGenesisSpec()
             .getSchemaDefinitions()
@@ -1144,7 +1148,7 @@ public final class DataStructureUtil {
             .getValidatorRegistrationSchema();
 
     ValidatorRegistrationV1 validatorRegistration =
-        schema.create(randomBytes20(), randomUInt64(), randomUInt64(), randomPublicKey());
+        schema.create(randomBytes20(), randomUInt64(), randomUInt64(), publicKey);
 
     return signedSchema.create(validatorRegistration, randomSignature());
   }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifier.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifier.java
@@ -13,18 +13,14 @@
 
 package tech.pegasys.teku.statetransition.forkchoice;
 
-import java.util.Collection;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
-import tech.pegasys.teku.spec.datastructures.operations.versions.bellatrix.BeaconPreparableProposer;
 import tech.pegasys.teku.spec.executionlayer.ForkChoiceState;
 
 public interface ForkChoiceNotifier {
-  void onUpdatePreparableProposers(Collection<BeaconPreparableProposer> proposers);
-
   void onForkChoiceUpdated(ForkChoiceState forkChoiceState);
 
   void onAttestationsDue(UInt64 slot);
@@ -35,8 +31,6 @@ public interface ForkChoiceNotifier {
       Bytes32 parentBeaconBlockRoot, UInt64 blockSlot);
 
   void onTerminalBlockReached(Bytes32 executionBlockHash);
-
-  ProposersDataManager getProposersDataManager();
 
   long subscribeToForkChoiceUpdatedResult(ForkChoiceUpdatedResultSubscriber subscriber);
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierImpl.java
@@ -101,12 +101,12 @@ public class ForkChoiceNotifierImpl implements ForkChoiceNotifier, ProposersData
   }
 
   @Override
-  public void onPreparedProposersUpdated(Optional<Void> emptyEvent) {
+  public void onPreparedProposersUpdated() {
     eventThread.execute(this::internalUpdatePreparableProposers);
   }
 
   @Override
-  public void onValidatorRegistrationsUpdated(Optional<Void> emptyEvent) {}
+  public void onValidatorRegistrationsUpdated() {}
 
   private void internalTerminalBlockReached(Bytes32 executionBlockHash) {
     eventThread.checkOnEventThread();

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ProposersDataManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ProposersDataManager.java
@@ -88,8 +88,7 @@ public class ProposersDataManager {
           new PreparedProposerInfo(expirySlot, proposer.getFeeRecipient()));
     }
 
-    subscribers.deliver(
-        ProposersDataManagerSubscriber::onPreparedProposersUpdated, Optional.empty());
+    subscribers.deliver(ProposersDataManagerSubscriber::onPreparedProposersUpdated);
   }
 
   public SafeFuture<Void> updateValidatorRegistrations(
@@ -125,9 +124,7 @@ public class ProposersDataManager {
                                   LOG.warn(
                                       "validator public key not found: {}",
                                       validatorRegistration.getMessage().getPublicKey())));
-              subscribers.deliver(
-                  ProposersDataManagerSubscriber::onValidatorRegistrationsUpdated,
-                  Optional.empty());
+              subscribers.deliver(ProposersDataManagerSubscriber::onValidatorRegistrationsUpdated);
             });
   }
 
@@ -280,8 +277,8 @@ public class ProposersDataManager {
   }
 
   public static interface ProposersDataManagerSubscriber {
-    void onPreparedProposersUpdated(Optional<Void> emptyEvent);
+    void onPreparedProposersUpdated();
 
-    void onValidatorRegistrationsUpdated(Optional<Void> emptyEvent);
+    void onValidatorRegistrationsUpdated();
   }
 }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
@@ -36,6 +36,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.invocation.InvocationOnMock;
 import tech.pegasys.teku.core.ChainBuilder;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.async.SafeFutureAssert;
 import tech.pegasys.teku.infrastructure.async.eventthread.InlineEventThread;
 import tech.pegasys.teku.infrastructure.bytes.Bytes8;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -832,8 +833,9 @@ class ForkChoiceNotifierTest {
     }
     validatorRegistration.ifPresent(
         signedValidatorRegistrationV1 ->
-            proposersDataManager.updateValidatorRegistrations(
-                List.of(signedValidatorRegistrationV1), recentChainData.getHeadSlot()));
+            SafeFutureAssert.safeJoin(
+                proposersDataManager.updateValidatorRegistrations(
+                    List.of(signedValidatorRegistrationV1), recentChainData.getHeadSlot())));
     return payloadBuildingAttributes;
   }
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
@@ -45,6 +45,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.eth1.Eth1Address;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
+import tech.pegasys.teku.spec.datastructures.execution.SignedValidatorRegistrationV1;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
 import tech.pegasys.teku.spec.datastructures.operations.versions.bellatrix.BeaconPreparableProposer;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
@@ -182,10 +183,11 @@ class ForkChoiceNotifierTest {
     final UInt64 blockSlot = headState.getSlot().plus(1);
 
     final int notTheNextProposer = spec.getBeaconProposerIndex(headState, blockSlot) + 1;
-    notifier.onUpdatePreparableProposers(
+    proposersDataManager.updatePreparedProposers(
         List.of(
             new BeaconPreparableProposer(
-                UInt64.valueOf(notTheNextProposer), dataStructureUtil.randomEth1Address())));
+                UInt64.valueOf(notTheNextProposer), dataStructureUtil.randomEth1Address())),
+        recentChainData.getHeadSlot());
 
     notifyForkChoiceUpdated(forkChoiceState);
     verify(executionLayerChannel).engineForkChoiceUpdated(forkChoiceState, Optional.empty());
@@ -319,7 +321,8 @@ class ForkChoiceNotifierTest {
             headState,
             blockSlot,
             false,
-            Optional.of(payloadBuildingAttributesArr.get(1).getFeeRecipient()));
+            Optional.of(payloadBuildingAttributesArr.get(1).getFeeRecipient()),
+            Optional.empty());
     final ForkChoiceState forkChoiceStateSlot3 = getCurrentForkChoiceState();
 
     // store real payload attributes and return an incomplete future
@@ -435,7 +438,7 @@ class ForkChoiceNotifierTest {
   }
 
   @Test
-  void onUpdatePreparableProposers_shouldNotIncludePayloadBuildingAttributesWhileSyncing() {
+  void onPreparedProposersUpdated_shouldNotIncludePayloadBuildingAttributesWhileSyncing() {
     final ForkChoiceState forkChoiceState = getCurrentForkChoiceState();
     notifyForkChoiceUpdated(forkChoiceState);
     verify(executionLayerChannel).engineForkChoiceUpdated(forkChoiceState, Optional.empty());
@@ -448,7 +451,7 @@ class ForkChoiceNotifierTest {
   }
 
   @Test
-  void onUpdatePreparableProposers_shouldSendNewNotificationWhenProposerAdded() {
+  void onPreparedProposersUpdated_shouldSendNewNotificationWhenProposerAdded() {
     final ForkChoiceState forkChoiceState = getCurrentForkChoiceState();
     final BeaconState headState = getHeadState();
     final UInt64 blockSlot = headState.getSlot().plus(1);
@@ -471,6 +474,42 @@ class ForkChoiceNotifierTest {
     final UInt64 blockSlot = headState.getSlot().plus(1);
     final PayloadBuildingAttributes payloadBuildingAttributes =
         withProposerForSlot(headState, blockSlot);
+
+    final SafeFuture<ForkChoiceUpdatedResult> responseFuture = new SafeFuture<>();
+    when(executionLayerChannel.engineForkChoiceUpdated(
+            forkChoiceState, Optional.of(payloadBuildingAttributes)))
+        .thenReturn(responseFuture);
+
+    notifyForkChoiceUpdated(forkChoiceState);
+
+    // Initially has no payload ID.
+    assertThatSafeFuture(notifier.getPayloadId(blockRoot, blockSlot)).isNotCompleted();
+
+    // But becomes available once we receive the response
+    final ExecutionPayloadContext executionPayloadContext =
+        new ExecutionPayloadContext(payloadId, forkChoiceState, payloadBuildingAttributes);
+    responseFuture.complete(
+        createForkChoiceUpdatedResult(ExecutionPayloadStatus.VALID, Optional.of(payloadId)));
+    assertThatSafeFuture(notifier.getPayloadId(blockRoot, blockSlot))
+        .isCompletedWithOptionalContaining(executionPayloadContext);
+  }
+
+  @Test
+  void getPayloadId_shouldReturnLatestPayloadIdWithValidatorRegistration() {
+    final Bytes8 payloadId = dataStructureUtil.randomBytes8();
+    final ForkChoiceState forkChoiceState = getCurrentForkChoiceState();
+    final BeaconState headState = getHeadState();
+    final Bytes32 blockRoot = recentChainData.getBestBlockRoot().orElseThrow();
+    final UInt64 blockSlot = headState.getSlot().plus(1);
+    final PayloadBuildingAttributes payloadBuildingAttributes =
+        withProposerForSlot(
+            headState,
+            blockSlot,
+            true,
+            Optional.empty(),
+            Optional.of(createValidatorRegistration(headState, blockSlot)));
+
+    assertThat(payloadBuildingAttributes.getValidatorRegistration()).isNotEmpty();
 
     final SafeFuture<ForkChoiceUpdatedResult> responseFuture = new SafeFuture<>();
     when(executionLayerChannel.engineForkChoiceUpdated(
@@ -766,28 +805,35 @@ class ForkChoiceNotifierTest {
       final BeaconState headState,
       final UInt64 blockSlot,
       final Optional<Eth1Address> overrideFeeRecipient) {
-    return withProposerForSlot(headState, blockSlot, false, overrideFeeRecipient);
+    return withProposerForSlot(headState, blockSlot, false, overrideFeeRecipient, Optional.empty());
   }
 
   private PayloadBuildingAttributes withProposerForSlot(
       final BeaconState headState, final UInt64 blockSlot) {
-    return withProposerForSlot(headState, blockSlot, true, Optional.empty());
+    return withProposerForSlot(headState, blockSlot, true, Optional.empty(), Optional.empty());
   }
 
   private PayloadBuildingAttributes withProposerForSlot(
       final BeaconState headState,
       final UInt64 blockSlot,
       final boolean doPrepare,
-      final Optional<Eth1Address> overrideFeeRecipient) {
+      final Optional<Eth1Address> overrideFeeRecipient,
+      final Optional<SignedValidatorRegistrationV1> validatorRegistration) {
     final int block2Proposer = spec.getBeaconProposerIndex(headState, blockSlot);
     final PayloadBuildingAttributes payloadBuildingAttributes =
-        getExpectedPayloadBuildingAttributes(headState, blockSlot, overrideFeeRecipient);
+        getExpectedPayloadBuildingAttributes(
+            headState, blockSlot, overrideFeeRecipient, validatorRegistration);
     if (doPrepare) {
-      notifier.onUpdatePreparableProposers(
+      proposersDataManager.updatePreparedProposers(
           List.of(
               new BeaconPreparableProposer(
-                  UInt64.valueOf(block2Proposer), payloadBuildingAttributes.getFeeRecipient())));
+                  UInt64.valueOf(block2Proposer), payloadBuildingAttributes.getFeeRecipient())),
+          recentChainData.getHeadSlot());
     }
+    validatorRegistration.ifPresent(
+        signedValidatorRegistrationV1 ->
+            proposersDataManager.updateValidatorRegistrations(
+                List.of(signedValidatorRegistrationV1), recentChainData.getHeadSlot()));
     return payloadBuildingAttributes;
   }
 
@@ -796,32 +842,36 @@ class ForkChoiceNotifierTest {
     final int block2Proposer1 = spec.getBeaconProposerIndex(headState, blockSlot1);
     final int block2Proposer2 = spec.getBeaconProposerIndex(headState, blockSlot2);
     final PayloadBuildingAttributes payloadBuildingAttributes1 =
-        getExpectedPayloadBuildingAttributes(headState, blockSlot1, Optional.empty());
+        getExpectedPayloadBuildingAttributes(
+            headState, blockSlot1, Optional.empty(), Optional.empty());
     final PayloadBuildingAttributes payloadBuildingAttributes2 =
-        getExpectedPayloadBuildingAttributes(headState, blockSlot2, Optional.empty());
+        getExpectedPayloadBuildingAttributes(
+            headState, blockSlot2, Optional.empty(), Optional.empty());
 
     if (block2Proposer1 == block2Proposer2) {
       throw new UnsupportedOperationException(
           "unsupported test scenario: with same proposer for different slots");
     }
-    notifier.onUpdatePreparableProposers(
+    proposersDataManager.updatePreparedProposers(
         List.of(
             new BeaconPreparableProposer(
                 UInt64.valueOf(block2Proposer1), payloadBuildingAttributes1.getFeeRecipient()),
             new BeaconPreparableProposer(
-                UInt64.valueOf(block2Proposer2), payloadBuildingAttributes2.getFeeRecipient())));
+                UInt64.valueOf(block2Proposer2), payloadBuildingAttributes2.getFeeRecipient())),
+        recentChainData.getHeadSlot());
     return List.of(payloadBuildingAttributes1, payloadBuildingAttributes2);
   }
 
   private PayloadBuildingAttributes getExpectedPayloadBuildingAttributes(
       final BeaconState headState,
       final UInt64 blockSlot,
-      final Optional<Eth1Address> overrideFeeRecipient) {
+      final Optional<Eth1Address> overrideFeeRecipient,
+      final Optional<SignedValidatorRegistrationV1> validatorRegistration) {
     final Eth1Address feeRecipient =
         overrideFeeRecipient.orElse(dataStructureUtil.randomEth1Address());
     final UInt64 timestamp = spec.computeTimeAtSlot(headState, blockSlot);
     final Bytes32 random = spec.getRandaoMix(headState, UInt64.ZERO);
-    return new PayloadBuildingAttributes(timestamp, random, feeRecipient, Optional.empty());
+    return new PayloadBuildingAttributes(timestamp, random, feeRecipient, validatorRegistration);
   }
 
   private ForkChoiceState getCurrentForkChoiceState() {
@@ -840,6 +890,13 @@ class ForkChoiceNotifierTest {
         headExecutionHash,
         finalizedExecutionHash,
         false);
+  }
+
+  private SignedValidatorRegistrationV1 createValidatorRegistration(
+      final BeaconState headState, final UInt64 blockSlot) {
+    final int block2Proposer = spec.getBeaconProposerIndex(headState, blockSlot);
+    return dataStructureUtil.randomValidatorRegistration(
+        spec.getValidatorPubKey(headState, UInt64.valueOf(block2Proposer)).orElseThrow());
   }
 
   private ForkChoiceUpdatedResult createForkChoiceUpdatedResult(

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/forkchoice/StubForkChoiceNotifier.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/forkchoice/StubForkChoiceNotifier.java
@@ -13,14 +13,12 @@
 
 package tech.pegasys.teku.statetransition.forkchoice;
 
-import java.util.Collection;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.subscribers.Subscribers;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
-import tech.pegasys.teku.spec.datastructures.operations.versions.bellatrix.BeaconPreparableProposer;
 import tech.pegasys.teku.spec.executionlayer.ForkChoiceState;
 import tech.pegasys.teku.spec.executionlayer.ForkChoiceUpdatedResult;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceUpdatedResultSubscriber.ForkChoiceUpdatedResultNotification;
@@ -48,9 +46,6 @@ public class StubForkChoiceNotifier implements ForkChoiceNotifier {
   }
 
   @Override
-  public void onUpdatePreparableProposers(Collection<BeaconPreparableProposer> proposers) {}
-
-  @Override
   public void onForkChoiceUpdated(ForkChoiceState forkChoiceState) {
     subscribers.deliver(
         ForkChoiceUpdatedResultSubscriber::onForkChoiceUpdatedResult,
@@ -72,9 +67,4 @@ public class StubForkChoiceNotifier implements ForkChoiceNotifier {
 
   @Override
   public void onTerminalBlockReached(Bytes32 executionBlockHash) {}
-
-  @Override
-  public ProposersDataManager getProposersDataManager() {
-    return null;
-  }
 }

--- a/infrastructure/subscribers/src/main/java/tech/pegasys/teku/infrastructure/subscribers/Subscribers.java
+++ b/infrastructure/subscribers/src/main/java/tech/pegasys/teku/infrastructure/subscribers/Subscribers.java
@@ -118,6 +118,15 @@ public class Subscribers<T> {
   }
 
   /**
+   * Deliver an event to each subscriber by calling eventMethod.
+   *
+   * @param eventMethod the method to call
+   */
+  public void deliver(final Consumer<T> eventMethod) {
+    forEach(eventMethod);
+  }
+
+  /**
    * Get the current subscriber count.
    *
    * @return the current number of subscribers.

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -97,6 +97,7 @@ import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceNotifierImpl;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceTrigger;
 import tech.pegasys.teku.statetransition.forkchoice.MergeTransitionBlockValidator;
 import tech.pegasys.teku.statetransition.forkchoice.MergeTransitionConfigCheck;
+import tech.pegasys.teku.statetransition.forkchoice.ProposersDataManager;
 import tech.pegasys.teku.statetransition.forkchoice.TerminalPowBlockMonitor;
 import tech.pegasys.teku.statetransition.genesis.GenesisHandler;
 import tech.pegasys.teku.statetransition.synccommittee.SignedContributionAndProofValidator;
@@ -204,6 +205,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
   protected volatile Optional<TerminalPowBlockMonitor> terminalPowBlockMonitor = Optional.empty();
   protected volatile Optional<MergeTransitionConfigCheck> mergeTransitionConfigCheck =
       Optional.empty();
+  protected volatile ProposersDataManager proposersDataManager;
 
   protected UInt64 genesisTimeTracker = ZERO;
   protected BlockManager blockManager;
@@ -597,7 +599,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
             performanceTracker,
             spec,
             forkChoiceTrigger,
-            forkChoiceNotifier,
+            proposersDataManager,
             syncCommitteeMessagePool,
             syncCommitteeContributionPool,
             syncCommitteeSubscriptionManager);
@@ -812,7 +814,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
             .proposerSlashingPool(proposerSlashingPool)
             .voluntaryExitPool(voluntaryExitPool)
             .syncCommitteeContributionPool(syncCommitteeContributionPool)
-            .proposersDataManager(Optional.of(forkChoiceNotifier.getProposersDataManager()))
+            .proposersDataManager(proposersDataManager)
             .build();
 
     if (beaconConfig.beaconRestApiConfig().isRestApiEnabled()) {
@@ -950,13 +952,15 @@ public class BeaconChainController extends Service implements BeaconChainControl
 
   protected void initForkChoiceNotifier() {
     LOG.debug("BeaconChainController.initForkChoiceNotifier()");
+    final AsyncRunnerEventThread eventThread =
+        new AsyncRunnerEventThread("forkChoiceNotifier", asyncRunnerFactory);
+    eventThread.start();
+    proposersDataManager =
+        new ProposersDataManager(
+            spec, eventThread, recentChainData, getProposerDefaultFeeRecipient());
     forkChoiceNotifier =
-        ForkChoiceNotifierImpl.create(
-            asyncRunnerFactory,
-            spec,
-            executionLayer,
-            recentChainData,
-            getProposerDefaultFeeRecipient());
+        new ForkChoiceNotifierImpl(
+            eventThread, spec, executionLayer, recentChainData, proposersDataManager);
   }
 
   private Optional<Eth1Address> getProposerDefaultFeeRecipient() {


### PR DESCRIPTION
- `ValidatorApiHandler` now depends on `ProposerDataManager` instead of `ForkChoiceNotifier` to serve beacon `prepare_proposer` and `register_validator` apis.
- `ProposerDataManager` will notify `ForkChoiceNotifier` that data has changed
- adds `ForkChoiceNotifier` unit test to cover validator registration data

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
