### PR TITLE
Add test for passing merge with optimistic import after safe slots

### DIFF
--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/OptimisticSyncSafeSlotsAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/OptimisticSyncSafeSlotsAcceptanceTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.test.acceptance;
+
+import com.google.common.io.Resources;
+import java.net.URL;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.time.SystemTimeProvider;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.test.acceptance.dsl.AcceptanceTestBase;
+import tech.pegasys.teku.test.acceptance.dsl.BesuNode;
+import tech.pegasys.teku.test.acceptance.dsl.TekuNode;
+
+public class OptimisticSyncSafeSlotsAcceptanceTest extends AcceptanceTestBase {
+  private static final String NETWORK_NAME = "less-swift";
+  private static final Integer SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY = 8;
+  private static final URL JWT_FILE = Resources.getResource("auth/ee-jwt-secret.hex");
+  private static final int VALIDATORS = 64;
+
+  private final SystemTimeProvider timeProvider = new SystemTimeProvider();
+  private BesuNode executionNode1;
+  private BesuNode executionNode2;
+  private TekuNode tekuNode1;
+  private TekuNode tekuNode2;
+
+  @BeforeEach
+  void setup() throws Exception {
+    final int genesisTime = timeProvider.getTimeInSeconds().plus(10).intValue();
+    executionNode1 =
+        createBesuNode(
+            config ->
+                config
+                    .withMiningEnabled(true)
+                    .withMergeSupport(true)
+                    .withP2pEnabled(false)
+                    .withGenesisFile("besu/preMergeGenesis.json")
+                    .withJwtTokenAuthorization(JWT_FILE));
+    executionNode1.start();
+    executionNode2 =
+        createBesuNode(
+            config ->
+                config
+                    .withMergeSupport(true)
+                    .withP2pEnabled(false)
+                    .withGenesisFile("besu/preMergeGenesis.json")
+                    .withJwtTokenAuthorization(JWT_FILE));
+    executionNode2.start();
+
+    tekuNode1 =
+        createTekuNode(
+            config ->
+                configureTekuNode(config, executionNode1, genesisTime)
+                    .withInteropValidators(0, VALIDATORS));
+    tekuNode1.start();
+    tekuNode2 =
+        createTekuNode(
+            config ->
+                configureTekuNode(config, executionNode2, genesisTime)
+                    .withInteropValidators(0, 0)
+                    .withPeers(tekuNode1)
+                    .withSafeSlotsToImportOptimistically(SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY));
+    tekuNode2.start();
+  }
+
+  @Test
+  void shouldPassMergeOptimisticallyAndBeginFinalizationAfterSafeSlotsToImport() {
+    tekuNode2.waitForNonDefaultExecutionPayload();
+    tekuNode2.waitForOptimisticBlock();
+  }
+
+  private TekuNode.Config configureTekuNode(
+      final TekuNode.Config config, final BesuNode executionEngine, final int genesisTime) {
+    return config
+        .withNetwork(NETWORK_NAME)
+        .withBellatrixEpoch(UInt64.ZERO)
+        .withTotalTerminalDifficulty(UInt64.valueOf(10001).toString())
+        .withGenesisTime(genesisTime)
+        .withRealNetwork()
+        .withStartupTargetPeerCount(0)
+        .withExecutionEngineEndpoint(executionEngine.getInternalEngineJsonRpcUrl())
+        .withJwtSecretFile(JWT_FILE);
+  }
+}

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNode.java
@@ -765,6 +765,11 @@ public class TekuNode extends Node {
       return this;
     }
 
+    public Config withSafeSlotsToImportOptimistically(final Integer slots) {
+      configMap.put("Xnetwork-safe-slots-to-import-optimistically", slots);
+      return this;
+    }
+
     public Config withStartupTargetPeerCount(Integer startupTargetPeerCount) {
       configMap.put("Xstartup-target-peer-count", startupTargetPeerCount);
       return this;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Acceptance test passes the Merge after `SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY` with EL still syncing.
Not closing #5074 yet, because testing of switching from optimistic sync back to normal is still blocked, see #5074 
## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
