### PR TITLE
Add timestamp and public key registration overrides to proposer config

### DIFF
--- a/data/serializer/src/main/java/tech/pegasys/teku/provider/BLSPublicKeyDeserializer.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/provider/BLSPublicKeyDeserializer.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.provider;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import java.io.IOException;
+import tech.pegasys.teku.bls.BLSPublicKey;
+
+public class BLSPublicKeyDeserializer extends JsonDeserializer<BLSPublicKey> {
+  @Override
+  public BLSPublicKey deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+    return BLSPublicKey.fromHexString(p.getValueAsString());
+  }
+}

--- a/data/serializer/src/main/java/tech/pegasys/teku/provider/BLSPublicKeySerializer.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/provider/BLSPublicKeySerializer.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.provider;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import java.io.IOException;
+import tech.pegasys.teku.bls.BLSPublicKey;
+
+public class BLSPublicKeySerializer extends JsonSerializer<BLSPublicKey> {
+  @Override
+  public void serialize(BLSPublicKey value, JsonGenerator gen, SerializerProvider serializers)
+      throws IOException {
+    gen.writeString(value.toHexString().toLowerCase());
+  }
+}

--- a/data/serializer/src/main/java/tech/pegasys/teku/provider/JsonProvider.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/provider/JsonProvider.java
@@ -28,6 +28,7 @@ import tech.pegasys.teku.api.response.v2.debug.GetStateResponseV2;
 import tech.pegasys.teku.api.response.v2.validator.GetNewBlockResponseV2;
 import tech.pegasys.teku.api.schema.BLSPubKey;
 import tech.pegasys.teku.api.schema.BLSSignature;
+import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.infrastructure.bytes.Bytes20;
 import tech.pegasys.teku.infrastructure.bytes.Bytes4;
 import tech.pegasys.teku.infrastructure.jackson.deserializers.bytes.ByteArrayDeserializer;
