### PR TITLE
Add metrics for failover BN requests

### DIFF
--- a/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/BeaconNodeRequestLabels.java
+++ b/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/BeaconNodeRequestLabels.java
@@ -15,31 +15,27 @@ package tech.pegasys.teku.validator.beaconnode.metrics;
 
 public class BeaconNodeRequestLabels {
 
-  public static final String GET_GENESIS_REQUEST_METHOD = "get_genesis";
-  public static final String GET_VALIDATOR_INDICES_REQUEST_METHOD = "get_validator_indices";
-  public static final String GET_VALIDATOR_STATUSES_REQUEST_METHOD = "get_validator_statuses";
-  public static final String GET_ATTESTATION_DUTIES_REQUEST_METHOD = "get_attestation_duties";
+  public static final String GET_GENESIS_METHOD = "get_genesis";
+  public static final String GET_VALIDATOR_INDICES_METHOD = "get_validator_indices";
+  public static final String GET_VALIDATOR_STATUSES_METHOD = "get_validator_statuses";
+  public static final String GET_ATTESTATION_DUTIES_METHOD = "get_attestation_duties";
   public static final String GET_PROPOSER_DUTIES_REQUESTS_METHOD = "get_proposer_duties";
-  public static final String GET_SYNC_COMMITTEE_DUTIES_REQUEST_METHOD = "get_sync_committee_duties";
-  public static final String CREATE_UNSIGNED_BLOCK_REQUEST_METHOD = "create_unsigned_block";
-  public static final String CREATE_ATTESTATION_REQUEST_METHOD = "create_attestation";
-  public static final String CREATE_AGGREGATE_REQUEST_METHOD = "create_aggregate";
-  public static final String CREATE_SYNC_COMMITTEE_CONTRIBUTION_REQUEST_METHOD =
+  public static final String GET_SYNC_COMMITTEE_DUTIES_METHOD = "get_sync_committee_duties";
+  public static final String CREATE_UNSIGNED_BLOCK_METHOD = "create_unsigned_block";
+  public static final String CREATE_ATTESTATION_METHOD = "create_attestation";
+  public static final String CREATE_AGGREGATE_METHOD = "create_aggregate";
+  public static final String CREATE_SYNC_COMMITTEE_CONTRIBUTION_METHOD =
       "create_sync_committee_contribution";
-  public static final String BEACON_COMMITTEE_SUBSCRIPTION_REQUEST_METHOD =
-      "beacon_committee_subscription";
-  public static final String SYNC_COMMITTEE_SUBNET_SUBSCRIPTION_REQUEST_METHOD =
+  public static final String BEACON_COMMITTEE_SUBSCRIPTION_METHOD = "beacon_committee_subscription";
+  public static final String SYNC_COMMITTEE_SUBNET_SUBSCRIPTION_METHOD =
       "sync_committee_subnet_subscription";
-  public static final String PERSISTENT_SUBNETS_SUBSCRIPTION_REQUEST_METHOD =
+  public static final String PERSISTENT_SUBNETS_SUBSCRIPTION_METHOD =
       "persistent_subnets_subscription";
-  public static final String PUBLISH_ATTESTATION_REQUEST_METHOD = "publish_attestation";
-  public static final String PUBLISH_AGGREGATE_AND_PROOFS_REQUEST_METHOD =
-      "publish_aggregate_and_proofs";
-  public static final String PUBLISH_BLOCK_REQUEST_METHOD = "publish_block";
-  public static final String SEND_SYNC_COMMITTEE_MESSAGES_REQUEST_METHOD =
-      "send_sync_committee_messages";
-  public static final String SEND_CONTRIBUTIONS_AND_PROOFS_REQUEST_METHOD =
-      "send_contributions_and_proofs";
-  public static final String PREPARE_BEACON_PROPOSERS_REQUEST_METHOD = "prepare_beacon_proposers";
-  public static final String REGISTER_VALIDATORS_REQUEST_METHOD = "register_validators";
+  public static final String PUBLISH_ATTESTATION_METHOD = "publish_attestation";
+  public static final String PUBLISH_AGGREGATE_AND_PROOFS_METHOD = "publish_aggregate_and_proofs";
+  public static final String PUBLISH_BLOCK_METHOD = "publish_block";
+  public static final String SEND_SYNC_COMMITTEE_MESSAGES_METHOD = "send_sync_committee_messages";
+  public static final String SEND_CONTRIBUTIONS_AND_PROOFS_METHOD = "send_contributions_and_proofs";
+  public static final String PREPARE_BEACON_PROPOSERS_METHOD = "prepare_beacon_proposers";
+  public static final String REGISTER_VALIDATORS_METHOD = "register_validators";
 }

--- a/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
+++ b/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
@@ -53,19 +53,19 @@ import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 
 public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
 
-  public static final String BEACON_NODE_REQUEST_COUNTER_NAME = "beacon_node_requests_total";
+  static final String BEACON_NODE_REQUESTS_COUNTER_NAME = "beacon_node_requests_total";
 
   private final ValidatorApiChannel delegate;
-  private final LabelledMetric<Counter> beaconNodeRequestCounter;
+  private final LabelledMetric<Counter> beaconNodeRequestsCounter;
 
   public MetricRecordingValidatorApiChannel(
       final MetricsSystem metricsSystem, final ValidatorApiChannel delegate) {
     this.delegate = delegate;
-    beaconNodeRequestCounter =
+    beaconNodeRequestsCounter =
         metricsSystem.createLabelledCounter(
             TekuMetricCategory.VALIDATOR,
-            BEACON_NODE_REQUEST_COUNTER_NAME,
-            "Counter recording the number of requests to the beacon node",
+            BEACON_NODE_REQUESTS_COUNTER_NAME,
+            "Counter recording the number of requests sent to the beacon node",
             "method",
             "outcome");
   }
@@ -73,7 +73,7 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
   @Override
   public SafeFuture<Optional<GenesisData>> getGenesisData() {
     return countOptionalDataRequest(
-        delegate.getGenesisData(), BeaconNodeRequestLabels.GET_GENESIS_REQUEST_METHOD);
+        delegate.getGenesisData(), BeaconNodeRequestLabels.GET_GENESIS_METHOD);
   }
 
   @Override
@@ -81,7 +81,7 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
       final Collection<BLSPublicKey> publicKeys) {
     return countDataRequest(
         delegate.getValidatorIndices(publicKeys),
-        BeaconNodeRequestLabels.GET_VALIDATOR_INDICES_REQUEST_METHOD);
+        BeaconNodeRequestLabels.GET_VALIDATOR_INDICES_METHOD);
   }
 
   @Override
@@ -89,7 +89,7 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
       final Collection<BLSPublicKey> validatorIdentifiers) {
     return countOptionalDataRequest(
         delegate.getValidatorStatuses(validatorIdentifiers),
-        BeaconNodeRequestLabels.GET_VALIDATOR_STATUSES_REQUEST_METHOD);
+        BeaconNodeRequestLabels.GET_VALIDATOR_STATUSES_METHOD);
   }
 
   @Override
@@ -97,7 +97,7 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
       final UInt64 epoch, final IntCollection validatorIndices) {
     return countOptionalDataRequest(
         delegate.getAttestationDuties(epoch, validatorIndices),
-        BeaconNodeRequestLabels.GET_ATTESTATION_DUTIES_REQUEST_METHOD);
+        BeaconNodeRequestLabels.GET_ATTESTATION_DUTIES_METHOD);
   }
 
   @Override
@@ -105,7 +105,7 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
       final UInt64 epoch, final IntCollection validatorIndices) {
     return countOptionalDataRequest(
         delegate.getSyncCommitteeDuties(epoch, validatorIndices),
-        BeaconNodeRequestLabels.GET_SYNC_COMMITTEE_DUTIES_REQUEST_METHOD);
+        BeaconNodeRequestLabels.GET_SYNC_COMMITTEE_DUTIES_METHOD);
   }
 
   @Override
@@ -123,7 +123,7 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
       final boolean blinded) {
     return countOptionalDataRequest(
         delegate.createUnsignedBlock(slot, randaoReveal, graffiti, blinded),
-        BeaconNodeRequestLabels.CREATE_UNSIGNED_BLOCK_REQUEST_METHOD);
+        BeaconNodeRequestLabels.CREATE_UNSIGNED_BLOCK_METHOD);
   }
 
   @Override
