### PR TITLE
Serialize JSON directly to response output stream

### DIFF
--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/AbstractMigratedBeaconHandlerTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/AbstractMigratedBeaconHandlerTest.java
@@ -13,27 +13,15 @@
 
 package tech.pegasys.teku.beaconrestapi;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 
-import io.javalin.http.Context;
-import java.io.ByteArrayInputStream;
-import java.nio.charset.StandardCharsets;
-import java.util.concurrent.ExecutionException;
-import org.assertj.core.api.AssertionsForClassTypes;
-import org.mockito.ArgumentCaptor;
 import tech.pegasys.teku.api.ChainDataProvider;
 import tech.pegasys.teku.api.NetworkDataProvider;
 import tech.pegasys.teku.api.SyncDataProvider;
 import tech.pegasys.teku.api.ValidatorDataProvider;
 import tech.pegasys.teku.beacon.sync.SyncService;
 import tech.pegasys.teku.beacon.sync.events.SyncingStatus;
-import tech.pegasys.teku.infrastructure.async.SafeFuture;
-import tech.pegasys.teku.infrastructure.restapi.endpoints.AsyncApiResponse;
-import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiRequest;
+import tech.pegasys.teku.infrastructure.restapi.StubRestApiRequest;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.Eth2P2PNetwork;
 import tech.pegasys.teku.provider.JsonProvider;
