### PR TITLE
Preserve ordering of updates and queries when async IO is enabled

### DIFF
--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -131,6 +131,7 @@ import tech.pegasys.teku.statetransition.validation.signatures.SignatureVerifica
 import tech.pegasys.teku.statetransition.validatorcache.ActiveValidatorCache;
 import tech.pegasys.teku.statetransition.validatorcache.ActiveValidatorChannel;
 import tech.pegasys.teku.storage.api.ChainHeadChannel;
+import tech.pegasys.teku.storage.api.CombinedStorageChannel;
 import tech.pegasys.teku.storage.api.FinalizedCheckpointChannel;
 import tech.pegasys.teku.storage.api.StorageQueryChannel;
 import tech.pegasys.teku.storage.api.StorageUpdateChannel;
@@ -219,6 +220,8 @@ public class BeaconChainController extends Service implements BeaconChainControl
       Optional.empty();
   protected volatile ProposersDataManager proposersDataManager;
   protected volatile KeyValueStore<String, Bytes> keyValueStore;
+  protected volatile StorageQueryChannel storageQueryChannel;
+  protected volatile StorageUpdateChannel storageUpdateChannel;
 
   protected UInt64 genesisTimeTracker = ZERO;
   protected BlockManager blockManager;
@@ -326,10 +329,17 @@ public class BeaconChainController extends Service implements BeaconChainControl
             eventChannels.getPublisher(ChainHeadChannel.class), EVENT_LOG);
     timerService = new TimerService(this::onTick);
 
-    StorageQueryChannel storageQueryChannel =
-        eventChannels.getPublisher(StorageQueryChannel.class, beaconAsyncRunner);
-    StorageUpdateChannel storageUpdateChannel =
-        eventChannels.getPublisher(StorageUpdateChannel.class, beaconAsyncRunner);
+    if (storeConfig.isAsyncStorageEnabled()) {
+      final CombinedStorageChannel combinedStorageChannel =
+          eventChannels.getPublisher(CombinedStorageChannel.class, beaconAsyncRunner);
+      storageQueryChannel = combinedStorageChannel;
+      storageUpdateChannel = combinedStorageChannel;
+    } else {
+      storageQueryChannel =
+          eventChannels.getPublisher(StorageQueryChannel.class, beaconAsyncRunner);
+      storageUpdateChannel =
+          eventChannels.getPublisher(StorageUpdateChannel.class, beaconAsyncRunner);
+    }
     final VoteUpdateChannel voteUpdateChannel = eventChannels.getPublisher(VoteUpdateChannel.class);
     // Init other services
     return initWeakSubjectivity(storageQueryChannel, storageUpdateChannel)
