### PR TITLE
rise BUILDER_GET_PAYLOAD_TIMEOUT to 3s

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/Constants.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/Constants.java
@@ -75,6 +75,6 @@ public class Constants {
   public static final Duration BUILDER_STATUS_TIMEOUT = Duration.ofSeconds(1);
   public static final Duration BUILDER_REGISTER_VALIDATOR_TIMEOUT = Duration.ofSeconds(8);
   public static final Duration BUILDER_PROPOSAL_DELAY_TOLERANCE = Duration.ofSeconds(1);
-  public static final Duration BUILDER_GET_PAYLOAD_TIMEOUT = Duration.ofSeconds(1);
+  public static final Duration BUILDER_GET_PAYLOAD_TIMEOUT = Duration.ofSeconds(3);
   public static final int EPOCHS_PER_VALIDATOR_REGISTRATION_SUBMISSION = 1;
 }


### PR DESCRIPTION
Rises `builder_getPayload` timeout to 3s. It worth waiting longer since at this stage we have no alternatives. We could still get some attestations if we manage to publish close 4s into the slot

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
