### PR TITLE
[MEV Boost\Builder] Add a readiness check for the fee recipient retrieval when registering

### DIFF
--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/BeaconProposerPreparer.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/BeaconProposerPreparer.java
@@ -186,15 +186,12 @@ public class BeaconProposerPreparer implements ValidatorTimingChannel, FeeRecipi
     this.maybeProposerConfig = maybeProposerConfig;
     return blsPublicKeyToIndexMap.entrySet().stream()
         .map(
-            entry -> {
-              final BLSPublicKey publicKey = entry.getKey();
-              final Integer validatorIndex = entry.getValue();
-              return getFeeRecipient(publicKey)
-                  .map(
-                      eth1Address ->
-                          new BeaconPreparableProposer(
-                              UInt64.valueOf(validatorIndex), eth1Address));
-            })
+            entry ->
+                getFeeRecipient(entry.getKey())
+                    .map(
+                        eth1Address ->
+                            new BeaconPreparableProposer(
+                                UInt64.valueOf(entry.getValue()), eth1Address)))
         .flatMap(Optional::stream)
         .collect(Collectors.toList());
   }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/BeaconProposerPreparer.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/BeaconProposerPreparer.java
@@ -123,7 +123,7 @@ public class BeaconProposerPreparer implements ValidatorTimingChannel, FeeRecipi
     if (eth1Address.equals(Eth1Address.ZERO)) {
       throw new SetFeeRecipientException("Cannot set fee recipient to 0x00 address.");
     }
