### PR TITLE
Update jvm-libp2p to 0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ For information on changes in released versions of Teku, see the [releases page]
 ### Additions and Improvements
  - Added support for Builder API
  - Enables fork choice before block proposals by default on MainNet (previously on by default on testnets only)
+ - Optimisations in jvm-libp2p to reduce CPU usage
 
 ### Bug Fixes
  - Fix `latestValidHash`with invalid Execution Payload in response from execution engine didn't trigger appropriate ForkChoice changes 

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -47,7 +47,7 @@ dependencyManagement {
     dependency 'io.protostuff:protostuff-core:1.6.2'
     dependency 'io.protostuff:protostuff-runtime:1.6.2'
 
-    dependency 'io.libp2p:jvm-libp2p-minimal:0.9.0-RELEASE'
+    dependency 'io.libp2p:jvm-libp2p-minimal:0.9.1-RELEASE'
     dependency 'tech.pegasys:jblst:0.3.8'
 
     dependency 'org.hdrhistogram:HdrHistogram:2.1.12'


### PR DESCRIPTION
## PR Description
Updates jvm-libp2p to 0.9.1 which includes a couple of optimisations from Anton. The GossipRouter moved to providing a builder so had to adjust how we create it.

fixes #5976 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
