### PR TITLE
Enforce responses match metadata in StubRestApiRequest

### DIFF
--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/paths/_eth_v1_node_peers_{peer_id}.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/paths/_eth_v1_node_peers_{peer_id}.json
@@ -26,8 +26,14 @@
         }
       },
       "404" : {
-        "description" : "Peer not found",
-        "content" : { }
+        "description" : "Not found",
+        "content" : {
+          "application/json" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/HttpErrorResponse"
+            }
+          }
+        }
       },
       "400" : {
         "description" : "The request could not be processed, check the response for more information.",

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/paths/_teku_v1_beacon_pool_eth1data.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/paths/_teku_v1_beacon_pool_eth1data.json
@@ -16,8 +16,14 @@
         }
       },
       "404" : {
-        "description" : "Corresponding state not found",
-        "content" : { }
+        "description" : "Not found",
+        "content" : {
+          "application/json" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/HttpErrorResponse"
+            }
+          }
+        }
       },
       "400" : {
         "description" : "The request could not be processed, check the response for more information.",

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_teku_v1_beacon_pool_eth1data.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_teku_v1_beacon_pool_eth1data.json
@@ -16,7 +16,7 @@
         }
       },
       "404" : {
-        "description" : "Corresponding state not found"
+        "description" : "Not Found"
       },
       "500" : {
         "description" : "Server Error"

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/beacon/GetEth1Data.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/beacon/GetEth1Data.java
@@ -13,7 +13,6 @@
 
 package tech.pegasys.teku.beaconrestapi.handlers.tekuv1.beacon;
 
-import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_NOT_FOUND;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.RES_INTERNAL_ERROR;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.RES_NOT_FOUND;
@@ -43,7 +42,6 @@ import tech.pegasys.teku.validator.coordinator.Eth1DataCache;
 public class GetEth1Data extends MigratingEndpointAdapter {
 
   public static final String ROUTE = "/teku/v1/beacon/pool/eth1data";
-  public static final String NOT_FOUND_MESSAGE = "Corresponding state not found";
 
   private static final SerializableTypeDefinition<Eth1Data> ETH1DATA_RESPONSE_TYPE =
       SerializableTypeDefinition.<Eth1Data>object()
@@ -63,7 +61,7 @@ public class GetEth1Data extends MigratingEndpointAdapter {
                 "Eth1Data that would be used in a new block created based on the current head.")
             .tags(TAG_TEKU)
             .response(SC_OK, "Request successful", ETH1DATA_RESPONSE_TYPE)
-            .response(SC_NOT_FOUND, NOT_FOUND_MESSAGE)
+            .withNotFoundResponse()
             .build());
     this.chainDataProvider = dataProvider.getChainDataProvider();
     this.eth1DataCache = eth1DataCache;
@@ -79,7 +77,7 @@ public class GetEth1Data extends MigratingEndpointAdapter {
         @OpenApiResponse(
             status = RES_OK,
             content = @OpenApiContent(from = GetEth1DataResponse.class)),
-        @OpenApiResponse(status = RES_NOT_FOUND, description = NOT_FOUND_MESSAGE),
+        @OpenApiResponse(status = RES_NOT_FOUND),
         @OpenApiResponse(status = RES_INTERNAL_ERROR)
       })
   @Override
