### PR TITLE
Report EL block information when creating blocks

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/BeaconBlockBody.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/BeaconBlockBody.java
@@ -68,7 +68,7 @@ public interface BeaconBlockBody extends SszContainer {
   }
 
   default Optional<ExecutionPayloadSummary> getOptionalExecutionPayloadSummary() {
-    return getOptionalExecutionPayload().or(getOptionalExecutionPayloadHeader());
+    return Optional.empty();
   }
 
   default boolean isBlinded() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/BeaconBlockBody.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/BeaconBlockBody.java
@@ -68,7 +68,7 @@ public interface BeaconBlockBody extends SszContainer {
   }
 
   default Optional<ExecutionPayloadSummary> getOptionalExecutionPayloadSummary() {
-    return Optional.empty();
+    return getOptionalExecutionPayload().or(getOptionalExecutionPayloadHeader());
   }
 
   default boolean isBlinded() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/BeaconBlockBody.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/BeaconBlockBody.java
@@ -26,6 +26,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.bellatrix
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.bellatrix.BlindedBeaconBlockBodyBellatrix;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSummary;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.Deposit;
@@ -63,6 +64,10 @@ public interface BeaconBlockBody extends SszContainer {
   }
 
   default Optional<ExecutionPayloadHeader> getOptionalExecutionPayloadHeader() {
+    return Optional.empty();
+  }
+
+  default Optional<ExecutionPayloadSummary> getOptionalExecutionPayloadSummary() {
     return Optional.empty();
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BeaconBlockBodyBellatrix.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BeaconBlockBodyBellatrix.java
@@ -17,6 +17,7 @@ import java.util.Optional;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.BeaconBlockBodyAltair;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSummary;
 
 /** A Beacon block body */
 public interface BeaconBlockBodyBellatrix extends BeaconBlockBodyAltair {
@@ -33,6 +34,11 @@ public interface BeaconBlockBodyBellatrix extends BeaconBlockBodyAltair {
 
   @Override
   default Optional<ExecutionPayload> getOptionalExecutionPayload() {
+    return Optional.of(getExecutionPayload());
+  }
+
+  @Override
+  default Optional<ExecutionPayloadSummary> getOptionalExecutionPayloadSummary() {
     return Optional.of(getExecutionPayload());
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BlindedBeaconBlockBodyBellatrix.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BlindedBeaconBlockBodyBellatrix.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.BeaconBlockBodyAltair;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSummary;
 
 /** A Beacon block body */
 public interface BlindedBeaconBlockBodyBellatrix extends BeaconBlockBodyAltair {
@@ -35,6 +36,11 @@ public interface BlindedBeaconBlockBodyBellatrix extends BeaconBlockBodyAltair {
 
   @Override
   default Optional<ExecutionPayloadHeader> getOptionalExecutionPayloadHeader() {
+    return Optional.of(getExecutionPayloadHeader());
+  }
+
+  @Override
+  default Optional<ExecutionPayloadSummary> getOptionalExecutionPayloadSummary() {
     return Optional.of(getExecutionPayloadHeader());
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayload.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayload.java
@@ -108,26 +108,32 @@ public class ExecutionPayload
     return (ExecutionPayloadSchema) super.getSchema();
   }
 
+  @Override
   public Bytes32 getParentHash() {
     return getField0().get();
   }
 
+  @Override
   public Bytes20 getFeeRecipient() {
     return Bytes20.leftPad(getField1().getBytes());
   }
 
+  @Override
   public Bytes32 getStateRoot() {
     return getField2().get();
   }
 
+  @Override
   public Bytes32 getReceiptsRoot() {
     return getField3().get();
   }
 
+  @Override
   public Bytes getLogsBloom() {
     return getField4().getBytes();
   }
 
+  @Override
   public Bytes32 getPrevRandao() {
     return getField5().get();
   }
@@ -147,14 +153,17 @@ public class ExecutionPayload
     return getField8().get();
   }
 
+  @Override
   public UInt64 getTimestamp() {
     return getField9().get();
   }
 
+  @Override
   public Bytes getExtraData() {
     return getField10().getBytes();
   }
 
+  @Override
   public UInt256 getBaseFeePerGas() {
     return getField11().get();
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayload.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayload.java
@@ -44,7 +44,8 @@ public class ExecutionPayload
         SszByteList,
         SszUInt256,
         SszBytes32,
-        SszList<Transaction>> {
+        SszList<Transaction>>
+    implements ExecutionPayloadSummary {
 
   ExecutionPayload(
       ContainerSchema14<
@@ -131,14 +132,17 @@ public class ExecutionPayload
     return getField5().get();
   }
 
+  @Override
   public UInt64 getBlockNumber() {
     return getField6().get();
   }
 
+  @Override
   public UInt64 getGasLimit() {
     return getField7().get();
   }
 
+  @Override
   public UInt64 getGasUsed() {
     return getField8().get();
   }
@@ -155,6 +159,7 @@ public class ExecutionPayload
     return getField11().get();
   }
 
+  @Override
   public Bytes32 getBlockHash() {
     return getField12().get();
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadHeader.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadHeader.java
@@ -111,26 +111,32 @@ public class ExecutionPayloadHeader
     return equals(getSchema().getHeaderOfDefaultPayload());
   }
 
+  @Override
   public Bytes32 getParentHash() {
     return getField0().get();
   }
 
+  @Override
   public Bytes20 getFeeRecipient() {
     return Bytes20.leftPad(getField1().getBytes());
   }
 
+  @Override
   public Bytes32 getStateRoot() {
     return getField2().get();
   }
 
+  @Override
   public Bytes32 getReceiptsRoot() {
     return getField3().get();
   }
 
+  @Override
   public Bytes getLogsBloom() {
     return getField4().getBytes();
   }
 
+  @Override
   public Bytes32 getPrevRandao() {
     return getField5().get();
   }
@@ -150,14 +156,17 @@ public class ExecutionPayloadHeader
     return getField8().get();
   }
 
+  @Override
   public UInt64 getTimestamp() {
     return getField9().get();
   }
 
+  @Override
   public Bytes getExtraData() {
     return getField10().getBytes();
   }
 
+  @Override
   public UInt256 getBaseFeePerGas() {
     return getField11().get();
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadHeader.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadHeader.java
@@ -43,7 +43,8 @@ public class ExecutionPayloadHeader
         SszByteList,
         SszUInt256,
         SszBytes32,
-        SszBytes32> {
+        SszBytes32>
+    implements ExecutionPayloadSummary {
 
   ExecutionPayloadHeader(
       ContainerSchema14<
@@ -134,14 +135,17 @@ public class ExecutionPayloadHeader
     return getField5().get();
   }
 
+  @Override
   public UInt64 getBlockNumber() {
     return getField6().get();
   }
 
+  @Override
   public UInt64 getGasLimit() {
     return getField7().get();
   }
 
+  @Override
   public UInt64 getGasUsed() {
     return getField8().get();
   }
@@ -158,6 +162,7 @@ public class ExecutionPayloadHeader
     return getField11().get();
   }
 
+  @Override
   public Bytes32 getBlockHash() {
     return getField12().get();
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadSummary.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadSummary.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.execution;
+
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+public interface ExecutionPayloadSummary {
+
+  UInt64 getGasLimit();
+
+  UInt64 getGasUsed();
+
+  UInt64 getBlockNumber();
+
+  Bytes32 getBlockHash();
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadSummary.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadSummary.java
@@ -13,7 +13,10 @@
 
 package tech.pegasys.teku.spec.datastructures.execution;
 
+import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.units.bigints.UInt256;
+import tech.pegasys.teku.infrastructure.bytes.Bytes20;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 public interface ExecutionPayloadSummary {
@@ -25,4 +28,22 @@ public interface ExecutionPayloadSummary {
   UInt64 getBlockNumber();
 
   Bytes32 getBlockHash();
+
+  UInt256 getBaseFeePerGas();
+
+  UInt64 getTimestamp();
+
+  Bytes32 getPrevRandao();
+
+  Bytes32 getReceiptsRoot();
+
+  Bytes32 getStateRoot();
+
+  Bytes20 getFeeRecipient();
+
+  Bytes32 getParentHash();
+
+  Bytes getLogsBloom();
+
+  Bytes getExtraData();
 }

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/ValidatorLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/ValidatorLogger.java
@@ -56,9 +56,10 @@ public class ValidatorLogger {
       final String producedType,
       final UInt64 slot,
       final int successCount,
-      final Set<Bytes32> blockRoots) {
+      final Set<Bytes32> blockRoots,
+      final Optional<String> context) {
     final String paddedType = Strings.padEnd(producedType, LONGEST_TYPE_LENGTH, ' ');
-    logDuty(paddedType, slot, successCount, blockRoots);
+    logDuty(paddedType, slot, successCount, blockRoots, context);
   }
 
   public void dutySkippedWhileSyncing(
@@ -101,12 +102,21 @@ public class ValidatorLogger {
   }
 
   private void logDuty(
-      final String type, final UInt64 slot, final int count, final Set<Bytes32> roots) {
+      final String type,
+      final UInt64 slot,
+      final int count,
+      final Set<Bytes32> roots,
+      final Optional<String> context) {
     log.info(
         ColorConsolePrinter.print(
             String.format(
-                "%sPublished %s  Count: %s, Slot: %s, Root: %s",
-                PREFIX, type, count, slot, formatBlockRoots(roots)),
+                "%sPublished %s  Count: %s, Slot: %s, Root: %s%s",
+                PREFIX,
+                type,
+                count,
+                slot,
+                formatBlockRoots(roots),
+                context.map(s -> ", " + s).orElse("")),
             Color.BLUE));
   }
 

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/AggregationDutyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/AggregationDutyTest.java
@@ -232,7 +232,8 @@ class AggregationDutyTest {
     // Only one proof should be sent.
     verify(validatorApiChannel, times(1)).sendAggregateAndProofs(anyList());
     verify(validatorLogger)
-        .dutyCompleted(TYPE, SLOT, 1, Set.of(aggregate.getData().getBeaconBlockRoot()));
+        .dutyCompleted(
+            TYPE, SLOT, 1, Set.of(aggregate.getData().getBeaconBlockRoot()), Optional.empty());
     verifyNoMoreInteractions(validatorLogger);
   }
 

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/AttestationProductionDutyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/AttestationProductionDutyTest.java
@@ -144,7 +144,8 @@ class AttestationProductionDutyTest {
 
     verify(validatorApiChannel).sendSignedAttestations(List.of(expectedAttestation));
     verify(validatorLogger)
-        .dutyCompleted(TYPE, SLOT, 1, Set.of(attestationData.getBeaconBlockRoot()));
+        .dutyCompleted(
+            TYPE, SLOT, 1, Set.of(attestationData.getBeaconBlockRoot()), Optional.empty());
     verify(validatorLogger)
         .dutyFailed(
             eq(TYPE),
@@ -191,7 +192,8 @@ class AttestationProductionDutyTest {
     verify(validatorApiChannel).sendSignedAttestations(List.of(expectedAttestation));
 
     verify(validatorLogger)
-        .dutyCompleted(TYPE, SLOT, 1, Set.of(attestationData.getBeaconBlockRoot()));
+        .dutyCompleted(
+            TYPE, SLOT, 1, Set.of(attestationData.getBeaconBlockRoot()), Optional.empty());
     verify(validatorLogger)
         .dutyFailed(TYPE, SLOT, Set.of(validator1.getPublicKey().toAbbreviatedString()), failure);
     verifyNoMoreInteractions(validatorLogger);
@@ -228,7 +230,8 @@ class AttestationProductionDutyTest {
     verify(validatorApiChannel).sendSignedAttestations(List.of(expectedAttestation));
 
     verify(validatorLogger)
-        .dutyCompleted(TYPE, SLOT, 1, Set.of(attestationData.getBeaconBlockRoot()));
+        .dutyCompleted(
+            TYPE, SLOT, 1, Set.of(attestationData.getBeaconBlockRoot()), Optional.empty());
     verify(validatorLogger)
         .dutyFailed(
             TYPE, SLOT, Set.of(validator1.getPublicKey().toAbbreviatedString()), signingFailure);
@@ -253,7 +256,8 @@ class AttestationProductionDutyTest {
 
     verify(validatorApiChannel).sendSignedAttestations(List.of(expectedAttestation));
     verify(validatorLogger)
-        .dutyCompleted(TYPE, SLOT, 1, Set.of(attestationData.getBeaconBlockRoot()));
+        .dutyCompleted(
+            TYPE, SLOT, 1, Set.of(attestationData.getBeaconBlockRoot()), Optional.empty());
     verifyNoMoreInteractions(validatorLogger);
   }
 
@@ -337,7 +341,8 @@ class AttestationProductionDutyTest {
     // Should have only needed to create one unsigned attestation and reused it for each validator
     verify(validatorApiChannel, times(1)).createAttestationData(any(), anyInt());
     verify(validatorLogger)
-        .dutyCompleted(TYPE, SLOT, 3, Set.of(attestationData.getBeaconBlockRoot()));
+        .dutyCompleted(
+            TYPE, SLOT, 3, Set.of(attestationData.getBeaconBlockRoot()), Optional.empty());
     verifyNoMoreInteractions(validatorLogger);
   }
 
@@ -397,7 +402,8 @@ class AttestationProductionDutyTest {
             3,
             Set.of(
                 unsignedAttestation1.getBeaconBlockRoot(),
-                unsignedAttestation2.getBeaconBlockRoot()));
+                unsignedAttestation2.getBeaconBlockRoot()),
+            Optional.empty());
     verifyNoMoreInteractions(validatorLogger);
   }
 

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/BlockProductionDutyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/BlockProductionDutyTest.java
@@ -25,7 +25,9 @@ import static tech.pegasys.teku.infrastructure.async.SafeFuture.failedFuture;
 
 import java.util.Optional;
 import java.util.Set;
+import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.units.bigints.UInt256;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -33,6 +35,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.core.signatures.Signer;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.bytes.Bytes20;
 import tech.pegasys.teku.infrastructure.logging.ValidatorLogger;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
@@ -227,6 +230,51 @@ class BlockProductionDutyTest {
     @Override
     public Bytes32 getBlockHash() {
       return blockHash;
+    }
+
+    @Override
+    public UInt256 getBaseFeePerGas() {
+      return null;
+    }
+
+    @Override
+    public UInt64 getTimestamp() {
+      return null;
+    }
+
+    @Override
+    public Bytes32 getPrevRandao() {
+      return null;
+    }
+
+    @Override
+    public Bytes32 getReceiptsRoot() {
+      return null;
+    }
+
+    @Override
+    public Bytes32 getStateRoot() {
+      return null;
+    }
+
+    @Override
+    public Bytes20 getFeeRecipient() {
+      return null;
+    }
+
+    @Override
+    public Bytes32 getParentHash() {
+      return null;
+    }
+
+    @Override
+    public Bytes getLogsBloom() {
+      return null;
+    }
+
+    @Override
+    public Bytes getExtraData() {
+      return null;
     }
   }
 }

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/ProductionResultTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/ProductionResultTest.java
@@ -25,6 +25,7 @@ import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import org.apache.tuweni.bytes.Bytes32;
@@ -88,7 +89,8 @@ class ProductionResultTest {
     final DutyResult dutyResult = result.join();
     dutyResult.report(PRODUCED_TYPE, SLOT, validatorLogger);
 
-    verify(validatorLogger).dutyCompleted(PRODUCED_TYPE, SLOT, 2, Set.of(blockRoot));
+    verify(validatorLogger)
+        .dutyCompleted(PRODUCED_TYPE, SLOT, 2, Set.of(blockRoot), Optional.empty());
     verify(validatorLogger)
         .dutyFailed(
             eq(PRODUCED_TYPE),
@@ -115,7 +117,8 @@ class ProductionResultTest {
     final DutyResult dutyResult = result.join();
     dutyResult.report(PRODUCED_TYPE, SLOT, validatorLogger);
 
-    verify(validatorLogger).dutyCompleted(PRODUCED_TYPE, SLOT, 1, Set.of(blockRoot));
+    verify(validatorLogger)
+        .dutyCompleted(PRODUCED_TYPE, SLOT, 1, Set.of(blockRoot), Optional.empty());
     verify(validatorLogger)
         .dutyFailed(PRODUCED_TYPE, SLOT, formatKeys(prodResult1.getValidatorPublicKeys()), error);
   }

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeAggregationDutyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeAggregationDutyTest.java
@@ -173,7 +173,7 @@ class SyncCommitteeAggregationDutyTest {
         List.of(
             syncCommitteeUtil.createSignedContributionAndProof(
                 contributionAndProof, contributionSignature));
-    verify(validatorLogger).dutyCompleted(TYPE, slot, 1, Set.of(beaconBlockRoot));
+    verify(validatorLogger).dutyCompleted(TYPE, slot, 1, Set.of(beaconBlockRoot), Optional.empty());
     verify(validatorApiChannel).sendSignedContributionAndProofs(expectedSignedContributions);
   }
 
@@ -197,7 +197,7 @@ class SyncCommitteeAggregationDutyTest {
             syncCommitteeUtil.createSignedContributionAndProof(
                 contributionAndProof, contributionSignature));
     // Successfully complete for validator1
-    verify(validatorLogger).dutyCompleted(TYPE, slot, 1, Set.of(beaconBlockRoot));
+    verify(validatorLogger).dutyCompleted(TYPE, slot, 1, Set.of(beaconBlockRoot), Optional.empty());
     verify(validatorApiChannel).sendSignedContributionAndProofs(expectedSignedContributions);
 
     // Validator 2 fails

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeProductionDutyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeProductionDutyTest.java
@@ -114,7 +114,8 @@ class SyncCommitteeProductionDutyTest {
 
     assertSentMessages(createMessage(slot, blockRoot, validatorIndex1, signature1));
 
-    verify(validatorLogger).dutyCompleted(MESSAGE_TYPE, slot, 1, Set.of(blockRoot));
+    verify(validatorLogger)
+        .dutyCompleted(MESSAGE_TYPE, slot, 1, Set.of(blockRoot), Optional.empty());
     verify(validatorLogger)
         .dutyFailed(
             MESSAGE_TYPE, slot, Set.of(validator2.getPublicKey().toAbbreviatedString()), exception);
@@ -148,7 +149,8 @@ class SyncCommitteeProductionDutyTest {
         createMessage(slot, blockRoot, validatorIndex1, signature1),
         createMessage(slot, blockRoot, validatorIndex2, signature2));
 
-    verify(validatorLogger).dutyCompleted(MESSAGE_TYPE, slot, 1, Set.of(blockRoot));
+    verify(validatorLogger)
+        .dutyCompleted(MESSAGE_TYPE, slot, 1, Set.of(blockRoot), Optional.empty());
     verify(validatorLogger)
         .dutyFailed(
             eq(MESSAGE_TYPE),
@@ -173,7 +175,8 @@ class SyncCommitteeProductionDutyTest {
     verify(validatorApiChannel)
         .sendSyncCommitteeMessages(
             List.of(createMessage(slot, blockRoot, validatorIndex, signature)));
-    verify(validatorLogger).dutyCompleted(MESSAGE_TYPE, slot, 1, Set.of(blockRoot));
+    verify(validatorLogger)
+        .dutyCompleted(MESSAGE_TYPE, slot, 1, Set.of(blockRoot), Optional.empty());
   }
 
   @Test
@@ -200,7 +203,8 @@ class SyncCommitteeProductionDutyTest {
         createMessage(slot, blockRoot, validatorIndex1, signature1),
         createMessage(slot, blockRoot, validatorIndex2, signature2));
 
-    verify(validatorLogger).dutyCompleted(MESSAGE_TYPE, slot, 2, Set.of(blockRoot));
+    verify(validatorLogger)
+        .dutyCompleted(MESSAGE_TYPE, slot, 2, Set.of(blockRoot), Optional.empty());
   }
 
   @SuppressWarnings("unchecked")


### PR DESCRIPTION
At the end of block production, now include the gas used and %, EL block number and EL block hash.

example:
```
*** Published block              Count: 1, Slot: 1754, Root: d5a288285e922d77bbcaa856d14a087bf5211aecc744f8c2e07511cb25bde587, 0 (0%) gas, EL block:  50a7cc34b5e81a6de7b9dcc142b439cd724f2c1e902d96ed4e006fd74ffd6241 (4)
```

partially addresses #5369

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