@@ -57,6 +58,8 @@ public class JsonProvider {
 
     module.addSerializer(BLSPubKey.class, new BLSPubKeySerializer());
     module.addDeserializer(BLSPubKey.class, new BLSPubKeyDeserializer());
+    module.addDeserializer(BLSPublicKey.class, new BLSPublicKeyDeserializer());
+    module.addSerializer(BLSPublicKey.class, new BLSPublicKeySerializer());
     module.addDeserializer(BLSSignature.class, new BLSSignatureDeserializer());
     module.addSerializer(BLSSignature.class, new BLSSignatureSerializer());
 

--- a/infrastructure/bls/src/main/java/tech/pegasys/teku/bls/BLSPublicKey.java
+++ b/infrastructure/bls/src/main/java/tech/pegasys/teku/bls/BLSPublicKey.java
@@ -154,6 +154,10 @@ public final class BLSPublicKey {
     return toBytesCompressed().toUnprefixedHexString().substring(0, 7);
   }
 
+  public String toHexString() {
+    return toBytesCompressed().toHexString();
+  }
+
   @Override
   public String toString() {
     return toBytesCompressed().toString();

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
@@ -52,7 +52,6 @@ public class ValidatorConfig {
   public static final boolean DEFAULT_VALIDATOR_BLINDED_BLOCKS_ENABLED = false;
   public static final int DEFAULT_VALIDATOR_REGISTRATION_SENDING_BATCH_SIZE = 100;
   public static final UInt64 DEFAULT_BUILDER_REGISTRATION_GAS_LIMIT = UInt64.valueOf(30_000_000);
-  public static final Optional<BLSPublicKey> DEFAULT_BUILDER_REGISTRATION_PUBLIC_KEY = Optional.empty();
   public static final Duration DEFAULT_PRIMARY_BEACON_NODE_EVENT_STREAM_RECONNECT_ATTEMPT_PERIOD =
       Duration.ofSeconds(30);
 
@@ -80,7 +79,6 @@ public class ValidatorConfig {
   private final boolean validatorClientUseSszBlocksEnabled;
   private final boolean failoversSendSubnetSubscriptionsEnabled;
   private final UInt64 builderRegistrationDefaultGasLimit;
-  private final BLSPublicKey builderRegistrationDefaultPublicKey;
   private final int builderRegistrationSendingBatchSize;
   private final Optional<UInt64> builderRegistrationTimestampOverride;
   private final Optional<BLSPublicKey> builderRegistrationPublicKeyOverride;
@@ -112,7 +110,6 @@ public class ValidatorConfig {
       final boolean validatorClientUseSszBlocksEnabled,
       final boolean failoversSendSubnetSubscriptionsEnabled,
       final UInt64 builderRegistrationDefaultGasLimit,
-      final BLSPublicKey builderRegistrationDefaultPublicKey,
       final int builderRegistrationSendingBatchSize,
       final Optional<UInt64> builderRegistrationTimestampOverride,
       final Optional<BLSPublicKey> builderRegistrationPublicKeyOverride,
@@ -145,7 +142,6 @@ public class ValidatorConfig {
     this.validatorClientUseSszBlocksEnabled = validatorClientUseSszBlocksEnabled;
     this.failoversSendSubnetSubscriptionsEnabled = failoversSendSubnetSubscriptionsEnabled;
     this.builderRegistrationDefaultGasLimit = builderRegistrationDefaultGasLimit;
-    this.builderRegistrationDefaultPublicKey = builderRegistrationDefaultPublicKey;
     this.builderRegistrationSendingBatchSize = builderRegistrationSendingBatchSize;
     this.builderRegistrationTimestampOverride = builderRegistrationTimestampOverride;
     this.builderRegistrationPublicKeyOverride = builderRegistrationPublicKeyOverride;
@@ -229,10 +225,6 @@ public class ValidatorConfig {
     return builderRegistrationDefaultGasLimit;
   }
 
-  public UInt64 getBuilderRegistrationDefaultPublicKey() {
-    return builderRegistrationDefaultPublicKey;
-  }
-
   public int getBuilderRegistrationSendingBatchSize() {
     return builderRegistrationSendingBatchSize;
   }
@@ -314,7 +306,6 @@ public class ValidatorConfig {
     private boolean failoversSendSubnetSubscriptionsEnabled =
         DEFAULT_FAILOVERS_SEND_SUBNET_SUBSCRIPTIONS_ENABLED;
     private UInt64 builderRegistrationDefaultGasLimit = DEFAULT_BUILDER_REGISTRATION_GAS_LIMIT;
-    private BLSPublicKey builderRegistrationDefaultPublicKey = DEFAULT_BUILDER_REGISTRATION_PUBLIC_KEY;
     private int builderRegistrationSendingBatchSize =
         DEFAULT_VALIDATOR_REGISTRATION_SENDING_BATCH_SIZE;
     private Optional<UInt64> builderRegistrationTimestampOverride = Optional.empty();
@@ -476,12 +467,6 @@ public class ValidatorConfig {
       return this;
     }
 
-    public Builder builderRegistrationDefaultPublicKey(
-        final UInt64 builderRegistrationDefaultPublicKey) {
-      this.builderRegistrationDefaultPublicKey = builderRegistrationDefaultPublicKey;
-      return this;
-    }
-
     public Builder builderRegistrationSendingBatchSize(
         final int builderRegistrationSendingBatchSize) {
       this.builderRegistrationSendingBatchSize = builderRegistrationSendingBatchSize;
@@ -547,7 +532,6 @@ public class ValidatorConfig {
           validatorClientSszBlocksEnabled,
           failoversSendSubnetSubscriptionsEnabled,
           builderRegistrationDefaultGasLimit,
-          builderRegistrationDefaultPublicKey,
           builderRegistrationSendingBatchSize,
           builderRegistrationTimestampOverride,
           builderRegistrationPublicKeyOverride,

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
@@ -52,6 +52,7 @@ public class ValidatorConfig {
   public static final boolean DEFAULT_VALIDATOR_BLINDED_BLOCKS_ENABLED = false;
   public static final int DEFAULT_VALIDATOR_REGISTRATION_SENDING_BATCH_SIZE = 100;
   public static final UInt64 DEFAULT_BUILDER_REGISTRATION_GAS_LIMIT = UInt64.valueOf(30_000_000);
+  public static final Optional<BLSPublicKey> DEFAULT_BUILDER_REGISTRATION_PUBLIC_KEY = Optional.empty();
   public static final Duration DEFAULT_PRIMARY_BEACON_NODE_EVENT_STREAM_RECONNECT_ATTEMPT_PERIOD =
       Duration.ofSeconds(30);
 
@@ -79,6 +80,7 @@ public class ValidatorConfig {
   private final boolean validatorClientUseSszBlocksEnabled;
   private final boolean failoversSendSubnetSubscriptionsEnabled;
   private final UInt64 builderRegistrationDefaultGasLimit;
+  private final BLSPublicKey builderRegistrationDefaultPublicKey;
   private final int builderRegistrationSendingBatchSize;
   private final Optional<UInt64> builderRegistrationTimestampOverride;
   private final Optional<BLSPublicKey> builderRegistrationPublicKeyOverride;
@@ -110,6 +112,7 @@ public class ValidatorConfig {
       final boolean validatorClientUseSszBlocksEnabled,
       final boolean failoversSendSubnetSubscriptionsEnabled,
       final UInt64 builderRegistrationDefaultGasLimit,
+      final BLSPublicKey builderRegistrationDefaultPublicKey,
       final int builderRegistrationSendingBatchSize,
       final Optional<UInt64> builderRegistrationTimestampOverride,
       final Optional<BLSPublicKey> builderRegistrationPublicKeyOverride,
@@ -142,6 +145,7 @@ public class ValidatorConfig {
     this.validatorClientUseSszBlocksEnabled = validatorClientUseSszBlocksEnabled;
     this.failoversSendSubnetSubscriptionsEnabled = failoversSendSubnetSubscriptionsEnabled;
     this.builderRegistrationDefaultGasLimit = builderRegistrationDefaultGasLimit;
+    this.builderRegistrationDefaultPublicKey = builderRegistrationDefaultPublicKey;
     this.builderRegistrationSendingBatchSize = builderRegistrationSendingBatchSize;
     this.builderRegistrationTimestampOverride = builderRegistrationTimestampOverride;
     this.builderRegistrationPublicKeyOverride = builderRegistrationPublicKeyOverride;
@@ -225,6 +229,10 @@ public class ValidatorConfig {
     return builderRegistrationDefaultGasLimit;
   }
 
+  public UInt64 getBuilderRegistrationDefaultPublicKey() {
+    return builderRegistrationDefaultPublicKey;
+  }
+
   public int getBuilderRegistrationSendingBatchSize() {
     return builderRegistrationSendingBatchSize;
   }
@@ -306,6 +314,7 @@ public class ValidatorConfig {
     private boolean failoversSendSubnetSubscriptionsEnabled =
         DEFAULT_FAILOVERS_SEND_SUBNET_SUBSCRIPTIONS_ENABLED;
     private UInt64 builderRegistrationDefaultGasLimit = DEFAULT_BUILDER_REGISTRATION_GAS_LIMIT;
+    private BLSPublicKey builderRegistrationDefaultPublicKey = DEFAULT_BUILDER_REGISTRATION_PUBLIC_KEY;
     private int builderRegistrationSendingBatchSize =
         DEFAULT_VALIDATOR_REGISTRATION_SENDING_BATCH_SIZE;
     private Optional<UInt64> builderRegistrationTimestampOverride = Optional.empty();
@@ -467,6 +476,12 @@ public class ValidatorConfig {
       return this;
     }
 
+    public Builder builderRegistrationDefaultPublicKey(
+        final UInt64 builderRegistrationDefaultPublicKey) {
+      this.builderRegistrationDefaultPublicKey = builderRegistrationDefaultPublicKey;
+      return this;
+    }
+
     public Builder builderRegistrationSendingBatchSize(
         final int builderRegistrationSendingBatchSize) {
       this.builderRegistrationSendingBatchSize = builderRegistrationSendingBatchSize;
@@ -532,6 +547,7 @@ public class ValidatorConfig {
           validatorClientSszBlocksEnabled,
           failoversSendSubnetSubscriptionsEnabled,
           builderRegistrationDefaultGasLimit,
+          builderRegistrationDefaultPublicKey,
           builderRegistrationSendingBatchSize,
           builderRegistrationTimestampOverride,
           builderRegistrationPublicKeyOverride,

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ProposerConfig.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ProposerConfig.java
@@ -68,6 +68,10 @@ public class ProposerConfig {
     return getConfigForPubKeyOrDefault(pubKey).getBuilder().flatMap(BuilderConfig::getGasLimit);
   }
 
+  public Optional<BLSPublicKey> getBuilderPublicKeyForPubKey(final BLSPublicKey pubKey) {
+    return getConfigForPubKeyOrDefault(pubKey).getBuilder().getRegistrationOverrides().flatMap(RegistrationOverridesConfig::getPublicKey);
+  }
+
   public Config getDefaultConfig() {
     return defaultConfig;
   }
@@ -145,13 +149,18 @@ public class ProposerConfig {
     @JsonProperty(value = "gas_limit")
     private UInt64 gasLimit;
 
+    @JsonProperty(value = "registration_overrides")
+    private RegistrationOverridesConfig registrationOverrides;
+
     @JsonCreator
     public BuilderConfig(
         @JsonProperty(value = "enabled") final Boolean enabled,
-        @JsonProperty(value = "gas_limit") final UInt64 gasLimit) {
+        @JsonProperty(value = "gas_limit") final UInt64 gasLimit 
+        @JsonProperty(value = "registration_overrides") final RegistrationOverridesConfig registrationOverrides) {
       checkNotNull(enabled, "enabled is required");
       this.enabled = enabled;
       this.gasLimit = gasLimit;
+      this.registrationOverrides = registrationOverrides;
     }
 
     public Boolean isEnabled() {
@@ -160,6 +169,10 @@ public class ProposerConfig {
 
     public Optional<UInt64> getGasLimit() {
       return Optional.ofNullable(gasLimit);
+    }
+
+    public Optional<RegistrationOverridesConfig> getRegistrationOverrides() {
+      return Optional.ofNullable(registrationOverrides);
     }
 
     @Override
@@ -171,12 +184,39 @@ public class ProposerConfig {
         return false;
       }
       final BuilderConfig that = (BuilderConfig) o;
-      return Objects.equals(enabled, that.enabled) && Objects.equals(gasLimit, that.gasLimit);
+      return Objects.equals(enabled, that.enabled) && Objects.equals(gasLimit, that.gasLimit) && Objects.equals(registrationOverrides, that.registrationOverrides);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(enabled, gasLimit);
+      return Objects.hash(enabled, gasLimit, registrationOverrides);
     }
+  }
+
+  @JsonCreator
+  public RegistrationOverridesConfig(
+      @JsonProperty(value = "public_key") final BLSPublicKey publicKey) {
+    this.publicKey = publicKey;
+  }
+
+  public Optional<BLSPublicKey> getPublicKey() {
+    return Optional.ofNullable(publicKey);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final RegistrationOverridesConfig that = (RegistrationOverridesConfig) o;
+    return Objects.equals(publicKey, that.publicKey);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(publicKey);
   }
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrator.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrator.java
@@ -197,6 +197,12 @@ public class ValidatorRegistrator implements ValidatorTimingChannel {
             .getBuilderRegistrationPublicKeyOverride()
             .orElseGet(validator::getPublicKey);
 
+    // publicKey in config takes priority over override
+    final BLSPublicKey publicKey =
+    validatorConfig
+        .getPublicKey(maybeProposerConfig, validator::getPublicKey)
+        .orElse(publicKey);
+
     if (!registrationIsEnabled(maybeProposerConfig, publicKey)) {
       LOG.trace("Validator registration is disabled for {}", publicKey);
       return Optional.empty();
@@ -248,6 +254,13 @@ public class ValidatorRegistrator implements ValidatorTimingChannel {
     return maybeProposerConfig
         .flatMap(proposerConfig -> proposerConfig.getBuilderGasLimitForPubKey(publicKey))
         .orElse(validatorConfig.getBuilderRegistrationDefaultGasLimit());
+  }
+
+  private UInt64 getPublicKey(
+      final Optional<ProposerConfig> maybeProposerConfig, final BLSPublicKey publicKey) {
+    return maybeProposerConfig
+        .flatMap(proposerConfig -> proposerConfig.getBuilderPublicKeyForPubKey(publicKey))
+        .orElse(validatorConfig.getBuilderRegistrationDefaultPublicKey());
   }
 
   private ValidatorRegistration createValidatorRegistration(

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrator.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrator.java
@@ -41,6 +41,7 @@ import tech.pegasys.teku.spec.schemas.ApiSchemas;
 import tech.pegasys.teku.spec.signatures.Signer;
 import tech.pegasys.teku.validator.api.ValidatorConfig;
 import tech.pegasys.teku.validator.api.ValidatorTimingChannel;
+import tech.pegasys.teku.validator.client.ProposerConfig.RegistrationOverrides;
 import tech.pegasys.teku.validator.client.loader.OwnedValidators;
 import tech.pegasys.teku.validator.client.proposerconfig.ProposerConfigProvider;
 
@@ -192,16 +193,8 @@ public class ValidatorRegistrator implements ValidatorTimingChannel {
 
   private Optional<SafeFuture<SignedValidatorRegistration>> createSignedValidatorRegistration(
       final Optional<ProposerConfig> maybeProposerConfig, final Validator validator) {
-    final BLSPublicKey publicKey =
-        validatorConfig
-            .getBuilderRegistrationPublicKeyOverride()
-            .orElseGet(validator::getPublicKey);
 
-    // publicKey in config takes priority over override
-    final BLSPublicKey publicKey =
-    validatorConfig
-        .getPublicKey(maybeProposerConfig, validator::getPublicKey)
-        .orElse(publicKey);
+    final BLSPublicKey publicKey = validator.getPublicKey();
 
     if (!registrationIsEnabled(maybeProposerConfig, publicKey)) {
       LOG.trace("Validator registration is disabled for {}", publicKey);
@@ -220,11 +213,26 @@ public class ValidatorRegistrator implements ValidatorTimingChannel {
     final Eth1Address feeRecipient = maybeFeeRecipient.get();
     final UInt64 gasLimit = getGasLimit(maybeProposerConfig, publicKey);
 
+    final Optional<UInt64> maybeTimestampOverride =
+        getTimestampOverride(maybeProposerConfig, publicKey);
+    final Optional<BLSPublicKey> maybePublicKeyOverride =
+        getPublicKeyOverride(maybeProposerConfig, publicKey);
+
+    final ValidatorRegistration validatorRegistration =
+        createValidatorRegistration(
+            maybePublicKeyOverride.orElse(publicKey),
+            feeRecipient,
+            gasLimit,
+            maybeTimestampOverride.orElse(timeProvider.getTimeInSeconds()));
+
     return Optional.ofNullable(cachedValidatorRegistrations.get(publicKey))
         .filter(
             cachedValidatorRegistration -> {
               final boolean needsUpdate =
-                  registrationNeedsUpdating(cachedValidatorRegistration, feeRecipient, gasLimit);
+                  registrationNeedsUpdating(
+                      cachedValidatorRegistration.getMessage(),
+                      validatorRegistration,
+                      maybeTimestampOverride);
               if (needsUpdate) {
                 LOG.debug(
                     "The cached registration for {} needs updating. Will create a new one.",
@@ -235,10 +243,9 @@ public class ValidatorRegistrator implements ValidatorTimingChannel {
         .map(SafeFuture::completedFuture)
         .or(
             () -> {
-              final ValidatorRegistration validatorRegistration =
-                  createValidatorRegistration(publicKey, feeRecipient, gasLimit);
               final Signer signer = validator.getSigner();
-              return Optional.of(signAndCacheValidatorRegistration(validatorRegistration, signer));
+              return Optional.of(
+                  signAndCacheValidatorRegistration(publicKey, validatorRegistration, signer));
             });
   }
 
@@ -256,25 +263,35 @@ public class ValidatorRegistrator implements ValidatorTimingChannel {
         .orElse(validatorConfig.getBuilderRegistrationDefaultGasLimit());
   }
 
-  private UInt64 getPublicKey(
-      final Optional<ProposerConfig> maybeProposerConfig, final BLSPublicKey publicKey) {
-    return maybeProposerConfig
-        .flatMap(proposerConfig -> proposerConfig.getBuilderPublicKeyForPubKey(publicKey))
-        .orElse(validatorConfig.getBuilderRegistrationDefaultPublicKey());
-  }
-
   private ValidatorRegistration createValidatorRegistration(
-      final BLSPublicKey publicKey, final Eth1Address feeRecipient, final UInt64 gasLimit) {
-    final UInt64 timestamp =
-        validatorConfig
-            .getBuilderRegistrationTimestampOverride()
-            .orElse(timeProvider.getTimeInSeconds());
+      final BLSPublicKey publicKey,
+      final Eth1Address feeRecipient,
+      final UInt64 gasLimit,
+      final UInt64 timestamp) {
     return ApiSchemas.VALIDATOR_REGISTRATION_SCHEMA.create(
         feeRecipient, gasLimit, timestamp, publicKey);
   }
 
+  private Optional<UInt64> getTimestampOverride(
+      final Optional<ProposerConfig> maybeProposerConfig, final BLSPublicKey publicKey) {
+    return maybeProposerConfig
+        .flatMap(proposerConfig -> proposerConfig.getBuilderRegistrationOverrides(publicKey))
+        .flatMap(RegistrationOverrides::getTimestamp)
+        .or(validatorConfig::getBuilderRegistrationTimestampOverride);
+  }
+
+  private Optional<BLSPublicKey> getPublicKeyOverride(
+      final Optional<ProposerConfig> maybeProposerConfig, final BLSPublicKey publicKey) {
+    return maybeProposerConfig
+        .flatMap(proposerConfig -> proposerConfig.getBuilderRegistrationOverrides(publicKey))
+        .flatMap(RegistrationOverrides::getPublicKey)
+        .or(validatorConfig::getBuilderRegistrationPublicKeyOverride);
+  }
+
   private SafeFuture<SignedValidatorRegistration> signAndCacheValidatorRegistration(
-      final ValidatorRegistration validatorRegistration, final Signer signer) {
+      final BLSPublicKey cacheKey,
+      final ValidatorRegistration validatorRegistration,
+      final Signer signer) {
     return signer
         .signValidatorRegistration(validatorRegistration)
         .thenApply(
@@ -282,20 +299,30 @@ public class ValidatorRegistrator implements ValidatorTimingChannel {
               final SignedValidatorRegistration signedValidatorRegistration =
                   ApiSchemas.SIGNED_VALIDATOR_REGISTRATION_SCHEMA.create(
                       validatorRegistration, signature);
-              final BLSPublicKey publicKey = validatorRegistration.getPublicKey();
-              LOG.debug("Validator registration signed for {}", publicKey);
-              cachedValidatorRegistrations.put(publicKey, signedValidatorRegistration);
+              LOG.debug("Validator registration signed for {}", cacheKey);
+              cachedValidatorRegistrations.put(cacheKey, signedValidatorRegistration);
               return signedValidatorRegistration;
             });
   }
 
   public boolean registrationNeedsUpdating(
-      final SignedValidatorRegistration signedValidatorRegistration,
-      final Eth1Address feeRecipient,
-      final UInt64 gasLimit) {
-    final ValidatorRegistration validatorRegistration = signedValidatorRegistration.getMessage();
-    return !validatorRegistration.getFeeRecipient().equals(feeRecipient)
-        || !validatorRegistration.getGasLimit().equals(gasLimit);
+      final ValidatorRegistration cachedValidatorRegistration,
+      final ValidatorRegistration newValidatorRegistration,
+      final Optional<UInt64> newMaybeTimestampOverride) {
+    final boolean cachedTimestampIsDifferentThanOverride =
+        newMaybeTimestampOverride
+            .map(
+                newTimestampOverride ->
+                    !cachedValidatorRegistration.getTimestamp().equals(newTimestampOverride))
+            .orElse(false);
+    return !cachedValidatorRegistration
+            .getFeeRecipient()
+            .equals(newValidatorRegistration.getFeeRecipient())
+        || !cachedValidatorRegistration.getGasLimit().equals(newValidatorRegistration.getGasLimit())
+        || !cachedValidatorRegistration
+            .getPublicKey()
+            .equals(newValidatorRegistration.getPublicKey())
+        || cachedTimestampIsDifferentThanOverride;
   }
 
   private void cleanupCache(final List<Validator> activeValidators) {
@@ -313,14 +340,8 @@ public class ValidatorRegistrator implements ValidatorTimingChannel {
         .keySet()
         .removeIf(
             cachedPublicKey -> {
-              final boolean cachedKeyIsTheConfiguredOverride =
-                  validatorConfig
-                      .getBuilderRegistrationPublicKeyOverride()
-                      .map(keyOverride -> keyOverride.equals(cachedPublicKey))
-                      .orElse(false);
               final boolean requiresRemoving =
-                  !activeValidatorsPublicKeys.contains(cachedPublicKey)
-                      && !cachedKeyIsTheConfiguredOverride;
+                  !activeValidatorsPublicKeys.contains(cachedPublicKey);
               if (requiresRemoving) {
                 LOG.debug(
                     "Removing cached registration for {} because validator is no longer active.",

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/ProposerConfigTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/ProposerConfigTest.java
@@ -106,4 +106,42 @@ class ProposerConfigTest {
             proposerConfig.getBuilderGasLimitForPubKey(BLSPublicKey.fromBytesCompressed(PUB_KEY)))
         .isEmpty();
   }
+
+  @Test
+  void gets_validatorRegistrationPublicKey_forPubKey() {
+    Map<Bytes48, Config> configByPubKey = new HashMap<>();
+    configByPubKey.put(
+        PUB_KEY, new Config(ETH1_ADDRESS, new BuilderConfig(true, null, new RegistrationOverridesConfig(CUSTOM_PUBLIC_KEY)));
+    ProposerConfig proposerConfig = new ProposerConfig(configByPubKey, DEFAULT_CONFIG);
+
+    assertThat(
+            proposerConfig.getBuilderPublicKeyForPubKey(BLSPublicKey.fromBytesCompressed(PUB_KEY)))
+        .hasValue(CUSTOM_PUBLIC_KEY);
+
+    // defaults to default config
+    assertThat(
+            proposerConfig.getBuilderPublicKeyForPubKey(
+                BLSPublicKey.fromBytesCompressed(ANOTHER_PUB_KEY)))
+        .hasValue(DEFAULT_PUBLIC_KEY);
+  }
+
+  @Test
+  void registrationPublicKeyDoesNotExist_whenRegistrationIsNull() {
+    ProposerConfig proposerConfig = new ProposerConfig(new HashMap<>(), NO_BUILDER_CONFIG);
+
+    assertThat(
+            proposerConfig.getBuilderPublicKeyForPubKey(BLSPublicKey.fromBytesCompressed(PUB_KEY)))
+        .isEmpty();
+  }
+
+  @Test
+  void registrationPublicKeyDoesNotExist_whenPublicKeyIsNull() {
+    Map<Bytes48, Config> configByPubKey = new HashMap<>();
+    configByPubKey.put(PUB_KEY, new Config(ETH1_ADDRESS, new BuilderConfig(true, null, new RegistrationOverridesConfig(null))));
+    ProposerConfig proposerConfig = new ProposerConfig(configByPubKey, DEFAULT_CONFIG);
+
+    assertThat(
+            proposerConfig.getBuilderPublicKeyForPubKey(BLSPublicKey.fromBytesCompressed(PUB_KEY)))
+        .isEmpty();
+  }
 }

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorRegistratorTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorRegistratorTest.java
@@ -83,6 +83,7 @@ class ValidatorRegistratorTest {
 
     eth1Address = dataStructureUtil.randomEth1Address();
     gasLimit = dataStructureUtil.randomUInt64();
+    publicKey = dataStructureUtil.randomPublicKey();
 
     validatorRegistrator =
         new ValidatorRegistrator(
@@ -100,6 +101,7 @@ class ValidatorRegistratorTest {
 
     when(proposerConfig.isBuilderEnabledForPubKey(any())).thenReturn(Optional.of(true));
     when(proposerConfig.getBuilderGasLimitForPubKey(any())).thenReturn(Optional.of(gasLimit));
+    when(proposerConfig.getBuilderPublicKeyForPubKey(any())).thenReturn(Optional.of(publicKey));
 
     when(feeRecipientProvider.isReadyToProvideFeeRecipient()).thenReturn(true);
     when(feeRecipientProvider.getFeeRecipient(any())).thenReturn(Optional.of(eth1Address));

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorRegistratorTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorRegistratorTest.java
@@ -86,7 +86,6 @@ class ValidatorRegistratorTest {
 
     eth1Address = dataStructureUtil.randomEth1Address();
     gasLimit = dataStructureUtil.randomUInt64();
-    //    publicKey = dataStructureUtil.randomPublicKey();
 
     validatorRegistrator =
         new ValidatorRegistrator(
@@ -104,8 +103,6 @@ class ValidatorRegistratorTest {
 
     when(proposerConfig.isBuilderEnabledForPubKey(any())).thenReturn(Optional.of(true));
     when(proposerConfig.getBuilderGasLimitForPubKey(any())).thenReturn(Optional.of(gasLimit));
-    //
-    // when(proposerConfig.getBuilderPublicKeyForPubKey(any())).thenReturn(Optional.of(publicKey));
 
     when(feeRecipientProvider.isReadyToProvideFeeRecipient()).thenReturn(true);
     when(feeRecipientProvider.getFeeRecipient(any())).thenReturn(Optional.of(eth1Address));

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/proposerconfig/loader/ProposerConfigLoaderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/proposerconfig/loader/ProposerConfigLoaderTest.java
@@ -20,11 +20,13 @@ import com.google.common.io.Resources;
 import java.net.URL;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.eth1.Eth1Address;
 import tech.pegasys.teku.validator.client.ProposerConfig;
 import tech.pegasys.teku.validator.client.ProposerConfig.BuilderConfig;
 import tech.pegasys.teku.validator.client.ProposerConfig.Config;
+import tech.pegasys.teku.validator.client.ProposerConfig.RegistrationOverrides;
 
 public class ProposerConfigLoaderTest {
   private final ProposerConfigLoader loader = new ProposerConfigLoader();
@@ -62,6 +64,20 @@ public class ProposerConfigLoaderTest {
     final URL resource = Resources.getResource("proposerConfigWithBuilderValid2.json");
 
     validateContentWithValidatorRegistration2(loader.getProposerConfig(resource));
+  }
+
+  @Test
+  void shouldLoadConfigWithRegistrationOverrides() {
+    final URL resource = Resources.getResource("proposerConfigWithRegistrationOverrides1.json");
+
+    validateContentWithRegistrationOverrides1(loader.getProposerConfig(resource));
+  }
+
+  @Test
+  void shouldLoadConfigWithEmptyDefaultRegistrationOverridesAndMissingFields() {
+    final URL resource = Resources.getResource("proposerConfigWithRegistrationOverrides2.json");
+
+    validateContentWithRegistrationOverrides2(loader.getProposerConfig(resource));
   }
 
   @Test
@@ -106,8 +122,8 @@ public class ProposerConfigLoaderTest {
     assertThatThrownBy(() -> loader.getProposerConfig(resource));
   }
 
-  private void validateContent1(ProposerConfig config) {
-    Optional<Config> theConfig =
+  private void validateContent1(final ProposerConfig config) {
+    final Optional<Config> theConfig =
         config.getConfigForPubKey(
             "0xa057816155ad77931185101128655c0191bd0214c201ca48ed887f6c4c6adf334070efcd75140eada5ac83a92506dd7a");
     assertThat(theConfig).isPresent();
@@ -115,44 +131,44 @@ public class ProposerConfigLoaderTest {
         .isEqualTo(
             Optional.of(Eth1Address.fromHexString("0x50155530FCE8a85ec7055A5F8b2bE214B3DaeFd3")));
 
-    Config defaultConfig = config.getDefaultConfig();
+    final Config defaultConfig = config.getDefaultConfig();
     assertThat(defaultConfig.getFeeRecipient())
         .isEqualTo(
             Optional.of(Eth1Address.fromHexString("0x6e35733c5af9B61374A128e6F85f553aF09ff89A")));
   }
 
-  private void validateContent2(ProposerConfig config) {
-    Optional<Config> theConfig =
+  private void validateContent2(final ProposerConfig config) {
+    final Optional<Config> theConfig =
         config.getConfigForPubKey(
             "0xa057816155ad77931185101128655c0191bd0214c201ca48ed887f6c4c6adf334070efcd75140eada5ac83a92506dd7a");
     assertThat(theConfig).isEmpty();
 
-    Config defaultConfig = config.getDefaultConfig();
+    final Config defaultConfig = config.getDefaultConfig();
     assertThat(defaultConfig.getFeeRecipient())
         .isEqualTo(
             Optional.of(Eth1Address.fromHexString("0x6e35733c5af9B61374A128e6F85f553aF09ff89A")));
   }
 
-  private void validateContent3(ProposerConfig config) {
-    Optional<Config> theConfig =
+  private void validateContent3(final ProposerConfig config) {
+    final Optional<Config> theConfig =
         config.getConfigForPubKey(
             "0xa057816155ad77931185101128655c0191bd0214c201ca48ed887f6c4c6adf334070efcd75140eada5ac83a92506dd7a");
     assertThat(theConfig).isPresent();
     assertThat(theConfig.get().getFeeRecipient()).isEmpty();
 
-    Config defaultConfig = config.getDefaultConfig();
+    final Config defaultConfig = config.getDefaultConfig();
     assertThat(defaultConfig.getFeeRecipient())
         .isEqualTo(
             Optional.of(Eth1Address.fromHexString("0x6e35733c5af9B61374A128e6F85f553aF09ff89A")));
   }
 
-  private void validateContentWithValidatorRegistration1(ProposerConfig config) {
-    Optional<Config> theConfig =
+  private void validateContentWithValidatorRegistration1(final ProposerConfig config) {
+    final Optional<Config> theConfig =
         config.getConfigForPubKey(
             "0xa057816155ad77931185101128655c0191bd0214c201ca48ed887f6c4c6adf334070efcd75140eada5ac83a92506dd7a");
     assertThat(theConfig).isEmpty();
 
-    Config defaultConfig = config.getDefaultConfig();
+    final Config defaultConfig = config.getDefaultConfig();
     assertThat(defaultConfig.getFeeRecipient())
         .isEqualTo(
             Optional.of(Eth1Address.fromHexString("0x6e35733c5af9B61374A128e6F85f553aF09ff89A")));
@@ -161,8 +177,8 @@ public class ProposerConfigLoaderTest {
     assertThat(defaultConfig.getBuilder().get().isEnabled()).isTrue();
   }
 
-  private void validateContentWithValidatorRegistration2(ProposerConfig config) {
-    Optional<Config> theConfig =
+  private void validateContentWithValidatorRegistration2(final ProposerConfig config) {
+    final Optional<Config> theConfig =
         config.getConfigForPubKey(
             "0xa057816155ad77931185101128655c0191bd0214c201ca48ed887f6c4c6adf334070efcd75140eada5ac83a92506dd7a");
     assertThat(theConfig).isPresent();
@@ -171,11 +187,11 @@ public class ProposerConfigLoaderTest {
             Optional.of(Eth1Address.fromHexString("0x50155530FCE8a85ec7055A5F8b2bE214B3DaeFd3")));
 
     assertThat(theConfig.get().getBuilder()).isPresent();
-    BuilderConfig builder = theConfig.get().getBuilder().get();
+    final BuilderConfig builder = theConfig.get().getBuilder().get();
     assertThat(builder.isEnabled()).isTrue();
     assertThat(builder.getGasLimit().orElseThrow()).isEqualTo(UInt64.valueOf(12345654321L));
 
-    Config defaultConfig = config.getDefaultConfig();
+    final Config defaultConfig = config.getDefaultConfig();
     assertThat(defaultConfig.getFeeRecipient())
         .isEqualTo(
             Optional.of(Eth1Address.fromHexString("0x6e35733c5af9B61374A128e6F85f553aF09ff89A")));
@@ -183,5 +199,57 @@ public class ProposerConfigLoaderTest {
     assertThat(defaultConfig.getBuilder()).isPresent();
     assertThat(defaultConfig.getBuilder().get().isEnabled()).isFalse();
     assertThat(defaultConfig.getBuilder().get().getGasLimit()).isEmpty();
+  }
+
+  private void validateContentWithRegistrationOverrides1(final ProposerConfig config) {
+    final Optional<RegistrationOverrides> pubKeyRegistrationOverrides =
+        config
+            .getConfigForPubKey(
+                "0xa057816155ad77931185101128655c0191bd0214c201ca48ed887f6c4c6adf334070efcd75140eada5ac83a92506dd7a")
+            .flatMap(this::getRegistrationOverrides);
+    assertThat(pubKeyRegistrationOverrides)
+        .hasValueSatisfying(
+            registrationOverrides -> {
+              assertThat(registrationOverrides.getPublicKey())
+                  .hasValue(
+                      BLSPublicKey.fromHexString(
+                          "0xb53d21a4cfd562c469cc81514d4ce5a6b577d8403d32a394dc265dd190b47fa9f829fdd7963afdf972e5e77854051f6f"));
+              assertThat(registrationOverrides.getTimestamp()).hasValue(UInt64.valueOf(1234));
+            });
+    final Optional<RegistrationOverrides> defaultRegistrationOverrides =
+        getRegistrationOverrides(config.getDefaultConfig());
+    assertThat(defaultRegistrationOverrides)
+        .hasValueSatisfying(
+            registrationOverrides -> {
+              assertThat(registrationOverrides.getPublicKey())
+                  .hasValue(
+                      BLSPublicKey.fromHexString(
+                          "0xa491d1b0ecd9bb917989f0e74f0dea0422eac4a873e5e2644f368dffb9a6e20fd6e10c1b77654d067c0618f6e5a7f79a"));
+              assertThat(registrationOverrides.getTimestamp()).hasValue(UInt64.valueOf(1235));
+            });
+  }
+
+  private void validateContentWithRegistrationOverrides2(final ProposerConfig config) {
+    final Optional<RegistrationOverrides> pubKeyRegistrationOverrides =
+        config
+            .getConfigForPubKey(
+                "0xa057816155ad77931185101128655c0191bd0214c201ca48ed887f6c4c6adf334070efcd75140eada5ac83a92506dd7a")
+            .flatMap(this::getRegistrationOverrides);
+    assertThat(pubKeyRegistrationOverrides)
+        .hasValueSatisfying(
+            registrationOverrides -> {
+              assertThat(registrationOverrides.getPublicKey())
+                  .hasValue(
+                      BLSPublicKey.fromHexString(
+                          "0xb53d21a4cfd562c469cc81514d4ce5a6b577d8403d32a394dc265dd190b47fa9f829fdd7963afdf972e5e77854051f6f"));
+              assertThat(registrationOverrides.getTimestamp()).isEmpty();
+            });
+    final Optional<RegistrationOverrides> defaultRegistrationOverrides =
+        getRegistrationOverrides(config.getDefaultConfig());
+    assertThat(defaultRegistrationOverrides).isEmpty();
+  }
+
+  private Optional<RegistrationOverrides> getRegistrationOverrides(final Config config) {
+    return config.getBuilder().flatMap(BuilderConfig::getRegistrationOverrides);
   }
 }

--- a/validator/client/src/test/resources/proposerConfigWithRegistrationOverrides1.json
+++ b/validator/client/src/test/resources/proposerConfigWithRegistrationOverrides1.json
@@ -1,0 +1,24 @@
+{
+  "proposer_config": {
+    "0xa057816155ad77931185101128655c0191bd0214c201ca48ed887f6c4c6adf334070efcd75140eada5ac83a92506dd7a": {
+      "fee_recipient": "0x50155530FCE8a85ec7055A5F8b2bE214B3DaeFd3",
+      "builder": {
+        "enabled": true,
+        "registration_overrides": {
+          "timestamp": "1234",
+          "public_key": "0xb53d21a4cfd562c469cc81514d4ce5a6b577d8403d32a394dc265dd190b47fa9f829fdd7963afdf972e5e77854051f6f"
+        }
+      }
+    }
+  },
+  "default_config": {
+    "fee_recipient": "0x6e35733c5af9B61374A128e6F85f553aF09ff89A",
+    "builder": {
+      "enabled": false,
+      "registration_overrides": {
+        "timestamp": "1235",
+        "public_key": "0xa491d1b0ecd9bb917989f0e74f0dea0422eac4a873e5e2644f368dffb9a6e20fd6e10c1b77654d067c0618f6e5a7f79a"
+      }
+    }
+  }
+}

--- a/validator/client/src/test/resources/proposerConfigWithRegistrationOverrides2.json
+++ b/validator/client/src/test/resources/proposerConfigWithRegistrationOverrides2.json
@@ -1,0 +1,19 @@
+{
+  "proposer_config": {
+    "0xa057816155ad77931185101128655c0191bd0214c201ca48ed887f6c4c6adf334070efcd75140eada5ac83a92506dd7a": {
+      "fee_recipient": "0x50155530FCE8a85ec7055A5F8b2bE214B3DaeFd3",
+      "builder": {
+        "enabled": true,
+        "registration_overrides": {
+          "public_key": "0xb53d21a4cfd562c469cc81514d4ce5a6b577d8403d32a394dc265dd190b47fa9f829fdd7963afdf972e5e77854051f6f"
+        }
+      }
+    }
+  },
+  "default_config": {
+    "fee_recipient": "0x6e35733c5af9B61374A128e6F85f553aF09ff89A",
+    "builder": {
+      "enabled": false
+    }
+  }
+}


### PR DESCRIPTION
## PR Description

Add publicKey to builder options in proposer config and removes the pubkey override flag that was a temporary solution to this problem.

This is needed in relation to making the builder spec compatible with Distributed Validator technology

This PR or #6010 is being discussed as the solution to #6009  

## Fixed Issue(s)

fixes #6009

## Documentation

Potentially add a paragraph to this document https://hackmd.io/@StefanBratanov/BkMlo1RO9
