### PR TITLE
Tighten viability check on finalized checkpoint in full progressive balances mode

### DIFF
--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArray.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArray.java
@@ -624,10 +624,15 @@ public class ProtoArray {
           node.getJustifiedCheckpoint()
               .getEpoch()
               .isGreaterThanOrEqualTo(justifiedCheckpoint.getEpoch());
-      final boolean correctFinalized =
-          isPreviousEpochJustified()
-              ? correctJustified
-              : doesCheckpointMatch(node.getFinalizedCheckpoint(), finalizedCheckpoint);
+      final boolean correctFinalized;
+      if (isPreviousEpochJustified()) {
+        correctFinalized =
+            node.getFinalizedCheckpoint()
+                .getEpoch()
+                .isGreaterThanOrEqualTo(finalizedCheckpoint.getEpoch());
+      } else {
+        correctFinalized = doesCheckpointMatch(node.getFinalizedCheckpoint(), finalizedCheckpoint);
+      }
       return correctJustified && correctFinalized;
     } else {
       return doesCheckpointMatch(node.getJustifiedCheckpoint(), justifiedCheckpoint)


### PR DESCRIPTION
## PR Description
Slight tweak to tighten the restriction on nodes being viable for head to ensure the finalized checkpoint is equal to or greater than the store finalized epoch.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
