### PR TITLE
Add initial state path to the provided url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ For information on changes in released versions of Teku, see the [releases page]
  - Updated Sepolia bootnodes
  - Enabled progressive balance tracking optimisation on MainNet
  - Replaced separate metrics for each beacon node request with one metric `beacon_node_requests_total`. Some old metrics were kept for backwards compatibility, but will be removed in future versions.
+ - Automatically add `/eth/v2/debug/beacon/states/finalized` to the initial state file url (`--initial-state` configuration parameter) when the provided url doesn't work and doesn't contain any path
 
 ### Bug Fixes
  - `--ee-endpoint` option was not used to retrieve deposits for networks where Bellatrix was not yet scheduled

--- a/ethereum/networks/src/main/java/tech/pegasys/teku/networks/Eth2NetworkConfiguration.java
+++ b/ethereum/networks/src/main/java/tech/pegasys/teku/networks/Eth2NetworkConfiguration.java
@@ -50,6 +50,8 @@ public class Eth2NetworkConfiguration {
   public static final ProgressiveBalancesMode DEFAULT_PROGRESSIVE_BALANCES_MODE =
       ProgressiveBalancesMode.USED;
 
+  public static final String INITIAL_STATE_URL_PATH = "eth/v2/debug/beacon/states/finalized";
+
   private final Spec spec;
   private final String constants;
   private final Optional<String> initialState;

--- a/infrastructure/http/src/main/java/tech/pegasys/teku/infrastructure/http/UrlSanitizer.java
+++ b/infrastructure/http/src/main/java/tech/pegasys/teku/infrastructure/http/UrlSanitizer.java
@@ -34,4 +34,13 @@ public class UrlSanitizer {
       return possibleUrl;
     }
   }
+
+  public static boolean urlContainsNonEmptyPath(final String url) {
+    try {
+      final URI uri = new URI(url);
+      return uri.getPath() != null && uri.getPath().length() > 1;
+    } catch (URISyntaxException e) {
+      return false;
+    }
+  }
 }

--- a/infrastructure/http/src/test/java/tech/pegasys/teku/infrastructure/http/UrlSanitizerTest.java
+++ b/infrastructure/http/src/test/java/tech/pegasys/teku/infrastructure/http/UrlSanitizerTest.java
@@ -45,4 +45,28 @@ class UrlSanitizerTest {
     final String result = UrlSanitizer.sanitizePotentialUrl(input);
     assertThat(result).isEqualTo("user:passlocalhost:2993/some%20path/b/c/?foo=bar#1234");
   }
+
+  @Test
+  void shouldDetectPathInUrl() {
+    final String input = "https://someurl.xyz/path";
+    assertThat(UrlSanitizer.urlContainsNonEmptyPath(input)).isTrue();
+  }
+
+  @Test
+  void shouldDetectNoPathInUrl() {
+    final String input = "https://someurl.xyz";
+    assertThat(UrlSanitizer.urlContainsNonEmptyPath(input)).isFalse();
+  }
+
+  @Test
+  void shouldIgnoreEmptyPath() {
+    final String input = "https://someurl.xyz/";
+    assertThat(UrlSanitizer.urlContainsNonEmptyPath(input)).isFalse();
+  }
+
+  @Test
+  void shouldNotDetectPathInStringThatIsNonUrl() {
+    final String input = "\\not-a-url/path";
+    assertThat(UrlSanitizer.urlContainsNonEmptyPath(input)).isFalse();
+  }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

Automatically add the path `/eth/v2/debug/beacon/states/finalized` to the finalized state's url (`--initial-state` parameter) only when:
- The provided url fails
AND
- The provided url does not have a path (https://www.example.com or https://www.example.com/)

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Fixes https://github.com/ConsenSys/teku/issues/5978
## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
