### PR TITLE
[MEV-Boost\Builder] Unhide hidden params for mev-boost\builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ For information on changes in released versions of Teku, see the [releases page]
  - Ensured dependencies are up to date
  - Validator Registration signature integration with external signer
  - Teku-specific Beacon Node API on `/teku/v1/beacon/deposit_snapshot` providing finalized Deposit Tree Snapshot according to the draft EIP-4881
+ - Added support for Builder API
 
 ### Bug Fixes
  - Fix not rendering emoticons correctly in graffiti when running in a Docker container

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ExecutionLayerOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ExecutionLayerOptions.java
@@ -50,7 +50,7 @@ public class ExecutionLayerOptions {
   @Option(
       names = {"--builder-endpoint"},
       paramLabel = "<NETWORK>",
-      description = "URL for Execution Builder node.",
+      description = "URL for an external Execution Builder node (optional).",
       arity = "1")
   private String executionBuilderEndpoint = null;
 

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ExecutionLayerOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ExecutionLayerOptions.java
@@ -48,7 +48,7 @@ public class ExecutionLayerOptions {
   private String engineJwtSecretFile = null;
 
   @Option(
-      names = {"--eb-endpoint"},
+      names = {"--builder-endpoint"},
       paramLabel = "<NETWORK>",
       description = "URL for Execution Builder node.",
       arity = "1")

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ExecutionLayerOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ExecutionLayerOptions.java
@@ -50,7 +50,7 @@ public class ExecutionLayerOptions {
   @Option(
       names = {"--builder-endpoint"},
       paramLabel = "<NETWORK>",
-      description = "URL for an external Execution Builder node (optional).",
+      description = "URL for an external Builder node (optional).",
       arity = "1")
   private String executionBuilderEndpoint = null;
 

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ExecutionLayerOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ExecutionLayerOptions.java
@@ -48,11 +48,10 @@ public class ExecutionLayerOptions {
   private String engineJwtSecretFile = null;
 
   @Option(
-      names = {"--Xeb-endpoint"},
+      names = {"--eb-endpoint"},
       paramLabel = "<NETWORK>",
       description = "URL for Execution Builder node.",
-      arity = "1",
-      hidden = true)
+      arity = "1")
   private String executionBuilderEndpoint = null;
 
   public void configure(final Builder builder) {

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorProposerOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorProposerOptions.java
@@ -82,12 +82,13 @@ public class ValidatorProposerOptions {
       ValidatorConfig.DEFAULT_VALIDATOR_REGISTRATION_SENDING_BATCH_SIZE;
 
   @Option(
-      names = {"--validators-registration-timestamp-override"},
+      names = {"--Xvalidators-registration-timestamp-override"},
       paramLabel = "<uint64>",
       showDefaultValue = Visibility.ALWAYS,
       description =
           "Set a constant timestamp in Unix format to be used in validator registrations against builder infrastructure.",
-      arity = "1")
+      arity = "1",
+      hidden = true)
   private UInt64 validatorsRegistrationTimestampOverride = null;
 
   @Option(

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorProposerOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorProposerOptions.java
@@ -56,19 +56,19 @@ public class ValidatorProposerOptions {
       description = "Enable validators registration to builder infrastructure.",
       arity = "0..1",
       fallbackValue = "true")
-  private boolean validatorsRegistrationDefaultEnabled =
-      ValidatorConfig.DEFAULT_VALIDATOR_REGISTRATION_DEFAULT_ENABLED;
+  private boolean builderRegistrationDefaultEnabled =
+      ValidatorConfig.DEFAULT_BUILDER_REGISTRATION_DEFAULT_ENABLED;
 
   @Option(
-      names = {"--Xvalidators-registration-default-gas-limit"},
+      names = {"--Xbuilder-registration-default-gas-limit"},
       paramLabel = "<uint64>",
       showDefaultValue = Visibility.ALWAYS,
       description = "Change the default gas limit used for the validators registration.",
       arity = "1",
       hidden = true,
       converter = UInt64Converter.class)
-  private UInt64 registrationDefaultGasLimit =
-      ValidatorConfig.DEFAULT_VALIDATOR_REGISTRATION_GAS_LIMIT;
+  private UInt64 builderRegistrationDefaultGasLimit =
+      ValidatorConfig.DEFAULT_BUILDER_REGISTRATION_GAS_LIMIT;
 
   @Option(
       names = {"--Xvalidators-registration-sending-batch-size"},
@@ -106,9 +106,9 @@ public class ValidatorProposerOptions {
                 .proposerDefaultFeeRecipient(proposerDefaultFeeRecipient)
                 .proposerConfigSource(proposerConfig)
                 .refreshProposerConfigFromSource(proposerConfigRefreshEnabled)
-                .validatorsRegistrationDefaultEnabled(validatorsRegistrationDefaultEnabled)
+                .validatorsRegistrationDefaultEnabled(builderRegistrationDefaultEnabled)
                 .blindedBeaconBlocksEnabled(blindedBlocksEnabled)
-                .validatorsRegistrationDefaultGasLimit(registrationDefaultGasLimit)
+                .validatorsRegistrationDefaultGasLimit(builderRegistrationDefaultGasLimit)
                 .validatorsRegistrationSendingBatchSize(registrationSendingBatchSize)
                 .validatorsRegistrationTimestampOverride(validatorsRegistrationTimestampOverride));
   }

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorProposerOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorProposerOptions.java
@@ -50,7 +50,7 @@ public class ValidatorProposerOptions {
       ValidatorConfig.DEFAULT_VALIDATOR_PROPOSER_CONFIG_REFRESH_ENABLED;
 
   @Option(
-      names = {"--builder-registration-default-enabled"},
+      names = {"--validators-builder-registration-default-enabled"},
       paramLabel = "<BOOLEAN>",
       showDefaultValue = Visibility.ALWAYS,
       description = "Enable validators registration to builder infrastructure.",
@@ -60,7 +60,7 @@ public class ValidatorProposerOptions {
       ValidatorConfig.DEFAULT_BUILDER_REGISTRATION_DEFAULT_ENABLED;
 
   @Option(
-      names = {"--Xbuilder-registration-default-gas-limit"},
+      names = {"--Xvalidators-builder-registration-default-gas-limit"},
       paramLabel = "<uint64>",
       showDefaultValue = Visibility.ALWAYS,
       description = "Change the default gas limit used for the validators registration.",
@@ -71,25 +71,25 @@ public class ValidatorProposerOptions {
       ValidatorConfig.DEFAULT_BUILDER_REGISTRATION_GAS_LIMIT;
 
   @Option(
-      names = {"--Xvalidators-registration-sending-batch-size"},
+      names = {"--Xvalidators-builder-registration-sending-batch-size"},
       paramLabel = "<INTEGER>",
       showDefaultValue = Visibility.ALWAYS,
       description =
           "Change the default batch size for sending validator registrations to the Beacon Node.",
       arity = "1",
       hidden = true)
-  private int registrationSendingBatchSize =
+  private int builderRegistrationSendingBatchSize =
       ValidatorConfig.DEFAULT_VALIDATOR_REGISTRATION_SENDING_BATCH_SIZE;
 
   @Option(
-      names = {"--Xvalidators-registration-timestamp-override"},
+      names = {"--validators-builder-registration-timestamp-override"},
       paramLabel = "<uint64>",
       showDefaultValue = Visibility.ALWAYS,
       description =
           "Set a constant timestamp in Unix format to be used in validator registrations against builder infrastructure.",
       arity = "1",
       hidden = true)
-  private UInt64 validatorsRegistrationTimestampOverride = null;
+  private UInt64 builderRegistrationTimestampOverride = null;
 
   @Option(
       names = {"--validators-proposer-blinded-blocks-enabled"},
@@ -107,10 +107,10 @@ public class ValidatorProposerOptions {
                 .proposerDefaultFeeRecipient(proposerDefaultFeeRecipient)
                 .proposerConfigSource(proposerConfig)
                 .refreshProposerConfigFromSource(proposerConfigRefreshEnabled)
-                .validatorsRegistrationDefaultEnabled(builderRegistrationDefaultEnabled)
+                .builderRegistrationDefaultEnabled(builderRegistrationDefaultEnabled)
                 .blindedBeaconBlocksEnabled(blindedBlocksEnabled)
-                .validatorsRegistrationDefaultGasLimit(builderRegistrationDefaultGasLimit)
-                .validatorsRegistrationSendingBatchSize(registrationSendingBatchSize)
-                .validatorsRegistrationTimestampOverride(validatorsRegistrationTimestampOverride));
+                .builderRegistrationDefaultGasLimit(builderRegistrationDefaultGasLimit)
+                .builderRegistrationSendingBatchSize(builderRegistrationSendingBatchSize)
+                .builderRegistrationTimestampOverride(builderRegistrationTimestampOverride));
   }
 }

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorProposerOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorProposerOptions.java
@@ -50,13 +50,12 @@ public class ValidatorProposerOptions {
       ValidatorConfig.DEFAULT_VALIDATOR_PROPOSER_CONFIG_REFRESH_ENABLED;
 
   @Option(
-      names = {"--Xvalidators-registration-default-enabled"},
+      names = {"--validators-registration-default-enabled"},
       paramLabel = "<BOOLEAN>",
       showDefaultValue = Visibility.ALWAYS,
       description = "Enable validators registration to builder infrastructure.",
       arity = "0..1",
-      fallbackValue = "true",
-      hidden = true)
+      fallbackValue = "true")
   private boolean validatorsRegistrationDefaultEnabled =
       ValidatorConfig.DEFAULT_VALIDATOR_REGISTRATION_DEFAULT_ENABLED;
 
@@ -83,22 +82,20 @@ public class ValidatorProposerOptions {
       ValidatorConfig.DEFAULT_VALIDATOR_REGISTRATION_SENDING_BATCH_SIZE;
 
   @Option(
-      names = {"--Xvalidators-registration-timestamp-override"},
+      names = {"--validators-registration-timestamp-override"},
       paramLabel = "<uint64>",
       showDefaultValue = Visibility.ALWAYS,
       description =
           "Set a constant timestamp in Unix format to be used in validator registrations against builder infrastructure.",
-      arity = "1",
-      hidden = true)
+      arity = "1")
   private UInt64 validatorsRegistrationTimestampOverride = null;
 
   @Option(
-      names = {"--Xvalidators-proposer-blinded-blocks-enabled"},
+      names = {"--validators-proposer-blinded-blocks-enabled"},
       paramLabel = "<BOOLEAN>",
       showDefaultValue = Visibility.ALWAYS,
       description = "Use blinded blocks when in block production duties",
       fallbackValue = "true",
-      hidden = true,
       arity = "0..1")
   private boolean blindedBlocksEnabled = DEFAULT_VALIDATOR_BLINDED_BLOCKS_ENABLED;
 

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorProposerOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorProposerOptions.java
@@ -50,7 +50,7 @@ public class ValidatorProposerOptions {
       ValidatorConfig.DEFAULT_VALIDATOR_PROPOSER_CONFIG_REFRESH_ENABLED;
 
   @Option(
-      names = {"--validators-registration-default-enabled"},
+      names = {"--builder-registration-default-enabled"},
       paramLabel = "<BOOLEAN>",
       showDefaultValue = Visibility.ALWAYS,
       description = "Enable validators registration to builder infrastructure.",

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/ExecutionLayerOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/ExecutionLayerOptionsTest.java
@@ -67,7 +67,7 @@ public class ExecutionLayerOptionsTest extends AbstractBeaconNodeCommandTest {
       "1",
       "--ee-endpoint",
       "http://example.com:1234/path/",
-      "--Xeb-endpoint",
+      "--eb-endpoint",
       "http://example2.com:1234/path2/"
     };
     final TekuConfiguration config = getTekuConfigurationFromArguments(args);

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/ExecutionLayerOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/ExecutionLayerOptionsTest.java
@@ -67,7 +67,7 @@ public class ExecutionLayerOptionsTest extends AbstractBeaconNodeCommandTest {
       "1",
       "--ee-endpoint",
       "http://example.com:1234/path/",
-      "--eb-endpoint",
+      "--builder-endpoint",
       "http://example2.com:1234/path2/"
     };
     final TekuConfiguration config = getTekuConfigurationFromArguments(args);

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/ValidatorOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/ValidatorOptionsTest.java
@@ -180,7 +180,7 @@ public class ValidatorOptionsTest extends AbstractBeaconNodeCommandTest {
 
   @Test
   public void shouldSETDefaultGasLimitIfRegistrationDefaultGasLimitIsSpecified() {
-    final String[] args = {"--Xvalidators-registration-default-gas-limit", "1000"};
+    final String[] args = {"--Xbuilder-registration-default-gas-limit", "1000"};
     final TekuConfiguration config = getTekuConfigurationFromArguments(args);
     assertThat(
             config

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/ValidatorOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/ValidatorOptionsTest.java
@@ -14,7 +14,7 @@
 package tech.pegasys.teku.cli.options;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static tech.pegasys.teku.validator.api.ValidatorConfig.DEFAULT_VALIDATOR_REGISTRATION_GAS_LIMIT;
+import static tech.pegasys.teku.validator.api.ValidatorConfig.DEFAULT_BUILDER_REGISTRATION_GAS_LIMIT;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -175,7 +175,7 @@ public class ValidatorOptionsTest extends AbstractBeaconNodeCommandTest {
                 .validatorClient()
                 .getValidatorConfig()
                 .getValidatorsRegistrationDefaultGasLimit())
-        .isEqualTo(DEFAULT_VALIDATOR_REGISTRATION_GAS_LIMIT);
+        .isEqualTo(DEFAULT_BUILDER_REGISTRATION_GAS_LIMIT);
   }
 
   @Test

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/ValidatorOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/ValidatorOptionsTest.java
@@ -121,7 +121,7 @@ public class ValidatorOptionsTest extends AbstractBeaconNodeCommandTest {
 
   @Test
   public void shouldEnableBlindedBeaconBlocks() {
-    final String[] args = {"--Xvalidators-proposer-blinded-blocks-enabled", "true"};
+    final String[] args = {"--validators-proposer-blinded-blocks-enabled", "true"};
     final TekuConfiguration config = getTekuConfigurationFromArguments(args);
     assertThat(config.validatorClient().getValidatorConfig().isBlindedBeaconBlocksEnabled())
         .isTrue();
@@ -137,7 +137,7 @@ public class ValidatorOptionsTest extends AbstractBeaconNodeCommandTest {
 
   @Test
   public void shouldEnableValidatorRegistrationtWithBlindedBlocks() {
-    final String[] args = {"--Xvalidators-registration-default-enabled", "true"};
+    final String[] args = {"--validators-registration-default-enabled", "true"};
     final TekuConfiguration config = getTekuConfigurationFromArguments(args);
     assertThat(
             config.validatorClient().getValidatorConfig().isValidatorsRegistrationDefaultEnabled())

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/ValidatorOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/ValidatorOptionsTest.java
@@ -137,10 +137,9 @@ public class ValidatorOptionsTest extends AbstractBeaconNodeCommandTest {
 
   @Test
   public void shouldEnableValidatorRegistrationtWithBlindedBlocks() {
-    final String[] args = {"--builder-registration-default-enabled", "true"};
+    final String[] args = {"--validators-builder-registration-default-enabled", "true"};
     final TekuConfiguration config = getTekuConfigurationFromArguments(args);
-    assertThat(
-            config.validatorClient().getValidatorConfig().isValidatorsRegistrationDefaultEnabled())
+    assertThat(config.validatorClient().getValidatorConfig().isBuilderRegistrationDefaultEnabled())
         .isTrue();
     assertThat(config.validatorClient().getValidatorConfig().isBlindedBeaconBlocksEnabled())
         .isTrue();
@@ -148,13 +147,10 @@ public class ValidatorOptionsTest extends AbstractBeaconNodeCommandTest {
 
   @Test
   public void shouldEnableValidatorRegistrationTimestampOverride() {
-    final String[] args = {"--Xvalidators-registration-timestamp-override", "120000"};
+    final String[] args = {"--validators-builder-registration-timestamp-override", "120000"};
     final TekuConfiguration config = getTekuConfigurationFromArguments(args);
     assertThat(
-            config
-                .validatorClient()
-                .getValidatorConfig()
-                .getValidatorsRegistrationTimestampOverride())
+            config.validatorClient().getValidatorConfig().getBuilderRegistrationTimestampOverride())
         .isEqualTo(Optional.of(UInt64.valueOf(120000)));
   }
 
@@ -162,8 +158,7 @@ public class ValidatorOptionsTest extends AbstractBeaconNodeCommandTest {
   public void shouldNotUseValidatorsRegistrationByDefault() {
     final String[] args = {};
     final TekuConfiguration config = getTekuConfigurationFromArguments(args);
-    assertThat(
-            config.validatorClient().getValidatorConfig().isValidatorsRegistrationDefaultEnabled())
+    assertThat(config.validatorClient().getValidatorConfig().isBuilderRegistrationDefaultEnabled())
         .isFalse();
   }
 
@@ -171,22 +166,16 @@ public class ValidatorOptionsTest extends AbstractBeaconNodeCommandTest {
   public void shouldReportDefaultGasLimitIfRegistrationDefaultGasLimitNotSpecified() {
     final TekuConfiguration config = getTekuConfigurationFromArguments();
     assertThat(
-            config
-                .validatorClient()
-                .getValidatorConfig()
-                .getValidatorsRegistrationDefaultGasLimit())
+            config.validatorClient().getValidatorConfig().getBuilderRegistrationDefaultGasLimit())
         .isEqualTo(DEFAULT_BUILDER_REGISTRATION_GAS_LIMIT);
   }
 
   @Test
   public void shouldSETDefaultGasLimitIfRegistrationDefaultGasLimitIsSpecified() {
-    final String[] args = {"--Xbuilder-registration-default-gas-limit", "1000"};
+    final String[] args = {"--Xvalidators-builder-registration-default-gas-limit", "1000"};
     final TekuConfiguration config = getTekuConfigurationFromArguments(args);
     assertThat(
-            config
-                .validatorClient()
-                .getValidatorConfig()
-                .getValidatorsRegistrationDefaultGasLimit())
+            config.validatorClient().getValidatorConfig().getBuilderRegistrationDefaultGasLimit())
         .isEqualTo(UInt64.valueOf(1000));
   }
 }

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/ValidatorOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/ValidatorOptionsTest.java
@@ -137,7 +137,7 @@ public class ValidatorOptionsTest extends AbstractBeaconNodeCommandTest {
 
   @Test
   public void shouldEnableValidatorRegistrationtWithBlindedBlocks() {
-    final String[] args = {"--validators-registration-default-enabled", "true"};
+    final String[] args = {"--builder-registration-default-enabled", "true"};
     final TekuConfiguration config = getTekuConfigurationFromArguments(args);
     assertThat(
             config.validatorClient().getValidatorConfig().isValidatorsRegistrationDefaultEnabled())

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
@@ -534,7 +534,7 @@ public class ValidatorConfig {
     private void validateValidatorsRegistrationAndBlindedBlocks() {
       if (validatorsRegistrationDefaultEnabled && !blindedBlocksEnabled) {
         LOG.info(
-            "'--validators-registration-default-enabled' requires '--validators-proposer-blinded-blocks-enabled', enabling it");
+            "'--builder-registration-default-enabled' requires '--validators-proposer-blinded-blocks-enabled', enabling it");
         blindedBlocksEnabled = true;
       }
     }
@@ -542,7 +542,7 @@ public class ValidatorConfig {
     private void validatorsRegistrationDefaultEnabledOrProposerConfigSource() {
       if (validatorsRegistrationDefaultEnabled && proposerConfigSource.isPresent()) {
         throw new InvalidConfigurationException(
-            "Invalid configuration. --validators-registration-default-enabled cannot be specified when --validators-proposer-config is used");
+            "Invalid configuration. --builder-registration-default-enabled cannot be specified when --validators-proposer-config is used");
       }
     }
 

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
@@ -71,11 +71,11 @@ public class ValidatorConfig {
   private final Optional<String> proposerConfigSource;
   private final boolean refreshProposerConfigFromSource;
   private final boolean blindedBeaconBlocksEnabled;
-  private final boolean validatorsRegistrationDefaultEnabled;
+  private final boolean builderRegistrationDefaultEnabled;
   private final boolean validatorClientUseSszBlocksEnabled;
-  private final UInt64 validatorsRegistrationDefaultGasLimit;
-  private final int validatorsRegistrationSendingBatchSize;
-  private final Optional<UInt64> validatorsRegistrationTimestampOverride;
+  private final UInt64 builderRegistrationDefaultGasLimit;
+  private final int builderRegistrationSendingBatchSize;
+  private final Optional<UInt64> builderRegistrationTimestampOverride;
 
   private final int executorMaxQueueSize;
 
@@ -99,12 +99,12 @@ public class ValidatorConfig {
       final Optional<Eth1Address> proposerDefaultFeeRecipient,
       final Optional<String> proposerConfigSource,
       final boolean refreshProposerConfigFromSource,
-      final boolean validatorsRegistrationDefaultEnabled,
+      final boolean builderRegistrationDefaultEnabled,
       final boolean blindedBeaconBlocksEnabled,
       final boolean validatorClientUseSszBlocksEnabled,
-      final UInt64 validatorsRegistrationDefaultGasLimit,
-      final int validatorsRegistrationSendingBatchSize,
-      final Optional<UInt64> validatorsRegistrationTimestampOverride,
+      final UInt64 builderRegistrationDefaultGasLimit,
+      final int builderRegistrationSendingBatchSize,
+      final Optional<UInt64> builderRegistrationTimestampOverride,
       final int executorMaxQueueSize) {
     this.validatorKeys = validatorKeys;
     this.validatorExternalSignerPublicKeySources = validatorExternalSignerPublicKeySources;
@@ -129,11 +129,11 @@ public class ValidatorConfig {
     this.proposerConfigSource = proposerConfigSource;
     this.refreshProposerConfigFromSource = refreshProposerConfigFromSource;
     this.blindedBeaconBlocksEnabled = blindedBeaconBlocksEnabled;
-    this.validatorsRegistrationDefaultEnabled = validatorsRegistrationDefaultEnabled;
+    this.builderRegistrationDefaultEnabled = builderRegistrationDefaultEnabled;
     this.validatorClientUseSszBlocksEnabled = validatorClientUseSszBlocksEnabled;
-    this.validatorsRegistrationDefaultGasLimit = validatorsRegistrationDefaultGasLimit;
-    this.validatorsRegistrationSendingBatchSize = validatorsRegistrationSendingBatchSize;
-    this.validatorsRegistrationTimestampOverride = validatorsRegistrationTimestampOverride;
+    this.builderRegistrationDefaultGasLimit = builderRegistrationDefaultGasLimit;
+    this.builderRegistrationSendingBatchSize = builderRegistrationSendingBatchSize;
+    this.builderRegistrationTimestampOverride = builderRegistrationTimestampOverride;
     this.executorMaxQueueSize = executorMaxQueueSize;
   }
 
@@ -208,16 +208,16 @@ public class ValidatorConfig {
     return proposerConfigSource;
   }
 
-  public UInt64 getValidatorsRegistrationDefaultGasLimit() {
-    return validatorsRegistrationDefaultGasLimit;
+  public UInt64 getBuilderRegistrationDefaultGasLimit() {
+    return builderRegistrationDefaultGasLimit;
   }
 
-  public int getValidatorsRegistrationSendingBatchSize() {
-    return validatorsRegistrationSendingBatchSize;
+  public int getBuilderRegistrationSendingBatchSize() {
+    return builderRegistrationSendingBatchSize;
   }
 
-  public Optional<UInt64> getValidatorsRegistrationTimestampOverride() {
-    return validatorsRegistrationTimestampOverride;
+  public Optional<UInt64> getBuilderRegistrationTimestampOverride() {
+    return builderRegistrationTimestampOverride;
   }
 
   public boolean getRefreshProposerConfigFromSource() {
@@ -232,8 +232,8 @@ public class ValidatorConfig {
     return validatorClientUseSszBlocksEnabled;
   }
 
-  public boolean isValidatorsRegistrationDefaultEnabled() {
-    return validatorsRegistrationDefaultEnabled;
+  public boolean isBuilderRegistrationDefaultEnabled() {
+    return builderRegistrationDefaultEnabled;
   }
 
   public int getExecutorMaxQueueSize() {
@@ -278,10 +278,10 @@ public class ValidatorConfig {
         DEFAULT_BUILDER_REGISTRATION_DEFAULT_ENABLED;
     private boolean blindedBlocksEnabled = DEFAULT_VALIDATOR_BLINDED_BLOCKS_ENABLED;
     private boolean validatorClientSszBlocksEnabled = DEFAULT_VALIDATOR_CLIENT_SSZ_BLOCKS_ENABLED;
-    private UInt64 validatorsRegistrationDefaultGasLimit = DEFAULT_BUILDER_REGISTRATION_GAS_LIMIT;
-    private int validatorsRegistrationSendingBatchSize =
+    private UInt64 builderRegistrationDefaultGasLimit = DEFAULT_BUILDER_REGISTRATION_GAS_LIMIT;
+    private int builderRegistrationSendingBatchSize =
         DEFAULT_VALIDATOR_REGISTRATION_SENDING_BATCH_SIZE;
-    private Optional<UInt64> validatorsRegistrationTimestampOverride = Optional.empty();
+    private Optional<UInt64> builderRegistrationTimestampOverride = Optional.empty();
     private int executorMaxQueueSize = DEFAULT_EXECUTOR_MAX_QUEUE_SIZE;
 
     private Builder() {}
@@ -408,7 +408,7 @@ public class ValidatorConfig {
       return this;
     }
 
-    public Builder validatorsRegistrationDefaultEnabled(
+    public Builder builderRegistrationDefaultEnabled(
         final boolean validatorsRegistrationDefaultEnabled) {
       this.validatorsRegistrationDefaultEnabled = validatorsRegistrationDefaultEnabled;
       return this;
@@ -425,22 +425,22 @@ public class ValidatorConfig {
       return this;
     }
 
-    public Builder validatorsRegistrationDefaultGasLimit(
-        final UInt64 validatorsRegistrationDefaultGasLimit) {
-      this.validatorsRegistrationDefaultGasLimit = validatorsRegistrationDefaultGasLimit;
+    public Builder builderRegistrationDefaultGasLimit(
+        final UInt64 builderRegistrationDefaultGasLimit) {
+      this.builderRegistrationDefaultGasLimit = builderRegistrationDefaultGasLimit;
       return this;
     }
 
-    public Builder validatorsRegistrationSendingBatchSize(
-        final int validatorsRegistrationSendingBatchSize) {
-      this.validatorsRegistrationSendingBatchSize = validatorsRegistrationSendingBatchSize;
+    public Builder builderRegistrationSendingBatchSize(
+        final int builderRegistrationSendingBatchSize) {
+      this.builderRegistrationSendingBatchSize = builderRegistrationSendingBatchSize;
       return this;
     }
 
-    public Builder validatorsRegistrationTimestampOverride(
-        final UInt64 validatorsRegistrationTimestampOverride) {
-      this.validatorsRegistrationTimestampOverride =
-          Optional.ofNullable(validatorsRegistrationTimestampOverride);
+    public Builder builderRegistrationTimestampOverride(
+        final UInt64 builderRegistrationTimestampOverride) {
+      this.builderRegistrationTimestampOverride =
+          Optional.ofNullable(builderRegistrationTimestampOverride);
       return this;
     }
 
@@ -479,9 +479,9 @@ public class ValidatorConfig {
           validatorsRegistrationDefaultEnabled,
           blindedBlocksEnabled,
           validatorClientSszBlocksEnabled,
-          validatorsRegistrationDefaultGasLimit,
-          validatorsRegistrationSendingBatchSize,
-          validatorsRegistrationTimestampOverride,
+          builderRegistrationDefaultGasLimit,
+          builderRegistrationSendingBatchSize,
+          builderRegistrationTimestampOverride,
           executorMaxQueueSize);
     }
 
@@ -534,7 +534,7 @@ public class ValidatorConfig {
     private void validateValidatorsRegistrationAndBlindedBlocks() {
       if (validatorsRegistrationDefaultEnabled && !blindedBlocksEnabled) {
         LOG.info(
-            "'--builder-registration-default-enabled' requires '--validators-proposer-blinded-blocks-enabled', enabling it");
+            "'--validators-builder-registration-default-enabled' requires '--validators-proposer-blinded-blocks-enabled', enabling it");
         blindedBlocksEnabled = true;
       }
     }
@@ -542,7 +542,7 @@ public class ValidatorConfig {
     private void validatorsRegistrationDefaultEnabledOrProposerConfigSource() {
       if (validatorsRegistrationDefaultEnabled && proposerConfigSource.isPresent()) {
         throw new InvalidConfigurationException(
-            "Invalid configuration. --builder-registration-default-enabled cannot be specified when --validators-proposer-config is used");
+            "Invalid configuration. --validators-builder-registration-default-enabled cannot be specified when --validators-proposer-config is used");
       }
     }
 

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
@@ -46,10 +46,10 @@ public class ValidatorConfig {
   public static final boolean DEFAULT_GENERATE_EARLY_ATTESTATIONS = true;
   public static final Optional<Bytes32> DEFAULT_GRAFFITI = Optional.empty();
   public static final boolean DEFAULT_VALIDATOR_PROPOSER_CONFIG_REFRESH_ENABLED = false;
-  public static final boolean DEFAULT_VALIDATOR_REGISTRATION_DEFAULT_ENABLED = false;
+  public static final boolean DEFAULT_BUILDER_REGISTRATION_DEFAULT_ENABLED = false;
   public static final boolean DEFAULT_VALIDATOR_BLINDED_BLOCKS_ENABLED = false;
   public static final int DEFAULT_VALIDATOR_REGISTRATION_SENDING_BATCH_SIZE = 100;
-  public static final UInt64 DEFAULT_VALIDATOR_REGISTRATION_GAS_LIMIT = UInt64.valueOf(30_000_000);
+  public static final UInt64 DEFAULT_BUILDER_REGISTRATION_GAS_LIMIT = UInt64.valueOf(30_000_000);
 
   private final List<String> validatorKeys;
   private final List<String> validatorExternalSignerPublicKeySources;
@@ -275,10 +275,10 @@ public class ValidatorConfig {
     private boolean refreshProposerConfigFromSource =
         DEFAULT_VALIDATOR_PROPOSER_CONFIG_REFRESH_ENABLED;
     private boolean validatorsRegistrationDefaultEnabled =
-        DEFAULT_VALIDATOR_REGISTRATION_DEFAULT_ENABLED;
+        DEFAULT_BUILDER_REGISTRATION_DEFAULT_ENABLED;
     private boolean blindedBlocksEnabled = DEFAULT_VALIDATOR_BLINDED_BLOCKS_ENABLED;
     private boolean validatorClientSszBlocksEnabled = DEFAULT_VALIDATOR_CLIENT_SSZ_BLOCKS_ENABLED;
-    private UInt64 validatorsRegistrationDefaultGasLimit = DEFAULT_VALIDATOR_REGISTRATION_GAS_LIMIT;
+    private UInt64 validatorsRegistrationDefaultGasLimit = DEFAULT_BUILDER_REGISTRATION_GAS_LIMIT;
     private int validatorsRegistrationSendingBatchSize =
         DEFAULT_VALIDATOR_REGISTRATION_SENDING_BATCH_SIZE;
     private Optional<UInt64> validatorsRegistrationTimestampOverride = Optional.empty();

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
@@ -534,7 +534,7 @@ public class ValidatorConfig {
     private void validateValidatorsRegistrationAndBlindedBlocks() {
       if (validatorsRegistrationDefaultEnabled && !blindedBlocksEnabled) {
         LOG.info(
-            "'--Xvalidators-registration-default-enabled' requires '--Xvalidators-proposer-blinded-blocks-enabled', enabling it");
+            "'--validators-registration-default-enabled' requires '--validators-proposer-blinded-blocks-enabled', enabling it");
         blindedBlocksEnabled = true;
       }
     }
@@ -542,7 +542,7 @@ public class ValidatorConfig {
     private void validatorsRegistrationDefaultEnabledOrProposerConfigSource() {
       if (validatorsRegistrationDefaultEnabled && proposerConfigSource.isPresent()) {
         throw new InvalidConfigurationException(
-            "Invalid configuration. --Xvalidators-registration-default-enabled cannot be specified when --validators-proposer-config is used");
+            "Invalid configuration. --validators-registration-default-enabled cannot be specified when --validators-proposer-config is used");
       }
     }
 

--- a/validator/api/src/test/java/tech/pegasys/teku/validator/api/ValidatorConfigTest.java
+++ b/validator/api/src/test/java/tech/pegasys/teku/validator/api/ValidatorConfigTest.java
@@ -106,7 +106,7 @@ class ValidatorConfigTest {
     Assertions.assertThatExceptionOfType(InvalidConfigurationException.class)
         .isThrownBy(builder::build)
         .withMessageContaining(
-            "Invalid configuration. --validators-registration-default-enabled cannot be specified when --validators-proposer-config is used");
+            "Invalid configuration. --builder-registration-default-enabled cannot be specified when --validators-proposer-config is used");
   }
 
   @Test

--- a/validator/api/src/test/java/tech/pegasys/teku/validator/api/ValidatorConfigTest.java
+++ b/validator/api/src/test/java/tech/pegasys/teku/validator/api/ValidatorConfigTest.java
@@ -101,12 +101,12 @@ class ValidatorConfigTest {
   public void
       shouldThrowIfValidatorsRegistrationDefaultEnabledAndValidatorProposerConfigSpecified() {
     final ValidatorConfig.Builder builder =
-        configBuilder.validatorsRegistrationDefaultEnabled(true).proposerConfigSource("somepath");
+        configBuilder.builderRegistrationDefaultEnabled(true).proposerConfigSource("somepath");
 
     Assertions.assertThatExceptionOfType(InvalidConfigurationException.class)
         .isThrownBy(builder::build)
         .withMessageContaining(
-            "Invalid configuration. --builder-registration-default-enabled cannot be specified when --validators-proposer-config is used");
+            "Invalid configuration. --validators-builder-registration-default-enabled cannot be specified when --validators-proposer-config is used");
   }
 
   @Test

--- a/validator/api/src/test/java/tech/pegasys/teku/validator/api/ValidatorConfigTest.java
+++ b/validator/api/src/test/java/tech/pegasys/teku/validator/api/ValidatorConfigTest.java
@@ -106,7 +106,7 @@ class ValidatorConfigTest {
     Assertions.assertThatExceptionOfType(InvalidConfigurationException.class)
         .isThrownBy(builder::build)
         .withMessageContaining(
-            "Invalid configuration. --Xvalidators-registration-default-enabled cannot be specified when --validators-proposer-config is used");
+            "Invalid configuration. --validators-registration-default-enabled cannot be specified when --validators-proposer-config is used");
   }
 
   @Test

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/BeaconProposerPreparer.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/BeaconProposerPreparer.java
@@ -136,7 +136,7 @@ public class BeaconProposerPreparer implements ValidatorTimingChannel, FeeRecipi
         .or(() -> runtimeProposerConfig.getEth1AddressForPubKey(publicKey))
         .or(
             () ->
-                maybeProposerConfig.map(
+                maybeProposerConfig.flatMap(
                     proposerConfig -> proposerConfig.getDefaultConfig().getFeeRecipient()))
         .or(() -> defaultFeeRecipient);
   }
@@ -226,7 +226,7 @@ public class BeaconProposerPreparer implements ValidatorTimingChannel, FeeRecipi
 
   private Optional<Eth1Address> getFeeRecipientFromProposerConfig(
       final ProposerConfig config, final BLSPublicKey publicKey) {
-    return config.getConfigForPubKey(publicKey).map(Config::getFeeRecipient);
+    return config.getConfigForPubKey(publicKey).flatMap(Config::getFeeRecipient);
   }
 
   private boolean validatorIndexCannotBeResolved(final BLSPublicKey publicKey) {

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ProposerConfig.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ProposerConfig.java
@@ -60,11 +60,11 @@ public class ProposerConfig {
   }
 
   public Optional<Boolean> isBuilderEnabledForPubKey(final BLSPublicKey pubKey) {
-    return getConfigForPubKeyOrDefault(pubKey).getBuilder().map(Builder::isEnabled);
+    return getConfigForPubKeyOrDefault(pubKey).getBuilder().map(BuilderConfig::isEnabled);
   }
 
   public Optional<UInt64> getBuilderGasLimitForPubKey(final BLSPublicKey pubKey) {
-    return getConfigForPubKeyOrDefault(pubKey).getBuilder().flatMap(Builder::getGasLimit);
+    return getConfigForPubKeyOrDefault(pubKey).getBuilder().flatMap(BuilderConfig::getGasLimit);
   }
 
   public Config getDefaultConfig() {
@@ -99,12 +99,12 @@ public class ProposerConfig {
     private Eth1Address feeRecipient;
 
     @JsonProperty(value = "builder")
-    private Builder builder;
+    private BuilderConfig builder;
 
     @JsonCreator
     public Config(
         @JsonProperty(value = "fee_recipient") final Eth1Address feeRecipient,
-        @JsonProperty(value = "builder") final Builder builder) {
+        @JsonProperty(value = "builder") final BuilderConfig builder) {
       checkNotNull(feeRecipient, "fee_recipient is required");
       this.feeRecipient = feeRecipient;
       this.builder = builder;
@@ -114,7 +114,7 @@ public class ProposerConfig {
       return feeRecipient;
     }
 
-    public Optional<Builder> getBuilder() {
+    public Optional<BuilderConfig> getBuilder() {
       return Optional.ofNullable(builder);
     }
 
@@ -138,7 +138,7 @@ public class ProposerConfig {
   }
 
   @JsonIgnoreProperties(ignoreUnknown = true)
-  public static class Builder {
+  public static class BuilderConfig {
     @JsonProperty(value = "enabled")
     private Boolean enabled;
 
@@ -146,7 +146,7 @@ public class ProposerConfig {
     private UInt64 gasLimit;
 
     @JsonCreator
-    public Builder(
+    public BuilderConfig(
         @JsonProperty(value = "enabled") final Boolean enabled,
         @JsonProperty(value = "gas_limit") final UInt64 gasLimit) {
       checkNotNull(enabled, "enabled is required");
@@ -170,7 +170,7 @@ public class ProposerConfig {
       if (o == null || getClass() != o.getClass()) {
         return false;
       }
-      final Builder that = (Builder) o;
+      final BuilderConfig that = (BuilderConfig) o;
       return Objects.equals(enabled, that.enabled) && Objects.equals(gasLimit, that.gasLimit);
     }
 

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ProposerConfig.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ProposerConfig.java
@@ -39,6 +39,7 @@ public class ProposerConfig {
       @JsonProperty(value = "proposer_config") final Map<Bytes48, Config> proposerConfig,
       @JsonProperty(value = "default_config") final Config defaultConfig) {
     checkNotNull(defaultConfig, "default_config is required");
+    checkNotNull(defaultConfig.feeRecipient, "fee_recipient is required in default_config");
     this.proposerConfig = proposerConfig == null ? ImmutableMap.of() : proposerConfig;
     this.defaultConfig = defaultConfig;
   }
@@ -105,13 +106,12 @@ public class ProposerConfig {
     public Config(
         @JsonProperty(value = "fee_recipient") final Eth1Address feeRecipient,
         @JsonProperty(value = "builder") final BuilderConfig builder) {
-      checkNotNull(feeRecipient, "fee_recipient is required");
       this.feeRecipient = feeRecipient;
       this.builder = builder;
     }
 
-    public Eth1Address getFeeRecipient() {
-      return feeRecipient;
+    public Optional<Eth1Address> getFeeRecipient() {
+      return Optional.ofNullable(feeRecipient);
     }
 
     public Optional<BuilderConfig> getBuilder() {

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ProposerConfig.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ProposerConfig.java
@@ -102,13 +102,13 @@ public class ProposerConfig {
     @JsonProperty(value = "fee_recipient")
     private Eth1Address feeRecipient;
 
-    @JsonProperty(value = "validator_registration")
+    @JsonProperty(value = "builder_registration")
     private ValidatorRegistration validatorRegistration;
 
     @JsonCreator
     public Config(
         @JsonProperty(value = "fee_recipient") final Eth1Address feeRecipient,
-        @JsonProperty(value = "validator_registration")
+        @JsonProperty(value = "builder_registration")
             final ValidatorRegistration validatorRegistration) {
       checkNotNull(feeRecipient, "fee_recipient is required");
       this.feeRecipient = feeRecipient;

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ProposerConfig.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ProposerConfig.java
@@ -59,16 +59,12 @@ public class ProposerConfig {
     return getConfigForPubKey(pubKey).orElse(defaultConfig);
   }
 
-  public Optional<Boolean> isValidatorRegistrationEnabledForPubKey(final BLSPublicKey pubKey) {
-    return getConfigForPubKeyOrDefault(pubKey)
-        .getValidatorRegistration()
-        .map(ValidatorRegistration::isEnabled);
+  public Optional<Boolean> isBuilderEnabledForPubKey(final BLSPublicKey pubKey) {
+    return getConfigForPubKeyOrDefault(pubKey).getBuilder().map(Builder::isEnabled);
   }
 
-  public Optional<UInt64> getValidatorRegistrationGasLimitForPubKey(final BLSPublicKey pubKey) {
-    return getConfigForPubKeyOrDefault(pubKey)
-        .getValidatorRegistration()
-        .flatMap(ValidatorRegistration::getGasLimit);
+  public Optional<UInt64> getBuilderGasLimitForPubKey(final BLSPublicKey pubKey) {
+    return getConfigForPubKeyOrDefault(pubKey).getBuilder().flatMap(Builder::getGasLimit);
   }
 
   public Config getDefaultConfig() {
@@ -102,25 +98,24 @@ public class ProposerConfig {
     @JsonProperty(value = "fee_recipient")
     private Eth1Address feeRecipient;
 
-    @JsonProperty(value = "builder_registration")
-    private ValidatorRegistration validatorRegistration;
+    @JsonProperty(value = "builder")
+    private Builder builder;
 
     @JsonCreator
     public Config(
         @JsonProperty(value = "fee_recipient") final Eth1Address feeRecipient,
-        @JsonProperty(value = "builder_registration")
-            final ValidatorRegistration validatorRegistration) {
+        @JsonProperty(value = "builder") final Builder builder) {
       checkNotNull(feeRecipient, "fee_recipient is required");
       this.feeRecipient = feeRecipient;
-      this.validatorRegistration = validatorRegistration;
+      this.builder = builder;
     }
 
     public Eth1Address getFeeRecipient() {
       return feeRecipient;
     }
 
-    public Optional<ValidatorRegistration> getValidatorRegistration() {
-      return Optional.ofNullable(validatorRegistration);
+    public Optional<Builder> getBuilder() {
+      return Optional.ofNullable(builder);
     }
 
     @Override
@@ -133,17 +128,17 @@ public class ProposerConfig {
       }
       final Config that = (Config) o;
       return Objects.equals(feeRecipient, that.feeRecipient)
-          && Objects.equals(validatorRegistration, that.validatorRegistration);
+          && Objects.equals(builder, that.builder);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(feeRecipient, validatorRegistration);
+      return Objects.hash(feeRecipient, builder);
     }
   }
 
   @JsonIgnoreProperties(ignoreUnknown = true)
-  public static class ValidatorRegistration {
+  public static class Builder {
     @JsonProperty(value = "enabled")
     private Boolean enabled;
 
@@ -151,7 +146,7 @@ public class ProposerConfig {
     private UInt64 gasLimit;
 
     @JsonCreator
-    public ValidatorRegistration(
+    public Builder(
         @JsonProperty(value = "enabled") final Boolean enabled,
         @JsonProperty(value = "gas_limit") final UInt64 gasLimit) {
       checkNotNull(enabled, "enabled is required");
@@ -175,7 +170,7 @@ public class ProposerConfig {
       if (o == null || getClass() != o.getClass()) {
         return false;
       }
-      final ValidatorRegistration that = (ValidatorRegistration) o;
+      final Builder that = (Builder) o;
       return Objects.equals(enabled, that.enabled) && Objects.equals(gasLimit, that.gasLimit);
     }
 

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
@@ -187,7 +187,7 @@ public class ValidatorClientService extends Service {
                   validatorConfig,
                   beaconProposerPreparer.get(),
                   new ValidatorRegistrationBatchSender(
-                      validatorConfig.getValidatorsRegistrationSendingBatchSize(),
+                      validatorConfig.getBuilderRegistrationSendingBatchSize(),
                       validatorApiChannel)));
     }
     if (validatorApiConfig.isRestApiEnabled()) {

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrator.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrator.java
@@ -237,21 +237,21 @@ public class ValidatorRegistrator implements ValidatorTimingChannel {
       final Optional<ProposerConfig> maybeProposerConfig, final BLSPublicKey publicKey) {
     return maybeProposerConfig
         .flatMap(proposerConfig -> proposerConfig.isBuilderEnabledForPubKey(publicKey))
-        .orElse(validatorConfig.isValidatorsRegistrationDefaultEnabled());
+        .orElse(validatorConfig.isBuilderRegistrationDefaultEnabled());
   }
 
   private UInt64 getGasLimit(
       final Optional<ProposerConfig> maybeProposerConfig, final BLSPublicKey publicKey) {
     return maybeProposerConfig
         .flatMap(proposerConfig -> proposerConfig.getBuilderGasLimitForPubKey(publicKey))
-        .orElse(validatorConfig.getValidatorsRegistrationDefaultGasLimit());
+        .orElse(validatorConfig.getBuilderRegistrationDefaultGasLimit());
   }
 
   private ValidatorRegistration createValidatorRegistration(
       final BLSPublicKey publicKey, final Eth1Address feeRecipient, final UInt64 gasLimit) {
     final UInt64 timestamp =
         validatorConfig
-            .getValidatorsRegistrationTimestampOverride()
+            .getBuilderRegistrationTimestampOverride()
             .orElse(timeProvider.getTimeInSeconds());
     return ApiSchemas.VALIDATOR_REGISTRATION_SCHEMA.create(
         feeRecipient, gasLimit, timestamp, publicKey);

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrator.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrator.java
@@ -236,16 +236,14 @@ public class ValidatorRegistrator implements ValidatorTimingChannel {
   private boolean registrationIsEnabled(
       final Optional<ProposerConfig> maybeProposerConfig, final BLSPublicKey publicKey) {
     return maybeProposerConfig
-        .flatMap(
-            proposerConfig -> proposerConfig.isValidatorRegistrationEnabledForPubKey(publicKey))
+        .flatMap(proposerConfig -> proposerConfig.isBuilderEnabledForPubKey(publicKey))
         .orElse(validatorConfig.isValidatorsRegistrationDefaultEnabled());
   }
 
   private UInt64 getGasLimit(
       final Optional<ProposerConfig> maybeProposerConfig, final BLSPublicKey publicKey) {
     return maybeProposerConfig
-        .flatMap(
-            proposerConfig -> proposerConfig.getValidatorRegistrationGasLimitForPubKey(publicKey))
+        .flatMap(proposerConfig -> proposerConfig.getBuilderGasLimitForPubKey(publicKey))
         .orElse(validatorConfig.getValidatorsRegistrationDefaultGasLimit());
   }
 

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/ProposerConfigTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/ProposerConfigTest.java
@@ -22,8 +22,8 @@ import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.eth1.Eth1Address;
+import tech.pegasys.teku.validator.client.ProposerConfig.Builder;
 import tech.pegasys.teku.validator.client.ProposerConfig.Config;
-import tech.pegasys.teku.validator.client.ProposerConfig.ValidatorRegistration;
 
 class ProposerConfigTest {
 
@@ -36,83 +36,72 @@ class ProposerConfigTest {
       Bytes48.fromHexString(
           "0x89ece308f9d1f0131765212deca99697b112d61f9be9a5f1f3780a51335b3ff981747a0b2ca2179b96d2c0c9024e5224");
 
-  private static final Config NO_VALIDATOR_REGISTRATION_CONFIG = new Config(ETH1_ADDRESS, null);
+  private static final Config NO_BUILDER_CONFIG = new Config(ETH1_ADDRESS, null);
 
   private static final UInt64 DEFAULT_GAS_LIMIT = UInt64.valueOf(30_000_000);
   private static final UInt64 CUSTOM_GAS_LIMIT = UInt64.valueOf(28_000_000);
 
   private static final Config DEFAULT_CONFIG =
-      new Config(ETH1_ADDRESS, new ValidatorRegistration(false, DEFAULT_GAS_LIMIT));
+      new Config(ETH1_ADDRESS, new Builder(false, DEFAULT_GAS_LIMIT));
 
   @Test
   void gets_isValidatorRegistrationEnabled_forPubKey() {
     Map<Bytes48, Config> configByPubKey = new HashMap<>();
-    configByPubKey.put(
-        PUB_KEY, new Config(ETH1_ADDRESS, new ValidatorRegistration(true, CUSTOM_GAS_LIMIT)));
+    configByPubKey.put(PUB_KEY, new Config(ETH1_ADDRESS, new Builder(true, CUSTOM_GAS_LIMIT)));
     ProposerConfig proposerConfig = new ProposerConfig(configByPubKey, DEFAULT_CONFIG);
 
-    assertThat(
-            proposerConfig.isValidatorRegistrationEnabledForPubKey(
-                BLSPublicKey.fromBytesCompressed(PUB_KEY)))
+    assertThat(proposerConfig.isBuilderEnabledForPubKey(BLSPublicKey.fromBytesCompressed(PUB_KEY)))
         .hasValue(true);
 
     // defaults to default config
     assertThat(
-            proposerConfig.isValidatorRegistrationEnabledForPubKey(
+            proposerConfig.isBuilderEnabledForPubKey(
                 BLSPublicKey.fromBytesCompressed(ANOTHER_PUB_KEY)))
         .hasValue(false);
   }
 
   @Test
   void registrationIsNotEnabledDoesNotExist_whenRegistrationIsNull() {
-    ProposerConfig proposerConfig =
-        new ProposerConfig(new HashMap<>(), NO_VALIDATOR_REGISTRATION_CONFIG);
+    ProposerConfig proposerConfig = new ProposerConfig(new HashMap<>(), NO_BUILDER_CONFIG);
 
-    assertThat(
-            proposerConfig.isValidatorRegistrationEnabledForPubKey(
-                BLSPublicKey.fromBytesCompressed(PUB_KEY)))
+    assertThat(proposerConfig.isBuilderEnabledForPubKey(BLSPublicKey.fromBytesCompressed(PUB_KEY)))
         .isEmpty();
   }
 
   @Test
   void gets_validatorRegistrationGasLimit_forPubKey() {
     Map<Bytes48, Config> configByPubKey = new HashMap<>();
-    configByPubKey.put(
-        PUB_KEY, new Config(ETH1_ADDRESS, new ValidatorRegistration(true, CUSTOM_GAS_LIMIT)));
+    configByPubKey.put(PUB_KEY, new Config(ETH1_ADDRESS, new Builder(true, CUSTOM_GAS_LIMIT)));
     ProposerConfig proposerConfig = new ProposerConfig(configByPubKey, DEFAULT_CONFIG);
 
     assertThat(
-            proposerConfig.getValidatorRegistrationGasLimitForPubKey(
-                BLSPublicKey.fromBytesCompressed(PUB_KEY)))
+            proposerConfig.getBuilderGasLimitForPubKey(BLSPublicKey.fromBytesCompressed(PUB_KEY)))
         .hasValue(CUSTOM_GAS_LIMIT);
 
     // defaults to default config
     assertThat(
-            proposerConfig.getValidatorRegistrationGasLimitForPubKey(
+            proposerConfig.getBuilderGasLimitForPubKey(
                 BLSPublicKey.fromBytesCompressed(ANOTHER_PUB_KEY)))
         .hasValue(DEFAULT_GAS_LIMIT);
   }
 
   @Test
   void registrationGasLimitDoesNotExist_whenRegistrationIsNull() {
-    ProposerConfig proposerConfig =
-        new ProposerConfig(new HashMap<>(), NO_VALIDATOR_REGISTRATION_CONFIG);
+    ProposerConfig proposerConfig = new ProposerConfig(new HashMap<>(), NO_BUILDER_CONFIG);
 
     assertThat(
-            proposerConfig.getValidatorRegistrationGasLimitForPubKey(
-                BLSPublicKey.fromBytesCompressed(PUB_KEY)))
+            proposerConfig.getBuilderGasLimitForPubKey(BLSPublicKey.fromBytesCompressed(PUB_KEY)))
         .isEmpty();
   }
 
   @Test
   void registrationGasLimitDoesNotExist_whenGasLimitIsNull() {
     Map<Bytes48, Config> configByPubKey = new HashMap<>();
-    configByPubKey.put(PUB_KEY, new Config(ETH1_ADDRESS, new ValidatorRegistration(true, null)));
+    configByPubKey.put(PUB_KEY, new Config(ETH1_ADDRESS, new Builder(true, null)));
     ProposerConfig proposerConfig = new ProposerConfig(configByPubKey, DEFAULT_CONFIG);
 
     assertThat(
-            proposerConfig.getValidatorRegistrationGasLimitForPubKey(
-                BLSPublicKey.fromBytesCompressed(PUB_KEY)))
+            proposerConfig.getBuilderGasLimitForPubKey(BLSPublicKey.fromBytesCompressed(PUB_KEY)))
         .isEmpty();
   }
 }

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/ProposerConfigTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/ProposerConfigTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.eth1.Eth1Address;
-import tech.pegasys.teku.validator.client.ProposerConfig.Builder;
+import tech.pegasys.teku.validator.client.ProposerConfig.BuilderConfig;
 import tech.pegasys.teku.validator.client.ProposerConfig.Config;
 
 class ProposerConfigTest {
@@ -42,12 +42,13 @@ class ProposerConfigTest {
   private static final UInt64 CUSTOM_GAS_LIMIT = UInt64.valueOf(28_000_000);
 
   private static final Config DEFAULT_CONFIG =
-      new Config(ETH1_ADDRESS, new Builder(false, DEFAULT_GAS_LIMIT));
+      new Config(ETH1_ADDRESS, new BuilderConfig(false, DEFAULT_GAS_LIMIT));
 
   @Test
   void gets_isValidatorRegistrationEnabled_forPubKey() {
     Map<Bytes48, Config> configByPubKey = new HashMap<>();
-    configByPubKey.put(PUB_KEY, new Config(ETH1_ADDRESS, new Builder(true, CUSTOM_GAS_LIMIT)));
+    configByPubKey.put(
+        PUB_KEY, new Config(ETH1_ADDRESS, new BuilderConfig(true, CUSTOM_GAS_LIMIT)));
     ProposerConfig proposerConfig = new ProposerConfig(configByPubKey, DEFAULT_CONFIG);
 
     assertThat(proposerConfig.isBuilderEnabledForPubKey(BLSPublicKey.fromBytesCompressed(PUB_KEY)))
@@ -71,7 +72,8 @@ class ProposerConfigTest {
   @Test
   void gets_validatorRegistrationGasLimit_forPubKey() {
     Map<Bytes48, Config> configByPubKey = new HashMap<>();
-    configByPubKey.put(PUB_KEY, new Config(ETH1_ADDRESS, new Builder(true, CUSTOM_GAS_LIMIT)));
+    configByPubKey.put(
+        PUB_KEY, new Config(ETH1_ADDRESS, new BuilderConfig(true, CUSTOM_GAS_LIMIT)));
     ProposerConfig proposerConfig = new ProposerConfig(configByPubKey, DEFAULT_CONFIG);
 
     assertThat(
@@ -97,7 +99,7 @@ class ProposerConfigTest {
   @Test
   void registrationGasLimitDoesNotExist_whenGasLimitIsNull() {
     Map<Bytes48, Config> configByPubKey = new HashMap<>();
-    configByPubKey.put(PUB_KEY, new Config(ETH1_ADDRESS, new Builder(true, null)));
+    configByPubKey.put(PUB_KEY, new Config(ETH1_ADDRESS, new BuilderConfig(true, null)));
     ProposerConfig proposerConfig = new ProposerConfig(configByPubKey, DEFAULT_CONFIG);
 
     assertThat(

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorRegistratorTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorRegistratorTest.java
@@ -98,10 +98,8 @@ class ValidatorRegistratorTest {
     when(proposerConfigProvider.getProposerConfig())
         .thenReturn(SafeFuture.completedFuture(Optional.of(proposerConfig)));
 
-    when(proposerConfig.isValidatorRegistrationEnabledForPubKey(any()))
-        .thenReturn(Optional.of(true));
-    when(proposerConfig.getValidatorRegistrationGasLimitForPubKey(any()))
-        .thenReturn(Optional.of(gasLimit));
+    when(proposerConfig.isBuilderEnabledForPubKey(any())).thenReturn(Optional.of(true));
+    when(proposerConfig.getBuilderGasLimitForPubKey(any())).thenReturn(Optional.of(gasLimit));
 
     when(feeRecipientProvider.isReadyToProvideFeeRecipient()).thenReturn(true);
     when(feeRecipientProvider.getFeeRecipient(any())).thenReturn(Optional.of(eth1Address));
@@ -201,7 +199,7 @@ class ValidatorRegistratorTest {
         .thenReturn(Optional.of(otherEth1Address));
 
     // gas limit changed for validator3
-    when(proposerConfig.getValidatorRegistrationGasLimitForPubKey(validator3.getPublicKey()))
+    when(proposerConfig.getBuilderGasLimitForPubKey(validator3.getPublicKey()))
         .thenReturn(Optional.of(otherGasLimit));
 
     runRegistrationFlowForSlot(UInt64.valueOf(slotsPerEpoch));
@@ -276,11 +274,11 @@ class ValidatorRegistratorTest {
     setActiveValidators(validator1, validator2, validator3);
 
     // validator registration is disabled for validator2
-    when(proposerConfig.isValidatorRegistrationEnabledForPubKey(validator2.getPublicKey()))
+    when(proposerConfig.isBuilderEnabledForPubKey(validator2.getPublicKey()))
         .thenReturn(Optional.of(false));
     // validator registration enabled flag is not present for validator 3, so will fall back to
     // false
-    when(proposerConfig.isValidatorRegistrationEnabledForPubKey(validator3.getPublicKey()))
+    when(proposerConfig.isBuilderEnabledForPubKey(validator3.getPublicKey()))
         .thenReturn(Optional.empty());
     when(validatorConfig.isValidatorsRegistrationDefaultEnabled()).thenReturn(false);
 
@@ -298,10 +296,10 @@ class ValidatorRegistratorTest {
     final UInt64 defaultGasLimit = UInt64.valueOf(27_000_000);
 
     // validator2 will have custom gas limit
-    when(proposerConfig.getValidatorRegistrationGasLimitForPubKey(validator2.getPublicKey()))
+    when(proposerConfig.getBuilderGasLimitForPubKey(validator2.getPublicKey()))
         .thenReturn(Optional.of(validator2GasLimit));
     // validator3 gas limit will fall back to a default
-    when(proposerConfig.getValidatorRegistrationGasLimitForPubKey(validator3.getPublicKey()))
+    when(proposerConfig.getBuilderGasLimitForPubKey(validator3.getPublicKey()))
         .thenReturn(Optional.empty());
     when(validatorConfig.getValidatorsRegistrationDefaultGasLimit()).thenReturn(defaultGasLimit);
 

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorRegistratorTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorRegistratorTest.java
@@ -154,7 +154,7 @@ class ValidatorRegistratorTest {
 
   @TestTemplate
   void registersValidators_shouldRegisterWithTimestampOverride() {
-    when(validatorConfig.getValidatorsRegistrationTimestampOverride())
+    when(validatorConfig.getBuilderRegistrationTimestampOverride())
         .thenReturn(Optional.of(UInt64.valueOf(140)));
     setActiveValidators(validator1);
 
@@ -280,7 +280,7 @@ class ValidatorRegistratorTest {
     // false
     when(proposerConfig.isBuilderEnabledForPubKey(validator3.getPublicKey()))
         .thenReturn(Optional.empty());
-    when(validatorConfig.isValidatorsRegistrationDefaultEnabled()).thenReturn(false);
+    when(validatorConfig.isBuilderRegistrationDefaultEnabled()).thenReturn(false);
 
     runRegistrationFlowForSlot(UInt64.ZERO);
 
@@ -301,7 +301,7 @@ class ValidatorRegistratorTest {
     // validator3 gas limit will fall back to a default
     when(proposerConfig.getBuilderGasLimitForPubKey(validator3.getPublicKey()))
         .thenReturn(Optional.empty());
-    when(validatorConfig.getValidatorsRegistrationDefaultGasLimit()).thenReturn(defaultGasLimit);
+    when(validatorConfig.getBuilderRegistrationDefaultGasLimit()).thenReturn(defaultGasLimit);
 
     runRegistrationFlowForSlot(UInt64.ZERO);
 
@@ -378,7 +378,7 @@ class ValidatorRegistratorTest {
 
     final UInt64 expectedTimestamp =
         validatorConfig
-            .getValidatorsRegistrationTimestampOverride()
+            .getBuilderRegistrationTimestampOverride()
             .orElse(stubTimeProvider.getTimeInSeconds());
 
     assertThat(validatorRegistrations)

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/proposerconfig/loader/ProposerConfigLoaderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/proposerconfig/loader/ProposerConfigLoaderTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.eth1.Eth1Address;
 import tech.pegasys.teku.validator.client.ProposerConfig;
+import tech.pegasys.teku.validator.client.ProposerConfig.BuilderConfig;
 import tech.pegasys.teku.validator.client.ProposerConfig.Config;
 
 public class ProposerConfigLoaderTest {
@@ -145,7 +146,7 @@ public class ProposerConfigLoaderTest {
         .isEqualTo(Eth1Address.fromHexString("0x50155530FCE8a85ec7055A5F8b2bE214B3DaeFd3"));
 
     assertThat(theConfig.get().getBuilder()).isPresent();
-    ProposerConfig.Builder builder = theConfig.get().getBuilder().get();
+    BuilderConfig builder = theConfig.get().getBuilder().get();
     assertThat(builder.isEnabled()).isTrue();
     assertThat(builder.getGasLimit().orElseThrow()).isEqualTo(UInt64.valueOf(12345654321L));
 

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/proposerconfig/loader/ProposerConfigLoaderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/proposerconfig/loader/ProposerConfigLoaderTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.eth1.Eth1Address;
 import tech.pegasys.teku.validator.client.ProposerConfig;
+import tech.pegasys.teku.validator.client.ProposerConfig.Builder;
 import tech.pegasys.teku.validator.client.ProposerConfig.Config;
 
 public class ProposerConfigLoaderTest {
@@ -44,14 +45,14 @@ public class ProposerConfigLoaderTest {
 
   @Test
   void shouldLoadConfigWithOnlyDefaultValidatorRegistrationEnabled() {
-    final URL resource = Resources.getResource("proposerConfigWithRegistrationValid1.json");
+    final URL resource = Resources.getResource("proposerConfigWithBuilderValid1.json");
 
     validateContentWithValidatorRegistration1(loader.getProposerConfig(resource));
   }
 
   @Test
   void shouldLoadConfigWithDefaultValidatorRegistrationDisabled() {
-    final URL resource = Resources.getResource("proposerConfigWithRegistrationValid2.json");
+    final URL resource = Resources.getResource("proposerConfigWithBuilderValid2.json");
 
     validateContentWithValidatorRegistration2(loader.getProposerConfig(resource));
   }
@@ -86,7 +87,7 @@ public class ProposerConfigLoaderTest {
 
   @Test
   void shouldNotLoadMissingEnabledInRegistration() {
-    final URL resource = Resources.getResource("proposerConfigWithRegistrationInvalid1.json");
+    final URL resource = Resources.getResource("proposerConfigWithBuilderInvalid1.json");
 
     assertThatThrownBy(() -> loader.getProposerConfig(resource));
   }
@@ -132,8 +133,8 @@ public class ProposerConfigLoaderTest {
     assertThat(defaultConfig.getFeeRecipient())
         .isEqualTo(Eth1Address.fromHexString("0x6e35733c5af9B61374A128e6F85f553aF09ff89A"));
 
-    assertThat(defaultConfig.getValidatorRegistration()).isPresent();
-    assertThat(defaultConfig.getValidatorRegistration().get().isEnabled()).isTrue();
+    assertThat(defaultConfig.getBuilder()).isPresent();
+    assertThat(defaultConfig.getBuilder().get().isEnabled()).isTrue();
   }
 
   private void validateContentWithValidatorRegistration2(ProposerConfig config) {
@@ -144,9 +145,8 @@ public class ProposerConfigLoaderTest {
     assertThat(theConfig.get().getFeeRecipient())
         .isEqualTo(Eth1Address.fromHexString("0x50155530FCE8a85ec7055A5F8b2bE214B3DaeFd3"));
 
-    assertThat(theConfig.get().getValidatorRegistration()).isPresent();
-    ProposerConfig.ValidatorRegistration validatorRegistration =
-        theConfig.get().getValidatorRegistration().get();
+    assertThat(theConfig.get().getBuilder()).isPresent();
+    Builder validatorRegistration = theConfig.get().getBuilder().get();
     assertThat(validatorRegistration.isEnabled()).isTrue();
     assertThat(validatorRegistration.getGasLimit().orElseThrow())
         .isEqualTo(UInt64.valueOf(12345654321L));
@@ -155,8 +155,8 @@ public class ProposerConfigLoaderTest {
     assertThat(defaultConfig.getFeeRecipient())
         .isEqualTo(Eth1Address.fromHexString("0x6e35733c5af9B61374A128e6F85f553aF09ff89A"));
 
-    assertThat(defaultConfig.getValidatorRegistration()).isPresent();
-    assertThat(defaultConfig.getValidatorRegistration().get().isEnabled()).isFalse();
-    assertThat(defaultConfig.getValidatorRegistration().get().getGasLimit()).isEmpty();
+    assertThat(defaultConfig.getBuilder()).isPresent();
+    assertThat(defaultConfig.getBuilder().get().isEnabled()).isFalse();
+    assertThat(defaultConfig.getBuilder().get().getGasLimit()).isEmpty();
   }
 }

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/proposerconfig/loader/ProposerConfigLoaderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/proposerconfig/loader/ProposerConfigLoaderTest.java
@@ -44,6 +44,13 @@ public class ProposerConfigLoaderTest {
   }
 
   @Test
+  void shouldLoadNullFeeRecipient() {
+    final URL resource = Resources.getResource("proposerConfigValid3.json");
+
+    validateContent3(loader.getProposerConfig(resource));
+  }
+
+  @Test
   void shouldLoadConfigWithOnlyDefaultValidatorRegistrationEnabled() {
     final URL resource = Resources.getResource("proposerConfigWithBuilderValid1.json");
 
@@ -65,7 +72,7 @@ public class ProposerConfigLoaderTest {
   }
 
   @Test
-  void shouldNotLoadNullFeeRecipient() {
+  void shouldNodLoadNullFeeRecipientInDefaultConfig() {
     final URL resource = Resources.getResource("proposerConfigInvalid2.json");
 
     assertThatThrownBy(() -> loader.getProposerConfig(resource));
@@ -105,11 +112,13 @@ public class ProposerConfigLoaderTest {
             "0xa057816155ad77931185101128655c0191bd0214c201ca48ed887f6c4c6adf334070efcd75140eada5ac83a92506dd7a");
     assertThat(theConfig).isPresent();
     assertThat(theConfig.get().getFeeRecipient())
-        .isEqualTo(Eth1Address.fromHexString("0x50155530FCE8a85ec7055A5F8b2bE214B3DaeFd3"));
+        .isEqualTo(
+            Optional.of(Eth1Address.fromHexString("0x50155530FCE8a85ec7055A5F8b2bE214B3DaeFd3")));
 
     Config defaultConfig = config.getDefaultConfig();
     assertThat(defaultConfig.getFeeRecipient())
-        .isEqualTo(Eth1Address.fromHexString("0x6e35733c5af9B61374A128e6F85f553aF09ff89A"));
+        .isEqualTo(
+            Optional.of(Eth1Address.fromHexString("0x6e35733c5af9B61374A128e6F85f553aF09ff89A")));
   }
 
   private void validateContent2(ProposerConfig config) {
@@ -120,7 +129,21 @@ public class ProposerConfigLoaderTest {
 
     Config defaultConfig = config.getDefaultConfig();
     assertThat(defaultConfig.getFeeRecipient())
-        .isEqualTo(Eth1Address.fromHexString("0x6e35733c5af9B61374A128e6F85f553aF09ff89A"));
+        .isEqualTo(
+            Optional.of(Eth1Address.fromHexString("0x6e35733c5af9B61374A128e6F85f553aF09ff89A")));
+  }
+
+  private void validateContent3(ProposerConfig config) {
+    Optional<Config> theConfig =
+        config.getConfigForPubKey(
+            "0xa057816155ad77931185101128655c0191bd0214c201ca48ed887f6c4c6adf334070efcd75140eada5ac83a92506dd7a");
+    assertThat(theConfig).isPresent();
+    assertThat(theConfig.get().getFeeRecipient()).isEmpty();
+
+    Config defaultConfig = config.getDefaultConfig();
+    assertThat(defaultConfig.getFeeRecipient())
+        .isEqualTo(
+            Optional.of(Eth1Address.fromHexString("0x6e35733c5af9B61374A128e6F85f553aF09ff89A")));
   }
 
   private void validateContentWithValidatorRegistration1(ProposerConfig config) {
@@ -131,7 +154,8 @@ public class ProposerConfigLoaderTest {
 
     Config defaultConfig = config.getDefaultConfig();
     assertThat(defaultConfig.getFeeRecipient())
-        .isEqualTo(Eth1Address.fromHexString("0x6e35733c5af9B61374A128e6F85f553aF09ff89A"));
+        .isEqualTo(
+            Optional.of(Eth1Address.fromHexString("0x6e35733c5af9B61374A128e6F85f553aF09ff89A")));
 
     assertThat(defaultConfig.getBuilder()).isPresent();
     assertThat(defaultConfig.getBuilder().get().isEnabled()).isTrue();
@@ -143,7 +167,8 @@ public class ProposerConfigLoaderTest {
             "0xa057816155ad77931185101128655c0191bd0214c201ca48ed887f6c4c6adf334070efcd75140eada5ac83a92506dd7a");
     assertThat(theConfig).isPresent();
     assertThat(theConfig.get().getFeeRecipient())
-        .isEqualTo(Eth1Address.fromHexString("0x50155530FCE8a85ec7055A5F8b2bE214B3DaeFd3"));
+        .isEqualTo(
+            Optional.of(Eth1Address.fromHexString("0x50155530FCE8a85ec7055A5F8b2bE214B3DaeFd3")));
 
     assertThat(theConfig.get().getBuilder()).isPresent();
     BuilderConfig builder = theConfig.get().getBuilder().get();
@@ -152,7 +177,8 @@ public class ProposerConfigLoaderTest {
 
     Config defaultConfig = config.getDefaultConfig();
     assertThat(defaultConfig.getFeeRecipient())
-        .isEqualTo(Eth1Address.fromHexString("0x6e35733c5af9B61374A128e6F85f553aF09ff89A"));
+        .isEqualTo(
+            Optional.of(Eth1Address.fromHexString("0x6e35733c5af9B61374A128e6F85f553aF09ff89A")));
 
     assertThat(defaultConfig.getBuilder()).isPresent();
     assertThat(defaultConfig.getBuilder().get().isEnabled()).isFalse();

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/proposerconfig/loader/ProposerConfigLoaderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/proposerconfig/loader/ProposerConfigLoaderTest.java
@@ -23,7 +23,6 @@ import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.eth1.Eth1Address;
 import tech.pegasys.teku.validator.client.ProposerConfig;
-import tech.pegasys.teku.validator.client.ProposerConfig.Builder;
 import tech.pegasys.teku.validator.client.ProposerConfig.Config;
 
 public class ProposerConfigLoaderTest {
@@ -146,10 +145,9 @@ public class ProposerConfigLoaderTest {
         .isEqualTo(Eth1Address.fromHexString("0x50155530FCE8a85ec7055A5F8b2bE214B3DaeFd3"));
 
     assertThat(theConfig.get().getBuilder()).isPresent();
-    Builder validatorRegistration = theConfig.get().getBuilder().get();
-    assertThat(validatorRegistration.isEnabled()).isTrue();
-    assertThat(validatorRegistration.getGasLimit().orElseThrow())
-        .isEqualTo(UInt64.valueOf(12345654321L));
+    ProposerConfig.Builder builder = theConfig.get().getBuilder().get();
+    assertThat(builder.isEnabled()).isTrue();
+    assertThat(builder.getGasLimit().orElseThrow()).isEqualTo(UInt64.valueOf(12345654321L));
 
     Config defaultConfig = config.getDefaultConfig();
     assertThat(defaultConfig.getFeeRecipient())

--- a/validator/client/src/test/resources/proposerConfigValid3.json
+++ b/validator/client/src/test/resources/proposerConfigValid3.json
@@ -1,10 +1,9 @@
 {
   "proposer_config": {
     "0xa057816155ad77931185101128655c0191bd0214c201ca48ed887f6c4c6adf334070efcd75140eada5ac83a92506dd7a": {
-      "fee_recipient": null
     }
   },
   "default_config": {
-    "fee_recipient": null
+    "fee_recipient": "0x6e35733c5af9B61374A128e6F85f553aF09ff89A"
   }
 }

--- a/validator/client/src/test/resources/proposerConfigWithBuilderInvalid1.json
+++ b/validator/client/src/test/resources/proposerConfigWithBuilderInvalid1.json
@@ -2,16 +2,12 @@
   "proposer_config": {
     "0xa057816155ad77931185101128655c0191bd0214c201ca48ed887f6c4c6adf334070efcd75140eada5ac83a92506dd7a": {
       "fee_recipient": "0x50155530FCE8a85ec7055A5F8b2bE214B3DaeFd3",
-      "builder_registration": {
-        "enabled": true,
+      "builder": {
         "gas_limit": "12345654321"
       }
     }
   },
   "default_config": {
-    "fee_recipient": "0x6e35733c5af9B61374A128e6F85f553aF09ff89A",
-    "builder_registration": {
-      "enabled": false
-    }
+    "fee_recipient": "0x6e35733c5af9B61374A128e6F85f553aF09ff89A"
   }
 }

--- a/validator/client/src/test/resources/proposerConfigWithBuilderValid1.json
+++ b/validator/client/src/test/resources/proposerConfigWithBuilderValid1.json
@@ -1,7 +1,7 @@
 {
   "default_config": {
     "fee_recipient": "0x6e35733c5af9B61374A128e6F85f553aF09ff89A",
-    "validator_registration": {
+    "builder": {
       "enabled": true
     }
   }

--- a/validator/client/src/test/resources/proposerConfigWithBuilderValid2.json
+++ b/validator/client/src/test/resources/proposerConfigWithBuilderValid2.json
@@ -2,12 +2,16 @@
   "proposer_config": {
     "0xa057816155ad77931185101128655c0191bd0214c201ca48ed887f6c4c6adf334070efcd75140eada5ac83a92506dd7a": {
       "fee_recipient": "0x50155530FCE8a85ec7055A5F8b2bE214B3DaeFd3",
-      "validator_registration": {
+      "builder": {
+        "enabled": true,
         "gas_limit": "12345654321"
       }
     }
   },
   "default_config": {
-    "fee_recipient": "0x6e35733c5af9B61374A128e6F85f553aF09ff89A"
+    "fee_recipient": "0x6e35733c5af9B61374A128e6F85f553aF09ff89A",
+    "builder": {
+      "enabled": false
+    }
   }
 }

--- a/validator/client/src/test/resources/proposerConfigWithRegistrationValid2.json
+++ b/validator/client/src/test/resources/proposerConfigWithRegistrationValid2.json
@@ -2,7 +2,7 @@
   "proposer_config": {
     "0xa057816155ad77931185101128655c0191bd0214c201ca48ed887f6c4c6adf334070efcd75140eada5ac83a92506dd7a": {
       "fee_recipient": "0x50155530FCE8a85ec7055A5F8b2bE214B3DaeFd3",
-      "validator_registration": {
+      "builder_registration": {
         "enabled": true,
         "gas_limit": "12345654321"
       }
@@ -10,7 +10,7 @@
   },
   "default_config": {
     "fee_recipient": "0x6e35733c5af9B61374A128e6F85f553aF09ff89A",
-    "validator_registration": {
+    "builder_registration": {
       "enabled": false
     }
   }


### PR DESCRIPTION
CLI argument changes changes:

`--eb-endpoint` -> `--builder-endpoint`

`--Xvalidators-registration-default-enabled` -> `--validators-builder-registration-default-enabled`
`--Xvalidators-registration-timestamp-override` -> `--validators-builder-registration-timestamp-override`
`--Xvalidators-proposer-blinded-blocks-enabled` -> `--validators-proposer-blinded-blocks-enabled`

`--Xvalidators-registration-default-gas-limit` -> `--Xvalidators-builder-registration-default-gas-limit`
`--Xvalidators-registration-sending-batch-size` -> `--Xvalidators-builder-registration-sending-batch-size`

Relaxed proposerConfig json rule to allow per pubkey configuration to have empty\null `fee_recipient`.
`default_config` still requires it.

Extended `proposer-config` json referenced by the existing `--validators-proposer-config`

A draft note covering the usage of the changes: https://hackmd.io/@StefanBratanov/BkMlo1RO9 

closes #5396

### Documentation content

#### Intro
When [The Merge](https://docs.teku.consensys.net/en/latest/Concepts/Merge/) completes, Consensus Clients will be responsible for proposing blocks containing an Execution Payload (the Ethereum PoW Block in the context of PoS) obtained from their local Execution Clients via the `Engine API`.
Optionally, instead of building it locally, a Consensus Clients can configure an external “builder” to delegate the Execution Payload construction to.
This new interface is called `Builder API` and has been introduced to standardize the interaction with MEV providers, in the effort of making it easily accessible and  interchangeable.

Teku supports this interface and allows to configure the Beacon Node to a single `builder endpoint` that will be trusted for generating Execution Payload. In case of failures or non timely responses, Teku will use the payload produced by the local Execution Client (the one specified with `ee-endpoint`)

The most common deployment is to run an specialised software (i.e. [mev-boost](https://github.com/flashbots/mev-boost)) and configure it as the `builder endpoint`. This software will be responsible for requesting a payload proposal from several entities (called relays) and selecting the best bid.

__Important Note__
In deployment where Validator Client runs in a separate process and communicate with a Beacon Node via rest API, make sure that the Beacon Node supports the blinded block API.

#### new CLI args

`--builder-endpoint`
Optionally specify the Builder API to delegate the execution payload construction to. 
example(`--builder-endpoint=http://127.0.0.1:18550/`)


`--validators-builder-registration-default-enabled`
When enabled, all validators managed by the validator client will be configured to register to builder endpoint and will use it when proposing a block.

`--validators-builder-registration-timestamp-override`
This parameter allows to specify a timestamp that will be used when registering validators against the builder endpoint. It is only useful in deployments where validator keys are shared between multiple nodes (Obol, SSV or similar)

`--validators-proposer-blinded-blocks-enabled`
This enables blinded blocks flow, a prerequisite for the usage of the builder endpoint. When `--validators-builder-registration-default-enabled` is enabled this option will be enabled automatically. It requires explicit enablement when used in conjunction with `--validators-proposer-config`.


#### CLI args changes
`—validators-proposer-config` 
The specified config file now supports a new `builder` attribute that can be specified in the `default_config` as well as for each public keys.

in `builder`
- `enabled` indicates if the applicable validator key should register to and use the builder endpoint when proposing blocks.
- `gas_limit` is an optional parameter that allows to specify the preferred `gas_limit` that the builder should respect. When not specified the default value `30000000` will be used.

`fee_recipient` attribute becomes optional in a public key config, but remains mandatory in the `default_config`

```jsonc
{
  "proposer_config": {
    "0xa057816155ad77931185101128655c0191bd0214c201ca48ed887f6c4c6adf334070efcd75140eada5ac83a92506dd7a": {
      "fee_recipient": "0x50155530FCE8a85ec7055A5F8b2bE214B3DaeFd3", //optional
      "builder": { //optional
        "enabled": true, //mandatory
        "gas_limit": "12345654321" //optional
      }
    }
  },
  "default_config": {
    "fee_recipient": "0x6e35733c5af9B61374A128e6F85f553aF09ff89A", //mandatory
    "builder": { //optional
      "enabled": false, //mandatory
       "gas_limit": "12345654321" //optional
    }
  }
}
```

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