@@ -95,7 +93,7 @@ public class GetEth1Data extends MigratingEndpointAdapter {
             .thenApply(
                 maybeStateAndMetadata -> {
                   if (maybeStateAndMetadata.isEmpty()) {
-                    return AsyncApiResponse.respondWithError(SC_NOT_FOUND, NOT_FOUND_MESSAGE);
+                    return AsyncApiResponse.respondNotFound();
                   } else {
                     final BeaconState beaconState = maybeStateAndMetadata.get().getData();
                     return AsyncApiResponse.respondOk(eth1DataCache.getEth1Vote(beaconState));

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetHealth.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetHealth.java
@@ -98,7 +98,7 @@ public class GetHealth extends MigratingEndpointAdapter {
     if (!chainDataProvider.isStoreAvailable() || syncProvider.getRejectedExecutionCount() > 0) {
       request.respondWithCode(SC_SERVICE_UNAVAILABLE);
     } else if (syncProvider.isSyncing()) {
-      request.respondWithCode(getResponseCodeFromQueryParams(request));
+      request.respondWithUndocumentedCode(getResponseCodeFromQueryParams(request));
     } else {
       request.respondWithCode(SC_OK);
     }

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetPeerById.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetPeerById.java
@@ -71,7 +71,7 @@ public class GetPeerById extends MigratingEndpointAdapter {
             .pathParam(PEER_ID_PARAMETER)
             .tags(TAG_NODE)
             .response(SC_OK, "Request successful", PEERS_BY_ID_RESPONSE_TYPE)
-            .response(SC_NOT_FOUND, "Peer not found")
+            .withNotFoundResponse()
             .build());
     this.network = network;
   }

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/AbstractGetNewBlockTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/AbstractGetNewBlockTest.java
@@ -35,11 +35,9 @@ import tech.pegasys.teku.storage.client.ChainDataUnavailableException;
 public abstract class AbstractGetNewBlockTest extends AbstractMigratedBeaconHandlerTest {
   protected final BLSSignature signature = BLSTestUtil.randomSignature(1234);
 
-  protected MigratingEndpointAdapter handler;
-
   @BeforeEach
   public void setup() {
-    handler = getHandler();
+    setHandler(getHandler());
     request.setPathParameter(SLOT, "1");
     request.setQueryParameter(RANDAO_REVEAL, signature.toBytesCompressed().toHexString());
     when(validatorDataProvider.getMilestoneAtSlot(UInt64.ONE)).thenReturn(SpecMilestone.ALTAIR);

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/AbstractMigratedBeaconHandlerTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/AbstractMigratedBeaconHandlerTest.java
@@ -36,7 +36,6 @@ public abstract class AbstractMigratedBeaconHandlerTest {
   protected final Eth2P2PNetwork eth2P2PNetwork = mock(Eth2P2PNetwork.class);
   protected Spec spec = TestSpecFactory.createMinimalPhase0();
 
-  protected final StubRestApiRequest request = new StubRestApiRequest();
   protected final JsonProvider jsonProvider = new JsonProvider();
   protected final NetworkDataProvider network = new NetworkDataProvider(eth2P2PNetwork);
 
@@ -50,6 +49,15 @@ public abstract class AbstractMigratedBeaconHandlerTest {
 
   protected ChainDataProvider chainDataProvider = mock(ChainDataProvider.class);
   protected final ValidatorDataProvider validatorDataProvider = mock(ValidatorDataProvider.class);
+
+  // Getting a NullPointerException from this? Call setHandler as the first thing you do. :)
+  protected StubRestApiRequest request;
+  protected MigratingEndpointAdapter handler;
+
+  protected void setHandler(final MigratingEndpointAdapter handler) {
+    this.handler = handler;
+    this.request = new StubRestApiRequest(handler.getMetadata());
+  }
 
   protected SyncingStatus getSyncStatus(
       final boolean isSyncing,

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/AbstractPostBlockTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/AbstractPostBlockTest.java
@@ -35,7 +35,6 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.validator.api.SendSignedBlockResult;
 
 public abstract class AbstractPostBlockTest extends AbstractMigratedBeaconHandlerTest {
-  protected MigratingEndpointAdapter handler;
 
   public abstract MigratingEndpointAdapter getHandler();
 
@@ -43,7 +42,7 @@ public abstract class AbstractPostBlockTest extends AbstractMigratedBeaconHandle
 
   @BeforeEach
   public void setup() {
-    handler = getHandler();
+    setHandler(getHandler());
   }
 
   @Test

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/admin/LivenessTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/admin/LivenessTest.java
@@ -24,11 +24,9 @@ import tech.pegasys.teku.infrastructure.restapi.endpoints.CacheLength;
 
 public class LivenessTest extends AbstractMigratedBeaconHandlerTest {
 
-  private Liveness handler;
-
   @BeforeEach
   public void setup() {
-    handler = new Liveness(syncDataProvider);
+    setHandler(new Liveness(syncDataProvider));
   }
 
   @Test

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/beacon/GetEth1DataTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/beacon/GetEth1DataTest.java
@@ -49,12 +49,11 @@ public class GetEth1DataTest extends AbstractMigratedBeaconHandlerTest {
               "0xaf01b1c1315d727d01f5991ae1481614a7f78e2beeefae22f48c76a05f973b0d"));
   private final DataProvider dataProvider = mock(DataProvider.class);
   private final Eth1DataCache eth1DataCache = mock(Eth1DataCache.class);
-  private GetEth1Data handler;
 
   @BeforeEach
   void setUp() {
     when(dataProvider.getChainDataProvider()).thenReturn(chainDataProvider);
-    handler = new GetEth1Data(dataProvider, eth1DataCache);
+    setHandler(new GetEth1Data(dataProvider, eth1DataCache));
     BeaconState beaconState = dataStructureUtil.randomBeaconState();
     when(chainDataProvider.getBeaconStateAtHead())
         .thenReturn(
@@ -71,7 +70,7 @@ public class GetEth1DataTest extends AbstractMigratedBeaconHandlerTest {
     handler.handleRequest(request);
     assertThat(request.getResponseCode()).isEqualTo(SC_NOT_FOUND);
     assertThat(request.getResponseBody())
-        .isEqualTo(new HttpErrorResponse(SC_NOT_FOUND, GetEth1Data.NOT_FOUND_MESSAGE));
+        .isEqualTo(new HttpErrorResponse(SC_NOT_FOUND, "Not found"));
   }
 
   @Test

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/AbstractGetSimpleDataFromStateTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/AbstractGetSimpleDataFromStateTest.java
@@ -28,6 +28,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
 import org.apache.tuweni.bytes.Bytes32;
 import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.api.ChainDataProvider;
 import tech.pegasys.teku.api.exceptions.BadRequestException;
@@ -51,7 +52,10 @@ public class AbstractGetSimpleDataFromStateTest extends AbstractMigratedBeaconHa
               stateAndMetaData -> stateAndMetaData.getData().hashTreeRoot())
           .build();
 
-  private final TestHandler handler = new TestHandler(chainDataProvider);
+  @BeforeEach
+  void setUp() {
+    setHandler(new TestHandler(chainDataProvider));
+  }
 
   @Test
   void shouldReturnNotFound()

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetAttestationsTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetAttestationsTest.java
@@ -36,13 +36,12 @@ import tech.pegasys.teku.beaconrestapi.AbstractMigratedBeaconHandlerTest;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 
 class GetAttestationsTest extends AbstractMigratedBeaconHandlerTest {
-  private GetAttestations handler;
   private NodeDataProvider nodeDataProvider;
 
   @BeforeEach
   void setup() {
     nodeDataProvider = mock(NodeDataProvider.class);
-    handler = new GetAttestations(nodeDataProvider, spec);
+    setHandler(new GetAttestations(nodeDataProvider, spec));
   }
 
   @Test

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetAttesterSlashingsTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetAttesterSlashingsTest.java
@@ -35,13 +35,12 @@ import tech.pegasys.teku.beaconrestapi.AbstractMigratedBeaconHandlerTest;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 
 class GetAttesterSlashingsTest extends AbstractMigratedBeaconHandlerTest {
-  private GetAttesterSlashings handler;
   private NodeDataProvider nodeDataProvider;
 
   @BeforeEach
   void setup() {
     nodeDataProvider = mock(NodeDataProvider.class);
-    handler = new GetAttesterSlashings(nodeDataProvider, spec);
+    setHandler(new GetAttesterSlashings(nodeDataProvider, spec));
   }
 
   @Test

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetBlockAttestationsTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetBlockAttestationsTest.java
@@ -35,7 +35,6 @@ import tech.pegasys.teku.spec.datastructures.metadata.ObjectAndMetaData;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 
 class GetBlockAttestationsTest extends AbstractMigratedBeaconHandlerTest {
-  private final GetBlockAttestations handler = new GetBlockAttestations(chainDataProvider, spec);
   private final List<Attestation> attestations =
       List.of(dataStructureUtil.randomAttestation(), dataStructureUtil.randomAttestation());
   private final ObjectAndMetaData<List<Attestation>> responseData =
@@ -43,6 +42,7 @@ class GetBlockAttestationsTest extends AbstractMigratedBeaconHandlerTest {
 
   @BeforeEach
   void setUp() {
+    setHandler(new GetBlockAttestations(chainDataProvider, spec));
     request.setPathParameter("block_id", "head");
   }
 

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetBlockHeaderTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetBlockHeaderTest.java
@@ -36,8 +36,6 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.metadata.BlockAndMetaData;
 
 class GetBlockHeaderTest extends AbstractMigratedBeaconHandlerWithChainDataProviderTest {
-  private GetBlockHeader handler;
-
   private final BeaconBlock message = dataStructureUtil.randomBeaconBlock(1);
   private final BLSSignature signature = dataStructureUtil.randomSignature();
   private final SignedBeaconBlock signedBeaconBlock =
@@ -49,8 +47,8 @@ class GetBlockHeaderTest extends AbstractMigratedBeaconHandlerWithChainDataProvi
   void setup() {
     initialise(SpecMilestone.PHASE0);
     genesis();
+    setHandler(new GetBlockHeader(chainDataProvider));
     request.setPathParameter("block_id", "head");
-    handler = new GetBlockHeader(chainDataProvider);
   }
 
   @Test

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetBlockHeadersTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetBlockHeadersTest.java
@@ -35,13 +35,12 @@ import tech.pegasys.teku.beaconrestapi.AbstractMigratedBeaconHandlerWithChainDat
 import tech.pegasys.teku.spec.SpecMilestone;
 
 class GetBlockHeadersTest extends AbstractMigratedBeaconHandlerWithChainDataProviderTest {
-  private GetBlockHeaders handler;
 
   @BeforeEach
   void setup() {
     initialise(SpecMilestone.PHASE0);
     genesis();
-    handler = new GetBlockHeaders(chainDataProvider);
+    setHandler(new GetBlockHeaders(chainDataProvider));
   }
 
   @Test

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetBlockRootTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetBlockRootTest.java
@@ -34,14 +34,13 @@ import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.metadata.ObjectAndMetaData;
 
 class GetBlockRootTest extends AbstractMigratedBeaconHandlerWithChainDataProviderTest {
-  private GetBlockRoot handler;
 
   @BeforeEach
   void setup() {
     initialise(SpecMilestone.PHASE0);
     genesis();
 
-    handler = new GetBlockRoot(chainDataProvider);
+    setHandler(new GetBlockRoot(chainDataProvider));
     request.setPathParameter("block_id", "head");
   }
 

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetBlockTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetBlockTest.java
@@ -36,14 +36,13 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.metadata.ObjectAndMetaData;
 
 class GetBlockTest extends AbstractMigratedBeaconHandlerWithChainDataProviderTest {
-  private GetBlock handler;
 
   @BeforeEach
   void setup() {
     initialise(SpecMilestone.PHASE0);
     genesis();
+    setHandler(new GetBlock(chainDataProvider, schemaDefinitionCache));
     request.setPathParameter("block_id", "head");
-    handler = new GetBlock(chainDataProvider, schemaDefinitionCache);
   }
 
   @Test

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetGenesisTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetGenesisTest.java
@@ -24,6 +24,7 @@ import static tech.pegasys.teku.infrastructure.restapi.MetadataTestUtil.verifyMe
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.beaconrestapi.AbstractMigratedBeaconHandlerWithChainDataProviderTest;
 import tech.pegasys.teku.infrastructure.bytes.Bytes4;
@@ -32,12 +33,16 @@ import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.genesis.GenesisData;
 
 public class GetGenesisTest extends AbstractMigratedBeaconHandlerWithChainDataProviderTest {
-  final GetGenesis handler = new GetGenesis(chainDataProvider);
   final UInt64 genesisTime = dataStructureUtil.randomUInt64();
   final Bytes32 genesisValidatorsRoot = dataStructureUtil.randomBytes32();
   final Bytes4 fork = dataStructureUtil.randomBytes4();
   final GetGenesis.ResponseData responseData =
       new GetGenesis.ResponseData(new GenesisData(genesisTime, genesisValidatorsRoot), fork);
+
+  @BeforeEach
+  void setUp() {
+    setHandler(new GetGenesis(chainDataProvider));
+  }
 
   @Test
   public void shouldReturnUnavailableWhenStoreNotAvailable() throws Exception {

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetProposerSlashingsTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetProposerSlashingsTest.java
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.io.Resources;
 import java.io.IOException;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.api.NodeDataProvider;
 import tech.pegasys.teku.beaconrestapi.AbstractMigratedBeaconHandlerTest;
@@ -34,10 +35,14 @@ import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 
 class GetProposerSlashingsTest extends AbstractMigratedBeaconHandlerTest {
   private final NodeDataProvider nodeDataProvider = mock(NodeDataProvider.class);
-  private final GetProposerSlashings handler = new GetProposerSlashings(nodeDataProvider);
   private final List<ProposerSlashing> responseData =
       List.of(
           dataStructureUtil.randomProposerSlashing(), dataStructureUtil.randomProposerSlashing());
+
+  @BeforeEach
+  void setUp() {
+    setHandler(new GetProposerSlashings(nodeDataProvider));
+  }
 
   @Test
   void shouldReturnProposerSlashingsInformation() throws JsonProcessingException {

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateCommitteesTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateCommitteesTest.java
@@ -42,20 +42,20 @@ import tech.pegasys.teku.spec.datastructures.metadata.ObjectAndMetaData;
 import tech.pegasys.teku.spec.datastructures.state.CommitteeAssignment;
 
 public class GetStateCommitteesTest extends AbstractMigratedBeaconHandlerWithChainDataProviderTest {
-  private GetStateCommittees handler;
 
   @BeforeEach
   void setup() {
     initialise(SpecMilestone.ALTAIR);
     genesis();
 
-    handler = new GetStateCommittees(chainDataProvider);
+    setHandler(new GetStateCommittees(chainDataProvider));
   }
 
   @Test
   public void shouldGetCommitteesFromState() throws Exception {
     final StubRestApiRequest request =
         StubRestApiRequest.builder()
+            .metadata(handler.getMetadata())
             .pathParameter("state_id", "head")
             .optionalQueryParameter("epoch", "0")
             .optionalQueryParameter("index", "0")
@@ -83,6 +83,7 @@ public class GetStateCommitteesTest extends AbstractMigratedBeaconHandlerWithCha
   public void shouldFailIfEpochInvalid(String queryParam) {
     final StubRestApiRequest request =
         StubRestApiRequest.builder()
+            .metadata(handler.getMetadata())
             .pathParameter("state_id", "head")
             .optionalQueryParameter(queryParam, "a")
             .build();

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateFinalityCheckpointsTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateFinalityCheckpointsTest.java
@@ -36,7 +36,6 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 public class GetStateFinalityCheckpointsTest
     extends AbstractMigratedBeaconHandlerWithChainDataProviderTest {
 
-  private GetStateFinalityCheckpoints handler;
   private StateAndMetaData responseData;
 
   @BeforeEach
@@ -51,13 +50,16 @@ public class GetStateFinalityCheckpointsTest
     responseData =
         new StateAndMetaData(beaconState, spec.getGenesisSpec().getMilestone(), false, true);
 
-    handler = new GetStateFinalityCheckpoints(chainDataProvider);
+    setHandler(new GetStateFinalityCheckpoints(chainDataProvider));
   }
 
   @Test
   public void shouldReturnFinalityCheckpointsInfo() throws JsonProcessingException {
     final StubRestApiRequest request =
-        StubRestApiRequest.builder().pathParameter("state_id", "head").build();
+        StubRestApiRequest.builder()
+            .metadata(handler.getMetadata())
+            .pathParameter("state_id", "head")
+            .build();
 
     handler.handleRequest(request);
 

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateForkTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateForkTest.java
@@ -34,15 +34,14 @@ import tech.pegasys.teku.spec.datastructures.metadata.StateAndMetaData;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 
 public class GetStateForkTest extends AbstractMigratedBeaconHandlerWithChainDataProviderTest {
-  private GetStateFork handler;
   private StateAndMetaData responseData;
 
   @BeforeEach
   void setup() throws ExecutionException, InterruptedException {
-    request.setPathParameter("state_id", "head");
     initialise(SpecMilestone.PHASE0);
     genesis();
-    handler = new GetStateFork(chainDataProvider);
+    setHandler(new GetStateFork(chainDataProvider));
+    request.setPathParameter("state_id", "head");
 
     final BeaconState beaconState = recentChainData.getBestState().orElseThrow().get();
     responseData =
@@ -62,6 +61,7 @@ public class GetStateForkTest extends AbstractMigratedBeaconHandlerWithChainData
   public void shouldReturnNotFound() throws Exception {
     final StubRestApiRequest request =
         StubRestApiRequest.builder()
+            .metadata(handler.getMetadata())
             .pathParameter("state_id", dataStructureUtil.randomBytes32().toHexString())
             .build();
 

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateRootTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateRootTest.java
@@ -30,14 +30,13 @@ import tech.pegasys.teku.spec.datastructures.metadata.StateAndMetaData;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 
 public class GetStateRootTest extends AbstractMigratedBeaconHandlerWithChainDataProviderTest {
-  private GetStateRoot handler;
 
   @BeforeEach
   public void setup() {
-    request.setPathParameter("state_id", "head");
     initialise(SpecMilestone.PHASE0);
     genesis();
-    handler = new GetStateRoot(chainDataProvider);
+    setHandler(new GetStateRoot(chainDataProvider));
+    request.setPathParameter("state_id", "head");
   }
 
   @Test

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateSyncCommitteesTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateSyncCommitteesTest.java
@@ -35,14 +35,13 @@ import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.metadata.ObjectAndMetaData;
 
 class GetStateSyncCommitteesTest extends AbstractMigratedBeaconHandlerWithChainDataProviderTest {
-  private GetStateSyncCommittees handler;
 
   @BeforeEach
   void setup() {
     initialise(SpecMilestone.ALTAIR);
     genesis();
 
-    handler = new GetStateSyncCommittees(chainDataProvider);
+    setHandler(new GetStateSyncCommittees(chainDataProvider));
   }
 
   @Test
@@ -50,6 +49,7 @@ class GetStateSyncCommitteesTest extends AbstractMigratedBeaconHandlerWithChainD
       throws JsonProcessingException, ExecutionException, InterruptedException {
     final StubRestApiRequest request =
         StubRestApiRequest.builder()
+            .metadata(handler.getMetadata())
             .pathParameter("state_id", "head")
             .optionalQueryParameter("epoch", "1")
             .build();

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateValidatorBalancesTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateValidatorBalancesTest.java
@@ -39,20 +39,20 @@ import tech.pegasys.teku.spec.datastructures.metadata.ObjectAndMetaData;
 
 public class GetStateValidatorBalancesTest
     extends AbstractMigratedBeaconHandlerWithChainDataProviderTest {
-  private GetStateValidatorBalances handler;
 
   @BeforeEach
   void setup() {
     initialise(SpecMilestone.ALTAIR);
     genesis();
 
-    handler = new GetStateValidatorBalances(chainDataProvider);
+    setHandler(new GetStateValidatorBalances(chainDataProvider));
   }
 
   @Test
   public void shouldGetSpecifiedValidatorBalancesFromState() throws Exception {
     StubRestApiRequest request =
         StubRestApiRequest.builder()
+            .metadata(handler.getMetadata())
             .pathParameter("state_id", "head")
             .listQueryParameter("id", List.of("1", "2"))
             .build();
@@ -69,7 +69,10 @@ public class GetStateValidatorBalancesTest
   @Test
   public void shouldGetAllValidatorBalancesFromState() throws Exception {
     StubRestApiRequest request =
-        StubRestApiRequest.builder().pathParameter("state_id", "head").build();
+        StubRestApiRequest.builder()
+            .metadata(handler.getMetadata())
+            .pathParameter("state_id", "head")
+            .build();
 
     final Optional<ObjectAndMetaData<List<StateValidatorBalanceData>>> stateValidatorBalancesData =
         chainDataProvider.getStateValidatorBalances("head", List.of()).get();

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateValidatorTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateValidatorTest.java
@@ -44,16 +44,15 @@ import tech.pegasys.teku.spec.datastructures.state.Validator;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 
 public class GetStateValidatorTest extends AbstractMigratedBeaconHandlerWithChainDataProviderTest {
-  private GetStateValidator handler;
   private ObjectAndMetaData<StateValidatorData> responseData;
 
   @BeforeEach
   void setup() throws ExecutionException, InterruptedException {
-    request.setPathParameter("state_id", "head");
-    request.setPathParameter("validator_id", "1");
     initialise(SpecMilestone.ALTAIR);
     genesis();
-    handler = new GetStateValidator(chainDataProvider);
+    setHandler(new GetStateValidator(chainDataProvider));
+    request.setPathParameter("state_id", "head");
+    request.setPathParameter("validator_id", "1");
 
     final Optional<StateAndMetaData> stateAndMetaData =
         chainDataProvider.getBeaconStateAndMetadata("head").get();
@@ -81,6 +80,7 @@ public class GetStateValidatorTest extends AbstractMigratedBeaconHandlerWithChai
   public void shouldGetNotFoundForMissingState() throws Exception {
     final StubRestApiRequest request =
         StubRestApiRequest.builder()
+            .metadata(handler.getMetadata())
             .pathParameter("state_id", dataStructureUtil.randomBytes32().toHexString())
             .pathParameter("validator_id", "1")
             .build();

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateValidatorsTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateValidatorsTest.java
@@ -46,20 +46,20 @@ import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.metadata.ObjectAndMetaData;
 
 public class GetStateValidatorsTest extends AbstractMigratedBeaconHandlerWithChainDataProviderTest {
-  private GetStateValidators handler;
 
   @BeforeEach
   void setup() {
     initialise(SpecMilestone.ALTAIR);
     genesis();
 
-    handler = new GetStateValidators(chainDataProvider);
+    setHandler(new GetStateValidators(chainDataProvider));
   }
 
   @Test
   public void shouldGetValidatorFromState() throws Exception {
     final StubRestApiRequest request =
         StubRestApiRequest.builder()
+            .metadata(handler.getMetadata())
             .pathParameter("state_id", "head")
             .listQueryParameter("id", List.of("1", "2", "3,4"))
             .build();
@@ -80,6 +80,7 @@ public class GetStateValidatorsTest extends AbstractMigratedBeaconHandlerWithCha
   public void shouldGetValidatorFromStateWithList() throws Exception {
     final StubRestApiRequest request =
         StubRestApiRequest.builder()
+            .metadata(handler.getMetadata())
             .pathParameter("state_id", "head")
             .listQueryParameter("id", List.of("1", "2"))
             .listQueryParameter(
@@ -103,6 +104,7 @@ public class GetStateValidatorsTest extends AbstractMigratedBeaconHandlerWithCha
   public void shouldGetBadRequestForInvalidState() {
     final StubRestApiRequest request =
         StubRestApiRequest.builder()
+            .metadata(handler.getMetadata())
             .pathParameter("state_id", "invalid")
             .listQueryParameter("id", List.of("1"))
             .build();

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetVoluntaryExitsTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetVoluntaryExitsTest.java
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.io.Resources;
 import java.io.IOException;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.api.NodeDataProvider;
 import tech.pegasys.teku.beaconrestapi.AbstractMigratedBeaconHandlerTest;
@@ -34,12 +35,16 @@ import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
 
 class GetVoluntaryExitsTest extends AbstractMigratedBeaconHandlerTest {
   private final NodeDataProvider nodeDataProvider = mock(NodeDataProvider.class);
-  private final GetVoluntaryExits handler = new GetVoluntaryExits(nodeDataProvider);
 
   List<SignedVoluntaryExit> responseData =
       List.of(
           dataStructureUtil.randomSignedVoluntaryExit(),
           dataStructureUtil.randomSignedVoluntaryExit());
+
+  @BeforeEach
+  void setUp() {
+    setHandler(new GetVoluntaryExits(nodeDataProvider));
+  }
 
   @Test
   public void shouldReturnVoluntaryExitsInformation() throws JsonProcessingException {

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostAttestationTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostAttestationTest.java
@@ -29,6 +29,7 @@ import com.google.common.io.Resources;
 import java.io.IOException;
 import java.util.List;
 import org.assertj.core.api.AssertionsForClassTypes;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.beaconrestapi.AbstractMigratedBeaconHandlerTest;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -37,8 +38,11 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.validator.api.SubmitDataError;
 
 public class PostAttestationTest extends AbstractMigratedBeaconHandlerTest {
-  private final PostAttestation handler =
-      new PostAttestation(validatorDataProvider, schemaDefinitionCache);
+
+  @BeforeEach
+  void setUp() {
+    setHandler(new PostAttestation(validatorDataProvider, schemaDefinitionCache));
+  }
 
   @Test
   void shouldBeAbleToSubmitAttestation() throws Exception {

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostRegisterValidatorTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostRegisterValidatorTest.java
@@ -30,11 +30,10 @@ import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.spec.datastructures.execution.SignedValidatorRegistration;
 
 public class PostRegisterValidatorTest extends AbstractMigratedBeaconHandlerTest {
-  private PostRegisterValidator handler;
 
   @BeforeEach
   void setup() {
-    handler = new PostRegisterValidator(validatorDataProvider);
+    setHandler(new PostRegisterValidator(validatorDataProvider));
   }
 
   @Test

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/config/GetDepositContractTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/config/GetDepositContractTest.java
@@ -21,23 +21,25 @@ import static tech.pegasys.teku.infrastructure.restapi.MetadataTestUtil.getRespo
 import static tech.pegasys.teku.infrastructure.restapi.MetadataTestUtil.verifyMetadataErrorResponse;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.api.ConfigProvider;
 import tech.pegasys.teku.beaconrestapi.AbstractMigratedBeaconHandlerTest;
-import tech.pegasys.teku.infrastructure.restapi.StubRestApiRequest;
 import tech.pegasys.teku.spec.datastructures.eth1.Eth1Address;
 
 class GetDepositContractTest extends AbstractMigratedBeaconHandlerTest {
   final Eth1Address eth1Address = dataStructureUtil.randomEth1Address();
   final int chainId = spec.getGenesisSpecConfig().getDepositChainId();
-  private final GetDepositContract handler =
-      new GetDepositContract(eth1Address, new ConfigProvider(spec));
   private final GetDepositContract.DepositContractData contractData =
       new GetDepositContract.DepositContractData(chainId, eth1Address);
 
+  @BeforeEach
+  void setUp() {
+    setHandler(new GetDepositContract(eth1Address, new ConfigProvider(spec)));
+  }
+
   @Test
   void shouldGetSuccessfulResponse() throws JsonProcessingException {
-    final StubRestApiRequest request = new StubRestApiRequest();
     handler.handleRequest(request);
     assertThat(request.getResponseCode()).isEqualTo(SC_OK);
     assertThat(request.getResponseBody()).isEqualTo(contractData);

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/config/GetForkScheduleTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/config/GetForkScheduleTest.java
@@ -22,19 +22,22 @@ import static tech.pegasys.teku.infrastructure.restapi.MetadataTestUtil.verifyMe
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.api.ConfigProvider;
 import tech.pegasys.teku.beaconrestapi.AbstractMigratedBeaconHandlerTest;
-import tech.pegasys.teku.infrastructure.restapi.StubRestApiRequest;
 import tech.pegasys.teku.spec.datastructures.state.Fork;
 
 class GetForkScheduleTest extends AbstractMigratedBeaconHandlerTest {
-  private final GetForkSchedule handler = new GetForkSchedule(new ConfigProvider(spec));
   private final List<Fork> forks = spec.getForkSchedule().getForks();
+
+  @BeforeEach
+  void setUp() {
+    setHandler(new GetForkSchedule(new ConfigProvider(spec)));
+  }
 
   @Test
   void shouldGetSuccessfulResponse() throws JsonProcessingException {
-    final StubRestApiRequest request = new StubRestApiRequest();
     handler.handleRequest(request);
     assertThat(request.getResponseCode()).isEqualTo(SC_OK);
     assertThat(request.getResponseBody()).isEqualTo(forks);

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/config/GetSpecTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/config/GetSpecTest.java
@@ -20,21 +20,24 @@ import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
 import static tech.pegasys.teku.infrastructure.restapi.MetadataTestUtil.verifyMetadataErrorResponse;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.api.ConfigProvider;
 import tech.pegasys.teku.api.GetSpecResponse;
 import tech.pegasys.teku.beaconrestapi.AbstractMigratedBeaconHandlerTest;
-import tech.pegasys.teku.infrastructure.restapi.StubRestApiRequest;
 
 class GetSpecTest extends AbstractMigratedBeaconHandlerTest {
   private final ConfigProvider configProvider = new ConfigProvider(spec);
-  private final GetSpec handler = new GetSpec(configProvider);
   private final GetSpecResponse response =
       new GetSpecResponse(configProvider.getGenesisSpecConfig());
 
+  @BeforeEach
+  void setUp() {
+    setHandler(new GetSpec(configProvider));
+  }
+
   @Test
   void shouldGetSuccessfulResponse() throws JsonProcessingException {
-    final StubRestApiRequest request = new StubRestApiRequest();
     handler.handleRequest(request);
     assertThat(request.getResponseCode()).isEqualTo(SC_OK);
     assertThat(request.getResponseBody()).isEqualTo(response.getConfigMap());

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/debug/GetChainHeadsV1Test.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/debug/GetChainHeadsV1Test.java
@@ -26,19 +26,17 @@ import org.assertj.core.api.AssertionsForClassTypes;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.beaconrestapi.AbstractMigratedBeaconHandlerWithChainDataProviderTest;
-import tech.pegasys.teku.infrastructure.restapi.StubRestApiRequest;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ProtoNodeData;
 
 class GetChainHeadsV1Test extends AbstractMigratedBeaconHandlerWithChainDataProviderTest {
-  private GetChainHeadsV1 handler;
   private List<ProtoNodeData> protoNodeDataList;
 
   @BeforeEach
   void setup() {
     initialise(SpecMilestone.ALTAIR);
     genesis();
-    handler = new GetChainHeadsV1(chainDataProvider);
+    setHandler(new GetChainHeadsV1(chainDataProvider));
     protoNodeDataList = chainDataProvider.getChainHeads();
   }
 
@@ -64,7 +62,6 @@ class GetChainHeadsV1Test extends AbstractMigratedBeaconHandlerWithChainDataProv
 
   @Test
   void shouldGetSuccessfulResponse() throws JsonProcessingException {
-    final StubRestApiRequest request = new StubRestApiRequest();
     handler.handleRequest(request);
     assertThat(request.getResponseCode()).isEqualTo(SC_OK);
     assertThat(request.getResponseBody()).isEqualTo(protoNodeDataList);

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/debug/GetStateTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/debug/GetStateTest.java
@@ -34,15 +34,14 @@ import tech.pegasys.teku.spec.datastructures.metadata.StateAndMetaData;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 
 class GetStateTest extends AbstractMigratedBeaconHandlerWithChainDataProviderTest {
-  private GetState handler;
 
   @BeforeEach
   void setup() {
     initialise(SpecMilestone.PHASE0);
     genesis();
 
+    setHandler(new GetState(chainDataProvider, spec, schemaDefinitionCache));
     request.setPathParameter("state_id", "head");
-    handler = new GetState(chainDataProvider, spec, schemaDefinitionCache);
   }
 
   @Test

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetHealthTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetHealthTest.java
@@ -26,12 +26,17 @@ import static tech.pegasys.teku.infrastructure.restapi.MetadataTestUtil.verifyMe
 import static tech.pegasys.teku.infrastructure.restapi.MetadataTestUtil.verifyMetadataErrorResponse;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.beacon.sync.events.SyncState;
 import tech.pegasys.teku.beaconrestapi.AbstractMigratedBeaconHandlerTest;
 
 public class GetHealthTest extends AbstractMigratedBeaconHandlerTest {
-  private final GetHealth handler = new GetHealth(syncDataProvider, chainDataProvider);
+
+  @BeforeEach
+  void setUp() {
+    setHandler(new GetHealth(syncDataProvider, chainDataProvider));
+  }
 
   @Test
   public void shouldReturnSyncingStatusWhenSyncing() throws Exception {

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetIdentityTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetIdentityTest.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.beaconrestapi.AbstractMigratedBeaconHandlerTest;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.node.GetIdentity.IdentityData;
@@ -34,12 +35,16 @@ import tech.pegasys.teku.networking.p2p.peer.NodeId;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.metadata.MetadataMessage;
 
 public class GetIdentityTest extends AbstractMigratedBeaconHandlerTest {
-  private final GetIdentity handler = new GetIdentity(network);
   private final MetadataMessage defaultMetadata =
       spec.getGenesisSchemaDefinitions().getMetadataMessageSchema().createDefault();
   private final IdentityData identityData =
       new IdentityData(
           "aeiou", Optional.empty(), List.of("address"), Collections.emptyList(), defaultMetadata);
+
+  @BeforeEach
+  void setUp() {
+    setHandler(new GetIdentity(network));
+  }
 
   @Test
   public void shouldReturnExpectedObjectType() throws Exception {

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetPeerByIdTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetPeerByIdTest.java
@@ -37,10 +37,10 @@ import tech.pegasys.teku.networking.p2p.network.PeerAddress;
 public class GetPeerByIdTest extends AbstractMigratedBeaconHandlerTest {
   private final MockNodeId peerId = new MockNodeId(123456);
   private final Eth2Peer peer = mock(Eth2Peer.class);
-  private final GetPeerById handler = new GetPeerById(network);
 
   @BeforeEach
   void setUp() {
+    setHandler(new GetPeerById(network));
     request.setPathParameter("peer_id", peerId.toBase58());
     when(peer.getId()).thenReturn(peerId);
     when(peer.getAddress()).thenReturn(new PeerAddress(peerId));

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetPeerCountTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetPeerCountTest.java
@@ -24,6 +24,7 @@ import static tech.pegasys.teku.infrastructure.restapi.MetadataTestUtil.verifyMe
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.api.NetworkDataProvider;
 import tech.pegasys.teku.beaconrestapi.AbstractMigratedBeaconHandlerTest;
@@ -33,9 +34,13 @@ class GetPeerCountTest extends AbstractMigratedBeaconHandlerTest {
   private final Eth2Peer peer1 = mock(Eth2Peer.class);
   private final Eth2Peer peer2 = mock(Eth2Peer.class);
   private final NetworkDataProvider networkDataProvider = mock(NetworkDataProvider.class);
-  private final GetPeerCount handler = new GetPeerCount(networkDataProvider);
   private final List<Eth2Peer> data = List.of(peer1, peer2);
   private final GetPeerCount.ResponseData peerCountData = new GetPeerCount.ResponseData(data);
+
+  @BeforeEach
+  void setUp() {
+    setHandler(new GetPeerCount(networkDataProvider));
+  }
 
   @Test
   public void shouldReturnListOfPeers() throws Exception {

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetPeersTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetPeersTest.java
@@ -42,12 +42,12 @@ public class GetPeersTest extends AbstractMigratedBeaconHandlerTest {
   private final Eth2Peer peer2 = mock(Eth2Peer.class);
 
   private final NetworkDataProvider networkDataProvider = mock(NetworkDataProvider.class);
-  private final GetPeers handler = new GetPeers(networkDataProvider);
   private final List<Eth2Peer> data = List.of(peer1, peer2);
   private final GetPeers.PeersData peersData = new PeersData(data);
 
   @BeforeEach
   void setup() {
+    setHandler(new GetPeers(networkDataProvider));
     when(peer1.getId()).thenReturn(peerId1);
     when(peer1.getAddress()).thenReturn(new PeerAddress(peerId1));
     when(peer1.isConnected()).thenReturn(true);

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetSyncingTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetSyncingTest.java
@@ -22,12 +22,17 @@ import static tech.pegasys.teku.infrastructure.restapi.MetadataTestUtil.getRespo
 import static tech.pegasys.teku.infrastructure.restapi.MetadataTestUtil.verifyMetadataErrorResponse;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.beacon.sync.events.SyncState;
 import tech.pegasys.teku.beaconrestapi.AbstractMigratedBeaconHandlerTest;
 
 public class GetSyncingTest extends AbstractMigratedBeaconHandlerTest {
-  private final GetSyncing handler = new GetSyncing(syncDataProvider);
+
+  @BeforeEach
+  void setUp() {
+    setHandler(new GetSyncing(syncDataProvider));
+  }
 
   @Test
   public void shouldGetSyncingStatusSyncing() throws Exception {

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetVersionTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetVersionTest.java
@@ -21,12 +21,17 @@ import static tech.pegasys.teku.infrastructure.restapi.MetadataTestUtil.getRespo
 import static tech.pegasys.teku.infrastructure.restapi.MetadataTestUtil.verifyMetadataErrorResponse;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.beaconrestapi.AbstractMigratedBeaconHandlerTest;
 import tech.pegasys.teku.infrastructure.version.VersionProvider;
 
 public class GetVersionTest extends AbstractMigratedBeaconHandlerTest {
-  private final GetVersion handler = new GetVersion();
+
+  @BeforeEach
+  void setUp() {
+    setHandler(new GetVersion());
+  }
 
   @Test
   public void shouldReturnVersionString() throws Exception {

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetAggregateAttestationTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetAggregateAttestationTest.java
@@ -29,6 +29,7 @@ import com.google.common.io.Resources;
 import java.io.IOException;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.beaconrestapi.AbstractMigratedBeaconHandlerTest;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -36,7 +37,11 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 
 class GetAggregateAttestationTest extends AbstractMigratedBeaconHandlerTest {
-  final GetAggregateAttestation handler = new GetAggregateAttestation(validatorDataProvider, spec);
+
+  @BeforeEach
+  void setUp() {
+    setHandler(new GetAggregateAttestation(validatorDataProvider, spec));
+  }
 
   @Test
   public void shouldReturnAttestationInformation() throws JsonProcessingException {

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetAttestationDataTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetAttestationDataTest.java
@@ -29,6 +29,7 @@ import com.google.common.io.Resources;
 import java.io.IOException;
 import java.util.Optional;
 import org.assertj.core.api.AssertionsForClassTypes;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.beaconrestapi.AbstractMigratedBeaconHandlerTest;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -37,8 +38,12 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 
 class GetAttestationDataTest extends AbstractMigratedBeaconHandlerTest {
-  private final GetAttestationData handler = new GetAttestationData(validatorDataProvider);
   private final AttestationData attestationData = dataStructureUtil.randomAttestationData();
+
+  @BeforeEach
+  void setUp() {
+    setHandler(new GetAttestationData(validatorDataProvider));
+  }
 
   @Test
   void shouldReturnAttestationDataInformation() throws Exception {

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetNewBlockTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetNewBlockTest.java
@@ -32,6 +32,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.io.Resources;
 import java.io.IOException;
 import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.beaconrestapi.AbstractMigratedBeaconHandlerTest;
 import tech.pegasys.teku.bls.BLSSignature;
@@ -39,7 +40,11 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 
 public class GetNewBlockTest extends AbstractMigratedBeaconHandlerTest {
-  private final GetNewBlock handler = new GetNewBlock(validatorDataProvider, schemaDefinitionCache);
+
+  @BeforeEach
+  void setUp() {
+    setHandler(new GetNewBlock(validatorDataProvider, schemaDefinitionCache));
+  }
 
   @Test
   public void shouldReturnAttestationInformation() throws JsonProcessingException {

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetProposerDutiesTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetProposerDutiesTest.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import org.assertj.core.api.AssertionsForClassTypes;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.beacon.sync.events.SyncState;
 import tech.pegasys.teku.beaconrestapi.AbstractMigratedBeaconHandlerTest;
@@ -41,12 +42,15 @@ import tech.pegasys.teku.validator.api.ProposerDuties;
 import tech.pegasys.teku.validator.api.ProposerDuty;
 
 public class GetProposerDutiesTest extends AbstractMigratedBeaconHandlerTest {
-  private final GetProposerDuties handler =
-      new GetProposerDuties(syncDataProvider, validatorDataProvider);
   private final ProposerDuties duties =
       new ProposerDuties(
           Bytes32.fromHexString("0x1234"),
           List.of(getProposerDuty(2, spec.computeStartSlotAtEpoch(UInt64.valueOf(100)))));
+
+  @BeforeEach
+  void setUp() {
+    setHandler(new GetProposerDuties(syncDataProvider, validatorDataProvider));
+  }
 
   @Test
   public void shouldGetProposerDuties() throws Exception {

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetSyncCommitteeContributionTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetSyncCommitteeContributionTest.java
@@ -31,6 +31,7 @@ import com.google.common.io.Resources;
 import java.io.IOException;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.beaconrestapi.AbstractMigratedBeaconHandlerTest;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -47,8 +48,10 @@ class GetSyncCommitteeContributionTest extends AbstractMigratedBeaconHandlerTest
   @SuppressWarnings("HidingField")
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
 
-  private final GetSyncCommitteeContribution handler =
-      new GetSyncCommitteeContribution(validatorDataProvider, schemaDefinitionCache);
+  @BeforeEach
+  void setUp() {
+    setHandler(new GetSyncCommitteeContribution(validatorDataProvider, schemaDefinitionCache));
+  }
 
   @Test
   void shouldReturnSyncCommitteeContributionInformation() throws Exception {

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v2/beacon/GetBlockTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v2/beacon/GetBlockTest.java
@@ -34,14 +34,13 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.metadata.ObjectAndMetaData;
 
 class GetBlockTest extends AbstractMigratedBeaconHandlerWithChainDataProviderTest {
-  private GetBlock handler;
 
   @BeforeEach
   void setup() {
     initialise(SpecMilestone.ALTAIR);
     genesis();
 
-    handler = new GetBlock(chainDataProvider, schemaDefinitionCache);
+    setHandler(new GetBlock(chainDataProvider, schemaDefinitionCache));
     request.setPathParameter("block_id", "head");
   }
 

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v2/debug/GetChainHeadsV2Test.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v2/debug/GetChainHeadsV2Test.java
@@ -26,19 +26,17 @@ import org.assertj.core.api.AssertionsForClassTypes;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.beaconrestapi.AbstractMigratedBeaconHandlerWithChainDataProviderTest;
-import tech.pegasys.teku.infrastructure.restapi.StubRestApiRequest;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ProtoNodeData;
 
 class GetChainHeadsV2Test extends AbstractMigratedBeaconHandlerWithChainDataProviderTest {
-  private GetChainHeadsV2 handler;
   private List<ProtoNodeData> protoNodeDataList;
 
   @BeforeEach
   void setup() {
     initialise(SpecMilestone.ALTAIR);
     genesis();
-    handler = new GetChainHeadsV2(chainDataProvider);
+    setHandler(new GetChainHeadsV2(chainDataProvider));
     protoNodeDataList = chainDataProvider.getChainHeads();
   }
 
@@ -64,7 +62,6 @@ class GetChainHeadsV2Test extends AbstractMigratedBeaconHandlerWithChainDataProv
 
   @Test
   void shouldGetSuccessfulResponse() throws JsonProcessingException {
-    final StubRestApiRequest request = new StubRestApiRequest();
     handler.handleRequest(request);
     assertThat(request.getResponseCode()).isEqualTo(SC_OK);
     assertThat(request.getResponseBody()).isEqualTo(protoNodeDataList);

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v2/debug/GetStateTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v2/debug/GetStateTest.java
@@ -34,15 +34,14 @@ import tech.pegasys.teku.spec.datastructures.metadata.StateAndMetaData;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 
 class GetStateTest extends AbstractMigratedBeaconHandlerWithChainDataProviderTest {
-  private GetState handler;
 
   @BeforeEach
   void setup() {
     initialise(SpecMilestone.ALTAIR);
     genesis();
 
+    setHandler(new GetState(chainDataProvider, schemaDefinitionCache));
     request.setPathParameter("state_id", "head");
-    handler = new GetState(chainDataProvider, schemaDefinitionCache);
   }
 
   @Test

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/EndpointMetadata.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/EndpointMetadata.java
@@ -208,6 +208,11 @@ public class EndpointMetadata {
     return responseType;
   }
 
+  public boolean isNoContentResponse(final int statusCode) {
+    final OpenApiResponse response = responses.get(Integer.toString(statusCode));
+    return response != null && response.getSupportedContentTypes().isEmpty();
+  }
+
   @SuppressWarnings("unchecked")
   public <T> ResponseMetadata createResponseMetadata(
       final int statusCode, final Optional<String> acceptHeader, final T response) {
@@ -232,7 +237,10 @@ public class EndpointMetadata {
     final String selectedType =
         ContentTypes.getResponseContentType(supportedTypes, acceptHeader)
             .orElse(defaultResponseContentType);
-    checkState(supportedTypes.contains(selectedType), "Default content type is not supported.");
+    checkState(
+        supportedTypes.contains(selectedType),
+        "Response content type %s was selected but is not supported.",
+        selectedType);
     return selectedType;
   }
 

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/JavalinRestApiRequest.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/JavalinRestApiRequest.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.infrastructure.restapi.endpoints;
 
+import static com.google.common.base.Preconditions.checkState;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_INTERNAL_SERVER_ERROR;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.HEADER_ACCEPT;
@@ -129,6 +130,15 @@ public class JavalinRestApiRequest implements RestApiRequest {
   /** This is only used when intending to return status code without a response body */
   @Override
   public void respondWithCode(final int statusCode) {
+    checkState(
+        metadata.isNoContentResponse(statusCode),
+        "Content required for status code %s but not provided",
+        statusCode);
+    respondWithUndocumentedCode(statusCode);
+  }
+  /** This is only used when intending to return status code without a response body */
+  @Override
+  public void respondWithUndocumentedCode(final int statusCode) {
     context.status(statusCode);
   }
 

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/RestApiRequest.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/RestApiRequest.java
@@ -32,6 +32,12 @@ public interface RestApiRequest {
 
   void respondWithCode(int statusCode);
 
+  /**
+   * Respond with a status code that may not be declared in the endpoint metadata. This is very
+   * rarely the right option and only applies in cases where the user supplies the response code.
+   */
+  void respondWithUndocumentedCode(int statusCode);
+
   void respondWithCode(int statusCode, CacheLength cacheLength);
 
   <T> T getPathParameter(ParameterMetadata<T> parameterMetadata);

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/apis/DeleteFeeRecipient.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/apis/DeleteFeeRecipient.java
@@ -61,7 +61,6 @@ public class DeleteFeeRecipient extends RestApiEndpoint {
       request.respondError(SC_FORBIDDEN, "Fee recipient for public key could not be removed.");
       return;
     }
-    ;
     request.respondWithCode(SC_NO_CONTENT);
   }
 }

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/restapi/apis/DeleteFeeRecipientTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/restapi/apis/DeleteFeeRecipientTest.java
@@ -43,6 +43,7 @@ class DeleteFeeRecipientTest {
   private final BLSPublicKey publicKey = dataStructureUtil.randomPublicKey();
   private final StubRestApiRequest request =
       StubRestApiRequest.builder()
+          .metadata(handler.getMetadata())
           .pathParameter("pubkey", publicKey.toBytesCompressed().toHexString())
           .build();
 

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/restapi/apis/GetFeeRecipientTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/restapi/apis/GetFeeRecipientTest.java
@@ -44,6 +44,7 @@ class GetFeeRecipientTest {
   private final BLSPublicKey publicKey = dataStructureUtil.randomPublicKey();
   private final StubRestApiRequest request =
       StubRestApiRequest.builder()
+          .metadata(handler.getMetadata())
           .pathParameter("pubkey", publicKey.toBytesCompressed().toHexString())
           .build();
 


### PR DESCRIPTION
## PR Description
Update `StubRestApiRequest` to require the endpoint metadata and verify that the metadata matches the actual response provided (at least that the code is declared and whether or not content is provided currently).

Fix cases where response codes were incorrectly declared.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
