### PR TITLE
Ensure POST invalid data returns 400

### DIFF
--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/validator/PostRegisterValidatorTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/validator/PostRegisterValidatorTest.java
@@ -14,7 +14,10 @@
 package tech.pegasys.teku.beaconrestapi.v1.validator;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_BAD_REQUEST;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
 import static tech.pegasys.teku.spec.schemas.ApiSchemas.SIGNED_VALIDATOR_REGISTRATIONS_SCHEMA;
 
@@ -22,6 +25,8 @@ import java.io.IOException;
 import okhttp3.Response;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import tech.pegasys.teku.beaconrestapi.AbstractDataBackedRestAPIIntegrationTest;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.PostRegisterValidator;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -44,15 +49,33 @@ public class PostRegisterValidatorTest extends AbstractDataBackedRestAPIIntegrat
   void shouldReturnOk() throws IOException {
     final SszList<SignedValidatorRegistration> request =
         dataStructureUtil.randomValidatorRegistrations(10);
-
     when(validatorApiChannel.registerValidators(request)).thenReturn(SafeFuture.COMPLETE);
 
-    Response response =
+    try (Response response =
         post(
             PostRegisterValidator.ROUTE,
             JsonUtil.serialize(
-                request, SIGNED_VALIDATOR_REGISTRATIONS_SCHEMA.getJsonTypeDefinition()));
+                request, SIGNED_VALIDATOR_REGISTRATIONS_SCHEMA.getJsonTypeDefinition()))) {
 
-    assertThat(response.code()).isEqualTo(SC_OK);
+      assertThat(response.code()).isEqualTo(SC_OK);
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"[{}]", "{}", "invalid"})
+  void shouldReturnBadRequest(final String body) throws IOException {
+    when(validatorApiChannel.registerValidators(any())).thenReturn(SafeFuture.COMPLETE);
+    try (Response response = post(PostRegisterValidator.ROUTE, body)) {
+      assertThat(response.code()).isEqualTo(SC_BAD_REQUEST);
+    }
+    verifyNoInteractions(validatorApiChannel);
+  }
+
+  @Test
+  void shouldHandleEmptyRequest() throws IOException {
+    when(validatorApiChannel.registerValidators(any())).thenReturn(SafeFuture.COMPLETE);
+    try (Response response = post(PostRegisterValidator.ROUTE, "[]")) {
+      assertThat(response.code()).isEqualTo(SC_OK);
+    }
   }
 }

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApi.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApi.java
@@ -20,6 +20,7 @@ import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_NO_CONTEN
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_SERVICE_UNAVAILABLE;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_UNSUPPORTED_MEDIA_TYPE;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.base.Throwables;
 import io.javalin.Javalin;
 import io.javalin.http.Context;
@@ -226,6 +227,7 @@ public class BeaconRestApi {
     app.exception(ServiceUnavailableException.class, this::serviceUnavailable);
     app.exception(ContentTypeNotSupportedException.class, this::unsupportedContentType);
     app.exception(BadRequestException.class, this::badRequest);
+    app.exception(JsonProcessingException.class, this::badRequest);
     app.exception(IllegalArgumentException.class, this::badRequest);
     // Add catch-all handler
     app.exception(


### PR DESCRIPTION
- added integration test for PostRegisterValidatorTest, showing invalid data coming in, and a resulting 400.
- had to add a default exception handler for `JsonProcessingException`.

fixes #5571

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
