### PR TITLE
Fix dump-hot-blocks command so it creates the file correctly

### DIFF
--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugDbCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugDbCommand.java
@@ -345,7 +345,8 @@ public class DebugDbCommand implements Runnable {
         final Stream<Bytes> blockStream = database.streamHotBlocksAsSsz().map(Map.Entry::getValue);
         final ZipOutputStream out =
             new ZipOutputStream(
-                Files.newOutputStream(outputFile, StandardOpenOption.TRUNCATE_EXISTING))) {
+                Files.newOutputStream(
+                    outputFile, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING))) {
       for (final Iterator<Bytes> iterator = blockStream.iterator(); iterator.hasNext(); ) {
         out.putNextEntry(new ZipEntry(index + ".ssz"));
         final Bytes blockData = iterator.next();


### PR DESCRIPTION
## PR Description
Previously the dump-hot-blocks debug command would only overwrite an existing file. Now it much more usefully also supports creating the output file when it doesn't exist.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
