### PR TITLE
use ValidatorStatuses when processing slashings during epoch transition.

### DIFF
--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/validatorInclusion/GetValidatorInclusionTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/validatorInclusion/GetValidatorInclusionTest.java
@@ -65,7 +65,13 @@ class GetValidatorInclusionTest extends AbstractMigratedBeaconHandlerWithChainDa
   @Test
   void metadata_shouldHandle200() throws IOException {
     final ValidatorStatus status =
-        new ValidatorStatus(false, false, UInt64.valueOf(32000000000L), true, true);
+        new ValidatorStatus(
+            false,
+            false,
+            UInt64.valueOf(32000000000L),
+            dataStructureUtil.randomEpoch(),
+            true,
+            true);
     GetValidatorInclusion.GetValidatorInclusionResponseData responseData =
         new GetValidatorInclusion.GetValidatorInclusionResponseData(status);
 

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/epoch_processing/EpochProcessingExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/epoch_processing/EpochProcessingExecutor.java
@@ -79,12 +79,7 @@ public class EpochProcessingExecutor {
   }
 
   public void processSlashings(final MutableBeaconState state) {
-    epochProcessor.processSlashings(
-        state,
-        validatorStatusFactory
-            .createValidatorStatuses(state)
-            .getTotalBalances()
-            .getCurrentEpochActiveValidators());
+    epochProcessor.processSlashings(state, validatorStatusFactory.createValidatorStatuses(state));
   }
 
   public void processRegistryUpdates(final MutableBeaconState state)

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/AbstractEpochProcessor.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/AbstractEpochProcessor.java
@@ -16,7 +16,6 @@ package tech.pegasys.teku.spec.logic.common.statetransition.epoch;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.ssz.SszMutableList;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszBitvector;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszMutableUInt64List;
@@ -97,7 +96,7 @@ public abstract class AbstractEpochProcessor implements EpochProcessor {
     processInactivityUpdates(state, validatorStatuses);
     processRewardsAndPenalties(state, validatorStatuses);
     processRegistryUpdates(state, validatorStatuses.getStatuses());
-    processSlashings(state, validatorStatuses.getTotalBalances().getCurrentEpochActiveValidators());
+    processSlashings(state, validatorStatuses);
     processEth1DataReset(state);
     processEffectiveBalanceUpdates(state);
     processSlashingsReset(state);
@@ -303,9 +302,12 @@ public abstract class AbstractEpochProcessor implements EpochProcessor {
 
   /** Processes slashings */
   @Override
-  public void processSlashings(MutableBeaconState state, final UInt64 totalBalance) {
-    UInt64 epoch = beaconStateAccessors.getCurrentEpoch(state);
-    UInt64 adjustedTotalSlashingBalance =
+  public void processSlashings(
+      MutableBeaconState state, final ValidatorStatuses validatorStatuses) {
+    final UInt64 totalBalance =
+        validatorStatuses.getTotalBalances().getCurrentEpochActiveValidators();
+    final UInt64 epoch = beaconStateAccessors.getCurrentEpoch(state);
+    final UInt64 adjustedTotalSlashingBalance =
         state
             .getSlashings()
             .streamUnboxed()
@@ -313,17 +315,16 @@ public abstract class AbstractEpochProcessor implements EpochProcessor {
             .times(getProportionalSlashingMultiplier())
             .min(totalBalance);
 
-    SszList<Validator> validators = state.getValidators();
-    for (int index = 0; index < validators.size(); index++) {
-      Validator validator = validators.get(index);
-      if (validator.isSlashed()
-          && epoch
-              .plus(specConfig.getEpochsPerSlashingsVector() / 2)
-              .equals(validator.getWithdrawableEpoch())) {
-        UInt64 increment = specConfig.getEffectiveBalanceIncrement();
-        UInt64 penaltyNumerator =
-            validator
-                .getEffectiveBalance()
+    List<ValidatorStatus> validatorStatusList = validatorStatuses.getStatuses();
+    final int halfEpochsPerSlashingsVector = specConfig.getEpochsPerSlashingsVector() / 2;
+    for (int index = 0; index < validatorStatusList.size(); index++) {
+      final ValidatorStatus status = validatorStatusList.get(index);
+      if (status.isSlashed()
+          && epoch.plus(halfEpochsPerSlashingsVector).equals(status.getWithdrawableEpoch())) {
+        final UInt64 increment = specConfig.getEffectiveBalanceIncrement();
+        final UInt64 penaltyNumerator =
+            status
+                .getCurrentEpochEffectiveBalance()
                 .dividedBy(increment)
                 .times(adjustedTotalSlashingBalance);
         UInt64 penalty = penaltyNumerator.dividedBy(totalBalance).times(increment);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/AbstractEpochProcessor.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/AbstractEpochProcessor.java
@@ -315,7 +315,7 @@ public abstract class AbstractEpochProcessor implements EpochProcessor {
             .times(getProportionalSlashingMultiplier())
             .min(totalBalance);
 
-    List<ValidatorStatus> validatorStatusList = validatorStatuses.getStatuses();
+    final List<ValidatorStatus> validatorStatusList = validatorStatuses.getStatuses();
     final int halfEpochsPerSlashingsVector = specConfig.getEpochsPerSlashingsVector() / 2;
     for (int index = 0; index < validatorStatusList.size(); index++) {
       final ValidatorStatus status = validatorStatusList.get(index);
@@ -327,7 +327,7 @@ public abstract class AbstractEpochProcessor implements EpochProcessor {
                 .getCurrentEpochEffectiveBalance()
                 .dividedBy(increment)
                 .times(adjustedTotalSlashingBalance);
-        UInt64 penalty = penaltyNumerator.dividedBy(totalBalance).times(increment);
+        final UInt64 penalty = penaltyNumerator.dividedBy(totalBalance).times(increment);
         beaconStateMutators.decreaseBalance(state, index, penalty);
       }
     }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/EpochProcessor.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/EpochProcessor.java
@@ -14,7 +14,6 @@
 package tech.pegasys.teku.spec.logic.common.statetransition.epoch;
 
 import java.util.List;
-import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
 import tech.pegasys.teku.spec.logic.common.statetransition.epoch.status.TotalBalances;
@@ -39,7 +38,7 @@ public interface EpochProcessor {
   void processRegistryUpdates(MutableBeaconState state, List<ValidatorStatus> statuses)
       throws EpochProcessingException;
 
-  void processSlashings(MutableBeaconState state, UInt64 totalBalance);
+  void processSlashings(MutableBeaconState state, ValidatorStatuses validatorStatuses);
 
   void processParticipationUpdates(MutableBeaconState genericState);
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/status/AbstractValidatorStatusFactory.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/status/AbstractValidatorStatusFactory.java
@@ -83,10 +83,12 @@ public abstract class AbstractValidatorStatusFactory implements ValidatorStatusF
 
     final UInt64 activationEpoch = validator.getActivationEpoch();
     final UInt64 exitEpoch = validator.getExitEpoch();
+    final UInt64 withdrawableEpoch = validator.getWithdrawableEpoch();
     return new ValidatorStatus(
         validator.isSlashed(),
-        validator.getWithdrawableEpoch().isLessThanOrEqualTo(currentEpoch),
+        withdrawableEpoch.isLessThanOrEqualTo(currentEpoch),
         validator.getEffectiveBalance(),
+        withdrawableEpoch,
         predicates.isActiveValidator(activationEpoch, exitEpoch, currentEpoch),
         predicates.isActiveValidator(activationEpoch, exitEpoch, previousEpoch));
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/status/ValidatorStatus.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/status/ValidatorStatus.java
@@ -18,6 +18,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 public class ValidatorStatus {
   private final UInt64 currentEpochEffectiveBalance;
+  final UInt64 withdrawableEpoch;
   private final boolean slashed;
   private final boolean withdrawableInCurrentEpoch;
   private final boolean activeInCurrentEpoch;
@@ -35,11 +36,13 @@ public class ValidatorStatus {
       final boolean slashed,
       final boolean withdrawableInCurrentEpoch,
       final UInt64 currentEpochEffectiveBalance,
+      final UInt64 withdrawableEpoch,
       final boolean activeInCurrentEpoch,
       final boolean activeInPreviousEpoch) {
     this.slashed = slashed;
     this.withdrawableInCurrentEpoch = withdrawableInCurrentEpoch;
     this.currentEpochEffectiveBalance = currentEpochEffectiveBalance;
+    this.withdrawableEpoch = withdrawableEpoch;
     this.activeInCurrentEpoch = activeInCurrentEpoch;
     this.activeInPreviousEpoch = activeInPreviousEpoch;
   }
@@ -172,5 +175,9 @@ public class ValidatorStatus {
       }
     }
     return this;
+  }
+
+  public UInt64 getWithdrawableEpoch() {
+    return withdrawableEpoch;
   }
 }

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/status/AbstractValidatorStatusFactoryTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/status/AbstractValidatorStatusFactoryTest.java
@@ -45,6 +45,8 @@ public abstract class AbstractValidatorStatusFactoryTest {
 
   protected abstract Spec createSpec();
 
+  private final UInt64 withdrawableEpoch = dataStructureUtil.randomEpoch();
+
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
   void createValidatorStatus_shouldSetSlashedCorrectly(final boolean slashed) {
@@ -154,9 +156,9 @@ public abstract class AbstractValidatorStatusFactoryTest {
   void createTotalBalances_shouldAddCurrentEpochActiveBalance() {
     final List<ValidatorStatus> statuses =
         List.of(
-            new ValidatorStatus(false, false, balance(7), true, false),
-            new ValidatorStatus(true, true, balance(5), true, true),
-            new ValidatorStatus(false, false, balance(13), false, false));
+            new ValidatorStatus(false, false, balance(7), withdrawableEpoch, true, false),
+            new ValidatorStatus(true, true, balance(5), withdrawableEpoch, true, true),
+            new ValidatorStatus(false, false, balance(13), withdrawableEpoch, false, false));
     // Should include both statuses active in current epoch for a total of 12.
     assertThat(
             validatorStatusFactory.createTotalBalances(statuses).getCurrentEpochActiveValidators())
@@ -167,9 +169,9 @@ public abstract class AbstractValidatorStatusFactoryTest {
   void createTotalBalances_shouldAddPreviousEpochActiveBalance() {
     final List<ValidatorStatus> statuses =
         List.of(
-            new ValidatorStatus(false, false, balance(7), false, true),
-            new ValidatorStatus(true, true, balance(5), true, true),
-            new ValidatorStatus(false, false, balance(13), false, false));
+            new ValidatorStatus(false, false, balance(7), withdrawableEpoch, false, true),
+            new ValidatorStatus(true, true, balance(5), withdrawableEpoch, true, true),
+            new ValidatorStatus(false, false, balance(13), withdrawableEpoch, false, false));
     // Should include both statuses active in previous epoch for a total of 12.
     assertThat(
             validatorStatusFactory.createTotalBalances(statuses).getPreviousEpochActiveValidators())
@@ -248,12 +250,14 @@ public abstract class AbstractValidatorStatusFactoryTest {
   }
 
   private ValidatorStatus createValidator(final int effectiveBalance) {
-    return new ValidatorStatus(false, false, balance(effectiveBalance), true, true);
+    return new ValidatorStatus(
+        false, false, balance(effectiveBalance), withdrawableEpoch, true, true);
   }
 
   private ValidatorStatus createWithAllAttesterFlags(
       final boolean slashed, final int effectiveBalance) {
-    return new ValidatorStatus(slashed, true, balance(effectiveBalance), true, true)
+    return new ValidatorStatus(
+            slashed, true, balance(effectiveBalance), withdrawableEpoch, true, true)
         .updateCurrentEpochSourceAttester(true)
         .updatePreviousEpochSourceAttester(true)
         .updateCurrentEpochTargetAttester(true)


### PR DESCRIPTION
```
before:
Benchmark                                 (validatorsCount)   Mode  Cnt  Score   Error  Units
EpochTransitionBenchmark.epochTransition             400000  thrpt   10  1.511 ± 0.063  ops/s
EpochTransitionBenchmark.epochTransition             400000  thrpt   10  1.494 ± 0.039  ops/s
EpochTransitionBenchmark.epochTransition             400000  thrpt   10  1.500 ± 0.043  ops/s
EpochTransitionBenchmark.epochTransition             400000  thrpt   10  1.442 ± 0.208  ops/s
EpochTransitionBenchmark.epochTransition             400000  thrpt   10  1.524 ± 0.032  ops/s
EpochTransitionBenchmark.epochTransition             400000  thrpt   10  1.446 ± 0.111  ops/s
EpochTransitionBenchmark.epochTransition             400000  thrpt   10  1.498 ± 0.042  ops/s
EpochTransitionBenchmark.epochTransition             400000  thrpt   10  1.497 ± 0.070  ops/s
EpochTransitionBenchmark.epochTransition             400000  thrpt   10  1.475 ± 0.044  ops/s
EpochTransitionBenchmark.epochTransition             400000  thrpt   10  1.521 ± 0.044  ops/s
EpochTransitionBenchmark.epochTransition             400000  thrpt   10  1.462 ± 0.066  ops/s

after:
Benchmark                                 (validatorsCount)   Mode  Cnt  Score   Error  Units
EpochTransitionBenchmark.epochTransition             400000  thrpt   10  1.524 ± 0.075  ops/s
EpochTransitionBenchmark.epochTransition             400000  thrpt   10  1.558 ± 0.073  ops/s
EpochTransitionBenchmark.epochTransition             400000  thrpt   10  1.550 ± 0.040  ops/s
EpochTransitionBenchmark.epochTransition             400000  thrpt   10  1.539 ± 0.056  ops/s
EpochTransitionBenchmark.epochTransition             400000  thrpt   10  1.568 ± 0.047  ops/s
EpochTransitionBenchmark.epochTransition             400000  thrpt   10  1.540 ± 0.058  ops/s
```

Primarily reducing the requirement to go through state.validators list, as going through validatorStatuses is more efficient. Small performance improvement with this change.

Signed-off-by: Paul Harris <paul.harris@consensys.net>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
