### PR TITLE
Change logging for fee recipient configuration

### DIFF
--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
@@ -74,16 +74,16 @@ public class StatusLogger {
   public void warnMissingProposerDefaultFeeRecipientWithRestAPIEnabled() {
     log.warn(
         print(
-            "Rest API is enabled but no fee recipient has been specified via the validators-proposer-default-fee-recipient option! "
-                + "It is strongly recommended to specify it to avoid possible block production failures in case the node has not been prepared for potential proposers by the Validator Client.",
+            "Rest API is enabled but no default fee recipient has been configured via the validators-proposer-default-fee-recipient option! "
+                + "It is strongly recommended to configure it to avoid possible block production failures in case the node has not been prepared for potential proposers by the Validator Client.",
             Color.RED));
   }
 
   public void warnMissingProposerDefaultFeeRecipientWithPreparedBeaconProposerBeingCalled() {
     log.warn(
         print(
-            "Remote Validator Client detected and no default fee recipient has been specified via the validators-proposer-default-fee-recipient option! "
-                + "It is strongly recommended to specify it to avoid possible block production failures in case the node has not been prepared for potential proposers by the Validator Client.",
+            "Remote Validator Client detected and no default fee recipient has been configured via the validators-proposer-default-fee-recipient option! "
+                + "It is strongly recommended to configure it to avoid possible block production failures in case the node has not been prepared for potential proposers by the Validator Client.",
             Color.RED));
   }
 

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
@@ -74,17 +74,16 @@ public class StatusLogger {
   public void warnMissingProposerDefaultFeeRecipientWithRestAPIEnabled() {
     log.warn(
         print(
-            "No default proposer fee recipient has been specified and rest API is enabled. "
-                + "If a Validator Client is going to use this node it is strongly recommended to "
-                + "configure it to avoid possible block production failures",
+            "Rest API is enabled but no fee recipient has been specified via the validators-proposer-default-fee-recipient option! "
+                + "It is strongly recommended to configure it to avoid possible block production failures in case the node has not been prepared for potential proposers by the Validator Client.",
             Color.RED));
   }
 
   public void warnMissingProposerDefaultFeeRecipientWithPreparedBeaconProposerBeingCalled() {
     log.warn(
         print(
-            "Remote Validator Client detected and no default proposer fee recipient configured! "
-                + "It is strongly recommended to configure fee recipient to avoid possible block production failures.",
+            "Remote Validator Client detected and no default fee recipient has been specified via the validators-proposer-default-fee-recipient option! "
+                + "It is strongly recommended to configure it to avoid possible block production failures in case the node has not been prepared for potential proposers by the Validator Client.",
             Color.RED));
   }
 

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
@@ -75,7 +75,7 @@ public class StatusLogger {
     log.warn(
         print(
             "Rest API is enabled but no fee recipient has been specified via the validators-proposer-default-fee-recipient option! "
-                + "It is strongly recommended to configure it to avoid possible block production failures in case the node has not been prepared for potential proposers by the Validator Client.",
+                + "It is strongly recommended to specify it to avoid possible block production failures in case the node has not been prepared for potential proposers by the Validator Client.",
             Color.RED));
   }
 
@@ -83,7 +83,7 @@ public class StatusLogger {
     log.warn(
         print(
             "Remote Validator Client detected and no default fee recipient has been specified via the validators-proposer-default-fee-recipient option! "
-                + "It is strongly recommended to configure it to avoid possible block production failures in case the node has not been prepared for potential proposers by the Validator Client.",
+                + "It is strongly recommended to specify it to avoid possible block production failures in case the node has not been prepared for potential proposers by the Validator Client.",
             Color.RED));
   }
 

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/ValidatorLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/ValidatorLogger.java
@@ -189,7 +189,7 @@ public class ValidatorLogger {
   public void registeringValidatorsFailed(final Throwable error) {
     final String errorString =
         String.format(
-            "%sFailed to send validator registrations to the builder network by the Beacon Node",
+            "%sFailed to send validator registrations to the builder network via the Beacon Node",
             PREFIX);
     log.error(ColorConsolePrinter.print(errorString, Color.RED), error);
   }

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -1005,8 +1005,9 @@ public class BeaconChainController extends Service implements BeaconChainControl
       return Optional.of(Eth1Address.ZERO);
     }
 
-    Optional<Eth1Address> defaultFeeRecipient =
+    final Optional<Eth1Address> defaultFeeRecipient =
         beaconConfig.validatorConfig().getProposerDefaultFeeRecipient();
+
     if (defaultFeeRecipient.isEmpty() && beaconConfig.beaconRestApiConfig().isRestApiEnabled()) {
       STATUS_LOG.warnMissingProposerDefaultFeeRecipientWithRestAPIEnabled();
     }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrationBatchSender.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrationBatchSender.java
@@ -82,7 +82,7 @@ public class ValidatorRegistrationBatchSender {
         .alwaysRun(
             () ->
                 LOG.info(
-                    "{} out of {} validator(s) registrations were successfully sent to the builder network by the Beacon Node.",
+                    "{} out of {} validator(s) registrations were successfully sent to the builder network via the Beacon Node.",
                     successfullySentRegistrations.get(),
                     validatorRegistrations.size()));
   }


### PR DESCRIPTION
## PR Description

- Change logging to be more UX friendly if the `validators-proposer-default-fee-recipient` hasn't been configured.
- Change `by` to `via` for registration logging

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
