### PR TITLE
Rename streamFinalizedBlocks, add getRaw

### DIFF
--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/BlindedBlockKvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/BlindedBlockKvStoreDatabase.java
@@ -289,7 +289,6 @@ public class BlindedBlockKvStoreDatabase
     if (storeNonCanonicalBlocks) {
       final Map<UInt64, Set<Bytes32>> nonCanonicalRootsBySlotBuffer = new HashMap<>();
       for (Bytes32 blockRoot : blockRoots) {
-        // TODO #5955
         if (finalizedChildToParentMap.containsKey(blockRoot)) {
           continue;
         }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/BlindedBlockKvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/BlindedBlockKvStoreDatabase.java
@@ -289,6 +289,10 @@ public class BlindedBlockKvStoreDatabase
     if (storeNonCanonicalBlocks) {
       final Map<UInt64, Set<Bytes32>> nonCanonicalRootsBySlotBuffer = new HashMap<>();
       for (Bytes32 blockRoot : blockRoots) {
+        // TODO #5955
+        if (finalizedChildToParentMap.containsKey(blockRoot)) {
+          continue;
+        }
         dao.getBlindedBlock(blockRoot)
             .map(SignedBeaconBlock::getSlot)
             .ifPresent(

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreAccessor.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreAccessor.java
@@ -77,6 +77,15 @@ public interface KvStoreAccessor extends AutoCloseable {
   Stream<ColumnEntry<Bytes, Bytes>> streamRaw(KvStoreColumn<?, ?> column);
 
   /**
+   * WARNING: should only be used to migrate data between tables
+   *
+   * @param column column to get value from
+   * @param key key of the data to retrieve
+   * @return Bytes representing the value found at key
+   */
+  <K, V> Optional<Bytes> getRaw(KvStoreColumn<K, V> column, K key);
+
+  /**
    * Stream entries from a column between keys from and to fully inclusive.
    *
    * @param column the column to stream entries from

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/UnblindedBlockKvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/UnblindedBlockKvStoreDatabase.java
@@ -139,7 +139,7 @@ public class UnblindedBlockKvStoreDatabase
   @MustBeClosed
   public Stream<SignedBeaconBlock> streamFinalizedBlocks(
       final UInt64 startSlot, final UInt64 endSlot) {
-    return dao.streamFinalizedBlocks(startSlot, endSlot);
+    return dao.streamUnblindedFinalizedBlocks(startSlot, endSlot);
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
@@ -270,6 +270,11 @@ public class CombinedKvStoreDao<S extends SchemaCombined>
   }
 
   @Override
+  public <K, V> Optional<Bytes> getRaw(final KvStoreColumn<K, V> kvStoreColumn, final K key) {
+    return db.getRaw(kvStoreColumn, key);
+  }
+
+  @Override
   public void close() throws Exception {
     db.close();
   }
@@ -337,10 +342,16 @@ public class CombinedKvStoreDao<S extends SchemaCombined>
 
   @Override
   @MustBeClosed
-  public Stream<SignedBeaconBlock> streamFinalizedBlocks(
+  public Stream<SignedBeaconBlock> streamUnblindedFinalizedBlocks(
       final UInt64 startSlot, final UInt64 endSlot) {
     return db.stream(schema.getColumnFinalizedBlocksBySlot(), startSlot, endSlot)
         .map(ColumnEntry::getValue);
+  }
+
+  @Override
+  @MustBeClosed
+  public Stream<Map.Entry<Bytes, Bytes>> streamUnblindedFinalizedBlocksRaw() {
+    return db.streamRaw(schema.getColumnFinalizedBlocksBySlot()).map(entry -> entry);
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
@@ -351,14 +351,6 @@ public class CombinedKvStoreDao<S extends SchemaCombined>
   }
 
   @Override
-  public long countUnblindedFinalizedBlocks() {
-    try (Stream<ColumnEntry<Bytes, Bytes>> entries =
-        db.streamRaw(schema.getColumnSlotsByFinalizedRoot())) {
-      return entries.count();
-    }
-  }
-
-  @Override
   public Optional<UInt64> getEarliestBlindedBlockSlot() {
     return db.getFirstEntry(schema.getColumnFinalizedBlockRootBySlot()).map(ColumnEntry::getKey);
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoAdapter.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoAdapter.java
@@ -217,17 +217,6 @@ public class KvStoreCombinedDaoAdapter
   }
 
   @Override
-  public long countUnblindedFinalizedBlocks() {
-    return finalizedDao.countUnblindedFinalizedBlocks();
-  }
-
-  @Override
-  @MustBeClosed
-  public Stream<Bytes> streamExecutionPayloads() {
-    return finalizedDao.streamExecutionPayloads();
-  }
-
-  @Override
   public Optional<SignedBeaconBlock> getBlindedBlock(final Bytes32 root) {
     return finalizedDao.getBlindedBlock(root);
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoAdapter.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoAdapter.java
@@ -209,9 +209,15 @@ public class KvStoreCombinedDaoAdapter
 
   @Override
   @MustBeClosed
-  public Stream<SignedBeaconBlock> streamFinalizedBlocks(
+  public Stream<SignedBeaconBlock> streamUnblindedFinalizedBlocks(
       final UInt64 startSlot, final UInt64 endSlot) {
     return finalizedDao.streamFinalizedBlocks(startSlot, endSlot);
+  }
+
+  @Override
+  @MustBeClosed
+  public Stream<Map.Entry<Bytes, Bytes>> streamUnblindedFinalizedBlocksRaw() {
+    return finalizedDao.streamUnblindedFinalizedBlocksRaw();
   }
 
   @Override
@@ -379,6 +385,15 @@ public class KvStoreCombinedDaoAdapter
       return hotDao.streamRawColumn(kvStoreColumn);
     } else {
       return finalizedDao.streamRawColumn(kvStoreColumn);
+    }
+  }
+
+  @Override
+  public <K, V> Optional<Bytes> getRaw(final KvStoreColumn<K, V> kvStoreColumn, final K key) {
+    if (hotDao.getColumnMap().containsValue(kvStoreColumn)) {
+      return hotDao.getRaw(kvStoreColumn, key);
+    } else {
+      return finalizedDao.getRaw(kvStoreColumn, key);
     }
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoUnblinded.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoUnblinded.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
+import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockAndCheckpoints;
@@ -54,7 +55,10 @@ public interface KvStoreCombinedDaoUnblinded extends KvStoreCombinedDaoCommon {
   List<SignedBeaconBlock> getNonCanonicalUnblindedBlocksAtSlot(UInt64 slot);
 
   @MustBeClosed
-  Stream<SignedBeaconBlock> streamFinalizedBlocks(UInt64 startSlot, UInt64 endSlot);
+  Stream<SignedBeaconBlock> streamUnblindedFinalizedBlocks(UInt64 startSlot, UInt64 endSlot);
+
+  @MustBeClosed
+  Stream<Map.Entry<Bytes, Bytes>> streamUnblindedFinalizedBlocksRaw();
 
   long countUnblindedFinalizedBlocks();
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4FinalizedKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4FinalizedKvStoreDao.java
@@ -92,6 +92,11 @@ public class V4FinalizedKvStoreDao {
         .collect(Collectors.toList());
   }
 
+  @MustBeClosed
+  public Stream<Map.Entry<Bytes, Bytes>> streamUnblindedFinalizedBlocksRaw() {
+    return db.streamRaw(schema.getColumnFinalizedBlocksBySlot()).map(entry -> entry);
+  }
+
   public Optional<BeaconState> getLatestAvailableFinalizedState(final UInt64 maxSlot) {
     return stateStorageLogic.getLatestAvailableFinalizedState(db, schema, maxSlot);
   }
@@ -213,6 +218,10 @@ public class V4FinalizedKvStoreDao {
 
   public Set<Bytes32> getNonCanonicalBlockRootsAtSlot(final UInt64 slot) {
     return db.get(schema.getColumnNonCanonicalRootsBySlot(), slot).orElseGet(HashSet::new);
+  }
+
+  public <V, K> Optional<Bytes> getRaw(final KvStoreColumn<K, V> kvStoreColumn, final K key) {
+    return db.getRaw(kvStoreColumn, key);
   }
 
   static class V4FinalizedUpdater implements FinalizedUpdaterBlinded, FinalizedUpdaterUnblinded {

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4HotKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4HotKvStoreDao.java
@@ -171,6 +171,10 @@ public class V4HotKvStoreDao {
     return schema.getVariableMap();
   }
 
+  public <V, K> Optional<Bytes> getRaw(final KvStoreColumn<K, V> kvStoreColumn, final K key) {
+    return db.getRaw(kvStoreColumn, key);
+  }
+
   static class V4HotUpdater implements HotUpdaterBlinded, HotUpdaterUnblinded {
 
     private final KvStoreTransaction transaction;

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4MigratableSourceDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4MigratableSourceDao.java
@@ -31,4 +31,6 @@ public interface V4MigratableSourceDao {
 
   @MustBeClosed
   <K, V> Stream<ColumnEntry<Bytes, Bytes>> streamRawColumn(final KvStoreColumn<K, V> kvStoreColumn);
+
+  <K, V> Optional<Bytes> getRaw(final KvStoreColumn<K, V> kvStoreColumn, K key);
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/leveldb/LevelDbInstance.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/leveldb/LevelDbInstance.java
@@ -235,6 +235,12 @@ public class LevelDbInstance implements KvStoreAccessor {
   }
 
   @Override
+  public <K, V> Optional<Bytes> getRaw(final KvStoreColumn<K, V> column, final K key) {
+    assertOpen();
+    return Optional.ofNullable(db.get(getColumnKey(column, key))).map(Bytes::wrap);
+  }
+
+  @Override
   @MustBeClosed
   public <K extends Comparable<K>, V> Stream<ColumnEntry<K, V>> stream(
       final KvStoreColumn<K, V> column, final K from, final K to) {

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbInstance.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbInstance.java
@@ -150,6 +150,18 @@ public class RocksDbInstance implements KvStoreAccessor {
   }
 
   @Override
+  public <K, V> Optional<Bytes> getRaw(final KvStoreColumn<K, V> column, final K key) {
+    assertOpen();
+    final ColumnFamilyHandle handle = columnHandles.get(column);
+    final byte[] keyBytes = column.getKeySerializer().serialize(key);
+    try {
+      return Optional.ofNullable(db.get(handle, keyBytes)).map(Bytes::wrap);
+    } catch (RocksDBException e) {
+      throw RocksDbExceptionUtil.wrapException("Failed to get value", e);
+    }
+  }
+
+  @Override
   @MustBeClosed
   public <K extends Comparable<K>, V> Stream<ColumnEntry<K, V>> stream(
       final KvStoreColumn<K, V> column, final K from, final K to) {

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/server/kvstore/MockKvStoreInstance.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/server/kvstore/MockKvStoreInstance.java
@@ -155,6 +155,12 @@ public class MockKvStoreInstance implements KvStoreAccessor {
   }
 
   @Override
+  public <K, V> Optional<Bytes> getRaw(final KvStoreColumn<K, V> column, final K key) {
+    final Bytes keyBytes = keyToBytes(column, key);
+    return Optional.ofNullable(columnData.get(column).get(keyBytes));
+  }
+
+  @Override
   public <K extends Comparable<K>, V> Stream<ColumnEntry<K, V>> stream(
       final KvStoreColumn<K, V> column, final K from, final K to) {
     assertOpen();


### PR DESCRIPTION
 - getRaw is needed to efficiently copy blocks from a column, which is not part of this PR, but will be just behind it, and with the plumbing involved it's easier to do by itself.

 - streamFinalizedBlocks is only hitting an unblinded column, so renamed to make that clear.

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
