### PR TITLE
Publish metrics for block duties being completed

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/DutyMetrics.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/DutyMetrics.java
@@ -13,13 +13,14 @@
 
 package tech.pegasys.teku.validator.coordinator;
 
-import static tech.pegasys.teku.infrastructure.time.TimeUtilities.secondsToMillis;
 import static tech.pegasys.teku.spec.constants.NetworkConstants.INTERVALS_PER_SLOT;
 
 import com.google.common.annotations.VisibleForTesting;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
-import tech.pegasys.teku.infrastructure.metrics.MetricsHistogram;
+import tech.pegasys.teku.infrastructure.metrics.MetricsCountersByIntervals;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -30,18 +31,21 @@ public class DutyMetrics {
 
   private final TimeProvider timeProvider;
   private final RecentChainData recentChainData;
-  private final MetricsHistogram attestationHistogram;
+  private final MetricsCountersByIntervals attestationTimings;
+  private final MetricsCountersByIntervals blockTimings;
   private final Spec spec;
 
   @VisibleForTesting
   DutyMetrics(
       final TimeProvider timeProvider,
       final RecentChainData recentChainData,
-      final MetricsHistogram attestationHistogram,
+      final MetricsCountersByIntervals attestationTimings,
+      final MetricsCountersByIntervals blockTimings,
       final Spec spec) {
     this.timeProvider = timeProvider;
     this.recentChainData = recentChainData;
-    this.attestationHistogram = attestationHistogram;
+    this.attestationTimings = attestationTimings;
+    this.blockTimings = blockTimings;
     this.spec = spec;
   }
 
@@ -50,33 +54,50 @@ public class DutyMetrics {
       final TimeProvider timeProvider,
       final RecentChainData recentChainData,
       final Spec spec) {
-    final MetricsHistogram attestationHistogram =
-        MetricsHistogram.create(
+    final MetricsCountersByIntervals attestationTimings =
+        MetricsCountersByIntervals.create(
             TekuMetricCategory.VALIDATOR,
             metricsSystem,
             "attestation_publication_delay",
-            "Histogram recording delay in milliseconds from scheduled time to an attestation being published",
-            1,
-            List.of());
-    return new DutyMetrics(timeProvider, recentChainData, attestationHistogram, spec);
+            "Counter of attestations published in different time intervals after their due time",
+            Collections.emptyList(),
+            Map.of(List.of(), List.of(1L, 500L, 1000L, 2000L, 3000L, 4000L, 5000L, 8000L)));
+    final MetricsCountersByIntervals blockTimings =
+        MetricsCountersByIntervals.create(
+            TekuMetricCategory.VALIDATOR,
+            metricsSystem,
+            "block_publication_delay",
+            "Counter of blocks published in different time intervals after their due time",
+            Collections.emptyList(),
+            Map.of(List.of(), List.of(1L, 500L, 1000L, 2000L, 3000L, 4000L, 5000L, 8000L, 12000L)));
+    return new DutyMetrics(timeProvider, recentChainData, attestationTimings, blockTimings, spec);
   }
 
   public void onAttestationPublished(final UInt64 slot) {
     final UInt64 currentTime = timeProvider.getTimeInMillis();
     final UInt64 expectedTime = calculateExpectedAttestationTimeInMillis(slot);
     if (currentTime.isGreaterThanOrEqualTo(expectedTime)) {
-      attestationHistogram.recordValue(currentTime.minus(expectedTime).longValue());
+      attestationTimings.recordValue(currentTime.minus(expectedTime).longValue());
     } else {
       // The attestation was published ahead of time, likely because the block was received
-      attestationHistogram.recordValue(0);
+      attestationTimings.recordValue(0);
     }
   }
 
+  public void onBlockPublished(final UInt64 slot) {
+    final UInt64 currentTime = timeProvider.getTimeInMillis();
+    final UInt64 expectedTime = calculateSlotStartTimeMillis(slot);
+    blockTimings.recordValue(currentTime.minusMinZero(expectedTime).longValue());
+  }
+
   private UInt64 calculateExpectedAttestationTimeInMillis(final UInt64 slot) {
-    final UInt64 genesisTime = recentChainData.getGenesisTime();
+    final UInt64 slotStartTimeMillis = calculateSlotStartTimeMillis(slot);
     UInt64 millisPerSlot = spec.getMillisPerSlot(slot);
-    return secondsToMillis(genesisTime)
-        .plus(slot.times(millisPerSlot))
-        .plus(millisPerSlot.dividedBy(INTERVALS_PER_SLOT));
+    return slotStartTimeMillis.plus(millisPerSlot.dividedBy(INTERVALS_PER_SLOT));
+  }
+
+  private UInt64 calculateSlotStartTimeMillis(final UInt64 slot) {
+    final UInt64 genesisTime = recentChainData.getGenesisTimeMillis();
+    return spec.getSlotStartTimeMillis(slot, genesisTime);
   }
 }

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -543,11 +543,13 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
                 LOG.trace(
                     "Successfully imported proposed block: {}",
                     () -> formatBlock(block.getSlot(), block.getRoot()));
+                dutyMetrics.onBlockPublished(block.getMessage().getSlot());
                 return SendSignedBlockResult.success(block.getRoot());
               } else if (result.getFailureReason() == FailureReason.BLOCK_IS_FROM_FUTURE) {
                 LOG.debug(
                     "Delayed processing proposed block {} because it is from the future",
                     formatBlock(block.getSlot(), block.getRoot()));
+                dutyMetrics.onBlockPublished(block.getMessage().getSlot());
                 return SendSignedBlockResult.notImported(result.getFailureReason().name());
               } else {
                 VALIDATOR_LOGGER.proposedBlockImportFailed(

--- a/infrastructure/metrics/src/main/java/tech/pegasys/teku/infrastructure/metrics/MetricsCountersByIntervals.java
+++ b/infrastructure/metrics/src/main/java/tech/pegasys/teku/infrastructure/metrics/MetricsCountersByIntervals.java
@@ -35,7 +35,7 @@ public class MetricsCountersByIntervals {
   private final List<Integer> labelValuesListSizes;
   private final LabelledMetric<Counter> labelledMetricCounter;
 
-  public MetricsCountersByIntervals(
+  private MetricsCountersByIntervals(
       final Map<List<String>, TreeMap<UInt64, String>> labelsToBoundariesToIntervalLabels,
       final List<Integer> labelValuesListSizes,
       final LabelledMetric<Counter> labelledMetricCounter) {


### PR DESCRIPTION
## PR Description
Add duty metrics for block timings when validators publish blocks through the beacon node.
Switch duty metrics to use counters of number of duties completed in specific time ranges rather than a histogram. Resulting data is similar but handles better granularity and is less affected by large outliers which tend to happen at startup.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
