### PR TITLE
Change debug-tools command to get-column-counts

### DIFF
--- a/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
@@ -103,11 +103,6 @@ public interface Database extends AutoCloseable {
   Stream<SignedBeaconBlock> streamFinalizedBlocks(UInt64 startSlot, UInt64 endSlot);
 
   @MustBeClosed
-  Stream<SignedBeaconBlock> streamHotBlocks();
-
-  long countUnblindedFinalizedBlocks();
-
-  @MustBeClosed
   Stream<Map.Entry<Bytes32, BlockCheckpoints>> streamBlockCheckpoints();
 
   List<Bytes32> getStateRootsBeforeSlot(final UInt64 slot);
@@ -133,11 +128,7 @@ public interface Database extends AutoCloseable {
 
   void storeVotes(Map<UInt64, VoteTracker> votes);
 
-  long countBlindedBlocks();
-
-  long countExecutionPayloads();
-
-  long countNonCanonicalSlots();
+  Map<String, Long> getColumnCounts();
 
   void migrate();
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/BlindedBlockKvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/BlindedBlockKvStoreDatabase.java
@@ -125,17 +125,6 @@ public class BlindedBlockKvStoreDatabase
 
   @Override
   @MustBeClosed
-  public Stream<SignedBeaconBlock> streamHotBlocks() {
-    return dao.streamBlindedHotBlocks().map(this::getUnblindedBlock);
-  }
-
-  @Override
-  public long countUnblindedFinalizedBlocks() {
-    return 0;
-  }
-
-  @Override
-  @MustBeClosed
   public Stream<SignedBeaconBlock> streamFinalizedBlocks(
       final UInt64 startSlot, final UInt64 endSlot) {
     return dao.streamFinalizedBlockRoots(startSlot, endSlot)
@@ -241,8 +230,8 @@ public class BlindedBlockKvStoreDatabase
   }
 
   @Override
-  public long countBlindedBlocks() {
-    return dao.countBlindedBlocks();
+  public Map<String, Long> getColumnCounts() {
+    return dao.getColumnCounts();
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
@@ -463,18 +463,6 @@ public abstract class KvStoreDatabase<
   }
 
   @Override
-  public long countExecutionPayloads() {
-    try (final Stream<?> stream = dao.streamExecutionPayloads()) {
-      return stream.count();
-    }
-  }
-
-  @Override
-  public long countNonCanonicalSlots() {
-    return dao.countNonCanonicalSlots();
-  }
-
-  @Override
   public void close() throws Exception {
     dao.close();
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/UnblindedBlockKvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/UnblindedBlockKvStoreDatabase.java
@@ -126,17 +126,6 @@ public class UnblindedBlockKvStoreDatabase
 
   @Override
   @MustBeClosed
-  public Stream<SignedBeaconBlock> streamHotBlocks() {
-    return dao.streamHotBlocks();
-  }
-
-  @Override
-  public long countUnblindedFinalizedBlocks() {
-    return dao.countUnblindedFinalizedBlocks();
-  }
-
-  @Override
-  @MustBeClosed
   public Stream<SignedBeaconBlock> streamFinalizedBlocks(
       final UInt64 startSlot, final UInt64 endSlot) {
     return dao.streamFinalizedBlocks(startSlot, endSlot);
@@ -203,8 +192,8 @@ public class UnblindedBlockKvStoreDatabase
   }
 
   @Override
-  public long countBlindedBlocks() {
-    return 0;
+  public Map<String, Long> getColumnCounts() {
+    return dao.getColumnCounts();
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
@@ -402,12 +402,7 @@ public class CombinedKvStoreDao<S extends SchemaCombined>
   @Override
   public Map<String, Long> getColumnCounts() {
     final Map<String, Long> columnCounts = new LinkedHashMap<>();
-    schema
-        .getColumnMap()
-        .forEach(
-            (k, v) -> {
-              columnCounts.put(k, db.size(v));
-            });
+    schema.getColumnMap().forEach((k, v) -> columnCounts.put(k, db.size(v)));
     return columnCounts;
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
@@ -18,6 +18,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import com.google.errorprone.annotations.MustBeClosed;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -331,24 +332,11 @@ public class CombinedKvStoreDao<S extends SchemaCombined>
   }
 
   @Override
-  public long countBlindedBlocks() {
-    return db.size(schema.getColumnBlindedBlocksByRoot());
-  }
-
-  @Override
   @MustBeClosed
   public Stream<SignedBeaconBlock> streamFinalizedBlocks(
       final UInt64 startSlot, final UInt64 endSlot) {
     return db.stream(schema.getColumnFinalizedBlocksBySlot(), startSlot, endSlot)
         .map(ColumnEntry::getValue);
-  }
-
-  @Override
-  public long countUnblindedFinalizedBlocks() {
-    try (Stream<ColumnEntry<Bytes, Bytes>> entries =
-        db.streamRaw(schema.getColumnSlotsByFinalizedRoot())) {
-      return entries.count();
-    }
   }
 
   @Override
@@ -377,22 +365,8 @@ public class CombinedKvStoreDao<S extends SchemaCombined>
   }
 
   @Override
-  @MustBeClosed
-  public Stream<Bytes> streamExecutionPayloads() {
-    return db.stream(schema.getColumnExecutionPayloadByPayloadHash()).map(ColumnEntry::getValue);
-  }
-
-  @Override
   public Optional<SignedBeaconBlock> getBlindedBlock(final Bytes32 root) {
     return db.get(schema.getColumnBlindedBlocksByRoot(), root);
-  }
-
-  @Override
-  @MustBeClosed
-  public Stream<SignedBeaconBlock> streamBlindedHotBlocks() {
-    return db.stream(schema.getColumnHotBlockCheckpointEpochsByRoot())
-        .map(ColumnEntry::getKey)
-        .flatMap(root -> getBlindedBlock(root).stream());
   }
 
   @Override
@@ -423,6 +397,18 @@ public class CombinedKvStoreDao<S extends SchemaCombined>
   @Override
   public Optional<UInt64> getOptimisticTransitionBlockSlot() {
     return db.get(schema.getOptimisticTransitionBlockSlot());
+  }
+
+  @Override
+  public Map<String, Long> getColumnCounts() {
+    final Map<String, Long> columnCounts = new LinkedHashMap<>();
+    schema
+        .getColumnMap()
+        .forEach(
+            (k, v) -> {
+              columnCounts.put(k, db.size(v));
+            });
+    return columnCounts;
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoAdapter.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoAdapter.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.storage.server.kvstore.dataaccess;
 
 import com.google.errorprone.annotations.MustBeClosed;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -203,11 +204,6 @@ public class KvStoreCombinedDaoAdapter
   }
 
   @Override
-  public long countBlindedBlocks() {
-    return finalizedDao.countBlindedBlocks();
-  }
-
-  @Override
   @MustBeClosed
   public Stream<SignedBeaconBlock> streamFinalizedBlocks(
       final UInt64 startSlot, final UInt64 endSlot) {
@@ -215,28 +211,8 @@ public class KvStoreCombinedDaoAdapter
   }
 
   @Override
-  public long countUnblindedFinalizedBlocks() {
-    return finalizedDao.countUnblindedFinalizedBlocks();
-  }
-
-  @Override
-  @MustBeClosed
-  public Stream<Bytes> streamExecutionPayloads() {
-    return finalizedDao.streamExecutionPayloads();
-  }
-
-  @Override
   public Optional<SignedBeaconBlock> getBlindedBlock(final Bytes32 root) {
     return finalizedDao.getBlindedBlock(root);
-  }
-
-  @Override
-  @MustBeClosed
-  public Stream<SignedBeaconBlock> streamBlindedHotBlocks() {
-    return hotDao
-        .streamBlockCheckpoints()
-        .map(Map.Entry::getKey)
-        .flatMap(blockRoot -> getBlindedBlock(blockRoot).stream());
   }
 
   @Override
@@ -283,6 +259,13 @@ public class KvStoreCombinedDaoAdapter
   @Override
   public Optional<UInt64> getOptimisticTransitionBlockSlot() {
     return finalizedDao.getOptimisticTransitionBlockSlot();
+  }
+
+  @Override
+  public Map<String, Long> getColumnCounts() {
+    final HashMap<String, Long> result = new LinkedHashMap<>(hotDao.getColumnCounts());
+    result.putAll(finalizedDao.getColumnCounts());
+    return result;
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoBlinded.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoBlinded.java
@@ -40,12 +40,7 @@ public interface KvStoreCombinedDaoBlinded extends KvStoreCombinedDaoCommon {
 
   List<SignedBeaconBlock> getBlindedNonCanonicalBlocksAtSlot(UInt64 slot);
 
-  long countBlindedBlocks();
-
   Optional<SignedBeaconBlock> getBlindedBlock(Bytes32 root);
-
-  @MustBeClosed
-  Stream<SignedBeaconBlock> streamBlindedHotBlocks();
 
   Optional<Bytes> getExecutionPayload(Bytes32 root);
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoCommon.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoCommon.java
@@ -20,7 +20,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
-import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.ethereum.pow.api.DepositsFromBlockEvent;
 import tech.pegasys.teku.ethereum.pow.api.MinGenesisTimeBlockEvent;
@@ -76,10 +75,9 @@ public interface KvStoreCombinedDaoCommon extends AutoCloseable {
 
   long countNonCanonicalSlots();
 
-  @MustBeClosed
-  Stream<Bytes> streamExecutionPayloads();
-
   Optional<UInt64> getOptimisticTransitionBlockSlot();
+
+  Map<String, Long> getColumnCounts();
 
   interface CombinedUpdaterCommon extends HotUpdaterCommon, FinalizedUpdaterCommon {}
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoUnblinded.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoUnblinded.java
@@ -56,8 +56,6 @@ public interface KvStoreCombinedDaoUnblinded extends KvStoreCombinedDaoCommon {
   @MustBeClosed
   Stream<SignedBeaconBlock> streamFinalizedBlocks(UInt64 startSlot, UInt64 endSlot);
 
-  long countUnblindedFinalizedBlocks();
-
   Optional<UInt64> getSlotForFinalizedBlockRoot(Bytes32 blockRoot);
 
   Optional<UInt64> getSlotForFinalizedStateRoot(Bytes32 stateRoot);

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4FinalizedKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4FinalizedKvStoreDao.java
@@ -213,12 +213,7 @@ public class V4FinalizedKvStoreDao {
 
   public Map<String, Long> getColumnCounts() {
     final Map<String, Long> columnCounts = new HashMap<>();
-    schema
-        .getColumnMap()
-        .forEach(
-            (k, v) -> {
-              columnCounts.put(k, db.size(v));
-            });
+    schema.getColumnMap().forEach((k, v) -> columnCounts.put(k, db.size(v)));
     return columnCounts;
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4FinalizedKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4FinalizedKvStoreDao.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.storage.server.kvstore.dataaccess;
 
 import com.google.errorprone.annotations.MustBeClosed;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -118,11 +119,6 @@ public class V4FinalizedKvStoreDao {
     }
   }
 
-  @MustBeClosed
-  public Stream<Bytes> streamExecutionPayloads() {
-    return db.stream(schema.getColumnExecutionPayloadByPayloadHash()).map(ColumnEntry::getValue);
-  }
-
   public Optional<SignedBeaconBlock> getBlindedBlock(final Bytes32 root) {
     return db.get(schema.getColumnBlindedBlocksByRoot(), root);
   }
@@ -213,6 +209,17 @@ public class V4FinalizedKvStoreDao {
 
   public Set<Bytes32> getNonCanonicalBlockRootsAtSlot(final UInt64 slot) {
     return db.get(schema.getColumnNonCanonicalRootsBySlot(), slot).orElseGet(HashSet::new);
+  }
+
+  public Map<String, Long> getColumnCounts() {
+    final Map<String, Long> columnCounts = new HashMap<>();
+    schema
+        .getColumnMap()
+        .forEach(
+            (k, v) -> {
+              columnCounts.put(k, db.size(v));
+            });
+    return columnCounts;
   }
 
   static class V4FinalizedUpdater implements FinalizedUpdaterBlinded, FinalizedUpdaterUnblinded {

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4HotKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4HotKvStoreDao.java
@@ -174,12 +174,7 @@ public class V4HotKvStoreDao {
 
   public Map<String, Long> getColumnCounts() {
     final Map<String, Long> columnCounts = new LinkedHashMap<>();
-    schema
-        .getColumnMap()
-        .forEach(
-            (k, v) -> {
-              columnCounts.put(k, db.size(v));
-            });
+    schema.getColumnMap().forEach((k, v) -> columnCounts.put(k, db.size(v)));
     return columnCounts;
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4HotKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4HotKvStoreDao.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.storage.server.kvstore.dataaccess;
 
 import com.google.errorprone.annotations.MustBeClosed;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -169,6 +170,17 @@ public class V4HotKvStoreDao {
 
   public Map<String, KvStoreVariable<?>> getVariableMap() {
     return schema.getVariableMap();
+  }
+
+  public Map<String, Long> getColumnCounts() {
+    final Map<String, Long> columnCounts = new LinkedHashMap<>();
+    schema
+        .getColumnMap()
+        .forEach(
+            (k, v) -> {
+              columnCounts.put(k, db.size(v));
+            });
+    return columnCounts;
   }
 
   static class V4HotUpdater implements HotUpdaterBlinded, HotUpdaterUnblinded {

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.storage.server.noop;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -126,16 +127,6 @@ public class NoOpDatabase implements Database {
   }
 
   @Override
-  public Stream<SignedBeaconBlock> streamHotBlocks() {
-    return Stream.empty();
-  }
-
-  @Override
-  public long countUnblindedFinalizedBlocks() {
-    return 0;
-  }
-
-  @Override
   public Stream<Map.Entry<Bytes32, BlockCheckpoints>> streamBlockCheckpoints() {
     return Stream.empty();
   }
@@ -187,18 +178,8 @@ public class NoOpDatabase implements Database {
   public void storeVotes(final Map<UInt64, VoteTracker> votes) {}
 
   @Override
-  public long countBlindedBlocks() {
-    return 0;
-  }
-
-  @Override
-  public long countExecutionPayloads() {
-    return 0;
-  }
-
-  @Override
-  public long countNonCanonicalSlots() {
-    return 0;
+  public Map<String, Long> getColumnCounts() {
+    return new HashMap<>();
   }
 
   @Override

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugDbCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugDbCommand.java
@@ -17,7 +17,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
-import java.util.stream.Stream;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
@@ -187,8 +186,8 @@ public class DebugDbCommand implements Runnable {
   }
 
   @Command(
-      name = "get-block-counts",
-      description = "Count blocks in block storage tables",
+      name = "get-column-counts",
+      description = "Count entries in columns in storage tables",
       mixinStandardHelpOptions = true,
       showDefaultValues = true,
       abbreviateSynopsis = true,
@@ -198,36 +197,20 @@ public class DebugDbCommand implements Runnable {
       optionListHeading = "%nOptions:%n",
       footerHeading = "%n",
       footer = "Teku is licensed under the Apache License 2.0")
-  public int getBlockCounts(
+  public int getColumnCounts(
       @Mixin final BeaconNodeDataOptions beaconNodeDataOptions,
       @Mixin final Eth2NetworkOptions eth2NetworkOptions)
       throws Exception {
     try (final Database database =
         createDatabase(beaconNodeDataOptions, false, eth2NetworkOptions)) {
-      try (Stream<SignedBeaconBlock> stream = database.streamHotBlocks()) {
-        printIfPresent("Hot blocks", stream.count());
-      }
-      printIfPresent("Finalized blocks", database.countUnblindedFinalizedBlocks());
-      try (Stream<?> stream = database.streamBlockCheckpoints()) {
-        printIfPresent("Checkpoint Epochs", stream.count());
-      }
+      database.getColumnCounts().forEach(this::printColumn);
     }
-    try (final Database database =
-        createDatabase(beaconNodeDataOptions, true, eth2NetworkOptions)) {
-
-      printIfPresent("Blinded blocks", database.countBlindedBlocks());
-      printIfPresent("Execution Payloads", database.countExecutionPayloads());
-      printIfPresent("Non-canonical Slots", database.countNonCanonicalSlots());
-
-      return 0;
-    }
+    return 0;
   }
 
-  private void printIfPresent(final String label, final long count) {
-    if (count > 0L) {
-      final String formatString = "%19s: %d%n";
-      System.out.printf(formatString, label, count);
-    }
+  private void printColumn(final String label, final long count) {
+    final String formatString = "%40s: %d%n";
+    System.out.printf(formatString, label, count);
   }
 
   private Database createDatabase(

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugDbCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugDbCommand.java
@@ -209,8 +209,7 @@ public class DebugDbCommand implements Runnable {
   }
 
   private void printColumn(final String label, final long count) {
-    final String formatString = "%40s: %d%n";
-    System.out.printf(formatString, label, count);
+    System.out.printf("%40s: %d%n", label, count);
   }
 
   private Database createDatabase(


### PR DESCRIPTION
The debug-tool has been updated to output the counts of all columns, along with the actual column name, and no longer filters 0's from output.

Also cleaned up some of the functions that were used in the debug-tool.

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
