### PR TITLE
[Mev Boost\Builder] validator registration beacon rest api (server side)

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -42,6 +42,7 @@ import tech.pegasys.teku.beacon.sync.events.SyncStateProvider;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.gossip.BlockGossipChannel;
 import tech.pegasys.teku.networking.eth2.gossip.subnets.AttestationTopicSubscriber;
@@ -626,7 +627,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
 
   @Override
   public SafeFuture<Void> registerValidators(
-      final Collection<SignedValidatorRegistration> validatorRegistrations) {
+      final SszList<SignedValidatorRegistration> validatorRegistrations) {
     return proposersDataManager.updateValidatorRegistrations(
         validatorRegistrations, combinedChainDataClient.getCurrentSlot());
   }

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -52,6 +52,7 @@ import tech.pegasys.teku.spec.datastructures.attestation.ValidateableAttestation
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
+import tech.pegasys.teku.spec.datastructures.execution.SignedValidatorRegistration;
 import tech.pegasys.teku.spec.datastructures.genesis.GenesisData;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
@@ -621,6 +622,13 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
       final Collection<BeaconPreparableProposer> beaconPreparableProposers) {
     proposersDataManager.updatePreparedProposers(
         beaconPreparableProposers, combinedChainDataClient.getCurrentSlot());
+  }
+
+  @Override
+  public SafeFuture<Void> registerValidators(
+      final Collection<SignedValidatorRegistration> validatorRegistrations) {
+    return proposersDataManager.updateValidatorRegistrations(
+        validatorRegistrations, combinedChainDataClient.getCurrentSlot());
   }
 
   private Optional<SubmitDataError> fromInternalValidationResult(

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/validator/PostRegisterValidatorTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/validator/PostRegisterValidatorTest.java
@@ -13,14 +13,13 @@
 
 package tech.pegasys.teku.beaconrestapi.v1.validator;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
-import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_BAD_REQUEST;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
 import static tech.pegasys.teku.spec.schemas.ApiSchemas.SIGNED_VALIDATOR_REGISTRATIONS_SCHEMA;
 
 import java.io.IOException;
 import okhttp3.Response;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.beaconrestapi.AbstractDataBackedRestAPIIntegrationTest;
@@ -54,18 +53,6 @@ public class PostRegisterValidatorTest extends AbstractDataBackedRestAPIIntegrat
             JsonUtil.serialize(
                 request, SIGNED_VALIDATOR_REGISTRATIONS_SCHEMA.getJsonTypeDefinition()));
 
-    Assertions.assertThat(response.code()).isEqualTo(SC_OK);
-  }
-
-  @Test
-  void shouldReturnBadRequest() throws IOException {
-    final SszList<SignedValidatorRegistration> request =
-        dataStructureUtil.randomValidatorRegistrations(10);
-
-    when(validatorApiChannel.registerValidators(request)).thenReturn(SafeFuture.COMPLETE);
-
-    Response response = post(PostRegisterValidator.ROUTE, "");
-
-    Assertions.assertThat(response.code()).isEqualTo(SC_BAD_REQUEST);
+    assertThat(response.code()).isEqualTo(SC_OK);
   }
 }

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/validator/PostRegisterValidatorTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/validator/PostRegisterValidatorTest.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.beaconrestapi.v1.validator;
 
 import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_BAD_REQUEST;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
 import static tech.pegasys.teku.spec.schemas.ApiSchemas.SIGNED_VALIDATOR_REGISTRATIONS_SCHEMA;
 
@@ -54,5 +55,17 @@ public class PostRegisterValidatorTest extends AbstractDataBackedRestAPIIntegrat
                 request, SIGNED_VALIDATOR_REGISTRATIONS_SCHEMA.getJsonTypeDefinition()));
 
     Assertions.assertThat(response.code()).isEqualTo(SC_OK);
