### PR TITLE
Enable progressive balances on MainNet.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ For information on changes in released versions of Teku, see the [releases page]
  - Added support for Builder API
  - Enables fork choice before block proposals by default on MainNet (previously on by default on testnets only)
  - Optimisations in jvm-libp2p to reduce CPU usage
+ - Enabled progressive balance tracking optimisation on MainNet
 
 ### Bug Fixes
  - `--ee-endpoint` option was not used to retrieve deposits for networks where Bellatrix was not yet scheduled

--- a/ethereum/networks/src/main/java/tech/pegasys/teku/networks/Eth2NetworkConfiguration.java
+++ b/ethereum/networks/src/main/java/tech/pegasys/teku/networks/Eth2NetworkConfiguration.java
@@ -48,7 +48,7 @@ public class Eth2NetworkConfiguration {
   public static final boolean DEFAULT_EQUIVOCATING_INDICES_ENABLED = true;
   public static final boolean DEFAULT_FORK_CHOICE_BEFORE_PROPOSING_ENABLED = true;
   public static final ProgressiveBalancesMode DEFAULT_PROGRESSIVE_BALANCES_MODE =
-      ProgressiveBalancesMode.DISABLED;
+      ProgressiveBalancesMode.USED;
 
   private final Spec spec;
   private final String constants;
@@ -460,7 +460,7 @@ public class Eth2NetworkConfiguration {
     }
 
     public Builder applyTestnetDefaults() {
-      return reset().progressiveBalancesEnabled(ProgressiveBalancesMode.USED);
+      return reset();
     }
 
     public Builder applyMinimalNetworkDefaults() {


### PR DESCRIPTION
## PR Description
Enable progressive balances by default on Mainnet (was already enabled by default on testnets).

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
