### PR TITLE
Don't throw unchecked exceptions when creating requests for builders

### DIFF
--- a/ethereum/executionclient/build.gradle
+++ b/ethereum/executionclient/build.gradle
@@ -23,4 +23,5 @@ dependencies {
   integrationTestImplementation testFixtures(project(':infrastructure:json'))
   integrationTestImplementation testFixtures(project(':infrastructure:time'))
   integrationTestImplementation 'com.squareup.okhttp3:mockwebserver'
+  integrationTestImplementation 'org.awaitility:awaitility'
 }

--- a/ethereum/executionclient/build.gradle
+++ b/ethereum/executionclient/build.gradle
@@ -23,5 +23,4 @@ dependencies {
   integrationTestImplementation testFixtures(project(':infrastructure:json'))
   integrationTestImplementation testFixtures(project(':infrastructure:time'))
   integrationTestImplementation 'com.squareup.okhttp3:mockwebserver'
-  integrationTestImplementation 'org.awaitility:awaitility'
 }

--- a/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/rest/OkHttpRestClientTest.java
+++ b/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/rest/OkHttpRestClientTest.java
@@ -15,9 +15,12 @@ package tech.pegasys.teku.ethereum.executionclient.rest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.fasterxml.jackson.core.JsonGenerator;
 import java.io.IOException;
+import java.net.SocketException;
 import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
 import java.util.function.Consumer;
 import okhttp3.OkHttpClient;
 import okhttp3.mockwebserver.MockResponse;
