### PR TITLE
Add a script to fetch initial state and blocks

### DIFF
--- a/scripts/fetch-blocks.sh
+++ b/scripts/fetch-blocks.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -euo pipefail
+
+START=${1:?Must specify a start slot to downlaod initial state from}
+END=${2:?Must specify an end slot to stop downloading blocks at}
+OUT=${3:-block-${START}-${END}}
+PORT=${4:-5051}
+
+mkdir -p "${OUT}"
+OUT="$(cd "${OUT}" &>/dev/null && pwd)"
+
+FIRST_BLOCK=$(($START + 1))
+echo "Starting state download"
+curl --fail -H 'Accept: application/octet-stream' http://localhost:$PORT/eth/v2/debug/beacon/states/{$START} -o "${OUT}/state.ssz" &
+
+BLOCK_ARGS=""
+for i in $(seq -f "%0.f" ${FIRST_BLOCK} ${END})
+do
+  echo "Fetching slot $i"
+  set +e
+  curl -s --fail -H 'Accept: application/octet-stream' http://localhost:$PORT/eth/v2/beacon/blocks/$i -o "${OUT}/$i.ssz" && BLOCK_ARGS="$BLOCK_ARGS $OUT/$i.ssz"
+  set -e
+done
+
+echo "Waiting for state download..."
+
+wait
+
+echo "teku transition blocks --pre ${OUT}/state.ssz --post ${OUT}/post.ssz $BLOCK_ARGS"


### PR DESCRIPTION
## PR Description
Useful for reproducing issues triggered by blocks on a public testnet by replaying the transition. Not as good as having it built into the transition tool, but quicker to build and still useful.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