+  }
+
+  @Test
+  void shouldReturnBadRequest() throws IOException {
+    final SszList<SignedValidatorRegistration> request =
+        dataStructureUtil.randomValidatorRegistrations(10);
+
+    when(validatorApiChannel.registerValidators(request)).thenReturn(SafeFuture.COMPLETE);
+
+    Response response = post(PostRegisterValidator.ROUTE, "");
+
+    Assertions.assertThat(response.code()).isEqualTo(SC_BAD_REQUEST);
   }
 }

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/validator/PostRegisterValidatorTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/validator/PostRegisterValidatorTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.beaconrestapi.v1.validator;
+
+import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
+import static tech.pegasys.teku.spec.schemas.ApiSchemas.SIGNED_VALIDATOR_REGISTRATIONS_SCHEMA;
+
+import java.io.IOException;
+import okhttp3.Response;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.beaconrestapi.AbstractDataBackedRestAPIIntegrationTest;
+import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.PostRegisterValidator;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.json.JsonUtil;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.datastructures.execution.SignedValidatorRegistration;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class PostRegisterValidatorTest extends AbstractDataBackedRestAPIIntegrationTest {
+  private DataStructureUtil dataStructureUtil;
+
+  @BeforeEach
+  void setup() {
+    startRestAPIAtGenesis(SpecMilestone.BELLATRIX);
+    dataStructureUtil = new DataStructureUtil(spec);
+  }
+
+  @Test
+  void shouldReturnOk() throws IOException {
+    final SszList<SignedValidatorRegistration> request =
+        dataStructureUtil.randomValidatorRegistrations(10);
+
+    when(validatorApiChannel.registerValidators(request)).thenReturn(SafeFuture.COMPLETE);
+
+    Response response =
+        post(
+            PostRegisterValidator.ROUTE,
+            JsonUtil.serialize(
+                request, SIGNED_VALIDATOR_REGISTRATIONS_SCHEMA.getJsonTypeDefinition()));
+
+    Assertions.assertThat(response.code()).isEqualTo(SC_OK);
+  }
+}

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/paths/_eth_v1_validator_register_validator.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/paths/_eth_v1_validator_register_validator.json
@@ -1,0 +1,52 @@
+{
+  "post" : {
+    "tags" : [ "Validator", "Validator Required Api" ],
+    "operationId" : "registerValidator",
+    "summary" : "Provide beacon node with registrations for the given validators to the external builder network.",
+    "description" : "Prepares the beacon node for engaging with external builders. The information will be sent by the beacon node to the builder network. It is expected that the validator client will send this information periodically to ensure the beacon node has correct and timely registration information to provide to builders. The validator client should not sign blinded beacon blocks that do not adhere to their latest fee recipient and gas limit preferences.",
+    "requestBody" : {
+      "content" : {
+        "application/octet-stream" : {
+          "schema" : {
+            "type" : "string",
+            "format" : "binary"
+          }
+        },
+        "application/json" : {
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/SignedValidatorRegistration"
+            }
+          }
+        }
+      }
+    },
+    "responses" : {
+      "200" : {
+        "description" : "Registration information has been received.",
+        "content" : { }
+      },
+      "400" : {
+        "description" : "The request could not be processed, check the response for more information.",
+        "content" : {
+          "application/json" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/HttpErrorResponse"
+            }
+          }
+        }
+      },
+      "500" : {
+        "description" : "Internal server error",
+        "content" : {
+          "application/json" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/HttpErrorResponse"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/schema/SignedValidatorRegistration.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/schema/SignedValidatorRegistration.json
@@ -1,0 +1,16 @@
+{
+  "title" : "SignedValidatorRegistration",
+  "type" : "object",
+  "required" : [ "message", "signature" ],
+  "properties" : {
+    "message" : {
+      "$ref" : "#/components/schemas/ValidatorRegistration"
+    },
+    "signature" : {
+      "type" : "string",
+      "pattern" : "^0x[a-fA-F0-9]{2,}$",
+      "description" : "SSZ hexadecimal",
+      "format" : "bytes"
+    }
+  }
+}

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/schema/ValidatorRegistration.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/schema/ValidatorRegistration.json
@@ -1,0 +1,31 @@
+{
+  "title" : "ValidatorRegistration",
+  "type" : "object",
+  "required" : [ "fee_recipient", "gas_limit", "timestamp", "pubkey" ],
+  "properties" : {
+    "fee_recipient" : {
+      "type" : "string",
+      "pattern" : "^0x[a-fA-F0-9]{2,}$",
+      "description" : "SSZ hexadecimal",
+      "format" : "bytes"
+    },
+    "gas_limit" : {
+      "type" : "string",
+      "description" : "unsigned 64 bit integer",
+      "example" : "1",
+      "format" : "uint64"
+    },
+    "timestamp" : {
+      "type" : "string",
+      "description" : "unsigned 64 bit integer",
+      "example" : "1",
+      "format" : "uint64"
+    },
+    "pubkey" : {
+      "type" : "string",
+      "pattern" : "^0x[a-fA-F0-9]{2,}$",
+      "description" : "Bytes48 hexadecimal",
+      "format" : "bytes"
+    }
+  }
+}

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_validator_register_validator.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_validator_register_validator.json
@@ -1,0 +1,31 @@
+{
+  "post" : {
+    "tags" : [ "Validator", "Validator Required Api" ],
+    "summary" : "Provide beacon node with registrations for the given validators to the external builder network.",
+    "description" : "Prepares the beacon node for potential proposers by supplying information required when proposing blocks for the given validators. The information supplied for each validator index is considered persistent until overwritten by new information for the given validator index, or until the beacon node restarts.\n\nNote that because the information is not persistent across beacon node restarts it is recommended that either the beacon node is monitored for restarts or this information is refreshed by resending this request periodically (for example, each epoch).\n\nAlso note that requests containing currently inactive or unknown validator indices will be accepted, as they may become active at a later epoch.",
+    "operationId" : "postEthV1ValidatorRegister_validator",
+    "requestBody" : {
+      "content" : {
+        "application/json" : {
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PostRegisterValidatorRequest"
+            }
+          }
+        }
+      }
+    },
+    "responses" : {
+      "200" : {
+        "description" : "Preparation information has been received."
+      },
+      "400" : {
+        "description" : "Invalid parameter supplied."
+      },
+      "500" : {
+        "description" : "Beacon node internal error."
+      }
+    }
+  }
+}

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/BeaconPreparableProposer.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/BeaconPreparableProposer.json
@@ -9,8 +9,8 @@
     "fee_recipient" : {
       "pattern" : "^0x[a-fA-F0-9]{40}$",
       "type" : "string",
-      "description" : "Bytes20 hexadecimal",
-      "format" : "byte"
+      "description" : "An address on the execution (Ethereum 1) network.",
+      "example" : "0xabcf8e0d4e9587369b2301d0790347320302cc09"
     }
   }
 }

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/PostRegisterValidatorRequest.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/PostRegisterValidatorRequest.json
@@ -1,0 +1,13 @@
+{
+  "type" : "object",
+  "properties" : {
+    "message" : {
+      "$ref" : "#/components/schemas/ValidatorRegistration"
+    },
+    "signature" : {
+      "type" : "string",
+      "description" : "Bytes96 hexadecimal",
+      "format" : "byte"
+    }
+  }
+}

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/ValidatorRegistration.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/ValidatorRegistration.json
@@ -1,0 +1,27 @@
+{
+  "type" : "object",
+  "properties" : {
+    "fee_recipient" : {
+      "pattern" : "^0x[a-fA-F0-9]{40}$",
+      "type" : "string",
+      "description" : "An address on the execution (Ethereum 1) network.",
+      "example" : "0xabcf8e0d4e9587369b2301d0790347320302cc09"
+    },
+    "gas_limit" : {
+      "type" : "string",
+      "format" : "uint64",
+      "example" : "1"
+    },
+    "timestamp" : {
+      "type" : "string",
+      "format" : "uint64",
+      "example" : "1"
+    },
+    "pubkey" : {
+      "pattern" : "^0x[a-fA-F0-9]{96}$",
+      "type" : "string",
+      "description" : "The validator's BLS public key, uniquely identifying them. 48-bytes, hex encoded with 0x prefix, case insensitive.",
+      "example" : "0x93247f2209abcacf57b75a51dafae777f9dd38bc7053d1af526f220a7489a6d3a2753e5f3e8b1cfe39b56f43611df74a"
+    }
+  }
+}

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApi.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApi.java
@@ -400,7 +400,7 @@ public class BeaconRestApi {
     app.post(
         PostContributionAndProofs.ROUTE, new PostContributionAndProofs(dataProvider, jsonProvider));
     addMigratedEndpoint(new PostPrepareBeaconProposer(dataProvider));
-    addMigratedEndpoint(new PostRegisterValidator(dataProvider, spec));
+    addMigratedEndpoint(new PostRegisterValidator(dataProvider));
   }
 
   private void addBeaconHandlers(final DataProvider dataProvider, final Spec spec) {

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApi.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApi.java
@@ -96,6 +96,7 @@ import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.PostAggregateAndPro
 import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.PostAttesterDuties;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.PostContributionAndProofs;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.PostPrepareBeaconProposer;
+import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.PostRegisterValidator;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.PostSubscribeToBeaconCommitteeSubnet;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.PostSyncCommitteeSubscriptions;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.PostSyncDuties;
@@ -114,6 +115,7 @@ import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.version.VersionProvider;
 import tech.pegasys.teku.provider.JsonProvider;
 import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.eth1.Eth1Address;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionCache;
 import tech.pegasys.teku.storage.client.ChainDataUnavailableException;
@@ -399,6 +401,9 @@ public class BeaconRestApi {
     app.post(
         PostContributionAndProofs.ROUTE, new PostContributionAndProofs(dataProvider, jsonProvider));
     addMigratedEndpoint(new PostPrepareBeaconProposer(dataProvider));
+    if (spec.isMilestoneSupported(SpecMilestone.BELLATRIX)) {
+      addMigratedEndpoint(new PostRegisterValidator(dataProvider, spec, schemaCache));
+    }
   }
 
   private void addBeaconHandlers(final DataProvider dataProvider, final Spec spec) {

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApi.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApi.java
@@ -115,7 +115,6 @@ import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.version.VersionProvider;
 import tech.pegasys.teku.provider.JsonProvider;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.eth1.Eth1Address;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionCache;
 import tech.pegasys.teku.storage.client.ChainDataUnavailableException;
@@ -401,9 +400,7 @@ public class BeaconRestApi {
     app.post(
         PostContributionAndProofs.ROUTE, new PostContributionAndProofs(dataProvider, jsonProvider));
     addMigratedEndpoint(new PostPrepareBeaconProposer(dataProvider));
-    if (spec.isMilestoneSupported(SpecMilestone.BELLATRIX)) {
-      addMigratedEndpoint(new PostRegisterValidator(dataProvider, spec, schemaCache));
-    }
+    addMigratedEndpoint(new PostRegisterValidator(dataProvider, spec));
   }
 
   private void addBeaconHandlers(final DataProvider dataProvider, final Spec spec) {

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostRegisterValidator.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostRegisterValidator.java
@@ -134,6 +134,7 @@ public class PostRegisterValidator extends MigratingEndpointAdapter {
         .getJsonTypeDefinition();
   }
 
+  @SuppressWarnings("JavaCase")
   public static class SignedValidatorRegistrationOpenApiSchema {
     @JsonProperty("message")
     ValidatorRegistration message;

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostRegisterValidator.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostRegisterValidator.java
@@ -13,13 +13,6 @@
 
 package tech.pegasys.teku.beaconrestapi.handlers.v1.validator;
 
-import static tech.pegasys.teku.api.schema.SchemaConstants.DESCRIPTION_BYTES96;
-import static tech.pegasys.teku.api.schema.SchemaConstants.DESCRIPTION_EXECUTION_ADDRESS;
-import static tech.pegasys.teku.api.schema.SchemaConstants.EXAMPLE_EXECUTION_ADDRESS;
-import static tech.pegasys.teku.api.schema.SchemaConstants.EXAMPLE_PUBKEY;
-import static tech.pegasys.teku.api.schema.SchemaConstants.EXAMPLE_UINT64;
-import static tech.pegasys.teku.api.schema.SchemaConstants.PATTERN_EXECUTION_ADDRESS;
-import static tech.pegasys.teku.api.schema.SchemaConstants.PATTERN_PUBKEY;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.RES_BAD_REQUEST;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.RES_INTERNAL_ERROR;
@@ -27,7 +20,6 @@ import static tech.pegasys.teku.infrastructure.http.RestApiConstants.RES_OK;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.TAG_VALIDATOR;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.TAG_VALIDATOR_REQUIRED;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.javalin.http.Context;
 import io.javalin.plugin.openapi.annotations.HttpMethod;
@@ -35,41 +27,34 @@ import io.javalin.plugin.openapi.annotations.OpenApi;
 import io.javalin.plugin.openapi.annotations.OpenApiContent;
 import io.javalin.plugin.openapi.annotations.OpenApiRequestBody;
 import io.javalin.plugin.openapi.annotations.OpenApiResponse;
-import io.swagger.v3.oas.annotations.media.Schema;
+import org.apache.tuweni.bytes.Bytes;
 import org.jetbrains.annotations.NotNull;
 import tech.pegasys.teku.api.DataProvider;
 import tech.pegasys.teku.api.ValidatorDataProvider;
-import tech.pegasys.teku.api.schema.BLSPubKey;
-import tech.pegasys.teku.api.schema.BLSSignature;
+import tech.pegasys.teku.api.request.v1.validator.PostRegisterValidatorRequest;
 import tech.pegasys.teku.beaconrestapi.MigratingEndpointAdapter;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.AsyncApiResponse;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.EndpointMetadata;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiRequest;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
-import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.datastructures.eth1.Eth1Address;
 import tech.pegasys.teku.spec.datastructures.execution.SignedValidatorRegistration;
-import tech.pegasys.teku.spec.schemas.SchemaDefinitionCache;
+import tech.pegasys.teku.spec.datastructures.execution.SignedValidatorRegistrationSchema;
+import tech.pegasys.teku.spec.datastructures.execution.SignedValidatorRegistrationsSchema;
+import tech.pegasys.teku.spec.datastructures.execution.ValidatorRegistrationSchema;
 
 public class PostRegisterValidator extends MigratingEndpointAdapter {
   public static final String ROUTE = "/eth/v1/validator/register_validator";
+  private static SignedValidatorRegistrationsSchema signedValidatorRegistrationsSchema;
 
   private final ValidatorDataProvider validatorDataProvider;
 
-  public PostRegisterValidator(
-      final DataProvider provider,
-      final Spec spec,
-      final SchemaDefinitionCache schemaDefinitionCache) {
-    this(provider.getValidatorDataProvider(), spec, schemaDefinitionCache);
+  public PostRegisterValidator(final DataProvider provider, final Spec spec) {
+    this(provider.getValidatorDataProvider(), spec);
   }
 
-  public PostRegisterValidator(
-      final ValidatorDataProvider validatorDataProvider,
-      final Spec spec,
-      final SchemaDefinitionCache schemaDefinitionCache) {
+  public PostRegisterValidator(final ValidatorDataProvider validatorDataProvider, final Spec spec) {
     super(
         EndpointMetadata.post(ROUTE)
             .operationId("registerValidator")
@@ -84,10 +69,11 @@ public class PostRegisterValidator extends MigratingEndpointAdapter {
                     + " blocks that do not adhere to their latest fee recipient and gas limit preferences.")
             .tags(TAG_VALIDATOR, TAG_VALIDATOR_REQUIRED)
             .requestBodyType(
-                getRequestType(schemaDefinitionCache),
-                spec::deserializeSignedValidatorRegistrations)
+                getRequestType(spec),
+                PostRegisterValidator::deserializeSignedValidatorRegistrations)
             .response(SC_OK, "Registration information has been received.")
             .build());
+
     this.validatorDataProvider = validatorDataProvider;
   }
 
@@ -99,7 +85,7 @@ public class PostRegisterValidator extends MigratingEndpointAdapter {
       tags = {TAG_VALIDATOR, TAG_VALIDATOR_REQUIRED},
       requestBody =
           @OpenApiRequestBody(
-              content = {@OpenApiContent(from = SignedValidatorRegistrationOpenApiSchema[].class)}),
+              content = {@OpenApiContent(from = PostRegisterValidatorRequest[].class)}),
       description =
           "Prepares the beacon node for potential proposers by supplying information required when proposing blocks for the given validators. The information supplied for each validator index is considered persistent until overwritten by new information for the given validator index, or until the beacon node restarts.\n\n"
               + "Note that because the information is not persistent across beacon node restarts it is recommended that either the beacon node is monitored for restarts or this information is refreshed by resending this request periodically (for example, each epoch).\n\n"
@@ -125,51 +111,17 @@ public class PostRegisterValidator extends MigratingEndpointAdapter {
   }
 
   private static DeserializableTypeDefinition<SszList<SignedValidatorRegistration>> getRequestType(
-      final SchemaDefinitionCache schemaDefinitionCache) {
-    return schemaDefinitionCache
-        .getSchemaDefinition(SpecMilestone.BELLATRIX)
-        .toVersionBellatrix()
-        .orElseThrow()
-        .getSignedValidatorRegistrationsSchema()
-        .getJsonTypeDefinition();
+      final Spec spec) {
+
+    signedValidatorRegistrationsSchema =
+        new SignedValidatorRegistrationsSchema(
+            new SignedValidatorRegistrationSchema(new ValidatorRegistrationSchema()),
+            spec.getGenesisSpecConfig().getValidatorRegistryLimit());
+    return signedValidatorRegistrationsSchema.getJsonTypeDefinition();
   }
 
-  @SuppressWarnings("JavaCase")
-  public static class SignedValidatorRegistrationOpenApiSchema {
-    @JsonProperty("message")
-    ValidatorRegistration message;
-
-    @JsonProperty("signature")
-    @Schema(type = "string", format = "byte", description = DESCRIPTION_BYTES96)
-    BLSSignature signature;
-
-    public static class ValidatorRegistration {
-
-      @JsonProperty("fee_recipient")
-      @Schema(
-          type = "string",
-          pattern = PATTERN_EXECUTION_ADDRESS,
-          example = EXAMPLE_EXECUTION_ADDRESS,
-          description = DESCRIPTION_EXECUTION_ADDRESS)
-      Eth1Address fee_recipient;
-
-      @JsonProperty("gas_limit")
-      @Schema(type = "string", format = "uint64", example = EXAMPLE_UINT64)
-      UInt64 gas_limit;
-
-      @JsonProperty("timestamp")
-      @Schema(type = "string", format = "uint64", example = EXAMPLE_UINT64)
-      UInt64 timestamp;
-
-      @JsonProperty("pubkey")
-      @Schema(
-          type = "string",
-          pattern = PATTERN_PUBKEY,
-          example = EXAMPLE_PUBKEY,
-          description =
-              "The validator's BLS public key, uniquely identifying them. "
-                  + "48-bytes, hex encoded with 0x prefix, case insensitive.")
-      BLSPubKey pubkey;
-    }
+  private static SszList<SignedValidatorRegistration> deserializeSignedValidatorRegistrations(
+      final Bytes serializedSignedValidatorRegistration) {
+    return signedValidatorRegistrationsSchema.sszDeserialize(serializedSignedValidatorRegistration);
   }
 }

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostRegisterValidator.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostRegisterValidator.java
@@ -43,6 +43,7 @@ import tech.pegasys.teku.api.schema.BLSPubKey;
 import tech.pegasys.teku.api.schema.BLSSignature;
 import tech.pegasys.teku.beaconrestapi.MigratingEndpointAdapter;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
+import tech.pegasys.teku.infrastructure.restapi.endpoints.AsyncApiResponse;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.EndpointMetadata;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiRequest;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
@@ -117,8 +118,10 @@ public class PostRegisterValidator extends MigratingEndpointAdapter {
 
   @Override
   public void handleRequest(final RestApiRequest request) throws JsonProcessingException {
-    validatorDataProvider.registerValidators(request.getRequestBody());
-    request.respondWithCode(SC_OK);
+    request.respondAsync(
+        validatorDataProvider
+            .registerValidators(request.getRequestBody())
+            .thenApply(AsyncApiResponse::respondOk));
   }
 
   private static DeserializableTypeDefinition<SszList<SignedValidatorRegistration>> getRequestType(

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostRegisterValidator.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostRegisterValidator.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.beaconrestapi.handlers.v1.validator;
+
+import static tech.pegasys.teku.api.schema.SchemaConstants.DESCRIPTION_BYTES96;
+import static tech.pegasys.teku.api.schema.SchemaConstants.DESCRIPTION_EXECUTION_ADDRESS;
+import static tech.pegasys.teku.api.schema.SchemaConstants.EXAMPLE_EXECUTION_ADDRESS;
+import static tech.pegasys.teku.api.schema.SchemaConstants.EXAMPLE_PUBKEY;
+import static tech.pegasys.teku.api.schema.SchemaConstants.EXAMPLE_UINT64;
+import static tech.pegasys.teku.api.schema.SchemaConstants.PATTERN_EXECUTION_ADDRESS;
+import static tech.pegasys.teku.api.schema.SchemaConstants.PATTERN_PUBKEY;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
+import static tech.pegasys.teku.infrastructure.http.RestApiConstants.RES_BAD_REQUEST;
+import static tech.pegasys.teku.infrastructure.http.RestApiConstants.RES_INTERNAL_ERROR;
+import static tech.pegasys.teku.infrastructure.http.RestApiConstants.RES_OK;
+import static tech.pegasys.teku.infrastructure.http.RestApiConstants.TAG_VALIDATOR;
+import static tech.pegasys.teku.infrastructure.http.RestApiConstants.TAG_VALIDATOR_REQUIRED;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.javalin.http.Context;
+import io.javalin.plugin.openapi.annotations.HttpMethod;
+import io.javalin.plugin.openapi.annotations.OpenApi;
+import io.javalin.plugin.openapi.annotations.OpenApiContent;
+import io.javalin.plugin.openapi.annotations.OpenApiRequestBody;
+import io.javalin.plugin.openapi.annotations.OpenApiResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.jetbrains.annotations.NotNull;
+import tech.pegasys.teku.api.DataProvider;
+import tech.pegasys.teku.api.ValidatorDataProvider;
+import tech.pegasys.teku.api.schema.BLSPubKey;
+import tech.pegasys.teku.api.schema.BLSSignature;
+import tech.pegasys.teku.beaconrestapi.MigratingEndpointAdapter;
+import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
+import tech.pegasys.teku.infrastructure.restapi.endpoints.EndpointMetadata;
+import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiRequest;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.datastructures.eth1.Eth1Address;
+import tech.pegasys.teku.spec.datastructures.execution.SignedValidatorRegistration;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionCache;
+
+public class PostRegisterValidator extends MigratingEndpointAdapter {
+  public static final String ROUTE = "/eth/v1/validator/register_validator";
+
+  private final ValidatorDataProvider validatorDataProvider;
+
+  public PostRegisterValidator(
+      final DataProvider provider,
+      final Spec spec,
+      final SchemaDefinitionCache schemaDefinitionCache) {
+    this(provider.getValidatorDataProvider(), spec, schemaDefinitionCache);
+  }
+
+  public PostRegisterValidator(
+      final ValidatorDataProvider validatorDataProvider,
+      final Spec spec,
+      final SchemaDefinitionCache schemaDefinitionCache) {
+    super(
+        EndpointMetadata.post(ROUTE)
+            .operationId("registerValidator")
+            .summary(
+                "Provide beacon node with registrations for the given validators to the external builder network.")
+            .description(
+                "Prepares the beacon node for engaging with external builders."
+                    + " The information will be sent by the beacon node to the builder network."
+                    + " It is expected that the validator client will send this information periodically"
+                    + " to ensure the beacon node has correct and timely registration information"
+                    + " to provide to builders. The validator client should not sign blinded beacon"
+                    + " blocks that do not adhere to their latest fee recipient and gas limit preferences.")
+            .tags(TAG_VALIDATOR, TAG_VALIDATOR_REQUIRED)
+            .requestBodyType(
+                getRequestType(schemaDefinitionCache),
+                spec::deserializeSignedValidatorRegistrations)
+            .response(SC_OK, "Registration information has been received.")
+            .build());
+    this.validatorDataProvider = validatorDataProvider;
+  }
+
+  @OpenApi(
+      path = ROUTE,
+      method = HttpMethod.POST,
+      summary =
+          "Provide beacon node with registrations for the given validators to the external builder network.",
+      tags = {TAG_VALIDATOR, TAG_VALIDATOR_REQUIRED},
+      requestBody =
+          @OpenApiRequestBody(
+              content = {@OpenApiContent(from = SignedValidatorRegistrationOpenApiSchema[].class)}),
+      description =
+          "Prepares the beacon node for potential proposers by supplying information required when proposing blocks for the given validators. The information supplied for each validator index is considered persistent until overwritten by new information for the given validator index, or until the beacon node restarts.\n\n"
+              + "Note that because the information is not persistent across beacon node restarts it is recommended that either the beacon node is monitored for restarts or this information is refreshed by resending this request periodically (for example, each epoch).\n\n"
+              + "Also note that requests containing currently inactive or unknown validator indices will be accepted, as they may become active at a later epoch.",
+      responses = {
+        @OpenApiResponse(
+            status = RES_OK,
+            description = "Preparation information has been received."),
+        @OpenApiResponse(status = RES_BAD_REQUEST, description = "Invalid parameter supplied."),
+        @OpenApiResponse(status = RES_INTERNAL_ERROR, description = "Beacon node internal error.")
+      })
+  @Override
+  public void handle(@NotNull final Context ctx) throws Exception {
+    adapt(ctx);
+  }
+
+  @Override
+  public void handleRequest(final RestApiRequest request) throws JsonProcessingException {
+    validatorDataProvider.registerValidators(request.getRequestBody());
+    request.respondWithCode(SC_OK);
+  }
+
+  private static DeserializableTypeDefinition<SszList<SignedValidatorRegistration>> getRequestType(
+      final SchemaDefinitionCache schemaDefinitionCache) {
+    return schemaDefinitionCache
+        .getSchemaDefinition(SpecMilestone.BELLATRIX)
+        .toVersionBellatrix()
+        .orElseThrow()
+        .getSignedValidatorRegistrationsSchema()
+        .getJsonTypeDefinition();
+  }
+
+  public static class SignedValidatorRegistrationOpenApiSchema {
+    @JsonProperty("message")
+    ValidatorRegistration message;
+
+    @JsonProperty("signature")
+    @Schema(type = "string", format = "byte", description = DESCRIPTION_BYTES96)
+    BLSSignature signature;
+
+    public static class ValidatorRegistration {
+
+      @JsonProperty("fee_recipient")
+      @Schema(
+          type = "string",
+          pattern = PATTERN_EXECUTION_ADDRESS,
+          example = EXAMPLE_EXECUTION_ADDRESS,
+          description = DESCRIPTION_EXECUTION_ADDRESS)
+      Eth1Address fee_recipient;
+
+      @JsonProperty("gas_limit")
+      @Schema(type = "string", format = "uint64", example = EXAMPLE_UINT64)
+      UInt64 gas_limit;
+
+      @JsonProperty("timestamp")
+      @Schema(type = "string", format = "uint64", example = EXAMPLE_UINT64)
+      UInt64 timestamp;
+
+      @JsonProperty("pubkey")
+      @Schema(
+          type = "string",
+          pattern = PATTERN_PUBKEY,
+          example = EXAMPLE_PUBKEY,
+          description =
+              "The validator's BLS public key, uniquely identifying them. "
+                  + "48-bytes, hex encoded with 0x prefix, case insensitive.")
+      BLSPubKey pubkey;
+    }
+  }
+}

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostRegisterValidator.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostRegisterValidator.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.beaconrestapi.handlers.v1.validator;
 
+import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.RES_BAD_REQUEST;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.RES_INTERNAL_ERROR;
@@ -97,9 +98,14 @@ public class PostRegisterValidator extends MigratingEndpointAdapter {
 
   @Override
   public void handleRequest(final RestApiRequest request) throws JsonProcessingException {
-    request.respondAsync(
-        validatorDataProvider
-            .registerValidators(request.getRequestBody())
-            .thenApply(AsyncApiResponse::respondOk));
+
+    try {
+      request.respondAsync(
+          validatorDataProvider
+              .registerValidators(request.getRequestBody())
+              .thenApply(AsyncApiResponse::respondOk));
+    } catch (final JsonProcessingException jsonProcessingException) {
+      request.respondError(SC_BAD_REQUEST, jsonProcessingException.getMessage());
+    }
   }
 }

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostRegisterValidatorTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostRegisterValidatorTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.beaconrestapi.handlers.v1.beacon;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_BAD_REQUEST;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_INTERNAL_SERVER_ERROR;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
+import static tech.pegasys.teku.infrastructure.restapi.MetadataTestUtil.verifyMetadataErrorResponse;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.api.ValidatorDataProvider;
+import tech.pegasys.teku.beaconrestapi.AbstractMigratedBeaconHandlerTest;
+import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.PostRegisterValidator;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
+import tech.pegasys.teku.spec.datastructures.execution.SignedValidatorRegistration;
+
+public class PostRegisterValidatorTest extends AbstractMigratedBeaconHandlerTest {
+  private PostRegisterValidator handler;
+  private ValidatorDataProvider validatorDataProvider;
+
+  @BeforeEach
+  void setup() {
+    validatorDataProvider = mock(ValidatorDataProvider.class);
+    handler = new PostRegisterValidator(validatorDataProvider);
+  }
+
+  @Test
+  public void shouldReturnOK() throws JsonProcessingException {
+
+    final SszList<SignedValidatorRegistration> requestBody =
+        dataStructureUtil.randomValidatorRegistrations(2);
+    when(validatorDataProvider.registerValidators(requestBody)).thenReturn(SafeFuture.COMPLETE);
+
+    request.setRequestBody(requestBody);
+    handler.handleRequest(request);
+    assertThat(request.getResponseCode()).isEqualTo(SC_OK);
+  }
+
+  @Test
+  void metadata_shouldHandle400() throws JsonProcessingException {
+    verifyMetadataErrorResponse(handler, SC_BAD_REQUEST);
+  }
+
+  @Test
+  void metadata_shouldHandle500() throws JsonProcessingException {
+    verifyMetadataErrorResponse(handler, SC_INTERNAL_SERVER_ERROR);
+  }
+}

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostRegisterValidatorTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostRegisterValidatorTest.java
@@ -14,7 +14,6 @@
 package tech.pegasys.teku.beaconrestapi.handlers.v1.beacon;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_BAD_REQUEST;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_INTERNAL_SERVER_ERROR;
@@ -24,7 +23,6 @@ import static tech.pegasys.teku.infrastructure.restapi.MetadataTestUtil.verifyMe
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import tech.pegasys.teku.api.ValidatorDataProvider;
 import tech.pegasys.teku.beaconrestapi.AbstractMigratedBeaconHandlerTest;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.PostRegisterValidator;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -33,11 +31,9 @@ import tech.pegasys.teku.spec.datastructures.execution.SignedValidatorRegistrati
 
 public class PostRegisterValidatorTest extends AbstractMigratedBeaconHandlerTest {
   private PostRegisterValidator handler;
-  private ValidatorDataProvider validatorDataProvider;
 
   @BeforeEach
   void setup() {
-    validatorDataProvider = mock(ValidatorDataProvider.class);
     handler = new PostRegisterValidator(validatorDataProvider);
   }
 

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
@@ -413,8 +413,9 @@ public class ValidatorDataProvider {
     validatorApiChannel.prepareBeaconProposer(beaconPreparableProposers);
   }
 
-  public void registerValidators(List<SignedValidatorRegistration> validatorRegistrations) {
-    validatorApiChannel.registerValidators(validatorRegistrations);
+  public SafeFuture<Void> registerValidators(
+      List<SignedValidatorRegistration> validatorRegistrations) {
+    return validatorApiChannel.registerValidators(validatorRegistrations);
   }
 
   public boolean isPhase0Slot(final UInt64 slot) {

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
@@ -60,6 +60,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.provider.JsonProvider;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.datastructures.execution.SignedValidatorRegistration;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.ContributionAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeContribution;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeContributionSchema;
@@ -410,6 +411,10 @@ public class ValidatorDataProvider {
                   .BeaconPreparableProposer>
           beaconPreparableProposers) {
     validatorApiChannel.prepareBeaconProposer(beaconPreparableProposers);
+  }
+
+  public void registerValidators(List<SignedValidatorRegistration> validatorRegistrations) {
+    validatorApiChannel.registerValidators(validatorRegistrations);
   }
 
   public boolean isPhase0Slot(final UInt64 slot) {

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
@@ -55,6 +55,7 @@ import tech.pegasys.teku.api.schema.bellatrix.SignedBlindedBeaconBlockBellatrix;
 import tech.pegasys.teku.api.schema.phase0.SignedBeaconBlockPhase0;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.http.HttpStatusCodes;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszBitvector;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.provider.JsonProvider;
@@ -414,7 +415,7 @@ public class ValidatorDataProvider {
   }
 
   public SafeFuture<Void> registerValidators(
-      List<SignedValidatorRegistration> validatorRegistrations) {
+      SszList<SignedValidatorRegistration> validatorRegistrations) {
     return validatorApiChannel.registerValidators(validatorRegistrations);
   }
 

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/request/v1/validator/PostRegisterValidatorRequest.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/request/v1/validator/PostRegisterValidatorRequest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.api.request.v1.validator;
+
+import static tech.pegasys.teku.api.schema.SchemaConstants.DESCRIPTION_BYTES96;
+import static tech.pegasys.teku.api.schema.SchemaConstants.DESCRIPTION_EXECUTION_ADDRESS;
+import static tech.pegasys.teku.api.schema.SchemaConstants.EXAMPLE_EXECUTION_ADDRESS;
+import static tech.pegasys.teku.api.schema.SchemaConstants.EXAMPLE_PUBKEY;
+import static tech.pegasys.teku.api.schema.SchemaConstants.EXAMPLE_UINT64;
+import static tech.pegasys.teku.api.schema.SchemaConstants.PATTERN_EXECUTION_ADDRESS;
+import static tech.pegasys.teku.api.schema.SchemaConstants.PATTERN_PUBKEY;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import tech.pegasys.teku.api.schema.BLSPubKey;
+import tech.pegasys.teku.api.schema.BLSSignature;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.eth1.Eth1Address;
+
+@SuppressWarnings("JavaCase")
+public class PostRegisterValidatorRequest {
+  public ValidatorRegistration message;
+
+  @Schema(type = "string", format = "byte", description = DESCRIPTION_BYTES96)
+  public BLSSignature signature;
+
+  public static class ValidatorRegistration {
+
+    @Schema(
+        type = "string",
+        pattern = PATTERN_EXECUTION_ADDRESS,
+        example = EXAMPLE_EXECUTION_ADDRESS,
+        description = DESCRIPTION_EXECUTION_ADDRESS)
+    public Eth1Address fee_recipient;
+
+    @Schema(type = "string", format = "uint64", example = EXAMPLE_UINT64)
+    public UInt64 gas_limit;
+
+    @Schema(type = "string", format = "uint64", example = EXAMPLE_UINT64)
+    public UInt64 timestamp;
+
+    @Schema(
+        type = "string",
+        pattern = PATTERN_PUBKEY,
+        example = EXAMPLE_PUBKEY,
+        description =
+            "The validator's BLS public key, uniquely identifying them. "
+                + "48-bytes, hex encoded with 0x prefix, case insensitive.")
+    public BLSPubKey pubkey;
+  }
+}

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/SchemaConstants.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/SchemaConstants.java
@@ -20,12 +20,15 @@ public class SchemaConstants {
   public static final String DESCRIPTION_BYTES48 = "Bytes48 hexadecimal";
   public static final String DESCRIPTION_BYTES20 = "Bytes20 hexadecimal";
   public static final String DESCRIPTION_BYTES_SSZ = "SSZ hexadecimal";
+  public static final String DESCRIPTION_EXECUTION_ADDRESS =
+      "An address on the execution (Ethereum 1) network.";
 
   public static final String PATTERN_UINT64 = "^0-9+$";
   public static final String PATTERN_PUBKEY = "^0x[a-fA-F0-9]{96}$";
   public static final String PATTERN_BYTES4 = "^0x[a-fA-F0-9]{8}$";
   public static final String PATTERN_BYTES32 = "^0x[a-fA-F0-9]{64}$";
   public static final String PATTERN_BYTES20 = "^0x[a-fA-F0-9]{40}$";
+  public static final String PATTERN_EXECUTION_ADDRESS = PATTERN_BYTES20;
 
   public static final String EXAMPLE_PUBKEY =
       "0x93247f2209abcacf57b75a51dafae777f9dd38bc7053d1af526f220a7489a6d3a2753e5f3e8b1cfe39b56f43611df74a";
@@ -33,4 +36,6 @@ public class SchemaConstants {
       "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2";
   public static final String EXAMPLE_UINT64 = "1";
   public static final String EXAMPLE_UINT8 = "1";
+  public static final String EXAMPLE_EXECUTION_ADDRESS =
+      "0xabcf8e0d4e9587369b2301d0790347320302cc09";
 }

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/bellatrix/BeaconPreparableProposer.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/bellatrix/BeaconPreparableProposer.java
@@ -13,9 +13,10 @@
 
 package tech.pegasys.teku.api.schema.bellatrix;
 
-import static tech.pegasys.teku.api.schema.SchemaConstants.DESCRIPTION_BYTES20;
+import static tech.pegasys.teku.api.schema.SchemaConstants.DESCRIPTION_EXECUTION_ADDRESS;
+import static tech.pegasys.teku.api.schema.SchemaConstants.EXAMPLE_EXECUTION_ADDRESS;
 import static tech.pegasys.teku.api.schema.SchemaConstants.EXAMPLE_UINT64;
-import static tech.pegasys.teku.api.schema.SchemaConstants.PATTERN_BYTES20;
+import static tech.pegasys.teku.api.schema.SchemaConstants.PATTERN_EXECUTION_ADDRESS;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -32,9 +33,9 @@ public class BeaconPreparableProposer {
   @JsonProperty("fee_recipient")
   @Schema(
       type = "string",
-      format = "byte",
-      pattern = PATTERN_BYTES20,
-      description = DESCRIPTION_BYTES20)
+      pattern = PATTERN_EXECUTION_ADDRESS,
+      example = EXAMPLE_EXECUTION_ADDRESS,
+      description = DESCRIPTION_EXECUTION_ADDRESS)
   public final Eth1Address fee_recipient;
 
   @JsonCreator

--- a/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/rest/RestExecutionBuilderClientTest.java
+++ b/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/rest/RestExecutionBuilderClientTest.java
@@ -47,6 +47,8 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.SignedBuilderBid;
 import tech.pegasys.teku.spec.datastructures.execution.SignedValidatorRegistration;
+import tech.pegasys.teku.spec.datastructures.execution.SignedValidatorRegistrationSchema;
+import tech.pegasys.teku.spec.datastructures.execution.ValidatorRegistrationSchema;
 import tech.pegasys.teku.spec.networks.Eth2Network;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsBellatrix;
 
@@ -86,6 +88,10 @@ class RestExecutionBuilderClientTest {
 
   private final MockWebServer mockWebServer = new MockWebServer();
   private final OkHttpClient okHttpClient = new OkHttpClient.Builder().build();
+  private final DeserializableTypeDefinition<SignedValidatorRegistration>
+      signedValidatorRegistrationType =
+          new SignedValidatorRegistrationSchema(new ValidatorRegistrationSchema())
+              .getJsonTypeDefinition();
 
   private SchemaDefinitionsBellatrix schemaDefinitionsBellatrix;
 
@@ -323,11 +329,7 @@ class RestExecutionBuilderClientTest {
 
   private SignedValidatorRegistration createSignedValidatorRegistration() {
     try {
-      return JsonUtil.parse(
-          SIGNED_VALIDATOR_REGISTRATION_REQUEST,
-          schemaDefinitionsBellatrix
-              .getSignedValidatorRegistrationSchema()
-              .getJsonTypeDefinition());
+      return JsonUtil.parse(SIGNED_VALIDATOR_REGISTRATION_REQUEST, signedValidatorRegistrationType);
     } catch (JsonProcessingException ex) {
       throw new UncheckedIOException(ex);
     }

--- a/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/rest/RestExecutionBuilderClientTest.java
+++ b/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/rest/RestExecutionBuilderClientTest.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.ethereum.executionclient.rest;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.spec.schemas.ApiSchemas.SIGNED_VALIDATOR_REGISTRATION_SCHEMA;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -47,8 +48,6 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.SignedBuilderBid;
 import tech.pegasys.teku.spec.datastructures.execution.SignedValidatorRegistration;
-import tech.pegasys.teku.spec.datastructures.execution.SignedValidatorRegistrationSchema;
-import tech.pegasys.teku.spec.datastructures.execution.ValidatorRegistrationSchema;
 import tech.pegasys.teku.spec.networks.Eth2Network;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsBellatrix;
 
@@ -88,10 +87,6 @@ class RestExecutionBuilderClientTest {
 
   private final MockWebServer mockWebServer = new MockWebServer();
   private final OkHttpClient okHttpClient = new OkHttpClient.Builder().build();
-  private final DeserializableTypeDefinition<SignedValidatorRegistration>
-      signedValidatorRegistrationType =
-          new SignedValidatorRegistrationSchema(new ValidatorRegistrationSchema())
-              .getJsonTypeDefinition();
 
   private SchemaDefinitionsBellatrix schemaDefinitionsBellatrix;
 
@@ -329,7 +324,9 @@ class RestExecutionBuilderClientTest {
 
   private SignedValidatorRegistration createSignedValidatorRegistration() {
     try {
-      return JsonUtil.parse(SIGNED_VALIDATOR_REGISTRATION_REQUEST, signedValidatorRegistrationType);
+      return JsonUtil.parse(
+          SIGNED_VALIDATOR_REGISTRATION_REQUEST,
+          SIGNED_VALIDATOR_REGISTRATION_SCHEMA.getJsonTypeDefinition());
     } catch (JsonProcessingException ex) {
       throw new UncheckedIOException(ex);
     }

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/RestExecutionBuilderClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/RestExecutionBuilderClient.java
@@ -17,6 +17,7 @@ import static tech.pegasys.teku.spec.config.Constants.EL_BUILDER_GET_HEADER_TIME
 import static tech.pegasys.teku.spec.config.Constants.EL_BUILDER_GET_PAYLOAD_TIMEOUT;
 import static tech.pegasys.teku.spec.config.Constants.EL_BUILDER_REGISTER_VALIDATOR_TIMEOUT;
 import static tech.pegasys.teku.spec.config.Constants.EL_BUILDER_STATUS_TIMEOUT;
+import static tech.pegasys.teku.spec.schemas.ApiSchemas.SIGNED_VALIDATOR_REGISTRATION_SCHEMA;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -38,8 +39,6 @@ import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSchema;
 import tech.pegasys.teku.spec.datastructures.execution.SignedBuilderBid;
 import tech.pegasys.teku.spec.datastructures.execution.SignedBuilderBidSchema;
 import tech.pegasys.teku.spec.datastructures.execution.SignedValidatorRegistration;
-import tech.pegasys.teku.spec.datastructures.execution.SignedValidatorRegistrationSchema;
-import tech.pegasys.teku.spec.datastructures.execution.ValidatorRegistrationSchema;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionCache;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsBellatrix;
 
@@ -55,9 +54,6 @@ public class RestExecutionBuilderClient implements ExecutionBuilderClient {
 
   private final RestClient restClient;
   private final SchemaDefinitionCache schemaDefinitionCache;
-
-  private final SignedValidatorRegistrationSchema signedValidatorRegistrationSchema =
-      new SignedValidatorRegistrationSchema(new ValidatorRegistrationSchema());
 
   public RestExecutionBuilderClient(final RestClient restClient, final Spec spec) {
     this.restClient = restClient;
@@ -76,7 +72,7 @@ public class RestExecutionBuilderClient implements ExecutionBuilderClient {
       final UInt64 slot, final SignedValidatorRegistration signedValidatorRegistration) {
 
     final DeserializableTypeDefinition<SignedValidatorRegistration> requestType =
-        signedValidatorRegistrationSchema.getJsonTypeDefinition();
+        SIGNED_VALIDATOR_REGISTRATION_SCHEMA.getJsonTypeDefinition();
     return restClient
         .postAsync(
             BuilderApiMethod.REGISTER_VALIDATOR.getPath(), signedValidatorRegistration, requestType)

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/RestExecutionBuilderClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/RestExecutionBuilderClient.java
@@ -38,6 +38,8 @@ import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSchema;
 import tech.pegasys.teku.spec.datastructures.execution.SignedBuilderBid;
 import tech.pegasys.teku.spec.datastructures.execution.SignedBuilderBidSchema;
 import tech.pegasys.teku.spec.datastructures.execution.SignedValidatorRegistration;
+import tech.pegasys.teku.spec.datastructures.execution.SignedValidatorRegistrationSchema;
+import tech.pegasys.teku.spec.datastructures.execution.ValidatorRegistrationSchema;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionCache;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsBellatrix;
 
@@ -53,6 +55,9 @@ public class RestExecutionBuilderClient implements ExecutionBuilderClient {
 
   private final RestClient restClient;
   private final SchemaDefinitionCache schemaDefinitionCache;
+
+  private final SignedValidatorRegistrationSchema signedValidatorRegistrationSchema =
+      new SignedValidatorRegistrationSchema(new ValidatorRegistrationSchema());
 
   public RestExecutionBuilderClient(final RestClient restClient, final Spec spec) {
     this.restClient = restClient;
@@ -70,12 +75,8 @@ public class RestExecutionBuilderClient implements ExecutionBuilderClient {
   public SafeFuture<Response<Void>> registerValidator(
       final UInt64 slot, final SignedValidatorRegistration signedValidatorRegistration) {
 
-    final SpecMilestone milestone = schemaDefinitionCache.milestoneAtSlot(slot);
-    final SchemaDefinitionsBellatrix schemaDefinitionsBellatrix =
-        getSchemaDefinitionsBellatrix(milestone);
-
     final DeserializableTypeDefinition<SignedValidatorRegistration> requestType =
-        schemaDefinitionsBellatrix.getSignedValidatorRegistrationSchema().getJsonTypeDefinition();
+        signedValidatorRegistrationSchema.getJsonTypeDefinition();
     return restClient
         .postAsync(
             BuilderApiMethod.REGISTER_VALIDATOR.getPath(), signedValidatorRegistration, requestType)

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -36,7 +36,6 @@ import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.bytes.Bytes4;
-import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszBitlist;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.cache.IndexedAttestationCache;
@@ -53,7 +52,6 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlockUnblinder;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodyBuilder;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
-import tech.pegasys.teku.spec.datastructures.execution.SignedValidatorRegistration;
 import tech.pegasys.teku.spec.datastructures.forkchoice.MutableStore;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyStore;
@@ -288,20 +286,6 @@ public class Spec {
                     "Bellatrix milestone is required to load execution payload header"))
         .getExecutionPayloadHeaderSchema()
         .jsonDeserialize(objectMapper.createParser(jsonFile));
-  }
-
-  public SszList<SignedValidatorRegistration> deserializeSignedValidatorRegistrations(
-      final Bytes serializedSignedValidatorRegistration) {
-    return Optional.ofNullable(forMilestone(SpecMilestone.BELLATRIX))
-        .orElseThrow(
-            () ->
-                new RuntimeException(
-                    "Bellatrix milestone is required to load execution payload header"))
-        .getSchemaDefinitions()
-        .toVersionBellatrix()
-        .orElseThrow()
-        .getSignedValidatorRegistrationsSchema()
-        .sszDeserialize(serializedSignedValidatorRegistration);
   }
 
   // BeaconState

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -36,6 +36,7 @@ import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.bytes.Bytes4;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszBitlist;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.cache.IndexedAttestationCache;
@@ -52,6 +53,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlockUnblinder;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodyBuilder;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
+import tech.pegasys.teku.spec.datastructures.execution.SignedValidatorRegistration;
 import tech.pegasys.teku.spec.datastructures.forkchoice.MutableStore;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyStore;
@@ -286,6 +288,20 @@ public class Spec {
                     "Bellatrix milestone is required to load execution payload header"))
         .getExecutionPayloadHeaderSchema()
         .jsonDeserialize(objectMapper.createParser(jsonFile));
+  }
+
+  public SszList<SignedValidatorRegistration> deserializeSignedValidatorRegistrations(
+      final Bytes serializedSignedValidatorRegistration) {
+    return Optional.ofNullable(forMilestone(SpecMilestone.BELLATRIX))
+        .orElseThrow(
+            () ->
+                new RuntimeException(
+                    "Bellatrix milestone is required to load execution payload header"))
+        .getSchemaDefinitions()
+        .toVersionBellatrix()
+        .orElseThrow()
+        .getSignedValidatorRegistrationsSchema()
+        .sszDeserialize(serializedSignedValidatorRegistration);
   }
 
   // BeaconState

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/SignedValidatorRegistrationsSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/SignedValidatorRegistrationsSchema.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.execution;
+
+import tech.pegasys.teku.infrastructure.ssz.SszList;
+import tech.pegasys.teku.infrastructure.ssz.impl.SszListImpl;
+import tech.pegasys.teku.infrastructure.ssz.schema.impl.AbstractSszListSchema;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+
+public class SignedValidatorRegistrationsSchema
+    extends AbstractSszListSchema<
+        SignedValidatorRegistration, SszList<SignedValidatorRegistration>> {
+
+  public SignedValidatorRegistrationsSchema(
+      SignedValidatorRegistrationSchema signedValidatorRegistrationSchema, long maxLength) {
+    super(signedValidatorRegistrationSchema, maxLength);
+  }
+
+  @Override
+  public SszList<SignedValidatorRegistration> createFromBackingNode(TreeNode node) {
+    return new SszListImpl<>(this, node);
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/ApiSchemas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/ApiSchemas.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.schemas;
+
+import tech.pegasys.teku.spec.datastructures.execution.SignedValidatorRegistrationSchema;
+import tech.pegasys.teku.spec.datastructures.execution.SignedValidatorRegistrationsSchema;
+import tech.pegasys.teku.spec.datastructures.execution.ValidatorRegistrationSchema;
+
+public class ApiSchemas {
+
+  public static final ValidatorRegistrationSchema VALIDATOR_REGISTRATION_SCHEMA =
+      new ValidatorRegistrationSchema();
+
+  public static final SignedValidatorRegistrationSchema SIGNED_VALIDATOR_REGISTRATION_SCHEMA =
+      new SignedValidatorRegistrationSchema(VALIDATOR_REGISTRATION_SCHEMA);
+
+  public static final long MAX_VALIDATOR_REGISTRATIONS_SIZE = 1099511627776L;
+  public static final SignedValidatorRegistrationsSchema SIGNED_VALIDATOR_REGISTRATIONS_SCHEMA =
+      new SignedValidatorRegistrationsSchema(
+          SIGNED_VALIDATOR_REGISTRATION_SCHEMA, MAX_VALIDATOR_REGISTRATIONS_SIZE);
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/ApiSchemas.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/ApiSchemas.java
@@ -25,6 +25,7 @@ public class ApiSchemas {
   public static final SignedValidatorRegistrationSchema SIGNED_VALIDATOR_REGISTRATION_SCHEMA =
       new SignedValidatorRegistrationSchema(VALIDATOR_REGISTRATION_SCHEMA);
 
+  // the max size is based on VALIDATOR_REGISTRY_LIMIT spec config
   public static final long MAX_VALIDATOR_REGISTRATIONS_SIZE = 1099511627776L;
   public static final SignedValidatorRegistrationsSchema SIGNED_VALIDATOR_REGISTRATIONS_SCHEMA =
       new SignedValidatorRegistrationsSchema(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsBellatrix.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsBellatrix.java
@@ -28,9 +28,6 @@ import tech.pegasys.teku.spec.datastructures.execution.BuilderBidSchema;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeaderSchema;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSchema;
 import tech.pegasys.teku.spec.datastructures.execution.SignedBuilderBidSchema;
-import tech.pegasys.teku.spec.datastructures.execution.SignedValidatorRegistrationSchema;
-import tech.pegasys.teku.spec.datastructures.execution.SignedValidatorRegistrationsSchema;
-import tech.pegasys.teku.spec.datastructures.execution.ValidatorRegistrationSchema;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchema;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.bellatrix.BeaconStateBellatrix;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.bellatrix.BeaconStateSchemaBellatrix;
@@ -47,9 +44,6 @@ public class SchemaDefinitionsBellatrix extends SchemaDefinitionsAltair {
   private final ExecutionPayloadHeaderSchema executionPayloadHeaderSchema;
   private final BuilderBidSchema builderBidSchema;
   private final SignedBuilderBidSchema signedBuilderBidSchema;
-  private final ValidatorRegistrationSchema validatorRegistrationSchema;
-  private final SignedValidatorRegistrationSchema signedValidatorRegistrationSchema;
-  private final SignedValidatorRegistrationsSchema signedValidatorRegistrationsSchema;
 
   public SchemaDefinitionsBellatrix(final SpecConfigBellatrix specConfig) {
     super(specConfig.toVersionAltair().orElseThrow());
@@ -70,12 +64,6 @@ public class SchemaDefinitionsBellatrix extends SchemaDefinitionsAltair {
     this.executionPayloadHeaderSchema = new ExecutionPayloadHeaderSchema(specConfig);
     this.builderBidSchema = new BuilderBidSchema(executionPayloadHeaderSchema);
     this.signedBuilderBidSchema = new SignedBuilderBidSchema(builderBidSchema);
-    this.validatorRegistrationSchema = new ValidatorRegistrationSchema();
-    this.signedValidatorRegistrationSchema =
-        new SignedValidatorRegistrationSchema(validatorRegistrationSchema);
-    this.signedValidatorRegistrationsSchema =
-        new SignedValidatorRegistrationsSchema(
-            signedValidatorRegistrationSchema, specConfig.getValidatorRegistryLimit());
   }
 
   public static SchemaDefinitionsBellatrix required(final SchemaDefinitions schemaDefinitions) {
@@ -137,18 +125,6 @@ public class SchemaDefinitionsBellatrix extends SchemaDefinitionsAltair {
 
   public SignedBuilderBidSchema getSignedBuilderBidSchema() {
     return signedBuilderBidSchema;
-  }
-
-  public ValidatorRegistrationSchema getValidatorRegistrationSchema() {
-    return validatorRegistrationSchema;
-  }
-
-  public SignedValidatorRegistrationSchema getSignedValidatorRegistrationSchema() {
-    return signedValidatorRegistrationSchema;
-  }
-
-  public SignedValidatorRegistrationsSchema getSignedValidatorRegistrationsSchema() {
-    return signedValidatorRegistrationsSchema;
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsBellatrix.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsBellatrix.java
@@ -29,6 +29,7 @@ import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeaderSch
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSchema;
 import tech.pegasys.teku.spec.datastructures.execution.SignedBuilderBidSchema;
 import tech.pegasys.teku.spec.datastructures.execution.SignedValidatorRegistrationSchema;
+import tech.pegasys.teku.spec.datastructures.execution.SignedValidatorRegistrationsSchema;
 import tech.pegasys.teku.spec.datastructures.execution.ValidatorRegistrationSchema;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchema;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.bellatrix.BeaconStateBellatrix;
@@ -48,6 +49,7 @@ public class SchemaDefinitionsBellatrix extends SchemaDefinitionsAltair {
   private final SignedBuilderBidSchema signedBuilderBidSchema;
   private final ValidatorRegistrationSchema validatorRegistrationSchema;
   private final SignedValidatorRegistrationSchema signedValidatorRegistrationSchema;
+  private final SignedValidatorRegistrationsSchema signedValidatorRegistrationsSchema;
 
   public SchemaDefinitionsBellatrix(final SpecConfigBellatrix specConfig) {
     super(specConfig.toVersionAltair().orElseThrow());
@@ -71,6 +73,9 @@ public class SchemaDefinitionsBellatrix extends SchemaDefinitionsAltair {
     this.validatorRegistrationSchema = new ValidatorRegistrationSchema();
     this.signedValidatorRegistrationSchema =
         new SignedValidatorRegistrationSchema(validatorRegistrationSchema);
+    this.signedValidatorRegistrationsSchema =
+        new SignedValidatorRegistrationsSchema(
+            signedValidatorRegistrationSchema, specConfig.getValidatorRegistryLimit());
   }
 
   public static SchemaDefinitionsBellatrix required(final SchemaDefinitions schemaDefinitions) {
@@ -140,6 +145,10 @@ public class SchemaDefinitionsBellatrix extends SchemaDefinitionsAltair {
 
   public SignedValidatorRegistrationSchema getSignedValidatorRegistrationSchema() {
     return signedValidatorRegistrationSchema;
+  }
+
+  public SignedValidatorRegistrationsSchema getSignedValidatorRegistrationsSchema() {
+    return signedValidatorRegistrationsSchema;
   }
 
   @Override

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -140,6 +140,11 @@ public final class DataStructureUtil {
   private int seed;
   private Supplier<BLSPublicKey> pubKeyGenerator = () -> BLSTestUtil.randomPublicKey(nextSeed());
 
+  private final ValidatorRegistrationSchema validatorRegistrationSchema =
+      new ValidatorRegistrationSchema();
+  private final SignedValidatorRegistrationSchema signedValidatorRegistrationSchema =
+      new SignedValidatorRegistrationSchema(validatorRegistrationSchema);
+
   public DataStructureUtil(final Spec spec) {
     this(92892824, spec);
   }
@@ -1148,23 +1153,11 @@ public final class DataStructureUtil {
   }
 
   public SignedValidatorRegistration randomValidatorRegistration(final BLSPublicKey publicKey) {
-    SignedValidatorRegistrationSchema signedSchema =
-        spec.getGenesisSpec()
-            .getSchemaDefinitions()
-            .toVersionBellatrix()
-            .orElseThrow()
-            .getSignedValidatorRegistrationSchema();
-    ValidatorRegistrationSchema schema =
-        spec.getGenesisSpec()
-            .getSchemaDefinitions()
-            .toVersionBellatrix()
-            .orElseThrow()
-            .getValidatorRegistrationSchema();
+    final ValidatorRegistration validatorRegistration =
+        validatorRegistrationSchema.create(
+            randomBytes20(), randomUInt64(), randomUInt64(), publicKey);
 
-    ValidatorRegistration validatorRegistration =
-        schema.create(randomBytes20(), randomUInt64(), randomUInt64(), publicKey);
-
-    return signedSchema.create(validatorRegistration, randomSignature());
+    return signedValidatorRegistrationSchema.create(validatorRegistration, randomSignature());
   }
 
   public ForkChoiceState randomForkChoiceState(final boolean optimisticHead) {

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -17,6 +17,8 @@ import static com.google.common.base.Preconditions.checkState;
 import static java.util.stream.Collectors.toList;
 import static tech.pegasys.teku.spec.config.SpecConfig.FAR_FUTURE_EPOCH;
 import static tech.pegasys.teku.spec.constants.NetworkConstants.SYNC_COMMITTEE_SUBNET_COUNT;
+import static tech.pegasys.teku.spec.schemas.ApiSchemas.SIGNED_VALIDATOR_REGISTRATION_SCHEMA;
+import static tech.pegasys.teku.spec.schemas.ApiSchemas.VALIDATOR_REGISTRATION_SCHEMA;
 
 import it.unimi.dsi.fastutil.ints.IntList;
 import java.util.ArrayList;
@@ -87,9 +89,7 @@ import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
 import tech.pegasys.teku.spec.datastructures.execution.SignedBuilderBid;
 import tech.pegasys.teku.spec.datastructures.execution.SignedValidatorRegistration;
-import tech.pegasys.teku.spec.datastructures.execution.SignedValidatorRegistrationSchema;
 import tech.pegasys.teku.spec.datastructures.execution.ValidatorRegistration;
-import tech.pegasys.teku.spec.datastructures.execution.ValidatorRegistrationSchema;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.EnrForkId;
 import tech.pegasys.teku.spec.datastructures.operations.AggregateAndProof;
@@ -139,11 +139,6 @@ public final class DataStructureUtil {
 
   private int seed;
   private Supplier<BLSPublicKey> pubKeyGenerator = () -> BLSTestUtil.randomPublicKey(nextSeed());
-
-  private final ValidatorRegistrationSchema validatorRegistrationSchema =
-      new ValidatorRegistrationSchema();
-  private final SignedValidatorRegistrationSchema signedValidatorRegistrationSchema =
-      new SignedValidatorRegistrationSchema(validatorRegistrationSchema);
 
   public DataStructureUtil(final Spec spec) {
     this(92892824, spec);
@@ -1154,10 +1149,10 @@ public final class DataStructureUtil {
 
   public SignedValidatorRegistration randomValidatorRegistration(final BLSPublicKey publicKey) {
     final ValidatorRegistration validatorRegistration =
-        validatorRegistrationSchema.create(
+        VALIDATOR_REGISTRATION_SCHEMA.create(
             randomBytes20(), randomUInt64(), randomUInt64(), publicKey);
 
-    return signedValidatorRegistrationSchema.create(validatorRegistration, randomSignature());
+    return SIGNED_VALIDATOR_REGISTRATION_SCHEMA.create(validatorRegistration, randomSignature());
   }
 
   public ForkChoiceState randomForkChoiceState(final boolean optimisticHead) {

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -17,6 +17,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static java.util.stream.Collectors.toList;
 import static tech.pegasys.teku.spec.config.SpecConfig.FAR_FUTURE_EPOCH;
 import static tech.pegasys.teku.spec.constants.NetworkConstants.SYNC_COMMITTEE_SUBNET_COUNT;
+import static tech.pegasys.teku.spec.schemas.ApiSchemas.SIGNED_VALIDATOR_REGISTRATIONS_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.ApiSchemas.SIGNED_VALIDATOR_REGISTRATION_SCHEMA;
 import static tech.pegasys.teku.spec.schemas.ApiSchemas.VALIDATOR_REGISTRATION_SCHEMA;
 
@@ -27,6 +28,7 @@ import java.util.Optional;
 import java.util.Random;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.apache.tuweni.bytes.Bytes;
@@ -1153,6 +1155,13 @@ public final class DataStructureUtil {
             randomBytes20(), randomUInt64(), randomUInt64(), publicKey);
 
     return SIGNED_VALIDATOR_REGISTRATION_SCHEMA.create(validatorRegistration, randomSignature());
+  }
+
+  public SszList<SignedValidatorRegistration> randomValidatorRegistrations(final int size) {
+    return SIGNED_VALIDATOR_REGISTRATIONS_SCHEMA.createFromElements(
+        IntStream.range(0, size)
+            .mapToObj(__ -> randomValidatorRegistration())
+            .collect(Collectors.toUnmodifiableList()));
   }
 
   public ForkChoiceState randomForkChoiceState(final boolean optimisticHead) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ProposersDataManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ProposersDataManager.java
@@ -29,6 +29,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.eventthread.EventThread;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.subscribers.Subscribers;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
@@ -99,8 +100,7 @@ public class ProposersDataManager {
   }
 
   public SafeFuture<Void> updateValidatorRegistrations(
-      final Collection<SignedValidatorRegistration> validatorRegistrations,
-      final UInt64 currentSlot) {
+      final SszList<SignedValidatorRegistration> validatorRegistrations, final UInt64 currentSlot) {
     // Remove expired validators
     validatorRegistrationInfoByValidatorIndex
         .values()

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThatSafeFuture;
+import static tech.pegasys.teku.spec.schemas.ApiSchemas.SIGNED_VALIDATOR_REGISTRATIONS_SCHEMA;
 
 import java.util.List;
 import java.util.Optional;
@@ -840,7 +841,9 @@ class ForkChoiceNotifierTest {
         signedValidatorRegistration ->
             SafeFutureAssert.safeJoin(
                 proposersDataManager.updateValidatorRegistrations(
-                    List.of(signedValidatorRegistration), recentChainData.getHeadSlot())));
+                    SIGNED_VALIDATOR_REGISTRATIONS_SCHEMA.createFromElements(
+                        List.of(signedValidatorRegistration)),
+                    recentChainData.getHeadSlot())));
     return payloadBuildingAttributes;
   }
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ProposerDataManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ProposerDataManagerTest.java
@@ -20,12 +20,12 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import java.net.http.HttpConnectTimeoutException;
-import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.SafeFutureAssert;
 import tech.pegasys.teku.infrastructure.async.eventthread.InlineEventThread;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
@@ -57,7 +57,7 @@ public class ProposerDataManagerTest implements ProposersDataManagerSubscriber {
   private boolean onValidatorRegistrationsUpdatedCalled = false;
 
   private final UInt64 slot = UInt64.ONE;
-  private List<SignedValidatorRegistration> registrations;
+  private SszList<SignedValidatorRegistration> registrations;
   private final SafeFuture<Void> response1 = new SafeFuture<>();
   private final SafeFuture<Void> response2 = new SafeFuture<>();
 
@@ -140,10 +140,7 @@ public class ProposerDataManagerTest implements ProposersDataManagerSubscriber {
   }
 
   private void prepareRegistrations() {
-    registrations =
-        List.of(
-            dataStructureUtil.randomValidatorRegistration(),
-            dataStructureUtil.randomValidatorRegistration());
+    registrations = dataStructureUtil.randomValidatorRegistrations(2);
 
     when(executionLayerChannel.builderRegisterValidator(registrations.get(0), slot))
         .thenReturn(response1);

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/EndpointMetadata.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/EndpointMetadata.java
@@ -493,6 +493,17 @@ public class EndpointMetadata {
     }
 
     public <T> EndpointMetaDataBuilder requestBodyType(
+        final DeserializableTypeDefinition<T> requestBodyType,
+        final IOFunction<Bytes, T> octetStreamParser) {
+      this.requestBodyTypes.put(
+          ContentTypes.JSON, new SimpleJsonRequestContentTypeDefinition<>(requestBodyType));
+      this.requestBodyTypes.put(
+          ContentTypes.OCTET_STREAM,
+          OctetStreamRequestContentTypeDefinition.parseBytes(octetStreamParser));
+      return this;
+    }
+
+    public <T> EndpointMetaDataBuilder requestBodyType(
         final SerializableOneOfTypeDefinition<T> requestBodyType,
         final BodyTypeSelector<T> bodyTypeSelector) {
       this.requestBodyTypes.put(

--- a/infrastructure/restapi/src/test/java/tech/pegasys/teku/infrastructure/restapi/endpoints/EndpointMetadataTest.java
+++ b/infrastructure/restapi/src/test/java/tech/pegasys/teku/infrastructure/restapi/endpoints/EndpointMetadataTest.java
@@ -336,6 +336,35 @@ class EndpointMetadataTest {
   }
 
   @Test
+  void getRequestBody_shouldSupportOctetStreamWithoutSelector() throws Exception {
+    final EndpointMetadata metadata =
+        validBuilder()
+            .requestBodyType(
+                STRING_TYPE, bytes -> new String(bytes.toArrayUnsafe(), StandardCharsets.UTF_8))
+            .response(SC_OK, "Success")
+            .build();
+    final byte[] data = "test".getBytes(StandardCharsets.UTF_8);
+    final String body =
+        metadata.getRequestBody(
+            new ByteArrayInputStream(data), Optional.of(ContentTypes.OCTET_STREAM));
+    assertThat(body).isEqualTo("test");
+  }
+
+  @Test
+  void getRequestBody_shouldSupportJsonWithoutSelector() throws Exception {
+    final EndpointMetadata metadata =
+        validBuilder()
+            .requestBodyType(
+                STRING_TYPE, bytes -> new String(bytes.toArrayUnsafe(), StandardCharsets.UTF_8))
+            .response(SC_OK, "Success")
+            .build();
+
+    final String body =
+        metadata.getRequestBody(toStream("\"abcdef\""), Optional.of(ContentTypes.JSON));
+    assertThat(body).isEqualTo("abcdef");
+  }
+
+  @Test
   void getRequestBody_shouldSupportJsonWithCharset() throws Exception {
     final EndpointMetadata metadata =
         validBuilder()

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
@@ -25,6 +25,7 @@ import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.events.ChannelInterface;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
@@ -90,5 +91,5 @@ public interface ValidatorApiChannel extends ChannelInterface {
   void prepareBeaconProposer(Collection<BeaconPreparableProposer> beaconPreparableProposers);
 
   SafeFuture<Void> registerValidators(
-      final Collection<SignedValidatorRegistration> validatorRegistrations);
+      final SszList<SignedValidatorRegistration> validatorRegistrations);
 }

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
@@ -28,6 +28,7 @@ import tech.pegasys.teku.infrastructure.events.ChannelInterface;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.execution.SignedValidatorRegistration;
 import tech.pegasys.teku.spec.datastructures.genesis.GenesisData;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
@@ -87,4 +88,7 @@ public interface ValidatorApiChannel extends ChannelInterface {
       Collection<SignedContributionAndProof> signedContributionAndProofs);
 
   void prepareBeaconProposer(Collection<BeaconPreparableProposer> beaconPreparableProposers);
+
+  SafeFuture<Void> registerValidators(
+      final Collection<SignedValidatorRegistration> validatorRegistrations);
 }

--- a/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
+++ b/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
@@ -27,6 +27,7 @@ import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
@@ -344,7 +345,7 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
 
   @Override
   public SafeFuture<Void> registerValidators(
-      Collection<SignedValidatorRegistration> validatorRegistrations) {
+      SszList<SignedValidatorRegistration> validatorRegistrations) {
     registrerValidatorCounter.inc();
     return delegate.registerValidators(validatorRegistrations);
   }

--- a/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
+++ b/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
@@ -30,6 +30,7 @@ import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.execution.SignedValidatorRegistration;
 import tech.pegasys.teku.spec.datastructures.genesis.GenesisData;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
@@ -85,6 +86,8 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
       "beacon_node_send_sync_committee_contributions_total";
   public static final String PREPARE_BEACON_PROPOSER_NAME =
       "beacon_node_prepare_beacon_proposer_requests_total";
+  public static final String REGISTER_VALIDATOR_NAME =
+      "beacon_node_register_validator_requests_total";
   private final ValidatorApiChannel delegate;
   private final BeaconChainRequestCounter genesisTimeRequestCounter;
   private final BeaconChainRequestCounter attestationDutiesRequestCounter;
@@ -104,6 +107,7 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
   private final Counter sendBlockRequestCounter;
   private final Counter sendContributionAndProofsRequestCounter;
   private final Counter prepareBeaconProposerCounter;
+  private final Counter registrerValidatorCounter;
 
   public MetricRecordingValidatorApiChannel(
       final MetricsSystem metricsSystem, final ValidatorApiChannel delegate) {
@@ -199,6 +203,11 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
             TekuMetricCategory.VALIDATOR,
             PREPARE_BEACON_PROPOSER_NAME,
             "Counter recording the number of prepare beacon proposer requests sent to the beacon node");
+    registrerValidatorCounter =
+        metricsSystem.createCounter(
+            TekuMetricCategory.VALIDATOR,
+            REGISTER_VALIDATOR_NAME,
+            "Counter recording the number of validator registration requests sent to the beacon node");
   }
 
   @Override
@@ -331,6 +340,13 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
       final Collection<BeaconPreparableProposer> beaconPreparableProposers) {
     prepareBeaconProposerCounter.inc();
     delegate.prepareBeaconProposer(beaconPreparableProposers);
+  }
+
+  @Override
+  public SafeFuture<Void> registerValidators(
+      Collection<SignedValidatorRegistration> validatorRegistrations) {
+    registrerValidatorCounter.inc();
+    return delegate.registerValidators(validatorRegistrations);
   }
 
   private <T> SafeFuture<List<T>> countSendRequest(

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
@@ -46,6 +46,7 @@ import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.ExceptionThrowingRunnable;
 import tech.pegasys.teku.infrastructure.async.ExceptionThrowingSupplier;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
@@ -429,7 +430,7 @@ public class RemoteValidatorApiHandler implements ValidatorApiChannel {
 
   @Override
   public SafeFuture<Void> registerValidators(
-      final Collection<SignedValidatorRegistration> validatorRegistrations) {
+      final SszList<SignedValidatorRegistration> validatorRegistrations) {
     return SafeFuture.failedFuture(new NotImplementedException("not yet implemented"));
   }
 

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
@@ -31,6 +31,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import org.apache.commons.lang3.NotImplementedException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
@@ -49,6 +50,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.execution.SignedValidatorRegistration;
 import tech.pegasys.teku.spec.datastructures.genesis.GenesisData;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
@@ -423,6 +425,12 @@ public class RemoteValidatorApiHandler implements ValidatorApiChannel {
                                     pbp.getValidatorIndex(), pbp.getFeeRecipient()))
                         .collect(toList())))
         .finish(error -> LOG.error("Failed to prepare beacon proposers", error));
+  }
+
+  @Override
+  public SafeFuture<Void> registerValidators(
+      final Collection<SignedValidatorRegistration> validatorRegistrations) {
+    return SafeFuture.failedFuture(new NotImplementedException("not yet implemented"));
   }
 
   private SafeFuture<Void> sendRequest(final ExceptionThrowingRunnable requestExecutor) {


### PR DESCRIPTION
This draft PR introduces:
- new `SszList` of `SignedValidatorRegistration`
- rest API serving validator registration supporting json and ssz content types
- moved `ValidatorRegistration` and related Ssz schemas to `tech.pegasys.teku.spec.schemas.ApiSchemas`

in next PR we migrate all Ssz API objects (non-milestone specific) to this new class

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
