### PR TITLE
Restore CONFIG_NAME=prater

### DIFF
--- a/ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/prater.yaml
+++ b/ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/prater.yaml
@@ -2,7 +2,7 @@
 PRESET_BASE: 'mainnet'
 
 # For backwards compatibility in the config/spec API
-CONFIG_NAME: "goerli"
+CONFIG_NAME: "prater"
 
 # Transition
 # ---------------------------------------------------------------

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/config/SpecConfigLoaderTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/config/SpecConfigLoaderTest.java
@@ -63,8 +63,7 @@ public class SpecConfigLoaderTest {
   @ValueSource(strings = {"prater", "mainnet"})
   public void shouldMaintainConfigNameBackwardsCompatibility(final String name) {
     final SpecConfig config = SpecConfigLoader.loadConfig(name);
-    final String expectedName = name.equals("prater") ? "goerli" : name;
-    assertThat(config.getRawConfig().get("CONFIG_NAME")).isEqualTo(expectedName);
+    assertThat(config.getRawConfig().get("CONFIG_NAME")).isEqualTo(name);
   }
 
   @Test


### PR DESCRIPTION
## PR Description
Change CONFIG_NAME back to prater to avoid any risk of incompatibility.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
