### PR TITLE
builder fallback improvements

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
@@ -153,18 +153,14 @@ public class BlockOperationSelectorFactory {
                         .getExecutionPayloadHeaderSchema()
                         .getHeaderOfDefaultPayload(),
                 (executionPayloadContext) -> {
-                  final boolean forceLocalFallback =
+                  final boolean transitionNotFinalized =
                       executionPayloadContext
                           .getForkChoiceState()
                           .getFinalizedExecutionBlockHash()
                           .isZero();
 
-                  if (forceLocalFallback) {
-                    LOG.info(
-                        "Merge transition not finalized: forcing block production using local execution engine");
-                  }
                   return executionLayerChannel.builderGetHeader(
-                      executionPayloadContext, blockSlotState, forceLocalFallback);
+                      executionPayloadContext, blockSlotState, transitionNotFinalized);
                 }));
         return;
       }

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
@@ -19,8 +19,6 @@ import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -47,8 +45,6 @@ import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceNotifier;
 import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeContributionPool;
 
 public class BlockOperationSelectorFactory {
-  private static final Logger LOG = LogManager.getLogger();
-
   private final Spec spec;
   private final AggregatingAttestationPool attestationPool;
   private final OperationPool<AttesterSlashing> attesterSlashingPool;

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImplTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImplTest.java
@@ -403,7 +403,7 @@ class ExecutionLayerManagerImplTest {
     verifyNoMoreInteractions(executionBuilderClient);
     verifyNoMoreInteractions(executionEngineClient);
 
-    verifySourceCounter(Source.BUILDER_LOCAL_EL_FALLBACK, FallbackReason.FORCED);
+    verifySourceCounter(Source.BUILDER_LOCAL_EL_FALLBACK, FallbackReason.TRANSITION_NOT_FINALIZED);
   }
 
   @Test

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannel.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannel.java
@@ -77,7 +77,7 @@ public interface ExecutionLayerChannel extends ChannelInterface {
         public SafeFuture<ExecutionPayloadHeader> builderGetHeader(
             final ExecutionPayloadContext executionPayloadContext,
             final BeaconState state,
-            final boolean forceLocalFallback) {
+            final boolean transitionNotFinalized) {
           return SafeFuture.completedFuture(null);
         }
 
@@ -113,7 +113,7 @@ public interface ExecutionLayerChannel extends ChannelInterface {
   SafeFuture<ExecutionPayloadHeader> builderGetHeader(
       ExecutionPayloadContext executionPayloadContext,
       BeaconState state,
-      boolean forceLocalFallback);
+      boolean transitionNotFinalized);
 
   SafeFuture<ExecutionPayload> builderGetPayload(SignedBeaconBlock signedBlindedBeaconBlock);
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
@@ -272,7 +272,7 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
   public SafeFuture<ExecutionPayloadHeader> builderGetHeader(
       final ExecutionPayloadContext executionPayloadContext,
       final BeaconState state,
-      final boolean forceLocalFallback) {
+      final boolean transitionNotFinalized) {
     final UInt64 slot = state.getSlot();
     LOG.info(
         "getPayloadHeader: payloadId: {} slot: {} ... delegating to getPayload ...",


### PR DESCRIPTION
Three new fallback reasons added

`NOT_NEEDED`: when builder is not configured and validator is not registered, which covers the configuration in which blinded flow is active but builder endpoint and validator registration are not configured. The fallback log in this case is at `DEBUG` level

`TRANSITION_NOT_FINALIZED`: substitute `FORCED`

`BUILDER_NOT_CONFIGURED`: indicates that the validator was registered but no builder endpoint was configured.


## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
