### PR TITLE
Cache empty participation flags array for faster resetting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ For information on changes in released versions of Teku, see the [releases page]
 - Fork choice before proposals is now enabled by default for testnets. It can be disabled with `--Xfork-choice-before-proposing-enabled=false` if required.
 - Updated the Ropsten network configuration to include the correct terminal difficulty.
 - Updated to BLST 0.3.8
+- Improve epoch transition speed.
 
 ### Bug Fixes
 - Fixed issue where the REST API may return content as SSZ instead of JSON if the header `Accept: */*` was specified.

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/statetransition/epoch/EpochProcessorAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/statetransition/epoch/EpochProcessorAltair.java
@@ -169,7 +169,7 @@ public class EpochProcessorAltair extends AbstractEpochProcessor {
         return Optional.empty();
       }
       if (flags.size() < state.getValidators().size()) {
-        // need to take a writable copy to update the list if the zero participation list is too small
+        // need to take a writable copy to update the list if the participation list is too small
         mutableFlags = flags.createWritableCopy();
         while (mutableFlags.size() < state.getValidators().size()) {
           mutableFlags.append(SszByte.ZERO);

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/SszCollectionSchema.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/SszCollectionSchema.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.infrastructure.ssz.schema;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
@@ -39,7 +38,7 @@ public interface SszCollectionSchema<
 
   @SuppressWarnings("unchecked")
   default SszCollectionT of(SszElementT... elements) {
-    return createFromElements(Arrays.asList(elements));
+    return createFromElements(List.of(elements));
   }
 
   @SuppressWarnings("unchecked")


### PR DESCRIPTION
Will still need to fall back to the old `setAll` behaviour if the number of validators is below the current (older states for example that may have less validators)

```
before:
   Benchmark                                 (validatorsCount)   Mode  Cnt  Score   Error  Units
   EpochTransitionBenchmark.epochTransition             400000  thrpt   10  1.047 ± 0.070  ops/s

after:
   Benchmark                                 (validatorsCount)   Mode  Cnt  Score   Error  Units
   EpochTransitionBenchmark.epochTransition             400000  thrpt   10  1.402 ± 0.147  ops/s
```

partially addresses #5448

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
