### PR TITLE
 Only log a warning if node is syncing while performing sync committee duties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ For information on changes in released versions of Teku, see the [releases page]
 ### Additions and Improvements
  - Added actual Sepolia TTD configuration
  - Further optimization of epoch transitions
+ - Log a warning if node is syncing while performing sync committee duties instead of a verbose error
 
 ### Bug Fixes
  - Fixed the beacon-rest-api opening a listen port on too many interfaces

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/DutyResult.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/DutyResult.java
@@ -40,6 +40,9 @@ import tech.pegasys.teku.validator.api.NodeSyncingException;
 
 public class DutyResult {
   public static final DutyResult NO_OP = new DutyResult(0, 0, emptySet(), emptyMap(), List.of());
+  public static final DutyResult NODE_SYNCING =
+      new DutyResult(0, 1, emptySet(), emptyMap(), List.of());
+
   private final int successCount;
   private final int nodeSyncingCount;
   private final Set<Bytes32> roots;
@@ -93,7 +96,7 @@ public class DutyResult {
       cause = cause.getCause();
     }
     if (cause instanceof NodeSyncingException) {
-      return new DutyResult(0, 1, emptySet(), emptyMap(), List.of());
+      return NODE_SYNCING;
     } else {
       return new DutyResult(
           0,

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/synccommittee/ChainHeadBeyondSlotException.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/synccommittee/ChainHeadBeyondSlotException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.client.duties.synccommittee;
+
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+public class ChainHeadBeyondSlotException extends RuntimeException {
+
+  public ChainHeadBeyondSlotException(final UInt64 slot) {
+    super("Chain head has advanced beyond slot " + slot);
+  }
+}

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/synccommittee/ChainHeadTracker.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/synccommittee/ChainHeadTracker.java
@@ -26,7 +26,7 @@ public class ChainHeadTracker implements ValidatorTimingChannel {
   public synchronized Optional<Bytes32> getCurrentChainHead(final UInt64 atSlot) {
     if (headBlockSlot.isGreaterThan(atSlot)) {
       // We've moved on and no longer have a reference to what the head block was at that slot
-      return Optional.empty();
+      throw new ChainHeadBeyondSlotException(atSlot);
     }
     return headBlockRoot;
   }

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/ChainHeadTrackerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/ChainHeadTrackerTest.java
@@ -14,12 +14,14 @@
 package tech.pegasys.teku.validator.client.duties;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.validator.client.duties.synccommittee.ChainHeadBeyondSlotException;
 import tech.pegasys.teku.validator.client.duties.synccommittee.ChainHeadTracker;
 
 class ChainHeadTrackerTest {
@@ -49,11 +51,13 @@ class ChainHeadTrackerTest {
   }
 
   @Test
-  void shouldReturnEmptyWhenHeadIsAfterRequestedSlot() {
+  void shouldThrowCustomExceptionWhenHeadIsAfterRequestedSlot() {
     final UInt64 slot = dataStructureUtil.randomUInt64();
     final Bytes32 headBlockRoot = dataStructureUtil.randomBytes32();
     updateHead(slot, headBlockRoot);
-    assertThat(tracker.getCurrentChainHead(slot.minus(1))).isEmpty();
+
+    assertThrows(
+        ChainHeadBeyondSlotException.class, () -> tracker.getCurrentChainHead(slot.minus(1)));
   }
 
   private void updateHead(final UInt64 slot, final Bytes32 headBlockRoot) {

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeScheduledDutiesTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeScheduledDutiesTest.java
@@ -100,7 +100,7 @@ class SyncCommitteeScheduledDutiesTest {
   void shouldNotProduceSignaturesWhenChainHeadIsNotAvailable(
       final HeadNotAvailableReason headNotAvailableReason) {
     final UInt64 slot = UInt64.valueOf(25);
-    setupHeadTrackerResponse(headNotAvailableReason);
+    setupHeadTrackerResponse(headNotAvailableReason, slot);
 
     final Validator validator1 = createValidator();
     final Validator validator2 = createValidator();
@@ -132,7 +132,7 @@ class SyncCommitteeScheduledDutiesTest {
   void shouldNotPerformDutyWhenNoActiveValidatorsAndChainHeadIsNotAvailable(
       final HeadNotAvailableReason headNotAvailableReason) {
     final UInt64 slot = UInt64.valueOf(25);
-    setupHeadTrackerResponse(headNotAvailableReason);
+    setupHeadTrackerResponse(headNotAvailableReason, slot);
 
     final SyncCommitteeScheduledDuties duties = validBuilder().build();
     final SafeFuture<DutyResult> result = duties.performProductionDuty(slot);
@@ -251,8 +251,8 @@ class SyncCommitteeScheduledDutiesTest {
     return new Validator(dataStructureUtil.randomPublicKey(), mock(Signer.class), Optional::empty);
   }
 
-  private void setupHeadTrackerResponse(final HeadNotAvailableReason headNotAvailableReason) {
-    final UInt64 slot = UInt64.valueOf(25);
+  private void setupHeadTrackerResponse(
+      final HeadNotAvailableReason headNotAvailableReason, final UInt64 slot) {
     doAnswer(
             __ -> {
               if (headNotAvailableReason.equals(HeadNotAvailableReason.NODE_SYNCING)) {

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeScheduledDutiesTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeScheduledDutiesTest.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.validator.client.duties.synccommittee;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -28,6 +29,8 @@ import java.util.Optional;
 import java.util.Set;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import tech.pegasys.teku.core.signatures.Signer;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.logging.ValidatorLogger;
@@ -92,10 +95,12 @@ class SyncCommitteeScheduledDutiesTest {
     verifyNoInteractions(validatorApiChannel);
   }
 
-  @Test
-  void shouldNotProduceSignaturesWhenChainHeadIsEmpty() {
+  @ParameterizedTest
+  @EnumSource(HeadNotAvailableReason.class)
+  void shouldNotProduceSignaturesWhenChainHeadIsNotAvailable(
+      final HeadNotAvailableReason headNotAvailableReason) {
     final UInt64 slot = UInt64.valueOf(25);
-    when(chainHeadTracker.getCurrentChainHead(slot)).thenReturn(Optional.empty());
+    setupHeadTrackerResponse(headNotAvailableReason);
 
     final Validator validator1 = createValidator();
     final Validator validator2 = createValidator();
@@ -107,21 +112,27 @@ class SyncCommitteeScheduledDutiesTest {
     final SafeFuture<DutyResult> result = duties.performProductionDuty(slot);
     reportDutyResult(slot, result);
 
-    verify(validatorLogger)
-        .dutyFailed(
-            eq(TYPE),
-            eq(slot),
-            eq(
-                Set.of(
-                    validator1.getPublicKey().toAbbreviatedString(),
-                    validator2.getPublicKey().toAbbreviatedString())),
-            any(IllegalStateException.class));
+    if (headNotAvailableReason.equals(HeadNotAvailableReason.NODE_SYNCING)) {
+      verify(validatorLogger).dutySkippedWhileSyncing(eq(TYPE), eq(slot), eq(1));
+    } else {
+      verify(validatorLogger)
+          .dutyFailed(
+              eq(TYPE),
+              eq(slot),
+              eq(
+                  Set.of(
+                      validator1.getPublicKey().toAbbreviatedString(),
+                      validator2.getPublicKey().toAbbreviatedString())),
+              any(ChainHeadBeyondSlotException.class));
+    }
   }
 
-  @Test
-  void shouldNotPerformDutyWhenNoActiveValidatorsAndChainHeadEmpty() {
+  @ParameterizedTest
+  @EnumSource(HeadNotAvailableReason.class)
+  void shouldNotPerformDutyWhenNoActiveValidatorsAndChainHeadIsNotAvailable(
+      final HeadNotAvailableReason headNotAvailableReason) {
     final UInt64 slot = UInt64.valueOf(25);
-    when(chainHeadTracker.getCurrentChainHead(slot)).thenReturn(Optional.empty());
+    setupHeadTrackerResponse(headNotAvailableReason);
 
     final SyncCommitteeScheduledDuties duties = validBuilder().build();
     final SafeFuture<DutyResult> result = duties.performProductionDuty(slot);
@@ -238,5 +249,24 @@ class SyncCommitteeScheduledDutiesTest {
 
   private Validator createValidator() {
     return new Validator(dataStructureUtil.randomPublicKey(), mock(Signer.class), Optional::empty);
+  }
+
+  private void setupHeadTrackerResponse(final HeadNotAvailableReason headNotAvailableReason) {
+    final UInt64 slot = UInt64.valueOf(25);
+    doAnswer(
+            __ -> {
+              if (headNotAvailableReason.equals(HeadNotAvailableReason.NODE_SYNCING)) {
+                return Optional.empty();
+              } else {
+                throw new ChainHeadBeyondSlotException(slot);
+              }
+            })
+        .when(chainHeadTracker)
+        .getCurrentChainHead(slot);
+  }
+
+  private enum HeadNotAvailableReason {
+    NODE_SYNCING,
+    HEAD_ADVANCED_BEYOND_SLOT
   }
 }


### PR DESCRIPTION
## PR Description

- Introduced a new `ChainHeadBeyondSlotException` to differentiate between an unsynced node and a node which has advanced a certain slot
- Changed `performProductionDuty` to only log a warning when node is still syncing and an error if the node has advanced beyond the slot

## Fixed Issue(s)
fixes #5759 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
