### PR TITLE
Optimize `TransitionCaches.committeeShuffle` cache utilization

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/TransitionCaches.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/TransitionCaches.java
@@ -34,7 +34,7 @@ public class TransitionCaches {
   private static final int MAX_BEACON_PROPOSER_INDEX_CACHE = 1;
   private static final int MAX_BEACON_COMMITTEE_CACHE = 64 * 64;
   private static final int MAX_TOTAL_ACTIVE_BALANCE_CACHE = 2;
-  private static final int MAX_COMMITTEE_SHUFFLE_CACHE = 2;
+  private static final int MAX_COMMITTEE_SHUFFLE_CACHE = 4;
   private static final int MAX_EFFECTIVE_BALANCE_CACHE = 1;
   private static final int MAX_SYNC_COMMITTEE_CACHE = 2;
   public static final int MAX_BASE_REWARD_PER_INCREMENT_CACHE = 1;

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/TransitionCaches.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/TransitionCaches.java
@@ -34,7 +34,7 @@ public class TransitionCaches {
   private static final int MAX_BEACON_PROPOSER_INDEX_CACHE = 1;
   private static final int MAX_BEACON_COMMITTEE_CACHE = 64 * 64;
   private static final int MAX_TOTAL_ACTIVE_BALANCE_CACHE = 2;
-  private static final int MAX_COMMITTEE_SHUFFLE_CACHE = 4;
+  private static final int MAX_COMMITTEE_SHUFFLE_CACHE = 3;
   private static final int MAX_EFFECTIVE_BALANCE_CACHE = 1;
   private static final int MAX_SYNC_COMMITTEE_CACHE = 2;
   public static final int MAX_BASE_REWARD_PER_INCREMENT_CACHE = 1;

--- a/infrastructure/collections/src/main/java/tech/pegasys/teku/infrastructure/collections/AbstractLimitedMap.java
+++ b/infrastructure/collections/src/main/java/tech/pegasys/teku/infrastructure/collections/AbstractLimitedMap.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.infrastructure.collections;
 
 import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.BiConsumer;
@@ -22,10 +23,26 @@ import java.util.function.Function;
 
 abstract class AbstractLimitedMap<K, V> implements LimitedMap<K, V> {
 
-  protected final Map<K, V> delegate;
+  protected static <K, V> Map<K, V> createLimitedMap(final int maxSize) {
+    return new LinkedHashMap<>(16, 0.75f, true) {
+      @Override
+      protected boolean removeEldestEntry(final Map.Entry<K, V> eldest) {
+        return size() > maxSize;
+      }
+    };
+  }
 
-  protected AbstractLimitedMap(Map<K, V> delegate) {
+  protected final Map<K, V> delegate;
+  protected final int maxSize;
+
+  protected AbstractLimitedMap(Map<K, V> delegate, int maxSize) {
     this.delegate = delegate;
+    this.maxSize = maxSize;
+  }
+
+  @Override
+  public int getMaxSize() {
+    return maxSize;
   }
 
   @Override

--- a/infrastructure/collections/src/main/java/tech/pegasys/teku/infrastructure/collections/AbstractLimitedMap.java
+++ b/infrastructure/collections/src/main/java/tech/pegasys/teku/infrastructure/collections/AbstractLimitedMap.java
@@ -27,7 +27,7 @@ abstract class AbstractLimitedMap<K, V> implements LimitedMap<K, V> {
     return new LinkedHashMap<>(16, 0.75f, true) {
       @Override
       protected boolean removeEldestEntry(final Map.Entry<K, V> eldest) {
-        return size() > maxSize;
+        return this.size() > maxSize;
       }
     };
   }

--- a/infrastructure/collections/src/main/java/tech/pegasys/teku/infrastructure/collections/LimitedMap.java
+++ b/infrastructure/collections/src/main/java/tech/pegasys/teku/infrastructure/collections/LimitedMap.java
@@ -19,6 +19,19 @@ import java.util.Map;
 public interface LimitedMap<K, V> extends Map<K, V> {
 
   /**
+   * Creates a limited map. The returned map is NOT thread safe and evicts the least recently used
+   * items.
+   *
+   * @param maxSize The maximum number of elements to keep in the map.
+   * @param <K> The key type of the map.
+   * @param <V> The value type of the map.
+   * @return A map that will evict elements when the max size is exceeded.
+   */
+  static <K, V> LimitedMap<K, V> createNonSynchronized(final int maxSize) {
+    return new NonSynchronizedLimitedMap<>(maxSize);
+  }
+
+  /**
    * Creates a limited map. The returned map is safe for concurrent access *except* iteration and
    * evicts the least recently used items. Iteration requires synchronizing on the map instance.
    *

--- a/infrastructure/collections/src/main/java/tech/pegasys/teku/infrastructure/collections/NonSynchronizedLimitedMap.java
+++ b/infrastructure/collections/src/main/java/tech/pegasys/teku/infrastructure/collections/NonSynchronizedLimitedMap.java
@@ -13,21 +13,17 @@
 
 package tech.pegasys.teku.infrastructure.collections;
 
-import java.util.Collections;
-
 /** Helper that creates a thread-safe map with a maximum capacity. */
-final class SynchronizedLimitedMap<K, V> extends AbstractLimitedMap<K, V> {
+final class NonSynchronizedLimitedMap<K, V> extends AbstractLimitedMap<K, V> {
 
-  public SynchronizedLimitedMap(final int maxSize) {
-    super(Collections.synchronizedMap(createLimitedMap(maxSize)), maxSize);
+  public NonSynchronizedLimitedMap(final int maxSize) {
+    super(createLimitedMap(maxSize), maxSize);
   }
 
   @Override
   public LimitedMap<K, V> copy() {
-    SynchronizedLimitedMap<K, V> map = new SynchronizedLimitedMap<>(getMaxSize());
-    synchronized (delegate) {
-      map.putAll(delegate);
-    }
+    NonSynchronizedLimitedMap<K, V> map = new NonSynchronizedLimitedMap<>(getMaxSize());
+    map.putAll(delegate);
     return map;
   }
 }

--- a/infrastructure/collections/src/main/java/tech/pegasys/teku/infrastructure/collections/cache/LRUCache.java
+++ b/infrastructure/collections/src/main/java/tech/pegasys/teku/infrastructure/collections/cache/LRUCache.java
@@ -27,7 +27,7 @@ import tech.pegasys.teku.infrastructure.collections.LimitedMap;
 public class LRUCache<K, V> implements Cache<K, V> {
 
   public static <K, V> LRUCache<K, V> create(int capacity) {
-    return new LRUCache<>(LimitedMap.createSynchronized(capacity));
+    return new LRUCache<>(LimitedMap.createNonSynchronized(capacity));
   }
 
   private final LimitedMap<K, V> cacheData;
@@ -37,7 +37,7 @@ public class LRUCache<K, V> implements Cache<K, V> {
   }
 
   @Override
-  public Cache<K, V> copy() {
+  public synchronized Cache<K, V> copy() {
     return new LRUCache<>(cacheData.copy());
   }
 
@@ -50,7 +50,7 @@ public class LRUCache<K, V> implements Cache<K, V> {
    * @return expected value result for provided key
    */
   @Override
-  public V get(K key, Function<K, V> fallback) {
+  public synchronized V get(K key, Function<K, V> fallback) {
     V result = cacheData.get(key);
 
     if (result == null) {
@@ -64,22 +64,22 @@ public class LRUCache<K, V> implements Cache<K, V> {
   }
 
   @Override
-  public Optional<V> getCached(K key) {
+  public synchronized Optional<V> getCached(K key) {
     return Optional.ofNullable(cacheData.get(key));
   }
 
   @Override
-  public void invalidate(K key) {
+  public synchronized void invalidate(K key) {
     cacheData.remove(key);
   }
 
   @Override
-  public void clear() {
+  public synchronized void clear() {
     cacheData.clear();
   }
 
   @Override
-  public int size() {
+  public synchronized int size() {
     return cacheData.size();
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

When running Teku with high peers load (around 500-600 connected peers), noticed that `MiscHelpers.shuffleList` takes about 6%  of CPU. Turned out that `MiscHelpers.shuffleList` could be executed up to ~20 times per epoch (when expected just once)

There are 2 issues with the `TransitionCaches.committeeShuffle`:
1. Thread racing: when a number of attestations arrives simultaneously on several network threads the attestation handler  requests corresponding committee in parallel for attestations validation. Since the `LRUCache` is not synchronized (only the underlying `Map` is synchronized) the missed cache entry is calculated on several threads simultaneously. 
2. Too small cache size (2 entries): prior to epoch `N` `EpochCachePrimer` precalculates shufflings for epochs `N` and `N+1`, after that processing older attestations requires back shuffling for the epoch `N-1`. The shuffling for the epoch `N` is thus evicted and then needed to be recalculated again. 
Not 100% sure but it seems sometimes even shuffling for `N-2` is requested for ancient attestatations come with last block in the epoch `N-1`

Solution: 
1. Synchronize `LRUCache` while using non-synchronized underlying map. The synchronization performance impact should be 0
2. Increase `committeeShuffle` cache size from 2 to 4. The memory consumption is expected to increase by ~3Mb per cross-epoch fork (just 3Mb when no forks) 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
