### PR TITLE
Improve registration logging and fix NullPointer scenario

### DIFF
--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/ValidatorLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/ValidatorLogger.java
@@ -188,7 +188,9 @@ public class ValidatorLogger {
 
   public void registeringValidatorsFailed(final Throwable error) {
     final String errorString =
-        String.format("%sFailed to send validator registrations to Beacon Node", PREFIX);
+        String.format(
+            "%sFailed to send validator registrations to the builder network by the Beacon Node",
+            PREFIX);
     log.error(ColorConsolePrinter.print(errorString, Color.RED), error);
   }
 

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/BeaconProposerPreparer.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/BeaconProposerPreparer.java
@@ -251,12 +251,9 @@ public class BeaconProposerPreparer
             entry ->
                 getFeeRecipient(entry.getKey())
                     .map(
-                        eth1Address -> {
-                          System.out.println("HERE FUCKAS");
-                          System.out.println(entry.getValue() + " -> " + eth1Address);
-                          return new BeaconPreparableProposer(
-                              UInt64.valueOf(entry.getValue()), eth1Address);
-                        }))
+                        eth1Address ->
+                            new BeaconPreparableProposer(
+                                UInt64.valueOf(entry.getValue()), eth1Address)))
         .flatMap(Optional::stream)
         .collect(Collectors.toList());
   }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/BeaconProposerPreparer.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/BeaconProposerPreparer.java
@@ -148,7 +148,7 @@ public class BeaconProposerPreparer
             () ->
                 maybeProposerConfig.flatMap(
                     proposerConfigProvider ->
-                        proposerConfigProvider.getDefaultConfig().getGasLimit()))
+                        proposerConfigProvider.getDefaultConfig().getBuilderGasLimit()))
         .or(() -> Optional.ofNullable(defaultGasLimit));
   }
 
@@ -251,9 +251,12 @@ public class BeaconProposerPreparer
             entry ->
                 getFeeRecipient(entry.getKey())
                     .map(
-                        eth1Address ->
-                            new BeaconPreparableProposer(
-                                UInt64.valueOf(entry.getValue()), eth1Address)))
+                        eth1Address -> {
+                          System.out.println("HERE FUCKAS");
+                          System.out.println(entry.getValue() + " -> " + eth1Address);
+                          return new BeaconPreparableProposer(
+                              UInt64.valueOf(entry.getValue()), eth1Address);
+                        }))
         .flatMap(Optional::stream)
         .collect(Collectors.toList());
   }
@@ -265,7 +268,7 @@ public class BeaconProposerPreparer
 
   private Optional<UInt64> getGasLimitFromProposerConfig(
       final ProposerConfig config, final BLSPublicKey publicKey) {
-    return config.getConfigForPubKey(publicKey).flatMap(Config::getGasLimit);
+    return config.getConfigForPubKey(publicKey).flatMap(Config::getBuilderGasLimit);
   }
 
   private boolean isOwnedValidator(final BLSPublicKey publicKey) {

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ProposerConfig.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ProposerConfig.java
@@ -57,7 +57,7 @@ public class ProposerConfig {
   }
 
   public Optional<UInt64> getBuilderGasLimitForPubKey(final BLSPublicKey pubKey) {
-    return getConfigForPubKeyOrDefault(pubKey).getBuilder().flatMap(BuilderConfig::getGasLimit);
+    return getConfigForPubKeyOrDefault(pubKey).getBuilderGasLimit();
   }
 
   public Optional<RegistrationOverrides> getBuilderRegistrationOverrides(
@@ -121,8 +121,8 @@ public class ProposerConfig {
       return Optional.ofNullable(feeRecipient);
     }
 
-    public Optional<UInt64> getGasLimit() {
-      return builder.getGasLimit();
+    public Optional<UInt64> getBuilderGasLimit() {
+      return getBuilder().flatMap(BuilderConfig::getGasLimit);
     }
 
     public Optional<BuilderConfig> getBuilder() {

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrationBatchSender.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrationBatchSender.java
@@ -82,7 +82,7 @@ public class ValidatorRegistrationBatchSender {
         .alwaysRun(
             () ->
                 LOG.info(
-                    "{} out of {} validator(s) registrations were successfully sent to the Beacon Node.",
+                    "{} out of {} validator(s) registrations were successfully sent to the builder network by the Beacon Node.",
                     successfullySentRegistrations.get(),
                     validatorRegistrations.size()));
   }


### PR DESCRIPTION
## PR Description

- Specify that registrations were sent to the builder network rather than only to the Beacon Node.
- Avoid Null Pointer exception when builder is not defined in the proposer config and the registrations are enabled via CLI. In that case, the default gas limit would be used.

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
