### PR TITLE
Update Jackson and SnakeYAML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,3 +23,4 @@ For information on changes in released versions of Teku, see the [releases page]
 ### Bug Fixes
 - Resolves an issue with public key validation.
 - Fix `/eth/v1/validator/register_validator` responding with a 400 status code and a misleading error message in case of exceptions
+- Update snakeyaml dependency to resolve cve-2022-25857 which could result in excessive memory usage when parsing YAML content.

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -1,13 +1,9 @@
 dependencyManagement {
   dependencies {
-    dependency 'com.fasterxml.jackson.core:jackson-databind:2.13.3'
-    dependency 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.3'
-    dependency 'com.fasterxml.jackson.dataformat:jackson-dataformat-toml:2.13.3'
-    dependency 'com.fasterxml.jackson.module:jackson-module-kotlin:2.13.3'
-
-    // Temporary version overrides to fix issues with 2.13.2.1 release not including
-    // a 2.13.2.1 version for jackson-bom
-    dependency 'com.fasterxml.jackson:jackson-bom:2.13.2'
+    dependency 'com.fasterxml.jackson.core:jackson-databind:2.13.4'
+    dependency 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.4'
+    dependency 'com.fasterxml.jackson.dataformat:jackson-dataformat-toml:2.13.4'
+    dependency 'com.fasterxml.jackson.module:jackson-module-kotlin:2.13.4'
 
 
     dependency 'com.google.auto.service:auto-service:1.0-rc7'


### PR DESCRIPTION
## PR Description
Pulls in the latest snakeyml to resolve cve-2022-25857 which is a potential DoS vector when parsing untrusted YAML content. Note that Teku's usage of YAML parsing is all for content that should already be trusted (ie configuration files).

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
