### PR TITLE
Include beacon block and payload info in warning when execuction client is still syncing

### DIFF
--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/BatchSync.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/BatchSync.java
@@ -33,12 +33,10 @@ import tech.pegasys.teku.beacon.sync.forward.multipeer.chains.TargetChain;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.eventthread.EventThread;
-import tech.pegasys.teku.infrastructure.logging.LogFormatter;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSummary;
+import tech.pegasys.teku.spec.datastructures.blocks.MinimalBeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
-import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
 /** Manages the sync process to reach a finalized chain. */
@@ -460,7 +458,7 @@ public class BatchSync implements Sync {
       activeBatches.removeAll();
       LOG.debug(
           "Unable to sync to target chain {} because it has no remaining peers",
-          () -> formatBlock(targetChain.getChainHead()));
+          () -> targetChain.getChainHead().toLogString());
       syncResult.complete(SyncResult.FAILED);
       return;
     }
@@ -517,7 +515,7 @@ public class BatchSync implements Sync {
             + "Common ancestor slot: %s%n"
             + "Active batches: %s%n"
             + "Peers on chain: %s",
-        formatBlock(targetChain.getChainHead()),
+        targetChain.getChainHead().toLogString(),
         switchingBranches,
         importingBatch.map(this::formatBatch).orElse("<none>"),
         commonAncestorSlot.isCompletedNormally() ? commonAncestorSlot.join() : commonAncestorSlot,
@@ -531,19 +529,11 @@ public class BatchSync implements Sync {
         batch.getFirstSlot(),
         batch.getLastSlot(),
         batch.getBlocks().size(),
-        batch.getFirstBlock().map(this::formatBlock).orElse("<none>"),
+        batch.getFirstBlock().map(MinimalBeaconBlockSummary::toLogString).orElse("<none>"),
         batch.isFirstBlockConfirmed() ? "confirmed" : "unconfirmed",
-        batch.getLastBlock().map(this::formatBlock).orElse("<none>"),
+        batch.getLastBlock().map(MinimalBeaconBlockSummary::toLogString).orElse("<none>"),
         batch.isConfirmed(),
         batch.isComplete(),
         batch.getSource());
-  }
-
-  private String formatBlock(final SlotAndBlockRoot block) {
-    return LogFormatter.formatBlock(block.getSlot(), block.getBlockRoot());
-  }
-
-  private String formatBlock(final BeaconBlockSummary block) {
-    return LogFormatter.formatBlock(block.getSlot(), block.getRoot());
   }
 }

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/SyncSourceBatch.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/SyncSourceBatch.java
@@ -32,6 +32,7 @@ import tech.pegasys.teku.networking.eth2.peers.SyncSource;
 import tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.BlocksByRangeResponseInvalidResponseException;
 import tech.pegasys.teku.networking.p2p.peer.PeerDisconnectedException;
 import tech.pegasys.teku.networking.p2p.rpc.RpcResponseListener;
