### PR TITLE
Run validator registrations when two slots in the epoch instead of the beginning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,5 +30,6 @@ For information on changes in released versions of Teku, see the [releases page]
 ### Bug Fixes
 - Resolves an issue with public key validation.
 - Fix `/eth/v1/validator/register_validator` responding with a 400 status code and a misleading error message in case of exceptions
+- Fix a `NullPointerException` for the gas limit when a proposer config is used and builder is enabled
 - Update snakeyaml dependency to resolve cve-2022-25857 which could result in excessive memory usage when parsing YAML content
 - Fixed an issue where the range requested for deposit logs was not reduced when using only `--ee-endpoint` leading to persistent timeouts with execution clients


### PR DESCRIPTION
## PR Description
Since a lot of operations are done in the beginning of the epoch, the validator registrations can be moved later in the epoch.

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
