### PR TITLE
Log error when EL says terminal block that it provided is INVALID

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -146,13 +146,12 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
                     forkChoiceUpdatedResult -> {
                       if (forkChoiceUpdatedResultNotification.isTerminalBlockCall()
                           && forkChoiceUpdatedResult.getPayloadStatus().hasInvalidStatus()) {
-                        throw new IllegalStateException(
-                            String.format(
-                                "Execution engine considers INVALID recently provided terminal block %s. "
-                                    + "Probably an execution engine misconfiguration.",
-                                forkChoiceUpdatedResultNotification
-                                    .getForkChoiceState()
-                                    .getHeadExecutionBlockHash()));
+                        LOG.error(
+                            "Execution engine considers INVALID recently provided terminal block {}",
+                            forkChoiceUpdatedResultNotification
+                                .getForkChoiceState()
+                                .getHeadExecutionBlockHash());
+                        return;
                       }
                       onExecutionPayloadResult(
                           forkChoiceUpdatedResultNotification

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierImpl.java
@@ -226,7 +226,9 @@ public class ForkChoiceNotifierImpl implements ForkChoiceNotifier, ProposersData
     subscribers.deliver(
         ForkChoiceUpdatedResultSubscriber::onForkChoiceUpdatedResult,
         new ForkChoiceUpdatedResultNotification(
-            forkChoiceUpdateData.getForkChoiceState(), forkChoiceUpdatedResult));
+            forkChoiceUpdateData.getForkChoiceState(),
+            forkChoiceUpdateData.hasTerminalBlockHash(),
+            forkChoiceUpdatedResult));
   }
 
   private void updatePayloadAttributes(final UInt64 blockSlot) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceUpdatedResultSubscriber.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceUpdatedResultSubscriber.java
@@ -24,17 +24,24 @@ public interface ForkChoiceUpdatedResultSubscriber {
 
   class ForkChoiceUpdatedResultNotification {
     private final ForkChoiceState forkChoiceState;
+    private final boolean isTerminalBlockCall;
     private final SafeFuture<Optional<ForkChoiceUpdatedResult>> forkChoiceUpdatedResult;
 
     public ForkChoiceUpdatedResultNotification(
-        ForkChoiceState forkChoiceState,
-        SafeFuture<Optional<ForkChoiceUpdatedResult>> forkChoiceUpdatedResult) {
+        final ForkChoiceState forkChoiceState,
+        final boolean isTerminalBlockCall,
+        final SafeFuture<Optional<ForkChoiceUpdatedResult>> forkChoiceUpdatedResult) {
       this.forkChoiceState = forkChoiceState;
+      this.isTerminalBlockCall = isTerminalBlockCall;
       this.forkChoiceUpdatedResult = forkChoiceUpdatedResult;
     }
 
     public ForkChoiceState getForkChoiceState() {
       return forkChoiceState;
+    }
+
+    public boolean isTerminalBlockCall() {
+      return isTerminalBlockCall;
     }
 
     public SafeFuture<Optional<ForkChoiceUpdatedResult>> getForkChoiceUpdatedResult() {

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
@@ -1074,7 +1074,9 @@ class ForkChoiceTest {
     return invocation -> {
       forkChoice.onForkChoiceUpdatedResult(
           new ForkChoiceUpdatedResultNotification(
-              invocation.getArgument(0), SafeFuture.completedFuture(Optional.ofNullable(result))));
+              invocation.getArgument(0),
+              false,
+              SafeFuture.completedFuture(Optional.ofNullable(result))));
       return null;
     };
   }

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/forkchoice/StubForkChoiceNotifier.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/forkchoice/StubForkChoiceNotifier.java
@@ -50,7 +50,7 @@ public class StubForkChoiceNotifier implements ForkChoiceNotifier {
     subscribers.deliver(
         ForkChoiceUpdatedResultSubscriber::onForkChoiceUpdatedResult,
         new ForkChoiceUpdatedResultNotification(
-            forkChoiceState, forkChoiceUpdatedResultNotification));
+            forkChoiceState, false, forkChoiceUpdatedResultNotification));
   }
 
   @Override


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Let's try this approach to get proper error when EL returns INVALID on previously provided terminal block hash.
I have no idea how to test it, exception is lost in `finish` part

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Fixes #6042 
## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
