### PR TITLE
Increase memory allocation for unit tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -248,7 +248,7 @@ jobs:
 
   unitTests:
     parallelism: 2
-    executor: medium_plus_executor
+    executor: large_executor
     steps:
       - prepare
       - attach_workspace:
@@ -270,6 +270,8 @@ jobs:
               echo "Failed to determine correct distribution of tests across nodes"
               exit 1
             fi
+            export JAVA_TOOL_OPTIONS="-Xmx2500m"
+            export GRADLE_OPTS="$GRADLE_OPTS -Dorg.gradle.workers.max=3"
             ./gradlew --no-daemon --parallel test $GRADLE_ARGS
       - notify
       - capture_test_results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -532,147 +532,147 @@ workflows:
           filters:
             tags: &filters-release-tags
               only: /^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?/
-      - spotless:
-          filters:
-            tags:
-              <<: *filters-release-tags
-      - windowsBuild:
-          filters:
-            tags:
-              <<: *filters-release-tags
-      - referenceTestsPrep:
-          requires:
-            - assemble
-          filters:
-            tags:
-              <<: *filters-release-tags
-      - referenceTests:
-          requires:
-            - assemble
-            - referenceTestsPrep
-          filters:
-            tags:
-              <<: *filters-release-tags
+#      - spotless:
+#          filters:
+#            tags:
+#              <<: *filters-release-tags
+#      - windowsBuild:
+#          filters:
+#            tags:
+#              <<: *filters-release-tags
+#      - referenceTestsPrep:
+#          requires:
+#            - assemble
+#          filters:
+#            tags:
+#              <<: *filters-release-tags
+#      - referenceTests:
+#          requires:
+#            - assemble
+#            - referenceTestsPrep
+#          filters:
+#            tags:
+#              <<: *filters-release-tags
       - unitTests:
           requires:
             - assemble
           filters:
             tags:
               <<: *filters-release-tags
-      - propertyTests:
-          requires:
-            - assemble
-          filters:
-            tags:
-              <<: *filters-release-tags
-      - integrationTests:
-          requires:
-            - assemble
-          filters:
-            tags:
-              <<: *filters-release-tags
-      - acceptanceTests:
-          requires:
-            - assemble
-          filters:
-            tags:
-              <<: *filters-release-tags
-      - extractAPISpec:
-          requires:
-            - assemble
-          filters:
-            tags:
-              <<: *filters-release-tags
-      - publish-cloudsmith:
-          filters:
-            branches:
-              only:
-                - master
-                - /^release-.*/
-            tags:
-              <<: *filters-release-tags
-          requires:
-            - unitTests
-            - propertyTests
-            - integrationTests
-            - acceptanceTests
-            - referenceTests
-            - extractAPISpec
-            - spotless
-            - windowsBuild
-          context:
-            - cloudsmith-protocols
-      - publishDockerAmd64:
-          filters:
-            branches:
-              only:
-                - master
-                - /^release-.*/
-            tags:
-              <<: *filters-release-tags
-          requires:
-            - unitTests
-            - propertyTests
-            - integrationTests
-            - acceptanceTests
-            - referenceTests
-            - extractAPISpec
-            - spotless
-            - windowsBuild
-          context:
-            - dockerhub-quorumengineering-rw
-            - dockerhub-opsquorum-dct         
-      - publishDockerArm64:
-          filters:
-            branches:
-              only:
-                - master
-                - /^release-.*/
-            tags:
-              <<: *filters-release-tags
-          requires:
-            - unitTests
-            - propertyTests
-            - integrationTests
-            - acceptanceTests
-            - referenceTests
-            - extractAPISpec
-            - spotless
-            - windowsBuild
-          context:
-            - dockerhub-quorumengineering-rw
-            - dockerhub-opsquorum-dct      
-      - manifestDocker:
-          filters:
-            branches:
-              only:
-                - master
-                - /^release-.*/
-            tags:
-              <<: *filters-release-tags
-          requires:
-            - publishDockerArm64
-            - publishDockerAmd64
-          context:
-            - dockerhub-quorumengineering-rw
-            - dockerhub-opsquorum-dct                               
-      - publishAPISpec:
-          filters:
-            branches:
-              only:
-                - master
-                - /^release-.*/
-            tags: # stable doc is published only on tags to prevent confusion on the doc site.
-              <<: *filters-release-tags
-          requires:
-            - unitTests
-            - propertyTests
-            - integrationTests
-            - acceptanceTests
-            - referenceTests
-            - extractAPISpec
-            - spotless
-            - windowsBuild
+#      - propertyTests:
+#          requires:
+#            - assemble
+#          filters:
+#            tags:
+#              <<: *filters-release-tags
+#      - integrationTests:
+#          requires:
+#            - assemble
+#          filters:
+#            tags:
+#              <<: *filters-release-tags
+#      - acceptanceTests:
+#          requires:
+#            - assemble
+#          filters:
+#            tags:
+#              <<: *filters-release-tags
+#      - extractAPISpec:
+#          requires:
+#            - assemble
+#          filters:
+#            tags:
+#              <<: *filters-release-tags
+#      - publish-cloudsmith:
+#          filters:
+#            branches:
+#              only:
+#                - master
+#                - /^release-.*/
+#            tags:
+#              <<: *filters-release-tags
+#          requires:
+#            - unitTests
+#            - propertyTests
+#            - integrationTests
+#            - acceptanceTests
+#            - referenceTests
+#            - extractAPISpec
+#            - spotless
+#            - windowsBuild
+#          context:
+#            - cloudsmith-protocols
+#      - publishDockerAmd64:
+#          filters:
+#            branches:
+#              only:
+#                - master
+#                - /^release-.*/
+#            tags:
+#              <<: *filters-release-tags
+#          requires:
+#            - unitTests
+#            - propertyTests
+#            - integrationTests
+#            - acceptanceTests
+#            - referenceTests
+#            - extractAPISpec
+#            - spotless
+#            - windowsBuild
+#          context:
+#            - dockerhub-quorumengineering-rw
+#            - dockerhub-opsquorum-dct
+#      - publishDockerArm64:
+#          filters:
+#            branches:
+#              only:
+#                - master
+#                - /^release-.*/
+#            tags:
+#              <<: *filters-release-tags
+#          requires:
+#            - unitTests
+#            - propertyTests
+#            - integrationTests
+#            - acceptanceTests
+#            - referenceTests
+#            - extractAPISpec
+#            - spotless
+#            - windowsBuild
+#          context:
+#            - dockerhub-quorumengineering-rw
+#            - dockerhub-opsquorum-dct
+#      - manifestDocker:
+#          filters:
+#            branches:
+#              only:
+#                - master
+#                - /^release-.*/
+#            tags:
+#              <<: *filters-release-tags
+#          requires:
+#            - publishDockerArm64
+#            - publishDockerAmd64
+#          context:
+#            - dockerhub-quorumengineering-rw
+#            - dockerhub-opsquorum-dct
+#      - publishAPISpec:
+#          filters:
+#            branches:
+#              only:
+#                - master
+#                - /^release-.*/
+#            tags: # stable doc is published only on tags to prevent confusion on the doc site.
+#              <<: *filters-release-tags
+#          requires:
+#            - unitTests
+#            - propertyTests
+#            - integrationTests
+#            - acceptanceTests
+#            - referenceTests
+#            - extractAPISpec
+#            - spotless
+#            - windowsBuild
   nightly:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -532,147 +532,147 @@ workflows:
           filters:
             tags: &filters-release-tags
               only: /^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?/
