### PR TITLE
Don't revalidate IndexedAttestation when attestation is coming from a reorged block

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/attestation/ValidateableAttestation.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/attestation/ValidateableAttestation.java
@@ -64,7 +64,7 @@ public class ValidateableAttestation {
 
   public static ValidateableAttestation fromReorgedBlock(
       final Spec spec, final Attestation attestation) {
-    ValidateableAttestation validateableAttestation =
+    final ValidateableAttestation validateableAttestation =
         new ValidateableAttestation(
             spec, attestation, Optional.empty(), OptionalInt.empty(), false);
     // An indexed attestation from a reorged block is valid because it already
@@ -140,7 +140,7 @@ public class ValidateableAttestation {
       return;
     }
 
-    Bytes32 committeeShufflingSeed =
+    final Bytes32 committeeShufflingSeed =
         spec.getSeed(
             state,
             spec.computeEpochAtSlot(attestation.getData().getSlot()),

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/attestation/ValidateableAttestation.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/attestation/ValidateableAttestation.java
@@ -68,7 +68,7 @@ public class ValidateableAttestation {
     ValidateableAttestation validateableAttestation =
         new ValidateableAttestation(
             spec, attestation, Optional.empty(), OptionalInt.empty(), false);
-    // An attestation signature from a reorged block is already valid because it already
+    // An attestation signature from a reorged block is valid because it already
     // has been validated when the block was part of the canonical chain
     validateableAttestation.setValidSignature();
     return validateableAttestation;

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/attestation/ValidateableAttestation.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/attestation/ValidateableAttestation.java
@@ -65,12 +65,11 @@ public class ValidateableAttestation {
 
   public static ValidateableAttestation fromReorgedBlock(
       final Spec spec, final Attestation attestation) {
-    // An attestation from a reorged block does not require signature
-    // validation because its signature already has been validated when the block was
-    // part of the canonical chain
     ValidateableAttestation validateableAttestation =
         new ValidateableAttestation(
             spec, attestation, Optional.empty(), OptionalInt.empty(), false);
+    // An attestation signature from a reorged block is already valid because it already
+    // has been validated when the block was part of the canonical chain
     validateableAttestation.setValidSignature();
     return validateableAttestation;
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/attestation/ValidateableAttestation.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/attestation/ValidateableAttestation.java
@@ -40,7 +40,6 @@ public class ValidateableAttestation {
   private final boolean producedLocally;
   private final OptionalInt receivedSubnetId;
 
-  private volatile boolean signatureValidated = false;
   private volatile boolean isValidIndexedAttestation = false;
 
   private volatile Optional<IndexedAttestation> indexedAttestation = Optional.empty();
@@ -68,9 +67,9 @@ public class ValidateableAttestation {
     ValidateableAttestation validateableAttestation =
         new ValidateableAttestation(
             spec, attestation, Optional.empty(), OptionalInt.empty(), false);
-    // An attestation signature from a reorged block is valid because it already
+    // An indexed attestation from a reorged block is valid because it already
     // has been validated when the block was part of the canonical chain
-    validateableAttestation.setValidSignature();
+    validateableAttestation.setValidIndexedAttestation();
     return validateableAttestation;
   }
 
@@ -110,14 +109,6 @@ public class ValidateableAttestation {
 
   public boolean isProducedLocally() {
     return producedLocally;
-  }
-
-  public boolean isSignatureValidated() {
-    return signatureValidated;
-  }
-
-  public void setValidSignature() {
-    this.signatureValidated = true;
   }
 
   public boolean isValidIndexedAttestation() {
@@ -221,7 +212,6 @@ public class ValidateableAttestation {
         .add("hashTreeRoot", hashTreeRoot)
         .add("gossiped", gossiped)
         .add("producedLocally", producedLocally)
-        .add("signatureValidated", signatureValidated)
         .add("isValidIndexedAttestation", isValidIndexedAttestation)
         .add("indexedAttestation", indexedAttestation)
         .add("committeeShufflingSeed", committeeShufflingSeed)

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/AttestationUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/AttestationUtil.java
@@ -169,12 +169,9 @@ public class AttestationUtil {
             })
         .thenCompose(
             att -> {
-              // An attestation from a non-canonical block does not require signature verification
-              // because its signature already has been verified when the block was part of the
-              // canonical chain
-              boolean skipSignatureVerification = attestation.isProducedFromNonCanonicalBlock();
+              final boolean skipSignatureValidation = attestation.isSignatureValidated();
               return isValidIndexedAttestationAsync(
-                  fork, state, att, blsSignatureVerifier, skipSignatureVerification);
+                  fork, state, att, blsSignatureVerifier, skipSignatureValidation);
             })
         .thenApply(
             result -> {
@@ -235,7 +232,7 @@ public class AttestationUtil {
       BeaconState state,
       IndexedAttestation indexedAttestation,
       AsyncBLSSignatureVerifier signatureVerifier,
-      boolean skipSignatureVerification) {
+      boolean skipSignatureValidation) {
     SszUInt64List indices = indexedAttestation.getAttestingIndices();
 
     if (indices.isEmpty()
@@ -254,7 +251,7 @@ public class AttestationUtil {
           AttestationProcessingResult.invalid("Attesting indices include non-existent validator"));
     }
 
-    if (skipSignatureVerification) {
+    if (skipSignatureValidation) {
       return SafeFuture.completedFuture(AttestationProcessingResult.SUCCESSFUL);
     }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/AttestationUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/AttestationUtil.java
@@ -172,10 +172,9 @@ public class AttestationUtil {
               // An attestation from a non-canonical block does not require signature verification
               // because its signature already has been verified when the block was part of the
               // canonical chain
-              boolean requiresSignatureVerification =
-                  !attestation.isProducedFromNonCanonicalBlock();
+              boolean skipSignatureVerification = attestation.isProducedFromNonCanonicalBlock();
               return isValidIndexedAttestationAsync(
-                  fork, state, att, blsSignatureVerifier, requiresSignatureVerification);
+                  fork, state, att, blsSignatureVerifier, skipSignatureVerification);
             })
         .thenApply(
             result -> {
@@ -227,7 +226,8 @@ public class AttestationUtil {
       BeaconState state,
       IndexedAttestation indexedAttestation,
       AsyncBLSSignatureVerifier signatureVerifier) {
-    return isValidIndexedAttestationAsync(fork, state, indexedAttestation, signatureVerifier, true);
+    return isValidIndexedAttestationAsync(
+        fork, state, indexedAttestation, signatureVerifier, false);
   }
 
   public SafeFuture<AttestationProcessingResult> isValidIndexedAttestationAsync(
@@ -235,7 +235,7 @@ public class AttestationUtil {
       BeaconState state,
       IndexedAttestation indexedAttestation,
       AsyncBLSSignatureVerifier signatureVerifier,
-      boolean requiresSignatureVerification) {
+      boolean skipSignatureVerification) {
     SszUInt64List indices = indexedAttestation.getAttestingIndices();
 
     if (indices.isEmpty()
@@ -254,7 +254,7 @@ public class AttestationUtil {
           AttestationProcessingResult.invalid("Attesting indices include non-existent validator"));
     }
 
-    if (!requiresSignatureVerification) {
+    if (skipSignatureVerification) {
       return SafeFuture.completedFuture(AttestationProcessingResult.SUCCESSFUL);
     }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/AttestationUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/AttestationUtil.java
@@ -180,6 +180,7 @@ public class AttestationUtil {
             result -> {
               if (result.isSuccessful()) {
                 attestation.saveCommitteeShufflingSeed(state);
+                attestation.setValidSignature();
                 attestation.setValidIndexedAttestation();
               }
               return result;

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/AttestationUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/AttestationUtil.java
@@ -74,7 +74,8 @@ public class AttestationUtil {
    * @see
    *     <a>https://github.com/ethereum/eth2.0-specs/blob/v0.8.0/specs/core/0_beacon-chain.md#is_slashable_attestation_data</a>
    */
-  public boolean isSlashableAttestationData(AttestationData data1, AttestationData data2) {
+  public boolean isSlashableAttestationData(
+      final AttestationData data1, final AttestationData data2) {
     return (
     // case 1: double vote || case 2: surround vote
     (!data1.equals(data2) && data1.getTarget().getEpoch().equals(data2.getTarget().getEpoch()))
@@ -91,8 +92,9 @@ public class AttestationUtil {
    * @see
    *     <a>https://github.com/ethereum/eth2.0-specs/blob/v0.8.0/specs/core/0_beacon-chain.md#get_indexed_attestation</a>
    */
-  public IndexedAttestation getIndexedAttestation(BeaconState state, Attestation attestation) {
-    List<Integer> attestingIndices =
+  public IndexedAttestation getIndexedAttestation(
+      final BeaconState state, final Attestation attestation) {
+    final List<Integer> attestingIndices =
         getAttestingIndices(state, attestation.getData(), attestation.getAggregationBits());
 
     final IndexedAttestationSchema indexedAttestationSchema =
@@ -117,12 +119,13 @@ public class AttestationUtil {
    * @see
    *     <a>https://github.com/ethereum/eth2.0-specs/blob/v0.8.0/specs/core/0_beacon-chain.md#get_attesting_indices</a>
    */
-  public IntList getAttestingIndices(BeaconState state, AttestationData data, SszBitlist bits) {
+  public IntList getAttestingIndices(
+      final BeaconState state, final AttestationData data, final SszBitlist bits) {
     return IntList.of(streamAttestingIndices(state, data, bits).toArray());
   }
 
   public IntStream streamAttestingIndices(
-      BeaconState state, AttestationData data, SszBitlist bits) {
+      final BeaconState state, final AttestationData data, final SszBitlist bits) {
     IntList committee =
         beaconStateAccessors.getBeaconCommittee(state, data.getSlot(), data.getIndex());
     checkArgument(
@@ -134,15 +137,15 @@ public class AttestationUtil {
   }
 
   public AttestationProcessingResult isValidIndexedAttestation(
-      Fork fork, BeaconState state, ValidateableAttestation attestation) {
+      final Fork fork, final BeaconState state, final ValidateableAttestation attestation) {
     return isValidIndexedAttestation(fork, state, attestation, BLSSignatureVerifier.SIMPLE);
   }
 
   public AttestationProcessingResult isValidIndexedAttestation(
-      Fork fork,
-      BeaconState state,
-      ValidateableAttestation attestation,
-      BLSSignatureVerifier blsSignatureVerifier) {
+      final Fork fork,
+      final BeaconState state,
+      final ValidateableAttestation attestation,
+      final BLSSignatureVerifier blsSignatureVerifier) {
     final SafeFuture<AttestationProcessingResult> result =
         isValidIndexedAttestationAsync(
             fork, state, attestation, AsyncBLSSignatureVerifier.wrap(blsSignatureVerifier));
@@ -151,10 +154,10 @@ public class AttestationUtil {
   }
 
   public SafeFuture<AttestationProcessingResult> isValidIndexedAttestationAsync(
-      Fork fork,
-      BeaconState state,
-      ValidateableAttestation attestation,
-      AsyncBLSSignatureVerifier blsSignatureVerifier) {
+      final Fork fork,
+      final BeaconState state,
+      final ValidateableAttestation attestation,
+      final AsyncBLSSignatureVerifier blsSignatureVerifier) {
     if (attestation.isValidIndexedAttestation()) {
       return completedFuture(AttestationProcessingResult.SUCCESSFUL);
     }
@@ -162,7 +165,7 @@ public class AttestationUtil {
     return SafeFuture.of(
             () -> {
               // getIndexedAttestation() throws, so wrap it in a future
-              IndexedAttestation indexedAttestation =
+              final IndexedAttestation indexedAttestation =
                   getIndexedAttestation(state, attestation.getAttestation());
               attestation.setIndexedAttestation(indexedAttestation);
               return indexedAttestation;
@@ -202,15 +205,15 @@ public class AttestationUtil {
    *     <a>https://github.com/ethereum/eth2.0-specs/blob/v0.8.0/specs/core/0_beacon-chain.md#is_valid_indexed_attestation</a>
    */
   public AttestationProcessingResult isValidIndexedAttestation(
-      Fork fork, BeaconState state, IndexedAttestation indexedAttestation) {
+      final Fork fork, final BeaconState state, final IndexedAttestation indexedAttestation) {
     return isValidIndexedAttestation(fork, state, indexedAttestation, BLSSignatureVerifier.SIMPLE);
   }
 
   public AttestationProcessingResult isValidIndexedAttestation(
-      Fork fork,
-      BeaconState state,
-      IndexedAttestation indexedAttestation,
-      BLSSignatureVerifier signatureVerifier) {
+      final Fork fork,
+      final BeaconState state,
+      final IndexedAttestation indexedAttestation,
+      final BLSSignatureVerifier signatureVerifier) {
     final SafeFuture<AttestationProcessingResult> result =
         isValidIndexedAttestationAsync(
             fork, state, indexedAttestation, AsyncBLSSignatureVerifier.wrap(signatureVerifier));
@@ -219,21 +222,21 @@ public class AttestationUtil {
   }
 
   public SafeFuture<AttestationProcessingResult> isValidIndexedAttestationAsync(
-      Fork fork,
-      BeaconState state,
-      IndexedAttestation indexedAttestation,
-      AsyncBLSSignatureVerifier signatureVerifier) {
+      final Fork fork,
+      final BeaconState state,
+      final IndexedAttestation indexedAttestation,
+      final AsyncBLSSignatureVerifier signatureVerifier) {
     return isValidIndexedAttestationAsync(
         fork, state, indexedAttestation, signatureVerifier, false);
   }
 
   public SafeFuture<AttestationProcessingResult> isValidIndexedAttestationAsync(
-      Fork fork,
-      BeaconState state,
-      IndexedAttestation indexedAttestation,
-      AsyncBLSSignatureVerifier signatureVerifier,
-      boolean skipSignatureValidation) {
-    SszUInt64List indices = indexedAttestation.getAttestingIndices();
+      final Fork fork,
+      final BeaconState state,
+      final IndexedAttestation indexedAttestation,
+      final AsyncBLSSignatureVerifier signatureVerifier,
+      final boolean skipSignatureValidation) {
+    final SszUInt64List indices = indexedAttestation.getAttestingIndices();
 
     if (indices.isEmpty()
         || !Comparators.isInStrictOrder(indices.asListUnboxed(), Comparator.naturalOrder())) {
@@ -241,7 +244,7 @@ public class AttestationUtil {
           AttestationProcessingResult.invalid("Attesting indices are not sorted"));
     }
 
-    List<BLSPublicKey> pubkeys =
+    final List<BLSPublicKey> pubkeys =
         indices
             .streamUnboxed()
             .flatMap(i -> beaconStateAccessors.getValidatorPubKey(state, i).stream())
@@ -255,14 +258,14 @@ public class AttestationUtil {
       return SafeFuture.completedFuture(AttestationProcessingResult.SUCCESSFUL);
     }
 
-    BLSSignature signature = indexedAttestation.getSignature();
-    Bytes32 domain =
+    final BLSSignature signature = indexedAttestation.getSignature();
+    final Bytes32 domain =
         beaconStateAccessors.getDomain(
             Domain.BEACON_ATTESTER,
             indexedAttestation.getData().getTarget().getEpoch(),
             fork,
             state.getGenesisValidatorsRoot());
-    Bytes signingRoot = miscHelpers.computeSigningRoot(indexedAttestation.getData(), domain);
+    final Bytes signingRoot = miscHelpers.computeSigningRoot(indexedAttestation.getData(), domain);
 
     return signatureVerifier
         .verify(pubkeys, signingRoot, signature)
@@ -278,30 +281,22 @@ public class AttestationUtil {
             });
   }
 
-  // Returns the index of the first attester in the Attestation
-  public int getAttesterIndexIntoCommittee(Attestation attestation) {
-    SszBitlist aggregationBits = attestation.getAggregationBits();
-    for (int i = 0; i < aggregationBits.size(); i++) {
-      if (aggregationBits.getBit(i)) {
-        return i;
-      }
-    }
-    throw new UnsupportedOperationException("Attestation doesn't have any aggregation bit set");
-  }
-
   // Get attestation data that does not include attester specific shard or crosslink information
   public AttestationData getGenericAttestationData(
-      UInt64 slot, BeaconState state, BeaconBlockSummary block, final UInt64 committeeIndex) {
-    UInt64 epoch = miscHelpers.computeEpochAtSlot(slot);
+      final UInt64 slot,
+      final BeaconState state,
+      final BeaconBlockSummary block,
+      final UInt64 committeeIndex) {
+    final UInt64 epoch = miscHelpers.computeEpochAtSlot(slot);
     // Get variables necessary that can be shared among Attestations of all validators
-    Bytes32 beaconBlockRoot = block.getRoot();
-    UInt64 startSlot = miscHelpers.computeStartSlotAtEpoch(epoch);
-    Bytes32 epochBoundaryBlockRoot =
+    final Bytes32 beaconBlockRoot = block.getRoot();
+    final UInt64 startSlot = miscHelpers.computeStartSlotAtEpoch(epoch);
+    final Bytes32 epochBoundaryBlockRoot =
         startSlot.compareTo(slot) == 0 || state.getSlot().compareTo(startSlot) <= 0
             ? block.getRoot()
             : beaconStateAccessors.getBlockRootAtSlot(state, startSlot);
-    Checkpoint source = state.getCurrentJustifiedCheckpoint();
-    Checkpoint target = new Checkpoint(epoch, epochBoundaryBlockRoot);
+    final Checkpoint source = state.getCurrentJustifiedCheckpoint();
+    final Checkpoint target = new Checkpoint(epoch, epochBoundaryBlockRoot);
 
     // Set attestation data
     return new AttestationData(slot, committeeIndex, beaconBlockRoot, source, target);

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/AttestationUtilTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/AttestationUtilTest.java
@@ -84,6 +84,8 @@ class AttestationUtilTest {
         executeValidation(validateableAttestation);
 
     assertThat(result).isCompletedWithValue(AttestationProcessingResult.SUCCESSFUL);
+
+    verifyNoInteractions(beaconStateAccessors, miscHelpers, asyncBLSSignatureVerifier);
   }
 
   @TestTemplate
@@ -101,17 +103,18 @@ class AttestationUtilTest {
   }
 
   @TestTemplate
-  void validatesButDoesNotCheckSignatureIfAttestationIsFromNonCanonicalBlock() {
+  void validatesButDoesNotCheckSignatureIfAttestationSignatureIsAlreadyValidated() {
     final Attestation attestation = dataStructureUtil.randomAttestation();
+    // reorged block does not need signature validation
     final ValidateableAttestation validateableAttestation =
-        ValidateableAttestation.fromNonCanonicalBlock(spec, attestation);
+        ValidateableAttestation.fromReorgedBlock(spec, attestation);
 
     final SafeFuture<AttestationProcessingResult> result =
         executeValidation(validateableAttestation);
 
     assertThat(result).isCompletedWithValue(AttestationProcessingResult.SUCCESSFUL);
 
-    verifyNoInteractions(asyncBLSSignatureVerifier);
+    verifyNoInteractions(miscHelpers, asyncBLSSignatureVerifier);
   }
 
   private SafeFuture<AttestationProcessingResult> executeValidation(

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/AttestationUtilTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/AttestationUtilTest.java
@@ -107,6 +107,7 @@ class AttestationUtilTest {
 
     assertThat(validateableAttestation.isValidIndexedAttestation()).isTrue();
     assertThat(validateableAttestation.getIndexedAttestation()).isPresent();
+    assertThat(validateableAttestation.getCommitteeShufflingSeed()).isPresent();
 
     verify(asyncBLSSignatureVerifier).verify(anyList(), any(Bytes.class), any(BLSSignature.class));
   }
@@ -126,6 +127,7 @@ class AttestationUtilTest {
 
     assertThat(validateableAttestation.isValidIndexedAttestation()).isTrue();
     assertThat(validateableAttestation.getIndexedAttestation()).isPresent();
+    assertThat(validateableAttestation.getCommitteeShufflingSeed()).isPresent();
 
     verifyNoInteractions(miscHelpers, asyncBLSSignatureVerifier);
   }

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/AttestationUtilTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/AttestationUtilTest.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package tech.pegasys.teku.spec.logic.common.util;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -576,8 +576,12 @@ public final class DataStructureUtil {
   }
 
   public AttestationData randomAttestationData(final UInt64 slot) {
+    return randomAttestationData(slot, randomUInt64());
+  }
+
+  public AttestationData randomAttestationData(final UInt64 slot, final UInt64 committeeIndex) {
     return new AttestationData(
-        slot, randomUInt64(), randomBytes32(), randomCheckpoint(), randomCheckpoint());
+        slot, committeeIndex, randomBytes32(), randomCheckpoint(), randomCheckpoint());
   }
 
   public AttestationData randomAttestationData(final UInt64 slot, final Bytes32 blockRoot) {
@@ -596,10 +600,17 @@ public final class DataStructureUtil {
         .create(randomBitlist(), randomAttestationData(), randomSignature());
   }
 
-  public Attestation randomAttestation(final long slot) {
+  public Attestation randomAttestation(final long slot, final UInt64 committeeIndex) {
     return spec.getGenesisSchemaDefinitions()
         .getAttestationSchema()
-        .create(randomBitlist(), randomAttestationData(UInt64.valueOf(slot)), randomSignature());
+        .create(
+            randomBitlist(),
+            randomAttestationData(UInt64.valueOf(slot), committeeIndex),
+            randomSignature());
+  }
+
+  public Attestation randomAttestation(final long slot) {
+    return randomAttestation(slot, randomUInt64());
   }
 
   public AggregateAndProof randomAggregateAndProof() {

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -576,12 +576,8 @@ public final class DataStructureUtil {
   }
 
   public AttestationData randomAttestationData(final UInt64 slot) {
-    return randomAttestationData(slot, randomUInt64());
-  }
-
-  public AttestationData randomAttestationData(final UInt64 slot, final UInt64 committeeIndex) {
     return new AttestationData(
-        slot, committeeIndex, randomBytes32(), randomCheckpoint(), randomCheckpoint());
+        slot, randomUInt64(), randomBytes32(), randomCheckpoint(), randomCheckpoint());
   }
 
   public AttestationData randomAttestationData(final UInt64 slot, final Bytes32 blockRoot) {
@@ -600,17 +596,10 @@ public final class DataStructureUtil {
         .create(randomBitlist(), randomAttestationData(), randomSignature());
   }
 
-  public Attestation randomAttestation(final long slot, final UInt64 committeeIndex) {
+  public Attestation randomAttestation(final long slot) {
     return spec.getGenesisSchemaDefinitions()
         .getAttestationSchema()
-        .create(
-            randomBitlist(),
-            randomAttestationData(UInt64.valueOf(slot), committeeIndex),
-            randomSignature());
-  }
-
-  public Attestation randomAttestation(final long slot) {
-    return randomAttestation(slot, randomUInt64());
+        .create(randomBitlist(), randomAttestationData(UInt64.valueOf(slot)), randomSignature());
   }
 
   public AggregateAndProof randomAggregateAndProof() {
@@ -1281,6 +1270,28 @@ public final class DataStructureUtil {
         .build();
   }
 
+  public BeaconState randomBeaconState(final int validatorCount, final UInt64 slot) {
+    return randomBeaconState(validatorCount).updated(state -> state.setSlot(slot));
+  }
+
+  public BeaconState randomBeaconState(final UInt64 slot) {
+    return randomBeaconState().updated(state -> state.setSlot(slot));
+  }
+
+  public BeaconState randomBeaconStatePreMerge(UInt64 slot) {
+    return randomBeaconState()
+        .updated(state -> state.setSlot(slot))
+        .updated(
+            state ->
+                state
+                    .toMutableVersionBellatrix()
+                    .orElseThrow()
+                    .setLatestExecutionPayloadHeader(
+                        getBellatrixSchemaDefinitions(slot)
+                            .getExecutionPayloadHeaderSchema()
+                            .getDefault()));
+  }
+
   public AbstractBeaconStateBuilder<
           ? extends BeaconState,
           ? extends MutableBeaconState,
@@ -1326,24 +1337,6 @@ public final class DataStructureUtil {
       final int defaultValidatorCount, final int defaultItemsInSSZLists) {
     return BeaconStateBuilderBellatrix.create(
         this, spec, defaultValidatorCount, defaultItemsInSSZLists);
-  }
-
-  public BeaconState randomBeaconState(UInt64 slot) {
-    return randomBeaconState().updated(state -> state.setSlot(slot));
-  }
-
-  public BeaconState randomBeaconStatePreMerge(UInt64 slot) {
-    return randomBeaconState()
-        .updated(state -> state.setSlot(slot))
-        .updated(
-            state ->
-                state
-                    .toMutableVersionBellatrix()
-                    .orElseThrow()
-                    .setLatestExecutionPayloadHeader(
-                        getBellatrixSchemaDefinitions(slot)
-                            .getExecutionPayloadHeaderSchema()
-                            .getDefault()));
   }
 
   public AnchorPoint randomAnchorPoint(final long epoch) {

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -127,6 +127,7 @@ import tech.pegasys.teku.spec.datastructures.state.SyncCommittee.SyncCommitteeSc
 import tech.pegasys.teku.spec.datastructures.state.Validator;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchema;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.altair.BeaconStateSchemaAltair;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.phase0.BeaconStateSchemaPhase0;
 import tech.pegasys.teku.spec.datastructures.type.SszPublicKey;
@@ -1265,18 +1266,25 @@ public final class DataStructureUtil {
   }
 
   public BeaconState randomBeaconState(final int validatorCount, final int numItemsInSSZLists) {
-    switch (spec.getGenesisSpec().getMilestone()) {
+    return stateBuilder(spec.getGenesisSpec().getMilestone(), validatorCount, numItemsInSSZLists)
+        .build();
+  }
+
+  public AbstractBeaconStateBuilder<
+          ? extends BeaconState,
+          ? extends MutableBeaconState,
+          ? extends AbstractBeaconStateBuilder<?, ?, ?>>
+      stateBuilder(
+          final SpecMilestone milestone, final int validatorCount, final int numItemsInSszLists) {
+    switch (milestone) {
       case PHASE0:
-        return BeaconStateBuilderPhase0.create(this, spec, validatorCount, numItemsInSSZLists)
-            .build();
+        return stateBuilderPhase0(validatorCount, numItemsInSszLists);
       case ALTAIR:
-        return BeaconStateBuilderAltair.create(this, spec, validatorCount, numItemsInSSZLists)
-            .build();
+        return stateBuilderAltair(validatorCount, numItemsInSszLists);
       case BELLATRIX:
-        return BeaconStateBuilderBellatrix.create(this, spec, validatorCount, numItemsInSSZLists)
-            .build();
+        return stateBuilderBellatrix(validatorCount, numItemsInSszLists);
       default:
-        throw new IllegalStateException("Unsupported milestone");
+        throw new IllegalArgumentException("Unsupported milestone: " + milestone);
     }
   }
 
@@ -1290,11 +1298,23 @@ public final class DataStructureUtil {
   }
 
   public BeaconStateBuilderAltair stateBuilderAltair() {
-    return BeaconStateBuilderAltair.create(this, spec, 10, 10);
+    return stateBuilderAltair(10, 10);
+  }
+
+  public BeaconStateBuilderAltair stateBuilderAltair(
+      final int defaultValidatorCount, final int defaultItemsInSSZLists) {
+    return BeaconStateBuilderAltair.create(
+        this, spec, defaultValidatorCount, defaultItemsInSSZLists);
   }
 
   public BeaconStateBuilderBellatrix stateBuilderBellatrix() {
-    return BeaconStateBuilderBellatrix.create(this, spec, 10, 10);
+    return stateBuilderBellatrix(10, 10);
+  }
+
+  public BeaconStateBuilderBellatrix stateBuilderBellatrix(
+      final int defaultValidatorCount, final int defaultItemsInSSZLists) {
+    return BeaconStateBuilderBellatrix.create(
+        this, spec, defaultValidatorCount, defaultItemsInSSZLists);
   }
 
   public BeaconState randomBeaconState(UInt64 slot) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/OperationsReOrgManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/OperationsReOrgManager.java
@@ -71,10 +71,10 @@ public class OperationsReOrgManager implements ChainHeadChannel {
       final Optional<ReorgContext> optionalReorgContext) {
     optionalReorgContext.ifPresent(
         reorgContext -> {
-          NavigableMap<UInt64, Bytes32> notCanonicalBlockRoots =
+          final NavigableMap<UInt64, Bytes32> notCanonicalBlockRoots =
               recentChainData.getAncestorsOnFork(
                   reorgContext.getCommonAncestorSlot(), reorgContext.getOldBestBlockRoot());
-          NavigableMap<UInt64, Bytes32> nowCanonicalBlockRoots =
+          final NavigableMap<UInt64, Bytes32> nowCanonicalBlockRoots =
               recentChainData.getAncestorsOnFork(
                   reorgContext.getCommonAncestorSlot(), bestBlockRoot);
 
@@ -86,17 +86,18 @@ public class OperationsReOrgManager implements ChainHeadChannel {
         });
   }
 
-  private void processNonCanonicalBlockOperations(Collection<Bytes32> nonCanonicalBlockRoots) {
+  private void processNonCanonicalBlockOperations(
+      final Collection<Bytes32> nonCanonicalBlockRoots) {
     nonCanonicalBlockRoots.forEach(
         root -> {
-          SafeFuture<Optional<BeaconBlock>> maybeBlockFuture =
+          final SafeFuture<Optional<BeaconBlock>> maybeBlockFuture =
               recentChainData.retrieveBlockByRoot(root);
           maybeBlockFuture
               .thenAccept(
                   maybeBlock ->
                       maybeBlock.ifPresentOrElse(
                           block -> {
-                            BeaconBlockBody blockBody = block.getBody();
+                            final BeaconBlockBody blockBody = block.getBody();
                             proposerSlashingPool.addAll(blockBody.getProposerSlashings());
                             attesterSlashingPool.addAll(blockBody.getAttesterSlashings());
                             exitPool.addAll(blockBody.getVoluntaryExits());
@@ -117,7 +118,7 @@ public class OperationsReOrgManager implements ChainHeadChannel {
   }
 
   private void processNonCanonicalBlockAttestations(
-      Iterable<Attestation> attestations, Bytes32 blockRoot) {
+      final Iterable<Attestation> attestations, final Bytes32 blockRoot) {
     // Attestations need to get re-processed through AttestationManager
     // because we don't have access to the state with which they were
     // verified anymore and we need to make sure later on
@@ -143,17 +144,17 @@ public class OperationsReOrgManager implements ChainHeadChannel {
                             err)));
   }
 
-  private void processCanonicalBlockOperations(Collection<Bytes32> canonicalBlockRoots) {
+  private void processCanonicalBlockOperations(final Collection<Bytes32> canonicalBlockRoots) {
     canonicalBlockRoots.forEach(
         root -> {
-          SafeFuture<Optional<BeaconBlock>> maybeBlockFuture =
+          final SafeFuture<Optional<BeaconBlock>> maybeBlockFuture =
               recentChainData.retrieveBlockByRoot(root);
           maybeBlockFuture
               .thenAccept(
                   maybeBlock ->
                       maybeBlock.ifPresentOrElse(
                           block -> {
-                            BeaconBlockBody blockBody = block.getBody();
+                            final BeaconBlockBody blockBody = block.getBody();
                             proposerSlashingPool.removeAll(blockBody.getProposerSlashings());
                             attesterSlashingPool.removeAll(blockBody.getAttesterSlashings());
                             exitPool.removeAll(blockBody.getVoluntaryExits());

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/OperationsReOrgManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/OperationsReOrgManager.java
@@ -123,23 +123,24 @@ public class OperationsReOrgManager implements ChainHeadChannel {
     // verified anymore and we need to make sure later on
     // that they're being included on the correct fork.
     attestations.forEach(
-        attestation -> {
-          attestationManager
-              .onAttestation(ValidateableAttestation.from(recentChainData.getSpec(), attestation))
-              .finish(
-                  result ->
-                      result.ifInvalid(
-                          reason ->
-                              LOG.debug(
-                                  "Rejected re-queued attestation from block: {} due to: {}",
-                                  blockRoot,
-                                  reason)),
-                  err ->
-                      LOG.error(
-                          "Failed to process re-queued attestation from block: {}",
-                          blockRoot,
-                          err));
-        });
+        attestation ->
+            attestationManager
+                .onAttestation(
+                    ValidateableAttestation.fromNonCanonicalBlock(
+                        recentChainData.getSpec(), attestation))
+                .finish(
+                    result ->
+                        result.ifInvalid(
+                            reason ->
+                                LOG.debug(
+                                    "Rejected re-queued attestation from block: {} due to: {}",
+                                    blockRoot,
+                                    reason)),
+                    err ->
+                        LOG.error(
+                            "Failed to process re-queued attestation from block: {}",
+                            blockRoot,
+                            err)));
   }
 
   private void processCanonicalBlockOperations(Collection<Bytes32> canonicalBlockRoots) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/OperationsReOrgManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/OperationsReOrgManager.java
@@ -126,7 +126,7 @@ public class OperationsReOrgManager implements ChainHeadChannel {
         attestation ->
             attestationManager
                 .onAttestation(
-                    ValidateableAttestation.fromNonCanonicalBlock(
+                    ValidateableAttestation.fromReorgedBlock(
                         recentChainData.getSpec(), attestation))
                 .finish(
                     result ->

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/OperationsReOrgManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/OperationsReOrgManagerTest.java
@@ -146,7 +146,7 @@ public class OperationsReOrgManagerTest {
             .collect(Collectors.toList()));
     assertThat(argument.getAllValues())
         .containsExactlyInAnyOrderElementsOf(attestationList)
-        .allMatch(ValidateableAttestation::isProducedFromNonCanonicalBlock);
+        .allMatch(ValidateableAttestation::isSignatureValidated);
 
     verify(proposerSlashingOperationPool).removeAll(fork2Block1.getBody().getProposerSlashings());
     verify(attesterSlashingOperationPool).removeAll(fork2Block1.getBody().getAttesterSlashings());

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/OperationsReOrgManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/OperationsReOrgManagerTest.java
@@ -146,7 +146,7 @@ public class OperationsReOrgManagerTest {
             .collect(Collectors.toList()));
     assertThat(argument.getAllValues())
         .containsExactlyInAnyOrderElementsOf(attestationList)
-        .allMatch(ValidateableAttestation::isSignatureValidated);
+        .allMatch(ValidateableAttestation::isValidIndexedAttestation);
 
     verify(proposerSlashingOperationPool).removeAll(fork2Block1.getBody().getProposerSlashings());
     verify(attesterSlashingOperationPool).removeAll(fork2Block1.getBody().getAttesterSlashings());

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/OperationsReOrgManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/OperationsReOrgManagerTest.java
@@ -144,7 +144,9 @@ public class OperationsReOrgManagerTest {
         fork1Block2.getBody().getAttestations().stream()
             .map(attestation -> ValidateableAttestation.from(spec, attestation))
             .collect(Collectors.toList()));
-    assertThat(argument.getAllValues()).containsExactlyInAnyOrderElementsOf(attestationList);
+    assertThat(argument.getAllValues())
+        .containsExactlyInAnyOrderElementsOf(attestationList)
+        .allMatch(ValidateableAttestation::isProducedFromNonCanonicalBlock);
 
     verify(proposerSlashingOperationPool).removeAll(fork2Block1.getBody().getProposerSlashings());
     verify(attesterSlashingOperationPool).removeAll(fork2Block1.getBody().getAttesterSlashings());


### PR DESCRIPTION
## PR Description

- Added `signatureValidated` in `ValidateableAttestation` object
- Marked the attestation as coming from reorged block in `OperationsReOrgManager`
- Added an ability to skip signature check by passing a flag in `AttestationUtil`
- Removed unused method from `AttestationUtil`
- Added bunch of `final`

## Fixed Issue(s)
fixes #5478 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
