### PR TITLE
Update reference tests to 1.2.0-rc.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -282,7 +282,7 @@ allprojects {
   }
 }
 
-def refTestVersion = 'v1.2.0-rc.1' // Arbitrary change to refresh cache number: 1
+def refTestVersion = 'v1.2.0-rc.2' // Arbitrary change to refresh cache number: 1
 def blsRefTestVersion = 'v0.1.1'
 def refTestBaseUrl = 'https://github.com/ethereum/eth2.0-spec-tests/releases/download'
 def blsRefTestBaseUrl = 'https://github.com/ethereum/bls12-381-tests/releases/download'

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/Eth2ReferenceTestCase.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/Eth2ReferenceTestCase.java
@@ -46,6 +46,9 @@ public abstract class Eth2ReferenceTestCase {
           .putAll(OperationsTestExecutor.OPERATIONS_TEST_TYPES)
           .putAll(SanityTests.SANITY_TEST_TYPES)
           .put("merkle/single_proof", TestExecutor.IGNORE_TESTS)
+          .put("light_client/single_merkle_proof", TestExecutor.IGNORE_TESTS)
+          .put("light_client/sync", TestExecutor.IGNORE_TESTS)
+          .put("light_client/update_ranking", TestExecutor.IGNORE_TESTS)
           .build();
 
   private static final ImmutableMap<String, TestExecutor> PHASE_0_TEST_TYPES =

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_static/SszTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_static/SszTestExecutor.java
@@ -128,6 +128,9 @@ public class SszTestExecutor<T extends SszData> implements TestExecutor {
                   schemas ->
                       SchemaDefinitionsAltair.required(schemas)
                           .getSyncAggregatorSelectionDataSchema()))
+          .put("ssz_static/LightClientBootstrap", IGNORE_TESTS)
+          .put("ssz_static/LightClientFinalityUpdate", IGNORE_TESTS)
+          .put("ssz_static/LightClientOptimisticUpdate", IGNORE_TESTS)
           .put("ssz_static/LightClientStore", IGNORE_TESTS)
           .put("ssz_static/LightClientSnapshot", IGNORE_TESTS)
           .put("ssz_static/LightClientUpdate", IGNORE_TESTS)

--- a/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/TestDefinition.java
+++ b/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/TestDefinition.java
@@ -13,9 +13,7 @@
 
 package tech.pegasys.teku.ethtests.finder;
 
-import java.math.BigInteger;
 import java.nio.file.Path;
-import org.apache.tuweni.units.bigints.UInt256;
 import tech.pegasys.teku.ethtests.TestFork;
 import tech.pegasys.teku.ethtests.TestSpecConfig;
 import tech.pegasys.teku.spec.Spec;
@@ -26,10 +24,6 @@ import tech.pegasys.teku.spec.networks.Eth2Network;
 
 public class TestDefinition {
 
-  public static final UInt256 PLACEHOLDER_TERMINAL_DIFFICULTY =
-      UInt256.valueOf(
-          new BigInteger(
-              "115792089237316195423570985008687907853269984665640564039457584007913129638912"));
   private final String fork;
   private final String configName;
   private final String testType;
@@ -96,11 +90,7 @@ public class TestDefinition {
         TestSpecFactory.create(
             highestSupportedMilestone,
             network,
-            builder ->
-                builder
-                    .progressiveBalancesMode(ProgressiveBalancesMode.CHECKED)
-                    .bellatrixBuilder(
-                        b -> b.terminalTotalDifficulty(PLACEHOLDER_TERMINAL_DIFFICULTY)));
+            builder -> builder.progressiveBalancesMode(ProgressiveBalancesMode.CHECKED));
   }
 
   public String getTestType() {


### PR DESCRIPTION
## PR Description
Update reference tests to 1.2.0-rc.2.  Some new light client tests are ignored since we don't support light clients. Ref tests now use the real mainnet TTD so we don't need to override it back to the placeholder value.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
