### PR TITLE
Remove Transaction.setTimeSeconds

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/MutableStore.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/MutableStore.java
@@ -31,8 +31,6 @@ public interface MutableStore extends ReadOnlyStore {
 
   void putStateRoot(Bytes32 stateRoot, SlotAndBlockRoot slotAndBlockRoot);
 
-  void setTimeSeconds(UInt64 timeSeconds);
-
   void setTimeMillis(UInt64 timeMillis);
 
   void setGenesisTime(UInt64 genesisTime);

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
@@ -249,11 +249,6 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
   }
 
   @Override
-  public void setTimeSeconds(final UInt64 timeSeconds) {
-    setTimeMillis(secondsToMillis(timeSeconds));
-  }
-
-  @Override
   public void setTimeMillis(final UInt64 time) {
     this.timeMillis = time;
   }

--- a/ethereum/statetransition/build.gradle
+++ b/ethereum/statetransition/build.gradle
@@ -41,6 +41,7 @@ dependencies {
   testFixturesImplementation project(':infrastructure:async')
   testFixturesImplementation testFixtures(project(':infrastructure:async'))
   testFixturesImplementation testFixtures(project(':infrastructure:subscribers'))
+  testFixturesImplementation project(':infrastructure:time')
   testFixturesImplementation testFixtures(project(':ethereum:core'))
   testFixturesImplementation testFixtures(project(':ethereum:spec'))
 }

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/BeaconChainUtil.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/BeaconChainUtil.java
@@ -18,6 +18,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 import static tech.pegasys.teku.infrastructure.async.SyncAsyncRunner.SYNC_RUNNER;
+import static tech.pegasys.teku.infrastructure.time.TimeUtilities.secondsToMillis;
 
 import java.util.List;
 import java.util.Optional;
@@ -192,7 +193,7 @@ public class BeaconChainUtil {
   public void setTime(final UInt64 time) {
     checkState(!recentChainData.isPreGenesis(), "Cannot set time before genesis");
     final StoreTransaction tx = recentChainData.startStoreTransaction();
-    tx.setTimeSeconds(time);
+    tx.setTimeMillis(secondsToMillis(time));
     tx.commit().join();
   }
 

--- a/storage/build.gradle
+++ b/storage/build.gradle
@@ -56,6 +56,7 @@ dependencies {
   testFixturesImplementation project(':ethereum:networks')
   testFixturesImplementation testFixtures(project(':infrastructure:async'))
   testFixturesImplementation project(':infrastructure:events')
+  testFixturesImplementation project(':infrastructure:time')
   testFixturesImplementation 'org.mockito:mockito-core'
   testFixturesImplementation 'org.junit.jupiter:junit-jupiter-api'
   testFixturesImplementation 'org.junit.jupiter:junit-jupiter-params'

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransaction.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransaction.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.storage.store;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static tech.pegasys.teku.dataproviders.generators.StateAtSlotTask.AsyncStateProvider.fromBlockAndState;
-import static tech.pegasys.teku.infrastructure.time.TimeUtilities.secondsToMillis;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -95,24 +94,6 @@ class StoreTransaction implements UpdatableStore.StoreTransaction {
   @Override
   public void putStateRoot(final Bytes32 stateRoot, final SlotAndBlockRoot slotAndBlockRoot) {
     stateRoots.put(stateRoot, slotAndBlockRoot);
-  }
-
-  @Override
-  public void setTimeSeconds(UInt64 timeSeconds) {
-    final UInt64 storeTime = store.getTimeSeconds();
-    checkArgument(
-        timeSeconds.isGreaterThanOrEqualTo(storeTime),
-        "Cannot revert time (seconds) from %s to %s",
-        storeTime,
-        timeSeconds);
-    UInt64 timeMillis = secondsToMillis(timeSeconds);
-    if (updatingMillisIsRequired(timeMillis)) {
-      this.timeMillis = Optional.of(timeMillis);
-    }
-  }
-
-  private boolean updatingMillisIsRequired(UInt64 timeMillis) {
-    return timeMillis.isGreaterThan(store.getTimeMillis());
   }
 
   @Override

--- a/storage/src/test/java/tech/pegasys/teku/storage/client/RecentChainDataTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/client/RecentChainDataTest.java
@@ -312,7 +312,7 @@ class RecentChainDataTest {
     final Checkpoint originalCheckpoint = recentChainData.getStore().getFinalizedCheckpoint();
 
     final StoreTransaction tx = recentChainData.startStoreTransaction();
-    tx.setTimeSeconds(UInt64.valueOf(11L));
+    tx.setTimeMillis(UInt64.valueOf(11000L));
     tx.commit().reportExceptions();
 
     final Checkpoint currentCheckpoint = recentChainData.getStore().getFinalizedCheckpoint();

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/client/ChainUpdater.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/client/ChainUpdater.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.storage.client;
 
 import static com.google.common.base.Preconditions.checkState;
 import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.infrastructure.time.TimeUtilities.secondsToMillis;
 
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes;
@@ -64,7 +65,7 @@ public class ChainUpdater {
   public void setTime(final UInt64 time) {
     checkState(!recentChainData.isPreGenesis(), "Cannot set time before genesis");
     final StoreTransaction tx = recentChainData.startStoreTransaction();
-    tx.setTimeSeconds(time);
+    tx.setTimeMillis(secondsToMillis(time));
     tx.commit().join();
   }
 


### PR DESCRIPTION
## PR Description
Remove `Transaction.setTimeSeconds`.  Production code was already using `setTimeMillis` so just covert the remaining test code over.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
