### PR TITLE
[MEV Boost\Builder] Use decimal instead of hex for logging the MEV Reward

### DIFF
--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
@@ -448,7 +448,7 @@ public class ExecutionLayerManagerImpl implements ExecutionLayerManager {
   private void logReceivedBuilderBid(final BuilderBid builderBid) {
     final ExecutionPayloadHeader payloadHeader = builderBid.getExecutionPayloadHeader();
     LOG.info(
-        "Received Builder Bid (Block Number = {}, Block Hash = {}, MEV Rewards (wei) = {}, Gas Limit = {}, Gas Used = {})",
+        "Received Builder Bid (Block Number = {}, Block Hash = {}, MEV Reward (wei) = {}, Gas Limit = {}, Gas Used = {})",
         payloadHeader.getBlockNumber(),
         payloadHeader.getBlockHash(),
         builderBid.getValue().toDecimalString(),

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
@@ -451,7 +451,7 @@ public class ExecutionLayerManagerImpl implements ExecutionLayerManager {
         "Received Builder Bid (Block Number = {}, Block Hash = {}, MEV Rewards (wei) = {}, Gas Limit = {}, Gas Used = {})",
         payloadHeader.getBlockNumber(),
         payloadHeader.getBlockHash(),
-        builderBid.getValue(),
+        builderBid.getValue().toDecimalString(),
         payloadHeader.getGasLimit(),
         payloadHeader.getGasUsed());
   }


### PR DESCRIPTION
## PR Description
Using a decimal instead of a hex for logging the MEV Reward will make it more readable.

## Fixed Issue(s)
fixes #5710

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
