### PR TITLE
Add roundTrip tests for operations structs

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/AttestationData.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/AttestationData.java
@@ -93,4 +93,9 @@ public class AttestationData
   public Checkpoint getTarget() {
     return getField4();
   }
+
+  @Override
+  public AttestationDataSchema getSchema() {
+    return (AttestationDataSchema) super.getSchema();
+  }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/Deposit.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/Deposit.java
@@ -66,4 +66,9 @@ public class Deposit extends Container2<Deposit, SszBytes32Vector, DepositData> 
   public DepositData getData() {
     return getField1();
   }
+
+  @Override
+  public DepositSchema getSchema() {
+    return (DepositSchema) super.getSchema();
+  }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/DepositMessage.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/DepositMessage.java
@@ -71,4 +71,9 @@ public class DepositMessage
   public UInt64 getAmount() {
     return getField2().get();
   }
+
+  @Override
+  public DepositMessageSchema getSchema() {
+    return (DepositMessageSchema) super.getSchema();
+  }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/ProposerSlashing.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/ProposerSlashing.java
@@ -54,4 +54,9 @@ public class ProposerSlashing
   public SignedBeaconBlockHeader getHeader2() {
     return getField1();
   }
+
+  @Override
+  public ProposerSlashingSchema getSchema() {
+    return (ProposerSlashingSchema) super.getSchema();
+  }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/SignedVoluntaryExit.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/SignedVoluntaryExit.java
@@ -65,4 +65,9 @@ public class SignedVoluntaryExit
         .add("signature", getSignature())
         .toString();
   }
+
+  @Override
+  public SignedVoluntaryExitSchema getSchema() {
+    return (SignedVoluntaryExitSchema) super.getSchema();
+  }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/VoluntaryExit.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/VoluntaryExit.java
@@ -55,4 +55,9 @@ public class VoluntaryExit extends Container2<VoluntaryExit, SszUInt64, SszUInt6
   public UInt64 getValidatorIndex() {
     return getField1().get();
   }
+
+  @Override
+  public VoluntaryExitSchema getSchema() {
+    return (VoluntaryExitSchema) super.getSchema();
+  }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/altair/ContributionAndProof.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/altair/ContributionAndProof.java
@@ -46,4 +46,9 @@ public class ContributionAndProof
   public BLSSignature getSelectionProof() {
     return getField2().getSignature();
   }
