### PR TITLE
Return unmodifiable view for private mutable fields

### DIFF
--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/Eth2EventHandler.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/Eth2EventHandler.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.test.acceptance.dsl;
 import com.launchdarkly.eventsource.EventHandler;
 import com.launchdarkly.eventsource.MessageEvent;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class Eth2EventHandler implements EventHandler {
@@ -33,7 +34,7 @@ public class Eth2EventHandler implements EventHandler {
   }
 
   public List<PackedMessage> getMessages() {
-    return eventList;
+    return Collections.unmodifiableList(eventList);
   }
 
   @Override

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuValidatorNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuValidatorNode.java
@@ -26,6 +26,7 @@ import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -277,7 +278,7 @@ public class TekuValidatorNode extends Node {
     }
 
     public Map<File, String> getConfigFileMap() {
-      return configFileMap;
+      return Collections.unmodifiableMap(configFileMap);
     }
   }
 }

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/Web3SignerNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/Web3SignerNode.java
@@ -18,6 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.File;
 import java.net.URI;
 import java.net.URL;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -152,7 +153,7 @@ public class Web3SignerNode extends Node {
     }
 
     public Map<File, String> getConfigFileMap() {
-      return configFileMap;
+      return Collections.unmodifiableMap(configFileMap);
     }
   }
 }

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/tools/deposits/DepositGenerator.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/tools/deposits/DepositGenerator.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.test.acceptance.dsl.tools.deposits;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -43,7 +44,7 @@ public class DepositGenerator implements AutoCloseable {
   }
 
   public List<ValidatorKeys> getKeys() {
-    return keys;
+    return Collections.unmodifiableList(keys);
   }
 
   public SafeFuture<Void> generate() {

--- a/beacon/pow/src/main/java/tech/pegasys/teku/beacon/pow/Eth1ProviderSelector.java
+++ b/beacon/pow/src/main/java/tech/pegasys/teku/beacon/pow/Eth1ProviderSelector.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.beacon.pow;
 
 import com.google.common.base.Preconditions;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -37,7 +38,7 @@ public class Eth1ProviderSelector {
   }
 
   public List<MonitorableEth1Provider> getProviders() {
-    return candidates;
+    return Collections.unmodifiableList(candidates);
   }
 
   public ValidEth1ProviderIterator getValidProviderIterator() {

--- a/beacon/pow/src/testFixtures/java/tech/pegasys/teku/beacon/pow/api/TrackingEth1EventsChannel.java
+++ b/beacon/pow/src/testFixtures/java/tech/pegasys/teku/beacon/pow/api/TrackingEth1EventsChannel.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.beacon.pow.api;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import tech.pegasys.teku.ethereum.pow.api.DepositsFromBlockEvent;
 import tech.pegasys.teku.ethereum.pow.api.Eth1EventsChannel;
@@ -39,6 +40,6 @@ public class TrackingEth1EventsChannel implements Eth1EventsChannel {
   }
 
   public List<Object> getOrderedList() {
-    return orderedList;
+    return Collections.unmodifiableList(orderedList);
   }
 }

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/SyncSourceBatch.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/SyncSourceBatch.java
@@ -19,6 +19,7 @@ import static com.google.common.base.Preconditions.checkState;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Throwables;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import org.apache.logging.log4j.LogManager;
@@ -97,7 +98,7 @@ public class SyncSourceBatch implements Batch {
 
   @Override
   public List<SignedBeaconBlock> getBlocks() {
-    return blocks;
+    return Collections.unmodifiableList(blocks);
   }
 
   @Override
@@ -309,7 +310,7 @@ public class SyncSourceBatch implements Batch {
     }
 
     public List<SignedBeaconBlock> complete() {
-      return blocks;
+      return Collections.unmodifiableList(blocks);
     }
   }
 }

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApiConfig.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApiConfig.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.beaconrestapi;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import tech.pegasys.teku.infrastructure.exceptions.InvalidConfigurationException;
 import tech.pegasys.teku.infrastructure.io.PortAvailability;
