### PR TITLE
[MEV Boost\Builder] validatorsRegistrationDefaultEnabled CLI option

### DIFF
--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorProposerOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorProposerOptions.java
@@ -48,15 +48,15 @@ public class ValidatorProposerOptions {
       ValidatorConfig.DEFAULT_VALIDATOR_PROPOSER_CONFIG_REFRESH_ENABLED;
 
   @Option(
-      names = {"--Xvalidators-proposer-mev-boost-enabled"},
+      names = {"--Xvalidators-registration-default-enabled"},
       paramLabel = "<BOOLEAN>",
       showDefaultValue = Visibility.ALWAYS,
-      description = "Enable MEV boost when proposing blocks.",
+      description = "Enable validators registration to builder infrastructure.",
       arity = "0..1",
       fallbackValue = "true",
       hidden = true)
-  private boolean proposerMevBoostEnabled =
-      ValidatorConfig.DEFAULT_VALIDATOR_PROPOSER_MEV_BOOST_ENABLED;
+  private boolean validatorsRegistrationDefaultEnabled =
+      ValidatorConfig.DEFAULT_VALIDATOR_REGISTRATION_DEFAULT_ENABLED;
 
   @Option(
       names = {"--Xvalidators-proposer-blinded-blocks-enabled"},
@@ -75,7 +75,7 @@ public class ValidatorProposerOptions {
                 .proposerDefaultFeeRecipient(proposerDefaultFeeRecipient)
                 .proposerConfigSource(proposerConfig)
                 .refreshProposerConfigFromSource(proposerConfigRefreshEnabled)
-                .proposerMevBoostEnabled(proposerMevBoostEnabled)
+                .validatorsRegistrationDefaultEnabled(validatorsRegistrationDefaultEnabled)
                 .blindedBeaconBlocksEnabled(blindedBlocksEnabled));
   }
 }

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/ValidatorOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/ValidatorOptionsTest.java
@@ -134,18 +134,22 @@ public class ValidatorOptionsTest extends AbstractBeaconNodeCommandTest {
   }
 
   @Test
