### PR TITLE
minor api updates

### DIFF
--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/paths/_eth_v1_beacon_blinded_blocks.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/paths/_eth_v1_beacon_blinded_blocks.json
@@ -1,6 +1,6 @@
 {
   "post" : {
-    "tags" : [ "Validator", "Validator Required Api", "Experimental" ],
+    "tags" : [ "Validator", "Validator Required Api"],
     "operationId" : "publishBlindedBlock",
     "summary" : "Publish a signed blinded block",
     "description" : "Submit a signed blinded beacon block to the beacon node to be imported. The beacon node performs the required validation.",

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/paths/_eth_v1_validator_blinded_blocks_{slot}.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/paths/_eth_v1_validator_blinded_blocks_{slot}.json
@@ -1,6 +1,6 @@
 {
   "get" : {
-    "tags" : [ "Validator", "Validator Required Api", "Experimental" ],
+    "tags" : [ "Validator", "Validator Required Api"],
     "operationId" : "getNewBlindedBlock",
     "summary" : "Produce unsigned blinded block",
     "description" : "Requests a beacon node to produce a valid blinded block, which can then be signed by a validator. A blinded block is a block with only a transactions root, rather than a full transactions list.\n\nMetadata in the response indicates the type of block produced, and the supported types of block will be added to as forks progress.\n\nPre-Bellatrix, this endpoint will return a `BeaconBlock`.",

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/paths/_eth_v1_validator_register_validator.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/paths/_eth_v1_validator_register_validator.json
@@ -2,7 +2,7 @@
   "post" : {
     "tags" : [ "Validator", "Validator Required Api" ],
     "operationId" : "registerValidator",
-    "summary" : "Provide beacon node with registrations for the given validators to the external builder network.",
+    "summary" : "Register validators with builder",
     "description" : "Prepares the beacon node for engaging with external builders. The information will be sent by the beacon node to the builder network. It is expected that the validator client will send this information periodically to ensure the beacon node has correct and timely registration information to provide to builders. The validator client should not sign blinded beacon blocks that do not adhere to their latest fee recipient and gas limit preferences.",
     "requestBody" : {
       "content" : {

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_beacon_blinded_blocks.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_beacon_blinded_blocks.json
@@ -1,6 +1,6 @@
 {
   "post" : {
-    "tags" : [ "Beacon", "Validator Required Api", "Experimental" ],
+    "tags" : [ "Beacon", "Validator Required Api"],
     "summary" : "Publish a signed blinded block",
     "description" : "Submit a signed blinded beacon block to the beacon node to be imported. The beacon node performs the required validation.",
     "operationId" : "postEthV1BeaconBlinded_blocks",

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_validator_blinded_blocks_{slot}.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_validator_blinded_blocks_{slot}.json
@@ -1,6 +1,6 @@
 {
   "get" : {
-    "tags" : [ "Validator", "Validator Required Api", "Experimental" ],
+    "tags" : [ "Validator", "Validator Required Api"],
     "summary" : "Produce unsigned blinded block",
     "description" : "Requests a beacon node to produce a valid blinded block, which can then be signed by a validator. A blinded block is a block with only a transactions root, rather than a full transactions list.\n\nMetadata in the response indicates the type of block produced, and the supported types of block will be added to as forks progress.\n\nPre-Bellatrix, this endpoint will return a `BeaconBlock`.",
     "operationId" : "getEthV1ValidatorBlinded_blocksWithSlot",

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_validator_prepare_beacon_proposer.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_validator_prepare_beacon_proposer.json
@@ -1,7 +1,7 @@
 {
   "post" : {
     "tags" : [ "Validator", "Validator Required Api" ],
-    "summary" : "Provide beacon node with proposals for the given validators.",
+    "summary" : "Prepare Beacon Proposers",
     "description" : "Prepares the beacon node for potential proposers by supplying information required when proposing blocks for the given validators. The information supplied for each validator index is considered persistent until overwritten by new information for the given validator index, or until the beacon node restarts.\n\nNote that because the information is not persistent across beacon node restarts it is recommended that either the beacon node is monitored for restarts or this information is refreshed by resending this request periodically (for example, each epoch).\n\nAlso note that requests containing currently inactive or unknown validator indices will be accepted, as they may become active at a later epoch.",
     "operationId" : "postEthV1ValidatorPrepare_beacon_proposer",
     "requestBody" : {

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_validator_register_validator.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_validator_register_validator.json
@@ -1,7 +1,7 @@
 {
   "post" : {
     "tags" : [ "Validator", "Validator Required Api" ],
-    "summary" : "Provide beacon node with registrations for the given validators to the external builder network.",
+    "summary" : "Register validators with builder",
     "description" : "Prepares the beacon node for potential proposers by supplying information required when proposing blocks for the given validators. The information supplied for each validator index is considered persistent until overwritten by new information for the given validator index, or until the beacon node restarts.\n\nNote that because the information is not persistent across beacon node restarts it is recommended that either the beacon node is monitored for restarts or this information is refreshed by resending this request periodically (for example, each epoch).\n\nAlso note that requests containing currently inactive or unknown validator indices will be accepted, as they may become active at a later epoch.",
     "operationId" : "postEthV1ValidatorRegister_validator",
     "requestBody" : {

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostBlindedBlock.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostBlindedBlock.java
@@ -26,7 +26,6 @@ import static tech.pegasys.teku.infrastructure.http.RestApiConstants.RES_OK;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.RES_SERVICE_UNAVAILABLE;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.RES_UNSUPPORTED_MEDIA_TYPE;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.TAG_BEACON;
-import static tech.pegasys.teku.infrastructure.http.RestApiConstants.TAG_EXPERIMENTAL;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.TAG_VALIDATOR;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.TAG_VALIDATOR_REQUIRED;
 import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.HTTP_ERROR_RESPONSE_TYPE;
@@ -86,7 +85,7 @@ public class PostBlindedBlock extends MigratingEndpointAdapter {
       path = ROUTE,
       method = HttpMethod.POST,
       summary = "Publish a signed blinded block",
-      tags = {TAG_BEACON, TAG_VALIDATOR_REQUIRED, TAG_EXPERIMENTAL},
+      tags = {TAG_BEACON, TAG_VALIDATOR_REQUIRED},
       requestBody =
           @OpenApiRequestBody(
               content = {
@@ -155,7 +154,7 @@ public class PostBlindedBlock extends MigratingEndpointAdapter {
         .description(
             "Submit a signed blinded beacon block to the beacon node to be imported."
                 + " The beacon node performs the required validation.")
-        .tags(TAG_VALIDATOR, TAG_VALIDATOR_REQUIRED, TAG_EXPERIMENTAL)
+        .tags(TAG_VALIDATOR, TAG_VALIDATOR_REQUIRED)
         .requestBodyType(
             getSchemaDefinitionForAllMilestones(
                 schemaDefinitionCache,

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetNewBlindedBlock.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetNewBlindedBlock.java
@@ -30,7 +30,6 @@ import static tech.pegasys.teku.infrastructure.http.RestApiConstants.RES_SERVICE
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.SERVICE_UNAVAILABLE;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.SLOT;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.SLOT_PATH_DESCRIPTION;
-import static tech.pegasys.teku.infrastructure.http.RestApiConstants.TAG_EXPERIMENTAL;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.TAG_VALIDATOR;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.TAG_VALIDATOR_REQUIRED;
 
@@ -88,7 +87,7 @@ public class GetNewBlindedBlock extends MigratingEndpointAdapter {
       path = OAPI_ROUTE,
       method = HttpMethod.GET,
       summary = "Produce unsigned blinded block",
-      tags = {TAG_VALIDATOR, TAG_VALIDATOR_REQUIRED, TAG_EXPERIMENTAL},
+      tags = {TAG_VALIDATOR, TAG_VALIDATOR_REQUIRED},
       description =
           "Requests a beacon node to produce a valid blinded block, which can then be signed by a validator. "
               + "A blinded block is a block with only a transactions root, rather than a full transactions list.\n\n"
@@ -150,7 +149,7 @@ public class GetNewBlindedBlock extends MigratingEndpointAdapter {
                 + "Metadata in the response indicates the type of block produced, and the supported types of block "
                 + "will be added to as forks progress.\n\n"
                 + "Pre-Bellatrix, this endpoint will return a `BeaconBlock`.")
-        .tags(TAG_VALIDATOR, TAG_VALIDATOR_REQUIRED, TAG_EXPERIMENTAL)
+        .tags(TAG_VALIDATOR, TAG_VALIDATOR_REQUIRED)
         .pathParam(SLOT_PARAMETER.withDescription(SLOT_PATH_DESCRIPTION))
         .queryParamRequired(RANDAO_PARAMETER)
         .queryParam(GRAFFITI_PARAMETER)

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetProposerDuties.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetProposerDuties.java
@@ -18,6 +18,7 @@ import static tech.pegasys.teku.beaconrestapi.BeaconRestApiTypes.EPOCH_PARAMETER
 import static tech.pegasys.teku.beaconrestapi.EthereumTypes.PUBLIC_KEY_TYPE;
 import static tech.pegasys.teku.beaconrestapi.handlers.AbstractHandler.routeWithBracedParameters;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
+import static tech.pegasys.teku.infrastructure.http.RestApiConstants.EXECUTION_OPTIMISTIC;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.RES_BAD_REQUEST;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.RES_INTERNAL_ERROR;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.RES_OK;
@@ -69,7 +70,7 @@ public class GetProposerDuties extends MigratingEndpointAdapter {
       SerializableTypeDefinition.object(ProposerDuties.class)
           .name("GetProposerDutiesResponse")
           .withOptionalField(
-              "execution_optimistic",
+              EXECUTION_OPTIMISTIC,
               BOOLEAN_TYPE,
               (proposerDuties) ->
                   proposerDuties.isExecutionOptimistic() ? Optional.of(true) : Optional.empty())

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostAttesterDuties.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostAttesterDuties.java
@@ -18,6 +18,7 @@ import static tech.pegasys.teku.beaconrestapi.BeaconRestApiTypes.EPOCH_PARAMETER
 import static tech.pegasys.teku.beaconrestapi.EthereumTypes.PUBLIC_KEY_TYPE;
 import static tech.pegasys.teku.beaconrestapi.handlers.AbstractHandler.routeWithBracedParameters;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
+import static tech.pegasys.teku.infrastructure.http.RestApiConstants.EXECUTION_OPTIMISTIC;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.RES_BAD_REQUEST;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.RES_INTERNAL_ERROR;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.RES_OK;
@@ -80,7 +81,7 @@ public class PostAttesterDuties extends MigratingEndpointAdapter {
       SerializableTypeDefinition.object(AttesterDuties.class)
           .name("GetAttesterDutiesResponse")
           .withOptionalField(
-              "execution_optimistic",
+              EXECUTION_OPTIMISTIC,
               BOOLEAN_TYPE,
               attesterDuties ->
                   attesterDuties.isExecutionOptimistic() ? Optional.of(true) : Optional.empty())

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostPrepareBeaconProposer.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostPrepareBeaconProposer.java
@@ -85,7 +85,7 @@ public class PostPrepareBeaconProposer extends MigratingEndpointAdapter {
   @OpenApi(
       path = ROUTE,
       method = HttpMethod.POST,
-      summary = "Submit proposals for validators",
+      summary = "Prepare Beacon Proposers",
       tags = {TAG_VALIDATOR, TAG_VALIDATOR_REQUIRED},
       requestBody =
           @OpenApiRequestBody(

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostPrepareBeaconProposer.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostPrepareBeaconProposer.java
@@ -85,7 +85,7 @@ public class PostPrepareBeaconProposer extends MigratingEndpointAdapter {
   @OpenApi(
       path = ROUTE,
       method = HttpMethod.POST,
-      summary = "Provide beacon node with proposals for the given validators.",
+      summary = "Submit proposals for validators",
       tags = {TAG_VALIDATOR, TAG_VALIDATOR_REQUIRED},
       requestBody =
           @OpenApiRequestBody(

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostRegisterValidator.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostRegisterValidator.java
@@ -51,8 +51,7 @@ public class PostRegisterValidator extends MigratingEndpointAdapter {
     super(
         EndpointMetadata.post(ROUTE)
             .operationId("registerValidator")
-            .summary(
-                "Provide beacon node with registrations for the given validators to the external builder network.")
+            .summary("Register validators with builder")
             .description(
                 "Prepares the beacon node for engaging with external builders."
                     + " The information will be sent by the beacon node to the builder network."
@@ -76,8 +75,7 @@ public class PostRegisterValidator extends MigratingEndpointAdapter {
   @OpenApi(
       path = ROUTE,
       method = HttpMethod.POST,
-      summary =
-          "Provide beacon node with registrations for the given validators to the external builder network.",
+      summary = "Register validators with builder",
       tags = {TAG_VALIDATOR, TAG_VALIDATOR_REQUIRED},
       requestBody =
           @OpenApiRequestBody(

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostSyncDuties.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostSyncDuties.java
@@ -56,6 +56,7 @@ public class PostSyncDuties extends AbstractHandler implements Handler {
   private final ValidatorDataProvider validatorDataProvider;
   private final SyncDataProvider syncDataProvider;
 
+  // TODO #5707 add execution_optimistic
   public PostSyncDuties(final DataProvider dataProvider, final JsonProvider jsonProvider) {
     super(jsonProvider);
     this.validatorDataProvider = dataProvider.getValidatorDataProvider();


### PR DESCRIPTION
 - removed EXPERIMENTAL from some of the newer endpoints
 - shortened some summaries in use
 - changes from v.2.2-v2.3 of spec look to be done
 - one outstanding `execution_optimstic` change from v.2.1-v2.2, added a TODO into PostSyncDuties, should try to get this into the next release.

 Currently it's a little difficult to reconcile which endpoints use Eth-Consensus-Version header, it should probably become an issue to document it - raised #5708 for this.

 fixes #4477

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
