### PR TITLE
Update TransitionBenchmark to use 400k validators

### DIFF
--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/TransitionBenchmark.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/TransitionBenchmark.java
@@ -65,7 +65,7 @@ public abstract class TransitionBenchmark {
   BlockImportResult lastResult;
   SignedBeaconBlock prefetchedBlock;
 
-  @Param({"32768"})
+  @Param({"400000"})
   int validatorsCount;
 
   @Setup(Level.Trial)
@@ -79,7 +79,7 @@ public abstract class TransitionBenchmark {
             + "_validators_"
             + validatorsCount
             + ".ssz.gz";
-    String keysFile = "/bls-key-pairs/bls-key-pairs-200k-seed-0.txt.gz";
+    String keysFile = "/bls-key-pairs/bls-key-pairs-400k-seed-0.txt.gz";
 
     System.out.println("Generating keypairs from " + keysFile);
     List<BLSKeyPair> validatorKeys =


### PR DESCRIPTION
## PR Description
Updates `TransitionBenchmark` to us 400k validators to give more realistic results.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
