### PR TITLE
[MEV Boost\Builder] Send Validator Registrations in Batches

### DIFF
--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/OkHttpClientCreator.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/OkHttpClientCreator.java
@@ -30,7 +30,8 @@ public class OkHttpClientCreator {
       final Logger logger,
       final Optional<JwtConfig> jwtConfig,
       final TimeProvider timeProvider) {
-    final OkHttpClient.Builder builder = new OkHttpClient.Builder().callTimeout(timeout);
+    final OkHttpClient.Builder builder =
+        new OkHttpClient.Builder().callTimeout(timeout).readTimeout(timeout);
     if (logger.isTraceEnabled()) {
       final HttpLoggingInterceptor loggingInterceptor = new HttpLoggingInterceptor(logger::trace);
       loggingInterceptor.setLevel(Level.BODY);

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/OkHttpRestClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/OkHttpRestClient.java
@@ -159,8 +159,7 @@ public class OkHttpRestClient implements RestClient {
           @Override
           public void onResponse(
               @NotNull final Call call, @NotNull final okhttp3.Response response) {
-            HttpUrl requestUrl = response.request().url();
-            LOG.trace("{} {} {}", response.request().method(), requestUrl, response.code());
+            LOG.trace("{} {} {}", request.method(), request.url(), response.code());
             if (!response.isSuccessful()) {
               handleFailure(response, futureResponse);
               return;

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorProposerOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorProposerOptions.java
@@ -72,6 +72,17 @@ public class ValidatorProposerOptions {
       ValidatorConfig.DEFAULT_VALIDATOR_REGISTRATION_GAS_LIMIT;
 
   @Option(
+      names = {"--Xvalidators-registration-sending-batch-size"},
+      paramLabel = "<INTEGER>",
+      showDefaultValue = Visibility.ALWAYS,
+      description =
+          "Change the default batch size for sending validator registrations to the Beacon Node.",
+      arity = "1",
+      hidden = true)
+  private int registrationSendingBatchSize =
+      ValidatorConfig.DEFAULT_VALIDATOR_REGISTRATION_SENDING_BATCH_SIZE;
+
+  @Option(
       names = {"--Xvalidators-proposer-blinded-blocks-enabled"},
       paramLabel = "<BOOLEAN>",
       showDefaultValue = Visibility.ALWAYS,

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorProposerOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorProposerOptions.java
@@ -101,6 +101,7 @@ public class ValidatorProposerOptions {
                 .refreshProposerConfigFromSource(proposerConfigRefreshEnabled)
                 .validatorsRegistrationDefaultEnabled(validatorsRegistrationDefaultEnabled)
                 .blindedBeaconBlocksEnabled(blindedBlocksEnabled)
-                .validatorsRegistrationDefaultGasLimit(registrationDefaultGasLimit));
+                .validatorsRegistrationDefaultGasLimit(registrationDefaultGasLimit)
+                .validatorsRegistrationSendingBatchSize(registrationSendingBatchSize));
   }
 }

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
@@ -47,6 +47,7 @@ public class ValidatorConfig {
   public static final boolean DEFAULT_VALIDATOR_PROPOSER_CONFIG_REFRESH_ENABLED = false;
   public static final boolean DEFAULT_VALIDATOR_REGISTRATION_DEFAULT_ENABLED = false;
   public static final boolean DEFAULT_VALIDATOR_BLINDED_BLOCKS_ENABLED = false;
+  public static final int DEFAULT_VALIDATOR_REGISTRATION_SENDING_BATCH_SIZE = 100;
   public static final UInt64 DEFAULT_VALIDATOR_REGISTRATION_GAS_LIMIT = UInt64.valueOf(30_000_000);
 
   private final List<String> validatorKeys;
@@ -71,6 +72,7 @@ public class ValidatorConfig {
   private final boolean validatorsRegistrationDefaultEnabled;
   private final boolean validatorClientUseSszBlocksEnabled;
   private final UInt64 validatorsRegistrationDefaultGasLimit;
+  private final int validatorsRegistrationSendingBatchSize;
   private final int executorMaxQueueSize;
 
   private ValidatorConfig(
@@ -96,6 +98,7 @@ public class ValidatorConfig {
       final boolean blindedBeaconBlocksEnabled,
       final boolean validatorClientUseSszBlocksEnabled,
       final UInt64 validatorsRegistrationDefaultGasLimit,
+      final int validatorsRegistrationSendingBatchSize,
       final int executorMaxQueueSize) {
     this.validatorKeys = validatorKeys;
     this.validatorExternalSignerPublicKeySources = validatorExternalSignerPublicKeySources;
@@ -122,6 +125,7 @@ public class ValidatorConfig {
     this.validatorsRegistrationDefaultEnabled = validatorsRegistrationDefaultEnabled;
     this.validatorClientUseSszBlocksEnabled = validatorClientUseSszBlocksEnabled;
     this.validatorsRegistrationDefaultGasLimit = validatorsRegistrationDefaultGasLimit;
+    this.validatorsRegistrationSendingBatchSize = validatorsRegistrationSendingBatchSize;
     this.executorMaxQueueSize = executorMaxQueueSize;
   }
 
@@ -196,6 +200,10 @@ public class ValidatorConfig {
     return validatorsRegistrationDefaultGasLimit;
   }
 
+  public int getValidatorsRegistrationSendingBatchSize() {
+    return validatorsRegistrationSendingBatchSize;
+  }
+
   public boolean getRefreshProposerConfigFromSource() {
     return refreshProposerConfigFromSource;
   }
@@ -254,6 +262,8 @@ public class ValidatorConfig {
     private boolean blindedBlocksEnabled = DEFAULT_VALIDATOR_BLINDED_BLOCKS_ENABLED;
     private boolean validatorClientSszBlocksEnabled = DEFAULT_VALIDATOR_CLIENT_SSZ_BLOCKS_ENABLED;
     private UInt64 validatorsRegistrationDefaultGasLimit = DEFAULT_VALIDATOR_REGISTRATION_GAS_LIMIT;
+    private int validatorsRegistrationSendingBatchSize =
+        DEFAULT_VALIDATOR_REGISTRATION_SENDING_BATCH_SIZE;
     private int executorMaxQueueSize = DEFAULT_EXECUTOR_MAX_QUEUE_SIZE;
 
     private Builder() {}
@@ -398,6 +408,12 @@ public class ValidatorConfig {
       return this;
     }
 
+    public Builder validatorsRegistrationSendingBatchSize(
+        final int validatorsRegistrationSendingBatchSize) {
+      this.validatorsRegistrationSendingBatchSize = validatorsRegistrationSendingBatchSize;
+      return this;
+    }
+
     public Builder executorMaxQueueSize(final int executorMaxQueueSize) {
       this.executorMaxQueueSize = executorMaxQueueSize;
       return this;
@@ -433,6 +449,7 @@ public class ValidatorConfig {
           blindedBlocksEnabled,
           validatorClientSszBlocksEnabled,
           validatorsRegistrationDefaultGasLimit,
+          validatorsRegistrationSendingBatchSize,
           executorMaxQueueSize);
     }
 

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
@@ -172,7 +172,7 @@ public class ValidatorClientService extends Service {
                   proposerConfigProvider.get(),
                   config.getValidatorConfig(),
                   beaconProposerPreparer.get(),
-                  validatorApiChannel));
+                  new ValidatorRegistrationBatchSender(100, validatorApiChannel)));
     }
     if (validatorApiConfig.isRestApiEnabled()) {
       validatorRestApi =

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
@@ -38,6 +38,7 @@ import tech.pegasys.teku.service.serviceutils.layout.DataDirLayout;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
+import tech.pegasys.teku.validator.api.ValidatorConfig;
 import tech.pegasys.teku.validator.api.ValidatorTimingChannel;
 import tech.pegasys.teku.validator.beaconnode.BeaconNodeApi;
 import tech.pegasys.teku.validator.beaconnode.GenesisDataProvider;
@@ -104,16 +105,15 @@ public class ValidatorClientService extends Service {
   public static ValidatorClientService create(
       final ServiceConfig services, final ValidatorClientConfiguration config) {
     final EventChannels eventChannels = services.getEventChannels();
+    final ValidatorConfig validatorConfig = config.getValidatorConfig();
+
     final AsyncRunner asyncRunner =
         services.createAsyncRunnerWithMaxQueueSize(
-            "validator", config.getValidatorConfig().getExecutorMaxQueueSize());
-    final boolean generateEarlyAttestations =
-        config.getValidatorConfig().generateEarlyAttestations();
-    final boolean preferSszBlockEncoding =
-        config.getValidatorConfig().isValidatorClientUseSszBlocksEnabled();
+            "validator", validatorConfig.getExecutorMaxQueueSize());
+    final boolean generateEarlyAttestations = validatorConfig.generateEarlyAttestations();
+    final boolean preferSszBlockEncoding = validatorConfig.isValidatorClientUseSszBlocksEnabled();
     final BeaconNodeApi beaconNodeApi =
-        config
-            .getValidatorConfig()
+        validatorConfig
             .getBeaconNodeApiEndpoint()
             .map(
                 endpoint ->
@@ -135,7 +135,6 @@ public class ValidatorClientService extends Service {
     final ForkProvider forkProvider = new ForkProvider(config.getSpec(), genesisDataProvider);
 
     final ValidatorLoader validatorLoader = createValidatorLoader(config, asyncRunner, services);
-
     final ValidatorRestApiConfig validatorApiConfig = config.getValidatorRestApiConfig();
     Optional<RestApi> validatorRestApi = Optional.empty();
     Optional<ProposerConfigProvider> proposerConfigProvider = Optional.empty();
@@ -146,10 +145,10 @@ public class ValidatorClientService extends Service {
           Optional.of(
               ProposerConfigProvider.create(
                   asyncRunner,
-                  config.getValidatorConfig().getRefreshProposerConfigFromSource(),
+                  validatorConfig.getRefreshProposerConfigFromSource(),
                   new ProposerConfigLoader(new JsonProvider().getObjectMapper()),
                   services.getTimeProvider(),
-                  config.getValidatorConfig().getProposerConfigSource()));
+                  validatorConfig.getProposerConfigSource()));
 
       beaconProposerPreparer =
           Optional.of(
@@ -157,7 +156,7 @@ public class ValidatorClientService extends Service {
                   validatorApiChannel,
                   Optional.empty(),
                   proposerConfigProvider.get(),
-                  config.getValidatorConfig().getProposerDefaultFeeRecipient(),
+                  validatorConfig.getProposerDefaultFeeRecipient(),
                   config.getSpec(),
                   Optional.of(
                       ValidatorClientService.getKeyManagerPath(services.getDataDirLayout())
@@ -170,9 +169,11 @@ public class ValidatorClientService extends Service {
                   services.getTimeProvider(),
                   validatorLoader.getOwnedValidators(),
                   proposerConfigProvider.get(),
-                  config.getValidatorConfig(),
+                  validatorConfig,
                   beaconProposerPreparer.get(),
-                  new ValidatorRegistrationBatchSender(100, validatorApiChannel)));
+                  new ValidatorRegistrationBatchSender(
+                      validatorConfig.getValidatorsRegistrationSendingBatchSize(),
+                      validatorApiChannel)));
     }
     if (validatorApiConfig.isRestApiEnabled()) {
       validatorRestApi =

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrationBatchSender.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrationBatchSender.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.client;
+
+import com.google.common.collect.Lists;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
+import tech.pegasys.teku.infrastructure.ssz.impl.SszUtils;
+import tech.pegasys.teku.spec.datastructures.execution.SignedValidatorRegistration;
+import tech.pegasys.teku.spec.schemas.ApiSchemas;
+import tech.pegasys.teku.validator.api.ValidatorApiChannel;
+
+public class ValidatorRegistrationBatchSender {
+  private static final Logger LOG = LogManager.getLogger();
+
+  private final int batchSize;
+  private final ValidatorApiChannel validatorApiChannel;
+
+  public ValidatorRegistrationBatchSender(
+      final int batchSize, final ValidatorApiChannel validatorApiChannel) {
+    this.batchSize = batchSize;
+    this.validatorApiChannel = validatorApiChannel;
+  }
+
+  public SafeFuture<Void> sendInBatches(
+      final List<SignedValidatorRegistration> validatorRegistrations) {
+    if (validatorRegistrations.isEmpty()) {
+      LOG.debug("No validator(s) registrations required to be sent.");
+      return SafeFuture.completedFuture(null);
+    }
+
+    final List<List<SignedValidatorRegistration>> batchedRegistrations =
+        Lists.partition(validatorRegistrations, batchSize);
+
+    final AtomicInteger processedBatches = new AtomicInteger(0);
+    final AtomicInteger successfullySentRegistrations = new AtomicInteger(0);
+
+    LOG.debug(
+        "Going to send {} validator(s) registrations to Beacon Node in {} batches",
+        validatorRegistrations.size(),
+        batchedRegistrations.size());
+
+    final Iterator<List<SignedValidatorRegistration>> batchedRegistrationsIterator =
+        batchedRegistrations.iterator();
+
+    return SafeFuture.asyncDoWhile(
+            () -> {
+              if (!batchedRegistrationsIterator.hasNext()) {
+                return SafeFuture.completedFuture(false);
+              }
+              final List<SignedValidatorRegistration> batch = batchedRegistrationsIterator.next();
+              return sendBatch(batch)
+                  .thenApply(
+                      __ -> {
+                        LOG.debug(
+                            "Batch {}/{} -> {} validator(s) registrations were sent to the Beacon Node.",
+                            processedBatches.incrementAndGet(),
+                            batchedRegistrations.size(),
+                            batch.size());
+                        successfullySentRegistrations.updateAndGet(count -> count + batch.size());
+                        return true;
+                      });
+            })
+        .whenComplete(
+            (__, throwable) ->
+                LOG.info(
+                    "{} out of {} validator(s) registrations were successfully sent to the Beacon Node.",
+                    successfullySentRegistrations.get(),
+                    validatorRegistrations.size()));
+  }
+
+  private SafeFuture<Void> sendBatch(
+      final List<SignedValidatorRegistration> validatorRegistrations) {
+    final SszList<SignedValidatorRegistration> sszValidatorRegistrations =
+        SszUtils.toSszList(
+            ApiSchemas.SIGNED_VALIDATOR_REGISTRATIONS_SCHEMA, validatorRegistrations);
+    return validatorApiChannel.registerValidators(sszValidatorRegistrations);
+  }
+}

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrationBatchSender.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrationBatchSender.java
@@ -66,14 +66,8 @@ public class ValidatorRegistrationBatchSender {
               }
               final List<SignedValidatorRegistration> batch = batchedRegistrationsIterator.next();
               final int currentBatch = batchCounter.incrementAndGet();
+              LOG.debug("Starting to send batch {}/{}", currentBatch, batchedRegistrations.size());
               return sendBatch(batch)
-                  .whenException(
-                      throwable ->
-                          LOG.debug(
-                              "Failed processing batch {}/{} : {}",
-                              currentBatch,
-                              batchedRegistrations.size(),
-                              throwable.getMessage()))
                   .thenApply(
                       __ -> {
                         successfullySentRegistrations.updateAndGet(count -> count + batch.size());

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrationBatchSender.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrationBatchSender.java
@@ -41,7 +41,7 @@ public class ValidatorRegistrationBatchSender {
   public SafeFuture<Void> sendInBatches(
       final List<SignedValidatorRegistration> validatorRegistrations) {
     if (validatorRegistrations.isEmpty()) {
-      LOG.debug("No validator(s) registrations required to be sent.");
+      LOG.debug("No validator(s) registrations required to be sent to the Beacon Node.");
       return SafeFuture.completedFuture(null);
     }
 
@@ -52,7 +52,7 @@ public class ValidatorRegistrationBatchSender {
     final AtomicInteger successfullySentRegistrations = new AtomicInteger(0);
 
     LOG.debug(
-        "Going to send {} validator(s) registrations to Beacon Node in {} batches",
+        "Going to send {} validator(s) registrations to the Beacon Node in {} batches",
         validatorRegistrations.size(),
         batchedRegistrations.size());
 

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrationBatchSender.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrationBatchSender.java
@@ -68,12 +68,13 @@ public class ValidatorRegistrationBatchSender {
               return sendBatch(batch)
                   .thenApply(
                       __ -> {
+                        successfullySentRegistrations.updateAndGet(count -> count + batch.size());
+                        final int currentProcessedBatch = processedBatches.incrementAndGet();
                         LOG.debug(
                             "Batch {}/{} -> {} validator(s) registrations were sent to the Beacon Node.",
-                            processedBatches.incrementAndGet(),
+                            currentProcessedBatch,
                             batchedRegistrations.size(),
                             batch.size());
-                        successfullySentRegistrations.updateAndGet(count -> count + batch.size());
                         return true;
                       });
             })

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrationBatchSender.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrationBatchSender.java
@@ -72,7 +72,7 @@ public class ValidatorRegistrationBatchSender {
                       __ -> {
                         successfullySentRegistrations.updateAndGet(count -> count + batch.size());
                         LOG.debug(
-                            "Batch {}/{} : {} validator(s) registrations were sent to the Beacon Node.",
+                            "Batch {}/{}: {} validator(s) registrations were sent to the Beacon Node.",
                             currentBatch,
                             batchedRegistrations.size(),
                             batch.size());

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrator.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrator.java
@@ -93,9 +93,12 @@ public class ValidatorRegistrator implements ValidatorTimingChannel {
           activeValidators.size(),
           epoch);
       registerValidators(activeValidators, epoch)
-          .whenComplete((__, throwable) -> registrationInProgress.set(false))
-          .finish(
-              () -> cleanupCache(activeValidators), VALIDATOR_LOGGER::registeringValidatorsFailed);
+          .handleException(VALIDATOR_LOGGER::registeringValidatorsFailed)
+          .always(
+              () -> {
+                cleanupCache(activeValidators);
+                registrationInProgress.set(false);
+              });
     }
   }
 

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrator.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrator.java
@@ -96,8 +96,8 @@ public class ValidatorRegistrator implements ValidatorTimingChannel {
           .handleException(VALIDATOR_LOGGER::registeringValidatorsFailed)
           .always(
               () -> {
-                cleanupCache(activeValidators);
                 registrationInProgress.set(false);
+                cleanupCache(activeValidators);
               });
     }
   }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrator.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrator.java
@@ -31,8 +31,6 @@ import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.core.signatures.Signer;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
-import tech.pegasys.teku.infrastructure.ssz.SszList;
-import tech.pegasys.teku.infrastructure.ssz.impl.SszUtils;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
@@ -40,7 +38,6 @@ import tech.pegasys.teku.spec.datastructures.eth1.Eth1Address;
 import tech.pegasys.teku.spec.datastructures.execution.SignedValidatorRegistration;
 import tech.pegasys.teku.spec.datastructures.execution.ValidatorRegistration;
 import tech.pegasys.teku.spec.schemas.ApiSchemas;
-import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 import tech.pegasys.teku.validator.api.ValidatorConfig;
 import tech.pegasys.teku.validator.api.ValidatorTimingChannel;
 import tech.pegasys.teku.validator.client.loader.OwnedValidators;
@@ -53,7 +50,8 @@ public class ValidatorRegistrator implements ValidatorTimingChannel {
       Maps.newConcurrentMap();
 
   private final AtomicBoolean firstCallDone = new AtomicBoolean(false);
-  private final AtomicReference<UInt64> lastProcessedEpoch = new AtomicReference<>();
+  private final AtomicBoolean registrationInProgress = new AtomicBoolean(false);
+  private final AtomicReference<UInt64> lastRunEpoch = new AtomicReference<>();
 
   private final Spec spec;
   private final TimeProvider timeProvider;
@@ -61,7 +59,7 @@ public class ValidatorRegistrator implements ValidatorTimingChannel {
   private final ProposerConfigProvider proposerConfigProvider;
   private final ValidatorConfig validatorConfig;
   private final FeeRecipientProvider feeRecipientProvider;
-  private final ValidatorApiChannel validatorApiChannel;
+  private final ValidatorRegistrationBatchSender validatorRegistrationBatchSender;
 
   public ValidatorRegistrator(
       final Spec spec,
@@ -70,13 +68,13 @@ public class ValidatorRegistrator implements ValidatorTimingChannel {
       final ProposerConfigProvider proposerConfigProvider,
       final ValidatorConfig validatorConfig,
       final FeeRecipientProvider feeRecipientProvider,
-      final ValidatorApiChannel validatorApiChannel) {
+      final ValidatorRegistrationBatchSender validatorRegistrationBatchSender) {
     this.spec = spec;
     this.timeProvider = timeProvider;
     this.ownedValidators = ownedValidators;
     this.proposerConfigProvider = proposerConfigProvider;
     this.feeRecipientProvider = feeRecipientProvider;
-    this.validatorApiChannel = validatorApiChannel;
+    this.validatorRegistrationBatchSender = validatorRegistrationBatchSender;
     this.validatorConfig = validatorConfig;
   }
 
@@ -85,15 +83,17 @@ public class ValidatorRegistrator implements ValidatorTimingChannel {
     if (isNotReadyToRegister()) {
       return;
     }
-    if (firstCallDone.compareAndSet(false, true) || isBeginningOfEpoch(slot)) {
+    if (registrationNeedsToBeRun(slot)) {
+      registrationInProgress.set(true);
       final UInt64 epoch = spec.computeEpochAtSlot(slot);
-      lastProcessedEpoch.set(epoch);
+      lastRunEpoch.set(epoch);
       final List<Validator> activeValidators = ownedValidators.getActiveValidators();
       LOG.debug(
           "Checking if registration is required for {} validator(s) at epoch {}",
           activeValidators.size(),
           epoch);
       registerValidators(activeValidators, epoch)
+          .whenComplete((__, throwable) -> registrationInProgress.set(false))
           .finish(
               () -> cleanupCache(activeValidators), VALIDATOR_LOGGER::registeringValidatorsFailed);
     }
@@ -111,7 +111,7 @@ public class ValidatorRegistrator implements ValidatorTimingChannel {
 
   @Override
   public void onValidatorsAdded() {
-    if (isNotReadyToRegister() || lastProcessedEpoch.get() == null) {
+    if (isNotReadyToRegister() || lastRunEpoch.get() == null) {
       return;
     }
 
@@ -121,7 +121,7 @@ public class ValidatorRegistrator implements ValidatorTimingChannel {
                 validator -> !cachedValidatorRegistrations.containsKey(validator.getPublicKey()))
             .collect(Collectors.toList());
 
-    registerValidators(newlyAddedValidators, lastProcessedEpoch.get())
+    registerValidators(newlyAddedValidators, lastRunEpoch.get())
         .finish(VALIDATOR_LOGGER::registeringValidatorsFailed);
   }
 
@@ -146,8 +146,19 @@ public class ValidatorRegistrator implements ValidatorTimingChannel {
     return false;
   }
 
-  private boolean isBeginningOfEpoch(final UInt64 slot) {
-    return slot.mod(spec.getSlotsPerEpoch(slot)).isZero();
+  private boolean registrationNeedsToBeRun(final UInt64 slot) {
+    final boolean isFirstCall = firstCallDone.compareAndSet(false, true);
+    if (isFirstCall) {
+      return true;
+    }
+    final boolean isBeginningOfEpoch = slot.mod(spec.getSlotsPerEpoch(slot)).isZero();
+    if (isBeginningOfEpoch && registrationInProgress.get()) {
+      LOG.warn(
+          "Validator(s) registration for epoch {} is still in progress. Will skip registration for the current epoch.",
+          lastRunEpoch.get());
+      return false;
+    }
+    return isBeginningOfEpoch;
   }
 
   private SafeFuture<Void> registerValidators(
@@ -169,7 +180,7 @@ public class ValidatorRegistrator implements ValidatorTimingChannel {
                       .flatMap(Optional::stream);
 
               return SafeFuture.collectAll(validatorRegistrationsFutures)
-                  .thenCompose(this::sendValidatorRegistrations);
+                  .thenCompose(validatorRegistrationBatchSender::sendInBatches);
             });
   }
 
@@ -217,22 +228,6 @@ public class ValidatorRegistrator implements ValidatorTimingChannel {
               return Optional.of(
                   signAndCacheValidatorRegistration(validatorRegistration, signer, epoch));
             });
-  }
-
-  private SafeFuture<Void> sendValidatorRegistrations(
-      final List<SignedValidatorRegistration> validatorRegistrations) {
-    if (validatorRegistrations.isEmpty()) {
-      LOG.debug("No validator(s) require registering.");
-      return SafeFuture.completedFuture(null);
-    }
-
-    final SszList<SignedValidatorRegistration> sszValidatorRegistrations =
-        SszUtils.toSszList(
-            ApiSchemas.SIGNED_VALIDATOR_REGISTRATIONS_SCHEMA, validatorRegistrations);
-
-    return validatorApiChannel
-        .registerValidators(sszValidatorRegistrations)
-        .thenPeek(__ -> LOG.info("{} validator(s) registered.", sszValidatorRegistrations.size()));
   }
 
   private boolean registrationIsEnabled(

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrator.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrator.java
@@ -84,7 +84,6 @@ public class ValidatorRegistrator implements ValidatorTimingChannel {
       return;
     }
     if (registrationNeedsToBeRun(slot)) {
-      registrationInProgress.set(true);
       final UInt64 epoch = spec.computeEpochAtSlot(slot);
       lastRunEpoch.set(epoch);
       final List<Validator> activeValidators = ownedValidators.getActiveValidators();
@@ -92,6 +91,7 @@ public class ValidatorRegistrator implements ValidatorTimingChannel {
           "Checking if registration is required for {} validator(s) at epoch {}",
           activeValidators.size(),
           epoch);
+      registrationInProgress.set(true);
       registerValidators(activeValidators, epoch)
           .handleException(VALIDATOR_LOGGER::registeringValidatorsFailed)
           .always(

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorRegistrationBatchSenderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorRegistrationBatchSenderTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.mockito.ArgumentCaptor;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecContext;
+import tech.pegasys.teku.spec.TestSpecInvocationContextProvider.SpecContext;
+import tech.pegasys.teku.spec.datastructures.execution.SignedValidatorRegistration;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.validator.api.ValidatorApiChannel;
+
+@TestSpecContext(milestone = SpecMilestone.BELLATRIX)
+class ValidatorRegistrationBatchSenderTest {
+
+  private static final int BATCH_SIZE = 2;
+
+  private final ValidatorApiChannel validatorApiChannel = mock(ValidatorApiChannel.class);
+
+  private DataStructureUtil dataStructureUtil;
+  private ValidatorRegistrationBatchSender validatorRegistrationBatchSender;
+
+  @BeforeEach
+  void setUp(SpecContext specContext) {
+    dataStructureUtil = specContext.getDataStructureUtil();
+
+    when(validatorApiChannel.registerValidators(any()))
+        .thenReturn(SafeFuture.completedFuture(null));
+
+    validatorRegistrationBatchSender =
+        new ValidatorRegistrationBatchSender(BATCH_SIZE, validatorApiChannel);
+  }
+
+  @TestTemplate
+  void noRegistrationsAreSentIfEmpty() {
+    final SafeFuture<Void> result = validatorRegistrationBatchSender.sendInBatches(List.of());
+
+    assertThat(result).isCompleted();
+
+    verifyNoInteractions(validatorApiChannel);
+  }
+
+  @TestTemplate
+  void sendsRegistrationsInBatches() {
+    SignedValidatorRegistration registration1 =
+        dataStructureUtil.randomSignedValidatorRegistration();
+    SignedValidatorRegistration registration2 =
+        dataStructureUtil.randomSignedValidatorRegistration();
+    SignedValidatorRegistration registration3 =
+        dataStructureUtil.randomSignedValidatorRegistration();
+    SignedValidatorRegistration registration4 =
+        dataStructureUtil.randomSignedValidatorRegistration();
+    SignedValidatorRegistration registration5 =
+        dataStructureUtil.randomSignedValidatorRegistration();
+
+    final SafeFuture<Void> result =
+        validatorRegistrationBatchSender.sendInBatches(
+            List.of(registration1, registration2, registration3, registration4, registration5));
+
+    assertThat(result).isCompleted();
+
+    final List<SszList<SignedValidatorRegistration>> sentRegistrations =
+        captureSentRegistrations(3);
+
+    assertThat(sentRegistrations.get(0)).containsExactly(registration1, registration2);
+    assertThat(sentRegistrations.get(1)).containsExactly(registration3, registration4);
+    assertThat(sentRegistrations.get(2)).containsExactly(registration5);
+  }
+
+  @TestTemplate
+  void stopsToSendBatchesOnFirstFailure() {
+    when(validatorApiChannel.registerValidators(any()))
+        .thenReturn(SafeFuture.failedFuture(new IllegalStateException("oopsy")));
+
+    SafeFuture<Void> result =
+        validatorRegistrationBatchSender.sendInBatches(
+            dataStructureUtil.randomSignedValidatorRegistrations(5).asList());
+
+    assertThat(result).isCompletedExceptionally();
+
+    final List<SszList<SignedValidatorRegistration>> sentRegistrations =
+        captureSentRegistrations(1);
+
+    assertThat(sentRegistrations.get(0)).hasSize(BATCH_SIZE);
+  }
+
+  private List<SszList<SignedValidatorRegistration>> captureSentRegistrations(final int times) {
+    @SuppressWarnings("unchecked")
+    final ArgumentCaptor<SszList<SignedValidatorRegistration>> argumentCaptor =
+        ArgumentCaptor.forClass(SszList.class);
+
+    verify(validatorApiChannel, times(times)).registerValidators(argumentCaptor.capture());
+
+    return argumentCaptor.getAllValues();
+  }
+}

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorRegistrationBatchSenderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorRegistrationBatchSenderTest.java
@@ -96,7 +96,7 @@ class ValidatorRegistrationBatchSenderTest {
     when(validatorApiChannel.registerValidators(any()))
         .thenReturn(SafeFuture.failedFuture(new IllegalStateException("oopsy")));
 
-    SafeFuture<Void> result =
+    final SafeFuture<Void> result =
         validatorRegistrationBatchSender.sendInBatches(
             dataStructureUtil.randomSignedValidatorRegistrations(5).asList());
 


### PR DESCRIPTION
## PR Description

- Added `ValidatorRegistrationBatchSender` to send registrations in batches
- Added a check in `ValidatorRegistrator` on beginning of epoch to make sure there is no registration still running for another epoch.
- Initialised the `ValidatorRegistrationBatchSender` in `ValidatorClientService`
- Add hidden CLI option for the batch size

## Fixed Issue(s)
related to #5396 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
