### PR TITLE
[MEV Boost\Builder] Don't send an empty list of validation registrations

### DIFF
--- a/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/rest/RestExecutionBuilderClientTest.java
+++ b/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/rest/RestExecutionBuilderClientTest.java
@@ -144,7 +144,7 @@ class RestExecutionBuilderClientTest {
   }
 
   @TestTemplate
-  void registerValidator_success() {
+  void registerValidators_success() {
 
     mockWebServer.enqueue(new MockResponse().setResponseCode(200));
 
@@ -163,7 +163,7 @@ class RestExecutionBuilderClientTest {
   }
 
   @TestTemplate
-  void registerValidator_zeroRegistrationsDoesNotMakeRequest() {
+  void registerValidators_zeroRegistrationsDoesNotMakeRequest() {
 
     SszList<SignedValidatorRegistration> zeroRegistrations =
         SIGNED_VALIDATOR_REGISTRATIONS_SCHEMA.getDefault();
@@ -180,7 +180,7 @@ class RestExecutionBuilderClientTest {
   }
 
   @TestTemplate
-  void registerValidator_failures() {
+  void registerValidators_failures() {
 
     String unknownValidatorError = "{\"code\":400,\"message\":\"unknown validator\"}";
 

--- a/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/rest/RestExecutionBuilderClientTest.java
+++ b/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/rest/RestExecutionBuilderClientTest.java
@@ -163,6 +163,23 @@ class RestExecutionBuilderClientTest {
   }
 
   @TestTemplate
+  void registerValidator_zeroRegistrationsDoesNotMakeRequest() {
+
+    SszList<SignedValidatorRegistration> zeroRegistrations =
+        SIGNED_VALIDATOR_REGISTRATIONS_SCHEMA.getDefault();
+
+    assertThat(restExecutionBuilderClient.registerValidators(SLOT, zeroRegistrations))
+        .succeedsWithin(WAIT_FOR_CALL_COMPLETION)
+        .satisfies(
+            response -> {
+              assertThat(response.isSuccess()).isTrue();
+              assertThat(response.getPayload()).isNull();
+            });
+
+    assertThat(mockWebServer.getRequestCount()).isEqualTo(0);
+  }
+
+  @TestTemplate
   void registerValidator_failures() {
 
     String unknownValidatorError = "{\"code\":400,\"message\":\"unknown validator\"}";

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/OkHttpRestClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/OkHttpRestClient.java
@@ -200,8 +200,8 @@ public class OkHttpRestClient implements RestClient {
     if (responseBody == null) {
       return errorCodeAndStatusMessage;
     }
-    final String failureBody = Strings.nullToEmpty(responseBody.string());
-    if (failureBody.isBlank() || failureBody.equals("null")) {
+    final String failureBody = responseBody.string();
+    if (Strings.nullToEmpty(failureBody).isBlank()) {
       return errorCodeAndStatusMessage;
     } else {
       return failureBody;

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/OkHttpRestClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/OkHttpRestClient.java
@@ -200,8 +200,8 @@ public class OkHttpRestClient implements RestClient {
     if (responseBody == null) {
       return errorCodeAndStatusMessage;
     }
-    final String failureBody = responseBody.string();
-    if (Strings.nullToEmpty(failureBody).isBlank()) {
+    final String failureBody = Strings.nullToEmpty(responseBody.string());
+    if (failureBody.isBlank() || failureBody.equals("null")) {
       return errorCodeAndStatusMessage;
     } else {
       return failureBody;

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/RestExecutionBuilderClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/RestExecutionBuilderClient.java
@@ -72,6 +72,10 @@ public class RestExecutionBuilderClient implements ExecutionBuilderClient {
   public SafeFuture<Response<Void>> registerValidators(
       final UInt64 slot, final SszList<SignedValidatorRegistration> signedValidatorRegistrations) {
 
+    if (signedValidatorRegistrations.isEmpty()) {
+      return SafeFuture.completedFuture(Response.withNullPayload());
+    }
+
     final DeserializableTypeDefinition<SszList<SignedValidatorRegistration>> requestType =
         SIGNED_VALIDATOR_REGISTRATIONS_SCHEMA.getJsonTypeDefinition();
     return restClient

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
@@ -413,7 +413,7 @@ public class ExecutionLayerManagerImpl implements ExecutionLayerManager {
 
   private static <K> K unwrapResponseOrThrow(Response<K> response) {
     checkArgument(response.isSuccess(), "Invalid remote response: %s", response.getErrorMessage());
-    return checkNotNull(response.getPayload(), "No payload content found");
+    return response.getPayload();
   }
 
   private void updateBuilderAvailability() {

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorRegistratorTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorRegistratorTest.java
@@ -207,6 +207,22 @@ class ValidatorRegistratorTest {
   }
 
   @TestTemplate
+  void validatorRegistrationsNotSentIfEmpty() {
+    // GIVEN
+    when(ownedValidators.getActiveValidators())
+        .thenReturn(List.of(validator1, validator2, validator3));
+
+    // all validator registrations disabled
+    when(proposerConfig.isValidatorRegistrationEnabledForPubKey(any()))
+        .thenReturn(Optional.of(false));
+
+    // WHEN
+    validatorRegistrator.onSlot(UInt64.ZERO);
+
+    verifyNoInteractions(validatorApiChannel);
+  }
+
+  @TestTemplate
   void retrievesCorrectGasLimitForValidators() {
     // GIVEN
     when(ownedValidators.getActiveValidators())


### PR DESCRIPTION
## PR Description
- Add empty list check in `ValidatorRegistrator` and `RestExecutionBuilderClient`
- Removed unnecessary null check (`response.isSuccess()` check is enough) in `ExecutionLayerManagerImpl`

## Fixed Issue(s)
fixes #5665 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
