### PR TITLE
Access fields/methods more directly

### DIFF
--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/auth/TokenProvider.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/auth/TokenProvider.java
@@ -15,8 +15,9 @@ package tech.pegasys.teku.ethereum.executionclient.auth;
 
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
-import java.sql.Date;
+
 import java.time.Instant;
+import java.util.Date;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/auth/TokenProvider.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/auth/TokenProvider.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.ethereum.executionclient.auth;
 
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
-
 import java.time.Instant;
 import java.util.Date;
 import java.util.Optional;

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/BlockManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/BlockManager.java
@@ -31,7 +31,6 @@ import tech.pegasys.teku.spec.datastructures.blocks.ImportedBlockListener;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSummary;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
-import tech.pegasys.teku.spec.logic.common.statetransition.results.FailedBlockImportResult;
 import tech.pegasys.teku.statetransition.util.FutureItems;
 import tech.pegasys.teku.statetransition.util.PendingPool;
 import tech.pegasys.teku.statetransition.validation.BlockValidator;

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/BlockManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/BlockManager.java
@@ -189,7 +189,7 @@ public class BlockManager extends Service
             .or(
                 () -> {
                   if (invalidBlockRoots.containsKey(block.getParentRoot())) {
-                    return Optional.of(FailedBlockImportResult.FAILED_DESCENDANT_OF_INVALID_BLOCK);
+                    return Optional.of(BlockImportResult.FAILED_DESCENDANT_OF_INVALID_BLOCK);
                   }
                   return Optional.empty();
                 });


### PR DESCRIPTION
## PR Description

Some real minor changes:

* `java.sql.Date#from` would call `java.util.Date#from`, might as well call it directly.
* `FAILED_DESCENDANT_OF_INVALID_BLOCK` is defined in `BlockImportResult`.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
