### PR TITLE
Stream SSZ response content

### DIFF
--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/openapi/response/OctetStreamResponseContentTypeDefinition.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/openapi/response/OctetStreamResponseContentTypeDefinition.java
@@ -30,25 +30,28 @@ public class OctetStreamResponseContentTypeDefinition<T> extends DelegatingOpenA
           .parser(Bytes::fromHexString)
           .format("binary")
           .build();
-  private final Function<T, Bytes> toBytes;
+  private final OctetStreamSerializer<T> serializer;
   private final Function<T, Map<String, String>> toAdditionalHeaders;
 
   public OctetStreamResponseContentTypeDefinition(
-      final Function<T, Bytes> toBytes,
+      final OctetStreamSerializer<T> serializer,
       final Function<T, Map<String, String>> toAdditionalHeaders) {
     super(OCTET_STREAM_BYTES_TYPE);
-    this.toBytes = toBytes;
+    this.serializer = serializer;
     this.toAdditionalHeaders = toAdditionalHeaders;
   }
 
   @Override
   public void serialize(final T value, final OutputStream out) throws IOException {
-    final Bytes data = toBytes.apply(value);
-    out.write(data.toArrayUnsafe());
+    serializer.serialize(value, out);
   }
 
   @Override
   public Map<String, String> getAdditionalHeaders(final T value) {
     return toAdditionalHeaders.apply(value);
+  }
+
+  public interface OctetStreamSerializer<T> {
+    void serialize(T data, OutputStream out) throws IOException;
   }
 }

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/SimpleOffsetSerializable.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/SimpleOffsetSerializable.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.infrastructure.ssz;
 
+import java.io.OutputStream;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.ssz.sos.SszWriter;
 
@@ -32,4 +33,6 @@ public interface SimpleOffsetSerializable {
    * @return number of bytes written
    */
   int sszSerialize(SszWriter writer);
+
+  int sszSerialize(OutputStream out);
 }

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/SszData.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/SszData.java
@@ -13,9 +13,11 @@
 
 package tech.pegasys.teku.infrastructure.ssz;
 
+import java.io.OutputStream;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszSchema;
+import tech.pegasys.teku.infrastructure.ssz.sos.SszOutputStreamWriter;
 import tech.pegasys.teku.infrastructure.ssz.sos.SszWriter;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 
@@ -59,5 +61,10 @@ public interface SszData extends Merkleizable, SimpleOffsetSerializable {
   @Override
   default int sszSerialize(SszWriter writer) {
     return getSchema().sszSerializeTree(getBackingNode(), writer);
+  }
+
+  @Override
+  default int sszSerialize(OutputStream out) {
+    return sszSerialize(new SszOutputStreamWriter(out));
   }
 }

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/sos/SszOutputStreamWriter.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/sos/SszOutputStreamWriter.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.ssz.sos;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+
+public class SszOutputStreamWriter implements SszWriter {
+  private final OutputStream out;
+
+  public SszOutputStreamWriter(final OutputStream out) {
+    this.out = out;
+  }
+
+  @Override
+  public void write(final byte[] bytes, final int offset, final int length) {
+    try {
+      out.write(bytes, offset, length);
+    } catch (final IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+}


### PR DESCRIPTION
## PR Description
Stream SSZ content when generating REST API responses rather than creating the full SSZ in memory then writing.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
