### PR TITLE
Log full block when block import fails with internal error

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/BlockImporter.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/BlockImporter.java
@@ -218,7 +218,7 @@ public class BlockImporter {
   }
 
   private String getBlockContent(final SignedBeaconBlock block) {
-    return block.getMessage().sszSerialize().toHexString();
+    return block.sszSerialize().toHexString();
   }
 
   private ReadOnlyForkChoiceStrategy getForkChoiceStrategy() {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/BlockImporter.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/BlockImporter.java
@@ -123,7 +123,7 @@ public class BlockImporter {
             })
         .exceptionally(
             (e) -> {
-              String internalErrorMessage =
+              final String internalErrorMessage =
                   String.format(
                       "Internal error while importing block: %s. Block content: %s",
                       formatBlock(block), getBlockContent(block));

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/BlockImporter.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/BlockImporter.java
@@ -123,7 +123,11 @@ public class BlockImporter {
             })
         .exceptionally(
             (e) -> {
-              LOG.error("Internal error while importing block: {}", formatBlock(block), e);
+              String internalErrorMessage =
+                  String.format(
+                      "Internal error while importing block: %s. Block content: %s",
+                      formatBlock(block), getBlockContent(block));
+              LOG.error(internalErrorMessage, e);
               return BlockImportResult.internalError(e);
             });
   }
@@ -211,6 +215,10 @@ public class BlockImporter {
 
   private String formatBlock(final SignedBeaconBlock block) {
     return LogFormatter.formatBlock(block.getSlot(), block.getRoot());
+  }
+
+  private String getBlockContent(final SignedBeaconBlock block) {
+    return block.getMessage().sszSerialize().toHexString();
   }
 
   private ReadOnlyForkChoiceStrategy getForkChoiceStrategy() {


### PR DESCRIPTION
## PR Description
Enhance error log when importing a block with hex encoded ssz of the block contents.

## Fixed Issue(s)
fixes #6021 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
