### PR TITLE
Fix link to the Weak Subjectivity Guide

### DIFF
--- a/ethereum/weaksubjectivity/src/main/java/tech/pegasys/teku/weaksubjectivity/WeakSubjectivityCalculator.java
+++ b/ethereum/weaksubjectivity/src/main/java/tech/pegasys/teku/weaksubjectivity/WeakSubjectivityCalculator.java
@@ -26,7 +26,7 @@ import tech.pegasys.teku.weaksubjectivity.config.WeakSubjectivityConfig;
 /**
  * This utility contains helpers for calculating weak-subjectivity-related values. Logic is derived
  * from <a href=https://notes.ethereum.org/@adiasg/weak-subjectvity-eth2>Weak Subjectivity in
- * Eth2.0</a></a> and the <a
+ * Eth2.0</a> and the <a
  * href=https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/weak-subjectivity.md>Weak
  * Subjectivity Guide</a>.
  */

--- a/ethereum/weaksubjectivity/src/main/java/tech/pegasys/teku/weaksubjectivity/WeakSubjectivityCalculator.java
+++ b/ethereum/weaksubjectivity/src/main/java/tech/pegasys/teku/weaksubjectivity/WeakSubjectivityCalculator.java
@@ -25,8 +25,10 @@ import tech.pegasys.teku.weaksubjectivity.config.WeakSubjectivityConfig;
 
 /**
  * This utility contains helpers for calculating weak-subjectivity-related values. Logic is derived
- * from: https://notes.ethereum.org/@adiasg/weak-subjectvity-eth2 and:
- * https://github.com/ethereum/eth2.0-specs/blob/weak-subjectivity-guide/specs/phase0/weak-subjectivity.md
+ * from <a href=https://notes.ethereum.org/@adiasg/weak-subjectvity-eth2>Weak Subjectivity in
+ * Eth2.0</a></a> and the <a
+ * href=https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/weak-subjectivity.md>Weak
+ * Subjectivity Guide</a>.
  */
 public class WeakSubjectivityCalculator {
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

The link to this document was broken. Fixed that and added hyperlink tags.
```diff
- https://github.com/ethereum/eth2.0-specs/blob/weak-subjectivity-guide/specs/phase0/weak-subjectivity.md
+ https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/weak-subjectivity.md
```

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
