### PR TITLE
Add option to track and log long tick processing times

### DIFF
--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
@@ -169,7 +169,7 @@ public class ForkChoiceTestExecutor implements TestExecutor {
         applyChecks(recentChainData, forkChoice, step);
 
       } else if (step.containsKey("tick")) {
-        forkChoice.onTick(secondsToMillis(getUInt64(step, "tick")));
+        forkChoice.onTick(secondsToMillis(getUInt64(step, "tick")), Optional.empty());
         final UInt64 currentSlot = recentChainData.getCurrentSlot().orElse(UInt64.ZERO);
         LOG.info("Current slot: {} Epoch: {}", currentSlot, spec.computeEpochAtSlot(currentSlot));
       } else if (step.containsKey("block")) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -635,13 +635,16 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
             });
   }
 
-  public void onTick(final UInt64 currentTimeMillis) {
+  public void onTick(
+      final UInt64 currentTimeMillis, final Optional<TickProcessingPerformance> performanceRecord) {
     final UInt64 previousSlot = spec.getCurrentSlot(recentChainData.getStore());
     tickProcessor.onTick(currentTimeMillis).join();
+    performanceRecord.ifPresent(TickProcessingPerformance::tickProcessorComplete);
     final UInt64 currentSlot = spec.getCurrentSlot(recentChainData.getStore());
     if (currentSlot.isGreaterThan(previousSlot)) {
       applyDeferredAttestations(currentSlot).ifExceptionGetsHereRaiseABug();
     }
+    performanceRecord.ifPresent(TickProcessingPerformance::deferredAttestationsApplied);
   }
 
   public SafeFuture<Void> prepareForBlockProduction(final UInt64 slot) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/TickProcessingPerformance.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/TickProcessingPerformance.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.forkchoice;
+
+import tech.pegasys.teku.infrastructure.logging.EventLogger;
+import tech.pegasys.teku.infrastructure.time.PerformanceTracker;
+import tech.pegasys.teku.infrastructure.time.TimeProvider;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+public class TickProcessingPerformance {
+
+  public static final String COMPLETE_LABEL = "complete";
+  public static final int LATE_EVENT_MS = 100;
+  private final PerformanceTracker performanceTracker;
+  private final UInt64 startTime;
+
+  public TickProcessingPerformance(final TimeProvider timeProvider, final UInt64 startTime) {
+    this.performanceTracker = new PerformanceTracker(timeProvider);
+    this.startTime = startTime;
+    performanceTracker.addEvent("start");
+  }
+
+  public void tickProcessorComplete() {
+    performanceTracker.addEvent("tick_processor_complete");
+  }
+
+  public void deferredAttestationsApplied() {
+    performanceTracker.addEvent("deferred_attestations_applied");
+  }
+
+  public void complete() {
+    final UInt64 completionTime = performanceTracker.addEvent(COMPLETE_LABEL);
+    final boolean isLateEvent = completionTime.minusMinZero(startTime).isGreaterThan(LATE_EVENT_MS);
+    performanceTracker.report(
+        startTime,
+        isLateEvent,
+        (event, stepDuration) -> {},
+        totalDuration -> {},
+        (totalDuration, timings) ->
+            EventLogger.EVENT_LOG.slowTickEvent(startTime, totalDuration, timings));
+  }
+
+  public void startSlotComplete() {
+    performanceTracker.addEvent("start_slot_complete");
+  }
+
+  public void attestationsDueComplete() {
+    performanceTracker.addEvent("attestations_due_complete");
+  }
+
+  public void precomputeEpochComplete() {
+    performanceTracker.addEvent("precompute_epoch_complete");
+  }
+
+  public void forkChoiceTriggerUpdated() {
+    performanceTracker.addEvent("forkchoice_trigger_updated");
+  }
+
+  public void forkChoiceNotifierUpdated() {
+    performanceTracker.addEvent("forkchoice_notifier_updated");
+  }
+}

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/TickProcessingPerformance.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/TickProcessingPerformance.java
@@ -21,7 +21,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 public class TickProcessingPerformance {
 
   public static final String COMPLETE_LABEL = "complete";
-  public static final int LATE_EVENT_MS = 100;
+  public static final int LATE_EVENT_MS = 500;
   private final PerformanceTracker performanceTracker;
   private final UInt64 startTime;
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
@@ -965,7 +965,8 @@ class ForkChoiceTest {
 
     // Should apply at start of next slot.
     forkChoice.onTick(
-        spec.getSlotStartTimeMillis(currentSlot.plus(1), recentChainData.getGenesisTimeMillis()));
+        spec.getSlotStartTimeMillis(currentSlot.plus(1), recentChainData.getGenesisTimeMillis()),
+        Optional.empty());
     processHead(currentSlot.plus(1));
 
     assertThat(forkChoiceStrategy.getWeight(targetBlock.getRoot()).orElseThrow())

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java
@@ -261,11 +261,20 @@ public class EventLogger {
 
   public void lateBlockImport(
       final Bytes32 root, final UInt64 slot, final UInt64 proposer, final String timings) {
-    String reorgEventLog =
+    String slowBlockLog =
         String.format(
             "Late Block Import *** Block: %s proposer %s %s",
             LogFormatter.formatBlock(slot, root), proposer, timings);
-    warn(reorgEventLog, Color.YELLOW);
+    warn(slowBlockLog, Color.YELLOW);
+  }
+
+  public void slowTickEvent(
+      final UInt64 tickTime, final UInt64 totalProcessingDuration, final String timings) {
+    final String slowTickLog =
+        String.format(
+            "Slow Tick Event   *** Time: %s %s total: %sms",
+            tickTime, timings, totalProcessingDuration);
+    warn(slowTickLog, Color.YELLOW);
   }
 
   public void executionLayerStubEnabled() {

--- a/infrastructure/metrics/src/main/java/tech/pegasys/teku/infrastructure/metrics/MetricsConfig.java
+++ b/infrastructure/metrics/src/main/java/tech/pegasys/teku/infrastructure/metrics/MetricsConfig.java
@@ -39,6 +39,7 @@ public class MetricsConfig {
   public static final int DEFAULT_IDLE_TIMEOUT_SECONDS = 60;
   public static final int DEFAULT_METRICS_PUBLICATION_INTERVAL = 60;
   public static final boolean DEFAULT_BLOCK_PERFORMANCE_ENABLED = false;
+  public static final boolean DEFAULT_TICK_PERFORMANCE_ENABLED = false;
 
   private final boolean metricsEnabled;
   private final int metricsPort;
@@ -49,6 +50,7 @@ public class MetricsConfig {
   private final int publicationInterval;
   private final int idleTimeoutSeconds;
   private final boolean blockPerformanceEnabled;
+  private final boolean tickPerformanceEnabled;
 
   private MetricsConfig(
       final boolean metricsEnabled,
@@ -59,7 +61,8 @@ public class MetricsConfig {
       final URL metricsEndpoint,
       final int publicationInterval,
       final int idleTimeoutSeconds,
-      final boolean blockPerformanceEnabled) {
+      final boolean blockPerformanceEnabled,
+      final boolean tickPerformanceEnabled) {
     this.metricsEnabled = metricsEnabled;
     this.metricsPort = metricsPort;
     this.metricsInterface = metricsInterface;
@@ -69,6 +72,7 @@ public class MetricsConfig {
     this.publicationInterval = publicationInterval;
     this.idleTimeoutSeconds = idleTimeoutSeconds;
     this.blockPerformanceEnabled = blockPerformanceEnabled;
+    this.tickPerformanceEnabled = tickPerformanceEnabled;
   }
 
   public static MetricsConfigBuilder builder() {
@@ -111,6 +115,10 @@ public class MetricsConfig {
     return blockPerformanceEnabled;
   }
 
+  public boolean isTickPerformanceEnabled() {
+    return tickPerformanceEnabled;
+  }
+
   public static final class MetricsConfigBuilder {
 
     private boolean metricsEnabled = false;
@@ -122,6 +130,7 @@ public class MetricsConfig {
     private int metricsPublishInterval = DEFAULT_METRICS_PUBLICATION_INTERVAL;
     private int idleTimeoutSeconds = DEFAULT_IDLE_TIMEOUT_SECONDS;
     private boolean blockPerformanceEnabled = DEFAULT_BLOCK_PERFORMANCE_ENABLED;
+    private boolean tickPerformanceEnabled = DEFAULT_TICK_PERFORMANCE_ENABLED;
 
     private MetricsConfigBuilder() {}
 
@@ -182,6 +191,11 @@ public class MetricsConfig {
       return this;
     }
 
+    public MetricsConfigBuilder tickPerformanceEnabled(final boolean tickPerformanceEnabled) {
+      this.tickPerformanceEnabled = tickPerformanceEnabled;
+      return this;
+    }
+
     public MetricsConfig build() {
       return new MetricsConfig(
           metricsEnabled,
@@ -192,7 +206,8 @@ public class MetricsConfig {
           metricsPublishEndpoint,
           metricsPublishInterval,
           idleTimeoutSeconds,
-          blockPerformanceEnabled);
+          blockPerformanceEnabled,
+          tickPerformanceEnabled);
     }
   }
 }

--- a/infrastructure/time/src/main/java/tech/pegasys/teku/infrastructure/time/PerformanceTracker.java
+++ b/infrastructure/time/src/main/java/tech/pegasys/teku/infrastructure/time/PerformanceTracker.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.time;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import org.apache.commons.lang3.tuple.Pair;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+public class PerformanceTracker {
+
+  private final TimeProvider timeProvider;
+  protected final List<Pair<String, UInt64>> events = new ArrayList<>();
+
+  public PerformanceTracker(final TimeProvider timeProvider) {
+    this.timeProvider = timeProvider;
+  }
+
+  public UInt64 addEvent(final String label) {
+    final UInt64 timestamp = timeProvider.getTimeInMillis();
+    events.add(Pair.of(label, timestamp));
+    return timestamp;
+  }
+
+  public void report(
+      final UInt64 startTime,
+      final boolean isLateEvent,
+      final EventReporter eventReporter,
+      final Consumer<UInt64> totalDurationReporter,
+      final SlowEventReporter slowEventReporter) {
+
+    final List<String> eventTimings = new ArrayList<>();
+
+    UInt64 previousEventTimestamp = startTime;
+    for (Pair<String, UInt64> event : events) {
+
+      // minusMinZero because sometimes time does actually go backwards so be safe.
+      final UInt64 stepDuration = event.getRight().minusMinZero(previousEventTimestamp);
+      previousEventTimestamp = event.getRight();
+
+      eventReporter.report(event, stepDuration);
+
+      if (isLateEvent) {
+        eventTimings.add(
+            event.getLeft() + (eventTimings.isEmpty() ? " " : " +") + stepDuration + "ms");
+      }
+    }
+
+    final UInt64 totalProcessingDuration =
+        events.get(events.size() - 1).getRight().minusMinZero(events.get(0).getRight());
+    totalDurationReporter.accept(totalProcessingDuration);
+
+    if (isLateEvent) {
+      final String combinedTimings = String.join(", ", eventTimings);
+      slowEventReporter.report(totalProcessingDuration, combinedTimings);
+    }
+  }
+
+  public interface EventReporter {
+    void report(Pair<String, UInt64> event, UInt64 stepDuration);
+  }
+
+  public interface SlowEventReporter {
+    void report(UInt64 totalDuration, String eventTimings);
+  }
+}

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/MetricsOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/MetricsOptions.java
@@ -99,6 +99,16 @@ public class MetricsOptions {
       arity = "0..1")
   private boolean blockPerformanceEnabled = MetricsConfig.DEFAULT_BLOCK_PERFORMANCE_ENABLED;
 
+  @Option(
+      names = {"--Xmetrics-tick-timing-tracking-enabled"},
+      hidden = true,
+      showDefaultValue = Visibility.ALWAYS,
+      paramLabel = "<BOOLEAN>",
+      description = "Whether time tick timing metrics are tracked and reported",
+      fallbackValue = "true",
+      arity = "0..1")
+  private boolean tickPerformanceEnabled = MetricsConfig.DEFAULT_TICK_PERFORMANCE_ENABLED;
+
   public void configure(TekuConfiguration.Builder builder) {
     builder.metrics(
         b ->
@@ -110,7 +120,8 @@ public class MetricsOptions {
                 .metricsPublishEndpoint(parseMetricsEndpointUrl())
                 .metricsPublishInterval(metricsPublicationInterval)
                 .idleTimeoutSeconds(idleTimeoutSeconds)
-                .blockPerformanceEnabled(blockPerformanceEnabled));
+                .blockPerformanceEnabled(blockPerformanceEnabled)
+                .tickPerformanceEnabled(tickPerformanceEnabled));
   }
 
   private URL parseMetricsEndpointUrl() {


### PR DESCRIPTION
## PR Description
Adds a hidden `--Xmetrics-tick-timing-tracking-enabled` option to track how long it takes to process a tick event and logs a warning if it takes more than 500ms (at which point the next tick event would be due).

The CLI option is in `MetricsOptions` to match the block timing option though at this stage metrics haven't been added for these timings. That is likely worth doing in a follow up.

## Fixed Issue(s)
#6016 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
