### PR TITLE
Stop scheduling new keep alive comments when the client is closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,3 +22,4 @@ For information on changes in released versions of Teku, see the [releases page]
 
 ### Bug Fixes
  - Fix not rendering emoticons correctly in graffiti when running in a Docker container
+ - Fix resource leak from closed SSE connections

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriber.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriber.java
@@ -59,7 +59,11 @@ public class EventSubscriber {
     this.queuedEvents = new ConcurrentLinkedQueue<>();
     this.processingQueue = new AtomicBoolean(false);
     this.asyncRunner = asyncRunner;
-    this.sseClient.onClose(closeCallback);
+    this.sseClient.onClose(
+        () -> {
+          stopped.set(true);
+          closeCallback.run();
+        });
 
     keepAlive();
   }
@@ -143,7 +147,7 @@ public class EventSubscriber {
                   sseClient.sendComment("");
                 }
               },
-              Duration.ofSeconds(30))
+              Duration.ofSeconds(5))
           .alwaysRun(this::keepAlive)
           .ifExceptionGetsHereRaiseABug();
     }

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriber.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriber.java
@@ -147,7 +147,7 @@ public class EventSubscriber {
                   sseClient.sendComment("");
                 }
               },
-              Duration.ofSeconds(5))
+              Duration.ofSeconds(30))
           .alwaysRun(this::keepAlive)
           .ifExceptionGetsHereRaiseABug();
     }

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriberTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriberTest.java
@@ -207,7 +207,7 @@ public class EventSubscriberTest {
   @Test
   @SuppressWarnings("unused")
   void shouldSendKeepAlive() {
-    final EventSubscriber subscriber = createSubscriber(EventType.voluntary_exit.name());
+    createSubscriber(EventType.voluntary_exit.name());
 
     assertThat(asyncRunner.countDelayedActions()).isEqualTo(1);
     asyncRunner.executeQueuedActions();
@@ -216,6 +216,18 @@ public class EventSubscriberTest {
 
     // Keep alive schedules another to be run
     assertThat(asyncRunner.countDelayedActions()).isEqualTo(1);
+  }
+
+  @Test
+  void shouldStopSendingKeepAliveWhenSseClientCloses() {
+    createSubscriber(EventType.voluntary_exit.name());
+
+    assertThat(asyncRunner.countDelayedActions()).isEqualTo(1);
+    sseClient.close();
+    asyncRunner.executeQueuedActions();
+
+    // Keep alive should not schedule another to be run
+    assertThat(asyncRunner.countDelayedActions()).isZero();
   }
 
   private EventSource<String> event(final String message) {

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriberTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriberTest.java
@@ -205,7 +205,6 @@ public class EventSubscriberTest {
   }
 
   @Test
-  @SuppressWarnings("unused")
   void shouldSendKeepAlive() {
     createSubscriber(EventType.voluntary_exit.name());
 


### PR DESCRIPTION
## PR Description
When the SSE client closes, make sure we stop sending keep alive comments, otherwise we can wind up filling the execution queue for those keep alives and spend all our CPU on retrying.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