@@ -131,7 +131,7 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
       final UInt64 slot, final int committeeIndex) {
     return countOptionalDataRequest(
         delegate.createAttestationData(slot, committeeIndex),
-        BeaconNodeRequestLabels.CREATE_ATTESTATION_REQUEST_METHOD);
+        BeaconNodeRequestLabels.CREATE_ATTESTATION_METHOD);
   }
 
   @Override
@@ -139,7 +139,7 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
       final UInt64 slot, final Bytes32 attestationHashTreeRoot) {
     return countOptionalDataRequest(
         delegate.createAggregate(slot, attestationHashTreeRoot),
-        BeaconNodeRequestLabels.CREATE_AGGREGATE_REQUEST_METHOD);
+        BeaconNodeRequestLabels.CREATE_AGGREGATE_METHOD);
   }
 
   @Override
@@ -147,7 +147,7 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
       final UInt64 slot, final int subcommitteeIndex, final Bytes32 beaconBlockRoot) {
     return countOptionalDataRequest(
         delegate.createSyncCommitteeContribution(slot, subcommitteeIndex, beaconBlockRoot),
-        BeaconNodeRequestLabels.CREATE_SYNC_COMMITTEE_CONTRIBUTION_REQUEST_METHOD);
+        BeaconNodeRequestLabels.CREATE_SYNC_COMMITTEE_CONTRIBUTION_METHOD);
   }
 
   @Override
@@ -155,7 +155,7 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
       final List<CommitteeSubscriptionRequest> requests) {
     return countDataRequest(
         delegate.subscribeToBeaconCommittee(requests),
-        BeaconNodeRequestLabels.BEACON_COMMITTEE_SUBSCRIPTION_REQUEST_METHOD);
+        BeaconNodeRequestLabels.BEACON_COMMITTEE_SUBSCRIPTION_METHOD);
   }
 
   @Override
@@ -163,7 +163,7 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
       final Collection<SyncCommitteeSubnetSubscription> subscriptions) {
     return countDataRequest(
         delegate.subscribeToSyncCommitteeSubnets(subscriptions),
-        BeaconNodeRequestLabels.SYNC_COMMITTEE_SUBNET_SUBSCRIPTION_REQUEST_METHOD);
+        BeaconNodeRequestLabels.SYNC_COMMITTEE_SUBNET_SUBSCRIPTION_METHOD);
   }
 
   @Override
@@ -171,7 +171,7 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
       final Set<SubnetSubscription> subnetSubscriptions) {
     return countDataRequest(
         delegate.subscribeToPersistentSubnets(subnetSubscriptions),
-        BeaconNodeRequestLabels.PERSISTENT_SUBNETS_SUBSCRIPTION_REQUEST_METHOD);
+        BeaconNodeRequestLabels.PERSISTENT_SUBNETS_SUBSCRIPTION_METHOD);
   }
 
   @Override
@@ -179,7 +179,7 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
       final List<Attestation> attestations) {
     return countSendRequest(
         delegate.sendSignedAttestations(attestations),
-        BeaconNodeRequestLabels.PUBLISH_ATTESTATION_REQUEST_METHOD);
+        BeaconNodeRequestLabels.PUBLISH_ATTESTATION_METHOD);
   }
 
   @Override
@@ -187,13 +187,13 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
       final List<SignedAggregateAndProof> aggregateAndProofs) {
     return countSendRequest(
         delegate.sendAggregateAndProofs(aggregateAndProofs),
-        BeaconNodeRequestLabels.PUBLISH_AGGREGATE_AND_PROOFS_REQUEST_METHOD);
+        BeaconNodeRequestLabels.PUBLISH_AGGREGATE_AND_PROOFS_METHOD);
   }
 
   @Override
   public SafeFuture<SendSignedBlockResult> sendSignedBlock(final SignedBeaconBlock block) {
     return countDataRequest(
-        delegate.sendSignedBlock(block), BeaconNodeRequestLabels.PUBLISH_BLOCK_REQUEST_METHOD);
+        delegate.sendSignedBlock(block), BeaconNodeRequestLabels.PUBLISH_BLOCK_METHOD);
   }
 
   @Override
@@ -201,7 +201,7 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
       final List<SyncCommitteeMessage> syncCommitteeMessages) {
     return countSendRequest(
         delegate.sendSyncCommitteeMessages(syncCommitteeMessages),
-        BeaconNodeRequestLabels.SEND_SYNC_COMMITTEE_MESSAGES_REQUEST_METHOD);
+        BeaconNodeRequestLabels.SEND_SYNC_COMMITTEE_MESSAGES_METHOD);
   }
 
   @Override
@@ -209,7 +209,7 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
       final Collection<SignedContributionAndProof> signedContributionAndProofs) {
     return countDataRequest(
         delegate.sendSignedContributionAndProofs(signedContributionAndProofs),
-        BeaconNodeRequestLabels.SEND_CONTRIBUTIONS_AND_PROOFS_REQUEST_METHOD);
+        BeaconNodeRequestLabels.SEND_CONTRIBUTIONS_AND_PROOFS_METHOD);
   }
 
   @Override
@@ -217,7 +217,7 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
       final Collection<BeaconPreparableProposer> beaconPreparableProposers) {
     return countDataRequest(
         delegate.prepareBeaconProposer(beaconPreparableProposers),
-        BeaconNodeRequestLabels.PREPARE_BEACON_PROPOSERS_REQUEST_METHOD);
+        BeaconNodeRequestLabels.PREPARE_BEACON_PROPOSERS_METHOD);
   }
 
   @Override
@@ -225,7 +225,7 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
       SszList<SignedValidatorRegistration> validatorRegistrations) {
     return countDataRequest(
         delegate.registerValidators(validatorRegistrations),
-        BeaconNodeRequestLabels.REGISTER_VALIDATORS_REQUEST_METHOD);
+        BeaconNodeRequestLabels.REGISTER_VALIDATORS_METHOD);
   }
 
   private <T> SafeFuture<T> countDataRequest(
@@ -272,10 +272,10 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
   }
 
   private void recordRequest(final String name, final RequestOutcome outcome) {
-    beaconNodeRequestCounter.labels(name, outcome.displayName).inc();
+    beaconNodeRequestsCounter.labels(name, outcome.displayName).inc();
   }
 
