### PR TITLE
Avoid waiting for a specific epoch in ATs

### DIFF
--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/LocalValidatorKeysAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/LocalValidatorKeysAcceptanceTest.java
@@ -66,7 +66,7 @@ public class LocalValidatorKeysAcceptanceTest extends AcceptanceTestBase {
     // a random key won't be found, remove should give not_found
     api.removeLocalValidatorAndCheckStatus(extraKeys.getPublicKeys().get(0), "not_found");
 
-    beaconNode.waitForEpoch(2);
+    beaconNode.waitForNextEpoch();
     // remove a validator
     final BLSPublicKey removedPubkey = validatorKeystores.getPublicKeys().get(0);
     api.removeLocalValidatorAndCheckStatus(removedPubkey, "deleted");

--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/SyncCommitteeGossipAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/SyncCommitteeGossipAcceptanceTest.java
@@ -71,7 +71,7 @@ public class SyncCommitteeGossipAcceptanceTest extends AcceptanceTestBase {
     watcherNode.start();
     watcherNode.startEventListener(List.of(EventType.contribution_and_proof));
 
-    primaryNode.waitForEpoch(1);
+    primaryNode.waitForEpochAtOrAbove(1);
 
     // Wait until we get a contribution over gossip. The watcher node doesn't run any validators.
     watcherNode.waitForContributionAndProofEvent();

--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/ValidatorLivenessAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/ValidatorLivenessAcceptanceTest.java
@@ -64,7 +64,7 @@ public class ValidatorLivenessAcceptanceTest extends AcceptanceTestBase {
   void shouldTrackValidatorLivenessOverEpochs() throws Exception {
     primaryNode.start();
 
-    primaryNode.waitForEpoch(2);
+    final int startEpoch = primaryNode.waitForEpochAtOrAbove(2);
     secondaryNode.start();
     primaryNode.checkValidatorLiveness(
         1,
@@ -72,9 +72,11 @@ public class ValidatorLivenessAcceptanceTest extends AcceptanceTestBase {
         expectLive(0, NODE_VALIDATORS),
         expectNotLive(NODE_VALIDATORS, NODE_VALIDATORS));
 
-    primaryNode.waitForEpoch(5);
-    primaryNode.checkValidatorLiveness(3, TOTAL_VALIDATORS, expectLive(0, TOTAL_VALIDATORS));
-    secondaryNode.checkValidatorLiveness(3, TOTAL_VALIDATORS, expectLive(0, TOTAL_VALIDATORS));
+    primaryNode.waitForEpochAtOrAbove(startEpoch + 3);
+    primaryNode.checkValidatorLiveness(
+        startEpoch + 1, TOTAL_VALIDATORS, expectLive(0, TOTAL_VALIDATORS));
+    secondaryNode.checkValidatorLiveness(
+        startEpoch + 1, TOTAL_VALIDATORS, expectLive(0, TOTAL_VALIDATORS));
 
     secondaryNode.stop();
     primaryNode.stop();


### PR DESCRIPTION
## PR Description
We don't control time in ATs so waiting for a specific epoch isn't safe as we may have already gone past that point.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
