### PR TITLE
Guarantee that epoch priming happens asynchronously

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/EpochCachePrimer.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/EpochCachePrimer.java
@@ -50,7 +50,9 @@ public class EpochCachePrimer {
                     && isAfterHeadBlockEpoch(epoch, headBlock))
         .ifPresent(
             headBlock ->
-                asyncRunner.runAsync(() -> primeCacheForBlockAtSlot(headBlock, firstSlot)));
+                asyncRunner
+                    .runAsync(() -> primeCacheForBlockAtSlot(headBlock, firstSlot))
+                    .ifExceptionGetsHereRaiseABug());
   }
 
   private void primeCacheForBlockAtSlot(

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -812,7 +812,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
             forkChoiceNotifier,
             p2pNetwork,
             slotEventsChannelPublisher,
-            new EpochCachePrimer(spec, recentChainData));
+            new EpochCachePrimer(spec, recentChainData, beaconAsyncRunner));
   }
 
   public void initAttestationPool() {


### PR DESCRIPTION
## PR Description
Use an async runner to ensure that epoch priming happens asynchronously even if the required state happens to already be in the cache. Otherwise we may block the tick processing thread.

fixes #6213 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
