### PR TITLE
migrate finalized blocks to blinded storage

### DIFF
--- a/services/chainstorage/src/main/java/tech/pegasys/teku/services/chainstorage/BlindedBlockMigrationService.java
+++ b/services/chainstorage/src/main/java/tech/pegasys/teku/services/chainstorage/BlindedBlockMigrationService.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.services.chainstorage;
+
+import java.util.Optional;
+import tech.pegasys.teku.infrastructure.async.AsyncRunner;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.service.serviceutils.Service;
+import tech.pegasys.teku.storage.server.Database;
+import tech.pegasys.teku.storage.server.kvstore.BlindedBlockMigration;
+
+public class BlindedBlockMigrationService extends Service {
+  private final AsyncRunner asyncRunner;
+  private final Optional<BlindedBlockMigration<?>> maybeMigrater;
+  private SafeFuture<Void> executor;
+
+  public BlindedBlockMigrationService(final AsyncRunner asyncRunner, final Database database) {
+    this.asyncRunner = asyncRunner;
+    this.maybeMigrater = database.getBlindedBlockMigrater();
+  }
+
+  @Override
+  protected SafeFuture<?> doStart() {
+    if (maybeMigrater.isPresent()) {
+      executor = asyncRunner.runAsync(() -> maybeMigrater.get().migrateBlocks());
+    } else {
+      executor = SafeFuture.COMPLETE;
+    }
+    return SafeFuture.COMPLETE;
+  }
+
+  @Override
+  protected SafeFuture<?> doStop() {
+    if (!executor.isDone()) {
+      maybeMigrater.ifPresent(BlindedBlockMigration::terminate);
+    }
+    return executor;
+  }
+}

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
@@ -35,6 +35,7 @@ import tech.pegasys.teku.storage.api.StorageUpdate;
 import tech.pegasys.teku.storage.api.UpdateResult;
 import tech.pegasys.teku.storage.api.WeakSubjectivityState;
 import tech.pegasys.teku.storage.api.WeakSubjectivityUpdate;
