### PR TITLE
[MEV Boost\Builder] Validator Registration default gas limit CLI

### DIFF
--- a/teku/src/main/java/tech/pegasys/teku/cli/converter/Eth1AddressConverter.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/converter/Eth1AddressConverter.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.cli.converter;
+
+import picocli.CommandLine;
+import picocli.CommandLine.TypeConversionException;
+import tech.pegasys.teku.spec.datastructures.eth1.Eth1Address;
+
+public class Eth1AddressConverter implements CommandLine.ITypeConverter<Eth1Address> {
+  @Override
+  public Eth1Address convert(final String value) throws Exception {
+    try {
+      return Eth1Address.fromHexString(value);
+    } catch (Exception e) {
+      throw new TypeConversionException("Invalid format: " + e.getMessage());
+    }
+  }
+}

--- a/teku/src/main/java/tech/pegasys/teku/cli/converter/UInt64Converter.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/converter/UInt64Converter.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.cli.converter;
+
+import picocli.CommandLine;
+import picocli.CommandLine.TypeConversionException;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+public class UInt64Converter implements CommandLine.ITypeConverter<UInt64> {
+  @Override
+  public UInt64 convert(final String value) {
+    try {
+      return UInt64.valueOf(value);
+    } catch (final NumberFormatException e) {
+      throw new TypeConversionException("Invalid format: must be a numeric value but was " + value);
+    }
+  }
+}

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorProposerOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorProposerOptions.java
@@ -17,7 +17,9 @@ import static tech.pegasys.teku.validator.api.ValidatorConfig.DEFAULT_VALIDATOR_
 
 import picocli.CommandLine.Help.Visibility;
 import picocli.CommandLine.Option;
+import tech.pegasys.teku.cli.converter.UInt64Converter;
 import tech.pegasys.teku.config.TekuConfiguration;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.validator.api.ValidatorConfig;
 
 public class ValidatorProposerOptions {
@@ -59,6 +61,17 @@ public class ValidatorProposerOptions {
       ValidatorConfig.DEFAULT_VALIDATOR_PROPOSER_MEV_BOOST_ENABLED;
 
   @Option(
+      names = {"--Xvalidators-registration-default-gas-limit"},
+      paramLabel = "<uint64>",
+      showDefaultValue = Visibility.ALWAYS,
+      description = "Enable MEV boost when proposing blocks.",
+      arity = "0..1",
+      hidden = true,
+      converter = UInt64Converter.class)
+  private UInt64 registrationDefaultGasLimit =
+      ValidatorConfig.DEFAULT_VALIDATOR_REGISTRATION_GAS_LIMIT;
+
+  @Option(
       names = {"--Xvalidators-proposer-blinded-blocks-enabled"},
       paramLabel = "<BOOLEAN>",
       showDefaultValue = Visibility.ALWAYS,
@@ -76,6 +89,7 @@ public class ValidatorProposerOptions {
                 .proposerConfigSource(proposerConfig)
                 .refreshProposerConfigFromSource(proposerConfigRefreshEnabled)
                 .proposerMevBoostEnabled(proposerMevBoostEnabled)
-                .blindedBeaconBlocksEnabled(blindedBlocksEnabled));
+                .blindedBeaconBlocksEnabled(blindedBlocksEnabled)
+                .validatorsRegistrationDefaultGasLimit(registrationDefaultGasLimit));
   }
 }

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/internal/validator/options/DepositOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/internal/validator/options/DepositOptions.java
@@ -22,13 +22,13 @@ import java.util.function.IntConsumer;
 import org.web3j.crypto.CipherException;
 import org.web3j.crypto.Credentials;
 import org.web3j.crypto.WalletUtils;
-import picocli.CommandLine;
 import picocli.CommandLine.ArgGroup;
 import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.ParameterException;
 import picocli.CommandLine.Spec;
-import picocli.CommandLine.TypeConversionException;
+import tech.pegasys.teku.cli.converter.Eth1AddressConverter;
+import tech.pegasys.teku.cli.converter.UInt64Converter;
 import tech.pegasys.teku.cli.subcommand.internal.validator.tools.ConsoleAdapter;
 import tech.pegasys.teku.cli.subcommand.internal.validator.tools.DepositSender;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -155,29 +155,6 @@ public class DepositOptions {
           commandSpec.commandLine(),
           "Error: Unable to decrypt Eth1 keystore [" + eth1KeystoreFile + "] : " + e.getMessage(),
           e);
-    }
-  }
-
-  private static class UInt64Converter implements CommandLine.ITypeConverter<UInt64> {
-    @Override
-    public UInt64 convert(final String value) {
-      try {
-        return UInt64.valueOf(value);
-      } catch (final NumberFormatException e) {
-        throw new TypeConversionException(
-            "Invalid format: must be a numeric value but was " + value);
-      }
-    }
-  }
-
-  private static class Eth1AddressConverter implements CommandLine.ITypeConverter<Eth1Address> {
-    @Override
-    public Eth1Address convert(final String value) throws Exception {
-      try {
-        return Eth1Address.fromHexString(value);
-      } catch (Exception e) {
-        throw new TypeConversionException("Invalid format: " + e.getMessage());
-      }
     }
   }
 }

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/ValidatorOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/ValidatorOptionsTest.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.cli.options;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.validator.api.ValidatorConfig.DEFAULT_VALIDATOR_REGISTRATION_GAS_LIMIT;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -23,6 +24,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.cli.AbstractBeaconNodeCommandTest;
 import tech.pegasys.teku.config.TekuConfiguration;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.eth1.Eth1Address;
 import tech.pegasys.teku.validator.api.ValidatorConfig;
 
