### PR TITLE
Handle non ssz initial state resource

### DIFF
--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/WeakSubjectivityInitializer.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/WeakSubjectivityInitializer.java
@@ -26,6 +26,7 @@ import org.jetbrains.annotations.NotNull;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.exceptions.InvalidConfigurationException;
 import tech.pegasys.teku.infrastructure.http.UrlSanitizer;
+import tech.pegasys.teku.infrastructure.ssz.sos.SszDeserializeException;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
@@ -49,7 +50,7 @@ public class WeakSubjectivityInitializer {
           final String sanitizedResource = UrlSanitizer.sanitizePotentialUrl(stateResource);
           try {
             return getAnchorPoint(spec, stateResource, sanitizedResource);
-          } catch (IOException e) {
+          } catch (IOException | SszDeserializeException e) {
             LOG.error(
                 String.format("Failed to load initial state from %s : ", sanitizedResource), e);
             if (!UrlSanitizer.urlContainsNonEmptyPath(stateResource)) {
@@ -64,7 +65,7 @@ public class WeakSubjectivityInitializer {
                       "Trying to load initial state from %s instead", sanitizedResourceWithPath));
               try {
                 return getAnchorPoint(spec, stateResourceWithPath, sanitizedResourceWithPath);
-              } catch (IOException ex) {
+              } catch (IOException | SszDeserializeException ex) {
                 throw new InvalidConfigurationException(
                     String.format(
                         "Failed to load initial state from both %s and %s : %s",


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

Try loading the initial state by adding `/eth/v2/debug/beacon/states/finalized` to the `--initial-state` url when the initial url responds OK but doesn't return valid ssz.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

[#6230](https://github.com/consensys/teku/issues/6230)

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
