### PR TITLE
Remove V1 from builder classes and change gas_target to gas_limit in RegisteredValidatorInfoSchema

### DIFF
--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/RegisteredValidatorInfoSchema.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/RegisteredValidatorInfoSchema.json
@@ -17,7 +17,7 @@
       "description" : "Bytes20 hexadecimal",
       "format" : "byte"
     },
-    "gas_target" : {
+    "gas_limit" : {
       "type" : "string",
       "format" : "uint64"
     },

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/teku/RegisteredValidatorInfoSchema.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/teku/RegisteredValidatorInfoSchema.java
@@ -49,8 +49,8 @@ public class RegisteredValidatorInfoSchema {
   Bytes20 fee_recipient;
 
   @Schema(type = "string", format = "uint64")
-  @JsonProperty("gas_target")
-  UInt64 gas_target;
+  @JsonProperty("gas_limit")
+  UInt64 gas_limit;
 
   @Schema(type = "string", format = "uint64")
   @JsonProperty("timestamp")

--- a/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/rest/RestExecutionBuilderClientTest.java
+++ b/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/rest/RestExecutionBuilderClientTest.java
@@ -45,8 +45,8 @@ import tech.pegasys.teku.spec.TestSpecContext;
 import tech.pegasys.teku.spec.TestSpecInvocationContextProvider.SpecContext;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
-import tech.pegasys.teku.spec.datastructures.execution.SignedBuilderBidV1;
-import tech.pegasys.teku.spec.datastructures.execution.SignedValidatorRegistrationV1;
+import tech.pegasys.teku.spec.datastructures.execution.SignedBuilderBid;
+import tech.pegasys.teku.spec.datastructures.execution.SignedValidatorRegistration;
 import tech.pegasys.teku.spec.networks.Eth2Network;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsBellatrix;
 
@@ -146,7 +146,7 @@ class RestExecutionBuilderClientTest {
 
     mockWebServer.enqueue(new MockResponse().setResponseCode(200));
 
-    SignedValidatorRegistrationV1 signedValidatorRegistration = createSignedValidatorRegistration();
+    SignedValidatorRegistration signedValidatorRegistration = createSignedValidatorRegistration();
 
     assertThat(restExecutionBuilderClient.registerValidator(SLOT, signedValidatorRegistration))
         .succeedsWithin(WAIT_FOR_CALL_COMPLETION)
@@ -166,7 +166,7 @@ class RestExecutionBuilderClientTest {
 
     mockWebServer.enqueue(new MockResponse().setResponseCode(400).setBody(unknownValidatorError));
 
-    SignedValidatorRegistrationV1 signedValidatorRegistration = createSignedValidatorRegistration();
+    SignedValidatorRegistration signedValidatorRegistration = createSignedValidatorRegistration();
 
     assertThat(restExecutionBuilderClient.registerValidator(SLOT, signedValidatorRegistration))
         .succeedsWithin(WAIT_FOR_CALL_COMPLETION)
@@ -203,8 +203,8 @@ class RestExecutionBuilderClientTest {
         .satisfies(
             response -> {
               assertThat(response.isSuccess()).isTrue();
-              SignedBuilderBidV1 responsePayload = response.getPayload();
-              verifySignedBuilderBidV1Response(responsePayload);
+              SignedBuilderBid responsePayload = response.getPayload();
+              verifySignedBuilderBidResponse(responsePayload);
             });
 
     verifyGetRequest("/eth/v1/builder/header/1/" + PARENT_HASH + "/" + PUB_KEY);
@@ -321,7 +321,7 @@ class RestExecutionBuilderClientTest {
     }
   }
 
-  private SignedValidatorRegistrationV1 createSignedValidatorRegistration() {
+  private SignedValidatorRegistration createSignedValidatorRegistration() {
     try {
       return JsonUtil.parse(
           SIGNED_VALIDATOR_REGISTRATION_REQUEST,
@@ -333,12 +333,12 @@ class RestExecutionBuilderClientTest {
     }
   }
 
-  private void verifySignedBuilderBidV1Response(SignedBuilderBidV1 actual) {
-    DeserializableTypeDefinition<BuilderApiResponse<SignedBuilderBidV1>> responseTypeDefinition =
+  private void verifySignedBuilderBidResponse(SignedBuilderBid actual) {
+    DeserializableTypeDefinition<BuilderApiResponse<SignedBuilderBid>> responseTypeDefinition =
         BuilderApiResponse.createTypeDefinition(
-            schemaDefinitionsBellatrix.getSignedBuilderBidV1Schema().getJsonTypeDefinition());
+            schemaDefinitionsBellatrix.getSignedBuilderBidSchema().getJsonTypeDefinition());
     try {
-      SignedBuilderBidV1 expected =
+      SignedBuilderBid expected =
           JsonUtil.parse(EXECUTION_PAYLOAD_HEADER_RESPONSE, responseTypeDefinition).getData();
       assertThat(actual).isEqualTo(expected);
     } catch (JsonProcessingException ex) {

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ExecutionBuilderClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ExecutionBuilderClient.java
@@ -20,17 +20,17 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
-import tech.pegasys.teku.spec.datastructures.execution.SignedBuilderBidV1;
-import tech.pegasys.teku.spec.datastructures.execution.SignedValidatorRegistrationV1;
+import tech.pegasys.teku.spec.datastructures.execution.SignedBuilderBid;
+import tech.pegasys.teku.spec.datastructures.execution.SignedValidatorRegistration;
 
 public interface ExecutionBuilderClient {
 
   SafeFuture<Response<Void>> status();
 
   SafeFuture<Response<Void>> registerValidator(
-      UInt64 slot, SignedValidatorRegistrationV1 signedValidatorRegistrationV1);
+      UInt64 slot, SignedValidatorRegistration signedValidatorRegistration);
 
-  SafeFuture<Response<SignedBuilderBidV1>> getHeader(
+  SafeFuture<Response<SignedBuilderBid>> getHeader(
       UInt64 slot, BLSPublicKey pubKey, Bytes32 parentHash);
 
   SafeFuture<Response<ExecutionPayload>> getPayload(SignedBeaconBlock signedBlindedBeaconBlock);

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ThrottlingExecutionBuilderClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ThrottlingExecutionBuilderClient.java
@@ -50,9 +50,8 @@ public class ThrottlingExecutionBuilderClient implements ExecutionBuilderClient 
 
   @Override
   public SafeFuture<Response<Void>> registerValidator(
-      UInt64 slot, final SignedValidatorRegistration signedValidatorRegistration) {
-    return taskQueue.queueTask(
-        () -> delegate.registerValidator(slot, signedValidatorRegistration));
+      final UInt64 slot, final SignedValidatorRegistration signedValidatorRegistration) {
+    return taskQueue.queueTask(() -> delegate.registerValidator(slot, signedValidatorRegistration));
   }
 
   @Override
@@ -63,7 +62,7 @@ public class ThrottlingExecutionBuilderClient implements ExecutionBuilderClient 
 
   @Override
   public SafeFuture<Response<ExecutionPayload>> getPayload(
-      SignedBeaconBlock signedBlindedBeaconBlock) {
+      final SignedBeaconBlock signedBlindedBeaconBlock) {
     return taskQueue.queueTask(() -> delegate.getPayload(signedBlindedBeaconBlock));
   }
 }

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ThrottlingExecutionBuilderClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ThrottlingExecutionBuilderClient.java
@@ -23,8 +23,8 @@ import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
-import tech.pegasys.teku.spec.datastructures.execution.SignedBuilderBidV1;
-import tech.pegasys.teku.spec.datastructures.execution.SignedValidatorRegistrationV1;
+import tech.pegasys.teku.spec.datastructures.execution.SignedBuilderBid;
+import tech.pegasys.teku.spec.datastructures.execution.SignedValidatorRegistration;
 
 public class ThrottlingExecutionBuilderClient implements ExecutionBuilderClient {
   private final ExecutionBuilderClient delegate;
@@ -50,13 +50,13 @@ public class ThrottlingExecutionBuilderClient implements ExecutionBuilderClient 
 
   @Override
   public SafeFuture<Response<Void>> registerValidator(
-      UInt64 slot, final SignedValidatorRegistrationV1 signedValidatorRegistrationV1) {
+      UInt64 slot, final SignedValidatorRegistration signedValidatorRegistration) {
     return taskQueue.queueTask(
-        () -> delegate.registerValidator(slot, signedValidatorRegistrationV1));
+        () -> delegate.registerValidator(slot, signedValidatorRegistration));
   }
 
   @Override
-  public SafeFuture<Response<SignedBuilderBidV1>> getHeader(
+  public SafeFuture<Response<SignedBuilderBid>> getHeader(
       final UInt64 slot, final BLSPublicKey pubKey, final Bytes32 parentHash) {
     return taskQueue.queueTask(() -> delegate.getHeader(slot, pubKey, parentHash));
   }

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/OkHttpRestClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/OkHttpRestClient.java
@@ -147,6 +147,7 @@ public class OkHttpRestClient implements RestClient {
   private <T> SafeFuture<Response<T>> makeAsyncRequest(
       final Request request,
       final Optional<DeserializableTypeDefinition<T>> responseTypeDefinitionMaybe) {
+    final Call call = httpClient.newCall(request);
     final SafeFuture<Response<T>> futureResponse = new SafeFuture<>();
     final Callback responseCallback =
         new Callback() {
@@ -178,7 +179,7 @@ public class OkHttpRestClient implements RestClient {
             }
           }
         };
-    httpClient.newCall(request).enqueue(responseCallback);
+    call.enqueue(responseCallback);
     return futureResponse;
   }
 

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/RestExecutionBuilderClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/RestExecutionBuilderClient.java
@@ -35,9 +35,9 @@ import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSchema;
-import tech.pegasys.teku.spec.datastructures.execution.SignedBuilderBidV1;
-import tech.pegasys.teku.spec.datastructures.execution.SignedBuilderBidV1Schema;
-import tech.pegasys.teku.spec.datastructures.execution.SignedValidatorRegistrationV1;
+import tech.pegasys.teku.spec.datastructures.execution.SignedBuilderBid;
+import tech.pegasys.teku.spec.datastructures.execution.SignedBuilderBidSchema;
+import tech.pegasys.teku.spec.datastructures.execution.SignedValidatorRegistration;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionCache;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsBellatrix;
 
@@ -48,8 +48,8 @@ public class RestExecutionBuilderClient implements ExecutionBuilderClient {
       cachedBuilderApiExecutionPayloadResponseType = new ConcurrentHashMap<>();
 
   private final Map<
-          SpecMilestone, DeserializableTypeDefinition<BuilderApiResponse<SignedBuilderBidV1>>>
-      cachedBuilderApiSignedBuilderBidV1ResponseType = new ConcurrentHashMap<>();
+          SpecMilestone, DeserializableTypeDefinition<BuilderApiResponse<SignedBuilderBid>>>
+      cachedBuilderApiSignedBuilderBidResponseType = new ConcurrentHashMap<>();
 
   private final RestClient restClient;
   private final SchemaDefinitionCache schemaDefinitionCache;
@@ -68,24 +68,24 @@ public class RestExecutionBuilderClient implements ExecutionBuilderClient {
 
   @Override
   public SafeFuture<Response<Void>> registerValidator(
-      final UInt64 slot, final SignedValidatorRegistrationV1 signedValidatorRegistrationV1) {
+      final UInt64 slot, final SignedValidatorRegistration signedValidatorRegistration) {
 
     final SpecMilestone milestone = schemaDefinitionCache.milestoneAtSlot(slot);
     final SchemaDefinitionsBellatrix schemaDefinitionsBellatrix =
         getSchemaDefinitionsBellatrix(milestone);
 
-    final DeserializableTypeDefinition<SignedValidatorRegistrationV1> requestType =
+    final DeserializableTypeDefinition<SignedValidatorRegistration> requestType =
         schemaDefinitionsBellatrix.getSignedValidatorRegistrationSchema().getJsonTypeDefinition();
     return restClient
         .postAsync(
             BuilderApiMethod.REGISTER_VALIDATOR.getPath(),
-            signedValidatorRegistrationV1,
+            signedValidatorRegistration,
             requestType)
         .orTimeout(EL_BUILDER_REGISTER_VALIDATOR_TIMEOUT);
   }
 
   @Override
-  public SafeFuture<Response<SignedBuilderBidV1>> getHeader(
+  public SafeFuture<Response<SignedBuilderBid>> getHeader(
       final UInt64 slot, final BLSPublicKey pubKey, final Bytes32 parentHash) {
 
     final Map<String, String> urlParams = new HashMap<>();
@@ -95,17 +95,17 @@ public class RestExecutionBuilderClient implements ExecutionBuilderClient {
 
     final SpecMilestone milestone = schemaDefinitionCache.milestoneAtSlot(slot);
 
-    final DeserializableTypeDefinition<BuilderApiResponse<SignedBuilderBidV1>>
+    final DeserializableTypeDefinition<BuilderApiResponse<SignedBuilderBid>>
         responseTypeDefinition =
-            cachedBuilderApiSignedBuilderBidV1ResponseType.computeIfAbsent(
+            cachedBuilderApiSignedBuilderBidResponseType.computeIfAbsent(
                 milestone,
                 __ -> {
                   final SchemaDefinitionsBellatrix schemaDefinitionsBellatrix =
                       getSchemaDefinitionsBellatrix(milestone);
-                  final SignedBuilderBidV1Schema signedBuilderBidV1Schema =
-                      schemaDefinitionsBellatrix.getSignedBuilderBidV1Schema();
+                  final SignedBuilderBidSchema signedBuilderBidSchema =
+                      schemaDefinitionsBellatrix.getSignedBuilderBidSchema();
                   return BuilderApiResponse.createTypeDefinition(
-                      signedBuilderBidV1Schema.getJsonTypeDefinition());
+                      signedBuilderBidSchema.getJsonTypeDefinition());
                 });
 
     return restClient

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/RestExecutionBuilderClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/RestExecutionBuilderClient.java
@@ -78,9 +78,7 @@ public class RestExecutionBuilderClient implements ExecutionBuilderClient {
         schemaDefinitionsBellatrix.getSignedValidatorRegistrationSchema().getJsonTypeDefinition();
     return restClient
         .postAsync(
-            BuilderApiMethod.REGISTER_VALIDATOR.getPath(),
-            signedValidatorRegistration,
-            requestType)
+            BuilderApiMethod.REGISTER_VALIDATOR.getPath(), signedValidatorRegistration, requestType)
         .orTimeout(EL_BUILDER_REGISTER_VALIDATOR_TIMEOUT);
   }
 

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JExecutionBuilderClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JExecutionBuilderClient.java
@@ -21,8 +21,8 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
-import tech.pegasys.teku.spec.datastructures.execution.SignedBuilderBidV1;
-import tech.pegasys.teku.spec.datastructures.execution.SignedValidatorRegistrationV1;
+import tech.pegasys.teku.spec.datastructures.execution.SignedBuilderBid;
+import tech.pegasys.teku.spec.datastructures.execution.SignedValidatorRegistration;
 
 public class Web3JExecutionBuilderClient implements ExecutionBuilderClient {
   @SuppressWarnings("unused") // will be removed in upcoming PRs
@@ -39,12 +39,12 @@ public class Web3JExecutionBuilderClient implements ExecutionBuilderClient {
 
   @Override
   public SafeFuture<Response<Void>> registerValidator(
-      UInt64 slot, final SignedValidatorRegistrationV1 signedValidatorRegistrationV1) {
+      UInt64 slot, final SignedValidatorRegistration signedValidatorRegistration) {
     return SafeFuture.failedFuture(new UnsupportedOperationException("Deprecated"));
   }
 
   @Override
-  public SafeFuture<Response<SignedBuilderBidV1>> getHeader(
+  public SafeFuture<Response<SignedBuilderBid>> getHeader(
       final UInt64 slot, final BLSPublicKey pubKey, final Bytes32 parentHash) {
     return SafeFuture.failedFuture(new UnsupportedOperationException("Deprecated"));
   }

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
@@ -50,12 +50,12 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
-import tech.pegasys.teku.spec.datastructures.execution.BuilderBidV1;
+import tech.pegasys.teku.spec.datastructures.execution.BuilderBid;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
 import tech.pegasys.teku.spec.datastructures.execution.PowBlock;
-import tech.pegasys.teku.spec.datastructures.execution.SignedBuilderBidV1;
+import tech.pegasys.teku.spec.datastructures.execution.SignedBuilderBid;
 import tech.pegasys.teku.spec.executionlayer.ForkChoiceState;
 import tech.pegasys.teku.spec.executionlayer.PayloadBuildingAttributes;
 import tech.pegasys.teku.spec.executionlayer.PayloadStatus;
@@ -287,8 +287,8 @@ public class ExecutionLayerManagerImpl implements ExecutionLayerManager {
         .getHeader(
             slot, registeredValidatorPublicKey.get(), executionPayloadContext.getParentHash())
         .thenApply(ExecutionLayerManagerImpl::unwrapResponseOrThrow)
-        .thenApply(SignedBuilderBidV1::getMessage)
-        .thenApply(BuilderBidV1::getExecutionPayloadHeader)
+        .thenApply(SignedBuilderBid::getMessage)
+        .thenApply(BuilderBid::getExecutionPayloadHeader)
         .thenPeek(
             executionPayloadHeader -> {
               // store that we haven't fallen back for this slot

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImplTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImplTest.java
@@ -38,7 +38,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
-import tech.pegasys.teku.spec.datastructures.execution.SignedBuilderBidV1;
+import tech.pegasys.teku.spec.datastructures.execution.SignedBuilderBid;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 class ExecutionLayerManagerImplTest {
@@ -334,7 +334,7 @@ class ExecutionLayerManagerImplTest {
       final ExecutionPayloadContext executionPayloadContext) {
     final UInt64 slot = executionPayloadContext.getForkChoiceState().getHeadBlockSlot();
 
-    SignedBuilderBidV1 signedBuilderBidV1 = dataStructureUtil.randomSignedBuilderBidV1();
+    SignedBuilderBid signedBuilderBid = dataStructureUtil.randomSignedBuilderBid();
 
     when(executionBuilderClient.getHeader(
             slot,
@@ -343,9 +343,9 @@ class ExecutionLayerManagerImplTest {
                 .getValidatorRegistrationPublicKey()
                 .orElseThrow(),
             executionPayloadContext.getParentHash()))
-        .thenReturn(SafeFuture.completedFuture(new Response<>(signedBuilderBidV1)));
+        .thenReturn(SafeFuture.completedFuture(new Response<>(signedBuilderBid)));
 
-    return signedBuilderBidV1.getMessage().getExecutionPayloadHeader();
+    return signedBuilderBid.getMessage().getExecutionPayloadHeader();
   }
 
   private ExecutionPayload prepareBuilderGetPayloadResponse(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/BuilderBid.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/BuilderBid.java
@@ -20,15 +20,15 @@ import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt256;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.spec.datastructures.type.SszPublicKey;
 
-public class BuilderBidV1
-    extends Container3<BuilderBidV1, ExecutionPayloadHeader, SszUInt256, SszPublicKey> {
+public class BuilderBid
+    extends Container3<BuilderBid, ExecutionPayloadHeader, SszUInt256, SszPublicKey> {
 
-  protected BuilderBidV1(BuilderBidV1Schema schema, TreeNode backingNode) {
+  protected BuilderBid(BuilderBidSchema schema, TreeNode backingNode) {
     super(schema, backingNode);
   }
 
-  protected BuilderBidV1(
-      BuilderBidV1Schema schema,
+  protected BuilderBid(
+      BuilderBidSchema schema,
       ExecutionPayloadHeader executionPayloadHeader,
       SszUInt256 value,
       SszPublicKey publicKey) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/BuilderBidSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/BuilderBidSchema.java
@@ -22,26 +22,26 @@ import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.spec.datastructures.type.SszPublicKey;
 import tech.pegasys.teku.spec.datastructures.type.SszPublicKeySchema;
 
-public class BuilderBidV1Schema
-    extends ContainerSchema3<BuilderBidV1, ExecutionPayloadHeader, SszUInt256, SszPublicKey> {
-  public BuilderBidV1Schema(final ExecutionPayloadHeaderSchema executionPayloadHeaderSchema) {
+public class BuilderBidSchema
+    extends ContainerSchema3<BuilderBid, ExecutionPayloadHeader, SszUInt256, SszPublicKey> {
+  public BuilderBidSchema(final ExecutionPayloadHeaderSchema executionPayloadHeaderSchema) {
     super(
-        "BuilderBidV1",
+        "BuilderBid",
         namedSchema("header", executionPayloadHeaderSchema),
         namedSchema("value", SszPrimitiveSchemas.UINT256_SCHEMA),
         namedSchema("pubkey", SszPublicKeySchema.INSTANCE));
   }
 
-  public BuilderBidV1 create(
+  public BuilderBid create(
       final ExecutionPayloadHeader executionPayloadHeader,
       final UInt256 value,
       final BLSPublicKey publicKey) {
-    return new BuilderBidV1(
+    return new BuilderBid(
         this, executionPayloadHeader, SszUInt256.of(value), new SszPublicKey(publicKey));
   }
 
   @Override
-  public BuilderBidV1 createFromBackingNode(TreeNode node) {
-    return new BuilderBidV1(this, node);
+  public BuilderBid createFromBackingNode(TreeNode node) {
+    return new BuilderBid(this, node);
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/SignedBuilderBid.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/SignedBuilderBid.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 ConsenSys AG.
+ * Copyright 2020 ConsenSys AG.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -14,27 +14,33 @@
 package tech.pegasys.teku.spec.datastructures.execution;
 
 import tech.pegasys.teku.bls.BLSSignature;
-import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema2;
+import tech.pegasys.teku.infrastructure.ssz.containers.Container2;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.spec.datastructures.type.SszSignature;
-import tech.pegasys.teku.spec.datastructures.type.SszSignatureSchema;
 
-public class SignedBuilderBidV1Schema
-    extends ContainerSchema2<SignedBuilderBidV1, BuilderBidV1, SszSignature> {
+public class SignedBuilderBid extends Container2<SignedBuilderBid, BuilderBid, SszSignature> {
 
-  public SignedBuilderBidV1Schema(final BuilderBidV1Schema builderBidV1Schema) {
-    super(
-        "SignedBuilderBidV1",
-        namedSchema("message", builderBidV1Schema),
-        namedSchema("signature", SszSignatureSchema.INSTANCE));
+  SignedBuilderBid(SignedBuilderBidSchema type, TreeNode backingNode) {
+    super(type, backingNode);
   }
 
-  public SignedBuilderBidV1 create(final BuilderBidV1 message, final BLSSignature signature) {
-    return new SignedBuilderBidV1(this, message, signature);
+  SignedBuilderBid(
+      final SignedBuilderBidSchema type,
+      final BuilderBid message,
+      final BLSSignature signature) {
+    super(type, message, new SszSignature(signature));
   }
 
   @Override
-  public SignedBuilderBidV1 createFromBackingNode(TreeNode node) {
-    return new SignedBuilderBidV1(this, node);
+  public SignedBuilderBidSchema getSchema() {
+    return (SignedBuilderBidSchema) super.getSchema();
+  }
+
+  public BuilderBid getMessage() {
+    return getField0();
+  }
+
+  public BLSSignature getSignature() {
+    return getField1().getSignature();
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/SignedBuilderBid.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/SignedBuilderBid.java
@@ -25,9 +25,7 @@ public class SignedBuilderBid extends Container2<SignedBuilderBid, BuilderBid, S
   }
 
   SignedBuilderBid(
-      final SignedBuilderBidSchema type,
-      final BuilderBid message,
-      final BLSSignature signature) {
+      final SignedBuilderBidSchema type, final BuilderBid message, final BLSSignature signature) {
     super(type, message, new SszSignature(signature));
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/SignedBuilderBidSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/SignedBuilderBidSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ConsenSys AG.
+ * Copyright 2022 ConsenSys AG.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -14,33 +14,27 @@
 package tech.pegasys.teku.spec.datastructures.execution;
 
 import tech.pegasys.teku.bls.BLSSignature;
-import tech.pegasys.teku.infrastructure.ssz.containers.Container2;
+import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema2;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.spec.datastructures.type.SszSignature;
+import tech.pegasys.teku.spec.datastructures.type.SszSignatureSchema;
 
-public class SignedBuilderBidV1 extends Container2<SignedBuilderBidV1, BuilderBidV1, SszSignature> {
+public class SignedBuilderBidSchema
+    extends ContainerSchema2<SignedBuilderBid, BuilderBid, SszSignature> {
 
-  SignedBuilderBidV1(SignedBuilderBidV1Schema type, TreeNode backingNode) {
-    super(type, backingNode);
+  public SignedBuilderBidSchema(final BuilderBidSchema builderBidSchema) {
+    super(
+        "SignedBuilderBid",
+        namedSchema("message", builderBidSchema),
+        namedSchema("signature", SszSignatureSchema.INSTANCE));
   }
 
-  SignedBuilderBidV1(
-      final SignedBuilderBidV1Schema type,
-      final BuilderBidV1 message,
-      final BLSSignature signature) {
-    super(type, message, new SszSignature(signature));
+  public SignedBuilderBid create(final BuilderBid message, final BLSSignature signature) {
+    return new SignedBuilderBid(this, message, signature);
   }
 
   @Override
-  public SignedBuilderBidV1Schema getSchema() {
-    return (SignedBuilderBidV1Schema) super.getSchema();
-  }
-
-  public BuilderBidV1 getMessage() {
-    return getField0();
-  }
-
-  public BLSSignature getSignature() {
-    return getField1().getSignature();
+  public SignedBuilderBid createFromBackingNode(TreeNode node) {
+    return new SignedBuilderBid(this, node);
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/SignedValidatorRegistration.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/SignedValidatorRegistration.java
@@ -18,26 +18,26 @@ import tech.pegasys.teku.infrastructure.ssz.containers.Container2;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.spec.datastructures.type.SszSignature;
 
-public class SignedValidatorRegistrationV1
-    extends Container2<SignedValidatorRegistrationV1, ValidatorRegistrationV1, SszSignature> {
+public class SignedValidatorRegistration
+    extends Container2<SignedValidatorRegistration, ValidatorRegistration, SszSignature> {
 
-  SignedValidatorRegistrationV1(SignedValidatorRegistrationV1Schema type, TreeNode backingNode) {
+  SignedValidatorRegistration(SignedValidatorRegistrationSchema type, TreeNode backingNode) {
     super(type, backingNode);
   }
 
-  SignedValidatorRegistrationV1(
-      final SignedValidatorRegistrationV1Schema type,
-      final ValidatorRegistrationV1 message,
+  SignedValidatorRegistration(
+      final SignedValidatorRegistrationSchema type,
+      final ValidatorRegistration message,
       final BLSSignature signature) {
     super(type, message, new SszSignature(signature));
   }
 
   @Override
-  public SignedValidatorRegistrationV1Schema getSchema() {
-    return (SignedValidatorRegistrationV1Schema) super.getSchema();
+  public SignedValidatorRegistrationSchema getSchema() {
+    return (SignedValidatorRegistrationSchema) super.getSchema();
   }
 
-  public ValidatorRegistrationV1 getMessage() {
+  public ValidatorRegistration getMessage() {
     return getField0();
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/SignedValidatorRegistrationSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/SignedValidatorRegistrationSchema.java
@@ -19,24 +19,24 @@ import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.spec.datastructures.type.SszSignature;
 import tech.pegasys.teku.spec.datastructures.type.SszSignatureSchema;
 
-public class SignedValidatorRegistrationV1Schema
-    extends ContainerSchema2<SignedValidatorRegistrationV1, ValidatorRegistrationV1, SszSignature> {
+public class SignedValidatorRegistrationSchema
+    extends ContainerSchema2<SignedValidatorRegistration, ValidatorRegistration, SszSignature> {
 
-  public SignedValidatorRegistrationV1Schema(
-      final ValidatorRegistrationV1Schema validatorRegistrationV1Schema) {
+  public SignedValidatorRegistrationSchema(
+      final ValidatorRegistrationSchema validatorRegistrationSchema) {
     super(
-        "SignedValidatorRegistrationV1",
-        namedSchema("message", validatorRegistrationV1Schema),
+        "SignedValidatorRegistration",
+        namedSchema("message", validatorRegistrationSchema),
         namedSchema("signature", SszSignatureSchema.INSTANCE));
   }
 
-  public SignedValidatorRegistrationV1 create(
-      final ValidatorRegistrationV1 message, final BLSSignature signature) {
-    return new SignedValidatorRegistrationV1(this, message, signature);
+  public SignedValidatorRegistration create(
+      final ValidatorRegistration message, final BLSSignature signature) {
+    return new SignedValidatorRegistration(this, message, signature);
   }
 
   @Override
-  public SignedValidatorRegistrationV1 createFromBackingNode(TreeNode node) {
-    return new SignedValidatorRegistrationV1(this, node);
+  public SignedValidatorRegistration createFromBackingNode(TreeNode node) {
+    return new SignedValidatorRegistration(this, node);
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ValidatorRegistration.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ValidatorRegistration.java
@@ -22,15 +22,15 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.eth1.Eth1Address;
 import tech.pegasys.teku.spec.datastructures.type.SszPublicKey;
 
-public class ValidatorRegistrationV1
-    extends Container4<ValidatorRegistrationV1, SszByteVector, SszUInt64, SszUInt64, SszPublicKey> {
+public class ValidatorRegistration
+    extends Container4<ValidatorRegistration, SszByteVector, SszUInt64, SszUInt64, SszPublicKey> {
 
-  protected ValidatorRegistrationV1(ValidatorRegistrationV1Schema schema, TreeNode backingNode) {
+  protected ValidatorRegistration(ValidatorRegistrationSchema schema, TreeNode backingNode) {
     super(schema, backingNode);
   }
 
-  protected ValidatorRegistrationV1(
-      ValidatorRegistrationV1Schema schema,
+  protected ValidatorRegistration(
+      ValidatorRegistrationSchema schema,
       SszByteVector feeRecipient,
       SszUInt64 gasLimit,
       SszUInt64 timestamp,

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ValidatorRegistrationSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ValidatorRegistrationSchema.java
@@ -25,24 +25,24 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.type.SszPublicKey;
 import tech.pegasys.teku.spec.datastructures.type.SszPublicKeySchema;
 
-public class ValidatorRegistrationV1Schema
+public class ValidatorRegistrationSchema
     extends ContainerSchema4<
-        ValidatorRegistrationV1, SszByteVector, SszUInt64, SszUInt64, SszPublicKey> {
-  public ValidatorRegistrationV1Schema() {
+    ValidatorRegistration, SszByteVector, SszUInt64, SszUInt64, SszPublicKey> {
+  public ValidatorRegistrationSchema() {
     super(
-        "ValidatorRegistrationV1",
+        "ValidatorRegistration",
         namedSchema("fee_recipient", SszByteVectorSchema.create(Bytes20.SIZE)),
         namedSchema("gas_limit", SszPrimitiveSchemas.UINT64_SCHEMA),
         namedSchema("timestamp", SszPrimitiveSchemas.UINT64_SCHEMA),
         namedSchema("pubkey", SszPublicKeySchema.INSTANCE));
   }
 
-  public ValidatorRegistrationV1 create(
+  public ValidatorRegistration create(
       final Bytes20 feeRecipient,
       final UInt64 gasLimit,
       final UInt64 timestamp,
       final BLSPublicKey publicKey) {
-    return new ValidatorRegistrationV1(
+    return new ValidatorRegistration(
         this,
         SszByteVector.fromBytes(feeRecipient.getWrappedBytes()),
         SszUInt64.of(gasLimit),
@@ -51,7 +51,7 @@ public class ValidatorRegistrationV1Schema
   }
 
   @Override
-  public ValidatorRegistrationV1 createFromBackingNode(TreeNode node) {
-    return new ValidatorRegistrationV1(this, node);
+  public ValidatorRegistration createFromBackingNode(TreeNode node) {
+    return new ValidatorRegistration(this, node);
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ValidatorRegistrationSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ValidatorRegistrationSchema.java
@@ -27,7 +27,7 @@ import tech.pegasys.teku.spec.datastructures.type.SszPublicKeySchema;
 
 public class ValidatorRegistrationSchema
     extends ContainerSchema4<
-    ValidatorRegistration, SszByteVector, SszUInt64, SszUInt64, SszPublicKey> {
+        ValidatorRegistration, SszByteVector, SszUInt64, SszUInt64, SszPublicKey> {
   public ValidatorRegistrationSchema() {
     super(
         "ValidatorRegistration",

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/PayloadBuildingAttributes.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/PayloadBuildingAttributes.java
@@ -20,19 +20,19 @@ import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.eth1.Eth1Address;
-import tech.pegasys.teku.spec.datastructures.execution.SignedValidatorRegistrationV1;
+import tech.pegasys.teku.spec.datastructures.execution.SignedValidatorRegistration;
 
 public class PayloadBuildingAttributes {
   private final UInt64 timestamp;
   private final Bytes32 prevRandao;
   private final Eth1Address feeRecipient;
-  private final Optional<SignedValidatorRegistrationV1> validatorRegistration;
+  private final Optional<SignedValidatorRegistration> validatorRegistration;
 
   public PayloadBuildingAttributes(
       final UInt64 timestamp,
       final Bytes32 prevRandao,
       final Eth1Address feeRecipient,
-      final Optional<SignedValidatorRegistrationV1> validatorRegistration) {
+      final Optional<SignedValidatorRegistration> validatorRegistration) {
     this.timestamp = timestamp;
     this.prevRandao = prevRandao;
     this.feeRecipient = feeRecipient;
@@ -51,7 +51,7 @@ public class PayloadBuildingAttributes {
     return feeRecipient;
   }
 
-  public Optional<SignedValidatorRegistrationV1> getValidatorRegistration() {
+  public Optional<SignedValidatorRegistration> getValidatorRegistration() {
     return validatorRegistration;
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsBellatrix.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsBellatrix.java
@@ -24,12 +24,12 @@ import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.bellatrix
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.bellatrix.BeaconBlockBodySchemaBellatrixImpl;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.bellatrix.BlindedBeaconBlockBodySchemaBellatrix;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.bellatrix.BlindedBeaconBlockBodySchemaBellatrixImpl;
-import tech.pegasys.teku.spec.datastructures.execution.BuilderBidV1Schema;
+import tech.pegasys.teku.spec.datastructures.execution.BuilderBidSchema;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeaderSchema;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSchema;
-import tech.pegasys.teku.spec.datastructures.execution.SignedBuilderBidV1Schema;
-import tech.pegasys.teku.spec.datastructures.execution.SignedValidatorRegistrationV1Schema;
-import tech.pegasys.teku.spec.datastructures.execution.ValidatorRegistrationV1Schema;
+import tech.pegasys.teku.spec.datastructures.execution.SignedBuilderBidSchema;
+import tech.pegasys.teku.spec.datastructures.execution.SignedValidatorRegistrationSchema;
+import tech.pegasys.teku.spec.datastructures.execution.ValidatorRegistrationSchema;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchema;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.bellatrix.BeaconStateBellatrix;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.bellatrix.BeaconStateSchemaBellatrix;
@@ -44,10 +44,10 @@ public class SchemaDefinitionsBellatrix extends SchemaDefinitionsAltair {
   private final SignedBeaconBlockSchema signedBeaconBlockSchema;
   private final SignedBeaconBlockSchema signedBlindedBeaconBlockSchema;
   private final ExecutionPayloadHeaderSchema executionPayloadHeaderSchema;
-  private final BuilderBidV1Schema builderBidV1Schema;
-  private final SignedBuilderBidV1Schema signedBuilderBidV1Schema;
-  private final ValidatorRegistrationV1Schema validatorRegistrationSchema;
-  private final SignedValidatorRegistrationV1Schema signedValidatorRegistrationSchema;
+  private final BuilderBidSchema builderBidSchema;
+  private final SignedBuilderBidSchema signedBuilderBidSchema;
+  private final ValidatorRegistrationSchema validatorRegistrationSchema;
+  private final SignedValidatorRegistrationSchema signedValidatorRegistrationSchema;
 
   public SchemaDefinitionsBellatrix(final SpecConfigBellatrix specConfig) {
     super(specConfig.toVersionAltair().orElseThrow());
@@ -66,11 +66,11 @@ public class SchemaDefinitionsBellatrix extends SchemaDefinitionsAltair {
     this.signedBlindedBeaconBlockSchema =
         new SignedBeaconBlockSchema(blindedBeaconBlockSchema, "SignedBlindedBlockBellatrix");
     this.executionPayloadHeaderSchema = new ExecutionPayloadHeaderSchema(specConfig);
-    this.builderBidV1Schema = new BuilderBidV1Schema(executionPayloadHeaderSchema);
-    this.signedBuilderBidV1Schema = new SignedBuilderBidV1Schema(builderBidV1Schema);
-    this.validatorRegistrationSchema = new ValidatorRegistrationV1Schema();
+    this.builderBidSchema = new BuilderBidSchema(executionPayloadHeaderSchema);
+    this.signedBuilderBidSchema = new SignedBuilderBidSchema(builderBidSchema);
+    this.validatorRegistrationSchema = new ValidatorRegistrationSchema();
     this.signedValidatorRegistrationSchema =
-        new SignedValidatorRegistrationV1Schema(validatorRegistrationSchema);
+        new SignedValidatorRegistrationSchema(validatorRegistrationSchema);
   }
 
   public static SchemaDefinitionsBellatrix required(final SchemaDefinitions schemaDefinitions) {
@@ -126,19 +126,19 @@ public class SchemaDefinitionsBellatrix extends SchemaDefinitionsAltair {
     return executionPayloadHeaderSchema;
   }
 
-  public BuilderBidV1Schema getBuilderBidV1Schema() {
-    return builderBidV1Schema;
+  public BuilderBidSchema getBuilderBidSchema() {
+    return builderBidSchema;
   }
 
-  public SignedBuilderBidV1Schema getSignedBuilderBidV1Schema() {
-    return signedBuilderBidV1Schema;
+  public SignedBuilderBidSchema getSignedBuilderBidSchema() {
+    return signedBuilderBidSchema;
   }
 
-  public ValidatorRegistrationV1Schema getValidatorRegistrationSchema() {
+  public ValidatorRegistrationSchema getValidatorRegistrationSchema() {
     return validatorRegistrationSchema;
   }
 
-  public SignedValidatorRegistrationV1Schema getSignedValidatorRegistrationSchema() {
+  public SignedValidatorRegistrationSchema getSignedValidatorRegistrationSchema() {
     return signedValidatorRegistrationSchema;
   }
 

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -81,15 +81,15 @@ import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodySch
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregate;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregateSchema;
 import tech.pegasys.teku.spec.datastructures.eth1.Eth1Address;
-import tech.pegasys.teku.spec.datastructures.execution.BuilderBidV1;
+import tech.pegasys.teku.spec.datastructures.execution.BuilderBid;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
-import tech.pegasys.teku.spec.datastructures.execution.SignedBuilderBidV1;
-import tech.pegasys.teku.spec.datastructures.execution.SignedValidatorRegistrationV1;
-import tech.pegasys.teku.spec.datastructures.execution.SignedValidatorRegistrationV1Schema;
-import tech.pegasys.teku.spec.datastructures.execution.ValidatorRegistrationV1;
-import tech.pegasys.teku.spec.datastructures.execution.ValidatorRegistrationV1Schema;
+import tech.pegasys.teku.spec.datastructures.execution.SignedBuilderBid;
+import tech.pegasys.teku.spec.datastructures.execution.SignedValidatorRegistration;
+import tech.pegasys.teku.spec.datastructures.execution.SignedValidatorRegistrationSchema;
+import tech.pegasys.teku.spec.datastructures.execution.ValidatorRegistration;
+import tech.pegasys.teku.spec.datastructures.execution.ValidatorRegistrationSchema;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.EnrForkId;
 import tech.pegasys.teku.spec.datastructures.operations.AggregateAndProof;
@@ -441,16 +441,16 @@ public final class DataStructureUtil {
             randomBytes32());
   }
 
-  public BuilderBidV1 randomBuilderBidV1() {
+  public BuilderBid randomBuilderBid() {
     return SchemaDefinitionsBellatrix.required(spec.getGenesisSchemaDefinitions())
-        .getBuilderBidV1Schema()
+        .getBuilderBidSchema()
         .create(randomExecutionPayloadHeader(), randomUInt256(), randomPublicKey());
   }
 
-  public SignedBuilderBidV1 randomSignedBuilderBidV1() {
+  public SignedBuilderBid randomSignedBuilderBid() {
     return SchemaDefinitionsBellatrix.required(spec.getGenesisSchemaDefinitions())
-        .getSignedBuilderBidV1Schema()
-        .create(randomBuilderBidV1(), randomSignature());
+        .getSignedBuilderBidSchema()
+        .create(randomBuilderBid(), randomSignature());
   }
 
   public ExecutionPayload randomExecutionPayloadIfRequiredBySchema(
@@ -1143,25 +1143,25 @@ public final class DataStructureUtil {
         withValidatorRegistration ? Optional.of(randomValidatorRegistration()) : Optional.empty());
   }
 
-  public SignedValidatorRegistrationV1 randomValidatorRegistration() {
+  public SignedValidatorRegistration randomValidatorRegistration() {
     return randomValidatorRegistration(randomPublicKey());
   }
 
-  public SignedValidatorRegistrationV1 randomValidatorRegistration(final BLSPublicKey publicKey) {
-    SignedValidatorRegistrationV1Schema signedSchema =
+  public SignedValidatorRegistration randomValidatorRegistration(final BLSPublicKey publicKey) {
+    SignedValidatorRegistrationSchema signedSchema =
         spec.getGenesisSpec()
             .getSchemaDefinitions()
             .toVersionBellatrix()
             .orElseThrow()
             .getSignedValidatorRegistrationSchema();
-    ValidatorRegistrationV1Schema schema =
+    ValidatorRegistrationSchema schema =
         spec.getGenesisSpec()
             .getSchemaDefinitions()
             .toVersionBellatrix()
             .orElseThrow()
             .getValidatorRegistrationSchema();
 
-    ValidatorRegistrationV1 validatorRegistration =
+    ValidatorRegistration validatorRegistration =
         schema.create(randomBytes20(), randomUInt64(), randomUInt64(), publicKey);
 
     return signedSchema.create(validatorRegistration, randomSignature());

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ProposersDataManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ProposersDataManager.java
@@ -31,7 +31,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.eth1.Eth1Address;
-import tech.pegasys.teku.spec.datastructures.execution.SignedValidatorRegistrationV1;
+import tech.pegasys.teku.spec.datastructures.execution.SignedValidatorRegistration;
 import tech.pegasys.teku.spec.datastructures.operations.versions.bellatrix.BeaconPreparableProposer;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.executionlayer.PayloadBuildingAttributes;
@@ -92,7 +92,7 @@ public class ProposersDataManager {
   }
 
   public SafeFuture<Void> updateValidatorRegistrations(
-      final Collection<SignedValidatorRegistrationV1> validatorRegistrations,
+      final Collection<SignedValidatorRegistration> validatorRegistrations,
       final UInt64 currentSlot) {
     // Remove expired validators
     validatorRegistrationInfoByValidatorIndex
@@ -174,7 +174,7 @@ public class ProposersDataManager {
     }
     final UInt64 timestamp = spec.computeTimeAtSlot(state, blockSlot);
     final Bytes32 random = spec.getRandaoMix(state, epoch);
-    final Optional<SignedValidatorRegistrationV1> validatorRegistration =
+    final Optional<SignedValidatorRegistration> validatorRegistration =
         Optional.ofNullable(validatorRegistrationInfoByValidatorIndex.get(proposerIndex))
             .map(RegisteredValidatorInfo::getSignedValidatorRegistration);
     return Optional.of(
@@ -251,7 +251,7 @@ public class ProposersDataManager {
                                     .getMessage()
                                     .getFeeRecipient())
                             .put(
-                                "gas_target",
+                                "gas_limit",
                                 registeredValidatorInfoEntry
                                     .getValue()
                                     .getSignedValidatorRegistration()

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/RegisteredValidatorInfo.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/RegisteredValidatorInfo.java
@@ -14,18 +14,18 @@
 package tech.pegasys.teku.statetransition.forkchoice;
 
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.datastructures.execution.SignedValidatorRegistrationV1;
+import tech.pegasys.teku.spec.datastructures.execution.SignedValidatorRegistration;
 
 class RegisteredValidatorInfo extends ExpiringInfo {
-  private final SignedValidatorRegistrationV1 signedValidatorRegistration;
+  private final SignedValidatorRegistration signedValidatorRegistration;
 
   public RegisteredValidatorInfo(
-      final UInt64 expirySlot, final SignedValidatorRegistrationV1 signedValidatorRegistration) {
+      final UInt64 expirySlot, final SignedValidatorRegistration signedValidatorRegistration) {
     super(expirySlot);
     this.signedValidatorRegistration = signedValidatorRegistration;
   }
 
-  public SignedValidatorRegistrationV1 getSignedValidatorRegistration() {
+  public SignedValidatorRegistration getSignedValidatorRegistration() {
     return signedValidatorRegistration;
   }
 }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
@@ -46,7 +46,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.eth1.Eth1Address;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
-import tech.pegasys.teku.spec.datastructures.execution.SignedValidatorRegistrationV1;
+import tech.pegasys.teku.spec.datastructures.execution.SignedValidatorRegistration;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
 import tech.pegasys.teku.spec.datastructures.operations.versions.bellatrix.BeaconPreparableProposer;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
@@ -819,7 +819,7 @@ class ForkChoiceNotifierTest {
       final UInt64 blockSlot,
       final boolean doPrepare,
       final Optional<Eth1Address> overrideFeeRecipient,
-      final Optional<SignedValidatorRegistrationV1> validatorRegistration) {
+      final Optional<SignedValidatorRegistration> validatorRegistration) {
     final int block2Proposer = spec.getBeaconProposerIndex(headState, blockSlot);
     final PayloadBuildingAttributes payloadBuildingAttributes =
         getExpectedPayloadBuildingAttributes(
@@ -832,10 +832,10 @@ class ForkChoiceNotifierTest {
           recentChainData.getHeadSlot());
     }
     validatorRegistration.ifPresent(
-        signedValidatorRegistrationV1 ->
+        signedValidatorRegistration ->
             SafeFutureAssert.safeJoin(
                 proposersDataManager.updateValidatorRegistrations(
-                    List.of(signedValidatorRegistrationV1), recentChainData.getHeadSlot())));
+                    List.of(signedValidatorRegistration), recentChainData.getHeadSlot())));
     return payloadBuildingAttributes;
   }
 
@@ -868,7 +868,7 @@ class ForkChoiceNotifierTest {
       final BeaconState headState,
       final UInt64 blockSlot,
       final Optional<Eth1Address> overrideFeeRecipient,
-      final Optional<SignedValidatorRegistrationV1> validatorRegistration) {
+      final Optional<SignedValidatorRegistration> validatorRegistration) {
     final Eth1Address feeRecipient =
         overrideFeeRecipient.orElse(dataStructureUtil.randomEth1Address());
     final UInt64 timestamp = spec.computeTimeAtSlot(headState, blockSlot);
@@ -894,7 +894,7 @@ class ForkChoiceNotifierTest {
         false);
   }
 
-  private SignedValidatorRegistrationV1 createValidatorRegistration(
+  private SignedValidatorRegistration createValidatorRegistration(
       final BeaconState headState, final UInt64 blockSlot) {
     final int block2Proposer = spec.getBeaconProposerIndex(headState, blockSlot);
     return dataStructureUtil.randomValidatorRegistration(


### PR DESCRIPTION
## PR Description
Removed `V1` suffix from builder spec classes
Changed `gas_target` to `gas_limit` in `RegisteredValidatorInfoSchema`

## Fixed Issue(s)
related to #5396 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
