### PR TITLE
Allow finalizing the deposit merkle tree with zero deposits

### DIFF
--- a/ethereum/pow/merkletree/src/main/java/tech/pegasys/teku/ethereum/pow/merkletree/ZeroMerkleTree.java
+++ b/ethereum/pow/merkletree/src/main/java/tech/pegasys/teku/ethereum/pow/merkletree/ZeroMerkleTree.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.teku.ethereum.pow.merkletree;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import java.util.List;
 import java.util.function.Consumer;
 import org.apache.tuweni.bytes.Bytes32;
@@ -54,7 +56,9 @@ class ZeroMerkleTree extends MerkleTree {
 
   @Override
   public MerkleTree finalize(final long depositsToFinalize, final int level) {
-    throw new UnsupportedOperationException("Cannot finalized an empty tree");
+    checkArgument(depositsToFinalize == 0, "Attempted to finalized more deposits than are present");
+    return this;
+    //    throw new UnsupportedOperationException("Cannot finalized an empty tree");
   }
 
   @Override

--- a/ethereum/pow/merkletree/src/main/java/tech/pegasys/teku/ethereum/pow/merkletree/ZeroMerkleTree.java
+++ b/ethereum/pow/merkletree/src/main/java/tech/pegasys/teku/ethereum/pow/merkletree/ZeroMerkleTree.java
@@ -58,7 +58,6 @@ class ZeroMerkleTree extends MerkleTree {
   public MerkleTree finalize(final long depositsToFinalize, final int level) {
     checkArgument(depositsToFinalize == 0, "Attempted to finalized more deposits than are present");
     return this;
-    //    throw new UnsupportedOperationException("Cannot finalized an empty tree");
   }
 
   @Override

--- a/ethereum/pow/merkletree/src/test/java/tech/pegasys/teku/ethereum/pow/merkletree/DepositTreeTest.java
+++ b/ethereum/pow/merkletree/src/test/java/tech/pegasys/teku/ethereum/pow/merkletree/DepositTreeTest.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.ethereum.pow.merkletree;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import java.util.List;
@@ -63,6 +64,15 @@ class DepositTreeTest {
       final DepositTree tree = DepositTree.fromSnapshot(testCase.snapshot);
       assertThat(tree.getRoot()).isEqualTo(testCase.eth1Data.getDepositRoot());
     }
+  }
+
+  @Test
+  void shouldFinalizeWithZeroDeposits() {
+    final DepositTree tree = new DepositTree();
+    final Eth1Data eth1Data =
+        new Eth1Data(Bytes32.fromHexString("0x1234"), UInt64.ZERO, Bytes32.fromHexString("0x5678"));
+
+    assertThatNoException().isThrownBy(() -> tree.finalize(eth1Data));
   }
 
   @Test


### PR DESCRIPTION
## PR Description
Fix exception when the finalised checkpoint has no deposits.

## Fixed Issue(s)
fixes #5617 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
