### PR TITLE
Remove `reportExceptions` from updateForkChoice

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -143,7 +143,7 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
                                 .getForkChoiceState()
                                 .getHeadBlockRoot(),
                             forkChoiceUpdatedResult.getPayloadStatus())))
-        .reportExceptions();
+        .finish(error -> LOG.error("Failed to update fork choice", error));
   }
 
   private void initializeProtoArrayForkChoice() {


### PR DESCRIPTION
Falling through to the generic exception handler isn't very helpful, added a simple message and it will still log the error and stacktrace.

fixes #5728

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
