### PR TITLE
Re-execute failed execution block if descendant is added to the pendi…

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/PendingPoolFactory.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/PendingPoolFactory.java
@@ -14,6 +14,8 @@
 package tech.pegasys.teku.statetransition.util;
 
 import java.util.Collections;
+import java.util.function.Function;
+import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.infrastructure.metrics.SettableLabelledGauge;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
@@ -26,6 +28,8 @@ public class PendingPoolFactory {
 
   private static final UInt64 DEFAULT_HISTORICAL_SLOT_TOLERANCE = UInt64.valueOf(320);
   private static final int DEFAULT_MAX_ITEMS = 5000;
+  public static final Function<SignedBeaconBlock, Bytes32> BLOCK_HASH_TREE_ROOT_FUNCTION =
+      block -> block.getMessage().hashTreeRoot();
   private final SettableLabelledGauge sizeGauge;
 
   public PendingPoolFactory(final MetricsSystem metricsSystem) {
@@ -58,7 +62,7 @@ public class PendingPoolFactory {
         historicalBlockTolerance,
         futureBlockTolerance,
         maxItems,
-        block -> block.getMessage().hashTreeRoot(),
+        BLOCK_HASH_TREE_ROOT_FUNCTION,
         block -> Collections.singleton(block.getParentRoot()),
         SignedBeaconBlock::getSlot);
   }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/PendingPoolTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/PendingPoolTest.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.statetransition.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.statetransition.util.PendingPoolFactory.BLOCK_HASH_TREE_ROOT_FUNCTION;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -488,5 +489,27 @@ public class PendingPoolTest {
 
     blocksToKeep.forEach(b -> assertThat(pendingPool.contains(b)).isTrue());
     blocksToPrune.forEach(b -> assertThat(pendingPool.contains(b)).isFalse());
+  }
+
+  @Test
+  public void shouldFindFirstRequiredInChain_withDepth() {
+    SignedBeaconBlock block1 = dataStructureUtil.randomSignedBeaconBlock(currentSlot.longValue());
+    pendingPool.add(block1);
+    assertThat(pendingPool.getFirstRequiredAncestor(BLOCK_HASH_TREE_ROOT_FUNCTION.apply(block1)))
+        .isEqualTo(block1.getParentRoot());
+
+    SignedBeaconBlock block2 =
+        dataStructureUtil.randomSignedBeaconBlock(
+            currentSlot.longValue() + 1, BLOCK_HASH_TREE_ROOT_FUNCTION.apply(block1));
+    pendingPool.add(block2);
+    assertThat(pendingPool.getFirstRequiredAncestor(BLOCK_HASH_TREE_ROOT_FUNCTION.apply(block2)))
+        .isEqualTo(block1.getParentRoot());
+
+    SignedBeaconBlock block3 =
+        dataStructureUtil.randomSignedBeaconBlock(
+            currentSlot.longValue() + 2, BLOCK_HASH_TREE_ROOT_FUNCTION.apply(block2));
+    pendingPool.add(block3);
+    assertThat(pendingPool.getFirstRequiredAncestor(BLOCK_HASH_TREE_ROOT_FUNCTION.apply(block3)))
+        .isEqualTo(block1.getParentRoot());
   }
 }


### PR DESCRIPTION
…ng pool

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Re-execute failed execution block even after 2 slots if descendant is added to the pending blocks.
- I'm not sure on `EXPIRES_IN_SLOTS` constant, looks like a magic number, maybe we could use other criteria to drop it
- Not focused on tailored structures, shouldn't run very often, exiting early when no action is needed
- Not sure that stack overflow protection really needed in pool, a bit paranoid on recursions

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Fixes #5824 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
