### PR TITLE
Remain in optimistic mode if there is no viable head

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ For information on changes in released versions of Teku, see the [releases page]
   This simplifies using the standard REST API to retrieve the initial state as just the base URL can be specified (e.g. `--initial-state https://<credentials@eth2-beacon-mainnet.infura.io`)
 - Ability to configure multiple beacon nodes for a single validator client using `--beacon-node-api-endpoints` CLI option
 - Primed cache for new justified checkpoints to reduce time required to run fork choice immediately after justification
+- Remain in optimistic mode when there are no viable branches in the block tree because blocks from every branch were marked INVALID during optimistic sync (https://github.com/ethereum/consensus-specs/pull/2955)
 
 ### Bug Fixes
 - Fixed `NullPointerException` when checking for the terminal PoW block while the EL was syncing

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
@@ -200,7 +200,7 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
           headExecutionBlockHash,
           justifiedExecutionHash,
           finalizedExecutionHash,
-          headNode.isOptimistic());
+          headNode.isOptimistic() || !protoArray.nodeIsViableForHead(headNode));
     } finally {
       protoArrayLock.readLock().unlock();
     }

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArray.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArray.java
@@ -241,7 +241,7 @@ public class ProtoArray {
 
     // Perform a sanity check that the node is indeed valid to be the head.
     if (!nodeIsViableForHead(bestNode) && !bestNode.equals(justifiedNode)) {
-      throw new RuntimeException("ProtoArray: Best node is not viable for head");
+      throw new IllegalStateException("ProtoArray: Best node is not viable for head");
     }
     return Optional.of(bestNode);
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArray.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArray.java
@@ -241,7 +241,8 @@ public class ProtoArray {
 
     // Perform a sanity check that the node is indeed valid to be the head.
     if (!nodeIsViableForHead(bestNode) && !bestNode.equals(justifiedNode)) {
-      throw new IllegalStateException("ProtoArray: Best node is not viable for head");
+      throw new IllegalStateException(
+          "ProtoArray: Best node " + bestNode.toLogString() + " is not viable for head");
     }
     return Optional.of(bestNode);
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoNode.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoNode.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.logging.LogFormatter;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ProtoNodeData;
@@ -269,5 +270,9 @@ public class ProtoNode {
         .add("bestDescendantIndex", bestDescendantIndex)
         .add("validationStatus", validationStatus)
         .toString();
+  }
+
+  public String toLogString() {
+    return LogFormatter.formatBlock(blockSlot, blockRoot);
   }
 }


### PR DESCRIPTION
## PR Description
During optimistic sync it is possible to import blocks that include enough attestations to update the justified checkpoint, but then discover the blocks including those attestations were invalid. This potentially makes the valid chain non-viable because it doesn't (yet) include enough attestations to reach that same justified checkpoint. Note that in this case the justified checkpoint itself is valid and eventually the attestations required to justify will be included in a valid chain.

Until that point though, our node should remain in optimistic mode so that it doesn't create attestations with the source of the updated justified checkpoint which may lead to later being unable to attest without creating a surround vote.

See https://github.com/ethereum/consensus-specs/pull/2955 for more details.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
