### PR TITLE
Change validator executor default max queue size and make it configurable

### DIFF
--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/AsyncRunnerFactory.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/AsyncRunnerFactory.java
@@ -16,12 +16,19 @@ package tech.pegasys.teku.infrastructure.async;
 import java.util.Collection;
 
 public interface AsyncRunnerFactory {
+
+  int DEFAULT_MAX_QUEUE_SIZE = 5000;
+
+  default AsyncRunner create(String name, int maxThreads) {
+    return create(name, maxThreads, DEFAULT_MAX_QUEUE_SIZE);
+  }
+
+  AsyncRunner create(String name, int maxThreads, int maxQueueSize);
+
+  Collection<AsyncRunner> getAsyncRunners();
+
   static DefaultAsyncRunnerFactory createDefault(
       final MetricTrackingExecutorFactory executorFactory) {
     return new DefaultAsyncRunnerFactory(executorFactory);
   }
-
-  AsyncRunner create(String name, int maxThreads);
-
-  Collection<AsyncRunner> getAsyncRunners();
 }

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/DefaultAsyncRunnerFactory.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/DefaultAsyncRunnerFactory.java
@@ -26,9 +26,9 @@ public class DefaultAsyncRunnerFactory implements AsyncRunnerFactory {
   }
 
   @Override
