### PR TITLE
Fix incorrect error logged when a newly imported block has an invalid payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,4 @@ For information on changes in released versions of Teku, see the [releases page]
 
 ### Bug Fixes
  - Fix `latestValidHash`with invalid Execution Payload in response from execution engine didn't trigger appropriate ForkChoice changes 
+ - Remove incorrect error about potentially finalizing an invalid execution payload when importing a block with an invalid payload

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArrayBuilder.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArrayBuilder.java
@@ -16,12 +16,15 @@ package tech.pegasys.teku.storage.protoarray;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.Optional;
+import tech.pegasys.teku.infrastructure.logging.StatusLogger;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.config.Constants;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 
 public class ProtoArrayBuilder {
+
+  private StatusLogger statusLog = StatusLogger.STATUS_LOG;
   private int pruneThreshold = Constants.PROTOARRAY_FORKCHOICE_PRUNE_THRESHOLD;
   private Checkpoint justifiedCheckpoint;
   private Checkpoint finalizedCheckpoint;
@@ -30,7 +33,13 @@ public class ProtoArrayBuilder {
   public ProtoArray build() {
     checkNotNull(justifiedCheckpoint, "Justified checkpoint must be supplied");
     checkNotNull(finalizedCheckpoint, "finalized checkpoint must be supplied");
-    return new ProtoArray(pruneThreshold, justifiedCheckpoint, finalizedCheckpoint, initialEpoch);
+    return new ProtoArray(
+        pruneThreshold, justifiedCheckpoint, finalizedCheckpoint, initialEpoch, statusLog);
+  }
+
+  public ProtoArrayBuilder statusLog(final StatusLogger statusLog) {
+    this.statusLog = statusLog;
+    return this;
   }
 
   public ProtoArrayBuilder pruneThreshold(final int pruneThreshold) {

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ProtoArrayTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ProtoArrayTest.java
@@ -15,6 +15,8 @@ package tech.pegasys.teku.storage.protoarray;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 import it.unimi.dsi.fastutil.longs.LongList;
 import java.util.Collections;
@@ -25,6 +27,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.crypto.Hash;
 import tech.pegasys.teku.infrastructure.exceptions.FatalServiceFailureException;
+import tech.pegasys.teku.infrastructure.logging.StatusLogger;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
@@ -40,6 +43,7 @@ class ProtoArrayTest {
   private final DataStructureUtil dataStructureUtil =
       new DataStructureUtil(TestSpecFactory.createMinimalPhase0());
   private final VoteUpdater voteUpdater = new StubVoteUpdater();
+  private final StatusLogger statusLog = mock(StatusLogger.class);
 
   private final Bytes32 block1a = dataStructureUtil.randomBytes32();
   private final Bytes32 block1b = dataStructureUtil.randomBytes32();
@@ -50,6 +54,7 @@ class ProtoArrayTest {
 
   private ProtoArray protoArray =
       new ProtoArrayBuilder()
+          .statusLog(statusLog)
           .justifiedCheckpoint(GENESIS_CHECKPOINT)
           .finalizedCheckpoint(GENESIS_CHECKPOINT)
           .build();
@@ -360,6 +365,7 @@ class ProtoArrayTest {
 
     assertHead(block3a);
     assertThat(protoArray.contains(block3a)).isTrue();
+    verifyNoInteractions(statusLog);
   }
 
   @Test


### PR DESCRIPTION
## PR Description
When a block with an invalid payload was imported while the EL was in sync, Teku failed to find the latestValidHash because it wasn't checking the direct parent in this case (the code was originally only dealing with blocks that were imported optimistically and then later found to be invalid).

Teku's behaviour was correct (and there was even a test for it) but in incorrectly logged:

```
2022-07-21 10:53:00.508 ERROR - Could not find latest valid execution payload hash (0xfa87aa1b3ee36c763fb5b083aa3fed49fd037371ffc4949b03f894fcf5c3c099) in the non-finalized chain. Optimistic sync may have finalized an invalid transition block.
```

Now it does not.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
