### PR TITLE
Use properties provider

### DIFF
--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/BeaconProposerPreparer.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/BeaconProposerPreparer.java
@@ -164,7 +164,7 @@ public class BeaconProposerPreparer
   }
 
   @Override
-  public boolean isReadyToProvideFeeRecipient() {
+  public boolean isReadyToProvideProperties() {
     return sentProposersAtLeastOnce.get();
   }
 

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrationPropertiesProvider.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrationPropertiesProvider.java
@@ -24,5 +24,5 @@ public interface ValidatorRegistrationPropertiesProvider {
 
   Optional<UInt64> getGasLimit(BLSPublicKey publicKey);
 
-  boolean isReadyToProvideFeeRecipient();
+  boolean isReadyToProvideProperties();
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrator.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrator.java
@@ -142,15 +142,14 @@ public class ValidatorRegistrator implements ValidatorTimingChannel {
     return cachedValidatorRegistrations.size();
   }
 
-  public UInt64 getGasLimit(
-      final Optional<ProposerConfig> maybeProposerConfig, final BLSPublicKey publicKey) {
-    return maybeProposerConfig
-        .flatMap(proposerConfig -> proposerConfig.getBuilderGasLimitForPubKey(publicKey))
+  private UInt64 getGasLimit(final BLSPublicKey publicKey) {
+    return validatorRegistrationPropertiesProvider
+        .getGasLimit(publicKey)
         .orElse(validatorConfig.getBuilderRegistrationDefaultGasLimit());
   }
 
   private boolean isNotReadyToRegister() {
-    if (!validatorRegistrationPropertiesProvider.isReadyToProvideFeeRecipient()) {
+    if (!validatorRegistrationPropertiesProvider.isReadyToProvideProperties()) {
       LOG.debug("Not ready to register validator(s).");
       return true;
     }
@@ -219,7 +218,7 @@ public class ValidatorRegistrator implements ValidatorTimingChannel {
     }
 
     final Eth1Address feeRecipient = maybeFeeRecipient.get();
-    final UInt64 gasLimit = getGasLimit(maybeProposerConfig, publicKey);
+    final UInt64 gasLimit = getGasLimit(publicKey);
 
     final Optional<UInt64> maybeTimestampOverride =
         getTimestampOverride(maybeProposerConfig, publicKey);

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/BeaconProposerPreparerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/BeaconProposerPreparerTest.java
@@ -143,7 +143,7 @@ public class BeaconProposerPreparerTest {
   void should_callPrepareBeaconProposerAtBeginningOfEpoch() {
     // not yet ready to provide a fee recipient to other consumers since the first sending hasn't
     // been done
-    assertThat(beaconProposerPreparer.isReadyToProvideFeeRecipient()).isFalse();
+    assertThat(beaconProposerPreparer.isReadyToProvideProperties()).isFalse();
 
     ArgumentCaptor<Collection<BeaconPreparableProposer>> captor = doCall();
 
@@ -154,7 +154,7 @@ public class BeaconProposerPreparerTest {
             new BeaconPreparableProposer(
                 UInt64.valueOf(validator2Index), defaultFeeRecipientConfig));
 
-    assertThat(beaconProposerPreparer.isReadyToProvideFeeRecipient()).isTrue();
+    assertThat(beaconProposerPreparer.isReadyToProvideProperties()).isTrue();
   }
 
   @TestTemplate

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorRegistratorTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorRegistratorTest.java
@@ -108,6 +108,8 @@ class ValidatorRegistratorTest {
     when(validatorRegistrationPropertiesProvider.isReadyToProvideProperties()).thenReturn(true);
     when(validatorRegistrationPropertiesProvider.getFeeRecipient(any()))
         .thenReturn(Optional.of(eth1Address));
+    when(validatorRegistrationPropertiesProvider.getGasLimit(any()))
+        .thenReturn(Optional.of(gasLimit));
 
     // random signature for all signings
     doAnswer(invocation -> SafeFuture.completedFuture(dataStructureUtil.randomSignature()))
@@ -309,7 +311,7 @@ class ValidatorRegistratorTest {
         .thenReturn(Optional.of(otherEth1Address));
 
     // gas limit changed for validator3
-    when(proposerConfig.getBuilderGasLimitForPubKey(validator3.getPublicKey()))
+    when(validatorRegistrationPropertiesProvider.getGasLimit(validator3.getPublicKey()))
         .thenReturn(Optional.of(otherGasLimit));
 
     // public key overwritten for validator4
@@ -429,6 +431,11 @@ class ValidatorRegistratorTest {
     when(proposerConfig.getBuilderGasLimitForPubKey(validator3.getPublicKey()))
         .thenReturn(Optional.empty());
     when(validatorConfig.getBuilderRegistrationDefaultGasLimit()).thenReturn(defaultGasLimit);
+
+    when(validatorRegistrationPropertiesProvider.getGasLimit(validator2.getPublicKey()))
+        .thenReturn(Optional.of(validator2GasLimit));
+    when(validatorRegistrationPropertiesProvider.getGasLimit(validator3.getPublicKey()))
+        .thenReturn(Optional.empty());
 
     runRegistrationFlowForSlot(UInt64.ZERO);
 

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorRegistratorTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorRegistratorTest.java
@@ -103,7 +103,6 @@ class ValidatorRegistratorTest {
         .thenReturn(SafeFuture.completedFuture(Optional.of(proposerConfig)));
 
     when(proposerConfig.isBuilderEnabledForPubKey(any())).thenReturn(Optional.of(true));
-    when(proposerConfig.getBuilderGasLimitForPubKey(any())).thenReturn(Optional.of(gasLimit));
 
     when(validatorRegistrationPropertiesProvider.isReadyToProvideProperties()).thenReturn(true);
     when(validatorRegistrationPropertiesProvider.getFeeRecipient(any()))
@@ -425,17 +424,12 @@ class ValidatorRegistratorTest {
     final UInt64 defaultGasLimit = UInt64.valueOf(27_000_000);
 
     // validator2 will have custom gas limit
-    when(proposerConfig.getBuilderGasLimitForPubKey(validator2.getPublicKey()))
-        .thenReturn(Optional.of(validator2GasLimit));
-    // validator3 gas limit will fall back to a default
-    when(proposerConfig.getBuilderGasLimitForPubKey(validator3.getPublicKey()))
-        .thenReturn(Optional.empty());
-    when(validatorConfig.getBuilderRegistrationDefaultGasLimit()).thenReturn(defaultGasLimit);
-
     when(validatorRegistrationPropertiesProvider.getGasLimit(validator2.getPublicKey()))
         .thenReturn(Optional.of(validator2GasLimit));
+    // validator3 gas limit will fall back to a default
     when(validatorRegistrationPropertiesProvider.getGasLimit(validator3.getPublicKey()))
         .thenReturn(Optional.empty());
+    when(validatorConfig.getBuilderRegistrationDefaultGasLimit()).thenReturn(defaultGasLimit);
 
     runRegistrationFlowForSlot(UInt64.ZERO);
 

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorRegistratorTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorRegistratorTest.java
@@ -105,7 +105,7 @@ class ValidatorRegistratorTest {
     when(proposerConfig.isBuilderEnabledForPubKey(any())).thenReturn(Optional.of(true));
     when(proposerConfig.getBuilderGasLimitForPubKey(any())).thenReturn(Optional.of(gasLimit));
 
-    when(validatorRegistrationPropertiesProvider.isReadyToProvideFeeRecipient()).thenReturn(true);
+    when(validatorRegistrationPropertiesProvider.isReadyToProvideProperties()).thenReturn(true);
     when(validatorRegistrationPropertiesProvider.getFeeRecipient(any()))
         .thenReturn(Optional.of(eth1Address));
 
@@ -117,7 +117,7 @@ class ValidatorRegistratorTest {
 
   @TestTemplate
   void doesNotRegisterValidators_ifNotReady() {
-    when(validatorRegistrationPropertiesProvider.isReadyToProvideFeeRecipient()).thenReturn(false);
+    when(validatorRegistrationPropertiesProvider.isReadyToProvideProperties()).thenReturn(false);
 
     runRegistrationFlowForSlot(UInt64.ONE);
 
@@ -367,7 +367,7 @@ class ValidatorRegistratorTest {
 
   @TestTemplate
   void doesNotRegisterNewlyAddedValidators_ifNotReady() {
-    when(validatorRegistrationPropertiesProvider.isReadyToProvideFeeRecipient()).thenReturn(false);
+    when(validatorRegistrationPropertiesProvider.isReadyToProvideProperties()).thenReturn(false);
 
     validatorRegistrator.onValidatorsAdded();
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
- Use properties provided in `ValidatorRegistrator`
- Rename `isReadyToProvideFeeRecipient` to `isReadyToProvideProperties`

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

https://github.com/ConsenSys/teku/issues/5999

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
