### PR TITLE
Adding converter for a hidden cli option

### DIFF
--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorProposerOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorProposerOptions.java
@@ -88,7 +88,8 @@ public class ValidatorProposerOptions {
       description =
           "Set a constant timestamp in Unix format to be used in validator registrations against builder infrastructure.",
       arity = "1",
-      hidden = true)
+      hidden = true,
+      converter = UInt64Converter.class)
   private UInt64 builderRegistrationTimestampOverride = null;
 
   @Option(


### PR DESCRIPTION
## PR Description
Fixing

```java
No TypeConverter registered for tech.pegasys.teku.infrastructure.unsigned.UInt64 of field tech.pegasys.teku.infrastructure.unsigned.UInt64 tech.pegasys.teku.cli.options.ValidatorProposerOptions.builderRegistrationTimestampOverride
```

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
