### PR TITLE
[MEV Boost\Builder] Handle no header available builder response

### DIFF
--- a/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/rest/RestExecutionBuilderClientTest.java
+++ b/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/rest/RestExecutionBuilderClientTest.java
@@ -224,8 +224,25 @@ class RestExecutionBuilderClientTest {
         .satisfies(
             response -> {
               assertThat(response.isSuccess()).isTrue();
-              SignedBuilderBid responsePayload = response.getPayload();
-              verifySignedBuilderBidResponse(responsePayload);
+              assertThat(response.getPayload())
+                  .isPresent()
+                  .hasValueSatisfying(this::verifySignedBuilderBidResponse);
+            });
+
+    verifyGetRequest("/eth/v1/builder/header/1/" + PARENT_HASH + "/" + PUB_KEY);
+  }
+
+  @TestTemplate
+  void getExecutionPayloadHeader_noHeaderAvailable() {
+
+    mockWebServer.enqueue(new MockResponse().setResponseCode(204));
+
+    assertThat(restExecutionBuilderClient.getHeader(SLOT, PUB_KEY, PARENT_HASH))
+        .succeedsWithin(WAIT_FOR_CALL_COMPLETION)
+        .satisfies(
+            response -> {
+              assertThat(response.isSuccess()).isTrue();
+              assertThat(response.getPayload()).isEmpty();
             });
 
     verifyGetRequest("/eth/v1/builder/header/1/" + PARENT_HASH + "/" + PUB_KEY);

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ExecutionBuilderClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ExecutionBuilderClient.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.ethereum.executionclient;
 
+import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.ethereum.executionclient.schema.Response;
@@ -31,7 +32,7 @@ public interface ExecutionBuilderClient {
   SafeFuture<Response<Void>> registerValidators(
       UInt64 slot, SszList<SignedValidatorRegistration> signedValidatorRegistrations);
 
-  SafeFuture<Response<SignedBuilderBid>> getHeader(
+  SafeFuture<Response<Optional<SignedBuilderBid>>> getHeader(
       UInt64 slot, BLSPublicKey pubKey, Bytes32 parentHash);
 
   SafeFuture<Response<ExecutionPayload>> getPayload(SignedBeaconBlock signedBlindedBeaconBlock);

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ThrottlingExecutionBuilderClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ThrottlingExecutionBuilderClient.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.ethereum.executionclient;
 
+import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.bls.BLSPublicKey;
@@ -57,7 +58,7 @@ public class ThrottlingExecutionBuilderClient implements ExecutionBuilderClient 
   }
 
   @Override
-  public SafeFuture<Response<SignedBuilderBid>> getHeader(
+  public SafeFuture<Response<Optional<SignedBuilderBid>>> getHeader(
       final UInt64 slot, final BLSPublicKey pubKey, final Bytes32 parentHash) {
     return taskQueue.queueTask(() -> delegate.getHeader(slot, pubKey, parentHash));
   }

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/metrics/MetricRecordingExecutionBuilderClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/metrics/MetricRecordingExecutionBuilderClient.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.ethereum.executionclient.metrics;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.bls.BLSPublicKey;
@@ -73,7 +74,7 @@ public class MetricRecordingExecutionBuilderClient extends MetricRecordingAbstra
   }
 
   @Override
-  public SafeFuture<Response<SignedBuilderBid>> getHeader(
+  public SafeFuture<Response<Optional<SignedBuilderBid>>> getHeader(
       final UInt64 slot, final BLSPublicKey pubKey, final Bytes32 parentHash) {
     return countRequest(() -> delegate.getHeader(slot, pubKey, parentHash), GET_HEADER_METHOD);
   }

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/OkHttpRestClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/OkHttpRestClient.java
@@ -17,7 +17,6 @@ import static java.util.Collections.emptyMap;
 import static java.util.Objects.requireNonNull;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.google.common.base.Strings;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Optional;
@@ -165,7 +164,7 @@ public class OkHttpRestClient implements RestClient {
               return;
             }
             try (final ResponseBody responseBody = response.body()) {
-              if (responseBody == null || responseTypeDefinitionMaybe.isEmpty()) {
+              if (bodyIsEmpty(responseBody) || responseTypeDefinitionMaybe.isEmpty()) {
                 futureResponse.complete(Response.withNullPayload());
                 return;
               }
@@ -194,16 +193,14 @@ public class OkHttpRestClient implements RestClient {
   private String getErrorMessageForFailedResponse(final okhttp3.Response response)
       throws IOException {
     try (final ResponseBody responseBody = response.body()) {
-      final String errorCodeAndStatusMessage = response.code() + ": " + response.message();
-      if (responseBody == null) {
-        return errorCodeAndStatusMessage;
+      if (bodyIsEmpty(responseBody)) {
+        return response.code() + ": " + response.message();
       }
-      final String failureBody = responseBody.string();
-      if (Strings.nullToEmpty(failureBody).isBlank()) {
-        return errorCodeAndStatusMessage;
-      } else {
-        return failureBody;
-      }
+      return responseBody.string();
     }
+  }
+
+  private boolean bodyIsEmpty(final ResponseBody responseBody) {
+    return responseBody == null || responseBody.contentLength() == 0;
   }
 }

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/Response.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/Response.java
@@ -15,6 +15,8 @@ package tech.pegasys.teku.ethereum.executionclient.schema;
 
 import com.google.common.base.MoreObjects;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
 
 public class Response<T> {
 
@@ -37,6 +39,27 @@ public class Response<T> {
 
   public static <T> Response<T> withErrorMessage(final String errorMessage) {
     return new Response<>(null, errorMessage);
+  }
+
+  public static <T, R> Response<R> unwrap(
+      final Response<T> response, final Function<T, R> unwrapFunction) {
+    if (response.isFailure()) {
+      return Response.withErrorMessage(response.getErrorMessage());
+    }
+    final T payload = response.getPayload();
+    return payload == null
+        ? Response.withNullPayload()
+        : new Response<>(unwrapFunction.apply(payload));
+  }
+
+  public static <T> Response<Optional<T>> convertToOptional(final Response<T> response) {
+    if (response.isFailure()) {
+      return Response.withErrorMessage(response.getErrorMessage());
+    }
+    final T payload = response.getPayload();
+    return payload == null
+        ? new Response<>(Optional.empty())
+        : new Response<>(Optional.of(payload));
   }
 
   public T getPayload() {

--- a/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/metrics/MetricRecordingAbstractClientTest.java
+++ b/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/metrics/MetricRecordingAbstractClientTest.java
@@ -42,7 +42,7 @@ public class MetricRecordingAbstractClientTest {
 
   @Test
   public void shouldCountSuccessfulRequest() {
-    final Response<String> response = new Response<>("value", null);
+    final Response<String> response = new Response<>("value");
     setupResponse(SafeFuture.completedFuture(response));
     final SafeFuture<Response<String>> result = clientTest.testMethod("test");
 

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
@@ -479,6 +479,18 @@ public class SafeFuture<T> extends CompletableFuture<T> {
     return (SafeFuture<U>) super.thenComposeAsync(fn, executor);
   }
 
+  public <U> SafeFuture<U> thenComposeChecked(
+      final ExceptionThrowingFunction<? super T, ? extends CompletionStage<U>> function) {
+    return thenCompose(
+        value -> {
+          try {
+            return function.apply(value);
+          } catch (final Throwable ex) {
+            return SafeFuture.failedFuture(ex);
+          }
+        });
+  }
+
   @SuppressWarnings("unchecked")
   @Override
   public <U, V> SafeFuture<V> thenCombineAsync(


### PR DESCRIPTION
## PR Description

- Change the builder client to return `Optional<SignedBuilderBid>`
- Added helper functions to `Response` class
- Introduced new fallback reason in `ExecutionLayerManagerImpl` and implemented the logic for falling back to local execution engine in case the header from the builder is not available.

## Fixed Issue(s)
fixes #5873 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
