### PR TITLE
Default max open files for leveldb to their built-in default of 1000.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ For information on changes in released versions of Teku, see the [releases page]
 - Detect Lodestar clients in `libp2p_connected_peers_current` metrics
 - Reduce CPU and Memory consumption in shuffling, which will improve epoch transition performance
 - Faster peer discovery on startup
+- Increased leveldb open files to 1000 files by default. If teku fails to start, update maximum open files to 2048 or unlimited.
 
 ### Bug Fixes
 - Resolves an issue with public key validation.

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreConfiguration.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreConfiguration.java
@@ -47,6 +47,8 @@ public class KvStoreConfiguration {
 
   public static final int DEFAULT_LEVELDB_WRITE_BUFFER_SIZE = 4194304;
 
+  public static final int DEFAULT_LEVELDB_MAX_OPEN_FILES = 1000;
+
   public static final int DEFAULT_MAX_BACKGROUND_JOBS = 6;
   public static final int DEFAULT_BACKGROUND_THREAD_COUNT = 6;
   public static final long DEFAULT_CACHE_CAPACITY = 8 << 20;
@@ -60,6 +62,9 @@ public class KvStoreConfiguration {
 
   @JsonProperty(value = "leveldbBlockSize", access = Access.WRITE_ONLY)
   private int leveldbBlockSize = DEFAULT_LEVELDB_BLOCK_SIZE;
+
+  @JsonProperty(value = "leveldbMaxOpenFiles", access = Access.WRITE_ONLY)
+  private int leveldbMaxOpenFiles = DEFAULT_LEVELDB_MAX_OPEN_FILES;
 
   @JsonProperty(value = "leveldbWriteBuffer", access = Access.WRITE_ONLY)
   private int leveldbWriteBufferSize = DEFAULT_LEVELDB_WRITE_BUFFER_SIZE;
@@ -119,6 +124,10 @@ public class KvStoreConfiguration {
 
   public int getMaxOpenFiles() {
     return maxOpenFiles;
+  }
+
+  public int getLeveldbMaxOpenFiles() {
+    return leveldbMaxOpenFiles;
   }
 
   public int getLeveldbBlockSize() {

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/leveldb/LevelDbInstanceFactory.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/leveldb/LevelDbInstanceFactory.java
@@ -40,7 +40,7 @@ public class LevelDbInstanceFactory {
     final Options options =
         new Options()
             .createIfMissing(true)
-            .maxOpenFiles(configuration.getMaxOpenFiles())
+            .maxOpenFiles(configuration.getLeveldbMaxOpenFiles())
             .blockSize(configuration.getLeveldbBlockSize())
             .writeBufferSize(configuration.getLeveldbWriteBufferSize());
 


### PR DESCRIPTION
Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
