### PR TITLE
Remove changelog items released as part of 22.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## Upcoming Breaking Changes
+- The `validator_beacon_node_published_attestation_total`, `validator_beacon_node_published_aggregate_total`,
+  `validator_beacon_node_send_sync_committee_messages_total`, `validator_beacon_node_send_sync_committee_contributions_total`
+  and `validator_beacon_node_published_block_total` metrics have been deprecated in favour of the new `validator_beacon_node_requests_total` metric.
+  The old metrics will be removed in a future release. An update to the [Teku Dashboard](https://grafana.com/grafana/dashboards/13457) that uses the new metric is available.
 - The `/eth/v1/debug/beacon/states/:state_id` endpoint has been deprecated in favor of the v2 Altair endpoint `/eth/v2/debug/beacon/states/:state_id`
 - The `/eth/v1/beacon/blocks/:block_id` endpoint has been deprecated in favor of the v2 Altair endpoint `/eth/v2/beacon/blocks/:block_id`
 - The `/eth/v1/validator/blocks/:slot` endpoint has been deprecated in favor of the v2 Altair endpoint `/eth/v2/validator/blocks/:slot`
@@ -14,15 +18,7 @@ For information on changes in released versions of Teku, see the [releases page]
 ### Breaking Changes
 
 ### Additions and Improvements
- - MEV-Boost\Builder support
- - Enables fork choice before block proposals by default on MainNet (previously on by default on testnets only)
- - Optimisations in jvm-libp2p to reduce CPU usage
- - Updated Sepolia bootnodes
- - Enabled progressive balance tracking optimisation on MainNet
- - Replaced separate metrics for each beacon node request with one metric `beacon_node_requests_total`. Some old metrics were kept for backwards compatibility, but will be removed in future versions.
- - Automatically add `/eth/v2/debug/beacon/states/finalized` to the initial state file url (`--initial-state` configuration parameter) when the provided url doesn't work and doesn't contain any path
+- Automatically add `/eth/v2/debug/beacon/states/finalized` to the initial state file url (`--initial-state` configuration parameter) when the provided url doesn't work and doesn't contain any path.
+  This simplifies using the standard REST API to retrieve the initial state as just the base URL can be specified (e.g. `--initial-state https://<credentials@eth2-beacon-mainnet.infura.io`)
 
 ### Bug Fixes
- - `--ee-endpoint` option was not used to retrieve deposits for networks where Bellatrix was not yet scheduled
- - Fix `latestValidHash`with invalid Execution Payload in response from execution engine didn't trigger appropriate ForkChoice changes 
- - Remove incorrect error about potentially finalizing an invalid execution payload when importing a block with an invalid payload


### PR DESCRIPTION
## PR Description
Removes changelog items released as part of 22.8.0. Also adds the metrics change to the upcoming breaking changes and tweaks wording of one item for next release.
## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
