### PR TITLE
Fix log message when VC refuses to perform a duty in the future

### DIFF
--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AbstractDutyScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AbstractDutyScheduler.java
@@ -158,9 +158,10 @@ public abstract class AbstractDutyScheduler implements ValidatorTimingChannel {
 
     if (!isAbleToVerifyEpoch(slot)) {
       LOG.info(
-          "Not performing {} duties for slot {} because it is too far ahead of the current slot {}",
+          "Not performing {} duties for slot {} because epoch {} is too far ahead of the current epoch {}",
           dutyType,
           slot,
+          spec.computeEpochAtSlot(slot),
           getCurrentEpoch().map(UInt64::toString).orElse("UNDEFINED"));
       return;
     }
@@ -179,9 +180,10 @@ public abstract class AbstractDutyScheduler implements ValidatorTimingChannel {
   public void onAttestationAggregationDue(final UInt64 slot) {
     if (!isAbleToVerifyEpoch(slot)) {
       LOG.info(
-          "Not performing {} aggregation duties for slot {} because it is too far ahead of the current slot {}",
+          "Not performing {} aggregation duties for slot {} because epoch {} is too far ahead of the current epoch {}",
           dutyType,
           slot,
+          spec.computeEpochAtSlot(slot),
           getCurrentEpoch().map(UInt64::toString).orElse("UNDEFINED"));
       return;
     }


### PR DESCRIPTION
## PR Description
Old message logged the current epoch but called it a slot which is confusing.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
