### PR TITLE
Include currently non-viable chain heads when updating progressive balanaces

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ReadOnlyForkChoiceStrategy.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ReadOnlyForkChoiceStrategy.java
@@ -34,7 +34,11 @@ public interface ReadOnlyForkChoiceStrategy {
 
   List<Bytes32> getBlockRootsAtSlot(UInt64 slot);
 
-  List<ProtoNodeData> getChainHeads();
+  default List<ProtoNodeData> getChainHeads() {
+    return getChainHeads(false);
+  }
+
+  List<ProtoNodeData> getChainHeads(boolean includeNonViableHeads);
 
   Optional<Bytes32> getOptimisticallySyncedTransitionBlockRoot(Bytes32 head);
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
@@ -243,7 +243,7 @@ public class ForkChoiceUtil {
     }
 
     final UInt64 previousEpoch = miscHelpers.computeEpochAtSlot(previousSlot);
-    for (ProtoNodeData nodeData : store.getForkChoiceStrategy().getChainHeads()) {
+    for (ProtoNodeData nodeData : store.getForkChoiceStrategy().getChainHeads(true)) {
       if (miscHelpers.computeEpochAtSlot(nodeData.getSlot()).equals(previousEpoch)) {
         store.pullUpBlockCheckpoints(nodeData.getRoot());
         updateCheckpoints(

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
@@ -362,7 +362,7 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
     }
 
     @Override
-    public List<ProtoNodeData> getChainHeads() {
+    public List<ProtoNodeData> getChainHeads(final boolean includeNonViableChainHeads) {
       final Map<Bytes32, ProtoNodeData> headsByRoot = new HashMap<>();
       getOrderedBlockRoots()
           .forEach(

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/RandomChainBuilderForkChoiceStrategy.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/RandomChainBuilderForkChoiceStrategy.java
@@ -92,7 +92,7 @@ public class RandomChainBuilderForkChoiceStrategy implements ReadOnlyForkChoiceS
   }
 
   @Override
-  public List<ProtoNodeData> getChainHeads() {
+  public List<ProtoNodeData> getChainHeads(final boolean includeNonViableHeads) {
     return chainBuilder
         .getChainHead()
         .map(

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
@@ -162,14 +162,14 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
   }
 
   @Override
-  public List<ProtoNodeData> getChainHeads() {
+  public List<ProtoNodeData> getChainHeads(final boolean includeNonViableHeads) {
     protoArrayLock.readLock().lock();
     try {
       return protoArray.getNodes().stream()
           .filter(
               protoNode ->
                   protoNode.getBestChildIndex().isEmpty()
-                      && protoArray.nodeIsViableForHead(protoNode))
+                      && (includeNonViableHeads || protoArray.nodeIsViableForHead(protoNode)))
           .map(ProtoNode::getBlockData)
           .collect(Collectors.toList());
     } finally {


### PR DESCRIPTION
## PR Description
Since the progressive balances update may cause the node to be viable, make sure we don't skip it because it currently appears non-viable.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
