### PR TITLE
Fix intermittency in shouldMaintainValidatorsInMutableClient

### DIFF
--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/LocalValidatorKeysAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/LocalValidatorKeysAcceptanceTest.java
@@ -66,7 +66,11 @@ public class LocalValidatorKeysAcceptanceTest extends AcceptanceTestBase {
     // a random key won't be found, remove should give not_found
     api.removeLocalValidatorAndCheckStatus(extraKeys.getPublicKeys().get(0), "not_found");
 
+    // Wait for a full epoch to pass so that all validators have attested
+    // This ensures they have all generated slashing protection data
     beaconNode.waitForNextEpoch();
+    beaconNode.waitForNextEpoch();
+
     // remove a validator
     final BLSPublicKey removedPubkey = validatorKeystores.getPublicKeys().get(0);
     api.removeLocalValidatorAndCheckStatus(removedPubkey, "deleted");


### PR DESCRIPTION
## PR Description
Wait a full epoch to pass so that all validators have attested and generated slashing protection data. Previously only waited until the next epoch.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
