### PR TITLE
VC fallback to normal block request if blinded block endpoint is not available

### DIFF
--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/BlindedBlockEndpointNotAvailableException.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/BlindedBlockEndpointNotAvailableException.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.remote.typedef;
+
+public class BlindedBlockEndpointNotAvailableException extends RuntimeException {}

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/OkHttpValidatorTypeDefClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/OkHttpValidatorTypeDefClient.java
@@ -16,6 +16,8 @@ package tech.pegasys.teku.validator.remote.typedef;
 import java.util.Optional;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
@@ -34,6 +36,8 @@ import tech.pegasys.teku.validator.remote.typedef.handlers.RegisterValidatorsReq
 import tech.pegasys.teku.validator.remote.typedef.handlers.SendSignedBlockRequest;
 
 public class OkHttpValidatorTypeDefClient {
+
+  private static final Logger LOG = LogManager.getLogger();
 
   private final OkHttpClient okHttpClient;
   private final HttpUrl baseEndpoint;
@@ -82,7 +86,14 @@ public class OkHttpValidatorTypeDefClient {
     final CreateBlockRequest createBlockRequest =
         new CreateBlockRequest(
             baseEndpoint, okHttpClient, spec, slot, blinded, preferSszBlockEncoding);
-    return createBlockRequest.createUnsignedBlock(randaoReveal, graffiti);
+    try {
+      return createBlockRequest.createUnsignedBlock(randaoReveal, graffiti);
+    } catch (BlindedBlockEndpointNotAvailableException ex) {
+      LOG.debug(
+          "Beacon Node {} does not support blinded block production. Falling back to normal block production.",
+          baseEndpoint);
+      return createUnsignedBlock(slot, randaoReveal, graffiti, false);
+    }
   }
 
   public void registerValidators(

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/OkHttpValidatorTypeDefClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/OkHttpValidatorTypeDefClient.java
@@ -89,7 +89,7 @@ public class OkHttpValidatorTypeDefClient {
     try {
       return createBlockRequest.createUnsignedBlock(randaoReveal, graffiti);
     } catch (BlindedBlockEndpointNotAvailableException ex) {
-      LOG.debug(
+      LOG.warn(
           "Beacon Node {} does not support blinded block production. Falling back to normal block production.",
           baseEndpoint);
       return createUnsignedBlock(slot, randaoReveal, graffiti, false);

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/handlers/CreateBlockRequest.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/handlers/CreateBlockRequest.java
@@ -48,10 +48,10 @@ public class CreateBlockRequest extends AbstractTypeDefRequest {
   private static final Logger LOG = LogManager.getLogger();
 
   private final UInt64 slot;
-  private final DeserializableTypeDefinition<GetBlockResponse> getBlockResponseDefinition;
-  private final BeaconBlockSchema beaconBlockSchema;
-  private final ValidatorApiMethod apiMethod;
   private final boolean preferSszBlockEncoding;
+  private final ValidatorApiMethod apiMethod;
+  private final BeaconBlockSchema beaconBlockSchema;
+  private final DeserializableTypeDefinition<GetBlockResponse> getBlockResponseDefinition;
   private final ResponseHandler<GetBlockResponse> responseHandler;
 
   public CreateBlockRequest(
@@ -64,11 +64,11 @@ public class CreateBlockRequest extends AbstractTypeDefRequest {
     super(baseEndpoint, okHttpClient);
     this.slot = slot;
     this.preferSszBlockEncoding = preferSszBlockEncoding;
+    apiMethod = blinded ? GET_UNSIGNED_BLINDED_BLOCK : GET_UNSIGNED_BLOCK_V2;
     beaconBlockSchema =
         blinded
             ? spec.atSlot(slot).getSchemaDefinitions().getBlindedBeaconBlockSchema()
             : spec.atSlot(slot).getSchemaDefinitions().getBeaconBlockSchema();
-    apiMethod = blinded ? GET_UNSIGNED_BLINDED_BLOCK : GET_UNSIGNED_BLOCK_V2;
     getBlockResponseDefinition =
         DeserializableTypeDefinition.object(GetBlockResponse.class)
             .initializer(GetBlockResponse::new)
@@ -107,8 +107,7 @@ public class CreateBlockRequest extends AbstractTypeDefRequest {
       // application/octet-stream is preferred, but will accept application/json
       headers.put("Accept", "application/octet-stream;q=0.9, application/json;q=0.4");
     }
-    return get(
-            apiMethod, Map.of("slot", this.slot.toString()), queryParams, headers, responseHandler)
+    return get(apiMethod, Map.of("slot", slot.toString()), queryParams, headers, responseHandler)
         .map(GetBlockResponse::getData);
   }
 

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/handlers/CreateBlockRequest.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/handlers/CreateBlockRequest.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.validator.remote.typedef.handlers;
 
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_NOT_FOUND;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_UNSIGNED_BLINDED_BLOCK;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_UNSIGNED_BLOCK_V2;
@@ -39,10 +40,13 @@ import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSchema;
 import tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod;
+import tech.pegasys.teku.validator.remote.typedef.BlindedBlockEndpointNotAvailableException;
 import tech.pegasys.teku.validator.remote.typedef.ResponseHandler;
 
 public class CreateBlockRequest extends AbstractTypeDefRequest {
+
   private static final Logger LOG = LogManager.getLogger();
+
   private final UInt64 slot;
   private final DeserializableTypeDefinition<GetBlockResponse> getBlockResponseDefinition;
   private final BeaconBlockSchema beaconBlockSchema;
@@ -58,14 +62,14 @@ public class CreateBlockRequest extends AbstractTypeDefRequest {
       final boolean blinded,
       final boolean preferSszBlockEncoding) {
     super(baseEndpoint, okHttpClient);
-    apiMethod = blinded ? GET_UNSIGNED_BLINDED_BLOCK : GET_UNSIGNED_BLOCK_V2;
     this.slot = slot;
     this.preferSszBlockEncoding = preferSszBlockEncoding;
-    this.beaconBlockSchema =
+    beaconBlockSchema =
         blinded
             ? spec.atSlot(slot).getSchemaDefinitions().getBlindedBeaconBlockSchema()
             : spec.atSlot(slot).getSchemaDefinitions().getBeaconBlockSchema();
-    this.getBlockResponseDefinition =
+    apiMethod = blinded ? GET_UNSIGNED_BLINDED_BLOCK : GET_UNSIGNED_BLOCK_V2;
+    getBlockResponseDefinition =
         DeserializableTypeDefinition.object(GetBlockResponse.class)
             .initializer(GetBlockResponse::new)
             .withField(
@@ -79,9 +83,17 @@ public class CreateBlockRequest extends AbstractTypeDefRequest {
                 GetBlockResponse::getSpecMilestone,
                 GetBlockResponse::setSpecMilestone)
             .build();
-    this.responseHandler =
+    final ResponseHandler<GetBlockResponse> responseHandler =
         new ResponseHandler<>(getBlockResponseDefinition)
             .withHandler(SC_OK, this::handleBeaconBlockResult);
+    this.responseHandler =
+        blinded
+            ? responseHandler.withHandler(
+                SC_NOT_FOUND,
+                (__, ___) -> {
+                  throw new BlindedBlockEndpointNotAvailableException();
+                })
+            : responseHandler;
   }
 
   public Optional<BeaconBlock> createUnsignedBlock(
@@ -95,8 +107,8 @@ public class CreateBlockRequest extends AbstractTypeDefRequest {
       // application/octet-stream is preferred, but will accept application/json
       headers.put("Accept", "application/octet-stream;q=0.9, application/json;q=0.4");
     }
-
-    return get(apiMethod, Map.of("slot", slot.toString()), queryParams, headers, responseHandler)
+    return get(
+            apiMethod, Map.of("slot", this.slot.toString()), queryParams, headers, responseHandler)
         .map(GetBlockResponse::getData);
   }
 


### PR DESCRIPTION
## PR Description

- Introduce `BlindedBlockEndpointNotAvailableException` which will be thrown in case blinded block endpoint is not available.
- Fallback to unblinded block in case the blinded block endpoint is not available.

## Fixed Issue(s)
fixes #5949 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
