### PR TITLE
[Mev Boost\Builder] implement builder registration call in `ProposersDataManager`

### DIFF
--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
@@ -267,7 +267,20 @@ public class ExecutionLayerManagerImpl implements ExecutionLayerManager {
   @Override
   public SafeFuture<Void> builderRegisterValidator(
       final SignedValidatorRegistration signedValidatorRegistration, final UInt64 slot) {
-    return SafeFuture.COMPLETE;
+    LOG.trace(
+        "calling builderRegisterValidator(slot={},signedValidatorRegistration={})",
+        slot,
+        signedValidatorRegistration);
+    return executionBuilderClient
+        .orElseThrow()
+        .registerValidator(slot, signedValidatorRegistration)
+        .thenApply(ExecutionLayerManagerImpl::unwrapResponseOrThrow)
+        .thenPeek(
+            __ ->
+                LOG.trace(
+                    "builderRegisterValidator(slot={},signedValidatorRegistration={}) -> success",
+                    slot,
+                    signedValidatorRegistration));
   }
 
   @Override

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
@@ -265,7 +265,7 @@ public class ExecutionLayerManagerImpl implements ExecutionLayerManager {
   }
 
   @Override
-  public SafeFuture<Void> registerValidator(
+  public SafeFuture<Void> builderRegisterValidator(
       final SignedValidatorRegistration signedValidatorRegistration, final UInt64 slot) {
     return SafeFuture.COMPLETE;
   }

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
@@ -57,6 +57,7 @@ import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
 import tech.pegasys.teku.spec.datastructures.execution.PowBlock;
 import tech.pegasys.teku.spec.datastructures.execution.SignedBuilderBid;
+import tech.pegasys.teku.spec.datastructures.execution.SignedValidatorRegistration;
 import tech.pegasys.teku.spec.executionlayer.ForkChoiceState;
 import tech.pegasys.teku.spec.executionlayer.PayloadBuildingAttributes;
 import tech.pegasys.teku.spec.executionlayer.PayloadStatus;
@@ -261,6 +262,12 @@ public class ExecutionLayerManagerImpl implements ExecutionLayerManager {
                     "engineExchangeTransitionConfiguration(transitionConfiguration={}) -> {}",
                     transitionConfiguration,
                     remoteTransitionConfiguration));
+  }
+
+  @Override
+  public SafeFuture<Void> registerValidator(
+      final SignedValidatorRegistration signedValidatorRegistration, final UInt64 slot) {
+    return SafeFuture.COMPLETE;
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannel.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannel.java
@@ -65,7 +65,7 @@ public interface ExecutionLayerChannel extends ChannelInterface {
         }
 
         @Override
-        public SafeFuture<Void> registerValidator(
+        public SafeFuture<Void> builderRegisterValidator(
             final SignedValidatorRegistration signedValidatorRegistration, final UInt64 slot) {
           return SafeFuture.COMPLETE;
         }
@@ -102,7 +102,7 @@ public interface ExecutionLayerChannel extends ChannelInterface {
       TransitionConfiguration transitionConfiguration);
 
   // builder namespace
-  SafeFuture<Void> registerValidator(
+  SafeFuture<Void> builderRegisterValidator(
       SignedValidatorRegistration signedValidatorRegistration, UInt64 slot);
 
   SafeFuture<ExecutionPayloadHeader> builderGetHeader(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannel.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannel.java
@@ -23,6 +23,7 @@ import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
 import tech.pegasys.teku.spec.datastructures.execution.PowBlock;
+import tech.pegasys.teku.spec.datastructures.execution.SignedValidatorRegistration;
 
 public interface ExecutionLayerChannel extends ChannelInterface {
   String STUB_ENDPOINT_IDENTIFIER = "stub";
@@ -59,8 +60,14 @@ public interface ExecutionLayerChannel extends ChannelInterface {
 
         @Override
         public SafeFuture<TransitionConfiguration> engineExchangeTransitionConfiguration(
-            TransitionConfiguration transitionConfiguration) {
+            final TransitionConfiguration transitionConfiguration) {
           return SafeFuture.completedFuture(transitionConfiguration);
+        }
+
+        @Override
+        public SafeFuture<Void> registerValidator(
+            final SignedValidatorRegistration signedValidatorRegistration, final UInt64 slot) {
+          return SafeFuture.COMPLETE;
         }
 
         @Override
@@ -77,28 +84,31 @@ public interface ExecutionLayerChannel extends ChannelInterface {
       };
 
   // eth namespace
-  SafeFuture<Optional<PowBlock>> eth1GetPowBlock(final Bytes32 blockHash);
+  SafeFuture<Optional<PowBlock>> eth1GetPowBlock(Bytes32 blockHash);
 
   SafeFuture<PowBlock> eth1GetPowChainHead();
 
   // engine namespace
   SafeFuture<ForkChoiceUpdatedResult> engineForkChoiceUpdated(
-      final ForkChoiceState forkChoiceState,
-      final Optional<PayloadBuildingAttributes> payloadBuildingAttributes);
+      ForkChoiceState forkChoiceState,
+      Optional<PayloadBuildingAttributes> payloadBuildingAttributes);
 
   SafeFuture<ExecutionPayload> engineGetPayload(
-      final ExecutionPayloadContext executionPayloadContext, final UInt64 slot);
+      ExecutionPayloadContext executionPayloadContext, UInt64 slot);
 
-  SafeFuture<PayloadStatus> engineNewPayload(final ExecutionPayload executionPayload);
+  SafeFuture<PayloadStatus> engineNewPayload(ExecutionPayload executionPayload);
 
   SafeFuture<TransitionConfiguration> engineExchangeTransitionConfiguration(
-      final TransitionConfiguration transitionConfiguration);
+      TransitionConfiguration transitionConfiguration);
 
   // builder namespace
-  SafeFuture<ExecutionPayloadHeader> builderGetHeader(
-      final ExecutionPayloadContext executionPayloadContext, final UInt64 slot);
+  SafeFuture<Void> registerValidator(
+      SignedValidatorRegistration signedValidatorRegistration, UInt64 slot);
 
-  SafeFuture<ExecutionPayload> builderGetPayload(final SignedBeaconBlock signedBlindedBeaconBlock);
+  SafeFuture<ExecutionPayloadHeader> builderGetHeader(
+      ExecutionPayloadContext executionPayloadContext, UInt64 slot);
+
+  SafeFuture<ExecutionPayload> builderGetPayload(SignedBeaconBlock signedBlindedBeaconBlock);
 
   enum Version {
     KILNV2;

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
@@ -261,7 +261,7 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
   }
 
   @Override
-  public SafeFuture<Void> registerValidator(
+  public SafeFuture<Void> builderRegisterValidator(
       SignedValidatorRegistration signedValidatorRegistration, UInt64 slot) {
     return SafeFuture.COMPLETE;
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
@@ -43,6 +43,7 @@ import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
 import tech.pegasys.teku.spec.datastructures.execution.PowBlock;
+import tech.pegasys.teku.spec.datastructures.execution.SignedValidatorRegistration;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsBellatrix;
 
 public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
@@ -257,6 +258,12 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
         transitionConfiguration,
         transitionConfigurationResponse);
     return SafeFuture.completedFuture(transitionConfigurationResponse);
+  }
+
+  @Override
+  public SafeFuture<Void> registerValidator(
+      SignedValidatorRegistration signedValidatorRegistration, UInt64 slot) {
+    return SafeFuture.COMPLETE;
   }
 
   @Override

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ProposersDataManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ProposersDataManager.java
@@ -141,7 +141,7 @@ public class ProposersDataManager {
     }
     final SignedValidatorRegistration registration = registrationIterator.next();
     return executionLayerChannel
-        .registerValidator(registration, currentSlot)
+        .builderRegisterValidator(registration, currentSlot)
         .handle(
             (__, error) -> {
               if (error != null) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ProposersDataManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ProposersDataManager.java
@@ -165,7 +165,7 @@ public class ProposersDataManager {
                               new RegisteredValidatorInfo(expirySlot, registration)),
                       () ->
                           LOG.warn(
-                              "validator public key not found: {}",
+                              "validator index not found for public key {}",
                               registration.getMessage().getPublicKey()));
 
               // continue asyncDoWhile

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
@@ -119,6 +119,8 @@ class ForkChoiceNotifierTest {
     storageSystem.chainUpdater().updateBestBlock(storageSystem.chainUpdater().advanceChain());
     forkChoiceStrategy = recentChainData.getForkChoiceStrategy().orElseThrow();
 
+    when(executionLayerChannel.builderRegisterValidator(any(), any()))
+        .thenReturn(SafeFuture.COMPLETE);
     when(executionLayerChannel.engineNewPayload(any()))
         .thenReturn(SafeFuture.completedFuture(PayloadStatus.VALID));
     when(executionLayerChannel.engineForkChoiceUpdated(any(), any()))

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
@@ -103,8 +103,9 @@ class ForkChoiceNotifierTest {
     proposersDataManager =
         spy(
             new ProposersDataManager(
-                spec,
                 eventThread,
+                spec,
+                executionLayerChannel,
                 recentChainData,
                 doNotInitializeWithDefaultFeeRecipient ? Optional.empty() : defaultFeeRecipient));
     notifier =
@@ -130,7 +131,9 @@ class ForkChoiceNotifierTest {
     storageSystem = InMemoryStorageSystemBuilder.buildDefault(spec);
     recentChainData = storageSystem.recentChainData();
     proposersDataManager =
-        spy(new ProposersDataManager(spec, eventThread, recentChainData, defaultFeeRecipient));
+        spy(
+            new ProposersDataManager(
+                eventThread, spec, executionLayerChannel, recentChainData, defaultFeeRecipient));
     notifier =
         new ForkChoiceNotifierImpl(
             eventThread, spec, executionLayerChannel, recentChainData, proposersDataManager);

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ProposerDataManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ProposerDataManagerTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.forkchoice;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.net.http.HttpConnectTimeoutException;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.async.eventthread.InlineEventThread;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.eth1.Eth1Address;
+import tech.pegasys.teku.spec.datastructures.execution.SignedValidatorRegistration;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannel;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.statetransition.forkchoice.ProposersDataManager.ProposersDataManagerSubscriber;
+import tech.pegasys.teku.storage.client.RecentChainData;
+
+public class ProposerDataManagerTest implements ProposersDataManagerSubscriber {
+  private final InlineEventThread eventThread = new InlineEventThread();
+  private final Spec spec = TestSpecFactory.createMinimalBellatrix();
+  private final Spec specMock = mock(Spec.class);
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+  private final ExecutionLayerChannel executionLayerChannel = mock(ExecutionLayerChannel.class);
+  private final RecentChainData recentChainData = mock(RecentChainData.class);
+
+  private final Optional<Eth1Address> defaultFeeRecipient =
+      Optional.of(Eth1Address.fromHexString("0x2Df386eFF130f991321bfC4F8372Ba838b9AB14B"));
+
+  private final ProposersDataManager proposersDataManager =
+      new ProposersDataManager(
+          eventThread, specMock, executionLayerChannel, recentChainData, defaultFeeRecipient);
+
+  private final BeaconState state = dataStructureUtil.randomBeaconState();
+
+  private boolean onPreparedProposersUpdatedCalled = false;
+  private boolean onValidatorRegistrationsUpdatedCalled = false;
+
+  private final UInt64 slot = UInt64.ONE;
+  private List<SignedValidatorRegistration> registrations;
+  private final SafeFuture<Void> response1 = new SafeFuture<>();
+  private final SafeFuture<Void> response2 = new SafeFuture<>();
+
+  @Test
+  void shouldCallRegisterValidator() {
+
+    prepareRegistrations();
+
+    proposersDataManager.updateValidatorRegistrations(registrations, slot);
+
+    // first registration
+    assertThat(onValidatorRegistrationsUpdatedCalled).isFalse();
+    verify(executionLayerChannel).registerValidator(registrations.get(0), slot);
+    verifyNoMoreInteractions(executionLayerChannel);
+
+    // resolve first registration
+    response1.complete(null);
+
+    // second registration
+    assertThat(onValidatorRegistrationsUpdatedCalled).isFalse();
+    verify(executionLayerChannel).registerValidator(registrations.get(1), slot);
+    verifyNoMoreInteractions(executionLayerChannel);
+
+    // resolve second registration
+    response2.complete(null);
+
+    // final update
+    assertThat(onValidatorRegistrationsUpdatedCalled).isTrue();
+  }
+
+  @Test
+  void shouldNotInterruptCallRegisterValidatorOnNonNetworkingException() {
+
+    prepareRegistrations();
+
+    proposersDataManager.updateValidatorRegistrations(registrations, slot);
+
+    // first registration
+    assertThat(onValidatorRegistrationsUpdatedCalled).isFalse();
+    verify(executionLayerChannel).registerValidator(registrations.get(0), slot);
+    verifyNoMoreInteractions(executionLayerChannel);
+
+    // resolve first registration
+    response1.completeExceptionally(new RuntimeException("generic error"));
+
+    // second registration
+    assertThat(onValidatorRegistrationsUpdatedCalled).isFalse();
+    verify(executionLayerChannel).registerValidator(registrations.get(1), slot);
+    verifyNoMoreInteractions(executionLayerChannel);
+
+    // resolve second registration
+    response2.complete(null);
+
+    // final update
+    assertThat(onValidatorRegistrationsUpdatedCalled).isTrue();
+  }
+
+  @Test
+  void shouldInterruptCallRegisterValidatorOnNetworkingException() {
+
+    prepareRegistrations();
+
+    proposersDataManager.updateValidatorRegistrations(registrations, slot);
+
+    // first registration
+    assertThat(onValidatorRegistrationsUpdatedCalled).isFalse();
+    verify(executionLayerChannel).registerValidator(registrations.get(0), slot);
+    verifyNoMoreInteractions(executionLayerChannel);
+
+    // resolve first registration
+    response1.completeExceptionally(new HttpConnectTimeoutException("timeout"));
+
+    verifyNoMoreInteractions(executionLayerChannel);
+
+    // final update
+    assertThat(onValidatorRegistrationsUpdatedCalled).isTrue();
+  }
+
+  private void prepareRegistrations() {
+    registrations =
+        List.of(
+            dataStructureUtil.randomValidatorRegistration(),
+            dataStructureUtil.randomValidatorRegistration());
+
+    when(executionLayerChannel.registerValidator(registrations.get(0), slot)).thenReturn(response1);
+    when(executionLayerChannel.registerValidator(registrations.get(1), slot)).thenReturn(response2);
+    when(recentChainData.getBestState()).thenReturn(Optional.of(SafeFuture.completedFuture(state)));
+    when(specMock.getValidatorIndex(state, registrations.get(0).getMessage().getPublicKey()))
+        .thenReturn(Optional.of(0));
+    when(specMock.getValidatorIndex(state, registrations.get(1).getMessage().getPublicKey()))
+        .thenReturn(Optional.of(1));
+
+    proposersDataManager.subscribeToProposersDataChanges(this);
+  }
+
+  @Override
+  public void onPreparedProposersUpdated() {
+    onPreparedProposersUpdatedCalled = true;
+  }
+
+  @Override
+  public void onValidatorRegistrationsUpdated() {
+    onValidatorRegistrationsUpdatedCalled = true;
+  }
+}

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ProposerDataManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ProposerDataManagerTest.java
@@ -71,7 +71,7 @@ public class ProposerDataManagerTest implements ProposersDataManagerSubscriber {
 
     // first registration
     assertThat(onValidatorRegistrationsUpdatedCalled).isFalse();
-    verify(executionLayerChannel).registerValidator(registrations.get(0), slot);
+    verify(executionLayerChannel).builderRegisterValidator(registrations.get(0), slot);
     verifyNoMoreInteractions(executionLayerChannel);
 
     // resolve first registration
@@ -79,7 +79,7 @@ public class ProposerDataManagerTest implements ProposersDataManagerSubscriber {
 
     // second registration
     assertThat(onValidatorRegistrationsUpdatedCalled).isFalse();
-    verify(executionLayerChannel).registerValidator(registrations.get(1), slot);
+    verify(executionLayerChannel).builderRegisterValidator(registrations.get(1), slot);
     verifyNoMoreInteractions(executionLayerChannel);
 
     // resolve second registration
@@ -99,7 +99,7 @@ public class ProposerDataManagerTest implements ProposersDataManagerSubscriber {
 
     // first registration
     assertThat(onValidatorRegistrationsUpdatedCalled).isFalse();
-    verify(executionLayerChannel).registerValidator(registrations.get(0), slot);
+    verify(executionLayerChannel).builderRegisterValidator(registrations.get(0), slot);
     verifyNoMoreInteractions(executionLayerChannel);
 
     // resolve first registration
@@ -107,7 +107,7 @@ public class ProposerDataManagerTest implements ProposersDataManagerSubscriber {
 
     // second registration
     assertThat(onValidatorRegistrationsUpdatedCalled).isFalse();
-    verify(executionLayerChannel).registerValidator(registrations.get(1), slot);
+    verify(executionLayerChannel).builderRegisterValidator(registrations.get(1), slot);
     verifyNoMoreInteractions(executionLayerChannel);
 
     // resolve second registration
@@ -127,7 +127,7 @@ public class ProposerDataManagerTest implements ProposersDataManagerSubscriber {
 
     // first registration
     assertThat(onValidatorRegistrationsUpdatedCalled).isFalse();
-    verify(executionLayerChannel).registerValidator(registrations.get(0), slot);
+    verify(executionLayerChannel).builderRegisterValidator(registrations.get(0), slot);
     verifyNoMoreInteractions(executionLayerChannel);
 
     // resolve first registration
@@ -145,8 +145,10 @@ public class ProposerDataManagerTest implements ProposersDataManagerSubscriber {
             dataStructureUtil.randomValidatorRegistration(),
             dataStructureUtil.randomValidatorRegistration());
 
-    when(executionLayerChannel.registerValidator(registrations.get(0), slot)).thenReturn(response1);
-    when(executionLayerChannel.registerValidator(registrations.get(1), slot)).thenReturn(response2);
+    when(executionLayerChannel.builderRegisterValidator(registrations.get(0), slot))
+        .thenReturn(response1);
+    when(executionLayerChannel.builderRegisterValidator(registrations.get(1), slot))
+        .thenReturn(response2);
     when(recentChainData.getBestState()).thenReturn(Optional.of(SafeFuture.completedFuture(state)));
     when(specMock.getValidatorIndex(state, registrations.get(0).getMessage().getPublicKey()))
         .thenReturn(Optional.of(0));

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ProposerDataManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ProposerDataManagerTest.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.async.SafeFutureAssert;
 import tech.pegasys.teku.infrastructure.async.eventthread.InlineEventThread;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
@@ -53,7 +54,6 @@ public class ProposerDataManagerTest implements ProposersDataManagerSubscriber {
 
   private final BeaconState state = dataStructureUtil.randomBeaconState();
 
-  private boolean onPreparedProposersUpdatedCalled = false;
   private boolean onValidatorRegistrationsUpdatedCalled = false;
 
   private final UInt64 slot = UInt64.ONE;
@@ -66,7 +66,8 @@ public class ProposerDataManagerTest implements ProposersDataManagerSubscriber {
 
     prepareRegistrations();
 
-    proposersDataManager.updateValidatorRegistrations(registrations, slot);
+    SafeFutureAssert.safeJoin(
+        proposersDataManager.updateValidatorRegistrations(registrations, slot));
 
     // first registration
     assertThat(onValidatorRegistrationsUpdatedCalled).isFalse();
@@ -93,7 +94,8 @@ public class ProposerDataManagerTest implements ProposersDataManagerSubscriber {
 
     prepareRegistrations();
 
-    proposersDataManager.updateValidatorRegistrations(registrations, slot);
+    SafeFutureAssert.safeJoin(
+        proposersDataManager.updateValidatorRegistrations(registrations, slot));
 
     // first registration
     assertThat(onValidatorRegistrationsUpdatedCalled).isFalse();
@@ -120,7 +122,8 @@ public class ProposerDataManagerTest implements ProposersDataManagerSubscriber {
 
     prepareRegistrations();
 
-    proposersDataManager.updateValidatorRegistrations(registrations, slot);
+    SafeFutureAssert.safeJoin(
+        proposersDataManager.updateValidatorRegistrations(registrations, slot));
 
     // first registration
     assertThat(onValidatorRegistrationsUpdatedCalled).isFalse();
@@ -154,9 +157,7 @@ public class ProposerDataManagerTest implements ProposersDataManagerSubscriber {
   }
 
   @Override
-  public void onPreparedProposersUpdated() {
-    onPreparedProposersUpdatedCalled = true;
-  }
+  public void onPreparedProposersUpdated() {}
 
   @Override
   public void onValidatorRegistrationsUpdated() {

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -966,7 +966,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
     eventThread.start();
     proposersDataManager =
         new ProposersDataManager(
-            spec, eventThread, recentChainData, getProposerDefaultFeeRecipient());
+            eventThread, spec, executionLayer, recentChainData, getProposerDefaultFeeRecipient());
     forkChoiceNotifier =
         new ForkChoiceNotifierImpl(
             eventThread, spec, executionLayer, recentChainData, proposersDataManager);


### PR DESCRIPTION
Implements the backend of the beacon rest api `register_validator` endpoint (ref: https://github.com/ethereum/beacon-APIs/pull/209)

since on the builder side the corresponding api do not accept array, this PR calls the builder api in sequence, one by one, stopping in case of networking issues or Timeout on SafeFuture. The reason is to avoid congesting the throttled rest client and delaying potential block building calls.


related to #5396 

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
