### PR TITLE
Implement keymanager-api deleteFeeRecipient

### DIFF
--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/BeaconProposerPreparer.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/BeaconProposerPreparer.java
@@ -140,6 +140,16 @@ public class BeaconProposerPreparer implements ValidatorTimingChannel {
     runtimeProposerConfig.addOrUpdate(publicKey, eth1Address);
   }
 
+  public boolean deleteFeeRecipient(final BLSPublicKey publicKey) {
+    Optional<Eth1Address> maybeEth1Address =
+        maybeProposerConfig.flatMap(config -> getFeeRecipientFromProposerConfig(config, publicKey));
+    if (maybeEth1Address.isPresent()) {
+      return false;
+    }
+    runtimeProposerConfig.delete(publicKey);
+    return true;
+  }
+
   private Optional<Eth1Address> getFeeRecipientFromProposerConfig(
       final ProposerConfig config, final BLSPublicKey publicKey) {
     return config.getConfigForPubKey(publicKey).map(Config::getFeeRecipient);

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/ValidatorRestApi.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/ValidatorRestApi.java
@@ -30,6 +30,7 @@ import tech.pegasys.teku.service.serviceutils.layout.DataDirLayout;
 import tech.pegasys.teku.validator.client.BeaconProposerPreparer;
 import tech.pegasys.teku.validator.client.KeyManager;
 import tech.pegasys.teku.validator.client.ValidatorClientService;
+import tech.pegasys.teku.validator.client.restapi.apis.DeleteFeeRecipient;
 import tech.pegasys.teku.validator.client.restapi.apis.DeleteKeys;
 import tech.pegasys.teku.validator.client.restapi.apis.DeleteRemoteKeys;
 import tech.pegasys.teku.validator.client.restapi.apis.GetFeeRecipient;
@@ -85,6 +86,7 @@ public class ValidatorRestApi {
         .endpoint(new DeleteRemoteKeys(keyManager))
         .endpoint(new GetFeeRecipient(beaconProposerPreparer))
         .endpoint(new SetFeeRecipient(beaconProposerPreparer))
+        .endpoint(new DeleteFeeRecipient(beaconProposerPreparer))
         .sslCertificate(config.getRestApiKeystoreFile(), config.getRestApiKeystorePasswordFile())
         .passwordFilePath(
             ValidatorClientService.getKeyManagerPath(dataDirLayout).resolve("validator-api-bearer"))

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/apis/DeleteFeeRecipient.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/apis/DeleteFeeRecipient.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.client.restapi.apis;
+
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_FORBIDDEN;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_NOT_FOUND;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_NO_CONTENT;
+import static tech.pegasys.teku.validator.client.restapi.ValidatorRestApi.TAG_FEE_RECIPIENT;
+import static tech.pegasys.teku.validator.client.restapi.apis.GetFeeRecipient.PARAM_PUBKEY_TYPE;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.util.Optional;
+import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.infrastructure.restapi.endpoints.EndpointMetadata;
+import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiEndpoint;
+import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiRequest;
+import tech.pegasys.teku.validator.client.BeaconProposerPreparer;
+
+public class DeleteFeeRecipient extends RestApiEndpoint {
+  public static final String ROUTE = "/eth/v1/validator/{pubkey}/feerecipient";
+  private final Optional<BeaconProposerPreparer> beaconProposerPreparer;
+
+  public DeleteFeeRecipient(final Optional<BeaconProposerPreparer> beaconProposerPreparer) {
+    super(
+        EndpointMetadata.delete(ROUTE)
+            .operationId("DeleteFeeRecipient")
+            .summary("Delete configured fee recipient")
+            .withBearerAuthSecurity()
+            .tags(TAG_FEE_RECIPIENT)
+            .pathParam(PARAM_PUBKEY_TYPE)
+            .description("Delete a configured fee recipient mapping for the specified public key.")
+            .response(SC_NO_CONTENT, "Success")
+            .response(
+                SC_FORBIDDEN,
+                "The fee recipient is set in configuration, and cannot be updated or removed via api.")
+            .withAuthenticationResponses()
+            .withNotFoundResponse()
+            .build());
+    this.beaconProposerPreparer = beaconProposerPreparer;
+  }
+
+  @Override
+  public void handleRequest(final RestApiRequest request) throws JsonProcessingException {
+    final BLSPublicKey publicKey = request.getPathParameter(PARAM_PUBKEY_TYPE);
+    if (beaconProposerPreparer.orElseThrow().getFeeRecipient(publicKey).isEmpty()) {
+      request.respondError(SC_NOT_FOUND, "Fee recipient not found");
+      return;
+    }
+    if (!beaconProposerPreparer.orElseThrow().deleteFeeRecipient(publicKey)) {
+      request.respondError(SC_FORBIDDEN, "Fee recipient for public key could not be removed.");
+      return;
+    }
+    ;
+    request.respondWithCode(SC_NO_CONTENT);
+  }
+}

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/BeaconProposerPreparerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/BeaconProposerPreparerTest.java
@@ -189,6 +189,29 @@ public class BeaconProposerPreparerTest {
   }
 
   @TestTemplate
+  void deleteFeeRecipient_shouldReturnFalseIfConfigurationSetsAddress() {
+    beaconProposerPreparer.onSlot(UInt64.ONE);
+    assertThat(beaconProposerPreparer.deleteFeeRecipient(validator1.getPublicKey())).isFalse();
+  }
+
+  @TestTemplate
+  void deleteFeeRecipient_shouldReturnTrueIfConfigHasPublicKey(@TempDir final Path tempDir)
+      throws IOException {
+    proposerWithRuntimeConfiguration(
+        tempDir, validator2.getPublicKey(), dataStructureUtil.randomEth1Address());
+    beaconProposerPreparer.onSlot(UInt64.ONE);
+    assertThat(beaconProposerPreparer.deleteFeeRecipient(validator2.getPublicKey())).isTrue();
+  }
+
+  @TestTemplate
+  void deleteFeeRecipient_shouldReturnTrueIfConfigMissingPublicKey() {
+    // successful in that it is not a configured key, and it is not listed in the runtime
+    // configuration.
+    beaconProposerPreparer.onSlot(UInt64.ONE);
+    assertThat(beaconProposerPreparer.deleteFeeRecipient(validator2.getPublicKey())).isTrue();
+  }
+
+  @TestTemplate
   void getFeeRecipient_shouldReturnRuntimeConfigIfNotPresentInConfigurationFile(
       @TempDir final Path tempDir) throws IOException {
     final Eth1Address address = dataStructureUtil.randomEth1Address();

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/restapi/apis/DeleteFeeRecipientTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/restapi/apis/DeleteFeeRecipientTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.client.restapi.apis;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_BAD_REQUEST;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_FORBIDDEN;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_INTERNAL_SERVER_ERROR;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_NOT_FOUND;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_NO_CONTENT;
+import static tech.pegasys.teku.infrastructure.restapi.MetadataTestUtil.verifyMetadataErrorResponse;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.infrastructure.restapi.StubRestApiRequest;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.validator.client.BeaconProposerPreparer;
+
+class DeleteFeeRecipientTest {
+  private final BeaconProposerPreparer beaconProposerPreparer = mock(BeaconProposerPreparer.class);
+  private final DeleteFeeRecipient handler =
+      new DeleteFeeRecipient(Optional.of(beaconProposerPreparer));
+  private final Spec spec = TestSpecFactory.createMinimalBellatrix();
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+  private final BLSPublicKey publicKey = dataStructureUtil.randomPublicKey();
+  private final StubRestApiRequest request =
+      StubRestApiRequest.builder()
+          .pathParameter("pubkey", publicKey.toBytesCompressed().toHexString())
+          .build();
+
+  @Test
+  void shouldReturnFailureWhenKeyNotFound() throws JsonProcessingException {
+    when(beaconProposerPreparer.getFeeRecipient(any())).thenReturn(Optional.empty());
+    handler.handleRequest(request);
+    assertThat(request.getResponseCode()).isEqualTo(SC_NOT_FOUND);
+  }
+
+  @Test
+  void shouldReturnForbiddenWhenDeleteFails() throws JsonProcessingException {
+    when(beaconProposerPreparer.getFeeRecipient(any()))
+        .thenReturn(Optional.of(dataStructureUtil.randomEth1Address()));
+    when(beaconProposerPreparer.deleteFeeRecipient(any())).thenReturn(false);
+    handler.handleRequest(request);
+    assertThat(request.getResponseCode()).isEqualTo(SC_FORBIDDEN);
+  }
+
+  @Test
+  void shouldReturnSuccessWhenDeleteSucceeds() throws JsonProcessingException {
+    when(beaconProposerPreparer.getFeeRecipient(any()))
+        .thenReturn(Optional.of(dataStructureUtil.randomEth1Address()));
+    when(beaconProposerPreparer.deleteFeeRecipient(any())).thenReturn(true);
+    handler.handleRequest(request);
+    assertThat(request.getResponseCode()).isEqualTo(SC_NO_CONTENT);
+  }
+
+  @Test
+  void metadata_shouldHandle400() throws JsonProcessingException {
+    verifyMetadataErrorResponse(handler, SC_BAD_REQUEST);
+  }
+
+  @Test
+  void metadata_shouldHandle403() throws JsonProcessingException {
+    verifyMetadataErrorResponse(handler, SC_FORBIDDEN);
+  }
+
+  @Test
+  void metadata_shouldHandle404() throws JsonProcessingException {
+    verifyMetadataErrorResponse(handler, SC_NOT_FOUND);
+  }
+
+  @Test
+  void metadata_shouldHandle500() throws JsonProcessingException {
+    verifyMetadataErrorResponse(handler, SC_INTERNAL_SERVER_ERROR);
+  }
+}

--- a/validator/client/src/test/resources/tech/pegasys/teku/validator/client/restapi/paths/_eth_v1_validator_{pubkey}_feerecipient.json
+++ b/validator/client/src/test/resources/tech/pegasys/teku/validator/client/restapi/paths/_eth_v1_validator_{pubkey}_feerecipient.json
@@ -173,5 +173,80 @@
         }
       }
     }