@@ -147,5 +149,28 @@ public class ValidatorOptionsTest extends AbstractBeaconNodeCommandTest {
     final String[] args = {};
     final TekuConfiguration config = getTekuConfigurationFromArguments(args);
     assertThat(config.validatorClient().getValidatorConfig().isProposerMevBoostEnabled()).isFalse();
+  }
+
+  @Test
+  public void shouldReportDefaultGasLimitIfRegistrationDefaultGasLimitNotSpecified() {
+    final TekuConfiguration config = getTekuConfigurationFromArguments();
+    assertThat(
+            config
+                .validatorClient()
+                .getValidatorConfig()
+                .getValidatorsRegistrationDefaultGasLimit())
+        .isEqualTo(DEFAULT_VALIDATOR_REGISTRATION_GAS_LIMIT);
+  }
+
+  @Test
+  public void shouldSETDefaultGasLimitIfRegistrationDefaultGasLimitIsSpecified() {
+    final String[] args = {"--Xvalidators-registration-default-gas-limit", "1000"};
+    final TekuConfiguration config = getTekuConfigurationFromArguments(args);
+    assertThat(
+            config
+                .validatorClient()
+                .getValidatorConfig()
+                .getValidatorsRegistrationDefaultGasLimit())
+        .isEqualTo(UInt64.valueOf(1000));
   }
 }

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
@@ -27,6 +27,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.exceptions.InvalidConfigurationException;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.eth1.Eth1Address;
 
 public class ValidatorConfig {
@@ -45,6 +46,7 @@ public class ValidatorConfig {
   public static final boolean DEFAULT_VALIDATOR_PROPOSER_CONFIG_REFRESH_ENABLED = false;
   public static final boolean DEFAULT_VALIDATOR_PROPOSER_MEV_BOOST_ENABLED = false;
   public static final boolean DEFAULT_VALIDATOR_BLINDED_BLOCKS_ENABLED = false;
+  public static final UInt64 DEFAULT_VALIDATOR_REGISTRATION_GAS_LIMIT = UInt64.valueOf(30_000_000);
 
   private final List<String> validatorKeys;
   private final List<String> validatorExternalSignerPublicKeySources;
@@ -67,6 +69,7 @@ public class ValidatorConfig {
   private final boolean blindedBeaconBlocksEnabled;
   private final boolean proposerMevBoostEnabled;
   private final boolean validatorClientUseSszBlocksEnabled;
+  private final UInt64 validatorsRegistrationDefaultGasLimit;
 
   private ValidatorConfig(
       final List<String> validatorKeys,
@@ -89,7 +92,8 @@ public class ValidatorConfig {
       final boolean refreshProposerConfigFromSource,
       final boolean proposerMevBoostEnabled,
       final boolean blindedBeaconBlocksEnabled,
-      final boolean validatorClientUseSszBlocksEnabled) {
+      final boolean validatorClientUseSszBlocksEnabled,
+      final UInt64 validatorsRegistrationDefaultGasLimit) {
     this.validatorKeys = validatorKeys;
     this.validatorExternalSignerPublicKeySources = validatorExternalSignerPublicKeySources;
     this.validatorExternalSignerUrl = validatorExternalSignerUrl;
@@ -114,6 +118,7 @@ public class ValidatorConfig {
     this.blindedBeaconBlocksEnabled = blindedBeaconBlocksEnabled;
     this.proposerMevBoostEnabled = proposerMevBoostEnabled;
     this.validatorClientUseSszBlocksEnabled = validatorClientUseSszBlocksEnabled;
+    this.validatorsRegistrationDefaultGasLimit = validatorsRegistrationDefaultGasLimit;
   }
 
   public static Builder builder() {
@@ -183,6 +188,10 @@ public class ValidatorConfig {
     return proposerConfigSource;
   }
 
+  public UInt64 getValidatorsRegistrationDefaultGasLimit() {
+    return validatorsRegistrationDefaultGasLimit;
+  }
+
   public boolean getRefreshProposerConfigFromSource() {
     return refreshProposerConfigFromSource;
   }
@@ -235,6 +244,7 @@ public class ValidatorConfig {
     private boolean proposerMevBoostEnabled = DEFAULT_VALIDATOR_PROPOSER_MEV_BOOST_ENABLED;
     private boolean blindedBlocksEnabled = DEFAULT_VALIDATOR_BLINDED_BLOCKS_ENABLED;
     private boolean validatorClientSszBlocksEnabled = DEFAULT_VALIDATOR_CLIENT_SSZ_BLOCKS_ENABLED;
+    private UInt64 validatorsRegistrationDefaultGasLimit = DEFAULT_VALIDATOR_REGISTRATION_GAS_LIMIT;
 
     private Builder() {}
 
@@ -376,6 +386,12 @@ public class ValidatorConfig {
       return this;
     }
 
+    public Builder validatorsRegistrationDefaultGasLimit(
+        final UInt64 validatorsRegistrationDefaultGasLimit) {
+      this.validatorsRegistrationDefaultGasLimit = validatorsRegistrationDefaultGasLimit;
+      return this;
+    }
+
     public ValidatorConfig build() {
       validateExternalSignerUrlAndPublicKeys();
       validateExternalSignerKeystoreAndPasswordFileConfig();
@@ -403,7 +419,8 @@ public class ValidatorConfig {
           refreshProposerConfigFromSource,
           proposerMevBoostEnabled,
           blindedBlocksEnabled,
-          validatorClientSszBlocksEnabled);
+          validatorClientSszBlocksEnabled,
+          validatorsRegistrationDefaultGasLimit);
     }
 
     private void validateExternalSignerUrlAndPublicKeys() {


### PR DESCRIPTION
providers `--Xvalidators-registration-default-gas-limit` with a default value set to `30_000_000` to match default mainnet

moves some private CLI converters to dedicated package

fixes #5639 

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