-  protected enum RequestOutcome {
+  enum RequestOutcome {
     SUCCESS("success"),
     ERROR("error"),
     DATA_UNAVAILABLE("data_unavailable");

--- a/validator/beaconnode/src/test/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannelTest.java
+++ b/validator/beaconnode/src/test/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannelTest.java
@@ -56,7 +56,7 @@ class MetricRecordingValidatorApiChannelTest {
   @MethodSource("getDataRequestArguments")
   public void shouldRecordSuccessfulRequestForData(
       final Function<ValidatorApiChannel, SafeFuture<Optional<Object>>> method,
-      final String counterMethod,
+      final String methodLabel,
       final Object value) {
     final Optional<Object> response = Optional.of(value);
     when(method.apply(delegate)).thenReturn(SafeFuture.completedFuture(response));
@@ -65,16 +65,16 @@ class MetricRecordingValidatorApiChannelTest {
 
     assertThat(result).isCompletedWithValue(response);
 
-    assertThat(getCounterValue(counterMethod, RequestOutcome.SUCCESS)).isEqualTo(1);
-    assertThat(getCounterValue(counterMethod, RequestOutcome.ERROR)).isZero();
-    assertThat(getCounterValue(counterMethod, RequestOutcome.DATA_UNAVAILABLE)).isZero();
+    assertThat(getCounterValue(methodLabel, RequestOutcome.SUCCESS)).isEqualTo(1);
+    assertThat(getCounterValue(methodLabel, RequestOutcome.ERROR)).isZero();
+    assertThat(getCounterValue(methodLabel, RequestOutcome.DATA_UNAVAILABLE)).isZero();
   }
 
   @ParameterizedTest(name = "{displayName} - {0}")
   @MethodSource("getDataRequestArguments")
   public void shouldRecordFailedRequestForData(
       final Function<ValidatorApiChannel, SafeFuture<Optional<Object>>> method,
-      final String counterMethod) {
+      final String methodLabel) {
     final RuntimeException exception = new RuntimeException("Nope");
     when(method.apply(delegate)).thenReturn(SafeFuture.failedFuture(exception));
 
@@ -82,47 +82,47 @@ class MetricRecordingValidatorApiChannelTest {
     assertThat(result).isCompletedExceptionally();
     assertThatThrownBy(result::join).hasRootCause(exception);
 
-    assertThat(getCounterValue(counterMethod, RequestOutcome.ERROR)).isEqualTo(1);
-    assertThat(getCounterValue(counterMethod, RequestOutcome.SUCCESS)).isZero();
-    assertThat(getCounterValue(counterMethod, RequestOutcome.DATA_UNAVAILABLE)).isZero();
+    assertThat(getCounterValue(methodLabel, RequestOutcome.ERROR)).isEqualTo(1);
+    assertThat(getCounterValue(methodLabel, RequestOutcome.SUCCESS)).isZero();
+    assertThat(getCounterValue(methodLabel, RequestOutcome.DATA_UNAVAILABLE)).isZero();
   }
 
   @ParameterizedTest(name = "{displayName} - {0}")
   @MethodSource("getDataRequestArguments")
   public void shouldRecordRequestForDataWhenDataUnavailable(
       final Function<ValidatorApiChannel, SafeFuture<Optional<Object>>> method,
-      final String counterMethod) {
+      final String methodLabel) {
     when(method.apply(delegate)).thenReturn(SafeFuture.completedFuture(Optional.empty()));
 
     final SafeFuture<Optional<Object>> result = method.apply(apiChannel);
     assertThat(result).isCompletedWithValue(Optional.empty());
 
-    assertThat(getCounterValue(counterMethod, RequestOutcome.DATA_UNAVAILABLE)).isEqualTo(1);
-    assertThat(getCounterValue(counterMethod, RequestOutcome.SUCCESS)).isZero();
-    assertThat(getCounterValue(counterMethod, RequestOutcome.ERROR)).isZero();
+    assertThat(getCounterValue(methodLabel, RequestOutcome.DATA_UNAVAILABLE)).isEqualTo(1);
+    assertThat(getCounterValue(methodLabel, RequestOutcome.SUCCESS)).isZero();
+    assertThat(getCounterValue(methodLabel, RequestOutcome.ERROR)).isZero();
   }
 
   @ParameterizedTest(name = "{displayName} - {0}")
   @MethodSource("getSendDataArguments")
   void shouldRecordSuccessfulSendRequest(
       final Function<ValidatorApiChannel, SafeFuture<List<Object>>> method,
-      final String counterMethod) {
+      final String methodLabel) {
     when(method.apply(delegate)).thenReturn(SafeFuture.completedFuture(emptyList()));
 
     final SafeFuture<List<Object>> result = method.apply(apiChannel);
 
     assertThat(result).isCompletedWithValue(emptyList());
 
-    assertThat(getCounterValue(counterMethod, RequestOutcome.SUCCESS)).isEqualTo(1);
-    assertThat(getCounterValue(counterMethod, RequestOutcome.ERROR)).isZero();
-    assertThat(getCounterValue(counterMethod, RequestOutcome.DATA_UNAVAILABLE)).isZero();
+    assertThat(getCounterValue(methodLabel, RequestOutcome.SUCCESS)).isEqualTo(1);
+    assertThat(getCounterValue(methodLabel, RequestOutcome.ERROR)).isZero();
+    assertThat(getCounterValue(methodLabel, RequestOutcome.DATA_UNAVAILABLE)).isZero();
   }
 
   @ParameterizedTest(name = "{displayName} - {0}")
   @MethodSource("getSendDataArguments")
   void shouldRecordFailingSendRequest(
       final Function<ValidatorApiChannel, SafeFuture<List<Object>>> method,
-      final String counterMethod,
+      final String methodLabel,
       final List<Object> failures) {
     when(method.apply(delegate)).thenReturn(SafeFuture.completedFuture(failures));
 
@@ -130,24 +130,24 @@ class MetricRecordingValidatorApiChannelTest {
 
     assertThat(result).isCompletedWithValue(failures);
 
-    assertThat(getCounterValue(counterMethod, RequestOutcome.SUCCESS)).isZero();
-    assertThat(getCounterValue(counterMethod, RequestOutcome.ERROR)).isEqualTo(1);
-    assertThat(getCounterValue(counterMethod, RequestOutcome.DATA_UNAVAILABLE)).isZero();
+    assertThat(getCounterValue(methodLabel, RequestOutcome.SUCCESS)).isZero();
+    assertThat(getCounterValue(methodLabel, RequestOutcome.ERROR)).isEqualTo(1);
+    assertThat(getCounterValue(methodLabel, RequestOutcome.DATA_UNAVAILABLE)).isZero();
   }
 
   @ParameterizedTest(name = "{displayName} - {0}")
   @MethodSource("getNoResponseCallArguments")
   public void shouldRecordCallsWithNoResponse(
-      final Function<ValidatorApiChannel, SafeFuture<Void>> method, final String counterMethod) {
+      final Function<ValidatorApiChannel, SafeFuture<Void>> method, final String methodLabel) {
     when(method.apply(delegate)).thenReturn(SafeFuture.COMPLETE);
 
     final SafeFuture<Void> result = method.apply(apiChannel);
 
     assertThat(result).isCompleted();
 
-    assertThat(getCounterValue(counterMethod, RequestOutcome.SUCCESS)).isEqualTo(1);
-    assertThat(getCounterValue(counterMethod, RequestOutcome.ERROR)).isZero();
-    assertThat(getCounterValue(counterMethod, RequestOutcome.DATA_UNAVAILABLE)).isZero();
+    assertThat(getCounterValue(methodLabel, RequestOutcome.SUCCESS)).isEqualTo(1);
+    assertThat(getCounterValue(methodLabel, RequestOutcome.ERROR)).isZero();
+    assertThat(getCounterValue(methodLabel, RequestOutcome.DATA_UNAVAILABLE)).isZero();
   }
 
   public static Stream<Arguments> getNoResponseCallArguments() {
@@ -155,18 +155,18 @@ class MetricRecordingValidatorApiChannelTest {
         noResponseTest(
             "subscribeToBeaconCommitteeForAggregation",
             channel -> channel.subscribeToBeaconCommittee(emptyList()),
-            BeaconNodeRequestLabels.BEACON_COMMITTEE_SUBSCRIPTION_REQUEST_METHOD),
+            BeaconNodeRequestLabels.BEACON_COMMITTEE_SUBSCRIPTION_METHOD),
         noResponseTest(
             "subscribeToPersistentSubnets",
             channel -> channel.subscribeToPersistentSubnets(emptySet()),
-            BeaconNodeRequestLabels.PERSISTENT_SUBNETS_SUBSCRIPTION_REQUEST_METHOD));
+            BeaconNodeRequestLabels.PERSISTENT_SUBNETS_SUBSCRIPTION_METHOD));
   }
 
   private static Arguments noResponseTest(
       final String name,
       final Function<ValidatorApiChannel, SafeFuture<Void>> method,
-      final String counterMethod) {
-    return Arguments.of(Named.named(name, method), counterMethod);
+      final String methodLabel) {
+    return Arguments.of(Named.named(name, method), methodLabel);
   }
 
   public static Stream<Arguments> getDataRequestArguments() {
@@ -181,29 +181,29 @@ class MetricRecordingValidatorApiChannelTest {
         requestDataTest(
             "getGenesisData",
             ValidatorApiChannel::getGenesisData,
-            BeaconNodeRequestLabels.GET_GENESIS_REQUEST_METHOD,
+            BeaconNodeRequestLabels.GET_GENESIS_METHOD,
             new GenesisData(dataStructureUtil.randomUInt64(), Bytes32.random())),
         requestDataTest(
             "createUnsignedBlock",
             channel -> channel.createUnsignedBlock(slot, signature, Optional.empty(), false),
-            BeaconNodeRequestLabels.CREATE_UNSIGNED_BLOCK_REQUEST_METHOD,
+            BeaconNodeRequestLabels.CREATE_UNSIGNED_BLOCK_METHOD,
             dataStructureUtil.randomBeaconBlock(slot)),
         requestDataTest(
             "createAttestationData",
             channel -> channel.createAttestationData(slot, 4),
-            BeaconNodeRequestLabels.CREATE_ATTESTATION_REQUEST_METHOD,
+            BeaconNodeRequestLabels.CREATE_ATTESTATION_METHOD,
             dataStructureUtil.randomAttestationData()),
         requestDataTest(
             "createAggregate",
             channel ->
                 channel.createAggregate(attestationData.getSlot(), attestationData.hashTreeRoot()),
-            BeaconNodeRequestLabels.CREATE_AGGREGATE_REQUEST_METHOD,
+            BeaconNodeRequestLabels.CREATE_AGGREGATE_METHOD,
             dataStructureUtil.randomAttestation()),
         requestDataTest(
             "createSyncCommitteeContribution",
             channel ->
                 channel.createSyncCommitteeContribution(slot, subcommitteeIndex, beaconBlockRoot),
-            BeaconNodeRequestLabels.CREATE_SYNC_COMMITTEE_CONTRIBUTION_REQUEST_METHOD,
+            BeaconNodeRequestLabels.CREATE_SYNC_COMMITTEE_CONTRIBUTION_METHOD,
             dataStructureUtil.randomSyncCommitteeContribution(slot)));
   }
 
@@ -221,41 +221,41 @@ class MetricRecordingValidatorApiChannelTest {
         sendDataTest(
             "sendSignedAttestations",
             channel -> channel.sendSignedAttestations(attestations),
-            BeaconNodeRequestLabels.PUBLISH_ATTESTATION_REQUEST_METHOD,
+            BeaconNodeRequestLabels.PUBLISH_ATTESTATION_METHOD,
             submissionErrors),
         sendDataTest(
             "sendSyncCommitteeMessages",
             channel -> channel.sendSyncCommitteeMessages(syncCommitteeMessages),
-            BeaconNodeRequestLabels.SEND_SYNC_COMMITTEE_MESSAGES_REQUEST_METHOD,
+            BeaconNodeRequestLabels.SEND_SYNC_COMMITTEE_MESSAGES_METHOD,
             submissionErrors),
         sendDataTest(
             "sendAggregateAndProofs",
             channel -> channel.sendAggregateAndProofs(aggregateAndProofs),
-            BeaconNodeRequestLabels.PUBLISH_AGGREGATE_AND_PROOFS_REQUEST_METHOD,
+            BeaconNodeRequestLabels.PUBLISH_AGGREGATE_AND_PROOFS_METHOD,
             submissionErrors));
   }
 
   private static <T> Arguments requestDataTest(
       final String name,
       final Function<ValidatorApiChannel, SafeFuture<Optional<T>>> method,
-      final String counterMethod,
+      final String methodLabel,
       final T presentValue) {
-    return Arguments.of(Named.named(name, method), counterMethod, presentValue);
+    return Arguments.of(Named.named(name, method), methodLabel, presentValue);
   }
 
   private static <T> Arguments sendDataTest(
       final String name,
       final Function<ValidatorApiChannel, SafeFuture<List<T>>> method,
-      final String counterMethod,
+      final String methodLabel,
       final List<T> errors) {
-    return Arguments.of(Named.named(name, method), counterMethod, errors);
+    return Arguments.of(Named.named(name, method), methodLabel, errors);
   }
 
-  private long getCounterValue(final String counterMethod, final RequestOutcome outcome) {
+  private long getCounterValue(final String methodLabel, final RequestOutcome outcome) {
     return metricsSystem
         .getCounter(
             TekuMetricCategory.VALIDATOR,
-            MetricRecordingValidatorApiChannel.BEACON_NODE_REQUEST_COUNTER_NAME)
-        .getValue(counterMethod, outcome.toString());
+            MetricRecordingValidatorApiChannel.BEACON_NODE_REQUESTS_COUNTER_NAME)
+        .getValue(methodLabel, outcome.toString());
   }
 }

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandler.java
@@ -29,11 +29,15 @@ import okhttp3.HttpUrl;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
+import org.hyperledger.besu.plugin.services.MetricsSystem;
+import org.hyperledger.besu.plugin.services.metrics.Counter;
+import org.hyperledger.besu.plugin.services.metrics.LabelledMetric;
 import tech.pegasys.teku.api.response.v1.beacon.ValidatorStatus;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.logging.ValidatorLogger;
+import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
@@ -56,20 +60,26 @@ import tech.pegasys.teku.validator.api.SubmitDataError;
 import tech.pegasys.teku.validator.api.SyncCommitteeDuties;
 import tech.pegasys.teku.validator.api.SyncCommitteeSubnetSubscription;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
+import tech.pegasys.teku.validator.beaconnode.metrics.BeaconNodeRequestLabels;
 
 public class FailoverValidatorApiHandler implements ValidatorApiChannel {
 
   private static final Logger LOG = LogManager.getLogger();
 
+  static final String FAILOVER_BEACON_NODES_REQUESTS_COUNTER_NAME =
+      "failover_beacon_nodes_requests_total";
+
   private final RemoteValidatorApiChannel primaryDelegate;
   private final List<RemoteValidatorApiChannel> failoverDelegates;
   private final boolean failoversSendSubnetSubscriptions;
+  private final LabelledMetric<Counter> failoverBeaconNodesRequestsCounter;
   private final ValidatorLogger validatorLogger;
 
   public FailoverValidatorApiHandler(
       final RemoteValidatorApiChannel primaryDelegate,
       final List<RemoteValidatorApiChannel> failoverDelegates,
       final boolean failoversSendSubnetSubscriptions,
+      final MetricsSystem metricsSystem,
       final ValidatorLogger validatorLogger) {
     this.primaryDelegate = primaryDelegate;
     checkArgument(
@@ -77,44 +87,60 @@ public class FailoverValidatorApiHandler implements ValidatorApiChannel {
         "One or more Beacon Nodes should be defined as a failover to use the failover feature.");
     this.failoverDelegates = failoverDelegates;
     this.failoversSendSubnetSubscriptions = failoversSendSubnetSubscriptions;
+    failoverBeaconNodesRequestsCounter =
+        metricsSystem.createLabelledCounter(
+            TekuMetricCategory.VALIDATOR,
+            FAILOVER_BEACON_NODES_REQUESTS_COUNTER_NAME,
+            "Counter recording the number of requests sent to the failover Beacon Nodes",
+            "failover_endpoint",
+            "method",
+            "outcome");
     this.validatorLogger = validatorLogger;
   }
 
   @Override
   public SafeFuture<Optional<GenesisData>> getGenesisData() {
-    return tryRequestUntilSuccess(ValidatorApiChannel::getGenesisData);
+    return tryRequestUntilSuccess(
+        ValidatorApiChannel::getGenesisData, BeaconNodeRequestLabels.GET_GENESIS_METHOD);
   }
 
   @Override
   public SafeFuture<Map<BLSPublicKey, Integer>> getValidatorIndices(
       final Collection<BLSPublicKey> publicKeys) {
-    return tryRequestUntilSuccess(apiChannel -> apiChannel.getValidatorIndices(publicKeys));
+    return tryRequestUntilSuccess(
+        apiChannel -> apiChannel.getValidatorIndices(publicKeys),
+        BeaconNodeRequestLabels.GET_VALIDATOR_INDICES_METHOD);
   }
 
   @Override
   public SafeFuture<Optional<Map<BLSPublicKey, ValidatorStatus>>> getValidatorStatuses(
       final Collection<BLSPublicKey> validatorIdentifiers) {
     return tryRequestUntilSuccess(
-        apiChannel -> apiChannel.getValidatorStatuses(validatorIdentifiers));
+        apiChannel -> apiChannel.getValidatorStatuses(validatorIdentifiers),
+        BeaconNodeRequestLabels.GET_VALIDATOR_STATUSES_METHOD);
   }
 
   @Override
   public SafeFuture<Optional<AttesterDuties>> getAttestationDuties(
       final UInt64 epoch, final IntCollection validatorIndices) {
     return tryRequestUntilSuccess(
-        apiChannel -> apiChannel.getAttestationDuties(epoch, validatorIndices));
+        apiChannel -> apiChannel.getAttestationDuties(epoch, validatorIndices),
+        BeaconNodeRequestLabels.GET_ATTESTATION_DUTIES_METHOD);
   }
 
   @Override
   public SafeFuture<Optional<SyncCommitteeDuties>> getSyncCommitteeDuties(
       final UInt64 epoch, final IntCollection validatorIndices) {
     return tryRequestUntilSuccess(
-        apiChannel -> apiChannel.getSyncCommitteeDuties(epoch, validatorIndices));
+        apiChannel -> apiChannel.getSyncCommitteeDuties(epoch, validatorIndices),
+        BeaconNodeRequestLabels.GET_SYNC_COMMITTEE_DUTIES_METHOD);
   }
 
   @Override
   public SafeFuture<Optional<ProposerDuties>> getProposerDuties(final UInt64 epoch) {
-    return tryRequestUntilSuccess(apiChannel -> apiChannel.getProposerDuties(epoch));
+    return tryRequestUntilSuccess(
+        apiChannel -> apiChannel.getProposerDuties(epoch),
+        BeaconNodeRequestLabels.GET_PROPOSER_DUTIES_REQUESTS_METHOD);
   }
 
   @Override
