### PR TITLE
Log to console when the execution client is first confirmed as online.

### DIFF
--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3jClientBuilder.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3jClientBuilder.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.ethereum.executionclient.web3j;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.Objects.requireNonNull;
+import static tech.pegasys.teku.infrastructure.logging.EventLogger.EVENT_LOG;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -69,12 +70,12 @@ public class Web3jClientBuilder {
     switch (endpoint.getScheme()) {
       case "http":
       case "https":
-        return new Web3jHttpClient(endpoint, timeProvider, timeout, jwtConfigOpt);
+        return new Web3jHttpClient(EVENT_LOG, endpoint, timeProvider, timeout, jwtConfigOpt);
       case "ws":
       case "wss":
-        return new Web3jWebsocketClient(endpoint, timeProvider, jwtConfigOpt);
+        return new Web3jWebsocketClient(EVENT_LOG, endpoint, timeProvider, jwtConfigOpt);
       case "file":
-        return new Web3jIpcClient(endpoint, timeProvider, jwtConfigOpt);
+        return new Web3jIpcClient(EVENT_LOG, endpoint, timeProvider, jwtConfigOpt);
       default:
         throw new InvalidConfigurationException(prepareInvalidSchemeMessage(endpoint));
     }

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3jHttpClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3jHttpClient.java
@@ -23,17 +23,19 @@ import org.web3j.protocol.Web3jService;
 import org.web3j.protocol.http.HttpService;
 import tech.pegasys.teku.ethereum.executionclient.OkHttpClientCreator;
 import tech.pegasys.teku.ethereum.executionclient.auth.JwtConfig;
+import tech.pegasys.teku.infrastructure.logging.EventLogger;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 
 class Web3jHttpClient extends Web3JClient {
   private static final Logger LOG = LogManager.getLogger();
 
   Web3jHttpClient(
+      final EventLogger eventLog,
       final URI endpoint,
       final TimeProvider timeProvider,
       final Duration timeout,
       final Optional<JwtConfig> jwtConfig) {
-    super(timeProvider);
+    super(eventLog, timeProvider);
     final OkHttpClient okHttpClient =
         OkHttpClientCreator.create(timeout, LOG, jwtConfig, timeProvider);
     final Web3jService httpService = new HttpService(endpoint.toString(), okHttpClient);

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3jIpcClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3jIpcClient.java
@@ -24,14 +24,18 @@ import org.web3j.protocol.ipc.UnixIpcService;
 import org.web3j.protocol.ipc.WindowsIpcService;
 import tech.pegasys.teku.ethereum.executionclient.auth.JwtConfig;
 import tech.pegasys.teku.infrastructure.exceptions.InvalidConfigurationException;
+import tech.pegasys.teku.infrastructure.logging.EventLogger;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 
 class Web3jIpcClient extends Web3JClient {
   private static final Logger LOG = LogManager.getLogger();
 
   Web3jIpcClient(
-      final URI endpoint, final TimeProvider timeProvider, final Optional<JwtConfig> jwtConfig) {
-    super(timeProvider);
+      final EventLogger eventLog,
+      final URI endpoint,
+      final TimeProvider timeProvider,
+      final Optional<JwtConfig> jwtConfig) {
+    super(eventLog, timeProvider);
     if (jwtConfig.isPresent()) {
       LOG.warn("JWT configuration is ignored with IPC endpoint URI");
     }

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3jWebsocketClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3jWebsocketClient.java
@@ -25,6 +25,7 @@ import tech.pegasys.teku.ethereum.executionclient.auth.JwtAuthWebsocketHelper;
 import tech.pegasys.teku.ethereum.executionclient.auth.JwtConfig;
 import tech.pegasys.teku.ethereum.executionclient.schema.Response;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.logging.EventLogger;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 
 class Web3jWebsocketClient extends Web3JClient {
@@ -33,8 +34,11 @@ class Web3jWebsocketClient extends Web3JClient {
   private Optional<JwtAuthWebsocketHelper> jwtAuth = Optional.empty();
 
   Web3jWebsocketClient(
-      final URI endpoint, final TimeProvider timeProvider, final Optional<JwtConfig> jwtConfig) {
-    super(timeProvider);
+      final EventLogger eventLog,
+      final URI endpoint,
+      final TimeProvider timeProvider,
+      final Optional<JwtConfig> jwtConfig) {
+    super(eventLog, timeProvider);
     this.webSocketClient = new WebSocketClient(endpoint);
     final WebSocketService webSocketService = new WebSocketService(webSocketClient, false);
     initWeb3jService(webSocketService);

--- a/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3jWebsocketClientTest.java
+++ b/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3jWebsocketClientTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.infrastructure.logging.EventLogger.EVENT_LOG;
 
 import java.net.ConnectException;
 import java.net.URI;
@@ -48,7 +49,8 @@ public class Web3jWebsocketClientTest {
 
   @BeforeEach
   public void setup() {
-    this.web3jWebsocketClient = new Web3jWebsocketClient(endpoint, timeProvider, Optional.empty());
+    this.web3jWebsocketClient =
+        new Web3jWebsocketClient(EVENT_LOG, endpoint, timeProvider, Optional.empty());
     web3jWebsocketClient.initWeb3jService(webSocketService);
   }
 

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java
@@ -140,7 +140,7 @@ public class EventLogger {
   }
 
   public void executionClientIsOnline() {
-    info("Execution Client is back online", Color.GREEN);
+    info("Execution Client is online", Color.GREEN);
   }
 
   public void builderIsOffline(final String errorMessage) {


### PR DESCRIPTION
## PR Description
Previously we would only log if it was offline and came back online but it's reassuring for users to get an explicit log indicating that Teku connected to the execution client correctly.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
