### PR TITLE
BUILDER_GET_PAYLOAD_TIMEOUT to 1s like engine_getPayload

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/Constants.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/Constants.java
@@ -75,6 +75,6 @@ public class Constants {
   public static final Duration BUILDER_STATUS_TIMEOUT = Duration.ofSeconds(1);
   public static final Duration BUILDER_REGISTER_VALIDATOR_TIMEOUT = Duration.ofSeconds(8);
   public static final Duration BUILDER_PROPOSAL_DELAY_TOLERANCE = Duration.ofSeconds(1);
-  public static final Duration BUILDER_GET_PAYLOAD_TIMEOUT = Duration.ofSeconds(8);
+  public static final Duration BUILDER_GET_PAYLOAD_TIMEOUT = Duration.ofSeconds(1);
   public static final int EPOCHS_PER_VALIDATOR_REGISTRATION_SUBMISSION = 1;
 }


### PR DESCRIPTION
Align `builder_getPayload` timeout to the corresponding `engine_getPayload`.