### PR TITLE
[MEV Boost\Builder] Retrieve the feeRecipient for a validator registration

### DIFF
--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/BeaconProposerPreparer.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/BeaconProposerPreparer.java
@@ -34,7 +34,7 @@ import tech.pegasys.teku.validator.api.ValidatorTimingChannel;
 import tech.pegasys.teku.validator.client.ProposerConfig.Config;
 import tech.pegasys.teku.validator.client.proposerconfig.ProposerConfigProvider;
 
-public class BeaconProposerPreparer implements ValidatorTimingChannel {
+public class BeaconProposerPreparer implements ValidatorTimingChannel, FeeRecipientProvider {
   private static final Logger LOG = LogManager.getLogger();
 
   private final ValidatorApiChannel validatorApiChannel;
@@ -98,6 +98,7 @@ public class BeaconProposerPreparer implements ValidatorTimingChannel {
   // - proposer set via the SET api (runtime configuration)
   // - default set in --validator-proposer-config file
   // - default set by --validators-proposer-default-fee-recipient
+  @Override
   public Optional<Eth1Address> getFeeRecipient(final BLSPublicKey publicKey) {
     if (validatorIndexProvider.isEmpty()
         || !validatorIndexProvider.get().containsPublicKey(publicKey)) {

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/FeeRecipientProvider.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/FeeRecipientProvider.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.client;
+
+import java.util.Optional;
+import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.spec.datastructures.eth1.Eth1Address;
+
+@FunctionalInterface
+public interface FeeRecipientProvider {
+
+  Optional<Eth1Address> getFeeRecipient(BLSPublicKey publicKey);
+}

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrator.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrator.java
@@ -174,10 +174,10 @@ public class ValidatorRegistrator implements ValidatorTimingChannel {
   }
 
   private ValidatorRegistrationIdentity createValidatorRegistrationIdentity(
-      final Validator validator, final Eth1Address eth1Address) {
+      final Validator validator, final Eth1Address feeRecipient) {
     // hardcoding gas_limit to ZERO for now. The real value will be
     // taken from the proposer config in a future PR.
-    return new ValidatorRegistrationIdentity(eth1Address, UInt64.ZERO, validator.getPublicKey());
+    return new ValidatorRegistrationIdentity(feeRecipient, UInt64.ZERO, validator.getPublicKey());
   }
 
   private ValidatorRegistration createValidatorRegistration(

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrator.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrator.java
@@ -18,18 +18,23 @@ import static tech.pegasys.teku.infrastructure.logging.ValidatorLogger.VALIDATOR
 import com.google.common.collect.Maps;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.core.signatures.Signer;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
-import tech.pegasys.teku.infrastructure.bytes.Bytes20;
 import tech.pegasys.teku.infrastructure.ssz.impl.SszUtils;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.datastructures.eth1.Eth1Address;
 import tech.pegasys.teku.spec.datastructures.execution.SignedValidatorRegistration;
 import tech.pegasys.teku.spec.datastructures.execution.ValidatorRegistration;
 import tech.pegasys.teku.spec.schemas.ApiSchemas;
@@ -38,6 +43,7 @@ import tech.pegasys.teku.validator.api.ValidatorTimingChannel;
 import tech.pegasys.teku.validator.client.loader.OwnedValidators;
 
 public class ValidatorRegistrator implements ValidatorTimingChannel {
+  private static final Logger LOG = LogManager.getLogger();
 
   private final Map<ValidatorRegistrationIdentity, SignedValidatorRegistration>
       cachedValidatorRegistrations = Maps.newConcurrentMap();
@@ -48,16 +54,19 @@ public class ValidatorRegistrator implements ValidatorTimingChannel {
   private final Spec spec;
   private final TimeProvider timeProvider;
   private final OwnedValidators ownedValidators;
+  private final FeeRecipientProvider feeRecipientProvider;
   private final ValidatorApiChannel validatorApiChannel;
 
   public ValidatorRegistrator(
-      final OwnedValidators ownedValidators,
-      final ValidatorApiChannel validatorApiChannel,
       final Spec spec,
-      final TimeProvider timeProvider) {
+      final TimeProvider timeProvider,
+      final OwnedValidators ownedValidators,
+      final FeeRecipientProvider feeRecipientProvider,
+      final ValidatorApiChannel validatorApiChannel) {
     this.spec = spec;
     this.timeProvider = timeProvider;
     this.ownedValidators = ownedValidators;
+    this.feeRecipientProvider = feeRecipientProvider;
     this.validatorApiChannel = validatorApiChannel;
   }
 
@@ -87,14 +96,15 @@ public class ValidatorRegistrator implements ValidatorTimingChannel {
       return;
     }
 
+    final Set<BLSPublicKey> alreadyAddedValidatorsPublicKeys =
+        cachedValidatorRegistrations.keySet().stream()
+            .map(ValidatorRegistrationIdentity::getPublicKey)
+            .collect(Collectors.toSet());
+
     final List<Validator> newlyAddedValidators =
         ownedValidators.getActiveValidators().stream()
             .filter(
-                validator -> {
-                  final ValidatorRegistrationIdentity validatorRegistrationIdentity =
-                      createValidatorRegistrationIdentity(validator);
-                  return !cachedValidatorRegistrations.containsKey(validatorRegistrationIdentity);
-                })
+                validator -> !alreadyAddedValidatorsPublicKeys.contains(validator.getPublicKey()))
             .collect(Collectors.toList());
 
     registerValidators(newlyAddedValidators, lastProcessedEpoch.get())
@@ -122,24 +132,37 @@ public class ValidatorRegistrator implements ValidatorTimingChannel {
 
     final Stream<SafeFuture<SignedValidatorRegistration>> validatorRegistrationsFutures =
         validators.stream()
-            .map(
+            .flatMap(
                 validator -> {
+                  final BLSPublicKey publicKey = validator.getPublicKey();
+                  final Optional<Eth1Address> maybeFeeRecipient =
+                      feeRecipientProvider.getFeeRecipient(publicKey);
+
+                  if (maybeFeeRecipient.isEmpty()) {
+                    LOG.warn(
+                        "There is no fee recipient configured for {}. Can't register.", validator);
+                    return Stream.empty();
+                  }
+
                   final ValidatorRegistrationIdentity validatorRegistrationIdentity =
-                      createValidatorRegistrationIdentity(validator);
+                      createValidatorRegistrationIdentity(validator, maybeFeeRecipient.get());
 
                   if (cachedValidatorRegistrations.containsKey(validatorRegistrationIdentity)) {
-                    return SafeFuture.completedFuture(
-                        cachedValidatorRegistrations.get(validatorRegistrationIdentity));
+                    final SignedValidatorRegistration cachedRegistration =
+                        cachedValidatorRegistrations.get(validatorRegistrationIdentity);
+                    return Stream.of(SafeFuture.completedFuture(cachedRegistration));
                   }
 
                   final ValidatorRegistration validatorRegistration =
                       createValidatorRegistration(validatorRegistrationIdentity);
                   final Signer signer = validator.getSigner();
-                  return signValidatorRegistration(validatorRegistration, signer, epoch)
-                      .thenPeek(
-                          signedValidatorRegistration ->
-                              cachedValidatorRegistrations.put(
-                                  validatorRegistrationIdentity, signedValidatorRegistration));
+                  final SafeFuture<SignedValidatorRegistration> registrationFuture =
+                      signValidatorRegistration(validatorRegistration, signer, epoch)
+                          .thenPeek(
+                              signedValidatorRegistration ->
+                                  cachedValidatorRegistrations.put(
+                                      validatorRegistrationIdentity, signedValidatorRegistration));
+                  return Stream.of(registrationFuture);
                 });
 
     return SafeFuture.collectAll(validatorRegistrationsFutures)
@@ -151,10 +174,10 @@ public class ValidatorRegistrator implements ValidatorTimingChannel {
   }
 
   private ValidatorRegistrationIdentity createValidatorRegistrationIdentity(
-      final Validator validator) {
-    // hardcoding fee_recipient and gas_limit to ZERO for now. The real values will be
+      final Validator validator, final Eth1Address eth1Address) {
+    // hardcoding gas_limit to ZERO for now. The real value will be
     // taken from the proposer config in a future PR.
-    return new ValidatorRegistrationIdentity(Bytes20.ZERO, UInt64.ZERO, validator.getPublicKey());
+    return new ValidatorRegistrationIdentity(eth1Address, UInt64.ZERO, validator.getPublicKey());
   }
 
   private ValidatorRegistration createValidatorRegistration(

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorRegistratorTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorRegistratorTest.java
@@ -30,8 +30,6 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.mockito.ArgumentCaptor;
-import org.mockito.InOrder;
-import org.mockito.Mockito;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.core.signatures.Signer;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -42,6 +40,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecContext;
 import tech.pegasys.teku.spec.TestSpecInvocationContextProvider.SpecContext;
+import tech.pegasys.teku.spec.datastructures.eth1.Eth1Address;
 import tech.pegasys.teku.spec.datastructures.execution.SignedValidatorRegistration;
 import tech.pegasys.teku.spec.datastructures.execution.ValidatorRegistration;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
@@ -52,6 +51,7 @@ import tech.pegasys.teku.validator.client.loader.OwnedValidators;
 class ValidatorRegistratorTest {
 
   private final OwnedValidators ownedValidators = mock(OwnedValidators.class);
+  private final FeeRecipientProvider feeRecipientProvider = mock(FeeRecipientProvider.class);
   private final ValidatorApiChannel validatorApiChannel = mock(ValidatorApiChannel.class);
   private final TimeProvider stubTimeProvider = StubTimeProvider.withTimeInMillis(500);
   private final Signer signer = mock(Signer.class);
@@ -63,6 +63,8 @@ class ValidatorRegistratorTest {
   private Validator validator2;
   private Validator validator3;
 
+  private Eth1Address eth1Address;
+
   private ValidatorRegistrator validatorRegistrator;
 
   @BeforeEach
@@ -72,11 +74,20 @@ class ValidatorRegistratorTest {
     validator1 = new Validator(dataStructureUtil.randomPublicKey(), signer, Optional::empty);
     validator2 = new Validator(dataStructureUtil.randomPublicKey(), signer, Optional::empty);
     validator3 = new Validator(dataStructureUtil.randomPublicKey(), signer, Optional::empty);
+    eth1Address = dataStructureUtil.randomEth1Address();
     validatorRegistrator =
         new ValidatorRegistrator(
-            ownedValidators, validatorApiChannel, specContext.getSpec(), stubTimeProvider);
+            specContext.getSpec(),
+            stubTimeProvider,
+            ownedValidators,
+            feeRecipientProvider,
+            validatorApiChannel);
     when(validatorApiChannel.registerValidators(any()))
         .thenReturn(SafeFuture.completedFuture(null));
+    // random signature for all signing
+    doAnswer(invocation -> SafeFuture.completedFuture(dataStructureUtil.randomSignature()))
+        .when(signer)
+        .signValidatorRegistration(any(ValidatorRegistration.class), any(UInt64.class));
   }
 
   @TestTemplate
@@ -100,34 +111,26 @@ class ValidatorRegistratorTest {
     when(ownedValidators.getActiveValidators())
         .thenReturn(List.of(validator1, validator2, validator3));
 
-    doAnswer(invocation -> SafeFuture.completedFuture(dataStructureUtil.randomSignature()))
-        .when(signer)
-        .signValidatorRegistration(any(ValidatorRegistration.class), any(UInt64.class));
+    when(feeRecipientProvider.getFeeRecipient(any())).thenReturn(Optional.of(eth1Address));
 
     // WHEN
     validatorRegistrator.onSlot(UInt64.ZERO);
 
-    // THEN
-    @SuppressWarnings("unchecked")
-    ArgumentCaptor<SszList<SignedValidatorRegistration>> argumentCaptor =
-        ArgumentCaptor.forClass(SszList.class);
-
-    InOrder inOrder = Mockito.inOrder(validatorApiChannel);
-
-    inOrder.verify(validatorApiChannel, timeout(1000)).registerValidators(argumentCaptor.capture());
-    verifyRegistrations(argumentCaptor.getValue());
+    // Make sure all the futures have completed before next call
+    verify(validatorApiChannel, timeout(1000)).registerValidators(any());
 
     // WHEN onSlot called again next epoch, registrations will be cached
     validatorRegistrator.onSlot(UInt64.valueOf(slotsPerEpoch));
 
     // THEN
+    List<SszList<SignedValidatorRegistration>> registrationCalls =
+        captureValidatorApiChannelCalls(2);
+
+    registrationCalls.forEach(this::verifyRegistrations);
 
     // signer will be called in total 3 times, since from the 2nd run the signed registrations will
     // be cached
     verify(signer, times(3)).signValidatorRegistration(any(), any());
-
-    inOrder.verify(validatorApiChannel, timeout(1000)).registerValidators(argumentCaptor.capture());
-    verifyRegistrations(argumentCaptor.getValue());
   }
 
   @TestTemplate
@@ -135,12 +138,13 @@ class ValidatorRegistratorTest {
     // GIVEN
     when(ownedValidators.getActiveValidators()).thenReturn(List.of(validator1));
 
-    doAnswer(invocation -> SafeFuture.completedFuture(dataStructureUtil.randomSignature()))
-        .when(signer)
-        .signValidatorRegistration(any(ValidatorRegistration.class), any(UInt64.class));
+    when(feeRecipientProvider.getFeeRecipient(any())).thenReturn(Optional.of(eth1Address));
 
     // Registering only validator1
     validatorRegistrator.onSlot(UInt64.ZERO);
+
+    // Make sure all the futures have completed before next call
+    verify(validatorApiChannel, timeout(1000)).registerValidators(any());
 
     // WHEN new validators are added
     when(ownedValidators.getActiveValidators())
@@ -149,14 +153,8 @@ class ValidatorRegistratorTest {
     // THEN only validator2 and validator3 should be registered
     validatorRegistrator.onValidatorsAdded();
 
-    @SuppressWarnings("unchecked")
-    ArgumentCaptor<SszList<SignedValidatorRegistration>> argumentCaptor =
-        ArgumentCaptor.forClass(SszList.class);
-
-    verify(validatorApiChannel, timeout(1000).times(2))
-        .registerValidators(argumentCaptor.capture());
-
-    List<SszList<SignedValidatorRegistration>> registrationCalls = argumentCaptor.getAllValues();
+    List<SszList<SignedValidatorRegistration>> registrationCalls =
+        captureValidatorApiChannelCalls(2);
 
     assertThat(registrationCalls).hasSize(2);
 
@@ -174,17 +172,60 @@ class ValidatorRegistratorTest {
         .containsExactlyInAnyOrder(validator2.getPublicKey(), validator3.getPublicKey());
   }
 
+  @TestTemplate
+  void skipsValidatorRegistrationIfFeeRecipientNotSpecified() {
+    // GIVEN
+    when(ownedValidators.getActiveValidators()).thenReturn(List.of(validator1, validator2));
+
+    when(feeRecipientProvider.getFeeRecipient(validator1.getPublicKey()))
+        .thenReturn(Optional.of(eth1Address));
+    // no fee recipient provided for validator2
+    when(feeRecipientProvider.getFeeRecipient(validator2.getPublicKey()))
+        .thenReturn(Optional.empty());
+
+    // WHEN
+    validatorRegistrator.onSlot(UInt64.ZERO);
+
+    // THEN
+    SszList<SignedValidatorRegistration> registrations = captureValidatorApiChannelCall();
+
+    assertThat(registrations).hasSize(1);
+    assertThat(getPublicKeys(registrations)).containsExactly(validator1.getPublicKey());
+  }
+
   private void verifyRegistrations(SszList<SignedValidatorRegistration> validatorRegistrations) {
 
     assertThat(validatorRegistrations).hasSize(3);
+
     assertThat(validatorRegistrations)
-        .allSatisfy(registration -> assertThat(registration.getSignature().isValid()).isTrue());
+        .allSatisfy(
+            registration -> {
+              ValidatorRegistration message = registration.getMessage();
+              assertThat(message.getFeeRecipient()).isEqualTo(eth1Address);
+              assertThat(message.getGasLimit()).isEqualTo(UInt64.ZERO);
+              assertThat(registration.getSignature().isValid()).isTrue();
+            });
 
     Stream<BLSPublicKey> validatorsPublicKeys = getPublicKeys(validatorRegistrations);
 
     assertThat(validatorsPublicKeys)
         .containsExactlyInAnyOrder(
             validator1.getPublicKey(), validator2.getPublicKey(), validator3.getPublicKey());
+  }
+
+  private SszList<SignedValidatorRegistration> captureValidatorApiChannelCall() {
+    return captureValidatorApiChannelCalls(1).get(0);
+  }
+
+  private List<SszList<SignedValidatorRegistration>> captureValidatorApiChannelCalls(int times) {
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<SszList<SignedValidatorRegistration>> argumentCaptor =
+        ArgumentCaptor.forClass(SszList.class);
+
+    verify(validatorApiChannel, timeout(1000).times(times))
+        .registerValidators(argumentCaptor.capture());
+
+    return argumentCaptor.getAllValues();
   }
 
   private Stream<BLSPublicKey> getPublicKeys(

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorRegistratorTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorRegistratorTest.java
@@ -17,7 +17,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -116,9 +115,6 @@ class ValidatorRegistratorTest {
     // WHEN
     validatorRegistrator.onSlot(UInt64.ZERO);
 
-    // Make sure all the futures have completed before next call
-    verify(validatorApiChannel, timeout(1000)).registerValidators(any());
-
     // WHEN onSlot called again next epoch, registrations will be cached
     validatorRegistrator.onSlot(UInt64.valueOf(slotsPerEpoch));
 
@@ -142,9 +138,6 @@ class ValidatorRegistratorTest {
 
     // Registering only validator1
     validatorRegistrator.onSlot(UInt64.ZERO);
-
-    // Make sure all the futures have completed before next call
-    verify(validatorApiChannel, timeout(1000)).registerValidators(any());
 
     // WHEN new validators are added
     when(ownedValidators.getActiveValidators())
@@ -222,8 +215,7 @@ class ValidatorRegistratorTest {
     ArgumentCaptor<SszList<SignedValidatorRegistration>> argumentCaptor =
         ArgumentCaptor.forClass(SszList.class);
 
-    verify(validatorApiChannel, timeout(1000).times(times))
-        .registerValidators(argumentCaptor.capture());
+    verify(validatorApiChannel, times(times)).registerValidators(argumentCaptor.capture());
 
     return argumentCaptor.getAllValues();
   }


### PR DESCRIPTION
## PR Description
- Introduced `FeeRecipientProvider` and attached it to the `BeaconProposerPreparer`
- Added `FeeRecipientProvider` to `ValidatorRegistrator` to use to retrieve the fee recipient
- Log warning in case fee recipient is not available and skip registration.
- Changed `onValidatorsAdded` implementation to check against the cached public keys to avoid calling `getFeeRecipient` twice (needed to build the `ValidatorRegistrationIdentity` object)
- Refactored `ValidatorRegistrator` test to avoid duplications

## Fixed Issue(s)
fixes #5636 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
