### PR TITLE
Improve Execution Layer error logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ For information on changes in released versions of Teku, see the [releases page]
 ### Breaking Changes
 
 ### Additions and Improvements
-- Filter out unknown validators when sending validator registrations to the builder network
+- Improve Execution Layer error logging
 
 ### Bug Fixes
+- Filter out unknown validators when sending validator registrations to the builder network

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JClient.java
@@ -17,6 +17,7 @@ import static tech.pegasys.teku.infrastructure.exceptions.ExceptionUtil.getMessa
 
 import java.io.IOException;
 import java.time.Duration;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
 import org.web3j.protocol.Web3j;
 import org.web3j.protocol.Web3jService;
@@ -28,16 +29,19 @@ import tech.pegasys.teku.infrastructure.logging.EventLogger;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 
 public abstract class Web3JClient {
+
   private static final int ERROR_REPEAT_DELAY_MILLIS = 30 * 1000;
   private static final int NO_ERROR_TIME = -1;
+  private static final long STARTUP_LAST_ERROR_TIME = 0;
+
   private final EventLogger eventLog;
   private final TimeProvider timeProvider;
   private Web3jService web3jService;
   private Web3j eth1Web3j;
 
-  // Default to the provider being offline at startup so we log when it is first available
-  // but uses a very old value to make sure we log if the first request fails
-  private final AtomicLong lastError = new AtomicLong(0);
+  // Default to the provider having a previous failure at startup so we log when it is first
+  // available but uses a very old value to make sure we log if the first request fails
+  private final AtomicLong lastError = new AtomicLong(STARTUP_LAST_ERROR_TIME);
   private boolean initialized = false;
 
   protected Web3JClient(final EventLogger eventLog, final TimeProvider timeProvider) {
@@ -66,7 +70,8 @@ public abstract class Web3JClient {
         .handle(
             (response, exception) -> {
               if (exception != null) {
-                handleError(exception, isAuthenticationException(exception));
+                final boolean couldBeAuthError = isAuthenticationException(exception);
+                handleError(exception, couldBeAuthError);
                 return Response.withErrorMessage(getMessageOrSimpleName(exception));
               } else if (response.hasError()) {
                 final String errorMessage =
@@ -88,23 +93,33 @@ public abstract class Web3JClient {
     return message.contains("received: 401") || message.contains("received: 403");
   }
 
+  private boolean isTimeoutException(final Throwable exception) {
+    return exception instanceof TimeoutException;
+  }
+
   protected void handleError(final Throwable error) {
     handleError(error, false);
   }
 
   protected void handleError(final Throwable error, final boolean couldBeAuthError) {
-    final long errorTime = lastError.get();
-    if (errorTime == NO_ERROR_TIME
-        || timeProvider.getTimeInMillis().longValue() - errorTime > ERROR_REPEAT_DELAY_MILLIS) {
-      if (lastError.compareAndSet(errorTime, timeProvider.getTimeInMillis().longValue())) {
-        eventLog.executionClientIsOffline(error, couldBeAuthError);
+    final long lastErrorTime = lastError.get();
+    final long timeNow = timeProvider.getTimeInMillis().longValue();
+    if (lastErrorTime == NO_ERROR_TIME || timeNow - lastErrorTime > ERROR_REPEAT_DELAY_MILLIS) {
+      lastError.set(timeNow);
+      if (isTimeoutException(error)) {
+        eventLog.executionClientRequestTimedOut();
+      } else {
+        eventLog.executionClientRequestFailed(error, couldBeAuthError);
       }
     }
   }
 
   protected void handleSuccess() {
-    if (lastError.getAndUpdate(x -> NO_ERROR_TIME) != NO_ERROR_TIME) {
+    final long lastErrorTime = lastError.getAndUpdate(x -> NO_ERROR_TIME);
+    if (lastErrorTime == STARTUP_LAST_ERROR_TIME) {
       eventLog.executionClientIsOnline();
+    } else if (lastErrorTime != NO_ERROR_TIME) {
+      eventLog.executionClientRecovered();
     }
   }
 

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java
@@ -34,6 +34,9 @@ public class EventLogger {
   public static final EventLogger EVENT_LOG =
       new EventLogger(LoggingConfigurator.EVENT_LOGGER_NAME);
 
+  private static final String EXECUTION_CLIENT_READINESS_USER_REMINDER =
+      "Make sure the Execution Client is online and ready.";
+
   @SuppressWarnings("PrivateStaticFinalLoggers")
   private final Logger log;
 
@@ -129,18 +132,28 @@ public class EventLogger {
     info("Beacon chain syncing complete, waiting for Execution Client", Color.YELLOW);
   }
 
-  public void executionClientIsOffline(final Throwable error, final boolean couldBeAuthError) {
+  public void executionClientIsOnline() {
+    info("Execution Client is online", Color.GREEN);
+  }
+
+  public void executionClientRequestFailed(final Throwable error, final boolean couldBeAuthError) {
     error(
-        "Execution Client is offline"
+        "Execution Client request failed. "
             + (couldBeAuthError
-                ? ". Check the same JWT secret is configured for Teku and the execution client."
-                : ""),
+                ? "Check the same JWT secret is configured for Teku and the Execution Client."
+                : EXECUTION_CLIENT_READINESS_USER_REMINDER),
         Color.RED,
         error);
   }
 
-  public void executionClientIsOnline() {
-    info("Execution Client is online", Color.GREEN);
+  public void executionClientRequestTimedOut() {
+    error(
+        "Execution Client request timed out. " + EXECUTION_CLIENT_READINESS_USER_REMINDER,
+        Color.RED);
+  }
+
+  public void executionClientRecovered() {
+    info("Execution Client request succeeded after a previous failure", Color.GREEN);
   }
 
   public void builderIsOffline(final String errorMessage) {


### PR DESCRIPTION
## PR Description

- Don't log stack trace in case of timeouts.
- Change `is offline` to `request failed`
- Haven't changed timeouts because of the timeouts defined in the engine spec https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md#timeouts

## Fixed Issue(s)
fixes #6249

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
