### PR TITLE
VC using failover nodes when retrieving network spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ For information on changes in released versions of Teku, see the [releases page]
 - Added Gas Limit APIs (GET/POST/DELETE)
 - Skip finding the PoW block that first satisfies the minimum genesis time condition when the genesis state is already known. Fixes an incompatibility with Nethermind's backwards sync for historic blocks.
 - Circuit breaker logic added when interacting with Builder endpoint
+- VC using failover nodes for retrieving the network spec when `--network=auto` and multiple beacon nodes are configured
 
 ### Bug Fixes
 - Fixed `io.libp2p.core.InternalErrorException: [peerHandler] not initialized yet` error from jvm-libp2p
+- Fixed VC incompatibility with Nimbus BN for `/eth/v1/validator/beacon_committee_subscriptions` endpoint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,4 +25,4 @@ For information on changes in released versions of Teku, see the [releases page]
 
 ### Bug Fixes
 - Fixed `io.libp2p.core.InternalErrorException: [peerHandler] not initialized yet` error from jvm-libp2p
-- Fixed VC incompatibility with Nimbus BN for `/eth/v1/validator/beacon_committee_subscriptions` endpoint
+- Fixed VC incompatibility with Nimbus BN for the `/eth/v1/validator/beacon_committee_subscriptions` endpoint

