### PR TITLE
Reduce memory allocation for each gradle runner

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ executors:
     resource_class: small
     working_directory: ~/project
     environment:
-      JAVA_TOOL_OPTIONS: -Xmx2g
+      JAVA_TOOL_OPTIONS: -Xmx1500m
       GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.parallel=true
 
   trivy_executor:
@@ -33,7 +33,7 @@ executors:
     working_directory: ~/project
     environment:
       DOCKER_CLI_EXPERIMENTAL: enabled
-      JAVA_TOOL_OPTIONS: -Xmx2g
+      JAVA_TOOL_OPTIONS: -Xmx1500m
       GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.parallel=true
 
   medium_plus_executor:
@@ -44,7 +44,7 @@ executors:
     resource_class: "medium+"
     working_directory: ~/project
     environment:
-      JAVA_TOOL_OPTIONS: -Xmx2g
+      JAVA_TOOL_OPTIONS: -Xmx1500m
       GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.parallel=true
 
   large_executor:


### PR DESCRIPTION
## PR Description
Periodically seeing gradle runners be killed by the OOM killer so try reducing the memory allocation.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
