### PR TITLE
Ensure event thread is started in executeLater

### DIFF
--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/eventthread/AsyncRunnerEventThread.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/eventthread/AsyncRunnerEventThread.java
@@ -65,6 +65,9 @@ public class AsyncRunnerEventThread implements EventThread {
 
   @Override
   public void executeLater(final Runnable task) {
+    if (!started.get()) {
+      throw new IllegalStateException("EventThread not started");
+    }
     thread.runAsync(() -> recordEventThreadIdAndExecute(asSupplier(task))).reportExceptions();
   }
 
@@ -92,7 +95,7 @@ public class AsyncRunnerEventThread implements EventThread {
   @Override
   public void execute(final Runnable task) {
     if (!started.get()) {
-      return;
+      throw new IllegalStateException("EventThread not started");
     }
     doExecute(asSupplier(task)).reportExceptions();
   }

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/eventthread/AsyncRunnerEventThread.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/eventthread/AsyncRunnerEventThread.java
@@ -95,7 +95,10 @@ public class AsyncRunnerEventThread implements EventThread {
   @Override
   public void execute(final Runnable task) {
     if (!started.get()) {
-      throw new IllegalStateException("EventThread not started");
+      // If we threw an exception here, it would cause a lot of noise at
+      // shutdown because started is set to false on shutdown. We may still be
+      // sending tasks to the executor which we deliberately want to ignore.
+      return;
     }
     doExecute(asSupplier(task)).reportExceptions();
   }

--- a/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/eventthread/AsyncRunnerEventThreadTest.java
+++ b/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/eventthread/AsyncRunnerEventThreadTest.java
@@ -40,12 +40,6 @@ class AsyncRunnerEventThreadTest {
   }
 
   @Test
-  void execute_shouldThrowWhenNotStarted() {
-    assertThatThrownBy(() -> eventThread.execute(eventThread::checkOnEventThread))
-        .isInstanceOf(IllegalStateException.class);
-  }
-
-  @Test
   void executeLater_shouldThrowWhenNotStarted() {
     assertThatThrownBy(() -> eventThread.executeLater(eventThread::checkOnEventThread))
         .isInstanceOf(IllegalStateException.class);

--- a/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/eventthread/AsyncRunnerEventThreadTest.java
+++ b/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/eventthread/AsyncRunnerEventThreadTest.java
@@ -40,6 +40,18 @@ class AsyncRunnerEventThreadTest {
   }
 
   @Test
+  void execute_shouldThrowWhenNotStarted() {
+    assertThatThrownBy(() -> eventThread.execute(eventThread::checkOnEventThread))
+        .isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  void executeLater_shouldThrowWhenNotStarted() {
+    assertThatThrownBy(() -> eventThread.executeLater(eventThread::checkOnEventThread))
+        .isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
   void checkOnEventThread_shouldNotBeOnEventThreadWhenNotStarted() {
     assertThatThrownBy(eventThread::checkOnEventThread).isInstanceOf(IllegalStateException.class);
   }


### PR DESCRIPTION
## PR Description

Noticed that the public `AsyncRunnerEventThread::executeLater` method would not check if the thread was started prior to executing which could result in a null pointer exception. The other execution methods would properly check this.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
