### PR TITLE
Handle known getLogs errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,4 +24,5 @@ For information on changes in released versions of Teku, see the [releases page]
 ### Bug Fixes
 - Resolves an issue with public key validation.
 - Fix `/eth/v1/validator/register_validator` responding with a 400 status code and a misleading error message in case of exceptions
-- Update snakeyaml dependency to resolve cve-2022-25857 which could result in excessive memory usage when parsing YAML content.
+- Update snakeyaml dependency to resolve cve-2022-25857 which could result in excessive memory usage when parsing YAML content
+- Fixed an issue where the range requested for deposit logs was not reduced when using only `--ee-endpoint` leading to persistent timeouts with execution clients

--- a/beacon/pow/src/main/java/tech/pegasys/teku/beacon/pow/DepositFetcher.java
+++ b/beacon/pow/src/main/java/tech/pegasys/teku/beacon/pow/DepositFetcher.java
@@ -106,13 +106,6 @@ public class DepositFetcher {
               final Throwable rootCause = Throwables.getRootCause(err);
               if (rootCause instanceof InvalidDepositEventsException) {
                 STATUS_LOG.eth1DepositEventsFailure(rootCause);
-              } else if (rootCause instanceof Eth1RequestException
-                  && ((Eth1RequestException) rootCause)
-                      .containsExceptionSolvableWithSmallerRange()) {
-                // This block is no longer entered as FallbackAwareEth1Provider isn't used anymore
-                // (right?), which is the only impl throwing a Eth1RequestException
-                STATUS_LOG.eth1FetchDepositsRequiresSmallerRange(fetchState.batchSize);
-                fetchState.reduceBatchSize();
               } else if (Eth1RequestException.shouldTryWithSmallerRange(err)) {
                 STATUS_LOG.eth1FetchDepositsRequiresSmallerRange(fetchState.batchSize);
                 fetchState.reduceBatchSize();

--- a/beacon/pow/src/main/java/tech/pegasys/teku/beacon/pow/DepositFetcher.java
+++ b/beacon/pow/src/main/java/tech/pegasys/teku/beacon/pow/DepositFetcher.java
@@ -109,6 +109,11 @@ public class DepositFetcher {
               } else if (rootCause instanceof Eth1RequestException
                   && ((Eth1RequestException) rootCause)
                       .containsExceptionSolvableWithSmallerRange()) {
+                // This block is no longer entered as FallbackAwareEth1Provider isn't used anymore
+                // (right?), which is the only impl throwing a Eth1RequestException
+                STATUS_LOG.eth1FetchDepositsRequiresSmallerRange(fetchState.batchSize);
+                fetchState.reduceBatchSize();
+              } else if (Eth1RequestException.shouldTryWithSmallerRange(err)) {
                 STATUS_LOG.eth1FetchDepositsRequiresSmallerRange(fetchState.batchSize);
                 fetchState.reduceBatchSize();
               }

--- a/beacon/pow/src/main/java/tech/pegasys/teku/beacon/pow/FallbackAwareEth1Provider.java
+++ b/beacon/pow/src/main/java/tech/pegasys/teku/beacon/pow/FallbackAwareEth1Provider.java
@@ -142,7 +142,7 @@ public class FallbackAwareEth1Provider implements Eth1Provider {
   private <T> SafeFuture<T> run(
       final Function<MonitorableEth1Provider, SafeFuture<T>> task,
       final Eth1ProviderSelector.ValidEth1ProviderIterator providers,
-      Eth1RequestException exceptionsContainer) {
+      final Eth1RequestException exceptionsContainer) {
 
     Throwable[] previousExceptions = exceptionsContainer.getSuppressed();
     return providers

--- a/beacon/pow/src/main/java/tech/pegasys/teku/beacon/pow/exception/Eth1RequestException.java
+++ b/beacon/pow/src/main/java/tech/pegasys/teku/beacon/pow/exception/Eth1RequestException.java
@@ -35,7 +35,7 @@ public class Eth1RequestException extends RuntimeException {
             .orElse(false);
   }
 
-  public boolean containsExceptionSolvableWithSmallerRange() {
+  private boolean containsExceptionSolvableWithSmallerRange() {
     return Stream.of(getSuppressed()).anyMatch(Eth1RequestException::shouldTryWithSmallerRange);
   }
 }

--- a/beacon/pow/src/main/java/tech/pegasys/teku/beacon/pow/exception/Eth1RequestException.java
+++ b/beacon/pow/src/main/java/tech/pegasys/teku/beacon/pow/exception/Eth1RequestException.java
@@ -24,14 +24,15 @@ public class Eth1RequestException extends RuntimeException {
     super("Some eth1 endpoints threw an Exception or no eth1 endpoints available");
   }
 
+  public static boolean shouldTryWithSmallerRange(Throwable err) {
+    return ExceptionUtil.hasCause(
+        err,
+        SocketTimeoutException.class,
+        RejectedRequestException.class,
+        InterruptedIOException.class);
+  }
+
   public boolean containsExceptionSolvableWithSmallerRange() {
-    return Stream.of(getSuppressed())
-        .anyMatch(
-            err ->
-                ExceptionUtil.hasCause(
-                    err,
-                    SocketTimeoutException.class,
-                    RejectedRequestException.class,
-                    InterruptedIOException.class));
+    return Stream.of(getSuppressed()).anyMatch(Eth1RequestException::shouldTryWithSmallerRange);
   }
 }

--- a/beacon/pow/src/main/java/tech/pegasys/teku/beacon/pow/exception/Eth1RequestException.java
+++ b/beacon/pow/src/main/java/tech/pegasys/teku/beacon/pow/exception/Eth1RequestException.java
@@ -26,10 +26,13 @@ public class Eth1RequestException extends RuntimeException {
 
   public static boolean shouldTryWithSmallerRange(Throwable err) {
     return ExceptionUtil.hasCause(
-        err,
-        SocketTimeoutException.class,
-        RejectedRequestException.class,
-        InterruptedIOException.class);
+            err,
+            SocketTimeoutException.class,
+            RejectedRequestException.class,
+            InterruptedIOException.class)
+        || ExceptionUtil.getCause(err, Eth1RequestException.class)
+            .map(Eth1RequestException::containsExceptionSolvableWithSmallerRange)
+            .orElse(false);
   }
 
   public boolean containsExceptionSolvableWithSmallerRange() {

--- a/beacon/pow/src/test/java/tech/pegasys/teku/beacon/pow/FallbackAwareEth1ProviderTest.java
+++ b/beacon/pow/src/test/java/tech/pegasys/teku/beacon/pow/FallbackAwareEth1ProviderTest.java
@@ -43,7 +43,7 @@ import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 @SuppressWarnings("FutureReturnValueIgnored")
-public class FallbackAwareEth1ProviderSelectorTest {
+public class FallbackAwareEth1ProviderTest {
 
   public static final String EXPECTED_TIMEOUT_MESSAGE =
       "Request to eth1 endpoint timed out. Retrying with next eth1 endpoint";

--- a/services/powchain/build.gradle
+++ b/services/powchain/build.gradle
@@ -21,4 +21,7 @@ dependencies {
   implementation 'org.apache.tuweni:tuweni-units'
 
   testImplementation testFixtures(project(':ethereum:spec'))
+  testImplementation testFixtures(project(':infrastructure:async'))
+  testImplementation testFixtures(project(':infrastructure:metrics'))
+  testImplementation testFixtures(project(':infrastructure:time'))
 }

--- a/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/Eth1Providers.java
+++ b/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/Eth1Providers.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.services.powchain;
+
+import static tech.pegasys.teku.spec.config.Constants.MAXIMUM_CONCURRENT_ETH1_REQUESTS;
+
+import java.util.Collections;
+import java.util.List;
+import org.hyperledger.besu.plugin.services.MetricsSystem;
+import tech.pegasys.teku.beacon.pow.ErrorTrackingEth1Provider;
+import tech.pegasys.teku.beacon.pow.Eth1Provider;
+import tech.pegasys.teku.beacon.pow.Eth1ProviderSelector;
+import tech.pegasys.teku.beacon.pow.FallbackAwareEth1Provider;
+import tech.pegasys.teku.beacon.pow.MonitorableEth1Provider;
+import tech.pegasys.teku.beacon.pow.ThrottlingEth1Provider;
+import tech.pegasys.teku.infrastructure.async.AsyncRunner;
+import tech.pegasys.teku.infrastructure.time.TimeProvider;
+
+public class Eth1Providers {
+
+  private final Eth1ProviderMonitor eth1ProviderMonitor;
+  private final Eth1Provider eth1Provider;
+
+  public Eth1Providers(
+      final Eth1ProviderMonitor eth1ProviderMonitor, final Eth1Provider eth1Provider) {
+    this.eth1ProviderMonitor = eth1ProviderMonitor;
+    this.eth1Provider = eth1Provider;
+  }
+
+  public static Eth1Providers create(
+      final List<MonitorableEth1Provider> baseProviders,
+      final AsyncRunner asyncRunner,
+      final TimeProvider timeProvider,
+      final MetricsSystem metricsSystem) {
+    final Eth1Provider eth1Provider;
+    final Eth1ProviderSelector eth1ProviderSelector;
+    if (baseProviders.size() == 1) {
+      final MonitorableEth1Provider web3jEth1Provider = baseProviders.get(0);
+      eth1ProviderSelector = new Eth1ProviderSelector(Collections.singletonList(web3jEth1Provider));
+
+      eth1Provider =
+          new ThrottlingEth1Provider(
+              new ErrorTrackingEth1Provider(web3jEth1Provider, asyncRunner, timeProvider),
+              MAXIMUM_CONCURRENT_ETH1_REQUESTS,
+              metricsSystem);
+    } else {
+      eth1ProviderSelector = new Eth1ProviderSelector(baseProviders);
+
+      eth1Provider =
+          new ThrottlingEth1Provider(
+              new ErrorTrackingEth1Provider(
+                  new FallbackAwareEth1Provider(eth1ProviderSelector, asyncRunner),
+                  asyncRunner,
+                  timeProvider),
+              MAXIMUM_CONCURRENT_ETH1_REQUESTS,
+              metricsSystem);
+    }
+    final Eth1ProviderMonitor eth1ProviderMonitor =
+        new Eth1ProviderMonitor(eth1ProviderSelector, asyncRunner);
+    return new Eth1Providers(eth1ProviderMonitor, eth1Provider);
+  }
+
+  public Eth1Provider getEth1Provider() {
+    return eth1Provider;
+  }
+
+  public void start() {
+    eth1ProviderMonitor.start();
+  }
+
+  public void stop() {
+    eth1ProviderMonitor.stop();
+  }
+}

--- a/services/powchain/src/test/java/tech/pegasys/teku/services/powchain/DepositRangeReductionTest.java
+++ b/services/powchain/src/test/java/tech/pegasys/teku/services/powchain/DepositRangeReductionTest.java
@@ -1,0 +1,235 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.services.powchain;
+
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.InterruptedIOException;
+import java.math.BigInteger;
+import java.net.SocketTimeoutException;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.web3j.protocol.core.DefaultBlockParameterNumber;
+import org.web3j.protocol.core.methods.request.EthFilter;
+import org.web3j.protocol.core.methods.response.EthLog;
+import tech.pegasys.teku.beacon.pow.DepositEventsAccessor;
+import tech.pegasys.teku.beacon.pow.DepositFetcher;
+import tech.pegasys.teku.beacon.pow.Eth1BlockFetcher;
+import tech.pegasys.teku.beacon.pow.MonitorableEth1Provider;
+import tech.pegasys.teku.beacon.pow.exception.RejectedRequestException;
+import tech.pegasys.teku.ethereum.pow.api.Eth1EventsChannel;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
+import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
+import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
+
+public class DepositRangeReductionTest {
+
+  private static final int MAX_BLOCK_RANGE = 10_000;
+  private static final int REDUCED_BLOCK_RANGE = MAX_BLOCK_RANGE / 2;
+  private final Eth1EventsChannel eth1EventsChannel = mock(Eth1EventsChannel.class);
+  private final Eth1BlockFetcher eth1BlockFetcher = mock(Eth1BlockFetcher.class);
+  private final StubAsyncRunner asyncRunner = new StubAsyncRunner();
+  private final StubTimeProvider timeProvider = StubTimeProvider.withTimeInSeconds(100);
+  private final StubMetricsSystem metricsSystem = new StubMetricsSystem();
+
+  private final BigInteger fromBlockNumber = BigInteger.ZERO;
+  private final BigInteger toBlockNumber = BigInteger.valueOf(MAX_BLOCK_RANGE * 2 + 100);
+
+  private final MonitorableEth1Provider underlyingEth1Provider1 =
+      mock(MonitorableEth1Provider.class);
+  private final MonitorableEth1Provider underlyingEth1Provider2 =
+      mock(MonitorableEth1Provider.class);
+
+  private Optional<BigInteger> provider1LastRequestSize = Optional.empty();
+  private SafeFuture<List<EthLog.LogResult<?>>> provider1LastResponse;
+  private Optional<BigInteger> provider2LastRequestSize = Optional.empty();
+  private SafeFuture<List<EthLog.LogResult<?>>> provider2LastResponse;
+
+  @BeforeEach
+  void setUp() {
+    when(underlyingEth1Provider1.validate()).thenReturn(SafeFuture.completedFuture(true));
+    when(underlyingEth1Provider1.isValid()).thenReturn(true);
+    when(underlyingEth1Provider1.ethGetLogs(any()))
+        .thenAnswer(
+            invocation -> {
+              final EthFilter filter = invocation.getArgument(0);
+              final BigInteger from =
+                  ((DefaultBlockParameterNumber) filter.getFromBlock()).getBlockNumber();
+              final BigInteger to =
+                  ((DefaultBlockParameterNumber) filter.getToBlock()).getBlockNumber();
+              provider1LastRequestSize = Optional.of(to.subtract(from));
+              provider1LastResponse = new SafeFuture<>();
+              return provider1LastResponse;
+            });
+
+    when(underlyingEth1Provider2.validate()).thenReturn(SafeFuture.completedFuture(true));
+    when(underlyingEth1Provider2.isValid()).thenReturn(true);
+    when(underlyingEth1Provider2.ethGetLogs(any()))
+        .thenAnswer(
+            invocation -> {
+              final EthFilter filter = invocation.getArgument(0);
+              final BigInteger from =
+                  ((DefaultBlockParameterNumber) filter.getFromBlock()).getBlockNumber();
+              final BigInteger to =
+                  ((DefaultBlockParameterNumber) filter.getToBlock()).getBlockNumber();
+              provider2LastRequestSize = Optional.of(to.subtract(from));
+              provider2LastResponse = new SafeFuture<>();
+              return provider2LastResponse;
+            });
+  }
+
+  @ParameterizedTest
+  @MethodSource("exceptionsToReduceRange")
+  void singleProvider_shouldReduceBatchSize(final Throwable error) {
+    final DepositFetcher depositFetcher = createWithProviders(underlyingEth1Provider1);
+    final SafeFuture<Void> result =
+        depositFetcher.fetchDepositsInRange(fromBlockNumber, toBlockNumber);
+
+    assertThat(provider1LastRequestSize).contains(BigInteger.valueOf(MAX_BLOCK_RANGE));
+    provider1LastResponse.completeExceptionally(error);
+    assertThat(result).isNotCompleted();
+
+    asyncRunner.executeQueuedActions();
+    assertThat(provider1LastRequestSize).contains(BigInteger.valueOf(REDUCED_BLOCK_RANGE));
+  }
+
+  @ParameterizedTest
+  @MethodSource("exceptionsToReduceRange")
+  void multipleProviders_shouldReduceBatchSize_secondOffline(final Throwable error) {
+    when(underlyingEth1Provider2.isValid()).thenReturn(false);
+
+    final DepositFetcher depositFetcher =
+        createWithProviders(underlyingEth1Provider1, underlyingEth1Provider2);
+    final SafeFuture<Void> result =
+        depositFetcher.fetchDepositsInRange(fromBlockNumber, toBlockNumber);
+
+    assertThat(provider1LastRequestSize).contains(BigInteger.valueOf(MAX_BLOCK_RANGE));
+    provider1LastResponse.completeExceptionally(error);
+    assertThat(result).isNotCompleted();
+
+    asyncRunner.executeQueuedActions();
+    assertThat(provider1LastRequestSize).contains(BigInteger.valueOf(REDUCED_BLOCK_RANGE));
+  }
+
+  @ParameterizedTest
+  @MethodSource("exceptionsToReduceRange")
+  void multipleProviders_shouldNotReduceBatchSizeWhenSecondSuccessful(final Throwable error) {
+    final DepositFetcher depositFetcher =
+        createWithProviders(underlyingEth1Provider1, underlyingEth1Provider2);
+    final SafeFuture<Void> result =
+        depositFetcher.fetchDepositsInRange(fromBlockNumber, toBlockNumber);
+
+    assertThat(provider1LastRequestSize).contains(BigInteger.valueOf(MAX_BLOCK_RANGE));
+    provider1LastResponse.completeExceptionally(error);
+
+    assertThat(provider2LastRequestSize).contains(BigInteger.valueOf(MAX_BLOCK_RANGE));
+    provider2LastResponse.complete(emptyList());
+    assertThat(result).isNotCompleted();
+
+    asyncRunner.executeQueuedActions();
+    assertThat(provider1LastRequestSize).contains(BigInteger.valueOf(MAX_BLOCK_RANGE));
+  }
+
+  @ParameterizedTest
+  @MethodSource("exceptionsToReduceRange")
+  void multipleProviders_shouldReduceBatchSize_secondSameError(final Throwable error) {
+    final DepositFetcher depositFetcher =
+        createWithProviders(underlyingEth1Provider1, underlyingEth1Provider2);
+    final SafeFuture<Void> result =
+        depositFetcher.fetchDepositsInRange(fromBlockNumber, toBlockNumber);
+
+    assertThat(provider1LastRequestSize).contains(BigInteger.valueOf(MAX_BLOCK_RANGE));
+    provider1LastResponse.completeExceptionally(error);
+
+    assertThat(provider2LastRequestSize).contains(BigInteger.valueOf(MAX_BLOCK_RANGE));
+    provider2LastResponse.completeExceptionally(error);
+    assertThat(result).isNotCompleted();
+
+    asyncRunner.executeQueuedActions();
+    assertThat(provider1LastRequestSize).contains(BigInteger.valueOf(REDUCED_BLOCK_RANGE));
+  }
+
+  @ParameterizedTest
+  @MethodSource("exceptionsToReduceRange")
+  void multipleProviders_shouldReduceBatchSize_secondNonReducingError(final Throwable error) {
+    final DepositFetcher depositFetcher =
+        createWithProviders(underlyingEth1Provider1, underlyingEth1Provider2);
+    final SafeFuture<Void> result =
+        depositFetcher.fetchDepositsInRange(fromBlockNumber, toBlockNumber);
+
+    assertThat(provider1LastRequestSize).contains(BigInteger.valueOf(MAX_BLOCK_RANGE));
+    provider1LastResponse.completeExceptionally(error);
+
+    assertThat(provider2LastRequestSize).contains(BigInteger.valueOf(MAX_BLOCK_RANGE));
+    provider2LastResponse.completeExceptionally(new IllegalArgumentException("Whoops"));
+    assertThat(result).isNotCompleted();
+
+    asyncRunner.executeQueuedActions();
+    assertThat(provider1LastRequestSize).contains(BigInteger.valueOf(REDUCED_BLOCK_RANGE));
+  }
+
+  @ParameterizedTest
+  @MethodSource("exceptionsToReduceRange")
+  void multipleProviders_shouldReduceBatchSize_firstNonReducingError(final Throwable error) {
+    final DepositFetcher depositFetcher =
+        createWithProviders(underlyingEth1Provider1, underlyingEth1Provider2);
+    final SafeFuture<Void> result =
+        depositFetcher.fetchDepositsInRange(fromBlockNumber, toBlockNumber);
+
+    assertThat(provider1LastRequestSize).contains(BigInteger.valueOf(MAX_BLOCK_RANGE));
+    provider1LastResponse.completeExceptionally(new IllegalArgumentException("Whoops"));
+
+    assertThat(provider2LastRequestSize).contains(BigInteger.valueOf(MAX_BLOCK_RANGE));
+    provider2LastResponse.completeExceptionally(error);
+    assertThat(result).isNotCompleted();
+
+    asyncRunner.executeQueuedActions();
+    assertThat(provider1LastRequestSize).contains(BigInteger.valueOf(REDUCED_BLOCK_RANGE));
+  }
+
+  static Stream<Arguments> exceptionsToReduceRange() {
+    return Stream.of(
+            new RejectedRequestException(-32005, "Nah mate"),
+            new SocketTimeoutException("Too slow!"),
+            new InterruptedIOException("Timed out"))
+        .map(Arguments::of);
+  }
+
+  private DepositFetcher createWithProviders(final MonitorableEth1Provider... providers) {
+    final Eth1Providers eth1Providers =
+        Eth1Providers.create(List.of(providers), asyncRunner, timeProvider, metricsSystem);
+    final DepositEventsAccessor depositEventsAccessor =
+        new DepositEventsAccessor(
+            eth1Providers.getEth1Provider(), "0xdddddddddddddddddddddddddddddddddddddddd");
+    eth1Providers.start();
+    asyncRunner.executeQueuedActions();
+    return new DepositFetcher(
+        eth1Providers.getEth1Provider(),
+        eth1EventsChannel,
+        depositEventsAccessor,
+        eth1BlockFetcher,
+        asyncRunner,
+        MAX_BLOCK_RANGE);
+  }
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
As part of debugging my validator setup, I encountered an [issue along at least a few others](https://github.com/hyperledger/besu/issues/4293) where teku is continually querying besu for a 10k range of deposit logs, causing timeouts.  The fix in https://github.com/ConsenSys/teku/pull/6061 does not seem to have actually fixed this issue.  I believe the root cause is that teku is no longer creating a `FallbackAwareEth1Provider` [when PowchainConfiguration is not enabled](https://github.com/ConsenSys/teku/blob/feb46ef53a8c8519edde37fbe8bd67d803bf9d9a/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/PowchainService.java#L84). This means no one is throwing `Eth1RequestException` anymore, which is what `DepositFetcher` is using for the auto-adjusting the range.  Meaning the range isn't being auto-adjusted.

The workaround is to change the config so the max range is 1000 (or less), in which besu responds in less than 8s, and all is good.

This is a hacky PR and there is likely a cleaner way to solve this, but I just wanted to expose the problem and a working solution.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
