### PR TITLE
[Merge] allow interop genesis creation with execution payload header

### DIFF
--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/auth/JwtSecretKeyLoader.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/auth/JwtSecretKeyLoader.java
@@ -59,6 +59,9 @@ public class JwtSecretKeyLoader {
   private void writeGeneratedKeyToFile(final Key key) {
     final Path generatedKeyFilePath = beaconDataDirectory.resolve(JWT_SECRET_FILE_NAME);
     try {
+      if (!beaconDataDirectory.toFile().mkdirs() && !beaconDataDirectory.toFile().isDirectory()) {
+        throw new IOException("Unable to create directory " + beaconDataDirectory);
+      }
       Files.writeString(generatedKeyFilePath, Bytes.wrap(key.getEncoded()).toHexString());
       LOG.info(
           "New execution engine JWT secret generated in {}", generatedKeyFilePath.toAbsolutePath());

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/ExecutionWeb3jClientProvider.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/ExecutionWeb3jClientProvider.java
@@ -51,12 +51,13 @@ public interface ExecutionWeb3jClientProvider {
       final TimeProvider timeProvider,
       final Duration timeout,
       final Optional<String> jwtSecretFile,
+      final boolean jwtSupported,
       final Path beaconDataDirectory) {
     if (endpoint.equals(STUB_ENDPOINT_IDENTIFIER)) {
       return STUB;
     } else {
       return new DefaultExecutionWeb3jClientProvider(
-          endpoint, timeProvider, timeout, jwtSecretFile, beaconDataDirectory);
+          endpoint, timeProvider, timeout, jwtSecretFile, jwtSupported, beaconDataDirectory);
     }
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -17,8 +17,11 @@ import static com.google.common.base.Preconditions.checkState;
 import static tech.pegasys.teku.infrastructure.time.TimeUtilities.millisToSeconds;
 import static tech.pegasys.teku.infrastructure.time.TimeUtilities.secondsToMillis;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
 import it.unimi.dsi.fastutil.ints.IntList;
+import java.io.File;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -270,6 +273,19 @@ public class Spec {
         .getSchemaDefinitions()
         .getBeaconBlockSchema()
         .sszDeserialize(serializedState);
+  }
+
+  public ExecutionPayloadHeader deserializeJsonExecutionPayloadHeader(
+      final ObjectMapper objectMapper, final File jsonFile, final UInt64 slot) throws IOException {
+    return atSlot(slot)
+        .getSchemaDefinitions()
+        .toVersionBellatrix()
+        .orElseThrow(
+            () ->
+                new RuntimeException(
+                    "Bellatrix milestone is required to load execution payload header"))
+        .getExecutionPayloadHeaderSchema()
+        .jsonDeserialize(objectMapper.createParser(jsonFile));
   }
 
   // BeaconState

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/interop/InteropStartupUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/interop/InteropStartupUtil.java
@@ -18,6 +18,7 @@ import java.util.Optional;
 import tech.pegasys.teku.bls.BLSKeyPair;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
 import tech.pegasys.teku.spec.datastructures.operations.DepositData;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.util.DepositGenerator;
@@ -25,27 +26,40 @@ import tech.pegasys.teku.spec.datastructures.util.DepositGenerator;
 public final class InteropStartupUtil {
 
   public static BeaconState createMockedStartInitialBeaconState(
-      final Spec spec, final long genesisTime, final int numValidators) {
+      final Spec spec,
+      final long genesisTime,
+      final int numValidators,
+      final Optional<ExecutionPayloadHeader> payloadHeader) {
     final List<BLSKeyPair> validatorKeys =
         new MockStartValidatorKeyPairFactory().generateKeyPairs(0, numValidators);
-    return createMockedStartInitialBeaconState(spec, genesisTime, validatorKeys, true);
+    return createMockedStartInitialBeaconState(
+        spec, genesisTime, validatorKeys, true, payloadHeader);
   }
 
   public static BeaconState createMockedStartInitialBeaconState(
-      final Spec spec, final long genesisTime, List<BLSKeyPair> validatorKeys) {
+      final Spec spec, final long genesisTime, final List<BLSKeyPair> validatorKeys) {
     return createMockedStartInitialBeaconState(spec, genesisTime, validatorKeys, true);
   }
 
   public static BeaconState createMockedStartInitialBeaconState(
       final Spec spec,
       final long genesisTime,
-      List<BLSKeyPair> validatorKeys,
-      boolean signDeposits) {
+      final List<BLSKeyPair> validatorKeys,
+      final boolean signDeposits) {
+    return createMockedStartInitialBeaconState(
+        spec, genesisTime, validatorKeys, signDeposits, Optional.empty());
+  }
+
+  public static BeaconState createMockedStartInitialBeaconState(
+      final Spec spec,
+      final long genesisTime,
+      final List<BLSKeyPair> validatorKeys,
+      final boolean signDeposits,
+      final Optional<ExecutionPayloadHeader> payloadHeader) {
     final List<DepositData> initialDepositData =
         new MockStartDepositGenerator(spec, new DepositGenerator(spec, signDeposits))
             .createDeposits(validatorKeys);
     return new MockStartBeaconStateGenerator(spec)
-        .createInitialBeaconState(
-            UInt64.valueOf(genesisTime), initialDepositData, Optional.empty());
+        .createInitialBeaconState(UInt64.valueOf(genesisTime), initialDepositData, payloadHeader);
   }
 }

--- a/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerService.java
+++ b/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerService.java
@@ -48,6 +48,7 @@ public class ExecutionLayerService extends Service {
             serviceConfig.getTimeProvider(),
             EL_ENGINE_BLOCK_EXECUTION_TIMEOUT,
             config.getEngineJwtSecretFile(),
+            true,
             serviceConfig.getDataDirLayout().getBeaconDataDirectory());
 
     final Optional<ExecutionWeb3jClientProvider> builderWeb3jClientProvider =
@@ -60,6 +61,7 @@ public class ExecutionLayerService extends Service {
                         serviceConfig.getTimeProvider(),
                         EL_ENGINE_BLOCK_EXECUTION_TIMEOUT,
                         Optional.empty(),
+                        false,
                         serviceConfig.getDataDirLayout().getBeaconDataDirectory()));
 
     final boolean builderIsStub =

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/InteropOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/InteropOptions.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.teku.cli.options;
 
+import com.google.common.base.Strings;
+import java.nio.file.Path;
 import picocli.CommandLine.Help.Visibility;
 import picocli.CommandLine.Option;
 import tech.pegasys.teku.config.TekuConfiguration;
@@ -27,6 +29,14 @@ public class InteropOptions {
       description = "Time of mocked genesis",
       arity = "1")
   private int interopGenesisTime = InteropConfig.DEFAULT_INTEROP_GENESIS_TIME;
+
+  @Option(
+      hidden = true,
+      names = {"--Xinterop-genesis-payload-header"},
+      paramLabel = "<FILE>",
+      description = "Payload header to be included in the mocked genesis",
+      arity = "0..1")
+  private String interopGenesisPayloadHeader = null;
 
   @Option(
       hidden = true,
@@ -66,9 +76,17 @@ public class InteropOptions {
         interopBuilder ->
             interopBuilder
                 .interopGenesisTime(interopGenesisTime)
+                .interopGenesisPayloadHeader(convertToPath(interopGenesisPayloadHeader))
                 .interopOwnedValidatorStartIndex(interopOwnerValidatorStartIndex)
                 .interopOwnedValidatorCount(interopOwnerValidatorCount)
                 .interopNumberOfValidators(interopNumberOfValidators)
                 .interopEnabled(interopEnabled));
+  }
+
+  private Path convertToPath(final String option) {
+    if (Strings.isNullOrEmpty(option)) {
+      return null;
+    }
+    return Path.of(option);
   }
 }

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/InteropConfig.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/InteropConfig.java
@@ -15,6 +15,8 @@ package tech.pegasys.teku.validator.api;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import java.nio.file.Path;
+import java.util.Optional;
 import tech.pegasys.teku.infrastructure.exceptions.InvalidConfigurationException;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.config.SpecConfig;
@@ -25,6 +27,7 @@ public class InteropConfig {
   public static final int DEFAULT_INTEROP_NUMBER_OF_VALIDATORS = 64;
 
   private final Integer interopGenesisTime;
+  private final Optional<Path> interopGenesisPayloadHeader;
   private final int interopOwnedValidatorStartIndex;
   private final int interopOwnedValidatorCount;
   private final int interopNumberOfValidators;
@@ -32,11 +35,13 @@ public class InteropConfig {
 
   private InteropConfig(
       final Integer interopGenesisTime,
+      final Optional<Path> interopGenesisPayloadHeader,
       final int interopOwnedValidatorStartIndex,
       final int interopOwnedValidatorCount,
       final int interopNumberOfValidators,
       final boolean interopEnabled) {
     this.interopGenesisTime = interopGenesisTime;
+    this.interopGenesisPayloadHeader = interopGenesisPayloadHeader;
     this.interopOwnedValidatorStartIndex = interopOwnedValidatorStartIndex;
     this.interopOwnedValidatorCount = interopOwnedValidatorCount;
     this.interopNumberOfValidators = interopNumberOfValidators;
@@ -49,6 +54,10 @@ public class InteropConfig {
 
   public Integer getInteropGenesisTime() {
     return interopGenesisTime;
+  }
+
+  public Optional<Path> getInteropGenesisPayloadHeader() {
+    return interopGenesisPayloadHeader;
   }
 
   public int getInteropOwnedValidatorStartIndex() {
@@ -70,6 +79,7 @@ public class InteropConfig {
   public static final class InteropConfigBuilder {
 
     private Integer interopGenesisTime = DEFAULT_INTEROP_GENESIS_TIME;
+    private Optional<Path> interopGenesisPayloadHeader = Optional.empty();
     private int interopOwnedValidatorStartIndex;
     private int interopOwnedValidatorCount;
     private int interopNumberOfValidators = DEFAULT_INTEROP_NUMBER_OF_VALIDATORS;
@@ -84,6 +94,12 @@ public class InteropConfig {
             String.format("Invalid interopGenesisTime: %d", interopGenesisTime));
       }
       this.interopGenesisTime = interopGenesisTime;
+      return this;
+    }
+
+    public InteropConfigBuilder interopGenesisPayloadHeader(
+        final Path interopGenesisPayloadHeader) {
+      this.interopGenesisPayloadHeader = Optional.ofNullable(interopGenesisPayloadHeader);
       return this;
     }
 
@@ -131,6 +147,7 @@ public class InteropConfig {
       validate();
       return new InteropConfig(
           interopGenesisTime,
+          interopGenesisPayloadHeader,
           interopOwnedValidatorStartIndex,
           interopOwnedValidatorCount,
           interopNumberOfValidators,


### PR DESCRIPTION
- introduces a new `--Xinterop-genesis-payload-header` for now it assumes a json file, which is convenient for quick adjustment. The header will be used to generate the genesis state.

- allows `DefaultExecutionWeb3jClientProvider` to not support jwt

- fixes jwt file generation when beaconDataDirectory do not exist

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
