### PR TITLE
Don't mark blocks before latestValidHash as fully validated

### DIFF
--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
@@ -565,7 +565,7 @@ class ForkChoiceTest {
     importBlockWithError(invalidBlock, FailureReason.FAILED_STATE_TRANSITION);
     assertThat(forkChoice.processHead(invalidBlock.getSlot())).isCompleted();
 
-    assertHeadIsFullyValidated(maybeValidBlock);
+    assertHeadIsOptimistic(maybeValidBlock);
     assertThat(forkChoiceStrategy.getChainHeads().get(0).getRoot())
         .isEqualTo(maybeValidBlock.getRoot());
   }
@@ -780,8 +780,8 @@ class ForkChoiceTest {
     ForkChoiceState lastNotifiedState = forkChoiceStateCaptor.getValue();
     assertThat(lastNotifiedState.getHeadBlockRoot()).isEqualTo(blockAndState.getRoot());
 
-    // we have now no optimistic head
-    assertHeadIsFullyValidated(blockAndState);
+    // New head is optimistic because latestValidHash might still point to an optimistic block
+    assertHeadIsOptimistic(blockAndState);
   }
 
   private void assertHeadIsOptimistic(final SignedBlockAndState blockAndState) {
@@ -790,14 +790,6 @@ class ForkChoiceTest {
     assertThat(optimisticHead.getRoot()).isEqualTo(blockAndState.getRoot());
     assertThat(optimisticHead.isOptimistic()).isTrue();
     assertThat(recentChainData.isChainHeadOptimistic()).isTrue();
-  }
-
-  private void assertHeadIsFullyValidated(final SignedBlockAndState blockAndState) {
-    assertThat(recentChainData.isChainHeadOptimistic()).isFalse();
-    assertThat(recentChainData.getChainHead().orElseThrow().getSlot())
-        .isEqualTo(blockAndState.getSlot());
-    assertThat(recentChainData.getChainHead().orElseThrow().getRoot())
-        .isEqualTo(blockAndState.getRoot());
   }
 
   private boolean isFullyValidated(final Bytes32 root) {

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArray.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArray.java
@@ -320,10 +320,6 @@ public class ProtoArray {
 
       index = maybeFirstInvalidNodeIndex.orElse(maybeIndex.get());
       node = getNodeByIndex(index);
-      // We found the latestValidHash so mark it as valid
-      if (maybeFirstInvalidNodeIndex.isPresent()) {
-        markNodeValid(node.getParentRoot());
-      }
     } else {
       index = maybeIndex.get();
       node = getNodeByIndex(index);

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ProtoArrayTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ProtoArrayTest.java
@@ -276,7 +276,7 @@ class ProtoArrayTest {
   }
 
   @Test
-  void markNodeInvalid_shouldMarkLastValidBlockAndAncestorsAsValid() {
+  void markNodeInvalid_shouldLeaveLastValidBlockAndAncestorsAsOptimistic() {
     addOptimisticBlock(1, block1a, GENESIS_CHECKPOINT.getRoot());
     addOptimisticBlock(2, block2a, block1a);
     addOptimisticBlock(3, block3a, block2a);
@@ -291,8 +291,8 @@ class ProtoArrayTest {
     assertThat(protoArray.contains(block3a)).isFalse();
     assertThat(protoArray.contains(block2a)).isTrue();
     assertThat(protoArray.contains(block1a)).isTrue();
-    assertThat(protoArray.getProtoNode(block1a).map(ProtoNode::isOptimistic)).contains(false);
-    assertThat(protoArray.getProtoNode(block2a).map(ProtoNode::isOptimistic)).contains(false);
+    assertThat(protoArray.getProtoNode(block1a).map(ProtoNode::isOptimistic)).contains(true);
+    assertThat(protoArray.getProtoNode(block2a).map(ProtoNode::isOptimistic)).contains(true);
   }
 
   @Test


### PR DESCRIPTION
## PR Description
While latestValidHash guarantees that every block after it is invalid, there are cases where the EL may not have fully executed the block returned as latestValidHash (typically because it's on a non-canonical fork). As such it is not safe to mark those nodes as fully VALID and they should be left as optimsitically imported.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
