### PR TITLE
[MEV Boost\Builder] Support for validator registration in VC

### DIFF
--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/ValidatorLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/ValidatorLogger.java
@@ -160,6 +160,12 @@ public class ValidatorLogger {
     log.error(ColorConsolePrinter.print(errorString, Color.RED), error);
   }
 
+  public void registeringValidatorsFailed(final Throwable error) {
+    final String errorString =
+        String.format("%sFailed to send validator registrations to Beacon Node", PREFIX);
+    log.error(ColorConsolePrinter.print(errorString, Color.RED), error);
+  }
+
   public void executionPayloadPreparedUsingBeaconDefaultFeeRecipient(final UInt64 slot) {
     log.warn(
         ColorConsolePrinter.print(

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
@@ -297,6 +297,7 @@ public class ValidatorClientService extends Service {
             preparer.initialize(Optional.of(validatorIndexProvider));
             validatorTimingChannels.add(preparer);
           });
+      validatorRegistrator.ifPresent(validatorTimingChannels::add);
     }
     addValidatorCountMetric(metricsSystem, validators);
     this.validatorStatusLogger =

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
@@ -72,6 +72,7 @@ public class ValidatorClientService extends Service {
   private ValidatorIndexProvider validatorIndexProvider;
   private final Optional<ProposerConfigProvider> proposerConfigProvider;
   private final Optional<BeaconProposerPreparer> beaconProposerPreparer;
+  private final Optional<ValidatorRegistrator> validatorRegistrator;
 
   private final SafeFuture<Void> initializationComplete = new SafeFuture<>();
 
@@ -85,6 +86,7 @@ public class ValidatorClientService extends Service {
       final ForkProvider forkProvider,
       final Optional<ProposerConfigProvider> proposerConfigProvider,
       final Optional<BeaconProposerPreparer> beaconProposerPreparer,
+      final Optional<ValidatorRegistrator> validatorRegistrator,
       final Spec spec,
       final MetricsSystem metricsSystem) {
     this.eventChannels = eventChannels;
@@ -94,6 +96,7 @@ public class ValidatorClientService extends Service {
     this.forkProvider = forkProvider;
     this.proposerConfigProvider = proposerConfigProvider;
     this.beaconProposerPreparer = beaconProposerPreparer;
+    this.validatorRegistrator = validatorRegistrator;
     this.spec = spec;
     this.metricsSystem = metricsSystem;
   }
@@ -135,6 +138,7 @@ public class ValidatorClientService extends Service {
     Optional<RestApi> validatorRestApi = Optional.empty();
     Optional<ProposerConfigProvider> proposerConfigProvider = Optional.empty();
     Optional<BeaconProposerPreparer> beaconProposerPreparer = Optional.empty();
+    Optional<ValidatorRegistrator> validatorRegistrator = Optional.empty();
     if (config.getSpec().isMilestoneSupported(SpecMilestone.BELLATRIX)) {
       proposerConfigProvider =
           Optional.of(
@@ -155,6 +159,15 @@ public class ValidatorClientService extends Service {
                   Optional.of(
                       ValidatorClientService.getKeyManagerPath(services.getDataDirLayout())
                           .resolve("api-proposer-config.json"))));
+
+      validatorRegistrator =
+          Optional.of(
+              new ValidatorRegistrator(
+                  forkProvider,
+                  validatorLoader.getOwnedValidators(),
+                  validatorApiChannel,
+                  config.getSpec(),
+                  services.getTimeProvider()));
     }
     if (validatorApiConfig.isRestApiEnabled()) {
       validatorRestApi =
@@ -178,6 +191,7 @@ public class ValidatorClientService extends Service {
             forkProvider,
             proposerConfigProvider,
             beaconProposerPreparer,
+            validatorRegistrator,
             config.getSpec(),
             services.getMetricsSystem());
 

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
@@ -159,15 +159,6 @@ public class ValidatorClientService extends Service {
                   Optional.of(
                       ValidatorClientService.getKeyManagerPath(services.getDataDirLayout())
                           .resolve("api-proposer-config.json"))));
-
-      validatorRegistrator =
-          Optional.of(
-              new ValidatorRegistrator(
-                  forkProvider,
-                  validatorLoader.getOwnedValidators(),
-                  validatorApiChannel,
-                  config.getSpec(),
-                  services.getTimeProvider()));
     }
     if (validatorApiConfig.isRestApiEnabled()) {
       validatorRestApi =

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorIdentity.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorIdentity.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.client;
+
+import java.util.Objects;
+import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.infrastructure.bytes.Bytes20;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+public class ValidatorIdentity {
+
+  private final Bytes20 feeRecipient;
+  private final UInt64 gasLimit;
+  private final BLSPublicKey publicKey;
+
+  public ValidatorIdentity(
+      final Bytes20 feeRecipient, final UInt64 gasLimit, final BLSPublicKey publicKey) {
+    this.feeRecipient = feeRecipient;
+    this.gasLimit = gasLimit;
+    this.publicKey = publicKey;
+  }
+
+  public Bytes20 getFeeRecipient() {
+    return feeRecipient;
+  }
+
+  public UInt64 getGasLimit() {
+    return gasLimit;
+  }
+
+  public BLSPublicKey getPublicKey() {
+    return publicKey;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ValidatorIdentity that = (ValidatorIdentity) o;
+    return Objects.equals(feeRecipient, that.feeRecipient)
+        && Objects.equals(gasLimit, that.gasLimit)
+        && Objects.equals(publicKey, that.publicKey);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(feeRecipient, gasLimit, publicKey);
+  }
+}

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrationIdentity.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrationIdentity.java
@@ -18,13 +18,13 @@ import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.infrastructure.bytes.Bytes20;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
-public class ValidatorIdentity {
+public class ValidatorRegistrationIdentity {
 
   private final Bytes20 feeRecipient;
   private final UInt64 gasLimit;
   private final BLSPublicKey publicKey;
 
-  public ValidatorIdentity(
+  public ValidatorRegistrationIdentity(
       final Bytes20 feeRecipient, final UInt64 gasLimit, final BLSPublicKey publicKey) {
     this.feeRecipient = feeRecipient;
     this.gasLimit = gasLimit;
@@ -51,7 +51,7 @@ public class ValidatorIdentity {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    ValidatorIdentity that = (ValidatorIdentity) o;
+    ValidatorRegistrationIdentity that = (ValidatorRegistrationIdentity) o;
     return Objects.equals(feeRecipient, that.feeRecipient)
         && Objects.equals(gasLimit, that.gasLimit)
         && Objects.equals(publicKey, that.publicKey);

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrator.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrator.java
@@ -66,7 +66,7 @@ public class ValidatorRegistrator implements ValidatorTimingChannel {
     if (isBeginningOfEpoch(slot) || firstCallDone.compareAndSet(false, true)) {
       forkProvider
           .getForkInfo(slot)
-          .thenApply(
+          .thenCompose(
               forkInfo -> {
                 final UInt64 epoch = spec.computeEpochAtSlot(slot);
                 return registerValidators(epoch, forkInfo);

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrator.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrator.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.client;
+
+import static tech.pegasys.teku.infrastructure.logging.ValidatorLogger.VALIDATOR_LOGGER;
+
+import com.google.common.collect.Maps;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Stream;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.core.signatures.Signer;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.bytes.Bytes20;
+import tech.pegasys.teku.infrastructure.ssz.impl.SszUtils;
+import tech.pegasys.teku.infrastructure.time.TimeProvider;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.datastructures.execution.SignedValidatorRegistration;
+import tech.pegasys.teku.spec.datastructures.execution.ValidatorRegistration;
+import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
+import tech.pegasys.teku.spec.schemas.ApiSchemas;
+import tech.pegasys.teku.validator.api.ValidatorApiChannel;
+import tech.pegasys.teku.validator.api.ValidatorTimingChannel;
+import tech.pegasys.teku.validator.client.loader.OwnedValidators;
+
+public class ValidatorRegistrator implements ValidatorTimingChannel {
+
+  private final Map<ValidatorIdentity, SignedValidatorRegistration> cachedValidatorRegistrations =
+      Maps.newConcurrentMap();
+
+  private final AtomicBoolean firstCallDone = new AtomicBoolean(false);
+
+  private final ForkProvider forkProvider;
+  private final Spec spec;
+  private final TimeProvider timeProvider;
+  private final OwnedValidators ownedValidators;
+  private final ValidatorApiChannel validatorApiChannel;
+
+  public ValidatorRegistrator(
+      final ForkProvider forkProvider,
+      final OwnedValidators ownedValidators,
+      final ValidatorApiChannel validatorApiChannel,
+      final Spec spec,
+      final TimeProvider timeProvider) {
+    this.forkProvider = forkProvider;
+    this.spec = spec;
+    this.timeProvider = timeProvider;
+    this.ownedValidators = ownedValidators;
+    this.validatorApiChannel = validatorApiChannel;
+  }
+
+  @Override
+  public void onSlot(UInt64 slot) {
+    if (isBeginningOfEpoch(slot) || firstCallDone.compareAndSet(false, true)) {
+      forkProvider
+          .getForkInfo(slot)
+          .thenApply(
+              forkInfo -> {
+                final UInt64 epoch = spec.computeEpochAtSlot(slot);
+                return registerValidators(epoch, forkInfo);
+              })
+          .finish(VALIDATOR_LOGGER::registeringValidatorsFailed);
+    }
+  }
+
+  @Override
+  public void onHeadUpdate(
+      UInt64 slot,
+      Bytes32 previousDutyDependentRoot,
+      Bytes32 currentDutyDependentRoot,
+      Bytes32 headBlockRoot) {}
+
+  @Override
+  public void onPossibleMissedEvents() {}
+
+  @Override
+  public void onValidatorsAdded() {}
+
+  @Override
+  public void onBlockProductionDue(UInt64 slot) {}
+
+  @Override
+  public void onAttestationCreationDue(UInt64 slot) {}
+
+  @Override
+  public void onAttestationAggregationDue(UInt64 slot) {}
+
+  private boolean isBeginningOfEpoch(final UInt64 slot) {
+    return slot.mod(spec.getSlotsPerEpoch(slot)).isZero();
+  }
+
+  private SafeFuture<Void> registerValidators(final UInt64 epoch, final ForkInfo forkInfo) {
+
+    final Stream<SafeFuture<SignedValidatorRegistration>> validatorRegistrationsFutures =
+        ownedValidators.getActiveValidators().stream()
+            .map(
+                validator -> {
+                  // hardcoding fee_recipient and gas_limit to ZERO for now. The real values will be
+                  // passed in a future PR.
+                  final ValidatorIdentity validatorIdentity =
+                      new ValidatorIdentity(Bytes20.ZERO, UInt64.ZERO, validator.getPublicKey());
+
+                  if (cachedValidatorRegistrations.containsKey(validatorIdentity)) {
+                    return SafeFuture.completedFuture(
+                        cachedValidatorRegistrations.get(validatorIdentity));
+                  }
+
+                  final ValidatorRegistration validatorRegistration =
+                      createValidatorRegistration(validatorIdentity);
+                  final Signer signer = validator.getSigner();
+                  return signValidatorRegistration(validatorRegistration, signer, epoch, forkInfo)
+                      .thenPeek(
+                          signedValidatorRegistration ->
+                              cachedValidatorRegistrations.put(
+                                  validatorIdentity, signedValidatorRegistration));
+                });
+
+    return SafeFuture.collectAll(validatorRegistrationsFutures)
+        .thenApply(
+            validatorRegistrations ->
+                SszUtils.toSszList(
+                    ApiSchemas.SIGNED_VALIDATOR_REGISTRATIONS_SCHEMA, validatorRegistrations))
+        .thenCompose(validatorApiChannel::registerValidators);
+  }
+
+  private ValidatorRegistration createValidatorRegistration(
+      final ValidatorIdentity validatorIdentity) {
+    return ApiSchemas.VALIDATOR_REGISTRATION_SCHEMA.create(
+        validatorIdentity.getFeeRecipient(),
+        validatorIdentity.getGasLimit(),
+        timeProvider.getTimeInSeconds(),
+        validatorIdentity.getPublicKey());
+  }
+
+  private SafeFuture<SignedValidatorRegistration> signValidatorRegistration(
+      final ValidatorRegistration validatorRegistration,
+      final Signer signer,
+      final UInt64 epoch,
+      final ForkInfo forkInfo) {
+    return signer
+        .signValidatorRegistration(validatorRegistration, epoch, forkInfo)
+        .thenApply(
+            signature ->
+                ApiSchemas.SIGNED_VALIDATOR_REGISTRATION_SCHEMA.create(
+                    validatorRegistration, signature));
+  }
+}

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrator.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrator.java
@@ -108,7 +108,7 @@ public class ValidatorRegistrator implements ValidatorTimingChannel {
             .map(
                 validator -> {
                   // hardcoding fee_recipient and gas_limit to ZERO for now. The real values will be
-                  // passed in a future PR.
+                  // taken from the proposer config in a future PR.
                   final ValidatorIdentity validatorIdentity =
                       new ValidatorIdentity(Bytes20.ZERO, UInt64.ZERO, validator.getPublicKey());
 

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorRegistratorTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorRegistratorTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.core.signatures.Signer;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
+import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
+import tech.pegasys.teku.infrastructure.time.TimeProvider;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecContext;
+import tech.pegasys.teku.spec.TestSpecInvocationContextProvider.SpecContext;
+import tech.pegasys.teku.spec.datastructures.execution.SignedValidatorRegistration;
+import tech.pegasys.teku.spec.datastructures.execution.ValidatorRegistration;
+import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.validator.api.ValidatorApiChannel;
+import tech.pegasys.teku.validator.client.loader.OwnedValidators;
+
+@TestSpecContext(milestone = SpecMilestone.BELLATRIX)
+class ValidatorRegistratorTest {
+
+  private final ForkProvider forkProvider = mock(ForkProvider.class);
+  private final OwnedValidators ownedValidators = mock(OwnedValidators.class);
+  private final ValidatorApiChannel validatorApiChannel = mock(ValidatorApiChannel.class);
+  private final TimeProvider stubTimeProvider = StubTimeProvider.withTimeInMillis(500);
+  private final Signer signer = mock(Signer.class);
+
+  private DataStructureUtil dataStructureUtil;
+
+  private Validator validator1;
+  private Validator validator2;
+  private Validator validator3;
+
+  private ValidatorRegistrator validatorRegistrator;
+
+  @BeforeEach
+  void setUp(SpecContext specContext) {
+    dataStructureUtil = specContext.getDataStructureUtil();
+    validator1 =
+        new Validator(
+            specContext.getDataStructureUtil().randomPublicKey(), signer, Optional::empty);
+    validator2 =
+        new Validator(
+            specContext.getDataStructureUtil().randomPublicKey(), signer, Optional::empty);
+    validator3 =
+        new Validator(
+            specContext.getDataStructureUtil().randomPublicKey(), signer, Optional::empty);
+    validatorRegistrator =
+        new ValidatorRegistrator(
+            forkProvider,
+            ownedValidators,
+            validatorApiChannel,
+            specContext.getSpec(),
+            stubTimeProvider);
+  }
+
+  @TestTemplate
+  void doesNotRegisterValidators_ifNotBeginningOfEpoch() {
+    when(forkProvider.getForkInfo(UInt64.ONE))
+        .thenReturn(SafeFuture.failedFuture(new IllegalStateException("doesn't matter")));
+
+    // initially validators will be registered anyway since it's the first call
+    validatorRegistrator.onSlot(UInt64.ONE);
+    verify(forkProvider).getForkInfo(UInt64.ONE);
+
+    // after the initial call, registration should not occur if not beginning of epoch
+    validatorRegistrator.onSlot(UInt64.ONE);
+    verifyNoMoreInteractions(forkProvider);
+
+    verifyNoInteractions(ownedValidators, validatorApiChannel, signer);
+  }
+
+  @TestTemplate
+  void registersValidators_onBeginningOfEpoch() {
+    // GIVEN
+    ForkInfo forkInfo = dataStructureUtil.randomForkInfo();
+    when(forkProvider.getForkInfo(UInt64.ZERO)).thenReturn(SafeFuture.completedFuture(forkInfo));
+
+    when(ownedValidators.getActiveValidators())
+        .thenReturn(List.of(validator1, validator2, validator3));
+
+    doAnswer(invocation -> SafeFuture.completedFuture(dataStructureUtil.randomSignature()))
+        .when(signer)
+        .signValidatorRegistration(any(ValidatorRegistration.class), eq(UInt64.ZERO), eq(forkInfo));
+
+    // WHEN
+    validatorRegistrator.onSlot(UInt64.ZERO);
+
+    // THEN
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<SszList<SignedValidatorRegistration>> argumentCaptor =
+        ArgumentCaptor.forClass(SszList.class);
+
+    InOrder inOrder = Mockito.inOrder(validatorApiChannel);
+
+    inOrder.verify(validatorApiChannel, timeout(5000)).registerValidators(argumentCaptor.capture());
+    verifyRegistrations(argumentCaptor.getValue());
+
+    // WHEN onSlot called again next time in a beginning of an epoch, registrations will be cached
+    validatorRegistrator.onSlot(UInt64.ZERO);
+
+    // THEN
+
+    // signer will be called in total 3 times, since from the 2nd run the signed registrations will
+    // be cached
+    verify(signer, times(3)).signValidatorRegistration(any(), any(), any());
+
+    inOrder.verify(validatorApiChannel, timeout(5000)).registerValidators(argumentCaptor.capture());
+    verifyRegistrations(argumentCaptor.getValue());
+  }
+
+  private void verifyRegistrations(SszList<SignedValidatorRegistration> validatorRegistrations) {
+
+    assertThat(validatorRegistrations).hasSize(3);
+    assertThat(validatorRegistrations)
+        .allSatisfy(registration -> assertThat(registration.getSignature().isValid()).isTrue());
+
+    Stream<BLSPublicKey> validatorsPublicKeys =
+        validatorRegistrations.stream()
+            .map(SignedValidatorRegistration::getMessage)
+            .map(ValidatorRegistration::getPublicKey);
+
+    assertThat(validatorsPublicKeys)
+        .containsExactlyInAnyOrder(
+            validator1.getPublicKey(), validator2.getPublicKey(), validator3.getPublicKey());
+  }
+}


### PR DESCRIPTION
## PR Description
Adding `ValidatorRegistrator` which will send validator registrations to the Beacon Node on beginning of epoch, on startup and when new validators are added.

## Fixed Issue(s)
fixes #5596 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
