### PR TITLE
Provide a version of LimitedMap and LimitedSet that are safe for iteration

### DIFF
--- a/ethereum/dataproviders/src/main/java/tech/pegasys/teku/dataproviders/generators/StateCache.java
+++ b/ethereum/dataproviders/src/main/java/tech/pegasys/teku/dataproviders/generators/StateCache.java
@@ -25,7 +25,7 @@ class StateCache {
   private final Map<Bytes32, BeaconState> knownStates;
 
   public StateCache(final int maxCachedStates, final Map<Bytes32, BeaconState> knownStates) {
-    this.cache = LimitedMap.create(maxCachedStates);
+    this.cache = LimitedMap.createSynchronized(maxCachedStates);
     this.knownStates = knownStates;
   }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/OperationPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/OperationPool.java
@@ -42,7 +42,7 @@ public class OperationPool<T extends SszData> {
   private static final int OPERATION_POOL_SIZE = 1000;
   private static final String OPERATION_POOL_SIZE_METRIC = "operation_pool_size_";
   private static final String OPERATION_POOL_SIZE_VALIDATION_REASON = "operation_pool_validation_";
-  private final Set<T> operations = LimitedSet.create(OPERATION_POOL_SIZE);
+  private final Set<T> operations = LimitedSet.createIterable(OPERATION_POOL_SIZE);
   private final Function<UInt64, SszListSchema<T, ?>> slotToSszListSchemaSupplier;
   private final OperationValidator<T> operationValidator;
   private final Optional<Comparator<T>> priorityOrderComparator;

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/BlockManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/BlockManager.java
@@ -55,7 +55,8 @@ public class BlockManager extends Service
   // in the invalidBlockRoots map we are going to store blocks whose import result is invalid
   // and will not require any further retry. Descendants of these blocks will be considered invalid
   // as well.
-  private final Map<Bytes32, BlockImportResult> invalidBlockRoots = LimitedMap.create(500);
+  private final Map<Bytes32, BlockImportResult> invalidBlockRoots =
+      LimitedMap.createSynchronized(500);
   private final Subscribers<ImportedBlockListener> receivedBlockSubscribers =
       Subscribers.create(true);
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/ReexecutingExecutionPayloadBlockManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/ReexecutingExecutionPayloadBlockManager.java
@@ -39,7 +39,8 @@ public class ReexecutingExecutionPayloadBlockManager extends BlockManager {
   private static final Duration RECHECK_INTERVAL = Duration.ofSeconds(2);
 
   private final AtomicBoolean reexecutingExecutionPayload = new AtomicBoolean(false);
-  private final Set<SignedBeaconBlock> pendingBlocksForEPReexecution = LimitedSet.create(10);
+  private final Set<SignedBeaconBlock> pendingBlocksForEPReexecution =
+      LimitedSet.createIterable(10);
   private final AsyncRunner asyncRunner;
 
   private Optional<Cancellable> cancellable = Optional.empty();

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SignedContributionAndProofValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SignedContributionAndProofValidator.java
@@ -54,7 +54,7 @@ public class SignedContributionAndProofValidator {
   private static final Logger LOG = LogManager.getLogger();
   private final Spec spec;
   private final Set<SourceUniquenessKey> seenIndices =
-      LimitedSet.create(VALID_CONTRIBUTION_AND_PROOF_SET_SIZE);
+      LimitedSet.createSynchronized(VALID_CONTRIBUTION_AND_PROOF_SET_SIZE);
   private final SeenAggregatesCache<TargetUniquenessKey> seenAggregatesCache =
       new SeenAggregatesCache<>(VALID_CONTRIBUTION_AND_PROOF_SET_SIZE);
   private final SyncCommitteeStateUtils syncCommitteeStateUtils;

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeMessageValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeMessageValidator.java
@@ -45,7 +45,7 @@ import tech.pegasys.teku.storage.client.RecentChainData;
 public class SyncCommitteeMessageValidator {
   private static final Logger LOG = LogManager.getLogger();
   private final Set<UniquenessKey> seenIndices =
-      LimitedSet.create(VALID_SYNC_COMMITTEE_MESSAGE_SET_SIZE);
+      LimitedSet.createSynchronized(VALID_SYNC_COMMITTEE_MESSAGE_SET_SIZE);
   private final Spec spec;
   private final SyncCommitteeStateUtils syncCommitteeStateUtils;
   private final AsyncBLSSignatureVerifier signatureVerifier;

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/FutureItems.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/FutureItems.java
@@ -96,7 +96,6 @@ public class FutureItems<T> implements SlotEventsChannel {
    * @param currentSlot The slot to be considered current
    * @return The set of items that are no longer in the future
    */
-  @SuppressWarnings("rawtypes")
   public List<T> prune(final UInt64 currentSlot) {
     final List<T> dequeued = new ArrayList<>();
     queuedFutureItems
@@ -118,6 +117,6 @@ public class FutureItems<T> implements SlotEventsChannel {
   }
 
   private Set<T> createNewSet() {
-    return LimitedSet.create(MAX_ITEMS_PER_SLOT);
+    return LimitedSet.createSynchronized(MAX_ITEMS_PER_SLOT);
   }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/SeenAggregatesCache.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/SeenAggregatesCache.java
@@ -25,7 +25,7 @@ public class SeenAggregatesCache<KeyT> {
   private final Map<KeyT, Set<SszBitSet>> seenAggregationBitsByDataRoot;
 
   public SeenAggregatesCache(final int rootCacheSize) {
-    this.seenAggregationBitsByDataRoot = LimitedMap.create(rootCacheSize);
+    this.seenAggregationBitsByDataRoot = LimitedMap.createSynchronized(rootCacheSize);
   }
 
   public boolean add(final KeyT root, final SszBitSet aggregationBits) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AggregateAttestationValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AggregateAttestationValidator.java
@@ -51,7 +51,7 @@ import tech.pegasys.teku.statetransition.util.SeenAggregatesCache;
 public class AggregateAttestationValidator {
   private static final Logger LOG = LogManager.getLogger();
   private final Set<AggregatorIndexAndEpoch> receivedAggregatorIndexAndEpochs =
-      LimitedSet.create(VALID_AGGREGATE_SET_SIZE);
+      LimitedSet.createSynchronized(VALID_AGGREGATE_SET_SIZE);
   private final SeenAggregatesCache<Bytes32> seenAggregationBits =
       new SeenAggregatesCache<>(VALID_ATTESTATION_DATA_SET_SIZE);
   private final AttestationValidator attestationValidator;

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AttesterSlashingValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AttesterSlashingValidator.java
@@ -32,7 +32,7 @@ public class AttesterSlashingValidator implements OperationValidator<AttesterSla
   private static final Logger LOG = LogManager.getLogger();
 
   private final RecentChainData recentChainData;
-  private final Set<UInt64> seenIndices = LimitedSet.create(VALID_VALIDATOR_SET_SIZE);
+  private final Set<UInt64> seenIndices = LimitedSet.createSynchronized(VALID_VALIDATOR_SET_SIZE);
   private final Spec spec;
 
   public AttesterSlashingValidator(RecentChainData recentChainData, final Spec spec) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlockValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlockValidator.java
@@ -45,7 +45,7 @@ public class BlockValidator {
   private final Spec spec;
   private final RecentChainData recentChainData;
   private final Set<SlotAndProposer> receivedValidBlockInfoSet =
-      LimitedSet.create(VALID_BLOCK_SET_SIZE);
+      LimitedSet.createSynchronized(VALID_BLOCK_SET_SIZE);
 
   public BlockValidator(final Spec spec, RecentChainData recentChainData) {
     this.spec = spec;

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ProposerSlashingValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ProposerSlashingValidator.java
@@ -36,7 +36,7 @@ public class ProposerSlashingValidator implements OperationValidator<ProposerSla
   private final Spec spec;
   private final RecentChainData recentChainData;
   private final Set<UInt64> receivedValidSlashingForProposerSet =
-      LimitedSet.create(VALID_VALIDATOR_SET_SIZE);
+      LimitedSet.createSynchronized(VALID_VALIDATOR_SET_SIZE);
 
   public ProposerSlashingValidator(final Spec spec, RecentChainData recentChainData) {
     this.spec = spec;

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/VoluntaryExitValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/VoluntaryExitValidator.java
@@ -36,7 +36,8 @@ public class VoluntaryExitValidator implements OperationValidator<SignedVoluntar
 
   private final Spec spec;
   private final RecentChainData recentChainData;
-  private final Set<UInt64> receivedValidExitSet = LimitedSet.create(VALID_VALIDATOR_SET_SIZE);
+  private final Set<UInt64> receivedValidExitSet =
+      LimitedSet.createSynchronized(VALID_VALIDATOR_SET_SIZE);
 
   public VoluntaryExitValidator(final Spec spec, RecentChainData recentChainData) {
     this.spec = spec;

--- a/infrastructure/collections/src/main/java/tech/pegasys/teku/infrastructure/collections/LimitedMap.java
+++ b/infrastructure/collections/src/main/java/tech/pegasys/teku/infrastructure/collections/LimitedMap.java
@@ -19,16 +19,31 @@ import java.util.Map;
 public interface LimitedMap<K, V> extends Map<K, V> {
 
   /**
-   * Creates a limited map. The returned map is safe for concurrent access and evicts the least
-   * recently used items.
+   * Creates a limited map. The returned map is safe for concurrent access *except* iteration and
+   * evicts the least recently used items. Iteration requires synchronizing on the map instance.
+   *
+   * <p>Synchronized instances are generally faster than iterable versions.
    *
    * @param maxSize The maximum number of elements to keep in the map.
    * @param <K> The key type of the map.
    * @param <V> The value type of the map.
    * @return A map that will evict elements when the max size is exceeded.
    */
-  static <K, V> LimitedMap<K, V> create(final int maxSize) {
+  static <K, V> LimitedMap<K, V> createSynchronized(final int maxSize) {
     return new SynchronizedLimitedMap<>(maxSize);
+  }
+
+  /**
+   * Creates a limited map. The returned map is safe for all forms of concurrent access including
+   * iteration and evicts the least recently used items.
+   *
+   * @param maxSize The maximum number of elements to keep in the map.
+   * @param <K> The key type of the map.
+   * @param <V> The value type of the map.
+   * @return A map that will evict elements when the max size is exceeded.
+   */
+  static <K, V> Map<K, V> createIterable(final int maxSize) {
+    return CacheBuilder.newBuilder().maximumSize(maxSize).<K, V>build().asMap();
   }
 
   /**

--- a/infrastructure/collections/src/main/java/tech/pegasys/teku/infrastructure/collections/LimitedSet.java
+++ b/infrastructure/collections/src/main/java/tech/pegasys/teku/infrastructure/collections/LimitedSet.java
@@ -22,14 +22,28 @@ public final class LimitedSet {
   private LimitedSet() {}
 
   /**
-   * Creates a limited set. The returned set is safe for concurrent access and evicts the least
-   * recently used items.
+   * Creates a limited set. The returned set is safe for concurrent access *except* iteration and
+   * evicts the least recently used items. There is no thread safe way to iterate this set.
+   *
+   * <p>Synchronized instances are generally faster than iterable versions.
    *
    * @param maxSize The maximum number of elements to keep in the set.
    * @param <T> The type of object held in the set.
    * @return A set that will evict elements when the max size is exceeded.
    */
-  public static <T> Set<T> create(final int maxSize) {
-    return Collections.newSetFromMap(LimitedMap.create(maxSize));
+  public static <T> Set<T> createSynchronized(final int maxSize) {
+    return Collections.newSetFromMap(LimitedMap.createSynchronized(maxSize));
+  }
+
+  /**
+   * Creates a limited set. The returned set is safe for all forms of concurrent access including
+   * iteration and evicts the least recently used items.
+   *
+   * @param maxSize The maximum number of elements to keep in the set.
+   * @param <T> The type of object held in the set.
+   * @return A set that will evict elements when the max size is exceeded.
+   */
+  public static <T> Set<T> createIterable(final int maxSize) {
+    return Collections.newSetFromMap(LimitedMap.createIterable(maxSize));
   }
 }

--- a/infrastructure/collections/src/main/java/tech/pegasys/teku/infrastructure/collections/cache/LRUCache.java
+++ b/infrastructure/collections/src/main/java/tech/pegasys/teku/infrastructure/collections/cache/LRUCache.java
@@ -27,7 +27,7 @@ import tech.pegasys.teku.infrastructure.collections.LimitedMap;
 public class LRUCache<K, V> implements Cache<K, V> {
 
   public static <K, V> LRUCache<K, V> create(int capacity) {
-    return new LRUCache<>(LimitedMap.create(capacity));
+    return new LRUCache<>(LimitedMap.createSynchronized(capacity));
   }
 
   private final LimitedMap<K, V> cacheData;

--- a/infrastructure/collections/src/test/java/tech/pegasys/teku/infrastructure/collections/LimitedMapTest.java
+++ b/infrastructure/collections/src/test/java/tech/pegasys/teku/infrastructure/collections/LimitedMapTest.java
@@ -22,7 +22,7 @@ public class LimitedMapTest {
 
   @Test
   public void create_evictLeastRecentlyAccessed() {
-    final Map<Integer, Integer> map = LimitedMap.create(2);
+    final Map<Integer, Integer> map = LimitedMap.createSynchronized(2);
     map.put(1, 1);
     assertThat(map.size()).isEqualTo(1);
     map.put(2, 2);

--- a/infrastructure/collections/src/test/java/tech/pegasys/teku/infrastructure/collections/LimitedSetTest.java
+++ b/infrastructure/collections/src/test/java/tech/pegasys/teku/infrastructure/collections/LimitedSetTest.java
@@ -22,7 +22,7 @@ public class LimitedSetTest {
 
   @Test
   public void create_evictLeastRecentlyAccessed() {
-    final Set<Integer> set = LimitedSet.create(2);
+    final Set<Integer> set = LimitedSet.createSynchronized(2);
     set.add(1);
     assertThat(set.size()).isEqualTo(1);
     set.add(2);

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4FinalizedStateTreeStorageLogic.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4FinalizedStateTreeStorageLogic.java
@@ -42,7 +42,7 @@ public class V4FinalizedStateTreeStorageLogic
   public V4FinalizedStateTreeStorageLogic(
       final MetricsSystem metricsSystem, final Spec spec, final int maxKnownNodeCacheSize) {
     this.spec = spec;
-    this.knownStoredBranchesCache = LimitedSet.create(maxKnownNodeCacheSize);
+    this.knownStoredBranchesCache = LimitedSet.createSynchronized(maxKnownNodeCacheSize);
     this.branchNodeStoredCounter =
         metricsSystem.createLabelledCounter(
             TekuMetricCategory.STORAGE_FINALIZED_DB,

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
@@ -180,7 +180,8 @@ class Store implements UpdatableStore {
       final StoreConfig config) {
 
     // Create limited collections for non-final data
-    final Map<Bytes32, SignedBeaconBlock> blocks = LimitedMap.create(config.getBlockCacheSize());
+    final Map<Bytes32, SignedBeaconBlock> blocks =
+        LimitedMap.createSynchronized(config.getBlockCacheSize());
     final CachingTaskQueue<SlotAndBlockRoot, BeaconState> checkpointStateTaskQueue =
         CachingTaskQueue.create(
             asyncRunner,


### PR DESCRIPTION
## PR Description
Provide a version of LimitedMap and LimitedSet that are safe for iteration - use it in `OperationPool` which needs to iterate.
Rename methods to make it clearer which thread safety approach is used.

## Fixed Issue(s)
fixes #5452 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
