### PR TITLE
Wait for all pending events to be processed before stopping event channels

### DIFF
--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
@@ -158,6 +158,10 @@ public class SafeFuture<T> extends CompletableFuture<T> {
     }
   }
 
+  public static SafeFuture<Void> allOf(final Stream<SafeFuture<?>> futures) {
+    return allOf(futures.toArray(SafeFuture[]::new));
+  }
+
   public static SafeFuture<Void> allOf(final SafeFuture<?>... futures) {
     return of(CompletableFuture.allOf(futures))
         .catchAndRethrow(completionException -> addSuppressedErrors(completionException, futures));

--- a/infrastructure/events/src/main/java/tech/pegasys/teku/infrastructure/events/EventChannel.java
+++ b/infrastructure/events/src/main/java/tech/pegasys/teku/infrastructure/events/EventChannel.java
@@ -167,7 +167,7 @@ class EventChannel<T> {
     invoker.subscribe(listener, requestedParallelism);
   }
 
-  public void stop() {
-    invoker.stop();
+  public SafeFuture<Void> stop() {
+    return invoker.stop();
   }
 }

--- a/infrastructure/events/src/main/java/tech/pegasys/teku/infrastructure/events/EventChannels.java
+++ b/infrastructure/events/src/main/java/tech/pegasys/teku/infrastructure/events/EventChannels.java
@@ -19,6 +19,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.function.Function;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
 
 public class EventChannels {
 
@@ -107,7 +108,7 @@ public class EventChannels {
     return (EventChannel<T>) channels.computeIfAbsent(channelInterface, eventChannelFactory);
   }
 
-  public void stop() {
-    channels.values().forEach(EventChannel::stop);
+  public SafeFuture<Void> stop() {
+    return SafeFuture.allOf(channels.values().stream().map(EventChannel::stop));
   }
 }

--- a/infrastructure/events/src/main/java/tech/pegasys/teku/infrastructure/events/EventDeliverer.java
+++ b/infrastructure/events/src/main/java/tech/pegasys/teku/infrastructure/events/EventDeliverer.java
@@ -75,5 +75,7 @@ abstract class EventDeliverer<T> {
   protected abstract <X> SafeFuture<X> deliverToWithResponse(
       T subscriber, Method method, Object[] args, AsyncRunner responseRunner);
 
-  public void stop() {}
+  public SafeFuture<Void> stop() {
+    return SafeFuture.COMPLETE;
+  }
 }

--- a/teku/src/main/java/tech/pegasys/teku/AbstractNode.java
+++ b/teku/src/main/java/tech/pegasys/teku/AbstractNode.java
@@ -157,7 +157,7 @@ public abstract class AbstractNode implements Node {
     eventChannels
         .stop()
         .orTimeout(30, TimeUnit.SECONDS)
-        .handleException(error -> LOG.error("Failed to stop event channels", error))
+        .handleException(error -> LOG.warn("Failed to stop event channels cleanly", error))
         .join();
 
     threadPool.shutdownNow();

--- a/teku/src/main/java/tech/pegasys/teku/AbstractNode.java
+++ b/teku/src/main/java/tech/pegasys/teku/AbstractNode.java
@@ -154,7 +154,12 @@ public abstract class AbstractNode implements Node {
   @Override
   public void stop() {
     // Stop processing new events
-    eventChannels.stop();
+    eventChannels
+        .stop()
+        .orTimeout(30, TimeUnit.SECONDS)
+        .handleException(error -> LOG.error("Failed to stop event channels", error))
+        .join();
+
     threadPool.shutdownNow();
     counterMaintainer.ifPresent(Cancellable::cancel);
 


### PR DESCRIPTION
## PR Description
Wait for all pending events to be processed before stopping event channels.

New events published after the channel is stopped are still dropped, but this ensures that all events published before shutdown starts are completed during a clean shutdown.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
