### PR TITLE
Enable async IO by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ For information on changes in released versions of Teku, see the [releases page]
 - The `--initial-state` and `--eth1-deposit-contract-address` options has been removed from the `validator-client` subcommand. They have been ignored for some time but are now completely removed.
 
 ### Additions and Improvements
+- Enables asynchronous database updates by default. This ensures slow disk access or LevelDB compactions don't cause delays in the beacon node.
 - Make Validator Client connect to a failover event stream (if failovers are configured) when the current Beacon Node is not synced
 - Detect Lodestar clients in `libp2p_connected_peers_current` metrics
 - Reduce CPU and Memory consumption in shuffling, which will improve epoch transition performance

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreConfig.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreConfig.java
@@ -25,7 +25,7 @@ public class StoreConfig {
   public static final int DEFAULT_BLOCK_CACHE_SIZE = 32;
   public static final int DEFAULT_CHECKPOINT_STATE_CACHE_SIZE = 20;
   public static final int DEFAULT_HOT_STATE_PERSISTENCE_FREQUENCY_IN_EPOCHS = 2;
-  public static final boolean DEFAULT_ASYNC_STORAGE_ENABLED = false;
+  public static final boolean DEFAULT_ASYNC_STORAGE_ENABLED = true;
 
   private final int stateCacheSize;
   private final int blockCacheSize;


### PR DESCRIPTION
## PR Description
Enables async IO by default.  There are some tests that will need updating to accommodate this change.

## Fixed Issue(s)
fixes #1934 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