+import tech.pegasys.teku.spec.datastructures.blocks.MinimalBeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 
 public class SyncSourceBatch implements Batch {
@@ -285,19 +286,17 @@ public class SyncSourceBatch implements Batch {
                 .map(block -> LogFormatter.formatHashRoot(block.getParentRoot()))
                 .orElse("<unknown>"))
         .add("firstBlock", getFirstBlock().map(this::formatBlockAndParent).orElse("<none>"))
-        .add("lastBlock", getLastBlock().map(this::formatBlock).orElse("<none>"))
+        .add(
+            "lastBlock",
+            getLastBlock().map(MinimalBeaconBlockSummary::toLogString).orElse("<none>"))
         .toString();
   }
 
   private String formatBlockAndParent(final SignedBeaconBlock block1) {
-    return formatBlock(block1)
+    return block1.toLogString()
         + " (parent: "
         + LogFormatter.formatHashRoot(block1.getParentRoot())
         + ")";
-  }
-
-  private String formatBlock(final SignedBeaconBlock block) {
-    return LogFormatter.formatBlock(block.getSlot(), block.getRoot());
   }
 
   private static class RequestHandler implements RpcResponseListener<SignedBeaconBlock> {

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.validator.coordinator;
 
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
-import static tech.pegasys.teku.infrastructure.logging.LogFormatter.formatBlock;
 import static tech.pegasys.teku.infrastructure.logging.ValidatorLogger.VALIDATOR_LOGGER;
 import static tech.pegasys.teku.spec.config.SpecConfig.GENESIS_SLOT;
 
@@ -553,15 +552,13 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
         .thenApply(
             result -> {
               if (result.isSuccessful()) {
-                LOG.trace(
-                    "Successfully imported proposed block: {}",
-                    () -> formatBlock(block.getSlot(), block.getRoot()));
+                LOG.trace("Successfully imported proposed block: {}", block::toLogString);
                 dutyMetrics.onBlockPublished(block.getMessage().getSlot());
                 return SendSignedBlockResult.success(block.getRoot());
               } else if (result.getFailureReason() == FailureReason.BLOCK_IS_FROM_FUTURE) {
                 LOG.debug(
                     "Delayed processing proposed block {} because it is from the future",
-                    formatBlock(block.getSlot(), block.getRoot()));
+                    block::toLogString);
                 dutyMetrics.onBlockPublished(block.getMessage().getSlot());
                 return SendSignedBlockResult.notImported(result.getFailureReason().name());
               } else {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/MinimalBeaconBlockSummary.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/MinimalBeaconBlockSummary.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.spec.datastructures.blocks;
 
 import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.logging.LogFormatter;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 public interface MinimalBeaconBlockSummary {
@@ -26,4 +27,8 @@ public interface MinimalBeaconBlockSummary {
 
   /** @return the hash tree root of the block */
   Bytes32 getRoot();
+
+  default String toLogString() {
+    return LogFormatter.formatBlock(getSlot(), getRoot());
+  }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/SlotAndBlockRoot.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/SlotAndBlockRoot.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.spec.datastructures.blocks;
 import com.google.common.base.MoreObjects;
 import java.util.Objects;
 import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.logging.LogFormatter;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 public class SlotAndBlockRoot {
@@ -33,6 +34,10 @@ public class SlotAndBlockRoot {
 
   public Bytes32 getBlockRoot() {
     return blockRoot;
+  }
+
+  public String toLogString() {
+    return LogFormatter.formatBlock(slot, blockRoot);
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadSummary.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadSummary.java
@@ -17,6 +17,7 @@ import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
 import tech.pegasys.teku.infrastructure.bytes.Bytes20;
+import tech.pegasys.teku.infrastructure.logging.LogFormatter;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 public interface ExecutionPayloadSummary {
@@ -50,4 +51,8 @@ public interface ExecutionPayloadSummary {
   Bytes32 getPayloadHash();
 
   boolean isDefaultPayload();
+
+  default String toLogString() {
+    return LogFormatter.formatBlock(getBlockNumber(), getBlockHash());
+  }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/AbstractBlockProcessor.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/AbstractBlockProcessor.java
@@ -34,7 +34,6 @@ import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.infrastructure.bytes.Bytes4;
 import tech.pegasys.teku.infrastructure.crypto.Hash;
-import tech.pegasys.teku.infrastructure.logging.LogFormatter;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.cache.CapturingIndexedAttestationCache;
@@ -138,8 +137,7 @@ public abstract class AbstractBlockProcessor implements BlockProcessor {
             payloadExecutor);
     if (!signatureVerifier.batchVerify()) {
       throw new StateTransitionException(
-          "Batch signature verification failed for block "
-              + LogFormatter.formatBlock(signedBlock.getSlot(), signedBlock.getRoot()));
+          "Batch signature verification failed for block " + signedBlock.toLogString());
     }
     return result;
   }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/BlockImporter.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/BlockImporter.java
@@ -22,7 +22,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.logging.EventLogger;
-import tech.pegasys.teku.infrastructure.logging.LogFormatter;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.subscribers.Subscribers;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -89,7 +88,7 @@ public class BlockImporter {
     if (knownOptimistic.isPresent()) {
       LOG.trace(
           "Importing known block {}.  Return successful result without re-processing.",
-          () -> formatBlock(block));
+          () -> block.toLogString());
       return SafeFuture.completedFuture(BlockImportResult.knownBlock(block, knownOptimistic.get()));
     }
 
@@ -106,10 +105,10 @@ public class BlockImporter {
                 LOG.trace(
                     "Failed to import block for reason {}: {}",
                     result::getFailureReason,
-                    () -> formatBlock(block));
+                    () -> block.toLogString());
                 return result;
               }
-              LOG.trace("Successfully imported block {}", () -> formatBlock(block));
+              LOG.trace("Successfully imported block {}", () -> block.toLogString());
 
               blockImportNotifications.onBlockImported(block);
 
@@ -126,7 +125,7 @@ public class BlockImporter {
               final String internalErrorMessage =
                   String.format(
                       "Internal error while importing block: %s. Block content: %s",
-                      formatBlock(block), getBlockContent(block));
+                      block.toLogString(), getBlockContent(block));
               LOG.error(internalErrorMessage, e);
               return BlockImportResult.internalError(e);
             });
@@ -211,10 +210,6 @@ public class BlockImporter {
   public void subscribeToVerifiedBlockVoluntaryExits(
       VerifiedBlockOperationsListener<SignedVoluntaryExit> verifiedBlockVoluntaryExitsListener) {
     voluntaryExitSubscribers.subscribe(verifiedBlockVoluntaryExitsListener);
-  }
-
-  private String formatBlock(final SignedBeaconBlock block) {
-    return LogFormatter.formatBlock(block.getSlot(), block.getRoot());
   }
 
   private String getBlockContent(final SignedBeaconBlock block) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/FailedExecutionPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/FailedExecutionPool.java
@@ -26,7 +26,6 @@ import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.exceptions.ExceptionUtil;
-import tech.pegasys.teku.infrastructure.logging.LogFormatter;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
 import tech.pegasys.teku.storage.server.ShuttingDownException;
@@ -61,8 +60,7 @@ public class FailedExecutionPool {
       }
       if (!awaitingExecutionQueue.offer(block)) {
         LOG.info(
-            "Discarding block {} as execution retry pool capacity exceeded",
-            LogFormatter.formatBlock(block.getSlot(), block.getRoot()));
+            "Discarding block {} as execution retry pool capacity exceeded", block.toLogString());
       }
     }
   }
@@ -108,9 +106,7 @@ public class FailedExecutionPool {
   }
 
   private synchronized void retryExecution(final SignedBeaconBlock block) {
-    LOG.info(
-        "Retrying execution of block {}",
-        LogFormatter.formatBlock(block.getSlot(), block.getRoot()));
+    LOG.info("Retrying execution of block {}", block.toLogString());
     SafeFuture.of(() -> blockManager.importBlock(block))
         .exceptionally(BlockImportResult::internalError)
         .thenAccept(result -> handleExecutionResult(block, result))


### PR DESCRIPTION
## PR Description
Include beacon block and payload info in warning when execuction client is still syncing.

Add toLogString methods to simplify calls to LogFormatter.formatBlock.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
