### PR TITLE
Change `prepareBeaconProposer` return type to be a future instead of void

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -619,10 +619,12 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
   }
 
   @Override
-  public void prepareBeaconProposer(
+  public SafeFuture<Void> prepareBeaconProposer(
       final Collection<BeaconPreparableProposer> beaconPreparableProposers) {
-    proposersDataManager.updatePreparedProposers(
-        beaconPreparableProposers, combinedChainDataClient.getCurrentSlot());
+    return SafeFuture.fromRunnable(
+        () ->
+            proposersDataManager.updatePreparedProposers(
+                beaconPreparableProposers, combinedChainDataClient.getCurrentSlot()));
   }
 
   @Override

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/validator/PostPrepareBeaconProposerTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/validator/PostPrepareBeaconProposerTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.beaconrestapi.v1.validator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.beaconrestapi.handlers.v1.validator.PostPrepareBeaconProposer.BEACON_PREPARABLE_PROPOSER_TYPE;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_BAD_REQUEST;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
+
+import java.io.IOException;
+import java.util.List;
+import okhttp3.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import tech.pegasys.teku.beaconrestapi.AbstractDataBackedRestAPIIntegrationTest;
+import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.PostPrepareBeaconProposer;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.json.JsonUtil;
+import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.datastructures.operations.versions.bellatrix.BeaconPreparableProposer;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class PostPrepareBeaconProposerTest extends AbstractDataBackedRestAPIIntegrationTest {
+  private DataStructureUtil dataStructureUtil;
+
+  @BeforeEach
+  void setup() {
+    startRestAPIAtGenesis(SpecMilestone.BELLATRIX);
+    dataStructureUtil = new DataStructureUtil(spec);
+  }
+
+  @Test
+  void shouldReturnOk() throws IOException {
+    final List<BeaconPreparableProposer> request =
+        dataStructureUtil.randomBeaconPreparableProposers(2);
+    when(validatorApiChannel.prepareBeaconProposer(request)).thenReturn(SafeFuture.COMPLETE);
+
+    try (Response response =
+        post(
+            PostPrepareBeaconProposer.ROUTE,
+            JsonUtil.serialize(
+                request, DeserializableTypeDefinition.listOf(BEACON_PREPARABLE_PROPOSER_TYPE)))) {
+
+      assertThat(response.code()).isEqualTo(SC_OK);
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"[{}]", "{}", "invalid"})
+  void shouldReturnBadRequest(final String body) throws IOException {
+    when(validatorApiChannel.prepareBeaconProposer(any())).thenReturn(SafeFuture.COMPLETE);
+    try (Response response = post(PostPrepareBeaconProposer.ROUTE, body)) {
+      assertThat(response.code()).isEqualTo(SC_BAD_REQUEST);
+    }
+    verifyNoInteractions(validatorApiChannel);
+  }
+
+  @Test
+  void shouldHandleEmptyRequest() throws IOException {
+    when(validatorApiChannel.prepareBeaconProposer(any())).thenReturn(SafeFuture.COMPLETE);
+    try (Response response = post(PostPrepareBeaconProposer.ROUTE, "[]")) {
+      assertThat(response.code()).isEqualTo(SC_OK);
+    }
+  }
+}

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostPrepareBeaconProposer.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostPrepareBeaconProposer.java
@@ -36,6 +36,7 @@ import tech.pegasys.teku.api.ValidatorDataProvider;
 import tech.pegasys.teku.beaconrestapi.MigratingEndpointAdapter;
 import tech.pegasys.teku.infrastructure.http.HttpStatusCodes;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
+import tech.pegasys.teku.infrastructure.restapi.endpoints.AsyncApiResponse;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.EndpointMetadata;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiRequest;
 import tech.pegasys.teku.spec.datastructures.operations.versions.bellatrix.BeaconPreparableProposer;
@@ -43,7 +44,7 @@ import tech.pegasys.teku.spec.datastructures.operations.versions.bellatrix.Beaco
 public class PostPrepareBeaconProposer extends MigratingEndpointAdapter {
   public static final String ROUTE = "/eth/v1/validator/prepare_beacon_proposer";
 
-  private static final DeserializableTypeDefinition<BeaconPreparableProposer>
+  public static final DeserializableTypeDefinition<BeaconPreparableProposer>
       BEACON_PREPARABLE_PROPOSER_TYPE =
           DeserializableTypeDefinition.object(
                   BeaconPreparableProposer.class, BeaconPreparableProposer.Builder.class)
@@ -113,8 +114,10 @@ public class PostPrepareBeaconProposer extends MigratingEndpointAdapter {
     if (!isProposerDefaultFeeRecipientDefined) {
       STATUS_LOG.warnMissingProposerDefaultFeeRecipientWithPreparedBeaconProposerBeingCalled();
     }
-    validatorDataProvider.prepareBeaconProposer(request.getRequestBody());
-    request.respondWithCode(SC_OK);
+    request.respondAsync(
+        validatorDataProvider
+            .prepareBeaconProposer(request.getRequestBody())
+            .thenApply(AsyncApiResponse::respondOk));
   }
 
   private static EndpointMetadata createMetadata() {

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
@@ -288,8 +288,9 @@ public class ValidatorDataProvider {
     return validatorApiChannel.sendSignedContributionAndProofs(contributionAndProofs);
   }
 
-  public void prepareBeaconProposer(List<BeaconPreparableProposer> beaconPreparableProposers) {
-    validatorApiChannel.prepareBeaconProposer(beaconPreparableProposers);
+  public SafeFuture<Void> prepareBeaconProposer(
+      List<BeaconPreparableProposer> beaconPreparableProposers) {
+    return validatorApiChannel.prepareBeaconProposer(beaconPreparableProposers);
   }
 
   public SafeFuture<Void> registerValidators(

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/bellatrix/BeaconPreparableProposer.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/bellatrix/BeaconPreparableProposer.java
@@ -45,12 +45,4 @@ public class BeaconPreparableProposer {
     this.validator_index = validator_index;
     this.fee_recipient = fee_recipient;
   }
-
-  public static tech.pegasys.teku.spec.datastructures.operations.versions.bellatrix
-          .BeaconPreparableProposer
-      asInternalBeaconPreparableProposer(BeaconPreparableProposer beaconPreparableProposer) {
-    return new tech.pegasys.teku.spec.datastructures.operations.versions.bellatrix
-        .BeaconPreparableProposer(
-        beaconPreparableProposer.validator_index, beaconPreparableProposer.fee_recipient);
-  }
 }

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -116,6 +116,7 @@ import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SignedCo
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncAggregatorSelectionData;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeContribution;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeMessage;
+import tech.pegasys.teku.spec.datastructures.operations.versions.bellatrix.BeaconPreparableProposer;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.Fork;
@@ -1213,6 +1214,16 @@ public final class DataStructureUtil {
         withValidatorRegistration
             ? Optional.of(randomSignedValidatorRegistration())
             : Optional.empty());
+  }
+
+  public BeaconPreparableProposer randomBeaconPreparableProposer() {
+    return new BeaconPreparableProposer(randomUInt64(), randomEth1Address());
+  }
+
+  public List<BeaconPreparableProposer> randomBeaconPreparableProposers(final int size) {
+    return IntStream.range(0, size)
+        .mapToObj(__ -> randomBeaconPreparableProposer())
+        .collect(toList());
   }
 
   public ValidatorRegistration randomValidatorRegistration() {

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
@@ -88,7 +88,8 @@ public interface ValidatorApiChannel extends ChannelInterface {
   SafeFuture<Void> sendSignedContributionAndProofs(
       Collection<SignedContributionAndProof> signedContributionAndProofs);
 
-  void prepareBeaconProposer(Collection<BeaconPreparableProposer> beaconPreparableProposers);
+  SafeFuture<Void> prepareBeaconProposer(
+      Collection<BeaconPreparableProposer> beaconPreparableProposers);
 
   SafeFuture<Void> registerValidators(
       final SszList<SignedValidatorRegistration> validatorRegistrations);

--- a/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
+++ b/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
@@ -337,10 +337,10 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
   }
 
   @Override
-  public void prepareBeaconProposer(
+  public SafeFuture<Void> prepareBeaconProposer(
       final Collection<BeaconPreparableProposer> beaconPreparableProposers) {
     prepareBeaconProposerCounter.inc();
-    delegate.prepareBeaconProposer(beaconPreparableProposers);
+    return delegate.prepareBeaconProposer(beaconPreparableProposers);
   }
 
   @Override

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/BeaconProposerPreparer.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/BeaconProposerPreparer.java
@@ -202,7 +202,7 @@ public class BeaconProposerPreparer implements ValidatorTimingChannel, FeeRecipi
                           return buildBeaconPreparableProposerList(
                               Optional.empty(), publicKeyToIndex);
                         }))
-        .thenAccept(validatorApiChannel::prepareBeaconProposer)
+        .thenCompose(validatorApiChannel::prepareBeaconProposer)
         .finish(
             () -> sentProposersAtLeastOnce.compareAndSet(false, true),
             VALIDATOR_LOGGER::beaconProposerPreparationFailed);

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/BeaconProposerPreparerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/BeaconProposerPreparerTest.java
@@ -16,8 +16,8 @@ package tech.pegasys.teku.validator.client;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -124,6 +124,7 @@ public class BeaconProposerPreparerTest {
     when(validatorIndexProvider.containsPublicKey(eq(validator2.getPublicKey()))).thenReturn(true);
     when(proposerConfigProvider.getProposerConfig())
         .thenReturn(SafeFuture.completedFuture(Optional.of(proposerConfig)));
+    when(validatorApiChannel.prepareBeaconProposer(anyList())).thenReturn(SafeFuture.COMPLETE);
   }
 
   @TestTemplate
@@ -321,7 +322,8 @@ public class BeaconProposerPreparerTest {
 
   @TestTemplate
   void should_catchApiExceptions() {
-    doThrow(new RuntimeException("error")).when(validatorApiChannel).prepareBeaconProposer(any());
+    when(validatorApiChannel.prepareBeaconProposer(anyList()))
+        .thenReturn(SafeFuture.failedFuture(new RuntimeException("error")));
 
     beaconProposerPreparer.onSlot(UInt64.ZERO);
     verify(validatorApiChannel, times(1)).prepareBeaconProposer(any());

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
@@ -421,9 +421,9 @@ public class RemoteValidatorApiHandler implements ValidatorApiChannel {
             apiClient.prepareBeaconProposer(
                 beaconPreparableProposers.stream()
                     .map(
-                        pbp ->
+                        bpp ->
                             new tech.pegasys.teku.api.schema.bellatrix.BeaconPreparableProposer(
-                                pbp.getValidatorIndex(), pbp.getFeeRecipient()))
+                                bpp.getValidatorIndex(), bpp.getFeeRecipient()))
                     .collect(toList())));
   }
 

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
@@ -414,18 +414,17 @@ public class RemoteValidatorApiHandler implements ValidatorApiChannel {
   }
 
   @Override
-  public void prepareBeaconProposer(
+  public SafeFuture<Void> prepareBeaconProposer(
       final Collection<BeaconPreparableProposer> beaconPreparableProposers) {
-    sendRequest(
-            () ->
-                apiClient.prepareBeaconProposer(
-                    beaconPreparableProposers.stream()
-                        .map(
-                            pbp ->
-                                new tech.pegasys.teku.api.schema.bellatrix.BeaconPreparableProposer(
-                                    pbp.getValidatorIndex(), pbp.getFeeRecipient()))
-                        .collect(toList())))
-        .finish(error -> LOG.error("Failed to prepare beacon proposers", error));
+    return sendRequest(
+        () ->
+            apiClient.prepareBeaconProposer(
+                beaconPreparableProposers.stream()
+                    .map(
+                        pbp ->
+                            new tech.pegasys.teku.api.schema.bellatrix.BeaconPreparableProposer(
+                                pbp.getValidatorIndex(), pbp.getFeeRecipient()))
+                    .collect(toList())));
   }
 
   @Override

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
@@ -421,9 +421,9 @@ public class RemoteValidatorApiHandler implements ValidatorApiChannel {
             apiClient.prepareBeaconProposer(
                 beaconPreparableProposers.stream()
                     .map(
-                        bpp ->
+                        proposer ->
                             new tech.pegasys.teku.api.schema.bellatrix.BeaconPreparableProposer(
-                                bpp.getValidatorIndex(), bpp.getFeeRecipient()))
+                                proposer.getValidatorIndex(), proposer.getFeeRecipient()))
                     .collect(toList())));
   }
 


### PR DESCRIPTION
## PR Description

- Changed signature of `prepareBeaconProposer` in `ValidatorApiChannel` to return SafeFuture<Void> instead of void
- Changed tests to be consistent with `PostRegisterValidator` tests which covered more scenarios


## Fixed Issue(s)
will help for #5237 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