@@ -47,7 +35,7 @@ public abstract class AbstractMigratedBeaconHandlerTest {
   protected final Eth2P2PNetwork eth2P2PNetwork = mock(Eth2P2PNetwork.class);
   protected Spec spec = TestSpecFactory.createMinimalPhase0();
 
-  protected final Context context = mock(Context.class);
+  protected final StubRestApiRequest request = new StubRestApiRequest();
   protected final JsonProvider jsonProvider = new JsonProvider();
   protected final NetworkDataProvider network = new NetworkDataProvider(eth2P2PNetwork);
 
@@ -55,16 +43,6 @@ public abstract class AbstractMigratedBeaconHandlerTest {
   protected final SyncDataProvider syncDataProvider = new SyncDataProvider(syncService);
   protected final SchemaDefinitionCache schemaDefinitionCache = new SchemaDefinitionCache(spec);
   protected final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
-
-  @SuppressWarnings("unchecked")
-  private final ArgumentCaptor<SafeFuture<ByteArrayInputStream>> futureArgs =
-      ArgumentCaptor.forClass(SafeFuture.class);
-
-  @SuppressWarnings("unchecked")
-  private final ArgumentCaptor<SafeFuture<AsyncApiResponse>> asyncFuture =
-      ArgumentCaptor.forClass(SafeFuture.class);
-
-  private final ArgumentCaptor<byte[]> args = ArgumentCaptor.forClass(byte[].class);
 
   protected ChainDataProvider chainDataProvider = mock(ChainDataProvider.class);
   protected final ValidatorDataProvider validatorDataProvider = mock(ValidatorDataProvider.class);
@@ -79,35 +57,6 @@ public abstract class AbstractMigratedBeaconHandlerTest {
         UInt64.valueOf(currentSlot),
         UInt64.valueOf(startSlot),
         UInt64.valueOf(highestSlot));
-  }
-
-  protected String getFutureResultString() throws ExecutionException, InterruptedException {
-    verify(context).future(futureArgs.capture());
-    SafeFuture<ByteArrayInputStream> future = futureArgs.getValue();
-    AssertionsForClassTypes.assertThat(future).isCompleted();
-    return new String(future.get().readAllBytes(), StandardCharsets.UTF_8);
-  }
-
-  protected String getResultString() {
-    verify(context).result(args.capture());
-    return new String(args.getValue(), StandardCharsets.UTF_8);
-  }
-
-  protected SafeFuture<ByteArrayInputStream> getResultFuture() {
-    verify(context).future(futureArgs.capture());
-    return futureArgs.getValue();
-  }
-
-  protected SafeFuture<AsyncApiResponse> getResultAsyncResponse(final RestApiRequest request) {
-    verify(request).respondAsync(asyncFuture.capture());
-    return asyncFuture.getValue();
-  }
-
-  protected String getResultStringFromSuccessfulFuture() {
-    final SafeFuture<ByteArrayInputStream> resultFuture = getResultFuture();
-    assertThat(resultFuture).isCompleted();
-    final ByteArrayInputStream byteArrayInputStream = safeJoin(getResultFuture());
-    return new String(byteArrayInputStream.readAllBytes(), UTF_8);
   }
 
   protected <T> ObjectAndMetaData<T> withMetaData(final T value) {

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetAttestationsTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetAttestationsTest.java
@@ -33,18 +33,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.api.NodeDataProvider;
 import tech.pegasys.teku.beaconrestapi.AbstractMigratedBeaconHandlerTest;
-import tech.pegasys.teku.infrastructure.restapi.StubRestApiRequest;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 
 class GetAttestationsTest extends AbstractMigratedBeaconHandlerTest {
-  private StubRestApiRequest request;
   private GetAttestations handler;
   private NodeDataProvider nodeDataProvider;
 
   @BeforeEach
   void setup() {
-    request = new StubRestApiRequest();
-
     nodeDataProvider = mock(NodeDataProvider.class);
     handler = new GetAttestations(nodeDataProvider, spec);
   }

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetAttesterSlashingsTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetAttesterSlashingsTest.java
@@ -32,17 +32,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.api.NodeDataProvider;
 import tech.pegasys.teku.beaconrestapi.AbstractMigratedBeaconHandlerTest;
-import tech.pegasys.teku.infrastructure.restapi.StubRestApiRequest;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 
 class GetAttesterSlashingsTest extends AbstractMigratedBeaconHandlerTest {
-  private StubRestApiRequest request;
   private GetAttesterSlashings handler;
   private NodeDataProvider nodeDataProvider;
 
   @BeforeEach
   void setup() {
-    request = new StubRestApiRequest();
     nodeDataProvider = mock(NodeDataProvider.class);
     handler = new GetAttesterSlashings(nodeDataProvider, spec);
   }

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetBlockAttestationsTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetBlockAttestationsTest.java
@@ -27,21 +27,24 @@ import com.google.common.io.Resources;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.beaconrestapi.AbstractMigratedBeaconHandlerTest;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
-import tech.pegasys.teku.infrastructure.restapi.StubRestApiRequest;
 import tech.pegasys.teku.spec.datastructures.metadata.ObjectAndMetaData;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 
 class GetBlockAttestationsTest extends AbstractMigratedBeaconHandlerTest {
-  private final StubRestApiRequest request =
-      StubRestApiRequest.builder().pathParameter("block_id", "head").build();
   private final GetBlockAttestations handler = new GetBlockAttestations(chainDataProvider, spec);
   private final List<Attestation> attestations =
       List.of(dataStructureUtil.randomAttestation(), dataStructureUtil.randomAttestation());
   private final ObjectAndMetaData<List<Attestation>> responseData =
       new ObjectAndMetaData<>(attestations, spec.getGenesisSpec().getMilestone(), false, true);
+
+  @BeforeEach
+  void setUp() {
+    request.setPathParameter("block_id", "head");
+  }
 
   @Test
   public void shouldReturnBlockAttestationsInformation() throws JsonProcessingException {

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetBlockHeaderTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetBlockHeaderTest.java
@@ -30,14 +30,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.beaconrestapi.AbstractMigratedBeaconHandlerWithChainDataProviderTest;
 import tech.pegasys.teku.bls.BLSSignature;
-import tech.pegasys.teku.infrastructure.restapi.StubRestApiRequest;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.metadata.BlockAndMetaData;
 
 class GetBlockHeaderTest extends AbstractMigratedBeaconHandlerWithChainDataProviderTest {
-  private StubRestApiRequest request;
   private GetBlockHeader handler;
 
   private final BeaconBlock message = dataStructureUtil.randomBeaconBlock(1);
@@ -51,7 +49,7 @@ class GetBlockHeaderTest extends AbstractMigratedBeaconHandlerWithChainDataProvi
   void setup() {
     initialise(SpecMilestone.PHASE0);
     genesis();
-    request = StubRestApiRequest.builder().pathParameter("block_id", "head").build();
+    request.setPathParameter("block_id", "head");
     handler = new GetBlockHeader(chainDataProvider);
   }
 

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetBlockHeadersTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetBlockHeadersTest.java
@@ -32,19 +32,16 @@ import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.api.migrated.BlockHeaderData;
 import tech.pegasys.teku.api.migrated.BlockHeadersResponse;
 import tech.pegasys.teku.beaconrestapi.AbstractMigratedBeaconHandlerWithChainDataProviderTest;
-import tech.pegasys.teku.infrastructure.restapi.StubRestApiRequest;
 import tech.pegasys.teku.spec.SpecMilestone;
 
 class GetBlockHeadersTest extends AbstractMigratedBeaconHandlerWithChainDataProviderTest {
   private GetBlockHeaders handler;
-  private StubRestApiRequest request;
 
   @BeforeEach
   void setup() {
     initialise(SpecMilestone.PHASE0);
     genesis();
     handler = new GetBlockHeaders(chainDataProvider);
-    request = new StubRestApiRequest();
   }
 
   @Test

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetBlockRootTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetBlockRootTest.java
@@ -30,13 +30,11 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.beaconrestapi.AbstractMigratedBeaconHandlerWithChainDataProviderTest;
-import tech.pegasys.teku.infrastructure.restapi.StubRestApiRequest;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.metadata.ObjectAndMetaData;
 
 class GetBlockRootTest extends AbstractMigratedBeaconHandlerWithChainDataProviderTest {
   private GetBlockRoot handler;
-  private StubRestApiRequest request;
 
   @BeforeEach
   void setup() {
@@ -44,7 +42,7 @@ class GetBlockRootTest extends AbstractMigratedBeaconHandlerWithChainDataProvide
     genesis();
 
     handler = new GetBlockRoot(chainDataProvider);
-    request = StubRestApiRequest.builder().pathParameter("block_id", "head").build();
+    request.setPathParameter("block_id", "head");
   }
 
   @Test

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetBlockTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetBlockTest.java
@@ -31,20 +31,18 @@ import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.beaconrestapi.AbstractMigratedBeaconHandlerWithChainDataProviderTest;
-import tech.pegasys.teku.infrastructure.restapi.StubRestApiRequest;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.metadata.ObjectAndMetaData;
 
 class GetBlockTest extends AbstractMigratedBeaconHandlerWithChainDataProviderTest {
-  private StubRestApiRequest request;
   private GetBlock handler;
 
   @BeforeEach
   void setup() {
     initialise(SpecMilestone.PHASE0);
     genesis();
-    request = StubRestApiRequest.builder().pathParameter("block_id", "head").build();
+    request.setPathParameter("block_id", "head");
     handler = new GetBlock(chainDataProvider, schemaDefinitionCache);
   }
 

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetGenesisTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetGenesisTest.java
@@ -24,28 +24,20 @@ import static tech.pegasys.teku.infrastructure.restapi.MetadataTestUtil.verifyMe
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.apache.tuweni.bytes.Bytes32;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.beaconrestapi.AbstractMigratedBeaconHandlerWithChainDataProviderTest;
 import tech.pegasys.teku.infrastructure.bytes.Bytes4;
-import tech.pegasys.teku.infrastructure.restapi.StubRestApiRequest;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.genesis.GenesisData;
 
 public class GetGenesisTest extends AbstractMigratedBeaconHandlerWithChainDataProviderTest {
-  private StubRestApiRequest request;
   final GetGenesis handler = new GetGenesis(chainDataProvider);
   final UInt64 genesisTime = dataStructureUtil.randomUInt64();
   final Bytes32 genesisValidatorsRoot = dataStructureUtil.randomBytes32();
   final Bytes4 fork = dataStructureUtil.randomBytes4();
   final GetGenesis.ResponseData responseData =
       new GetGenesis.ResponseData(new GenesisData(genesisTime, genesisValidatorsRoot), fork);
-
-  @BeforeEach
-  void setup() {
-    request = StubRestApiRequest.builder().build();
-  }
 
   @Test
   public void shouldReturnUnavailableWhenStoreNotAvailable() throws Exception {

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetProposerSlashingsTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetProposerSlashingsTest.java
@@ -30,13 +30,11 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.api.NodeDataProvider;
 import tech.pegasys.teku.beaconrestapi.AbstractMigratedBeaconHandlerTest;
-import tech.pegasys.teku.infrastructure.restapi.StubRestApiRequest;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 
 class GetProposerSlashingsTest extends AbstractMigratedBeaconHandlerTest {
   private final NodeDataProvider nodeDataProvider = mock(NodeDataProvider.class);
   private final GetProposerSlashings handler = new GetProposerSlashings(nodeDataProvider);
-  private final StubRestApiRequest request = new StubRestApiRequest();
   private final List<ProposerSlashing> responseData =
       List.of(
           dataStructureUtil.randomProposerSlashing(), dataStructureUtil.randomProposerSlashing());

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateForkTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateForkTest.java
@@ -36,11 +36,10 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 public class GetStateForkTest extends AbstractMigratedBeaconHandlerWithChainDataProviderTest {
   private GetStateFork handler;
   private StateAndMetaData responseData;
-  private final StubRestApiRequest request =
-      StubRestApiRequest.builder().pathParameter("state_id", "head").build();
 
   @BeforeEach
   void setup() throws ExecutionException, InterruptedException {
+    request.setPathParameter("state_id", "head");
     initialise(SpecMilestone.PHASE0);
     genesis();
     handler = new GetStateFork(chainDataProvider);

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateRootTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateRootTest.java
@@ -25,18 +25,16 @@ import java.io.IOException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.beaconrestapi.AbstractMigratedBeaconHandlerWithChainDataProviderTest;
-import tech.pegasys.teku.infrastructure.restapi.StubRestApiRequest;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.metadata.StateAndMetaData;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 
 public class GetStateRootTest extends AbstractMigratedBeaconHandlerWithChainDataProviderTest {
   private GetStateRoot handler;
-  private final StubRestApiRequest request =
-      StubRestApiRequest.builder().pathParameter("state_id", "head").build();
 
   @BeforeEach
   public void setup() {
+    request.setPathParameter("state_id", "head");
     initialise(SpecMilestone.PHASE0);
     genesis();
     handler = new GetStateRoot(chainDataProvider);

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateValidatorTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateValidatorTest.java
@@ -45,15 +45,12 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 
 public class GetStateValidatorTest extends AbstractMigratedBeaconHandlerWithChainDataProviderTest {
   private GetStateValidator handler;
-  private final StubRestApiRequest request =
-      StubRestApiRequest.builder()
-          .pathParameter("state_id", "head")
-          .pathParameter("validator_id", "1")
-          .build();
   private ObjectAndMetaData<StateValidatorData> responseData;
 
   @BeforeEach
   void setup() throws ExecutionException, InterruptedException {
+    request.setPathParameter("state_id", "head");
+    request.setPathParameter("validator_id", "1");
     initialise(SpecMilestone.ALTAIR);
     genesis();
     handler = new GetStateValidator(chainDataProvider);

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetVoluntaryExitsTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetVoluntaryExitsTest.java
@@ -30,11 +30,9 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.api.NodeDataProvider;
 import tech.pegasys.teku.beaconrestapi.AbstractMigratedBeaconHandlerTest;
-import tech.pegasys.teku.infrastructure.restapi.StubRestApiRequest;
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
 
 class GetVoluntaryExitsTest extends AbstractMigratedBeaconHandlerTest {
-  private final StubRestApiRequest request = new StubRestApiRequest();
   private final NodeDataProvider nodeDataProvider = mock(NodeDataProvider.class);
   private final GetVoluntaryExits handler = new GetVoluntaryExits(nodeDataProvider);
 

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetHealthTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetHealthTest.java
@@ -29,11 +29,9 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.beacon.sync.events.SyncState;
 import tech.pegasys.teku.beaconrestapi.AbstractMigratedBeaconHandlerTest;
-import tech.pegasys.teku.infrastructure.restapi.StubRestApiRequest;
 
 public class GetHealthTest extends AbstractMigratedBeaconHandlerTest {
   private final GetHealth handler = new GetHealth(syncDataProvider, chainDataProvider);
-  private StubRestApiRequest request = new StubRestApiRequest();
 
   @Test
   public void shouldReturnSyncingStatusWhenSyncing() throws Exception {
@@ -57,7 +55,7 @@ public class GetHealthTest extends AbstractMigratedBeaconHandlerTest {
   public void shouldReturnCustomSyncingStatusWhenSyncing() throws Exception {
     when(chainDataProvider.isStoreAvailable()).thenReturn(true);
     when(syncService.getCurrentSyncState()).thenReturn(SyncState.SYNCING);
-    request = StubRestApiRequest.builder().optionalQueryParameter(SYNCING_STATUS, "100").build();
+    request.setOptionalQueryParameter(SYNCING_STATUS, "100");
 
     handler.handleRequest(request);
     assertThat(request.getResponseCode()).isEqualTo(SC_CONTINUE);
@@ -67,7 +65,7 @@ public class GetHealthTest extends AbstractMigratedBeaconHandlerTest {
   public void shouldReturnDefaultSyncingStatusWhenSyncingWrongParam() throws Exception {
     when(chainDataProvider.isStoreAvailable()).thenReturn(true);
     when(syncService.getCurrentSyncState()).thenReturn(SyncState.SYNCING);
-    request = StubRestApiRequest.builder().optionalQueryParameter(SYNCING_STATUS, "a").build();
+    request.setOptionalQueryParameter(SYNCING_STATUS, "a");
     handler.handleRequest(request);
     assertThat(request.getResponseCode()).isEqualTo(SC_PARTIAL_CONTENT);
   }
@@ -76,7 +74,7 @@ public class GetHealthTest extends AbstractMigratedBeaconHandlerTest {
   public void shouldReturnDefaultSyncingStatusWhenSyncingMultipleParams() throws Exception {
     when(chainDataProvider.isStoreAvailable()).thenReturn(true);
     when(syncService.getCurrentSyncState()).thenReturn(SyncState.SYNCING);
-    request = StubRestApiRequest.builder().optionalQueryParameter(SYNCING_STATUS, "1,2").build();
+    request.setOptionalQueryParameter(SYNCING_STATUS, "1,2");
 
     handler.handleRequest(request);
     assertThat(request.getResponseCode()).isEqualTo(SC_PARTIAL_CONTENT);

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetIdentityTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetIdentityTest.java
@@ -29,13 +29,11 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.beaconrestapi.AbstractMigratedBeaconHandlerTest;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.node.GetIdentity.IdentityData;
-import tech.pegasys.teku.infrastructure.restapi.StubRestApiRequest;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.CacheLength;
 import tech.pegasys.teku.networking.p2p.peer.NodeId;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.metadata.MetadataMessage;
 
 public class GetIdentityTest extends AbstractMigratedBeaconHandlerTest {
-  private final StubRestApiRequest request = new StubRestApiRequest();
   private final GetIdentity handler = new GetIdentity(network);
   private final MetadataMessage defaultMetadata =
       spec.getGenesisSchemaDefinitions().getMetadataMessageSchema().createDefault();

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetPeerByIdTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetPeerByIdTest.java
@@ -30,7 +30,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.beaconrestapi.AbstractMigratedBeaconHandlerTest;
 import tech.pegasys.teku.infrastructure.http.HttpErrorResponse;
-import tech.pegasys.teku.infrastructure.restapi.StubRestApiRequest;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.teku.networking.p2p.mock.MockNodeId;
 import tech.pegasys.teku.networking.p2p.network.PeerAddress;
@@ -38,12 +37,11 @@ import tech.pegasys.teku.networking.p2p.network.PeerAddress;
 public class GetPeerByIdTest extends AbstractMigratedBeaconHandlerTest {
   private final MockNodeId peerId = new MockNodeId(123456);
   private final Eth2Peer peer = mock(Eth2Peer.class);
-  private final StubRestApiRequest request =
-      StubRestApiRequest.builder().pathParameter("peer_id", peerId.toBase58()).build();
   private final GetPeerById handler = new GetPeerById(network);
 
   @BeforeEach
   void setUp() {
+    request.setPathParameter("peer_id", peerId.toBase58());
     when(peer.getId()).thenReturn(peerId);
     when(peer.getAddress()).thenReturn(new PeerAddress(peerId));
     when(peer.isConnected()).thenReturn(true);

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetPeerCountTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetPeerCountTest.java
@@ -27,7 +27,6 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.api.NetworkDataProvider;
 import tech.pegasys.teku.beaconrestapi.AbstractMigratedBeaconHandlerTest;
-import tech.pegasys.teku.infrastructure.restapi.StubRestApiRequest;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 
 class GetPeerCountTest extends AbstractMigratedBeaconHandlerTest {
@@ -35,7 +34,6 @@ class GetPeerCountTest extends AbstractMigratedBeaconHandlerTest {
   private final Eth2Peer peer2 = mock(Eth2Peer.class);
   private final NetworkDataProvider networkDataProvider = mock(NetworkDataProvider.class);
   private final GetPeerCount handler = new GetPeerCount(networkDataProvider);
-  private final StubRestApiRequest request = new StubRestApiRequest();
   private final List<Eth2Peer> data = List.of(peer1, peer2);
   private final GetPeerCount.ResponseData peerCountData = new GetPeerCount.ResponseData(data);
 

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetPeersTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetPeersTest.java
@@ -29,7 +29,6 @@ import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.api.NetworkDataProvider;
 import tech.pegasys.teku.beaconrestapi.AbstractMigratedBeaconHandlerTest;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.node.GetPeers.PeersData;
-import tech.pegasys.teku.infrastructure.restapi.StubRestApiRequest;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.CacheLength;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.teku.networking.p2p.mock.MockNodeId;
@@ -44,7 +43,6 @@ public class GetPeersTest extends AbstractMigratedBeaconHandlerTest {
 
   private final NetworkDataProvider networkDataProvider = mock(NetworkDataProvider.class);
   private final GetPeers handler = new GetPeers(networkDataProvider);
-  private final StubRestApiRequest request = new StubRestApiRequest();
   private final List<Eth2Peer> data = List.of(peer1, peer2);
   private final GetPeers.PeersData peersData = new PeersData(data);
 

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetSyncingTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetSyncingTest.java
@@ -25,11 +25,9 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.beacon.sync.events.SyncState;
 import tech.pegasys.teku.beaconrestapi.AbstractMigratedBeaconHandlerTest;
-import tech.pegasys.teku.infrastructure.restapi.StubRestApiRequest;
 
 public class GetSyncingTest extends AbstractMigratedBeaconHandlerTest {
   private final GetSyncing handler = new GetSyncing(syncDataProvider);
-  private StubRestApiRequest request = new StubRestApiRequest();
 
   @Test
   public void shouldGetSyncingStatusSyncing() throws Exception {

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetVersionTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetVersionTest.java
@@ -23,11 +23,9 @@ import static tech.pegasys.teku.infrastructure.restapi.MetadataTestUtil.verifyMe
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.beaconrestapi.AbstractMigratedBeaconHandlerTest;
-import tech.pegasys.teku.infrastructure.restapi.StubRestApiRequest;
 import tech.pegasys.teku.infrastructure.version.VersionProvider;
 
 public class GetVersionTest extends AbstractMigratedBeaconHandlerTest {
-  private final StubRestApiRequest request = new StubRestApiRequest();
   private final GetVersion handler = new GetVersion();
 
   @Test

--- a/infrastructure/async/src/testFixtures/java/tech/pegasys/teku/infrastructure/async/SafeFutureAssert.java
+++ b/infrastructure/async/src/testFixtures/java/tech/pegasys/teku/infrastructure/async/SafeFutureAssert.java
@@ -73,7 +73,7 @@ public class SafeFutureAssert<T> extends AbstractCompletableFutureAssert<SafeFut
   }
 
   public T joinsImmediately() {
-    isCompleted();
+    isDone();
     return actual.join();
   }
 

--- a/infrastructure/restapi/build.gradle
+++ b/infrastructure/restapi/build.gradle
@@ -21,6 +21,7 @@ dependencies {
   testImplementation testFixtures(project(':infrastructure:async'))
   testImplementation testFixtures(project(':infrastructure:json'))
 
+  testFixturesImplementation testFixtures(project(':infrastructure:async'))
   testFixturesImplementation testFixtures(project(':infrastructure:json'))
   testFixturesImplementation project(':infrastructure:http')
   testFixturesImplementation 'org.apache.logging.log4j:log4j-api'

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/EndpointMetadata.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/EndpointMetadata.java
@@ -27,9 +27,9 @@ import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.HTTP_ERROR_R
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.javalin.http.HandlerType;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.io.UncheckedIOException;
 import java.util.Collection;
 import java.util.Collections;
@@ -230,14 +230,13 @@ public class EndpointMetadata {
   }
 
   @SuppressWarnings("unchecked")
-  public <T> byte[] serialize(final int statusCode, final String contentType, final T response)
+  public <T> void serialize(
+      final int statusCode, final String contentType, final T response, final OutputStream out)
       throws JsonProcessingException {
     final ResponseContentTypeDefinition<T> type =
         (ResponseContentTypeDefinition<T>) getResponseType(statusCode, contentType);
-    final ByteArrayOutputStream out = new ByteArrayOutputStream();
     try {
       type.serialize(response, out);
-      return out.toByteArray();
     } catch (final JsonProcessingException e) {
       throw e;
     } catch (final IOException e) {

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/JavalinRestApiRequest.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/JavalinRestApiRequest.java
@@ -21,6 +21,9 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import io.javalin.core.util.Header;
 import io.javalin.http.Context;
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -54,7 +57,7 @@ public class JavalinRestApiRequest implements RestApiRequest {
 
   @Override
   public void respondOk(final Object response) throws JsonProcessingException {
-    respond(SC_OK, response);
+    respond(SC_OK, response, getResponseOutputStream());
   }
 
   @Override
@@ -64,12 +67,15 @@ public class JavalinRestApiRequest implements RestApiRequest {
             .thenApply(
                 result -> {
                   try {
-                    return respond(result.getResponseCode(), result.getResponseBody());
+                    respond(
+                        result.getResponseCode(),
+                        result.getResponseBody(),
+                        getResponseOutputStream());
                   } catch (JsonProcessingException e) {
                     LOG.trace("Failed to generate API response", e);
                     context.status(SC_INTERNAL_SERVER_ERROR);
-                    return Bytes.EMPTY.toArrayUnsafe();
                   }
+                  return Bytes.EMPTY.toArrayUnsafe();
                 })
             .thenApply(ByteArrayInputStream::new));
   }
@@ -78,38 +84,46 @@ public class JavalinRestApiRequest implements RestApiRequest {
   public void respondOk(final Object response, final CacheLength cacheLength)
       throws JsonProcessingException {
     context.header(Header.CACHE_CONTROL, cacheLength.getHttpHeaderValue());
-    respond(SC_OK, response);
+    respond(SC_OK, response, getResponseOutputStream());
   }
 
   @Override
   public void respondError(final int statusCode, final String message)
       throws JsonProcessingException {
-    respond(statusCode, new HttpErrorResponse(statusCode, message));
+    respond(statusCode, new HttpErrorResponse(statusCode, message), getResponseOutputStream());
   }
 
-  private byte[] respond(final int statusCode, final Optional<Object> response)
+  private OutputStream getResponseOutputStream() {
+    try {
+      return context.res.getOutputStream();
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  private void respond(
+      final int statusCode, final Optional<Object> response, final OutputStream out)
       throws JsonProcessingException {
     context.status(statusCode);
     if (response.isPresent()) {
-      return respondImpl(statusCode, response.get());
+      respondImpl(statusCode, response.get(), out);
     }
-    return Bytes.EMPTY.toArrayUnsafe();
   }
 
-  private void respond(final int statusCode, final Object response) throws JsonProcessingException {
+  private void respond(final int statusCode, final Object response, final OutputStream out)
+      throws JsonProcessingException {
     context.status(statusCode);
-    final byte[] responseData = respondImpl(statusCode, response);
-    context.result(responseData);
+    respondImpl(statusCode, response, out);
   }
 
-  private byte[] respondImpl(final int statusCode, final Object response)
+  private void respondImpl(final int statusCode, final Object response, final OutputStream out)
       throws JsonProcessingException {
     final ResponseMetadata responseMetadata =
         metadata.createResponseMetadata(
             statusCode, Optional.ofNullable(context.header(HEADER_ACCEPT)), response);
     context.contentType(responseMetadata.getContentType());
     responseMetadata.getAdditionalHeaders().forEach(context::header);
-    return metadata.serialize(statusCode, responseMetadata.getContentType(), response);
+    metadata.serialize(statusCode, responseMetadata.getContentType(), response, out);
   }
 
   /** This is only used when intending to return status code without a response body */


### PR DESCRIPTION
## PR Description
Avoid creating the full JSON content in memory by streaming it straight to the response output stream.

Also converted a whole bunch of tests over to use the stub request rather than a mock context because it's pretty much impossible to mock the context in the way we need to stream responses.

One downside is that while JSON content is streamed, SSZ is not currently because `SszData` only provides a method that returns the SSZ as `Bytes`. SSZ tends to be much more compact though so is less of an issue.  Get state validators on the other hand returns 181Mb of JSON.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