@@ -495,10 +505,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
   protected void initCombinedChainDataClient() {
     LOG.debug("BeaconChainController.initCombinedChainDataClient()");
     combinedChainDataClient =
-        new CombinedChainDataClient(
-            recentChainData,
-            eventChannels.getPublisher(StorageQueryChannel.class, beaconAsyncRunner),
-            spec);
+        new CombinedChainDataClient(recentChainData, storageQueryChannel, spec);
   }
 
   protected SafeFuture<Void> initWeakSubjectivity(
@@ -770,8 +777,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
             .gossipedSyncCommitteeMessageProcessor(syncCommitteeMessagePool::addRemote)
             .processedAttestationSubscriptionProvider(
                 attestationManager::subscribeToAttestationsToSend)
-            .historicalChainData(
-                eventChannels.getPublisher(StorageQueryChannel.class, beaconAsyncRunner))
+            .historicalChainData(storageQueryChannel)
             .metricsSystem(metricsSystem)
             .timeProvider(timeProvider)
             .asyncRunner(networkAsyncRunner)
@@ -930,7 +936,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
         timeProvider,
         recentChainData,
         combinedChainDataClient,
-        eventChannels.getPublisher(StorageUpdateChannel.class, beaconAsyncRunner),
+        storageUpdateChannel,
         p2pNetwork,
         blockImporter,
         pendingBlocks,

--- a/services/chainstorage/src/main/java/tech/pegasys/teku/services/chainstorage/StorageService.java
+++ b/services/chainstorage/src/main/java/tech/pegasys/teku/services/chainstorage/StorageService.java
@@ -20,15 +20,18 @@ import tech.pegasys.teku.ethereum.pow.api.Eth1EventsChannel;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.eventthread.AsyncRunnerEventThread;
+import tech.pegasys.teku.infrastructure.events.EventChannels;
 import tech.pegasys.teku.service.serviceutils.Service;
 import tech.pegasys.teku.service.serviceutils.ServiceConfig;
 import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannel;
+import tech.pegasys.teku.storage.api.CombinedStorageChannel;
 import tech.pegasys.teku.storage.api.Eth1DepositStorageChannel;
 import tech.pegasys.teku.storage.api.StorageQueryChannel;
 import tech.pegasys.teku.storage.api.StorageUpdateChannel;
 import tech.pegasys.teku.storage.api.VoteUpdateChannel;
 import tech.pegasys.teku.storage.server.BatchingVoteUpdateChannel;
 import tech.pegasys.teku.storage.server.ChainStorage;
+import tech.pegasys.teku.storage.server.CombinedStorageChannelSplitter;
 import tech.pegasys.teku.storage.server.Database;
 import tech.pegasys.teku.storage.server.DepositStorage;
 import tech.pegasys.teku.storage.server.RetryingStorageUpdateChannel;
@@ -64,17 +67,15 @@ public class StorageService extends Service implements StorageServiceFacade {
 
           database.migrate();
 
+          final EventChannels eventChannels = serviceConfig.getEventChannels();
           chainStorage =
               ChainStorage.create(
                   database,
                   Optional.of(
-                      serviceConfig
-                          .getEventChannels()
-                          .getPublisher(ExecutionLayerChannel.class, storageAsyncRunner)),
+                      eventChannels.getPublisher(ExecutionLayerChannel.class, storageAsyncRunner)),
                   config.getSpec());
           final DepositStorage depositStorage =
-              DepositStorage.create(
-                  serviceConfig.getEventChannels().getPublisher(Eth1EventsChannel.class), database);
+              DepositStorage.create(eventChannels.getPublisher(Eth1EventsChannel.class), database);
 
           batchingVoteUpdateChannel =
               new BatchingVoteUpdateChannel(
@@ -82,18 +83,25 @@ public class StorageService extends Service implements StorageServiceFacade {
                   new AsyncRunnerEventThread(
                       "batch-vote-updater", serviceConfig.getAsyncRunnerFactory()));
 
-          final StorageUpdateChannel storageUpdateChannel =
-              config.isAsyncStorageEnabled()
-                  ? new RetryingStorageUpdateChannel(chainStorage, serviceConfig.getTimeProvider())
-                  : chainStorage;
-          serviceConfig
-              .getEventChannels()
+          if (config.isAsyncStorageEnabled()) {
+            eventChannels.subscribe(
+                CombinedStorageChannel.class,
+                new CombinedStorageChannelSplitter(
+                    serviceConfig.createAsyncRunner(
+                        "storage-query", STORAGE_QUERY_CHANNEL_PARALLELISM),
+                    new RetryingStorageUpdateChannel(chainStorage, serviceConfig.getTimeProvider()),
+                    chainStorage));
+          } else {
+            eventChannels
+                .subscribe(StorageUpdateChannel.class, chainStorage)
+                .subscribeMultithreaded(
+                    StorageQueryChannel.class, chainStorage, STORAGE_QUERY_CHANNEL_PARALLELISM);
+          }
+
+          eventChannels
               .subscribe(Eth1DepositStorageChannel.class, depositStorage)
               .subscribe(Eth1EventsChannel.class, depositStorage)
-              .subscribe(StorageUpdateChannel.class, storageUpdateChannel)
-              .subscribe(VoteUpdateChannel.class, batchingVoteUpdateChannel)
-              .subscribeMultithreaded(
-                  StorageQueryChannel.class, chainStorage, STORAGE_QUERY_CHANNEL_PARALLELISM);
+              .subscribe(VoteUpdateChannel.class, batchingVoteUpdateChannel);
         });
   }
 