-#      - spotless:
-#          filters:
-#            tags:
-#              <<: *filters-release-tags
-#      - windowsBuild:
-#          filters:
-#            tags:
-#              <<: *filters-release-tags
-#      - referenceTestsPrep:
-#          requires:
-#            - assemble
-#          filters:
-#            tags:
-#              <<: *filters-release-tags
-#      - referenceTests:
-#          requires:
-#            - assemble
-#            - referenceTestsPrep
-#          filters:
-#            tags:
-#              <<: *filters-release-tags
+      - spotless:
+          filters:
+            tags:
+              <<: *filters-release-tags
+      - windowsBuild:
+          filters:
+            tags:
+              <<: *filters-release-tags
+      - referenceTestsPrep:
+          requires:
+            - assemble
+          filters:
+            tags:
+              <<: *filters-release-tags
+      - referenceTests:
+          requires:
+            - assemble
+            - referenceTestsPrep
+          filters:
+            tags:
+              <<: *filters-release-tags
       - unitTests:
           requires:
             - assemble
           filters:
             tags:
               <<: *filters-release-tags
-#      - propertyTests:
-#          requires:
-#            - assemble
-#          filters:
-#            tags:
-#              <<: *filters-release-tags
-#      - integrationTests:
-#          requires:
-#            - assemble
-#          filters:
-#            tags:
-#              <<: *filters-release-tags
-#      - acceptanceTests:
-#          requires:
-#            - assemble
-#          filters:
-#            tags:
-#              <<: *filters-release-tags
-#      - extractAPISpec:
-#          requires:
-#            - assemble
-#          filters:
-#            tags:
-#              <<: *filters-release-tags
-#      - publish-cloudsmith:
-#          filters:
-#            branches:
-#              only:
-#                - master
-#                - /^release-.*/
-#            tags:
-#              <<: *filters-release-tags
-#          requires:
-#            - unitTests
-#            - propertyTests
-#            - integrationTests
-#            - acceptanceTests
-#            - referenceTests
-#            - extractAPISpec
-#            - spotless
-#            - windowsBuild
-#          context:
-#            - cloudsmith-protocols
-#      - publishDockerAmd64:
-#          filters:
-#            branches:
-#              only:
-#                - master
-#                - /^release-.*/
-#            tags:
-#              <<: *filters-release-tags
-#          requires:
-#            - unitTests
-#            - propertyTests
-#            - integrationTests
-#            - acceptanceTests
-#            - referenceTests
-#            - extractAPISpec
-#            - spotless
-#            - windowsBuild
-#          context:
-#            - dockerhub-quorumengineering-rw
-#            - dockerhub-opsquorum-dct
-#      - publishDockerArm64:
-#          filters:
-#            branches:
-#              only:
-#                - master
-#                - /^release-.*/
-#            tags:
-#              <<: *filters-release-tags
-#          requires:
-#            - unitTests
-#            - propertyTests
-#            - integrationTests
-#            - acceptanceTests
-#            - referenceTests
-#            - extractAPISpec
-#            - spotless
-#            - windowsBuild
-#          context:
-#            - dockerhub-quorumengineering-rw
-#            - dockerhub-opsquorum-dct
-#      - manifestDocker:
-#          filters:
-#            branches:
-#              only:
-#                - master
-#                - /^release-.*/
-#            tags:
-#              <<: *filters-release-tags
-#          requires:
-#            - publishDockerArm64
-#            - publishDockerAmd64
-#          context:
-#            - dockerhub-quorumengineering-rw
-#            - dockerhub-opsquorum-dct
-#      - publishAPISpec:
-#          filters:
-#            branches:
-#              only:
-#                - master
-#                - /^release-.*/
-#            tags: # stable doc is published only on tags to prevent confusion on the doc site.
-#              <<: *filters-release-tags
-#          requires:
-#            - unitTests
-#            - propertyTests
-#            - integrationTests
-#            - acceptanceTests
-#            - referenceTests
-#            - extractAPISpec
-#            - spotless
-#            - windowsBuild
+      - propertyTests:
+          requires:
+            - assemble
+          filters:
+            tags:
+              <<: *filters-release-tags
+      - integrationTests:
+          requires:
+            - assemble
+          filters:
+            tags:
+              <<: *filters-release-tags
+      - acceptanceTests:
+          requires:
+            - assemble
+          filters:
+            tags:
+              <<: *filters-release-tags
+      - extractAPISpec:
+          requires:
+            - assemble
+          filters:
+            tags:
+              <<: *filters-release-tags
+      - publish-cloudsmith:
+          filters:
+            branches:
+              only:
+                - master
+                - /^release-.*/
+            tags:
+              <<: *filters-release-tags
+          requires:
+            - unitTests
+            - propertyTests
+            - integrationTests
+            - acceptanceTests
+            - referenceTests
+            - extractAPISpec
+            - spotless
+            - windowsBuild
+          context:
+            - cloudsmith-protocols
+      - publishDockerAmd64:
+          filters:
+            branches:
+              only:
+                - master
+                - /^release-.*/
+            tags:
+              <<: *filters-release-tags
+          requires:
+            - unitTests
+            - propertyTests
+            - integrationTests
+            - acceptanceTests
+            - referenceTests
+            - extractAPISpec
+            - spotless
+            - windowsBuild
+          context:
+            - dockerhub-quorumengineering-rw
+            - dockerhub-opsquorum-dct         
+      - publishDockerArm64:
+          filters:
+            branches:
+              only:
+                - master
+                - /^release-.*/
+            tags:
+              <<: *filters-release-tags
+          requires:
+            - unitTests
+            - propertyTests
+            - integrationTests
+            - acceptanceTests
+            - referenceTests
+            - extractAPISpec
+            - spotless
+            - windowsBuild
+          context:
+            - dockerhub-quorumengineering-rw
+            - dockerhub-opsquorum-dct      
+      - manifestDocker:
+          filters:
+            branches:
+              only:
+                - master
+                - /^release-.*/
+            tags:
+              <<: *filters-release-tags
+          requires:
+            - publishDockerArm64
+            - publishDockerAmd64
+          context:
+            - dockerhub-quorumengineering-rw
+            - dockerhub-opsquorum-dct                               
+      - publishAPISpec:
+          filters:
+            branches:
+              only:
+                - master
+                - /^release-.*/
+            tags: # stable doc is published only on tags to prevent confusion on the doc site.
+              <<: *filters-release-tags
+          requires:
+            - unitTests
+            - propertyTests
+            - integrationTests
+            - acceptanceTests
+            - referenceTests
+            - extractAPISpec
+            - spotless
+            - windowsBuild
   nightly:
     triggers:
       - schedule:


### PR DESCRIPTION
## PR Description
Control maximum number of workers but give each more memory to see if it stops the crashing. Uses a larger executor as well to make sure there's enough memory.


## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
