### PR TITLE
Cast to ExecutionPayloadCommon in equals

### DIFF
--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/bellatrix/ExecutionPayloadCommon.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/bellatrix/ExecutionPayloadCommon.java
@@ -159,7 +159,7 @@ public abstract class ExecutionPayloadCommon {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    final ExecutionPayload that = (ExecutionPayload) o;
+    final ExecutionPayloadCommon that = (ExecutionPayloadCommon) o;
     return Objects.equals(parentHash, that.parentHash)
         && Objects.equals(feeRecipient, that.feeRecipient)
         && Objects.equals(stateRoot, that.stateRoot)


### PR DESCRIPTION
## PR Description

When comparing two `schema.bellatrix.BeaconStateBellatrix` objects, I ran into this issue:

```
  java.lang.ClassCastException:
    class tech.pegasys.teku.api.schema.bellatrix.ExecutionPayloadHeader cannot be cast to class tech.pegasys.teku.api.schema.bellatrix.ExecutionPayload (tech.pegasys.teku.api.schema.bellatrix.ExecutionPayloadHeader and tech.pegasys.teku.api.schema.bellatrix.ExecutionPayload are in unnamed module of loader 'app')
```

In the `ExecutionPayloadCommon.equals` function, it should cast to `ExecutionPayloadCommon` instead.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
