### PR TITLE
Store finalizedEpoch when processing registry updates

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/AbstractEpochProcessor.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/AbstractEpochProcessor.java
@@ -229,6 +229,7 @@ public abstract class AbstractEpochProcessor implements EpochProcessor {
       // Process activation eligibility and ejections
       SszMutableList<Validator> validators = state.getValidators();
       final UInt64 currentEpoch = beaconStateAccessors.getCurrentEpoch(state);
+      final UInt64 finalizedEpoch = state.getFinalizedCheckpoint().getEpoch();
       for (int index = 0; index < validators.size(); index++) {
         final ValidatorStatus status = statuses.get(index);
 
@@ -254,7 +255,6 @@ public abstract class AbstractEpochProcessor implements EpochProcessor {
           beaconStateMutators.initiateValidatorExit(state, index);
         }
       }
-
       // Queue validators eligible for activation and not yet dequeued for activation
       List<Integer> activationQueue =
           IntStream.range(0, state.getValidators().size())
@@ -263,7 +263,7 @@ public abstract class AbstractEpochProcessor implements EpochProcessor {
               .filter(
                   index -> {
                     Validator validator = state.getValidators().get(index);
-                    return validatorsUtil.isEligibleForActivation(state, validator);
+                    return validatorsUtil.isEligibleForActivation(finalizedEpoch, validator);
                   })
               .boxed()
               .sorted(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ValidatorsUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ValidatorsUtil.java
@@ -61,6 +61,11 @@ public class ValidatorsUtil {
         && validator.getActivationEpoch().equals(SpecConfig.FAR_FUTURE_EPOCH);
   }
 
+  public boolean isEligibleForActivation(final UInt64 finalizedEpoch, final Validator validator) {
+    return validator.getActivationEligibilityEpoch().compareTo(finalizedEpoch) <= 0
+        && validator.getActivationEpoch().equals(SpecConfig.FAR_FUTURE_EPOCH);
+  }
+
   public Optional<Integer> getValidatorIndex(BeaconState state, BLSPublicKey publicKey) {
     return BeaconStateCache.getTransitionCaches(state)
         .getValidatorIndexCache()


### PR DESCRIPTION
Another step in reducing state accesses.

```
before:
Benchmark                                 (validatorsCount)   Mode  Cnt  Score   Error  Units
EpochTransitionBenchmark.epochTransition             400000  thrpt   10  1.470 ± 0.051  ops/s
EpochTransitionBenchmark.epochTransition             400000  thrpt   10  1.557 ± 0.076  ops/s
EpochTransitionBenchmark.epochTransition             400000  thrpt   10  1.523 ± 0.035  ops/s
EpochTransitionBenchmark.epochTransition             400000  thrpt   10  1.542 ± 0.053  ops/s
EpochTransitionBenchmark.epochTransition             400000  thrpt   10  1.499 ± 0.058  ops/s
EpochTransitionBenchmark.epochTransition             400000  thrpt   10  1.548 ± 0.061  ops/s

after
EpochTransitionBenchmark.epochTransition             400000  thrpt   10  1.534 ± 0.039  ops/s
EpochTransitionBenchmark.epochTransition             400000  thrpt   10  1.555 ± 0.065  ops/s
EpochTransitionBenchmark.epochTransition             400000  thrpt   10  1.467 ± 0.031  ops/s
EpochTransitionBenchmark.epochTransition             400000  thrpt   10  1.505 ± 0.127  ops/s
EpochTransitionBenchmark.epochTransition             400000  thrpt   10  1.558 ± 0.054  ops/s
EpochTransitionBenchmark.epochTransition             400000  thrpt   10  1.548 ± 0.049  ops/s
EpochTransitionBenchmark.epochTransition             400000  thrpt   10  1.522 ± 0.033  ops/s
```

Doesn't appear to speed things up but is in line with our general direction.

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
