### PR TITLE
Improve error logs when multiple beacon nodes are configured

### DIFF
--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverRequestException.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverRequestException.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package tech.pegasys.teku.validator.remote;
 
 import java.util.Map;

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverRequestException.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverRequestException.java
@@ -1,0 +1,25 @@
+package tech.pegasys.teku.validator.remote;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+import okhttp3.HttpUrl;
+
+public class FailoverRequestException extends RuntimeException {
+
+  public FailoverRequestException(
+      final String method, final Map<HttpUrl, Throwable> capturedExceptions) {
+    super(createErrorMessage(method, capturedExceptions));
+  }
+
+  private static String createErrorMessage(
+      final String method, final Map<HttpUrl, Throwable> capturedExceptions) {
+    final String prefix =
+        String.format(
+            "Remote request (%s) failed on all configured Beacon Node endpoints.%n", method);
+    final String errorSummary =
+        capturedExceptions.entrySet().stream()
+            .map(entry -> entry.getKey() + ": " + entry.getValue())
+            .collect(Collectors.joining(System.lineSeparator()));
+    return prefix + errorSummary;
+  }
+}


### PR DESCRIPTION
## PR Description
Improve logs to show summary of errors from all configured beacon nodes when all of them fail.

**Before**
![image](https://user-images.githubusercontent.com/14827647/186445131-fbca0e99-1ea5-45f2-bdf4-0eab2e14a314.png)

**After**
![image](https://user-images.githubusercontent.com/14827647/186444085-dc7506f8-a864-4b22-8618-f92e3bec50a0.png)

## Fixed Issue(s)
fixes #6123 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
