### PR TITLE
Optimise creating validator statuses

### DIFF
--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/EpochTransitionBenchmark.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/EpochTransitionBenchmark.java
@@ -87,7 +87,6 @@ public class EpochTransitionBenchmark {
 
   @Setup(Level.Trial)
   public void init() throws Exception {
-    spec = TestSpecFactory.createMainnetAltair();
     AbstractBlockProcessor.blsVerifyDeposit = false;
 
     spec = TestSpecFactory.createMainnetAltair();
@@ -158,6 +157,15 @@ public class EpochTransitionBenchmark {
     } catch (EpochProcessingException e) {
       throw new RuntimeException(e);
     }
+  }
+
+  @Benchmark
+  public void createValidatorStatuses(Blackhole bh) {
+    final ValidatorStatuses statuses =
+        spec.atSlot(preEpochTransitionState.getSlot())
+            .getValidatorStatusFactory()
+            .createValidatorStatuses(preEpochTransitionState);
+    bh.consume(statuses);
   }
 
   @Benchmark

--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/util/backing/BeaconStateBenchmark.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/util/backing/BeaconStateBenchmark.java
@@ -33,8 +33,9 @@ public class BeaconStateBenchmark {
 
   private static final BLSPublicKey pubkey = BLSTestUtil.randomPublicKey(0);
   private static final DataStructureUtil dataStructureUtil =
-      new DataStructureUtil(0, TestSpecFactory.createDefault()).withPubKeyGenerator(() -> pubkey);
-  private static final BeaconState beaconState = dataStructureUtil.randomBeaconState(32 * 1024);
+      new DataStructureUtil(0, TestSpecFactory.createMainnetAltair())
+          .withPubKeyGenerator(() -> pubkey);
+  private static final BeaconState beaconState = dataStructureUtil.randomBeaconState(400_000);
 
   @Benchmark
   @Warmup(iterations = 5, time = 1000, timeUnit = TimeUnit.MILLISECONDS)

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/Predicates.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/Predicates.java
@@ -24,15 +24,18 @@ public class Predicates {
   /**
    * Check if (this) validator is active in the given epoch.
    *
+   * @param validator The validator under consideration.
    * @param epoch - The epoch under consideration.
    * @return A boolean indicating if the validator is active.
-   * @see <a>
-   *     https://github.com/ethereum/eth2.0-specs/blob/v0.8.0/specs/core/0_beacon-chain.md#is_active_validator
-   *     </a>
+   * @see <a
+   *     href="https://github.com/ethereum/eth2.0-specs/blob/v0.8.0/specs/core/0_beacon-chain.md#is_active_validator">is_active_validator</a>
    */
   public boolean isActiveValidator(Validator validator, UInt64 epoch) {
-    return validator.getActivationEpoch().compareTo(epoch) <= 0
-        && epoch.compareTo(validator.getExitEpoch()) < 0;
+    return isActiveValidator(validator.getActivationEpoch(), validator.getExitEpoch(), epoch);
+  }
+
+  public boolean isActiveValidator(UInt64 activationEpoch, UInt64 exitEpoch, UInt64 epoch) {
+    return activationEpoch.compareTo(epoch) <= 0 && epoch.compareTo(exitEpoch) < 0;
   }
 
   public boolean isValidMerkleBranch(
@@ -52,11 +55,8 @@ public class Predicates {
   /**
    * Determines if a validator has a balance that can be slashed
    *
-   * @param validator
-   * @param epoch
-   * @return
-   * @see
-   *     <a>https://github.com/ethereum/eth2.0-specs/blob/v0.8.0/specs/core/0_beacon-chain.md#is_slashable_validator<a/>
+   * @see <a
+   *     href="https://github.com/ethereum/eth2.0-specs/blob/v0.8.0/specs/core/0_beacon-chain.md#is_slashable_validator">is_slashable_validator</a>
    */
   public boolean isSlashableValidator(Validator validator, UInt64 epoch) {
     return !validator.isSlashed()

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/status/AbstractValidatorStatusFactory.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/status/AbstractValidatorStatusFactory.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.spec.logic.common.statetransition.epoch.status;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -61,25 +60,35 @@ public abstract class AbstractValidatorStatusFactory implements ValidatorStatusF
     final UInt64 previousEpoch = beaconStateAccessors.getPreviousEpoch(state);
 
     final List<ValidatorStatus> statuses =
-        validators.stream()
-            .map(validator -> createValidatorStatus(validator, previousEpoch, currentEpoch))
-            .collect(Collectors.toCollection(() -> new ArrayList<>(validators.size())));
+        createInitialValidatorStatuses(validators, currentEpoch, previousEpoch);
 
     processParticipation(statuses, state, previousEpoch, currentEpoch);
 
     return new ValidatorStatuses(statuses, createTotalBalances(statuses));
   }
 
+  private List<ValidatorStatus> createInitialValidatorStatuses(
+      final SszList<Validator> validators, final UInt64 currentEpoch, final UInt64 previousEpoch) {
+    final int validatorCount = validators.size();
+    final List<ValidatorStatus> statuses = new ArrayList<>(validatorCount);
+    for (Validator validator : validators) {
+      statuses.add(createValidatorStatus(validator, previousEpoch, currentEpoch));
+    }
+    return statuses;
+  }
+
   @Override
   public ValidatorStatus createValidatorStatus(
       final Validator validator, final UInt64 previousEpoch, final UInt64 currentEpoch) {
 
+    final UInt64 activationEpoch = validator.getActivationEpoch();
+    final UInt64 exitEpoch = validator.getExitEpoch();
     return new ValidatorStatus(
         validator.isSlashed(),
         validator.getWithdrawableEpoch().isLessThanOrEqualTo(currentEpoch),
         validator.getEffectiveBalance(),
-        predicates.isActiveValidator(validator, currentEpoch),
-        predicates.isActiveValidator(validator, previousEpoch));
+        predicates.isActiveValidator(activationEpoch, exitEpoch, currentEpoch),
+        predicates.isActiveValidator(activationEpoch, exitEpoch, previousEpoch));
   }
 
   protected TotalBalances createTotalBalances(final List<ValidatorStatus> statuses) {


### PR DESCRIPTION
## PR Description
Enhanced for loop turns out to be faster than a stream (at least in this case) and avoid accessing fields from the Validator multiple times - while they are cached it incurs a cache lookup which adds up.

```
Before:
EpochTransitionBenchmark.createValidatorStatuses             400000  thrpt   10  11.028 ± 0.835  ops/s

After:
EpochTransitionBenchmark.createValidatorStatuses             400000  thrpt   10  15.271 ± 0.243  ops/s
```

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