+  },
+  "delete" : {
+    "tags" : [ "Fee Recipient" ],
+    "operationId" : "DeleteFeeRecipient",
+    "summary" : "Delete configured fee recipient",
+    "description" : "Delete a configured fee recipient mapping for the specified public key.",
+    "parameters" : [ {
+      "name" : "pubkey",
+      "required" : true,
+      "in" : "path",
+      "schema" : {
+        "type" : "string",
+        "pattern" : "^0x[a-fA-F0-9]{96}$",
+        "example" : "0x93247f2209abcacf57b75a51dafae777f9dd38bc7053d1af526f220a7489a6d3a2753e5f3e8b1cfe39b56f43611df74a"
+      }
+    } ],
+    "security" : [ {
+      "bearerAuth" : [ ]
+    } ],
+    "responses" : {
+      "204" : {
+        "description" : "Success",
+        "content" : { }
+      },
+      "403" : {
+        "description" : "Forbidden, a token is found but is invalid",
+        "content" : {
+          "application/json" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/HttpErrorResponse"
+            }
+          }
+        }
+      },
+      "401" : {
+        "description" : "Unauthorized, no token is found",
+        "content" : {
+          "application/json" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/HttpErrorResponse"
+            }
+          }
+        }
+      },
+      "404" : {
+        "description" : "Not found",
+        "content" : {
+          "application/json" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/HttpErrorResponse"
+            }
+          }
+        }
+      },
+      "400" : {
+        "description" : "The request could not be processed, check the response for more information.",
+        "content" : {
+          "application/json" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/HttpErrorResponse"
+            }
+          }
+        }
+      },
+      "500" : {
+        "description" : "Internal server error",
+        "content" : {
+          "application/json" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/HttpErrorResponse"
+            }
+          }
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
 - fee recipient configured via the config file loaded at startup are not candidates to be removed, and will throw a 403.

 - the intent is that a fee_recipient added via setFeeRecipient will be able to be deleted so that the nominated pubkey can again use the default recipient.

 - if a pubkey that we own is specified, it is not configured via config file, and was using default fee recipient, a delete will 'succeed', it'll continue to use the default fee recipient.

 - delete takes no body, and returns no body (204 response) on success.

 fixes #5587

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
