### PR TITLE
Fix "defintion" typo in variables

### DIFF
--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/SszPrimitiveSchemas.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/SszPrimitiveSchemas.java
@@ -14,7 +14,7 @@
 package tech.pegasys.teku.infrastructure.ssz.schema;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static tech.pegasys.teku.infrastructure.ssz.schema.json.SszPrimitiveTypeDefinitions.SSZ_BIT_TYPE_DEFINTION;
+import static tech.pegasys.teku.infrastructure.ssz.schema.json.SszPrimitiveTypeDefinitions.SSZ_BIT_TYPE_DEFINITION;
 import static tech.pegasys.teku.infrastructure.ssz.schema.json.SszPrimitiveTypeDefinitions.SSZ_BYTES32_TYPE_DEFINITION;
 import static tech.pegasys.teku.infrastructure.ssz.schema.json.SszPrimitiveTypeDefinitions.SSZ_BYTES4_TYPE_DEFINITION;
 import static tech.pegasys.teku.infrastructure.ssz.schema.json.SszPrimitiveTypeDefinitions.SSZ_NONE_TYPE_DEFINITION;
@@ -118,7 +118,7 @@ public interface SszPrimitiveSchemas {
 
         @Override
         public DeserializableTypeDefinition<SszBit> getJsonTypeDefinition() {
-          return SSZ_BIT_TYPE_DEFINTION;
+          return SSZ_BIT_TYPE_DEFINITION;
         }
 
         @Override
@@ -163,7 +163,7 @@ public interface SszPrimitiveSchemas {
 
         @Override
         public DeserializableTypeDefinition<SszByte> getJsonTypeDefinition() {
-          return SszPrimitiveTypeDefinitions.SSZ_BYTE_TYPE_DEFINTION;
+          return SszPrimitiveTypeDefinitions.SSZ_BYTE_TYPE_DEFINITION;
         }
 
         @Override

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/json/SszPrimitiveTypeDefinitions.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/json/SszPrimitiveTypeDefinitions.java
@@ -46,10 +46,10 @@ public interface SszPrimitiveTypeDefinitions {
           .format("null")
           .build();
 
-  DeserializableTypeDefinition<SszBit> SSZ_BIT_TYPE_DEFINTION =
+  DeserializableTypeDefinition<SszBit> SSZ_BIT_TYPE_DEFINITION =
       new SszTypeDefinitionWrapper<>(SszPrimitiveSchemas.BIT_SCHEMA, new BooleanTypeDefinition());
 
-  DeserializableTypeDefinition<SszByte> SSZ_BYTE_TYPE_DEFINTION =
+  DeserializableTypeDefinition<SszByte> SSZ_BYTE_TYPE_DEFINITION =
       new SszTypeDefinitionWrapper<>(SszPrimitiveSchemas.BYTE_SCHEMA, CoreTypes.BYTE_TYPE);
 
   DeserializableTypeDefinition<SszBytes32> SSZ_BYTES32_TYPE_DEFINITION =


### PR DESCRIPTION
## PR Description

Simply fixes a typo I noticed.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
