### PR TITLE
Run DatabaseTest in multiple threads

### DIFF
--- a/storage/src/test/java/tech/pegasys/teku/storage/server/kvstore/DatabaseTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/kvstore/DatabaseTest.java
@@ -49,6 +49,8 @@ import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import tech.pegasys.teku.bls.BLSKeyGenerator;
 import tech.pegasys.teku.bls.BLSKeyPair;
 import tech.pegasys.teku.dataproviders.lookup.BlockProvider;
@@ -90,6 +92,7 @@ import tech.pegasys.teku.storage.store.UpdatableStore;
 import tech.pegasys.teku.storage.store.UpdatableStore.StoreTransaction;
 
 @TestDatabaseContext
+@Execution(ExecutionMode.CONCURRENT)
 public class DatabaseTest {
 
   private static final List<BLSKeyPair> VALIDATOR_KEYS = BLSKeyGenerator.generateKeyPairs(3);

--- a/storage/src/test/java/tech/pegasys/teku/storage/store/FileKeyValueStoreTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/store/FileKeyValueStoreTest.java
@@ -78,7 +78,7 @@ public class FileKeyValueStoreTest {
     }
 
     SafeFuture<Void> allFut = SafeFuture.allOfFailFast(futs);
-    assertThatCode(() -> allFut.get(30, TimeUnit.SECONDS)).doesNotThrowAnyException();
+    assertThatCode(() -> allFut.get(60, TimeUnit.SECONDS)).doesNotThrowAnyException();
 
     Optional<Bytes> finalVal = store.get("aaa");
     assertThat(finalVal).isNotEmpty();

--- a/storage/src/test/resources/junit-platform.properties
+++ b/storage/src/test/resources/junit-platform.properties
@@ -1,0 +1,1 @@
+junit.jupiter.execution.parallel.enabled=true


### PR DESCRIPTION
## PR Description
`DatabaseTest` dynamically generates a _lot_ of tests and takes a long time to run, to the point where it becomes the critical path for completing the build.  Enable parallel execution for each of its test methods to make it faster.

Note that this puts quite a lot more pressure on disk operations so had to extend a timeout in the FileKeyValueStoreTest.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
