### PR TITLE
Apply gossip validations to attestations and aggregate submitted via the REST API

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -63,7 +63,6 @@ import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncComm
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.ValidateableSyncCommitteeMessage;
 import tech.pegasys.teku.spec.datastructures.operations.versions.bellatrix.BeaconPreparableProposer;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
-import tech.pegasys.teku.spec.datastructures.util.AttestationProcessingResult;
 import tech.pegasys.teku.spec.datastructures.validator.SubnetSubscription;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult.FailureReason;
 import tech.pegasys.teku.spec.logic.common.util.SyncCommitteeUtil;
@@ -244,10 +243,6 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
         .thenApply(
             optionalState ->
                 optionalState.map(state -> getProposerDutiesFromIndicesAndState(state, epoch)));
-  }
-
-  public Optional<ProposerDuties> getProposerDuties(final BeaconState state, final UInt64 epoch) {
-    return Optional.of(getProposerDutiesFromIndicesAndState(state, epoch));
   }
 
   @Override
@@ -477,39 +472,36 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
         .thenApply(this::convertAttestationProcessingResultsToErrorList);
   }
 
-  private SafeFuture<AttestationProcessingResult> processAttestation(
-      final Attestation attestation) {
+  private SafeFuture<InternalValidationResult> processAttestation(final Attestation attestation) {
     return attestationManager
-        .onAttestation(ValidateableAttestation.fromValidator(spec, attestation))
+        .addAttestation(ValidateableAttestation.fromValidator(spec, attestation))
         .thenPeek(
             result -> {
-              if (!result.isInvalid()) {
+              if (!result.isReject()) {
                 dutyMetrics.onAttestationPublished(attestation.getData().getSlot());
                 performanceTracker.saveProducedAttestation(attestation);
               } else {
                 VALIDATOR_LOGGER.producedInvalidAttestation(
-                    attestation.getData().getSlot(), result.getInvalidReason());
+                    attestation.getData().getSlot(),
+                    result.getDescription().orElse("Unknown reason"));
               }
             })
         .exceptionally(
-            error -> {
-              final String errorText =
-                  "Failed to send signed attestation for slot "
-                      + attestation.getData().getSlot()
-                      + ", block "
-                      + attestation.getData().getBeaconBlockRoot();
-              LOG.debug(errorText, error);
-              return AttestationProcessingResult.invalid(errorText);
-            });
+            error ->
+                InternalValidationResult.reject(
+                    "Failed to send signed attestation for slot %s, block %s",
+                    attestation.getData().getSlot(), attestation.getData().getBeaconBlockRoot()));
   }
 
   private List<SubmitDataError> convertAttestationProcessingResultsToErrorList(
-      final List<AttestationProcessingResult> results) {
+      final List<InternalValidationResult> results) {
     final List<SubmitDataError> errorList = new ArrayList<>();
     for (int index = 0; index < results.size(); index++) {
-      final AttestationProcessingResult result = results.get(index);
-      if (result.isInvalid()) {
-        errorList.add(new SubmitDataError(UInt64.valueOf(index), result.getInvalidReason()));
+      final InternalValidationResult result = results.get(index);
+      if (result.isReject()) {
+        errorList.add(
+            new SubmitDataError(
+                UInt64.valueOf(index), result.getDescription().orElse("Unknown reason")));
       }
     }
     return errorList;
@@ -522,17 +514,18 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
         .thenApply(this::convertAttestationProcessingResultsToErrorList);
   }
 
-  private SafeFuture<AttestationProcessingResult> processAggregateAndProof(
+  private SafeFuture<InternalValidationResult> processAggregateAndProof(
       final SignedAggregateAndProof aggregateAndProof) {
     return attestationManager
-        .onAttestation(ValidateableAttestation.aggregateFromValidator(spec, aggregateAndProof))
+        .addAggregate(ValidateableAttestation.aggregateFromValidator(spec, aggregateAndProof))
         .thenPeek(
-            result ->
-                result.ifInvalid(
-                    reason ->
-                        VALIDATOR_LOGGER.producedInvalidAggregate(
-                            aggregateAndProof.getMessage().getAggregate().getData().getSlot(),
-                            reason)));
+            result -> {
+              if (result.isReject()) {
+                VALIDATOR_LOGGER.producedInvalidAggregate(
+                    aggregateAndProof.getMessage().getAggregate().getData().getSlot(),
+                    result.getDescription().orElse("Unknown reason"));
+              }
+            });
   }
 
   @Override

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -31,7 +31,6 @@ import static tech.pegasys.teku.infrastructure.async.SafeFuture.completedFuture;
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThatSafeFuture;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
-import static tech.pegasys.teku.spec.datastructures.util.AttestationProcessingResult.SUCCESSFUL;
 import static tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult.FailureReason.DOES_NOT_DESCEND_FROM_LATEST_FINALIZED;
 
 import it.unimi.dsi.fastutil.ints.IntList;
@@ -72,7 +71,6 @@ import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.CheckpointState;
 import tech.pegasys.teku.spec.datastructures.state.Validator;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
-import tech.pegasys.teku.spec.datastructures.util.AttestationProcessingResult;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
 import tech.pegasys.teku.spec.logic.common.util.SyncCommitteeUtil;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
@@ -678,20 +676,20 @@ class ValidatorApiHandlerTest {
   @Test
   public void sendSignedAttestations_shouldAddAttestationToAttestationManager() {
     final Attestation attestation = dataStructureUtil.randomAttestation();
-    when(attestationManager.onAttestation(any(ValidateableAttestation.class)))
-        .thenReturn(completedFuture(SUCCESSFUL));
+    when(attestationManager.addAttestation(any(ValidateableAttestation.class)))
+        .thenReturn(completedFuture(InternalValidationResult.ACCEPT));
     final SafeFuture<List<SubmitDataError>> result =
         validatorApiHandler.sendSignedAttestations(List.of(attestation));
     assertThat(result).isCompletedWithValue(emptyList());
 
-    verify(attestationManager).onAttestation(ValidateableAttestation.from(spec, attestation));
+    verify(attestationManager).addAttestation(ValidateableAttestation.from(spec, attestation));
   }
 
   @Test
   void sendSignedAttestations_shouldAddToDutyMetricsAndPerformanceTrackerWhenNotInvalid() {
     final Attestation attestation = dataStructureUtil.randomAttestation();
-    when(attestationManager.onAttestation(any(ValidateableAttestation.class)))
-        .thenReturn(completedFuture(AttestationProcessingResult.SAVED_FOR_FUTURE));
+    when(attestationManager.addAttestation(any(ValidateableAttestation.class)))
+        .thenReturn(completedFuture(InternalValidationResult.SAVE_FOR_FUTURE));
 
     final SafeFuture<List<SubmitDataError>> result =
         validatorApiHandler.sendSignedAttestations(List.of(attestation));
@@ -704,8 +702,8 @@ class ValidatorApiHandlerTest {
   @Test
   void sendSignedAttestations_shouldNotAddToDutyMetricsAndPerformanceTrackerWhenInvalid() {
     final Attestation attestation = dataStructureUtil.randomAttestation();
-    when(attestationManager.onAttestation(any(ValidateableAttestation.class)))
-        .thenReturn(completedFuture(AttestationProcessingResult.invalid("Bad juju")));
+    when(attestationManager.addAttestation(any(ValidateableAttestation.class)))
+        .thenReturn(completedFuture(InternalValidationResult.reject("Bad juju")));
 
     final SafeFuture<List<SubmitDataError>> result =
         validatorApiHandler.sendSignedAttestations(List.of(attestation));
@@ -719,10 +717,10 @@ class ValidatorApiHandlerTest {
   void sendSignedAttestations_shouldProcessMixOfValidAndInvalidAttestations() {
     final Attestation invalidAttestation = dataStructureUtil.randomAttestation();
     final Attestation validAttestation = dataStructureUtil.randomAttestation();
-    when(attestationManager.onAttestation(validatableAttestationOf(invalidAttestation)))
-        .thenReturn(completedFuture(AttestationProcessingResult.invalid("Bad juju")));
-    when(attestationManager.onAttestation(validatableAttestationOf(validAttestation)))
-        .thenReturn(completedFuture(SUCCESSFUL));
+    when(attestationManager.addAttestation(validatableAttestationOf(invalidAttestation)))
+        .thenReturn(completedFuture(InternalValidationResult.reject("Bad juju")));
+    when(attestationManager.addAttestation(validatableAttestationOf(validAttestation)))
+        .thenReturn(completedFuture(InternalValidationResult.ACCEPT));
 
     final SafeFuture<List<SubmitDataError>> result =
         validatorApiHandler.sendSignedAttestations(List.of(invalidAttestation, validAttestation));
@@ -781,14 +779,14 @@ class ValidatorApiHandlerTest {
   public void sendAggregateAndProofs_shouldPostAggregateAndProof() {
     final SignedAggregateAndProof aggregateAndProof =
         dataStructureUtil.randomSignedAggregateAndProof();
-    when(attestationManager.onAttestation(any(ValidateableAttestation.class)))
-        .thenReturn(completedFuture(SUCCESSFUL));
+    when(attestationManager.addAggregate(any(ValidateableAttestation.class)))
+        .thenReturn(completedFuture(InternalValidationResult.ACCEPT));
     final SafeFuture<List<SubmitDataError>> result =
         validatorApiHandler.sendAggregateAndProofs(List.of(aggregateAndProof));
     assertThat(result).isCompletedWithValue(emptyList());
 
     verify(attestationManager)
-        .onAttestation(ValidateableAttestation.aggregateFromValidator(spec, aggregateAndProof));
+        .addAggregate(ValidateableAttestation.aggregateFromValidator(spec, aggregateAndProof));
   }
 
   @Test
@@ -797,12 +795,12 @@ class ValidatorApiHandlerTest {
         dataStructureUtil.randomSignedAggregateAndProof();
     final SignedAggregateAndProof validAggregate =
         dataStructureUtil.randomSignedAggregateAndProof();
-    when(attestationManager.onAttestation(
+    when(attestationManager.addAggregate(
             ValidateableAttestation.aggregateFromValidator(spec, invalidAggregate)))
-        .thenReturn(completedFuture(AttestationProcessingResult.invalid("Bad juju")));
-    when(attestationManager.onAttestation(
+        .thenReturn(completedFuture(InternalValidationResult.reject("Bad juju")));
+    when(attestationManager.addAggregate(
             ValidateableAttestation.aggregateFromValidator(spec, validAggregate)))
-        .thenReturn(completedFuture(SUCCESSFUL));
+        .thenReturn(completedFuture(InternalValidationResult.ACCEPT));
 
     final SafeFuture<List<SubmitDataError>> result =
         validatorApiHandler.sendAggregateAndProofs(List.of(invalidAggregate, validAggregate));
@@ -810,12 +808,12 @@ class ValidatorApiHandlerTest {
 
     // Should send both to the attestation manager.
     verify(attestationManager)
-        .onAttestation(
+        .addAggregate(
             argThat(
                 validatableAttestation ->
                     validatableAttestation.getSignedAggregateAndProof().equals(validAggregate)));
     verify(attestationManager)
-        .onAttestation(
+        .addAggregate(
             argThat(
                 validatableAttestation ->
                     validatableAttestation.getSignedAggregateAndProof().equals(invalidAggregate)));


### PR DESCRIPTION
## PR Description
Apply gossip validations to attestations and aggregate submitted via the REST API. Previously only the operation validity checks were performed.

## Fixed Issue(s)
#6089 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