@@ -124,21 +150,24 @@ public class FailoverValidatorApiHandler implements ValidatorApiChannel {
       final Optional<Bytes32> graffiti,
       final boolean blinded) {
     return tryRequestUntilSuccess(
-        apiChannel -> apiChannel.createUnsignedBlock(slot, randaoReveal, graffiti, blinded));
+        apiChannel -> apiChannel.createUnsignedBlock(slot, randaoReveal, graffiti, blinded),
+        BeaconNodeRequestLabels.CREATE_UNSIGNED_BLOCK_METHOD);
   }
 
   @Override
   public SafeFuture<Optional<AttestationData>> createAttestationData(
       final UInt64 slot, final int committeeIndex) {
     return tryRequestUntilSuccess(
-        apiChannel -> apiChannel.createAttestationData(slot, committeeIndex));
+        apiChannel -> apiChannel.createAttestationData(slot, committeeIndex),
+        BeaconNodeRequestLabels.CREATE_ATTESTATION_METHOD);
   }
 
   @Override
   public SafeFuture<Optional<Attestation>> createAggregate(
       final UInt64 slot, final Bytes32 attestationHashTreeRoot) {
     return tryRequestUntilSuccess(
-        apiChannel -> apiChannel.createAggregate(slot, attestationHashTreeRoot));
+        apiChannel -> apiChannel.createAggregate(slot, attestationHashTreeRoot),
+        BeaconNodeRequestLabels.CREATE_AGGREGATE_METHOD);
   }
 
   @Override
