### PR TITLE
Resend `ForkChoiceUpdated` if not changing for 30 seconds

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierImpl.java
@@ -20,6 +20,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.eventthread.EventThread;
 import tech.pegasys.teku.infrastructure.subscribers.Subscribers;
+import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.config.SpecConfig;
@@ -39,6 +40,7 @@ public class ForkChoiceNotifierImpl implements ForkChoiceNotifier, ProposersData
   private final RecentChainData recentChainData;
   private final ProposersDataManager proposersDataManager;
   private final Spec spec;
+  private final TimeProvider timeProvider;
 
   private final Subscribers<ForkChoiceUpdatedResultSubscriber> subscribers =
       Subscribers.create(true);
@@ -49,6 +51,7 @@ public class ForkChoiceNotifierImpl implements ForkChoiceNotifier, ProposersData
 
   public ForkChoiceNotifierImpl(
       final EventThread eventThread,
+      final TimeProvider timeProvider,
       final Spec spec,
       final ExecutionLayerChannel executionLayerChannel,
       final RecentChainData recentChainData,
@@ -58,6 +61,7 @@ public class ForkChoiceNotifierImpl implements ForkChoiceNotifier, ProposersData
     this.executionLayerChannel = executionLayerChannel;
     this.recentChainData = recentChainData;
     this.proposersDataManager = proposersDataManager;
+    this.timeProvider = timeProvider;
     proposersDataManager.subscribeToProposersDataChanges(this);
   }
 
@@ -218,8 +222,7 @@ public class ForkChoiceNotifierImpl implements ForkChoiceNotifier, ProposersData
 
   private void sendForkChoiceUpdated() {
     final SafeFuture<Optional<ForkChoiceUpdatedResult>> forkChoiceUpdatedResult =
-        forkChoiceUpdateData.send(executionLayerChannel);
-
+        forkChoiceUpdateData.send(executionLayerChannel, timeProvider.getTimeInMillis());
     subscribers.deliver(
         ForkChoiceUpdatedResultSubscriber::onForkChoiceUpdatedResult,
         new ForkChoiceUpdatedResultNotification(

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -985,7 +985,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
     eventChannels.subscribe(SlotEventsChannel.class, proposersDataManager);
     forkChoiceNotifier =
         new ForkChoiceNotifierImpl(
-            eventThread, spec, executionLayer, recentChainData, proposersDataManager);
+            eventThread, timeProvider, spec, executionLayer, recentChainData, proposersDataManager);
   }
 
   private Optional<Eth1Address> getProposerDefaultFeeRecipient() {


### PR DESCRIPTION
As per my analysis we are calling `ForkChoiceNotifier::onForkChoiceUpdated` at least on every slot via 
`tech.pegasys.teku.statetransition.forkchoice.ForkChoiceTrigger#onAttestationsDueForSlot` -> `processHead` ->  `notifyForkChoiceUpdatedAndOptimisticSyncingChanged`.

That given, to periodically resend `fcu` it's just matter of relaxing the "already sent"  condition `ForkChoiceUpdateData` and make it time dependant.

for the records, this covers also the situation in which were marking `ForkChoiceUpdateData` as `sent` even if the actual call was throwing (timeout or other networking issues). With this change we will resend it no matter what.

## Fixed Issue(s)
fixes #5370

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
