### PR TITLE
Set preEpochTransitionMutableState in init for benchmark

### DIFF
--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/EpochTransitionBenchmark.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/EpochTransitionBenchmark.java
@@ -137,6 +137,8 @@ public class EpochTransitionBenchmark {
     }
 
     preEpochTransitionState = safeJoin(recentChainData.getBestState().orElseThrow());
+    preEpochTransitionMutableState =
+        (MutableBeaconState) preEpochTransitionState.createWritableCopy();
 
     validatorStatuses =
         spec.getGenesisSpec()


### PR DESCRIPTION
## PR Description

When running the `EpochTransitionBenchmark` benchmarks, I noticed that two of them (`applyDeltas` and `processRewardsAndPenalties`) are broken. They use the `preEpochTransitionMutableState` variable which is never set to anything during initialization, so they would always throw a null pointer exception.

In the `applyDeltas` benchmark:
```
java.lang.NullPointerException: Cannot invoke "tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState.getBalances()" because "this.preEpochTransitionMutableState" is null
        at tech.pegasys.teku.benchmarks.EpochTransitionBenchmark.applyDeltas(EpochTransitionBenchmark.java:182)
        at tech.pegasys.teku.benchmarks.jmh_generated.EpochTransitionBenchmark_applyDeltas_jmhTest.applyDeltas_thrpt_jmhStub(EpochTransitionBenchmark_applyDeltas_jmhTest.java:119)
        at tech.pegasys.teku.benchmarks.jmh_generated.EpochTransitionBenchmark_applyDeltas_jmhTest.applyDeltas_Throughput(EpochTransitionBenchmark_applyDeltas_jmhTest.java:83)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:568)
        at org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask.call(BenchmarkHandler.java:475)
        at org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask.call(BenchmarkHandler.java:458)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
        at java.base/java.lang.Thread.run(Thread.java:833)
```

In the `processRewardsAndPenalties` benchmark:
```
java.lang.NullPointerException: Cannot invoke "tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState.getSlot()" because "state" is null
        at tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors.getCurrentEpoch(BeaconStateAccessors.java:53)
        at tech.pegasys.teku.spec.logic.common.statetransition.epoch.AbstractEpochProcessor.processRewardsAndPenalties(AbstractEpochProcessor.java:198)
        at tech.pegasys.teku.benchmarks.EpochTransitionBenchmark.processRewardsAndPenalties(EpochTransitionBenchmark.java:174)
        at tech.pegasys.teku.benchmarks.jmh_generated.EpochTransitionBenchmark_processRewardsAndPenalties_jmhTest.processRewardsAndPenalties_thrpt_jmhStub(EpochTransitionBenchmark_processRewardsAndPenalties_jmhTest.java:119)
        at tech.pegasys.teku.benchmarks.jmh_generated.EpochTransitionBenchmark_processRewardsAndPenalties_jmhTest.processRewardsAndPenalties_Throughput(EpochTransitionBenchmark_processRewardsAndPenalties_jmhTest.java:83)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:568)
        at org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask.call(BenchmarkHandler.java:475)
        at org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask.call(BenchmarkHandler.java:458)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
        at java.base/java.lang.Thread.run(Thread.java:833)
```

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