-  public AsyncRunner create(final String name, final int maxThreads) {
+  public AsyncRunner create(final String name, final int maxThreads, final int maxQueueSize) {
     final AsyncRunner asyncRunner =
-        ScheduledExecutorAsyncRunner.create(name, maxThreads, executorFactory);
+        ScheduledExecutorAsyncRunner.create(name, maxThreads, maxQueueSize, executorFactory);
     asyncRunners.add(asyncRunner);
     return asyncRunner;
   }

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/ScheduledExecutorAsyncRunner.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/ScheduledExecutorAsyncRunner.java
@@ -26,7 +26,6 @@ import org.apache.logging.log4j.Logger;
 
 public class ScheduledExecutorAsyncRunner implements AsyncRunner {
   private static final Logger LOG = LogManager.getLogger();
-  private static final int QUEUE_CAPACITY = 5000;
   private final AtomicBoolean shutdown = new AtomicBoolean(false);
   private final ScheduledExecutorService scheduler;
   private final ExecutorService workerPool;
@@ -40,6 +39,7 @@ public class ScheduledExecutorAsyncRunner implements AsyncRunner {
   public static AsyncRunner create(
       final String name,
       final int maxThreads,
+      final int maxQueueSize,
       final MetricTrackingExecutorFactory executorFactory) {
     final ScheduledExecutorService scheduler =
         Executors.newSingleThreadScheduledExecutor(
@@ -51,7 +51,7 @@ public class ScheduledExecutorAsyncRunner implements AsyncRunner {
         executorFactory.newCachedThreadPool(
             name,
             maxThreads,
-            QUEUE_CAPACITY,
+            maxQueueSize,
             new ThreadFactoryBuilder().setNameFormat(name + "-async-%d").setDaemon(false).build());
 
     return new ScheduledExecutorAsyncRunner(scheduler, workerPool);

--- a/infrastructure/async/src/testFixtures/java/tech/pegasys/teku/infrastructure/async/StubAsyncRunnerFactory.java
+++ b/infrastructure/async/src/testFixtures/java/tech/pegasys/teku/infrastructure/async/StubAsyncRunnerFactory.java
@@ -21,7 +21,7 @@ public class StubAsyncRunnerFactory implements AsyncRunnerFactory {
   private final List<StubAsyncRunner> runners = new ArrayList<>();
 
   @Override
-  public AsyncRunner create(final String name, final int maxThreads) {
+  public AsyncRunner create(final String name, final int maxThreads, final int maxQueueSize) {
     final StubAsyncRunner asyncRunner = new StubAsyncRunner();
     runners.add(asyncRunner);
     return asyncRunner;

--- a/infrastructure/serviceutils/src/main/java/tech/pegasys/teku/service/serviceutils/ServiceConfig.java
+++ b/infrastructure/serviceutils/src/main/java/tech/pegasys/teku/service/serviceutils/ServiceConfig.java
@@ -67,16 +67,29 @@ public class ServiceConfig {
   }
 
   public AsyncRunner createAsyncRunner(final String name) {
-    // We use a bunch of blocking calls so need to ensure the thread pool is reasonably large
-    // as many threads may be blocked.
-    return createAsyncRunner(name, Math.max(Runtime.getRuntime().availableProcessors(), 5));
+    return createAsyncRunner(name, calculateMaxThreads());
+  }
+
+  public AsyncRunner createAsyncRunnerWithMaxQueueSize(final String name, final int maxQueueSize) {
+    return createAsyncRunner(name, calculateMaxThreads(), maxQueueSize);
   }
 
   public AsyncRunner createAsyncRunner(final String name, final int maxThreads) {
     return asyncRunnerFactory.create(name, maxThreads);
   }
 
+  public AsyncRunner createAsyncRunner(
+      final String name, final int maxThreads, final int maxQueueSize) {
+    return asyncRunnerFactory.create(name, maxThreads, maxQueueSize);
+  }
+
   public AsyncRunnerFactory getAsyncRunnerFactory() {
     return asyncRunnerFactory;
+  }
+
+  private int calculateMaxThreads() {
+    // We use a bunch of blocking calls so need to ensure the thread pool is reasonably large
+    // as many threads may be blocked.
+    return Math.max(Runtime.getRuntime().availableProcessors(), 5);
   }
 }

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
@@ -91,6 +91,15 @@ public class ValidatorOptions {
       arity = "0..1")
   private boolean generateEarlyAttestations = ValidatorConfig.DEFAULT_GENERATE_EARLY_ATTESTATIONS;
 
+  @Option(
+      names = {"--Xvalidator-executor-max-queue-size"},
+      paramLabel = "<INTEGER>",
+      showDefaultValue = Visibility.ALWAYS,
+      description = "Set the maximum queue size of the validator executor",
+      hidden = true,
+      arity = "1")
+  private int executorMaxQueueSize = ValidatorConfig.DEFAULT_EXECUTOR_MAX_QUEUE_SIZE;
+
   public void configure(TekuConfiguration.Builder builder) {
     builder.validator(
         config ->
@@ -102,7 +111,8 @@ public class ValidatorOptions {
                 .graffitiProvider(
                     new FileBackedGraffitiProvider(
                         Optional.ofNullable(graffiti), Optional.ofNullable(graffitiFile)))
-                .generateEarlyAttestations(generateEarlyAttestations));
+                .generateEarlyAttestations(generateEarlyAttestations)
+                .executorMaxQueueSize(executorMaxQueueSize));
     validatorProposerOptions.configure(builder);
     validatorKeysOptions.configure(builder);
   }

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugDbCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugDbCommand.java
@@ -28,8 +28,8 @@ import tech.pegasys.teku.cli.options.Eth2NetworkOptions;
 import tech.pegasys.teku.dataproviders.lookup.BlockProvider;
 import tech.pegasys.teku.dataproviders.lookup.StateAndBlockSummaryProvider;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
+import tech.pegasys.teku.infrastructure.async.AsyncRunnerFactory;
 import tech.pegasys.teku.infrastructure.async.MetricTrackingExecutorFactory;
-import tech.pegasys.teku.infrastructure.async.ScheduledExecutorAsyncRunner;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.service.serviceutils.layout.DataDirLayout;
 import tech.pegasys.teku.spec.Spec;
@@ -142,9 +142,10 @@ public class DebugDbCommand implements Runnable {
               description = "File to write the block matching the latest finalized state to")
           final Path blockOutputFile)
       throws Exception {
-    final AsyncRunner asyncRunner =
-        ScheduledExecutorAsyncRunner.create(
-            "async", 1, new MetricTrackingExecutorFactory(new NoOpMetricsSystem()));
+    final AsyncRunnerFactory asyncRunnerFactory =
+        AsyncRunnerFactory.createDefault(
+            new MetricTrackingExecutorFactory(new NoOpMetricsSystem()));
+    final AsyncRunner asyncRunner = asyncRunnerFactory.create("async", 1);
     try (final Database database = createDatabase(beaconNodeDataOptions, eth2NetworkOptions)) {
       final Optional<AnchorPoint> finalizedAnchor =
           database

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
@@ -37,6 +37,7 @@ public class ValidatorConfig {
   public static final String DEFAULT_BEACON_NODE_API_ENDPOINT =
       "http://127.0.0.1:" + DEFAULT_REST_API_PORT;
   public static final boolean DEFAULT_VALIDATOR_CLIENT_SSZ_BLOCKS_ENABLED = false;
+  public static final int DEFAULT_EXECUTOR_MAX_QUEUE_SIZE = 20_000;
   public static final Duration DEFAULT_VALIDATOR_EXTERNAL_SIGNER_TIMEOUT = Duration.ofSeconds(5);
   public static final int DEFAULT_VALIDATOR_EXTERNAL_SIGNER_CONCURRENT_REQUEST_LIMIT = 32;
   public static final boolean DEFAULT_VALIDATOR_KEYSTORE_LOCKING_ENABLED = true;
@@ -70,6 +71,7 @@ public class ValidatorConfig {
   private final boolean validatorsRegistrationDefaultEnabled;
   private final boolean validatorClientUseSszBlocksEnabled;
   private final UInt64 validatorsRegistrationDefaultGasLimit;
+  private final int executorMaxQueueSize;
 
   private ValidatorConfig(
       final List<String> validatorKeys,
@@ -93,7 +95,8 @@ public class ValidatorConfig {
       final boolean validatorsRegistrationDefaultEnabled,
       final boolean blindedBeaconBlocksEnabled,
       final boolean validatorClientUseSszBlocksEnabled,
-      final UInt64 validatorsRegistrationDefaultGasLimit) {
+      final UInt64 validatorsRegistrationDefaultGasLimit,
+      final int executorMaxQueueSize) {
     this.validatorKeys = validatorKeys;
     this.validatorExternalSignerPublicKeySources = validatorExternalSignerPublicKeySources;
     this.validatorExternalSignerUrl = validatorExternalSignerUrl;
@@ -119,6 +122,7 @@ public class ValidatorConfig {
     this.validatorsRegistrationDefaultEnabled = validatorsRegistrationDefaultEnabled;
     this.validatorClientUseSszBlocksEnabled = validatorClientUseSszBlocksEnabled;
     this.validatorsRegistrationDefaultGasLimit = validatorsRegistrationDefaultGasLimit;
+    this.executorMaxQueueSize = executorMaxQueueSize;
   }
 
   public static Builder builder() {
@@ -208,6 +212,10 @@ public class ValidatorConfig {
     return validatorsRegistrationDefaultEnabled;
   }
 
+  public int getExecutorMaxQueueSize() {
+    return executorMaxQueueSize;
+  }
+
   private void validateProposerDefaultFeeRecipientOrProposerConfigSource() {
     if (proposerDefaultFeeRecipient.isEmpty()
         && proposerConfigSource.isEmpty()
@@ -246,6 +254,7 @@ public class ValidatorConfig {
     private boolean blindedBlocksEnabled = DEFAULT_VALIDATOR_BLINDED_BLOCKS_ENABLED;
     private boolean validatorClientSszBlocksEnabled = DEFAULT_VALIDATOR_CLIENT_SSZ_BLOCKS_ENABLED;
     private UInt64 validatorsRegistrationDefaultGasLimit = DEFAULT_VALIDATOR_REGISTRATION_GAS_LIMIT;
+    private int executorMaxQueueSize = DEFAULT_EXECUTOR_MAX_QUEUE_SIZE;
 
     private Builder() {}
 
@@ -346,11 +355,6 @@ public class ValidatorConfig {
       return this;
     }
 
-    public Builder proposerDefaultFeeRecipient(final Eth1Address proposerDefaultFeeRecipient) {
-      this.proposerDefaultFeeRecipient = Optional.ofNullable(proposerDefaultFeeRecipient);
-      return this;
-    }
-
     public Builder proposerDefaultFeeRecipient(final String proposerDefaultFeeRecipient) {
       if (proposerDefaultFeeRecipient == null) {
         this.proposerDefaultFeeRecipient = Optional.empty();
@@ -394,6 +398,11 @@ public class ValidatorConfig {
       return this;
     }
 
+    public Builder executorMaxQueueSize(final int executorMaxQueueSize) {
+      this.executorMaxQueueSize = executorMaxQueueSize;
+      return this;
+    }
+
     public ValidatorConfig build() {
       validateExternalSignerUrlAndPublicKeys();
       validateExternalSignerKeystoreAndPasswordFileConfig();
@@ -423,7 +432,8 @@ public class ValidatorConfig {
           validatorsRegistrationDefaultEnabled,
           blindedBlocksEnabled,
           validatorClientSszBlocksEnabled,
-          validatorsRegistrationDefaultGasLimit);
+          validatorsRegistrationDefaultGasLimit,
+          executorMaxQueueSize);
     }
 
     private void validateExternalSignerUrlAndPublicKeys() {

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
@@ -104,7 +104,9 @@ public class ValidatorClientService extends Service {
   public static ValidatorClientService create(
       final ServiceConfig services, final ValidatorClientConfiguration config) {
     final EventChannels eventChannels = services.getEventChannels();
-    final AsyncRunner asyncRunner = services.createAsyncRunner("validator");
+    final AsyncRunner asyncRunner =
+        services.createAsyncRunnerWithMaxQueueSize(
+            "validator", config.getValidatorConfig().getExecutorMaxQueueSize());
     final boolean generateEarlyAttestations =
         config.getValidatorConfig().generateEarlyAttestations();
     final boolean preferSszBlockEncoding =


### PR DESCRIPTION
## PR Description
Changed `AsyncRunnerFactory` to allow creating `AsyncRunner` with custom max queue size
Added `--Xvalidator-executor-max-queue-size` as a CLI option to allow the user to be able to set a custom number
Changed the `AsyncRunner` in `ValidatorClientService` to use the CLI option when initializing. (the VC `Signer` uses that AsyncRunner.

## Fixed Issue(s)
fixes #5790 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
