### PR TITLE
Enable guava-beta-checker and fix findings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -791,6 +791,8 @@ subprojects {
     testFixturesRuntimeOnly 'org.apiguardian:apiguardian-api'
 
     propertyTestImplementation 'net.jqwik:jqwik'
+
+    annotationProcessor 'com.google.guava:guava-beta-checker'
   }
 
   if (!baseInfrastructureProjects.contains(project.path)) {

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -181,5 +181,7 @@ dependencyManagement {
     }
 
     dependency 'net.jqwik:jqwik:1.6.5'
+
+    dependency 'com.google.guava:guava-beta-checker:1.0'
   }
 }

--- a/infrastructure/bls/src/main/java/tech/pegasys/teku/bls/BLS.java
+++ b/infrastructure/bls/src/main/java/tech/pegasys/teku/bls/BLS.java
@@ -16,7 +16,7 @@ package tech.pegasys.teku.bls;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.common.collect.Lists;
-import com.google.common.collect.Streams;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -152,12 +152,11 @@ public class BLS {
       if (publicKeys.isEmpty()) {
         return false;
       }
-      List<PublicKeyMessagePair> publicKeyMessagePairs =
-          Streams.zip(
-                  publicKeys.stream(),
-                  messages.stream(),
-                  (pk, msg) -> new PublicKeyMessagePair(pk.getPublicKey(), msg))
-              .collect(Collectors.toList());
+      List<PublicKeyMessagePair> publicKeyMessagePairs = new ArrayList<>();
+      for (int i = 0; i < publicKeys.size(); i++) {
+        publicKeyMessagePairs.add(
+            new PublicKeyMessagePair(publicKeys.get(i).getPublicKey(), messages.get(i)));
+      }
       try {
         return signature.getSignature().verify(publicKeyMessagePairs);
       } catch (BlsException e) {

--- a/infrastructure/bls/src/main/java/tech/pegasys/teku/bls/impl/PublicKeyMessagePair.java
+++ b/infrastructure/bls/src/main/java/tech/pegasys/teku/bls/impl/PublicKeyMessagePair.java
@@ -15,9 +15,8 @@ package tech.pegasys.teku.bls.impl;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import com.google.common.collect.Streams;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.apache.tuweni.bytes.Bytes;
 
 /**
@@ -30,8 +29,11 @@ public class PublicKeyMessagePair {
   public static List<PublicKeyMessagePair> fromLists(
       List<PublicKey> publicKeys, List<Bytes> messages) {
     checkArgument(publicKeys.size() == messages.size());
-    return Streams.zip(publicKeys.stream(), messages.stream(), PublicKeyMessagePair::new)
-        .collect(Collectors.toList());
+    List<PublicKeyMessagePair> publicKeyMessagePairs = new ArrayList<>();
+    for (int i = 0; i < publicKeys.size(); i++) {
+      publicKeyMessagePairs.add(new PublicKeyMessagePair(publicKeys.get(i), messages.get(i)));
+    }
+    return publicKeyMessagePairs;
   }
 
   private final PublicKey publicKey;

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/ListQueryParameterUtils.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/ListQueryParameterUtils.java
@@ -43,6 +43,9 @@ public class ListQueryParameterUtils {
       final Map<String, List<String>> parameterMap, final String key)
       throws IllegalArgumentException {
     final String list = String.join(",", validateQueryParameter(parameterMap, key));
-    return SPLITTER.splitToStream(list).distinct().map(String::trim).collect(Collectors.toList());
+    return SPLITTER.splitToList(list).stream()
+        .distinct()
+        .map(String::trim)
+        .collect(Collectors.toList());
   }
 }


### PR DESCRIPTION
## PR Description

[`guava-beta-checker`](https://github.com/google/guava-beta-checker) is Google's EP checker that identifies usage of beta Guava APIs. This checker is limited to the main source tree and doesn't produce warnings for test code. There weren't many findings.

> Such APIs should never be used in library code that other projects may depend on; using the Beta Checker can help library projects ensure that they don't use them.

When removing `Streams.zip` I was worried that the new implementation might be slower, so I added a benchmark function for the `BLS.aggregateVerify` method. In the process of adding this, I made a some changes to whole benchmark class; things could be simpler with a setup function.

#### Before

```
Benchmark                              (sigCnt)   Mode  Cnt    Score   Error  Units
BLSBenchmark.aggregateVerifySignature         1  thrpt   10  926.271 ± 1.448  ops/s
BLSBenchmark.aggregateVerifySignature         2  thrpt   10  710.323 ± 1.462  ops/s
BLSBenchmark.aggregateVerifySignature         4  thrpt   10  481.074 ± 5.471  ops/s
BLSBenchmark.aggregateVerifySignature         8  thrpt   10  295.479 ± 2.709  ops/s
BLSBenchmark.aggregateVerifySignature        16  thrpt   10  163.657 ± 1.735  ops/s
BLSBenchmark.aggregateVerifySignature        32  thrpt   10   86.401 ± 0.738  ops/s
BLSBenchmark.aggregateVerifySignature        64  thrpt   10   44.565 ± 0.155  ops/s
BLSBenchmark.aggregateVerifySignature       128  thrpt   10   22.638 ± 0.093  ops/s
```

#### After

```
Benchmark                              (sigCnt)   Mode  Cnt    Score   Error  Units
BLSBenchmark.aggregateVerifySignature         1  thrpt   10  927.673 ± 1.370  ops/s
BLSBenchmark.aggregateVerifySignature         2  thrpt   10  712.032 ± 0.952  ops/s
BLSBenchmark.aggregateVerifySignature         4  thrpt   10  485.891 ± 2.164  ops/s
BLSBenchmark.aggregateVerifySignature         8  thrpt   10  294.099 ± 1.980  ops/s
BLSBenchmark.aggregateVerifySignature        16  thrpt   10  162.698 ± 1.052  ops/s
BLSBenchmark.aggregateVerifySignature        32  thrpt   10   86.303 ± 0.847  ops/s
BLSBenchmark.aggregateVerifySignature        64  thrpt   10   44.676 ± 0.309  ops/s
BLSBenchmark.aggregateVerifySignature       128  thrpt   10   22.720 ± 0.018  ops/s
```

So things are pretty much the exact same. The new version might actually be a hair faster.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