@@ -44,23 +47,25 @@ class OkHttpRestClientTest {
 
   private DeserializableTypeDefinition<TestObject> responseTypeDefinition;
   private SerializableTypeDefinition<TestObject2> requestTypeDefinition;
+  private SerializableTypeDefinition<TestObject2> failingRequestTypeDefinition;
 
   private OkHttpRestClient underTest;
 
   @BeforeEach
   void setUp() throws IOException {
     mockWebServer.start();
-    String endpoint = "http://localhost:" + mockWebServer.getPort();
-    this.responseTypeDefinition =
+    final String endpoint = "http://localhost:" + mockWebServer.getPort();
+    responseTypeDefinition =
         DeserializableTypeDefinition.object(TestObject.class)
             .initializer(TestObject::new)
             .withField("foo", CoreTypes.STRING_TYPE, TestObject::getFoo, TestObject::setFoo)
             .build();
-    this.requestTypeDefinition =
+    requestTypeDefinition =
         SerializableTypeDefinition.object(TestObject2.class)
             .withField("block_hash", CoreTypes.BYTES32_TYPE, TestObject2::getBlockHash)
             .build();
-    this.underTest = new OkHttpRestClient(okHttpClient, endpoint);
+    failingRequestTypeDefinition = new FailingSerializableTypeDefinition();
+    underTest = new OkHttpRestClient(okHttpClient, endpoint);
   }
 
   @AfterEach
@@ -76,11 +81,11 @@ class OkHttpRestClientTest {
             .setResponseCode(200)
             .addHeader("Content-Type", "application/json"));
 
-    SafeFuture<Response<TestObject>> responseFuture =
+    final SafeFuture<Response<TestObject>> responseFuture =
         underTest.getAsync(TEST_PATH, responseTypeDefinition);
 
     assertThat(responseFuture)
-        .succeedsWithin(Duration.ofSeconds(10))
+        .succeedsWithin(Duration.ofSeconds(1))
         .satisfies(
             response -> {
               assertThat(response.getErrorMessage()).isNull();
@@ -88,7 +93,7 @@ class OkHttpRestClientTest {
                   .satisfies(testObject -> assertThat(testObject.getFoo()).isEqualTo("bar"));
             });
 
-    RecordedRequest request = mockWebServer.takeRequest();
+    final RecordedRequest request = mockWebServer.takeRequest();
 
     assertThat(request.getPath()).isEqualTo("/" + TEST_PATH);
     assertThat(request.getMethod()).isEqualTo("GET");
@@ -98,17 +103,17 @@ class OkHttpRestClientTest {
   void getsResponseAsyncIgnoringResponseBody() throws InterruptedException {
     mockWebServer.enqueue(new MockResponse().setResponseCode(200));
 
-    SafeFuture<Response<Void>> responseFuture = underTest.getAsync(TEST_PATH);
+    final SafeFuture<Response<Void>> responseFuture = underTest.getAsync(TEST_PATH);
 
     assertThat(responseFuture)
-        .succeedsWithin(Duration.ofSeconds(5))
+        .succeedsWithin(Duration.ofSeconds(1))
         .satisfies(
             response -> {
               assertThat(response.getErrorMessage()).isNull();
               assertThat(response.getPayload()).isNull();
             });
 
-    RecordedRequest request = mockWebServer.takeRequest();
+    final RecordedRequest request = mockWebServer.takeRequest();
 
     assertThat(request.getPath()).isEqualTo("/" + TEST_PATH);
     assertThat(request.getMethod()).isEqualTo("GET");
@@ -116,14 +121,14 @@ class OkHttpRestClientTest {
 
   @Test
   void getAsyncHandlesFailures() throws InterruptedException {
-    String errorBody = "{\"code\":400,\"message\":\"Invalid block: missing signature\"}";
+    final String errorBody = "{\"code\":400,\"message\":\"Invalid block: missing signature\"}";
     mockWebServer.enqueue(new MockResponse().setResponseCode(400).setBody(errorBody));
 
-    SafeFuture<Response<TestObject>> responseFuture =
+    final SafeFuture<Response<TestObject>> responseFuture =
         underTest.getAsync(TEST_PATH, responseTypeDefinition);
 
     assertThat(responseFuture)
-        .succeedsWithin(Duration.ofSeconds(5))
+        .succeedsWithin(Duration.ofSeconds(1))
         .satisfies(
             response -> {
               assertThat(response.getErrorMessage()).isEqualTo(errorBody);
@@ -133,11 +138,11 @@ class OkHttpRestClientTest {
     // error without a body
     mockWebServer.enqueue(new MockResponse().setResponseCode(500));
 
-    SafeFuture<Response<TestObject>> secondResponseFuture =
+    final SafeFuture<Response<TestObject>> secondResponseFuture =
         underTest.getAsync(TEST_PATH, responseTypeDefinition);
 
     assertThat(secondResponseFuture)
-        .succeedsWithin(Duration.ofSeconds(5))
+        .succeedsWithin(Duration.ofSeconds(1))
         .satisfies(
             response -> {
               assertThat(response.getErrorMessage()).isEqualTo("500: Server Error");
@@ -146,8 +151,8 @@ class OkHttpRestClientTest {
 
     assertThat(mockWebServer.getRequestCount()).isEqualTo(2);
 
-    RecordedRequest request = mockWebServer.takeRequest();
-    RecordedRequest secondRequest = mockWebServer.takeRequest();
+    final RecordedRequest request = mockWebServer.takeRequest();
+    final RecordedRequest secondRequest = mockWebServer.takeRequest();
 
     Consumer<RecordedRequest> requestsAssertions =
         (req) -> {
@@ -166,13 +171,13 @@ class OkHttpRestClientTest {
             .setResponseCode(200)
             .addHeader("Content-Type", "application/json"));
 
-    TestObject2 requestBodyObject = new TestObject2(TEST_BLOCK_HASH);
-    SafeFuture<Response<TestObject>> responseFuture =
+    final TestObject2 requestBodyObject = new TestObject2(TEST_BLOCK_HASH);
+    final SafeFuture<Response<TestObject>> responseFuture =
         underTest.postAsync(
             TEST_PATH, requestBodyObject, requestTypeDefinition, responseTypeDefinition);
 
     assertThat(responseFuture)
-        .succeedsWithin(Duration.ofSeconds(10))
+        .succeedsWithin(Duration.ofSeconds(1))
         .satisfies(
             response -> {
               assertThat(response.getErrorMessage()).isNull();
@@ -180,13 +185,31 @@ class OkHttpRestClientTest {
                   .satisfies(testObject -> assertThat(testObject.getFoo()).isEqualTo("bar"));
             });
 
-    RecordedRequest request = mockWebServer.takeRequest();
+    final RecordedRequest request = mockWebServer.takeRequest();
 
     assertThat(request.getPath()).isEqualTo("/" + TEST_PATH);
     assertThat(request.getBody().readUtf8())
         .isEqualTo(
             "{\"block_hash\":\"0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2\"}");
     assertThat(request.getMethod()).isEqualTo("POST");
+  }
+
+  @Test
+  void postsAsyncHandlesRequestBodyCreationFailure() {
+    final TestObject2 requestBodyObject = new TestObject2(TEST_BLOCK_HASH);
+
+    final SafeFuture<Response<TestObject>> responseFuture =
+        underTest.postAsync(
+            TEST_PATH, requestBodyObject, failingRequestTypeDefinition, responseTypeDefinition);
+
+    assertThat(responseFuture)
+        .failsWithin(Duration.ofSeconds(1))
+        .withThrowableOfType(ExecutionException.class)
+        .havingCause()
+        .withMessage("Broken pipe");
+
+    // ensure no running calls
+    assertThat(okHttpClient.dispatcher().runningCalls()).isEmpty();
   }
 
   @Test
@@ -197,25 +220,42 @@ class OkHttpRestClientTest {
             .setResponseCode(200)
             .addHeader("Content-Type", "application/json"));
 
-    TestObject2 requestBodyObject = new TestObject2(TEST_BLOCK_HASH);
-    SafeFuture<Response<Void>> responseFuture =
+    final TestObject2 requestBodyObject = new TestObject2(TEST_BLOCK_HASH);
+    final SafeFuture<Response<Void>> responseFuture =
         underTest.postAsync(TEST_PATH, requestBodyObject, requestTypeDefinition);
 
     assertThat(responseFuture)
-        .succeedsWithin(Duration.ofSeconds(10))
+        .succeedsWithin(Duration.ofSeconds(1))
         .satisfies(
             response -> {
               assertThat(response.getErrorMessage()).isNull();
               assertThat(response.getPayload()).isNull();
             });
 
-    RecordedRequest request = mockWebServer.takeRequest();
+    final RecordedRequest request = mockWebServer.takeRequest();
 
     assertThat(request.getPath()).isEqualTo("/" + TEST_PATH);
     assertThat(request.getBody().readUtf8())
         .isEqualTo(
             "{\"block_hash\":\"0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2\"}");
     assertThat(request.getMethod()).isEqualTo("POST");
+  }
+
+  private static class FailingSerializableTypeDefinition
+      implements SerializableTypeDefinition<TestObject2> {
+
+    @Override
+    public void serializeOpenApiType(final JsonGenerator gen) {}
+
+    @Override
+    public void serialize(final TestObject2 value, final JsonGenerator gen) throws IOException {
+      throw new SocketException("Broken pipe");
+    }
+
+    @Override
+    public SerializableTypeDefinition<TestObject2> withDescription(final String description) {
+      return this;
+    }
   }
 
   private static class TestObject {
@@ -225,7 +265,7 @@ class OkHttpRestClientTest {
       return foo;
     }
 
-    public void setFoo(String foo) {
+    public void setFoo(final String foo) {
       this.foo = foo;
     }
   }
@@ -233,7 +273,7 @@ class OkHttpRestClientTest {
   private static class TestObject2 {
     private final Bytes32 blockHash;
 
-    public TestObject2(Bytes32 blockHash) {
+    public TestObject2(final Bytes32 blockHash) {
       this.blockHash = blockHash;
     }
 

--- a/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/rest/OkHttpRestClientTest.java
+++ b/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/rest/OkHttpRestClientTest.java
@@ -223,6 +223,7 @@ class OkHttpRestClientTest {
 
     testThread.start();
 
+    // this will fail if exceptions are thrown in other threads
     await().catchUncaughtExceptions().atMost(Duration.ofSeconds(1)).until(testFinished::get);
   }
 

--- a/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/rest/OkHttpRestClientTest.java
+++ b/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/rest/OkHttpRestClientTest.java
@@ -14,13 +14,13 @@
 package tech.pegasys.teku.ethereum.executionclient.rest;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import java.io.IOException;
 import java.net.SocketException;
 import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import okhttp3.OkHttpClient;
 import okhttp3.mockwebserver.MockResponse;
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.ethereum.executionclient.schema.Response;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.SafeFutureAssert;
+import tech.pegasys.teku.infrastructure.async.Waiter;
 import tech.pegasys.teku.infrastructure.json.types.CoreTypes;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 import tech.pegasys.teku.infrastructure.json.types.SerializableTypeDefinition;
@@ -203,8 +204,8 @@ class OkHttpRestClientTest {
         underTest.postAsync(
             TEST_PATH, requestBodyObject, failingRequestTypeDefinition, responseTypeDefinition);
 
-    // this will fail if exceptions are thrown in other threads
-    await().catchUncaughtExceptions().atMost(Duration.ofSeconds(1)).until(responseFuture::isDone);
+    // this will fail if there are uncaught exceptions in other threads
+    Waiter.waitFor(() -> assertThat(responseFuture).isDone(), 30, TimeUnit.SECONDS, false);
 
     SafeFutureAssert.assertThatSafeFuture(responseFuture)
         .isCompletedExceptionallyWithMessage("Broken pipe");

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/OkHttpRestClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/OkHttpRestClient.java
@@ -17,7 +17,6 @@ import static java.util.Collections.emptyMap;
 import static java.util.Objects.requireNonNull;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.Map;
 import java.util.Optional;
 import okhttp3.Call;
@@ -32,7 +31,6 @@ import okio.BufferedSink;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import tech.pegasys.teku.ethereum.executionclient.schema.Response;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
@@ -119,13 +117,10 @@ public class OkHttpRestClient implements RestClient {
 
       @Override
       public void writeTo(@NotNull final BufferedSink bufferedSink) throws IOException {
-        try (bufferedSink;
-            final OutputStream outputStream = bufferedSink.outputStream()) {
-          JsonUtil.serializeToBytes(requestBodyObject, requestTypeDefinition, outputStream);
-        }
+        JsonUtil.serializeToBytesUnchecked(
+            requestBodyObject, requestTypeDefinition, bufferedSink.outputStream());
       }
 
-      @Nullable
       @Override
       public MediaType contentType() {
         return JSON_MEDIA_TYPE;
@@ -173,7 +168,7 @@ public class OkHttpRestClient implements RestClient {
               final T payload =
                   JsonUtil.parse(responseBody.byteStream(), responseTypeDefinitionMaybe.get());
               futureResponse.complete(new Response<>(payload));
-            } catch (Throwable ex) {
+            } catch (final Throwable ex) {
               futureResponse.completeExceptionally(ex);
             }
           }
@@ -187,7 +182,7 @@ public class OkHttpRestClient implements RestClient {
     try {
       final String errorMessage = getErrorMessageForFailedResponse(response);
       futureResponse.complete(Response.withErrorMessage(errorMessage));
-    } catch (Throwable ex) {
+    } catch (final Throwable ex) {
       futureResponse.completeExceptionally(ex);
     }
   }

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/OkHttpRestClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/OkHttpRestClient.java
@@ -16,8 +16,8 @@ package tech.pegasys.teku.ethereum.executionclient.rest;
 import static java.util.Collections.emptyMap;
 import static java.util.Objects.requireNonNull;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.util.Map;
 import java.util.Optional;
 import okhttp3.Call;
@@ -118,9 +118,11 @@ public class OkHttpRestClient implements RestClient {
     return new RequestBody() {
 
       @Override
-      public void writeTo(@NotNull BufferedSink bufferedSink) throws JsonProcessingException {
-        JsonUtil.serializeToBytes(
-            requestBodyObject, requestTypeDefinition, bufferedSink.outputStream());
+      public void writeTo(@NotNull final BufferedSink bufferedSink) throws IOException {
+        try (bufferedSink;
+            final OutputStream outputStream = bufferedSink.outputStream()) {
+          JsonUtil.serializeToBytes(requestBodyObject, requestTypeDefinition, outputStream);
+        }
       }
 
       @Nullable

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/OkHttpRestClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/OkHttpRestClient.java
@@ -30,7 +30,6 @@ import okhttp3.ResponseBody;
 import okio.BufferedSink;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.jetbrains.annotations.NotNull;
 import tech.pegasys.teku.ethereum.executionclient.schema.Response;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
@@ -116,7 +115,7 @@ public class OkHttpRestClient implements RestClient {
     return new RequestBody() {
 
       @Override
-      public void writeTo(@NotNull final BufferedSink bufferedSink) throws IOException {
+      public void writeTo(final BufferedSink bufferedSink) throws IOException {
         JsonUtil.serializeToBytesChecked(
             requestBodyObject, requestTypeDefinition, bufferedSink.outputStream());
       }
@@ -148,13 +147,12 @@ public class OkHttpRestClient implements RestClient {
     final Callback responseCallback =
         new Callback() {
           @Override
-          public void onFailure(@NotNull final Call call, @NotNull final IOException ex) {
+          public void onFailure(final Call call, final IOException ex) {
             futureResponse.completeExceptionally(ex);
           }
 
           @Override
-          public void onResponse(
-              @NotNull final Call call, @NotNull final okhttp3.Response response) {
+          public void onResponse(final Call call, final okhttp3.Response response) {
             LOG.trace("{} {} {}", request.method(), request.url(), response.code());
             if (!response.isSuccessful()) {
               handleFailure(response, futureResponse);

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/OkHttpRestClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/OkHttpRestClient.java
@@ -117,7 +117,7 @@ public class OkHttpRestClient implements RestClient {
 
       @Override
       public void writeTo(@NotNull final BufferedSink bufferedSink) throws IOException {
-        JsonUtil.serializeToBytesUnchecked(
+        JsonUtil.serializeToBytesChecked(
             requestBodyObject, requestTypeDefinition, bufferedSink.outputStream());
       }
 

--- a/infrastructure/async/src/testFixtures/java/tech/pegasys/teku/infrastructure/async/Waiter.java
+++ b/infrastructure/async/src/testFixtures/java/tech/pegasys/teku/infrastructure/async/Waiter.java
@@ -19,6 +19,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.awaitility.Awaitility;
+import org.awaitility.core.ConditionFactory;
 import org.awaitility.pollinterval.IterativePollInterval;
 
 /**
@@ -34,8 +35,19 @@ public class Waiter {
 
   public static void waitFor(
       final Condition assertion, final int timeoutValue, final TimeUnit timeUnit) {
-    Awaitility.waitAtMost(timeoutValue, timeUnit)
-        .ignoreExceptions()
+    waitFor(assertion, timeoutValue, timeUnit, true);
+  }
+
+  public static void waitFor(
+      final Condition assertion,
+      final int timeoutValue,
+      final TimeUnit timeUnit,
+      final boolean ignoreExceptions) {
+    ConditionFactory conditionFactory = Awaitility.waitAtMost(timeoutValue, timeUnit);
+    if (ignoreExceptions) {
+      conditionFactory = conditionFactory.ignoreExceptions();
+    }
+    conditionFactory
         .pollInterval(
             IterativePollInterval.iterative(Waiter::nextPollInterval, INITIAL_POLL_INTERVAL))
         .untilAsserted(assertion::run);

--- a/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/JsonUtil.java
+++ b/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/JsonUtil.java
@@ -63,12 +63,26 @@ public class JsonUtil {
   public static void serializeToBytes(
       final JsonFactory factory, final JsonWriter serializer, final OutputStream out)
       throws JsonProcessingException {
-    try (final JsonGenerator gen = factory.createGenerator(out)) {
-      serializer.accept(gen);
+    try {
+      serializeToBytesUnchecked(factory, serializer, out);
     } catch (final JsonProcessingException e) {
       throw e;
     } catch (final IOException e) {
       throw new UncheckedIOException(e);
+    }
+  }
+
+  public static <T> void serializeToBytesUnchecked(
+      final T value, final SerializableTypeDefinition<T> type, final OutputStream out)
+      throws IOException {
+    serializeToBytesUnchecked(FACTORY, gen -> type.serialize(value, gen), out);
+  }
+
+  public static void serializeToBytesUnchecked(
+      final JsonFactory factory, final JsonWriter serializer, final OutputStream out)
+      throws IOException {
+    try (final JsonGenerator gen = factory.createGenerator(out)) {
+      serializer.accept(gen);
     }
   }
 

--- a/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/JsonUtil.java
+++ b/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/JsonUtil.java
@@ -64,7 +64,7 @@ public class JsonUtil {
       final JsonFactory factory, final JsonWriter serializer, final OutputStream out)
       throws JsonProcessingException {
     try {
-      serializeToBytesUnchecked(factory, serializer, out);
+      serializeToBytesChecked(factory, serializer, out);
     } catch (final JsonProcessingException e) {
       throw e;
     } catch (final IOException e) {
@@ -72,13 +72,13 @@ public class JsonUtil {
     }
   }
 
-  public static <T> void serializeToBytesUnchecked(
+  public static <T> void serializeToBytesChecked(
       final T value, final SerializableTypeDefinition<T> type, final OutputStream out)
       throws IOException {
-    serializeToBytesUnchecked(FACTORY, gen -> type.serialize(value, gen), out);
+    serializeToBytesChecked(FACTORY, gen -> type.serialize(value, gen), out);
   }
 
-  public static void serializeToBytesUnchecked(
+  public static void serializeToBytesChecked(
       final JsonFactory factory, final JsonWriter serializer, final OutputStream out)
       throws IOException {
     try (final JsonGenerator gen = factory.createGenerator(out)) {


### PR DESCRIPTION
## PR Description
All exceptions are currently handled in the OkHttp callback `onFailure` method. 

This PR makes sure no unchecked exception (different from expected IOException) is thrown in `RequestBody.writeTo` method. If such is thrown, then an exception will be thrown in a background thread, which will trigger `TekuDefaultExceptionHandler` to print a scary log message.

## Fixed Issue(s)
fixes #6109 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
