### PR TITLE
Add `ProposerDataManager` gauges

### DIFF
--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
@@ -70,12 +70,13 @@ class ForkChoiceNotifierTest {
   private final InlineEventThread eventThread = new InlineEventThread();
   private final Spec spec = TestSpecFactory.createMinimalBellatrix();
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
-  private final StubMetricsSystem metricsSystem = new StubMetricsSystem();
 
+  private StubMetricsSystem metricsSystem;
   private StorageSystem storageSystem;
   private RecentChainData recentChainData;
   private ReadOnlyForkChoiceStrategy forkChoiceStrategy;
   private ProposersDataManager proposersDataManager;
+
   private final Optional<Eth1Address> defaultFeeRecipient =
       Optional.of(Eth1Address.fromHexString("0x2Df386eFF130f991321bfC4F8372Ba838b9AB14B"));
 
@@ -103,6 +104,7 @@ class ForkChoiceNotifierTest {
     // initialize post-merge by default
     storageSystem = InMemoryStorageSystemBuilder.buildDefault(spec);
     recentChainData = storageSystem.recentChainData();
+    metricsSystem = new StubMetricsSystem();
     proposersDataManager =
         spy(
             new ProposersDataManager(
@@ -136,6 +138,7 @@ class ForkChoiceNotifierTest {
   void reInitializePreMerge() {
     storageSystem = InMemoryStorageSystemBuilder.buildDefault(spec);
     recentChainData = storageSystem.recentChainData();
+    metricsSystem = new StubMetricsSystem();
     proposersDataManager =
         spy(
             new ProposersDataManager(

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
@@ -40,6 +40,7 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.SafeFutureAssert;
 import tech.pegasys.teku.infrastructure.async.eventthread.InlineEventThread;
 import tech.pegasys.teku.infrastructure.bytes.Bytes8;
+import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
@@ -69,6 +70,7 @@ class ForkChoiceNotifierTest {
   private final InlineEventThread eventThread = new InlineEventThread();
   private final Spec spec = TestSpecFactory.createMinimalBellatrix();
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+  private final StubMetricsSystem metricsSystem = new StubMetricsSystem();
 
   private StorageSystem storageSystem;
   private RecentChainData recentChainData;
@@ -106,6 +108,7 @@ class ForkChoiceNotifierTest {
             new ProposersDataManager(
                 eventThread,
                 spec,
+                metricsSystem,
                 executionLayerChannel,
                 recentChainData,
                 doNotInitializeWithDefaultFeeRecipient ? Optional.empty() : defaultFeeRecipient));
@@ -136,7 +139,12 @@ class ForkChoiceNotifierTest {
     proposersDataManager =
         spy(
             new ProposersDataManager(
-                eventThread, spec, executionLayerChannel, recentChainData, defaultFeeRecipient));
+                eventThread,
+                spec,
+                metricsSystem,
+                executionLayerChannel,
+                recentChainData,
+                defaultFeeRecipient));
     notifier =
         new ForkChoiceNotifierImpl(
             eventThread, spec, executionLayerChannel, recentChainData, proposersDataManager);

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -972,7 +972,12 @@ public class BeaconChainController extends Service implements BeaconChainControl
     eventThread.start();
     proposersDataManager =
         new ProposersDataManager(
-            eventThread, spec, executionLayer, recentChainData, getProposerDefaultFeeRecipient());
+            eventThread,
+            spec,
+            metricsSystem,
+            executionLayer,
+            recentChainData,
+            getProposerDefaultFeeRecipient());
     eventChannels.subscribe(SlotEventsChannel.class, proposersDataManager);
     forkChoiceNotifier =
         new ForkChoiceNotifierImpl(


### PR DESCRIPTION
Introducing `proposers_data_total` labelled gauge with label `type` and label values `prepared_proposers` and `registered_validators`.

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
