### PR TITLE
Add goerli as an alias for prater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ For information on changes in released versions of Teku, see the [releases page]
 ### Breaking Changes
 
 ### Additions and Improvements
+ - Support `--network=goerli` as an alias for `--network=prater`
  - Log a warning instead of a verbose error if node is syncing while performing sync committee duties
  - Distributions created from the same git commit and docker image will be identical
  - Optimised storage of latest vote information by batching updates

--- a/ethereum/networks/src/test/java/tech/pegasys/teku/networks/Eth2NetworkConfigurationTest.java
+++ b/ethereum/networks/src/test/java/tech/pegasys/teku/networks/Eth2NetworkConfigurationTest.java
@@ -44,6 +44,15 @@ public class Eth2NetworkConfigurationTest {
   }
 
   @Test
+  void shouldAliasGoerliToPrater() {
+    final Eth2NetworkConfiguration goerliConfig =
+        Eth2NetworkConfiguration.builder("goerli").build();
+    final Eth2NetworkConfiguration praterConfig =
+        Eth2NetworkConfiguration.builder("prater").build();
+    assertThat(goerliConfig).usingRecursiveComparison().isEqualTo(praterConfig);
+  }
+
+  @Test
   public void builder_usingConstantsUrl() {
     final URL url =
         getClass().getClassLoader().getResource("tech/pegasys/teku/networks/test-constants.yaml");

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/networks/Eth2Network.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/networks/Eth2Network.java
@@ -52,6 +52,9 @@ public enum Eth2Network {
         return Optional.of(value);
       }
     }
+    if (normalizedNetworkName.equals("GOERLI")) {
+      return Optional.of(PRATER);
+    }
     return Optional.empty();
   }
 }


### PR DESCRIPTION
## PR Description
Support `--network=goerli` as an alias for `--network=prater`.

## Fixed Issue(s)
fixes #5931 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
