### PR TITLE
validator builder registration request payload endpoint flag

### DIFF
--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorProposerOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorProposerOptions.java
@@ -92,6 +92,16 @@ public class ValidatorProposerOptions {
   private UInt64 builderRegistrationTimestampOverride = null;
 
   @Option(
+    names = {"--Xvalidators-builder-registration-request-payload-endpoint"},
+    paramLabel = "<ENDPOINT>",
+    showDefaultValue = Visibility.ALWAYS,
+    description =
+        "Endpoint will be called with postfix /{pubkey} to get validator registration payload. Will only re-request when timestamp field changes. Secondary to overrides",
+    arity = "1",
+    hidden = true)
+    private String builderRegistrationRequestPayloadEndpoint = null;
+
+  @Option(
       names = {"--validators-proposer-blinded-blocks-enabled"},
       paramLabel = "<BOOLEAN>",
       showDefaultValue = Visibility.ALWAYS,
@@ -111,6 +121,7 @@ public class ValidatorProposerOptions {
                 .blindedBeaconBlocksEnabled(blindedBlocksEnabled)
                 .builderRegistrationDefaultGasLimit(builderRegistrationDefaultGasLimit)
                 .builderRegistrationSendingBatchSize(builderRegistrationSendingBatchSize)
-                .builderRegistrationTimestampOverride(builderRegistrationTimestampOverride));
+                .builderRegistrationTimestampOverride(builderRegistrationTimestampOverride)
+                .builderRegistrationRequestPayloadEndpoint(builderRegistrationRequestPayloadEndpoint));
   }
 }

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/ValidatorOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/ValidatorOptionsTest.java
@@ -178,4 +178,25 @@ public class ValidatorOptionsTest extends AbstractBeaconNodeCommandTest {
             config.validatorClient().getValidatorConfig().getBuilderRegistrationDefaultGasLimit())
         .isEqualTo(UInt64.valueOf(1000));
   }
