### PR TITLE
Make `registerValidator` respond with 500 status code when there are errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,3 +21,4 @@ For information on changes in released versions of Teku, see the [releases page]
 
 ### Bug Fixes
 - Resolves an issue with public key validation.
+- Fix `/eth/v1/validator/register_validator` responding with a 400 status code and not a helpful error message in case of exceptions

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostRegisterValidator.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostRegisterValidator.java
@@ -13,7 +13,7 @@
 
 package tech.pegasys.teku.beaconrestapi.handlers.v1.validator;
 
-import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_BAD_GATEWAY;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_INTERNAL_SERVER_ERROR;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.RES_BAD_REQUEST;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.RES_INTERNAL_ERROR;
@@ -103,7 +103,8 @@ public class PostRegisterValidator extends MigratingEndpointAdapter {
             .handle(
                 (__, error) -> {
                   if (error != null) {
-                    return AsyncApiResponse.respondWithError(SC_BAD_GATEWAY, error.getMessage());
+                    return AsyncApiResponse.respondWithError(
+                        SC_INTERNAL_SERVER_ERROR, error.getMessage());
                   }
                   return AsyncApiResponse.respondOk(null);
                 }));


### PR DESCRIPTION
## PR Description
Make the return code of the API to be the expected 500 from the spec instead of 502 which resulted in `java.lang.IllegalArgumentException: Invalid params response from Beacon Node API (url = http://consensus:4000/eth/v1/validator/register_validator, status = 400, message = Status code 502 not supported)`

## Fixed Issue(s)
fixes #6172 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
