### PR TITLE
Check if discoveryConfig is null before dereference

### DIFF
--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/DiscoveryNetworkBuilder.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/DiscoveryNetworkBuilder.java
@@ -66,6 +66,13 @@ public class DiscoveryNetworkBuilder {
 
   public DiscoveryNetwork<?> build() {
     initMissingDefaults();
+
+    checkNotNull(p2pNetwork);
+    checkNotNull(discoveryService);
+    checkNotNull(connectionManager);
+    checkNotNull(spec);
+    checkNotNull(currentSchemaDefinitionsSupplier);
+
     return new DiscoveryNetwork<>(
         p2pNetwork, discoveryService, connectionManager, spec, currentSchemaDefinitionsSupplier);
   }
@@ -91,10 +98,11 @@ public class DiscoveryNetworkBuilder {
 
   protected DiscoveryService createDiscoveryService() {
     final DiscoveryService discoveryService;
+
+    checkNotNull(discoveryConfig);
     if (discoveryConfig.isDiscoveryEnabled()) {
       checkNotNull(metricsSystem);
       checkNotNull(asyncRunner);
-      checkNotNull(discoveryConfig);
       checkNotNull(p2pConfig);
       checkNotNull(kvStore);
       checkNotNull(p2pNetwork);


### PR DESCRIPTION
## PR Description

Noticed that `checkNotNull(discoveryConfig)` was called after dereferencing `discoveryConfig`. I believe this check should happen _before_ dereferencing the value. I also noticed some missing null checks in `build()`, notably `spec` and `currentSchemaDefinitionsSupplier` could have been null; added checks for all of the arguments to be safe.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
