### PR TITLE
Added getExecutionPayload database interface

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayload.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayload.java
@@ -104,7 +104,7 @@ public class ExecutionPayload
   }
 
   @Override
-  public boolean isDefault() {
+  public boolean isDefaultPayload() {
     return super.isDefault();
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayload.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayload.java
@@ -104,6 +104,11 @@ public class ExecutionPayload
   }
 
   @Override
+  public boolean isDefault() {
+    return super.isDefault();
+  }
+
+  @Override
   public ExecutionPayloadSchema getSchema() {
     return (ExecutionPayloadSchema) super.getSchema();
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadHeader.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadHeader.java
@@ -103,8 +103,8 @@ public class ExecutionPayloadHeader
   }
 
   @Override
-  public boolean isDefault() {
-    return super.isDefault();
+  public boolean isDefaultPayload() {
+    return isHeaderOfDefaultPayload();
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadHeader.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadHeader.java
@@ -103,6 +103,11 @@ public class ExecutionPayloadHeader
   }
 
   @Override
+  public boolean isDefault() {
+    return super.isDefault();
+  }
+
+  @Override
   public ExecutionPayloadHeaderSchema getSchema() {
     return (ExecutionPayloadHeaderSchema) super.getSchema();
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadSummary.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadSummary.java
@@ -49,5 +49,5 @@ public interface ExecutionPayloadSummary {
 
   Bytes32 getPayloadHash();
 
-  boolean isDefault();
+  boolean isDefaultPayload();
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadSummary.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadSummary.java
@@ -48,4 +48,6 @@ public interface ExecutionPayloadSummary {
   Bytes getExtraData();
 
   Bytes32 getPayloadHash();
+
+  boolean isDefault();
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/SlotAndExecutionPayloadSummary.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/SlotAndExecutionPayloadSummary.java
@@ -19,28 +19,29 @@ import java.util.Optional;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 
-public class SlotAndExecutionPayload {
+public class SlotAndExecutionPayloadSummary {
   private final UInt64 slot;
-  private final ExecutionPayload executionPayload;
+  private final ExecutionPayloadSummary executionPayload;
 
-  public SlotAndExecutionPayload(final UInt64 slot, final ExecutionPayload executionPayload) {
+  public SlotAndExecutionPayloadSummary(
+      final UInt64 slot, final ExecutionPayloadSummary executionPayloadSummary) {
     this.slot = slot;
-    this.executionPayload = executionPayload;
+    this.executionPayload = executionPayloadSummary;
   }
 
-  public static Optional<SlotAndExecutionPayload> fromBlock(final SignedBeaconBlock block) {
+  public static Optional<SlotAndExecutionPayloadSummary> fromBlock(final SignedBeaconBlock block) {
     return block
         .getMessage()
         .getBody()
-        .getOptionalExecutionPayload()
-        .map(payload -> new SlotAndExecutionPayload(block.getSlot(), payload));
+        .getOptionalExecutionPayloadSummary()
+        .map(payload -> new SlotAndExecutionPayloadSummary(block.getSlot(), payload));
   }
 
   public UInt64 getSlot() {
     return slot;
   }
 
-  public ExecutionPayload getExecutionPayload() {
+  public ExecutionPayloadSummary getExecutionPayload() {
     return executionPayload;
   }
 
@@ -52,7 +53,7 @@ public class SlotAndExecutionPayload {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    final SlotAndExecutionPayload that = (SlotAndExecutionPayload) o;
+    final SlotAndExecutionPayloadSummary that = (SlotAndExecutionPayloadSummary) o;
     return Objects.equals(slot, that.slot)
         && Objects.equals(executionPayload, that.executionPayload);
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/SlotAndExecutionPayloadSummary.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/SlotAndExecutionPayloadSummary.java
@@ -21,12 +21,12 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 
 public class SlotAndExecutionPayloadSummary {
   private final UInt64 slot;
-  private final ExecutionPayloadSummary executionPayload;
+  private final ExecutionPayloadSummary executionPayloadSummary;
 
   public SlotAndExecutionPayloadSummary(
       final UInt64 slot, final ExecutionPayloadSummary executionPayloadSummary) {
     this.slot = slot;
-    this.executionPayload = executionPayloadSummary;
+    this.executionPayloadSummary = executionPayloadSummary;
   }
 
   public static Optional<SlotAndExecutionPayloadSummary> fromBlock(final SignedBeaconBlock block) {
@@ -41,8 +41,8 @@ public class SlotAndExecutionPayloadSummary {
     return slot;
   }
 
-  public ExecutionPayloadSummary getExecutionPayload() {
-    return executionPayload;
+  public ExecutionPayloadSummary getExecutionPayloadSummary() {
+    return executionPayloadSummary;
   }
 
   @Override
@@ -55,19 +55,19 @@ public class SlotAndExecutionPayloadSummary {
     }
     final SlotAndExecutionPayloadSummary that = (SlotAndExecutionPayloadSummary) o;
     return Objects.equals(slot, that.slot)
-        && Objects.equals(executionPayload, that.executionPayload);
+        && Objects.equals(executionPayloadSummary, that.executionPayloadSummary);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(slot, executionPayload);
+    return Objects.hash(slot, executionPayloadSummary);
   }
 
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
         .add("slot", slot)
-        .add("executionPayload", executionPayload)
+        .add("executionPayload", executionPayloadSummary)
         .toString();
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ReadOnlyStore.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ReadOnlyStore.java
@@ -26,7 +26,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
-import tech.pegasys.teku.spec.datastructures.execution.SlotAndExecutionPayload;
+import tech.pegasys.teku.spec.datastructures.execution.SlotAndExecutionPayloadSummary;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.CheckpointState;
@@ -74,7 +74,7 @@ public interface ReadOnlyStore {
 
   AnchorPoint getLatestFinalized();
 
-  Optional<SlotAndExecutionPayload> getFinalizedOptimisticTransitionPayload();
+  Optional<SlotAndExecutionPayloadSummary> getFinalizedOptimisticTransitionPayload();
 
   Checkpoint getBestJustifiedCheckpoint();
 

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadSummaryTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadSummaryTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.execution;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsBellatrix;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+class ExecutionPayloadSummaryTest {
+  private final Spec spec = TestSpecFactory.createMainnetBellatrix();
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+
+  @Test
+  void shouldIdentifyDefaultPayload() {
+    final ExecutionPayload defaultPayload =
+        SchemaDefinitionsBellatrix.required(spec.getGenesisSpec().getSchemaDefinitions())
+            .getExecutionPayloadSchema()
+            .getDefault();
+
+    final ExecutionPayloadSummary summary = defaultPayload;
+    assertThat(defaultPayload.isDefault()).isTrue();
+    assertThat(defaultPayload.isDefaultPayload()).isTrue();
+    assertThat(summary.isDefaultPayload()).isTrue();
+  }
+
+  @Test
+  void shouldIdentifyNonDefaultPayload() {
+    final ExecutionPayload payload = dataStructureUtil.randomExecutionPayload();
+    final ExecutionPayloadSummary summary = payload;
+    assertThat(payload.isDefault()).isFalse();
+    assertThat(payload.isDefaultPayload()).isFalse();
+    assertThat(summary.isDefaultPayload()).isFalse();
+  }
+
+  @Test
+  void shouldIdentifyDefaultPayloadHeader() {
+    final ExecutionPayloadHeader header =
+        SchemaDefinitionsBellatrix.required(spec.getGenesisSpec().getSchemaDefinitions())
+            .getExecutionPayloadHeaderSchema()
+            .getHeaderOfDefaultPayload();
+    final ExecutionPayloadSummary summary = header;
+    /* note - header identifies non default from the ssz `isDefault` */
+    assertThat(header.isDefault()).isFalse();
+    assertThat(summary.isDefaultPayload()).isTrue();
+  }
+
+  @Test
+  void shouldIdentifyNonDefaultPayloadHeader() {
+    final ExecutionPayloadHeader header = dataStructureUtil.randomExecutionPayloadHeader();
+    final ExecutionPayloadSummary summary = header;
+    assertThat(header.isDefault()).isFalse();
+    assertThat(header.isDefaultPayload()).isFalse();
+    assertThat(summary.isDefaultPayload()).isFalse();
+  }
+}

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
@@ -32,7 +32,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
-import tech.pegasys.teku.spec.datastructures.execution.SlotAndExecutionPayload;
+import tech.pegasys.teku.spec.datastructures.execution.SlotAndExecutionPayloadSummary;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.CheckpointState;
@@ -121,7 +121,7 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
   }
 
   @Override
-  public Optional<SlotAndExecutionPayload> getFinalizedOptimisticTransitionPayload() {
+  public Optional<SlotAndExecutionPayloadSummary> getFinalizedOptimisticTransitionPayload() {
     return Optional.empty();
   }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/MergeTransitionBlockValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/MergeTransitionBlockValidator.java
@@ -26,6 +26,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.bellatrix.BeaconBlockBodyBellatrix;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSummary;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannel;
 import tech.pegasys.teku.spec.executionlayer.PayloadStatus;
@@ -134,7 +135,7 @@ public class MergeTransitionBlockValidator {
   }
 
   private SafeFuture<PayloadStatus> verifyTransitionPayload(
-      final UInt64 slot, final ExecutionPayload executionPayload) {
+      final UInt64 slot, final ExecutionPayloadSummary executionPayload) {
     final BellatrixTransitionHelpers bellatrixTransitionHelpers =
         spec.atSlot(slot)
             .getBellatrixTransitionHelpers()

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/MergeTransitionBlockValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/MergeTransitionBlockValidator.java
@@ -91,7 +91,7 @@ public class MergeTransitionBlockValidator {
         .map(
             slotAndPayload ->
                 verifyTransitionPayload(
-                    slotAndPayload.getSlot(), slotAndPayload.getExecutionPayload()))
+                    slotAndPayload.getSlot(), slotAndPayload.getExecutionPayloadSummary()))
         .orElse(SafeFuture.completedFuture(PayloadStatus.VALID))
         .thenCompose(
             status -> {

--- a/storage/api/src/main/java/tech/pegasys/teku/storage/api/OnDiskStoreData.java
+++ b/storage/api/src/main/java/tech/pegasys/teku/storage/api/OnDiskStoreData.java
@@ -18,7 +18,7 @@ import java.util.Objects;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.datastructures.execution.SlotAndExecutionPayload;
+import tech.pegasys.teku.spec.datastructures.execution.SlotAndExecutionPayloadSummary;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
@@ -33,14 +33,14 @@ public class OnDiskStoreData {
   private final Checkpoint bestJustifiedCheckpoint;
   private final Map<Bytes32, StoredBlockMetadata> blockInformation;
   private final Map<UInt64, VoteTracker> votes;
-  private final Optional<SlotAndExecutionPayload> finalizedOptimisticTransitionPayload;
+  private final Optional<SlotAndExecutionPayloadSummary> finalizedOptimisticTransitionPayload;
 
   public OnDiskStoreData(
       final UInt64 time,
       final Optional<Checkpoint> anchor,
       final UInt64 genesisTime,
       final AnchorPoint latestFinalized,
-      final Optional<SlotAndExecutionPayload> finalizedOptimisticTransitionPayload,
+      final Optional<SlotAndExecutionPayloadSummary> finalizedOptimisticTransitionPayload,
       final Checkpoint justifiedCheckpoint,
       final Checkpoint bestJustifiedCheckpoint,
       final Map<Bytes32, StoredBlockMetadata> blockInformation,
@@ -89,7 +89,7 @@ public class OnDiskStoreData {
     return votes;
   }
 
-  public Optional<SlotAndExecutionPayload> getFinalizedOptimisticTransitionPayload() {
+  public Optional<SlotAndExecutionPayloadSummary> getFinalizedOptimisticTransitionPayload() {
     return finalizedOptimisticTransitionPayload;
   }
 

--- a/storage/api/src/main/java/tech/pegasys/teku/storage/api/UpdateResult.java
+++ b/storage/api/src/main/java/tech/pegasys/teku/storage/api/UpdateResult.java
@@ -14,25 +14,24 @@
 package tech.pegasys.teku.storage.api;
 
 import java.util.Optional;
-import tech.pegasys.teku.spec.datastructures.execution.SlotAndExecutionPayload;
+import tech.pegasys.teku.spec.datastructures.execution.SlotAndExecutionPayloadSummary;
 
 public class UpdateResult {
 
   public static final UpdateResult EMPTY = new UpdateResult(Optional.empty());
 
-  private final Optional<SlotAndExecutionPayload> finalizedOptimisticTransitionPayload;
+  private final Optional<SlotAndExecutionPayloadSummary> finalizedOptimisticTransitionPayload;
 
   public UpdateResult(
-      final Optional<SlotAndExecutionPayload> finalizedOptimisticTransitionPayload) {
+      final Optional<SlotAndExecutionPayloadSummary> finalizedOptimisticTransitionPayload) {
     this.finalizedOptimisticTransitionPayload = finalizedOptimisticTransitionPayload;
   }
 
   /**
-   * Get the slot and execution payload from the block specified in {@link
-   * FinalizedChainData#getOptimisticTransitionBlockRoot()}. If no transition block root is
-   * specified this will always be empty.
+   * Get the slot and execution payload summary from the block specified in FinalizedChainData. If
+   * no transition block root is specified this will always be empty.
    */
-  public Optional<SlotAndExecutionPayload> getFinalizedOptimisticTransitionPayload() {
+  public Optional<SlotAndExecutionPayloadSummary> getFinalizedOptimisticTransitionPayload() {
     return finalizedOptimisticTransitionPayload;
   }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
@@ -28,6 +28,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
@@ -77,6 +78,8 @@ public interface Database extends AutoCloseable {
   Optional<SignedBeaconBlock> getLastAvailableFinalizedBlock();
 
   Optional<Bytes32> getFinalizedBlockRootBySlot(UInt64 slot);
+
+  Optional<ExecutionPayload> getExecutionPayload(Bytes32 blockRoot, final UInt64 slot);
 
   /**
    * Returns the latest finalized block at or prior to the given slot

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/BlindedBlockKvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/BlindedBlockKvStoreDatabase.java
@@ -118,7 +118,7 @@ public class BlindedBlockKvStoreDatabase
               .getDefault());
     }
 
-    final Optional<Bytes> maybePayload = dao.getExecutionPayload(blockRoot);
+    final Optional<ExecutionPayload> maybePayload = getExecutionPayload(blockRoot, block.getSlot());
     if (maybePayload.isEmpty()) {
       throw new StorageException(
           "Blinded block had a non default payload, but payload could not be retrieved from store for block "
@@ -126,9 +126,7 @@ public class BlindedBlockKvStoreDatabase
               + ".");
     }
 
-    final ExecutionPayload executionPayload =
-        spec.deserializeExecutionPayload(maybePayload.get(), block.getSlot());
-    return block.unblind(spec.atSlot(block.getSlot()).getSchemaDefinitions(), executionPayload);
+    return block.unblind(spec.atSlot(block.getSlot()).getSchemaDefinitions(), maybePayload.get());
   }
 
   @Override
@@ -260,6 +258,13 @@ public class BlindedBlockKvStoreDatabase
   @Override
   public Optional<Bytes32> getFinalizedBlockRootBySlot(final UInt64 slot) {
     return dao.getFinalizedBlockRootAtSlot(slot);
+  }
+
+  @Override
+  public Optional<ExecutionPayload> getExecutionPayload(
+      final Bytes32 blockRoot, final UInt64 slot) {
+    final Optional<Bytes> maybePayload = dao.getExecutionPayload(blockRoot);
+    return maybePayload.map(payload -> spec.deserializeExecutionPayload(payload, slot));
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
@@ -50,7 +50,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
-import tech.pegasys.teku.spec.datastructures.execution.SlotAndExecutionPayload;
+import tech.pegasys.teku.spec.datastructures.execution.SlotAndExecutionPayloadSummary;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.spec.datastructures.hashtree.HashTree;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
@@ -382,10 +382,10 @@ public abstract class KvStoreDatabase<
         getFinalizedBlock(finalizedCheckpoint.getRoot());
     final AnchorPoint latestFinalized =
         AnchorPoint.create(spec, finalizedCheckpoint, finalizedState, finalizedBlock);
-    final Optional<SlotAndExecutionPayload> finalizedOptimisticTransitionPayload =
+    final Optional<SlotAndExecutionPayloadSummary> finalizedOptimisticTransitionPayload =
         dao.getOptimisticTransitionBlockSlot()
             .flatMap(this::getFinalizedBlockAtSlot)
-            .flatMap(SlotAndExecutionPayload::fromBlock);
+            .flatMap(SlotAndExecutionPayloadSummary::fromBlock);
 
     // Make sure time is set to a reasonable value in the case where we start up before genesis when
     // the clock time would be prior to genesis
@@ -517,7 +517,7 @@ public abstract class KvStoreDatabase<
   private UpdateResult doUpdate(final StorageUpdate update) {
     LOG.trace("Applying finalized updates");
     // Update finalized blocks and states
-    final Optional<SlotAndExecutionPayload> finalizedOptimisticExecutionPayload =
+    final Optional<SlotAndExecutionPayloadSummary> finalizedOptimisticExecutionPayload =
         updateFinalizedData(
             update.getFinalizedChildToParentMap(),
             update.getFinalizedBlocks(),
@@ -575,7 +575,7 @@ public abstract class KvStoreDatabase<
       final Set<Bytes32> deletedHotBlockRoots,
       final Set<Bytes32> finalizedBlockRoots);
 
-  private Optional<SlotAndExecutionPayload> updateFinalizedData(
+  private Optional<SlotAndExecutionPayloadSummary> updateFinalizedData(
       Map<Bytes32, Bytes32> finalizedChildToParentMap,
       final Map<Bytes32, SignedBeaconBlock> finalizedBlocks,
       final Map<Bytes32, BeaconState> finalizedStates,
@@ -587,7 +587,7 @@ public abstract class KvStoreDatabase<
       return Optional.empty();
     }
 
-    final Optional<SlotAndExecutionPayload> optimisticTransitionPayload =
+    final Optional<SlotAndExecutionPayloadSummary> optimisticTransitionPayload =
         updateFinalizedOptimisticTransitionBlock(
             isFinalizedOptimisticBlockRootSet, finalizedOptimisticTransitionBlockRoot);
     switch (stateStorageMode) {
@@ -608,7 +608,7 @@ public abstract class KvStoreDatabase<
     return optimisticTransitionPayload;
   }
 
-  private Optional<SlotAndExecutionPayload> updateFinalizedOptimisticTransitionBlock(
+  private Optional<SlotAndExecutionPayloadSummary> updateFinalizedOptimisticTransitionBlock(
       final boolean isFinalizedOptimisticBlockRootSet,
       final Optional<Bytes32> finalizedOptimisticTransitionBlockRoot) {
     if (isFinalizedOptimisticBlockRootSet) {
@@ -618,7 +618,7 @@ public abstract class KvStoreDatabase<
         updater.setOptimisticTransitionBlockSlot(transitionBlock.map(SignedBeaconBlock::getSlot));
         updater.commit();
       }
-      return transitionBlock.flatMap(SlotAndExecutionPayload::fromBlock);
+      return transitionBlock.flatMap(SlotAndExecutionPayloadSummary::fromBlock);
     } else {
       return Optional.empty();
     }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/UnblindedBlockKvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/UnblindedBlockKvStoreDatabase.java
@@ -116,7 +116,10 @@ public class UnblindedBlockKvStoreDatabase
   @Override
   public Optional<ExecutionPayload> getExecutionPayload(
       final Bytes32 blockRoot, final UInt64 slot) {
-    return Optional.empty();
+    return getFinalizedBlock(blockRoot)
+        .flatMap(
+            signedBeaconBlock ->
+                signedBeaconBlock.getMessage().getBody().getOptionalExecutionPayload());
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/UnblindedBlockKvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/UnblindedBlockKvStoreDatabase.java
@@ -114,6 +114,12 @@ public class UnblindedBlockKvStoreDatabase
   }
 
   @Override
+  public Optional<ExecutionPayload> getExecutionPayload(
+      final Bytes32 blockRoot, final UInt64 slot) {
+    return Optional.empty();
+  }
+
+  @Override
   public Optional<SignedBeaconBlock> getLatestFinalizedBlockAtSlot(final UInt64 slot) {
     return dao.getLatestFinalizedBlockAtSlot(slot);
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
@@ -31,6 +31,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
@@ -108,6 +109,12 @@ public class NoOpDatabase implements Database {
 
   @Override
   public Optional<Bytes32> getFinalizedBlockRootBySlot(final UInt64 slot) {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<ExecutionPayload> getExecutionPayload(
+      final Bytes32 blockRoot, final UInt64 slot) {
     return Optional.empty();
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
@@ -51,7 +51,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
-import tech.pegasys.teku.spec.datastructures.execution.SlotAndExecutionPayload;
+import tech.pegasys.teku.spec.datastructures.execution.SlotAndExecutionPayloadSummary;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteUpdater;
 import tech.pegasys.teku.spec.datastructures.hashtree.HashTree;
@@ -89,7 +89,7 @@ class Store implements UpdatableStore {
   AnchorPoint finalizedAnchor;
   Checkpoint justifiedCheckpoint;
   Checkpoint bestJustifiedCheckpoint;
-  Optional<SlotAndExecutionPayload> finalizedOptimisticTransitionPayload;
+  Optional<SlotAndExecutionPayloadSummary> finalizedOptimisticTransitionPayload;
   Optional<Bytes32> proposerBoostRoot = Optional.empty();
   final CachingTaskQueue<Bytes32, StateAndBlockSummary> states;
   final Map<Bytes32, SignedBeaconBlock> blocks;
@@ -108,7 +108,7 @@ class Store implements UpdatableStore {
       final UInt64 time,
       final UInt64 genesisTime,
       final AnchorPoint finalizedAnchor,
-      final Optional<SlotAndExecutionPayload> finalizedOptimisticTransitionPayload,
+      final Optional<SlotAndExecutionPayloadSummary> finalizedOptimisticTransitionPayload,
       final Checkpoint justifiedCheckpoint,
       final Checkpoint bestJustifiedCheckpoint,
       final ForkChoiceStrategy forkChoiceStrategy,
@@ -172,7 +172,7 @@ class Store implements UpdatableStore {
       final UInt64 time,
       final UInt64 genesisTime,
       final AnchorPoint finalizedAnchor,
-      final Optional<SlotAndExecutionPayload> finalizedOptimisticTransitionPayload,
+      final Optional<SlotAndExecutionPayloadSummary> finalizedOptimisticTransitionPayload,
       final Checkpoint justifiedCheckpoint,
       final Checkpoint bestJustifiedCheckpoint,
       final Map<Bytes32, StoredBlockMetadata> blockInfoByRoot,
@@ -351,7 +351,7 @@ class Store implements UpdatableStore {
   }
 
   @Override
-  public Optional<SlotAndExecutionPayload> getFinalizedOptimisticTransitionPayload() {
+  public Optional<SlotAndExecutionPayloadSummary> getFinalizedOptimisticTransitionPayload() {
     readLock.lock();
     try {
       return finalizedOptimisticTransitionPayload;

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreBuilder.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreBuilder.java
@@ -26,7 +26,7 @@ import tech.pegasys.teku.dataproviders.lookup.StateAndBlockSummaryProvider;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.datastructures.execution.SlotAndExecutionPayload;
+import tech.pegasys.teku.spec.datastructures.execution.SlotAndExecutionPayloadSummary;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
@@ -49,7 +49,8 @@ public class StoreBuilder {
   private Checkpoint justifiedCheckpoint;
   private Checkpoint bestJustifiedCheckpoint;
   private Map<UInt64, VoteTracker> votes;
-  private Optional<SlotAndExecutionPayload> finalizedOptimisticTransitionPayload = Optional.empty();
+  private Optional<SlotAndExecutionPayloadSummary> finalizedOptimisticTransitionPayload =
+      Optional.empty();
 
   private StoreBuilder() {}
 
@@ -205,7 +206,7 @@ public class StoreBuilder {
   }
 
   public StoreBuilder finalizedOptimisticTransitionPayload(
-      final Optional<SlotAndExecutionPayload> finalizedOptimisticTransitionPayload) {
+      final Optional<SlotAndExecutionPayloadSummary> finalizedOptimisticTransitionPayload) {
     checkNotNull(finalizedOptimisticTransitionPayload);
     this.finalizedOptimisticTransitionPayload = finalizedOptimisticTransitionPayload;
     return this;

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransaction.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransaction.java
@@ -39,7 +39,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
-import tech.pegasys.teku.spec.datastructures.execution.SlotAndExecutionPayload;
+import tech.pegasys.teku.spec.datastructures.execution.SlotAndExecutionPayloadSummary;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
@@ -231,7 +231,7 @@ class StoreTransaction implements UpdatableStore.StoreTransaction {
   }
 
   @Override
-  public Optional<SlotAndExecutionPayload> getFinalizedOptimisticTransitionPayload() {
+  public Optional<SlotAndExecutionPayloadSummary> getFinalizedOptimisticTransitionPayload() {
     return store.getFinalizedOptimisticTransitionPayload();
   }
 

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/kvstore/DatabaseTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/kvstore/DatabaseTest.java
@@ -65,7 +65,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
-import tech.pegasys.teku.spec.datastructures.execution.SlotAndExecutionPayload;
+import tech.pegasys.teku.spec.datastructures.execution.SlotAndExecutionPayloadSummary;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
@@ -629,8 +629,8 @@ public class DatabaseTest {
     tx.setFinalizedCheckpoint(finalizedCheckpoint, false);
     assertThat(tx.commit()).isCompleted();
 
-    final Optional<SlotAndExecutionPayload> transitionPayload =
-        SlotAndExecutionPayload.fromBlock(transitionBlock.getBlock());
+    final Optional<SlotAndExecutionPayloadSummary> transitionPayload =
+        SlotAndExecutionPayloadSummary.fromBlock(transitionBlock.getBlock());
     assertThat(transitionPayload).isPresent();
     assertThat(transitionPayload.get().getExecutionPayload().isDefault()).isFalse();
     assertThat(recentChainData.getStore().getFinalizedOptimisticTransitionPayload())
@@ -690,8 +690,8 @@ public class DatabaseTest {
     tx.setFinalizedCheckpoint(finalizedCheckpoint, false);
     assertThat(tx.commit()).isCompleted();
 
-    final Optional<SlotAndExecutionPayload> transitionPayload =
-        SlotAndExecutionPayload.fromBlock(transitionBlock.getBlock());
+    final Optional<SlotAndExecutionPayloadSummary> transitionPayload =
+        SlotAndExecutionPayloadSummary.fromBlock(transitionBlock.getBlock());
     assertThat(transitionPayload).isPresent();
     assertThat(transitionPayload.get().getExecutionPayload().isDefault()).isFalse();
     assertThat(recentChainData.getStore().getFinalizedOptimisticTransitionPayload())
@@ -716,8 +716,8 @@ public class DatabaseTest {
     tx.setFinalizedCheckpoint(finalizedCheckpoint, false);
     assertThat(tx.commit()).isCompleted();
 
-    final Optional<SlotAndExecutionPayload> transitionPayload =
-        SlotAndExecutionPayload.fromBlock(transitionBlock.getBlock());
+    final Optional<SlotAndExecutionPayloadSummary> transitionPayload =
+        SlotAndExecutionPayloadSummary.fromBlock(transitionBlock.getBlock());
     assertThat(transitionPayload).isPresent();
     assertThat(recentChainData.getStore().getFinalizedOptimisticTransitionPayload())
         .isEqualTo(transitionPayload);
@@ -743,8 +743,8 @@ public class DatabaseTest {
     final StoreTransaction tx = recentChainData.startStoreTransaction();
     tx.setFinalizedCheckpoint(finalizedCheckpoint, false);
     assertThat(tx.commit()).isCompleted();
-    final Optional<SlotAndExecutionPayload> transitionPayload =
-        SlotAndExecutionPayload.fromBlock(transitionBlock.getBlock());
+    final Optional<SlotAndExecutionPayloadSummary> transitionPayload =
+        SlotAndExecutionPayloadSummary.fromBlock(transitionBlock.getBlock());
     assertThat(transitionPayload).isPresent();
     assertThat(recentChainData.getStore().getFinalizedOptimisticTransitionPayload())
         .isEqualTo(transitionPayload);
@@ -790,8 +790,8 @@ public class DatabaseTest {
     tx2.setFinalizedCheckpoint(finalizedCheckpoint2, false);
     assertThat(tx2.commit()).isCompleted();
 
-    final Optional<SlotAndExecutionPayload> transitionPayload =
-        SlotAndExecutionPayload.fromBlock(transitionBlock.getBlock());
+    final Optional<SlotAndExecutionPayloadSummary> transitionPayload =
+        SlotAndExecutionPayloadSummary.fromBlock(transitionBlock.getBlock());
     assertThat(transitionPayload).isPresent();
     assertThat(transitionPayload.get().getExecutionPayload().isDefault()).isFalse();
     assertThat(recentChainData.getStore().getFinalizedOptimisticTransitionPayload())

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/kvstore/DatabaseTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/kvstore/DatabaseTest.java
@@ -632,7 +632,7 @@ public class DatabaseTest {
     final Optional<SlotAndExecutionPayloadSummary> transitionPayload =
         SlotAndExecutionPayloadSummary.fromBlock(transitionBlock.getBlock());
     assertThat(transitionPayload).isPresent();
-    assertThat(transitionPayload.get().getExecutionPayload().isDefault()).isFalse();
+    assertThat(transitionPayload.get().getExecutionPayloadSummary().isDefaultPayload()).isFalse();
     assertThat(recentChainData.getStore().getFinalizedOptimisticTransitionPayload())
         .isEqualTo(transitionPayload);
   }
@@ -693,7 +693,7 @@ public class DatabaseTest {
     final Optional<SlotAndExecutionPayloadSummary> transitionPayload =
         SlotAndExecutionPayloadSummary.fromBlock(transitionBlock.getBlock());
     assertThat(transitionPayload).isPresent();
-    assertThat(transitionPayload.get().getExecutionPayload().isDefault()).isFalse();
+    assertThat(transitionPayload.get().getExecutionPayloadSummary().isDefaultPayload()).isFalse();
     assertThat(recentChainData.getStore().getFinalizedOptimisticTransitionPayload())
         .isEqualTo(transitionPayload);
   }
@@ -793,7 +793,7 @@ public class DatabaseTest {
     final Optional<SlotAndExecutionPayloadSummary> transitionPayload =
         SlotAndExecutionPayloadSummary.fromBlock(transitionBlock.getBlock());
     assertThat(transitionPayload).isPresent();
-    assertThat(transitionPayload.get().getExecutionPayload().isDefault()).isFalse();
+    assertThat(transitionPayload.get().getExecutionPayloadSummary().isDefaultPayload()).isFalse();
     assertThat(recentChainData.getStore().getFinalizedOptimisticTransitionPayload())
         .isEqualTo(transitionPayload);
   }

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/BlockProductionDutyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/BlockProductionDutyTest.java
@@ -281,5 +281,10 @@ class BlockProductionDutyTest {
     public Bytes32 getPayloadHash() {
       return null;
     }
+
+    @Override
+    public boolean isDefault() {
+      return false;
+    }
   }
 }

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/BlockProductionDutyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/BlockProductionDutyTest.java
@@ -283,7 +283,7 @@ class BlockProductionDutyTest {
     }
 
     @Override
-    public boolean isDefault() {
+    public boolean isDefaultPayload() {
       return false;
     }
   }


### PR DESCRIPTION
 - get Execution Payload from the database

 - use Payload Summary in the update result, and added isDefault to allow either header or full payload to be used for the update result.

 - renamed SlotAndExecutionPayload now that it's using the payload summary.

 This will ensure the update results continue to succeed once the full execution payload is not stored.

 partially addresses #5312

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
