### PR TITLE
Change domain computation for signing builder api message

### DIFF
--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/signatures/DeletableSigner.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/signatures/DeletableSigner.java
@@ -106,10 +106,8 @@ public class DeletableSigner implements Signer {
 
   @Override
   public SafeFuture<BLSSignature> signValidatorRegistration(
-      final ValidatorRegistration validatorRegistration,
-      final UInt64 epoch,
-      final ForkInfo forkInfo) {
-    return sign(() -> delegate.signValidatorRegistration(validatorRegistration, epoch, forkInfo));
+      final ValidatorRegistration validatorRegistration, final UInt64 epoch) {
+    return sign(() -> delegate.signValidatorRegistration(validatorRegistration, epoch));
   }
 
   @Override

--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/signatures/LocalSigner.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/signatures/LocalSigner.java
@@ -118,12 +118,8 @@ public class LocalSigner implements Signer {
 
   @Override
   public SafeFuture<BLSSignature> signValidatorRegistration(
-      final ValidatorRegistration validatorRegistration,
-      final UInt64 epoch,
-      final ForkInfo forkInfo) {
-    return sign(
-        signingRootUtil.signingRootForValidatorRegistration(
-            validatorRegistration, epoch, forkInfo));
+      final ValidatorRegistration validatorRegistration, final UInt64 epoch) {
+    return sign(signingRootUtil.signingRootForValidatorRegistration(validatorRegistration, epoch));
   }
 
   private SafeFuture<Bytes> signingRootFromSyncCommitteeUtils(

--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/signatures/Signer.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/signatures/Signer.java
@@ -55,7 +55,7 @@ public interface Signer {
       ContributionAndProof contributionAndProof, ForkInfo forkInfo);
 
   SafeFuture<BLSSignature> signValidatorRegistration(
-      ValidatorRegistration validatorRegistration, UInt64 epoch, ForkInfo forkInfo);
+      ValidatorRegistration validatorRegistration, UInt64 epoch);
 
   default boolean isLocal() {
     return getSigningServiceUrl().isEmpty();

--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/signatures/SigningRootUtil.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/signatures/SigningRootUtil.java
@@ -26,6 +26,7 @@ import tech.pegasys.teku.spec.datastructures.operations.AggregateAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.VoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
+import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
 
 public class SigningRootUtil {
   private final Spec spec;
@@ -111,16 +112,9 @@ public class SigningRootUtil {
   }
 
   public Bytes signingRootForValidatorRegistration(
-      final ValidatorRegistration validatorRegistration,
-      final UInt64 epoch,
-      final ForkInfo forkInfo) {
-    final SpecVersion specVersion = spec.atEpoch(epoch);
-    final Bytes32 domain =
-        spec.getDomain(
-            Domain.APPLICATION_BUILDER,
-            epoch,
-            forkInfo.getFork(),
-            forkInfo.getGenesisValidatorsRoot());
-    return specVersion.miscHelpers().computeSigningRoot(validatorRegistration, domain);
+      final ValidatorRegistration validatorRegistration, final UInt64 epoch) {
+    final MiscHelpers miscHelpers = spec.atEpoch(epoch).miscHelpers();
+    final Bytes32 domain = miscHelpers.computeDomain(Domain.APPLICATION_BUILDER);
+    return miscHelpers.computeSigningRoot(validatorRegistration, domain);
   }
 }

--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/signatures/SlashingProtectedSigner.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/signatures/SlashingProtectedSigner.java
@@ -144,8 +144,8 @@ public class SlashingProtectedSigner implements Signer {
 
   @Override
   public SafeFuture<BLSSignature> signValidatorRegistration(
-      ValidatorRegistration validatorRegistration, UInt64 epoch, ForkInfo forkInfo) {
-    return delegate.signValidatorRegistration(validatorRegistration, epoch, forkInfo);
+      final ValidatorRegistration validatorRegistration, final UInt64 epoch) {
+    return delegate.signValidatorRegistration(validatorRegistration, epoch);
   }
 
   @Override

--- a/ethereum/core/src/test/java/tech/pegasys/teku/core/signatures/DeletableSignerTest.java
+++ b/ethereum/core/src/test/java/tech/pegasys/teku/core/signatures/DeletableSignerTest.java
@@ -240,11 +240,10 @@ public class DeletableSignerTest {
 
     final ValidatorRegistration validatorRegistration =
         dataStructureUtil.randomValidatorRegistration();
-    when(delegate.signValidatorRegistration(validatorRegistration, UInt64.ONE, forkInfo))
+    when(delegate.signValidatorRegistration(validatorRegistration, UInt64.ONE))
         .thenReturn(signatureFuture);
 
-    assertThatSafeFuture(
-            signer.signValidatorRegistration(validatorRegistration, UInt64.ONE, forkInfo))
+    assertThatSafeFuture(signer.signValidatorRegistration(validatorRegistration, UInt64.ONE))
         .isCompletedWithValue(signature);
   }
 
@@ -254,12 +253,10 @@ public class DeletableSignerTest {
         dataStructureUtil.randomValidatorRegistration();
     signer.delete();
 
-    assertThatSafeFuture(
-            signer.signValidatorRegistration(validatorRegistration, UInt64.ONE, forkInfo))
+    assertThatSafeFuture(signer.signValidatorRegistration(validatorRegistration, UInt64.ONE))
         .isCompletedExceptionallyWith(SignerNotActiveException.class);
 
-    verify(delegate, never())
-        .signValidatorRegistration(validatorRegistration, UInt64.ONE, forkInfo);
+    verify(delegate, never()).signValidatorRegistration(validatorRegistration, UInt64.ONE);
   }
 
   @Test

--- a/ethereum/core/src/test/java/tech/pegasys/teku/core/signatures/LocalSignerTest.java
+++ b/ethereum/core/src/test/java/tech/pegasys/teku/core/signatures/LocalSignerTest.java
@@ -145,7 +145,7 @@ class LocalSignerTest {
     final BLSSignature expectedSignature =
         BLSSignature.fromBytesCompressed(
             Bytes.fromBase64String(
-                "hQLueiLQoxQIVdziM1Fu9VRFHUdHsyBVdTezeBQBlJ7eLL/7o4fVCEwn7C4DShcmFpYiUjU2Fx942SGPTHGyn42dEMsB/GX1s+jJ0ynkTGiFVFGujX8de2UELM5QExg3"));
+                "ggHTUowAW471R7uqFWu+teYVFhYZMGXEZpJTmi5aB/sDJzclCvgUygj4/m+woEkFBBMv7n5tDRd0jEuo2VkLQWSwWiDsssXWLKDUXSCdRWjiUyYUSXiUSEyZ/d7Zf2wG"));
 
     final SafeFuture<BLSSignature> result =
         signer.signValidatorRegistration(validatorRegistration, UInt64.valueOf(7));

--- a/ethereum/core/src/test/java/tech/pegasys/teku/core/signatures/LocalSignerTest.java
+++ b/ethereum/core/src/test/java/tech/pegasys/teku/core/signatures/LocalSignerTest.java
@@ -148,7 +148,7 @@ class LocalSignerTest {
                 "hQLueiLQoxQIVdziM1Fu9VRFHUdHsyBVdTezeBQBlJ7eLL/7o4fVCEwn7C4DShcmFpYiUjU2Fx942SGPTHGyn42dEMsB/GX1s+jJ0ynkTGiFVFGujX8de2UELM5QExg3"));
 
     final SafeFuture<BLSSignature> result =
-        signer.signValidatorRegistration(validatorRegistration, UInt64.valueOf(7), fork);
+        signer.signValidatorRegistration(validatorRegistration, UInt64.valueOf(7));
     asyncRunner.executeQueuedActions();
 
     assertThat(result).isCompletedWithValue(expectedSignature);

--- a/ethereum/core/src/test/java/tech/pegasys/teku/core/signatures/SlashingProtectedSignerTest.java
+++ b/ethereum/core/src/test/java/tech/pegasys/teku/core/signatures/SlashingProtectedSignerTest.java
@@ -137,11 +137,10 @@ class SlashingProtectedSignerTest {
   void signValidatorRegistration_shouldAlwaysSign() {
     final ValidatorRegistration validatorRegistration =
         dataStructureUtil.randomValidatorRegistration();
-    when(delegate.signValidatorRegistration(validatorRegistration, UInt64.ONE, forkInfo))
+    when(delegate.signValidatorRegistration(validatorRegistration, UInt64.ONE))
         .thenReturn(signatureFuture);
 
-    assertThatSafeFuture(
-            signer.signValidatorRegistration(validatorRegistration, UInt64.ONE, forkInfo))
+    assertThatSafeFuture(signer.signValidatorRegistration(validatorRegistration, UInt64.ONE))
         .isCompletedWithValue(signature);
   }
 

--- a/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/signatures/NoOpSigner.java
+++ b/ethereum/core/src/testFixtures/java/tech/pegasys/teku/core/signatures/NoOpSigner.java
@@ -88,9 +88,7 @@ public abstract class NoOpSigner implements Signer {
 
   @Override
   public SafeFuture<BLSSignature> signValidatorRegistration(
-      final ValidatorRegistration validatorRegistration,
-      final UInt64 epoch,
-      final ForkInfo forkInfo) {
+      final ValidatorRegistration validatorRegistration, final UInt64 epoch) {
     return new SafeFuture<>();
   }
 

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/signer/ExternalSigner.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/signer/ExternalSigner.java
@@ -256,9 +256,7 @@ public class ExternalSigner implements Signer {
 
   @Override
   public SafeFuture<BLSSignature> signValidatorRegistration(
-      final ValidatorRegistration validatorRegistration,
-      final UInt64 epoch,
-      final ForkInfo forkInfo) {
+      final ValidatorRegistration validatorRegistration, final UInt64 epoch) {
     return SafeFuture.failedFuture(new UnsupportedOperationException("Not implemented"));
   }
 


### PR DESCRIPTION
## PR Description
Changed the signature of signing the validator registration since `ForkInfo` not necessary
Changed the domain computation in `SigningRootUtil`

## Fixed Issue(s)
fixes #5613 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
