### PR TITLE
Prevent unboxing of a nullable variable

### DIFF
--- a/data/serializer/src/main/java/tech/pegasys/teku/provider/GetStateResponseV2Deserializer.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/provider/GetStateResponseV2Deserializer.java
@@ -39,9 +39,7 @@ public class GetStateResponseV2Deserializer extends JsonDeserializer<GetStateRes
     JsonNode node = jp.getCodec().readTree(jp);
     final Version version =
         Version.valueOf(node.findValue("version").asText().toLowerCase(Locale.ROOT));
-    final JsonNode executionOptimisticNode = node.findValue("execution_optimistic");
-    final Boolean executionOptimistic =
-        executionOptimisticNode != null ? executionOptimisticNode.asBoolean() : null;
+    final boolean executionOptimistic = node.findValue("execution_optimistic").asBoolean();
     final BeaconState state;
     switch (version) {
       case altair:


### PR DESCRIPTION
## PR Description

Recently, `executionOptimistic` was changed from `Boolean` to `boolean` but the (old style) deserializer still treated the field as optional and as a result it could be null. When `executionOptimistic` is null, it would throw a null pointer exception when unboxing the value for the `GetStateResponseV2` constructor. To be fair, it doesn't make that much of a difference; it will now throw a NPE a little earlier if the field is missing.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