+import tech.pegasys.teku.storage.server.kvstore.BlindedBlockMigration;
 
 public interface Database extends AutoCloseable {
 
@@ -138,4 +139,12 @@ public interface Database extends AutoCloseable {
   long countExecutionPayloads();
 
   long countNonCanonicalSlots();
+
+  long countNonCanonicalBlocks();
+
+  Optional<BlindedBlockMigration<?>> getBlindedBlockMigrater();
+
+  long countUnblindedFinalizedBlockIndices();
+
+  long countBlindedFinalizedBlockIndices();
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/BlindedBlockMigration.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/BlindedBlockMigration.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.server.kvstore;
+
+import com.google.common.primitives.Longs;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Stream;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.storage.server.kvstore.dataaccess.KvStoreCombinedDaoBlinded;
+import tech.pegasys.teku.storage.server.kvstore.dataaccess.KvStoreCombinedDaoUnblinded;
+
+public class BlindedBlockMigration<
+    T extends KvStoreCombinedDaoBlinded & KvStoreCombinedDaoUnblinded> {
+  private static final Logger LOG = LogManager.getLogger();
+  private static final int BLOCK_BATCH_SIZE = 25;
+
+  private static final int INDEX_BATCH_SIZE = 10_000;
+  private static final int PAUSE_BETWEEN_BATCH_MS = 100;
+  private static final int LOGGING_FREQUENCY = 10_000;
+
+  private final Spec spec;
+
+  private final T dao;
+
+  private final AtomicBoolean active = new AtomicBoolean(true);
+
+  public BlindedBlockMigration(final Spec spec, final T dao) {
+    this.spec = spec;
+    this.dao = dao;
+  }
+
+  public void terminate() {
+    active.set(false);
+  }
+
+  public void migrateBlocks() {
+    if (active.get()) {
+      copyFinalizedBlockIndexToBlindedStorage();
+    }
+    if (active.get()) {
+      migrateFinalizedBlocksPreBellatrix();
+    }
+    if (active.get()) {
+      migrateFinalizedBlocks();
+    }
+    if (active.get()) {
+      migrateNonCanonicalBlocks();
+    }
+  }
+
+  private void copyFinalizedBlockIndexToBlindedStorage() {
+    final long migrationCounter = dao.countUnblindedFinalizedBlocks();
+    if (migrationCounter == 0) {
+      return;
+    }
+    LOG.info(
+        "Copying finalized block index to blinded storage, {} entries to copy", migrationCounter);
+    long counter = 0;
+    try (final Stream<ColumnEntry<Bytes32, UInt64>> blockRoots =
+        dao.streamUnblindedFinalizedBlockRoots()) {
+      for (Iterator<ColumnEntry<Bytes32, UInt64>> it = blockRoots.iterator();
+          it.hasNext() && active.get(); ) {
+        try (KvStoreCombinedDaoBlinded.FinalizedUpdaterBlinded finalizedUpdaterBlinded =
+            dao.finalizedUpdaterBlinded()) {
+          for (int i = 0; i < INDEX_BATCH_SIZE && it.hasNext() && active.get(); i++) {
+            final ColumnEntry<Bytes32, UInt64> entry = it.next();
+            final Bytes32 root = entry.getKey();
+            final UInt64 slot = entry.getValue();
+            finalizedUpdaterBlinded.addFinalizedBlockRootBySlot(slot, root);
+            counter++;
+            if (counter % LOGGING_FREQUENCY == 0 || counter == migrationCounter) {
+              double pct = getPercentageOfTotal(counter, migrationCounter);
+              LOG.info(
+                  "{} finalized block indices copied ({} %)", counter, String.format("%.2f", pct));
+            }
+          }
+          finalizedUpdaterBlinded.commit();
+        }
+
+        pause();
+      }
+    }
+  }
+
+  private void migrateFinalizedBlocksPreBellatrix() {
+    final long migrationCounter = dao.countUnblindedFinalizedBlocks();
+    if (migrationCounter == 0) {
+      return;
+    }
+    LOG.info(
+        "Migrating pre-bellatrix blocks to blinded storage, {} finalized blocks to migrate",
+        migrationCounter);
+
+    long counter = 0;
+    boolean preBellatrix = true;
+    try (final Stream<Map.Entry<Bytes, Bytes>> stream = dao.streamUnblindedFinalizedBlocksRaw()) {
+      for (Iterator<Map.Entry<Bytes, Bytes>> it = stream.iterator();
+          it.hasNext() && active.get() && preBellatrix; ) {
+        try (KvStoreCombinedDaoBlinded.FinalizedUpdaterBlinded finalizedUpdaterBlinded =
+                dao.finalizedUpdaterBlinded();
+            KvStoreCombinedDaoUnblinded.FinalizedUpdaterUnblinded finalizedUpdaterUnblinded =
+                dao.finalizedUpdaterUnblinded()) {
+          for (int i = 0;
+              i < BLOCK_BATCH_SIZE && it.hasNext() && active.get() && preBellatrix;
+              i++) {
+            final Map.Entry<Bytes, Bytes> entry = it.next();
+            final UInt64 slot =
+                UInt64.fromLongBits(Longs.fromByteArray(entry.getKey().toArrayUnsafe()));
+            if (spec.atSlot(slot).getMilestone().isGreaterThanOrEqualTo(SpecMilestone.BELLATRIX)) {
+              preBellatrix = false;
+              continue;
+            }
+            final Optional<Bytes32> maybeRoot = dao.getFinalizedBlockRootAtSlot(slot);
+            if (maybeRoot.isEmpty()) {
+              LOG.warn("Could not find block root for slot {}", slot);
+              continue;
+            }
+            finalizedUpdaterBlinded.addBlindedFinalizedBlockRaw(
+                entry.getValue(), maybeRoot.get(), slot);
+            finalizedUpdaterUnblinded.deleteUnblindedFinalizedBlock(slot, maybeRoot.get());
+            counter++;
+            if (counter % LOGGING_FREQUENCY == 0 || counter == migrationCounter) {
+              double pct = getPercentageOfTotal(counter, migrationCounter);
+              LOG.info("{} finalized blocks moved ({} %)", counter, String.format("%.2f", pct));
+            }
+          }
+          finalizedUpdaterBlinded.commit();
+          finalizedUpdaterUnblinded.commit();
+        }
+
+        pause();
+      }
+    } catch (Exception e) {
+      LOG.error("Failed to migrate finalized blocks", e);
+    }
+    if (counter < migrationCounter && !preBellatrix) {
+      double pct = getPercentageOfTotal(counter, migrationCounter);
+      LOG.info(
+          "All {} pre-bellatrix blocks have now been migrated ({} % of finalized blocks).",
+          counter, String.format("%.2f", pct));
+    }
+  }
+
+  private void migrateFinalizedBlocks() {
+    final long migrationCounter = dao.countUnblindedFinalizedBlocks();
+    if (migrationCounter == 0) {
+      return;
+    }
+    LOG.info(
+        "Migrating remaining blocks to blinded storage, {} finalized blocks to migrate",
+        migrationCounter);
+    long counter = 0;
+    try (final Stream<SignedBeaconBlock> stream =
+        dao.streamUnblindedFinalizedBlocks(UInt64.ZERO, UInt64.MAX_VALUE)) {
+      for (Iterator<SignedBeaconBlock> it = stream.iterator(); it.hasNext() && active.get(); ) {
+        try (KvStoreCombinedDaoBlinded.FinalizedUpdaterBlinded finalizedUpdaterBlinded =
+                dao.finalizedUpdaterBlinded();
+            KvStoreCombinedDaoUnblinded.FinalizedUpdaterUnblinded finalizedUpdaterUnblinded =
+                dao.finalizedUpdaterUnblinded()) {
+          for (int i = 0; i < BLOCK_BATCH_SIZE && it.hasNext() && active.get(); i++) {
+            final SignedBeaconBlock block = it.next();
+            finalizedUpdaterBlinded.addBlindedFinalizedBlock(block, block.getRoot(), spec);
+            finalizedUpdaterUnblinded.deleteUnblindedFinalizedBlock(
+                block.getSlot(), block.getRoot());
+            counter++;
+            if (counter % LOGGING_FREQUENCY == 0 || counter == migrationCounter) {
+              double pct = getPercentageOfTotal(counter, migrationCounter);
+              LOG.info("{} finalized blocks moved ({} %)", counter, String.format("%.2f", pct));
+            }
+          }
+          finalizedUpdaterBlinded.commit();
+          finalizedUpdaterUnblinded.commit();
+        }
+        pause();
+      }
+    } catch (Exception e) {
+      LOG.error("Failed to migrate finalized blocks", e);
+    }
+  }
+
+  private void migrateNonCanonicalBlocks() {
+    final long migrationCounter = dao.countNonCanonicalBlocks();
+    if (migrationCounter == 0) {
+      return;
+    }
+    LOG.info("Migrating {} non-canonical blocks to blinded storage", migrationCounter);
+    long counter = 0;
+    try (final Stream<ColumnEntry<Bytes32, SignedBeaconBlock>> entries =
+        dao.streamUnblindedNonCanonicalBlocks()) {
+      for (Iterator<ColumnEntry<Bytes32, SignedBeaconBlock>> it = entries.iterator();
+          it.hasNext() && active.get(); ) {
+        try (KvStoreCombinedDaoBlinded.FinalizedUpdaterBlinded finalizedUpdaterBlinded =
+                dao.finalizedUpdaterBlinded();
+            KvStoreCombinedDaoUnblinded.FinalizedUpdaterUnblinded finalizedUpdaterUnblinded =
+                dao.finalizedUpdaterUnblinded()) {
+          for (int i = 0; i < BLOCK_BATCH_SIZE && it.hasNext() && active.get(); i++) {
+            final ColumnEntry<Bytes32, SignedBeaconBlock> entry = it.next();
+            final Bytes32 root = entry.getKey();
+            final SignedBeaconBlock block = entry.getValue();
+            finalizedUpdaterBlinded.addBlindedBlock(block, root, spec);
+            finalizedUpdaterUnblinded.deleteUnblindedNonCanonicalBlockOnly(root);
+            counter++;
+            if (counter % LOGGING_FREQUENCY == 0) {
+              double pct = counter;
+              pct /= migrationCounter;
+              pct *= 100;
+              LOG.info("{} non-canonical blocks moved ({} %)", counter, String.format("%.2f", pct));
+            }
+          }
+          finalizedUpdaterBlinded.commit();
+          finalizedUpdaterUnblinded.commit();
+        }
+
+        pause();
+      }
+    }
+  }
+
+  private double getPercentageOfTotal(final long current, final long total) {
+    double pct = current;
+    pct /= total;
+    pct *= 100;
+    return pct;
+  }
+
+  private void pause() {
+    if (!active.get()) {
+      return;
+    }
+    try {
+      Thread.sleep(PAUSE_BETWEEN_BATCH_MS);
+    } catch (InterruptedException e) {
+      LOG.debug("Interrupted while processing blocks", e);
+    }
+  }
+}

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreAccessor.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreAccessor.java
@@ -76,6 +76,8 @@ public interface KvStoreAccessor extends AutoCloseable {
   @MustBeClosed
   Stream<ColumnEntry<Bytes, Bytes>> streamRaw(KvStoreColumn<?, ?> column);
 
+  <K, V> Optional<Bytes> getRaw(KvStoreColumn<K, V> column, K key);
+
   /**
    * Stream entries from a column between keys from and to fully inclusive.
    *

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
@@ -116,7 +116,12 @@ public abstract class KvStoreDatabase<
             new V4FinalizedKvStoreDao(finalizedDb, schemaFinalized, finalizedStateStorageLogic));
     if (storeBlockExecutionPayloadSeparately) {
       BlindedHotBlockMigration.migrateBlocks(dao, spec);
-      return new BlindedBlockKvStoreDatabase(dao, stateStorageMode, storeNonCanonicalBlocks, spec);
+      return new BlindedBlockKvStoreDatabase(
+          dao,
+          new BlindedBlockMigration<>(spec, dao),
+          stateStorageMode,
+          storeNonCanonicalBlocks,
+          spec);
     }
     return new UnblindedBlockKvStoreDatabase(dao, stateStorageMode, storeNonCanonicalBlocks, spec);
   }
@@ -175,7 +180,12 @@ public abstract class KvStoreDatabase<
         new CombinedKvStoreDao<>(db, schema, finalizedStateStorageLogic);
     if (storeBlockExecutionPayloadSeparately) {
       BlindedHotBlockMigration.migrateBlocks(dao, spec);
-      return new BlindedBlockKvStoreDatabase(dao, stateStorageMode, storeNonCanonicalBlocks, spec);
+      return new BlindedBlockKvStoreDatabase(
+          dao,
+          new BlindedBlockMigration<>(spec, dao),
+          stateStorageMode,
+          storeNonCanonicalBlocks,
+          spec);
     }
     return new UnblindedBlockKvStoreDatabase(dao, stateStorageMode, storeNonCanonicalBlocks, spec);
   }
@@ -464,6 +474,16 @@ public abstract class KvStoreDatabase<
   @Override
   public long countNonCanonicalSlots() {
     return dao.countNonCanonicalSlots();
+  }
+
+  @Override
+  public long countNonCanonicalBlocks() {
+    return dao.countNonCanonicalBlocks();
+  }
+
+  @Override
+  public Optional<BlindedBlockMigration<?>> getBlindedBlockMigrater() {
+    return Optional.empty();
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/UnblindedBlockKvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/UnblindedBlockKvStoreDatabase.java
@@ -139,7 +139,7 @@ public class UnblindedBlockKvStoreDatabase
   @MustBeClosed
   public Stream<SignedBeaconBlock> streamFinalizedBlocks(
       final UInt64 startSlot, final UInt64 endSlot) {
-    return dao.streamFinalizedBlocks(startSlot, endSlot);
+    return dao.streamUnblindedFinalizedBlocks(startSlot, endSlot);
   }
 
   @Override
@@ -205,6 +205,16 @@ public class UnblindedBlockKvStoreDatabase
   @Override
   public long countBlindedBlocks() {
     return 0;
+  }
+
+  @Override
+  public long countUnblindedFinalizedBlockIndices() {
+    return dao.countUnblindedFinalizedBlockIndices();
+  }
+
+  @Override
+  public long countBlindedFinalizedBlockIndices() {
+    return dao.countBlindedFinalizedBlockIndices();
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoAdapter.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoAdapter.java
@@ -203,13 +203,18 @@ public class KvStoreCombinedDaoAdapter
   }
 
   @Override
+  public long countNonCanonicalBlocks() {
+    return finalizedDao.countNonCanonicalBlocks();
+  }
+
+  @Override
   public long countBlindedBlocks() {
     return finalizedDao.countBlindedBlocks();
   }
 
   @Override
   @MustBeClosed
-  public Stream<SignedBeaconBlock> streamFinalizedBlocks(
+  public Stream<SignedBeaconBlock> streamUnblindedFinalizedBlocks(
       final UInt64 startSlot, final UInt64 endSlot) {
     return finalizedDao.streamFinalizedBlocks(startSlot, endSlot);
   }
@@ -286,14 +291,47 @@ public class KvStoreCombinedDaoAdapter
   }
 
   @Override
+  public long countUnblindedFinalizedBlockIndices() {
+    return finalizedDao.countUnblindedFinalizedBlockIndices();
+  }
+
+  @Override
   public Optional<? extends SignedBeaconBlock> getNonCanonicalBlock(final Bytes32 root) {
     return finalizedDao.getNonCanonicalBlock(root);
+  }
+
+  @Override
+  public Optional<Bytes> getUnblindedFinalizedBlockRaw(final UInt64 slot) {
+    return finalizedDao.getUnblindedFinalizedBlockRaw(slot);
+  }
+
+  @Override
+  @MustBeClosed
+  public Stream<Map.Entry<Bytes, Bytes>> streamUnblindedFinalizedBlocksRaw() {
+    return finalizedDao.streamUnblindedFinalizedBlocksRaw();
   }
 
   @Override
   @MustBeClosed
   public Stream<Bytes32> streamFinalizedBlockRoots(final UInt64 startSlot, final UInt64 endSlot) {
     return finalizedDao.streamFinalizedBlockRoots(startSlot, endSlot);
+  }
+
+  @Override
+  @MustBeClosed
+  public Stream<ColumnEntry<Bytes32, UInt64>> streamUnblindedFinalizedBlockRoots() {
+    return finalizedDao.streamUnblindedFinalizedBlockRoots();
+  }
+
+  @Override
+  @MustBeClosed
+  public Stream<ColumnEntry<Bytes32, SignedBeaconBlock>> streamUnblindedNonCanonicalBlocks() {
+    return finalizedDao.streamUnblindedNonCanonicalBlocks();
+  }
+
+  @Override
+  public long countBlindedFinalizedBlockIndices() {
+    return finalizedDao.countBlindedFinalizedBlockIndices();
   }
 
   @Override
@@ -368,6 +406,15 @@ public class KvStoreCombinedDaoAdapter
       return hotDao.getRawVariable(var);
     } else {
       return finalizedDao.getRawVariable(var);
+    }
+  }
+
+  @Override
+  public <K, V> Optional<Bytes> getRaw(final KvStoreColumn<K, V> kvStoreColumn, final K key) {
+    if (hotDao.getColumnMap().containsValue(kvStoreColumn)) {
+      return hotDao.getRaw(kvStoreColumn, key);
+    } else {
+      return finalizedDao.getRaw(kvStoreColumn, key);
     }
   }
 
@@ -512,6 +559,12 @@ public class KvStoreCombinedDaoAdapter
     }
 
     @Override
+    public void addBlindedFinalizedBlockRaw(
+        final Bytes blockBytes, final Bytes32 root, final UInt64 slot) {
+      finalizedUpdater.addBlindedFinalizedBlockRaw(blockBytes, root, slot);
+    }
+
+    @Override
     public void addBlindedBlock(
         final SignedBeaconBlock block, final Bytes32 blockRoot, final Spec spec) {
       finalizedUpdater.addBlindedBlock(block, blockRoot, spec);
@@ -540,6 +593,11 @@ public class KvStoreCombinedDaoAdapter
     @Override
     public void deleteUnblindedFinalizedBlock(final UInt64 slot, final Bytes32 blockRoot) {
       finalizedUpdater.deleteUnblindedFinalizedBlock(slot, blockRoot);
+    }
+
+    @Override
+    public void deleteUnblindedNonCanonicalBlockOnly(final Bytes32 blockRoot) {
+      finalizedUpdater.deleteUnblindedNonCanonicalBlockOnly(blockRoot);
     }
 
     @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoBlinded.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoBlinded.java
@@ -26,6 +26,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.BlockAndCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
+import tech.pegasys.teku.storage.server.kvstore.ColumnEntry;
 
 public interface KvStoreCombinedDaoBlinded extends KvStoreCombinedDaoCommon {
 
@@ -62,6 +63,12 @@ public interface KvStoreCombinedDaoBlinded extends KvStoreCombinedDaoCommon {
   @MustBeClosed
   Stream<Bytes32> streamFinalizedBlockRoots(UInt64 startSlot, UInt64 endSlot);
 
+  @MustBeClosed
+  Stream<ColumnEntry<Bytes32, UInt64>> streamUnblindedFinalizedBlockRoots();
+
+  @MustBeClosed
+  Stream<ColumnEntry<Bytes32, SignedBeaconBlock>> streamUnblindedNonCanonicalBlocks();
+
   interface CombinedUpdaterBlinded
       extends HotUpdaterBlinded, FinalizedUpdaterBlinded, CombinedUpdaterCommon {}
 
@@ -81,6 +88,8 @@ public interface KvStoreCombinedDaoBlinded extends KvStoreCombinedDaoCommon {
 
     void addBlindedFinalizedBlock(
         final SignedBeaconBlock block, final Bytes32 root, final Spec spec);
+
+    void addBlindedFinalizedBlockRaw(Bytes blockBytes, Bytes32 root, UInt64 slot);
 
     void addBlindedBlock(final SignedBeaconBlock block, final Bytes32 blockRoot, final Spec spec);
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoCommon.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoCommon.java
@@ -76,10 +76,16 @@ public interface KvStoreCombinedDaoCommon extends AutoCloseable {
 
   long countNonCanonicalSlots();
 
+  long countNonCanonicalBlocks();
+
   @MustBeClosed
   Stream<Bytes> streamExecutionPayloads();
 
   Optional<UInt64> getOptimisticTransitionBlockSlot();
+
+  long countUnblindedFinalizedBlockIndices();
+
+  long countBlindedFinalizedBlockIndices();
 
   interface CombinedUpdaterCommon extends HotUpdaterCommon, FinalizedUpdaterCommon {}
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoUnblinded.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoUnblinded.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
+import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockAndCheckpoints;
@@ -54,7 +55,7 @@ public interface KvStoreCombinedDaoUnblinded extends KvStoreCombinedDaoCommon {
   List<SignedBeaconBlock> getNonCanonicalUnblindedBlocksAtSlot(UInt64 slot);
 
   @MustBeClosed
-  Stream<SignedBeaconBlock> streamFinalizedBlocks(UInt64 startSlot, UInt64 endSlot);
+  Stream<SignedBeaconBlock> streamUnblindedFinalizedBlocks(UInt64 startSlot, UInt64 endSlot);
 
   long countUnblindedFinalizedBlocks();
 
@@ -63,6 +64,11 @@ public interface KvStoreCombinedDaoUnblinded extends KvStoreCombinedDaoCommon {
   Optional<UInt64> getSlotForFinalizedStateRoot(Bytes32 stateRoot);
 
   Optional<? extends SignedBeaconBlock> getNonCanonicalBlock(Bytes32 root);
+
+  Optional<Bytes> getUnblindedFinalizedBlockRaw(UInt64 slot);
+
+  @MustBeClosed
+  Stream<Map.Entry<Bytes, Bytes>> streamUnblindedFinalizedBlocksRaw();
 
   interface CombinedUpdaterUnblinded
       extends HotUpdaterUnblinded, FinalizedUpdaterUnblinded, CombinedUpdaterCommon {}
@@ -86,5 +92,7 @@ public interface KvStoreCombinedDaoUnblinded extends KvStoreCombinedDaoCommon {
     void addNonCanonicalBlock(final SignedBeaconBlock block);
 
     void deleteUnblindedFinalizedBlock(final UInt64 slot, final Bytes32 blockRoot);
+
+    void deleteUnblindedNonCanonicalBlockOnly(final Bytes32 blockRoot);
   }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4HotKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4HotKvStoreDao.java
@@ -153,6 +153,10 @@ public class V4HotKvStoreDao {
     return db.getRaw(var);
   }
 
+  public <K, V> Optional<Bytes> getRaw(final KvStoreColumn<K, V> column, final K key) {
+    return db.getRaw(column, key);
+  }
+
   @MustBeClosed
   public <K, V> Stream<ColumnEntry<Bytes, Bytes>> streamRawColumn(
       final KvStoreColumn<K, V> kvStoreColumn) {

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4MigratableSourceDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4MigratableSourceDao.java
@@ -29,6 +29,8 @@ public interface V4MigratableSourceDao {
 
   <T> Optional<Bytes> getRawVariable(final KvStoreVariable<T> var);
 
+  <K, V> Optional<Bytes> getRaw(final KvStoreColumn<K, V> kvStoreColumn, K key);
+
   @MustBeClosed
   <K, V> Stream<ColumnEntry<Bytes, Bytes>> streamRawColumn(final KvStoreColumn<K, V> kvStoreColumn);
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/leveldb/LevelDbInstance.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/leveldb/LevelDbInstance.java
@@ -235,6 +235,12 @@ public class LevelDbInstance implements KvStoreAccessor {
   }
 
   @Override
+  public <K, V> Optional<Bytes> getRaw(final KvStoreColumn<K, V> column, final K key) {
+    assertOpen();
+    return Optional.ofNullable(db.get(getColumnKey(column, key))).map(Bytes::wrap);
+  }
+
+  @Override
   @MustBeClosed
   public <K extends Comparable<K>, V> Stream<ColumnEntry<K, V>> stream(
       final KvStoreColumn<K, V> column, final K from, final K to) {

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
@@ -37,6 +37,7 @@ import tech.pegasys.teku.storage.api.UpdateResult;
 import tech.pegasys.teku.storage.api.WeakSubjectivityState;
 import tech.pegasys.teku.storage.api.WeakSubjectivityUpdate;
 import tech.pegasys.teku.storage.server.Database;
+import tech.pegasys.teku.storage.server.kvstore.BlindedBlockMigration;
 
 public class NoOpDatabase implements Database {
 
@@ -198,6 +199,26 @@ public class NoOpDatabase implements Database {
 
   @Override
   public long countNonCanonicalSlots() {
+    return 0;
+  }
+
+  @Override
+  public long countNonCanonicalBlocks() {
+    return 0;
+  }
+
+  @Override
+  public Optional<BlindedBlockMigration<?>> getBlindedBlockMigrater() {
+    return Optional.empty();
+  }
+
+  @Override
+  public long countUnblindedFinalizedBlockIndices() {
+    return 0;
+  }
+
+  @Override
+  public long countBlindedFinalizedBlockIndices() {
     return 0;
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbInstance.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbInstance.java
@@ -150,6 +150,18 @@ public class RocksDbInstance implements KvStoreAccessor {
   }
 
   @Override
+  public <K, V> Optional<Bytes> getRaw(final KvStoreColumn<K, V> column, final K key) {
+    assertOpen();
+    final ColumnFamilyHandle handle = columnHandles.get(column);
+    final byte[] keyBytes = column.getKeySerializer().serialize(key);
+    try {
+      return Optional.ofNullable(db.get(handle, keyBytes)).map(Bytes::wrap);
+    } catch (RocksDBException e) {
+      throw RocksDbExceptionUtil.wrapException("Failed to get value", e);
+    }
+  }
+
+  @Override
   @MustBeClosed
   public <K extends Comparable<K>, V> Stream<ColumnEntry<K, V>> stream(
       final KvStoreColumn<K, V> column, final K from, final K to) {

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/server/kvstore/MockKvStoreInstance.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/server/kvstore/MockKvStoreInstance.java
@@ -155,6 +155,12 @@ public class MockKvStoreInstance implements KvStoreAccessor {
   }
 
   @Override
+  public <K, V> Optional<Bytes> getRaw(final KvStoreColumn<K, V> column, final K key) {
+    final Bytes keyBytes = keyToBytes(column, key);
+    return Optional.ofNullable(columnData.get(column).get(keyBytes));
+  }
+
+  @Override
   public <K extends Comparable<K>, V> Stream<ColumnEntry<K, V>> stream(
       final KvStoreColumn<K, V> column, final K from, final K to) {
     assertOpen();

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugDbCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugDbCommand.java
@@ -208,6 +208,7 @@ public class DebugDbCommand implements Runnable {
         printIfPresent("Hot blocks", stream.count());
       }
       printIfPresent("Finalized blocks", database.countUnblindedFinalizedBlocks());
+      printIfPresent("Finalized Indices", database.countUnblindedFinalizedBlockIndices());
       try (Stream<?> stream = database.streamBlockCheckpoints()) {
         printIfPresent("Checkpoint Epochs", stream.count());
       }
@@ -216,8 +217,10 @@ public class DebugDbCommand implements Runnable {
         createDatabase(beaconNodeDataOptions, true, eth2NetworkOptions)) {
 
       printIfPresent("Blinded blocks", database.countBlindedBlocks());
+      printIfPresent("Blinded indices", database.countBlindedFinalizedBlockIndices());
       printIfPresent("Execution Payloads", database.countExecutionPayloads());
       printIfPresent("Non-canonical Slots", database.countNonCanonicalSlots());
+      printIfPresent("Non-canonical blocks", database.countNonCanonicalBlocks());
 
       return 0;
     }
@@ -225,7 +228,7 @@ public class DebugDbCommand implements Runnable {
 
   private void printIfPresent(final String label, final long count) {
     if (count > 0L) {
-      final String formatString = "%19s: %d%n";
+      final String formatString = "%20s: %d%n";
       System.out.printf(formatString, label, count);
     }
   }


### PR DESCRIPTION
 - Add counters for all of the various block storage options to the debug tool
 - fixed non-canonical block indices getting touched when they shouldnt, but un-tested
 - finalized block migration - several spins on it...
 - block migration will occur at startup in batches, sleeping between to try to give the server some time too.

 This is more of a tracer PR, likely to pull a lot out and submit smaller sections.

 Several aspects are easy to separate. Need the CI to build it so that we're able to test on infra boxes.

 partially addresses #5312

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
