### PR TITLE
Add `ValidatorApiChannel` failover implementation

### DIFF
--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
@@ -238,36 +238,26 @@ public class SafeFuture<T> extends CompletableFuture<T> {
   /**
    * Returns a new {@link SafeFuture} with the result of the first successful future from the given
    * futures. If all futures complete exceptionally, the returned {@link SafeFuture} will complete
-   * exceptionally with the exception from the first future. If the provided {@link List} of futures
-   * is an empty collection, the returned {@link SafeFuture} will complete exceptionally with an
-   * {@link IllegalArgumentException} exception.
+   * exceptionally with the exception from the {@link #allOf(SafeFuture[])} call. If the provided
+   * {@link List} of futures is an empty collection, the returned {@link SafeFuture} will complete
+   * exceptionally with an {@link IllegalArgumentException} exception.
    *
-   * @param futures the futures which will need to be completed
+   * @param futures a List of futures that need to be completed
    * @return a new {@link SafeFuture} that is completed with the first successful result from the
    *     given futures or completed exceptionally if all futures complete exceptionally
    */
   public static <T> SafeFuture<T> firstSuccess(final List<SafeFuture<T>> futures) {
     if (futures.isEmpty()) {
       return SafeFuture.failedFuture(
-          new IllegalArgumentException("The provided list of SafeFuture<T> should not be empty"));
+          new IllegalArgumentException("The provided list of futures should not be empty"));
     }
-    return asyncDoWhile(
-            () ->
-                SafeFuture.of(
-                    () -> {
-                      final boolean canProceed =
-                          futures.stream().anyMatch(SafeFuture::isCompletedNormally)
-                              || futures.stream().allMatch(SafeFuture::isCompletedExceptionally);
-                      return !canProceed;
-                    }))
-        .thenCompose(
-            __ ->
-                futures.stream()
-                    .filter(SafeFuture::isCompletedNormally)
-                    .findFirst()
-                    // at this point, all futures have completed exceptionally, so just
-                    // return the first error future
-                    .orElse(futures.get(0)));
+    final SafeFuture<T> result = new SafeFuture<>();
+    allOf(
+            futures.stream()
+                .map(future -> future.thenAccept(result::complete))
+                .toArray(SafeFuture[]::new))
+        .propagateExceptionTo(result);
+    return result;
   }
 
   public static SafeFuture<Object> anyOf(final SafeFuture<?>... futures) {

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
@@ -249,7 +249,7 @@ public class SafeFuture<T> extends CompletableFuture<T> {
   public static <T> SafeFuture<T> firstSuccess(final List<SafeFuture<T>> futures) {
     if (futures.isEmpty()) {
       return SafeFuture.failedFuture(
-          new IllegalArgumentException("The provided list of futures should not be empty"));
+          new IllegalArgumentException("The provided List of futures should not be empty"));
     }
     final SafeFuture<T> result = new SafeFuture<>();
     allOf(

--- a/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/SafeFutureTest.java
+++ b/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/SafeFutureTest.java
@@ -1100,6 +1100,18 @@ public class SafeFutureTest {
   }
 
   @Test
+  public void firstSuccess_completesEvenWhenOneOfTheFuturesNeverCompletes() {
+    final SafeFuture<String> result =
+        SafeFuture.firstSuccess(
+            List.of(
+                new SafeFuture<>(),
+                SafeFuture.completedFuture("foo"),
+                SafeFuture.completedFuture("bar")));
+
+    assertThat(result).isCompletedWithValue("foo");
+  }
+
+  @Test
   public void firstSuccess_completesExceptionallyWhenAllFuturesFail() {
     final IllegalStateException exception = new IllegalStateException("oopsy");
 

--- a/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/SafeFutureTest.java
+++ b/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/SafeFutureTest.java
@@ -1082,7 +1082,7 @@ public class SafeFutureTest {
     final SafeFuture<String> result = SafeFuture.firstSuccess(List.of());
     SafeFutureAssert.assertThatSafeFuture(result)
         .isCompletedExceptionallyWith(IllegalArgumentException.class)
-        .hasMessage("The provided list of futures should not be empty");
+        .hasMessage("The provided List of futures should not be empty");
   }
 
   @Test

--- a/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/SafeFutureTest.java
+++ b/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/SafeFutureTest.java
@@ -831,7 +831,7 @@ public class SafeFutureTest {
   }
 
   @Test
-  public void orInterrupt_complexInterruptImmediately() throws Exception {
+  public void orInterrupt_complexInterruptImmediately() {
     InterruptTest test = new InterruptTest();
 
     test.interruptorFut2.complete(0);
@@ -1075,6 +1075,44 @@ public class SafeFutureTest {
     assertThatThrownBy(future::getImmediately)
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("Expected result to be available immediately, but was not");
+  }
+
+  @Test
+  public void firstSuccess_completesExceptionallyIfPassedListIsEmpty() {
+    final SafeFuture<String> result = SafeFuture.firstSuccess(List.of());
+    SafeFutureAssert.assertThatSafeFuture(result)
+        .isCompletedExceptionallyWith(IllegalArgumentException.class)
+        .hasMessage("The provided list of futures should not be empty");
+  }
+
+  @Test
+  public void firstSuccess_completesWithFirstSuccessfulResponse() {
+    final IllegalStateException exception = new IllegalStateException("oopsy");
+
+    final SafeFuture<String> result =
+        SafeFuture.firstSuccess(
+            List.of(
+                SafeFuture.completedFuture("foo"),
+                SafeFuture.completedFuture("bar"),
+                SafeFuture.failedFuture(exception)));
+
+    assertThat(result).isCompletedWithValue("foo");
+  }
+
+  @Test
+  public void firstSuccess_completesExceptionallyWhenAllFuturesFail() {
+    final IllegalStateException exception = new IllegalStateException("oopsy");
+
+    final SafeFuture<String> result =
+        SafeFuture.firstSuccess(
+            List.of(
+                SafeFuture.failedFuture(exception),
+                SafeFuture.failedFuture(exception),
+                SafeFuture.failedFuture(exception)));
+
+    SafeFutureAssert.assertThatSafeFuture(result)
+        .isCompletedExceptionallyWith(IllegalStateException.class)
+        .hasMessage("oopsy");
   }
 
   private List<Throwable> collectUncaughtExceptions() {

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/ValidatorLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/ValidatorLogger.java
@@ -163,6 +163,13 @@ public class ValidatorLogger {
             PREFIX + "Produced invalid aggregate for slot " + slot + ": " + reason, Color.RED));
   }
 
+  public void remoteBeaconNodeRequestFailedOnAllConfiguredEndpoints() {
+    final String warningMessage =
+        String.format(
+            "%sRemote request to the Beacon Node failed on all configured endpoints.", PREFIX);
+    log.error(ColorConsolePrinter.print(warningMessage, Color.RED));
+  }
+
   public void beaconProposerPreparationFailed(final Throwable error) {
     final String errorString = String.format("%sFailed to send proposers to Beacon Node", PREFIX);
     log.error(ColorConsolePrinter.print(errorString, Color.RED), error);

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/RemoteValidatorApiChannel.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/RemoteValidatorApiChannel.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.api;
+
+import java.net.URI;
+
+public interface RemoteValidatorApiChannel extends ValidatorApiChannel {
+
+  URI getEndpoint();
+}

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandler.java
@@ -1,0 +1,275 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.remote;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.google.common.annotations.VisibleForTesting;
+import it.unimi.dsi.fastutil.ints.IntCollection;
+import java.net.URI;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.api.response.v1.beacon.ValidatorStatus;
+import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.logging.ValidatorLogger;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.execution.SignedValidatorRegistration;
+import tech.pegasys.teku.spec.datastructures.genesis.GenesisData;
+import tech.pegasys.teku.spec.datastructures.operations.Attestation;
+import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
+import tech.pegasys.teku.spec.datastructures.operations.SignedAggregateAndProof;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SignedContributionAndProof;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeContribution;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeMessage;
+import tech.pegasys.teku.spec.datastructures.operations.versions.bellatrix.BeaconPreparableProposer;
+import tech.pegasys.teku.spec.datastructures.validator.SubnetSubscription;
+import tech.pegasys.teku.validator.api.AttesterDuties;
+import tech.pegasys.teku.validator.api.CommitteeSubscriptionRequest;
+import tech.pegasys.teku.validator.api.ProposerDuties;
+import tech.pegasys.teku.validator.api.RemoteValidatorApiChannel;
+import tech.pegasys.teku.validator.api.SendSignedBlockResult;
+import tech.pegasys.teku.validator.api.SubmitDataError;
+import tech.pegasys.teku.validator.api.SyncCommitteeDuties;
+import tech.pegasys.teku.validator.api.SyncCommitteeSubnetSubscription;
+import tech.pegasys.teku.validator.api.ValidatorApiChannel;
+
+public class FailoverValidatorApiHandler implements ValidatorApiChannel {
+
+  private static final Logger LOG = LogManager.getLogger();
+
+  private final RemoteValidatorApiChannel primaryDelegate;
+  private final List<RemoteValidatorApiChannel> failoverDelegates;
+  private final ValidatorLogger validatorLogger;
+
+  public FailoverValidatorApiHandler(
+      final RemoteValidatorApiChannel primaryDelegate,
+      final List<RemoteValidatorApiChannel> failoverDelegates,
+      final ValidatorLogger validatorLogger) {
+    this.primaryDelegate = primaryDelegate;
+    checkArgument(
+        !failoverDelegates.isEmpty(),
+        "One or more Beacon Nodes should be defined as a failover to use the failover feature.");
+    this.failoverDelegates = failoverDelegates;
+    this.validatorLogger = validatorLogger;
+  }
+
+  @Override
+  public SafeFuture<Optional<GenesisData>> getGenesisData() {
+    return tryRequestUntilSuccess(ValidatorApiChannel::getGenesisData);
+  }
+
+  @Override
+  public SafeFuture<Map<BLSPublicKey, Integer>> getValidatorIndices(
+      final Collection<BLSPublicKey> publicKeys) {
+    return tryRequestUntilSuccess(apiChannel -> apiChannel.getValidatorIndices(publicKeys));
+  }
+
+  @Override
+  public SafeFuture<Optional<Map<BLSPublicKey, ValidatorStatus>>> getValidatorStatuses(
+      final Collection<BLSPublicKey> validatorIdentifiers) {
+    return tryRequestUntilSuccess(
+        apiChannel -> apiChannel.getValidatorStatuses(validatorIdentifiers));
+  }
+
+  @Override
+  public SafeFuture<Optional<AttesterDuties>> getAttestationDuties(
+      final UInt64 epoch, final IntCollection validatorIndices) {
+    return tryRequestUntilSuccess(
+        apiChannel -> apiChannel.getAttestationDuties(epoch, validatorIndices));
+  }
+
+  @Override
+  public SafeFuture<Optional<SyncCommitteeDuties>> getSyncCommitteeDuties(
+      final UInt64 epoch, final IntCollection validatorIndices) {
+    return tryRequestUntilSuccess(
+        apiChannel -> apiChannel.getSyncCommitteeDuties(epoch, validatorIndices));
+  }
+
+  @Override
+  public SafeFuture<Optional<ProposerDuties>> getProposerDuties(final UInt64 epoch) {
+    return tryRequestUntilSuccess(apiChannel -> apiChannel.getProposerDuties(epoch));
+  }
+
+  @Override
+  public SafeFuture<Optional<BeaconBlock>> createUnsignedBlock(
+      final UInt64 slot,
+      final BLSSignature randaoReveal,
+      final Optional<Bytes32> graffiti,
+      final boolean blinded) {
+    return tryRequestUntilSuccess(
+        apiChannel -> apiChannel.createUnsignedBlock(slot, randaoReveal, graffiti, blinded));
+  }
+
+  @Override
+  public SafeFuture<Optional<AttestationData>> createAttestationData(
+      final UInt64 slot, final int committeeIndex) {
+    return tryRequestUntilSuccess(
+        apiChannel -> apiChannel.createAttestationData(slot, committeeIndex));
+  }
+
+  @Override
+  public SafeFuture<Optional<Attestation>> createAggregate(
+      final UInt64 slot, final Bytes32 attestationHashTreeRoot) {
+    return tryRequestUntilSuccess(
+        apiChannel -> apiChannel.createAggregate(slot, attestationHashTreeRoot));
+  }
+
+  @Override
+  public SafeFuture<Optional<SyncCommitteeContribution>> createSyncCommitteeContribution(
+      final UInt64 slot, final int subcommitteeIndex, final Bytes32 beaconBlockRoot) {
+    return tryRequestUntilSuccess(
+        apiChannel ->
+            apiChannel.createSyncCommitteeContribution(slot, subcommitteeIndex, beaconBlockRoot));
+  }
+
+  @Override
+  public SafeFuture<Void> subscribeToBeaconCommittee(List<CommitteeSubscriptionRequest> requests) {
+    return relayRequest(apiChannel -> apiChannel.subscribeToBeaconCommittee(requests));
+  }
+
+  @Override
+  public SafeFuture<Void> subscribeToSyncCommitteeSubnets(
+      Collection<SyncCommitteeSubnetSubscription> subscriptions) {
+    return relayRequest(apiChannel -> apiChannel.subscribeToSyncCommitteeSubnets(subscriptions));
+  }
+
+  @Override
+  public SafeFuture<Void> subscribeToPersistentSubnets(
+      Set<SubnetSubscription> subnetSubscriptions) {
+    return relayRequest(apiChannel -> apiChannel.subscribeToPersistentSubnets(subnetSubscriptions));
+  }
+
+  @Override
+  public SafeFuture<List<SubmitDataError>> sendSignedAttestations(List<Attestation> attestations) {
+    return relayRequest(apiChannel -> apiChannel.sendSignedAttestations(attestations));
+  }
+
+  @Override
+  public SafeFuture<List<SubmitDataError>> sendAggregateAndProofs(
+      final List<SignedAggregateAndProof> aggregateAndProofs) {
+    return relayRequest(apiChannel -> apiChannel.sendAggregateAndProofs(aggregateAndProofs));
+  }
+
+  @Override
+  public SafeFuture<SendSignedBlockResult> sendSignedBlock(final SignedBeaconBlock block) {
+    return relayRequest(apiChannel -> apiChannel.sendSignedBlock(block));
+  }
+
+  @Override
+  public SafeFuture<List<SubmitDataError>> sendSyncCommitteeMessages(
+      final List<SyncCommitteeMessage> syncCommitteeMessages) {
+    return relayRequest(apiChannel -> apiChannel.sendSyncCommitteeMessages(syncCommitteeMessages));
+  }
+
+  @Override
+  public SafeFuture<Void> sendSignedContributionAndProofs(
+      final Collection<SignedContributionAndProof> signedContributionAndProofs) {
+    return relayRequest(
+        apiChannel -> apiChannel.sendSignedContributionAndProofs(signedContributionAndProofs));
+  }
+
+  @Override
+  public SafeFuture<Void> prepareBeaconProposer(
+      final Collection<BeaconPreparableProposer> beaconPreparableProposers) {
+    return relayRequest(apiChannel -> apiChannel.prepareBeaconProposer(beaconPreparableProposers));
+  }
+
+  @Override
+  public SafeFuture<Void> registerValidators(
+      final SszList<SignedValidatorRegistration> validatorRegistrations) {
+    return relayRequest(apiChannel -> apiChannel.registerValidators(validatorRegistrations));
+  }
+
+  /**
+   * Relays the given request to the primary Beacon Node along with all failover Beacon Node
+   * endpoints. The returned {@link SafeFuture} will complete with the response from the primary
+   * Beacon Node or in case in failure, it will complete with the first successful response from a
+   * failover node. The returned {@link SafeFuture} will only complete exceptionally when the
+   * request to the primary Beacon Node and all requests to the failover nodes fail. In this case,
+   * the returned error will be the primary Beacon node error and all other failover errors will be
+   * part of it as suppressed.
+   */
+  private <T> SafeFuture<T> relayRequest(final ValidatorApiChannelRequest<T> request) {
+    final SafeFuture<T> primaryResponse = request.run(primaryDelegate);
+    final List<SafeFuture<T>> failoversResponses =
+        failoverDelegates.stream().map(request::run).collect(Collectors.toList());
+    return primaryResponse.exceptionallyCompose(
+        primaryThrowable ->
+            SafeFuture.firstSuccess(failoversResponses)
+                .exceptionallyCompose(
+                    __ -> {
+                      validatorLogger.remoteBeaconNodeRequestFailedOnAllConfiguredEndpoints();
+                      SafeFuture.addSuppressedErrors(
+                          primaryThrowable, failoversResponses.toArray(new SafeFuture<?>[0]));
+                      return SafeFuture.failedFuture(primaryThrowable);
+                    }));
+  }
+
+  /**
+   * Tries the given request first with the primary Beacon Node. If it fails, it will retry the
+   * request against each failover Beacon Node in order until there is a successful response. In
+   * case all requests fail, the returned {@link SafeFuture} will complete exceptionally with the
+   * last error and all previous errors will be part of it as suppressed.
+   */
+  private <T> SafeFuture<T> tryRequestUntilSuccess(final ValidatorApiChannelRequest<T> request) {
+    return makeFailoverRequest(
+        primaryDelegate, failoverDelegates.iterator(), request, new HashSet<>());
+  }
+
+  private <T> SafeFuture<T> makeFailoverRequest(
+      final RemoteValidatorApiChannel currentDelegate,
+      final Iterator<RemoteValidatorApiChannel> failoverDelegates,
+      final ValidatorApiChannelRequest<T> request,
+      final Set<Throwable> capturedExceptions) {
+    return request
+        .run(currentDelegate)
+        .exceptionallyCompose(
+            throwable -> {
+              final URI failedEndpoint = currentDelegate.getEndpoint();
+              if (!failoverDelegates.hasNext()) {
+                validatorLogger.remoteBeaconNodeRequestFailedOnAllConfiguredEndpoints();
+                capturedExceptions.forEach(throwable::addSuppressed);
+                return SafeFuture.failedFuture(throwable);
+              }
+              capturedExceptions.add(throwable);
+              final RemoteValidatorApiChannel nextDelegate = failoverDelegates.next();
+              LOG.debug(
+                  String.format(
+                      "Request to Beacon Node %s failed. Will try sending request to failover %s",
+                      failedEndpoint, nextDelegate.getEndpoint()));
+              return makeFailoverRequest(
+                  nextDelegate, failoverDelegates, request, capturedExceptions);
+            });
+  }
+
+  @VisibleForTesting
+  @FunctionalInterface
+  interface ValidatorApiChannelRequest<T> {
+    SafeFuture<T> run(final ValidatorApiChannel apiChannel);
+  }
+}

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandler.java
@@ -210,9 +210,9 @@ public class FailoverValidatorApiHandler implements ValidatorApiChannel {
    * endpoints. The returned {@link SafeFuture} will complete with the response from the primary
    * Beacon Node or in case in failure, it will complete with the first successful response from a
    * failover node. The returned {@link SafeFuture} will only complete exceptionally when the
-   * request to the primary Beacon Node and all requests to the failover nodes fail. In this case,
-   * the returned error will be the primary Beacon node error and all other failover errors will be
-   * part of it as suppressed.
+   * request to the primary Beacon Node and all the requests to the failover nodes fail. In this
+   * case, the returned error will be the primary Beacon Node error and all the failovers errors
+   * will be part of it as suppressed.
    */
   private <T> SafeFuture<T> relayRequest(final ValidatorApiChannelRequest<T> request) {
     final SafeFuture<T> primaryResponse = request.run(primaryDelegate);
@@ -233,8 +233,8 @@ public class FailoverValidatorApiHandler implements ValidatorApiChannel {
   /**
    * Tries the given request first with the primary Beacon Node. If it fails, it will retry the
    * request against each failover Beacon Node in order until there is a successful response. In
-   * case all requests fail, the returned {@link SafeFuture} will complete exceptionally with the
-   * last error and all previous errors will be part of it as suppressed.
+   * case all the requests fail, the returned {@link SafeFuture} will complete exceptionally with
+   * the last error and all previous errors will be part of it as suppressed.
    */
   private <T> SafeFuture<T> tryRequestUntilSuccess(final ValidatorApiChannelRequest<T> request) {
     return makeFailoverRequest(

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApi.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApi.java
@@ -78,7 +78,8 @@ public class RemoteBeaconNodeApi implements BeaconNodeApi {
     final ValidatorApiChannel validatorApiChannel =
         new MetricRecordingValidatorApiChannel(
             serviceConfig.getMetricsSystem(),
-            new RemoteValidatorApiHandler(spec, apiClient, typeDefClient, asyncRunner));
+            new RemoteValidatorApiHandler(
+                spec, apiEndpoint, apiClient, typeDefClient, asyncRunner));
 
     final ValidatorTimingChannel validatorTimingChannel =
         serviceConfig.getEventChannels().getPublisher(ValidatorTimingChannel.class);

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
@@ -21,6 +21,7 @@ import static java.util.stream.Collectors.toMap;
 import com.google.common.base.Throwables;
 import it.unimi.dsi.fastutil.ints.IntCollection;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import java.net.URI;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -31,6 +32,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import okhttp3.HttpUrl;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
@@ -65,37 +67,44 @@ import tech.pegasys.teku.validator.api.AttesterDuty;
 import tech.pegasys.teku.validator.api.CommitteeSubscriptionRequest;
 import tech.pegasys.teku.validator.api.ProposerDuties;
 import tech.pegasys.teku.validator.api.ProposerDuty;
+import tech.pegasys.teku.validator.api.RemoteValidatorApiChannel;
 import tech.pegasys.teku.validator.api.SendSignedBlockResult;
 import tech.pegasys.teku.validator.api.SubmitDataError;
 import tech.pegasys.teku.validator.api.SyncCommitteeDuties;
 import tech.pegasys.teku.validator.api.SyncCommitteeDuty;
 import tech.pegasys.teku.validator.api.SyncCommitteeSubnetSubscription;
-import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 import tech.pegasys.teku.validator.remote.apiclient.RateLimitedException;
 import tech.pegasys.teku.validator.remote.apiclient.ValidatorRestApiClient;
 import tech.pegasys.teku.validator.remote.typedef.OkHttpValidatorTypeDefClient;
 
-public class RemoteValidatorApiHandler implements ValidatorApiChannel {
+public class RemoteValidatorApiHandler implements RemoteValidatorApiChannel {
 
   private static final Logger LOG = LogManager.getLogger();
   static final int MAX_PUBLIC_KEY_BATCH_SIZE = 50;
   static final int MAX_RATE_LIMITING_RETRIES = 3;
 
   private final Spec spec;
+  private final HttpUrl endpoint;
   private final ValidatorRestApiClient apiClient;
-  private final AsyncRunner asyncRunner;
-
   private final OkHttpValidatorTypeDefClient typeDefClient;
+  private final AsyncRunner asyncRunner;
 
   public RemoteValidatorApiHandler(
       final Spec spec,
+      final HttpUrl endpoint,
       final ValidatorRestApiClient apiClient,
       final OkHttpValidatorTypeDefClient typeDefClient,
       final AsyncRunner asyncRunner) {
     this.spec = spec;
+    this.endpoint = endpoint;
     this.apiClient = apiClient;
     this.asyncRunner = asyncRunner;
     this.typeDefClient = typeDefClient;
+  }
+
+  @Override
+  public URI getEndpoint() {
+    return endpoint.uri();
   }
 
   @Override

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandlerTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandlerTest.java
@@ -1,0 +1,461 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.remote;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import it.unimi.dsi.fastutil.ints.IntCollection;
+import it.unimi.dsi.fastutil.ints.IntLists;
+import it.unimi.dsi.fastutil.ints.IntSet;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+import org.apache.tuweni.bytes.Bytes32;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import tech.pegasys.teku.api.response.v1.beacon.ValidatorStatus;
+import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.async.SafeFutureAssert;
+import tech.pegasys.teku.infrastructure.logging.ValidatorLogger;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.execution.SignedValidatorRegistration;
+import tech.pegasys.teku.spec.datastructures.genesis.GenesisData;
+import tech.pegasys.teku.spec.datastructures.operations.Attestation;
+import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
+import tech.pegasys.teku.spec.datastructures.operations.SignedAggregateAndProof;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SignedContributionAndProof;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeContribution;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeMessage;
+import tech.pegasys.teku.spec.datastructures.validator.SubnetSubscription;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.validator.api.AttesterDuties;
+import tech.pegasys.teku.validator.api.CommitteeSubscriptionRequest;
+import tech.pegasys.teku.validator.api.ProposerDuties;
+import tech.pegasys.teku.validator.api.RemoteValidatorApiChannel;
+import tech.pegasys.teku.validator.api.SendSignedBlockResult;
+import tech.pegasys.teku.validator.api.SubmitDataError;
+import tech.pegasys.teku.validator.api.SyncCommitteeDuties;
+import tech.pegasys.teku.validator.api.SyncCommitteeSubnetSubscription;
+import tech.pegasys.teku.validator.api.ValidatorApiChannel;
+import tech.pegasys.teku.validator.remote.FailoverValidatorApiHandler.ValidatorApiChannelRequest;
+
+class FailoverValidatorApiHandlerTest {
+
+  private static final Spec SPEC = TestSpecFactory.createMinimalAltair();
+  private static final DataStructureUtil DATA_STRUCTURE_UTIL = new DataStructureUtil(SPEC);
+
+  private RemoteValidatorApiChannel primaryApiChannel;
+  private RemoteValidatorApiChannel failoverApiChannel1;
+  private RemoteValidatorApiChannel failoverApiChannel2;
+
+  private ValidatorLogger validatorLogger;
+
+  private FailoverValidatorApiHandler failoverApiHandler;
+
+  @BeforeEach
+  void setUp() {
+    primaryApiChannel = mock(RemoteValidatorApiChannel.class);
+    failoverApiChannel1 = mock(RemoteValidatorApiChannel.class);
+    failoverApiChannel2 = mock(RemoteValidatorApiChannel.class);
+
+    validatorLogger = mock(ValidatorLogger.class);
+
+    final Supplier<URI> randomUriGenerator =
+        () -> URI.create("http://" + DATA_STRUCTURE_UTIL.randomBytes4().toHexString() + ".com");
+
+    when(primaryApiChannel.getEndpoint()).thenReturn(randomUriGenerator.get());
+    when(failoverApiChannel1.getEndpoint()).thenReturn(randomUriGenerator.get());
+    when(failoverApiChannel2.getEndpoint()).thenReturn(randomUriGenerator.get());
+
+    failoverApiHandler =
+        new FailoverValidatorApiHandler(
+            primaryApiChannel, List.of(failoverApiChannel1, failoverApiChannel2), validatorLogger);
+  }
+
+  @Test
+  void initializationFailsWhenNoFailoversAreDefined() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            failoverApiHandler =
+                new FailoverValidatorApiHandler(primaryApiChannel, List.of(), validatorLogger));
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("getRequestsUsingFailover")
+  <T> void requestSucceedsWithoutFailover(
+      final ValidatorApiChannelRequest<T> request, final T response) {
+
+    setupSuccesses(request, response, primaryApiChannel);
+
+    final SafeFuture<T> result = request.run(failoverApiHandler);
+
+    assertThat(result).isCompletedWithValue(response);
+
+    verifyNoInteractions(failoverApiChannel1, failoverApiChannel2, validatorLogger);
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("getRequestsUsingFailover")
+  <T> void requestFailoversOnFailure(
+      final ValidatorApiChannelRequest<T> request, final T response) {
+
+    setupSuccesses(request, response, failoverApiChannel2);
+    setupFailures(request, primaryApiChannel, failoverApiChannel1);
+
+    final SafeFuture<T> result = request.run(failoverApiHandler);
+
+    assertThat(result).isCompletedWithValue(response);
+
+    verifyNoInteractions(validatorLogger);
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("getRequestsUsingFailover")
+  <T> void requestFailsOnAllFailovers(final ValidatorApiChannelRequest<T> request) {
+
+    setupFailures(request, primaryApiChannel, failoverApiChannel1, failoverApiChannel2);
+
+    final SafeFuture<T> result = request.run(failoverApiHandler);
+
+    SafeFutureAssert.assertThatSafeFuture(result)
+        .isCompletedExceptionallyWith(IllegalStateException.class)
+        .satisfies(
+            throwable -> {
+              assertThat(throwable)
+                  .hasMessage("Request failed for " + failoverApiChannel2.getEndpoint());
+              assertThat(throwable.getSuppressed()).hasSize(2);
+            });
+
+    verify(validatorLogger).remoteBeaconNodeRequestFailedOnAllConfiguredEndpoints();
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("getRelayRequests")
+  <T> void requestIsRelayedToAllNodes(
+      final ValidatorApiChannelRequest<T> request,
+      final Consumer<ValidatorApiChannel> verifyCallIsMade,
+      final T response) {
+
+    setupSuccesses(request, response, primaryApiChannel, failoverApiChannel1, failoverApiChannel2);
+
+    final SafeFuture<T> result = request.run(failoverApiHandler);
+
+    assertThat(result).isCompletedWithValue(response);
+    verifyCallIsMade.accept(primaryApiChannel);
+
+    verifyCallIsMade.accept(failoverApiChannel1);
+    verifyCallIsMade.accept(failoverApiChannel2);
+
+    verifyNoInteractions(validatorLogger);
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("getRelayRequests")
+  <T> void requestIsRelayedToAllNodesButFailsOnOneFailover(
+      final ValidatorApiChannelRequest<T> request,
+      final Consumer<ValidatorApiChannel> verifyCallIsMade,
+      final T response) {
+
+    setupSuccesses(request, response, primaryApiChannel, failoverApiChannel1);
+    setupFailures(request, failoverApiChannel2);
+
+    final SafeFuture<T> result = request.run(failoverApiHandler);
+
+    assertThat(result).isCompletedWithValue(response);
+    verifyCallIsMade.accept(primaryApiChannel);
+
+    verifyCallIsMade.accept(failoverApiChannel1);
+    verifyCallIsMade.accept(failoverApiChannel2);
+
+    verifyNoInteractions(validatorLogger);
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("getRelayRequests")
+  <T> void requestFailsOnPrimaryNodeButRelayedToFailoverNodes(
+      final ValidatorApiChannelRequest<T> request,
+      final Consumer<ValidatorApiChannel> verifyCallIsMade,
+      final T response) {
+
+    setupFailures(request, primaryApiChannel);
+    setupSuccesses(request, response, failoverApiChannel1, failoverApiChannel2);
+
+    final SafeFuture<T> result = request.run(failoverApiHandler);
+
+    assertThat(result).isCompletedWithValue(response);
+    verifyCallIsMade.accept(primaryApiChannel);
+
+    verifyCallIsMade.accept(failoverApiChannel1);
+    verifyCallIsMade.accept(failoverApiChannel2);
+
+    verifyNoInteractions(validatorLogger);
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("getRelayRequests")
+  <T> void requestFailsOnPrimaryNodeAndOneFailoverIsVerySlow(
+      final ValidatorApiChannelRequest<T> request,
+      final Consumer<ValidatorApiChannel> verifyCallIsMade,
+      final T response) {
+
+    setupFailures(request, primaryApiChannel);
+    // one failover is very slow
+    SafeFuture<T> longRunningFuture =
+        SafeFuture.supplyAsync(
+            () -> {
+              try {
+                TimeUnit.MINUTES.sleep(1);
+              } catch (InterruptedException ex) {
+                Assertions.fail(ex);
+              }
+              return response;
+            });
+    when(request.run(failoverApiChannel1)).thenReturn(longRunningFuture);
+    setupSuccesses(request, response, failoverApiChannel2);
+
+    final SafeFuture<T> result = request.run(failoverApiHandler);
+
+    assertThat(result).isCompletedWithValue(response);
+    verifyCallIsMade.accept(primaryApiChannel);
+
+    verifyCallIsMade.accept(failoverApiChannel1);
+    verifyCallIsMade.accept(failoverApiChannel2);
+
+    verifyNoInteractions(validatorLogger);
+
+    // cleanup
+    longRunningFuture.cancel(true);
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("getRelayRequests")
+  <T> void requestFailsOnPrimaryNodeAndAllFailoverNodes(
+      final ValidatorApiChannelRequest<T> request,
+      @NotNull final Consumer<ValidatorApiChannel> verifyCallIsMade) {
+
+    setupFailures(request, primaryApiChannel, failoverApiChannel1, failoverApiChannel2);
+
+    final SafeFuture<T> result = request.run(failoverApiHandler);
+
+    SafeFutureAssert.assertThatSafeFuture(result)
+        .isCompletedExceptionallyWith(IllegalStateException.class)
+        .satisfies(
+            throwable -> {
+              assertThat(throwable)
+                  .hasMessage("Request failed for " + primaryApiChannel.getEndpoint());
+              assertThat(throwable.getSuppressed()).hasSize(2);
+            });
+
+    verifyCallIsMade.accept(primaryApiChannel);
+
+    verifyCallIsMade.accept(failoverApiChannel1);
+    verifyCallIsMade.accept(failoverApiChannel2);
+
+    verify(validatorLogger).remoteBeaconNodeRequestFailedOnAllConfiguredEndpoints();
+  }
+
+  private <T> void setupSuccesses(
+      final ValidatorApiChannelRequest<T> request,
+      final T response,
+      final RemoteValidatorApiChannel... apiChannels) {
+    Stream.of(apiChannels)
+        .forEach(
+            apiChannel ->
+                when(request.run(apiChannel)).thenReturn(SafeFuture.completedFuture(response)));
+  }
+
+  private <T> void setupFailures(
+      final ValidatorApiChannelRequest<T> request, final RemoteValidatorApiChannel... apiChannels) {
+    Stream.of(apiChannels)
+        .forEach(
+            apiChannel -> {
+              final IllegalStateException exception =
+                  new IllegalStateException(
+                      String.format("Request failed for %s", apiChannel.getEndpoint()));
+              when(request.run(apiChannel)).thenReturn(SafeFuture.failedFuture(exception));
+            });
+  }
+
+  private static Stream<Arguments> getRequestsUsingFailover() {
+    final GenesisData genesisData =
+        new GenesisData(DATA_STRUCTURE_UTIL.randomUInt64(), DATA_STRUCTURE_UTIL.randomBytes32());
+    final BLSPublicKey publicKey = DATA_STRUCTURE_UTIL.randomPublicKey();
+    final IntCollection validatorIndices = IntLists.singleton(0);
+    final UInt64 slot = DATA_STRUCTURE_UTIL.randomUInt64();
+    final BLSSignature randaoReveal = DATA_STRUCTURE_UTIL.randomSignature();
+    final UInt64 epoch = DATA_STRUCTURE_UTIL.randomUInt64();
+    final Bytes32 randomBytes32 = DATA_STRUCTURE_UTIL.randomBytes32();
+    final Attestation attestation = DATA_STRUCTURE_UTIL.randomAttestation();
+
+    return Stream.of(
+        getArguments(
+            "getGenesisData", ValidatorApiChannel::getGenesisData, Optional.of(genesisData)),
+        getArguments(
+            "getValidatorIndices",
+            apiChannel -> apiChannel.getValidatorIndices(List.of(publicKey)),
+            Map.of(publicKey, 0)),
+        getArguments(
+            "getValidatorStatuses",
+            apiChannel -> apiChannel.getValidatorStatuses(List.of(publicKey)),
+            Optional.of(Map.of(publicKey, ValidatorStatus.active_ongoing))),
+        getArguments(
+            "getAttestationDuties",
+            apiChannel -> apiChannel.getAttestationDuties(epoch, validatorIndices),
+            Optional.of(mock(AttesterDuties.class))),
+        getArguments(
+            "getSyncCommitteeDuties",
+            apiChannel -> apiChannel.getSyncCommitteeDuties(epoch, validatorIndices),
+            Optional.of(mock(SyncCommitteeDuties.class))),
+        getArguments(
+            "getProposerDuties",
+            apiChannel -> apiChannel.getProposerDuties(epoch),
+            Optional.of(mock(ProposerDuties.class))),
+        getArguments(
+            "createUnsignedBlock",
+            apiChannel ->
+                apiChannel.createUnsignedBlock(slot, randaoReveal, Optional.empty(), true),
+            Optional.of(mock(BeaconBlock.class))),
+        getArguments(
+            "createAttestationData",
+            apiChannel -> apiChannel.createAttestationData(slot, 0),
+            Optional.of(mock(AttestationData.class))),
+        getArguments(
+            "createAggregate",
+            apiChannel -> apiChannel.createAggregate(slot, randomBytes32),
+            Optional.of(attestation)),
+        getArguments(
+            "createSyncCommitteeContribution",
+            apiChannel -> apiChannel.createSyncCommitteeContribution(slot, 0, randomBytes32),
+            Optional.of(mock(SyncCommitteeContribution.class))));
+  }
+
+  private static Stream<Arguments> getRelayRequests() {
+    final CommitteeSubscriptionRequest committeeSubscriptionRequest =
+        new CommitteeSubscriptionRequest(0, 0, UInt64.ZERO, UInt64.ONE, true);
+    final SyncCommitteeSubnetSubscription syncCommitteeSubnetSubscription =
+        new SyncCommitteeSubnetSubscription(0, IntSet.of(1), UInt64.ZERO);
+    final SubnetSubscription subnetSubscription = new SubnetSubscription(0, UInt64.ONE);
+    final Attestation attestation = DATA_STRUCTURE_UTIL.randomAttestation();
+    final SubmitDataError submitDataError =
+        new SubmitDataError(DATA_STRUCTURE_UTIL.randomUInt64(), "foo");
+    final SignedAggregateAndProof signedAggregateAndProof =
+        DATA_STRUCTURE_UTIL.randomSignedAggregateAndProof();
+    final SignedBeaconBlock signedBeaconBlock =
+        DATA_STRUCTURE_UTIL.randomSignedBlindedBeaconBlock();
+    final SyncCommitteeMessage syncCommitteeMessage =
+        DATA_STRUCTURE_UTIL.randomSyncCommitteeMessage();
+    final SignedContributionAndProof signedContributionAndProof =
+        DATA_STRUCTURE_UTIL.randomSignedContributionAndProof(2);
+    final SszList<SignedValidatorRegistration> validatorRegistrations =
+        DATA_STRUCTURE_UTIL.randomSignedValidatorRegistrations(3);
+
+    return Stream.of(
+        getArguments(
+            "subscribeToBeaconCommittee",
+            apiChannel ->
+                apiChannel.subscribeToBeaconCommittee(List.of(committeeSubscriptionRequest)),
+            apiChannel ->
+                verify(apiChannel)
+                    .subscribeToBeaconCommittee(List.of(committeeSubscriptionRequest)),
+            null),
+        getArguments(
+            "subscribeToSyncCommitteeSubnets",
+            apiChannel ->
+                apiChannel.subscribeToSyncCommitteeSubnets(
+                    List.of(syncCommitteeSubnetSubscription)),
+            apiChannel ->
+                verify(apiChannel)
+                    .subscribeToSyncCommitteeSubnets(List.of(syncCommitteeSubnetSubscription)),
+            null),
+        getArguments(
+            "subscribeToPersistentSubnets",
+            apiChannel -> apiChannel.subscribeToPersistentSubnets(Set.of(subnetSubscription)),
+            apiChannel ->
+                verify(apiChannel).subscribeToPersistentSubnets(Set.of(subnetSubscription)),
+            null),
+        getArguments(
+            "sendSignedAttestations",
+            apiChannel -> apiChannel.sendSignedAttestations(List.of(attestation)),
+            apiChannel -> verify(apiChannel).sendSignedAttestations(List.of(attestation)),
+            List.of(submitDataError)),
+        getArguments(
+            "sendAggregateAndProofs",
+            apiChannel -> apiChannel.sendAggregateAndProofs(List.of(signedAggregateAndProof)),
+            apiChannel ->
+                verify(apiChannel).sendAggregateAndProofs(List.of(signedAggregateAndProof)),
+            List.of(submitDataError)),
+        getArguments(
+            "sendSignedBlock",
+            apiChannel -> apiChannel.sendSignedBlock(signedBeaconBlock),
+            apiChannel -> verify(apiChannel).sendSignedBlock(signedBeaconBlock),
+            mock(SendSignedBlockResult.class)),
+        getArguments(
+            "sendSyncCommitteeMessages",
+            apiChannel -> apiChannel.sendSyncCommitteeMessages(List.of(syncCommitteeMessage)),
+            apiChannel ->
+                verify(apiChannel).sendSyncCommitteeMessages(List.of(syncCommitteeMessage)),
+            List.of(submitDataError)),
+        getArguments(
+            "sendSignedContributionAndProofs",
+            apiChannel ->
+                apiChannel.sendSignedContributionAndProofs(List.of(signedContributionAndProof)),
+            apiChannel ->
+                verify(apiChannel)
+                    .sendSignedContributionAndProofs(List.of(signedContributionAndProof)),
+            null),
+        getArguments(
+            "registerValidators",
+            apiChannel -> apiChannel.registerValidators(validatorRegistrations),
+            apiChannel -> verify(apiChannel).registerValidators(validatorRegistrations),
+            null));
+  }
+
+  private static <T> Arguments getArguments(
+      final String name, final ValidatorApiChannelRequest<T> request, final T response) {
+    return Arguments.of(Named.of(name, request), response);
+  }
+
+  private static <T> Arguments getArguments(
+      final String name,
+      final ValidatorApiChannelRequest<T> request,
+      final Consumer<ValidatorApiChannel> verifyCallIsMade,
+      final T response) {
+    return Arguments.of(Named.of(name, request), verifyCallIsMade, response);
+  }
+}

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
@@ -39,6 +39,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.IntStream;
+import okhttp3.HttpUrl;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -84,6 +85,7 @@ import tech.pegasys.teku.validator.remote.typedef.OkHttpValidatorTypeDefClient;
 class RemoteValidatorApiHandlerTest {
 
   private final Spec spec = TestSpecFactory.createMinimalPhase0();
+  private final HttpUrl endpoint = HttpUrl.get("http://localhost:5051");
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
   private final StubAsyncRunner asyncRunner = new StubAsyncRunner();
 
@@ -96,7 +98,13 @@ class RemoteValidatorApiHandlerTest {
 
   @BeforeEach
   public void beforeEach() {
-    apiHandler = new RemoteValidatorApiHandler(spec, apiClient, typeDefClient, asyncRunner);
+    apiHandler =
+        new RemoteValidatorApiHandler(spec, endpoint, apiClient, typeDefClient, asyncRunner);
+  }
+
+  @Test
+  public void getsEndpoint() {
+    assertThat(apiHandler.getEndpoint()).isEqualTo(endpoint.uri());
   }
 
   @Test


### PR DESCRIPTION
## PR Description

In future PRs, this failover implementation will be used as part of the VC initialization when more than one BN endpoints are specified.

- Introduced` FailoverValidatorApiHandler` which implements `ValidatorApiChannel`
- Introduced `firstSuccess` in `SafeFuture`
- Introduced `RemoteValidatorApiHandler` in order to expose the endpoint as part of the interface implementations

## Fixed Issue(s)
will help for #5237 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
