### PR TITLE
Add a debug subcommand to dump all hot blocks into a zip file as SSZ.

### DIFF
--- a/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
+import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.ethereum.pow.api.DepositsFromBlockEvent;
 import tech.pegasys.teku.ethereum.pow.api.MinGenesisTimeBlockEvent;
@@ -98,6 +99,9 @@ public interface Database extends AutoCloseable {
   Map<Bytes32, SignedBeaconBlock> getHotBlocks(final Set<Bytes32> blockRoots);
 
   Optional<SignedBeaconBlock> getHotBlock(final Bytes32 blockRoot);
+
+  @MustBeClosed
+  Stream<Bytes> streamHotBlocksAsSsz();
 
   /**
    * Return a {@link Stream} of blocks beginning at startSlot and ending at endSlot, both inclusive.

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/BlindedBlockKvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/BlindedBlockKvStoreDatabase.java
@@ -125,6 +125,12 @@ public class BlindedBlockKvStoreDatabase
 
   @Override
   @MustBeClosed
+  public Stream<Bytes> streamHotBlocksAsSsz() {
+    return dao.streamBlindedHotBlocksAsSsz();
+  }
+
+  @Override
+  @MustBeClosed
   public Stream<SignedBeaconBlock> streamFinalizedBlocks(
       final UInt64 startSlot, final UInt64 endSlot) {
     return dao.streamFinalizedBlockRoots(startSlot, endSlot)

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/UnblindedBlockKvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/UnblindedBlockKvStoreDatabase.java
@@ -26,6 +26,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
@@ -134,6 +135,11 @@ public class UnblindedBlockKvStoreDatabase
   @Override
   public Optional<SignedBeaconBlock> getHotBlock(final Bytes32 blockRoot) {
     return dao.getHotBlock(blockRoot);
+  }
+
+  @Override
+  public Stream<Bytes> streamHotBlocksAsSsz() {
+    return dao.streamUnblindedHotBlocksAsSsz();
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
@@ -113,6 +113,12 @@ public class CombinedKvStoreDao<S extends SchemaCombined>
   }
 
   @Override
+  @MustBeClosed
+  public Stream<Bytes> streamUnblindedHotBlocksAsSsz() {
+    return db.streamRaw(schema.getColumnHotBlocksByRoot()).map(ColumnEntry::getValue);
+  }
+
+  @Override
   public long countUnblindedHotBlocks() {
     try (final Stream<ColumnEntry<Bytes, Bytes>> rawEntries =
         db.streamRaw(schema.getColumnHotBlocksByRoot())) {
@@ -451,6 +457,14 @@ public class CombinedKvStoreDao<S extends SchemaCombined>
   @Override
   public Stream<SignedBeaconBlock> streamBlindedBlocks() {
     return db.stream(schema.getColumnBlindedBlocksByRoot()).map(ColumnEntry::getValue);
+  }
+
+  @Override
+  @MustBeClosed
+  public Stream<Bytes> streamBlindedHotBlocksAsSsz() {
+    return streamBlockCheckpoints()
+        .map(Map.Entry::getKey)
+        .flatMap(root -> getRaw(schema.getColumnBlindedBlocksByRoot(), root).stream());
   }
 
   private Optional<UInt64> displayCopyColumnMessage(

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoAdapter.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoAdapter.java
@@ -120,6 +120,21 @@ public class KvStoreCombinedDaoAdapter
   }
 
   @Override
+  @MustBeClosed
+  public Stream<Bytes> streamUnblindedHotBlocksAsSsz() {
+    return hotDao.streamUnblindedHotBlocksAsSsz();
+  }
+
+  @Override
+  @MustBeClosed
+  public Stream<Bytes> streamBlindedHotBlocksAsSsz() {
+    return hotDao
+        .streamBlockCheckpoints()
+        .map(Map.Entry::getKey)
+        .flatMap(root -> finalizedDao.getBlindedBlockAsSsz(root).stream());
+  }
+
+  @Override
   public long countUnblindedHotBlocks() {
     return hotDao.countUnblindedHotBlocks();
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoBlinded.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoBlinded.java
@@ -65,6 +65,9 @@ public interface KvStoreCombinedDaoBlinded extends KvStoreCombinedDaoCommon {
 
   Stream<SignedBeaconBlock> streamBlindedBlocks();
 
+  @MustBeClosed
+  Stream<Bytes> streamBlindedHotBlocksAsSsz();
+
   interface CombinedUpdaterBlinded
       extends HotUpdaterBlinded, FinalizedUpdaterBlinded, CombinedUpdaterCommon {}
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoUnblinded.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoUnblinded.java
@@ -40,6 +40,8 @@ public interface KvStoreCombinedDaoUnblinded extends KvStoreCombinedDaoCommon {
   @MustBeClosed
   Stream<SignedBeaconBlock> streamHotBlocks();
 
+  Stream<Bytes> streamUnblindedHotBlocksAsSsz();
+
   long countUnblindedHotBlocks();
 
   Optional<SignedBeaconBlock> getFinalizedBlock(final Bytes32 root);

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4FinalizedKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4FinalizedKvStoreDao.java
@@ -240,6 +240,10 @@ public class V4FinalizedKvStoreDao {
     return db.stream(schema.getColumnBlindedBlocksByRoot()).map(ColumnEntry::getValue);
   }
 
+  public Optional<Bytes> getBlindedBlockAsSsz(final Bytes32 blockRoot) {
+    return db.getRaw(schema.getColumnBlindedBlocksByRoot(), blockRoot);
+  }
+
   static class V4FinalizedUpdater implements FinalizedUpdaterBlinded, FinalizedUpdaterUnblinded {
     private final KvStoreTransaction transaction;
     private final KvStoreAccessor db;

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4HotKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4HotKvStoreDao.java
@@ -88,6 +88,11 @@ public class V4HotKvStoreDao {
     return db.stream(schema.getColumnHotBlocksByRoot()).map(ColumnEntry::getValue);
   }
 
+  @MustBeClosed
+  public Stream<Bytes> streamUnblindedHotBlocksAsSsz() {
+    return streamRawColumn(schema.getColumnHotBlocksByRoot()).map(ColumnEntry::getValue);
+  }
+
   public long countUnblindedHotBlocks() {
     try (final Stream<ColumnEntry<Bytes, Bytes>> rawEntries =
         db.streamRaw(schema.getColumnHotBlocksByRoot())) {

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
+import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.ethereum.pow.api.DepositsFromBlockEvent;
 import tech.pegasys.teku.ethereum.pow.api.MinGenesisTimeBlockEvent;
@@ -133,6 +134,11 @@ public class NoOpDatabase implements Database {
   @Override
   public Optional<SignedBeaconBlock> getHotBlock(final Bytes32 blockRoot) {
     return Optional.empty();
+  }
+
+  @Override
+  public Stream<Bytes> streamHotBlocksAsSsz() {
+    return Stream.empty();
   }
 
   @Override


### PR DESCRIPTION
## PR Description
Adds a `debug-tools db dump-hot-blocks` subcommand to dump all hot blocks as SSZ into a zip file. Importantly it dumps them without attempting to parse the SSZ so should work even for databases that didn't update for a hard fork.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