--- a/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/JsonUtil.java
+++ b/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/JsonUtil.java
@@ -28,7 +28,6 @@ import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 import tech.pegasys.teku.infrastructure.json.types.SerializableTypeDefinition;
 
 public class JsonUtil {
-  public static final String JSON_CONTENT_TYPE = "application/json";
 
   public static final JsonFactory FACTORY = new JsonFactory();
 

--- a/teku/src/integration-test/java/tech/pegasys/teku/cli/subcommand/ValidatorClientCommandTest.java
+++ b/teku/src/integration-test/java/tech/pegasys/teku/cli/subcommand/ValidatorClientCommandTest.java
@@ -54,11 +54,11 @@ public class ValidatorClientCommandTest {
 
   private String[] argsNetworkOptDefault;
   private String[] argsNetworkOptAuto;
-  private String[] argsNetworkOptAutoWithFallback;
+  private String[] argsNetworkOptAutoWithFailover;
   private String[] argsNetworkOptAutoInConfig;
 
   private ClientAndServer mockBeaconServer;
-  private ClientAndServer fallbackMockBeaconServer;
+  private ClientAndServer failoverMockBeaconServer;
 
   private final Spec testSpec =
       SpecFactory.create(
@@ -75,11 +75,11 @@ public class ValidatorClientCommandTest {
   @BeforeEach
   public void setup(ClientAndServer server) {
     this.mockBeaconServer = server;
-    this.fallbackMockBeaconServer =
+    this.failoverMockBeaconServer =
         ClientAndServer.startClientAndServer(PortFactory.findFreePort());
     final String mockBeaconServerEndpoint = getMockBeaconServerEndpoint(mockBeaconServer);
-    final String fallbackMockBeaconServerEndpoint =
-        getMockBeaconServerEndpoint(fallbackMockBeaconServer);
+    final String failoverMockBeaconServerEndpoint =
+        getMockBeaconServerEndpoint(failoverMockBeaconServer);
 
     argsNetworkOptDefault =
         new String[] {"vc", "--beacon-node-api-endpoint", mockBeaconServerEndpoint};
@@ -87,13 +87,13 @@ public class ValidatorClientCommandTest {
         new String[] {
           "vc", "--network", "auto", "--beacon-node-api-endpoint", mockBeaconServerEndpoint
         };
-    argsNetworkOptAutoWithFallback =
+    argsNetworkOptAutoWithFailover =
         new String[] {
           "vc",
           "--network",
           "auto",
           "--beacon-node-api-endpoints",
-          mockBeaconServerEndpoint + "," + fallbackMockBeaconServerEndpoint
+          mockBeaconServerEndpoint + "," + failoverMockBeaconServerEndpoint
         };
     argsNetworkOptAutoInConfig =
         new String[] {
@@ -108,7 +108,7 @@ public class ValidatorClientCommandTest {
   @AfterEach
   public void tearDown() {
     mockBeaconServer.reset();
-    fallbackMockBeaconServer.stop();
+    failoverMockBeaconServer.stop();
   }
 
   @Test
@@ -124,19 +124,19 @@ public class ValidatorClientCommandTest {
   }
 
   @Test
-  public void autoDetectNetwork_ShouldFetchNetworkDetailsFromFallbackNode() {
+  public void autoDetectNetwork_ShouldFetchNetworkDetailsFromFailoverNode() {
     // primary node always fails
     configureMockServer(-1);
-    configureSuccessfulResponse(fallbackMockBeaconServer);
-    fetchAndVerifySpec(argsNetworkOptAutoWithFallback);
+    configureSuccessfulResponse(failoverMockBeaconServer);
+    fetchAndVerifySpec(argsNetworkOptAutoWithFailover);
   }
 
   @Test
   public void autoDetectNetwork_ShouldRetryRequest_IfFailsToFetchFromAllConfiguredBeaconNodes() {
     configureMockServer(1);
-    // fallback node always fails
-    configureFailedResponse(fallbackMockBeaconServer, -1);
-    fetchAndVerifySpec(argsNetworkOptAutoWithFallback);
+    // failover node always fails
+    configureFailedResponse(failoverMockBeaconServer, -1);
+    fetchAndVerifySpec(argsNetworkOptAutoWithFailover);
   }
 
   @Test

--- a/teku/src/integration-test/java/tech/pegasys/teku/cli/subcommand/ValidatorClientCommandTest.java
+++ b/teku/src/integration-test/java/tech/pegasys/teku/cli/subcommand/ValidatorClientCommandTest.java
@@ -151,15 +151,15 @@ public class ValidatorClientCommandTest {
     fetchAndVerifySpec(argsNetworkOptDefault);
   }
 
-  private void fetchAndVerifySpec(String[] args) {
-    int parseResult = beaconNodeCommand.parse(args);
+  private void fetchAndVerifySpec(final String[] args) {
+    final int parseResult = beaconNodeCommand.parse(args);
     assertThat(parseResult).isEqualTo(0);
 
-    TekuConfiguration config = getResultingTekuConfiguration();
+    final TekuConfiguration config = getResultingTekuConfiguration();
     assertThat(config.eth2NetworkConfiguration().getSpec()).isEqualTo(testSpec);
   }
 
-  private void configureMockServer(int fails) {
+  private void configureMockServer(final int fails) {
     configureFailedResponse(mockBeaconServer, fails);
     configureSuccessfulResponse(mockBeaconServer);
   }

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorClientOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorClientOptions.java
@@ -89,11 +89,7 @@ public class ValidatorClientOptions {
                 .sentryNodeConfigurationFile(sentryConfigFile));
   }
 
-  public URI getPrimaryBeaconNodeApiEndpoint() {
-    return getBeaconNodeApiEndpoints().get(0);
-  }
-
-  private List<URI> getBeaconNodeApiEndpoints() {
+  public List<URI> getBeaconNodeApiEndpoints() {
     return beaconNodeApiEndpoints.stream()
         .map(this::parseBeaconNodeApiEndpoint)
         .collect(Collectors.toList());

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/ValidatorClientCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/ValidatorClientCommand.java
@@ -130,7 +130,7 @@ public class ValidatorClientCommand implements Callable<Integer> {
 
   private void configureWithSpecFromBeaconNode(Eth2NetworkConfiguration.Builder builder) {
     try {
-      var spec = getSpecWithRetry(validatorClientOptions.getPrimaryBeaconNodeApiEndpoint());
+      var spec = getSpecWithRetry(validatorClientOptions.getBeaconNodeApiEndpoints());
       builder.spec(spec);
     } catch (Throwable e) {
       throw new InvalidConfigurationException(e);


### PR DESCRIPTION
## PR Description

- Changed `RemoteSpecLoader` to retrieve spec when multiple nodes are configured
- Added tests to `ValidatorClientCommandTest`
- Added changes to the CHANGELOG

## Fixed Issue(s)
fixes #6117 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