-  public void shouldEnableMevBoostWithBlindedBlocks() {
-    final String[] args = {"--Xvalidators-proposer-mev-boost-enabled", "true"};
+  public void shouldEnableValidatorRegistrationtWithBlindedBlocks() {
+    final String[] args = {"--Xvalidators-registration-default-enabled", "true"};
     final TekuConfiguration config = getTekuConfigurationFromArguments(args);
-    assertThat(config.validatorClient().getValidatorConfig().isProposerMevBoostEnabled()).isTrue();
+    assertThat(
+            config.validatorClient().getValidatorConfig().isValidatorsRegistrationDefaultEnabled())
+        .isTrue();
     assertThat(config.validatorClient().getValidatorConfig().isBlindedBeaconBlocksEnabled())
         .isTrue();
   }
 
   @Test
-  public void shouldNotUseMevBoostByDefault() {
+  public void shouldNotUseValidatorsRegistrationByDefault() {
     final String[] args = {};
     final TekuConfiguration config = getTekuConfigurationFromArguments(args);
-    assertThat(config.validatorClient().getValidatorConfig().isProposerMevBoostEnabled()).isFalse();
+    assertThat(
+            config.validatorClient().getValidatorConfig().isValidatorsRegistrationDefaultEnabled())
+        .isFalse();
   }
 }

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
@@ -43,7 +43,7 @@ public class ValidatorConfig {
   public static final boolean DEFAULT_GENERATE_EARLY_ATTESTATIONS = true;
   public static final Optional<Bytes32> DEFAULT_GRAFFITI = Optional.empty();
   public static final boolean DEFAULT_VALIDATOR_PROPOSER_CONFIG_REFRESH_ENABLED = false;
-  public static final boolean DEFAULT_VALIDATOR_PROPOSER_MEV_BOOST_ENABLED = false;
+  public static final boolean DEFAULT_VALIDATOR_REGISTRATION_DEFAULT_ENABLED = false;
   public static final boolean DEFAULT_VALIDATOR_BLINDED_BLOCKS_ENABLED = false;
 
   private final List<String> validatorKeys;
@@ -65,7 +65,7 @@ public class ValidatorConfig {
   private final Optional<String> proposerConfigSource;
   private final boolean refreshProposerConfigFromSource;
   private final boolean blindedBeaconBlocksEnabled;
-  private final boolean proposerMevBoostEnabled;
+  private final boolean validatorsRegistrationDefaultEnabled;
   private final boolean validatorClientUseSszBlocksEnabled;
 
   private ValidatorConfig(
@@ -87,7 +87,7 @@ public class ValidatorConfig {
       final Optional<Eth1Address> proposerDefaultFeeRecipient,
       final Optional<String> proposerConfigSource,
       final boolean refreshProposerConfigFromSource,
-      final boolean proposerMevBoostEnabled,
+      final boolean validatorsRegistrationDefaultEnabled,
       final boolean blindedBeaconBlocksEnabled,
       final boolean validatorClientUseSszBlocksEnabled) {
     this.validatorKeys = validatorKeys;
@@ -112,7 +112,7 @@ public class ValidatorConfig {
     this.proposerConfigSource = proposerConfigSource;
     this.refreshProposerConfigFromSource = refreshProposerConfigFromSource;
     this.blindedBeaconBlocksEnabled = blindedBeaconBlocksEnabled;
-    this.proposerMevBoostEnabled = proposerMevBoostEnabled;
+    this.validatorsRegistrationDefaultEnabled = validatorsRegistrationDefaultEnabled;
     this.validatorClientUseSszBlocksEnabled = validatorClientUseSszBlocksEnabled;
   }
 
@@ -195,8 +195,8 @@ public class ValidatorConfig {
     return validatorClientUseSszBlocksEnabled;
   }
 
-  public boolean isProposerMevBoostEnabled() {
-    return proposerMevBoostEnabled;
+  public boolean isValidatorsRegistrationDefaultEnabled() {
+    return validatorsRegistrationDefaultEnabled;
   }
 
   private void validateProposerDefaultFeeRecipientOrProposerConfigSource() {
@@ -232,7 +232,8 @@ public class ValidatorConfig {
     private Optional<String> proposerConfigSource = Optional.empty();
     private boolean refreshProposerConfigFromSource =
         DEFAULT_VALIDATOR_PROPOSER_CONFIG_REFRESH_ENABLED;
-    private boolean proposerMevBoostEnabled = DEFAULT_VALIDATOR_PROPOSER_MEV_BOOST_ENABLED;
+    private boolean validatorsRegistrationDefaultEnabled =
+        DEFAULT_VALIDATOR_REGISTRATION_DEFAULT_ENABLED;
     private boolean blindedBlocksEnabled = DEFAULT_VALIDATOR_BLINDED_BLOCKS_ENABLED;
     private boolean validatorClientSszBlocksEnabled = DEFAULT_VALIDATOR_CLIENT_SSZ_BLOCKS_ENABLED;
 
@@ -360,8 +361,9 @@ public class ValidatorConfig {
       return this;
     }
 
-    public Builder proposerMevBoostEnabled(final boolean proposerMevBoostEnabled) {
-      this.proposerMevBoostEnabled = proposerMevBoostEnabled;
+    public Builder validatorsRegistrationDefaultEnabled(
+        final boolean validatorsRegistrationDefaultEnabled) {
+      this.validatorsRegistrationDefaultEnabled = validatorsRegistrationDefaultEnabled;
       return this;
     }
 
@@ -381,7 +383,8 @@ public class ValidatorConfig {
       validateExternalSignerKeystoreAndPasswordFileConfig();
       validateExternalSignerTruststoreAndPasswordFileConfig();
       validateExternalSignerURLScheme();
-      validateMevBoostAndBlindedBlocks();
+      validateValidatorsRegistrationAndBlindedBlocks();
+      validatorsRegistrationDefaultEnabledOrProposerConfigSource();
       return new ValidatorConfig(
           validatorKeys,
           validatorExternalSignerPublicKeySources,
@@ -401,7 +404,7 @@ public class ValidatorConfig {
           proposerDefaultFeeRecipient,
           proposerConfigSource,
           refreshProposerConfigFromSource,
-          proposerMevBoostEnabled,
+          validatorsRegistrationDefaultEnabled,
           blindedBlocksEnabled,
           validatorClientSszBlocksEnabled);
     }
@@ -452,11 +455,18 @@ public class ValidatorConfig {
       }
     }
 
-    private void validateMevBoostAndBlindedBlocks() {
-      if (proposerMevBoostEnabled && !blindedBlocksEnabled) {
+    private void validateValidatorsRegistrationAndBlindedBlocks() {
+      if (validatorsRegistrationDefaultEnabled && !blindedBlocksEnabled) {
         LOG.info(
-            "'--Xvalidators-proposer-mev-boost-enabled' requires '--Xvalidators-proposer-blinded-blocks-enabled', enabling it");
+            "'--Xvalidators-registration-default-enabled' requires '--Xvalidators-proposer-blinded-blocks-enabled', enabling it");
         blindedBlocksEnabled = true;
+      }
+    }
+
+    private void validatorsRegistrationDefaultEnabledOrProposerConfigSource() {
+      if (validatorsRegistrationDefaultEnabled && proposerConfigSource.isPresent()) {
+        throw new InvalidConfigurationException(
+            "Invalid configuration. --Xvalidators-registration-default-enabled cannot be specified when --validators-proposer-config is used");
       }
     }
 

--- a/validator/api/src/test/java/tech/pegasys/teku/validator/api/ValidatorConfigTest.java
+++ b/validator/api/src/test/java/tech/pegasys/teku/validator/api/ValidatorConfigTest.java
@@ -98,6 +98,18 @@ class ValidatorConfigTest {
   }
 
   @Test
+  public void
+      shouldThrowIfValidatorsRegistrationDefaultEnabledAndValidatorProposerConfigSpecified() {
+    final ValidatorConfig.Builder builder =
+        configBuilder.validatorsRegistrationDefaultEnabled(true).proposerConfigSource("somepath");
+
+    Assertions.assertThatExceptionOfType(InvalidConfigurationException.class)
+        .isThrownBy(builder::build)
+        .withMessageContaining(
+            "Invalid configuration. --Xvalidators-registration-default-enabled cannot be specified when --validators-proposer-config is used");
+  }
+
+  @Test
   public void shouldThrowIfExternalSignerTruststorePasswordFileIsSpecifiedWithoutTruststore() {
     final ValidatorConfig.Builder builder =
         configBuilder.validatorExternalSignerTruststorePasswordFile(Path.of("somepath"));


### PR DESCRIPTION
Introduces `--Xvalidators-registration-default-enabled` and removes `--Xvalidators-proposer-mev-boost-enabled`.

The new parameter will enable validator registration process for all validators managed by the validator client.
It automatically enables blinded Blocks flow, which is a prerequisite.

fixes #5638 

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
