### PR TITLE
Draft: Remote validator acceptance test fails when using the `--beacon-node-api-endpoints` parameter

### DIFF
--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/RemoteValidatorAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/RemoteValidatorAcceptanceTest.java
@@ -86,9 +86,20 @@ public class RemoteValidatorAcceptanceTest extends AcceptanceTestBase {
                     .withNetwork("swift")
                     .withInteropValidators(0, VALIDATOR_COUNT)
                     .withPrimaryBeaconNodeEventStreamReconnectAttemptPeriod(Duration.ofMillis(100))
-                    .withBeaconNodes(beaconNode, failoverBeaconNode));
+                    .withBeaconNodeApiEndpoint(beaconNode, failoverBeaconNode));
 
     validatorClient.start();
+
+    // validator using `--beacon-node-api-endpoints` instead of `--beacon-node-api-endpoint`
+    TekuValidatorNode validatorClient2 = createValidatorNode(
+            config ->
+                    config
+                            .withNetwork("swift")
+                            .withInteropValidators(0, VALIDATOR_COUNT)
+                            .withPrimaryBeaconNodeEventStreamReconnectAttemptPeriod(Duration.ofMillis(100))
+                            .withBeaconNodeApiEndpoints(beaconNode, failoverBeaconNode));
+
+    validatorClient2.start();
 
     waitForSuccessfulEventStreamConnection();
     waitForValidatorDutiesToComplete();
@@ -97,6 +108,8 @@ public class RemoteValidatorAcceptanceTest extends AcceptanceTestBase {
 
     validatorClient.waitForLogMessageContaining(
         "Switching to failover beacon node for event streaming");
+    validatorClient2.waitForLogMessageContaining(
+            "Switching to failover beacon node for event streaming");
     waitForSuccessfulEventStreamConnection();
     waitForValidatorDutiesToComplete();
 
@@ -105,6 +118,8 @@ public class RemoteValidatorAcceptanceTest extends AcceptanceTestBase {
 
     validatorClient.waitForLogMessageContaining(
         "Primary beacon node is back and ready for event streaming. Will attempt connecting.");
+    validatorClient2.waitForLogMessageContaining(
+            "Primary beacon node is back and ready for event streaming. Will attempt connecting.");
     waitForSuccessfulEventStreamConnection();
     waitForValidatorDutiesToComplete();
   }

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuValidatorNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuValidatorNode.java
@@ -193,15 +193,24 @@ public class TekuValidatorNode extends Node {
     }
 
     public TekuValidatorNode.Config withBeaconNode(final TekuNode beaconNode) {
-      return withBeaconNodes(beaconNode);
+      return withBeaconNodeApiEndpoint(beaconNode);
     }
 
-    public TekuValidatorNode.Config withBeaconNodes(final TekuNode... beaconNodes) {
+    public TekuValidatorNode.Config withBeaconNodeApiEndpoint(final TekuNode... beaconNodes) {
       configMap.put(
           "beacon-node-api-endpoint",
           Arrays.stream(beaconNodes)
               .map(TekuNode::getBeaconRestApiUrl)
               .collect(Collectors.joining(",")));
+      return this;
+    }
+
+    public TekuValidatorNode.Config withBeaconNodeApiEndpoints(final TekuNode... beaconNodes) {
+      configMap.put(
+              "beacon-node-api-endpoints",
+              Arrays.stream(beaconNodes)
+                      .map(TekuNode::getBeaconRestApiUrl)
+                      .collect(Collectors.joining(",")));
       return this;
     }
 

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorClientOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorClientOptions.java
@@ -29,7 +29,7 @@ import tech.pegasys.teku.validator.api.ValidatorConfig;
 public class ValidatorClientOptions {
 
   @Option(
-      names = {"--beacon-node-api-endpoint", "--beacon-node-api-endpoints"},
+      names = {"--beacon-node-api-endpoints", "--beacon-node-api-endpoint"},
       paramLabel = "<ENDPOINT>",
       description =
           "Beacon Node REST API endpoint(s). If more than one endpoint is defined, the first node will be used as a primary and others as failovers.",

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorClientOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorClientOptions.java
@@ -29,7 +29,7 @@ import tech.pegasys.teku.validator.api.ValidatorConfig;
 public class ValidatorClientOptions {
 
   @Option(
-      names = {"--beacon-node-api-endpoints", "--beacon-node-api-endpoint"},
+      names = {"--beacon-node-api-endpoint", "--beacon-node-api-endpoints"},
       paramLabel = "<ENDPOINT>",
       description =
           "Beacon Node REST API endpoint(s). If more than one endpoint is defined, the first node will be used as a primary and others as failovers.",


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

Issue originally raised in discord. I modified the test `RemoteValidatorAcceptanceTest.shouldFailoverWhenPrimaryBeaconNodeGoesDown` and it fails when the `--beacon-node-api-endpoints` is used instead of `--beacon-node-api-endpoint`. Switching the order in the Validator client `@Option` makes both scenarios pass.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
