### PR TITLE
Cache inactivity leak and finality delay in RewardsAndPenaltiesCalculator

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/RewardsAndPenaltiesCalculator.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/RewardsAndPenaltiesCalculator.java
@@ -25,8 +25,10 @@ public abstract class RewardsAndPenaltiesCalculator {
   protected final MiscHelpers miscHelpers;
   protected final BeaconStateAccessors beaconStateAccessors;
 
-  protected final BeaconState state;
   protected final ValidatorStatuses validatorStatuses;
+
+  private final boolean isInactivityLeak;
+  private final UInt64 finalityDelay;
 
   protected RewardsAndPenaltiesCalculator(
       final SpecConfig specConfig,
@@ -37,14 +39,15 @@ public abstract class RewardsAndPenaltiesCalculator {
     this.specConfig = specConfig;
     this.miscHelpers = miscHelpers;
     this.beaconStateAccessors = beaconStateAccessors;
-    this.state = state;
     this.validatorStatuses = validatorStatuses;
+    this.finalityDelay = beaconStateAccessors.getFinalityDelay(state);
+    this.isInactivityLeak = beaconStateAccessors.isInactivityLeak(state);
   }
 
   public abstract RewardAndPenaltyDeltas getDeltas() throws IllegalArgumentException;
 
   protected UInt64 getFinalityDelay() {
-    return beaconStateAccessors.getFinalityDelay(state);
+    return finalityDelay;
   }
 
   protected boolean isInactivityLeak(final UInt64 finalityDelay) {
@@ -52,6 +55,6 @@ public abstract class RewardsAndPenaltiesCalculator {
   }
 
   protected boolean isInactivityLeak() {
-    return beaconStateAccessors.isInactivityLeak(state);
+    return isInactivityLeak;
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/statetransition/epoch/RewardsAndPenaltiesCalculatorAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/statetransition/epoch/RewardsAndPenaltiesCalculatorAltair.java
@@ -88,7 +88,7 @@ public class RewardsAndPenaltiesCalculatorAltair extends RewardsAndPenaltiesCalc
     // Cache baseRewardPerIncrement - while it is also cached in transition caches,
     // looking it up from there for every single validator is quite expensive.
     final UInt64 baseRewardPerIncrement =
-        beaconStateAccessorsAltair.getBaseRewardPerIncrement(state);
+        beaconStateAccessorsAltair.getBaseRewardPerIncrement(stateAltair);
     for (int i = 0; i < statusList.size(); i++) {
       final ValidatorStatus validator = statusList.get(i);
       if (!validator.isEligibleValidator()) {


### PR DESCRIPTION
This value doesn't change so it can just be read once.

Doesn't really improve performance in our benchmark, but is cleaner.

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