-    if (!checkValidatorIndexIsResolved(publicKey)) {
+    if (!validatorIndexCanBeResolved(publicKey)) {
       throw new SetFeeRecipientException(
           "Validator public key not found when attempting to set fee recipient.");
     }
@@ -186,7 +186,7 @@ public class BeaconProposerPreparer implements ValidatorTimingChannel, FeeRecipi
             entry -> {
               final BLSPublicKey publicKey = entry.getKey();
               final Optional<Eth1Address> maybeFeeRecipient;
-              if (checkValidatorIndexIsResolved(publicKey)) {
+              if (validatorIndexCanBeResolved(publicKey)) {
                 maybeFeeRecipient = getFeeRecipient(publicKey);
               } else {
                 maybeFeeRecipient = Optional.empty();
@@ -199,7 +199,7 @@ public class BeaconProposerPreparer implements ValidatorTimingChannel, FeeRecipi
         .collect(Collectors.toList());
   }
 
-  private boolean checkValidatorIndexIsResolved(final BLSPublicKey publicKey) {
+  private boolean validatorIndexCanBeResolved(final BLSPublicKey publicKey) {
     return validatorIndexProvider.isPresent()
         && validatorIndexProvider.get().containsPublicKey(publicKey);
   }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/BeaconProposerPreparer.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/BeaconProposerPreparer.java
@@ -100,19 +100,13 @@ public class BeaconProposerPreparer implements ValidatorTimingChannel, FeeRecipi
   // - default set by --validators-proposer-default-fee-recipient
   @Override
   public Optional<Eth1Address> getFeeRecipient(final BLSPublicKey publicKey) {
-    Optional<Eth1Address> maybeEth1Address =
-        maybeProposerConfig.flatMap(config -> getFeeRecipientFromProposerConfig(config, publicKey));
-    if (maybeEth1Address.isPresent()) {
-      return maybeEth1Address;
-    }
-
-    maybeEth1Address = runtimeProposerConfig.getEth1AddressForPubKey(publicKey);
-    if (maybeEth1Address.isPresent()) {
-      return maybeEth1Address;
-    }
-
     return maybeProposerConfig
-        .map(proposerConfig -> proposerConfig.getDefaultConfig().getFeeRecipient())
+        .flatMap(config -> getFeeRecipientFromProposerConfig(config, publicKey))
+        .or(() -> runtimeProposerConfig.getEth1AddressForPubKey(publicKey))
+        .or(
+            () ->
+                maybeProposerConfig.map(
+                    proposerConfig -> proposerConfig.getDefaultConfig().getFeeRecipient()))
         .or(() -> defaultFeeRecipient);
   }
 

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/BeaconProposerPreparer.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/BeaconProposerPreparer.java
@@ -101,6 +101,7 @@ public class BeaconProposerPreparer implements ValidatorTimingChannel, FeeRecipi
   // - proposer set via the SET api (runtime configuration)
   // - default set in --validator-proposer-config file
   // - default set by --validators-proposer-default-fee-recipient
+  @Override
   public Optional<Eth1Address> getFeeRecipient(final BLSPublicKey publicKey) {
     if (validatorIndexCannotBeResolved(publicKey)) {
       return Optional.empty();

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/FeeRecipientProvider.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/FeeRecipientProvider.java
@@ -20,5 +20,6 @@ import tech.pegasys.teku.spec.datastructures.eth1.Eth1Address;
 @FunctionalInterface
 public interface FeeRecipientProvider {
 
-  Optional<Eth1Address> getFeeRecipient(BLSPublicKey publicKey);
+  Optional<Eth1Address> getFeeRecipient(
+      Optional<ProposerConfig> maybeProposerConfig, BLSPublicKey publicKey);
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/FeeRecipientProvider.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/FeeRecipientProvider.java
@@ -17,9 +17,9 @@ import java.util.Optional;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.spec.datastructures.eth1.Eth1Address;
 
-@FunctionalInterface
 public interface FeeRecipientProvider {
 
-  Optional<Eth1Address> getFeeRecipient(
-      Optional<ProposerConfig> maybeProposerConfig, BLSPublicKey publicKey);
+  Optional<Eth1Address> getFeeRecipient(BLSPublicKey publicKey);
+
+  boolean isReadyToProvideFeeRecipient();
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrator.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrator.java
@@ -81,7 +81,10 @@ public class ValidatorRegistrator implements ValidatorTimingChannel {
 
   @Override
   public void onSlot(UInt64 slot) {
-    if (isBeginningOfEpoch(slot) || firstCallDone.compareAndSet(false, true)) {
+    if (!isReadyToRegister()) {
+      return;
+    }
+    if (firstCallDone.compareAndSet(false, true) || isBeginningOfEpoch(slot)) {
       final UInt64 epoch = spec.computeEpochAtSlot(slot);
       lastProcessedEpoch.set(epoch);
       final List<Validator> activeValidators = ownedValidators.getActiveValidators();
@@ -106,7 +109,7 @@ public class ValidatorRegistrator implements ValidatorTimingChannel {
 
   @Override
   public void onValidatorsAdded() {
-    if (lastProcessedEpoch.get() == null) {
+    if (!isReadyToRegister() || lastProcessedEpoch.get() == null) {
       return;
     }
 
@@ -133,6 +136,14 @@ public class ValidatorRegistrator implements ValidatorTimingChannel {
 
   @Override
   public void onAttestationAggregationDue(UInt64 slot) {}
+
+  private boolean isReadyToRegister() {
+    if (feeRecipientProvider.isReadyToProvideFeeRecipient()) {
+      return true;
+    }
+    LOG.debug("Not ready to register validator(s).");
+    return false;
+  }
 
   private boolean isBeginningOfEpoch(final UInt64 slot) {
     return slot.mod(spec.getSlotsPerEpoch(slot)).isZero();
@@ -172,11 +183,12 @@ public class ValidatorRegistrator implements ValidatorTimingChannel {
       return Optional.empty();
     }
 
-    final Optional<Eth1Address> maybeFeeRecipient =
-        feeRecipientProvider.getFeeRecipient(maybeProposerConfig, publicKey);
+    final Optional<Eth1Address> maybeFeeRecipient = feeRecipientProvider.getFeeRecipient(publicKey);
 
     if (maybeFeeRecipient.isEmpty()) {
-      LOG.warn("There is no fee recipient configured for {}. Can't register.", publicKey);
+      LOG.debug(
+          "Couldn't retrieve fee recipient for {}. Will skip registering this validator.",
+          publicKey);
       return Optional.empty();
     }
 

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrator.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrator.java
@@ -86,7 +86,9 @@ public class ValidatorRegistrator implements ValidatorTimingChannel {
       lastProcessedEpoch.set(epoch);
       final List<Validator> activeValidators = ownedValidators.getActiveValidators();
       LOG.debug(
-          "Checking registration of {} validator(s) at epoch {}", activeValidators.size(), epoch);
+          "Checking if registration is required for {} validator(s) at epoch {}",
+          activeValidators.size(),
+          epoch);
       registerValidators(activeValidators, epoch)
           .finish(VALIDATOR_LOGGER::registeringValidatorsFailed);
     }
@@ -170,7 +172,8 @@ public class ValidatorRegistrator implements ValidatorTimingChannel {
       return Optional.empty();
     }
 
-    final Optional<Eth1Address> maybeFeeRecipient = feeRecipientProvider.getFeeRecipient(publicKey);
+    final Optional<Eth1Address> maybeFeeRecipient =
+        feeRecipientProvider.getFeeRecipient(maybeProposerConfig, publicKey);
 
     if (maybeFeeRecipient.isEmpty()) {
       LOG.warn("There is no fee recipient configured for {}. Can't register.", publicKey);

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrator.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrator.java
@@ -173,7 +173,7 @@ public class ValidatorRegistrator implements ValidatorTimingChannel {
     final Optional<Eth1Address> maybeFeeRecipient = feeRecipientProvider.getFeeRecipient(publicKey);
 
     if (maybeFeeRecipient.isEmpty()) {
-      LOG.warn("There is no fee recipient configured for {}. Can't register.", validator);
+      LOG.warn("There is no fee recipient configured for {}. Can't register.", publicKey);
       return Optional.empty();
     }
 

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/BeaconProposerPreparerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/BeaconProposerPreparerTest.java
@@ -21,7 +21,6 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
@@ -128,22 +127,6 @@ public class BeaconProposerPreparerTest {
   }
 
   @TestTemplate
-  void shouldNotCallPrepareBeaconProposer_IfValidatorIndexProviderMissing() {
-    beaconProposerPreparer =
-        new BeaconProposerPreparer(
-            validatorApiChannel,
-            Optional.empty(),
-            proposerConfigProvider,
-            Optional.of(defaultFeeRecipient),
-            spec,
-            Optional.empty());
-
-    beaconProposerPreparer.onSlot(UInt64.valueOf(slotsPerEpoch * 2));
-
-    verifyNoInteractions(validatorApiChannel);
-  }
-
-  @TestTemplate
   void should_callPrepareBeaconProposerAtBeginningOfEpoch() {
     ArgumentCaptor<Collection<BeaconPreparableProposer>> captor = doCall();
 
@@ -153,19 +136,6 @@ public class BeaconProposerPreparerTest {
                 UInt64.valueOf(validator1Index), validator1FeeRecipientConfig),
             new BeaconPreparableProposer(
                 UInt64.valueOf(validator2Index), defaultFeeRecipientConfig));
-  }
-
-  @TestTemplate
-  void shouldNotPrepareBeaconProposer_IfValidatorIndexProviderMissingPubkey() {
-    when(validatorIndexProvider.containsPublicKey(eq(validator2.getPublicKey()))).thenReturn(false);
-
-    ArgumentCaptor<Collection<BeaconPreparableProposer>> captor = doCall();
-
-    // only validator1 is prepared
-    assertThat(captor.getValue())
-        .containsExactlyInAnyOrder(
-            new BeaconPreparableProposer(
-                UInt64.valueOf(validator1Index), validator1FeeRecipientConfig));
   }
 
   @TestTemplate
@@ -182,9 +152,29 @@ public class BeaconProposerPreparerTest {
   }
 
   @TestTemplate
+  void getFeeRecipient_shouldReturnEmptyIfValidatorIndexProviderMissing() {
+    beaconProposerPreparer =
+        new BeaconProposerPreparer(
+            validatorApiChannel,
+            Optional.empty(),
+            proposerConfigProvider,
+            Optional.of(defaultFeeRecipient),
+            spec,
+            Optional.empty());
+
+    assertThat(beaconProposerPreparer.getFeeRecipient(validator1.getPublicKey())).isEmpty();
+  }
+
+  @TestTemplate
   void getFeeRecipient_shouldReturnDefaultFeeRecipientWhenProposerConfigMissing() {
     assertThat(beaconProposerPreparer.getFeeRecipient(validator1.getPublicKey()))
         .contains(defaultFeeRecipient);
+  }
+
+  @TestTemplate
+  void getFeeRecipient_shouldReturnEmptyIfValidatorIndexProviderMissingPubkey() {
+    assertThat(beaconProposerPreparer.getFeeRecipient(dataStructureUtil.randomPublicKey()))
+        .isEmpty();
   }
 
   @TestTemplate

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/BeaconProposerPreparerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/BeaconProposerPreparerTest.java
@@ -128,6 +128,10 @@ public class BeaconProposerPreparerTest {
 
   @TestTemplate
   void should_callPrepareBeaconProposerAtBeginningOfEpoch() {
+    // not yet ready to provide a fee recipient to other consumers since the first sending hasn't
+    // been done
+    assertThat(beaconProposerPreparer.isReadyToProvideFeeRecipient()).isFalse();
+
     ArgumentCaptor<Collection<BeaconPreparableProposer>> captor = doCall();
 
     assertThat(captor.getValue())
@@ -136,6 +140,8 @@ public class BeaconProposerPreparerTest {
                 UInt64.valueOf(validator1Index), validator1FeeRecipientConfig),
             new BeaconPreparableProposer(
                 UInt64.valueOf(validator2Index), defaultFeeRecipientConfig));
+
+    assertThat(beaconProposerPreparer.isReadyToProvideFeeRecipient()).isTrue();
   }
 
   @TestTemplate

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorRegistratorTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorRegistratorTest.java
@@ -101,7 +101,8 @@ class ValidatorRegistratorTest {
     when(proposerConfig.getValidatorRegistrationGasLimitForPubKey(any()))
         .thenReturn(Optional.of(CUSTOM_GAS_LIMIT));
 
-    when(feeRecipientProvider.getFeeRecipient(any(), any())).thenReturn(Optional.of(eth1Address));
+    when(feeRecipientProvider.isReadyToProvideFeeRecipient()).thenReturn(true);
+    when(feeRecipientProvider.getFeeRecipient(any())).thenReturn(Optional.of(eth1Address));
 
     // random signature for all signings
     doAnswer(invocation -> SafeFuture.completedFuture(dataStructureUtil.randomSignature()))
@@ -110,11 +111,20 @@ class ValidatorRegistratorTest {
   }
 
   @TestTemplate
+  void doesNotRegisterValidators_ifNotReady() {
+    when(feeRecipientProvider.isReadyToProvideFeeRecipient()).thenReturn(false);
+
+    validatorRegistrator.onSlot(UInt64.ONE);
+
+    verifyNoInteractions(ownedValidators, validatorApiChannel, signer);
+  }
+
+  @TestTemplate
   void doesNotRegisterValidators_ifNotBeginningOfEpoch() {
     when(ownedValidators.getActiveValidators()).thenReturn(List.of());
 
-    // initially validators will be registered anyway since it's the first call
-    validatorRegistrator.onSlot(UInt64.ONE);
+    // initially validators will be registered since it's the first call
+    validatorRegistrator.onSlot(UInt64.ZERO);
     verify(ownedValidators).getActiveValidators();
 
     // after the initial call, registration should not occur if not beginning of epoch
@@ -152,6 +162,15 @@ class ValidatorRegistratorTest {
     // signer will be called in total 3 times, since from the 2nd run the signed registrations will
     // be cached
     verify(signer, times(3)).signValidatorRegistration(any(), any());
+  }
+
+  @TestTemplate
+  void doesNotRegisterNewlyAddedValidators_ifNotReady() {
+    when(feeRecipientProvider.isReadyToProvideFeeRecipient()).thenReturn(false);
+
+    validatorRegistrator.onValidatorsAdded();
+
+    verifyNoInteractions(ownedValidators, validatorApiChannel, signer);
   }
 
   @TestTemplate
@@ -272,12 +291,10 @@ class ValidatorRegistratorTest {
     // GIVEN
     when(ownedValidators.getActiveValidators()).thenReturn(List.of(validator1, validator2));
 
-    when(feeRecipientProvider.getFeeRecipient(
-            Optional.of(proposerConfig), validator1.getPublicKey()))
+    when(feeRecipientProvider.getFeeRecipient(validator1.getPublicKey()))
         .thenReturn(Optional.of(eth1Address));
     // no fee recipient provided for validator2
-    when(feeRecipientProvider.getFeeRecipient(
-            Optional.of(proposerConfig), validator2.getPublicKey()))
+    when(feeRecipientProvider.getFeeRecipient(validator2.getPublicKey()))
         .thenReturn(Optional.empty());
 
     // WHEN

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorRegistratorTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorRegistratorTest.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.validator.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -102,8 +101,7 @@ class ValidatorRegistratorTest {
     when(proposerConfig.getValidatorRegistrationGasLimitForPubKey(any()))
         .thenReturn(Optional.of(CUSTOM_GAS_LIMIT));
 
-    when(feeRecipientProvider.getFeeRecipient(eq(Optional.of(proposerConfig)), any()))
-        .thenReturn(Optional.of(eth1Address));
+    when(feeRecipientProvider.getFeeRecipient(any(), any())).thenReturn(Optional.of(eth1Address));
 
     // random signature for all signings
     doAnswer(invocation -> SafeFuture.completedFuture(dataStructureUtil.randomSignature()))

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorRegistratorTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorRegistratorTest.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.validator.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -101,7 +102,8 @@ class ValidatorRegistratorTest {
     when(proposerConfig.getValidatorRegistrationGasLimitForPubKey(any()))
         .thenReturn(Optional.of(CUSTOM_GAS_LIMIT));
 
-    when(feeRecipientProvider.getFeeRecipient(any())).thenReturn(Optional.of(eth1Address));
+    when(feeRecipientProvider.getFeeRecipient(eq(Optional.of(proposerConfig)), any()))
+        .thenReturn(Optional.of(eth1Address));
 
     // random signature for all signings
     doAnswer(invocation -> SafeFuture.completedFuture(dataStructureUtil.randomSignature()))
@@ -272,10 +274,12 @@ class ValidatorRegistratorTest {
     // GIVEN
     when(ownedValidators.getActiveValidators()).thenReturn(List.of(validator1, validator2));
 
-    when(feeRecipientProvider.getFeeRecipient(validator1.getPublicKey()))
+    when(feeRecipientProvider.getFeeRecipient(
+            Optional.of(proposerConfig), validator1.getPublicKey()))
         .thenReturn(Optional.of(eth1Address));
     // no fee recipient provided for validator2
-    when(feeRecipientProvider.getFeeRecipient(validator2.getPublicKey()))
+    when(feeRecipientProvider.getFeeRecipient(
+            Optional.of(proposerConfig), validator2.getPublicKey()))
         .thenReturn(Optional.empty());
 
     // WHEN


### PR DESCRIPTION
## PR Description

- Changed signature of `FeeRecipientProvider.getFeeRecipient()` to add a readiness check.
- Implemented the readiness check in the `BeaconProposerPreparer` (one successful sending of proposers)
- Added the readiness check in `ValidatorRegistrator` in `onSlot` and `onValidatorsAdded`
- Changed the implementation of `getFeeRecipient` to be one optional pipeline using `or`
- Logging changes
- Changed the `warn` log to `debug` log for the missing fee recipient.

## Fixed Issue(s)
fixes #5716

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
