### PR TITLE
Reject negative values in byte deserializer

### DIFF
--- a/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/ByteTypeDefinition.java
+++ b/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/ByteTypeDefinition.java
@@ -50,7 +50,7 @@ class ByteTypeDefinition extends PrimitiveTypeDefinition<Byte> {
     final String valueToParse =
         valueAsString.startsWith("0x") ? valueAsString.substring("0x".length()) : valueAsString;
     final int value = Integer.parseUnsignedInt(valueToParse, RADIX);
-    checkArgument(0 <= value && value <= 255, "byte value %s should be between 0 and 255", value);
+    checkArgument(0 <= value && value <= 255, "value %s is outside range for unsigned byte", value);
     return (byte) value;
   }
 }

--- a/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/ByteTypeDefinition.java
+++ b/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/ByteTypeDefinition.java
@@ -50,7 +50,7 @@ class ByteTypeDefinition extends PrimitiveTypeDefinition<Byte> {
     final String valueToParse =
         valueAsString.startsWith("0x") ? valueAsString.substring("0x".length()) : valueAsString;
     final int value = Integer.parseUnsignedInt(valueToParse, RADIX);
-    checkArgument(0 <= value && value <= 255, "Value %s should be between 0 and 255", value);
+    checkArgument(0 <= value && value <= 255, "byte value %s should be between 0 and 255", value);
     return (byte) value;
   }
 }

--- a/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/ByteTypeDefinition.java
+++ b/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/ByteTypeDefinition.java
@@ -50,8 +50,7 @@ class ByteTypeDefinition extends PrimitiveTypeDefinition<Byte> {
     final String valueToParse =
         valueAsString.startsWith("0x") ? valueAsString.substring("0x".length()) : valueAsString;
     final int value = Integer.parseUnsignedInt(valueToParse, RADIX);
-    checkArgument(
-        value < Math.pow(2, Byte.SIZE), "Value %s exceeds maximum for unsigned byte", value);
+    checkArgument(0 <= value && value <= 255, "Value %s should be between 0 and 255", value);
     return (byte) value;
   }
 }

--- a/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/ByteTypeDefinition.java
+++ b/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/ByteTypeDefinition.java
@@ -50,7 +50,7 @@ class ByteTypeDefinition extends PrimitiveTypeDefinition<Byte> {
     final String valueToParse =
         valueAsString.startsWith("0x") ? valueAsString.substring("0x".length()) : valueAsString;
     final int value = Integer.parseUnsignedInt(valueToParse, RADIX);
-    checkArgument(0 <= value && value <= 255, "value %s is outside range for unsigned byte", value);
+    checkArgument(0 <= value && value <= 255, "Value %s is outside range for unsigned byte", value);
     return (byte) value;
   }
 }

--- a/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/UInt8TypeDefinition.java
+++ b/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/UInt8TypeDefinition.java
@@ -47,7 +47,7 @@ class UInt8TypeDefinition extends PrimitiveTypeDefinition<Byte> {
   @Override
   public Byte deserializeFromString(final String valueAsString) {
     final int value = Integer.parseUnsignedInt(valueAsString, 10);
-    checkArgument(0 <= value && value <= 255, "value %s is outside range for uint8", value);
+    checkArgument(0 <= value && value <= 255, "Value %s is outside range for uint8", value);
     return (byte) value;
   }
 }

--- a/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/UInt8TypeDefinition.java
+++ b/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/UInt8TypeDefinition.java
@@ -47,7 +47,7 @@ class UInt8TypeDefinition extends PrimitiveTypeDefinition<Byte> {
   @Override
   public Byte deserializeFromString(final String valueAsString) {
     final int value = Integer.parseUnsignedInt(valueAsString, 10);
-    checkArgument(value < Math.pow(2, Byte.SIZE), "Value %s exceeds maximum for uint8", value);
+    checkArgument(0 <= value && value <= 255, "uint8 value %s should be between 0 and 255", value);
     return (byte) value;
   }
 }

--- a/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/UInt8TypeDefinition.java
+++ b/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/UInt8TypeDefinition.java
@@ -47,7 +47,7 @@ class UInt8TypeDefinition extends PrimitiveTypeDefinition<Byte> {
   @Override
   public Byte deserializeFromString(final String valueAsString) {
     final int value = Integer.parseUnsignedInt(valueAsString, 10);
-    checkArgument(0 <= value && value <= 255, "uint8 value %s should be between 0 and 255", value);
+    checkArgument(0 <= value && value <= 255, "value %s is outside range for uint8", value);
     return (byte) value;
   }
 }

