### PR TITLE
Upgrade reference tests to 1.2.0 - optimistic sync tests support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -282,7 +282,7 @@ allprojects {
   }
 }
 
-def refTestVersion = 'v1.2.0-rc.3' // Arbitrary change to refresh cache number: 1
+def refTestVersion = 'v1.2.0' // Arbitrary change to refresh cache number: 1
 def blsRefTestVersion = 'v0.1.1'
 def refTestBaseUrl = 'https://github.com/ethereum/eth2.0-spec-tests/releases/download'
 def blsRefTestBaseUrl = 'https://github.com/ethereum/bls12-381-tests/releases/download'

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/ManualReferenceTestRunner.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/ManualReferenceTestRunner.java
@@ -39,7 +39,7 @@ public class ManualReferenceTestRunner extends Eth2ReferenceTestCase {
    * <p>e.g. set to "ssz_static" to run only ssz static tests or "ssz_static/Attestation" for only
    * attestation ssz tests.
    */
-  private static final String TEST_TYPE = "ssz_generic/basic_vector";
+  private static final String TEST_TYPE = "sync/optimistic";
 
   /** Filter test to run to those from the specified spec. One of general, minimal or mainnet */
   private static final String SPEC = "";

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
@@ -227,11 +227,8 @@ public class ForkChoiceTestExecutor implements TestExecutor {
 
   private void applyPosBlock(
       final Map<String, Object> step, final ExecutionLayerChannelStub executionLayer) {
-
     final Bytes32 blockHash = getBytes32(step, "block_hash");
-
     final Map<String, Object> payloadStatus = get(step, "payload_status");
-
     final PayloadStatus parsePayloadStatus = parsePayloadStatus(payloadStatus);
 
     executionLayer.addPosBlock(blockHash, parsePayloadStatus);
@@ -241,11 +238,10 @@ public class ForkChoiceTestExecutor implements TestExecutor {
     final ExecutionPayloadStatus status =
         ExecutionPayloadStatus.valueOf(get(payloadStatus, "status"));
     final Optional<Bytes32> latestValidHash =
-        getOptionalBytes32(payloadStatus, "latest_valid_hash");
-    final Optional<String> validation_error =
-        Optional.ofNullable(get(payloadStatus, "validation_error"));
+        getOptionallyBytes32(payloadStatus, "latest_valid_hash");
+    final Optional<String> validationError = getOptionally(payloadStatus, "validation_error");
 
-    return PayloadStatus.create(status, latestValidHash, validation_error);
+    return PayloadStatus.create(status, latestValidHash, validationError);
   }
 
   private void applyAttestation(
@@ -413,20 +409,26 @@ public class ForkChoiceTestExecutor implements TestExecutor {
   }
 
   @SuppressWarnings({"unchecked", "TypeParameterUnusedInFormals"})
-  private <T> T get(final Map<String, Object> yamlData, final String key) {
+  private static <T> T get(final Map<String, Object> yamlData, final String key) {
     return (T) yamlData.get(key);
   }
 
-  private UInt64 getUInt64(final Map<String, Object> yamlData, final String key) {
+  @SuppressWarnings({"unchecked", "TypeParameterUnusedInFormals"})
+  private static <T> Optional<T> getOptionally(
+      final Map<String, Object> yamlData, final String key) {
+    return Optional.ofNullable((T) yamlData.get(key));
+  }
+
+  private static UInt64 getUInt64(final Map<String, Object> yamlData, final String key) {
     return UInt64.valueOf(get(yamlData, key).toString());
   }
 
-  private Bytes32 getBytes32(final Map<String, Object> yamlData, final String key) {
+  private static Bytes32 getBytes32(final Map<String, Object> yamlData, final String key) {
     return Bytes32.fromHexString(get(yamlData, key));
   }
 
-  private Optional<Bytes32> getOptionalBytes32(
+  private static Optional<Bytes32> getOptionallyBytes32(
       final Map<String, Object> yamlData, final String key) {
-    return Optional.<String>ofNullable(get(yamlData, key)).map(Bytes32::fromHexString);
+    return ForkChoiceTestExecutor.<String>getOptionally(yamlData, key).map(Bytes32::fromHexString);
   }
 }


### PR DESCRIPTION
implements the new step to set `engineNewPayload` response for a given payload.

fixes #6153

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
