### PR TITLE
Allow overriding of the public key in validator registrations

### DIFF
--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorProposerOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorProposerOptions.java
@@ -92,6 +92,16 @@ public class ValidatorProposerOptions {
   private UInt64 builderRegistrationTimestampOverride = null;
 
   @Option(
+      names = {"--validators-builder-registration-pubkey-override"},
+      paramLabel = "<uint64>",
+      showDefaultValue = Visibility.ALWAYS,
+      description =
+          "Set a constant pubkey in BLS format to be used in validator registrations against builder infrastructure.",
+      arity = "1",
+      hidden = true)
+  private BLSPublicKey builderRegistrationPubkeyOverride = null;
+
+  @Option(
       names = {"--validators-proposer-blinded-blocks-enabled"},
       paramLabel = "<BOOLEAN>",
       showDefaultValue = Visibility.ALWAYS,
@@ -111,6 +121,7 @@ public class ValidatorProposerOptions {
                 .blindedBeaconBlocksEnabled(blindedBlocksEnabled)
                 .builderRegistrationDefaultGasLimit(builderRegistrationDefaultGasLimit)
                 .builderRegistrationSendingBatchSize(builderRegistrationSendingBatchSize)
-                .builderRegistrationTimestampOverride(builderRegistrationTimestampOverride));
+                .builderRegistrationTimestampOverride(builderRegistrationTimestampOverride)
+                .builderRegistrationPubkeyOverride(builderRegistrationPubkeyOverride));
   }
 }

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorProposerOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorProposerOptions.java
@@ -92,14 +92,14 @@ public class ValidatorProposerOptions {
   private UInt64 builderRegistrationTimestampOverride = null;
 
   @Option(
-      names = {"--validators-builder-registration-pubkey-override"},
-      paramLabel = "<BLSPublicKey>",
+      names = {"--validators-builder-registration-public-key-override"},
+      paramLabel = "<PUBLIC_KEY>",
       showDefaultValue = Visibility.ALWAYS,
       description =
-          "Set a constant pubkey in BLS format to be used in validator registrations against builder infrastructure.",
+          "Set a constant public key to be used in validator registrations against builder infrastructure.",
       arity = "1",
       hidden = true)
-  private BLSPublicKey builderRegistrationPubkeyOverride = null;
+  private String builderRegistrationPublicKeyOverride = null;
 
   @Option(
       names = {"--validators-proposer-blinded-blocks-enabled"},
@@ -122,6 +122,6 @@ public class ValidatorProposerOptions {
                 .builderRegistrationDefaultGasLimit(builderRegistrationDefaultGasLimit)
                 .builderRegistrationSendingBatchSize(builderRegistrationSendingBatchSize)
                 .builderRegistrationTimestampOverride(builderRegistrationTimestampOverride)
-                .builderRegistrationPubkeyOverride(builderRegistrationPubkeyOverride));
+                .builderRegistrationPublicKeyOverride(builderRegistrationPublicKeyOverride));
   }
 }

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorProposerOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorProposerOptions.java
@@ -93,7 +93,7 @@ public class ValidatorProposerOptions {
 
   @Option(
       names = {"--validators-builder-registration-pubkey-override"},
-      paramLabel = "<uint64>",
+      paramLabel = "<BLSPublicKey>",
       showDefaultValue = Visibility.ALWAYS,
       description =
           "Set a constant pubkey in BLS format to be used in validator registrations against builder infrastructure.",

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorProposerOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorProposerOptions.java
@@ -92,7 +92,7 @@ public class ValidatorProposerOptions {
   private UInt64 builderRegistrationTimestampOverride = null;
 
   @Option(
-      names = {"--validators-builder-registration-public-key-override"},
+      names = {"--Xvalidators-builder-registration-public-key-override"},
       paramLabel = "<PUBLIC_KEY>",
       showDefaultValue = Visibility.ALWAYS,
       description =

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/ValidatorOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/ValidatorOptionsTest.java
@@ -166,7 +166,7 @@ public class ValidatorOptionsTest extends AbstractBeaconNodeCommandTest {
   @Test
   public void shouldSetValidatorRegistrationPublicKeyOverride() {
     final String[] args = {
-      "--validators-builder-registration-public-key-override",
+      "--Xvalidators-builder-registration-public-key-override",
       "0xa057816155ad77931185101128655c0191bd0214c201ca48ed887f6c4c6adf334070efcd75140eada5ac83a92506dd7a"
     };
     final TekuConfiguration config = getTekuConfigurationFromArguments(args);

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/ValidatorOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/ValidatorOptionsTest.java
@@ -22,6 +22,7 @@ import java.time.Duration;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.cli.AbstractBeaconNodeCommandTest;
 import tech.pegasys.teku.config.TekuConfiguration;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -155,12 +156,26 @@ public class ValidatorOptionsTest extends AbstractBeaconNodeCommandTest {
   }
 
   @Test
-  public void shouldEnableValidatorRegistrationPubkeyOverride() {
-    final String[] args = {"--validators-builder-registration-pubkey-override", "120000"};
+  public void shouldReportEmptyIfValidatorRegistrationPublicKeyOverrideNotSpecified() {
+    final TekuConfiguration config = getTekuConfigurationFromArguments();
+    assertThat(
+            config.validatorClient().getValidatorConfig().getBuilderRegistrationPublicKeyOverride())
+        .isEmpty();
+  }
+
+  @Test
+  public void shouldSetValidatorRegistrationPublicKeyOverride() {
+    final String[] args = {
+      "--validators-builder-registration-public-key-override",
+      "0xa057816155ad77931185101128655c0191bd0214c201ca48ed887f6c4c6adf334070efcd75140eada5ac83a92506dd7a"
+    };
     final TekuConfiguration config = getTekuConfigurationFromArguments(args);
     assertThat(
-            config.validatorClient().getValidatorConfig().getBuilderRegistrationPubkeyOverride())
-        .isEqualTo(Optional.of(BLSPublicKey.valueOf(120000)));
+            config.validatorClient().getValidatorConfig().getBuilderRegistrationPublicKeyOverride())
+        .isEqualTo(
+            Optional.of(
+                BLSPublicKey.fromHexString(
+                    "0xa057816155ad77931185101128655c0191bd0214c201ca48ed887f6c4c6adf334070efcd75140eada5ac83a92506dd7a")));
   }
 
   @Test

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/ValidatorOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/ValidatorOptionsTest.java
@@ -155,6 +155,15 @@ public class ValidatorOptionsTest extends AbstractBeaconNodeCommandTest {
   }
 
   @Test
+  public void shouldEnableValidatorRegistrationPubkeyOverride() {
+    final String[] args = {"--validators-builder-registration-pubkey-override", "120000"};
+    final TekuConfiguration config = getTekuConfigurationFromArguments(args);
+    assertThat(
+            config.validatorClient().getValidatorConfig().getBuilderRegistrationPubkeyOverride())
+        .isEqualTo(Optional.of(BLSPublicKey.valueOf(120000)));
+  }
+
+  @Test
   public void shouldNotUseValidatorsRegistrationByDefault() {
     final String[] args = {};
     final TekuConfiguration config = getTekuConfigurationFromArguments(args);

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
@@ -26,6 +26,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.infrastructure.exceptions.InvalidConfigurationException;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.eth1.Eth1Address;
@@ -80,7 +81,7 @@ public class ValidatorConfig {
   private final UInt64 builderRegistrationDefaultGasLimit;
   private final int builderRegistrationSendingBatchSize;
   private final Optional<UInt64> builderRegistrationTimestampOverride;
-  private final Optional<BLSPublicKey> builderRegistrationPubkeyOverride;
+  private final Optional<BLSPublicKey> builderRegistrationPublicKeyOverride;
   private final int executorMaxQueueSize;
   private final Duration primaryBeaconNodeEventStreamReconnectAttemptPeriod;
 
@@ -111,7 +112,7 @@ public class ValidatorConfig {
       final UInt64 builderRegistrationDefaultGasLimit,
       final int builderRegistrationSendingBatchSize,
       final Optional<UInt64> builderRegistrationTimestampOverride,
-      final Optional<BLSPublicKey> builderRegistrationPubkeyOverride,
+      final Optional<BLSPublicKey> builderRegistrationPublicKeyOverride,
       final int executorMaxQueueSize,
       final Duration primaryBeaconNodeEventStreamReconnectAttemptPeriod) {
     this.validatorKeys = validatorKeys;
@@ -143,7 +144,7 @@ public class ValidatorConfig {
     this.builderRegistrationDefaultGasLimit = builderRegistrationDefaultGasLimit;
     this.builderRegistrationSendingBatchSize = builderRegistrationSendingBatchSize;
     this.builderRegistrationTimestampOverride = builderRegistrationTimestampOverride;
-    this.builderRegistrationPubkeyOverride = builderRegistrationPubkeyOverride;
+    this.builderRegistrationPublicKeyOverride = builderRegistrationPublicKeyOverride;
     this.executorMaxQueueSize = executorMaxQueueSize;
     this.primaryBeaconNodeEventStreamReconnectAttemptPeriod =
         primaryBeaconNodeEventStreamReconnectAttemptPeriod;
@@ -232,8 +233,8 @@ public class ValidatorConfig {
     return builderRegistrationTimestampOverride;
   }
 
-  public Optional<BLSPublicKey> getBuilderRegistrationPubkeyOverride() {
-    return builderRegistrationPubkeyOverride;
+  public Optional<BLSPublicKey> getBuilderRegistrationPublicKeyOverride() {
+    return builderRegistrationPublicKeyOverride;
   }
 
   public boolean getRefreshProposerConfigFromSource() {
@@ -308,7 +309,7 @@ public class ValidatorConfig {
     private int builderRegistrationSendingBatchSize =
         DEFAULT_VALIDATOR_REGISTRATION_SENDING_BATCH_SIZE;
     private Optional<UInt64> builderRegistrationTimestampOverride = Optional.empty();
-    private Optional<BLSPublicKey> builderRegistrationPubkeyOverride = Optional.empty();
+    private Optional<BLSPublicKey> builderRegistrationPublicKeyOverride = Optional.empty();
     private int executorMaxQueueSize = DEFAULT_EXECUTOR_MAX_QUEUE_SIZE;
     private Duration primaryBeaconNodeEventStreamReconnectAttemptPeriod =
         DEFAULT_PRIMARY_BEACON_NODE_EVENT_STREAM_RECONNECT_ATTEMPT_PERIOD;
@@ -479,10 +480,14 @@ public class ValidatorConfig {
       return this;
     }
 
-    public Builder builderRegistrationPubkeyOverride(
-        final BLSPublicKey builderRegistrationPubkeyOverride) {
-      this.builderRegistrationPubkeyOverride =
-          Optional.ofNullable(builderRegistrationPubkeyOverride);
+    public Builder builderRegistrationPublicKeyOverride(
+        final String builderRegistrationPublicKeyOverride) {
+      if (builderRegistrationPublicKeyOverride == null) {
+        this.builderRegistrationPublicKeyOverride = Optional.empty();
+      } else {
+        this.builderRegistrationPublicKeyOverride =
+            Optional.of(BLSPublicKey.fromHexString(builderRegistrationPublicKeyOverride));
+      }
       return this;
     }
 
@@ -532,7 +537,7 @@ public class ValidatorConfig {
           builderRegistrationDefaultGasLimit,
           builderRegistrationSendingBatchSize,
           builderRegistrationTimestampOverride,
-          builderRegistrationPubkeyOverride,
+          builderRegistrationPublicKeyOverride,
           executorMaxQueueSize,
           primaryBeaconNodeEventStreamReconnectAttemptPeriod);
     }

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
@@ -482,12 +482,9 @@ public class ValidatorConfig {
 
     public Builder builderRegistrationPublicKeyOverride(
         final String builderRegistrationPublicKeyOverride) {
-      if (builderRegistrationPublicKeyOverride == null) {
-        this.builderRegistrationPublicKeyOverride = Optional.empty();
-      } else {
-        this.builderRegistrationPublicKeyOverride =
-            Optional.of(BLSPublicKey.fromHexString(builderRegistrationPublicKeyOverride));
-      }
+      this.builderRegistrationPublicKeyOverride =
+          Optional.ofNullable(builderRegistrationPublicKeyOverride)
+              .map(BLSPublicKey::fromHexString);
       return this;
     }
 

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
@@ -80,6 +80,7 @@ public class ValidatorConfig {
   private final UInt64 builderRegistrationDefaultGasLimit;
   private final int builderRegistrationSendingBatchSize;
   private final Optional<UInt64> builderRegistrationTimestampOverride;
+  private final Optional<BLSPublicKey> builderRegistrationPubkeyOverride;
   private final int executorMaxQueueSize;
   private final Duration primaryBeaconNodeEventStreamReconnectAttemptPeriod;
 
@@ -110,6 +111,7 @@ public class ValidatorConfig {
       final UInt64 builderRegistrationDefaultGasLimit,
       final int builderRegistrationSendingBatchSize,
       final Optional<UInt64> builderRegistrationTimestampOverride,
+      final Optional<BLSPublicKey> builderRegistrationPubkeyOverride,
       final int executorMaxQueueSize,
       final Duration primaryBeaconNodeEventStreamReconnectAttemptPeriod) {
     this.validatorKeys = validatorKeys;
@@ -141,6 +143,7 @@ public class ValidatorConfig {
     this.builderRegistrationDefaultGasLimit = builderRegistrationDefaultGasLimit;
     this.builderRegistrationSendingBatchSize = builderRegistrationSendingBatchSize;
     this.builderRegistrationTimestampOverride = builderRegistrationTimestampOverride;
+    this.builderRegistrationPubkeyOverride = builderRegistrationPubkeyOverride;
     this.executorMaxQueueSize = executorMaxQueueSize;
     this.primaryBeaconNodeEventStreamReconnectAttemptPeriod =
         primaryBeaconNodeEventStreamReconnectAttemptPeriod;
@@ -229,6 +232,10 @@ public class ValidatorConfig {
     return builderRegistrationTimestampOverride;
   }
 
+  public Optional<BLSPublicKey> getBuilderRegistrationPubkeyOverride() {
+    return builderRegistrationPubkeyOverride;
+  }
+
   public boolean getRefreshProposerConfigFromSource() {
     return refreshProposerConfigFromSource;
   }
@@ -301,6 +308,7 @@ public class ValidatorConfig {
     private int builderRegistrationSendingBatchSize =
         DEFAULT_VALIDATOR_REGISTRATION_SENDING_BATCH_SIZE;
     private Optional<UInt64> builderRegistrationTimestampOverride = Optional.empty();
+    private Optional<BLSPublicKey> builderRegistrationPubkeyOverride = Optional.empty();
     private int executorMaxQueueSize = DEFAULT_EXECUTOR_MAX_QUEUE_SIZE;
     private Duration primaryBeaconNodeEventStreamReconnectAttemptPeriod =
         DEFAULT_PRIMARY_BEACON_NODE_EVENT_STREAM_RECONNECT_ATTEMPT_PERIOD;
@@ -471,6 +479,13 @@ public class ValidatorConfig {
       return this;
     }
 
+    public Builder builderRegistrationPubkeyOverride(
+        final BLSPublicKey builderRegistrationPubkeyOverride) {
+      this.builderRegistrationPubkeyOverride =
+          Optional.ofNullable(builderRegistrationPubkeyOverride);
+      return this;
+    }
+
     public Builder executorMaxQueueSize(final int executorMaxQueueSize) {
       this.executorMaxQueueSize = executorMaxQueueSize;
       return this;
@@ -517,6 +532,7 @@ public class ValidatorConfig {
           builderRegistrationDefaultGasLimit,
           builderRegistrationSendingBatchSize,
           builderRegistrationTimestampOverride,
+          builderRegistrationPubkeyOverride,
           executorMaxQueueSize,
           primaryBeaconNodeEventStreamReconnectAttemptPeriod);
     }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrator.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrator.java
@@ -253,6 +253,10 @@ public class ValidatorRegistrator implements ValidatorTimingChannel {
         validatorConfig
             .getBuilderRegistrationTimestampOverride()
             .orElse(timeProvider.getTimeInSeconds());
+    final BLSPublicKey publickey =
+        validatorConfig
+            .getBuilderRegistrationPubkeyOverride()
+            .orElse(public);
     return ApiSchemas.VALIDATOR_REGISTRATION_SCHEMA.create(
         feeRecipient, gasLimit, timestamp, publicKey);
   }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrator.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrator.java
@@ -192,7 +192,10 @@ public class ValidatorRegistrator implements ValidatorTimingChannel {
 
   private Optional<SafeFuture<SignedValidatorRegistration>> createSignedValidatorRegistration(
       final Optional<ProposerConfig> maybeProposerConfig, final Validator validator) {
-    final BLSPublicKey publicKey = validator.getPublicKey();
+    final BLSPublicKey publicKey =
+        validatorConfig
+            .getBuilderRegistrationPublicKeyOverride()
+            .orElseGet(validator::getPublicKey);
 
     if (!registrationIsEnabled(maybeProposerConfig, publicKey)) {
       LOG.trace("Validator registration is disabled for {}", publicKey);
@@ -253,10 +256,6 @@ public class ValidatorRegistrator implements ValidatorTimingChannel {
         validatorConfig
             .getBuilderRegistrationTimestampOverride()
             .orElse(timeProvider.getTimeInSeconds());
-    final BLSPublicKey publickey =
-        validatorConfig
-            .getBuilderRegistrationPubkeyOverride()
-            .orElse(public);
     return ApiSchemas.VALIDATOR_REGISTRATION_SCHEMA.create(
         feeRecipient, gasLimit, timestamp, publicKey);
   }
@@ -301,8 +300,14 @@ public class ValidatorRegistrator implements ValidatorTimingChannel {
         .keySet()
         .removeIf(
             cachedPublicKey -> {
+              final boolean cachedKeyIsTheConfiguredOverride =
+                  validatorConfig
+                      .getBuilderRegistrationPublicKeyOverride()
+                      .map(keyOverride -> keyOverride.equals(cachedPublicKey))
+                      .orElse(false);
               final boolean requiresRemoving =
-                  !activeValidatorsPublicKeys.contains(cachedPublicKey);
+                  !activeValidatorsPublicKeys.contains(cachedPublicKey)
+                      && !cachedKeyIsTheConfiguredOverride;
               if (requiresRemoving) {
                 LOG.debug(
                     "Removing cached registration for {} because validator is no longer active.",

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorRegistratorTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorRegistratorTest.java
@@ -170,6 +170,23 @@ class ValidatorRegistratorTest {
   }
 
   @TestTemplate
+  void registersValidators_shouldRegisterWithPubkeyOverride() {
+    when(validatorConfig.getBuilderRegistrationPubkeyOverride())
+        .thenReturn(Optional.of(BLSPublicKey.valueOf(140)));
+    setActiveValidators(validator1);
+
+    runRegistrationFlowForSlot(UInt64.ZERO);
+    runRegistrationFlowForSlot(UInt64.valueOf(slotsPerEpoch));
+
+    final List<List<SignedValidatorRegistration>> registrationCalls = captureRegistrationCalls(2);
+
+    registrationCalls.forEach(
+        registrationCall -> verifyRegistrations(registrationCall, List.of(validator1)));
+
+    verify(signer, times(1)).signValidatorRegistration(any());
+  }
+
+  @TestTemplate
   void cleanupsCache_ifValidatorIsNoLongerActive() {
     setActiveValidators(validator1, validator2, validator3);
 
@@ -380,6 +397,11 @@ class ValidatorRegistratorTest {
         validatorConfig
             .getBuilderRegistrationTimestampOverride()
             .orElse(stubTimeProvider.getTimeInSeconds());
+
+    final UInt64 expectedPubkey =
+        validatorConfig
+            .getBuilderRegistrationPubkeyOverride()
+            .orElse();
 
     assertThat(validatorRegistrations)
         .hasSize(expectedRegisteredValidators.size())


### PR DESCRIPTION
## PR Description

Add a flag that enables users to hardcode the pubkey in the ValidatorRegistrationV1 schema, this is required for distributed validators to come to consensus since in DVT each co-validators owns a pubkeyshare rather than the pubkey meaning each registration will be 

## Fixed Issue(s)

fixes #5985

## Documentation

- Potentially add a paragraph to this document https://hackmd.io/@StefanBratanov/BkMlo1RO9
