### PR TITLE
Utilise progressive balances in more ways

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -465,6 +465,10 @@ public class Spec {
         .getCurrentSlot(store);
   }
 
+  public UInt64 getCurrentEpoch(final ReadOnlyStore store) {
+    return computeEpochAtSlot(getCurrentSlot(store));
+  }
+
   public UInt64 getSlotStartTime(UInt64 slotNumber, UInt64 genesisTime) {
     return atSlot(slotNumber).getForkChoiceUtil().getSlotStartTime(slotNumber, genesisTime);
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/ProgressiveBalancesMode.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/ProgressiveBalancesMode.java
@@ -16,5 +16,22 @@ package tech.pegasys.teku.spec.config;
 public enum ProgressiveBalancesMode {
   DISABLED,
   CHECKED,
-  USED
+  USED,
+  FULL;
+
+  public boolean isDisabled() {
+    return this == DISABLED;
+  }
+
+  public boolean isChecked() {
+    return ordinal() >= CHECKED.ordinal();
+  }
+
+  public boolean isUsed() {
+    return ordinal() >= USED.ordinal();
+  }
+
+  public boolean isFull() {
+    return ordinal() >= FULL.ordinal();
+  }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigBuilder.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigBuilder.java
@@ -102,7 +102,7 @@ public class SpecConfigBuilder {
   private Integer depositNetworkId;
   private Eth1Address depositContractAddress;
 
-  private ProgressiveBalancesMode progressiveBalancesMode = ProgressiveBalancesMode.DISABLED;
+  private ProgressiveBalancesMode progressiveBalancesMode = ProgressiveBalancesMode.USED;
 
   // Altair
   private Optional<AltairBuilder> altairBuilder = Optional.empty();

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/VoteUpdater.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/VoteUpdater.java
@@ -28,6 +28,7 @@ public interface VoteUpdater {
   void putVote(UInt64 validatorIndex, VoteTracker vote);
 
   Bytes32 applyForkChoiceScoreChanges(
+      UInt64 currentEpoch,
       Checkpoint finalizedCheckpoint,
       Checkpoint justifiedCheckpoint,
       List<UInt64> justifiedCheckpointEffectiveBalances,

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/AbstractEpochProcessor.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/AbstractEpochProcessor.java
@@ -23,7 +23,6 @@ import tech.pegasys.teku.infrastructure.ssz.collections.SszBitvector;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszMutableUInt64List;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszUInt64List;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.config.ProgressiveBalancesMode;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockHeader;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
@@ -116,7 +115,7 @@ public abstract class AbstractEpochProcessor implements EpochProcessor {
     processParticipationUpdates(state);
     processSyncCommitteeUpdates(state);
 
-    if (specConfig.getProgressiveBalancesMode() == ProgressiveBalancesMode.USED) {
+    if (specConfig.getProgressiveBalancesMode().isUsed()) {
       progressiveTotalBalances
           .getTotalBalances(specConfig)
           .ifPresent(
@@ -147,7 +146,7 @@ public abstract class AbstractEpochProcessor implements EpochProcessor {
     final Checkpoint currentJustifiedCheckpoint = preState.getCurrentJustifiedCheckpoint();
     final Checkpoint currentFinalizedCheckpoint = preState.getFinalizedCheckpoint();
     if (currentEpoch.isLessThanOrEqualTo(SpecConfig.GENESIS_EPOCH.plus(1))
-        || specConfig.getProgressiveBalancesMode() != ProgressiveBalancesMode.USED) {
+        || !specConfig.getProgressiveBalancesMode().isUsed()) {
       return new BlockCheckpoints(
           currentJustifiedCheckpoint,
           currentFinalizedCheckpoint,

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/statetransition/epoch/EpochProcessorAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/statetransition/epoch/EpochProcessorAltair.java
@@ -20,7 +20,6 @@ import tech.pegasys.teku.infrastructure.ssz.SszMutableList;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszMutableUInt64List;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszByte;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.config.ProgressiveBalancesMode;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.config.SpecConfigAltair;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
@@ -130,7 +129,7 @@ public class EpochProcessorAltair extends AbstractEpochProcessor {
   @Override
   public void initProgressiveTotalBalancesIfRequired(
       final BeaconState state, final TotalBalances totalBalances) {
-    if (specConfigAltair.getProgressiveBalancesMode() == ProgressiveBalancesMode.DISABLED) {
+    if (specConfigAltair.getProgressiveBalancesMode().isDisabled()) {
       return;
     }
     final TransitionCaches transitionCaches = BeaconStateCache.getTransitionCaches(state);

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/StubVoteUpdater.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/StubVoteUpdater.java
@@ -44,6 +44,7 @@ public class StubVoteUpdater implements VoteUpdater {
 
   @Override
   public Bytes32 applyForkChoiceScoreChanges(
+      final UInt64 currentEpoch,
       final Checkpoint finalizedCheckpoint,
       final Checkpoint justifiedCheckpoint,
       final List<UInt64> justifiedCheckpointEffectiveBalances,

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
@@ -317,6 +317,7 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
 
   @Override
   public Bytes32 applyForkChoiceScoreChanges(
+      final UInt64 currentEpoch,
       final Checkpoint finalizedCheckpoint,
       final Checkpoint justifiedCheckpoint,
       final List<UInt64> justifiedCheckpointEffectiveBalances,

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -205,6 +205,7 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
 
                       Bytes32 headBlockRoot =
                           transaction.applyForkChoiceScoreChanges(
+                              recentChainData.getCurrentEpoch().orElseThrow(),
                               finalizedCheckpoint,
                               justifiedCheckpoint,
                               justifiedEffectiveBalances,
@@ -490,7 +491,8 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
     // ProtoArray skips updating all ancestors when adding a new block but it's cheap when in sync.
     final Checkpoint justifiedCheckpoint = recentChainData.getJustifiedCheckpoint().orElseThrow();
     final Checkpoint finalizedCheckpoint = recentChainData.getFinalizedCheckpoint().orElseThrow();
-    return forkChoiceStrategy.findHead(justifiedCheckpoint, finalizedCheckpoint);
+    return forkChoiceStrategy.findHead(
+        recentChainData.getCurrentEpoch().orElseThrow(), justifiedCheckpoint, finalizedCheckpoint);
   }
 
   private void reportInvalidBlock(final SignedBeaconBlock block, final BlockImportResult result) {
@@ -509,6 +511,7 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
     final ForkChoiceState forkChoiceState =
         getForkChoiceStrategy()
             .getForkChoiceState(
+                recentChainData.getCurrentEpoch().orElseThrow(),
                 recentChainData.getJustifiedCheckpoint().orElseThrow(),
                 recentChainData.getFinalizedCheckpoint().orElseThrow());
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/EpochCachePrimerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/EpochCachePrimerTest.java
@@ -63,8 +63,8 @@ class EpochCachePrimerTest {
         .thenAnswer(invocation -> realSpec.getMaxLookaheadEpoch(invocation.getArgument(0)));
     when(mockSpec.computeEpochAtSlot(any()))
         .thenAnswer(invocation -> realSpec.computeEpochAtSlot(invocation.getArgument(0)));
-    when(mockSpec.getCurrentEpoch(any()))
-        .thenAnswer(invocation -> realSpec.getCurrentEpoch(invocation.getArgument(0)));
+    when(mockSpec.getCurrentEpoch(any(BeaconState.class)))
+        .thenAnswer(invocation -> realSpec.getCurrentEpoch(invocation.<BeaconState>getArgument(0)));
     when(mockSpec.getSpecConfig(any()))
         .thenAnswer(invocation -> realSpec.getSpecConfig(invocation.getArgument(0)));
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolTest.java
@@ -71,7 +71,8 @@ class AggregatingAttestationPoolTest {
     when(mockSpec.computeEpochAtSlot(any()))
         .thenAnswer(i -> spec.computeEpochAtSlot(i.getArgument(0)));
     when(mockSpec.getSlotsPerEpoch(any())).thenAnswer(i -> spec.getSlotsPerEpoch(i.getArgument(0)));
-    when(mockSpec.getCurrentEpoch(any())).thenAnswer(i -> spec.getCurrentEpoch(i.getArgument(0)));
+    when(mockSpec.getCurrentEpoch(any(BeaconState.class)))
+        .thenAnswer(i -> spec.getCurrentEpoch(i.<BeaconState>getArgument(0)));
     when(mockSpec.createAttestationWorthinessChecker(any()))
         .thenAnswer(i -> spec.createAttestationWorthinessChecker(i.getArgument(0)));
     when(mockSpec.atSlot(any())).thenAnswer(invocation -> spec.atSlot(invocation.getArgument(0)));

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArray.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArray.java
@@ -620,15 +620,13 @@ public class ProtoArray {
     }
 
     if (progressiveBalancesMode.isFull()) {
-      final boolean correctJustified;
-      final boolean correctFinalized;
       final boolean isPreviousEpochJustified =
           justifiedCheckpoint.getEpoch().plus(1).isGreaterThanOrEqualTo(currentEpoch);
-      correctJustified =
+      final boolean correctJustified =
           node.getJustifiedCheckpoint()
               .getEpoch()
               .isGreaterThanOrEqualTo(justifiedCheckpoint.getEpoch());
-      correctFinalized =
+      final boolean correctFinalized =
           isPreviousEpochJustified
               ? correctJustified
               : doesCheckpointMatch(node.getFinalizedCheckpoint(), finalizedCheckpoint);

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArray.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArray.java
@@ -624,19 +624,14 @@ public class ProtoArray {
       final boolean correctFinalized;
       final boolean isPreviousEpochJustified =
           justifiedCheckpoint.getEpoch().plus(1).isGreaterThanOrEqualTo(currentEpoch);
-      if (isPreviousEpochJustified) {
-        correctJustified =
-            node.getJustifiedCheckpoint()
-                .getEpoch()
-                .isGreaterThanOrEqualTo(justifiedCheckpoint.getEpoch());
-        correctFinalized = correctJustified;
-      } else {
-        correctJustified =
-            node.getJustifiedCheckpoint()
-                .getEpoch()
-                .isGreaterThanOrEqualTo(justifiedCheckpoint.getEpoch());
-        correctFinalized = doesCheckpointMatch(node.getFinalizedCheckpoint(), finalizedCheckpoint);
-      }
+      correctJustified =
+          node.getJustifiedCheckpoint()
+              .getEpoch()
+              .isGreaterThanOrEqualTo(justifiedCheckpoint.getEpoch());
+      correctFinalized =
+          isPreviousEpochJustified
+              ? correctJustified
+              : doesCheckpointMatch(node.getFinalizedCheckpoint(), finalizedCheckpoint);
       return correctJustified && correctFinalized;
     } else {
       return doesCheckpointMatch(node.getJustifiedCheckpoint(), justifiedCheckpoint)

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArray.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArray.java
@@ -620,14 +620,12 @@ public class ProtoArray {
     }
 
     if (progressiveBalancesMode.isFull()) {
-      final boolean isPreviousEpochJustified =
-          justifiedCheckpoint.getEpoch().plus(1).isGreaterThanOrEqualTo(currentEpoch);
       final boolean correctJustified =
           node.getJustifiedCheckpoint()
               .getEpoch()
               .isGreaterThanOrEqualTo(justifiedCheckpoint.getEpoch());
       final boolean correctFinalized =
-          isPreviousEpochJustified
+          isPreviousEpochJustified()
               ? correctJustified
               : doesCheckpointMatch(node.getFinalizedCheckpoint(), finalizedCheckpoint);
       return correctJustified && correctFinalized;
@@ -635,6 +633,10 @@ public class ProtoArray {
       return doesCheckpointMatch(node.getJustifiedCheckpoint(), justifiedCheckpoint)
           && doesCheckpointMatch(node.getFinalizedCheckpoint(), finalizedCheckpoint);
     }
+  }
+
+  private boolean isPreviousEpochJustified() {
+    return justifiedCheckpoint.getEpoch().plus(1).isGreaterThanOrEqualTo(currentEpoch);
   }
 
   private boolean doesCheckpointMatch(final Checkpoint actual, final Checkpoint required) {

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArray.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArray.java
@@ -36,6 +36,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.exceptions.FatalServiceFailureException;
 import tech.pegasys.teku.infrastructure.logging.StatusLogger;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.config.ProgressiveBalancesMode;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 
@@ -44,11 +45,13 @@ public class ProtoArray {
 
   private int pruneThreshold;
 
+  private UInt64 currentEpoch;
   private Checkpoint justifiedCheckpoint;
   private Checkpoint finalizedCheckpoint;
   // The epoch of our initial startup state
   // When starting from genesis, this value is zero (genesis epoch)
   private final UInt64 initialEpoch;
+  private final ProgressiveBalancesMode progressiveBalancesMode;
   private final StatusLogger statusLog;
 
   /**
@@ -71,14 +74,18 @@ public class ProtoArray {
 
   ProtoArray(
       final int pruneThreshold,
+      final UInt64 currentEpoch,
       final Checkpoint justifiedCheckpoint,
       final Checkpoint finalizedCheckpoint,
       final UInt64 initialEpoch,
+      final ProgressiveBalancesMode progressiveBalancesMode,
       final StatusLogger statusLog) {
     this.pruneThreshold = pruneThreshold;
+    this.currentEpoch = currentEpoch;
     this.justifiedCheckpoint = justifiedCheckpoint;
     this.finalizedCheckpoint = finalizedCheckpoint;
     this.initialEpoch = initialEpoch;
+    this.progressiveBalancesMode = progressiveBalancesMode;
     this.statusLog = statusLog;
   }
 
@@ -156,13 +163,16 @@ public class ProtoArray {
    * Follows the best-descendant links to find the best-block (i.e. head-block), including any
    * optimistic nodes which have not yet been fully validated.
    *
+   * @param currentEpoch the current epoch according to the Store current time
    * @param justifiedCheckpoint the justified checkpoint
    * @param finalizedCheckpoint the finalized checkpoint
    * @return the best node according to fork choice
    */
   public ProtoNode findOptimisticHead(
-      final Checkpoint justifiedCheckpoint, final Checkpoint finalizedCheckpoint) {
-    return findHead(justifiedCheckpoint, finalizedCheckpoint)
+      final UInt64 currentEpoch,
+      final Checkpoint justifiedCheckpoint,
+      final Checkpoint finalizedCheckpoint) {
+    return findHead(currentEpoch, justifiedCheckpoint, finalizedCheckpoint)
         .orElseThrow(fatalException("Finalized block was found to be invalid."));
   }
 
@@ -195,9 +205,13 @@ public class ProtoArray {
   }
 
   private Optional<ProtoNode> findHead(
-      final Checkpoint justifiedCheckpoint, final Checkpoint finalizedCheckpoint) {
-    if (!this.justifiedCheckpoint.equals(justifiedCheckpoint)
+      final UInt64 currentEpoch,
+      final Checkpoint justifiedCheckpoint,
+      final Checkpoint finalizedCheckpoint) {
+    if ((progressiveBalancesMode.isFull() && !this.currentEpoch.equals(currentEpoch))
+        || !this.justifiedCheckpoint.equals(justifiedCheckpoint)
         || !this.finalizedCheckpoint.equals(finalizedCheckpoint)) {
+      this.currentEpoch = currentEpoch;
       this.justifiedCheckpoint = justifiedCheckpoint;
       this.finalizedCheckpoint = finalizedCheckpoint;
       // Justified or finalized epoch changed so we have to re-evaluate all best descendants.
@@ -397,6 +411,7 @@ public class ProtoArray {
    */
   public void applyScoreChanges(
       final LongList deltas,
+      final UInt64 currentEpoch,
       final Checkpoint justifiedCheckpoint,
       final Checkpoint finalizedCheckpoint) {
     checkArgument(
@@ -405,11 +420,9 @@ public class ProtoArray {
         getTotalTrackedNodeCount(),
         deltas.size());
 
-    if (!justifiedCheckpoint.equals(this.justifiedCheckpoint)
-        || !finalizedCheckpoint.equals(this.finalizedCheckpoint)) {
-      this.justifiedCheckpoint = justifiedCheckpoint;
-      this.finalizedCheckpoint = finalizedCheckpoint;
-    }
+    this.currentEpoch = currentEpoch;
+    this.justifiedCheckpoint = justifiedCheckpoint;
+    this.finalizedCheckpoint = finalizedCheckpoint;
 
     applyDeltas(deltas);
   }
@@ -605,8 +618,30 @@ public class ProtoArray {
     if (node.isInvalid()) {
       return false;
     }
-    return doesCheckpointMatch(node.getJustifiedCheckpoint(), justifiedCheckpoint)
-        && doesCheckpointMatch(node.getFinalizedCheckpoint(), finalizedCheckpoint);
+
+    if (progressiveBalancesMode.isFull()) {
+      final boolean correctJustified;
+      final boolean correctFinalized;
+      final boolean isPreviousEpochJustified =
+          justifiedCheckpoint.getEpoch().plus(1).isGreaterThanOrEqualTo(currentEpoch);
+      if (isPreviousEpochJustified) {
+        correctJustified =
+            node.getJustifiedCheckpoint()
+                .getEpoch()
+                .isGreaterThanOrEqualTo(justifiedCheckpoint.getEpoch());
+        correctFinalized = correctJustified;
+      } else {
+        correctJustified =
+            node.getJustifiedCheckpoint()
+                .getEpoch()
+                .isGreaterThanOrEqualTo(justifiedCheckpoint.getEpoch());
+        correctFinalized = doesCheckpointMatch(node.getFinalizedCheckpoint(), finalizedCheckpoint);
+      }
+      return correctJustified && correctFinalized;
+    } else {
+      return doesCheckpointMatch(node.getJustifiedCheckpoint(), justifiedCheckpoint)
+          && doesCheckpointMatch(node.getFinalizedCheckpoint(), finalizedCheckpoint);
+    }
   }
 
   private boolean doesCheckpointMatch(final Checkpoint actual, final Checkpoint required) {

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArrayBuilder.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArrayBuilder.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 import tech.pegasys.teku.infrastructure.logging.StatusLogger;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.config.Constants;
+import tech.pegasys.teku.spec.config.ProgressiveBalancesMode;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 
@@ -26,15 +27,25 @@ public class ProtoArrayBuilder {
 
   private StatusLogger statusLog = StatusLogger.STATUS_LOG;
   private int pruneThreshold = Constants.PROTOARRAY_FORKCHOICE_PRUNE_THRESHOLD;
+  private UInt64 currentEpoch;
   private Checkpoint justifiedCheckpoint;
   private Checkpoint finalizedCheckpoint;
   private UInt64 initialEpoch = SpecConfig.GENESIS_EPOCH;
+  private ProgressiveBalancesMode progressiveBalancesMode;
 
   public ProtoArray build() {
+    checkNotNull(progressiveBalancesMode, "Progressive balances mode must be supplied");
+    checkNotNull(currentEpoch, "Current epoch must be supplied");
     checkNotNull(justifiedCheckpoint, "Justified checkpoint must be supplied");
     checkNotNull(finalizedCheckpoint, "finalized checkpoint must be supplied");
     return new ProtoArray(
-        pruneThreshold, justifiedCheckpoint, finalizedCheckpoint, initialEpoch, statusLog);
+        pruneThreshold,
+        currentEpoch,
+        justifiedCheckpoint,
+        finalizedCheckpoint,
+        initialEpoch,
+        progressiveBalancesMode,
+        statusLog);
   }
 
   public ProtoArrayBuilder statusLog(final StatusLogger statusLog) {
@@ -49,6 +60,11 @@ public class ProtoArrayBuilder {
 
   public ProtoArrayBuilder initialEpoch(final UInt64 initialEpoch) {
     this.initialEpoch = initialEpoch;
+    return this;
+  }
+
+  public ProtoArrayBuilder currentEpoch(final UInt64 currentEpoch) {
+    this.currentEpoch = currentEpoch;
     return this;
   }
 
@@ -68,6 +84,12 @@ public class ProtoArrayBuilder {
     initialCheckpoint.ifPresentOrElse(
         checkpoint -> initialEpoch(checkpoint.getEpoch()),
         () -> initialEpoch(SpecConfig.GENESIS_EPOCH));
+    return this;
+  }
+
+  public ProtoArrayBuilder progressiveBalancesMode(
+      final ProgressiveBalancesMode progressiveBalancesMode) {
+    this.progressiveBalancesMode = progressiveBalancesMode;
     return this;
   }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreVoteUpdater.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreVoteUpdater.java
@@ -65,6 +65,7 @@ public class StoreVoteUpdater implements VoteUpdater {
 
   @Override
   public Bytes32 applyForkChoiceScoreChanges(
+      final UInt64 currentEpoch,
       final Checkpoint finalizedCheckpoint,
       final Checkpoint justifiedCheckpoint,
       final List<UInt64> justifiedCheckpointEffectiveBalances,
@@ -81,6 +82,7 @@ public class StoreVoteUpdater implements VoteUpdater {
           .applyPendingVotes(
               this,
               proposerBoostRoot,
+              currentEpoch,
               finalizedCheckpoint,
               justifiedCheckpoint,
               justifiedCheckpointEffectiveBalances,

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/FFGUpdatesTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/FFGUpdatesTest.java
@@ -331,6 +331,7 @@ public class FFGUpdatesTest {
     return forkChoice.applyPendingVotes(
         store,
         Optional.empty(),
+        UInt64.valueOf(1000),
         finalizedCheckpoint,
         justifiedCheckpoint,
         justifiedStateEffectiveBalances,

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategyTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategyTest.java
@@ -67,8 +67,10 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
     final BeaconState latestState = chainBuilder.getLatestBlockAndState().getState();
     final ProtoArray protoArray =
         ProtoArray.builder()
+            .currentEpoch(ZERO)
             .finalizedCheckpoint(latestState.getFinalizedCheckpoint())
             .justifiedCheckpoint(latestState.getCurrentJustifiedCheckpoint())
+            .progressiveBalancesMode(spec.getGenesisSpecConfig().getProgressiveBalancesMode())
             .build();
     addBlocksFromBuilder(chainBuilder, protoArray);
 
@@ -132,8 +134,10 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
     final ProtoArray protoArray =
         ProtoArray.builder()
             .initialCheckpoint(Optional.of(anchor.getCheckpoint()))
+            .currentEpoch(anchor.getEpoch())
             .justifiedCheckpoint(anchorState.getCurrentJustifiedCheckpoint())
             .finalizedCheckpoint(anchorState.getFinalizedCheckpoint())
+            .progressiveBalancesMode(spec.getGenesisSpecConfig().getProgressiveBalancesMode())
             .build();
     protoArray.onBlock(
         anchor.getBlockSlot(),
@@ -160,6 +164,7 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
         forkChoiceStrategy.applyPendingVotes(
             store,
             Optional.empty(),
+            spec.getCurrentSlot(store),
             anchor.getCheckpoint(),
             anchor.getCheckpoint(),
             effectiveBalances,
@@ -372,6 +377,7 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
         strategy.applyPendingVotes(
             transaction,
             Optional.empty(),
+            storageSystem.recentChainData().getCurrentEpoch().orElseThrow(),
             storageSystem.recentChainData().getFinalizedCheckpoint().orElseThrow(),
             storageSystem.recentChainData().getStore().getBestJustifiedCheckpoint(),
             effectiveBalances,
@@ -445,6 +451,7 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
         strategy.applyPendingVotes(
             transaction3,
             Optional.empty(),
+            storageSystem.recentChainData().getCurrentEpoch().orElseThrow(),
             storageSystem.recentChainData().getFinalizedCheckpoint().orElseThrow(),
             storageSystem.recentChainData().getStore().getBestJustifiedCheckpoint(),
             effectiveBalances,
@@ -498,12 +505,14 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
     // Find new chain head
     final SlotAndBlockRoot revertHead =
         protoArray.findHead(
+            recentChainData.getCurrentEpoch().orElseThrow(),
             recentChainData.getJustifiedCheckpoint().orElseThrow(),
             recentChainData.getFinalizedCheckpoint().orElseThrow());
     recentChainData.updateHead(revertHead.getBlockRoot(), optimisticHead.getSlot());
 
     final ForkChoiceState forkChoiceState =
         protoArray.getForkChoiceState(
+            recentChainData.getCurrentEpoch().orElseThrow(),
             recentChainData.getJustifiedCheckpoint().orElseThrow(),
             recentChainData.getFinalizedCheckpoint().orElseThrow());
 

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/NoVotesTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/NoVotesTest.java
@@ -227,6 +227,7 @@ public class NoVotesTest {
     return forkChoice.applyPendingVotes(
         store,
         Optional.empty(),
+        spec.getCurrentSlot(store),
         finalizedCheckpoint,
         justifiedCheckpoint,
         justifiedStateEffectiveBalances,

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/VotesTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/VotesTest.java
@@ -606,6 +606,7 @@ public class VotesTest {
     return forkChoice.applyPendingVotes(
         store,
         Optional.empty(),
+        UInt64.valueOf(1000),
         finalizedCheckpoint,
         justifiedCheckpoint,
         justifiedStateEffectiveBalances,

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/protoarray/ProtoArrayTestUtil.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/protoarray/ProtoArrayTestUtil.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.storage.protoarray;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -40,8 +41,10 @@ public class ProtoArrayTestUtil {
 
     final ProtoArray protoArray =
         ProtoArray.builder()
+            .currentEpoch(ZERO)
             .justifiedCheckpoint(new Checkpoint(justifiedCheckpointEpoch, Bytes32.ZERO))
             .finalizedCheckpoint(new Checkpoint(finalizedCheckpointEpoch, Bytes32.ZERO))
+            .progressiveBalancesMode(spec.getGenesisSpecConfig().getProgressiveBalancesMode())
             .build();
 
     ForkChoiceStrategy forkChoice = ForkChoiceStrategy.initialize(spec, protoArray);


### PR DESCRIPTION
## PR Description
Uses information from progressive balances to identify the future justified checkpoints in more places.  Toggled off by default for now.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