+
+  @Override
+  public ContributionAndProofSchema getSchema() {
+    return (ContributionAndProofSchema) super.getSchema();
+  }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/AggregateAndProofPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/AggregateAndProofPropertyTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.operations;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import tech.pegasys.teku.infrastructure.json.JsonUtil;
+import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class AggregateAndProofPropertyTest {
+  @Property
+  void roundTrip(
+      @ForAll final int seed,
+      @ForAll final SpecMilestone specMilestone,
+      @ForAll final Eth2Network network)
+      throws JsonProcessingException {
+    final Spec spec = TestSpecFactory.create(specMilestone, network);
+    final DataStructureUtil dataStructureUtil = new DataStructureUtil(seed, spec);
+    final AggregateAndProof aggregateAndProof = dataStructureUtil.randomAggregateAndProof();
+    final DeserializableTypeDefinition<AggregateAndProof> typeDefinition =
+        spec.forMilestone(specMilestone)
+            .getSchemaDefinitions()
+            .getAggregateAndProofSchema()
+            .getJsonTypeDefinition();
+    final String json = JsonUtil.serialize(aggregateAndProof, typeDefinition);
+    final AggregateAndProof result = JsonUtil.parse(json, typeDefinition);
+    assertThat(result).isEqualTo(aggregateAndProof);
+  }
+}

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/AttestationDataPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/AttestationDataPropertyTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.operations;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import tech.pegasys.teku.infrastructure.json.JsonUtil;
+import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class AttestationDataPropertyTest {
+  @Property
+  void roundTrip(
+      @ForAll final int seed,
+      @ForAll final SpecMilestone specMilestone,
+      @ForAll final Eth2Network network)
+      throws JsonProcessingException {
+    final Spec spec = TestSpecFactory.create(specMilestone, network);
+    final DataStructureUtil dataStructureUtil = new DataStructureUtil(seed, spec);
+    final AttestationData attestationData = dataStructureUtil.randomAttestationData();
+    final DeserializableTypeDefinition<AttestationData> typeDefinition =
+        attestationData.getSchema().getJsonTypeDefinition();
+    final String json = JsonUtil.serialize(attestationData, typeDefinition);
+    final AttestationData result = JsonUtil.parse(json, typeDefinition);
+    assertThat(result).isEqualTo(attestationData);
+  }
+}

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/AttestationPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/AttestationPropertyTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.operations;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import tech.pegasys.teku.infrastructure.json.JsonUtil;
+import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class AttestationPropertyTest {
+  @Property
+  void roundTrip(
+      @ForAll final int seed,
+      @ForAll final SpecMilestone specMilestone,
+      @ForAll final Eth2Network network)
+      throws JsonProcessingException {
+    final Spec spec = TestSpecFactory.create(specMilestone, network);
+    final DataStructureUtil dataStructureUtil = new DataStructureUtil(seed, spec);
+    final Attestation attestation = dataStructureUtil.randomAttestation();
+    final DeserializableTypeDefinition<Attestation> typeDefinition =
+        spec.forMilestone(specMilestone)
+            .getSchemaDefinitions()
+            .getAttestationSchema()
+            .getJsonTypeDefinition();
+    final String json = JsonUtil.serialize(attestation, typeDefinition);
+    final Attestation result = JsonUtil.parse(json, typeDefinition);
+    assertThat(result).isEqualTo(attestation);
+  }
+}

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/AttesterSlashingPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/AttesterSlashingPropertyTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.operations;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import tech.pegasys.teku.infrastructure.json.JsonUtil;
+import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class AttesterSlashingPropertyTest {
+  @Property
+  void roundTrip(
+      @ForAll final int seed,
+      @ForAll final SpecMilestone specMilestone,
+      @ForAll final Eth2Network network)
+      throws JsonProcessingException {
+    final Spec spec = TestSpecFactory.create(specMilestone, network);
+    final DataStructureUtil dataStructureUtil = new DataStructureUtil(seed, spec);
+    final AttesterSlashing attesterSlashing = dataStructureUtil.randomAttesterSlashing();
+    final DeserializableTypeDefinition<AttesterSlashing> typeDefinition =
+        spec.forMilestone(specMilestone)
+            .getSchemaDefinitions()
+            .getAttesterSlashingSchema()
+            .getJsonTypeDefinition();
+    final String json = JsonUtil.serialize(attesterSlashing, typeDefinition);
+    final AttesterSlashing result = JsonUtil.parse(json, typeDefinition);
+    assertThat(result).isEqualTo(attesterSlashing);
+  }
+}

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/ContributionAndProofPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/ContributionAndProofPropertyTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.operations;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
+import net.jqwik.api.constraints.Size;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.json.JsonUtil;
+import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.ContributionAndProof;
+import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class ContributionAndProofPropertyTest {
+  @Property
+  void roundTrip(
+      @ForAll final int seed,
+      @ForAll("milestone") final SpecMilestone specMilestone,
+      @ForAll final Eth2Network network,
+      @ForAll final long slot,
+      @ForAll @Size(32) final byte[] beaconBlockRoot)
+      throws JsonProcessingException {
+    final Spec spec = TestSpecFactory.create(specMilestone, network);
+    final DataStructureUtil dataStructureUtil = new DataStructureUtil(seed, spec);
+    final ContributionAndProof contributionAndProof =
+        dataStructureUtil.randomContributionAndProof(
+            UInt64.fromLongBits(slot), Bytes32.wrap(beaconBlockRoot));
+    final DeserializableTypeDefinition<ContributionAndProof> typeDefinition =
+        contributionAndProof.getSchema().getJsonTypeDefinition();
+    final String json = JsonUtil.serialize(contributionAndProof, typeDefinition);
+    final ContributionAndProof result = JsonUtil.parse(json, typeDefinition);
+    assertThat(result).isEqualTo(contributionAndProof);
+  }
+
+  @Provide
+  Arbitrary<SpecMilestone> milestone() {
+    return Arbitraries.of(SpecMilestone.class)
+        .filter(m -> m.isGreaterThanOrEqualTo(SpecMilestone.ALTAIR));
+  }
+}

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/DepositMessagePropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/DepositMessagePropertyTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.operations;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import tech.pegasys.teku.infrastructure.json.JsonUtil;
+import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class DepositMessagePropertyTest {
+  @Property
+  void roundTrip(
+      @ForAll final int seed,
+      @ForAll final SpecMilestone specMilestone,
+      @ForAll final Eth2Network network)
+      throws JsonProcessingException {
+    final Spec spec = TestSpecFactory.create(specMilestone, network);
+    final DataStructureUtil dataStructureUtil = new DataStructureUtil(seed, spec);
+    final DepositMessage depositMessage = dataStructureUtil.randomDepositMessage();
+    final DeserializableTypeDefinition<DepositMessage> typeDefinition =
+        depositMessage.getSchema().getJsonTypeDefinition();
+    final String json = JsonUtil.serialize(depositMessage, typeDefinition);
+    final DepositMessage result = JsonUtil.parse(json, typeDefinition);
+    assertThat(result).isEqualTo(depositMessage);
+  }
+}

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/DepositPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/DepositPropertyTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.operations;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import tech.pegasys.teku.infrastructure.json.JsonUtil;
+import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class DepositPropertyTest {
+  @Property
+  void roundTrip(
+      @ForAll final int seed,
+      @ForAll final SpecMilestone specMilestone,
+      @ForAll final Eth2Network network)
+      throws JsonProcessingException {
+    final Spec spec = TestSpecFactory.create(specMilestone, network);
+    final DataStructureUtil dataStructureUtil = new DataStructureUtil(seed, spec);
+    final Deposit deposit = dataStructureUtil.randomDeposit();
+    final DeserializableTypeDefinition<Deposit> typeDefinition =
+        deposit.getSchema().getJsonTypeDefinition();
+    final String json = JsonUtil.serialize(deposit, typeDefinition);
+    final Deposit result = JsonUtil.parse(json, typeDefinition);
+    assertThat(result).isEqualTo(deposit);
+  }
+}

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/IndexedAttestationPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/IndexedAttestationPropertyTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.operations;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import tech.pegasys.teku.infrastructure.json.JsonUtil;
+import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class IndexedAttestationPropertyTest {
+  @Property
+  void roundTrip(
+      @ForAll final int seed,
+      @ForAll final SpecMilestone specMilestone,
+      @ForAll final Eth2Network network)
+      throws JsonProcessingException {
+    final Spec spec = TestSpecFactory.create(specMilestone, network);
+    final DataStructureUtil dataStructureUtil = new DataStructureUtil(seed, spec);
+    final IndexedAttestation indexedAttestation = dataStructureUtil.randomIndexedAttestation();
+    final DeserializableTypeDefinition<IndexedAttestation> typeDefinition =
+        spec.forMilestone(specMilestone)
+            .getSchemaDefinitions()
+            .getIndexedAttestationSchema()
+            .getJsonTypeDefinition();
+    final String json = JsonUtil.serialize(indexedAttestation, typeDefinition);
+    final IndexedAttestation result = JsonUtil.parse(json, typeDefinition);
+    assertThat(result).isEqualTo(indexedAttestation);
+  }
+}

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/ProposerSlashingPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/ProposerSlashingPropertyTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.operations;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import tech.pegasys.teku.infrastructure.json.JsonUtil;
+import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class ProposerSlashingPropertyTest {
+  @Property
+  void roundTrip(
+      @ForAll final int seed,
+      @ForAll final SpecMilestone specMilestone,
+      @ForAll final Eth2Network network)
+      throws JsonProcessingException {
+    final Spec spec = TestSpecFactory.create(specMilestone, network);
+    final DataStructureUtil dataStructureUtil = new DataStructureUtil(seed, spec);
+    final ProposerSlashing proposerSlashing = dataStructureUtil.randomProposerSlashing();
+    final DeserializableTypeDefinition<ProposerSlashing> typeDefinition =
+        proposerSlashing.getSchema().getJsonTypeDefinition();
+    final String json = JsonUtil.serialize(proposerSlashing, typeDefinition);
+    final ProposerSlashing result = JsonUtil.parse(json, typeDefinition);
+    assertThat(result).isEqualTo(proposerSlashing);
+  }
+}

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SignedAggregateAndProofPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SignedAggregateAndProofPropertyTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.operations;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import tech.pegasys.teku.infrastructure.json.JsonUtil;
+import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class SignedAggregateAndProofPropertyTest {
+  @Property
+  void roundTrip(
+      @ForAll final int seed,
+      @ForAll final SpecMilestone specMilestone,
+      @ForAll final Eth2Network network)
+      throws JsonProcessingException {
+    final Spec spec = TestSpecFactory.create(specMilestone, network);
+    final DataStructureUtil dataStructureUtil = new DataStructureUtil(seed, spec);
+    final SignedAggregateAndProof signedAggregateAndProof =
+        dataStructureUtil.randomSignedAggregateAndProof();
+    final DeserializableTypeDefinition<SignedAggregateAndProof> typeDefinition =
+        spec.forMilestone(specMilestone)
+            .getSchemaDefinitions()
+            .getSignedAggregateAndProofSchema()
+            .getJsonTypeDefinition();
+    final String json = JsonUtil.serialize(signedAggregateAndProof, typeDefinition);
+    final SignedAggregateAndProof result = JsonUtil.parse(json, typeDefinition);
+    assertThat(result).isEqualTo(signedAggregateAndProof);
+  }
+}

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SignedContributionAndProofPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SignedContributionAndProofPropertyTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.operations;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
+import net.jqwik.api.constraints.Size;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.json.JsonUtil;
+import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SignedContributionAndProof;
+import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class SignedContributionAndProofPropertyTest {
+  @Property
+  void roundTrip(
+      @ForAll final int seed,
+      @ForAll("milestone") final SpecMilestone specMilestone,
+      @ForAll final Eth2Network network,
+      @ForAll final long slot,
+      @ForAll @Size(32) final byte[] beaconBlockRoot)
+      throws JsonProcessingException {
+    final Spec spec = TestSpecFactory.create(specMilestone, network);
+    final DataStructureUtil dataStructureUtil = new DataStructureUtil(seed, spec);
+    final SignedContributionAndProof signedContributionAndProof =
+        dataStructureUtil.randomSignedContributionAndProof(
+            UInt64.fromLongBits(slot), Bytes32.wrap(beaconBlockRoot));
+    final DeserializableTypeDefinition<SignedContributionAndProof> typeDefinition =
+        signedContributionAndProof.getSchema().getJsonTypeDefinition();
+    final String json = JsonUtil.serialize(signedContributionAndProof, typeDefinition);
+    final SignedContributionAndProof result = JsonUtil.parse(json, typeDefinition);
+    assertThat(result).isEqualTo(signedContributionAndProof);
+  }
+
+  @Provide
+  Arbitrary<SpecMilestone> milestone() {
+    return Arbitraries.of(SpecMilestone.class)
+        .filter(m -> m.isGreaterThanOrEqualTo(SpecMilestone.ALTAIR));
+  }
+}

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SignedVoluntaryExitPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SignedVoluntaryExitPropertyTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.operations;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import tech.pegasys.teku.infrastructure.json.JsonUtil;
+import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class SignedVoluntaryExitPropertyTest {
+  @Property
+  void roundTrip(
+      @ForAll final int seed,
+      @ForAll final SpecMilestone specMilestone,
+      @ForAll final Eth2Network network)
+      throws JsonProcessingException {
+    final Spec spec = TestSpecFactory.create(specMilestone, network);
+    final DataStructureUtil dataStructureUtil = new DataStructureUtil(seed, spec);
+    final SignedVoluntaryExit signedVoluntaryExit = dataStructureUtil.randomSignedVoluntaryExit();
+    final DeserializableTypeDefinition<SignedVoluntaryExit> typeDefinition =
+        signedVoluntaryExit.getSchema().getJsonTypeDefinition();
+    final String json = JsonUtil.serialize(signedVoluntaryExit, typeDefinition);
+    final SignedVoluntaryExit result = JsonUtil.parse(json, typeDefinition);
+    assertThat(result).isEqualTo(signedVoluntaryExit);
+  }
+}

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SyncAggregatorSelectionDataPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SyncAggregatorSelectionDataPropertyTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.operations;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
+import tech.pegasys.teku.infrastructure.json.JsonUtil;
+import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncAggregatorSelectionData;
+import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class SyncAggregatorSelectionDataPropertyTest {
+  @Property
+  void roundTrip(
+      @ForAll final int seed,
+      @ForAll("milestone") final SpecMilestone specMilestone,
+      @ForAll final Eth2Network network)
+      throws JsonProcessingException {
+    final Spec spec = TestSpecFactory.create(specMilestone, network);
+    final DataStructureUtil dataStructureUtil = new DataStructureUtil(seed, spec);
+    final SyncAggregatorSelectionData syncAggregatorSelectionData =
+        dataStructureUtil.randomSyncAggregatorSelectionData();
+    final DeserializableTypeDefinition<SyncAggregatorSelectionData> typeDefinition =
+        spec.forMilestone(specMilestone)
+            .getSchemaDefinitions()
+            .toVersionAltair()
+            .orElseThrow()
+            .getSyncAggregatorSelectionDataSchema()
+            .getJsonTypeDefinition();
+    final String json = JsonUtil.serialize(syncAggregatorSelectionData, typeDefinition);
+    final SyncAggregatorSelectionData result = JsonUtil.parse(json, typeDefinition);
+    assertThat(result).isEqualTo(syncAggregatorSelectionData);
+  }
+
+  @Provide
+  Arbitrary<SpecMilestone> milestone() {
+    return Arbitraries.of(SpecMilestone.class)
+        .filter(m -> m.isGreaterThanOrEqualTo(SpecMilestone.ALTAIR));
+  }
+}

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SyncCommitteeContributionPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SyncCommitteeContributionPropertyTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.operations;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
+import tech.pegasys.teku.infrastructure.json.JsonUtil;
+import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeContribution;
+import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class SyncCommitteeContributionPropertyTest {
+  @Property
+  void roundTrip(
+      @ForAll final int seed,
+      @ForAll("milestone") final SpecMilestone specMilestone,
+      @ForAll final Eth2Network network,
+      @ForAll final long slot)
+      throws JsonProcessingException {
+    final Spec spec = TestSpecFactory.create(specMilestone, network);
+    final DataStructureUtil dataStructureUtil = new DataStructureUtil(seed, spec);
+    final SyncCommitteeContribution syncCommitteeContribution =
+        dataStructureUtil.randomSyncCommitteeContribution(UInt64.fromLongBits(slot));
+    final DeserializableTypeDefinition<SyncCommitteeContribution> typeDefinition =
+        spec.forMilestone(specMilestone)
+            .getSchemaDefinitions()
+            .toVersionAltair()
+            .orElseThrow()
+            .getSyncCommitteeContributionSchema()
+            .getJsonTypeDefinition();
+    final String json = JsonUtil.serialize(syncCommitteeContribution, typeDefinition);
+    final SyncCommitteeContribution result = JsonUtil.parse(json, typeDefinition);
+    assertThat(result).isEqualTo(syncCommitteeContribution);
+  }
+
+  @Provide
+  Arbitrary<SpecMilestone> milestone() {
+    return Arbitraries.of(SpecMilestone.class)
+        .filter(m -> m.isGreaterThanOrEqualTo(SpecMilestone.ALTAIR));
+  }
+}

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SyncCommitteeMessagePropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SyncCommitteeMessagePropertyTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.operations;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
+import tech.pegasys.teku.infrastructure.json.JsonUtil;
+import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeMessage;
+import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class SyncCommitteeMessagePropertyTest {
+  @Property
+  void roundTrip(
+      @ForAll final int seed,
+      @ForAll("milestone") final SpecMilestone specMilestone,
+      @ForAll final Eth2Network network)
+      throws JsonProcessingException {
+    final Spec spec = TestSpecFactory.create(specMilestone, network);
+    final DataStructureUtil dataStructureUtil = new DataStructureUtil(seed, spec);
+    final SyncCommitteeMessage syncCommitteeMessage =
+        dataStructureUtil.randomSyncCommitteeMessage();
+    final DeserializableTypeDefinition<SyncCommitteeMessage> typeDefinition =
+        spec.forMilestone(specMilestone)
+            .getSchemaDefinitions()
+            .toVersionAltair()
+            .orElseThrow()
+            .getSyncCommitteeMessageSchema()
+            .getJsonTypeDefinition();
+    final String json = JsonUtil.serialize(syncCommitteeMessage, typeDefinition);
+    final SyncCommitteeMessage result = JsonUtil.parse(json, typeDefinition);
+    assertThat(result).isEqualTo(syncCommitteeMessage);
+  }
+
+  @Provide
+  Arbitrary<SpecMilestone> milestone() {
+    return Arbitraries.of(SpecMilestone.class)
+        .filter(m -> m.isGreaterThanOrEqualTo(SpecMilestone.ALTAIR));
+  }
+}

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/VoluntaryExitPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/VoluntaryExitPropertyTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.operations;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import tech.pegasys.teku.infrastructure.json.JsonUtil;
+import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class VoluntaryExitPropertyTest {
+  @Property
+  void roundTrip(
+      @ForAll final int seed,
+      @ForAll final SpecMilestone specMilestone,
+      @ForAll final Eth2Network network)
+      throws JsonProcessingException {
+    final Spec spec = TestSpecFactory.create(specMilestone, network);
+    final DataStructureUtil dataStructureUtil = new DataStructureUtil(seed, spec);
+    final VoluntaryExit voluntaryExit = dataStructureUtil.randomVoluntaryExit();
+    final DeserializableTypeDefinition<VoluntaryExit> typeDefinition =
+        voluntaryExit.getSchema().getJsonTypeDefinition();
+    final String json = JsonUtil.serialize(voluntaryExit, typeDefinition);
+    final VoluntaryExit result = JsonUtil.parse(json, typeDefinition);
+    assertThat(result).isEqualTo(voluntaryExit);
+  }
+}


### PR DESCRIPTION
## PR Description

Adding some PBT tests for operations data structures. Found no problems. Added some methods to `dataStructureUtil`.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
