### PR TITLE
Break gossip params layout into separate sections to make it easier to read

### DIFF
--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/gossip/LibP2PGossipNetworkBuilder.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/gossip/LibP2PGossipNetworkBuilder.java
@@ -13,7 +13,7 @@
 
 package tech.pegasys.teku.networking.p2p.libp2p.gossip;
 
-import static tech.pegasys.teku.networking.p2p.libp2p.config.LibP2PParamsFactory.MAX_SUBSCIPTIONS_PER_MESSAGE;
+import static tech.pegasys.teku.networking.p2p.libp2p.config.LibP2PParamsFactory.MAX_SUBSCRIPTIONS_PER_MESSAGE;
 import static tech.pegasys.teku.networking.p2p.libp2p.gossip.LibP2PGossipNetwork.NULL_SEQNO_GENERATOR;
 import static tech.pegasys.teku.networking.p2p.libp2p.gossip.LibP2PGossipNetwork.STRICT_FIELDS_VALIDATOR;
 
@@ -86,7 +86,7 @@ public class LibP2PGossipNetworkBuilder {
 
     final TopicSubscriptionFilter subscriptionFilter =
         new MaxCountTopicSubscriptionFilter(
-            MAX_SUBSCIPTIONS_PER_MESSAGE,
+            MAX_SUBSCRIPTIONS_PER_MESSAGE,
             MAX_SUBSCRIBED_TOPICS,
             gossipTopicFilter::isRelevantTopic);
 


### PR DESCRIPTION
## PR Description
Refactors the gossip params config setup to break it into separate groups. Makes it easier to read and verify against other sources which tend to use this grouping.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
