### PR TITLE
Add metrics back in `MetricRecordingValidatorApiChannel` for compatibility

### DIFF
--- a/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/BeaconChainRequestCounter.java
+++ b/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/BeaconChainRequestCounter.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.beaconnode.metrics;
+
+import org.hyperledger.besu.plugin.services.MetricsSystem;
+import org.hyperledger.besu.plugin.services.metrics.Counter;
+import org.hyperledger.besu.plugin.services.metrics.LabelledMetric;
+import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
+
+public class BeaconChainRequestCounter {
+
+  private final LabelledMetric<Counter> counter;
+
+  public BeaconChainRequestCounter(final LabelledMetric<Counter> counter) {
+    this.counter = counter;
+  }
+
+  public static BeaconChainRequestCounter create(
+      final MetricsSystem metricsSystem, final String name, final String help) {
+    return new BeaconChainRequestCounter(
+        metricsSystem.createLabelledCounter(TekuMetricCategory.VALIDATOR, name, help, "outcome"));
+  }
+
+  public void onSuccess() {
+    recordRequest(RequestOutcome.SUCCESS);
+  }
+
+  public void onDataUnavailable() {
+    recordRequest(RequestOutcome.DATA_UNAVAILABLE);
+  }
+
+  public void onError() {
+    recordRequest(RequestOutcome.ERROR);
+  }
+
+  private void recordRequest(final RequestOutcome outcome) {
+    counter.labels(outcome.name()).inc();
+  }
+
+  public enum RequestOutcome {
+    SUCCESS,
+    DATA_UNAVAILABLE,
+    ERROR
+  }
+}

--- a/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
+++ b/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
@@ -220,7 +220,7 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
     return countSendRequest(
         delegate.sendSignedAttestations(attestations),
         BeaconNodeRequestLabels.PUBLISH_ATTESTATION_METHOD,
-        Optional.of(sendAttestationRequestCounter));
+        sendAttestationRequestCounter);
   }
 
   @Override
@@ -229,7 +229,7 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
     return countSendRequest(
         delegate.sendAggregateAndProofs(aggregateAndProofs),
         BeaconNodeRequestLabels.PUBLISH_AGGREGATE_AND_PROOFS_METHOD,
-        Optional.of(sendAggregateRequestCounter));
+        sendAggregateRequestCounter);
   }
 
   @Override
@@ -245,7 +245,7 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
     return countSendRequest(
         delegate.sendSyncCommitteeMessages(syncCommitteeMessages),
         BeaconNodeRequestLabels.SEND_SYNC_COMMITTEE_MESSAGES_METHOD,
-        Optional.of(sendSyncCommitteeMessagesRequestCounter));
+        sendSyncCommitteeMessagesRequestCounter);
   }
 
   @Override
@@ -293,21 +293,21 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
   private <T> SafeFuture<List<T>> countSendRequest(
       final SafeFuture<List<T>> request,
       final String requestName,
-      final Optional<BeaconChainRequestCounter> legacyCounter) {
+      final BeaconChainRequestCounter legacyCounter) {
     return request
         .catchAndRethrow(
             __ -> {
               recordError(requestName);
-              legacyCounter.ifPresent(BeaconChainRequestCounter::onError);
+              legacyCounter.onError();
             })
         .thenPeek(
             result -> {
               if (result.isEmpty()) {
                 recordSuccess(requestName);
-                legacyCounter.ifPresent(BeaconChainRequestCounter::onSuccess);
+                legacyCounter.onSuccess();
               } else {
                 recordError(requestName);
-                legacyCounter.ifPresent(BeaconChainRequestCounter::onError);
+                legacyCounter.onError();
               }
             });
   }

--- a/validator/beaconnode/src/test/java/tech/pegasys/teku/validator/beaconnode/metrics/BeaconChainRequestCounterTest.java
+++ b/validator/beaconnode/src/test/java/tech/pegasys/teku/validator/beaconnode/metrics/BeaconChainRequestCounterTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.beaconnode.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
+import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
+import tech.pegasys.teku.validator.beaconnode.metrics.BeaconChainRequestCounter.RequestOutcome;
+
+class BeaconChainRequestCounterTest {
+
+  public static final String METRIC_NAME = "metricName";
+  private final StubMetricsSystem metricsSystem = new StubMetricsSystem();
+
+  private final BeaconChainRequestCounter counter =
+      BeaconChainRequestCounter.create(metricsSystem, METRIC_NAME, "Some help");
+
+  @Test
+  public void shouldIncrementSuccessCounter() {
+    counter.onSuccess();
+    assertThat(getValue(RequestOutcome.SUCCESS)).isEqualTo(1);
+    assertThat(getValue(RequestOutcome.ERROR)).isZero();
+    assertThat(getValue(RequestOutcome.DATA_UNAVAILABLE)).isZero();
+  }
+
+  @Test
+  public void shouldIncrementErrorCounter() {
+    counter.onError();
+    assertThat(getValue(RequestOutcome.ERROR)).isEqualTo(1);
+    assertThat(getValue(RequestOutcome.SUCCESS)).isZero();
+    assertThat(getValue(RequestOutcome.DATA_UNAVAILABLE)).isZero();
+  }
+
+  @Test
+  public void shouldIncrementDataUnavailableCounter() {
+    counter.onDataUnavailable();
+    assertThat(getValue(RequestOutcome.DATA_UNAVAILABLE)).isEqualTo(1);
+    assertThat(getValue(RequestOutcome.ERROR)).isZero();
+    assertThat(getValue(RequestOutcome.SUCCESS)).isZero();
+  }
+
+  private long getValue(final RequestOutcome requestOutcome) {
+    return metricsSystem
+        .getCounter(TekuMetricCategory.VALIDATOR, METRIC_NAME)
+        .getValue(requestOutcome.name());
+  }
+}


### PR DESCRIPTION
## PR Description
Bring back metrics which are used in older versions of Teku dashboard and were changed as part of #5977 

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
