### PR TITLE
Remove unnecessary configuration exception

### DIFF
--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
@@ -253,7 +253,7 @@ public class ExecutionLayerManagerImpl implements ExecutionLayerManager {
     if (!isFallbackCall
         && isBuilderAvailable()
         && spec.atSlot(slot).getMilestone().isGreaterThanOrEqualTo(SpecMilestone.BELLATRIX)) {
-      LOG.warn("builder endpoint is available but a non-blinded block has been requested");
+      LOG.warn("Builder endpoint is available but a non-blinded block has been requested");
     }
 
     return executionEngineClient
@@ -319,7 +319,7 @@ public class ExecutionLayerManagerImpl implements ExecutionLayerManager {
 
     if (!isBuilderAvailable()) {
       return SafeFuture.failedFuture(
-          new RuntimeException("unable to register validators: builder not available"));
+          new RuntimeException("Unable to register validators: builder not available"));
     }
 
     return executionBuilderClient
@@ -426,7 +426,7 @@ public class ExecutionLayerManagerImpl implements ExecutionLayerManager {
 
     if (maybeProcessedSlot.isEmpty()) {
       LOG.warn(
-          "Blinded block seems not been built via either builder or local engine. Trying to unblind it via builder endpoint anyway.");
+          "Blinded block seems to not be built via either builder or local EL. Trying to unblind it via builder endpoint anyway.");
       return getPayloadFromBuilder(signedBlindedBeaconBlock);
     }
 
@@ -467,7 +467,7 @@ public class ExecutionLayerManagerImpl implements ExecutionLayerManager {
         .orElseThrow(
             () ->
                 new RuntimeException(
-                    "unable to get payload from builder: builder endpoint not available"))
+                    "Unable to get payload from builder: builder endpoint not available"))
         .getPayload(signedBlindedBeaconBlock)
         .thenApply(ExecutionLayerManagerImpl::unwrapResponseOrThrow)
         .thenPeek(

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
@@ -506,7 +506,6 @@ public class ValidatorConfig {
       validateExternalSignerTruststoreAndPasswordFileConfig();
       validateExternalSignerURLScheme();
       validateValidatorsRegistrationAndBlindedBlocks();
-      validatorsRegistrationDefaultEnabledOrProposerConfigSource();
       return new ValidatorConfig(
           validatorKeys,
           validatorExternalSignerPublicKeySources,
@@ -590,13 +589,6 @@ public class ValidatorConfig {
         LOG.info(
             "'--validators-builder-registration-default-enabled' requires '--validators-proposer-blinded-blocks-enabled', enabling it");
         blindedBlocksEnabled = true;
-      }
-    }
-
-    private void validatorsRegistrationDefaultEnabledOrProposerConfigSource() {
-      if (validatorsRegistrationDefaultEnabled && proposerConfigSource.isPresent()) {
-        throw new InvalidConfigurationException(
-            "Invalid configuration. --validators-builder-registration-default-enabled cannot be specified when --validators-proposer-config is used");
       }
     }
 

--- a/validator/api/src/test/java/tech/pegasys/teku/validator/api/ValidatorConfigTest.java
+++ b/validator/api/src/test/java/tech/pegasys/teku/validator/api/ValidatorConfigTest.java
@@ -98,18 +98,6 @@ class ValidatorConfigTest {
   }
 
   @Test
-  public void
-      shouldThrowIfValidatorsRegistrationDefaultEnabledAndValidatorProposerConfigSpecified() {
-    final ValidatorConfig.Builder builder =
-        configBuilder.builderRegistrationDefaultEnabled(true).proposerConfigSource("somepath");
-
-    Assertions.assertThatExceptionOfType(InvalidConfigurationException.class)
-        .isThrownBy(builder::build)
-        .withMessageContaining(
-            "Invalid configuration. --validators-builder-registration-default-enabled cannot be specified when --validators-proposer-config is used");
-  }
-
-  @Test
   public void shouldThrowIfExternalSignerTruststorePasswordFileIsSpecifiedWithoutTruststore() {
     final ValidatorConfig.Builder builder =
         configBuilder.validatorExternalSignerTruststorePasswordFile(Path.of("somepath"));


### PR DESCRIPTION
## PR Description
Remove `InvalidConfigurationException` since it is unnecessary. The `ValidatorRegistrator` would prefer a value from the proposer config if specified, but otherwise it defaults to the cli option. It is good to allow this since `builder` in the proposer config is an optional element.

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
