### PR TITLE
Fix VC to BN compatibility for `/eth/v1/validator/beacon_committee_subscriptions`

### DIFF
--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/BeaconCommitteeSubscriptionRequest.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/BeaconCommitteeSubscriptionRequest.json
@@ -2,12 +2,10 @@
   "type" : "object",
   "properties" : {
     "validator_index" : {
-      "type" : "integer",
-      "format" : "int32"
+      "type" : "string"
     },
     "committee_index" : {
-      "type" : "integer",
-      "format" : "int32"
+      "type" : "string"
     },
     "committees_at_slot" : {
       "type" : "string",

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/request/v1/validator/BeaconCommitteeSubscriptionRequest.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/request/v1/validator/BeaconCommitteeSubscriptionRequest.java
@@ -21,11 +21,11 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 @SuppressWarnings("JavaCase")
 public class BeaconCommitteeSubscriptionRequest {
 
-  @Schema(type = "string", format = "uint64")
-  public final int validator_index;
+  @Schema(type = "string")
+  public final String validator_index;
 
-  @Schema(type = "string", format = "uint64")
-  public final int committee_index;
+  @Schema(type = "string")
+  public final String committee_index;
 
   @Schema(type = "string", format = "uint64")
   public final UInt64 committees_at_slot;
@@ -37,8 +37,8 @@ public class BeaconCommitteeSubscriptionRequest {
 
   @JsonCreator
   public BeaconCommitteeSubscriptionRequest(
-      @JsonProperty("validator_index") final int validator_index,
-      @JsonProperty("committee_index") final int committee_index,
+      @JsonProperty("validator_index") final String validator_index,
+      @JsonProperty("committee_index") final String committee_index,
       @JsonProperty("committees_at_slot") final UInt64 committees_at_slot,
       @JsonProperty("slot") final UInt64 slot,
       @JsonProperty("is_aggregator") final boolean is_aggregator) {

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/request/v1/validator/BeaconCommitteeSubscriptionRequest.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/request/v1/validator/BeaconCommitteeSubscriptionRequest.java
@@ -15,16 +15,15 @@ package tech.pegasys.teku.api.request.v1.validator;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
 import io.swagger.v3.oas.annotations.media.Schema;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 @SuppressWarnings("JavaCase")
 public class BeaconCommitteeSubscriptionRequest {
 
-  @Schema(type = "string")
   public final String validator_index;
 
-  @Schema(type = "string")
   public final String committee_index;
 
   @Schema(type = "string", format = "uint64")
@@ -42,8 +41,10 @@ public class BeaconCommitteeSubscriptionRequest {
       @JsonProperty("committees_at_slot") final UInt64 committees_at_slot,
       @JsonProperty("slot") final UInt64 slot,
       @JsonProperty("is_aggregator") final boolean is_aggregator) {
-    this.committee_index = committee_index;
+    Preconditions.checkNotNull(validator_index, "validator_index should be specified");
     this.validator_index = validator_index;
+    Preconditions.checkNotNull(committee_index, "committee_index should be specified");
+    this.committee_index = committee_index;
     this.committees_at_slot = committees_at_slot;
     this.slot = slot;
     this.is_aggregator = is_aggregator;

--- a/data/serializer/src/test/java/tech/pegasys/teku/api/request/v1/validator/BeaconCommitteeSubscriptionRequestTest.java
+++ b/data/serializer/src/test/java/tech/pegasys/teku/api/request/v1/validator/BeaconCommitteeSubscriptionRequestTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.api.request.v1.validator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+public class BeaconCommitteeSubscriptionRequestTest {
+
+  @Test
+  public void shouldFailInitializingIfValidatorIndexIsNull() {
+    final NullPointerException exception =
+        Assertions.assertThrows(
+            NullPointerException.class,
+            () -> new BeaconCommitteeSubscriptionRequest(null, "1", UInt64.ONE, UInt64.ONE, true));
+    assertThat(exception).hasMessage("validator_index should be specified");
+  }
+
+  @Test
+  public void shouldFailInitializingIfCommitteeIndexIsNull() {
+    final NullPointerException exception =
+        Assertions.assertThrows(
+            NullPointerException.class,
+            () -> new BeaconCommitteeSubscriptionRequest("1", null, UInt64.ONE, UInt64.ONE, true));
+    assertThat(exception).hasMessage("committee_index should be specified");
+  }
+}

--- a/validator/remote/src/integration-test/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClientTest.java
+++ b/validator/remote/src/integration-test/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClientTest.java
@@ -43,7 +43,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import tech.pegasys.teku.api.exceptions.RemoteServiceNotAvailableException;
-import tech.pegasys.teku.api.request.v1.validator.BeaconCommitteeSubscriptionRequest;
 import tech.pegasys.teku.api.response.v1.beacon.GetGenesisResponse;
 import tech.pegasys.teku.api.response.v1.beacon.GetStateValidatorsResponse;
 import tech.pegasys.teku.api.response.v1.beacon.PostDataFailure;
@@ -628,12 +627,9 @@ class OkHttpValidatorRestApiClientTest {
     final UInt64 slot2 = UInt64.valueOf(16);
     final boolean aggregator2 = false;
 
-    final BeaconCommitteeSubscriptionRequest[] expectedRequest = {
-      new BeaconCommitteeSubscriptionRequest(
-          validatorIndex1, committeeIndex1, committeesAtSlot1, slot1, aggregator1),
-      new BeaconCommitteeSubscriptionRequest(
-          validatorIndex2, committeeIndex2, committeesAtSlot2, slot2, aggregator2)
-    };
+    final String expectedRequest =
+        "[{\"validator_index\":\"6\",\"committee_index\":\"1\",\"committees_at_slot\":\"10\",\"slot\":\"15\",\"is_aggregator\":true},"
+            + "{\"validator_index\":\"7\",\"committee_index\":\"2\",\"committees_at_slot\":\"11\",\"slot\":\"16\",\"is_aggregator\":false}]";
 
     mockWebServer.enqueue(new MockResponse().setResponseCode(SC_OK));
 
@@ -649,8 +645,7 @@ class OkHttpValidatorRestApiClientTest {
     assertThat(request.getMethod()).isEqualTo("POST");
     assertThat(request.getPath())
         .contains(ValidatorApiMethod.SUBSCRIBE_TO_BEACON_COMMITTEE_SUBNET.getPath(emptyMap()));
-    assertThat(request.getBody().readString(StandardCharsets.UTF_8))
-        .isEqualTo(asJson(expectedRequest));
+    assertThat(request.getBody().readUtf8()).isEqualTo(expectedRequest);
   }
 
   @Test

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
@@ -266,8 +266,8 @@ public class OkHttpValidatorRestApiClient implements ValidatorRestApiClient {
             .map(
                 request ->
                     new BeaconCommitteeSubscriptionRequest(
-                        request.getValidatorIndex(),
-                        request.getCommitteeIndex(),
+                        String.valueOf(request.getValidatorIndex()),
+                        String.valueOf(request.getCommitteeIndex()),
                         request.getCommitteesAtSlot(),
                         request.getSlot(),
                         request.isAggregator()))


### PR DESCRIPTION
## PR Description
Change `BeaconCommitteeSubscriptionRequest` to use String instead of int in order to make Jackson quote the `validator_index` and `committee_index`

## Fixed Issue(s)
fixes #6121 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
