### PR TITLE
5818 disk operations warning

### DIFF
--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/DbLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/DbLogger.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.infrastructure.logging;
 
 import static tech.pegasys.teku.infrastructure.logging.ColorConsolePrinter.print;
 
+import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.infrastructure.logging.ColorConsolePrinter.Color;
@@ -23,7 +24,7 @@ public class DbLogger {
 
   public static final DbLogger DB_LOGGER = new DbLogger(LoggingConfigurator.DB_LOGGER_NAME);
 
-  private final int dbOpAlertThreshold = LoggingConfigurator.dbOpAlertThreshold();
+  private final int dbOpAlertThresholdMillis = LoggingConfigurator.dbOpAlertThresholdMillis();
 
   @SuppressWarnings("PrivateStaticFinalLoggers")
   private final Logger logger;
@@ -32,14 +33,14 @@ public class DbLogger {
     this.logger = LogManager.getLogger(name);
   }
 
-  public void onDbOpAlertThreshold(String opName, long startTime, long endTime) {
-    long duration = (endTime - startTime) / 1000000;
-    if (dbOpAlertThreshold > 0 && duration >= dbOpAlertThreshold) {
+  public void onDbOpAlertThreshold(String opName, long startTimeNanos, long endTimeNanos) {
+    long duration = TimeUnit.NANOSECONDS.toMillis(endTimeNanos - startTimeNanos);
+    if (dbOpAlertThresholdMillis > 0 && duration >= dbOpAlertThresholdMillis) {
       logger.warn(
           print(
               String.format(
                   "DB operation: \"%s\" took too long: %d milliseconds. The alert threshold is set to: %d milliseconds",
-                  opName, duration, dbOpAlertThreshold),
+                  opName, duration, dbOpAlertThresholdMillis),
               Color.YELLOW));
     }
   }

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/DbLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/DbLogger.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.logging;
+
+import static tech.pegasys.teku.infrastructure.logging.ColorConsolePrinter.print;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import tech.pegasys.teku.infrastructure.logging.ColorConsolePrinter.Color;
+
+public class DbLogger {
+
+  public static final DbLogger DB_LOGGER = new DbLogger(LoggingConfigurator.DB_LOGGER_NAME);
+
+  private final int dbOpAlertThreshold = LoggingConfigurator.dbOpAlertThreshold();
+
+  @SuppressWarnings("PrivateStaticFinalLoggers")
+  private final Logger logger;
+
+  public DbLogger(String name) {
+    this.logger = LogManager.getLogger(name);
+  }
+
+  public void onDbOpAlertThreshold(String opName, long startTime, long endTime) {
+    long duration = (endTime - startTime) / 1000000;
+    if (dbOpAlertThreshold > 0 && duration >= dbOpAlertThreshold) {
+      logger.warn(
+          print(
+              String.format(
+                  "DB operation: \"%s\" took too long: %d milliseconds. The alert threshold is set to: %d milliseconds",
+                  opName, duration, dbOpAlertThreshold),
+              Color.YELLOW));
+    }
+  }
+}

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/LoggingConfig.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/LoggingConfig.java
@@ -24,7 +24,7 @@ public class LoggingConfig {
   public static final String DEFAULT_LOG_FILE_NAME_PATTERN_SUFFIX = "_%d{yyyy-MM-dd}.log";
 
   public static final String DATA_LOG_SUBDIRECTORY = "logs";
-
+  public static final int DEFAULT_DB_OP_ALERT_THRESHOLD = 0;
   private final Optional<Level> logLevel;
   private final boolean colorEnabled;
   private final boolean includeEventsEnabled;
@@ -33,6 +33,7 @@ public class LoggingConfig {
   private final LoggingDestination destination;
   private final String logFile;
   private final String logFileNamePattern;
+  private final int dbOpAlertThreshold;
 
   private LoggingConfig(
       final Optional<Level> logLevel,
@@ -42,7 +43,8 @@ public class LoggingConfig {
       final boolean includeP2pWarningsEnabled,
       final LoggingDestination destination,
       final String logFile,
-      final String logFileNamePattern) {
+      final String logFileNamePattern,
+      final int dbOpAlertThreshold) {
     this.logLevel = logLevel;
     this.colorEnabled = colorEnabled;
     this.includeEventsEnabled = includeEventsEnabled;
@@ -51,6 +53,7 @@ public class LoggingConfig {
     this.destination = destination;
     this.logFile = logFile;
     this.logFileNamePattern = logFileNamePattern;
+    this.dbOpAlertThreshold = dbOpAlertThreshold;
   }
 
   public static LoggingConfigBuilder builder() {
@@ -89,6 +92,10 @@ public class LoggingConfig {
     return logFileNamePattern;
   }
 
+  public int getDbOpAlertThreshold() {
+    return dbOpAlertThreshold;
+  }
+
   public static final class LoggingConfigBuilder {
     public static final String SEP = System.getProperty("file.separator");
 
@@ -107,6 +114,7 @@ public class LoggingConfig {
     private String logDirectory;
     private String logPath;
     private String logPathPattern;
+    private int dbOpAlertThreshold;
 
     private LoggingConfigBuilder() {}
 
@@ -139,6 +147,9 @@ public class LoggingConfig {
       checkArgument(
           logPathPattern != null,
           "LoggingConfig error: none of logPathPattern, dataDirectory or logDirectory values was specified");
+      checkArgument(
+          !(dbOpAlertThreshold < 0),
+          "LoggingConfig error: dbOpAlertThreshold must be a positive value");
     }
 
     public LoggingConfigBuilder logLevel(Level logLevel) {
@@ -207,6 +218,11 @@ public class LoggingConfig {
       return this;
     }
 
+    public LoggingConfigBuilder dbOpAlertThreshold(int dbOpAlertThreshold) {
+      this.dbOpAlertThreshold = dbOpAlertThreshold;
+      return this;
+    }
+
     public LoggingConfig build() {
       initMissingDefaults();
       validateValues();
@@ -218,7 +234,8 @@ public class LoggingConfig {
           includeP2pWarningsEnabled,
           destination,
           logPath,
-          logPathPattern);
+          logPathPattern,
+          dbOpAlertThreshold);
     }
   }
 }

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/LoggingConfig.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/LoggingConfig.java
@@ -24,7 +24,7 @@ public class LoggingConfig {
   public static final String DEFAULT_LOG_FILE_NAME_PATTERN_SUFFIX = "_%d{yyyy-MM-dd}.log";
 
   public static final String DATA_LOG_SUBDIRECTORY = "logs";
-  public static final int DEFAULT_DB_OP_ALERT_THRESHOLD = 0;
+  public static final int DEFAULT_DB_OP_ALERT_THRESHOLD_MILLIS = 0;
   private final Optional<Level> logLevel;
   private final boolean colorEnabled;
   private final boolean includeEventsEnabled;
@@ -33,7 +33,7 @@ public class LoggingConfig {
   private final LoggingDestination destination;
   private final String logFile;
   private final String logFileNamePattern;
-  private final int dbOpAlertThreshold;
+  private final int dbOpAlertThresholdMillis;
 
   private LoggingConfig(
       final Optional<Level> logLevel,
@@ -44,7 +44,7 @@ public class LoggingConfig {
       final LoggingDestination destination,
       final String logFile,
       final String logFileNamePattern,
-      final int dbOpAlertThreshold) {
+      final int dbOpAlertThresholdMillis) {
     this.logLevel = logLevel;
     this.colorEnabled = colorEnabled;
     this.includeEventsEnabled = includeEventsEnabled;
@@ -53,7 +53,7 @@ public class LoggingConfig {
     this.destination = destination;
     this.logFile = logFile;
     this.logFileNamePattern = logFileNamePattern;
-    this.dbOpAlertThreshold = dbOpAlertThreshold;
+    this.dbOpAlertThresholdMillis = dbOpAlertThresholdMillis;
   }
 
   public static LoggingConfigBuilder builder() {
@@ -92,8 +92,8 @@ public class LoggingConfig {
     return logFileNamePattern;
   }
 
-  public int getDbOpAlertThreshold() {
-    return dbOpAlertThreshold;
+  public int getDbOpAlertThresholdMillis() {
+    return dbOpAlertThresholdMillis;
   }
 
   public static final class LoggingConfigBuilder {
@@ -114,7 +114,7 @@ public class LoggingConfig {
     private String logDirectory;
     private String logPath;
     private String logPathPattern;
-    private int dbOpAlertThreshold;
+    private int dbOpAlertThresholdMillis;
 
     private LoggingConfigBuilder() {}
 
@@ -148,7 +148,7 @@ public class LoggingConfig {
           logPathPattern != null,
           "LoggingConfig error: none of logPathPattern, dataDirectory or logDirectory values was specified");
       checkArgument(
-          !(dbOpAlertThreshold < 0),
+          !(dbOpAlertThresholdMillis < 0),
           "LoggingConfig error: dbOpAlertThreshold must be a positive value");
     }
 
@@ -218,8 +218,8 @@ public class LoggingConfig {
       return this;
     }
 
-    public LoggingConfigBuilder dbOpAlertThreshold(int dbOpAlertThreshold) {
-      this.dbOpAlertThreshold = dbOpAlertThreshold;
+    public LoggingConfigBuilder dbOpAlertThresholdMillis(int dbOpAlertThresholdMillis) {
+      this.dbOpAlertThresholdMillis = dbOpAlertThresholdMillis;
       return this;
     }
 
@@ -235,7 +235,7 @@ public class LoggingConfig {
           destination,
           logPath,
           logPathPattern,
-          dbOpAlertThreshold);
+          dbOpAlertThresholdMillis);
     }
   }
 }

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/LoggingConfigurator.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/LoggingConfigurator.java
@@ -146,6 +146,7 @@ public class LoggingConfigurator {
         setUpStatusLogger(consoleAppender);
         setUpEventsLogger(consoleAppender);
         setUpValidatorLogger(consoleAppender);
+        setUpDbLogger(consoleAppender);
 
         addAppenderToRootLogger(configuration, consoleAppender);
         break;
@@ -155,6 +156,7 @@ public class LoggingConfigurator {
         setUpStatusLogger(fileAppender);
         setUpEventsLogger(fileAppender);
         setUpValidatorLogger(fileAppender);
+        setUpDbLogger(fileAppender);
 
         addAppenderToRootLogger(configuration, fileAppender);
         break;
@@ -168,9 +170,11 @@ public class LoggingConfigurator {
         final LoggerConfig eventsLogger = setUpEventsLogger(consoleAppender);
         final LoggerConfig statusLogger = setUpStatusLogger(consoleAppender);
         final LoggerConfig validatorLogger = setUpValidatorLogger(consoleAppender);
+        final LoggerConfig dbLogger = setUpDbLogger(consoleAppender);
         configuration.addLogger(eventsLogger.getName(), eventsLogger);
         configuration.addLogger(statusLogger.getName(), statusLogger);
         configuration.addLogger(validatorLogger.getName(), validatorLogger);
+        configuration.addLogger(dbLogger.getName(), dbLogger);
 
         fileAppender = fileAppender(configuration);
 
@@ -280,6 +284,12 @@ public class LoggingConfigurator {
             ? rootLogLevel
             : Level.ERROR;
     final LoggerConfig logger = new LoggerConfig(VALIDATOR_LOGGER_NAME, validatorLogLevel, true);
+    logger.addAppender(appender, rootLogLevel, null);
+    return logger;
+  }
+
+  private static LoggerConfig setUpDbLogger(final Appender appender) {
+    final LoggerConfig logger = new LoggerConfig(DB_LOGGER_NAME, rootLogLevel, true);
     logger.addAppender(appender, rootLogLevel, null);
     return logger;
   }

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/LoggingConfigurator.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/LoggingConfigurator.java
@@ -42,6 +42,7 @@ public class LoggingConfigurator {
   static final String STATUS_LOGGER_NAME = "teku-status-log";
   static final String VALIDATOR_LOGGER_NAME = "teku-validator-log";
   static final String P2P_LOGGER_NAME = "teku-p2p-log";
+  static final String DB_LOGGER_NAME = "teku-db-log";
 
   private static final String LOG4J_CONFIG_FILE_KEY = "LOG4J_CONFIGURATION_FILE";
   private static final String LOG4J_LEGACY_CONFIG_FILE_KEY = "log4j.configurationFile";
@@ -58,6 +59,7 @@ public class LoggingConfigurator {
   private static String file;
   private static String filePattern;
   private static Level rootLogLevel = Level.INFO;
+  private static int dbOpAlertThreshold;
   private static final StatusLogger STATUS_LOG = StatusLogger.getLogger();
 
   public static boolean isColorEnabled() {
@@ -66,6 +68,10 @@ public class LoggingConfigurator {
 
   public static boolean isIncludeP2pWarnings() {
     return includeP2pWarnings;
+  }
+
+  public static int dbOpAlertThreshold() {
+    return dbOpAlertThreshold;
   }
 
   public static synchronized void setColorEnabled(final boolean isEnabled) {
@@ -100,6 +106,7 @@ public class LoggingConfigurator {
     includeP2pWarnings = configuration.isIncludeP2pWarningsEnabled();
     file = configuration.getLogFile();
     filePattern = configuration.getLogFileNamePattern();
+    dbOpAlertThreshold = configuration.getDbOpAlertThreshold();
 
     final LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
     addLoggers((AbstractConfiguration) ctx.getConfiguration());

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/LoggingConfigurator.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/LoggingConfigurator.java
@@ -59,7 +59,7 @@ public class LoggingConfigurator {
   private static String file;
   private static String filePattern;
   private static Level rootLogLevel = Level.INFO;
-  private static int dbOpAlertThreshold;
+  private static int dbOpAlertThresholdMillis;
   private static final StatusLogger STATUS_LOG = StatusLogger.getLogger();
 
   public static boolean isColorEnabled() {
@@ -70,8 +70,8 @@ public class LoggingConfigurator {
     return includeP2pWarnings;
   }
 
-  public static int dbOpAlertThreshold() {
-    return dbOpAlertThreshold;
+  public static int dbOpAlertThresholdMillis() {
+    return dbOpAlertThresholdMillis;
   }
 
   public static synchronized void setColorEnabled(final boolean isEnabled) {
@@ -106,7 +106,7 @@ public class LoggingConfigurator {
     includeP2pWarnings = configuration.isIncludeP2pWarningsEnabled();
     file = configuration.getLogFile();
     filePattern = configuration.getLogFileNamePattern();
-    dbOpAlertThreshold = configuration.getDbOpAlertThreshold();
+    dbOpAlertThresholdMillis = configuration.getDbOpAlertThresholdMillis();
 
     final LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
     addLoggers((AbstractConfiguration) ctx.getConfiguration());

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
@@ -557,7 +557,7 @@ public abstract class KvStoreDatabase<
       updater.commit();
     }
     long endTime = System.nanoTime();
-    DB_LOGGER.onDbOpAlertThreshold("KvStoreDatabase update", startTime, endTime);
+    DB_LOGGER.onDbOpAlertThreshold("Block Import", startTime, endTime);
     LOG.trace("Update complete");
     return new UpdateResult(finalizedOptimisticExecutionPayload);
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.storage.server.kvstore;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static tech.pegasys.teku.infrastructure.logging.DbLogger.DB_LOGGER;
 import static tech.pegasys.teku.infrastructure.logging.StatusLogger.STATUS_LOG;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -520,6 +521,7 @@ public abstract class KvStoreDatabase<
             update.isFinalizedOptimisticTransitionBlockRootSet(),
             update.getOptimisticTransitionBlockRoot());
     LOG.trace("Applying hot updates");
+    long startTime = System.nanoTime();
     try (final HotUpdaterT updater = hotUpdater()) {
       // Store new hot data
       update.getGenesisTime().ifPresent(updater::setGenesisTime);
@@ -554,6 +556,8 @@ public abstract class KvStoreDatabase<
       LOG.trace("Committing hot db changes");
       updater.commit();
     }
+    long endTime = System.nanoTime();
+    DB_LOGGER.onDbOpAlertThreshold("KvStoreDatabase update", startTime, endTime);
     LOG.trace("Update complete");
     return new UpdateResult(finalizedOptimisticExecutionPayload);
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/leveldb/LevelDbTransaction.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/leveldb/LevelDbTransaction.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.storage.server.leveldb;
 
+import static tech.pegasys.teku.infrastructure.logging.DbLogger.DB_LOGGER;
 import static tech.pegasys.teku.storage.server.leveldb.LevelDbUtils.getColumnKey;
 import static tech.pegasys.teku.storage.server.leveldb.LevelDbUtils.getVariableKey;
 
@@ -92,7 +93,10 @@ public class LevelDbTransaction implements KvStoreTransaction {
     applyUpdate(
         () -> {
           try {
+            long startTime = System.nanoTime();
             db.write(writeBatch);
+            long endTime = System.nanoTime();
+            DB_LOGGER.onDbOpAlertThreshold("LevelDB update", startTime, endTime);
           } finally {
             close();
           }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/leveldb/LevelDbTransaction.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/leveldb/LevelDbTransaction.java
@@ -96,7 +96,7 @@ public class LevelDbTransaction implements KvStoreTransaction {
             long startTime = System.nanoTime();
             db.write(writeBatch);
             long endTime = System.nanoTime();
-            DB_LOGGER.onDbOpAlertThreshold("LevelDB update", startTime, endTime);
+            DB_LOGGER.onDbOpAlertThreshold("Transaction Commit", startTime, endTime);
           } finally {
             close();
           }

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/LoggingOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/LoggingOptions.java
@@ -147,7 +147,7 @@ public class LoggingOptions {
       paramLabel = "<INTEGER>",
       description = "Execution duration in milliseconds at which warning logs are raised",
       arity = "1")
-  private int dbOpAlertThreshold = LoggingConfig.DEFAULT_DB_OP_ALERT_THRESHOLD;
+  private int dbOpAlertThresholdMillis = LoggingConfig.DEFAULT_DB_OP_ALERT_THRESHOLD_MILLIS;
 
   private boolean containsPath(String file) {
     return file.contains(LINUX_SEP) || file.contains(WINDOWS_SEP);
@@ -181,7 +181,7 @@ public class LoggingOptions {
         loggingBuilder.logFileNamePattern(logFileNamePattern);
       }
     }
-    loggingBuilder.dbOpAlertThreshold(dbOpAlertThreshold);
+    loggingBuilder.dbOpAlertThresholdMillis(dbOpAlertThresholdMillis);
     loggingBuilder
         .logLevel(logLevel)
         .colorEnabled(logColorEnabled)

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/LoggingOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/LoggingOptions.java
@@ -141,6 +141,14 @@ public class LoggingOptions {
       arity = "0..1")
   private boolean logWireGossipEnabled = false;
 
+  @Option(
+      hidden = true,
+      names = {"--Xlog-db-op-alert-threshold"},
+      paramLabel = "<INTEGER>",
+      description = "Duration in milliseconds from which alerts are triggered",
+      arity = "1")
+  private int dbOpAlertThreshold = LoggingConfig.DEFAULT_DB_OP_ALERT_THRESHOLD;
+
   private boolean containsPath(String file) {
     return file.contains(LINUX_SEP) || file.contains(WINDOWS_SEP);
   }
@@ -173,6 +181,7 @@ public class LoggingOptions {
         loggingBuilder.logFileNamePattern(logFileNamePattern);
       }
     }
+    loggingBuilder.dbOpAlertThreshold(dbOpAlertThreshold);
     loggingBuilder
         .logLevel(logLevel)
         .colorEnabled(logColorEnabled)

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/LoggingOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/LoggingOptions.java
@@ -145,7 +145,7 @@ public class LoggingOptions {
       hidden = true,
       names = {"--Xlog-db-op-alert-threshold"},
       paramLabel = "<INTEGER>",
-      description = "Duration in milliseconds from which alerts are triggered",
+      description = "Execution duration in milliseconds at which warning logs are raised",
       arity = "1")
   private int dbOpAlertThreshold = LoggingConfig.DEFAULT_DB_OP_ALERT_THRESHOLD;
 

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/LoggingOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/LoggingOptionsTest.java
@@ -138,10 +138,12 @@ public class LoggingOptionsTest extends AbstractBeaconNodeCommandTest {
 
   @Test
   public void shouldSetDbOpAlertThresholdFromCommandLine() {
-    final int dbOpAlertThreshold = 250;
-    final String[] args = {"--Xlog-db-op-alert-threshold", String.valueOf(dbOpAlertThreshold)};
+    final int dbOpAlertThresholdMillis = 250;
+    final String[] args = {
+      "--Xlog-db-op-alert-threshold", String.valueOf(dbOpAlertThresholdMillis)
+    };
     final LoggingConfig config = getLoggingConfigurationFromArguments(args);
-    assertThat(config.getDbOpAlertThreshold()).isEqualTo(dbOpAlertThreshold);
+    assertThat(config.getDbOpAlertThresholdMillis()).isEqualTo(dbOpAlertThresholdMillis);
   }
 
   @Test

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/LoggingOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/LoggingOptionsTest.java
@@ -137,6 +137,14 @@ public class LoggingOptionsTest extends AbstractBeaconNodeCommandTest {
   }
 
   @Test
+  public void shouldSetDbOpAlertThresholdFromCommandLine() {
+    final int dbOpAlertThreshold = 250;
+    final String[] args = {"--Xlog-db-op-alert-threshold", String.valueOf(dbOpAlertThreshold)};
+    final LoggingConfig config = getLoggingConfigurationFromArguments(args);
+    assertThat(config.getDbOpAlertThreshold()).isEqualTo(dbOpAlertThreshold);
+  }
+
+  @Test
   public void shouldSetLogPatternOnWithoutPath() {
     final String[] args = {"--log-file-name-pattern", "%d.log"};
     final String expectedLogPatternPath =


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Add a database operations monitoring:
- Execution duration alert threshold can be set with cli option `--Xlog-db-op-alert-threshold` (Value in milliseconds)
- No alerts when the value is set to zero (default value)
- For now only two db operations are monitored: LevelDB write batch and KvStoreDatabase updates

## Fixed Issue(s)
Solution to https://github.com/ConsenSys/teku/issues/5818

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
