### PR TITLE
[MEV Boost\Builder] Change gas limit CLI Option description

### DIFF
--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorProposerOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorProposerOptions.java
@@ -64,7 +64,7 @@ public class ValidatorProposerOptions {
       names = {"--Xvalidators-registration-default-gas-limit"},
       paramLabel = "<uint64>",
       showDefaultValue = Visibility.ALWAYS,
-      description = "Enable MEV boost when proposing blocks.",
+      description = "Change the default gas limit used for the validators registration.",
       arity = "0..1",
       hidden = true,
       converter = UInt64Converter.class)


### PR DESCRIPTION
## PR Description
Change the CLI Option description for `--Xvalidators-registration-default-gas-limit`

## Fixed Issue(s)
related to #5396 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