--- a/infrastructure/json/src/property-test/java/tech/pegasys/teku/infrastructure/json/types/ByteTypeDefinitionPropertyTest.java
+++ b/infrastructure/json/src/property-test/java/tech/pegasys/teku/infrastructure/json/types/ByteTypeDefinitionPropertyTest.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.infrastructure.json.types;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static tech.pegasys.teku.infrastructure.json.DeserializableTypeUtil.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -28,14 +29,13 @@ public class ByteTypeDefinitionPropertyTest {
   }
 
   @Property
-  @SuppressWarnings("EmptyCatch")
-  void shouldRejectInvalidRange(@ForAll int value) {
-    try {
-      final String serialized = Integer.toHexString(value);
-      JsonUtil.parse(serialized, CoreTypes.BYTE_TYPE);
-      assertThat(value).isBetween(0, 255);
-    } catch (JsonProcessingException e) {
-    } catch (IllegalArgumentException e) {
+  void shouldRejectInvalidRange(@ForAll int value) throws JsonProcessingException {
+    final String serialized = "\"" + Integer.toHexString(value) + "\"";
+    if (value >= 0 && value <= 255) {
+      assertThat(JsonUtil.parse(serialized, CoreTypes.BYTE_TYPE)).isEqualTo((byte) value);
+    } else {
+      assertThatThrownBy(() -> JsonUtil.parse(serialized, CoreTypes.BYTE_TYPE))
+          .isInstanceOfAny(JsonProcessingException.class, IllegalArgumentException.class);
     }
   }
 }

--- a/infrastructure/json/src/property-test/java/tech/pegasys/teku/infrastructure/json/types/ByteTypeDefinitionPropertyTest.java
+++ b/infrastructure/json/src/property-test/java/tech/pegasys/teku/infrastructure/json/types/ByteTypeDefinitionPropertyTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.json.types;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.infrastructure.json.DeserializableTypeUtil.assertRoundTrip;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import tech.pegasys.teku.infrastructure.json.JsonUtil;
+
+public class ByteTypeDefinitionPropertyTest {
+  @Property
+  void roundTrip(@ForAll Byte value) throws JsonProcessingException {
+    assertRoundTrip(value, CoreTypes.BYTE_TYPE);
+  }
+
+  @Property
+  @SuppressWarnings("EmptyCatch")
+  void shouldRejectInvalidRange(@ForAll int value) {
+    try {
+      final String serialized = Integer.toHexString(value);
+      JsonUtil.parse(serialized, CoreTypes.BYTE_TYPE);
+      assertThat(value).isBetween(0, 255);
+    } catch (JsonProcessingException e) {
+    } catch (IllegalArgumentException e) {
+    }
+  }
+}

--- a/infrastructure/json/src/property-test/java/tech/pegasys/teku/infrastructure/json/types/UInt8TypeDefinitionPropertyTest.java
+++ b/infrastructure/json/src/property-test/java/tech/pegasys/teku/infrastructure/json/types/UInt8TypeDefinitionPropertyTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.json.types;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.infrastructure.json.DeserializableTypeUtil.assertRoundTrip;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.math.BigInteger;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import tech.pegasys.teku.infrastructure.json.JsonUtil;
+
+public class UInt8TypeDefinitionPropertyTest {
+  private static final BigInteger UINT8_MAX_VALUE = new BigInteger("255");
+
+  @Property
+  void roundTrip(@ForAll Byte value) throws JsonProcessingException {
+    assertRoundTrip(value, CoreTypes.UINT8_TYPE);
+  }
+
+  @Property
+  @SuppressWarnings("EmptyCatch")
+  void shouldRejectInvalidRange(@ForAll BigInteger value) {
+    try {
+      final String serialized = value.toString(10);
+      JsonUtil.parse(serialized, CoreTypes.UINT8_TYPE);
+      assertThat(value).isBetween(BigInteger.ZERO, UINT8_MAX_VALUE);
+    } catch (JsonProcessingException e) {
+    } catch (IllegalArgumentException e) {
+    }
+  }
+}

--- a/infrastructure/json/src/property-test/java/tech/pegasys/teku/infrastructure/json/types/UInt8TypeDefinitionPropertyTest.java
+++ b/infrastructure/json/src/property-test/java/tech/pegasys/teku/infrastructure/json/types/UInt8TypeDefinitionPropertyTest.java
@@ -29,7 +29,6 @@ public class UInt8TypeDefinitionPropertyTest {
   }
 
   @Property
-  @SuppressWarnings("EmptyCatch")
   void shouldRejectInvalidRange(@ForAll int value) throws JsonProcessingException {
     final String serialized = "\"" + value + "\"";
     if (value >= 0 && value <= 255) {

--- a/infrastructure/json/src/property-test/java/tech/pegasys/teku/infrastructure/json/types/UInt8TypeDefinitionPropertyTest.java
+++ b/infrastructure/json/src/property-test/java/tech/pegasys/teku/infrastructure/json/types/UInt8TypeDefinitionPropertyTest.java
@@ -17,14 +17,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static tech.pegasys.teku.infrastructure.json.DeserializableTypeUtil.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import java.math.BigInteger;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 
 public class UInt8TypeDefinitionPropertyTest {
-  private static final BigInteger UINT8_MAX_VALUE = new BigInteger("255");
-
   @Property
   void roundTrip(@ForAll Byte value) throws JsonProcessingException {
     assertRoundTrip(value, CoreTypes.UINT8_TYPE);
@@ -32,11 +29,11 @@ public class UInt8TypeDefinitionPropertyTest {
 
   @Property
   @SuppressWarnings("EmptyCatch")
-  void shouldRejectInvalidRange(@ForAll BigInteger value) {
+  void shouldRejectInvalidRange(@ForAll int value) {
     try {
-      final String serialized = value.toString(10);
+      final String serialized = Integer.toUnsignedString(value, 10);
       JsonUtil.parse(serialized, CoreTypes.UINT8_TYPE);
-      assertThat(value).isBetween(BigInteger.ZERO, UINT8_MAX_VALUE);
+      assertThat(value).isBetween(-127, 255);
     } catch (JsonProcessingException e) {
     } catch (IllegalArgumentException e) {
     }

--- a/infrastructure/json/src/property-test/java/tech/pegasys/teku/infrastructure/json/types/UInt8TypeDefinitionPropertyTest.java
+++ b/infrastructure/json/src/property-test/java/tech/pegasys/teku/infrastructure/json/types/UInt8TypeDefinitionPropertyTest.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.infrastructure.json.types;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static tech.pegasys.teku.infrastructure.json.DeserializableTypeUtil.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -29,13 +30,13 @@ public class UInt8TypeDefinitionPropertyTest {
 
   @Property
   @SuppressWarnings("EmptyCatch")
-  void shouldRejectInvalidRange(@ForAll int value) {
-    try {
-      final String serialized = Integer.toUnsignedString(value, 10);
-      JsonUtil.parse(serialized, CoreTypes.UINT8_TYPE);
-      assertThat(value).isBetween(0, 255);
-    } catch (JsonProcessingException e) {
-    } catch (IllegalArgumentException e) {
+  void shouldRejectInvalidRange(@ForAll int value) throws JsonProcessingException {
+    final String serialized = "\"" + value + "\"";
+    if (value >= 0 && value <= 255) {
+      assertThat(JsonUtil.parse(serialized, CoreTypes.UINT8_TYPE)).isEqualTo((byte) value);
+    } else {
+      assertThatThrownBy(() -> JsonUtil.parse(serialized, CoreTypes.UINT8_TYPE))
+          .isInstanceOfAny(JsonProcessingException.class, IllegalArgumentException.class);
     }
   }
 }

--- a/infrastructure/json/src/property-test/java/tech/pegasys/teku/infrastructure/json/types/UInt8TypeDefinitionPropertyTest.java
+++ b/infrastructure/json/src/property-test/java/tech/pegasys/teku/infrastructure/json/types/UInt8TypeDefinitionPropertyTest.java
@@ -33,7 +33,7 @@ public class UInt8TypeDefinitionPropertyTest {
     try {
       final String serialized = Integer.toUnsignedString(value, 10);
       JsonUtil.parse(serialized, CoreTypes.UINT8_TYPE);
-      assertThat(value).isBetween(-127, 255);
+      assertThat(value).isBetween(0, 255);
     } catch (JsonProcessingException e) {
     } catch (IllegalArgumentException e) {
     }

--- a/infrastructure/json/src/test/java/tech/pegasys/teku/infrastructure/json/types/ByteTypeDefinitionTest.java
+++ b/infrastructure/json/src/test/java/tech/pegasys/teku/infrastructure/json/types/ByteTypeDefinitionTest.java
@@ -14,8 +14,10 @@
 package tech.pegasys.teku.infrastructure.json.types;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -38,6 +40,13 @@ class ByteTypeDefinitionTest {
   void shouldDeserializeFromHexWithoutPrefix(final byte value, final String serialized) {
     assertThat(CoreTypes.BYTE_TYPE.deserializeFromString(serialized.substring("0x".length())))
         .isEqualTo(value);
+  }
+
+  @Test
+  void shouldRejectNegativeIntegerHexStrings() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> CoreTypes.BYTE_TYPE.deserializeFromString(Integer.toHexString(-1)));
   }
 
   static Stream<Arguments> testValues() {

--- a/infrastructure/json/src/test/java/tech/pegasys/teku/infrastructure/json/types/ByteTypeDefinitionTest.java
+++ b/infrastructure/json/src/test/java/tech/pegasys/teku/infrastructure/json/types/ByteTypeDefinitionTest.java
@@ -43,7 +43,7 @@ class ByteTypeDefinitionTest {
   }
 
   @Test
-  void shouldRejectNegativeIntegerHexStrings() {
+  void shouldRejectNegativeInteger() {
     assertThrows(
         IllegalArgumentException.class,
         () -> CoreTypes.BYTE_TYPE.deserializeFromString(Integer.toHexString(-1)));

--- a/infrastructure/json/src/test/java/tech/pegasys/teku/infrastructure/json/types/UInt8TypeDefinitionTest.java
+++ b/infrastructure/json/src/test/java/tech/pegasys/teku/infrastructure/json/types/UInt8TypeDefinitionTest.java
@@ -40,7 +40,7 @@ class UInt8TypeDefinitionTest {
   void shouldRejectNegativeInteger() {
     assertThrows(
         IllegalArgumentException.class,
-        () -> CoreTypes.UINT8_TYPE.deserializeFromString(Integer.toUnsignedString(-1, 10)));
+        () -> CoreTypes.UINT8_TYPE.deserializeFromString(Integer.toUnsignedString(-1)));
   }
 
   static Stream<Arguments> testValues() {

--- a/infrastructure/json/src/test/java/tech/pegasys/teku/infrastructure/json/types/UInt8TypeDefinitionTest.java
+++ b/infrastructure/json/src/test/java/tech/pegasys/teku/infrastructure/json/types/UInt8TypeDefinitionTest.java
@@ -14,8 +14,11 @@
 package tech.pegasys.teku.infrastructure.json.types;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.math.BigInteger;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -32,6 +35,13 @@ class UInt8TypeDefinitionTest {
   @MethodSource("testValues")
   void shouldDeserializeFromDecimal(final byte value, final String serialized) {
     assertThat(CoreTypes.UINT8_TYPE.deserializeFromString(serialized)).isEqualTo(value);
+  }
+
+  @Test
+  void shouldRejectNegativeInteger() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> CoreTypes.UINT8_TYPE.deserializeFromString(BigInteger.ONE.toString(10)));
   }
 
   static Stream<Arguments> testValues() {

--- a/infrastructure/json/src/test/java/tech/pegasys/teku/infrastructure/json/types/UInt8TypeDefinitionTest.java
+++ b/infrastructure/json/src/test/java/tech/pegasys/teku/infrastructure/json/types/UInt8TypeDefinitionTest.java
@@ -16,7 +16,6 @@ package tech.pegasys.teku.infrastructure.json.types;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import java.math.BigInteger;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -41,7 +40,7 @@ class UInt8TypeDefinitionTest {
   void shouldRejectNegativeInteger() {
     assertThrows(
         IllegalArgumentException.class,
-        () -> CoreTypes.UINT8_TYPE.deserializeFromString(BigInteger.ONE.toString(10)));
+        () -> CoreTypes.UINT8_TYPE.deserializeFromString(Integer.toUnsignedString(-1, 10)));
   }
 
   static Stream<Arguments> testValues() {

--- a/infrastructure/restapi/src/test/java/tech/pegasys/teku/infrastructure/restapi/endpoints/RestApiRequestTest.java
+++ b/infrastructure/restapi/src/test/java/tech/pegasys/teku/infrastructure/restapi/endpoints/RestApiRequestTest.java
@@ -140,7 +140,7 @@ public class RestApiRequestTest {
   @ParameterizedTest
   @ValueSource(bytes = {Byte.MIN_VALUE, -5, -1, 0, 1, 5, Byte.MAX_VALUE})
   void shouldDeserializeUInt8FromParameters(final byte value) {
-    final String stringValue = Integer.toUnsignedString(value, 10);
+    final String stringValue = Integer.toString(Byte.toUnsignedInt(value));
     when(context.pathParamMap()).thenReturn(Map.of("uint8", stringValue));
     when(context.queryParamMap()).thenReturn(Map.of("uint8", List.of(stringValue)));
     final JavalinRestApiRequest request = new JavalinRestApiRequest(context, METADATA);


### PR DESCRIPTION
## PR Description

Due to recent changes to the byte type definition, negative integer values (`"0x80000000"` - `"0xffffffff"`) are allowed.

I do not believe this should be allowed.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
