### PR TITLE
Avoid division by zero when estimating time to TTD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,3 +23,4 @@ For information on changes in released versions of Teku, see the [releases page]
 ### Bug Fixes
 - Fixed issue where the REST API may return content as SSZ instead of JSON if the header `Accept: */*` was specified.
 - Fixed issue where sync committee aggregations were skipped, but reported failed because there were no signatures to aggregate.
+- Fixed division by zero when estimating time to TTD during a period with no new PoW blocks.

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/TerminalPowBlockMonitor.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/TerminalPowBlockMonitor.java
@@ -302,7 +302,10 @@ public class TerminalPowBlockMonitor {
     final UInt256 timeFrameInSeconds =
         UInt256.valueOf(
             latestBlock.getBlockTimestamp().minus(oldestBlock.getBlockTimestamp()).longValue());
-
+    // Make sure we don't just have the same block multiple times.
+    if (timeFrameInSeconds.isZero()) {
+      return;
+    }
     final UInt256 averageTdPerSeconds =
         lastPowBlocks
             .getFirst()


### PR DESCRIPTION
## PR Description
When there are no new blocks for a long period, all samples might be for the same block and thus have the same timestamp.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
