### PR TITLE
Enable Error Prone's PreferredInterfaceType check

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -220,6 +220,7 @@ allprojects {
       check('InitializeInline', net.ltgt.gradle.errorprone.CheckSeverity.WARN)
       check('ClassName', net.ltgt.gradle.errorprone.CheckSeverity.WARN)
       check('InterfaceWithOnlyStatics', net.ltgt.gradle.errorprone.CheckSeverity.WARN)
+      check('PreferredInterfaceType', net.ltgt.gradle.errorprone.CheckSeverity.WARN)
     }
     options.encoding = 'UTF-8'
   }

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/DefaultAsyncRunnerFactory.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/DefaultAsyncRunnerFactory.java
@@ -14,10 +14,11 @@
 package tech.pegasys.teku.infrastructure.async;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 public class DefaultAsyncRunnerFactory implements AsyncRunnerFactory {
-  private final Collection<AsyncRunner> asyncRunners = new CopyOnWriteArrayList<>();
+  private final List<AsyncRunner> asyncRunners = new CopyOnWriteArrayList<>();
 
   private final MetricTrackingExecutorFactory executorFactory;
 

--- a/infrastructure/metrics/src/main/java/tech/pegasys/teku/infrastructure/metrics/MetricsConfig.java
+++ b/infrastructure/metrics/src/main/java/tech/pegasys/teku/infrastructure/metrics/MetricsConfig.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.infrastructure.metrics;
 import com.google.common.collect.ImmutableSet;
 import java.net.URL;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
@@ -27,11 +28,13 @@ import tech.pegasys.teku.infrastructure.io.PortAvailability;
 
 public class MetricsConfig {
 
-  public static final ImmutableSet<MetricCategory> DEFAULT_METRICS_CATEGORIES =
-      ImmutableSet.<MetricCategory>builder()
-          .addAll(EnumSet.allOf(StandardMetricCategory.class))
-          .addAll(EnumSet.allOf(TekuMetricCategory.class))
-          .build();
+  public static final Set<MetricCategory> DEFAULT_METRICS_CATEGORIES =
+      Collections.unmodifiableSet(
+          ImmutableSet.<MetricCategory>builder()
+              .addAll(EnumSet.allOf(StandardMetricCategory.class))
+              .addAll(EnumSet.allOf(TekuMetricCategory.class))
+              .build());
+
   public static final int DEFAULT_METRICS_PORT = 8008;
   public static final String DEFAULT_METRICS_INTERFACE = "127.0.0.1";
   public static final List<String> DEFAULT_METRICS_HOST_ALLOWLIST =

--- a/infrastructure/restapi/src/testFixtures/java/tech/pegasys/teku/infrastructure/restapi/OpenApiTestUtil.java
+++ b/infrastructure/restapi/src/testFixtures/java/tech/pegasys/teku/infrastructure/restapi/OpenApiTestUtil.java
@@ -75,7 +75,7 @@ public class OpenApiTestUtil<TObject> {
    */
   public void compareToKnownDefinitions(
       final Path tempDir, final String path, final JsonNode parentNode) throws IOException {
-    List<String> fieldNames = ImmutableList.copyOf(parentNode.fieldNames());
+    ImmutableList<String> fieldNames = ImmutableList.copyOf(parentNode.fieldNames());
     for (String current : fieldNames) {
       checkStructureIsConsistent(path, tempDir, current, parentNode.path(current));
     }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/BeaconChainMethods.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/BeaconChainMethods.java
@@ -67,7 +67,7 @@ public class BeaconChainMethods {
   private final Eth2RpcMethod<EmptyMessage, MetadataMessage> getMetadata;
   private final Eth2RpcMethod<PingMessage, PingMessage> ping;
 
-  private final Collection<Eth2RpcMethod<?, ?>> allMethods;
+  private final List<Eth2RpcMethod<?, ?>> allMethods;
 
   private BeaconChainMethods(
       final Eth2RpcMethod<StatusMessage, StatusMessage> status,

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/subnets/PeerSubnetSubscriptionsTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/subnets/PeerSubnetSubscriptionsTest.java
@@ -68,7 +68,7 @@ class PeerSubnetSubscriptionsTest {
     // Set up some sync committee subnets we should be participating in
     syncnetSubscriptions.setSubscriptions(IntList.of(0, 1));
 
-    final Map<String, Collection<NodeId>> subscribersByTopic =
+    final ImmutableMap<String, Collection<NodeId>> subscribersByTopic =
         ImmutableMap.<String, Collection<NodeId>>builder()
             .put("attnet_0", Set.of(PEER1, PEER2, PEER3))
             .put("attnet_1", Set.of(PEER1))

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/connection/ConnectionManager.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/connection/ConnectionManager.java
@@ -56,7 +56,7 @@ public class ConnectionManager extends Service {
   private final Counter successfulConnectionCounter;
   private final Counter failedConnectionCounter;
   private final PeerPools peerPools = new PeerPools();
-  private final Collection<Predicate<DiscoveryPeer>> peerPredicates = new CopyOnWriteArrayList<>();
+  private final List<Predicate<DiscoveryPeer>> peerPredicates = new CopyOnWriteArrayList<>();
 
   private volatile long peerConnectedSubscriptionId;
   private volatile Cancellable periodicPeerSearch;

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/storageSystem/SupportedDatabaseVersionArgumentsProvider.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/storageSystem/SupportedDatabaseVersionArgumentsProvider.java
@@ -16,7 +16,6 @@ package tech.pegasys.teku.storage.storageSystem;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -26,7 +25,7 @@ import tech.pegasys.teku.storage.server.DatabaseVersion;
 
 public class SupportedDatabaseVersionArgumentsProvider implements ArgumentsProvider {
 
-  public static Collection<DatabaseVersion> supportedDatabaseVersions() {
+  public static List<DatabaseVersion> supportedDatabaseVersions() {
     final List<DatabaseVersion> supportedVersions = new ArrayList<>();
     if (DatabaseVersion.isRocksDbSupported()) {
       supportedVersions.add(DatabaseVersion.V4);

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/BeaconProposerPreparer.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/BeaconProposerPreparer.java
@@ -16,7 +16,7 @@ package tech.pegasys.teku.validator.client;
 import static tech.pegasys.teku.infrastructure.logging.ValidatorLogger.VALIDATOR_LOGGER;
 
 import java.nio.file.Path;
-import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -182,7 +182,7 @@ public class BeaconProposerPreparer implements ValidatorTimingChannel, FeeRecipi
         .finish(VALIDATOR_LOGGER::beaconProposerPreparationFailed);
   }
 
-  private Collection<BeaconPreparableProposer> buildBeaconPreparableProposerList(
+  private List<BeaconPreparableProposer> buildBeaconPreparableProposerList(
       Optional<ProposerConfig> maybeProposerConfig,
       Map<BLSPublicKey, Integer> blsPublicKeyToIndexMap) {
     this.maybeProposerConfig = maybeProposerConfig;

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorIndexProvider.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorIndexProvider.java
@@ -19,8 +19,8 @@ import com.google.common.collect.Sets;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntCollection;
 import java.time.Duration;
-import java.util.Collection;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -56,7 +56,7 @@ public class ValidatorIndexProvider {
   }
 
   public void lookupValidators() {
-    final Collection<BLSPublicKey> unknownValidators = getUnknownValidators();
+    final Set<BLSPublicKey> unknownValidators = getUnknownValidators();
     if (unknownValidators.isEmpty()) {
       return;
     }
@@ -82,7 +82,7 @@ public class ValidatorIndexProvider {
             });
   }
 
-  private Collection<BLSPublicKey> getUnknownValidators() {
+  private Set<BLSPublicKey> getUnknownValidators() {
     return Sets.difference(ownedValidators.getPublicKeys(), validatorIndicesByPublicKey.keySet());
   }
 

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/AbstractDutySchedulerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/AbstractDutySchedulerTest.java
@@ -19,9 +19,7 @@ import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.async.SafeFuture.completedFuture;
 
 import it.unimi.dsi.fastutil.ints.IntList;
-import java.util.Collection;
 import java.util.Optional;
-import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.bls.BLSSignature;
@@ -39,7 +37,6 @@ import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 public abstract class AbstractDutySchedulerTest {
   static final BLSPublicKey VALIDATOR1_KEY = BLSTestUtil.randomPublicKey(100);
   static final BLSPublicKey VALIDATOR2_KEY = BLSTestUtil.randomPublicKey(200);
-  static final Collection<BLSPublicKey> VALIDATOR_KEYS = Set.of(VALIDATOR1_KEY, VALIDATOR2_KEY);
   static final IntList VALIDATOR_INDICES = IntList.of(123, 559);
   final ValidatorIndexProvider validatorIndexProvider = mock(ValidatorIndexProvider.class);
   final Signer validator1Signer = mock(Signer.class);

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/DefaultValidatorStatusLoggerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/DefaultValidatorStatusLoggerTest.java
@@ -20,7 +20,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.core.signatures.NoOpLocalSigner.NO_OP_SIGNER;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
@@ -43,7 +42,7 @@ public class DefaultValidatorStatusLoggerTest {
   public static final String VALIDATOR_COUNTS_METRIC = "local_validator_counts";
   private final ValidatorApiChannel validatorApiChannel = mock(ValidatorApiChannel.class);
   private final BLSPublicKey validatorKey = BLSTestUtil.randomPublicKey(0);
-  private final Collection<BLSPublicKey> validatorKeys = Set.of(validatorKey);
+  private final Set<BLSPublicKey> validatorKeys = Set.of(validatorKey);
   private final StubAsyncRunner asyncRunner = new StubAsyncRunner();
   private final StubMetricsSystem metricsSystem = new StubMetricsSystem();
 


### PR DESCRIPTION
## PR Description

The [PreferredInterfaceType](http://errorprone.info/bugpattern/PreferredInterfaceType) check will:

> Where possible, prefer referring to some types by a subtype which conveys more information. For example: ImmutableList conveys more information (the [immutability](https://guava.dev/releases/21.0/api/docs/com/google/common/collect/ImmutableCollection.html) of the type) than List, List conveys more information than Collection, and ListMultimap conveys more information than Multimap.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
