### PR TITLE
Add acceptance test for a VC with multiple BN

### DIFF
--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/ExternalMetricNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/ExternalMetricNode.java
@@ -208,8 +208,8 @@ public class ExternalMetricNode extends Node {
     if (!started) {
       return;
     }
-    started = false;
     LOG.debug("Shutting down");
+    started = false;
     container.stop();
   }
 }

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNode.java
@@ -579,8 +579,8 @@ public class TekuNode extends Node {
     if (!started) {
       return;
     }
-    started = false;
     LOG.debug("Shutting down");
+    started = false;
     maybeEventStreamListener.ifPresent(EventStreamListener::close);
     configFiles.forEach(
         configFile -> {

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNode.java
@@ -43,7 +43,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -91,7 +90,7 @@ public class TekuNode extends Node {
   private final Spec spec;
   private Optional<EventStreamListener> maybeEventStreamListener = Optional.empty();
 
-  private AtomicBoolean started = new AtomicBoolean(false);
+  private boolean started = false;
   private Set<File> configFiles;
 
   private TekuNode(final Network network, final DockerVersion version, final Config config) {
@@ -135,9 +134,9 @@ public class TekuNode extends Node {
   }
 
   public void start() throws Exception {
-    assertThat(started.get()).isFalse();
+    assertThat(started).isFalse();
     LOG.debug("Start node {}", nodeAlias);
-    started.set(true);
+    started = true;
     final Map<File, String> configFiles = config.write();
     this.configFiles = configFiles.keySet();
     configFiles.forEach(
@@ -577,9 +576,10 @@ public class TekuNode extends Node {
 
   @Override
   public void stop() {
-    if (started.compareAndSet(false, false)) {
+    if (!started) {
       return;
     }
+    started = false;
     LOG.debug("Shutting down");
     maybeEventStreamListener.ifPresent(EventStreamListener::close);
     configFiles.forEach(

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNode.java
@@ -588,6 +588,7 @@ public class TekuNode extends Node {
           }
         });
     container.stop();
+    started = false;
   }
 
   @Override

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuValidatorNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuValidatorNode.java
@@ -24,11 +24,14 @@ import java.io.OutputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.testcontainers.containers.Network;
@@ -185,6 +188,23 @@ public class TekuValidatorNode extends Node {
 
     public TekuValidatorNode.Config withBeaconNode(final TekuNode beaconNode) {
       configMap.put("beacon-node-api-endpoint", beaconNode.getBeaconRestApiUrl());
+      return this;
+    }
+
+    public TekuValidatorNode.Config withBeaconNodes(final TekuNode... beaconNodes) {
+      configMap.put(
+          "Xbeacon-node-api-endpoints",
+          Arrays.stream(beaconNodes)
+              .map(TekuNode::getBeaconRestApiUrl)
+              .collect(Collectors.toList()));
+      return this;
+    }
+
+    public TekuValidatorNode.Config withPrimaryBeaconNodeEventStreamReconnectAttemptPeriod(
+        final Duration reconnectAttemptPeriod) {
+      configMap.put(
+          "Xprimary-beacon-node-event-stream-reconnect-attempt-period",
+          reconnectAttemptPeriod.toMillis());
       return this;
     }
 

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuValidatorNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuValidatorNode.java
@@ -119,6 +119,7 @@ public class TekuValidatorNode extends Node {
     if (!started) {
       return;
     }
+    started = false;
     LOG.debug("Shutting down");
     configFiles.forEach(
         configFile -> {

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuValidatorNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuValidatorNode.java
@@ -119,8 +119,8 @@ public class TekuValidatorNode extends Node {
     if (!started) {
       return;
     }
-    started = false;
     LOG.debug("Shutting down");
+    started = false;
     configFiles.forEach(
         configFile -> {
           if (!configFile.delete() && configFile.exists()) {

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuVoluntaryExit.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuVoluntaryExit.java
@@ -84,6 +84,7 @@ public class TekuVoluntaryExit extends Node {
     if (!started) {
       return;
     }
+    started = false;
     LOG.debug("Shutting down");
     configFiles.forEach(
         configFile -> {

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuVoluntaryExit.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuVoluntaryExit.java
@@ -84,8 +84,8 @@ public class TekuVoluntaryExit extends Node {
     if (!started) {
       return;
     }
-    started = false;
     LOG.debug("Shutting down");
+    started = false;
     configFiles.forEach(
         configFile -> {
           if (!configFile.delete() && configFile.exists()) {

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/Web3SignerNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/Web3SignerNode.java
@@ -96,8 +96,8 @@ public class Web3SignerNode extends Node {
     if (!started) {
       return;
     }
-    started = false;
     LOG.debug("Shutting down web3signer");
+    started = false;
     configFiles.forEach(
         configFile -> {
           if (!configFile.delete() && configFile.exists()) {

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/Web3SignerNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/Web3SignerNode.java
@@ -96,6 +96,7 @@ public class Web3SignerNode extends Node {
     if (!started) {
       return;
     }
+    started = false;
     LOG.debug("Shutting down web3signer");
     configFiles.forEach(
         configFile -> {

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorClientOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorClientOptions.java
@@ -17,6 +17,7 @@ import static tech.pegasys.teku.validator.api.ValidatorConfig.DEFAULT_VALIDATOR_
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.time.Duration;
 import java.util.List;
 import java.util.stream.Collectors;
 import picocli.CommandLine;
@@ -55,6 +56,17 @@ public class ValidatorClientOptions {
   private boolean failoversSendSubnetSubscriptionsEnabled =
       ValidatorConfig.DEFAULT_FAILOVERS_SEND_SUBNET_SUBSCRIPTIONS_ENABLED;
 
+  @CommandLine.Option(
+      names = {"--Xprimary-beacon-node-event-stream-reconnect-attempt-period"},
+      paramLabel = "<INTEGER>",
+      description =
+          "How often (in milliseconds) will a reconnection to the primary Beacon Node event stream be attempted during a failover.",
+      hidden = true,
+      showDefaultValue = CommandLine.Help.Visibility.ALWAYS,
+      arity = "1")
+  private long primaryBeaconNodeEventStreamReconnectAttemptPeriod =
+      ValidatorConfig.DEFAULT_PRIMARY_BEACON_NODE_EVENT_STREAM_RECONNECT_ATTEMPT_PERIOD.toMillis();
+
   @Option(
       names = {"--Xbeacon-node-ssz-blocks-enabled"},
       paramLabel = "<BOOLEAN>",
@@ -72,7 +84,9 @@ public class ValidatorClientOptions {
                 .beaconNodeApiEndpoint(getBeaconNodeApiEndpoint())
                 .beaconNodeApiEndpoints(getBeaconNodeApiEndpoints())
                 .validatorClientUseSszBlocksEnabled(validatorClientSszBlocksEnabled)
-                .failoversSendSubnetSubscriptionsEnabled(failoversSendSubnetSubscriptionsEnabled));
+                .failoversSendSubnetSubscriptionsEnabled(failoversSendSubnetSubscriptionsEnabled)
+                .primaryBeaconNodeEventStreamReconnectAttemptPeriod(
+                    Duration.ofMillis(primaryBeaconNodeEventStreamReconnectAttemptPeriod)));
   }
 
   public URI getBeaconNodeApiEndpoint() {

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
@@ -51,6 +51,8 @@ public class ValidatorConfig {
   public static final boolean DEFAULT_VALIDATOR_BLINDED_BLOCKS_ENABLED = false;
   public static final int DEFAULT_VALIDATOR_REGISTRATION_SENDING_BATCH_SIZE = 100;
   public static final UInt64 DEFAULT_BUILDER_REGISTRATION_GAS_LIMIT = UInt64.valueOf(30_000_000);
+  public static final Duration DEFAULT_PRIMARY_BEACON_NODE_EVENT_STREAM_RECONNECT_ATTEMPT_PERIOD =
+      Duration.ofSeconds(30);
 
   private final List<String> validatorKeys;
   private final List<String> validatorExternalSignerPublicKeySources;
@@ -78,8 +80,8 @@ public class ValidatorConfig {
   private final UInt64 builderRegistrationDefaultGasLimit;
   private final int builderRegistrationSendingBatchSize;
   private final Optional<UInt64> builderRegistrationTimestampOverride;
-
   private final int executorMaxQueueSize;
+  private final Duration primaryBeaconNodeEventStreamReconnectAttemptPeriod;
 
   private ValidatorConfig(
       final List<String> validatorKeys,
@@ -108,7 +110,8 @@ public class ValidatorConfig {
       final UInt64 builderRegistrationDefaultGasLimit,
       final int builderRegistrationSendingBatchSize,
       final Optional<UInt64> builderRegistrationTimestampOverride,
-      final int executorMaxQueueSize) {
+      final int executorMaxQueueSize,
+      final Duration primaryBeaconNodeEventStreamReconnectAttemptPeriod) {
     this.validatorKeys = validatorKeys;
     this.validatorExternalSignerPublicKeySources = validatorExternalSignerPublicKeySources;
     this.validatorExternalSignerUrl = validatorExternalSignerUrl;
@@ -139,6 +142,8 @@ public class ValidatorConfig {
     this.builderRegistrationSendingBatchSize = builderRegistrationSendingBatchSize;
     this.builderRegistrationTimestampOverride = builderRegistrationTimestampOverride;
     this.executorMaxQueueSize = executorMaxQueueSize;
+    this.primaryBeaconNodeEventStreamReconnectAttemptPeriod =
+        primaryBeaconNodeEventStreamReconnectAttemptPeriod;
   }
 
   public static Builder builder() {
@@ -248,6 +253,10 @@ public class ValidatorConfig {
     return executorMaxQueueSize;
   }
 
+  public Duration getPrimaryBeaconNodeEventStreamReconnectAttemptPeriod() {
+    return primaryBeaconNodeEventStreamReconnectAttemptPeriod;
+  }
+
   private void validateProposerDefaultFeeRecipientOrProposerConfigSource() {
     if (proposerDefaultFeeRecipient.isEmpty()
         && proposerConfigSource.isEmpty()
@@ -293,6 +302,8 @@ public class ValidatorConfig {
         DEFAULT_VALIDATOR_REGISTRATION_SENDING_BATCH_SIZE;
     private Optional<UInt64> builderRegistrationTimestampOverride = Optional.empty();
     private int executorMaxQueueSize = DEFAULT_EXECUTOR_MAX_QUEUE_SIZE;
+    private Duration primaryBeaconNodeEventStreamReconnectAttemptPeriod =
+        DEFAULT_PRIMARY_BEACON_NODE_EVENT_STREAM_RECONNECT_ATTEMPT_PERIOD;
 
     private Builder() {}
 
@@ -465,6 +476,13 @@ public class ValidatorConfig {
       return this;
     }
 
+    public Builder primaryBeaconNodeEventStreamReconnectAttemptPeriod(
+        final Duration primaryBeaconNodeEventStreamReconnectAttemptPeriod) {
+      this.primaryBeaconNodeEventStreamReconnectAttemptPeriod =
+          primaryBeaconNodeEventStreamReconnectAttemptPeriod;
+      return this;
+    }
+
     public ValidatorConfig build() {
       validateExternalSignerUrlAndPublicKeys();
       validateExternalSignerKeystoreAndPasswordFileConfig();
@@ -499,7 +517,8 @@ public class ValidatorConfig {
           builderRegistrationDefaultGasLimit,
           builderRegistrationSendingBatchSize,
           builderRegistrationTimestampOverride,
-          executorMaxQueueSize);
+          executorMaxQueueSize,
+          primaryBeaconNodeEventStreamReconnectAttemptPeriod);
     }
 
     private void validateExternalSignerUrlAndPublicKeys() {

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.validator.client;
 
 import java.net.URI;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -115,6 +116,8 @@ public class ValidatorClientService extends Service {
     final boolean preferSszBlockEncoding = validatorConfig.isValidatorClientUseSszBlocksEnabled();
     final boolean failoversSendSubnetSubscriptions =
         validatorConfig.isFailoversSendSubnetSubscriptionsEnabled();
+    final Duration primaryBeaconNodeEventStreamReconnectAttemptPeriod =
+        validatorConfig.getPrimaryBeaconNodeEventStreamReconnectAttemptPeriod();
     final List<URI> beaconNodeApiEndpoints = validatorConfig.getBeaconNodeApiEndpoints();
 
     BeaconNodeApi beaconNodeApi;
@@ -131,7 +134,8 @@ public class ValidatorClientService extends Service {
                           config.getSpec(),
                           generateEarlyAttestations,
                           preferSszBlockEncoding,
-                          failoversSendSubnetSubscriptions))
+                          failoversSendSubnetSubscriptions,
+                          primaryBeaconNodeEventStreamReconnectAttemptPeriod))
               .orElseGet(
                   () ->
                       InProcessBeaconNodeApi.create(
@@ -145,7 +149,8 @@ public class ValidatorClientService extends Service {
               config.getSpec(),
               generateEarlyAttestations,
               preferSszBlockEncoding,
-              failoversSendSubnetSubscriptions);
+              failoversSendSubnetSubscriptions,
+              primaryBeaconNodeEventStreamReconnectAttemptPeriod);
     }
 
     final ValidatorApiChannel validatorApiChannel = beaconNodeApi.getValidatorApi();

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApi.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApi.java
@@ -65,7 +65,8 @@ public class RemoteBeaconNodeApi implements BeaconNodeApi {
       final Spec spec,
       final boolean generateEarlyAttestations,
       final boolean preferSszBlockEncoding,
-      final boolean failoversSendSubnetSubscriptions) {
+      final boolean failoversSendSubnetSubscriptions,
+      final Duration primaryBeaconNodeEventStreamReconnectAttemptPeriod) {
     Preconditions.checkArgument(
         !beaconNodeApiEndpoints.isEmpty(),
         "One or more Beacon Node endpoints should be defined for enabling remote connectivity from VC to BN.");
@@ -125,7 +126,8 @@ public class RemoteBeaconNodeApi implements BeaconNodeApi {
             validatorTimingChannel,
             asyncRunner,
             serviceConfig.getMetricsSystem(),
-            generateEarlyAttestations);
+            generateEarlyAttestations,
+            primaryBeaconNodeEventStreamReconnectAttemptPeriod);
 
     return new RemoteBeaconNodeApi(beaconChainEventAdapter, validatorApiWithMetrics);
   }

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/eventsource/EventSourceBeaconChainEventAdapter.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/eventsource/EventSourceBeaconChainEventAdapter.java
@@ -62,7 +62,7 @@ public class EventSourceBeaconChainEventAdapter implements BeaconChainEventAdapt
   private final AsyncRunner asyncRunner;
   private final BeaconChainEventAdapter timeBasedEventAdapter;
   private final EventSourceHandler eventSourceHandler;
-  private final Duration primaryBeaconNodeEventStreamReconnectAttemptPeriodDuringFailover;
+  private final Duration primaryBeaconNodeEventStreamReconnectAttemptPeriod;
 
   public EventSourceBeaconChainEventAdapter(
       final RemoteValidatorApiChannel primaryBeaconNodeApi,
@@ -74,7 +74,7 @@ public class EventSourceBeaconChainEventAdapter implements BeaconChainEventAdapt
       final AsyncRunner asyncRunner,
       final MetricsSystem metricsSystem,
       final boolean generateEarlyAttestations,
-      final Duration primaryBeaconNodeEventStreamReconnectAttemptPeriodDuringFailover) {
+      final Duration primaryBeaconNodeEventStreamReconnectAttemptPeriod) {
     this.primaryBeaconNodeApi = primaryBeaconNodeApi;
     this.failoverBeaconNodeApis = failoverBeaconNodeApis;
     this.okHttpClient = okHttpClient;
@@ -83,8 +83,8 @@ public class EventSourceBeaconChainEventAdapter implements BeaconChainEventAdapt
     this.timeBasedEventAdapter = timeBasedEventAdapter;
     this.eventSourceHandler =
         new EventSourceHandler(validatorTimingChannel, metricsSystem, generateEarlyAttestations);
-    this.primaryBeaconNodeEventStreamReconnectAttemptPeriodDuringFailover =
-        primaryBeaconNodeEventStreamReconnectAttemptPeriodDuringFailover;
+    this.primaryBeaconNodeEventStreamReconnectAttemptPeriod =
+        primaryBeaconNodeEventStreamReconnectAttemptPeriod;
     this.primaryEventSource = createEventSource(primaryBeaconNodeApi);
   }
 
@@ -193,8 +193,8 @@ public class EventSourceBeaconChainEventAdapter implements BeaconChainEventAdapt
             () ->
                 checkBeaconNodeIsReadyForEventStreaming(primaryBeaconNodeApi)
                     .thenRun(this::switchToPrimaryEventStream),
-            primaryBeaconNodeEventStreamReconnectAttemptPeriodDuringFailover,
-            primaryBeaconNodeEventStreamReconnectAttemptPeriodDuringFailover,
+            primaryBeaconNodeEventStreamReconnectAttemptPeriod,
+            primaryBeaconNodeEventStreamReconnectAttemptPeriod,
             throwable ->
                 LOG.trace(
                     "Couldn't reconnect to the primary Beacon Node event stream.", throwable));

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/eventsource/EventSourceBeaconChainEventAdapter.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/eventsource/EventSourceBeaconChainEventAdapter.java
@@ -46,11 +46,10 @@ public class EventSourceBeaconChainEventAdapter implements BeaconChainEventAdapt
   private static final Logger LOG = LogManager.getLogger();
 
   private static final Duration MAX_RECONNECT_TIME = Duration.ofSeconds(12);
-  private static final Duration PING_PRIMARY_BEACON_NODE_DURING_FAILOVER = Duration.ofSeconds(30);
 
   private final CountDownLatch runningLatch = new CountDownLatch(1);
 
-  private final AtomicReference<Cancellable> primaryBeaconNodeCheckStatusTask =
+  private final AtomicReference<Cancellable> primaryBeaconNodeReconnectAttemptTask =
       new AtomicReference<>();
 
   private volatile EventSource primaryEventSource;
@@ -63,6 +62,7 @@ public class EventSourceBeaconChainEventAdapter implements BeaconChainEventAdapt
   private final AsyncRunner asyncRunner;
   private final BeaconChainEventAdapter timeBasedEventAdapter;
   private final EventSourceHandler eventSourceHandler;
+  private final Duration primaryBeaconNodeEventStreamReconnectAttemptPeriodDuringFailover;
 
   public EventSourceBeaconChainEventAdapter(
       final RemoteValidatorApiChannel primaryBeaconNodeApi,
@@ -73,7 +73,8 @@ public class EventSourceBeaconChainEventAdapter implements BeaconChainEventAdapt
       final ValidatorTimingChannel validatorTimingChannel,
       final AsyncRunner asyncRunner,
       final MetricsSystem metricsSystem,
-      final boolean generateEarlyAttestations) {
+      final boolean generateEarlyAttestations,
+      final Duration primaryBeaconNodeEventStreamReconnectAttemptPeriodDuringFailover) {
     this.primaryBeaconNodeApi = primaryBeaconNodeApi;
     this.failoverBeaconNodeApis = failoverBeaconNodeApis;
     this.okHttpClient = okHttpClient;
@@ -82,6 +83,8 @@ public class EventSourceBeaconChainEventAdapter implements BeaconChainEventAdapt
     this.timeBasedEventAdapter = timeBasedEventAdapter;
     this.eventSourceHandler =
         new EventSourceHandler(validatorTimingChannel, metricsSystem, generateEarlyAttestations);
+    this.primaryBeaconNodeEventStreamReconnectAttemptPeriodDuringFailover =
+        primaryBeaconNodeEventStreamReconnectAttemptPeriodDuringFailover;
     this.primaryEventSource = createEventSource(primaryBeaconNodeApi);
   }
 
@@ -153,7 +156,7 @@ public class EventSourceBeaconChainEventAdapter implements BeaconChainEventAdapt
   }
 
   // switchToFailoverEventStreamIfNeeded is async, so there could be multiple quick calls to
-  // this method for the same failover endpoint because of the ConnectionErrorHandler callback
+  // this method for different failover endpoints because of the ConnectionErrorHandler callback
   private synchronized void switchToFailoverEventStream(
       final RemoteValidatorApiChannel beaconNodeApi) {
     if (alreadyFailedOver(beaconNodeApi)) {
@@ -164,18 +167,24 @@ public class EventSourceBeaconChainEventAdapter implements BeaconChainEventAdapt
     validatorLogger.switchingToFailoverBeaconNodeForEventStreaming();
     failoverEventSource.start();
     maybeFailoverEventSource = Optional.of(failoverEventSource);
-    startPrimaryBeaconNodeCheckStatusTask();
+    startPrimaryBeaconNodeReconnectAttemptTask();
   }
 
   private boolean alreadyFailedOver(final RemoteValidatorApiChannel beaconNodeApi) {
     return maybeFailoverEventSource
-        .map(EventSource::getHttpUrl)
-        .map(endpoint -> endpoint.equals(createHeadEventSourceUrl(beaconNodeApi.getEndpoint())))
+        .map(
+            eventSource -> {
+              final boolean isSameEndpoint =
+                  eventSource
+                      .getHttpUrl()
+                      .equals(createHeadEventSourceUrl(beaconNodeApi.getEndpoint()));
+              return isSameEndpoint || eventSource.getState().equals(ReadyState.OPEN);
+            })
         .orElse(false);
   }
 
-  private void startPrimaryBeaconNodeCheckStatusTask() {
-    final Cancellable currentCheckStatusTask = primaryBeaconNodeCheckStatusTask.get();
+  private void startPrimaryBeaconNodeReconnectAttemptTask() {
+    final Cancellable currentCheckStatusTask = primaryBeaconNodeReconnectAttemptTask.get();
     if (currentCheckStatusTask != null && !currentCheckStatusTask.isCancelled()) {
       return;
     }
@@ -184,13 +193,12 @@ public class EventSourceBeaconChainEventAdapter implements BeaconChainEventAdapt
             () ->
                 checkBeaconNodeIsReadyForEventStreaming(primaryBeaconNodeApi)
                     .thenRun(this::switchToPrimaryEventStream),
-            PING_PRIMARY_BEACON_NODE_DURING_FAILOVER,
-            PING_PRIMARY_BEACON_NODE_DURING_FAILOVER,
+            primaryBeaconNodeEventStreamReconnectAttemptPeriodDuringFailover,
+            primaryBeaconNodeEventStreamReconnectAttemptPeriodDuringFailover,
             throwable ->
                 LOG.trace(
-                    "The primary beacon node is not ready for event streaming or switching over to it failed.",
-                    throwable));
-    primaryBeaconNodeCheckStatusTask.set(checkStatusTask);
+                    "Couldn't reconnect to the primary Beacon Node event stream.", throwable));
+    primaryBeaconNodeReconnectAttemptTask.set(checkStatusTask);
   }
 
   private void switchToPrimaryEventStream() {
@@ -221,14 +229,12 @@ public class EventSourceBeaconChainEventAdapter implements BeaconChainEventAdapt
   }
 
   private void closeCurrentEventStream() {
-    if (primaryEventSource.getState() != ReadyState.SHUTDOWN) {
-      primaryEventSource.close();
-    }
+    primaryEventSource.close();
     maybeFailoverEventSource.ifPresent(EventSource::close);
   }
 
   private void cancelScheduledCheckPrimaryBeaconNodeCheckStatusTask() {
-    Optional.ofNullable(primaryBeaconNodeCheckStatusTask.get()).ifPresent(Cancellable::cancel);
+    Optional.ofNullable(primaryBeaconNodeReconnectAttemptTask.get()).ifPresent(Cancellable::cancel);
   }
 
   private void waitForExit() {

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApiTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApiTest.java
@@ -17,6 +17,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
 import java.net.URI;
+import java.time.Duration;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
@@ -41,7 +42,8 @@ class RemoteBeaconNodeApiTest {
                     spec,
                     false,
                     false,
-                    true))
+                    true,
+                    Duration.ofMillis(1)))
         .hasMessageContaining("Failed to convert remote api endpoint");
   }
 }


### PR DESCRIPTION
## PR Description

- Add a new test case in `RemoteValidatorAcceptanceTest`
- Introduce new hidden CLI option `--Xprimary-beacon-node-event-stream-reconnect-attempt-period` to control the primary beacon node reconnection period during failover
- Changed `alreadyFailedOver` method to return true when other failover has already started and is receiving events
## Fixed Issue(s)
acceptance test for #5237 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
