### PR TITLE
Enable discarding equivocating indices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ For information on changes in released versions of Teku, see the [releases page]
 
 ### Additions and Improvements
 - Reduced memory requirements for storing the deposit merkle tree.
+- Enable spec change to ignore weightings from attestations from equivocating validators.
 
 ### Bug Fixes
 - Fixed issue where the REST API may return content as SSZ instead of JSON if the header `Accept: */*` was specified.

--- a/ethereum/networks/src/main/java/tech/pegasys/teku/networks/Eth2NetworkConfiguration.java
+++ b/ethereum/networks/src/main/java/tech/pegasys/teku/networks/Eth2NetworkConfiguration.java
@@ -43,7 +43,7 @@ public class Eth2NetworkConfiguration {
   private static final int DEFAULT_STARTUP_TARGET_PEER_COUNT = 5;
   private static final int DEFAULT_STARTUP_TIMEOUT_SECONDS = 30;
   public static final boolean DEFAULT_PROPOSER_BOOST_ENABLED = true;
-  public static final boolean DEFAULT_EQUIVOCATING_INDICES_ENABLED = false;
+  public static final boolean DEFAULT_EQUIVOCATING_INDICES_ENABLED = true;
   public static final boolean DEFAULT_FORK_CHOICE_BEFORE_PROPOSING_ENABLED = false;
 
   private final Spec spec;

--- a/services/chainstorage/src/main/java/tech/pegasys/teku/services/chainstorage/StorageConfiguration.java
+++ b/services/chainstorage/src/main/java/tech/pegasys/teku/services/chainstorage/StorageConfiguration.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.services.chainstorage;
 
 import tech.pegasys.teku.infrastructure.exceptions.InvalidConfigurationException;
+import tech.pegasys.teku.networks.Eth2NetworkConfiguration;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.eth1.Eth1Address;
 import tech.pegasys.teku.storage.server.DatabaseVersion;
@@ -23,7 +24,6 @@ import tech.pegasys.teku.storage.server.VersionedDatabaseFactory;
 public class StorageConfiguration {
 
   public static final boolean DEFAULT_STORE_NON_CANONICAL_BLOCKS_ENABLED = false;
-  public static final boolean DEFAULT_STORE_VOTES_EQUIVOCATION = false;
   public static final int DEFAULT_MAX_KNOWN_NODE_CACHE_SIZE = 100_000;
 
   private final Eth1Address eth1DepositContract;
@@ -97,7 +97,8 @@ public class StorageConfiguration {
     private StateStorageMode dataStorageMode = StateStorageMode.DEFAULT_MODE;
     private long dataStorageFrequency = VersionedDatabaseFactory.DEFAULT_STORAGE_FREQUENCY;
     private DatabaseVersion dataStorageCreateDbVersion = DatabaseVersion.DEFAULT_VERSION;
-    private boolean storeVotesEquivocation = DEFAULT_STORE_VOTES_EQUIVOCATION;
+    private boolean storeVotesEquivocation =
+        Eth2NetworkConfiguration.DEFAULT_EQUIVOCATING_INDICES_ENABLED;
     private Spec spec;
     private boolean storeNonCanonicalBlocks = DEFAULT_STORE_NON_CANONICAL_BLOCKS_ENABLED;
     private int maxKnownNodeCacheSize = DEFAULT_MAX_KNOWN_NODE_CACHE_SIZE;


### PR DESCRIPTION
## PR Description
Enable discarding equivocating indices by default.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
