### PR TITLE
Change return type of subscription methods in `ValidatorApiChannel` to a future

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -422,7 +422,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
     return SafeFuture.fromRunnable(() -> processCommitteeSubscriptionRequests(requests));
   }
 
-  public void processCommitteeSubscriptionRequests(
+  private void processCommitteeSubscriptionRequests(
       final List<CommitteeSubscriptionRequest> requests) {
     requests.forEach(
         request -> {

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -417,11 +417,19 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
   }
 
   @Override
-  public void subscribeToBeaconCommittee(final List<CommitteeSubscriptionRequest> requests) {
+  public SafeFuture<Void> subscribeToBeaconCommittee(
+      final List<CommitteeSubscriptionRequest> requests) {
+    return SafeFuture.fromRunnable(() -> processCommitteeSubscriptionRequests(requests));
+  }
+
+  public void processCommitteeSubscriptionRequests(
+      final List<CommitteeSubscriptionRequest> requests) {
     requests.forEach(
         request -> {
-          // The old subscription API can't provide the validator ID so until it can be removed,
-          // don't track validators from those calls - they should use the old API to subscribe to
+          // The old subscription API can't provide the validator ID so until it can be
+          // removed,
+          // don't track validators from those calls - they should use the old API to
+          // subscribe to
           // persistent subnets.
           if (request.getValidatorIndex() != UNKNOWN_VALIDATOR_ID) {
             activeValidatorTracker.onCommitteeSubscriptionRequest(
@@ -436,7 +444,12 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
   }
 
   @Override
-  public void subscribeToSyncCommitteeSubnets(
+  public SafeFuture<Void> subscribeToSyncCommitteeSubnets(
+      final Collection<SyncCommitteeSubnetSubscription> subscriptions) {
+    return SafeFuture.fromRunnable(() -> processSyncCommitteeSubnetSubscriptions(subscriptions));
+  }
+
+  private void processSyncCommitteeSubnetSubscriptions(
       final Collection<SyncCommitteeSubnetSubscription> subscriptions) {
     for (final SyncCommitteeSubnetSubscription subscription : subscriptions) {
       // untilEpoch is exclusive, so it will unsubscribe at the first slot of the specified index
@@ -454,8 +467,10 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
   }
 
   @Override
-  public void subscribeToPersistentSubnets(Set<SubnetSubscription> subnetSubscriptions) {
-    attestationTopicSubscriber.subscribeToPersistentSubnets(subnetSubscriptions);
+  public SafeFuture<Void> subscribeToPersistentSubnets(
+      Set<SubnetSubscription> subnetSubscriptions) {
+    return SafeFuture.fromRunnable(
+        () -> attestationTopicSubscriber.subscribeToPersistentSubnets(subnetSubscriptions));
   }
 
   @Override

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -426,10 +426,8 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
       final List<CommitteeSubscriptionRequest> requests) {
     requests.forEach(
         request -> {
-          // The old subscription API can't provide the validator ID so until it can be
-          // removed,
-          // don't track validators from those calls - they should use the old API to
-          // subscribe to
+          // The old subscription API can't provide the validator ID so until it can be removed,
+          // don't track validators from those calls - they should use the old API to subscribe to
           // persistent subnets.
           if (request.getValidatorIndex() != UNKNOWN_VALIDATOR_ID) {
             activeValidatorTracker.onCommitteeSubscriptionRequest(

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -620,11 +620,14 @@ class ValidatorApiHandlerTest {
     final UInt64 aggregationSlot = UInt64.valueOf(13);
     final UInt64 committeesAtSlot = UInt64.valueOf(10);
     final int validatorIndex = 1;
-    validatorApiHandler.subscribeToBeaconCommittee(
-        List.of(
-            new CommitteeSubscriptionRequest(
-                validatorIndex, committeeIndex, committeesAtSlot, aggregationSlot, true)));
 
+    final SafeFuture<Void> result =
+        validatorApiHandler.subscribeToBeaconCommittee(
+            List.of(
+                new CommitteeSubscriptionRequest(
+                    validatorIndex, committeeIndex, committeesAtSlot, aggregationSlot, true)));
+
+    assertThat(result).isCompleted();
     verify(attestationTopicSubscriptions)
         .subscribeToCommitteeForAggregation(committeeIndex, committeesAtSlot, aggregationSlot);
     verify(activeValidatorTracker).onCommitteeSubscriptionRequest(validatorIndex, aggregationSlot);
@@ -636,11 +639,14 @@ class ValidatorApiHandlerTest {
     final UInt64 aggregationSlot = UInt64.valueOf(13);
     final UInt64 committeesAtSlot = UInt64.valueOf(10);
     final int validatorIndex = 1;
-    validatorApiHandler.subscribeToBeaconCommittee(
-        List.of(
-            new CommitteeSubscriptionRequest(
-                validatorIndex, committeeIndex, committeesAtSlot, aggregationSlot, false)));
 
+    final SafeFuture<Void> result =
+        validatorApiHandler.subscribeToBeaconCommittee(
+            List.of(
+                new CommitteeSubscriptionRequest(
+                    validatorIndex, committeeIndex, committeesAtSlot, aggregationSlot, false)));
+
+    assertThat(result).isCompleted();
     verifyNoInteractions(attestationTopicSubscriptions);
     verify(activeValidatorTracker).onCommitteeSubscriptionRequest(validatorIndex, aggregationSlot);
   }
@@ -651,9 +657,15 @@ class ValidatorApiHandlerTest {
         new SyncCommitteeSubnetSubscription(1, IntSet.of(1, 2, 15, 30), UInt64.valueOf(44));
     final SyncCommitteeSubnetSubscription subscription2 =
         new SyncCommitteeSubnetSubscription(1, IntSet.of(5, 10), UInt64.valueOf(35));
-    validatorApiHandler.subscribeToSyncCommitteeSubnets(List.of(subscription1, subscription2));
+
+    final SafeFuture<Void> result =
+        validatorApiHandler.subscribeToSyncCommitteeSubnets(List.of(subscription1, subscription2));
+
+    assertThat(result).isCompleted();
+
     final UInt64 unsubscribeSlotSubscription1 = spec.computeStartSlotAtEpoch(UInt64.valueOf(44));
     final UInt64 unsubscribeSlotSubscription2 = spec.computeStartSlotAtEpoch(UInt64.valueOf(35));
+
     verify(syncCommitteeSubscriptionManager).subscribe(0, unsubscribeSlotSubscription1);
     verify(syncCommitteeSubscriptionManager).subscribe(1, unsubscribeSlotSubscription1);
     verify(syncCommitteeSubscriptionManager).subscribe(3, unsubscribeSlotSubscription1);

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/validator/PostSyncCommitteeSubscriptionsIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/validator/PostSyncCommitteeSubscriptionsIntegrationTest.java
@@ -14,6 +14,8 @@
 package tech.pegasys.teku.beaconrestapi.v1.validator;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_BAD_REQUEST;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
@@ -26,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.api.schema.altair.SyncCommitteeSubnetSubscription;
 import tech.pegasys.teku.beaconrestapi.AbstractDataBackedRestAPIIntegrationTest;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.validator.PostSyncCommitteeSubscriptions;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.spec.SpecMilestone;
 
 public class PostSyncCommitteeSubscriptionsIntegrationTest
@@ -40,6 +43,8 @@ public class PostSyncCommitteeSubscriptionsIntegrationTest
 
   @Test
   void shouldPostSubscriptions() throws IOException {
+    when(validatorApiChannel.subscribeToSyncCommitteeSubnets(any()))
+        .thenReturn(SafeFuture.COMPLETE);
     final List<SyncCommitteeSubnetSubscription> validators =
         List.of(new SyncCommitteeSubnetSubscription(ONE, List.of(ONE), ONE));
     startRestAPIAtGenesis(SpecMilestone.ALTAIR);

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostPrepareBeaconProposer.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostPrepareBeaconProposer.java
@@ -24,12 +24,14 @@ import static tech.pegasys.teku.infrastructure.logging.StatusLogger.STATUS_LOG;
 import static tech.pegasys.teku.spec.datastructures.eth1.Eth1Address.ETH1ADDRESS_TYPE;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.annotations.VisibleForTesting;
 import io.javalin.http.Context;
 import io.javalin.plugin.openapi.annotations.HttpMethod;
 import io.javalin.plugin.openapi.annotations.OpenApi;
 import io.javalin.plugin.openapi.annotations.OpenApiContent;
 import io.javalin.plugin.openapi.annotations.OpenApiRequestBody;
 import io.javalin.plugin.openapi.annotations.OpenApiResponse;
+import java.util.List;
 import java.util.Optional;
 import tech.pegasys.teku.api.DataProvider;
 import tech.pegasys.teku.api.ValidatorDataProvider;
@@ -44,6 +46,7 @@ import tech.pegasys.teku.spec.datastructures.operations.versions.bellatrix.Beaco
 public class PostPrepareBeaconProposer extends MigratingEndpointAdapter {
   public static final String ROUTE = "/eth/v1/validator/prepare_beacon_proposer";
 
+  @VisibleForTesting
   public static final DeserializableTypeDefinition<BeaconPreparableProposer>
       BEACON_PREPARABLE_PROPOSER_TYPE =
           DeserializableTypeDefinition.object(
@@ -114,9 +117,10 @@ public class PostPrepareBeaconProposer extends MigratingEndpointAdapter {
     if (!isProposerDefaultFeeRecipientDefined) {
       STATUS_LOG.warnMissingProposerDefaultFeeRecipientWithPreparedBeaconProposerBeingCalled();
     }
+    final List<BeaconPreparableProposer> proposers = request.getRequestBody();
     request.respondAsync(
         validatorDataProvider
-            .prepareBeaconProposer(request.getRequestBody())
+            .prepareBeaconProposer(proposers)
             .thenApply(AsyncApiResponse::respondOk));
   }
 

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostSyncCommitteeSubscriptions.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostSyncCommitteeSubscriptions.java
@@ -39,6 +39,7 @@ import tech.pegasys.teku.api.DataProvider;
 import tech.pegasys.teku.api.ValidatorDataProvider;
 import tech.pegasys.teku.beaconrestapi.MigratingEndpointAdapter;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
+import tech.pegasys.teku.infrastructure.restapi.endpoints.AsyncApiResponse;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.EndpointMetadata;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiRequest;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -118,11 +119,14 @@ public class PostSyncCommitteeSubscriptions extends MigratingEndpointAdapter {
   @Override
   public void handleRequest(RestApiRequest request) throws JsonProcessingException {
     final List<PostSyncCommitteeData> requestData = request.getRequestBody();
-    provider.subscribeToSyncCommitteeSubnets(
+    final List<SyncCommitteeSubnetSubscription> subscriptions =
         requestData.stream()
             .map(PostSyncCommitteeData::toSyncCommitteeSubnetSubscription)
-            .collect(Collectors.toList()));
-    request.respondWithCode(SC_OK);
+            .collect(Collectors.toList());
+    request.respondAsync(
+        provider
+            .subscribeToSyncCommitteeSubnets(subscriptions)
+            .thenApply(AsyncApiResponse::respondOk));
   }
 
   public static class PostSyncCommitteeData {

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostSubscribeToBeaconCommitteeSubnetTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostSubscribeToBeaconCommitteeSubnetTest.java
@@ -15,6 +15,8 @@ package tech.pegasys.teku.beaconrestapi.handlers.v1.validator;
 
 import static javax.servlet.http.HttpServletResponse.SC_OK;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_BAD_REQUEST;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_INTERNAL_SERVER_ERROR;
 import static tech.pegasys.teku.infrastructure.restapi.MetadataTestUtil.getRequestBodyFromMetadata;
@@ -27,12 +29,14 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.beaconrestapi.AbstractMigratedBeaconHandlerTest;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 class PostSubscribeToBeaconCommitteeSubnetTest extends AbstractMigratedBeaconHandlerTest {
 
   @BeforeEach
   void setup() {
+    when(validatorDataProvider.subscribeToBeaconCommittee(any())).thenReturn(SafeFuture.COMPLETE);
     setHandler(new PostSubscribeToBeaconCommitteeSubnet(validatorDataProvider));
   }
 

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostSyncCommitteeSubscriptionsTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostSyncCommitteeSubscriptionsTest.java
@@ -15,6 +15,8 @@ package tech.pegasys.teku.beaconrestapi.handlers.v1.validator;
 
 import static javax.servlet.http.HttpServletResponse.SC_OK;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_BAD_REQUEST;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_INTERNAL_SERVER_ERROR;
 import static tech.pegasys.teku.infrastructure.restapi.MetadataTestUtil.getRequestBodyFromMetadata;
@@ -28,6 +30,7 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.beaconrestapi.AbstractMigratedBeaconHandlerTest;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 class PostSyncCommitteeSubscriptionsTest extends AbstractMigratedBeaconHandlerTest {
@@ -38,6 +41,8 @@ class PostSyncCommitteeSubscriptionsTest extends AbstractMigratedBeaconHandlerTe
 
   @BeforeEach
   void setup() {
+    when(validatorDataProvider.subscribeToSyncCommitteeSubnets(any()))
+        .thenReturn(SafeFuture.COMPLETE);
     setHandler(new PostSyncCommitteeSubscriptions(validatorDataProvider));
   }
 

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
@@ -247,13 +247,14 @@ public class ValidatorDataProvider {
     return validatorApiChannel.sendAggregateAndProofs(aggregateAndProofs);
   }
 
-  public void subscribeToBeaconCommittee(final List<CommitteeSubscriptionRequest> requests) {
-    validatorApiChannel.subscribeToBeaconCommittee(requests);
+  public SafeFuture<Void> subscribeToBeaconCommittee(
+      final List<CommitteeSubscriptionRequest> requests) {
+    return validatorApiChannel.subscribeToBeaconCommittee(requests);
   }
 
-  public void subscribeToSyncCommitteeSubnets(
+  public SafeFuture<Void> subscribeToSyncCommitteeSubnets(
       final Collection<SyncCommitteeSubnetSubscription> subscriptions) {
-    validatorApiChannel.subscribeToSyncCommitteeSubnets(
+    return validatorApiChannel.subscribeToSyncCommitteeSubnets(
         subscriptions.stream()
             .map(
                 subscription ->

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
@@ -60,36 +60,42 @@ public interface ValidatorApiChannel extends ChannelInterface {
   SafeFuture<Optional<ProposerDuties>> getProposerDuties(final UInt64 epoch);
 
   SafeFuture<Optional<BeaconBlock>> createUnsignedBlock(
-      UInt64 slot, BLSSignature randaoReveal, Optional<Bytes32> graffiti, boolean blinded);
+      final UInt64 slot,
+      final BLSSignature randaoReveal,
+      final Optional<Bytes32> graffiti,
+      final boolean blinded);
 
-  SafeFuture<Optional<AttestationData>> createAttestationData(UInt64 slot, int committeeIndex);
+  SafeFuture<Optional<AttestationData>> createAttestationData(
+      final UInt64 slot, final int committeeIndex);
 
-  SafeFuture<Optional<Attestation>> createAggregate(UInt64 slot, Bytes32 attestationHashTreeRoot);
+  SafeFuture<Optional<Attestation>> createAggregate(
+      final UInt64 slot, final Bytes32 attestationHashTreeRoot);
 
   SafeFuture<Optional<SyncCommitteeContribution>> createSyncCommitteeContribution(
-      UInt64 slot, int subcommitteeIndex, Bytes32 beaconBlockRoot);
+      final UInt64 slot, final int subcommitteeIndex, final Bytes32 beaconBlockRoot);
 
-  void subscribeToBeaconCommittee(List<CommitteeSubscriptionRequest> requests);
+  SafeFuture<Void> subscribeToBeaconCommittee(final List<CommitteeSubscriptionRequest> requests);
 
-  void subscribeToSyncCommitteeSubnets(Collection<SyncCommitteeSubnetSubscription> subscriptions);
+  SafeFuture<Void> subscribeToSyncCommitteeSubnets(
+      final Collection<SyncCommitteeSubnetSubscription> subscriptions);
 
-  void subscribeToPersistentSubnets(Set<SubnetSubscription> subnetSubscriptions);
+  SafeFuture<Void> subscribeToPersistentSubnets(final Set<SubnetSubscription> subnetSubscriptions);
 
-  SafeFuture<List<SubmitDataError>> sendSignedAttestations(List<Attestation> attestations);
+  SafeFuture<List<SubmitDataError>> sendSignedAttestations(final List<Attestation> attestations);
 
   SafeFuture<List<SubmitDataError>> sendAggregateAndProofs(
-      List<SignedAggregateAndProof> aggregateAndProofs);
+      final List<SignedAggregateAndProof> aggregateAndProofs);
 
-  SafeFuture<SendSignedBlockResult> sendSignedBlock(SignedBeaconBlock block);
+  SafeFuture<SendSignedBlockResult> sendSignedBlock(final SignedBeaconBlock block);
 
   SafeFuture<List<SubmitDataError>> sendSyncCommitteeMessages(
-      List<SyncCommitteeMessage> syncCommitteeMessages);
+      final List<SyncCommitteeMessage> syncCommitteeMessages);
 
   SafeFuture<Void> sendSignedContributionAndProofs(
-      Collection<SignedContributionAndProof> signedContributionAndProofs);
+      final Collection<SignedContributionAndProof> signedContributionAndProofs);
 
   SafeFuture<Void> prepareBeaconProposer(
-      Collection<BeaconPreparableProposer> beaconPreparableProposers);
+      final Collection<BeaconPreparableProposer> beaconPreparableProposers);
 
   SafeFuture<Void> registerValidators(
       final SszList<SignedValidatorRegistration> validatorRegistrations);

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
@@ -45,58 +45,51 @@ public interface ValidatorApiChannel extends ChannelInterface {
 
   SafeFuture<Optional<GenesisData>> getGenesisData();
 
-  SafeFuture<Map<BLSPublicKey, Integer>> getValidatorIndices(
-      final Collection<BLSPublicKey> publicKeys);
+  SafeFuture<Map<BLSPublicKey, Integer>> getValidatorIndices(Collection<BLSPublicKey> publicKeys);
 
   SafeFuture<Optional<Map<BLSPublicKey, ValidatorStatus>>> getValidatorStatuses(
-      final Collection<BLSPublicKey> validatorIdentifiers);
+      Collection<BLSPublicKey> validatorIdentifiers);
 
   SafeFuture<Optional<AttesterDuties>> getAttestationDuties(
-      final UInt64 epoch, final IntCollection validatorIndices);
+      UInt64 epoch, IntCollection validatorIndices);
 
   SafeFuture<Optional<SyncCommitteeDuties>> getSyncCommitteeDuties(
-      final UInt64 epoch, final IntCollection validatorIndices);
+      UInt64 epoch, IntCollection validatorIndices);
 
-  SafeFuture<Optional<ProposerDuties>> getProposerDuties(final UInt64 epoch);
+  SafeFuture<Optional<ProposerDuties>> getProposerDuties(UInt64 epoch);
 
   SafeFuture<Optional<BeaconBlock>> createUnsignedBlock(
-      final UInt64 slot,
-      final BLSSignature randaoReveal,
-      final Optional<Bytes32> graffiti,
-      final boolean blinded);
+      UInt64 slot, BLSSignature randaoReveal, Optional<Bytes32> graffiti, boolean blinded);
 
-  SafeFuture<Optional<AttestationData>> createAttestationData(
-      final UInt64 slot, final int committeeIndex);
+  SafeFuture<Optional<AttestationData>> createAttestationData(UInt64 slot, int committeeIndex);
 
-  SafeFuture<Optional<Attestation>> createAggregate(
-      final UInt64 slot, final Bytes32 attestationHashTreeRoot);
+  SafeFuture<Optional<Attestation>> createAggregate(UInt64 slot, Bytes32 attestationHashTreeRoot);
 
   SafeFuture<Optional<SyncCommitteeContribution>> createSyncCommitteeContribution(
-      final UInt64 slot, final int subcommitteeIndex, final Bytes32 beaconBlockRoot);
+      UInt64 slot, int subcommitteeIndex, Bytes32 beaconBlockRoot);
 
-  SafeFuture<Void> subscribeToBeaconCommittee(final List<CommitteeSubscriptionRequest> requests);
+  SafeFuture<Void> subscribeToBeaconCommittee(List<CommitteeSubscriptionRequest> requests);
 
   SafeFuture<Void> subscribeToSyncCommitteeSubnets(
-      final Collection<SyncCommitteeSubnetSubscription> subscriptions);
+      Collection<SyncCommitteeSubnetSubscription> subscriptions);
 
-  SafeFuture<Void> subscribeToPersistentSubnets(final Set<SubnetSubscription> subnetSubscriptions);
+  SafeFuture<Void> subscribeToPersistentSubnets(Set<SubnetSubscription> subnetSubscriptions);
 
-  SafeFuture<List<SubmitDataError>> sendSignedAttestations(final List<Attestation> attestations);
+  SafeFuture<List<SubmitDataError>> sendSignedAttestations(List<Attestation> attestations);
 
   SafeFuture<List<SubmitDataError>> sendAggregateAndProofs(
-      final List<SignedAggregateAndProof> aggregateAndProofs);
+      List<SignedAggregateAndProof> aggregateAndProofs);
 
-  SafeFuture<SendSignedBlockResult> sendSignedBlock(final SignedBeaconBlock block);
+  SafeFuture<SendSignedBlockResult> sendSignedBlock(SignedBeaconBlock block);
 
   SafeFuture<List<SubmitDataError>> sendSyncCommitteeMessages(
-      final List<SyncCommitteeMessage> syncCommitteeMessages);
+      List<SyncCommitteeMessage> syncCommitteeMessages);
 
   SafeFuture<Void> sendSignedContributionAndProofs(
-      final Collection<SignedContributionAndProof> signedContributionAndProofs);
+      Collection<SignedContributionAndProof> signedContributionAndProofs);
 
   SafeFuture<Void> prepareBeaconProposer(
-      final Collection<BeaconPreparableProposer> beaconPreparableProposers);
+      Collection<BeaconPreparableProposer> beaconPreparableProposers);
 
-  SafeFuture<Void> registerValidators(
-      final SszList<SignedValidatorRegistration> validatorRegistrations);
+  SafeFuture<Void> registerValidators(SszList<SignedValidatorRegistration> validatorRegistrations);
 }

--- a/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
+++ b/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
@@ -283,22 +283,24 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
   }
 
   @Override
-  public void subscribeToBeaconCommittee(final List<CommitteeSubscriptionRequest> requests) {
+  public SafeFuture<Void> subscribeToBeaconCommittee(
+      final List<CommitteeSubscriptionRequest> requests) {
     subscribeAggregationRequestCounter.inc();
-    delegate.subscribeToBeaconCommittee(requests);
+    return delegate.subscribeToBeaconCommittee(requests);
   }
 
   @Override
-  public void subscribeToSyncCommitteeSubnets(
+  public SafeFuture<Void> subscribeToSyncCommitteeSubnets(
       final Collection<SyncCommitteeSubnetSubscription> subscriptions) {
     subscribeSyncCommitteeRequestCounter.inc();
-    delegate.subscribeToSyncCommitteeSubnets(subscriptions);
+    return delegate.subscribeToSyncCommitteeSubnets(subscriptions);
   }
 
   @Override
-  public void subscribeToPersistentSubnets(final Set<SubnetSubscription> subnetSubscriptions) {
+  public SafeFuture<Void> subscribeToPersistentSubnets(
+      final Set<SubnetSubscription> subnetSubscriptions) {
     subscribePersistentRequestCounter.inc();
-    delegate.subscribeToPersistentSubnets(subnetSubscriptions);
+    return delegate.subscribeToPersistentSubnets(subnetSubscriptions);
   }
 
   @Override

--- a/validator/beaconnode/src/test/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannelTest.java
+++ b/validator/beaconnode/src/test/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannelTest.java
@@ -26,6 +26,7 @@ import java.util.function.Function;
 import java.util.stream.Stream;
 import org.apache.tuweni.bytes.Bytes32;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Named;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -55,7 +56,6 @@ class MetricRecordingValidatorApiChannelTest {
   @ParameterizedTest(name = "{displayName} - {0}")
   @MethodSource("getDataRequestArguments")
   public void shouldRecordSuccessfulRequestForData(
-      final String name,
       final Function<ValidatorApiChannel, SafeFuture<Optional<Object>>> method,
       final String counterName,
       final Object value) {
@@ -74,10 +74,8 @@ class MetricRecordingValidatorApiChannelTest {
   @ParameterizedTest(name = "{displayName} - {0}")
   @MethodSource("getDataRequestArguments")
   public void shouldRecordFailedRequestForData(
-      final String name,
       final Function<ValidatorApiChannel, SafeFuture<Optional<Object>>> method,
-      final String counterName,
-      final Object value) {
+      final String counterName) {
     final RuntimeException exception = new RuntimeException("Nope");
     when(method.apply(delegate)).thenReturn(SafeFuture.failedFuture(exception));
 
@@ -93,10 +91,8 @@ class MetricRecordingValidatorApiChannelTest {
   @ParameterizedTest(name = "{displayName} - {0}")
   @MethodSource("getDataRequestArguments")
   public void shouldRecordRequestForDataWhenDataUnavailable(
-      final String name,
       final Function<ValidatorApiChannel, SafeFuture<Optional<Object>>> method,
-      final String counterName,
-      final Object value) {
+      final String counterName) {
     when(method.apply(delegate)).thenReturn(SafeFuture.completedFuture(Optional.empty()));
 
     final SafeFuture<Optional<Object>> result = method.apply(apiChannel);
@@ -110,10 +106,8 @@ class MetricRecordingValidatorApiChannelTest {
   @ParameterizedTest(name = "{displayName} - {0}")
   @MethodSource("getSendDataArguments")
   void shouldRecordSuccessfulSendRequest(
-      final String name,
       final Function<ValidatorApiChannel, SafeFuture<List<Object>>> method,
-      final String counterName,
-      final List<Object> failures) {
+      final String counterName) {
     when(method.apply(delegate)).thenReturn(SafeFuture.completedFuture(emptyList()));
 
     final SafeFuture<List<Object>> result = method.apply(apiChannel);
@@ -128,7 +122,6 @@ class MetricRecordingValidatorApiChannelTest {
   @ParameterizedTest(name = "{displayName} - {0}")
   @MethodSource("getSendDataArguments")
   void shouldRecordFailingSendRequest(
-      final String name,
       final Function<ValidatorApiChannel, SafeFuture<List<Object>>> method,
       final String counterName,
       final List<Object> failures) {
@@ -146,9 +139,7 @@ class MetricRecordingValidatorApiChannelTest {
   @ParameterizedTest(name = "{displayName} - {0}")
   @MethodSource("getNoResponseCallArguments")
   public void shouldRecordCallsWithNoResponse(
-      final String name,
-      final Function<ValidatorApiChannel, SafeFuture<Void>> method,
-      final String counterName) {
+      final Function<ValidatorApiChannel, SafeFuture<Void>> method, final String counterName) {
     when(method.apply(delegate)).thenReturn(SafeFuture.COMPLETE);
 
     final SafeFuture<Void> result = method.apply(apiChannel);
@@ -176,7 +167,7 @@ class MetricRecordingValidatorApiChannelTest {
       final String name,
       final Function<ValidatorApiChannel, SafeFuture<Void>> method,
       final String counterName) {
-    return Arguments.of(name, method, counterName);
+    return Arguments.of(Named.named(name, method), counterName);
   }
 
   public static Stream<Arguments> getDataRequestArguments() {
@@ -251,7 +242,7 @@ class MetricRecordingValidatorApiChannelTest {
       final Function<ValidatorApiChannel, SafeFuture<Optional<T>>> method,
       final String counterName,
       final T presentValue) {
-    return Arguments.of(name, method, counterName, presentValue);
+    return Arguments.of(Named.named(name, method), counterName, presentValue);
   }
 
   private static <T> Arguments sendDataTest(
@@ -259,7 +250,7 @@ class MetricRecordingValidatorApiChannelTest {
       final Function<ValidatorApiChannel, SafeFuture<List<T>>> method,
       final String counterName,
       final List<T> errors) {
-    return Arguments.of(name, method, counterName, errors);
+    return Arguments.of(Named.named(name, method), counterName, errors);
   }
 
   private long getCounterValue(final String counterName, final RequestOutcome outcome) {

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/BeaconCommitteeSubscriptions.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/BeaconCommitteeSubscriptions.java
@@ -17,11 +17,16 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.validator.api.CommitteeSubscriptionRequest;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 
 /** Batches requests to subscribe to beacon committees. */
 public class BeaconCommitteeSubscriptions {
+
+  private static final Logger LOG = LogManager.getLogger();
+
   private final Queue<CommitteeSubscriptionRequest> pendingRequests = new ConcurrentLinkedQueue<>();
   private final ValidatorApiChannel validatorApiChannel;
 
@@ -43,6 +48,9 @@ public class BeaconCommitteeSubscriptions {
     if (requestsToSend.isEmpty()) {
       return;
     }
-    validatorApiChannel.subscribeToBeaconCommittee(requestsToSend);
+    validatorApiChannel
+        .subscribeToBeaconCommittee(requestsToSend)
+        .finish(
+            error -> LOG.error("Failed to subscribe to beacon committee for aggregation.", error));
   }
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeScheduledDuties.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeScheduledDuties.java
@@ -140,7 +140,7 @@ public class SyncCommitteeScheduledDuties implements ScheduledDuties {
     if (assignments.isEmpty()) {
       return;
     }
-    validatorApiChannel.subscribeToSyncCommitteeSubnets(
+    final Set<SyncCommitteeSubnetSubscription> subscriptions =
         assignments.stream()
             .map(
                 assignment ->
@@ -148,7 +148,10 @@ public class SyncCommitteeScheduledDuties implements ScheduledDuties {
                         assignment.getValidatorIndex(),
                         assignment.getCommitteeIndices(),
                         lastEpochInCommitteePeriod.increment()))
-            .collect(Collectors.toSet()));
+            .collect(Collectors.toSet());
+    validatorApiChannel
+        .subscribeToSyncCommitteeSubnets(subscriptions)
+        .finish(error -> LOG.error("Failed to subscribe to sync committee subnets.", error));
   }
 
   public static class Builder {

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/SyncCommitteeDutyLoaderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/SyncCommitteeDutyLoaderTest.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.validator.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -70,6 +71,8 @@ class SyncCommitteeDutyLoaderTest {
 
   @BeforeEach
   void setUp() {
+    when(validatorApiChannel.subscribeToSyncCommitteeSubnets(any()))
+        .thenReturn(SafeFuture.COMPLETE);
     when(validatorIndexProvider.getValidatorIndices())
         .thenReturn(SafeFuture.completedFuture(validatorIndices));
   }

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/BeaconCommitteeSubscriptionsTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/BeaconCommitteeSubscriptionsTest.java
@@ -16,9 +16,11 @@ package tech.pegasys.teku.validator.client.duties;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.validator.api.CommitteeSubscriptionRequest;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
@@ -43,6 +45,8 @@ class BeaconCommitteeSubscriptionsTest {
             new CommitteeSubscriptionRequest(1, 2, UInt64.valueOf(3), UInt64.valueOf(5), true),
             new CommitteeSubscriptionRequest(6, 7, UInt64.valueOf(8), UInt64.valueOf(9), false));
     requests.forEach(subscriptions::subscribeToBeaconCommittee);
+    when(validatorApiChannel.subscribeToBeaconCommittee(requests)).thenReturn(SafeFuture.COMPLETE);
+
     subscriptions.sendRequests();
 
     verify(validatorApiChannel).subscribeToBeaconCommittee(requests);

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeScheduledDutiesTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeScheduledDutiesTest.java
@@ -66,6 +66,9 @@ class SyncCommitteeScheduledDutiesTest {
 
   @Test
   void shouldSubscribeToSubnets() {
+    when(validatorApiChannel.subscribeToSyncCommitteeSubnets(any()))
+        .thenReturn(SafeFuture.COMPLETE);
+
     final SyncCommitteeScheduledDuties duties =
         validBuilder()
             .committeeAssignment(validator1, 50, 1)

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
@@ -371,36 +371,34 @@ public class RemoteValidatorApiHandler implements ValidatorApiChannel {
   }
 
   @Override
-  public void subscribeToBeaconCommittee(final List<CommitteeSubscriptionRequest> requests) {
-    sendRequest(() -> apiClient.subscribeToBeaconCommittee(requests))
-        .finish(
-            error -> LOG.error("Failed to subscribe to beacon committee for aggregation", error));
+  public SafeFuture<Void> subscribeToBeaconCommittee(
+      final List<CommitteeSubscriptionRequest> requests) {
+    return sendRequest(() -> apiClient.subscribeToBeaconCommittee(requests));
   }
 
   @Override
-  public void subscribeToSyncCommitteeSubnets(
+  public SafeFuture<Void> subscribeToSyncCommitteeSubnets(
       final Collection<SyncCommitteeSubnetSubscription> subscriptions) {
-    sendRequest(
-            () ->
-                apiClient.subscribeToSyncCommitteeSubnets(
-                    subscriptions.stream()
-                        .map(
-                            subscription ->
-                                new tech.pegasys.teku.api.schema.altair
-                                    .SyncCommitteeSubnetSubscription(
-                                    UInt64.valueOf(subscription.getValidatorIndex()),
-                                    subscription
-                                        .getSyncCommitteeIndices()
-                                        .intStream()
-                                        .mapToObj(UInt64::valueOf)
-                                        .collect(toList()),
-                                    subscription.getUntilEpoch()))
-                        .collect(toList())))
-        .finish(error -> LOG.error("Failed to subscribe to sync committee subnets", error));
+    return sendRequest(
+        () ->
+            apiClient.subscribeToSyncCommitteeSubnets(
+                subscriptions.stream()
+                    .map(
+                        subscription ->
+                            new tech.pegasys.teku.api.schema.altair.SyncCommitteeSubnetSubscription(
+                                UInt64.valueOf(subscription.getValidatorIndex()),
+                                subscription
+                                    .getSyncCommitteeIndices()
+                                    .intStream()
+                                    .mapToObj(UInt64::valueOf)
+                                    .collect(toList()),
+                                subscription.getUntilEpoch()))
+                    .collect(toList())));
   }
 
   @Override
-  public void subscribeToPersistentSubnets(final Set<SubnetSubscription> subnetSubscriptions) {
+  public SafeFuture<Void> subscribeToPersistentSubnets(
+      final Set<SubnetSubscription> subnetSubscriptions) {
     final Set<tech.pegasys.teku.api.schema.SubnetSubscription> schemaSubscriptions =
         subnetSubscriptions.stream()
             .map(
@@ -409,8 +407,7 @@ public class RemoteValidatorApiHandler implements ValidatorApiChannel {
                         s.getSubnetId(), s.getUnsubscriptionSlot()))
             .collect(Collectors.toSet());
 
-    sendRequest(() -> apiClient.subscribeToPersistentSubnets(schemaSubscriptions))
-        .finish(error -> LOG.error("Failed to subscribe to persistent subnets", error));
+    return sendRequest(() -> apiClient.subscribeToPersistentSubnets(schemaSubscriptions));
   }
 
   @Override

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
@@ -471,9 +471,11 @@ class RemoteValidatorApiHandlerTest {
         List.of(
             new CommitteeSubscriptionRequest(
                 validatorIndex, committeeIndex, committeesAtSlot, aggregationSlot, isAggregator));
-    apiHandler.subscribeToBeaconCommittee(requests);
+
+    final SafeFuture<Void> result = apiHandler.subscribeToBeaconCommittee(requests);
     asyncRunner.executeQueuedActions();
 
+    assertThat(result).isCompleted();
     verify(apiClient).subscribeToBeaconCommittee(requests);
   }
 
@@ -487,12 +489,14 @@ class RemoteValidatorApiHandlerTest {
     final tech.pegasys.teku.api.schema.SubnetSubscription schemaSubnetSubscription =
         new tech.pegasys.teku.api.schema.SubnetSubscription(subnetId, slot);
 
-    ArgumentCaptor<Set<tech.pegasys.teku.api.schema.SubnetSubscription>> argumentCaptor =
+    final ArgumentCaptor<Set<tech.pegasys.teku.api.schema.SubnetSubscription>> argumentCaptor =
         ArgumentCaptor.forClass(Set.class);
 
-    apiHandler.subscribeToPersistentSubnets(Set.of(subnetSubscription));
+    final SafeFuture<Void> result =
+        apiHandler.subscribeToPersistentSubnets(Set.of(subnetSubscription));
     asyncRunner.executeQueuedActions();
 
+    assertThat(result).isCompleted();
     verify(apiClient).subscribeToPersistentSubnets(argumentCaptor.capture());
 
     final Set<tech.pegasys.teku.api.schema.SubnetSubscription> request = argumentCaptor.getValue();


### PR DESCRIPTION
## PR Description
- Change `subscribeToBeaconCommittee` `subscribeToSyncCommitteeSubnets` and `subscribeToPersistentSubnets` to return `SafeFuture<Void>` instead of `void`
- Remove finals from `ValidatorApiChannel` for consistency

## Fixed Issue(s)
will help for #5237 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
