### PR TITLE
Reduce size of in memory block cache

### DIFF
--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreConfig.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreConfig.java
@@ -22,8 +22,7 @@ public class StoreConfig {
   public static final int MAX_CACHE_SIZE = 10_000;
 
   public static final int DEFAULT_STATE_CACHE_SIZE = 32 * 5;
-  // Max block size is about 20x smaller than the minimum state size
-  public static final int DEFAULT_BLOCK_CACHE_SIZE = DEFAULT_STATE_CACHE_SIZE * 2;
+  public static final int DEFAULT_BLOCK_CACHE_SIZE = 32;
   public static final int DEFAULT_CHECKPOINT_STATE_CACHE_SIZE = 20;
   public static final int DEFAULT_HOT_STATE_PERSISTENCE_FREQUENCY_IN_EPOCHS = 2;
   public static final boolean DEFAULT_ASYNC_STORAGE_ENABLED = false;


### PR DESCRIPTION
## PR Description
Post merge blocks are about 3 times bigger, so reduce the size of the cache. In normal finalization we would typically store up to 96 blocks so reduce that to a single epoch worth at a time to reduce GC pressure and ensure states can be held in memory.


## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
