### PR TITLE
Don't print the exception trace for remote metrics publishing

### DIFF
--- a/data/publisher/src/main/java/tech/pegasys/teku/data/publisher/MetricsPublisherManager.java
+++ b/data/publisher/src/main/java/tech/pegasys/teku/data/publisher/MetricsPublisherManager.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.teku.data.publisher;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.base.Throwables;
 import java.io.File;
 import java.io.IOException;
 import java.time.Duration;
@@ -98,7 +100,14 @@ public class MetricsPublisherManager extends Service {
         asyncRunner.runWithFixedDelay(
             this::publishMetrics,
             Duration.ofSeconds(intervalBetweenPublications),
-            (err) -> LOG.error("Error while attempting to publish metrics to remote service", err));
+            (err) -> {
+              if (Throwables.getRootCause(err) instanceof IOException
+                  && !(Throwables.getRootCause(err) instanceof JsonProcessingException)) {
+                LOG.warn("Error publishing metrics to remote service: " + err.getMessage());
+              } else {
+                LOG.warn("Error publishing metrics to remote service", err);
+              }
+            });
     return SafeFuture.COMPLETE;
   }
 


### PR DESCRIPTION
If the remote metrics service isn't available, stack trace is not helpful.

If the error is a JsonProcessingException, it will still print stack trace as it may be a bug we need context of, or a change in the specification that we need to update our client to handle.

Also, the log message should be warning level for this specific message.

fixes #5416

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
