### PR TITLE
Change the arity of few CLI options

### DIFF
--- a/teku/src/main/java/tech/pegasys/teku/cli/options/InteropOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/InteropOptions.java
@@ -35,7 +35,7 @@ public class InteropOptions {
       names = {"--Xinterop-genesis-payload-header"},
       paramLabel = "<FILE>",
       description = "Payload header to be included in the mocked genesis",
-      arity = "0..1")
+      arity = "1")
   private String interopGenesisPayloadHeader = null;
 
   @Option(

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorProposerOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorProposerOptions.java
@@ -28,14 +28,14 @@ public class ValidatorProposerOptions {
       paramLabel = "<ADDRESS>",
       description =
           "Default fee recipient sent to the execution engine, which could use it as fee recipient when producing a new execution block.",
-      arity = "0..1")
+      arity = "1")
   private String proposerDefaultFeeRecipient = null;
 
   @Option(
       names = {"--validators-proposer-config"},
       paramLabel = "<STRING>",
       description = "remote URL or local file path to load proposer configuration from",
-      arity = "0..1")
+      arity = "1")
   private String proposerConfig = null;
 
   @Option(
@@ -65,7 +65,7 @@ public class ValidatorProposerOptions {
       paramLabel = "<uint64>",
       showDefaultValue = Visibility.ALWAYS,
       description = "Change the default gas limit used for the validators registration.",
-      arity = "0..1",
+      arity = "1",
       hidden = true,
       converter = UInt64Converter.class)
   private UInt64 registrationDefaultGasLimit =


### PR DESCRIPTION
Modified the arity in 3 CLI options which were using 0..1 when not necessary

## PR Description

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
