### PR TITLE
Added debug command to count blocks in storage

### DIFF
--- a/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
@@ -24,6 +24,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.ethereum.pow.api.DepositsFromBlockEvent;
 import tech.pegasys.teku.ethereum.pow.api.MinGenesisTimeBlockEvent;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.blocks.CheckpointEpochs;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
@@ -34,6 +35,7 @@ import tech.pegasys.teku.storage.api.StorageUpdate;
 import tech.pegasys.teku.storage.api.UpdateResult;
 import tech.pegasys.teku.storage.api.WeakSubjectivityState;
 import tech.pegasys.teku.storage.api.WeakSubjectivityUpdate;
+import tech.pegasys.teku.storage.server.kvstore.ColumnEntry;
 
 public interface Database extends AutoCloseable {
 
@@ -100,6 +102,12 @@ public interface Database extends AutoCloseable {
    */
   @MustBeClosed
   Stream<SignedBeaconBlock> streamFinalizedBlocks(UInt64 startSlot, UInt64 endSlot);
+
+  @MustBeClosed
+  Stream<SignedBeaconBlock> streamHotBlocks();
+
+  @MustBeClosed
+  Stream<ColumnEntry<Bytes32, CheckpointEpochs>> streamCheckpointEpochs();
 
   List<Bytes32> getStateRootsBeforeSlot(final UInt64 slot);
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
@@ -35,7 +35,6 @@ import tech.pegasys.teku.storage.api.StorageUpdate;
 import tech.pegasys.teku.storage.api.UpdateResult;
 import tech.pegasys.teku.storage.api.WeakSubjectivityState;
 import tech.pegasys.teku.storage.api.WeakSubjectivityUpdate;
-import tech.pegasys.teku.storage.server.kvstore.ColumnEntry;
 
 public interface Database extends AutoCloseable {
 
@@ -107,7 +106,7 @@ public interface Database extends AutoCloseable {
   Stream<SignedBeaconBlock> streamHotBlocks();
 
   @MustBeClosed
-  Stream<ColumnEntry<Bytes32, CheckpointEpochs>> streamCheckpointEpochs();
+  Stream<Map.Entry<Bytes32, CheckpointEpochs>> streamCheckpointEpochs();
 
   List<Bytes32> getStateRootsBeforeSlot(final UInt64 slot);
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
@@ -446,6 +446,18 @@ public class KvStoreDatabase implements Database {
   }
 
   @Override
+  @MustBeClosed
+  public Stream<SignedBeaconBlock> streamHotBlocks() {
+    return dao.streamHotBlocks();
+  }
+
+  @Override
+  @MustBeClosed
+  public Stream<ColumnEntry<Bytes32, CheckpointEpochs>> streamCheckpointEpochs() {
+    return dao.streamCheckpointEpochs();
+  }
+
+  @Override
   public List<Bytes32> getStateRootsBeforeSlot(final UInt64 slot) {
     return dao.getStateRootsBeforeSlot(slot);
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
@@ -453,7 +453,7 @@ public class KvStoreDatabase implements Database {
 
   @Override
   @MustBeClosed
-  public Stream<ColumnEntry<Bytes32, CheckpointEpochs>> streamCheckpointEpochs() {
+  public Stream<Map.Entry<Bytes32, CheckpointEpochs>> streamCheckpointEpochs() {
     return dao.streamCheckpointEpochs();
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
@@ -146,8 +146,8 @@ public class CombinedKvStoreDao<S extends SchemaCombined>
 
   @Override
   @MustBeClosed
-  public Stream<ColumnEntry<Bytes32, CheckpointEpochs>> streamCheckpointEpochs() {
-    return db.stream(schema.getColumnHotBlockCheckpointEpochsByRoot());
+  public Stream<Map.Entry<Bytes32, CheckpointEpochs>> streamCheckpointEpochs() {
+    return db.stream(schema.getColumnHotBlockCheckpointEpochsByRoot()).map(entry->entry);
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
@@ -147,7 +147,7 @@ public class CombinedKvStoreDao<S extends SchemaCombined>
   @Override
   @MustBeClosed
   public Stream<Map.Entry<Bytes32, CheckpointEpochs>> streamCheckpointEpochs() {
-    return db.stream(schema.getColumnHotBlockCheckpointEpochsByRoot()).map(entry->entry);
+    return db.stream(schema.getColumnHotBlockCheckpointEpochsByRoot()).map(entry -> entry);
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
@@ -145,6 +145,12 @@ public class CombinedKvStoreDao<S extends SchemaCombined>
   }
 
   @Override
+  @MustBeClosed
+  public Stream<ColumnEntry<Bytes32, CheckpointEpochs>> streamCheckpointEpochs() {
+    return db.stream(schema.getColumnHotBlockCheckpointEpochsByRoot());
+  }
+
+  @Override
   public Optional<MinGenesisTimeBlockEvent> getMinGenesisTimeBlock() {
     return db.get(schema.getVariableMinGenesisTimeBlock());
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoAdapter.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoAdapter.java
@@ -212,7 +212,7 @@ public class KvStoreCombinedDaoAdapter implements KvStoreCombinedDao, V4Migratab
 
   @Override
   @MustBeClosed
-  public Stream<ColumnEntry<Bytes32, CheckpointEpochs>> streamCheckpointEpochs() {
+  public Stream<Map.Entry<Bytes32, CheckpointEpochs>> streamCheckpointEpochs() {
     return hotDao.streamCheckpointEpochs();
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoAdapter.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoAdapter.java
@@ -211,6 +211,12 @@ public class KvStoreCombinedDaoAdapter implements KvStoreCombinedDao, V4Migratab
   }
 
   @Override
+  @MustBeClosed
+  public Stream<ColumnEntry<Bytes32, CheckpointEpochs>> streamCheckpointEpochs() {
+    return hotDao.streamCheckpointEpochs();
+  }
+
+  @Override
   public Optional<MinGenesisTimeBlockEvent> getMinGenesisTimeBlock() {
     return hotDao.getMinGenesisTimeBlock();
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreHotDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreHotDao.java
@@ -29,7 +29,6 @@ import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
-import tech.pegasys.teku.storage.server.kvstore.ColumnEntry;
 
 /**
  * Provides an abstract "data access object" interface for working with hot data (non-finalized)
@@ -73,7 +72,7 @@ public interface KvStoreHotDao extends AutoCloseable {
   Stream<DepositsFromBlockEvent> streamDepositsFromBlocks();
 
   @MustBeClosed
-  Stream<ColumnEntry<Bytes32, CheckpointEpochs>> streamCheckpointEpochs();
+  Stream<Map.Entry<Bytes32, CheckpointEpochs>> streamCheckpointEpochs();
 
   Optional<MinGenesisTimeBlockEvent> getMinGenesisTimeBlock();
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreHotDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreHotDao.java
@@ -29,6 +29,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.storage.server.kvstore.ColumnEntry;
 
 /**
  * Provides an abstract "data access object" interface for working with hot data (non-finalized)
@@ -70,6 +71,9 @@ public interface KvStoreHotDao extends AutoCloseable {
 
   @MustBeClosed
   Stream<DepositsFromBlockEvent> streamDepositsFromBlocks();
+
+  @MustBeClosed
+  Stream<ColumnEntry<Bytes32, CheckpointEpochs>> streamCheckpointEpochs();
 
   Optional<MinGenesisTimeBlockEvent> getMinGenesisTimeBlock();
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4HotKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4HotKvStoreDao.java
@@ -133,8 +133,8 @@ public class V4HotKvStoreDao implements KvStoreHotDao {
 
   @Override
   @MustBeClosed
-  public Stream<ColumnEntry<Bytes32, CheckpointEpochs>> streamCheckpointEpochs() {
-    return db.stream(schema.getColumnHotBlockCheckpointEpochsByRoot());
+  public Stream<Map.Entry<Bytes32, CheckpointEpochs>> streamCheckpointEpochs() {
+    return db.stream(schema.getColumnHotBlockCheckpointEpochsByRoot()).map(entry->entry);
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4HotKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4HotKvStoreDao.java
@@ -132,6 +132,12 @@ public class V4HotKvStoreDao implements KvStoreHotDao {
   }
 
   @Override
+  @MustBeClosed
+  public Stream<ColumnEntry<Bytes32, CheckpointEpochs>> streamCheckpointEpochs() {
+    return db.stream(schema.getColumnHotBlockCheckpointEpochsByRoot());
+  }
+
+  @Override
   public Optional<MinGenesisTimeBlockEvent> getMinGenesisTimeBlock() {
     return db.get(schema.getVariableMinGenesisTimeBlock());
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4HotKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4HotKvStoreDao.java
@@ -134,7 +134,7 @@ public class V4HotKvStoreDao implements KvStoreHotDao {
   @Override
   @MustBeClosed
   public Stream<Map.Entry<Bytes32, CheckpointEpochs>> streamCheckpointEpochs() {
-    return db.stream(schema.getColumnHotBlockCheckpointEpochsByRoot()).map(entry->entry);
+    return db.stream(schema.getColumnHotBlockCheckpointEpochsByRoot()).map(entry -> entry);
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
@@ -25,6 +25,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.ethereum.pow.api.DepositsFromBlockEvent;
 import tech.pegasys.teku.ethereum.pow.api.MinGenesisTimeBlockEvent;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.blocks.CheckpointEpochs;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
@@ -36,6 +37,7 @@ import tech.pegasys.teku.storage.api.UpdateResult;
 import tech.pegasys.teku.storage.api.WeakSubjectivityState;
 import tech.pegasys.teku.storage.api.WeakSubjectivityUpdate;
 import tech.pegasys.teku.storage.server.Database;
+import tech.pegasys.teku.storage.server.kvstore.ColumnEntry;
 
 public class NoOpDatabase implements Database {
 
@@ -121,6 +123,16 @@ public class NoOpDatabase implements Database {
   @Override
   public Stream<SignedBeaconBlock> streamFinalizedBlocks(
       final UInt64 startSlot, final UInt64 endSlot) {
+    return Stream.empty();
+  }
+
+  @Override
+  public Stream<SignedBeaconBlock> streamHotBlocks() {
+    return Stream.empty();
+  }
+
+  @Override
+  public Stream<ColumnEntry<Bytes32, CheckpointEpochs>> streamCheckpointEpochs() {
     return Stream.empty();
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
@@ -37,7 +37,6 @@ import tech.pegasys.teku.storage.api.UpdateResult;
 import tech.pegasys.teku.storage.api.WeakSubjectivityState;
 import tech.pegasys.teku.storage.api.WeakSubjectivityUpdate;
 import tech.pegasys.teku.storage.server.Database;
-import tech.pegasys.teku.storage.server.kvstore.ColumnEntry;
 
 public class NoOpDatabase implements Database {
 
@@ -132,7 +131,7 @@ public class NoOpDatabase implements Database {
   }
 
   @Override
-  public Stream<ColumnEntry<Bytes32, CheckpointEpochs>> streamCheckpointEpochs() {
+  public Stream<Map.Entry<Bytes32, CheckpointEpochs>> streamCheckpointEpochs() {
     return Stream.empty();
   }
 

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugDbCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugDbCommand.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
+import java.util.stream.Stream;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
@@ -170,6 +171,48 @@ public class DebugDbCommand implements Runnable {
       return result;
     } finally {
       asyncRunner.shutdown();
+    }
+  }
+
+  @Command(
+      name = "get-block-counts",
+      description = "Count blocks in block storage tables",
+      mixinStandardHelpOptions = true,
+      showDefaultValues = true,
+      abbreviateSynopsis = true,
+      versionProvider = PicoCliVersionProvider.class,
+      synopsisHeading = "%n",
+      descriptionHeading = "%nDescription:%n%n",
+      optionListHeading = "%nOptions:%n",
+      footerHeading = "%n",
+      footer = "Teku is licensed under the Apache License 2.0")
+  public int getBlockCounts(
+      @Mixin final BeaconNodeDataOptions beaconNodeDataOptions,
+      @Mixin final Eth2NetworkOptions eth2NetworkOptions)
+      throws Exception {
+    try (final Database database = createDatabase(beaconNodeDataOptions, eth2NetworkOptions)) {
+      try (Stream<SignedBeaconBlock> stream = database.streamHotBlocks()) {
+        printIfPresent("Hot blocks", stream.count());
+      }
+      try (Stream<SignedBeaconBlock> stream =
+          database.streamFinalizedBlocks(UInt64.ZERO, UInt64.MAX_VALUE)) {
+        printIfPresent("Finalized blocks", stream.count());
+      }
+      try (Stream<?> stream = database.streamCheckpointEpochs()) {
+        printIfPresent("Checkpoint Epochs", stream.count());
+      }
+      //
+      //      try (Stream<SignedBeaconBlock> stream = database.streamBlindedBlocks()) {
+      //        printIfPresent("Blinded blocks", stream.count());
+      //      }
+      return 0;
+    }
+  }
+
+  private void printIfPresent(final String label, final long count) {
+    if (count > 0L) {
+      final String formatString = "%17s: %d%n";
+      System.out.printf(formatString, label, count);
     }
   }
 

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugDbCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugDbCommand.java
@@ -201,10 +201,6 @@ public class DebugDbCommand implements Runnable {
       try (Stream<?> stream = database.streamCheckpointEpochs()) {
         printIfPresent("Checkpoint Epochs", stream.count());
       }
-      //
-      //      try (Stream<SignedBeaconBlock> stream = database.streamBlindedBlocks()) {
-      //        printIfPresent("Blinded blocks", stream.count());
-      //      }
       return 0;
     }
   }


### PR DESCRIPTION
```
teku debug-tools db --config-file ~/Library/teku/mainnet.yaml get-block-counts
       Hot blocks: 75
 Finalized blocks: 76880
Checkpoint Epochs: 75
```

Will help to see where blocks are ending up, as part of blinded block implementation.

partially addresses #5312

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
