### PR TITLE
Skip unknown object fields correctly

### DIFF
--- a/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/DeserializableObjectTypeDefinition.java
+++ b/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/DeserializableObjectTypeDefinition.java
@@ -73,6 +73,7 @@ class DeserializableObjectTypeDefinition<TObject, TBuilder>
         presentFields.add(fieldName);
       } else {
         LOG.debug("Unknown field: {}", fieldName);
+        p.skipChildren();
       }
     }
 

--- a/infrastructure/json/src/test/java/tech/pegasys/teku/infrastructure/json/types/DeserializableObjectTypeDefinitionTest.java
+++ b/infrastructure/json/src/test/java/tech/pegasys/teku/infrastructure/json/types/DeserializableObjectTypeDefinitionTest.java
@@ -105,6 +105,43 @@ class DeserializableObjectTypeDefinitionTest {
     assertThat(result.optional).isEmpty();
   }
 
+  @Test
+  void shouldIgnoreUnknownFieldWithSimpleValue() throws Exception {
+    final ImmutableValue result =
+        JsonUtil.parse(
+            "{\"required\":\"value\", \"unknown\":\"ignored\"}", IMMUTABLE_TYPE_DEFINITION);
+    assertThat(result.required).isEqualTo("value");
+  }
+
+  @Test
+  void shouldIgnoreUnknownFieldWithObjectValue() throws Exception {
+    final ImmutableValue result =
+        JsonUtil.parse(
+            "{\"unknown\":{\"optional\":\"ignored\"}, \"required\":\"value\"}",
+            IMMUTABLE_TYPE_DEFINITION);
+    assertThat(result.required).isEqualTo("value");
+    assertThat(result.optional).isEmpty();
+  }
+
+  @Test
+  void shouldIgnoreUnknownFieldWithArrayValue() throws Exception {
+    final ImmutableValue result =
+        JsonUtil.parse(
+            "{\"unknown\":[\"optional\"], \"required\":\"value\"}", IMMUTABLE_TYPE_DEFINITION);
+    assertThat(result.required).isEqualTo("value");
+    assertThat(result.optional).isEmpty();
+  }
+
+  @Test
+  void shouldIgnoreUnknownFieldWithArrayOfObjectValue() throws Exception {
+    final ImmutableValue result =
+        JsonUtil.parse(
+            "{\"unknown\":[{\"optional\":\"ignored\"}], \"required\":\"value\"}",
+            IMMUTABLE_TYPE_DEFINITION);
+    assertThat(result.required).isEqualTo("value");
+    assertThat(result.optional).isEmpty();
+  }
+
   private static class MutableValue {
     private String required;
     private Optional<String> optional = Optional.empty();


### PR DESCRIPTION
## PR Description
When an unknown field is reached when parsing an object, ensure the value is skipped even if it's not a simple value (e.g an object or array).

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
