### PR TITLE
Use SafeFuture COMPLETE constant variable where applicable

### DIFF
--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/BatchImporterTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/BatchImporterTest.java
@@ -126,7 +126,7 @@ class BatchImporterTest {
 
   @Test
   void shouldDisconnectPeersForWeakSubjectivityViolation() {
-    when(syncSource.disconnectCleanly(any())).thenReturn(SafeFuture.completedFuture(null));
+    when(syncSource.disconnectCleanly(any())).thenReturn(SafeFuture.COMPLETE);
 
     final SignedBeaconBlock block1 = dataStructureUtil.randomSignedBeaconBlock(1);
     final SignedBeaconBlock block2 = dataStructureUtil.randomSignedBeaconBlock(2);
@@ -160,7 +160,7 @@ class BatchImporterTest {
 
   @Test
   void shouldNotDisconnectPeersWhenServiceOffline() {
-    when(syncSource.disconnectCleanly(any())).thenReturn(SafeFuture.completedFuture(null));
+    when(syncSource.disconnectCleanly(any())).thenReturn(SafeFuture.COMPLETE);
 
     final SignedBeaconBlock block1 = dataStructureUtil.randomSignedBeaconBlock(1);
     final SignedBeaconBlock block2 = dataStructureUtil.randomSignedBeaconBlock(2);

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/singlepeer/PeerSyncTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/singlepeer/PeerSyncTest.java
@@ -72,7 +72,7 @@ public class PeerSyncTest extends AbstractSyncTest {
     super.setup();
     when(storageClient.getFinalizedEpoch()).thenReturn(UInt64.ZERO);
     when(peer.getStatus()).thenReturn(PEER_STATUS);
-    when(peer.disconnectCleanly(any())).thenReturn(SafeFuture.completedFuture(null));
+    when(peer.disconnectCleanly(any())).thenReturn(SafeFuture.COMPLETE);
     // By default set up block import to succeed
     final SignedBeaconBlock block = mock(SignedBeaconBlock.class);
     final SafeFuture<BlockImportResult> result =

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/PeerChainValidatorTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/PeerChainValidatorTest.java
@@ -108,7 +108,7 @@ public class PeerChainValidatorTest {
     setupRemoteStatusAndValidator(remoteFinalizedCheckpoint);
     when(peer.getId()).thenReturn(new MockNodeId());
     when(peer.hasStatus()).thenReturn(true);
-    when(peer.disconnectCleanly(any())).thenReturn(SafeFuture.completedFuture(null));
+    when(peer.disconnectCleanly(any())).thenReturn(SafeFuture.COMPLETE);
 
     when(combinedChainData.getCurrentEpoch()).thenReturn(spec.computeEpochAtSlot(laterBlockSlot));
     when(combinedChainData.getStore()).thenReturn(store);

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/DefaultValidatorStatusLogger.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/DefaultValidatorStatusLogger.java
@@ -93,7 +93,7 @@ public class DefaultValidatorStatusLogger implements ValidatorStatusLogger {
               updateValidatorCountMetrics(validatorStatuses);
 
               startupComplete.set(true);
-              return SafeFuture.completedFuture(null);
+              return SafeFuture.COMPLETE;
             })
         .exceptionallyCompose((__) -> retryInitialValidatorStatusCheck());
   }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrationBatchSender.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrationBatchSender.java
@@ -42,7 +42,7 @@ public class ValidatorRegistrationBatchSender {
       final List<SignedValidatorRegistration> validatorRegistrations) {
     if (validatorRegistrations.isEmpty()) {
       LOG.debug("No validator(s) registrations required to be sent to the Beacon Node.");
-      return SafeFuture.completedFuture(null);
+      return SafeFuture.COMPLETE;
     }
 
     final List<List<SignedValidatorRegistration>> batchedRegistrations =

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrator.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrator.java
@@ -173,7 +173,7 @@ public class ValidatorRegistrator implements ValidatorTimingChannel {
   private SafeFuture<Void> registerValidators(
       final List<Validator> validators, final UInt64 epoch) {
     if (validators.isEmpty()) {
-      return SafeFuture.completedFuture(null);
+      return SafeFuture.COMPLETE;
     }
 
     return proposerConfigProvider

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorRegistrationBatchSenderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorRegistrationBatchSenderTest.java
@@ -49,7 +49,7 @@ class ValidatorRegistrationBatchSenderTest {
     dataStructureUtil = specContext.getDataStructureUtil();
 
     when(validatorApiChannel.registerValidators(any()))
-        .thenReturn(SafeFuture.completedFuture(null));
+        .thenReturn(SafeFuture.COMPLETE);
 
     validatorRegistrationBatchSender =
         new ValidatorRegistrationBatchSender(BATCH_SIZE, validatorApiChannel);

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorRegistrationBatchSenderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorRegistrationBatchSenderTest.java
@@ -48,8 +48,7 @@ class ValidatorRegistrationBatchSenderTest {
   void setUp(SpecContext specContext) {
     dataStructureUtil = specContext.getDataStructureUtil();
 
-    when(validatorApiChannel.registerValidators(any()))
-        .thenReturn(SafeFuture.COMPLETE);
+    when(validatorApiChannel.registerValidators(any())).thenReturn(SafeFuture.COMPLETE);
 
     validatorRegistrationBatchSender =
         new ValidatorRegistrationBatchSender(BATCH_SIZE, validatorApiChannel);

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorRegistratorTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorRegistratorTest.java
@@ -93,8 +93,7 @@ class ValidatorRegistratorTest {
             validatorConfig,
             feeRecipientProvider,
             validatorRegistrationBatchSender);
-    when(validatorRegistrationBatchSender.sendInBatches(any()))
-        .thenReturn(SafeFuture.COMPLETE);
+    when(validatorRegistrationBatchSender.sendInBatches(any())).thenReturn(SafeFuture.COMPLETE);
 
     when(proposerConfigProvider.getProposerConfig())
         .thenReturn(SafeFuture.completedFuture(Optional.of(proposerConfig)));

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorRegistratorTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorRegistratorTest.java
@@ -94,7 +94,7 @@ class ValidatorRegistratorTest {
             feeRecipientProvider,
             validatorRegistrationBatchSender);
     when(validatorRegistrationBatchSender.sendInBatches(any()))
-        .thenReturn(SafeFuture.completedFuture(null));
+        .thenReturn(SafeFuture.COMPLETE);
 
     when(proposerConfigProvider.getProposerConfig())
         .thenReturn(SafeFuture.completedFuture(Optional.of(proposerConfig)));


### PR DESCRIPTION
## PR Description

- Replace `SafeFuture.completedFuture(null)` with the `SafeFuture.COMPLETE` constant in the places in the codebase where it is applicable.

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
