### PR TITLE
Enable async IO by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ For information on changes in released versions of Teku, see the [releases page]
 - The `--initial-state` and `--eth1-deposit-contract-address` options has been removed from the `validator-client` subcommand. They have been ignored for some time but are now completely removed.
 
 ### Additions and Improvements
+- Enables asynchronous database updates by default. This ensures slow disk access or LevelDB compactions don't cause delays in the beacon node.
 - Make Validator Client connect to a failover event stream (if failovers are configured) when the current Beacon Node is not synced
 - Detect Lodestar clients in `libp2p_connected_peers_current` metrics
 - Reduce CPU and Memory consumption in shuffling, which will improve epoch transition performance

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreConfig.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreConfig.java
@@ -25,7 +25,7 @@ public class StoreConfig {
   public static final int DEFAULT_BLOCK_CACHE_SIZE = 32;
   public static final int DEFAULT_CHECKPOINT_STATE_CACHE_SIZE = 20;
   public static final int DEFAULT_HOT_STATE_PERSISTENCE_FREQUENCY_IN_EPOCHS = 2;
-  public static final boolean DEFAULT_ASYNC_STORAGE_ENABLED = false;
+  public static final boolean DEFAULT_ASYNC_STORAGE_ENABLED = true;
 
   private final int stateCacheSize;
   private final int blockCacheSize;

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/kvstore/DatabaseTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/kvstore/DatabaseTest.java
@@ -128,7 +128,8 @@ public class DatabaseTest {
 
   private void initialize(final DatabaseContext context, final StateStorageMode storageMode)
       throws IOException {
-    createStorageSystem(context, storageMode, StoreConfig.createDefault(), false);
+    final StoreConfig config = StoreConfig.builder().asyncStorageEnabled(false).build();
+    createStorageSystem(context, storageMode, config, false);
 
     // Initialize genesis store
     initGenesis();

--- a/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTest.java
@@ -251,9 +251,11 @@ class StoreTest extends AbstractStoreTest {
   }
 
   public void testApplyChangesWhenTransactionCommits(final boolean withInterleavedTransaction) {
+    final StoreConfig configWithAsyncIoDisabled =
+        StoreConfig.builder().asyncStorageEnabled(false).build();
     final UpdatableStore store =
         withInterleavedTransaction
-            ? createGenesisStore(StoreConfig.builder().asyncStorageEnabled(false).build())
+            ? createGenesisStore(configWithAsyncIoDisabled)
             : createGenesisStore();
     final UInt64 epoch3 = UInt64.valueOf(4);
     final UInt64 epoch3Slot = spec.computeStartSlotAtEpoch(epoch3);

--- a/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTest.java
@@ -251,7 +251,10 @@ class StoreTest extends AbstractStoreTest {
   }
 
   public void testApplyChangesWhenTransactionCommits(final boolean withInterleavedTransaction) {
-    final UpdatableStore store = createGenesisStore();
+    final UpdatableStore store =
+        withInterleavedTransaction
+            ? createGenesisStore(StoreConfig.builder().asyncStorageEnabled(false).build())
+            : createGenesisStore();
     final UInt64 epoch3 = UInt64.valueOf(4);
     final UInt64 epoch3Slot = spec.computeStartSlotAtEpoch(epoch3);
     chainBuilder.generateBlocksUpToSlot(epoch3Slot);


### PR DESCRIPTION
## PR Description
Enable `--Xdata-storage-async-enabled` by default

## Fixed Issue(s)
fixes https://github.com/ConsenSys/teku/issues/1934

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
