### PR TITLE
Support optimised lists and vectors of uint8

### DIFF
--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/schema/BeaconStateAltair.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/schema/BeaconStateAltair.json
@@ -106,14 +106,18 @@
       "type" : "array",
       "items" : {
         "type" : "string",
-        "format" : "byte"
+        "example" : "1",
+        "description" : "unsigned 8 bit integer, max value 255",
+        "format" : "uint8"
       }
     },
     "current_epoch_participation" : {
       "type" : "array",
       "items" : {
         "type" : "string",
-        "format" : "byte"
+        "example" : "1",
+        "description" : "unsigned 8 bit integer, max value 255",
+        "format" : "uint8"
       }
     },
     "justification_bits" : {

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/schema/BeaconStateBellatrix.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/schema/BeaconStateBellatrix.json
@@ -106,14 +106,18 @@
       "type" : "array",
       "items" : {
         "type" : "string",
-        "format" : "byte"
+        "example" : "1",
+        "description" : "unsigned 8 bit integer, max value 255",
+        "format" : "uint8"
       }
     },
     "current_epoch_participation" : {
       "type" : "array",
       "items" : {
         "type" : "string",
-        "format" : "byte"
+        "example" : "1",
+        "description" : "unsigned 8 bit integer, max value 255",
+        "format" : "uint8"
       }
     },
     "justification_bits" : {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/TransactionSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/TransactionSchema.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.datastructures.execution;
 
+import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
 import tech.pegasys.teku.infrastructure.ssz.schema.collections.impl.SszByteListSchemaImpl;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.spec.config.SpecConfigBellatrix;
@@ -20,7 +21,7 @@ import tech.pegasys.teku.spec.config.SpecConfigBellatrix;
 public class TransactionSchema extends SszByteListSchemaImpl<Transaction> {
 
   public TransactionSchema(final SpecConfigBellatrix specConfig) {
-    super(specConfig.getMaxBytesPerTransaction());
+    super(SszPrimitiveSchemas.BYTE_SCHEMA, specConfig.getMaxBytesPerTransaction());
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/altair/BeaconStateSchemaAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/altair/BeaconStateSchemaAltair.java
@@ -56,14 +56,14 @@ public class BeaconStateSchemaAltair
             BeaconStateFields.PREVIOUS_EPOCH_PARTICIPATION,
             () ->
                 SszListSchema.create(
-                    SszPrimitiveSchemas.BYTE_SCHEMA, specConfig.getValidatorRegistryLimit()));
+                    SszPrimitiveSchemas.UINT8_SCHEMA, specConfig.getValidatorRegistryLimit()));
     final SszField currentEpochAttestationsField =
         new SszField(
             CURRENT_EPOCH_PARTICIPATION_FIELD_INDEX,
             BeaconStateFields.CURRENT_EPOCH_PARTICIPATION,
             () ->
                 SszListSchema.create(
-                    SszPrimitiveSchemas.BYTE_SCHEMA, specConfig.getValidatorRegistryLimit()));
+                    SszPrimitiveSchemas.UINT8_SCHEMA, specConfig.getValidatorRegistryLimit()));
 
     final SszField inactivityScores =
         new SszField(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/type/SszPublicKeySchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/type/SszPublicKeySchema.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.spec.datastructures.type;
 
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
 import tech.pegasys.teku.infrastructure.ssz.schema.collections.impl.SszByteVectorSchemaImpl;
 import tech.pegasys.teku.infrastructure.ssz.schema.json.SszPrimitiveTypeDefinitions;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
@@ -24,7 +25,7 @@ public class SszPublicKeySchema extends SszByteVectorSchemaImpl<SszPublicKey> {
   public static final SszPublicKeySchema INSTANCE = new SszPublicKeySchema();
 
   private SszPublicKeySchema() {
-    super(BLS_COMPRESSED_PUBLIC_KEY_SIZE);
+    super(SszPrimitiveSchemas.BYTE_SCHEMA, BLS_COMPRESSED_PUBLIC_KEY_SIZE);
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/type/SszSignatureSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/type/SszSignatureSchema.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.datastructures.type;
 
+import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
 import tech.pegasys.teku.infrastructure.ssz.schema.collections.impl.SszByteVectorSchemaImpl;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 
@@ -22,7 +23,7 @@ public class SszSignatureSchema extends SszByteVectorSchemaImpl<SszSignature> {
   public static final SszSignatureSchema INSTANCE = new SszSignatureSchema();
 
   private SszSignatureSchema() {
-    super(BLS_COMPRESSED_SIGNATURE_SIZE);
+    super(SszPrimitiveSchemas.BYTE_SCHEMA, BLS_COMPRESSED_SIGNATURE_SIZE);
   }
 
   @Override

--- a/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/CoreTypes.java
+++ b/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/CoreTypes.java
@@ -57,6 +57,8 @@ public class CoreTypes {
           .format("byte")
           .build();
 
+  public static final UInt8TypeDefinition UINT8_TYPE = new UInt8TypeDefinition();
+
   public static final StringValueTypeDefinition<UInt64> UINT64_TYPE =
       DeserializableTypeDefinition.string(UInt64.class)
           .formatter(UInt64::toString)

--- a/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/UInt8TypeDefinition.java
+++ b/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/UInt8TypeDefinition.java
@@ -18,16 +18,15 @@ import static com.google.common.base.Preconditions.checkArgument;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import java.io.IOException;
-import org.apache.tuweni.bytes.Bytes;
 
-class ByteTypeDefinition extends PrimitiveTypeDefinition<Byte> {
-
-  public static final int RADIX = 16;
+class UInt8TypeDefinition extends PrimitiveTypeDefinition<Byte> {
 
   @Override
   public void serializeOpenApiTypeFields(final JsonGenerator gen) throws IOException {
     gen.writeStringField("type", "string");
-    gen.writeStringField("format", "byte");
+    gen.writeStringField("example", "1");
+    gen.writeStringField("description", "unsigned 8 bit integer, max value 255");
+    gen.writeStringField("format", "uint8");
   }
 
   @Override
@@ -42,16 +41,13 @@ class ByteTypeDefinition extends PrimitiveTypeDefinition<Byte> {
 
   @Override
   public String serializeToString(final Byte value) {
-    return value != null ? Bytes.of(value).toHexString() : null;
+    return value != null ? Integer.toString(Byte.toUnsignedInt(value)) : null;
   }
 
   @Override
   public Byte deserializeFromString(final String valueAsString) {
-    final String valueToParse =
-        valueAsString.startsWith("0x") ? valueAsString.substring("0x".length()) : valueAsString;
-    final int value = Integer.parseUnsignedInt(valueToParse, RADIX);
-    checkArgument(
-        value < Math.pow(2, Byte.SIZE), "Value %s exceeds maximum for unsigned byte", value);
+    final int value = Integer.parseUnsignedInt(valueAsString, 10);
+    checkArgument(value < Math.pow(2, Byte.SIZE), "Value %s exceeds maximum for uint8", value);
     return (byte) value;
   }
 }

--- a/infrastructure/json/src/test/java/tech/pegasys/teku/infrastructure/json/types/ByteTypeDefinitionTest.java
+++ b/infrastructure/json/src/test/java/tech/pegasys/teku/infrastructure/json/types/ByteTypeDefinitionTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.json.types;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class ByteTypeDefinitionTest {
+  @ParameterizedTest
+  @MethodSource("testValues")
+  void shouldSerializeAsHex(final byte value, final String serialized) {
+    assertThat(CoreTypes.BYTE_TYPE.serializeToString(value)).isEqualTo(serialized);
+  }
+
+  @ParameterizedTest
+  @MethodSource("testValues")
+  void shouldDeserializeFromHex(final byte value, final String serialized) {
+    assertThat(CoreTypes.BYTE_TYPE.deserializeFromString(serialized)).isEqualTo(value);
+  }
+
+  @ParameterizedTest
+  @MethodSource("testValues")
+  void shouldDeserializeFromHexWithoutPrefix(final byte value, final String serialized) {
+    assertThat(CoreTypes.BYTE_TYPE.deserializeFromString(serialized.substring("0x".length())))
+        .isEqualTo(value);
+  }
+
+  static Stream<Arguments> testValues() {
+    return Stream.of(
+        Arguments.of(Byte.MIN_VALUE, "0x80"),
+        Arguments.of((byte) -1, "0xff"),
+        Arguments.of((byte) 0, "0x00"),
+        Arguments.of((byte) 1, "0x01"),
+        Arguments.of(Byte.MAX_VALUE, "0x7f"));
+  }
+}

--- a/infrastructure/json/src/test/java/tech/pegasys/teku/infrastructure/json/types/UInt8TypeDefinitionTest.java
+++ b/infrastructure/json/src/test/java/tech/pegasys/teku/infrastructure/json/types/UInt8TypeDefinitionTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.json.types;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class UInt8TypeDefinitionTest {
+
+  @ParameterizedTest
+  @MethodSource("testValues")
+  void shouldSerializeAsDecimal(final byte value, final String serialized) {
+    assertThat(CoreTypes.UINT8_TYPE.serializeToString(value)).isEqualTo(serialized);
+  }
+
+  @ParameterizedTest
+  @MethodSource("testValues")
+  void shouldDeserializeFromDecimal(final byte value, final String serialized) {
+    assertThat(CoreTypes.UINT8_TYPE.deserializeFromString(serialized)).isEqualTo(value);
+  }
+
+  static Stream<Arguments> testValues() {
+    return Stream.of(
+        Arguments.of(Byte.MIN_VALUE, "128"),
+        Arguments.of((byte) -1, "255"),
+        Arguments.of((byte) 0, "0"),
+        Arguments.of((byte) 1, "1"),
+        Arguments.of(Byte.MAX_VALUE, "127"));
+  }
+}

--- a/infrastructure/json/src/test/java/tech/pegasys/teku/infrastructure/json/types/UInt8TypeDefinitionTest.java
+++ b/infrastructure/json/src/test/java/tech/pegasys/teku/infrastructure/json/types/UInt8TypeDefinitionTest.java
@@ -14,7 +14,6 @@
 package tech.pegasys.teku.infrastructure.json.types;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/SszPrimitiveSchemas.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/SszPrimitiveSchemas.java
@@ -137,30 +137,7 @@ public interface SszPrimitiveSchemas {
       };
 
   AbstractSszPrimitiveSchema<Byte, SszByte> BYTE_SCHEMA =
-      new AbstractSszPrimitiveSchema<>(8) {
-        @Override
-        public SszByte createFromLeafBackingNode(LeafDataNode node, int internalIndex) {
-          return SszByte.of(node.getData().get(internalIndex));
-        }
-
-        @Override
-        public TreeNode updateBackingNode(TreeNode srcNode, int index, SszData newValue) {
-          byte aByte = ((SszByte) newValue).get();
-          Bytes curVal = ((LeafNode) srcNode).getData();
-          Bytes newBytes = updateExtending(curVal, index, Bytes.of(aByte));
-          return LeafNode.create(newBytes);
-        }
-
-        @Override
-        public SszByte boxed(Byte rawValue) {
-          return SszByte.of(rawValue);
-        }
-
-        @Override
-        public TreeNode getDefaultTree() {
-          return LeafNode.ZERO_LEAVES[1];
-        }
-
+      new SszByteSchema() {
         @Override
         public DeserializableTypeDefinition<SszByte> getJsonTypeDefinition() {
           return SszPrimitiveTypeDefinitions.SSZ_BYTE_TYPE_DEFINITION;
@@ -168,7 +145,20 @@ public interface SszPrimitiveSchemas {
 
         @Override
         public String toString() {
-          return "Byte";
+          return "Bytes";
+        }
+      };
+
+  AbstractSszPrimitiveSchema<Byte, SszByte> UINT8_SCHEMA =
+      new SszByteSchema() {
+        @Override
+        public DeserializableTypeDefinition<SszByte> getJsonTypeDefinition() {
+          return SszPrimitiveTypeDefinitions.SSZ_UINT8_TYPE_DEFINITION;
+        }
+
+        @Override
+        public String toString() {
+          return "UInt8";
         }
       };
 
@@ -372,6 +362,36 @@ public interface SszPrimitiveSchemas {
       }
       newBytes.copyTo(dest, origOff);
       return dest;
+    }
+  }
+
+  abstract class SszByteSchema extends AbstractSszPrimitiveSchema<Byte, SszByte> {
+
+    private SszByteSchema() {
+      super(8);
+    }
+
+    @Override
+    public SszByte createFromLeafBackingNode(LeafDataNode node, int internalIndex) {
+      return SszByte.of(node.getData().get(internalIndex));
+    }
+
+    @Override
+    public TreeNode updateBackingNode(TreeNode srcNode, int index, SszData newValue) {
+      byte aByte = ((SszByte) newValue).get();
+      Bytes curVal = ((LeafNode) srcNode).getData();
+      Bytes newBytes = updateExtending(curVal, index, Bytes.of(aByte));
+      return LeafNode.create(newBytes);
+    }
+
+    @Override
+    public SszByte boxed(Byte rawValue) {
+      return SszByte.of(rawValue);
+    }
+
+    @Override
+    public TreeNode getDefaultTree() {
+      return LeafNode.ZERO_LEAVES[1];
     }
   }
 }

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/SszByteListSchema.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/SszByteListSchema.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.infrastructure.ssz.schema.collections;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszByteList;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszByte;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
 import tech.pegasys.teku.infrastructure.ssz.schema.collections.impl.SszByteListSchemaImpl;
 
 public interface SszByteListSchema<SszListT extends SszByteList>
@@ -24,6 +25,10 @@ public interface SszByteListSchema<SszListT extends SszByteList>
   SszListT fromBytes(Bytes bytes);
 
   static SszByteListSchema<SszByteList> create(long maxLength) {
-    return new SszByteListSchemaImpl<>(maxLength);
+    return new SszByteListSchemaImpl<>(SszPrimitiveSchemas.BYTE_SCHEMA, maxLength);
+  }
+
+  static SszByteListSchema<SszByteList> createUInt8(long maxLength) {
+    return new SszByteListSchemaImpl<>(SszPrimitiveSchemas.UINT8_SCHEMA, maxLength);
   }
 }

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/SszByteVectorSchema.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/SszByteVectorSchema.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.infrastructure.ssz.schema.collections;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszByteVector;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszByte;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
 import tech.pegasys.teku.infrastructure.ssz.schema.collections.impl.SszByteVectorSchemaImpl;
 
 public interface SszByteVectorSchema<SszVectorT extends SszByteVector>
@@ -24,6 +25,10 @@ public interface SszByteVectorSchema<SszVectorT extends SszByteVector>
   SszVectorT fromBytes(Bytes bytes);
 
   static SszByteVectorSchema<SszByteVector> create(int length) {
-    return new SszByteVectorSchemaImpl<>(length);
+    return new SszByteVectorSchemaImpl<>(SszPrimitiveSchemas.BYTE_SCHEMA, length);
+  }
+
+  static SszByteVectorSchema<SszByteVector> createUInt8(int length) {
+    return new SszByteVectorSchemaImpl<>(SszPrimitiveSchemas.UINT8_SCHEMA, length);
   }
 }

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/SszPrimitiveListSchema.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/SszPrimitiveListSchema.java
@@ -42,6 +42,10 @@ public interface SszPrimitiveListSchema<
       return (SszPrimitiveListSchema<PrimT, SszPrimT, ?>) SszBitlistSchema.create(maxLength);
     } else if (elementSchema == SszPrimitiveSchemas.UINT64_SCHEMA) {
       return (SszPrimitiveListSchema<PrimT, SszPrimT, ?>) SszUInt64ListSchema.create(maxLength);
+    } else if (elementSchema == SszPrimitiveSchemas.BYTE_SCHEMA) {
+      return (SszPrimitiveListSchema<PrimT, SszPrimT, ?>) SszByteListSchema.create(maxLength);
+    } else if (elementSchema == SszPrimitiveSchemas.UINT8_SCHEMA) {
+      return (SszPrimitiveListSchema<PrimT, SszPrimT, ?>) SszByteListSchema.createUInt8(maxLength);
     } else {
       return new SszPrimitiveListSchemaImpl<>(elementSchema, maxLength);
     }

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/SszPrimitiveVectorSchema.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/SszPrimitiveVectorSchema.java
@@ -43,6 +43,9 @@ public interface SszPrimitiveVectorSchema<
     } else if (elementSchema == SszPrimitiveSchemas.BYTE_SCHEMA) {
       return (SszPrimitiveVectorSchema<PrimT, SszPrimT, ?>)
           SszByteVectorSchema.create((int) length);
+    } else if (elementSchema == SszPrimitiveSchemas.UINT8_SCHEMA) {
+      return (SszPrimitiveVectorSchema<PrimT, SszPrimT, ?>)
+          SszByteVectorSchema.createUInt8((int) length);
     } else if (elementSchema == SszPrimitiveSchemas.BYTES32_SCHEMA) {
       return (SszPrimitiveVectorSchema<PrimT, SszPrimT, ?>)
           SszBytes32VectorSchema.create((int) length);

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/impl/SszByteListSchemaImpl.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/impl/SszByteListSchemaImpl.java
@@ -17,10 +17,12 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import java.util.List;
 import org.apache.tuweni.bytes.Bytes;
+import tech.pegasys.teku.infrastructure.json.types.DeserializableArrayTypeDefinition;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszByteList;
 import tech.pegasys.teku.infrastructure.ssz.collections.impl.SszByteListImpl;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszByte;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchema;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
 import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszByteListSchema;
 import tech.pegasys.teku.infrastructure.ssz.schema.json.SszPrimitiveTypeDefinitions;
@@ -30,8 +32,16 @@ public class SszByteListSchemaImpl<SszListT extends SszByteList>
     extends SszPrimitiveListSchemaImpl<Byte, SszByte, SszListT>
     implements SszByteListSchema<SszListT> {
 
-  public SszByteListSchemaImpl(long maxLength) {
-    super(SszPrimitiveSchemas.BYTE_SCHEMA, maxLength);
+  private final DeserializableTypeDefinition<SszListT> jsonTypeDefinition;
+
+  public SszByteListSchemaImpl(
+      final SszPrimitiveSchema<Byte, SszByte> elementSchema, final long maxLength) {
+    super(elementSchema, maxLength);
+    this.jsonTypeDefinition =
+        elementSchema == SszPrimitiveSchemas.BYTE_SCHEMA
+            ? SszPrimitiveTypeDefinitions.sszSerializedType(this, "SSZ encoded byte list")
+            : new DeserializableArrayTypeDefinition<>(
+                getElementSchema().getJsonTypeDefinition(), this::createFromElements);
   }
 
   @Override
@@ -56,6 +66,6 @@ public class SszByteListSchemaImpl<SszListT extends SszByteList>
 
   @Override
   public DeserializableTypeDefinition<SszListT> getJsonTypeDefinition() {
-    return SszPrimitiveTypeDefinitions.sszSerializedType(this, "SSZ encoded byte list");
+    return jsonTypeDefinition;
   }
 }

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/impl/SszByteVectorSchemaImpl.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/impl/SszByteVectorSchemaImpl.java
@@ -22,6 +22,7 @@ import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszByteVector;
 import tech.pegasys.teku.infrastructure.ssz.collections.impl.SszByteVectorImpl;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszByte;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchema;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
 import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszByteVectorSchema;
 import tech.pegasys.teku.infrastructure.ssz.schema.impl.AbstractSszVectorSchema;
@@ -32,13 +33,16 @@ public class SszByteVectorSchemaImpl<SszVectorT extends SszByteVector>
     extends AbstractSszVectorSchema<SszByte, SszVectorT>
     implements SszByteVectorSchema<SszVectorT> {
 
-  public SszByteVectorSchemaImpl(long vectorLength) {
-    super(SszPrimitiveSchemas.BYTE_SCHEMA, vectorLength);
+  public SszByteVectorSchemaImpl(
+      final SszPrimitiveSchema<Byte, SszByte> elementSchema, final long vectorLength) {
+    super(elementSchema, vectorLength);
   }
 
   @Override
   protected DeserializableTypeDefinition<SszVectorT> createTypeDefinition() {
-    return sszSerializedType(this, "SSZ hexadecimal");
+    return getElementSchema() == SszPrimitiveSchemas.BYTE_SCHEMA
+        ? sszSerializedType(this, "SSZ hexadecimal")
+        : super.createTypeDefinition();
   }
 
   @Override

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/json/SszPrimitiveTypeDefinitions.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/json/SszPrimitiveTypeDefinitions.java
@@ -52,6 +52,9 @@ public interface SszPrimitiveTypeDefinitions {
   DeserializableTypeDefinition<SszByte> SSZ_BYTE_TYPE_DEFINITION =
       new SszTypeDefinitionWrapper<>(SszPrimitiveSchemas.BYTE_SCHEMA, CoreTypes.BYTE_TYPE);
 
+  DeserializableTypeDefinition<SszByte> SSZ_UINT8_TYPE_DEFINITION =
+      new SszTypeDefinitionWrapper<>(SszPrimitiveSchemas.UINT8_SCHEMA, CoreTypes.UINT8_TYPE);
+
   DeserializableTypeDefinition<SszBytes32> SSZ_BYTES32_TYPE_DEFINITION =
       new SszTypeDefinitionWrapper<>(SszPrimitiveSchemas.BYTES32_SCHEMA, CoreTypes.BYTES32_TYPE);
 


### PR DESCRIPTION
## PR Description
Support optimised lists and vectors of uint8.

Makes the semantic distinction between byte and uint8 clearer by having different primitive types for each even though they use the same SSZ data format. They can then support different JSON serializations easily.

Only change to the JSON schemas is because the uint8 JSON type definition now provides a better description (it's a uint8 not a byte).

```
Before:
ByteListBenchmark.iterateBeaconStateParticipationFlags       thrpt   50   77.113 ± 2.701  ops/s

After:
ByteListBenchmark.iterateBeaconStateParticipationFlags       thrpt   50  104.759 ± 0.829  ops/s
```

## Fixed Issue(s)
fixes #5623

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
