### PR TITLE
Default to burn address for fee recipient

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ProposersDataManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ProposersDataManager.java
@@ -226,8 +226,8 @@ public class ProposersDataManager implements SlotEventsChannel {
       VALIDATOR_LOGGER.executionPayloadPreparedUsingBeaconDefaultFeeRecipient(blockSlot);
       return proposerDefaultFeeRecipient.get();
     }
-    throw new IllegalStateException(
-        "Unable to determine proposer fee recipient address for slot " + blockSlot);
+    VALIDATOR_LOGGER.executionPayloadPreparedUsingBurnAddressForFeeRecipient(blockSlot);
+    return Eth1Address.ZERO;
   }
 
   private SafeFuture<Optional<BeaconState>> getStateInEpoch(final UInt64 requiredEpoch) {

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/ValidatorLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/ValidatorLogger.java
@@ -184,6 +184,15 @@ public class ValidatorLogger {
             Color.YELLOW));
   }
 
+  public void executionPayloadPreparedUsingBurnAddressForFeeRecipient(final UInt64 slot) {
+    log.error(
+        ColorConsolePrinter.print(
+            "Producing block at slot "
+                + slot
+                + ", no proposer was prepared, and no default fee recipient defined, using 0x00 BURN address",
+            Color.RED));
+  }
+
   public void proposedBlockImportFailed(
       final String failureReason,
       final UInt64 slot,

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/ValidatorLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/ValidatorLogger.java
@@ -189,7 +189,7 @@ public class ValidatorLogger {
         ColorConsolePrinter.print(
             "Producing block at slot "
                 + slot
-                + ", no proposer was prepared, and no default fee recipient defined, using 0x00 BURN address",
+                + ", no proposer was prepared, and no default fee recipient defined, inclusion fees will be lost",
             Color.RED));
   }
 


### PR DESCRIPTION
Rather than forcing inactivity penalties, default to the burn address if eth1address has not been specified.

fixes #5763

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
