### PR TITLE
Enable use of ee-endpoint as eth1-endpoint before bellatrix is scheduled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,5 +19,6 @@ For information on changes in released versions of Teku, see the [releases page]
  - Optimisations in jvm-libp2p to reduce CPU usage
 
 ### Bug Fixes
+ - `--ee-endpoint` option was not used to retrieve deposits for networks where Bellatrix was not yet scheduled
  - Fix `latestValidHash`with invalid Execution Payload in response from execution engine didn't trigger appropriate ForkChoice changes 
  - Remove incorrect error about potentially finalizing an invalid execution payload when importing a block with an invalid payload

--- a/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerConfiguration.java
+++ b/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerConfiguration.java
@@ -49,7 +49,7 @@ public class ExecutionLayerConfiguration {
   }
 
   public boolean isEnabled() {
-    return spec.isMilestoneSupported(SpecMilestone.BELLATRIX);
+    return engineEndpoint.isPresent() || spec.isMilestoneSupported(SpecMilestone.BELLATRIX);
   }
 
   public Spec getSpec() {

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/ExecutionLayerOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/ExecutionLayerOptionsTest.java
@@ -29,8 +29,7 @@ public class ExecutionLayerOptionsTest extends AbstractBeaconNodeCommandTest {
     final TekuConfiguration config =
         getTekuConfigurationFromFile("executionLayerOptions_config.yaml");
 
-    // Spec doesn't include the merge so execution engine is disabled
-    assertThat(config.executionLayer().isEnabled()).isFalse();
+    assertThat(config.executionLayer().isEnabled()).isTrue();
     assertThat(config.executionLayer().getEngineEndpoint())
         .isEqualTo("http://example.com:1234/path/");
   }


### PR DESCRIPTION
## PR Description
If the user moves from `--eth1-endpoint` to `--ee-endpoint` before Bellatrix is scheduled we should still use the `ee-endpoint` to retrieve deposits instead of ignoring it.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
