### PR TITLE
Avoid finding min genesis PoW block when genesis state already known

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ For information on changes in released versions of Teku, see the [releases page]
 - Primed cache for new justified checkpoints to reduce time required to run fork choice immediately after justification
 - Remain in optimistic mode when there are no viable branches in the block tree because blocks from every branch were marked INVALID during optimistic sync (https://github.com/ethereum/consensus-specs/pull/2955)
 - Added Gas Limit APIs (GET/POST/DELETE)
+- Skip finding the PoW block that first satisfies the minimum genesis time condition when the genesis state is already known. Fixes an incompatibility with Nethermind's backwards sync for historic blocks.
 
 ### Bug Fixes
 - Fixed `NullPointerException` when checking for the terminal PoW block while the EL was syncing


### PR DESCRIPTION
## PR Description

Skip finding the PoW block that first satisfies the minimum genesis time condition when we already have an anchor state.

The min genesis time block is only required as part of the process to generate genesis so if we already have a BeaconState to start from, we don't need to generate the genesis state and thus don't need to find this block.

This improves compatibility with ELs (particularly Nethermind) that may not download all historic blocks or may backfill them after eth_syncing reports the node is in sync.


## Fixed Issue(s)
#6059 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
