### PR TITLE
Remove `INVALID_TERMINAL_BLOCK` since it has been deprecated

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionPayloadStatus.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionPayloadStatus.java
@@ -18,8 +18,7 @@ public enum ExecutionPayloadStatus {
   INVALID(Validity.INVALID),
   SYNCING(Validity.NOT_VALIDATED),
   ACCEPTED(Validity.NOT_VALIDATED),
-  INVALID_BLOCK_HASH(Validity.INVALID),
-  INVALID_TERMINAL_BLOCK(Validity.INVALID);
+  INVALID_BLOCK_HASH(Validity.INVALID);
 
   private final Validity validity;
 


### PR DESCRIPTION
I think we waited enough time, it is safe to remove it.

fixes #5498

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
