### PR TITLE
Add debug db command to delete invalid blocks

### DIFF
--- a/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
@@ -101,7 +101,7 @@ public interface Database extends AutoCloseable {
   Optional<SignedBeaconBlock> getHotBlock(final Bytes32 blockRoot);
 
   @MustBeClosed
-  Stream<Bytes> streamHotBlocksAsSsz();
+  Stream<Map.Entry<Bytes, Bytes>> streamHotBlocksAsSsz();
 
   /**
    * Return a {@link Stream} of blocks beginning at startSlot and ending at endSlot, both inclusive.
@@ -150,4 +150,8 @@ public interface Database extends AutoCloseable {
 
   @MustBeClosed
   Stream<SignedBeaconBlock> streamBlindedBlocks();
+
+  Optional<Checkpoint> getJustifiedCheckpoint();
+
+  void deleteHotBlocks(Set<Bytes32> blockRootsToDelete);
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/BlindedBlockKvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/BlindedBlockKvStoreDatabase.java
@@ -125,7 +125,7 @@ public class BlindedBlockKvStoreDatabase
 
   @Override
   @MustBeClosed
-  public Stream<Bytes> streamHotBlocksAsSsz() {
+  public Stream<Map.Entry<Bytes, Bytes>> streamHotBlocksAsSsz() {
     return dao.streamBlindedHotBlocksAsSsz();
   }
 
@@ -261,6 +261,18 @@ public class BlindedBlockKvStoreDatabase
   @Override
   public Stream<SignedBeaconBlock> streamBlindedBlocks() {
     return dao.streamBlindedBlocks();
+  }
+
+  @Override
+  public void deleteHotBlocks(final Set<Bytes32> blockRootsToDelete) {
+    try (final CombinedUpdaterBlinded updater = dao.combinedUpdaterBlinded()) {
+      blockRootsToDelete.forEach(
+          root -> {
+            updater.deleteBlindedBlock(root);
+            updater.pruneHotBlockContext(root);
+          });
+      updater.commit();
+    }
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
@@ -506,6 +506,11 @@ public abstract class KvStoreDatabase<
   }
 
   @Override
+  public Optional<Checkpoint> getJustifiedCheckpoint() {
+    return dao.getJustifiedCheckpoint();
+  }
+
+  @Override
   public void close() throws Exception {
     dao.close();
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/UnblindedBlockKvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/UnblindedBlockKvStoreDatabase.java
@@ -138,7 +138,7 @@ public class UnblindedBlockKvStoreDatabase
   }
 
   @Override
-  public Stream<Bytes> streamHotBlocksAsSsz() {
+  public Stream<Map.Entry<Bytes, Bytes>> streamHotBlocksAsSsz() {
     return dao.streamUnblindedHotBlocksAsSsz();
   }
 
@@ -221,6 +221,14 @@ public class UnblindedBlockKvStoreDatabase
   @Override
   public Stream<SignedBeaconBlock> streamBlindedBlocks() {
     return Stream.empty();
+  }
+
+  @Override
+  public void deleteHotBlocks(final Set<Bytes32> blockRootsToDelete) {
+    try (final HotUpdaterUnblinded updater = hotUpdater()) {
+      blockRootsToDelete.forEach(updater::deleteHotBlock);
+      updater.commit();
+    }
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
@@ -114,8 +114,8 @@ public class CombinedKvStoreDao<S extends SchemaCombined>
 
   @Override
   @MustBeClosed
-  public Stream<Bytes> streamUnblindedHotBlocksAsSsz() {
-    return db.streamRaw(schema.getColumnHotBlocksByRoot()).map(ColumnEntry::getValue);
+  public Stream<Map.Entry<Bytes, Bytes>> streamUnblindedHotBlocksAsSsz() {
+    return db.streamRaw(schema.getColumnHotBlocksByRoot()).map(a -> a);
   }
 
   @Override
@@ -461,10 +461,14 @@ public class CombinedKvStoreDao<S extends SchemaCombined>
 
   @Override
   @MustBeClosed
-  public Stream<Bytes> streamBlindedHotBlocksAsSsz() {
+  public Stream<Map.Entry<Bytes, Bytes>> streamBlindedHotBlocksAsSsz() {
     return streamBlockCheckpoints()
         .map(Map.Entry::getKey)
-        .flatMap(root -> getRaw(schema.getColumnBlindedBlocksByRoot(), root).stream());
+        .flatMap(
+            root ->
+                getRaw(schema.getColumnBlindedBlocksByRoot(), root)
+                    .<Map.Entry<Bytes, Bytes>>map(block -> ColumnEntry.create(root, block))
+                    .stream());
   }
 
   private Optional<UInt64> displayCopyColumnMessage(

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
@@ -115,7 +115,7 @@ public class CombinedKvStoreDao<S extends SchemaCombined>
   @Override
   @MustBeClosed
   public Stream<Map.Entry<Bytes, Bytes>> streamUnblindedHotBlocksAsSsz() {
-    return db.streamRaw(schema.getColumnHotBlocksByRoot()).map(a -> a);
+    return db.streamRaw(schema.getColumnHotBlocksByRoot()).map(entry -> entry);
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoAdapter.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoAdapter.java
@@ -121,17 +121,22 @@ public class KvStoreCombinedDaoAdapter
 
   @Override
   @MustBeClosed
-  public Stream<Bytes> streamUnblindedHotBlocksAsSsz() {
+  public Stream<Map.Entry<Bytes, Bytes>> streamUnblindedHotBlocksAsSsz() {
     return hotDao.streamUnblindedHotBlocksAsSsz();
   }
 
   @Override
   @MustBeClosed
-  public Stream<Bytes> streamBlindedHotBlocksAsSsz() {
+  public Stream<Map.Entry<Bytes, Bytes>> streamBlindedHotBlocksAsSsz() {
     return hotDao
         .streamBlockCheckpoints()
         .map(Map.Entry::getKey)
-        .flatMap(root -> finalizedDao.getBlindedBlockAsSsz(root).stream());
+        .flatMap(
+            root ->
+                finalizedDao
+                    .getBlindedBlockAsSsz(root)
+                    .<Map.Entry<Bytes, Bytes>>map(block -> ColumnEntry.create(root, block))
+                    .stream());
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoBlinded.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoBlinded.java
@@ -66,7 +66,7 @@ public interface KvStoreCombinedDaoBlinded extends KvStoreCombinedDaoCommon {
   Stream<SignedBeaconBlock> streamBlindedBlocks();
 
   @MustBeClosed
-  Stream<Bytes> streamBlindedHotBlocksAsSsz();
+  Stream<Map.Entry<Bytes, Bytes>> streamBlindedHotBlocksAsSsz();
 
   interface CombinedUpdaterBlinded
       extends HotUpdaterBlinded, FinalizedUpdaterBlinded, CombinedUpdaterCommon {}

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoUnblinded.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoUnblinded.java
@@ -40,7 +40,7 @@ public interface KvStoreCombinedDaoUnblinded extends KvStoreCombinedDaoCommon {
   @MustBeClosed
   Stream<SignedBeaconBlock> streamHotBlocks();
 
-  Stream<Bytes> streamUnblindedHotBlocksAsSsz();
+  Stream<Map.Entry<Bytes, Bytes>> streamUnblindedHotBlocksAsSsz();
 
   long countUnblindedHotBlocks();
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4HotKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4HotKvStoreDao.java
@@ -89,8 +89,8 @@ public class V4HotKvStoreDao {
   }
 
   @MustBeClosed
-  public Stream<Bytes> streamUnblindedHotBlocksAsSsz() {
-    return streamRawColumn(schema.getColumnHotBlocksByRoot()).map(ColumnEntry::getValue);
+  public Stream<Map.Entry<Bytes, Bytes>> streamUnblindedHotBlocksAsSsz() {
+    return streamRawColumn(schema.getColumnHotBlocksByRoot()).map(a -> a);
   }
 
   public long countUnblindedHotBlocks() {

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4HotKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4HotKvStoreDao.java
@@ -90,7 +90,7 @@ public class V4HotKvStoreDao {
 
   @MustBeClosed
   public Stream<Map.Entry<Bytes, Bytes>> streamUnblindedHotBlocksAsSsz() {
-    return streamRawColumn(schema.getColumnHotBlocksByRoot()).map(a -> a);
+    return streamRawColumn(schema.getColumnHotBlocksByRoot()).map(entry -> entry);
   }
 
   public long countUnblindedHotBlocks() {

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
@@ -137,7 +137,7 @@ public class NoOpDatabase implements Database {
   }
 
   @Override
-  public Stream<Bytes> streamHotBlocksAsSsz() {
+  public Stream<Map.Entry<Bytes, Bytes>> streamHotBlocksAsSsz() {
     return Stream.empty();
   }
 
@@ -221,6 +221,14 @@ public class NoOpDatabase implements Database {
   public Stream<SignedBeaconBlock> streamBlindedBlocks() {
     return Stream.empty();
   }
+
+  @Override
+  public Optional<Checkpoint> getJustifiedCheckpoint() {
+    return Optional.empty();
+  }
+
+  @Override
+  public void deleteHotBlocks(final Set<Bytes32> blockRootsToDelete) {}
 
   @Override
   public void close() {}

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugDbCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugDbCommand.java
@@ -17,8 +17,11 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.util.HashSet;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
@@ -27,6 +30,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
+import picocli.CommandLine.Help.Visibility;
 import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Option;
 import tech.pegasys.teku.cli.converter.PicoCliVersionProvider;
@@ -40,8 +44,10 @@ import tech.pegasys.teku.infrastructure.async.MetricTrackingExecutorFactory;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.service.serviceutils.layout.DataDirLayout;
 import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockInvariants;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
+import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.storage.server.Database;
 import tech.pegasys.teku.storage.server.DatabaseStorageException;
@@ -325,7 +331,7 @@ public class DebugDbCommand implements Runnable {
       optionListHeading = "%nOptions:%n",
       footerHeading = "%n",
       footer = "Teku is licensed under the Apache License 2.0")
-  public int validateBlockHistory(
+  public int dumpHotBlocks(
       @Mixin final BeaconNodeDataOptions beaconNodeDataOptions,
       @Mixin final Eth2NetworkOptions eth2NetworkOptions,
       @Option(
@@ -336,7 +342,7 @@ public class DebugDbCommand implements Runnable {
       throws Exception {
     int index = 0;
     try (final Database database = createDatabase(beaconNodeDataOptions, eth2NetworkOptions);
-        final Stream<Bytes> blockStream = database.streamHotBlocksAsSsz();
+        final Stream<Bytes> blockStream = database.streamHotBlocksAsSsz().map(Map.Entry::getValue);
         final ZipOutputStream out =
             new ZipOutputStream(
                 Files.newOutputStream(outputFile, StandardOpenOption.TRUNCATE_EXISTING))) {
@@ -349,6 +355,95 @@ public class DebugDbCommand implements Runnable {
     }
     System.out.println("Wrote " + index + " blocks to " + outputFile.toAbsolutePath());
     return 0;
+  }
+
+  @Command(
+      name = "delete-hot-blocks",
+      description = "Writes all non-finalized blocks in the database as a zip of SSZ files",
+      mixinStandardHelpOptions = true,
+      showDefaultValues = true,
+      abbreviateSynopsis = true,
+      versionProvider = PicoCliVersionProvider.class,
+      synopsisHeading = "%n",
+      descriptionHeading = "%nDescription:%n%n",
+      optionListHeading = "%nOptions:%n",
+      footerHeading = "%n",
+      footer = "Teku is licensed under the Apache License 2.0")
+  public int deleteHotBlocks(
+      @Mixin final BeaconNodeDataOptions beaconNodeDataOptions,
+      @Mixin final Eth2NetworkOptions eth2NetworkOptions,
+      @Option(
+              names = {"--delete-all", "-a"},
+              description =
+                  "Delete all non-finalized blocks, not just those from an invalid hard fork",
+              defaultValue = "false",
+              fallbackValue = "true",
+              showDefaultValue = Visibility.ALWAYS)
+          final boolean deleteAll)
+      throws Exception {
+    final Spec spec = eth2NetworkOptions.getNetworkConfiguration().getSpec();
+    try (final Database database = createDatabase(beaconNodeDataOptions, eth2NetworkOptions); ) {
+      final Optional<Checkpoint> justified = database.getJustifiedCheckpoint();
+      if (justified.isEmpty()) {
+        System.out.println(
+            "Unable to delete hot blocks because the justified checkpoint is not available");
+        return 1;
+      }
+      final UInt64 justifiedSlot = justified.get().getEpochStartSlot(spec);
+      System.out.println("Justified slot is " + justifiedSlot);
+      final Set<Bytes32> blockRootsToDelete = new HashSet<>();
+      try (final Stream<Map.Entry<Bytes, Bytes>> blockStream = database.streamHotBlocksAsSsz()) {
+        // Iterate through and find the block roots to delete first
+        for (final Iterator<Map.Entry<Bytes, Bytes>> iterator = blockStream.iterator();
+            iterator.hasNext(); ) {
+          final Map.Entry<Bytes, Bytes> rootAndBlock = iterator.next();
+          final Bytes blockData = rootAndBlock.getValue();
+          final UInt64 blockSlot = BeaconBlockInvariants.extractSignedBeaconBlockSlot(blockData);
+          final boolean shouldDelete;
+          final boolean isJustifiedBlock = blockSlot.isLessThanOrEqualTo(justifiedSlot);
+          if (deleteAll) {
+            if (isJustifiedBlock) {
+              System.out.printf(
+                  "Not deleting block at slot %s as it has been justified%n", blockSlot);
+              shouldDelete = false;
+            } else {
+              shouldDelete = true;
+            }
+          } else {
+            final boolean canParse = canParseBlock(beaconNodeDataOptions, spec, blockData);
+            if (!canParse && isJustifiedBlock) {
+              System.out.printf(
+                  "Block at slot %s is justified but cannot be parsed. Unable to recover this database.%n",
+                  blockSlot);
+              return 1;
+            }
+            shouldDelete = !canParse;
+          }
+
+          if (shouldDelete) {
+            blockRootsToDelete.add(Bytes32.wrap(rootAndBlock.getKey()));
+          }
+        }
+      }
+
+      System.out.printf("Deleting %d blocks%n", blockRootsToDelete.size());
+      database.deleteHotBlocks(blockRootsToDelete);
+    }
+    return 0;
+  }
+
+  private boolean canParseBlock(
+      final BeaconNodeDataOptions beaconNodeDataOptions, final Spec spec, final Bytes blockData) {
+    try {
+      if (beaconNodeDataOptions.isStoreBlockExecutionPayloadSeparately()) {
+        spec.deserializeSignedBlindedBeaconBlock(blockData);
+      } else {
+        spec.deserializeSignedBeaconBlock(blockData);
+      }
+      return true;
+    } catch (final Exception e) {
+      return false;
+    }
   }
 
   private Optional<SignedBeaconBlock> findFinalizedBlockBeforeSlot(

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugDbCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugDbCommand.java
@@ -359,7 +359,7 @@ public class DebugDbCommand implements Runnable {
 
   @Command(
       name = "delete-hot-blocks",
-      description = "Writes all non-finalized blocks in the database as a zip of SSZ files",
+      description = "Writes all non-justified blocks in the database as a zip of SSZ files",
       mixinStandardHelpOptions = true,
       showDefaultValues = true,
       abbreviateSynopsis = true,
@@ -375,7 +375,7 @@ public class DebugDbCommand implements Runnable {
       @Option(
               names = {"--delete-all", "-a"},
               description =
-                  "Delete all non-finalized blocks, not just those from an invalid hard fork",
+                  "Delete all blocks that have not been justified, not just those from an invalid hard fork",
               defaultValue = "false",
               fallbackValue = "true",
               showDefaultValue = Visibility.ALWAYS)


### PR DESCRIPTION
## PR Description
Enables recovery of the database when a node is not upgraded before a hard fork without having to do a full re-sync.

It will refuse to delete any blocks at or before the justified checkpoint as doing so would mean Teku has no valid head when it restarts.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
