### PR TITLE
Updated ATs DSL with utility methods to check metrics

### DIFF
--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/Node.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/Node.java
@@ -16,15 +16,16 @@ package tech.pegasys.teku.test.acceptance.dsl;
 import static com.fasterxml.jackson.dataformat.yaml.YAMLGenerator.Feature.WRITE_DOC_START_MARKER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
+import static tech.pegasys.teku.test.acceptance.dsl.metrics.MetricConditions.anyLabels;
+import static tech.pegasys.teku.test.acceptance.dsl.metrics.MetricConditions.withNameEqualsTo;
+import static tech.pegasys.teku.test.acceptance.dsl.metrics.MetricConditions.withValueEqualTo;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.StringReader;
 import java.net.URI;
 import java.net.URL;
 import java.nio.file.Files;
@@ -43,8 +44,15 @@ import org.testcontainers.images.PullPolicy;
 import org.testcontainers.images.builder.ImageFromDockerfile;
 import tech.pegasys.teku.infrastructure.async.Waiter;
 import tech.pegasys.teku.provider.JsonProvider;
+import tech.pegasys.teku.test.acceptance.dsl.metrics.MetricConditions.MetricLabelsCondition;
+import tech.pegasys.teku.test.acceptance.dsl.metrics.MetricConditions.MetricNameCondition;
+import tech.pegasys.teku.test.acceptance.dsl.metrics.MetricConditions.MetricValuesCondition;
+import tech.pegasys.teku.test.acceptance.dsl.metrics.MetricFetcher;
+import tech.pegasys.teku.test.acceptance.dsl.metrics.MetricMatcher;
+import tech.pegasys.teku.test.acceptance.dsl.metrics.MetricValue;
 
 public abstract class Node {
+
   private static final Logger LOG = LogManager.getLogger();
   public static final String TEKU_DOCKER_IMAGE_NAME = "consensys/teku";
   protected final SimpleHttpClient httpClient = new SimpleHttpClient();
@@ -120,24 +128,48 @@ public abstract class Node {
     waitForEpochAtOrAbove(currentEpoch + 1);
   }
 
-  public double getMetricValue(final String metricName) throws IOException {
-    final String allMetrics = httpClient.get(getMetricsUrl(), "/metrics");
-    final String prefix = metricName + " ";
-    try (BufferedReader reader = new BufferedReader(new StringReader(allMetrics))) {
-      for (String line = reader.readLine(); line != null; line = reader.readLine()) {
-        if (line.startsWith(prefix)) {
-          final String value = line.substring(prefix.length());
-          LOG.debug("Metric {}: {}", metricName, value);
-          return Double.parseDouble(value);
-        }
-      }
-    }
-    throw new IllegalArgumentException(
-        "Did not find metric " + metricName + " in: \n" + allMetrics);
+  // gauge
+  public double getMetricValue(final String metricName) {
+    final MetricFetcher metricFetcher = new MetricFetcher(httpClient, getMetricsUrl());
+    final MetricValue metricValue = metricFetcher.getSingleMetricByName(metricName);
+
+    LOG.debug("Metric {}: {}", metricName, metricValue.getValue());
+    return metricValue.getValue();
   }
 
   public void waitForLogMessageContaining(final String filter) {
     waitFor(() -> assertThat(getFilteredOutput(filter)).isNotEmpty(), 2, TimeUnit.MINUTES);
+  }
+
+  public void waitForMetricWithValue(final String metricName, final double value) {
+    waitForMetric(withNameEqualsTo(metricName), anyLabels(), withValueEqualTo(value));
+  }
+
+  public void waitForMetric(
+      final MetricNameCondition nameCondition,
+      final MetricLabelsCondition labelsCondition,
+      final MetricValuesCondition valueCondition) {
+    waitForMetric(nameCondition, labelsCondition, valueCondition, 5, TimeUnit.MINUTES);
+  }
+
+  public void waitForMetric(
+      final MetricNameCondition nameCondition,
+      final MetricLabelsCondition labelsCondition,
+      final MetricValuesCondition valueCondition,
+      final int timeoutAmount,
+      final TimeUnit timeoutUnit) {
+    final MetricFetcher metricFetcher = new MetricFetcher(httpClient, getMetricsUrl());
+
+    waitFor(
+        () -> {
+          final List<MetricValue> metrics = metricFetcher.getAllMetrics();
+          assertThat(
+                  MetricMatcher.anyMatching(
+                      metrics, nameCondition, labelsCondition, valueCondition))
+              .isPresent();
+        },
+        timeoutAmount,
+        timeoutUnit);
   }
 
   protected void waitFor(
@@ -201,11 +233,7 @@ public abstract class Node {
     return tmpFile;
   }
 
-  /**
-   * Copies contents of the given directory into node's working directory.
-   *
-   * @param tarFile
-   */
+  /** Copies contents of the given directory into node's working directory. */
   public void copyContentsToWorkingDirectory(File tarFile) {
     container.withExpandedTarballToContainer(tarFile, WORKING_DIRECTORY);
   }

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/Node.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/Node.java
@@ -128,7 +128,6 @@ public abstract class Node {
     waitForEpochAtOrAbove(currentEpoch + 1);
   }
 
-  // gauge
   public double getMetricValue(final String metricName) {
     final MetricFetcher metricFetcher = new MetricFetcher(httpClient, getMetricsUrl());
     final MetricValue metricValue = metricFetcher.getSingleMetricByName(metricName);

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/Node.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/Node.java
@@ -16,7 +16,7 @@ package tech.pegasys.teku.test.acceptance.dsl;
 import static com.fasterxml.jackson.dataformat.yaml.YAMLGenerator.Feature.WRITE_DOC_START_MARKER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
-import static tech.pegasys.teku.test.acceptance.dsl.metrics.MetricConditions.anyLabels;
+import static tech.pegasys.teku.test.acceptance.dsl.metrics.MetricConditions.withAnyLabels;
 import static tech.pegasys.teku.test.acceptance.dsl.metrics.MetricConditions.withNameEqualsTo;
 import static tech.pegasys.teku.test.acceptance.dsl.metrics.MetricConditions.withValueEqualTo;
 
@@ -141,7 +141,7 @@ public abstract class Node {
   }
 
   public void waitForMetricWithValue(final String metricName, final double value) {
-    waitForMetric(withNameEqualsTo(metricName), anyLabels(), withValueEqualTo(value));
+    waitForMetric(withNameEqualsTo(metricName), withAnyLabels(), withValueEqualTo(value));
   }
 
   public void waitForMetric(

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/metrics/MetricConditions.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/metrics/MetricConditions.java
@@ -38,7 +38,7 @@ public class MetricConditions {
     boolean test(final Double value);
   }
 
-  public static MetricNameCondition anyName() {
+  public static MetricNameCondition withAnyName() {
     return (n) -> true;
   }
 
@@ -46,7 +46,7 @@ public class MetricConditions {
     return (n) -> n.equals(name);
   }
 
-  public static MetricLabelsCondition anyLabels() {
+  public static MetricLabelsCondition withAnyLabels() {
     return (l) -> true;
   }
 
@@ -83,7 +83,7 @@ public class MetricConditions {
         DoubleMath.fuzzyCompare(actualValue, value, DOUBLE_COMPARE_TOLERANCE) <= 0;
   }
 
-  public static MetricValuesCondition anyValue() {
+  public static MetricValuesCondition withAnyValue() {
     return (actualValue) -> true;
   }
 }

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/metrics/MetricConditions.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/metrics/MetricConditions.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.test.acceptance.dsl.metrics;
+
+import com.google.common.math.DoubleMath;
+import java.util.Map;
+
+public class MetricConditions {
+
+  public static final double DOUBLE_COMPARE_TOLERANCE = 0.000001;
+
+  @FunctionalInterface
+  public interface MetricNameCondition {
+
+    boolean test(final String name);
+  }
+
+  @FunctionalInterface
+  public interface MetricLabelsCondition {
+
+    boolean test(final Map<String, String> labels);
+  }
+
+  @FunctionalInterface
+  public interface MetricValuesCondition {
+
+    boolean test(final Double value);
+  }
+
+  public static MetricNameCondition anyName() {
+    return (n) -> true;
+  }
+
+  public static MetricNameCondition withNameEqualsTo(final String name) {
+    return (n) -> n.equals(name);
+  }
+
+  public static MetricLabelsCondition anyLabels() {
+    return (l) -> true;
+  }
+
+  public static MetricLabelsCondition withLabelsContaining(final Map<String, String> labels) {
+    return (actualLabels) ->
+        labels.entrySet().stream()
+            .allMatch(
+                entry ->
+                    actualLabels.containsKey(entry.getKey())
+                        && actualLabels.get(entry.getKey()).equals(entry.getValue()));
+  }
+
+  public static MetricValuesCondition withValueEqualTo(double value) {
+    return (actualValue) -> DoubleMath.fuzzyEquals(actualValue, value, DOUBLE_COMPARE_TOLERANCE);
+  }
+
+  public static MetricValuesCondition withValueGreaterThan(double value) {
+    return (actualValue) ->
+        DoubleMath.fuzzyCompare(actualValue, value, DOUBLE_COMPARE_TOLERANCE) > 0;
+  }
+
+  public static MetricValuesCondition withValueGreaterThanOrEqualTo(double value) {
+    return (actualValue) ->
+        DoubleMath.fuzzyCompare(actualValue, value, DOUBLE_COMPARE_TOLERANCE) >= 0;
+  }
+
+  public static MetricValuesCondition withValueLessThan(double value) {
+    return (actualValue) ->
+        DoubleMath.fuzzyCompare(actualValue, value, DOUBLE_COMPARE_TOLERANCE) < 0;
+  }
+
+  public static MetricValuesCondition withValueLessThanOrEqualTo(double value) {
+    return (actualValue) ->
+        DoubleMath.fuzzyCompare(actualValue, value, DOUBLE_COMPARE_TOLERANCE) <= 0;
+  }
+
+  public static MetricValuesCondition anyValue() {
+    return (actualValue) -> true;
+  }
+}

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/metrics/MetricFetcher.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/metrics/MetricFetcher.java
@@ -13,9 +13,9 @@
 
 package tech.pegasys.teku.test.acceptance.dsl.metrics;
 
-import static tech.pegasys.teku.test.acceptance.dsl.metrics.MetricConditions.anyLabels;
-import static tech.pegasys.teku.test.acceptance.dsl.metrics.MetricConditions.anyName;
-import static tech.pegasys.teku.test.acceptance.dsl.metrics.MetricConditions.anyValue;
+import static tech.pegasys.teku.test.acceptance.dsl.metrics.MetricConditions.withAnyLabels;
+import static tech.pegasys.teku.test.acceptance.dsl.metrics.MetricConditions.withAnyName;
+import static tech.pegasys.teku.test.acceptance.dsl.metrics.MetricConditions.withAnyValue;
 import static tech.pegasys.teku.test.acceptance.dsl.metrics.MetricConditions.withNameEqualsTo;
 import static tech.pegasys.teku.test.acceptance.dsl.metrics.MetricMatcher.allMatching;
 
@@ -41,12 +41,12 @@ public class MetricFetcher {
   }
 
   public List<MetricValue> getAllMetrics() {
-    return allMatching(fetchAllMetricsFromEndpoint(), anyName(), anyLabels(), anyValue());
+    return allMatching(fetchAllMetricsFromEndpoint(), withAnyName(), withAnyLabels(), withAnyValue());
   }
 
   public List<MetricValue> getMetricsByName(final String name) {
     return allMatching(
-        fetchAllMetricsFromEndpoint(), withNameEqualsTo(name), anyLabels(), anyValue());
+        fetchAllMetricsFromEndpoint(), withNameEqualsTo(name), withAnyLabels(), withAnyValue());
   }
 
   /**

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/metrics/MetricFetcher.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/metrics/MetricFetcher.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.test.acceptance.dsl.metrics;
+
+import static tech.pegasys.teku.test.acceptance.dsl.metrics.MetricConditions.anyLabels;
+import static tech.pegasys.teku.test.acceptance.dsl.metrics.MetricConditions.anyName;
+import static tech.pegasys.teku.test.acceptance.dsl.metrics.MetricConditions.anyValue;
+import static tech.pegasys.teku.test.acceptance.dsl.metrics.MetricConditions.withNameEqualsTo;
+import static tech.pegasys.teku.test.acceptance.dsl.metrics.MetricMatcher.allMatching;
+
+import java.io.BufferedReader;
+import java.io.StringReader;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import tech.pegasys.teku.test.acceptance.dsl.SimpleHttpClient;
+
+public class MetricFetcher {
+
+  private final SimpleHttpClient httpClient;
+  private final URI metricsEndpoint;
+
+  public MetricFetcher(final SimpleHttpClient httpClient, final URI metricsEndpoint) {
+    this.httpClient = httpClient;
+    this.metricsEndpoint = metricsEndpoint;
+  }
+
+  public List<MetricValue> getAllMetrics() {
+    return allMatching(fetchAllMetricsFromEndpoint(), anyName(), anyLabels(), anyValue());
+  }
+
+  public List<MetricValue> getMetricsByName(final String name) {
+    return allMatching(
+        fetchAllMetricsFromEndpoint(), withNameEqualsTo(name), anyLabels(), anyValue());
+  }
+
+  /**
+   * Search a single metric with the specified name. If more than one metric is found (usually due
+   * to different labels) an error is thrown.
+   *
+   * @param name Name of the metric
+   * @return a {@link MetricValue} for the metric
+   */
+  public MetricValue getSingleMetricByName(final String name) {
+    final List<MetricValue> metrics = getMetricsByName(name);
+    if (metrics.size() == 0) {
+      throw new RuntimeException("Can't find metrics with name " + name);
+    }
+
+    if (metrics.size() > 1) {
+      throw new RuntimeException(
+          "Multiple entries found for metric "
+              + name
+              + ". Consider using getSingleMetricValueByNameAndLabels(..) in your test.");
+    }
+
+    return metrics.get(0);
+  }
+
+  private List<MetricValue> fetchAllMetricsFromEndpoint() {
+    try {
+      final String allMetrics = httpClient.get(metricsEndpoint, "/metrics");
+      try (BufferedReader reader = new BufferedReader(new StringReader(allMetrics))) {
+        return reader
+            .lines()
+            .filter(l -> !l.startsWith("#")) // removing comments from response
+            .map(MetricFetcher::parse)
+            .collect(Collectors.toList());
+      }
+    } catch (final Exception e) {
+      throw new RuntimeException(
+          "Error getting metric values from " + metricsEndpoint + "/metrics", e);
+    }
+  }
+
+  public static MetricValue parse(String line) {
+    if (line.contains("{")) {
+      final String metricName = line.substring(0, line.indexOf("{"));
+
+      final Double metricValue = Double.parseDouble(line.substring(line.indexOf("} ") + 1));
+
+      final Map<String, String> metricLabels = new HashMap<>();
+      final String labelsString = line.substring(line.indexOf("{") + 1, line.indexOf("}"));
+      final Pattern p = Pattern.compile("(.*?)=\"(.*?)\",");
+      final Matcher m = p.matcher(labelsString);
+      while (m.find()) {
+        metricLabels.put(m.group(1), m.group(2));
+      }
+
+      return new MetricValue(metricName, metricLabels, metricValue);
+    } else {
+      final String name = line.split("\\s", -1)[0];
+      final Double value = Double.parseDouble(line.split("\\s", -1)[1]);
+
+      return new MetricValue(name, null, value);
+    }
+  }
+}

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/metrics/MetricFetcher.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/metrics/MetricFetcher.java
@@ -41,7 +41,8 @@ public class MetricFetcher {
   }
 
   public List<MetricValue> getAllMetrics() {
-    return allMatching(fetchAllMetricsFromEndpoint(), withAnyName(), withAnyLabels(), withAnyValue());
+    return allMatching(
+        fetchAllMetricsFromEndpoint(), withAnyName(), withAnyLabels(), withAnyValue());
   }
 
   public List<MetricValue> getMetricsByName(final String name) {

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/metrics/MetricMatcher.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/metrics/MetricMatcher.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.test.acceptance.dsl.metrics;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import tech.pegasys.teku.test.acceptance.dsl.metrics.MetricConditions.MetricLabelsCondition;
+import tech.pegasys.teku.test.acceptance.dsl.metrics.MetricConditions.MetricNameCondition;
+import tech.pegasys.teku.test.acceptance.dsl.metrics.MetricConditions.MetricValuesCondition;
+
+public class MetricMatcher {
+
+  public static List<MetricValue> allMatching(
+      final List<MetricValue> metrics,
+      final MetricNameCondition nameCondition,
+      final MetricLabelsCondition labelsCondition,
+      final MetricValuesCondition valueCondition) {
+    return metrics.stream()
+        .filter(metric -> nameCondition.test(metric.getName()))
+        .filter(metric -> labelsCondition.test(metric.getLabels()))
+        .filter(metric -> valueCondition.test(metric.getValue()))
+        .collect(Collectors.toList());
+  }
+
+  public static Optional<MetricValue> anyMatching(
+      final List<MetricValue> metrics,
+      final MetricNameCondition nameCondition,
+      final MetricLabelsCondition labelsCondition,
+      final MetricValuesCondition valueCondition) {
+    return metrics.stream()
+        .filter(metric -> nameCondition.test(metric.getName()))
+        .filter(metric -> labelsCondition.test(metric.getLabels()))
+        .filter(metric -> valueCondition.test(metric.getValue()))
+        .findAny();
+  }
+}

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/metrics/MetricValue.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/metrics/MetricValue.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.test.acceptance.dsl.metrics;
+
+import com.google.common.base.MoreObjects;
+import java.util.Map;
+
+public class MetricValue {
+
+  private final String name;
+  private final Map<String, String> labels;
+  private final Double value;
+
+  public MetricValue(final String name, final Map<String, String> labels, final Double value) {
+    this.name = name;
+    this.labels = labels;
+    this.value = value;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public Map<String, String> getLabels() {
+    return labels;
+  }
+
+  public Double getValue() {
+    return value;
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("name", name)
+        .add("labels", labels)
+        .add("value", value)
+        .omitNullValues()
+        .toString();
+  }
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

Some example usage:
```
node.waitForMetricWithValue("jvm_classes_unloaded_total", 0);

node.waitForMetric(
    withNameEqualsTo("jvm_classes_unloaded_total"),
    withAnyLabels(),
    withValueEqualTo(0));  

node.waitForMetric(
    withNameEqualsTo("validator_beacon_node_requests_total"), 
    withLabelsContaining(Map.of("method", "publish_block", "outcome", "success")), 
    withAnyValue());

node.waitForMetric(
    withNameEqualsTo("validator_beacon_node_requests_total"),
    withLabelsContaining(Map.of("method", "create_attestation", "outcome", "success")), 
    withValueGreaterThan(2));
```