@@ -146,13 +175,15 @@ public class FailoverValidatorApiHandler implements ValidatorApiChannel {
       final UInt64 slot, final int subcommitteeIndex, final Bytes32 beaconBlockRoot) {
     return tryRequestUntilSuccess(
         apiChannel ->
-            apiChannel.createSyncCommitteeContribution(slot, subcommitteeIndex, beaconBlockRoot));
+            apiChannel.createSyncCommitteeContribution(slot, subcommitteeIndex, beaconBlockRoot),
+        BeaconNodeRequestLabels.CREATE_SYNC_COMMITTEE_CONTRIBUTION_METHOD);
   }
 
   @Override
   public SafeFuture<Void> subscribeToBeaconCommittee(List<CommitteeSubscriptionRequest> requests) {
     return relayRequest(
         apiChannel -> apiChannel.subscribeToBeaconCommittee(requests),
+        BeaconNodeRequestLabels.BEACON_COMMITTEE_SUBSCRIPTION_METHOD,
         failoversSendSubnetSubscriptions);
   }
 
@@ -161,6 +192,7 @@ public class FailoverValidatorApiHandler implements ValidatorApiChannel {
       Collection<SyncCommitteeSubnetSubscription> subscriptions) {
     return relayRequest(
         apiChannel -> apiChannel.subscribeToSyncCommitteeSubnets(subscriptions),
+        BeaconNodeRequestLabels.SYNC_COMMITTEE_SUBNET_SUBSCRIPTION_METHOD,
         failoversSendSubnetSubscriptions);
   }
 
@@ -169,52 +201,67 @@ public class FailoverValidatorApiHandler implements ValidatorApiChannel {
       Set<SubnetSubscription> subnetSubscriptions) {
     return relayRequest(
         apiChannel -> apiChannel.subscribeToPersistentSubnets(subnetSubscriptions),
+        BeaconNodeRequestLabels.PERSISTENT_SUBNETS_SUBSCRIPTION_METHOD,
         failoversSendSubnetSubscriptions);
   }
 
   @Override
   public SafeFuture<List<SubmitDataError>> sendSignedAttestations(List<Attestation> attestations) {
-    return relayRequest(apiChannel -> apiChannel.sendSignedAttestations(attestations));
+    return relayRequest(
+        apiChannel -> apiChannel.sendSignedAttestations(attestations),
+        BeaconNodeRequestLabels.PUBLISH_ATTESTATION_METHOD);
   }
 
   @Override
   public SafeFuture<List<SubmitDataError>> sendAggregateAndProofs(
       final List<SignedAggregateAndProof> aggregateAndProofs) {
-    return relayRequest(apiChannel -> apiChannel.sendAggregateAndProofs(aggregateAndProofs));
+    return relayRequest(
+        apiChannel -> apiChannel.sendAggregateAndProofs(aggregateAndProofs),
+        BeaconNodeRequestLabels.PUBLISH_AGGREGATE_AND_PROOFS_METHOD);
   }
 
   @Override
   public SafeFuture<SendSignedBlockResult> sendSignedBlock(final SignedBeaconBlock block) {
-    return relayRequest(apiChannel -> apiChannel.sendSignedBlock(block));
+    return relayRequest(
+        apiChannel -> apiChannel.sendSignedBlock(block),
+        BeaconNodeRequestLabels.PUBLISH_BLOCK_METHOD);
   }
 
   @Override
   public SafeFuture<List<SubmitDataError>> sendSyncCommitteeMessages(
       final List<SyncCommitteeMessage> syncCommitteeMessages) {
-    return relayRequest(apiChannel -> apiChannel.sendSyncCommitteeMessages(syncCommitteeMessages));
+    return relayRequest(
+        apiChannel -> apiChannel.sendSyncCommitteeMessages(syncCommitteeMessages),
+        BeaconNodeRequestLabels.SEND_SYNC_COMMITTEE_MESSAGES_METHOD);
   }
 
   @Override
   public SafeFuture<Void> sendSignedContributionAndProofs(
       final Collection<SignedContributionAndProof> signedContributionAndProofs) {
     return relayRequest(
-        apiChannel -> apiChannel.sendSignedContributionAndProofs(signedContributionAndProofs));
+        apiChannel -> apiChannel.sendSignedContributionAndProofs(signedContributionAndProofs),
+        BeaconNodeRequestLabels.SEND_CONTRIBUTIONS_AND_PROOFS_METHOD);
   }
 
   @Override
   public SafeFuture<Void> prepareBeaconProposer(
       final Collection<BeaconPreparableProposer> beaconPreparableProposers) {
-    return relayRequest(apiChannel -> apiChannel.prepareBeaconProposer(beaconPreparableProposers));
+    return relayRequest(
+        apiChannel -> apiChannel.prepareBeaconProposer(beaconPreparableProposers),
+        BeaconNodeRequestLabels.PREPARE_BEACON_PROPOSERS_METHOD);
   }
 
   @Override
   public SafeFuture<Void> registerValidators(
       final SszList<SignedValidatorRegistration> validatorRegistrations) {
-    return relayRequest(apiChannel -> apiChannel.registerValidators(validatorRegistrations));
+    return relayRequest(
+        apiChannel -> apiChannel.registerValidators(validatorRegistrations),
+        BeaconNodeRequestLabels.REGISTER_VALIDATORS_METHOD);
   }
 
