### PR TITLE
log invalid options in config YAML

### DIFF
--- a/teku/src/main/java/tech/pegasys/teku/cli/BeaconNodeCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/BeaconNodeCommand.java
@@ -243,8 +243,12 @@ public class BeaconNodeCommand implements Callable<Integer> {
     final AdditionalParamsProvider additionalParamsProvider =
         additionalParamsProvider(commandLine, configFile);
 
-    final Map<String, String> additionalParams =
-        additionalParamsProvider.getAdditionalParams(potentialAdditionalParams);
+    final Map<String, String> additionalParams;
+    try {
+      additionalParams = additionalParamsProvider.getAdditionalParams(potentialAdditionalParams);
+    } catch (ParameterException e) {
+      return handleParseException(e, args);
+    }
 
     // build new argument list by concatenating original args and the additional params
     final String[] enrichedArgs =

--- a/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
@@ -345,8 +345,7 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
   private Path createInvalidConfigFile() throws IOException {
     final URL configFile = this.getClass().getResource("/complete_config.yaml");
     final String updatedConfig =
-            Resources.toString(configFile, UTF_8)
-                    .replace("network:", "xnetwork:");
+        Resources.toString(configFile, UTF_8).replace("network:", "xnetwork:");
     return createTempFile(updatedConfig.getBytes(UTF_8));
   }
 

--- a/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
@@ -94,6 +94,19 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
   }
 
   @Test
+  public void unknownOptionInConfigFileShouldDisplayShortHelpMessage() throws IOException {
+    final Path configFile = createInvalidConfigFile();
+    final String[] args = {CONFIG_FILE_OPTION_NAME, configFile.toString()};
+
+    beaconNodeCommand.parse(args);
+    String str = getCommandLineOutput();
+    assertThat(str).contains("Unknown option");
+    assertThat(str).contains("To display full help:");
+    assertThat(str).contains("--help");
+    assertThat(str).doesNotContain("Default");
+  }
+
+  @Test
   public void unmatchedOptionsNotAllowedAsOptionParameters() {
     final String[] args = {"--eth1-endpoints http://localhost:8545 --foo"};
 
@@ -326,6 +339,14 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
             .replace(
                 "data-path: \".\"",
                 "data-path: \"" + dataPath.toString().replace("\\", "\\\\") + "\"");
+    return createTempFile(updatedConfig.getBytes(UTF_8));
+  }
+
+  private Path createInvalidConfigFile() throws IOException {
+    final URL configFile = this.getClass().getResource("/complete_config.yaml");
+    final String updatedConfig =
+            Resources.toString(configFile, UTF_8)
+                    .replace("network:", "xnetwork:");
     return createTempFile(updatedConfig.getBytes(UTF_8));
   }
 

--- a/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
@@ -333,7 +333,7 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
   }
 
   private Path createConfigFile() throws IOException {
-    final URL configFile = this.getClass().getResource("/complete_config.yaml");
+    final URL configFile = BeaconNodeCommandTest.class.getResource("/complete_config.yaml");
     final String updatedConfig =
         Resources.toString(configFile, UTF_8)
             .replace(
@@ -343,7 +343,7 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
   }
 
   private Path createInvalidConfigFile() throws IOException {
-    final URL configFile = this.getClass().getResource("/complete_config.yaml");
+    final URL configFile = BeaconNodeCommandTest.class.getResource("/complete_config.yaml");
     final String updatedConfig =
         Resources.toString(configFile, UTF_8).replace("network:", "xnetwork:");
     return createTempFile(updatedConfig.getBytes(UTF_8));


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

Reports invalid options when Teku fails to startup due to unknown options.

e.g. config.yaml contains a typo `networks` instead of `network`

```
networks=prater
```

the following is logged when executing `build/install/teku/bin/teku --config-file config.yaml`

```
Unknown option in yaml configuration file: networks
```

## Fixed Issue(s)
fixes #5984 
