### PR TITLE
Enable fork_choice/on_merge_block reference tests

### DIFF
--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
@@ -70,7 +70,7 @@ public class ForkChoiceTestExecutor implements TestExecutor {
           .put(
               "fork_choice/on_block",
               new ForkChoiceTestExecutor("new_finalized_slot_is_justified_checkpoint_ancestor"))
-          .put("fork_choice/on_merge_block", IGNORE_TESTS)
+          .put("fork_choice/on_merge_block", new ForkChoiceTestExecutor())
           .build();
 
   private final List<?> testsToSkip;
@@ -188,7 +188,6 @@ public class ForkChoiceTestExecutor implements TestExecutor {
                   reader
                       .readFixedBytes(Bytes32.SIZE)
                       .toUnsignedBigInteger(ByteOrder.LITTLE_ENDIAN));
-          reader.readFixedBytes(Bytes32.SIZE); // Read difficulty even though we don't use it.
           // We don't get a timestamp but as long as it's in the past that's fine
           final UInt64 timestamp = UInt64.ZERO;
           return new PowBlock(blockHash, parentHash, totalDifficulty, timestamp);


### PR DESCRIPTION
## PR Description
Enables the on_merge_block reference tests.  All passing - just needed to update the parsing of the pow blocks from the test data

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
