### PR TITLE
Add CLI flag for sending subnet subscriptions to BN failovers

### DIFF
--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorClientOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorClientOptions.java
@@ -45,6 +45,17 @@ public class ValidatorClientOptions {
   private List<String> beaconNodeApiEndpoints = ValidatorConfig.DEFAULT_BEACON_NODE_API_ENDPOINTS;
 
   @Option(
+      names = {"--Xfailovers-send-subnet-subscriptions-enabled"},
+      paramLabel = "<BOOLEAN>",
+      description = "Send subnet subscriptions to Beacon Nodes which are used as failovers",
+      hidden = true,
+      showDefaultValue = CommandLine.Help.Visibility.ALWAYS,
+      arity = "0..1",
+      fallbackValue = "true")
+  private boolean failoversSendSubnetSubscriptionsEnabled =
+      ValidatorConfig.DEFAULT_FAILOVERS_SEND_SUBNET_SUBSCRIPTIONS_ENABLED;
+
+  @Option(
       names = {"--Xbeacon-node-ssz-blocks-enabled"},
       paramLabel = "<BOOLEAN>",
       description = "Use SSZ encoding for API block requests",
@@ -60,7 +71,8 @@ public class ValidatorClientOptions {
             config
                 .beaconNodeApiEndpoint(getBeaconNodeApiEndpoint())
                 .beaconNodeApiEndpoints(getBeaconNodeApiEndpoints())
-                .validatorClientUseSszBlocksEnabled(validatorClientSszBlocksEnabled));
+                .validatorClientUseSszBlocksEnabled(validatorClientSszBlocksEnabled)
+                .failoversSendSubnetSubscriptionsEnabled(failoversSendSubnetSubscriptionsEnabled));
   }
 
   public URI getBeaconNodeApiEndpoint() {

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
@@ -37,6 +37,7 @@ public class ValidatorConfig {
   public static final String DEFAULT_BEACON_NODE_API_ENDPOINT =
       "http://127.0.0.1:" + DEFAULT_REST_API_PORT;
   public static final List<String> DEFAULT_BEACON_NODE_API_ENDPOINTS = List.of();
+  public static final boolean DEFAULT_FAILOVERS_SEND_SUBNET_SUBSCRIPTIONS_ENABLED = true;
   public static final boolean DEFAULT_VALIDATOR_CLIENT_SSZ_BLOCKS_ENABLED = false;
   public static final int DEFAULT_EXECUTOR_MAX_QUEUE_SIZE = 20_000;
   public static final Duration DEFAULT_VALIDATOR_EXTERNAL_SIGNER_TIMEOUT = Duration.ofSeconds(5);
@@ -73,6 +74,7 @@ public class ValidatorConfig {
   private final boolean blindedBeaconBlocksEnabled;
   private final boolean builderRegistrationDefaultEnabled;
   private final boolean validatorClientUseSszBlocksEnabled;
+  private final boolean failoversSendSubnetSubscriptionsEnabled;
   private final UInt64 builderRegistrationDefaultGasLimit;
   private final int builderRegistrationSendingBatchSize;
   private final Optional<UInt64> builderRegistrationTimestampOverride;
@@ -102,6 +104,7 @@ public class ValidatorConfig {
       final boolean builderRegistrationDefaultEnabled,
       final boolean blindedBeaconBlocksEnabled,
       final boolean validatorClientUseSszBlocksEnabled,
+      final boolean failoversSendSubnetSubscriptionsEnabled,
       final UInt64 builderRegistrationDefaultGasLimit,
       final int builderRegistrationSendingBatchSize,
       final Optional<UInt64> builderRegistrationTimestampOverride,
@@ -131,6 +134,7 @@ public class ValidatorConfig {
     this.blindedBeaconBlocksEnabled = blindedBeaconBlocksEnabled;
     this.builderRegistrationDefaultEnabled = builderRegistrationDefaultEnabled;
     this.validatorClientUseSszBlocksEnabled = validatorClientUseSszBlocksEnabled;
+    this.failoversSendSubnetSubscriptionsEnabled = failoversSendSubnetSubscriptionsEnabled;
     this.builderRegistrationDefaultGasLimit = builderRegistrationDefaultGasLimit;
     this.builderRegistrationSendingBatchSize = builderRegistrationSendingBatchSize;
     this.builderRegistrationTimestampOverride = builderRegistrationTimestampOverride;
@@ -232,6 +236,10 @@ public class ValidatorConfig {
     return validatorClientUseSszBlocksEnabled;
   }
 
+  public boolean isFailoversSendSubnetSubscriptionsEnabled() {
+    return failoversSendSubnetSubscriptionsEnabled;
+  }
+
   public boolean isBuilderRegistrationDefaultEnabled() {
     return builderRegistrationDefaultEnabled;
   }
@@ -278,6 +286,8 @@ public class ValidatorConfig {
         DEFAULT_BUILDER_REGISTRATION_DEFAULT_ENABLED;
     private boolean blindedBlocksEnabled = DEFAULT_VALIDATOR_BLINDED_BLOCKS_ENABLED;
     private boolean validatorClientSszBlocksEnabled = DEFAULT_VALIDATOR_CLIENT_SSZ_BLOCKS_ENABLED;
+    private boolean failoversSendSubnetSubscriptionsEnabled =
+        DEFAULT_FAILOVERS_SEND_SUBNET_SUBSCRIPTIONS_ENABLED;
     private UInt64 builderRegistrationDefaultGasLimit = DEFAULT_BUILDER_REGISTRATION_GAS_LIMIT;
     private int builderRegistrationSendingBatchSize =
         DEFAULT_VALIDATOR_REGISTRATION_SENDING_BATCH_SIZE;
@@ -425,6 +435,12 @@ public class ValidatorConfig {
       return this;
     }
 
+    public Builder failoversSendSubnetSubscriptionsEnabled(
+        final boolean failoversSendSubnetSubscriptionsEnabled) {
+      this.failoversSendSubnetSubscriptionsEnabled = failoversSendSubnetSubscriptionsEnabled;
+      return this;
+    }
+
     public Builder builderRegistrationDefaultGasLimit(
         final UInt64 builderRegistrationDefaultGasLimit) {
       this.builderRegistrationDefaultGasLimit = builderRegistrationDefaultGasLimit;
@@ -479,6 +495,7 @@ public class ValidatorConfig {
           validatorsRegistrationDefaultEnabled,
           blindedBlocksEnabled,
           validatorClientSszBlocksEnabled,
+          failoversSendSubnetSubscriptionsEnabled,
           builderRegistrationDefaultGasLimit,
           builderRegistrationSendingBatchSize,
           builderRegistrationTimestampOverride,

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
@@ -113,6 +113,8 @@ public class ValidatorClientService extends Service {
             "validator", validatorConfig.getExecutorMaxQueueSize());
     final boolean generateEarlyAttestations = validatorConfig.generateEarlyAttestations();
     final boolean preferSszBlockEncoding = validatorConfig.isValidatorClientUseSszBlocksEnabled();
+    final boolean failoversSendSubnetSubscriptions =
+        validatorConfig.isFailoversSendSubnetSubscriptionsEnabled();
     final List<URI> beaconNodeApiEndpoints = validatorConfig.getBeaconNodeApiEndpoints();
 
     BeaconNodeApi beaconNodeApi;
@@ -128,7 +130,8 @@ public class ValidatorClientService extends Service {
                           List.of(endpoint),
                           config.getSpec(),
                           generateEarlyAttestations,
-                          preferSszBlockEncoding))
+                          preferSszBlockEncoding,
+                          failoversSendSubnetSubscriptions))
               .orElseGet(
                   () ->
                       InProcessBeaconNodeApi.create(
@@ -141,7 +144,8 @@ public class ValidatorClientService extends Service {
               beaconNodeApiEndpoints,
               config.getSpec(),
               generateEarlyAttestations,
-              preferSszBlockEncoding);
+              preferSszBlockEncoding,
+              failoversSendSubnetSubscriptions);
     }
 
     final ValidatorApiChannel validatorApiChannel = beaconNodeApi.getValidatorApi();

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApi.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApi.java
@@ -64,7 +64,8 @@ public class RemoteBeaconNodeApi implements BeaconNodeApi {
       final List<URI> beaconNodeApiEndpoints,
       final Spec spec,
       final boolean generateEarlyAttestations,
-      final boolean preferSszBlockEncoding) {
+      final boolean preferSszBlockEncoding,
+      final boolean failoversSendSubnetSubscriptions) {
     Preconditions.checkArgument(
         !beaconNodeApiEndpoints.isEmpty(),
         "One or more Beacon Node endpoints should be defined for enabling remote connectivity from VC to BN.");
@@ -97,7 +98,10 @@ public class RemoteBeaconNodeApi implements BeaconNodeApi {
               .collect(Collectors.toList());
       validatorApi =
           new FailoverValidatorApiHandler(
-              primaryValidatorApi, failoversValidatorApis, ValidatorLogger.VALIDATOR_LOGGER);
+              primaryValidatorApi,
+              failoversValidatorApis,
+              failoversSendSubnetSubscriptions,
+              ValidatorLogger.VALIDATOR_LOGGER);
     }
 
     final ValidatorApiChannel validatorApiWithMetrics =

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApiTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApiTest.java
@@ -35,7 +35,13 @@ class RemoteBeaconNodeApiTest {
     assertThatThrownBy(
             () ->
                 RemoteBeaconNodeApi.create(
-                    serviceConfig, asyncRunner, List.of(new URI("notvalid")), spec, false, false))
+                    serviceConfig,
+                    asyncRunner,
+                    List.of(new URI("notvalid")),
+                    spec,
+                    false,
+                    false,
+                    true))
         .hasMessageContaining("Failed to convert remote api endpoint");
   }
 }


### PR DESCRIPTION
## PR Description
Add hidden CLI option `--Xfailovers-send-subnet-subscriptions-enabled` which enables/disables sending subnet subscriptions to failover beacon nodes if such are configured

## Fixed Issue(s)
will help for #5237 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