-  private <T> SafeFuture<T> relayRequest(final ValidatorApiChannelRequest<T> request) {
-    return relayRequest(request, true);
+  private <T> SafeFuture<T> relayRequest(
+      final ValidatorApiChannelRequest<T> request, final String method) {
+    return relayRequest(request, method, true);
   }
 
   /**
@@ -227,17 +274,21 @@ public class FailoverValidatorApiHandler implements ValidatorApiChannel {
    * and all the failovers errors will be part of it as suppressed.
    */
   private <T> SafeFuture<T> relayRequest(
-      final ValidatorApiChannelRequest<T> request, final boolean relayRequestToFailovers) {
+      final ValidatorApiChannelRequest<T> request,
+      final String method,
+      final boolean relayRequestToFailovers) {
     final SafeFuture<T> primaryResponse = request.run(primaryDelegate);
     if (!relayRequestToFailovers) {
       return primaryResponse;
     }
     final List<SafeFuture<T>> failoversResponses =
-        failoverDelegates.stream().map(request::run).collect(Collectors.toList());
+        failoverDelegates.stream()
+            .map(failover -> runFailoverRequest(failover, request, method))
+            .collect(Collectors.toList());
     return primaryResponse.exceptionallyCompose(
         primaryThrowable -> {
           LOG.debug(
-              "Request which is sent to all configured Beacon Node endpoints failed on the primary Beacon Node {} . Will try to use a response from a failover.",
+              "Request which is sent to all configured Beacon Node endpoints failed on the primary Beacon Node {} Will try to use a response from a failover.",
               primaryDelegate.getEndpoint());
           return SafeFuture.firstSuccess(failoversResponses)
               .exceptionallyCompose(
@@ -256,40 +307,101 @@ public class FailoverValidatorApiHandler implements ValidatorApiChannel {
    * case all the requests fail, the returned {@link SafeFuture} will complete exceptionally with
    * the last error and all previous errors will be part of it as suppressed.
    */
-  private <T> SafeFuture<T> tryRequestUntilSuccess(final ValidatorApiChannelRequest<T> request) {
+  private <T> SafeFuture<T> tryRequestUntilSuccess(
+      final ValidatorApiChannelRequest<T> request, final String method) {
     return makeFailoverRequest(
-        primaryDelegate, failoverDelegates.iterator(), request, new HashSet<>());
+        primaryDelegate, failoverDelegates.iterator(), request, false, method, new HashSet<>());
   }
 
   private <T> SafeFuture<T> makeFailoverRequest(
       final RemoteValidatorApiChannel currentDelegate,
       final Iterator<RemoteValidatorApiChannel> failoverDelegates,
       final ValidatorApiChannelRequest<T> request,
+      final boolean isFailoverRequest,
+      final String method,
       final Set<Throwable> capturedExceptions) {
-    return request
-        .run(currentDelegate)
+    return runRequest(currentDelegate, request, method, isFailoverRequest)
         .exceptionallyCompose(
             throwable -> {
-              final HttpUrl failedEndpoint = currentDelegate.getEndpoint();
               if (!failoverDelegates.hasNext()) {
                 validatorLogger.remoteBeaconNodeRequestFailedOnAllConfiguredEndpoints();
                 capturedExceptions.forEach(throwable::addSuppressed);
                 return SafeFuture.failedFuture(throwable);
               }
               capturedExceptions.add(throwable);
+              final HttpUrl failedEndpoint = currentDelegate.getEndpoint();
               final RemoteValidatorApiChannel nextDelegate = failoverDelegates.next();
               LOG.debug(
                   "Request to Beacon Node {} failed. Will try sending request to failover {}",
                   failedEndpoint,
                   nextDelegate.getEndpoint());
               return makeFailoverRequest(
-                  nextDelegate, failoverDelegates, request, capturedExceptions);
+                  nextDelegate, failoverDelegates, request, true, method, capturedExceptions);
             });
   }
 
+  private <T> SafeFuture<T> runFailoverRequest(
+      final RemoteValidatorApiChannel failover,
+      final ValidatorApiChannelRequest<T> request,
+      final String method) {
+    return runRequest(failover, request, method, true);
+  }
+
+  private <T> SafeFuture<T> runRequest(
+      final RemoteValidatorApiChannel delegate,
+      final ValidatorApiChannelRequest<T> request,
+      final String method,
+      final boolean isFailoverRequest) {
+    final SafeFuture<T> futureResponse = request.run(delegate);
+    if (isFailoverRequest) {
+      return futureResponse.handleComposed(
+          (response, throwable) -> {
+            if (throwable != null) {
+              recordFailedFailoverRequest(delegate, method);
+              return SafeFuture.failedFuture(throwable);
+            }
+            recordSuccessfulFailoverRequest(delegate, method);
+            return SafeFuture.completedFuture(response);
+          });
+    }
+    return futureResponse;
+  }
+
+  private void recordSuccessfulFailoverRequest(
+      final RemoteValidatorApiChannel failover, final String method) {
+    recordFailoverRequest(failover, method, RequestOutcome.SUCCESS);
+  }
+
+  private void recordFailedFailoverRequest(
+      final RemoteValidatorApiChannel failover, final String method) {
+    recordFailoverRequest(failover, method, RequestOutcome.ERROR);
+  }
+
+  private void recordFailoverRequest(
+      final RemoteValidatorApiChannel failover, final String method, final RequestOutcome outcome) {
+    failoverBeaconNodesRequestsCounter
+        .labels(failover.getEndpoint().toString(), method, outcome.displayName)
+        .inc();
+  }
+
   @VisibleForTesting
-  @FunctionalInterface
   interface ValidatorApiChannelRequest<T> {
     SafeFuture<T> run(final ValidatorApiChannel apiChannel);
+  }
+
+  enum RequestOutcome {
+    SUCCESS("success"),
+    ERROR("error");
+
+    private final String displayName;
+
+    RequestOutcome(final String displayName) {
+      this.displayName = displayName;
+    }
+
+    @Override
+    public String toString() {
+      return displayName;
+    }
   }
 }

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandler.java
@@ -91,7 +91,7 @@ public class FailoverValidatorApiHandler implements ValidatorApiChannel {
         metricsSystem.createLabelledCounter(
             TekuMetricCategory.VALIDATOR,
             FAILOVER_BEACON_NODES_REQUESTS_COUNTER_NAME,
-            "Counter recording the number of requests sent to the failover Beacon Nodes",
+            "Counter recording the number of requests sent to the configured failover Beacon Nodes",
             "failover_endpoint",
             "method",
             "outcome");
@@ -385,6 +385,7 @@ public class FailoverValidatorApiHandler implements ValidatorApiChannel {
   }
 
   @VisibleForTesting
+  @FunctionalInterface
   interface ValidatorApiChannelRequest<T> {
     SafeFuture<T> run(final ValidatorApiChannel apiChannel);
   }

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandlerTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandlerTest.java
@@ -46,6 +46,8 @@ import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.SafeFutureAssert;
 import tech.pegasys.teku.infrastructure.logging.ValidatorLogger;
+import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
+import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
@@ -70,12 +72,16 @@ import tech.pegasys.teku.validator.api.SubmitDataError;
 import tech.pegasys.teku.validator.api.SyncCommitteeDuties;
 import tech.pegasys.teku.validator.api.SyncCommitteeSubnetSubscription;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
+import tech.pegasys.teku.validator.beaconnode.metrics.BeaconNodeRequestLabels;
+import tech.pegasys.teku.validator.remote.FailoverValidatorApiHandler.RequestOutcome;
 import tech.pegasys.teku.validator.remote.FailoverValidatorApiHandler.ValidatorApiChannelRequest;
 
 class FailoverValidatorApiHandlerTest {
 
   private static final Spec SPEC = TestSpecFactory.createMinimalAltair();
   private static final DataStructureUtil DATA_STRUCTURE_UTIL = new DataStructureUtil(SPEC);
+
+  private final StubMetricsSystem stubMetricsSystem = new StubMetricsSystem();
 
   private RemoteValidatorApiChannel primaryApiChannel;
   private RemoteValidatorApiChannel failoverApiChannel1;
@@ -105,6 +111,7 @@ class FailoverValidatorApiHandlerTest {
             primaryApiChannel,
             List.of(failoverApiChannel1, failoverApiChannel2),
             true,
+            stubMetricsSystem,
             validatorLogger);
   }
 
@@ -115,13 +122,13 @@ class FailoverValidatorApiHandlerTest {
         () ->
             failoverApiHandler =
                 new FailoverValidatorApiHandler(
-                    primaryApiChannel, List.of(), true, validatorLogger));
+                    primaryApiChannel, List.of(), true, stubMetricsSystem, validatorLogger));
   }
 
   @ParameterizedTest(name = "{0}")
   @MethodSource("getRequestsUsingFailover")
   <T> void requestSucceedsWithoutFailover(
-      final ValidatorApiChannelRequest<T> request, final T response) {
+      final ValidatorApiChannelRequest<T> request, final String methodLabel, final T response) {
 
     setupSuccesses(request, response, primaryApiChannel);
 
@@ -130,12 +137,21 @@ class FailoverValidatorApiHandlerTest {
     assertThat(result).isCompletedWithValue(response);
 
     verifyNoInteractions(failoverApiChannel1, failoverApiChannel2, validatorLogger);
+
+    verifyFailoverCounters(
+        failoverApiChannel1,
+        methodLabel,
+        Map.of(RequestOutcome.SUCCESS, 0L, RequestOutcome.ERROR, 0L));
+    verifyFailoverCounters(
+        failoverApiChannel2,
+        methodLabel,
+        Map.of(RequestOutcome.SUCCESS, 0L, RequestOutcome.ERROR, 0L));
   }
 
   @ParameterizedTest(name = "{0}")
   @MethodSource("getRequestsUsingFailover")
   <T> void requestFailoversOnFailure(
-      final ValidatorApiChannelRequest<T> request, final T response) {
+      final ValidatorApiChannelRequest<T> request, final String methodLabel, final T response) {
 
     setupSuccesses(request, response, failoverApiChannel2);
     setupFailures(request, primaryApiChannel, failoverApiChannel1);
@@ -145,11 +161,21 @@ class FailoverValidatorApiHandlerTest {
     assertThat(result).isCompletedWithValue(response);
 
     verifyNoInteractions(validatorLogger);
+
+    verifyFailoverCounters(
+        failoverApiChannel1,
+        methodLabel,
+        Map.of(RequestOutcome.SUCCESS, 0L, RequestOutcome.ERROR, 1L));
+    verifyFailoverCounters(
+        failoverApiChannel2,
+        methodLabel,
+        Map.of(RequestOutcome.SUCCESS, 1L, RequestOutcome.ERROR, 0L));
   }
 
   @ParameterizedTest(name = "{0}")
   @MethodSource("getRequestsUsingFailover")
-  <T> void requestFailsOnAllFailovers(final ValidatorApiChannelRequest<T> request) {
+  <T> void requestFailsOnAllFailovers(
+      final ValidatorApiChannelRequest<T> request, final String methodLabel) {
 
     setupFailures(request, primaryApiChannel, failoverApiChannel1, failoverApiChannel2);
 
@@ -165,6 +191,15 @@ class FailoverValidatorApiHandlerTest {
             });
 
     verify(validatorLogger).remoteBeaconNodeRequestFailedOnAllConfiguredEndpoints();
+
+    verifyFailoverCounters(
+        failoverApiChannel1,
+        methodLabel,
+        Map.of(RequestOutcome.SUCCESS, 0L, RequestOutcome.ERROR, 1L));
+    verifyFailoverCounters(
+        failoverApiChannel2,
+        methodLabel,
+        Map.of(RequestOutcome.SUCCESS, 0L, RequestOutcome.ERROR, 1L));
   }
 
   @ParameterizedTest(name = "{0}")
@@ -172,6 +207,7 @@ class FailoverValidatorApiHandlerTest {
   <T> void requestIsNotRelayedToFailoversIfFailoversSendSubnetSubscriptionsIsDisabled(
       final ValidatorApiChannelRequest<T> request,
       final Consumer<ValidatorApiChannel> verifyCallIsMade,
+      final String methodLabel,
       final T response) {
 
     failoverApiHandler =
@@ -179,6 +215,7 @@ class FailoverValidatorApiHandlerTest {
             primaryApiChannel,
             List.of(failoverApiChannel1, failoverApiChannel2),
             false,
+            stubMetricsSystem,
             validatorLogger);
 
     setupSuccesses(request, response, primaryApiChannel);
@@ -189,6 +226,15 @@ class FailoverValidatorApiHandlerTest {
     verifyCallIsMade.accept(primaryApiChannel);
 
     verifyNoInteractions(validatorLogger, failoverApiChannel1, failoverApiChannel2);
+
+    verifyFailoverCounters(
+        failoverApiChannel1,
+        methodLabel,
+        Map.of(RequestOutcome.SUCCESS, 0L, RequestOutcome.ERROR, 0L));
+    verifyFailoverCounters(
+        failoverApiChannel2,
+        methodLabel,
+        Map.of(RequestOutcome.SUCCESS, 0L, RequestOutcome.ERROR, 0L));
   }
 
   @ParameterizedTest(name = "{0}")
@@ -196,6 +242,7 @@ class FailoverValidatorApiHandlerTest {
   <T> void requestIsRelayedToAllNodes(
       final ValidatorApiChannelRequest<T> request,
       final Consumer<ValidatorApiChannel> verifyCallIsMade,
+      final String methodLabel,
       final T response) {
 
     setupSuccesses(request, response, primaryApiChannel, failoverApiChannel1, failoverApiChannel2);
@@ -209,6 +256,15 @@ class FailoverValidatorApiHandlerTest {
     verifyCallIsMade.accept(failoverApiChannel2);
 
     verifyNoInteractions(validatorLogger);
+
+    verifyFailoverCounters(
+        failoverApiChannel1,
+        methodLabel,
+        Map.of(RequestOutcome.SUCCESS, 1L, RequestOutcome.ERROR, 0L));
+    verifyFailoverCounters(
+        failoverApiChannel2,
+        methodLabel,
+        Map.of(RequestOutcome.SUCCESS, 1L, RequestOutcome.ERROR, 0L));
   }
 
   @ParameterizedTest(name = "{0}")
@@ -216,6 +272,7 @@ class FailoverValidatorApiHandlerTest {
   <T> void requestIsRelayedToAllNodesButFailsOnOneFailover(
       final ValidatorApiChannelRequest<T> request,
       final Consumer<ValidatorApiChannel> verifyCallIsMade,
+      final String methodLabel,
       final T response) {
 
     setupSuccesses(request, response, primaryApiChannel, failoverApiChannel1);
@@ -230,6 +287,15 @@ class FailoverValidatorApiHandlerTest {
     verifyCallIsMade.accept(failoverApiChannel2);
 
     verifyNoInteractions(validatorLogger);
+
+    verifyFailoverCounters(
+        failoverApiChannel1,
+        methodLabel,
+        Map.of(RequestOutcome.SUCCESS, 1L, RequestOutcome.ERROR, 0L));
+    verifyFailoverCounters(
+        failoverApiChannel2,
+        methodLabel,
+        Map.of(RequestOutcome.SUCCESS, 0L, RequestOutcome.ERROR, 1L));
   }
 
   @ParameterizedTest(name = "{0}")
@@ -237,6 +303,7 @@ class FailoverValidatorApiHandlerTest {
   <T> void requestFailsOnPrimaryNodeButRelayedToFailoverNodes(
       final ValidatorApiChannelRequest<T> request,
       final Consumer<ValidatorApiChannel> verifyCallIsMade,
+      final String methodLabel,
       final T response) {
 
     setupFailures(request, primaryApiChannel);
@@ -251,13 +318,23 @@ class FailoverValidatorApiHandlerTest {
     verifyCallIsMade.accept(failoverApiChannel2);
 
     verifyNoInteractions(validatorLogger);
+
+    verifyFailoverCounters(
+        failoverApiChannel1,
+        methodLabel,
+        Map.of(RequestOutcome.SUCCESS, 1L, RequestOutcome.ERROR, 0L));
+    verifyFailoverCounters(
+        failoverApiChannel2,
+        methodLabel,
+        Map.of(RequestOutcome.SUCCESS, 1L, RequestOutcome.ERROR, 0L));
   }
 
   @ParameterizedTest(name = "{0}")
   @MethodSource("getRelayRequests")
-  <T> void requestFailsOnPrimaryNodeAndOneFailoverDoesNotResponse(
+  <T> void requestFailsOnPrimaryNodeAndOneFailoverDoesNotRespond(
       final ValidatorApiChannelRequest<T> request,
       final Consumer<ValidatorApiChannel> verifyCallIsMade,
+      final String methodLabel,
       final T response) {
 
     setupFailures(request, primaryApiChannel);
@@ -274,13 +351,23 @@ class FailoverValidatorApiHandlerTest {
     verifyCallIsMade.accept(failoverApiChannel2);
 
     verifyNoInteractions(validatorLogger);
+
+    verifyFailoverCounters(
+        failoverApiChannel1,
+        methodLabel,
+        Map.of(RequestOutcome.SUCCESS, 0L, RequestOutcome.ERROR, 0L));
+    verifyFailoverCounters(
+        failoverApiChannel2,
+        methodLabel,
+        Map.of(RequestOutcome.SUCCESS, 1L, RequestOutcome.ERROR, 0L));
   }
 
   @ParameterizedTest(name = "{0}")
   @MethodSource("getRelayRequests")
   <T> void requestFailsOnPrimaryNodeAndAllFailoverNodes(
       final ValidatorApiChannelRequest<T> request,
-      @NotNull final Consumer<ValidatorApiChannel> verifyCallIsMade) {
+      @NotNull final Consumer<ValidatorApiChannel> verifyCallIsMade,
+      final String methodLabel) {
 
     setupFailures(request, primaryApiChannel, failoverApiChannel1, failoverApiChannel2);
 
@@ -301,6 +388,15 @@ class FailoverValidatorApiHandlerTest {
     verifyCallIsMade.accept(failoverApiChannel2);
 
     verify(validatorLogger).remoteBeaconNodeRequestFailedOnAllConfiguredEndpoints();
+
+    verifyFailoverCounters(
+        failoverApiChannel1,
+        methodLabel,
+        Map.of(RequestOutcome.SUCCESS, 0L, RequestOutcome.ERROR, 1L));
+    verifyFailoverCounters(
+        failoverApiChannel2,
+        methodLabel,
+        Map.of(RequestOutcome.SUCCESS, 0L, RequestOutcome.ERROR, 1L));
   }
 
   private <T> void setupSuccesses(
@@ -338,43 +434,55 @@ class FailoverValidatorApiHandlerTest {
 
     return Stream.of(
         getArguments(
-            "getGenesisData", ValidatorApiChannel::getGenesisData, Optional.of(genesisData)),
+            "getGenesisData",
+            ValidatorApiChannel::getGenesisData,
+            BeaconNodeRequestLabels.GET_GENESIS_METHOD,
+            Optional.of(genesisData)),
         getArguments(
             "getValidatorIndices",
             apiChannel -> apiChannel.getValidatorIndices(List.of(publicKey)),
+            BeaconNodeRequestLabels.GET_VALIDATOR_INDICES_METHOD,
             Map.of(publicKey, 0)),
         getArguments(
             "getValidatorStatuses",
             apiChannel -> apiChannel.getValidatorStatuses(List.of(publicKey)),
+            BeaconNodeRequestLabels.GET_VALIDATOR_STATUSES_METHOD,
             Optional.of(Map.of(publicKey, ValidatorStatus.active_ongoing))),
         getArguments(
             "getAttestationDuties",
             apiChannel -> apiChannel.getAttestationDuties(epoch, validatorIndices),
+            BeaconNodeRequestLabels.GET_ATTESTATION_DUTIES_METHOD,
             Optional.of(mock(AttesterDuties.class))),
         getArguments(
             "getSyncCommitteeDuties",
             apiChannel -> apiChannel.getSyncCommitteeDuties(epoch, validatorIndices),
+            BeaconNodeRequestLabels.GET_SYNC_COMMITTEE_DUTIES_METHOD,
             Optional.of(mock(SyncCommitteeDuties.class))),
         getArguments(
             "getProposerDuties",
             apiChannel -> apiChannel.getProposerDuties(epoch),
+            BeaconNodeRequestLabels.GET_PROPOSER_DUTIES_REQUESTS_METHOD,
             Optional.of(mock(ProposerDuties.class))),
         getArguments(
             "createUnsignedBlock",
             apiChannel ->
                 apiChannel.createUnsignedBlock(slot, randaoReveal, Optional.empty(), true),
+            BeaconNodeRequestLabels.CREATE_UNSIGNED_BLOCK_METHOD,
             Optional.of(mock(BeaconBlock.class))),
         getArguments(
             "createAttestationData",
             apiChannel -> apiChannel.createAttestationData(slot, 0),
+            BeaconNodeRequestLabels.CREATE_ATTESTATION_METHOD,
             Optional.of(mock(AttestationData.class))),
         getArguments(
             "createAggregate",
             apiChannel -> apiChannel.createAggregate(slot, randomBytes32),
+            BeaconNodeRequestLabels.CREATE_AGGREGATE_METHOD,
             Optional.of(attestation)),
         getArguments(
             "createSyncCommitteeContribution",
             apiChannel -> apiChannel.createSyncCommitteeContribution(slot, 0, randomBytes32),
+            BeaconNodeRequestLabels.CREATE_SYNC_COMMITTEE_CONTRIBUTION_METHOD,
             Optional.of(mock(SyncCommitteeContribution.class))));
   }
 
@@ -400,23 +508,27 @@ class FailoverValidatorApiHandlerTest {
                 "sendSignedAttestations",
                 apiChannel -> apiChannel.sendSignedAttestations(List.of(attestation)),
                 apiChannel -> verify(apiChannel).sendSignedAttestations(List.of(attestation)),
+                BeaconNodeRequestLabels.PUBLISH_ATTESTATION_METHOD,
                 List.of(submitDataError)),
             getArguments(
                 "sendAggregateAndProofs",
                 apiChannel -> apiChannel.sendAggregateAndProofs(List.of(signedAggregateAndProof)),
                 apiChannel ->
                     verify(apiChannel).sendAggregateAndProofs(List.of(signedAggregateAndProof)),
+                BeaconNodeRequestLabels.PUBLISH_AGGREGATE_AND_PROOFS_METHOD,
                 List.of(submitDataError)),
             getArguments(
                 "sendSignedBlock",
                 apiChannel -> apiChannel.sendSignedBlock(signedBeaconBlock),
                 apiChannel -> verify(apiChannel).sendSignedBlock(signedBeaconBlock),
+                BeaconNodeRequestLabels.PUBLISH_BLOCK_METHOD,
                 mock(SendSignedBlockResult.class)),
             getArguments(
                 "sendSyncCommitteeMessages",
                 apiChannel -> apiChannel.sendSyncCommitteeMessages(List.of(syncCommitteeMessage)),
                 apiChannel ->
                     verify(apiChannel).sendSyncCommitteeMessages(List.of(syncCommitteeMessage)),
+                BeaconNodeRequestLabels.SEND_SYNC_COMMITTEE_MESSAGES_METHOD,
                 List.of(submitDataError)),
             getArguments(
                 "sendSignedContributionAndProofs",
@@ -425,11 +537,13 @@ class FailoverValidatorApiHandlerTest {
                 apiChannel ->
                     verify(apiChannel)
                         .sendSignedContributionAndProofs(List.of(signedContributionAndProof)),
+                BeaconNodeRequestLabels.SEND_CONTRIBUTIONS_AND_PROOFS_METHOD,
                 null),
             getArguments(
                 "registerValidators",
                 apiChannel -> apiChannel.registerValidators(validatorRegistrations),
                 apiChannel -> verify(apiChannel).registerValidators(validatorRegistrations),
+                BeaconNodeRequestLabels.REGISTER_VALIDATORS_METHOD,
                 null)));
   }
 
@@ -448,6 +562,7 @@ class FailoverValidatorApiHandlerTest {
             apiChannel ->
                 verify(apiChannel)
                     .subscribeToBeaconCommittee(List.of(committeeSubscriptionRequest)),
+            BeaconNodeRequestLabels.BEACON_COMMITTEE_SUBSCRIPTION_METHOD,
             null),
         getArguments(
             "subscribeToSyncCommitteeSubnets",
@@ -457,25 +572,52 @@ class FailoverValidatorApiHandlerTest {
             apiChannel ->
                 verify(apiChannel)
                     .subscribeToSyncCommitteeSubnets(List.of(syncCommitteeSubnetSubscription)),
+            BeaconNodeRequestLabels.SYNC_COMMITTEE_SUBNET_SUBSCRIPTION_METHOD,
             null),
         getArguments(
             "subscribeToPersistentSubnets",
             apiChannel -> apiChannel.subscribeToPersistentSubnets(Set.of(subnetSubscription)),
             apiChannel ->
                 verify(apiChannel).subscribeToPersistentSubnets(Set.of(subnetSubscription)),
+            BeaconNodeRequestLabels.PERSISTENT_SUBNETS_SUBSCRIPTION_METHOD,
             null));
   }
 
   private static <T> Arguments getArguments(
-      final String name, final ValidatorApiChannelRequest<T> request, final T response) {
-    return Arguments.of(Named.of(name, request), response);
+      final String name,
+      final ValidatorApiChannelRequest<T> request,
+      final String methodLabel,
+      final T response) {
+    return Arguments.of(Named.of(name, request), methodLabel, response);
   }
 
   private static <T> Arguments getArguments(
       final String name,
       final ValidatorApiChannelRequest<T> request,
       final Consumer<ValidatorApiChannel> verifyCallIsMade,
+      final String methodLabel,
       final T response) {
-    return Arguments.of(Named.of(name, request), verifyCallIsMade, response);
+    return Arguments.of(Named.of(name, request), verifyCallIsMade, methodLabel, response);
+  }
+
+  private void verifyFailoverCounters(
+      final RemoteValidatorApiChannel failoverApiChannel,
+      final String methodLabel,
+      final Map<RequestOutcome, Long> expectedCountByRequestOutcome) {
+    expectedCountByRequestOutcome.forEach(
+        (key, value) ->
+            assertThat(getFailoverCounterValue(failoverApiChannel, methodLabel, key))
+                .isEqualTo(value));
+  }
+
+  private long getFailoverCounterValue(
+      final RemoteValidatorApiChannel apiChannel,
+      final String methodLabel,
+      final RequestOutcome outcome) {
+    return stubMetricsSystem
+        .getCounter(
+            TekuMetricCategory.VALIDATOR,
+            FailoverValidatorApiHandler.FAILOVER_BEACON_NODES_REQUESTS_COUNTER_NAME)
+        .getValue(apiChannel.getEndpoint().toString(), methodLabel, outcome.toString());
   }
 }


### PR DESCRIPTION
## PR Description

- Add labelled counters for requests sent to failover beacon nodes
- Simplify variable names of request method labels

## Fixed Issue(s)
will help for #5237 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
