### PR TITLE
Improve handling of signature service capacity being exceeded

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/AttestationUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/AttestationUtil.java
@@ -176,13 +176,14 @@ public class AttestationUtil {
               }
               return result;
             })
-        .exceptionally(
+        .exceptionallyCompose(
             err -> {
               if (err.getCause() instanceof IllegalArgumentException) {
                 LOG.debug("on_attestation: Attestation is not valid: ", err);
-                return AttestationProcessingResult.invalid(err.getMessage());
+                return SafeFuture.completedFuture(
+                    AttestationProcessingResult.invalid(err.getMessage()));
               } else {
-                throw new RuntimeException(err);
+                return SafeFuture.failedFuture(err);
               }
             });
   }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/topichandlers/Eth2TopicHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/topichandlers/Eth2TopicHandler.java
@@ -35,6 +35,7 @@ import tech.pegasys.teku.networking.eth2.gossip.topics.GossipTopics;
 import tech.pegasys.teku.networking.eth2.gossip.topics.OperationProcessor;
 import tech.pegasys.teku.networking.p2p.gossip.PreparedGossipMessage;
 import tech.pegasys.teku.networking.p2p.gossip.TopicHandler;
+import tech.pegasys.teku.service.serviceutils.ServiceCapacityExceededException;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
@@ -149,6 +150,11 @@ public class Eth2TopicHandler<MessageT extends SszData> implements TopicHandler 
     } else if (ExceptionUtil.getCause(err, RejectedExecutionException.class).isPresent()) {
       LOG.warn(
           "Discarding gossip message for topic {} because the executor queue is full", getTopic());
+      response = ValidationResult.Ignore;
+    } else if (ExceptionUtil.getCause(err, ServiceCapacityExceededException.class).isPresent()) {
+      LOG.warn(
+          "Discarding gossip message for topic {} because the signature verification queue is full",
+          getTopic());
       response = ValidationResult.Ignore;
     } else {
       LOG.warn("Encountered exception while processing message for topic {}", getTopic(), err);


### PR DESCRIPTION
## PR Description
* Don't print stack trace when service capacity exceeded
* Avoid wrapping in additional exception unnecessarily.


## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