@@ -99,11 +100,11 @@ public class BeaconRestApiConfig {
   }
 
   public List<String> getRestApiHostAllowlist() {
-    return restApiHostAllowlist;
+    return Collections.unmodifiableList(restApiHostAllowlist);
   }
 
   public List<String> getRestApiCorsAllowedOrigins() {
-    return restApiCorsAllowedOrigins;
+    return Collections.unmodifiableList(restApiCorsAllowedOrigins);
   }
 
   public Eth1Address getEth1DepositContractAddress() {

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/beacon/GetEth1VotingSummary.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/beacon/GetEth1VotingSummary.java
@@ -30,6 +30,7 @@ import io.javalin.plugin.openapi.annotations.OpenApi;
 import io.javalin.plugin.openapi.annotations.OpenApiContent;
 import io.javalin.plugin.openapi.annotations.OpenApiParam;
 import io.javalin.plugin.openapi.annotations.OpenApiResponse;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
@@ -168,7 +169,7 @@ public class GetEth1VotingSummary extends MigratingEndpointAdapter {
     }
 
     public List<Pair<Eth1Data, UInt64>> getEth1DataVotes() {
-      return eth1DataVotes;
+      return Collections.unmodifiableList(eth1DataVotes);
     }
 
     public UInt64 getVotingPeriodSlots() {

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetIdentity.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetIdentity.java
@@ -28,6 +28,7 @@ import io.javalin.plugin.openapi.annotations.HttpMethod;
 import io.javalin.plugin.openapi.annotations.OpenApi;
 import io.javalin.plugin.openapi.annotations.OpenApiContent;
 import io.javalin.plugin.openapi.annotations.OpenApiResponse;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -190,11 +191,11 @@ public class GetIdentity extends MigratingEndpointAdapter {
     }
 
     public List<String> getListeningAddresses() {
-      return listeningAddresses;
+      return Collections.unmodifiableList(listeningAddresses);
     }
 
     public List<String> getDiscoveryAddresses() {
-      return discoveryAddresses;
+      return Collections.unmodifiableList(discoveryAddresses);
     }
 
     public MetadataMessage getMetadata() {

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetPeers.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetPeers.java
@@ -28,6 +28,7 @@ import io.javalin.plugin.openapi.annotations.HttpMethod;
 import io.javalin.plugin.openapi.annotations.OpenApi;
 import io.javalin.plugin.openapi.annotations.OpenApiContent;
 import io.javalin.plugin.openapi.annotations.OpenApiResponse;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -155,7 +156,7 @@ public class GetPeers extends MigratingEndpointAdapter {
     }
 
     public List<Eth2Peer> getPeers() {
-      return peers;
+      return Collections.unmodifiableList(peers);
     }
 
     public Integer getCount() {

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/schema/ErrorListBadRequest.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/schema/ErrorListBadRequest.java
@@ -18,6 +18,7 @@ import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.RAW_INTEGER_
 import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.STRING_TYPE;
 import static tech.pegasys.teku.infrastructure.json.types.SerializableTypeDefinition.listOf;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import tech.pegasys.teku.infrastructure.json.types.SerializableTypeDefinition;
@@ -42,7 +43,7 @@ public class ErrorListBadRequest {
   }
 
   public List<SubmitDataError> getErrors() {
-    return errors;
+    return Collections.unmodifiableList(errors);
   }
 
   public static ErrorListBadRequest convert(

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/migrated/AllBlocksAtSlotData.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/migrated/AllBlocksAtSlotData.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.api.migrated;
 
 import com.google.common.base.Preconditions;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -42,7 +43,7 @@ public class AllBlocksAtSlotData {
   }
 
   public List<SignedBeaconBlock> getBlocks() {
-    return blocks;
+    return Collections.unmodifiableList(blocks);
   }
 
   @Override

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/migrated/BlockHeadersResponse.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/migrated/BlockHeadersResponse.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.api.migrated;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -38,7 +39,7 @@ public class BlockHeadersResponse {
   }
 
   public List<BlockHeaderData> getData() {
-    return data;
+    return Collections.unmodifiableList(data);
   }
 
   @Override

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/migrated/StateSyncCommitteesData.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/migrated/StateSyncCommitteesData.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.teku.api.migrated;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -28,11 +30,15 @@ public class StateSyncCommitteesData {
   }
 
   public List<UInt64> getValidators() {
-    return validators;
+    return Collections.unmodifiableList(validators);
   }
 
   public List<List<UInt64>> getValidatorAggregates() {
-    return validatorAggregates;
+    final List<List<UInt64>> copy = new ArrayList<>();
+    for (List<UInt64> validatorAggregate : validatorAggregates) {
+      copy.add(Collections.unmodifiableList(validatorAggregate));
+    }
+    return Collections.unmodifiableList(copy);
   }
 
   @Override

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/migrated/ValidatorLivenessRequest.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/migrated/ValidatorLivenessRequest.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.api.migrated;
 
 import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.UINT64_TYPE;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
@@ -40,7 +41,7 @@ public class ValidatorLivenessRequest {
   }
 
   public List<UInt64> getIndices() {
-    return indices;
+    return Collections.unmodifiableList(indices);
   }
 
   private void setIndices(List<UInt64> indices) {

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/teku/GetAllBlocksAtSlotResponse.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/teku/GetAllBlocksAtSlotResponse.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.api.response.v1.teku;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Collections;
 import java.util.Set;
 import tech.pegasys.teku.api.schema.SignedBeaconBlockWithRoot;
 import tech.pegasys.teku.api.schema.Version;
@@ -25,7 +26,7 @@ public class GetAllBlocksAtSlotResponse {
   private final Set<SignedBeaconBlockWithRoot> data;
 
   public Set<SignedBeaconBlockWithRoot> getData() {
-    return data;
+    return Collections.unmodifiableSet(data);
   }
 
   public Version getVersion() {

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/teku/GetProposersDataResponse.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/teku/GetProposersDataResponse.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.api.response.v1.teku;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.Collections;
 import java.util.Map;
 
 @SuppressWarnings("JavaCase")
@@ -29,6 +30,6 @@ public class GetProposersDataResponse {
   }
 
   public Map<String, Object> getData() {
-    return data;
+    return Collections.unmodifiableMap(data);
   }
 }

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/teku/GetProtoArrayResponse.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/teku/GetProtoArrayResponse.java
@@ -15,6 +15,8 @@ package tech.pegasys.teku.api.response.v1.teku;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -27,6 +29,10 @@ public class GetProtoArrayResponse {
   }
 
   public List<Map<String, Object>> getData() {
-    return data;
+    final List<Map<String, Object>> copy = new ArrayList<>();
+    for (Map<String, Object> d : data) {
+      copy.add(Collections.unmodifiableMap(d));
+    }
+    return Collections.unmodifiableList(copy);
   }
 }

--- a/ethereum/dataproviders/src/test/java/tech/pegasys/teku/dataproviders/generators/StateGenerationTaskTest.java
+++ b/ethereum/dataproviders/src/test/java/tech/pegasys/teku/dataproviders/generators/StateGenerationTaskTest.java
@@ -167,7 +167,7 @@ class StateGenerationTaskTest {
     }
 
     public Set<Bytes32> getRequestedBlocks() {
-      return requestedBlocks;
+      return Collections.unmodifiableSet(requestedBlocks);
     }
   }
 

--- a/ethereum/networks/src/main/java/tech/pegasys/teku/networks/Eth2NetworkConfiguration.java
+++ b/ethereum/networks/src/main/java/tech/pegasys/teku/networks/Eth2NetworkConfiguration.java
@@ -28,6 +28,7 @@ import static tech.pegasys.teku.spec.networks.Eth2Network.SEPOLIA;
 import static tech.pegasys.teku.spec.networks.Eth2Network.SWIFT;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
@@ -159,7 +160,7 @@ public class Eth2NetworkConfiguration {
   }
 
   public List<String> getDiscoveryBootnodes() {
-    return discoveryBootnodes;
+    return Collections.unmodifiableList(discoveryBootnodes);
   }
 
   public Eth1Address getEth1DepositContractAddress() {

--- a/ethereum/pow/api/src/main/java/tech/pegasys/teku/ethereum/pow/api/DepositsFromBlockEvent.java
+++ b/ethereum/pow/api/src/main/java/tech/pegasys/teku/ethereum/pow/api/DepositsFromBlockEvent.java
@@ -17,6 +17,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.stream.Collectors.toList;
 
 import com.google.common.base.MoreObjects;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
@@ -93,7 +94,7 @@ public class DepositsFromBlockEvent {
   }
 
   public List<Deposit> getDeposits() {
-    return deposits;
+    return Collections.unmodifiableList(deposits);
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigPhase0.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.config;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 import org.apache.tuweni.bytes.Bytes;
@@ -210,7 +211,7 @@ public class SpecConfigPhase0 implements SpecConfig {
 
   @Override
   public Map<String, Object> getRawConfig() {
-    return rawConfig;
+    return Collections.unmodifiableMap(rawConfig);
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.spec.executionlayer;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -354,7 +355,7 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
   }
 
   public Set<Bytes32> getRequestedPowBlocks() {
-    return requestedPowBlocks;
+    return Collections.unmodifiableSet(requestedPowBlocks);
   }
 
   private static class HeadAndAttributes {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/status/ValidatorStatuses.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/status/ValidatorStatuses.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.logic.common.statetransition.epoch.status;
 
+import java.util.Collections;
 import java.util.List;
 
 public class ValidatorStatuses {
@@ -30,7 +31,7 @@ public class ValidatorStatuses {
   }
 
   public List<ValidatorStatus> getStatuses() {
-    return statuses;
+    return Collections.unmodifiableList(statuses);
   }
 
   public int getValidatorCount() {

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/ChainBuilder.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/ChainBuilder.java
@@ -122,7 +122,7 @@ public class ChainBuilder {
   }
 
   public List<BLSKeyPair> getValidatorKeys() {
-    return validatorKeys;
+    return Collections.unmodifiableList(validatorKeys);
   }
 
   public UInt64 getLatestSlot() {
@@ -652,7 +652,7 @@ public class ChainBuilder {
     }
 
     public List<AttesterSlashing> getAttesterSlashings() {
-      return attesterSlashings;
+      return Collections.unmodifiableList(attesterSlashings);
     }
   }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregateAttestationBuilder.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregateAttestationBuilder.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.statetransition.attestation;
 import static com.google.common.base.Preconditions.checkState;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -79,6 +80,6 @@ class AggregateAttestationBuilder {
   }
 
   public Collection<ValidateableAttestation> getIncludedAttestations() {
-    return includedAttestations;
+    return Collections.unmodifiableCollection(includedAttestations);
   }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ProposersDataManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ProposersDataManager.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.statetransition.forkchoice;
 import static tech.pegasys.teku.infrastructure.logging.ValidatorLogger.VALIDATOR_LOGGER;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -243,11 +244,11 @@ public class ProposersDataManager implements SlotEventsChannel {
   }
 
   public Map<UInt64, PreparedProposerInfo> getPreparedProposerInfo() {
-    return preparedProposerInfoByValidatorIndex;
+    return Collections.unmodifiableMap(preparedProposerInfoByValidatorIndex);
   }
 
   public Map<UInt64, RegisteredValidatorInfo> getValidatorRegistrationInfo() {
-    return validatorRegistrationInfoByValidatorIndex;
+    return Collections.unmodifiableMap(validatorRegistrationInfoByValidatorIndex);
   }
 
   public boolean isProposerDefaultFeeRecipientDefined() {

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/BeaconChainUtil.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/BeaconChainUtil.java
@@ -20,6 +20,7 @@ import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 import static tech.pegasys.teku.infrastructure.async.SyncAsyncRunner.SYNC_RUNNER;
 import static tech.pegasys.teku.infrastructure.time.TimeUtilities.secondsToMillis;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
@@ -365,7 +366,7 @@ public class BeaconChainUtil {
   }
 
   public List<BLSKeyPair> getValidatorKeys() {
-    return validatorKeys;
+    return Collections.unmodifiableList(validatorKeys);
   }
 
   public int getWrongProposerIndex(final int actualProposerIndex) {

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/DefaultAsyncRunnerFactory.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/DefaultAsyncRunnerFactory.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.infrastructure.async;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 public class DefaultAsyncRunnerFactory implements AsyncRunnerFactory {
@@ -35,6 +36,6 @@ public class DefaultAsyncRunnerFactory implements AsyncRunnerFactory {
 
   @Override
   public Collection<AsyncRunner> getAsyncRunners() {
-    return asyncRunners;
+    return Collections.unmodifiableCollection(asyncRunners);
   }
 }

--- a/infrastructure/async/src/testFixtures/java/tech/pegasys/teku/infrastructure/async/StubAsyncRunnerFactory.java
+++ b/infrastructure/async/src/testFixtures/java/tech/pegasys/teku/infrastructure/async/StubAsyncRunnerFactory.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.infrastructure.async;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 public class StubAsyncRunnerFactory implements AsyncRunnerFactory {
@@ -33,6 +34,6 @@ public class StubAsyncRunnerFactory implements AsyncRunnerFactory {
   }
 
   public List<StubAsyncRunner> getStubAsyncRunners() {
-    return runners;
+    return Collections.unmodifiableList(runners);
   }
 }

--- a/infrastructure/async/src/testFixtures/java/tech/pegasys/teku/infrastructure/async/TrackingUncaughtExceptionHandler.java
+++ b/infrastructure/async/src/testFixtures/java/tech/pegasys/teku/infrastructure/async/TrackingUncaughtExceptionHandler.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.infrastructure.async;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class TrackingUncaughtExceptionHandler implements Thread.UncaughtExceptionHandler {
@@ -25,6 +26,6 @@ public class TrackingUncaughtExceptionHandler implements Thread.UncaughtExceptio
   }
 
   public List<Throwable> getUncaughtExceptions() {
-    return uncaughtExceptions;
+    return Collections.unmodifiableList(uncaughtExceptions);
   }
 }

--- a/infrastructure/metrics/src/main/java/tech/pegasys/teku/infrastructure/metrics/MetricsConfig.java
+++ b/infrastructure/metrics/src/main/java/tech/pegasys/teku/infrastructure/metrics/MetricsConfig.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.infrastructure.metrics;
 import com.google.common.collect.ImmutableSet;
 import java.net.URL;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
@@ -92,11 +93,11 @@ public class MetricsConfig {
   }
 
   public Set<MetricCategory> getMetricsCategories() {
-    return metricsCategories;
+    return Collections.unmodifiableSet(metricsCategories);
   }
 
   public List<String> getMetricsHostAllowlist() {
-    return metricsHostAllowlist;
+    return Collections.unmodifiableList(metricsHostAllowlist);
   }
 
   public Optional<URL> getMetricsEndpoint() {

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/EndpointMetadata.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/EndpointMetadata.java
@@ -173,7 +173,7 @@ public class EndpointMetadata {
   }
 
   public List<String> getTags() {
-    return tags;
+    return Collections.unmodifiableList(tags);
   }
 
   public StringValueTypeDefinition<?> getPathParameterDefinition(final String parameterName) {

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/ResponseMetadata.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/ResponseMetadata.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.infrastructure.restapi.endpoints;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 
@@ -30,7 +31,7 @@ public class ResponseMetadata {
   }
 
   public Map<String, String> getAdditionalHeaders() {
-    return additionalHeaders;
+    return Collections.unmodifiableMap(additionalHeaders);
   }
 
   @Override

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/AbstractSszMutablePrimitiveCollection.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/collections/impl/AbstractSszMutablePrimitiveCollection.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.infrastructure.ssz.collections.impl;
 import it.unimi.dsi.fastutil.longs.LongArrayList;
 import it.unimi.dsi.fastutil.longs.LongList;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -135,7 +136,7 @@ public abstract class AbstractSszMutablePrimitiveCollection<
     }
 
     public List<PackedNodeUpdate<ElementT, SszElementT>> getUpdates() {
-      return updates;
+      return Collections.unmodifiableList(updates);
     }
   }
 }

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/impl/AbstractSszContainerSchema.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/impl/AbstractSszContainerSchema.java
@@ -22,6 +22,7 @@ import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -246,7 +247,7 @@ public abstract class AbstractSszContainerSchema<C extends SszContainer>
 
   @Override
   public List<SszSchema<?>> getFieldSchemas() {
-    return childrenSchemas;
+    return Collections.unmodifiableList(childrenSchemas);
   }
 
   @Override
@@ -358,7 +359,7 @@ public abstract class AbstractSszContainerSchema<C extends SszContainer>
 
   @Override
   public List<String> getFieldNames() {
-    return childrenNames;
+    return Collections.unmodifiableList(childrenNames);
   }
 
   @Override

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/impl/SszUnionSchemaImpl.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/impl/SszUnionSchemaImpl.java
@@ -19,6 +19,7 @@ import static com.google.common.base.Preconditions.checkState;
 import com.google.common.base.Objects;
 import com.google.common.base.Suppliers;
 import java.nio.ByteOrder;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
@@ -132,7 +133,7 @@ public abstract class SszUnionSchemaImpl<SszUnionT extends SszUnion>
 
   @Override
   public List<SszSchema<?>> getChildrenSchemas() {
-    return childrenSchemas;
+    return Collections.unmodifiableList(childrenSchemas);
   }
 
   @Override

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/BeaconChainMethods.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/BeaconChainMethods.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.networking.eth2.rpc.beaconchain;
 import static tech.pegasys.teku.spec.config.Constants.MAX_BLOCK_BY_RANGE_REQUEST_SIZE;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
@@ -352,7 +353,7 @@ public class BeaconChainMethods {
   }
 
   public Collection<RpcMethod<?, ?, ?>> all() {
-    return allMethods;
+    return Collections.unmodifiableCollection(allMethods);
   }
 
   public Eth2RpcMethod<StatusMessage, StatusMessage> status() {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/methods/VersionedEth2RpcMethod.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/methods/VersionedEth2RpcMethod.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.networking.eth2.rpc.core.methods;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -94,7 +95,7 @@ public class VersionedEth2RpcMethod<
 
   @Override
   public List<String> getIds() {
-    return protocolIds;
+    return Collections.unmodifiableList(protocolIds);
   }
 
   @Override

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/DiscoveryConfig.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/DiscoveryConfig.java
@@ -73,11 +73,11 @@ public class DiscoveryConfig {
   }
 
   public List<String> getStaticPeers() {
-    return staticPeers;
+    return Collections.unmodifiableList(staticPeers);
   }
 
   public List<String> getBootnodes() {
-    return bootnodes;
+    return Collections.unmodifiableList(bootnodes);
   }
 
   public int getMinPeers() {

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/gossip/config/GossipScoringConfig.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/gossip/config/GossipScoringConfig.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.networking.p2p.gossip.config;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.function.Consumer;
 
@@ -57,7 +58,7 @@ public class GossipScoringConfig {
   }
 
   public Map<String, GossipTopicScoringConfig> getTopicScoringConfig() {
-    return topicScoringConfig;
+    return Collections.unmodifiableMap(topicScoringConfig);
   }
 
   public double getGossipThreshold() {

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/gossip/config/GossipTopicsScoringConfig.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/gossip/config/GossipTopicsScoringConfig.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.networking.p2p.gossip.config;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -35,7 +36,7 @@ public class GossipTopicsScoringConfig {
   }
 
   public Map<String, GossipTopicScoringConfig> getTopicConfigs() {
-    return topicConfigs;
+    return Collections.unmodifiableMap(topicConfigs);
   }
 
   public static class Builder {

--- a/networking/p2p/src/testFixtures/java/tech/pegasys/teku/network/p2p/jvmlibp2p/MockMessageApi.java
+++ b/networking/p2p/src/testFixtures/java/tech/pegasys/teku/network/p2p/jvmlibp2p/MockMessageApi.java
@@ -19,6 +19,7 @@ import io.libp2p.core.pubsub.Topic;
 import io.libp2p.pubsub.PubsubMessage;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.tuweni.bytes.Bytes;
@@ -60,7 +61,7 @@ public class MockMessageApi implements MessageApi {
 
   @Override
   public List<Topic> getTopics() {
-    return topics;
+    return Collections.unmodifiableList(topics);
   }
 
   @NotNull

--- a/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/PowchainConfiguration.java
+++ b/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/PowchainConfiguration.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.services.powchain;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -67,7 +68,7 @@ public class PowchainConfiguration {
   }
 
   public List<String> getEth1Endpoints() {
-    return eth1Endpoints;
+    return Collections.unmodifiableList(eth1Endpoints);
   }
 
   public Eth1Address getDepositContract() {

--- a/storage/api/src/main/java/tech/pegasys/teku/storage/api/FinalizedChainData.java
+++ b/storage/api/src/main/java/tech/pegasys/teku/storage/api/FinalizedChainData.java
@@ -17,6 +17,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.tuweni.bytes.Bytes32;
@@ -55,15 +56,15 @@ public class FinalizedChainData {
   }
 
   public Map<Bytes32, Bytes32> getFinalizedChildToParentMap() {
-    return finalizedChildToParentMap;
+    return Collections.unmodifiableMap(finalizedChildToParentMap);
   }
 
   public Map<Bytes32, SignedBeaconBlock> getBlocks() {
-    return finalizedBlocks;
+    return Collections.unmodifiableMap(finalizedBlocks);
   }
 
   public Map<Bytes32, BeaconState> getStates() {
-    return finalizedStates;
+    return Collections.unmodifiableMap(finalizedStates);
   }
 
   public AnchorPoint getLatestFinalized() {

--- a/storage/api/src/main/java/tech/pegasys/teku/storage/api/OnDiskStoreData.java
+++ b/storage/api/src/main/java/tech/pegasys/teku/storage/api/OnDiskStoreData.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.storage.api;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -82,11 +83,11 @@ public class OnDiskStoreData {
   }
 
   public Map<Bytes32, StoredBlockMetadata> getBlockInformation() {
-    return blockInformation;
+    return Collections.unmodifiableMap(blockInformation);
   }
 
   public Map<UInt64, VoteTracker> getVotes() {
-    return votes;
+    return Collections.unmodifiableMap(votes);
   }
 
   public Optional<SlotAndExecutionPayloadSummary> getFinalizedOptimisticTransitionPayload() {

--- a/storage/api/src/main/java/tech/pegasys/teku/storage/api/StorageUpdate.java
+++ b/storage/api/src/main/java/tech/pegasys/teku/storage/api/StorageUpdate.java
@@ -88,15 +88,15 @@ public class StorageUpdate {
   }
 
   public Map<Bytes32, BlockAndCheckpoints> getHotBlocks() {
-    return hotBlocks;
+    return Collections.unmodifiableMap(hotBlocks);
   }
 
   public Map<Bytes32, BeaconState> getHotStates() {
-    return hotStates;
+    return Collections.unmodifiableMap(hotStates);
   }
 
   public Set<Bytes32> getDeletedHotBlocks() {
-    return deletedHotBlocks;
+    return Collections.unmodifiableSet(deletedHotBlocks);
   }
 
   public Map<Bytes32, Bytes32> getFinalizedChildToParentMap() {
@@ -126,6 +126,6 @@ public class StorageUpdate {
   }
 
   public Map<Bytes32, SlotAndBlockRoot> getStateRoots() {
-    return stateRoots;
+    return Collections.unmodifiableMap(stateRoots);
   }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArray.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArray.java
@@ -114,7 +114,7 @@ public class ProtoArray {
   }
 
   public List<ProtoNode> getNodes() {
-    return nodes;
+    return Collections.unmodifiableList(nodes);
   }
 
   public void setPruneThreshold(int pruneThreshold) {

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreTreeNodeStore.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreTreeNodeStore.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.storage.server.kvstore.dataaccess;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import org.apache.tuweni.bytes.Bytes32;
@@ -82,7 +83,7 @@ public class KvStoreTreeNodeStore implements TreeNodeStore {
 
   @Override
   public Collection<Bytes32> getStoredBranchRoots() {
-    return newlyStoredBranches;
+    return Collections.unmodifiableCollection(newlyStoredBranches);
   }
 
   @Override

--- a/storage/src/test/java/tech/pegasys/teku/storage/client/RecentChainDataTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/client/RecentChainDataTest.java
@@ -348,7 +348,7 @@ class RecentChainDataTest {
     final List<HeadEvent> headEvents = storageSystem.chainHeadChannel().getHeadEvents();
     assertThat(headEvents).isNotEmpty();
     headEvents.forEach(this::verifyDependentRoots);
-    headEvents.clear();
+    storageSystem.chainHeadChannel().clearHeadEvents();
     assertProtoArrayHasNoFinalizedBlocks();
 
     final SignedBlockAndState latestBlockAndState = storageSystem.chainUpdater().advanceChain();
@@ -440,7 +440,7 @@ class RecentChainDataTest {
     importBlocksAndStates(recentChainData, chainBuilder);
     recentChainData.updateHead(slot1Block.getRoot(), slot1Block.getSlot());
     // Clear head updates from setup
-    storageSystem.chainHeadChannel().getHeadEvents().clear();
+    storageSystem.chainHeadChannel().clearHeadEvents();
 
     recentChainData.updateHead(slot1Block.getRoot(), slot1Block.getSlot().plus(1));
     assertThat(storageSystem.chainHeadChannel().getHeadEvents()).isEmpty();

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/TrackingChainHeadChannel.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/TrackingChainHeadChannel.java
@@ -15,10 +15,12 @@ package tech.pegasys.teku.storage.api;
 
 import com.google.common.base.MoreObjects;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
+import org.assertj.core.util.VisibleForTesting;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 public class TrackingChainHeadChannel implements ChainHeadChannel {
@@ -57,11 +59,16 @@ public class TrackingChainHeadChannel implements ChainHeadChannel {
   }
 
   public List<HeadEvent> getHeadEvents() {
-    return headEvents;
+    return Collections.unmodifiableList(headEvents);
+  }
+
+  @VisibleForTesting
+  public void clearHeadEvents() {
+    headEvents.clear();
   }
 
   public List<ReorgEvent> getReorgEvents() {
-    return reorgEvents;
+    return Collections.unmodifiableList(reorgEvents);
   }
 
   public static class HeadEvent {

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/AttesterDuties.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/AttesterDuties.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.validator.api;
 
 import com.google.common.base.MoreObjects;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import org.apache.tuweni.bytes.Bytes32;
@@ -41,7 +42,7 @@ public class AttesterDuties {
   }
 
   public List<AttesterDuty> getDuties() {
-    return duties;
+    return Collections.unmodifiableList(duties);
   }
 
   @Override

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ProposerDuties.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ProposerDuties.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.validator.api;
 
 import com.google.common.base.MoreObjects;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import org.apache.tuweni.bytes.Bytes32;
@@ -38,7 +39,7 @@ public class ProposerDuties {
   }
 
   public List<ProposerDuty> getDuties() {
-    return duties;
+    return Collections.unmodifiableList(duties);
   }
 
   public boolean isExecutionOptimistic() {

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/SyncCommitteeDuties.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/SyncCommitteeDuties.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.validator.api;
 
 import com.google.common.base.MoreObjects;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -32,7 +33,7 @@ public class SyncCommitteeDuties {
   }
 
   public List<SyncCommitteeDuty> getDuties() {
-    return duties;
+    return Collections.unmodifiableList(duties);
   }
 
   @Override

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
@@ -20,6 +20,7 @@ import java.net.URL;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import org.apache.commons.lang3.tuple.Pair;
@@ -163,7 +164,7 @@ public class ValidatorConfig {
   }
 
   public List<String> getValidatorExternalSignerPublicKeySources() {
-    return validatorExternalSignerPublicKeySources;
+    return Collections.unmodifiableList(validatorExternalSignerPublicKeySources);
   }
 
   public boolean isValidatorExternalSignerSlashingProtectionEnabled() {
@@ -204,7 +205,7 @@ public class ValidatorConfig {
   }
 
   public List<String> getValidatorKeys() {
-    return validatorKeys;
+    return Collections.unmodifiableList(validatorKeys);
   }
 
   public boolean generateEarlyAttestations() {

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/ProductionResult.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/ProductionResult.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.validator.client.duties;
 
 import static java.util.stream.Collectors.toList;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -122,7 +123,7 @@ public class ProductionResult<T> {
   }
 
   public Set<BLSPublicKey> getValidatorPublicKeys() {
-    return validatorPublicKeys;
+    return Collections.unmodifiableSet(validatorPublicKeys);
   }
 
   public DutyResult getResult() {

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/attestations/ScheduledCommittee.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/attestations/ScheduledCommittee.java
@@ -17,6 +17,7 @@ import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -47,7 +48,7 @@ class ScheduledCommittee {
   }
 
   public List<ValidatorWithCommitteePositionAndIndex> getValidators() {
-    return validators;
+    return Collections.unmodifiableList(validators);
   }
 
   public Set<BLSPublicKey> getValidatorPublicKeys() {

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/ValidatorRestApiConfig.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/ValidatorRestApiConfig.java
@@ -83,11 +83,11 @@ public class ValidatorRestApiConfig {
   }
 
   public List<String> getRestApiHostAllowlist() {
-    return restApiHostAllowlist;
+    return Collections.unmodifiableList(restApiHostAllowlist);
   }
 
   public List<String> getRestApiCorsAllowedOrigins() {
-    return restApiCorsAllowedOrigins;
+    return Collections.unmodifiableList(restApiCorsAllowedOrigins);
   }
 
   public int getMaxUrlLength() {

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/apis/schema/DeleteKeysRequest.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/apis/schema/DeleteKeysRequest.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.validator.client.restapi.apis.schema;
 
 import com.google.common.base.MoreObjects;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import tech.pegasys.teku.bls.BLSPublicKey;
@@ -23,7 +24,7 @@ public class DeleteKeysRequest {
   private List<BLSPublicKey> publicKeys = new ArrayList<>();
 
   public List<BLSPublicKey> getPublicKeys() {
-    return publicKeys;
+    return Collections.unmodifiableList(publicKeys);
   }
 
   public void setPublicKeys(final List<BLSPublicKey> publicKeys) {

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/apis/schema/DeleteKeysResponse.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/apis/schema/DeleteKeysResponse.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.validator.client.restapi.apis.schema;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -29,7 +30,7 @@ public class DeleteKeysResponse {
   }
 
   public List<DeleteKeyResult> getData() {
-    return data;
+    return Collections.unmodifiableList(data);
   }
 
   public String getSlashingProtection() {

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/apis/schema/DeleteRemoteKeysResponse.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/apis/schema/DeleteRemoteKeysResponse.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.validator.client.restapi.apis.schema;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -27,7 +28,7 @@ public class DeleteRemoteKeysResponse {
   }
 
   public List<DeleteKeyResult> getData() {
-    return data;
+    return Collections.unmodifiableList(data);
   }
 
   @Override

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/apis/schema/PostKeysRequest.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/apis/schema/PostKeysRequest.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.validator.client.restapi.apis.schema;
 
 import com.google.common.base.MoreObjects;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -36,7 +37,7 @@ public class PostKeysRequest {
   }
 
   public List<String> getKeystores() {
-    return keystores;
+    return Collections.unmodifiableList(keystores);
   }
 
   public void setKeystores(final List<String> keystores) {
@@ -44,7 +45,7 @@ public class PostKeysRequest {
   }
 
   public List<String> getPasswords() {
-    return passwords;
+    return Collections.unmodifiableList(passwords);
   }
 
   public void setPasswords(final List<String> passwords) {

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/apis/schema/PostRemoteKeysRequest.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/apis/schema/PostRemoteKeysRequest.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.validator.client.restapi.apis.schema;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class PostRemoteKeysRequest {
@@ -26,7 +27,7 @@ public class PostRemoteKeysRequest {
   }
 
   public List<ExternalValidator> getExternalValidators() {
-    return externalValidators;
+    return Collections.unmodifiableList(externalValidators);
   }
 
   public void setExternalValidators(List<ExternalValidator> externalValidators) {

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/signer/SigningRequestBody.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/signer/SigningRequestBody.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.validator.client.signer;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.tuweni.bytes.Bytes;
@@ -42,7 +43,7 @@ public class SigningRequestBody {
 
   @JsonAnyGetter
   public Map<String, Object> getMetadata() {
-    return metadata;
+    return Collections.unmodifiableMap(metadata);
   }
 
   public void setSigningRoot(final Bytes signingRoot) {


### PR DESCRIPTION
## PR Description

Sorry, this PR touches a lot of different files. The changes are pretty minor though, hope that makes it okay.

In the spirit of defensive programming, when a public method returns a private field that is mutable (`List`, `Set`, `Map`, etc.), I think we should return an unmodifiable view of that field. My intention is to help prevent the modification of private variables outside of the class. There were a couple instances of this happening in some tests. For example:

```java
storageSystem.chainHeadChannel().getHeadEvents().clear();
```

`getHeadEvents` returns a reference to a private field. To fix this, I created a new method, `clearHeadEvents` with the `@VisibleForTesting` decorator, that clears the clears the events internally.

I chose to use `Collections.unmodifiable*` instead of using immutable objects because immutable objects are a lot slower. The unmodifiable view just ["replaces" the modification methods with `UnsupportedOperationException`](https://stackoverflow.com/a/6604553), therefore the performance penalty will be very minor, if anything. There were two places that I decided to create unmodifiable copies; because the field was a list of lists or list of maps. It would have been possible to modify the entries.

These were identified with a pretty simple error-prone check that I just made:
 * https://github.com/ConsenSys/errorprone-checks/pull/10

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
