### PR TITLE
Added development cli arg for block/payload separation

### DIFF
--- a/services/chainstorage/src/main/java/tech/pegasys/teku/services/chainstorage/StorageConfiguration.java
+++ b/services/chainstorage/src/main/java/tech/pegasys/teku/services/chainstorage/StorageConfiguration.java
@@ -24,6 +24,8 @@ import tech.pegasys.teku.storage.server.VersionedDatabaseFactory;
 public class StorageConfiguration {
 
   public static final boolean DEFAULT_STORE_NON_CANONICAL_BLOCKS_ENABLED = false;
+
+  public static final boolean DEFAULT_STORE_BLOCK_PAYLOAD_SEPARATELY = false;
   public static final int DEFAULT_MAX_KNOWN_NODE_CACHE_SIZE = 100_000;
 
   private final Eth1Address eth1DepositContract;
@@ -31,6 +33,7 @@ public class StorageConfiguration {
   private final StateStorageMode dataStorageMode;
   private final long dataStorageFrequency;
   private final DatabaseVersion dataStorageCreateDbVersion;
+  private boolean storeBlockExecutionPayloadSeparately;
   private final Spec spec;
   private final boolean storeNonCanonicalBlocks;
   private final int maxKnownNodeCacheSize;
@@ -44,6 +47,7 @@ public class StorageConfiguration {
       final boolean storeNonCanonicalBlocks,
       final int maxKnownNodeCacheSize,
       final boolean storeVotesEquivocation,
+      final boolean storeBlockExecutionPayloadSeparately,
       final Spec spec) {
     this.eth1DepositContract = eth1DepositContract;
     this.dataStorageMode = dataStorageMode;
@@ -52,6 +56,7 @@ public class StorageConfiguration {
     this.storeNonCanonicalBlocks = storeNonCanonicalBlocks;
     this.maxKnownNodeCacheSize = maxKnownNodeCacheSize;
     this.storeVotesEquivocation = storeVotesEquivocation;
+    this.storeBlockExecutionPayloadSeparately = storeBlockExecutionPayloadSeparately;
     this.spec = spec;
   }
 
@@ -87,6 +92,10 @@ public class StorageConfiguration {
     return storeVotesEquivocation;
   }
 
+  public boolean isStoreBlockExecutionPayloadSeparately() {
+    return storeBlockExecutionPayloadSeparately;
+  }
+
   public Spec getSpec() {
     return spec;
   }
@@ -102,6 +111,7 @@ public class StorageConfiguration {
     private Spec spec;
     private boolean storeNonCanonicalBlocks = DEFAULT_STORE_NON_CANONICAL_BLOCKS_ENABLED;
     private int maxKnownNodeCacheSize = DEFAULT_MAX_KNOWN_NODE_CACHE_SIZE;
+    private boolean storeBlockExecutionPayloadSeparately = DEFAULT_STORE_BLOCK_PAYLOAD_SEPARATELY;
 
     private Builder() {}
 
@@ -169,7 +179,14 @@ public class StorageConfiguration {
           storeNonCanonicalBlocks,
           maxKnownNodeCacheSize,
           storeVotesEquivocation,
+          storeBlockExecutionPayloadSeparately,
           spec);
+    }
+
+    public Builder storeBlockExecutionPayloadSeparately(
+        final boolean storeBlockExecutionPayloadSeparately) {
+      this.storeBlockExecutionPayloadSeparately = storeBlockExecutionPayloadSeparately;
+      return this;
     }
   }
 }

--- a/services/chainstorage/src/main/java/tech/pegasys/teku/services/chainstorage/StorageService.java
+++ b/services/chainstorage/src/main/java/tech/pegasys/teku/services/chainstorage/StorageService.java
@@ -55,6 +55,7 @@ public class StorageService extends Service implements StorageServiceFacade {
                   config.isStoreNonCanonicalBlocksEnabled(),
                   config.getMaxKnownNodeCacheSize(),
                   config.isStoreVotesEquivocation(),
+                  config.isStoreBlockExecutionPayloadSeparately(),
                   config.getSpec());
           database = dbFactory.createDatabase();
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/VersionedDatabaseFactory.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/VersionedDatabaseFactory.java
@@ -46,6 +46,7 @@ public class VersionedDatabaseFactory implements DatabaseFactory {
   private final MetricsSystem metricsSystem;
   private final File dataDirectory;
   private final int maxKnownNodeCacheSize;
+  private boolean storeBlockExecutionPayloadSeparately;
   private final File dbDirectory;
   private final File v5ArchiveDirectory;
   private final File dbVersionFile;
@@ -64,6 +65,7 @@ public class VersionedDatabaseFactory implements DatabaseFactory {
       final Eth1Address depositContractAddress,
       final boolean storeNonCanonicalBlocks,
       final boolean storeVotesEquivocation,
+      final boolean storeBlockExecutionPayloadSeparately,
       final Spec spec) {
     this(
         metricsSystem,
@@ -75,6 +77,7 @@ public class VersionedDatabaseFactory implements DatabaseFactory {
         storeNonCanonicalBlocks,
         0,
         storeVotesEquivocation,
+        storeBlockExecutionPayloadSeparately,
         spec);
   }
 
@@ -88,10 +91,12 @@ public class VersionedDatabaseFactory implements DatabaseFactory {
       final boolean storeNonCanonicalBlocks,
       final int maxKnownNodeCacheSize,
       final boolean storeVotesEquivocation,
+      final boolean storeBlockExecutionPayloadSeparately,
       final Spec spec) {
     this.metricsSystem = metricsSystem;
     this.dataDirectory = dataPath.toFile();
     this.maxKnownNodeCacheSize = maxKnownNodeCacheSize;
+    this.storeBlockExecutionPayloadSeparately = storeBlockExecutionPayloadSeparately;
     this.dbDirectory = this.dataDirectory.toPath().resolve(DB_PATH).toFile();
     this.v5ArchiveDirectory = this.dataDirectory.toPath().resolve(ARCHIVE_PATH).toFile();
     this.dbVersionFile = this.dataDirectory.toPath().resolve(DB_VERSION_PATH).toFile();
@@ -191,6 +196,7 @@ public class VersionedDatabaseFactory implements DatabaseFactory {
           stateStorageFrequency,
           storeNonCanonicalBlocks,
           storeVotesEquivocation,
+          storeBlockExecutionPayloadSeparately,
           spec);
     } catch (final IOException e) {
       throw DatabaseStorageException.unrecoverable("Failed to read configuration file", e);
@@ -216,6 +222,7 @@ public class VersionedDatabaseFactory implements DatabaseFactory {
           stateStorageFrequency,
           storeNonCanonicalBlocks,
           storeVotesEquivocation,
+          storeBlockExecutionPayloadSeparately,
           spec);
     } catch (final IOException e) {
       throw DatabaseStorageException.unrecoverable("Failed to read metadata", e);
@@ -236,6 +243,7 @@ public class VersionedDatabaseFactory implements DatabaseFactory {
           stateStorageMode,
           stateStorageFrequency,
           storeNonCanonicalBlocks,
+          storeBlockExecutionPayloadSeparately,
           spec);
     } catch (final IOException e) {
       throw DatabaseStorageException.unrecoverable("Failed to read metadata", e);
@@ -260,6 +268,7 @@ public class VersionedDatabaseFactory implements DatabaseFactory {
           stateStorageMode,
           stateStorageFrequency,
           storeNonCanonicalBlocks,
+          storeBlockExecutionPayloadSeparately,
           storeVotesEquivocation,
           spec);
     } catch (final IOException e) {
@@ -277,6 +286,7 @@ public class VersionedDatabaseFactory implements DatabaseFactory {
           stateStorageMode,
           stateStorageFrequency,
           storeNonCanonicalBlocks,
+          storeBlockExecutionPayloadSeparately,
           storeVotesEquivocation,
           spec);
     } catch (final IOException e) {
@@ -293,6 +303,7 @@ public class VersionedDatabaseFactory implements DatabaseFactory {
           dbConfiguration.withDatabaseDir(dbDirectory.toPath()),
           stateStorageMode,
           storeNonCanonicalBlocks,
+          storeBlockExecutionPayloadSeparately,
           maxKnownNodeCacheSize,
           storeVotesEquivocation,
           spec);

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
@@ -96,6 +96,9 @@ public class KvStoreDatabase implements Database {
   private final boolean storeNonCanonicalBlocks;
   @VisibleForTesting final KvStoreCombinedDao dao;
 
+  @SuppressWarnings("unused")
+  private boolean storeBlockExecutionPayloadSeparately;
+
   public static Database createV4(
       final KvStoreAccessor hotDb,
       final KvStoreAccessor finalizedDb,
@@ -104,6 +107,7 @@ public class KvStoreDatabase implements Database {
       final StateStorageMode stateStorageMode,
       final long stateStorageFrequency,
       final boolean storeNonCanonicalBlocks,
+      final boolean storeBlockExecutionPayloadSeparately,
       final Spec spec) {
     final V4FinalizedStateSnapshotStorageLogic<SchemaFinalizedSnapshotStateAdapter>
         finalizedStateStorageLogic =
@@ -113,7 +117,8 @@ public class KvStoreDatabase implements Database {
         new KvStoreCombinedDaoAdapter(
             hotDao,
             new V4FinalizedKvStoreDao(finalizedDb, schemaFinalized, finalizedStateStorageLogic));
-    return new KvStoreDatabase(dao, stateStorageMode, storeNonCanonicalBlocks, spec);
+    return new KvStoreDatabase(
+        dao, stateStorageMode, storeNonCanonicalBlocks, storeBlockExecutionPayloadSeparately, spec);
   }
 
   public static Database createWithStateSnapshots(
@@ -122,12 +127,19 @@ public class KvStoreDatabase implements Database {
       final StateStorageMode stateStorageMode,
       final long stateStorageFrequency,
       final boolean storeNonCanonicalBlocks,
+      final boolean storeBlockExecutionPayloadSeparately,
       final Spec spec) {
     final V4FinalizedStateSnapshotStorageLogic<SchemaCombinedSnapshotState>
         finalizedStateStorageLogic =
             new V4FinalizedStateSnapshotStorageLogic<>(stateStorageFrequency);
     return create(
-        db, schema, stateStorageMode, storeNonCanonicalBlocks, spec, finalizedStateStorageLogic);
+        db,
+        schema,
+        stateStorageMode,
+        storeNonCanonicalBlocks,
+        storeBlockExecutionPayloadSeparately,
+        spec,
+        finalizedStateStorageLogic);
   }
 
   public static Database createWithStateTree(
@@ -136,12 +148,19 @@ public class KvStoreDatabase implements Database {
       final SchemaCombinedTreeState schema,
       final StateStorageMode stateStorageMode,
       final boolean storeNonCanonicalBlocks,
+      final boolean storeBlockExecutionPayloadSeparately,
       final int maxKnownNodeCacheSize,
       final Spec spec) {
     final V4FinalizedStateStorageLogic<SchemaCombinedTreeState> finalizedStateStorageLogic =
         new V4FinalizedStateTreeStorageLogic(metricsSystem, spec, maxKnownNodeCacheSize);
     return create(
-        db, schema, stateStorageMode, storeNonCanonicalBlocks, spec, finalizedStateStorageLogic);
+        db,
+        schema,
+        stateStorageMode,
+        storeNonCanonicalBlocks,
+        storeBlockExecutionPayloadSeparately,
+        spec,
+        finalizedStateStorageLogic);
   }
 
   private static <S extends SchemaCombined> KvStoreDatabase create(
@@ -149,19 +168,23 @@ public class KvStoreDatabase implements Database {
       final S schema,
       final StateStorageMode stateStorageMode,
       final boolean storeNonCanonicalBlocks,
+      final boolean storeBlockExecutionPayloadSeparately,
       final Spec spec,
       final V4FinalizedStateStorageLogic<S> finalizedStateStorageLogic) {
     final CombinedKvStoreDao<S> dao =
         new CombinedKvStoreDao<S>(db, schema, finalizedStateStorageLogic);
-    return new KvStoreDatabase(dao, stateStorageMode, storeNonCanonicalBlocks, spec);
+    return new KvStoreDatabase(
+        dao, stateStorageMode, storeNonCanonicalBlocks, storeBlockExecutionPayloadSeparately, spec);
   }
 
   private KvStoreDatabase(
       final KvStoreCombinedDao dao,
       final StateStorageMode stateStorageMode,
       final boolean storeNonCanonicalBlocks,
+      final boolean storeBlockExecutionPayloadSeparately,
       final Spec spec) {
     this.dao = dao;
+    this.storeBlockExecutionPayloadSeparately = storeBlockExecutionPayloadSeparately;
     checkNotNull(spec);
     this.stateStorageMode = stateStorageMode;
     this.storeNonCanonicalBlocks = storeNonCanonicalBlocks;

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/leveldb/LevelDbDatabaseFactory.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/leveldb/LevelDbDatabaseFactory.java
@@ -38,6 +38,7 @@ public class LevelDbDatabaseFactory {
       final StateStorageMode stateStorageMode,
       final long stateStorageFrequency,
       final boolean storeNonCanonicalBlocks,
+      final boolean storeBlockExecutionPayloadSeparately,
       final boolean storeVotesEquivocation,
       final Spec spec) {
     final V6SchemaCombinedSnapshot combinedSchema =
@@ -61,6 +62,7 @@ public class LevelDbDatabaseFactory {
         stateStorageMode,
         stateStorageFrequency,
         storeNonCanonicalBlocks,
+        storeBlockExecutionPayloadSeparately,
         spec);
   }
 
@@ -70,6 +72,7 @@ public class LevelDbDatabaseFactory {
       final StateStorageMode stateStorageMode,
       final long stateStorageFrequency,
       final boolean storeNonCanonicalBlocks,
+      final boolean storeBlockExecutionPayloadSeparately,
       final boolean storeVotesEquivocation,
       final Spec spec) {
     final V6SchemaCombinedSnapshot schema =
@@ -79,7 +82,13 @@ public class LevelDbDatabaseFactory {
             metricsSystem, STORAGE, hotConfiguration, schema.getAllColumns());
 
     return KvStoreDatabase.createWithStateSnapshots(
-        db, schema, stateStorageMode, stateStorageFrequency, storeNonCanonicalBlocks, spec);
+        db,
+        schema,
+        stateStorageMode,
+        stateStorageFrequency,
+        storeNonCanonicalBlocks,
+        storeBlockExecutionPayloadSeparately,
+        spec);
   }
 
   public static Database createLevelDbTree(
@@ -87,6 +96,7 @@ public class LevelDbDatabaseFactory {
       final KvStoreConfiguration hotConfiguration,
       final StateStorageMode stateStorageMode,
       final boolean storeNonCanonicalBlocks,
+      final boolean storeBlockExecutionPayloadSeparately,
       final int maxKnownNodeCacheSize,
       final boolean storeVotesEquivocation,
       final Spec spec) {
@@ -102,6 +112,7 @@ public class LevelDbDatabaseFactory {
         schema,
         stateStorageMode,
         storeNonCanonicalBlocks,
+        storeBlockExecutionPayloadSeparately,
         maxKnownNodeCacheSize,
         spec);
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbDatabaseFactory.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbDatabaseFactory.java
@@ -39,6 +39,7 @@ public class RocksDbDatabaseFactory {
       final long stateStorageFrequency,
       final boolean storeNonCanonicalBlocks,
       final boolean storeVotesEquivocation,
+      final boolean storeBlockExecutionPayloadSeparately,
       final Spec spec) {
 
     final V6SchemaCombinedSnapshot combinedSchema =
@@ -62,6 +63,7 @@ public class RocksDbDatabaseFactory {
         stateStorageMode,
         stateStorageFrequency,
         storeNonCanonicalBlocks,
+        storeBlockExecutionPayloadSeparately,
         spec);
   }
 
@@ -72,6 +74,7 @@ public class RocksDbDatabaseFactory {
       final StateStorageMode stateStorageMode,
       final long stateStorageFrequency,
       final boolean storeNonCanonicalBlocks,
+      final boolean storeBlockExecutionPayloadSeparately,
       final Spec spec) {
 
     final KvStoreAccessor db =
@@ -79,6 +82,12 @@ public class RocksDbDatabaseFactory {
             metricsSystem, STORAGE, hotConfiguration, schema.getAllColumns());
 
     return KvStoreDatabase.createWithStateSnapshots(
-        db, schema, stateStorageMode, stateStorageFrequency, storeNonCanonicalBlocks, spec);
+        db,
+        schema,
+        stateStorageMode,
+        stateStorageFrequency,
+        storeNonCanonicalBlocks,
+        storeBlockExecutionPayloadSeparately,
+        spec);
   }
 }

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/VersionedDatabaseFactoryTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/VersionedDatabaseFactoryTest.java
@@ -45,7 +45,14 @@ public class VersionedDatabaseFactoryTest {
   public void createDatabase_fromEmptyDataDir() throws Exception {
     final DatabaseFactory dbFactory =
         new VersionedDatabaseFactory(
-            new StubMetricsSystem(), dataDir, DATA_STORAGE_MODE, eth1Address, false, false, spec);
+            new StubMetricsSystem(),
+            dataDir,
+            DATA_STORAGE_MODE,
+            eth1Address,
+            false,
+            false,
+            false,
+            spec);
     try (final Database db = dbFactory.createDatabase()) {
       assertThat(db).isNotNull();
 
@@ -65,7 +72,14 @@ public class VersionedDatabaseFactoryTest {
 
     final VersionedDatabaseFactory dbFactory =
         new VersionedDatabaseFactory(
-            new StubMetricsSystem(), dataDir, DATA_STORAGE_MODE, eth1Address, false, false, spec);
+            new StubMetricsSystem(),
+            dataDir,
+            DATA_STORAGE_MODE,
+            eth1Address,
+            false,
+            false,
+            false,
+            spec);
     try (final Database db = dbFactory.createDatabase()) {
       assertThat(db).isNotNull();
     }
@@ -79,7 +93,14 @@ public class VersionedDatabaseFactoryTest {
 
     final DatabaseFactory dbFactory =
         new VersionedDatabaseFactory(
-            new StubMetricsSystem(), dataDir, DATA_STORAGE_MODE, eth1Address, false, false, spec);
+            new StubMetricsSystem(),
+            dataDir,
+            DATA_STORAGE_MODE,
+            eth1Address,
+            false,
+            false,
+            false,
+            spec);
     assertThatThrownBy(dbFactory::createDatabase)
         .isInstanceOf(DatabaseStorageException.class)
         .hasMessageContaining("Unrecognized database version: bla");
@@ -91,7 +112,14 @@ public class VersionedDatabaseFactoryTest {
 
     final DatabaseFactory dbFactory =
         new VersionedDatabaseFactory(
-            new StubMetricsSystem(), dataDir, DATA_STORAGE_MODE, eth1Address, false, false, spec);
+            new StubMetricsSystem(),
+            dataDir,
+            DATA_STORAGE_MODE,
+            eth1Address,
+            false,
+            false,
+            false,
+            spec);
     assertThatThrownBy(dbFactory::createDatabase)
         .isInstanceOf(DatabaseStorageException.class)
         .hasMessageContaining("No database version file was found");
@@ -111,6 +139,7 @@ public class VersionedDatabaseFactoryTest {
             eth1Address,
             false,
             MAX_KNOWN_NODE_CACHE_SIZE,
+            false,
             false,
             spec);
     assertThat(dbFactory.getDatabaseVersion()).isEqualTo(version);

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/server/kvstore/InMemoryKvStoreDatabaseFactory.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/server/kvstore/InMemoryKvStoreDatabaseFactory.java
@@ -30,6 +30,7 @@ public class InMemoryKvStoreDatabaseFactory {
       final StateStorageMode storageMode,
       final long stateStorageFrequency,
       final boolean storeNonCanonicalBlocks,
+      final boolean storeBlockExecutionPayloadSeparately,
       final boolean storeVotesEquivocation,
       final Spec spec) {
 
@@ -45,6 +46,7 @@ public class InMemoryKvStoreDatabaseFactory {
         storageMode,
         stateStorageFrequency,
         storeNonCanonicalBlocks,
+        storeBlockExecutionPayloadSeparately,
         spec);
   }
 
@@ -53,23 +55,38 @@ public class InMemoryKvStoreDatabaseFactory {
       final StateStorageMode storageMode,
       final long stateStorageFrequency,
       final boolean storeNonCanonicalBlocks,
+      final boolean storeBlockExecutionPayloadSeparately,
       final boolean storeVotesEquivocation,
       final Spec spec) {
     final V6SchemaCombinedSnapshot combinedSchema =
         V6SchemaCombinedSnapshot.createV6(spec, storeVotesEquivocation);
     return KvStoreDatabase.createWithStateSnapshots(
-        db, combinedSchema, storageMode, stateStorageFrequency, storeNonCanonicalBlocks, spec);
+        db,
+        combinedSchema,
+        storageMode,
+        stateStorageFrequency,
+        storeNonCanonicalBlocks,
+        storeBlockExecutionPayloadSeparately,
+        spec);
   }
 
   public static Database createTree(
       MockKvStoreInstance db,
       final StateStorageMode storageMode,
       final boolean storeNonCanonicalBlocks,
+      final boolean storeBlockExecutionPayloadSeparately,
       final boolean storeVotesEquivocation,
       final Spec spec) {
     final V6SchemaCombinedTreeState schema =
         new V6SchemaCombinedTreeState(spec, storeVotesEquivocation);
     return KvStoreDatabase.createWithStateTree(
-        new StubMetricsSystem(), db, schema, storageMode, storeNonCanonicalBlocks, 1000, spec);
+        new StubMetricsSystem(),
+        db,
+        schema,
+        storageMode,
+        storeNonCanonicalBlocks,
+        storeBlockExecutionPayloadSeparately,
+        1000,
+        spec);
   }
 }

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/storageSystem/FileBackedStorageSystemBuilder.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/storageSystem/FileBackedStorageSystemBuilder.java
@@ -43,6 +43,7 @@ public class FileBackedStorageSystemBuilder {
   private long stateStorageFrequency = 1L;
   private boolean storeNonCanonicalBlocks = false;
   private boolean storeVotesEquivocation = false;
+  private boolean storeBlockExecutionPayloadSeparately = false;
 
   private FileBackedStorageSystemBuilder() {}
 
@@ -112,6 +113,12 @@ public class FileBackedStorageSystemBuilder {
     return this;
   }
 
+  public FileBackedStorageSystemBuilder storeBlockExecutionPayloadSeparately(
+      final boolean storeBlockExecutionPayloadSeparately) {
+    this.storeBlockExecutionPayloadSeparately = storeBlockExecutionPayloadSeparately;
+    return this;
+  }
+
   public FileBackedStorageSystemBuilder specProvider(final Spec spec) {
     this.spec = spec;
     return this;
@@ -154,6 +161,7 @@ public class FileBackedStorageSystemBuilder {
         storageMode,
         stateStorageFrequency,
         storeNonCanonicalBlocks,
+        storeBlockExecutionPayloadSeparately,
         storeVotesEquivocation,
         spec);
   }
@@ -170,6 +178,7 @@ public class FileBackedStorageSystemBuilder {
         storageMode,
         stateStorageFrequency,
         storeNonCanonicalBlocks,
+        storeBlockExecutionPayloadSeparately,
         spec);
   }
 
@@ -181,6 +190,7 @@ public class FileBackedStorageSystemBuilder {
         storageMode,
         stateStorageFrequency,
         storeNonCanonicalBlocks,
+        storeBlockExecutionPayloadSeparately,
         storeVotesEquivocation,
         spec);
   }
@@ -192,6 +202,7 @@ public class FileBackedStorageSystemBuilder {
         configDefault.withDatabaseDir(hotDir),
         storageMode,
         storeNonCanonicalBlocks,
+        storeBlockExecutionPayloadSeparately,
         10_000,
         storeVotesEquivocation,
         spec);
@@ -206,6 +217,7 @@ public class FileBackedStorageSystemBuilder {
         stateStorageFrequency,
         storeNonCanonicalBlocks,
         storeVotesEquivocation,
+        storeBlockExecutionPayloadSeparately,
         spec);
   }
 
@@ -218,6 +230,7 @@ public class FileBackedStorageSystemBuilder {
         stateStorageFrequency,
         storeNonCanonicalBlocks,
         storeVotesEquivocation,
+        storeBlockExecutionPayloadSeparately,
         spec);
   }
 }

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/storageSystem/InMemoryStorageSystemBuilder.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/storageSystem/InMemoryStorageSystemBuilder.java
@@ -48,6 +48,7 @@ public class InMemoryStorageSystemBuilder {
   MockKvStoreInstance unifiedDb;
   private MockKvStoreInstance hotDb;
   private MockKvStoreInstance coldDb;
+  private boolean storeBlockExecutionPayloadSeparately = false;
 
   private InMemoryStorageSystemBuilder() {}
 
@@ -132,6 +133,12 @@ public class InMemoryStorageSystemBuilder {
     return this;
   }
 
+  public InMemoryStorageSystemBuilder storeBlockExecutionPayloadSeparately(
+      final boolean storeBlockExecutionPayloadSeparately) {
+    this.storeBlockExecutionPayloadSeparately = storeBlockExecutionPayloadSeparately;
+    return this;
+  }
+
   public InMemoryStorageSystemBuilder storageMode(final StateStorageMode storageMode) {
     checkNotNull(storageMode);
     this.storageMode = storageMode;
@@ -169,7 +176,12 @@ public class InMemoryStorageSystemBuilder {
       hotDb = MockKvStoreInstance.createEmpty(schema.getAllColumns(), schema.getAllVariables());
     }
     return InMemoryKvStoreDatabaseFactory.createTree(
-        hotDb, storageMode, storeNonCanonicalBlocks, storeVotesEquivocation, spec);
+        hotDb,
+        storageMode,
+        storeNonCanonicalBlocks,
+        storeBlockExecutionPayloadSeparately,
+        storeVotesEquivocation,
+        spec);
   }
 
   private Database createV6Database() {
@@ -183,6 +195,7 @@ public class InMemoryStorageSystemBuilder {
         storageMode,
         stateStorageFrequency,
         storeNonCanonicalBlocks,
+        storeBlockExecutionPayloadSeparately,
         storeVotesEquivocation,
         spec);
   }
@@ -214,6 +227,7 @@ public class InMemoryStorageSystemBuilder {
         storageMode,
         stateStorageFrequency,
         storeNonCanonicalBlocks,
+        storeBlockExecutionPayloadSeparately,
         storeVotesEquivocation,
         spec);
   }

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/BeaconNodeDataOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/BeaconNodeDataOptions.java
@@ -71,6 +71,17 @@ public class BeaconNodeDataOptions extends ValidatorClientDataOptions {
   private boolean storeNonCanonicalBlocksEnabled =
       StorageConfiguration.DEFAULT_STORE_NON_CANONICAL_BLOCKS_ENABLED;
 
+  @CommandLine.Option(
+      names = {"--Xdata-storage-store-payload-separately-enabled"},
+      paramLabel = "<BOOLEAN>",
+      showDefaultValue = Visibility.ALWAYS,
+      description = "Store the execution payload of blocks separate to the rest of the block",
+      fallbackValue = "true",
+      hidden = true,
+      arity = "0..1")
+  private boolean storeBlockExecutionPayloadSeparately =
+      StorageConfiguration.DEFAULT_STORE_BLOCK_PAYLOAD_SEPARATELY;
+
   /**
    * Default value selected based on experimentation to minimise memory usage without affecting sync
    * time. Not that states later in the chain with more validators have more branches so need a
@@ -103,6 +114,7 @@ public class BeaconNodeDataOptions extends ValidatorClientDataOptions {
                 .dataStorageFrequency(dataStorageFrequency)
                 .dataStorageCreateDbVersion(parseDatabaseVersion())
                 .storeNonCanonicalBlocks(storeNonCanonicalBlocksEnabled)
+                .storeBlockExecutionPayloadSeparately(storeBlockExecutionPayloadSeparately)
                 .maxKnownNodeCacheSize(maxKnownNodeCacheSize));
   }
 
@@ -117,5 +129,9 @@ public class BeaconNodeDataOptions extends ValidatorClientDataOptions {
 
   public boolean isStoreNonCanonicalBlocks() {
     return storeNonCanonicalBlocksEnabled;
+  }
+
+  public boolean isStoreBlockExecutionPayloadSeparately() {
+    return storeBlockExecutionPayloadSeparately;
   }
 }

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/admin/WeakSubjectivityCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/admin/WeakSubjectivityCommand.java
@@ -112,6 +112,7 @@ public class WeakSubjectivityCommand implements Runnable {
             eth2NetworkOptions.getNetworkConfiguration().getEth1DepositContractAddress(),
             beaconNodeDataOptions.isStoreNonCanonicalBlocks(),
             eth2NetworkOptions.getNetworkConfiguration().isEquivocatingIndicesEnabled(),
+            beaconNodeDataOptions.isStoreBlockExecutionPayloadSeparately(),
             spec);
     return databaseFactory.createDatabase();
   }

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugDbCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugDbCommand.java
@@ -185,6 +185,7 @@ public class DebugDbCommand implements Runnable {
             eth2NetworkOptions.getNetworkConfiguration().getEth1DepositContractAddress(),
             beaconNodeDataOptions.isStoreNonCanonicalBlocks(),
             eth2NetworkOptions.getNetworkConfiguration().isEquivocatingIndicesEnabled(),
+            beaconNodeDataOptions.isStoreBlockExecutionPayloadSeparately(),
             spec);
     return databaseFactory.createDatabase();
   }

--- a/teku/src/main/java/tech/pegasys/teku/cli/util/DatabaseMigrater.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/util/DatabaseMigrater.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.cli.util;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static tech.pegasys.teku.services.chainstorage.StorageConfiguration.DEFAULT_STORE_BLOCK_PAYLOAD_SEPARATELY;
 import static tech.pegasys.teku.storage.server.VersionedDatabaseFactory.DEFAULT_STORAGE_FREQUENCY;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -186,6 +187,7 @@ public class DatabaseMigrater {
             true,
             0,
             false,
+            DEFAULT_STORE_BLOCK_PAYLOAD_SEPARATELY,
             spec);
     final Database database = databaseFactory.createDatabase();
     if (!(database instanceof KvStoreDatabase)) {


### PR DESCRIPTION
Specify `--Xdata-storage-store-payload-separately-enabled` to enable the feature.

For this change, only the command argument is present, feature to follow

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
