### PR TITLE
Failed to produce sync_contribution for noop duties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,3 +21,4 @@ For information on changes in released versions of Teku, see the [releases page]
 
 ### Bug Fixes
 - Fixed issue where the REST API may return content as SSZ instead of JSON if the header `Accept: */*` was specified.
+- Fixed issue where sync committee aggregations were skipped, but reported failed because there were no signatures to aggregate.

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/ValidatorLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/ValidatorLogger.java
@@ -136,13 +136,11 @@ public class ValidatorLogger {
             Color.YELLOW));
   }
 
-  public void syncSubcommitteeAggregationSkipped(final UInt64 slot, final int subcommitteeIndex) {
+  public void syncCommitteeAggregationFailed(final UInt64 slot) {
     log.warn(
         ColorConsolePrinter.print(
             PREFIX
-                + "Skipped aggregation for sync subcommittee "
-                + subcommitteeIndex
-                + " at slot "
+                + "Skipped aggregation at slot "
                 + slot
                 + " because there was nothing to aggregate",
             Color.YELLOW));

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/ValidatorLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/ValidatorLogger.java
@@ -136,7 +136,7 @@ public class ValidatorLogger {
             Color.YELLOW));
   }
 
-  public void syncCommitteeAggregationFailed(final UInt64 slot) {
+  public void syncCommitteeAggregationSkipped(final UInt64 slot) {
     log.warn(
         ColorConsolePrinter.print(
             PREFIX

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeAggregationDuty.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeAggregationDuty.java
@@ -162,7 +162,7 @@ public class SyncCommitteeAggregationDuty {
         .thenCompose(
             maybeContribution -> {
               if (maybeContribution.isEmpty()) {
-                validatorLogger.syncCommitteeAggregationFailed(slot);
+                validatorLogger.syncCommitteeAggregationSkipped(slot);
                 return SafeFuture.completedFuture(
                     new AggregationResult(validatorPublicKey, DutyResult.NO_OP));
               }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeAggregationDuty.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeAggregationDuty.java
@@ -162,7 +162,7 @@ public class SyncCommitteeAggregationDuty {
         .thenCompose(
             maybeContribution -> {
               if (maybeContribution.isEmpty()) {
-                validatorLogger.syncSubcommitteeAggregationSkipped(slot, subcommitteeIndex);
+                validatorLogger.syncCommitteeAggregationFailed(slot);
                 return SafeFuture.completedFuture(
                     new AggregationResult(validatorPublicKey, DutyResult.NO_OP));
               }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeScheduledDuties.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeScheduledDuties.java
@@ -119,7 +119,7 @@ public class SyncCommitteeScheduledDuties implements ScheduledDuties {
     if (lastSignatureSlot.isEmpty()
         || lastSignatureBlockRoot.isEmpty()
         || !lastSignatureSlot.get().equals(slot)) {
-      validatorLogger.syncCommitteeAggregationFailed(slot);
+      validatorLogger.syncCommitteeAggregationSkipped(slot);
       return SafeFuture.completedFuture(DutyResult.NO_OP);
     }
     return aggregationDuty.produceAggregates(slot, lastSignatureBlockRoot.get());

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeAggregationDutyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeAggregationDutyTest.java
@@ -218,7 +218,7 @@ class SyncCommitteeAggregationDutyTest {
     final SafeFuture<DutyResult> result = duty.produceAggregates(slot, beaconBlockRoot);
     assertThat(result).isCompletedWithValue(DutyResult.NO_OP);
 
-    verify(validatorLogger).syncCommitteeAggregationFailed(slot);
+    verify(validatorLogger).syncCommitteeAggregationSkipped(slot);
   }
 
   @Test

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeAggregationDutyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeAggregationDutyTest.java
@@ -218,7 +218,7 @@ class SyncCommitteeAggregationDutyTest {
     final SafeFuture<DutyResult> result = duty.produceAggregates(slot, beaconBlockRoot);
     assertThat(result).isCompletedWithValue(DutyResult.NO_OP);
 
-    verify(validatorLogger).syncSubcommitteeAggregationSkipped(slot, 0);
+    verify(validatorLogger).syncCommitteeAggregationFailed(slot);
   }
 
   @Test

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeScheduledDutiesTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeScheduledDutiesTest.java
@@ -174,12 +174,7 @@ class SyncCommitteeScheduledDutiesTest {
     final SafeFuture<DutyResult> result = duties.performAggregationDuty(UInt64.ZERO);
     reportDutyResult(UInt64.ZERO, result);
 
-    verify(validatorLogger)
-        .dutyFailed(
-            eq(TYPE),
-            eq(UInt64.ZERO),
-            eq(Set.of(validator1.getPublicKey().toAbbreviatedString())),
-            any(IllegalStateException.class));
+    verify(validatorLogger).syncCommitteeAggregationSkipped(eq(UInt64.ZERO));
   }
 
   @Test
@@ -193,12 +188,7 @@ class SyncCommitteeScheduledDutiesTest {
     final SafeFuture<DutyResult> result = duties.performAggregationDuty(UInt64.ONE);
     reportDutyResult(UInt64.ZERO, result);
 
-    verify(validatorLogger)
-        .dutyFailed(
-            eq(TYPE),
-            eq(UInt64.ZERO),
-            eq(Set.of(validator1.getPublicKey().toAbbreviatedString())),
-            any(IllegalStateException.class));
+    verify(validatorLogger).syncCommitteeAggregationSkipped(eq(UInt64.ONE));
   }
 
   @Test
@@ -212,12 +202,7 @@ class SyncCommitteeScheduledDutiesTest {
     final SafeFuture<DutyResult> result = duties.performAggregationDuty(UInt64.ZERO);
     reportDutyResult(UInt64.ZERO, result);
 
-    verify(validatorLogger)
-        .dutyFailed(
-            eq(TYPE),
-            eq(UInt64.ZERO),
-            eq(Set.of(validator1.getPublicKey().toAbbreviatedString())),
-            any(IllegalStateException.class));
+    verify(validatorLogger).syncCommitteeAggregationSkipped(eq(UInt64.ZERO));
   }
 
   public SyncCommitteeScheduledDuties.Builder validBuilder() {

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeScheduledDutiesTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeScheduledDutiesTest.java
@@ -242,6 +242,7 @@ class SyncCommitteeScheduledDutiesTest {
         chainHeadTracker,
         validatorApiChannel,
         validatorAndCommitteeIndices,
+        validatorLogger,
         UInt64.ZERO);
   }
 


### PR DESCRIPTION
When there are no signatures to aggregate, a duty failure is reported but it should really just be a skipped duty.

fixes #5614

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