+
+  @Test
+  public void shouldReportEmptyIfValidatorRegistrationRequestPayloadEndpointNotSpecified() {
+    final TekuConfiguration config = getTekuConfigurationFromArguments();
+    assertThat(
+            config.validatorClient().getValidatorConfig().getBuilderRegistrationRequestPayloadEndpoint())
+        .isEmpty();
+  }
+
+    @Test
+  public void shouldSetValidatorRegistrationRequestPayloadEndpoint() {
+    final String[] args = {
+      "--Xvalidators-builder-registration-request-payload-endpoint",
+      "https://localhost:8080"
+    };
+    final TekuConfiguration config = getTekuConfigurationFromArguments(args);
+    assertThat(
+            config.validatorClient().getValidatorConfig().getBuilderRegistrationRequestPayloadEndpoint())
+        .isEqualTo(
+            Optional.of("https://localhost:8080"));
+  }
 }

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
@@ -80,6 +80,7 @@ public class ValidatorConfig {
   private final UInt64 builderRegistrationDefaultGasLimit;
   private final int builderRegistrationSendingBatchSize;
   private final Optional<UInt64> builderRegistrationTimestampOverride;
+  private final Optional<String> builderRegistrationRequestPayloadEndpoint;
   private final int executorMaxQueueSize;
   private final Duration primaryBeaconNodeEventStreamReconnectAttemptPeriod;
 
@@ -110,6 +111,7 @@ public class ValidatorConfig {
       final UInt64 builderRegistrationDefaultGasLimit,
       final int builderRegistrationSendingBatchSize,
       final Optional<UInt64> builderRegistrationTimestampOverride,
+      final Optional<String> builderRegistrationRequestPayloadEndpoint,
       final int executorMaxQueueSize,
       final Duration primaryBeaconNodeEventStreamReconnectAttemptPeriod) {
     this.validatorKeys = validatorKeys;
@@ -141,6 +143,7 @@ public class ValidatorConfig {
     this.builderRegistrationDefaultGasLimit = builderRegistrationDefaultGasLimit;
     this.builderRegistrationSendingBatchSize = builderRegistrationSendingBatchSize;
     this.builderRegistrationTimestampOverride = builderRegistrationTimestampOverride;
+    this.builderRegistrationRequestPayloadEndpoint = builderRegistrationRequestPayloadEndpoint;
     this.executorMaxQueueSize = executorMaxQueueSize;
     this.primaryBeaconNodeEventStreamReconnectAttemptPeriod =
         primaryBeaconNodeEventStreamReconnectAttemptPeriod;
@@ -229,6 +232,10 @@ public class ValidatorConfig {
     return builderRegistrationTimestampOverride;
   }
 
+  public Optional<String> getBuilderRegistrationRequestPayloadEndpoint() {
+    return builderRegistrationRequestPayloadEndpoint;
+  }
+
   public boolean getRefreshProposerConfigFromSource() {
     return refreshProposerConfigFromSource;
   }
@@ -301,6 +308,7 @@ public class ValidatorConfig {
     private int builderRegistrationSendingBatchSize =
         DEFAULT_VALIDATOR_REGISTRATION_SENDING_BATCH_SIZE;
     private Optional<UInt64> builderRegistrationTimestampOverride = Optional.empty();
+    private Optional<String> builderRegistrationRequestPayloadEndpoint = Optional.empty();
     private int executorMaxQueueSize = DEFAULT_EXECUTOR_MAX_QUEUE_SIZE;
     private Duration primaryBeaconNodeEventStreamReconnectAttemptPeriod =
         DEFAULT_PRIMARY_BEACON_NODE_EVENT_STREAM_RECONNECT_ATTEMPT_PERIOD;
@@ -471,6 +479,13 @@ public class ValidatorConfig {
       return this;
     }
 
+    public Builder builderRegistrationRequestPayloadEndpoint(
+        final String builderRegistrationRequestPayloadEndpoint) {
+      this.builderRegistrationRequestPayloadEndpoint =
+          Optional.ofNullable(builderRegistrationRequestPayloadEndpoint);
+      return this;
+    }
+
     public Builder executorMaxQueueSize(final int executorMaxQueueSize) {
       this.executorMaxQueueSize = executorMaxQueueSize;
       return this;
@@ -517,6 +532,7 @@ public class ValidatorConfig {
           builderRegistrationDefaultGasLimit,
           builderRegistrationSendingBatchSize,
           builderRegistrationTimestampOverride,
+          builderRegistrationRequestPayloadEndpoint,
           executorMaxQueueSize,
           primaryBeaconNodeEventStreamReconnectAttemptPeriod);
     }

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorRegistratorTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorRegistratorTest.java
@@ -170,6 +170,32 @@ class ValidatorRegistratorTest {
   }
 
   @TestTemplate
+  void registersValidators_shouldRegisterWithRequestPayloadEndpoint() {
+    // mock returned payload for RequestPayloadEndpoint
+
+    when(validatorConfig.getBuilderRegistrationRequestPayload())
+        .thenReturn(Optional.of(BuilderRegistrationRequestPayload));
+
+    setActiveValidators(validator1, validator2);
+
+    runRegistrationFlowForSlot(UInt64.ZERO);
+    runRegistrationFlowForSlot(UInt64.valueOf(slotsPerEpoch));
+
+    final List<List<SignedValidatorRegistration>> registrationCalls = captureRegistrationCalls(2);
+
+    final Validator validatorWithOverridenPublicKey =
+        new Validator(publicKeyOverride, signer, Optional::empty);
+
+    registrationCalls.forEach(
+        registrationCall ->
+            verifyRegistrations(
+                registrationCall,
+                List.of(validatorWithOverridenPublicKey, validatorWithOverridenPublicKey)));
+
+    verify(signer, times(1)).signValidatorRegistration(any());
+  }
+
+  @TestTemplate
   void cleanupsCache_ifValidatorIsNoLongerActive() {
     setActiveValidators(validator1, validator2, validator3);
 


### PR DESCRIPTION
## PR Description

Add a builder registration request payload endpoint and retrieve values to be signed from that endpoint.

This is needed in relatation to making the builder spec compatible with Dsitributed Validator technology

We have another fix pubkey-override but this only enables 1 validator per VC (validator cli) see #6009 for further details

## Fixed Issue(s)

#6009 

## Documentation

- Potentially add a paragraph to this document https://hackmd.io/@StefanBratanov/BkMlo1RO9
