### PR TITLE
Fix bug in GetAllBlocksAtSlot

### DIFF
--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/beacon/GetAllBlocksAtSlot.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/beacon/GetAllBlocksAtSlot.java
@@ -40,6 +40,7 @@ import io.javalin.plugin.openapi.annotations.OpenApi;
 import io.javalin.plugin.openapi.annotations.OpenApiContent;
 import io.javalin.plugin.openapi.annotations.OpenApiParam;
 import io.javalin.plugin.openapi.annotations.OpenApiResponse;
+import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pegasys.teku.api.ChainDataProvider;
 import tech.pegasys.teku.api.DataProvider;
@@ -55,6 +56,7 @@ import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiRequest;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.metadata.BlockAndMetaData;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionCache;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
 
@@ -111,16 +113,16 @@ public class GetAllBlocksAtSlot extends MigratingEndpointAdapter {
     request.header(Header.CACHE_CONTROL, CACHE_NONE);
 
     final UInt64 slot = request.getPathParameter(SLOT_PARAMETER);
-    final SafeFuture<AllBlocksAtSlotData> future = chainDataProvider.getAllBlocksAtSlot(slot);
+    final SafeFuture<List<BlockAndMetaData>> future = chainDataProvider.getAllBlocksAtSlot(slot);
 
     request.respondAsync(
         future.thenApply(
-            result -> {
-              if (result.getBlocks().isEmpty()) {
+            blockAndMetaDataList -> {
+              if (blockAndMetaDataList.isEmpty()) {
                 return AsyncApiResponse.respondWithError(SC_NOT_FOUND, "Blocks not found: " + slot);
               }
 
-              return AsyncApiResponse.respondOk(result);
+              return AsyncApiResponse.respondOk(new AllBlocksAtSlotData(blockAndMetaDataList));
             }));
   }
 

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/beacon/GetAllBlocksAtSlotTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/beacon/GetAllBlocksAtSlotTest.java
@@ -38,10 +38,15 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.metadata.BlockAndMetaData;
 
 public class GetAllBlocksAtSlotTest extends AbstractMigratedBeaconHandlerTest {
-  final List<SignedBeaconBlock> blocks = List.of(dataStructureUtil.randomSignedBeaconBlock(1));
-  final AllBlocksAtSlotData responseData = new AllBlocksAtSlotData(SpecMilestone.ALTAIR, blocks);
+  final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(1);
+  final SpecMilestone specMilestone = SpecMilestone.ALTAIR;
+  final AllBlocksAtSlotData responseData = new AllBlocksAtSlotData(specMilestone, List.of(block));
+
+  final List<BlockAndMetaData> blocksAtSlot =
+      List.of(new BlockAndMetaData(block, specMilestone, false, true));
 
   @BeforeEach
   void setup() {
@@ -52,7 +57,7 @@ public class GetAllBlocksAtSlotTest extends AbstractMigratedBeaconHandlerTest {
   @Test
   public void shouldReturnAllBlocksAtSlot() throws JsonProcessingException {
     when(chainDataProvider.getAllBlocksAtSlot(eq(UInt64.ONE)))
-        .thenReturn(SafeFuture.completedFuture(responseData));
+        .thenReturn(SafeFuture.completedFuture(blocksAtSlot));
 
     handler.handleRequest(request);
 

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
@@ -39,7 +39,6 @@ import org.apache.tuweni.bytes.Bytes48;
 import tech.pegasys.teku.api.blockselector.BlockSelectorFactory;
 import tech.pegasys.teku.api.exceptions.BadRequestException;
 import tech.pegasys.teku.api.exceptions.ServiceUnavailableException;
-import tech.pegasys.teku.api.migrated.AllBlocksAtSlotData;
 import tech.pegasys.teku.api.migrated.BlockHeadersResponse;
 import tech.pegasys.teku.api.migrated.StateSyncCommitteesData;
 import tech.pegasys.teku.api.migrated.StateValidatorBalanceData;
@@ -172,11 +171,8 @@ public class ChainDataProvider {
     return defaultStateSelectorFactory.defaultStateSelector(stateIdParam).getState();
   }
 
-  public SafeFuture<AllBlocksAtSlotData> getAllBlocksAtSlot(final UInt64 slot) {
-    return defaultBlockSelectorFactory
-        .nonCanonicalBlocksSelector(slot)
-        .getBlocks()
-        .thenApply(AllBlocksAtSlotData::new);
+  public SafeFuture<List<BlockAndMetaData>> getAllBlocksAtSlot(final UInt64 slot) {
+    return defaultBlockSelectorFactory.nonCanonicalBlocksSelector(slot).getBlocks();
   }
 
   public SafeFuture<Optional<SszResponse>> getBeaconStateSszByBlockRoot(

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/migrated/AllBlocksAtSlotData.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/migrated/AllBlocksAtSlotData.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.api.migrated;
 
 import com.google.common.base.Preconditions;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
@@ -26,7 +27,7 @@ public class AllBlocksAtSlotData {
   private final List<SignedBeaconBlock> blocks;
 
   public AllBlocksAtSlotData(final List<BlockAndMetaData> blocks) {
-    Preconditions.checkArgument(!blocks.isEmpty());
+    Preconditions.checkArgument(!blocks.isEmpty(), "BlockAndMetaData list must not be empty");
     this.version = blocks.get(0).getMilestone();
     this.blocks = blocks.stream().map(ObjectAndMetaData::getData).collect(Collectors.toList());
   }
@@ -42,5 +43,27 @@ public class AllBlocksAtSlotData {
 
   public List<SignedBeaconBlock> getBlocks() {
     return blocks;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    AllBlocksAtSlotData that = (AllBlocksAtSlotData) o;
+    return version == that.version && Objects.equals(blocks, that.blocks);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(version, blocks);
+  }
+
+  @Override
+  public String toString() {
+    return "AllBlocksAtSlotData{" + "version=" + version + ", blocks=" + blocks + '}';
   }
 }


### PR DESCRIPTION
Fixes bug where `IllegalArgumentException` would be thrown where we want to see the empty list of `BlockAndMetaData` to then return not found. This now ensures `GetAllBlocksAtSlot` handles the empty list before creating the `AllBlocksAtSlotData` object which throws the exception. This exception should never be thrown now as it is handled prior to the object creation.

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
