### PR TITLE
Update QuantityChecker error message

### DIFF
--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/serialization/QuantityChecker.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/serialization/QuantityChecker.java
@@ -27,6 +27,6 @@ public class QuantityChecker {
         "Hex QUANTITY must start with 0x and can't be empty");
     checkArgument(
         hexQuantity.charAt(2) != '0' || hexQuantity.length() == 3,
-        "Hex QUANTITY must not have trailing zeros");
+        "Hex QUANTITY must not have leading zeros");
   }
 }

--- a/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/SchemaSerializationTests.java
+++ b/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/SchemaSerializationTests.java
@@ -166,7 +166,7 @@ public class SchemaSerializationTests {
   }
 
   @TestTemplate
-  void shouldThrowDeserializingUIntQuantityWithTrailingZeros() {
+  void shouldThrowDeserializingUIntQuantityWithLeadingZeros() {
 
     assertThrows(
         IllegalArgumentException.class,


### PR DESCRIPTION
## PR Description

I think the error message should say "leading zeros" instead of "trailing zeros."

* `0x00001234` has leading zeros (invalid).
* `0x12340000` has trailing zeros (valid).

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
