### PR TITLE
[Java API] Make GossipTopicHandlers class public

### DIFF
--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/gossip/GossipTopicHandlers.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/gossip/GossipTopicHandlers.java
@@ -18,7 +18,7 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import tech.pegasys.teku.networking.p2p.gossip.TopicHandler;
 
-class GossipTopicHandlers {
+public class GossipTopicHandlers {
 
   private final Map<String, TopicHandler> topicToHandlerMap = new ConcurrentHashMap<>();
 


### PR DESCRIPTION
## PR Description

Make `GossipTopicHandlers` class public as it's a part of unofficial Java API: used as a `LibP2PGossipNetworkBuilder.createGossip()` parameter

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