--- a/storage/api/src/main/java/tech/pegasys/teku/storage/api/CombinedStorageChannel.java
+++ b/storage/api/src/main/java/tech/pegasys/teku/storage/api/CombinedStorageChannel.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.api;
+
+public interface CombinedStorageChannel extends StorageUpdateChannel, StorageQueryChannel {}

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/CombinedStorageChannelSplitter.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/CombinedStorageChannelSplitter.java
@@ -41,7 +41,7 @@ import tech.pegasys.teku.storage.api.WeakSubjectivityUpdate;
 /**
  * Splits calls to {@link CombinedStorageChannelSplitter} into the separate {@link
  * StorageUpdateChannel} and {@link StorageQueryChannel} components with updates being handled
- * syncrhonously and queries being run asyncrhonously.
+ * synchronously and queries being run asynchronously.
  *
  * <p>This guarantees that queries are only ever processed after the updates that were sent before
  * them but without allowing queries to delay updates.

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/CombinedStorageChannelSplitter.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/CombinedStorageChannelSplitter.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.server;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.async.AsyncRunner;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
+import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
+import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
+import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
+import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.storage.api.CombinedStorageChannel;
+import tech.pegasys.teku.storage.api.OnDiskStoreData;
+import tech.pegasys.teku.storage.api.StorageQueryChannel;
+import tech.pegasys.teku.storage.api.StorageUpdate;
+import tech.pegasys.teku.storage.api.StorageUpdateChannel;
+import tech.pegasys.teku.storage.api.UpdateResult;
+import tech.pegasys.teku.storage.api.WeakSubjectivityState;
+import tech.pegasys.teku.storage.api.WeakSubjectivityUpdate;
+
+/**
+ * Splits calls to {@link CombinedStorageChannelSplitter} into the separate {@link
+ * StorageUpdateChannel} and {@link StorageQueryChannel} components with updates being handled
+ * syncrhonously and queries being run asyncrhonously.
+ *
+ * <p>This guarantees that queries are only ever processed after the updates that were sent before
+ * them but without allowing queries to delay updates.
+ */
+public class CombinedStorageChannelSplitter implements CombinedStorageChannel {
+  private final AsyncRunner asyncRunner;
+  private final StorageQueryChannel queryDelegate;
+  private final StorageUpdateChannel updateDelegate;
+
+  public CombinedStorageChannelSplitter(
+      final AsyncRunner asyncRunner,
+      final StorageUpdateChannel updateDelegate,
+      final StorageQueryChannel queryDelegate) {
+    this.asyncRunner = asyncRunner;
+    this.queryDelegate = queryDelegate;
+    this.updateDelegate = updateDelegate;
+  }
+
+  @Override
+  public SafeFuture<UpdateResult> onStorageUpdate(final StorageUpdate event) {
+    return updateDelegate.onStorageUpdate(event);
+  }
+
+  @Override
+  public SafeFuture<Void> onFinalizedBlocks(final Collection<SignedBeaconBlock> finalizedBlocks) {
+    return updateDelegate.onFinalizedBlocks(finalizedBlocks);
+  }
+
+  @Override
+  public SafeFuture<Void> onFinalizedState(
+      final BeaconState finalizedState, final Bytes32 blockRoot) {
+    return updateDelegate.onFinalizedState(finalizedState, blockRoot);
+  }
+
+  @Override
+  public SafeFuture<Void> onWeakSubjectivityUpdate(
+      final WeakSubjectivityUpdate weakSubjectivityUpdate) {
+    return updateDelegate.onWeakSubjectivityUpdate(weakSubjectivityUpdate);
+  }
+
+  @Override
+  public void onChainInitialized(final AnchorPoint initialAnchor) {
+    updateDelegate.onChainInitialized(initialAnchor);
+  }
+
+  @Override
+  public SafeFuture<Optional<OnDiskStoreData>> onStoreRequest() {
+    return asyncRunner.runAsync(queryDelegate::onStoreRequest);
+  }
+
+  @Override
+  public SafeFuture<WeakSubjectivityState> getWeakSubjectivityState() {
+    return asyncRunner.runAsync(queryDelegate::getWeakSubjectivityState);
+  }
+
+  @Override
+  public SafeFuture<Optional<UInt64>> getEarliestAvailableBlockSlot() {
+    return asyncRunner.runAsync(queryDelegate::getEarliestAvailableBlockSlot);
+  }
+
+  @Override
+  public SafeFuture<Optional<SignedBeaconBlock>> getEarliestAvailableBlock() {
+    return asyncRunner.runAsync(queryDelegate::getEarliestAvailableBlock);
+  }
+
+  @Override
+  public SafeFuture<Optional<SignedBeaconBlock>> getFinalizedBlockAtSlot(final UInt64 slot) {
+    return asyncRunner.runAsync(() -> queryDelegate.getFinalizedBlockAtSlot(slot));
+  }
+
+  @Override
+  public SafeFuture<Optional<SignedBeaconBlock>> getLatestFinalizedBlockAtSlot(final UInt64 slot) {
+    return asyncRunner.runAsync(() -> queryDelegate.getLatestFinalizedBlockAtSlot(slot));
+  }
+
+  @Override
+  public SafeFuture<Optional<SignedBeaconBlock>> getBlockByBlockRoot(final Bytes32 blockRoot) {
+    return asyncRunner.runAsync(() -> queryDelegate.getBlockByBlockRoot(blockRoot));
+  }
+
+  @Override
+  public SafeFuture<Optional<SignedBlockAndState>> getHotBlockAndStateByBlockRoot(
+      final Bytes32 blockRoot) {
+    return asyncRunner.runAsync(() -> queryDelegate.getHotBlockAndStateByBlockRoot(blockRoot));
+  }
+
+  @Override
+  public SafeFuture<Optional<StateAndBlockSummary>> getHotStateAndBlockSummaryByBlockRoot(
+      final Bytes32 blockRoot) {
+    return asyncRunner.runAsync(
+        () -> queryDelegate.getHotStateAndBlockSummaryByBlockRoot(blockRoot));
+  }
+
+  @Override
+  public SafeFuture<Map<Bytes32, SignedBeaconBlock>> getHotBlocksByRoot(
+      final Set<Bytes32> blockRoots) {
+    return asyncRunner.runAsync(() -> queryDelegate.getHotBlocksByRoot(blockRoots));
+  }
+
+  @Override
+  public SafeFuture<Optional<SlotAndBlockRoot>> getSlotAndBlockRootByStateRoot(
+      final Bytes32 stateRoot) {
+    return asyncRunner.runAsync(() -> queryDelegate.getSlotAndBlockRootByStateRoot(stateRoot));
+  }
+
+  @Override
+  public SafeFuture<Optional<BeaconState>> getLatestFinalizedStateAtSlot(final UInt64 slot) {
+    return asyncRunner.runAsync(() -> queryDelegate.getLatestFinalizedStateAtSlot(slot));
+  }
+
+  @Override
+  public SafeFuture<Optional<BeaconState>> getFinalizedStateByBlockRoot(final Bytes32 blockRoot) {
+    return asyncRunner.runAsync(() -> queryDelegate.getFinalizedStateByBlockRoot(blockRoot));
+  }
+
+  @Override
+  public SafeFuture<Optional<UInt64>> getFinalizedSlotByStateRoot(final Bytes32 stateRoot) {
+    return asyncRunner.runAsync(() -> queryDelegate.getFinalizedSlotByStateRoot(stateRoot));
+  }
+
+  @Override
+  public SafeFuture<List<SignedBeaconBlock>> getNonCanonicalBlocksBySlot(final UInt64 slot) {
+    return asyncRunner.runAsync(() -> queryDelegate.getNonCanonicalBlocksBySlot(slot));
+  }
+
+  @Override
+  public SafeFuture<Optional<Checkpoint>> getAnchor() {
+    return asyncRunner.runAsync(queryDelegate::getAnchor);
+  }
+}

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/CombinedStorageChannelSplitterTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/CombinedStorageChannelSplitterTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.server;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.lang.reflect.Method;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
+import tech.pegasys.teku.storage.api.StorageQueryChannel;
+import tech.pegasys.teku.storage.api.StorageUpdateChannel;
+
+class CombinedStorageChannelSplitterTest {
+  private final StubAsyncRunner asyncRunner = new StubAsyncRunner();
+  private final StorageQueryChannel storageQueryChannel = mock(StorageQueryChannel.class);
+  private final StorageUpdateChannel storageUpdateChannel = mock(StorageUpdateChannel.class);
+
+  private final CombinedStorageChannelSplitter splitter =
+      new CombinedStorageChannelSplitter(asyncRunner, storageUpdateChannel, storageQueryChannel);
+
+  @ParameterizedTest
+  @MethodSource("updateChannelMethods")
+  void shouldApplyUpdateMethodsSynchronously(final Method method) throws Exception {
+    final Object[] args = new Object[method.getParameterCount()];
+
+    method.invoke(splitter, args);
+
+    final StorageUpdateChannel preppedMock = verify(storageUpdateChannel);
+    method.invoke(preppedMock, args);
+  }
+
+  @ParameterizedTest
+  @MethodSource("queryChannelMethods")
+  void shouldApplyQueryMethodsAsynchronously(final Method method) throws Exception {
+    final Object[] args = new Object[method.getParameterCount()];
+
+    method.invoke(splitter, args);
+
+    method.invoke(verify(storageQueryChannel, never()), args);
+
+    asyncRunner.executeQueuedActions();
+
+    method.invoke(verify(storageQueryChannel), args);
+  }
+
+  static Stream<Arguments> updateChannelMethods() {
+    return channelMethods(StorageUpdateChannel.class);
+  }
+
+  static Stream<Arguments> queryChannelMethods() {
+    final Class<StorageQueryChannel> channelClass = StorageQueryChannel.class;
+    return channelMethods(channelClass);
+  }
+
+  private static Stream<Arguments> channelMethods(final Class<?> channelClass) {
+    return Stream.of(channelClass.getDeclaredMethods())
+        .map(method -> Named.named(method.getName(), method))
+        .map(Arguments::of);
+  }
+}


### PR DESCRIPTION
## PR Description
Moves storage updates and queries to use the same event channel when async IO is enabled. This ensures that any query sent to the channel after an update only begins executing after the update completes. To avoid updates being delayed by queries, the queries are actually executed on a separate async runner. This means that queries may be delayed by updates but not the other way around. It avoids the need to try and buffer content to deal with updates being asynchronous and finalized data being unavailable until the update completes.

Separate channels are still used when async IO is disabled so there's no impact to current behaviour by default.

## Fixed Issue(s)
#6194 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
