### PR TITLE
Make using execution engine stub scarier

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -475,7 +475,7 @@ jobs:
           command: |
             mkdir -p .openapidoc/spec
 
-            build/install/teku/bin/teku --network=mainnet --ee-endpoint=stub --Xinterop-enabled=true --rest-api-enabled=true --rest-api-docs-enabled=true 2>&1 > teku_output.log &
+            build/install/teku/bin/teku --network=mainnet --ee-endpoint=unsafe-test-stub --Xinterop-enabled=true --rest-api-enabled=true --rest-api-docs-enabled=true 2>&1 > teku_output.log &
             TEKU_PID=$!
 
             EXIT_CODE=0

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/RestClientProvider.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/RestClientProvider.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.ethereum.executionclient.rest;
 
+import static tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannel.PREVIOUS_STUB_ENDPOINT_PREFIX;
 import static tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannel.STUB_ENDPOINT_PREFIX;
 
 import java.nio.file.Path;
@@ -45,7 +46,10 @@ public interface RestClientProvider {
       final Optional<String> jwtSecretFile,
       final Path beaconDataDirectory,
       final TimeProvider timeProvider) {
-    if (endpoint.startsWith(STUB_ENDPOINT_PREFIX)) {
+    if (endpoint.startsWith(PREVIOUS_STUB_ENDPOINT_PREFIX)) {
+      throw new InvalidConfigurationException(
+          "Using the stub execution engine is unsafe. This is only designed for testing. Please use a real execution client.");
+    } else if (endpoint.startsWith(STUB_ENDPOINT_PREFIX)) {
       return STUB;
     } else {
       final Optional<JwtConfig> jwtConfig =

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/ExecutionWeb3jClientProvider.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/ExecutionWeb3jClientProvider.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.ethereum.executionclient.web3j;
 
+import static tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannel.PREVIOUS_STUB_ENDPOINT_PREFIX;
 import static tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannel.STUB_ENDPOINT_PREFIX;
 
 import java.nio.file.Path;
@@ -54,7 +55,10 @@ public interface ExecutionWeb3jClientProvider {
       final Optional<String> jwtSecretFile,
       final Path beaconDataDirectory,
       final TimeProvider timeProvider) {
-    if (endpoint.startsWith(STUB_ENDPOINT_PREFIX)) {
+    if (endpoint.startsWith(PREVIOUS_STUB_ENDPOINT_PREFIX)) {
+      throw new InvalidConfigurationException(
+          "Using the stub execution engine is unsafe. This is only designed for testing. Please use a real execution client.");
+    } else if (endpoint.startsWith(STUB_ENDPOINT_PREFIX)) {
       return STUB;
     } else {
       final Optional<JwtConfig> jwtConfig =

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannel.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannel.java
@@ -28,7 +28,8 @@ import tech.pegasys.teku.spec.datastructures.execution.PowBlock;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 
 public interface ExecutionLayerChannel extends ChannelInterface {
-  String STUB_ENDPOINT_PREFIX = "stub";
+  String PREVIOUS_STUB_ENDPOINT_PREFIX = "stub";
+  String STUB_ENDPOINT_PREFIX = "unsafe-test-stub";
   ExecutionLayerChannel NOOP =
       new ExecutionLayerChannel() {
         @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
@@ -31,6 +31,7 @@ import org.apache.tuweni.units.bigints.UInt256;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.bytes.Bytes8;
 import tech.pegasys.teku.infrastructure.collections.cache.LRUCache;
+import tech.pegasys.teku.infrastructure.logging.EventLogger;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.time.SystemTimeProvider;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
@@ -264,6 +265,7 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
               transitionConfiguration.getTerminalBlockHash(),
               UInt64.ONE);
     }
+    EventLogger.EVENT_LOG.executionLayerStubEnabled();
     LOG.info(
         "exchangeTransitionConfiguration: {} -> {}",
         transitionConfiguration,

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java
@@ -278,9 +278,9 @@ public class EventLogger {
   }
 
   public void executionLayerStubEnabled() {
-    info(
-        "Execution Layer Stub has been enabled. Please make sure this is intentional.",
-        Color.YELLOW);
+    error(
+        "Execution Layer Stub has been enabled! This is UNSAFE! You WILL fail to produce blocks and may follow an invalid chain.",
+        Color.RED);
   }
 
   public void builderBidNotHonouringGasLimit(

--- a/teku/src/test/java/tech/pegasys/teku/config/TekuConfigurationTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/config/TekuConfigurationTest.java
@@ -105,7 +105,7 @@ public class TekuConfigurationTest {
     TekuConfiguration tekuConfiguration =
         TekuConfiguration.builder()
             .data(b -> b.dataBasePath(tempDir))
-            .executionLayer(b -> b.engineEndpoint("stub"))
+            .executionLayer(b -> b.engineEndpoint("unsafe-test-stub"))
             .beaconChainControllerFactory(customControllerFactory)
             .build();
 


### PR DESCRIPTION
## PR Description
Change the prefix used to activate the execution engine stub to `unsafe-test-stub` and refuse to startup with a scary message if the old `stub` value is used.

Also makes the warning logged at startup a scarier sounding error and it repeats every time the transition configuration is called.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
