### PR TITLE
Add fuzzy round-trip SSZ serialization tests for datastructs

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/builder/BuilderBid.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/builder/BuilderBid.java
@@ -47,4 +47,9 @@ public class BuilderBid
   public BLSPublicKey getPublicKey() {
     return getField2().getBLSPublicKey();
   }
+
+  @Override
+  public BuilderBidSchema getSchema() {
+    return (BuilderBidSchema) super.getSchema();
+  }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/AggregateAndProof.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/AggregateAndProof.java
@@ -77,4 +77,9 @@ public class AggregateAndProof
   public BLSSignature getSelectionProof() {
     return getField2().getSignature();
   }
+
+  @Override
+  public AggregateAndProofSchema getSchema() {
+    return (AggregateAndProofSchema) super.getSchema();
+  }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/altair/SyncAggregatorSelectionData.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/altair/SyncAggregatorSelectionData.java
@@ -40,4 +40,9 @@ public class SyncAggregatorSelectionData
   public UInt64 getSubcommitteeIndex() {
     return getField1().get();
   }
+
+  @Override
+  public SyncAggregatorSelectionDataSchema getSchema() {
+    return (SyncAggregatorSelectionDataSchema) super.getSchema();
+  }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/altair/SyncCommitteeContribution.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/versions/altair/SyncCommitteeContribution.java
@@ -65,4 +65,9 @@ public class SyncCommitteeContribution
   public BLSSignature getSignature() {
     return getField4().getSignature();
   }
+
+  @Override
+  public SyncCommitteeContributionSchema getSchema() {
+    return (SyncCommitteeContributionSchema) super.getSchema();
+  }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/BeaconBlockBodyPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/BeaconBlockBodyPropertyTest.java
@@ -16,27 +16,18 @@ package tech.pegasys.teku.spec.datastructures.blocks;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.Combinators;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import net.jqwik.api.Provide;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
-import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodySchema;
-import tech.pegasys.teku.spec.networks.Eth2Network;
-import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class BeaconBlockBodyPropertyTest {
   @Property
   @SuppressWarnings("unchecked")
-  void roundTrip(@ForAll("beaconBlockBody") final BeaconBlockBody body)
+  void roundTrip(@ForAll(supplier = BeaconBlockBodySupplier.class) final BeaconBlockBody body)
       throws JsonProcessingException {
     final BeaconBlockBodySchema<?> schema = body.getSchema();
     final DeserializableTypeDefinition<BeaconBlockBody> typeDefinition =
@@ -51,15 +42,5 @@ public class BeaconBlockBodyPropertyTest {
     final String json = JsonUtil.serialize(body, typeDefinition);
     final BeaconBlockBody fromJson = JsonUtil.parse(json, typeDefinition);
     assertThat(fromJson).isEqualTo(body);
-  }
-
-  @Provide
-  Arbitrary<BeaconBlockBody> beaconBlockBody() {
-    Arbitrary<Integer> seed = Arbitraries.integers();
-    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
-    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
-    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
-    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
-    return dsu.map(DataStructureUtil::randomBeaconBlockBody);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/BeaconBlockBodyPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/BeaconBlockBodyPropertyTest.java
@@ -18,12 +18,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
+import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodySchema;
 import tech.pegasys.teku.spec.networks.Eth2Network;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
@@ -38,14 +40,19 @@ public class BeaconBlockBodyPropertyTest {
     final Spec spec = TestSpecFactory.create(specMilestone, network);
     final DataStructureUtil dataStructureUtil = new DataStructureUtil(seed, spec);
     final BeaconBlockBody body = dataStructureUtil.randomBeaconBlockBody();
+    final BeaconBlockBodySchema<?> schema =
+        spec.forMilestone(specMilestone).getSchemaDefinitions().getBeaconBlockBodySchema();
     final DeserializableTypeDefinition<BeaconBlockBody> typeDefinition =
-        (DeserializableTypeDefinition<BeaconBlockBody>)
-            spec.forMilestone(specMilestone)
-                .getSchemaDefinitions()
-                .getBeaconBlockBodySchema()
-                .getJsonTypeDefinition();
+        (DeserializableTypeDefinition<BeaconBlockBody>) schema.getJsonTypeDefinition();
+
+    // Round-trip SSZ serialization.
+    final Bytes ssz = body.sszSerialize();
+    final BeaconBlockBody fromSsz = schema.sszDeserialize(ssz);
+    assertThat(fromSsz).isEqualTo(body);
+
+    // Round-trip JSON serialization.
     final String json = JsonUtil.serialize(body, typeDefinition);
-    final BeaconBlockBody result = JsonUtil.parse(json, typeDefinition);
-    assertThat(result).isEqualTo(body);
+    final BeaconBlockBody fromJson = JsonUtil.parse(json, typeDefinition);
+    assertThat(fromJson).isEqualTo(body);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/BeaconBlockBodySupplier.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/BeaconBlockBodySupplier.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.blocks;
+
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.ArbitrarySupplier;
+import net.jqwik.api.Combinators;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
+import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class BeaconBlockBodySupplier implements ArbitrarySupplier<BeaconBlockBody> {
+  @Override
+  public Arbitrary<BeaconBlockBody> get() {
+    Arbitrary<Integer> seed = Arbitraries.integers();
+    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
+    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
+    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
+    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
+    return dsu.map(DataStructureUtil::randomBeaconBlockBody);
+  }
+}

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/BeaconBlockHeaderPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/BeaconBlockHeaderPropertyTest.java
@@ -16,24 +16,15 @@ package tech.pegasys.teku.spec.datastructures.blocks;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.Combinators;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import net.jqwik.api.Provide;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
-import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.networks.Eth2Network;
-import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class BeaconBlockHeaderPropertyTest {
   @Property
-  void roundTrip(@ForAll("beaconBlockHeader") final BeaconBlockHeader header)
+  void roundTrip(@ForAll(supplier = BeaconBlockHeaderSupplier.class) final BeaconBlockHeader header)
       throws JsonProcessingException {
     final BeaconBlockHeader.BeaconBlockHeaderSchema schema = header.getSchema();
     final DeserializableTypeDefinition<BeaconBlockHeader> typeDefinition =
@@ -48,15 +39,5 @@ public class BeaconBlockHeaderPropertyTest {
     final String json = JsonUtil.serialize(header, typeDefinition);
     final BeaconBlockHeader fromJson = JsonUtil.parse(json, typeDefinition);
     assertThat(fromJson).isEqualTo(header);
-  }
-
-  @Provide
-  Arbitrary<BeaconBlockHeader> beaconBlockHeader() {
-    Arbitrary<Integer> seed = Arbitraries.integers();
-    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
-    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
-    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
-    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
-    return dsu.map(DataStructureUtil::randomBeaconBlockHeader);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/BeaconBlockHeaderSupplier.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/BeaconBlockHeaderSupplier.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.blocks;
+
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.ArbitrarySupplier;
+import net.jqwik.api.Combinators;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class BeaconBlockHeaderSupplier implements ArbitrarySupplier<BeaconBlockHeader> {
+  @Override
+  public Arbitrary<BeaconBlockHeader> get() {
+    Arbitrary<Integer> seed = Arbitraries.integers();
+    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
+    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
+    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
+    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
+    return dsu.map(DataStructureUtil::randomBeaconBlockHeader);
+  }
+}

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/BeaconBlockPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/BeaconBlockPropertyTest.java
@@ -16,12 +16,15 @@ package tech.pegasys.teku.spec.datastructures.blocks;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.Combinators;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
-import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecFactory;
@@ -30,17 +33,8 @@ import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class BeaconBlockPropertyTest {
   @Property
-  void roundTrip(
-      @ForAll final int seed,
-      @ForAll final SpecMilestone specMilestone,
-      @ForAll final Eth2Network network,
-      @ForAll final long slot)
-      throws JsonProcessingException {
-    final Spec spec = TestSpecFactory.create(specMilestone, network);
-    final DataStructureUtil dataStructureUtil = new DataStructureUtil(seed, spec);
-    final BeaconBlock block = dataStructureUtil.randomBeaconBlock(UInt64.fromLongBits(slot));
-    final BeaconBlockSchema schema =
-        spec.forMilestone(specMilestone).getSchemaDefinitions().getBeaconBlockSchema();
+  void roundTrip(@ForAll("beaconBlock") final BeaconBlock block) throws JsonProcessingException {
+    final BeaconBlockSchema schema = block.getSchema();
     final DeserializableTypeDefinition<BeaconBlock> typeDefinition = schema.getJsonTypeDefinition();
 
     // Round-trip SSZ serialization.
@@ -52,5 +46,15 @@ public class BeaconBlockPropertyTest {
     final String json = JsonUtil.serialize(block, typeDefinition);
     final BeaconBlock fromJson = JsonUtil.parse(json, typeDefinition);
     assertThat(fromJson).isEqualTo(block);
+  }
+
+  @Provide
+  Arbitrary<BeaconBlock> beaconBlock() {
+    Arbitrary<Integer> seed = Arbitraries.integers();
+    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
+    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
+    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
+    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
+    return dsu.map(DataStructureUtil::randomBeaconBlock);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/BeaconBlockPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/BeaconBlockPropertyTest.java
@@ -16,24 +16,16 @@ package tech.pegasys.teku.spec.datastructures.blocks;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.Combinators;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import net.jqwik.api.Provide;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
-import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.networks.Eth2Network;
-import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class BeaconBlockPropertyTest {
   @Property
-  void roundTrip(@ForAll("beaconBlock") final BeaconBlock block) throws JsonProcessingException {
+  void roundTrip(@ForAll(supplier = BeaconBlockSupplier.class) final BeaconBlock block)
+      throws JsonProcessingException {
     final BeaconBlockSchema schema = block.getSchema();
     final DeserializableTypeDefinition<BeaconBlock> typeDefinition = schema.getJsonTypeDefinition();
 
@@ -46,15 +38,5 @@ public class BeaconBlockPropertyTest {
     final String json = JsonUtil.serialize(block, typeDefinition);
     final BeaconBlock fromJson = JsonUtil.parse(json, typeDefinition);
     assertThat(fromJson).isEqualTo(block);
-  }
-
-  @Provide
-  Arbitrary<BeaconBlock> beaconBlock() {
-    Arbitrary<Integer> seed = Arbitraries.integers();
-    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
-    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
-    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
-    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
-    return dsu.map(DataStructureUtil::randomBeaconBlock);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/BeaconBlockPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/BeaconBlockPropertyTest.java
@@ -18,6 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
+import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -38,13 +39,18 @@ public class BeaconBlockPropertyTest {
     final Spec spec = TestSpecFactory.create(specMilestone, network);
     final DataStructureUtil dataStructureUtil = new DataStructureUtil(seed, spec);
     final BeaconBlock block = dataStructureUtil.randomBeaconBlock(UInt64.fromLongBits(slot));
-    final DeserializableTypeDefinition<BeaconBlock> typeDefinition =
-        spec.forMilestone(specMilestone)
-            .getSchemaDefinitions()
-            .getBeaconBlockSchema()
-            .getJsonTypeDefinition();
+    final BeaconBlockSchema schema =
+        spec.forMilestone(specMilestone).getSchemaDefinitions().getBeaconBlockSchema();
+    final DeserializableTypeDefinition<BeaconBlock> typeDefinition = schema.getJsonTypeDefinition();
+
+    // Round-trip SSZ serialization.
+    final Bytes ssz = block.sszSerialize();
+    final BeaconBlock fromSsz = schema.sszDeserialize(ssz);
+    assertThat(fromSsz).isEqualTo(block);
+
+    // Round-trip JSON serialization.
     final String json = JsonUtil.serialize(block, typeDefinition);
-    final BeaconBlock result = JsonUtil.parse(json, typeDefinition);
-    assertThat(result).isEqualTo(block);
+    final BeaconBlock fromJson = JsonUtil.parse(json, typeDefinition);
+    assertThat(fromJson).isEqualTo(block);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/BeaconBlockSupplier.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/BeaconBlockSupplier.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.blocks;
+
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.ArbitrarySupplier;
+import net.jqwik.api.Combinators;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class BeaconBlockSupplier implements ArbitrarySupplier<BeaconBlock> {
+  @Override
+  public Arbitrary<BeaconBlock> get() {
+    Arbitrary<Integer> seed = Arbitraries.integers();
+    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
+    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
+    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
+    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
+    return dsu.map(DataStructureUtil::randomBeaconBlock);
+  }
+}

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/BlindedBeaconBlockBodyPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/BlindedBeaconBlockBodyPropertyTest.java
@@ -18,6 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
+import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -25,6 +26,7 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodySchema;
 import tech.pegasys.teku.spec.networks.Eth2Network;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
@@ -41,14 +43,19 @@ public class BlindedBeaconBlockBodyPropertyTest {
     final DataStructureUtil dataStructureUtil = new DataStructureUtil(seed, spec);
     final BeaconBlockBody body =
         dataStructureUtil.randomBlindedBeaconBlockBody(UInt64.fromLongBits(slot));
+    final BeaconBlockBodySchema<?> schema =
+        spec.forMilestone(specMilestone).getSchemaDefinitions().getBlindedBeaconBlockBodySchema();
     final DeserializableTypeDefinition<BeaconBlockBody> typeDefinition =
-        (DeserializableTypeDefinition<BeaconBlockBody>)
-            spec.forMilestone(specMilestone)
-                .getSchemaDefinitions()
-                .getBlindedBeaconBlockBodySchema()
-                .getJsonTypeDefinition();
+        (DeserializableTypeDefinition<BeaconBlockBody>) schema.getJsonTypeDefinition();
+
+    // Round-trip SSZ serialization.
+    final Bytes ssz = body.sszSerialize();
+    final BeaconBlockBody fromSsz = schema.sszDeserialize(ssz);
+    assertThat(fromSsz).isEqualTo(body);
+
+    // Round-trip JSON serialization.
     final String json = JsonUtil.serialize(body, typeDefinition);
-    final BeaconBlockBody result = JsonUtil.parse(json, typeDefinition);
-    assertThat(result).isEqualTo(body);
+    final BeaconBlockBody fromJson = JsonUtil.parse(json, typeDefinition);
+    assertThat(fromJson).isEqualTo(body);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/BlindedBeaconBlockBodyPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/BlindedBeaconBlockBodyPropertyTest.java
@@ -16,27 +16,18 @@ package tech.pegasys.teku.spec.datastructures.blocks;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.Combinators;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import net.jqwik.api.Provide;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
-import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodySchema;
-import tech.pegasys.teku.spec.networks.Eth2Network;
-import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class BlindedBeaconBlockBodyPropertyTest {
   @Property
   @SuppressWarnings("unchecked")
-  void roundTrip(@ForAll("blindedBeaconBlockBody") final BeaconBlockBody body)
+  void roundTrip(@ForAll(supplier = BeaconBlockBodySupplier.class) final BeaconBlockBody body)
       throws JsonProcessingException {
     final BeaconBlockBodySchema<?> schema = body.getSchema();
     final DeserializableTypeDefinition<BeaconBlockBody> typeDefinition =
@@ -51,15 +42,5 @@ public class BlindedBeaconBlockBodyPropertyTest {
     final String json = JsonUtil.serialize(body, typeDefinition);
     final BeaconBlockBody fromJson = JsonUtil.parse(json, typeDefinition);
     assertThat(fromJson).isEqualTo(body);
-  }
-
-  @Provide
-  Arbitrary<BeaconBlockBody> blindedBeaconBlockBody() {
-    Arbitrary<Integer> seed = Arbitraries.integers();
-    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
-    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
-    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
-    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
-    return dsu.map(DataStructureUtil::randomBlindedBeaconBlockBody);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/BlindedBeaconBlockBodyPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/BlindedBeaconBlockBodyPropertyTest.java
@@ -16,12 +16,15 @@ package tech.pegasys.teku.spec.datastructures.blocks;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.Combinators;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
-import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecFactory;
@@ -33,18 +36,9 @@ import tech.pegasys.teku.spec.util.DataStructureUtil;
 public class BlindedBeaconBlockBodyPropertyTest {
   @Property
   @SuppressWarnings("unchecked")
-  void roundTrip(
-      @ForAll final int seed,
-      @ForAll final SpecMilestone specMilestone,
-      @ForAll final Eth2Network network,
-      @ForAll final long slot)
+  void roundTrip(@ForAll("blindedBeaconBlockBody") final BeaconBlockBody body)
       throws JsonProcessingException {
-    final Spec spec = TestSpecFactory.create(specMilestone, network);
-    final DataStructureUtil dataStructureUtil = new DataStructureUtil(seed, spec);
-    final BeaconBlockBody body =
-        dataStructureUtil.randomBlindedBeaconBlockBody(UInt64.fromLongBits(slot));
-    final BeaconBlockBodySchema<?> schema =
-        spec.forMilestone(specMilestone).getSchemaDefinitions().getBlindedBeaconBlockBodySchema();
+    final BeaconBlockBodySchema<?> schema = body.getSchema();
     final DeserializableTypeDefinition<BeaconBlockBody> typeDefinition =
         (DeserializableTypeDefinition<BeaconBlockBody>) schema.getJsonTypeDefinition();
 
@@ -57,5 +51,15 @@ public class BlindedBeaconBlockBodyPropertyTest {
     final String json = JsonUtil.serialize(body, typeDefinition);
     final BeaconBlockBody fromJson = JsonUtil.parse(json, typeDefinition);
     assertThat(fromJson).isEqualTo(body);
+  }
+
+  @Provide
+  Arbitrary<BeaconBlockBody> blindedBeaconBlockBody() {
+    Arbitrary<Integer> seed = Arbitraries.integers();
+    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
+    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
+    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
+    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
+    return dsu.map(DataStructureUtil::randomBlindedBeaconBlockBody);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/BlindedBeaconBlockBodySupplier.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/BlindedBeaconBlockBodySupplier.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.blocks;
+
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.ArbitrarySupplier;
+import net.jqwik.api.Combinators;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
+import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class BlindedBeaconBlockBodySupplier implements ArbitrarySupplier<BeaconBlockBody> {
+  @Override
+  public Arbitrary<BeaconBlockBody> get() {
+    Arbitrary<Integer> seed = Arbitraries.integers();
+    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
+    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
+    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
+    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
+    return dsu.map(DataStructureUtil::randomBlindedBeaconBlockBody);
+  }
+}

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/BlindedBeaconBlockPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/BlindedBeaconBlockPropertyTest.java
@@ -16,12 +16,15 @@ package tech.pegasys.teku.spec.datastructures.blocks;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.Combinators;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
-import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecFactory;
@@ -30,17 +33,9 @@ import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class BlindedBeaconBlockPropertyTest {
   @Property
-  void roundTrip(
-      @ForAll final int seed,
-      @ForAll final SpecMilestone specMilestone,
-      @ForAll final Eth2Network network,
-      @ForAll final long slot)
+  void roundTrip(@ForAll("blindedBeaconBlock") final BeaconBlock block)
       throws JsonProcessingException {
-    final Spec spec = TestSpecFactory.create(specMilestone, network);
-    final DataStructureUtil dataStructureUtil = new DataStructureUtil(seed, spec);
-    final BeaconBlock block = dataStructureUtil.randomBlindedBeaconBlock(UInt64.fromLongBits(slot));
-    final BeaconBlockSchema schema =
-        spec.forMilestone(specMilestone).getSchemaDefinitions().getBlindedBeaconBlockSchema();
+    final BeaconBlockSchema schema = block.getSchema();
     final DeserializableTypeDefinition<BeaconBlock> typeDefinition = schema.getJsonTypeDefinition();
 
     // Round-trip SSZ serialization.
@@ -52,5 +47,15 @@ public class BlindedBeaconBlockPropertyTest {
     final String json = JsonUtil.serialize(block, typeDefinition);
     final BeaconBlock fromJson = JsonUtil.parse(json, typeDefinition);
     assertThat(fromJson).isEqualTo(block);
+  }
+
+  @Provide
+  Arbitrary<BeaconBlock> blindedBeaconBlock() {
+    Arbitrary<Integer> seed = Arbitraries.integers();
+    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
+    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
+    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
+    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
+    return dsu.map(DataStructureUtil::randomBlindedBeaconBlock);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/BlindedBeaconBlockPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/BlindedBeaconBlockPropertyTest.java
@@ -16,24 +16,15 @@ package tech.pegasys.teku.spec.datastructures.blocks;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.Combinators;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import net.jqwik.api.Provide;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
-import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.networks.Eth2Network;
-import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class BlindedBeaconBlockPropertyTest {
   @Property
-  void roundTrip(@ForAll("blindedBeaconBlock") final BeaconBlock block)
+  void roundTrip(@ForAll(supplier = BeaconBlockSupplier.class) final BeaconBlock block)
       throws JsonProcessingException {
     final BeaconBlockSchema schema = block.getSchema();
     final DeserializableTypeDefinition<BeaconBlock> typeDefinition = schema.getJsonTypeDefinition();
@@ -47,15 +38,5 @@ public class BlindedBeaconBlockPropertyTest {
     final String json = JsonUtil.serialize(block, typeDefinition);
     final BeaconBlock fromJson = JsonUtil.parse(json, typeDefinition);
     assertThat(fromJson).isEqualTo(block);
-  }
-
-  @Provide
-  Arbitrary<BeaconBlock> blindedBeaconBlock() {
-    Arbitrary<Integer> seed = Arbitraries.integers();
-    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
-    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
-    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
-    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
-    return dsu.map(DataStructureUtil::randomBlindedBeaconBlock);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/BlindedBeaconBlockSupplier.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/BlindedBeaconBlockSupplier.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.blocks;
+
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.ArbitrarySupplier;
+import net.jqwik.api.Combinators;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class BlindedBeaconBlockSupplier implements ArbitrarySupplier<BeaconBlock> {
+  @Override
+  public Arbitrary<BeaconBlock> get() {
+    Arbitrary<Integer> seed = Arbitraries.integers();
+    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
+    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
+    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
+    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
+    return dsu.map(DataStructureUtil::randomBlindedBeaconBlock);
+  }
+}

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/Eth1DataPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/Eth1DataPropertyTest.java
@@ -16,24 +16,16 @@ package tech.pegasys.teku.spec.datastructures.blocks;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.Combinators;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import net.jqwik.api.Provide;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
-import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.networks.Eth2Network;
-import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class Eth1DataPropertyTest {
   @Property
-  void roundTrip(@ForAll("eth1Data") final Eth1Data data) throws JsonProcessingException {
+  void roundTrip(@ForAll(supplier = Eth1DataSupplier.class) final Eth1Data data)
+      throws JsonProcessingException {
     final Eth1Data.Eth1DataSchema schema = data.getSchema();
     final DeserializableTypeDefinition<Eth1Data> typeDefinition = schema.getJsonTypeDefinition();
 
@@ -46,15 +38,5 @@ public class Eth1DataPropertyTest {
     final String json = JsonUtil.serialize(data, typeDefinition);
     final Eth1Data fromJson = JsonUtil.parse(json, typeDefinition);
     assertThat(fromJson).isEqualTo(data);
-  }
-
-  @Provide
-  Arbitrary<Eth1Data> eth1Data() {
-    Arbitrary<Integer> seed = Arbitraries.integers();
-    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
-    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
-    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
-    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
-    return dsu.map(DataStructureUtil::randomEth1Data);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/Eth1DataPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/Eth1DataPropertyTest.java
@@ -18,6 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
+import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 import tech.pegasys.teku.spec.Spec;
@@ -36,10 +37,17 @@ public class Eth1DataPropertyTest {
     final Spec spec = TestSpecFactory.create(specMilestone, network);
     final DataStructureUtil dataStructureUtil = new DataStructureUtil(seed, spec);
     final Eth1Data data = dataStructureUtil.randomEth1Data();
-    final DeserializableTypeDefinition<Eth1Data> typeDefinition =
-        data.getSchema().getJsonTypeDefinition();
+    final Eth1Data.Eth1DataSchema schema = data.getSchema();
+    final DeserializableTypeDefinition<Eth1Data> typeDefinition = schema.getJsonTypeDefinition();
+
+    // Round-trip SSZ serialization.
+    final Bytes ssz = data.sszSerialize();
+    final Eth1Data fromSsz = schema.sszDeserialize(ssz);
+    assertThat(fromSsz).isEqualTo(data);
+
+    // Round-trip JSON serialization.
     final String json = JsonUtil.serialize(data, typeDefinition);
-    final Eth1Data result = JsonUtil.parse(json, typeDefinition);
-    assertThat(result).isEqualTo(data);
+    final Eth1Data fromJson = JsonUtil.parse(json, typeDefinition);
+    assertThat(fromJson).isEqualTo(data);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/Eth1DataSupplier.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/Eth1DataSupplier.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.blocks;
+
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.ArbitrarySupplier;
+import net.jqwik.api.Combinators;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class Eth1DataSupplier implements ArbitrarySupplier<Eth1Data> {
+  @Override
+  public Arbitrary<Eth1Data> get() {
+    Arbitrary<Integer> seed = Arbitraries.integers();
+    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
+    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
+    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
+    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
+    return dsu.map(DataStructureUtil::randomEth1Data);
+  }
+}

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBeaconBlockHeaderPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBeaconBlockHeaderPropertyTest.java
@@ -16,24 +16,17 @@ package tech.pegasys.teku.spec.datastructures.blocks;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.Combinators;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import net.jqwik.api.Provide;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
-import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.networks.Eth2Network;
-import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class SignedBeaconBlockHeaderPropertyTest {
   @Property
-  void roundTrip(@ForAll("signedBeaconBlockHeader") final SignedBeaconBlockHeader header)
+  void roundTrip(
+      @ForAll(supplier = SignedBeaconBlockHeaderSupplier.class)
+          final SignedBeaconBlockHeader header)
       throws JsonProcessingException {
     final SignedBeaconBlockHeader.SignedBeaconBlockHeaderSchema schema = header.getSchema();
     final DeserializableTypeDefinition<SignedBeaconBlockHeader> typeDefinition =
@@ -48,15 +41,5 @@ public class SignedBeaconBlockHeaderPropertyTest {
     final String json = JsonUtil.serialize(header, typeDefinition);
     final SignedBeaconBlockHeader fromJson = JsonUtil.parse(json, typeDefinition);
     assertThat(fromJson).isEqualTo(header);
-  }
-
-  @Provide
-  Arbitrary<SignedBeaconBlockHeader> signedBeaconBlockHeader() {
-    Arbitrary<Integer> seed = Arbitraries.integers();
-    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
-    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
-    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
-    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
-    return dsu.map(DataStructureUtil::randomSignedBeaconBlockHeader);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBeaconBlockHeaderPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBeaconBlockHeaderPropertyTest.java
@@ -18,6 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
+import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 import tech.pegasys.teku.spec.Spec;
@@ -36,10 +37,18 @@ public class SignedBeaconBlockHeaderPropertyTest {
     final Spec spec = TestSpecFactory.create(specMilestone, network);
     final DataStructureUtil dataStructureUtil = new DataStructureUtil(seed, spec);
     final SignedBeaconBlockHeader header = dataStructureUtil.randomSignedBeaconBlockHeader();
+    final SignedBeaconBlockHeader.SignedBeaconBlockHeaderSchema schema = header.getSchema();
     final DeserializableTypeDefinition<SignedBeaconBlockHeader> typeDefinition =
-        header.getSchema().getJsonTypeDefinition();
+        schema.getJsonTypeDefinition();
+
+    // Round-trip SSZ serialization.
+    final Bytes ssz = header.sszSerialize();
+    final SignedBeaconBlockHeader fromSsz = schema.sszDeserialize(ssz);
+    assertThat(fromSsz).isEqualTo(header);
+
+    // Round-trip JSON serialization.
     final String json = JsonUtil.serialize(header, typeDefinition);
-    final SignedBeaconBlockHeader result = JsonUtil.parse(json, typeDefinition);
-    assertThat(result).isEqualTo(header);
+    final SignedBeaconBlockHeader fromJson = JsonUtil.parse(json, typeDefinition);
+    assertThat(fromJson).isEqualTo(header);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBeaconBlockHeaderSupplier.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBeaconBlockHeaderSupplier.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.blocks;
+
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.ArbitrarySupplier;
+import net.jqwik.api.Combinators;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class SignedBeaconBlockHeaderSupplier implements ArbitrarySupplier<SignedBeaconBlockHeader> {
+  @Override
+  public Arbitrary<SignedBeaconBlockHeader> get() {
+    Arbitrary<Integer> seed = Arbitraries.integers();
+    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
+    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
+    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
+    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
+    return dsu.map(DataStructureUtil::randomSignedBeaconBlockHeader);
+  }
+}

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBeaconBlockPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBeaconBlockPropertyTest.java
@@ -16,24 +16,15 @@ package tech.pegasys.teku.spec.datastructures.blocks;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.Combinators;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import net.jqwik.api.Provide;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
-import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.networks.Eth2Network;
-import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class SignedBeaconBlockPropertyTest {
   @Property
-  void roundTrip(@ForAll("signedBeaconBlock") final SignedBeaconBlock block)
+  void roundTrip(@ForAll(supplier = SignedBeaconBlockProvider.class) final SignedBeaconBlock block)
       throws JsonProcessingException {
     final SignedBeaconBlockSchema schema = block.getSchema();
     final DeserializableTypeDefinition<SignedBeaconBlock> typeDefinition =
@@ -48,15 +39,5 @@ public class SignedBeaconBlockPropertyTest {
     final String json = JsonUtil.serialize(block, typeDefinition);
     final SignedBeaconBlock result = JsonUtil.parse(json, typeDefinition);
     assertThat(result).isEqualTo(block);
-  }
-
-  @Provide
-  Arbitrary<SignedBeaconBlock> signedBeaconBlock() {
-    Arbitrary<Integer> seed = Arbitraries.integers();
-    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
-    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
-    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
-    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
-    return dsu.map(DataStructureUtil::randomSignedBeaconBlock);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBeaconBlockProvider.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBeaconBlockProvider.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.blocks;
+
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.ArbitrarySupplier;
+import net.jqwik.api.Combinators;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class SignedBeaconBlockProvider implements ArbitrarySupplier<SignedBeaconBlock> {
+  @Override
+  public Arbitrary<SignedBeaconBlock> get() {
+    Arbitrary<Integer> seed = Arbitraries.integers();
+    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
+    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
+    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
+    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
+    return dsu.map(DataStructureUtil::randomSignedBeaconBlock);
+  }
+}

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/SyncAggregatePropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/SyncAggregatePropertyTest.java
@@ -18,6 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import net.jqwik.api.Arbitraries;
 import net.jqwik.api.Arbitrary;
+import net.jqwik.api.Combinators;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
 import net.jqwik.api.Provide;
@@ -34,21 +35,9 @@ import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class SyncAggregatePropertyTest {
   @Property
-  void roundTrip(
-      @ForAll final int seed,
-      @ForAll("milestone") final SpecMilestone specMilestone,
-      @ForAll final Eth2Network network)
+  void roundTrip(@ForAll("syncAggregate") final SyncAggregate syncAggregate)
       throws JsonProcessingException {
-    final Spec spec = TestSpecFactory.create(specMilestone, network);
-    final DataStructureUtil dataStructureUtil = new DataStructureUtil(seed, spec);
-    final SyncAggregate syncAggregate = dataStructureUtil.randomSyncAggregate();
-    final SyncAggregateSchema schema =
-        spec.forMilestone(specMilestone)
-            .getSchemaDefinitions()
-            .getBeaconBlockBodySchema()
-            .toVersionAltair()
-            .orElseThrow()
-            .getSyncAggregateSchema();
+    final SyncAggregateSchema schema = syncAggregate.getSchema();
     final DeserializableTypeDefinition<SyncAggregate> typeDefinition =
         schema.getJsonTypeDefinition();
 
@@ -64,8 +53,14 @@ public class SyncAggregatePropertyTest {
   }
 
   @Provide
-  Arbitrary<SpecMilestone> milestone() {
-    return Arbitraries.of(SpecMilestone.class)
-        .filter(m -> m.isGreaterThanOrEqualTo(SpecMilestone.ALTAIR));
+  Arbitrary<SyncAggregate> syncAggregate() {
+    Arbitrary<Integer> seed = Arbitraries.integers();
+    Arbitrary<SpecMilestone> milestone =
+        Arbitraries.of(SpecMilestone.class)
+            .filter(m -> m.isGreaterThanOrEqualTo(SpecMilestone.ALTAIR));
+    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
+    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
+    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
+    return dsu.map(DataStructureUtil::randomSyncAggregate);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/SyncAggregatePropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/SyncAggregatePropertyTest.java
@@ -16,26 +16,17 @@ package tech.pegasys.teku.spec.datastructures.blocks;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.Combinators;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import net.jqwik.api.Provide;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
-import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregate;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregateSchema;
-import tech.pegasys.teku.spec.networks.Eth2Network;
-import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class SyncAggregatePropertyTest {
   @Property
-  void roundTrip(@ForAll("syncAggregate") final SyncAggregate syncAggregate)
+  void roundTrip(@ForAll(supplier = SyncAggregateSupplier.class) final SyncAggregate syncAggregate)
       throws JsonProcessingException {
     final SyncAggregateSchema schema = syncAggregate.getSchema();
     final DeserializableTypeDefinition<SyncAggregate> typeDefinition =
@@ -50,17 +41,5 @@ public class SyncAggregatePropertyTest {
     final String json = JsonUtil.serialize(syncAggregate, typeDefinition);
     final SyncAggregate fromJson = JsonUtil.parse(json, typeDefinition);
     assertThat(fromJson).isEqualTo(syncAggregate);
-  }
-
-  @Provide
-  Arbitrary<SyncAggregate> syncAggregate() {
-    Arbitrary<Integer> seed = Arbitraries.integers();
-    Arbitrary<SpecMilestone> milestone =
-        Arbitraries.of(SpecMilestone.class)
-            .filter(m -> m.isGreaterThanOrEqualTo(SpecMilestone.ALTAIR));
-    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
-    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
-    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
-    return dsu.map(DataStructureUtil::randomSyncAggregate);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/SyncAggregateSupplier.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/SyncAggregateSupplier.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.blocks;
+
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.ArbitrarySupplier;
+import net.jqwik.api.Combinators;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregate;
+import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class SyncAggregateSupplier implements ArbitrarySupplier<SyncAggregate> {
+  @Override
+  public Arbitrary<SyncAggregate> get() {
+    Arbitrary<Integer> seed = Arbitraries.integers();
+    Arbitrary<SpecMilestone> milestone =
+        Arbitraries.of(SpecMilestone.class)
+            .filter(m -> m.isGreaterThanOrEqualTo(SpecMilestone.ALTAIR));
+    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
+    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
+    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
+    return dsu.map(DataStructureUtil::randomSyncAggregate);
+  }
+}

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/builder/BuilderBidPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/builder/BuilderBidPropertyTest.java
@@ -16,24 +16,16 @@ package tech.pegasys.teku.spec.datastructures.builder;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.Combinators;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import net.jqwik.api.Provide;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
-import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.networks.Eth2Network;
-import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class BuilderBidPropertyTest {
   @Property
-  void roundTrip(@ForAll("builderBid") final BuilderBid bid) throws JsonProcessingException {
+  void roundTrip(@ForAll(supplier = BuilderBidSupplier.class) final BuilderBid bid)
+      throws JsonProcessingException {
     final BuilderBidSchema schema = bid.getSchema();
     final DeserializableTypeDefinition<BuilderBid> typeDefinition = schema.getJsonTypeDefinition();
 
@@ -46,17 +38,5 @@ public class BuilderBidPropertyTest {
     final String json = JsonUtil.serialize(bid, typeDefinition);
     final BuilderBid fromJson = JsonUtil.parse(json, typeDefinition);
     assertThat(fromJson).isEqualTo(bid);
-  }
-
-  @Provide
-  Arbitrary<BuilderBid> builderBid() {
-    Arbitrary<Integer> seed = Arbitraries.integers();
-    Arbitrary<SpecMilestone> milestone =
-        Arbitraries.of(SpecMilestone.class)
-            .filter(m -> m.isGreaterThanOrEqualTo(SpecMilestone.BELLATRIX));
-    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
-    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
-    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
-    return dsu.map(DataStructureUtil::randomBuilderBid);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/builder/BuilderBidPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/builder/BuilderBidPropertyTest.java
@@ -18,6 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import net.jqwik.api.Arbitraries;
 import net.jqwik.api.Arbitrary;
+import net.jqwik.api.Combinators;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
 import net.jqwik.api.Provide;
@@ -32,20 +33,8 @@ import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class BuilderBidPropertyTest {
   @Property
-  void roundTrip(
-      @ForAll final int seed,
-      @ForAll("milestone") final SpecMilestone specMilestone,
-      @ForAll final Eth2Network network)
-      throws JsonProcessingException {
-    final Spec spec = TestSpecFactory.create(specMilestone, network);
-    final DataStructureUtil dataStructureUtil = new DataStructureUtil(seed, spec);
-    final BuilderBid bid = dataStructureUtil.randomBuilderBid();
-    final BuilderBidSchema schema =
-        spec.forMilestone(specMilestone)
-            .getSchemaDefinitions()
-            .toVersionBellatrix()
-            .orElseThrow()
-            .getBuilderBidSchema();
+  void roundTrip(@ForAll("builderBid") final BuilderBid bid) throws JsonProcessingException {
+    final BuilderBidSchema schema = bid.getSchema();
     final DeserializableTypeDefinition<BuilderBid> typeDefinition = schema.getJsonTypeDefinition();
 
     // Round-trip SSZ serialization.
@@ -60,8 +49,14 @@ public class BuilderBidPropertyTest {
   }
 
   @Provide
-  Arbitrary<SpecMilestone> milestone() {
-    return Arbitraries.of(SpecMilestone.class)
-        .filter(m -> m.isGreaterThanOrEqualTo(SpecMilestone.BELLATRIX));
+  Arbitrary<BuilderBid> builderBid() {
+    Arbitrary<Integer> seed = Arbitraries.integers();
+    Arbitrary<SpecMilestone> milestone =
+        Arbitraries.of(SpecMilestone.class)
+            .filter(m -> m.isGreaterThanOrEqualTo(SpecMilestone.BELLATRIX));
+    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
+    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
+    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
+    return dsu.map(DataStructureUtil::randomBuilderBid);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/builder/BuilderBidPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/builder/BuilderBidPropertyTest.java
@@ -21,6 +21,7 @@ import net.jqwik.api.Arbitrary;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
 import net.jqwik.api.Provide;
+import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 import tech.pegasys.teku.spec.Spec;
@@ -39,16 +40,23 @@ public class BuilderBidPropertyTest {
     final Spec spec = TestSpecFactory.create(specMilestone, network);
     final DataStructureUtil dataStructureUtil = new DataStructureUtil(seed, spec);
     final BuilderBid bid = dataStructureUtil.randomBuilderBid();
-    final DeserializableTypeDefinition<BuilderBid> typeDefinition =
+    final BuilderBidSchema schema =
         spec.forMilestone(specMilestone)
             .getSchemaDefinitions()
             .toVersionBellatrix()
             .orElseThrow()
-            .getBuilderBidSchema()
-            .getJsonTypeDefinition();
+            .getBuilderBidSchema();
+    final DeserializableTypeDefinition<BuilderBid> typeDefinition = schema.getJsonTypeDefinition();
+
+    // Round-trip SSZ serialization.
+    final Bytes ssz = bid.sszSerialize();
+    final BuilderBid fromSsz = schema.sszDeserialize(ssz);
+    assertThat(fromSsz).isEqualTo(bid);
+
+    // Round-trip JSON serialization.
     final String json = JsonUtil.serialize(bid, typeDefinition);
-    final BuilderBid result = JsonUtil.parse(json, typeDefinition);
-    assertThat(result).isEqualTo(bid);
+    final BuilderBid fromJson = JsonUtil.parse(json, typeDefinition);
+    assertThat(fromJson).isEqualTo(bid);
   }
 
   @Provide

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/builder/BuilderBidSupplier.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/builder/BuilderBidSupplier.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.builder;
+
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.ArbitrarySupplier;
+import net.jqwik.api.Combinators;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class BuilderBidSupplier implements ArbitrarySupplier<BuilderBid> {
+  @Override
+  public Arbitrary<BuilderBid> get() {
+    Arbitrary<Integer> seed = Arbitraries.integers();
+    Arbitrary<SpecMilestone> milestone =
+        Arbitraries.of(SpecMilestone.class)
+            .filter(m -> m.isGreaterThanOrEqualTo(SpecMilestone.BELLATRIX));
+    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
+    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
+    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
+    return dsu.map(DataStructureUtil::randomBuilderBid);
+  }
+}

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/builder/SignedBuilderBidPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/builder/SignedBuilderBidPropertyTest.java
@@ -21,6 +21,7 @@ import net.jqwik.api.Arbitrary;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
 import net.jqwik.api.Provide;
+import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 import tech.pegasys.teku.spec.Spec;
@@ -39,16 +40,24 @@ public class SignedBuilderBidPropertyTest {
     final Spec spec = TestSpecFactory.create(specMilestone, network);
     final DataStructureUtil dataStructureUtil = new DataStructureUtil(seed, spec);
     final SignedBuilderBid bid = dataStructureUtil.randomSignedBuilderBid();
-    final DeserializableTypeDefinition<SignedBuilderBid> typeDefinition =
+    final SignedBuilderBidSchema schema =
         spec.forMilestone(specMilestone)
             .getSchemaDefinitions()
             .toVersionBellatrix()
             .orElseThrow()
-            .getSignedBuilderBidSchema()
-            .getJsonTypeDefinition();
+            .getSignedBuilderBidSchema();
+    final DeserializableTypeDefinition<SignedBuilderBid> typeDefinition =
+        schema.getJsonTypeDefinition();
+
+    // Round-trip SSZ serialization.
+    final Bytes ssz = bid.sszSerialize();
+    final SignedBuilderBid fromSsz = schema.sszDeserialize(ssz);
+    assertThat(fromSsz).isEqualTo(bid);
+
+    // Round-trip JSON serialization.
     final String json = JsonUtil.serialize(bid, typeDefinition);
-    final SignedBuilderBid result = JsonUtil.parse(json, typeDefinition);
-    assertThat(result).isEqualTo(bid);
+    final SignedBuilderBid fromJson = JsonUtil.parse(json, typeDefinition);
+    assertThat(fromJson).isEqualTo(bid);
   }
 
   @Provide

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/builder/SignedBuilderBidPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/builder/SignedBuilderBidPropertyTest.java
@@ -16,24 +16,15 @@ package tech.pegasys.teku.spec.datastructures.builder;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.Combinators;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import net.jqwik.api.Provide;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
-import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.networks.Eth2Network;
-import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class SignedBuilderBidPropertyTest {
   @Property
-  void roundTrip(@ForAll("signedBuilderBid") final SignedBuilderBid bid)
+  void roundTrip(@ForAll(supplier = SignedBuilderBidSupplier.class) final SignedBuilderBid bid)
       throws JsonProcessingException {
     final SignedBuilderBidSchema schema = bid.getSchema();
     final DeserializableTypeDefinition<SignedBuilderBid> typeDefinition =
@@ -48,17 +39,5 @@ public class SignedBuilderBidPropertyTest {
     final String json = JsonUtil.serialize(bid, typeDefinition);
     final SignedBuilderBid fromJson = JsonUtil.parse(json, typeDefinition);
     assertThat(fromJson).isEqualTo(bid);
-  }
-
-  @Provide
-  Arbitrary<SignedBuilderBid> signedBuilderBid() {
-    Arbitrary<Integer> seed = Arbitraries.integers();
-    Arbitrary<SpecMilestone> milestone =
-        Arbitraries.of(SpecMilestone.class)
-            .filter(m -> m.isGreaterThanOrEqualTo(SpecMilestone.BELLATRIX));
-    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
-    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
-    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
-    return dsu.map(DataStructureUtil::randomSignedBuilderBid);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/builder/SignedBuilderBidSupplier.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/builder/SignedBuilderBidSupplier.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.builder;
+
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.ArbitrarySupplier;
+import net.jqwik.api.Combinators;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class SignedBuilderBidSupplier implements ArbitrarySupplier<SignedBuilderBid> {
+  @Override
+  public Arbitrary<SignedBuilderBid> get() {
+    Arbitrary<Integer> seed = Arbitraries.integers();
+    Arbitrary<SpecMilestone> milestone =
+        Arbitraries.of(SpecMilestone.class)
+            .filter(m -> m.isGreaterThanOrEqualTo(SpecMilestone.BELLATRIX));
+    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
+    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
+    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
+    return dsu.map(DataStructureUtil::randomSignedBuilderBid);
+  }
+}

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/builder/SignedValidatorRegistrationPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/builder/SignedValidatorRegistrationPropertyTest.java
@@ -16,25 +16,17 @@ package tech.pegasys.teku.spec.datastructures.builder;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.Combinators;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import net.jqwik.api.Provide;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
-import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.networks.Eth2Network;
-import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class SignedValidatorRegistrationPropertyTest {
   @Property
   void roundTrip(
-      @ForAll("signedValidatorRegistration") final SignedValidatorRegistration registration)
+      @ForAll(supplier = SignedValidatorRegistrationSupplier.class)
+          final SignedValidatorRegistration registration)
       throws JsonProcessingException {
     final SignedValidatorRegistrationSchema schema = registration.getSchema();
     final DeserializableTypeDefinition<SignedValidatorRegistration> typeDefinition =
@@ -49,17 +41,5 @@ public class SignedValidatorRegistrationPropertyTest {
     final String json = JsonUtil.serialize(registration, typeDefinition);
     final SignedValidatorRegistration fromJson = JsonUtil.parse(json, typeDefinition);
     assertThat(fromJson).isEqualTo(registration);
-  }
-
-  @Provide
-  Arbitrary<SignedValidatorRegistration> signedValidatorRegistration() {
-    Arbitrary<Integer> seed = Arbitraries.integers();
-    Arbitrary<SpecMilestone> milestone =
-        Arbitraries.of(SpecMilestone.class)
-            .filter(m -> m.isGreaterThanOrEqualTo(SpecMilestone.BELLATRIX));
-    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
-    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
-    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
-    return dsu.map(DataStructureUtil::randomSignedValidatorRegistration);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/builder/SignedValidatorRegistrationPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/builder/SignedValidatorRegistrationPropertyTest.java
@@ -21,6 +21,7 @@ import net.jqwik.api.Arbitrary;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
 import net.jqwik.api.Provide;
+import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 import tech.pegasys.teku.spec.Spec;
@@ -40,11 +41,19 @@ public class SignedValidatorRegistrationPropertyTest {
     final DataStructureUtil dataStructureUtil = new DataStructureUtil(seed, spec);
     final SignedValidatorRegistration registration =
         dataStructureUtil.randomSignedValidatorRegistration();
+    final SignedValidatorRegistrationSchema schema = registration.getSchema();
     final DeserializableTypeDefinition<SignedValidatorRegistration> typeDefinition =
-        registration.getSchema().getJsonTypeDefinition();
+        schema.getJsonTypeDefinition();
+
+    // Round-trip SSZ serialization.
+    final Bytes ssz = registration.sszSerialize();
+    final SignedValidatorRegistration fromSsz = schema.sszDeserialize(ssz);
+    assertThat(fromSsz).isEqualTo(registration);
+
+    // Round-trip JSON serialization.
     final String json = JsonUtil.serialize(registration, typeDefinition);
-    final SignedValidatorRegistration result = JsonUtil.parse(json, typeDefinition);
-    assertThat(result).isEqualTo(registration);
+    final SignedValidatorRegistration fromJson = JsonUtil.parse(json, typeDefinition);
+    assertThat(fromJson).isEqualTo(registration);
   }
 
   @Provide

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/builder/SignedValidatorRegistrationSupplier.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/builder/SignedValidatorRegistrationSupplier.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.builder;
+
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.ArbitrarySupplier;
+import net.jqwik.api.Combinators;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class SignedValidatorRegistrationSupplier
+    implements ArbitrarySupplier<SignedValidatorRegistration> {
+  @Override
+  public Arbitrary<SignedValidatorRegistration> get() {
+    Arbitrary<Integer> seed = Arbitraries.integers();
+    Arbitrary<SpecMilestone> milestone =
+        Arbitraries.of(SpecMilestone.class)
+            .filter(m -> m.isGreaterThanOrEqualTo(SpecMilestone.BELLATRIX));
+    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
+    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
+    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
+    return dsu.map(DataStructureUtil::randomSignedValidatorRegistration);
+  }
+}

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/builder/ValidatorRegistrationPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/builder/ValidatorRegistrationPropertyTest.java
@@ -18,6 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import net.jqwik.api.Arbitraries;
 import net.jqwik.api.Arbitrary;
+import net.jqwik.api.Combinators;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
 import net.jqwik.api.Provide;
@@ -32,14 +33,8 @@ import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class ValidatorRegistrationPropertyTest {
   @Property
-  void roundTrip(
-      @ForAll final int seed,
-      @ForAll("milestone") final SpecMilestone specMilestone,
-      @ForAll final Eth2Network network)
+  void roundTrip(@ForAll("validatorRegistration") final ValidatorRegistration registration)
       throws JsonProcessingException {
-    final Spec spec = TestSpecFactory.create(specMilestone, network);
-    final DataStructureUtil dataStructureUtil = new DataStructureUtil(seed, spec);
-    final ValidatorRegistration registration = dataStructureUtil.randomValidatorRegistration();
     final ValidatorRegistrationSchema schema = registration.getSchema();
     final DeserializableTypeDefinition<ValidatorRegistration> typeDefinition =
         schema.getJsonTypeDefinition();
@@ -56,8 +51,14 @@ public class ValidatorRegistrationPropertyTest {
   }
 
   @Provide
-  Arbitrary<SpecMilestone> milestone() {
-    return Arbitraries.of(SpecMilestone.class)
-        .filter(m -> m.isGreaterThanOrEqualTo(SpecMilestone.BELLATRIX));
+  Arbitrary<ValidatorRegistration> validatorRegistration() {
+    Arbitrary<Integer> seed = Arbitraries.integers();
+    Arbitrary<SpecMilestone> milestone =
+        Arbitraries.of(SpecMilestone.class)
+            .filter(m -> m.isGreaterThanOrEqualTo(SpecMilestone.BELLATRIX));
+    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
+    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
+    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
+    return dsu.map(DataStructureUtil::randomValidatorRegistration);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/builder/ValidatorRegistrationPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/builder/ValidatorRegistrationPropertyTest.java
@@ -16,24 +16,17 @@ package tech.pegasys.teku.spec.datastructures.builder;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.Combinators;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import net.jqwik.api.Provide;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
-import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.networks.Eth2Network;
-import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class ValidatorRegistrationPropertyTest {
   @Property
-  void roundTrip(@ForAll("validatorRegistration") final ValidatorRegistration registration)
+  void roundTrip(
+      @ForAll(supplier = ValidatorRegistrationSupplier.class)
+          final ValidatorRegistration registration)
       throws JsonProcessingException {
     final ValidatorRegistrationSchema schema = registration.getSchema();
     final DeserializableTypeDefinition<ValidatorRegistration> typeDefinition =
@@ -48,17 +41,5 @@ public class ValidatorRegistrationPropertyTest {
     final String json = JsonUtil.serialize(registration, typeDefinition);
     final ValidatorRegistration fromJson = JsonUtil.parse(json, typeDefinition);
     assertThat(fromJson).isEqualTo(registration);
-  }
-
-  @Provide
-  Arbitrary<ValidatorRegistration> validatorRegistration() {
-    Arbitrary<Integer> seed = Arbitraries.integers();
-    Arbitrary<SpecMilestone> milestone =
-        Arbitraries.of(SpecMilestone.class)
-            .filter(m -> m.isGreaterThanOrEqualTo(SpecMilestone.BELLATRIX));
-    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
-    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
-    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
-    return dsu.map(DataStructureUtil::randomValidatorRegistration);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/builder/ValidatorRegistrationSupplier.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/builder/ValidatorRegistrationSupplier.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.builder;
+
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.ArbitrarySupplier;
+import net.jqwik.api.Combinators;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class ValidatorRegistrationSupplier implements ArbitrarySupplier<ValidatorRegistration> {
+  @Override
+  public Arbitrary<ValidatorRegistration> get() {
+    Arbitrary<Integer> seed = Arbitraries.integers();
+    Arbitrary<SpecMilestone> milestone =
+        Arbitraries.of(SpecMilestone.class)
+            .filter(m -> m.isGreaterThanOrEqualTo(SpecMilestone.BELLATRIX));
+    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
+    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
+    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
+    return dsu.map(DataStructureUtil::randomValidatorRegistration);
+  }
+}

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadHeaderPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadHeaderPropertyTest.java
@@ -16,24 +16,16 @@ package tech.pegasys.teku.spec.datastructures.execution;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.Combinators;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import net.jqwik.api.Provide;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
-import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.networks.Eth2Network;
-import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class ExecutionPayloadHeaderPropertyTest {
   @Property
-  void roundTrip(@ForAll("executionPayloadHeader") ExecutionPayloadHeader header)
+  void roundTrip(
+      @ForAll(supplier = ExecutionPayloadHeaderSupplier.class) ExecutionPayloadHeader header)
       throws JsonProcessingException {
     final ExecutionPayloadHeaderSchema schema = header.getSchema();
     final DeserializableTypeDefinition<ExecutionPayloadHeader> typeDefinition =
@@ -48,17 +40,5 @@ public class ExecutionPayloadHeaderPropertyTest {
     final String json = JsonUtil.serialize(header, typeDefinition);
     final ExecutionPayloadHeader fromJson = JsonUtil.parse(json, typeDefinition);
     assertThat(fromJson).isEqualTo(header);
-  }
-
-  @Provide
-  Arbitrary<ExecutionPayloadHeader> executionPayloadHeader() {
-    Arbitrary<Integer> seed = Arbitraries.integers();
-    Arbitrary<SpecMilestone> milestone =
-        Arbitraries.of(SpecMilestone.class)
-            .filter(m -> m.isGreaterThanOrEqualTo(SpecMilestone.BELLATRIX));
-    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
-    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
-    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
-    return dsu.map(DataStructureUtil::randomExecutionPayloadHeader);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadHeaderSupplier.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadHeaderSupplier.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.execution;
+
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.ArbitrarySupplier;
+import net.jqwik.api.Combinators;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class ExecutionPayloadHeaderSupplier implements ArbitrarySupplier<ExecutionPayloadHeader> {
+  @Override
+  public Arbitrary<ExecutionPayloadHeader> get() {
+    Arbitrary<Integer> seed = Arbitraries.integers();
+    Arbitrary<SpecMilestone> milestone =
+        Arbitraries.of(SpecMilestone.class)
+            .filter(m -> m.isGreaterThanOrEqualTo(SpecMilestone.BELLATRIX));
+    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
+    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
+    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
+    return dsu.map(DataStructureUtil::randomExecutionPayloadHeader);
+  }
+}

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadPropertyTest.java
@@ -18,6 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import net.jqwik.api.Arbitraries;
 import net.jqwik.api.Arbitrary;
+import net.jqwik.api.Combinators;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
 import net.jqwik.api.Provide;
@@ -32,14 +33,8 @@ import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class ExecutionPayloadPropertyTest {
   @Property
-  void roundTrip(
-      @ForAll final int seed,
-      @ForAll("milestone") final SpecMilestone specMilestone,
-      @ForAll final Eth2Network network)
+  void roundTrip(@ForAll("executionPayload") final ExecutionPayload payload)
       throws JsonProcessingException {
-    final Spec spec = TestSpecFactory.create(specMilestone, network);
-    final DataStructureUtil dataStructureUtil = new DataStructureUtil(seed, spec);
-    final ExecutionPayload payload = dataStructureUtil.randomExecutionPayload();
     final ExecutionPayloadSchema schema = payload.getSchema();
     final DeserializableTypeDefinition<ExecutionPayload> typeDefinition =
         schema.getJsonTypeDefinition();
@@ -56,8 +51,14 @@ public class ExecutionPayloadPropertyTest {
   }
 
   @Provide
-  Arbitrary<SpecMilestone> milestone() {
-    return Arbitraries.of(SpecMilestone.class)
-        .filter(m -> m.isGreaterThanOrEqualTo(SpecMilestone.BELLATRIX));
+  Arbitrary<ExecutionPayload> executionPayload() {
+    Arbitrary<Integer> seed = Arbitraries.integers();
+    Arbitrary<SpecMilestone> milestone =
+        Arbitraries.of(SpecMilestone.class)
+            .filter(m -> m.isGreaterThanOrEqualTo(SpecMilestone.BELLATRIX));
+    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
+    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
+    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
+    return dsu.map(DataStructureUtil::randomExecutionPayload);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadPropertyTest.java
@@ -16,24 +16,15 @@ package tech.pegasys.teku.spec.datastructures.execution;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.Combinators;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import net.jqwik.api.Provide;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
-import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.networks.Eth2Network;
-import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class ExecutionPayloadPropertyTest {
   @Property
-  void roundTrip(@ForAll("executionPayload") final ExecutionPayload payload)
+  void roundTrip(@ForAll(supplier = ExecutionPayloadSupplier.class) final ExecutionPayload payload)
       throws JsonProcessingException {
     final ExecutionPayloadSchema schema = payload.getSchema();
     final DeserializableTypeDefinition<ExecutionPayload> typeDefinition =
@@ -48,17 +39,5 @@ public class ExecutionPayloadPropertyTest {
     final String json = JsonUtil.serialize(payload, typeDefinition);
     final ExecutionPayload fromJson = JsonUtil.parse(json, typeDefinition);
     assertThat(fromJson).isEqualTo(payload);
-  }
-
-  @Provide
-  Arbitrary<ExecutionPayload> executionPayload() {
-    Arbitrary<Integer> seed = Arbitraries.integers();
-    Arbitrary<SpecMilestone> milestone =
-        Arbitraries.of(SpecMilestone.class)
-            .filter(m -> m.isGreaterThanOrEqualTo(SpecMilestone.BELLATRIX));
-    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
-    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
-    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
-    return dsu.map(DataStructureUtil::randomExecutionPayload);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadSupplier.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadSupplier.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.execution;
+
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.ArbitrarySupplier;
+import net.jqwik.api.Combinators;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class ExecutionPayloadSupplier implements ArbitrarySupplier<ExecutionPayload> {
+  @Override
+  public Arbitrary<ExecutionPayload> get() {
+    Arbitrary<Integer> seed = Arbitraries.integers();
+    Arbitrary<SpecMilestone> milestone =
+        Arbitraries.of(SpecMilestone.class)
+            .filter(m -> m.isGreaterThanOrEqualTo(SpecMilestone.BELLATRIX));
+    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
+    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
+    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
+    return dsu.map(DataStructureUtil::randomExecutionPayload);
+  }
+}

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/execution/TransactionPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/execution/TransactionPropertyTest.java
@@ -16,24 +16,15 @@ package tech.pegasys.teku.spec.datastructures.execution;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.Combinators;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import net.jqwik.api.Provide;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
-import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.networks.Eth2Network;
-import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class TransactionPropertyTest {
   @Property
-  void roundTrip(@ForAll("transaction") final Transaction transaction)
+  void roundTrip(@ForAll(supplier = TransactionSupplier.class) final Transaction transaction)
       throws JsonProcessingException {
     final TransactionSchema schema = transaction.getSchema();
     final DeserializableTypeDefinition<Transaction> typeDefinition = schema.getJsonTypeDefinition();
@@ -47,17 +38,5 @@ public class TransactionPropertyTest {
     final String json = JsonUtil.serialize(transaction, typeDefinition);
     final Transaction fromJson = JsonUtil.parse(json, typeDefinition);
     assertThat(fromJson).isEqualTo(transaction);
-  }
-
-  @Provide
-  Arbitrary<Transaction> transaction() {
-    Arbitrary<Integer> seed = Arbitraries.integers();
-    Arbitrary<SpecMilestone> milestone =
-        Arbitraries.of(SpecMilestone.class)
-            .filter(m -> m.isGreaterThanOrEqualTo(SpecMilestone.BELLATRIX));
-    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
-    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
-    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
-    return dsu.map(DataStructureUtil::randomExecutionPayloadTransaction);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/execution/TransactionPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/execution/TransactionPropertyTest.java
@@ -18,6 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import net.jqwik.api.Arbitraries;
 import net.jqwik.api.Arbitrary;
+import net.jqwik.api.Combinators;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
 import net.jqwik.api.Provide;
@@ -32,14 +33,8 @@ import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class TransactionPropertyTest {
   @Property
-  void roundTrip(
-      @ForAll final int seed,
-      @ForAll("milestone") final SpecMilestone specMilestone,
-      @ForAll final Eth2Network network)
+  void roundTrip(@ForAll("transaction") final Transaction transaction)
       throws JsonProcessingException {
-    final Spec spec = TestSpecFactory.create(specMilestone, network);
-    final DataStructureUtil dataStructureUtil = new DataStructureUtil(seed, spec);
-    final Transaction transaction = dataStructureUtil.randomExecutionPayloadTransaction();
     final TransactionSchema schema = transaction.getSchema();
     final DeserializableTypeDefinition<Transaction> typeDefinition = schema.getJsonTypeDefinition();
 
@@ -55,8 +50,14 @@ public class TransactionPropertyTest {
   }
 
   @Provide
-  Arbitrary<SpecMilestone> milestone() {
-    return Arbitraries.of(SpecMilestone.class)
-        .filter(m -> m.isGreaterThanOrEqualTo(SpecMilestone.BELLATRIX));
+  Arbitrary<Transaction> transaction() {
+    Arbitrary<Integer> seed = Arbitraries.integers();
+    Arbitrary<SpecMilestone> milestone =
+        Arbitraries.of(SpecMilestone.class)
+            .filter(m -> m.isGreaterThanOrEqualTo(SpecMilestone.BELLATRIX));
+    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
+    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
+    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
+    return dsu.map(DataStructureUtil::randomExecutionPayloadTransaction);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/execution/TransactionSupplier.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/execution/TransactionSupplier.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.execution;
+
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.ArbitrarySupplier;
+import net.jqwik.api.Combinators;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class TransactionSupplier implements ArbitrarySupplier<Transaction> {
+  @Override
+  public Arbitrary<Transaction> get() {
+    Arbitrary<Integer> seed = Arbitraries.integers();
+    Arbitrary<SpecMilestone> milestone =
+        Arbitraries.of(SpecMilestone.class)
+            .filter(m -> m.isGreaterThanOrEqualTo(SpecMilestone.BELLATRIX));
+    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
+    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
+    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
+    return dsu.map(DataStructureUtil::randomExecutionPayloadTransaction);
+  }
+}

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/AggregateAndProofPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/AggregateAndProofPropertyTest.java
@@ -53,19 +53,4 @@ public class AggregateAndProofPropertyTest {
     final AggregateAndProof fromJson = JsonUtil.parse(json, typeDefinition);
     assertThat(fromJson).isEqualTo(aggregateAndProof);
   }
-
-  @Property
-  void randomSszDeserializationNoUnexpectedExceptions(
-      @ForAll final SpecMilestone specMilestone,
-      @ForAll final Eth2Network network,
-      @ForAll final byte[] ssz) {
-    final Spec spec = TestSpecFactory.create(specMilestone, network);
-    final AggregateAndProof.AggregateAndProofSchema schema =
-        spec.forMilestone(specMilestone).getSchemaDefinitions().getAggregateAndProofSchema();
-    try {
-      schema.sszDeserialize(Bytes.wrap(ssz));
-    } catch (SszDeserializeException e) {
-      // Expected error.
-    }
-  }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/AggregateAndProofPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/AggregateAndProofPropertyTest.java
@@ -16,24 +16,16 @@ package tech.pegasys.teku.spec.datastructures.operations;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.Combinators;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import net.jqwik.api.Provide;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
-import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.networks.Eth2Network;
-import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class AggregateAndProofPropertyTest {
   @Property
-  void roundTrip(@ForAll("aggregateAndProof") final AggregateAndProof aggregateAndProof)
+  void roundTrip(
+      @ForAll(supplier = AggregateAndProofSupplier.class) final AggregateAndProof aggregateAndProof)
       throws JsonProcessingException {
     final AggregateAndProof.AggregateAndProofSchema schema = aggregateAndProof.getSchema();
     final DeserializableTypeDefinition<AggregateAndProof> typeDefinition =
@@ -48,15 +40,5 @@ public class AggregateAndProofPropertyTest {
     final String json = JsonUtil.serialize(aggregateAndProof, typeDefinition);
     final AggregateAndProof fromJson = JsonUtil.parse(json, typeDefinition);
     assertThat(fromJson).isEqualTo(aggregateAndProof);
-  }
-
-  @Provide
-  Arbitrary<AggregateAndProof> aggregateAndProof() {
-    Arbitrary<Integer> seed = Arbitraries.integers();
-    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
-    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
-    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
-    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
-    return dsu.map(DataStructureUtil::randomAggregateAndProof);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/AggregateAndProofPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/AggregateAndProofPropertyTest.java
@@ -21,7 +21,6 @@ import net.jqwik.api.Property;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
-import tech.pegasys.teku.infrastructure.ssz.sos.SszDeserializeException;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecFactory;

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/AggregateAndProofPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/AggregateAndProofPropertyTest.java
@@ -16,8 +16,12 @@ package tech.pegasys.teku.spec.datastructures.operations;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.Combinators;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
@@ -29,16 +33,9 @@ import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class AggregateAndProofPropertyTest {
   @Property
-  void roundTrip(
-      @ForAll final int seed,
-      @ForAll final SpecMilestone specMilestone,
-      @ForAll final Eth2Network network)
+  void roundTrip(@ForAll("aggregateAndProof") final AggregateAndProof aggregateAndProof)
       throws JsonProcessingException {
-    final Spec spec = TestSpecFactory.create(specMilestone, network);
-    final DataStructureUtil dataStructureUtil = new DataStructureUtil(seed, spec);
-    final AggregateAndProof aggregateAndProof = dataStructureUtil.randomAggregateAndProof();
-    final AggregateAndProof.AggregateAndProofSchema schema =
-        spec.forMilestone(specMilestone).getSchemaDefinitions().getAggregateAndProofSchema();
+    final AggregateAndProof.AggregateAndProofSchema schema = aggregateAndProof.getSchema();
     final DeserializableTypeDefinition<AggregateAndProof> typeDefinition =
         schema.getJsonTypeDefinition();
 
@@ -51,5 +48,15 @@ public class AggregateAndProofPropertyTest {
     final String json = JsonUtil.serialize(aggregateAndProof, typeDefinition);
     final AggregateAndProof fromJson = JsonUtil.parse(json, typeDefinition);
     assertThat(fromJson).isEqualTo(aggregateAndProof);
+  }
+
+  @Provide
+  Arbitrary<AggregateAndProof> aggregateAndProof() {
+    Arbitrary<Integer> seed = Arbitraries.integers();
+    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
+    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
+    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
+    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
+    return dsu.map(DataStructureUtil::randomAggregateAndProof);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/AggregateAndProofSupplier.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/AggregateAndProofSupplier.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.operations;
+
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.ArbitrarySupplier;
+import net.jqwik.api.Combinators;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class AggregateAndProofSupplier implements ArbitrarySupplier<AggregateAndProof> {
+  @Override
+  public Arbitrary<AggregateAndProof> get() {
+    Arbitrary<Integer> seed = Arbitraries.integers();
+    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
+    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
+    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
+    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
+    return dsu.map(DataStructureUtil::randomAggregateAndProof);
+  }
+}

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/AttestationDataPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/AttestationDataPropertyTest.java
@@ -16,8 +16,12 @@ package tech.pegasys.teku.spec.datastructures.operations;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.Combinators;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
@@ -29,14 +33,8 @@ import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class AttestationDataPropertyTest {
   @Property
-  void roundTrip(
-      @ForAll final int seed,
-      @ForAll final SpecMilestone specMilestone,
-      @ForAll final Eth2Network network)
+  void roundTrip(@ForAll("attestationData") final AttestationData attestationData)
       throws JsonProcessingException {
-    final Spec spec = TestSpecFactory.create(specMilestone, network);
-    final DataStructureUtil dataStructureUtil = new DataStructureUtil(seed, spec);
-    final AttestationData attestationData = dataStructureUtil.randomAttestationData();
     final AttestationData.AttestationDataSchema schema = attestationData.getSchema();
     final DeserializableTypeDefinition<AttestationData> typeDefinition =
         schema.getJsonTypeDefinition();
@@ -50,5 +48,15 @@ public class AttestationDataPropertyTest {
     final String json = JsonUtil.serialize(attestationData, typeDefinition);
     final AttestationData fromJson = JsonUtil.parse(json, typeDefinition);
     assertThat(fromJson).isEqualTo(attestationData);
+  }
+
+  @Provide
+  Arbitrary<AttestationData> attestationData() {
+    Arbitrary<Integer> seed = Arbitraries.integers();
+    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
+    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
+    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
+    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
+    return dsu.map(DataStructureUtil::randomAttestationData);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/AttestationDataPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/AttestationDataPropertyTest.java
@@ -18,6 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
+import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 import tech.pegasys.teku.spec.Spec;
@@ -36,10 +37,18 @@ public class AttestationDataPropertyTest {
     final Spec spec = TestSpecFactory.create(specMilestone, network);
     final DataStructureUtil dataStructureUtil = new DataStructureUtil(seed, spec);
     final AttestationData attestationData = dataStructureUtil.randomAttestationData();
+    final AttestationData.AttestationDataSchema schema = attestationData.getSchema();
     final DeserializableTypeDefinition<AttestationData> typeDefinition =
-        attestationData.getSchema().getJsonTypeDefinition();
+        schema.getJsonTypeDefinition();
+
+    // Round-trip SSZ serialization.
+    final Bytes ssz = attestationData.sszSerialize();
+    final AttestationData fromSsz = schema.sszDeserialize(ssz);
+    assertThat(fromSsz).isEqualTo(attestationData);
+
+    // Round-trip JSON serialization.
     final String json = JsonUtil.serialize(attestationData, typeDefinition);
-    final AttestationData result = JsonUtil.parse(json, typeDefinition);
-    assertThat(result).isEqualTo(attestationData);
+    final AttestationData fromJson = JsonUtil.parse(json, typeDefinition);
+    assertThat(fromJson).isEqualTo(attestationData);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/AttestationDataPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/AttestationDataPropertyTest.java
@@ -16,24 +16,16 @@ package tech.pegasys.teku.spec.datastructures.operations;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.Combinators;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import net.jqwik.api.Provide;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
-import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.networks.Eth2Network;
-import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class AttestationDataPropertyTest {
   @Property
-  void roundTrip(@ForAll("attestationData") final AttestationData attestationData)
+  void roundTrip(
+      @ForAll(supplier = AttestationDataSupplier.class) final AttestationData attestationData)
       throws JsonProcessingException {
     final AttestationData.AttestationDataSchema schema = attestationData.getSchema();
     final DeserializableTypeDefinition<AttestationData> typeDefinition =
@@ -48,15 +40,5 @@ public class AttestationDataPropertyTest {
     final String json = JsonUtil.serialize(attestationData, typeDefinition);
     final AttestationData fromJson = JsonUtil.parse(json, typeDefinition);
     assertThat(fromJson).isEqualTo(attestationData);
-  }
-
-  @Provide
-  Arbitrary<AttestationData> attestationData() {
-    Arbitrary<Integer> seed = Arbitraries.integers();
-    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
-    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
-    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
-    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
-    return dsu.map(DataStructureUtil::randomAttestationData);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/AttestationDataSupplier.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/AttestationDataSupplier.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.operations;
+
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.ArbitrarySupplier;
+import net.jqwik.api.Combinators;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class AttestationDataSupplier implements ArbitrarySupplier<AttestationData> {
+  @Override
+  public Arbitrary<AttestationData> get() {
+    Arbitrary<Integer> seed = Arbitraries.integers();
+    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
+    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
+    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
+    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
+    return dsu.map(DataStructureUtil::randomAttestationData);
+  }
+}

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/AttestationPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/AttestationPropertyTest.java
@@ -16,8 +16,12 @@ package tech.pegasys.teku.spec.datastructures.operations;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.Combinators;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
@@ -29,16 +33,9 @@ import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class AttestationPropertyTest {
   @Property
-  void roundTrip(
-      @ForAll final int seed,
-      @ForAll final SpecMilestone specMilestone,
-      @ForAll final Eth2Network network)
+  void roundTrip(@ForAll("attestation") final Attestation attestation)
       throws JsonProcessingException {
-    final Spec spec = TestSpecFactory.create(specMilestone, network);
-    final DataStructureUtil dataStructureUtil = new DataStructureUtil(seed, spec);
-    final Attestation attestation = dataStructureUtil.randomAttestation();
-    final Attestation.AttestationSchema schema =
-        spec.forMilestone(specMilestone).getSchemaDefinitions().getAttestationSchema();
+    final Attestation.AttestationSchema schema = attestation.getSchema();
     final DeserializableTypeDefinition<Attestation> typeDefinition = schema.getJsonTypeDefinition();
 
     // Round-trip SSZ serialization.
@@ -50,5 +47,15 @@ public class AttestationPropertyTest {
     final String json = JsonUtil.serialize(attestation, typeDefinition);
     final Attestation fromJson = JsonUtil.parse(json, typeDefinition);
     assertThat(fromJson).isEqualTo(attestation);
+  }
+
+  @Provide
+  Arbitrary<Attestation> attestation() {
+    Arbitrary<Integer> seed = Arbitraries.integers();
+    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
+    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
+    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
+    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
+    return dsu.map(DataStructureUtil::randomAttestation);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/AttestationPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/AttestationPropertyTest.java
@@ -16,24 +16,15 @@ package tech.pegasys.teku.spec.datastructures.operations;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.Combinators;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import net.jqwik.api.Provide;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
-import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.networks.Eth2Network;
-import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class AttestationPropertyTest {
   @Property
-  void roundTrip(@ForAll("attestation") final Attestation attestation)
+  void roundTrip(@ForAll(supplier = AttestationSupplier.class) final Attestation attestation)
       throws JsonProcessingException {
     final Attestation.AttestationSchema schema = attestation.getSchema();
     final DeserializableTypeDefinition<Attestation> typeDefinition = schema.getJsonTypeDefinition();
@@ -47,15 +38,5 @@ public class AttestationPropertyTest {
     final String json = JsonUtil.serialize(attestation, typeDefinition);
     final Attestation fromJson = JsonUtil.parse(json, typeDefinition);
     assertThat(fromJson).isEqualTo(attestation);
-  }
-
-  @Provide
-  Arbitrary<Attestation> attestation() {
-    Arbitrary<Integer> seed = Arbitraries.integers();
-    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
-    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
-    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
-    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
-    return dsu.map(DataStructureUtil::randomAttestation);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/AttestationPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/AttestationPropertyTest.java
@@ -18,6 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
+import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 import tech.pegasys.teku.spec.Spec;
@@ -36,13 +37,18 @@ public class AttestationPropertyTest {
     final Spec spec = TestSpecFactory.create(specMilestone, network);
     final DataStructureUtil dataStructureUtil = new DataStructureUtil(seed, spec);
     final Attestation attestation = dataStructureUtil.randomAttestation();
-    final DeserializableTypeDefinition<Attestation> typeDefinition =
-        spec.forMilestone(specMilestone)
-            .getSchemaDefinitions()
-            .getAttestationSchema()
-            .getJsonTypeDefinition();
+    final Attestation.AttestationSchema schema =
+        spec.forMilestone(specMilestone).getSchemaDefinitions().getAttestationSchema();
+    final DeserializableTypeDefinition<Attestation> typeDefinition = schema.getJsonTypeDefinition();
+
+    // Round-trip SSZ serialization.
+    final Bytes ssz = attestation.sszSerialize();
+    final Attestation fromSsz = schema.sszDeserialize(ssz);
+    assertThat(fromSsz).isEqualTo(attestation);
+
+    // Round-trip JSON serialization.
     final String json = JsonUtil.serialize(attestation, typeDefinition);
-    final Attestation result = JsonUtil.parse(json, typeDefinition);
-    assertThat(result).isEqualTo(attestation);
+    final Attestation fromJson = JsonUtil.parse(json, typeDefinition);
+    assertThat(fromJson).isEqualTo(attestation);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/AttestationSupplier.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/AttestationSupplier.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.operations;
+
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.ArbitrarySupplier;
+import net.jqwik.api.Combinators;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class AttestationSupplier implements ArbitrarySupplier<Attestation> {
+  @Override
+  public Arbitrary<Attestation> get() {
+    Arbitrary<Integer> seed = Arbitraries.integers();
+    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
+    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
+    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
+    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
+    return dsu.map(DataStructureUtil::randomAttestation);
+  }
+}

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/AttesterSlashingPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/AttesterSlashingPropertyTest.java
@@ -16,24 +16,16 @@ package tech.pegasys.teku.spec.datastructures.operations;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.Combinators;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import net.jqwik.api.Provide;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
-import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.networks.Eth2Network;
-import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class AttesterSlashingPropertyTest {
   @Property
-  void roundTrip(@ForAll("attesterSlashing") final AttesterSlashing attesterSlashing)
+  void roundTrip(
+      @ForAll(supplier = AttesterSlashingSupplier.class) final AttesterSlashing attesterSlashing)
       throws JsonProcessingException {
     final AttesterSlashing.AttesterSlashingSchema schema = attesterSlashing.getSchema();
     final DeserializableTypeDefinition<AttesterSlashing> typeDefinition =
@@ -48,15 +40,5 @@ public class AttesterSlashingPropertyTest {
     final String json = JsonUtil.serialize(attesterSlashing, typeDefinition);
     final AttesterSlashing fromJson = JsonUtil.parse(json, typeDefinition);
     assertThat(fromJson).isEqualTo(attesterSlashing);
-  }
-
-  @Provide
-  Arbitrary<AttesterSlashing> attesterSlashing() {
-    Arbitrary<Integer> seed = Arbitraries.integers();
-    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
-    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
-    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
-    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
-    return dsu.map(DataStructureUtil::randomAttesterSlashing);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/AttesterSlashingPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/AttesterSlashingPropertyTest.java
@@ -16,8 +16,12 @@ package tech.pegasys.teku.spec.datastructures.operations;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.Combinators;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
@@ -29,16 +33,9 @@ import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class AttesterSlashingPropertyTest {
   @Property
-  void roundTrip(
-      @ForAll final int seed,
-      @ForAll final SpecMilestone specMilestone,
-      @ForAll final Eth2Network network)
+  void roundTrip(@ForAll("attesterSlashing") final AttesterSlashing attesterSlashing)
       throws JsonProcessingException {
-    final Spec spec = TestSpecFactory.create(specMilestone, network);
-    final DataStructureUtil dataStructureUtil = new DataStructureUtil(seed, spec);
-    final AttesterSlashing attesterSlashing = dataStructureUtil.randomAttesterSlashing();
-    final AttesterSlashing.AttesterSlashingSchema schema =
-        spec.forMilestone(specMilestone).getSchemaDefinitions().getAttesterSlashingSchema();
+    final AttesterSlashing.AttesterSlashingSchema schema = attesterSlashing.getSchema();
     final DeserializableTypeDefinition<AttesterSlashing> typeDefinition =
         schema.getJsonTypeDefinition();
 
@@ -51,5 +48,15 @@ public class AttesterSlashingPropertyTest {
     final String json = JsonUtil.serialize(attesterSlashing, typeDefinition);
     final AttesterSlashing fromJson = JsonUtil.parse(json, typeDefinition);
     assertThat(fromJson).isEqualTo(attesterSlashing);
+  }
+
+  @Provide
+  Arbitrary<AttesterSlashing> attesterSlashing() {
+    Arbitrary<Integer> seed = Arbitraries.integers();
+    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
+    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
+    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
+    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
+    return dsu.map(DataStructureUtil::randomAttesterSlashing);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/AttesterSlashingSupplier.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/AttesterSlashingSupplier.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.operations;
+
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.ArbitrarySupplier;
+import net.jqwik.api.Combinators;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class AttesterSlashingSupplier implements ArbitrarySupplier<AttesterSlashing> {
+  @Override
+  public Arbitrary<AttesterSlashing> get() {
+    Arbitrary<Integer> seed = Arbitraries.integers();
+    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
+    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
+    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
+    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
+    return dsu.map(DataStructureUtil::randomAttesterSlashing);
+  }
+}

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/ContributionAndProofPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/ContributionAndProofPropertyTest.java
@@ -22,6 +22,7 @@ import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
 import net.jqwik.api.Provide;
 import net.jqwik.api.constraints.Size;
+import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
@@ -30,6 +31,7 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.ContributionAndProof;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.ContributionAndProofSchema;
 import tech.pegasys.teku.spec.networks.Eth2Network;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
@@ -47,11 +49,19 @@ public class ContributionAndProofPropertyTest {
     final ContributionAndProof contributionAndProof =
         dataStructureUtil.randomContributionAndProof(
             UInt64.fromLongBits(slot), Bytes32.wrap(beaconBlockRoot));
+    final ContributionAndProofSchema schema = contributionAndProof.getSchema();
     final DeserializableTypeDefinition<ContributionAndProof> typeDefinition =
-        contributionAndProof.getSchema().getJsonTypeDefinition();
+        schema.getJsonTypeDefinition();
+
+    // Round-trip SSZ serialization.
+    final Bytes ssz = contributionAndProof.sszSerialize();
+    final ContributionAndProof fromSsz = schema.sszDeserialize(ssz);
+    assertThat(fromSsz).isEqualTo(contributionAndProof);
+
+    // Round-trip JSON serialization.
     final String json = JsonUtil.serialize(contributionAndProof, typeDefinition);
-    final ContributionAndProof result = JsonUtil.parse(json, typeDefinition);
-    assertThat(result).isEqualTo(contributionAndProof);
+    final ContributionAndProof fromJson = JsonUtil.parse(json, typeDefinition);
+    assertThat(fromJson).isEqualTo(contributionAndProof);
   }
 
   @Provide

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/ContributionAndProofPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/ContributionAndProofPropertyTest.java
@@ -16,26 +16,19 @@ package tech.pegasys.teku.spec.datastructures.operations;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.Combinators;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import net.jqwik.api.Provide;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
-import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.ContributionAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.ContributionAndProofSchema;
-import tech.pegasys.teku.spec.networks.Eth2Network;
-import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class ContributionAndProofPropertyTest {
   @Property
-  void roundTrip(@ForAll("contributionAndProof") final ContributionAndProof contributionAndProof)
+  void roundTrip(
+      @ForAll(supplier = ContributionAndProofSupplier.class)
+          final ContributionAndProof contributionAndProof)
       throws JsonProcessingException {
     final ContributionAndProofSchema schema = contributionAndProof.getSchema();
     final DeserializableTypeDefinition<ContributionAndProof> typeDefinition =
@@ -50,17 +43,5 @@ public class ContributionAndProofPropertyTest {
     final String json = JsonUtil.serialize(contributionAndProof, typeDefinition);
     final ContributionAndProof fromJson = JsonUtil.parse(json, typeDefinition);
     assertThat(fromJson).isEqualTo(contributionAndProof);
-  }
-
-  @Provide
-  Arbitrary<ContributionAndProof> contributionAndProof() {
-    Arbitrary<Integer> seed = Arbitraries.integers();
-    Arbitrary<SpecMilestone> milestone =
-        Arbitraries.of(SpecMilestone.class)
-            .filter(m -> m.isGreaterThanOrEqualTo(SpecMilestone.ALTAIR));
-    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
-    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
-    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
-    return dsu.map(DataStructureUtil::randomContributionAndProof);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/ContributionAndProofSupplier.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/ContributionAndProofSupplier.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.operations;
+
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.ArbitrarySupplier;
+import net.jqwik.api.Combinators;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.ContributionAndProof;
+import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class ContributionAndProofSupplier implements ArbitrarySupplier<ContributionAndProof> {
+  @Override
+  public Arbitrary<ContributionAndProof> get() {
+    Arbitrary<Integer> seed = Arbitraries.integers();
+    Arbitrary<SpecMilestone> milestone =
+        Arbitraries.of(SpecMilestone.class)
+            .filter(m -> m.isGreaterThanOrEqualTo(SpecMilestone.ALTAIR));
+    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
+    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
+    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
+    return dsu.map(DataStructureUtil::randomContributionAndProof);
+  }
+}

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/DepositMessagePropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/DepositMessagePropertyTest.java
@@ -16,24 +16,16 @@ package tech.pegasys.teku.spec.datastructures.operations;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.Combinators;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import net.jqwik.api.Provide;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
-import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.networks.Eth2Network;
-import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class DepositMessagePropertyTest {
   @Property
-  void roundTrip(@ForAll("depositMessage") final DepositMessage depositMessage)
+  void roundTrip(
+      @ForAll(supplier = DepositMessageSupplier.class) final DepositMessage depositMessage)
       throws JsonProcessingException {
     final DepositMessage.DepositMessageSchema schema = depositMessage.getSchema();
     final DeserializableTypeDefinition<DepositMessage> typeDefinition =
@@ -48,15 +40,5 @@ public class DepositMessagePropertyTest {
     final String json = JsonUtil.serialize(depositMessage, typeDefinition);
     final DepositMessage fromJson = JsonUtil.parse(json, typeDefinition);
     assertThat(fromJson).isEqualTo(depositMessage);
-  }
-
-  @Provide
-  Arbitrary<DepositMessage> depositMessage() {
-    Arbitrary<Integer> seed = Arbitraries.integers();
-    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
-    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
-    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
-    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
-    return dsu.map(DataStructureUtil::randomDepositMessage);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/DepositMessagePropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/DepositMessagePropertyTest.java
@@ -16,8 +16,12 @@ package tech.pegasys.teku.spec.datastructures.operations;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.Combinators;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
@@ -29,14 +33,8 @@ import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class DepositMessagePropertyTest {
   @Property
-  void roundTrip(
-      @ForAll final int seed,
-      @ForAll final SpecMilestone specMilestone,
-      @ForAll final Eth2Network network)
+  void roundTrip(@ForAll("depositMessage") final DepositMessage depositMessage)
       throws JsonProcessingException {
-    final Spec spec = TestSpecFactory.create(specMilestone, network);
-    final DataStructureUtil dataStructureUtil = new DataStructureUtil(seed, spec);
-    final DepositMessage depositMessage = dataStructureUtil.randomDepositMessage();
     final DepositMessage.DepositMessageSchema schema = depositMessage.getSchema();
     final DeserializableTypeDefinition<DepositMessage> typeDefinition =
         schema.getJsonTypeDefinition();
@@ -50,5 +48,15 @@ public class DepositMessagePropertyTest {
     final String json = JsonUtil.serialize(depositMessage, typeDefinition);
     final DepositMessage fromJson = JsonUtil.parse(json, typeDefinition);
     assertThat(fromJson).isEqualTo(depositMessage);
+  }
+
+  @Provide
+  Arbitrary<DepositMessage> depositMessage() {
+    Arbitrary<Integer> seed = Arbitraries.integers();
+    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
+    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
+    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
+    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
+    return dsu.map(DataStructureUtil::randomDepositMessage);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/DepositMessageSupplier.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/DepositMessageSupplier.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.operations;
+
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.ArbitrarySupplier;
+import net.jqwik.api.Combinators;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class DepositMessageSupplier implements ArbitrarySupplier<DepositMessage> {
+  @Override
+  public Arbitrary<DepositMessage> get() {
+    Arbitrary<Integer> seed = Arbitraries.integers();
+    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
+    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
+    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
+    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
+    return dsu.map(DataStructureUtil::randomDepositMessage);
+  }
+}

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/DepositPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/DepositPropertyTest.java
@@ -16,24 +16,16 @@ package tech.pegasys.teku.spec.datastructures.operations;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.Combinators;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import net.jqwik.api.Provide;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
-import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.networks.Eth2Network;
-import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class DepositPropertyTest {
   @Property
-  void roundTrip(@ForAll("deposit") final Deposit deposit) throws JsonProcessingException {
+  void roundTrip(@ForAll(supplier = DepositSupplier.class) final Deposit deposit)
+      throws JsonProcessingException {
     final Deposit.DepositSchema schema = deposit.getSchema();
     final DeserializableTypeDefinition<Deposit> typeDefinition = schema.getJsonTypeDefinition();
 
@@ -46,15 +38,5 @@ public class DepositPropertyTest {
     final String json = JsonUtil.serialize(deposit, typeDefinition);
     final Deposit fromJson = JsonUtil.parse(json, typeDefinition);
     assertThat(fromJson).isEqualTo(deposit);
-  }
-
-  @Provide
-  Arbitrary<Deposit> deposit() {
-    Arbitrary<Integer> seed = Arbitraries.integers();
-    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
-    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
-    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
-    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
-    return dsu.map(DataStructureUtil::randomDeposit);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/DepositPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/DepositPropertyTest.java
@@ -18,6 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
+import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 import tech.pegasys.teku.spec.Spec;
@@ -36,10 +37,17 @@ public class DepositPropertyTest {
     final Spec spec = TestSpecFactory.create(specMilestone, network);
     final DataStructureUtil dataStructureUtil = new DataStructureUtil(seed, spec);
     final Deposit deposit = dataStructureUtil.randomDeposit();
-    final DeserializableTypeDefinition<Deposit> typeDefinition =
-        deposit.getSchema().getJsonTypeDefinition();
+    final Deposit.DepositSchema schema = deposit.getSchema();
+    final DeserializableTypeDefinition<Deposit> typeDefinition = schema.getJsonTypeDefinition();
+
+    // Round-trip SSZ serialization.
+    final Bytes ssz = deposit.sszSerialize();
+    final Deposit fromSsz = schema.sszDeserialize(ssz);
+    assertThat(fromSsz).isEqualTo(deposit);
+
+    // Round-trip JSON serialization.
     final String json = JsonUtil.serialize(deposit, typeDefinition);
-    final Deposit result = JsonUtil.parse(json, typeDefinition);
-    assertThat(result).isEqualTo(deposit);
+    final Deposit fromJson = JsonUtil.parse(json, typeDefinition);
+    assertThat(fromJson).isEqualTo(deposit);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/DepositSupplier.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/DepositSupplier.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.operations;
+
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.ArbitrarySupplier;
+import net.jqwik.api.Combinators;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class DepositSupplier implements ArbitrarySupplier<Deposit> {
+  @Override
+  public Arbitrary<Deposit> get() {
+    Arbitrary<Integer> seed = Arbitraries.integers();
+    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
+    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
+    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
+    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
+    return dsu.map(DataStructureUtil::randomDeposit);
+  }
+}

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/IndexedAttestationPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/IndexedAttestationPropertyTest.java
@@ -16,24 +16,17 @@ package tech.pegasys.teku.spec.datastructures.operations;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.Combinators;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import net.jqwik.api.Provide;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
-import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.networks.Eth2Network;
-import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class IndexedAttestationPropertyTest {
   @Property
-  void roundTrip(@ForAll("indexedAttestation") final IndexedAttestation indexedAttestation)
+  void roundTrip(
+      @ForAll(supplier = IndexedAttestationSupplier.class)
+          final IndexedAttestation indexedAttestation)
       throws JsonProcessingException {
     final IndexedAttestation.IndexedAttestationSchema schema = indexedAttestation.getSchema();
     final DeserializableTypeDefinition<IndexedAttestation> typeDefinition =
@@ -48,15 +41,5 @@ public class IndexedAttestationPropertyTest {
     final String json = JsonUtil.serialize(indexedAttestation, typeDefinition);
     final IndexedAttestation fromJson = JsonUtil.parse(json, typeDefinition);
     assertThat(fromJson).isEqualTo(indexedAttestation);
-  }
-
-  @Provide
-  Arbitrary<IndexedAttestation> indexedAttestation() {
-    Arbitrary<Integer> seed = Arbitraries.integers();
-    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
-    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
-    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
-    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
-    return dsu.map(DataStructureUtil::randomIndexedAttestation);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/IndexedAttestationPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/IndexedAttestationPropertyTest.java
@@ -18,6 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
+import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 import tech.pegasys.teku.spec.Spec;
@@ -36,13 +37,19 @@ public class IndexedAttestationPropertyTest {
     final Spec spec = TestSpecFactory.create(specMilestone, network);
     final DataStructureUtil dataStructureUtil = new DataStructureUtil(seed, spec);
     final IndexedAttestation indexedAttestation = dataStructureUtil.randomIndexedAttestation();
+    final IndexedAttestation.IndexedAttestationSchema schema =
+        spec.forMilestone(specMilestone).getSchemaDefinitions().getIndexedAttestationSchema();
     final DeserializableTypeDefinition<IndexedAttestation> typeDefinition =
-        spec.forMilestone(specMilestone)
-            .getSchemaDefinitions()
-            .getIndexedAttestationSchema()
-            .getJsonTypeDefinition();
+        schema.getJsonTypeDefinition();
+
+    // Round-trip SSZ serialization.
+    final Bytes ssz = indexedAttestation.sszSerialize();
+    final IndexedAttestation fromSsz = schema.sszDeserialize(ssz);
+    assertThat(fromSsz).isEqualTo(indexedAttestation);
+
+    // Round-trip JSON serialization.
     final String json = JsonUtil.serialize(indexedAttestation, typeDefinition);
-    final IndexedAttestation result = JsonUtil.parse(json, typeDefinition);
-    assertThat(result).isEqualTo(indexedAttestation);
+    final IndexedAttestation fromJson = JsonUtil.parse(json, typeDefinition);
+    assertThat(fromJson).isEqualTo(indexedAttestation);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/IndexedAttestationPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/IndexedAttestationPropertyTest.java
@@ -16,8 +16,12 @@ package tech.pegasys.teku.spec.datastructures.operations;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.Combinators;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
@@ -29,16 +33,9 @@ import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class IndexedAttestationPropertyTest {
   @Property
-  void roundTrip(
-      @ForAll final int seed,
-      @ForAll final SpecMilestone specMilestone,
-      @ForAll final Eth2Network network)
+  void roundTrip(@ForAll("indexedAttestation") final IndexedAttestation indexedAttestation)
       throws JsonProcessingException {
-    final Spec spec = TestSpecFactory.create(specMilestone, network);
-    final DataStructureUtil dataStructureUtil = new DataStructureUtil(seed, spec);
-    final IndexedAttestation indexedAttestation = dataStructureUtil.randomIndexedAttestation();
-    final IndexedAttestation.IndexedAttestationSchema schema =
-        spec.forMilestone(specMilestone).getSchemaDefinitions().getIndexedAttestationSchema();
+    final IndexedAttestation.IndexedAttestationSchema schema = indexedAttestation.getSchema();
     final DeserializableTypeDefinition<IndexedAttestation> typeDefinition =
         schema.getJsonTypeDefinition();
 
@@ -51,5 +48,15 @@ public class IndexedAttestationPropertyTest {
     final String json = JsonUtil.serialize(indexedAttestation, typeDefinition);
     final IndexedAttestation fromJson = JsonUtil.parse(json, typeDefinition);
     assertThat(fromJson).isEqualTo(indexedAttestation);
+  }
+
+  @Provide
+  Arbitrary<IndexedAttestation> indexedAttestation() {
+    Arbitrary<Integer> seed = Arbitraries.integers();
+    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
+    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
+    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
+    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
+    return dsu.map(DataStructureUtil::randomIndexedAttestation);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/IndexedAttestationSupplier.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/IndexedAttestationSupplier.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.operations;
+
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.ArbitrarySupplier;
+import net.jqwik.api.Combinators;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class IndexedAttestationSupplier implements ArbitrarySupplier<IndexedAttestation> {
+  @Override
+  public Arbitrary<IndexedAttestation> get() {
+    Arbitrary<Integer> seed = Arbitraries.integers();
+    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
+    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
+    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
+    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
+    return dsu.map(DataStructureUtil::randomIndexedAttestation);
+  }
+}

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/ProposerSlashingPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/ProposerSlashingPropertyTest.java
@@ -16,24 +16,16 @@ package tech.pegasys.teku.spec.datastructures.operations;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.Combinators;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import net.jqwik.api.Provide;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
-import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.networks.Eth2Network;
-import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class ProposerSlashingPropertyTest {
   @Property
-  void roundTrip(@ForAll("proposerSlashing") final ProposerSlashing proposerSlashing)
+  void roundTrip(
+      @ForAll(supplier = ProposerSlashingSupplier.class) final ProposerSlashing proposerSlashing)
       throws JsonProcessingException {
     final ProposerSlashing.ProposerSlashingSchema schema = proposerSlashing.getSchema();
     final DeserializableTypeDefinition<ProposerSlashing> typeDefinition =
@@ -48,15 +40,5 @@ public class ProposerSlashingPropertyTest {
     final String json = JsonUtil.serialize(proposerSlashing, typeDefinition);
     final ProposerSlashing fromJson = JsonUtil.parse(json, typeDefinition);
     assertThat(fromJson).isEqualTo(proposerSlashing);
-  }
-
-  @Provide
-  Arbitrary<ProposerSlashing> proposerSlashing() {
-    Arbitrary<Integer> seed = Arbitraries.integers();
-    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
-    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
-    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
-    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
-    return dsu.map(DataStructureUtil::randomProposerSlashing);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/ProposerSlashingPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/ProposerSlashingPropertyTest.java
@@ -16,8 +16,12 @@ package tech.pegasys.teku.spec.datastructures.operations;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.Combinators;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
@@ -29,14 +33,8 @@ import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class ProposerSlashingPropertyTest {
   @Property
-  void roundTrip(
-      @ForAll final int seed,
-      @ForAll final SpecMilestone specMilestone,
-      @ForAll final Eth2Network network)
+  void roundTrip(@ForAll("proposerSlashing") final ProposerSlashing proposerSlashing)
       throws JsonProcessingException {
-    final Spec spec = TestSpecFactory.create(specMilestone, network);
-    final DataStructureUtil dataStructureUtil = new DataStructureUtil(seed, spec);
-    final ProposerSlashing proposerSlashing = dataStructureUtil.randomProposerSlashing();
     final ProposerSlashing.ProposerSlashingSchema schema = proposerSlashing.getSchema();
     final DeserializableTypeDefinition<ProposerSlashing> typeDefinition =
         schema.getJsonTypeDefinition();
@@ -50,5 +48,15 @@ public class ProposerSlashingPropertyTest {
     final String json = JsonUtil.serialize(proposerSlashing, typeDefinition);
     final ProposerSlashing fromJson = JsonUtil.parse(json, typeDefinition);
     assertThat(fromJson).isEqualTo(proposerSlashing);
+  }
+
+  @Provide
+  Arbitrary<ProposerSlashing> proposerSlashing() {
+    Arbitrary<Integer> seed = Arbitraries.integers();
+    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
+    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
+    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
+    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
+    return dsu.map(DataStructureUtil::randomProposerSlashing);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/ProposerSlashingPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/ProposerSlashingPropertyTest.java
@@ -18,6 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
+import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 import tech.pegasys.teku.spec.Spec;
@@ -36,10 +37,18 @@ public class ProposerSlashingPropertyTest {
     final Spec spec = TestSpecFactory.create(specMilestone, network);
     final DataStructureUtil dataStructureUtil = new DataStructureUtil(seed, spec);
     final ProposerSlashing proposerSlashing = dataStructureUtil.randomProposerSlashing();
+    final ProposerSlashing.ProposerSlashingSchema schema = proposerSlashing.getSchema();
     final DeserializableTypeDefinition<ProposerSlashing> typeDefinition =
-        proposerSlashing.getSchema().getJsonTypeDefinition();
+        schema.getJsonTypeDefinition();
+
+    // Round-trip SSZ serialization.
+    final Bytes ssz = proposerSlashing.sszSerialize();
+    final ProposerSlashing fromSsz = schema.sszDeserialize(ssz);
+    assertThat(fromSsz).isEqualTo(proposerSlashing);
+
+    // Round-trip JSON serialization.
     final String json = JsonUtil.serialize(proposerSlashing, typeDefinition);
-    final ProposerSlashing result = JsonUtil.parse(json, typeDefinition);
-    assertThat(result).isEqualTo(proposerSlashing);
+    final ProposerSlashing fromJson = JsonUtil.parse(json, typeDefinition);
+    assertThat(fromJson).isEqualTo(proposerSlashing);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/ProposerSlashingSupplier.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/ProposerSlashingSupplier.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.operations;
+
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.ArbitrarySupplier;
+import net.jqwik.api.Combinators;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class ProposerSlashingSupplier implements ArbitrarySupplier<ProposerSlashing> {
+  @Override
+  public Arbitrary<ProposerSlashing> get() {
+    Arbitrary<Integer> seed = Arbitraries.integers();
+    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
+    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
+    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
+    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
+    return dsu.map(DataStructureUtil::randomProposerSlashing);
+  }
+}

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SignedAggregateAndProofPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SignedAggregateAndProofPropertyTest.java
@@ -16,25 +16,17 @@ package tech.pegasys.teku.spec.datastructures.operations;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.Combinators;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import net.jqwik.api.Provide;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
-import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.networks.Eth2Network;
-import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class SignedAggregateAndProofPropertyTest {
   @Property
   void roundTrip(
-      @ForAll("signedAggregateAndProof") final SignedAggregateAndProof signedAggregateAndProof)
+      @ForAll(supplier = SignedAggregateAndProofSupplier.class)
+          final SignedAggregateAndProof signedAggregateAndProof)
       throws JsonProcessingException {
     final SignedAggregateAndProof.SignedAggregateAndProofSchema schema =
         signedAggregateAndProof.getSchema();
@@ -50,15 +42,5 @@ public class SignedAggregateAndProofPropertyTest {
     final String json = JsonUtil.serialize(signedAggregateAndProof, typeDefinition);
     final SignedAggregateAndProof fromJson = JsonUtil.parse(json, typeDefinition);
     assertThat(fromJson).isEqualTo(signedAggregateAndProof);
-  }
-
-  @Provide
-  Arbitrary<SignedAggregateAndProof> signedAggregateAndProof() {
-    Arbitrary<Integer> seed = Arbitraries.integers();
-    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
-    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
-    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
-    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
-    return dsu.map(DataStructureUtil::randomSignedAggregateAndProof);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SignedAggregateAndProofSupplier.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SignedAggregateAndProofSupplier.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.operations;
+
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.ArbitrarySupplier;
+import net.jqwik.api.Combinators;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class SignedAggregateAndProofSupplier implements ArbitrarySupplier<SignedAggregateAndProof> {
+  @Override
+  public Arbitrary<SignedAggregateAndProof> get() {
+    Arbitrary<Integer> seed = Arbitraries.integers();
+    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
+    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
+    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
+    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
+    return dsu.map(DataStructureUtil::randomSignedAggregateAndProof);
+  }
+}

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SignedContributionAndProofPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SignedContributionAndProofPropertyTest.java
@@ -16,27 +16,18 @@ package tech.pegasys.teku.spec.datastructures.operations;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.Combinators;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import net.jqwik.api.Provide;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
-import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SignedContributionAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SignedContributionAndProofSchema;
-import tech.pegasys.teku.spec.networks.Eth2Network;
-import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class SignedContributionAndProofPropertyTest {
   @Property
   void roundTrip(
-      @ForAll("signedContributionAndProof")
+      @ForAll(supplier = SignedContributionAndProofSupplier.class)
           final SignedContributionAndProof signedContributionAndProof)
       throws JsonProcessingException {
     final SignedContributionAndProofSchema schema = signedContributionAndProof.getSchema();
@@ -52,17 +43,5 @@ public class SignedContributionAndProofPropertyTest {
     final String json = JsonUtil.serialize(signedContributionAndProof, typeDefinition);
     final SignedContributionAndProof fromJson = JsonUtil.parse(json, typeDefinition);
     assertThat(fromJson).isEqualTo(signedContributionAndProof);
-  }
-
-  @Provide
-  Arbitrary<SignedContributionAndProof> signedContributionAndProof() {
-    Arbitrary<Integer> seed = Arbitraries.integers();
-    Arbitrary<SpecMilestone> milestone =
-        Arbitraries.of(SpecMilestone.class)
-            .filter(m -> m.isGreaterThanOrEqualTo(SpecMilestone.ALTAIR));
-    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
-    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
-    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
-    return dsu.map(DataStructureUtil::randomSignedContributionAndProof);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SignedContributionAndProofSupplier.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SignedContributionAndProofSupplier.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.operations;
+
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.ArbitrarySupplier;
+import net.jqwik.api.Combinators;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SignedContributionAndProof;
+import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class SignedContributionAndProofSupplier
+    implements ArbitrarySupplier<SignedContributionAndProof> {
+  @Override
+  public Arbitrary<SignedContributionAndProof> get() {
+    Arbitrary<Integer> seed = Arbitraries.integers();
+    Arbitrary<SpecMilestone> milestone =
+        Arbitraries.of(SpecMilestone.class)
+            .filter(m -> m.isGreaterThanOrEqualTo(SpecMilestone.ALTAIR));
+    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
+    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
+    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
+    return dsu.map(DataStructureUtil::randomSignedContributionAndProof);
+  }
+}

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SignedVoluntaryExitPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SignedVoluntaryExitPropertyTest.java
@@ -16,8 +16,12 @@ package tech.pegasys.teku.spec.datastructures.operations;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.Combinators;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
@@ -29,14 +33,8 @@ import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class SignedVoluntaryExitPropertyTest {
   @Property
-  void roundTrip(
-      @ForAll final int seed,
-      @ForAll final SpecMilestone specMilestone,
-      @ForAll final Eth2Network network)
+  void roundTrip(@ForAll("signedVoluntaryExit") final SignedVoluntaryExit signedVoluntaryExit)
       throws JsonProcessingException {
-    final Spec spec = TestSpecFactory.create(specMilestone, network);
-    final DataStructureUtil dataStructureUtil = new DataStructureUtil(seed, spec);
-    final SignedVoluntaryExit signedVoluntaryExit = dataStructureUtil.randomSignedVoluntaryExit();
     final SignedVoluntaryExit.SignedVoluntaryExitSchema schema = signedVoluntaryExit.getSchema();
     final DeserializableTypeDefinition<SignedVoluntaryExit> typeDefinition =
         schema.getJsonTypeDefinition();
@@ -50,5 +48,15 @@ public class SignedVoluntaryExitPropertyTest {
     final String json = JsonUtil.serialize(signedVoluntaryExit, typeDefinition);
     final SignedVoluntaryExit fromJson = JsonUtil.parse(json, typeDefinition);
     assertThat(fromJson).isEqualTo(signedVoluntaryExit);
+  }
+
+  @Provide
+  Arbitrary<SignedVoluntaryExit> signedVoluntaryExit() {
+    Arbitrary<Integer> seed = Arbitraries.integers();
+    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
+    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
+    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
+    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
+    return dsu.map(DataStructureUtil::randomSignedVoluntaryExit);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SignedVoluntaryExitPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SignedVoluntaryExitPropertyTest.java
@@ -18,6 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
+import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 import tech.pegasys.teku.spec.Spec;
@@ -36,10 +37,18 @@ public class SignedVoluntaryExitPropertyTest {
     final Spec spec = TestSpecFactory.create(specMilestone, network);
     final DataStructureUtil dataStructureUtil = new DataStructureUtil(seed, spec);
     final SignedVoluntaryExit signedVoluntaryExit = dataStructureUtil.randomSignedVoluntaryExit();
+    final SignedVoluntaryExit.SignedVoluntaryExitSchema schema = signedVoluntaryExit.getSchema();
     final DeserializableTypeDefinition<SignedVoluntaryExit> typeDefinition =
-        signedVoluntaryExit.getSchema().getJsonTypeDefinition();
+        schema.getJsonTypeDefinition();
+
+    // Round-trip SSZ serialization.
+    final Bytes ssz = signedVoluntaryExit.sszSerialize();
+    final SignedVoluntaryExit fromSsz = schema.sszDeserialize(ssz);
+    assertThat(fromSsz).isEqualTo(signedVoluntaryExit);
+
+    // Round-trip JSON serialization.
     final String json = JsonUtil.serialize(signedVoluntaryExit, typeDefinition);
-    final SignedVoluntaryExit result = JsonUtil.parse(json, typeDefinition);
-    assertThat(result).isEqualTo(signedVoluntaryExit);
+    final SignedVoluntaryExit fromJson = JsonUtil.parse(json, typeDefinition);
+    assertThat(fromJson).isEqualTo(signedVoluntaryExit);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SignedVoluntaryExitPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SignedVoluntaryExitPropertyTest.java
@@ -16,24 +16,17 @@ package tech.pegasys.teku.spec.datastructures.operations;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.Combinators;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import net.jqwik.api.Provide;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
-import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.networks.Eth2Network;
-import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class SignedVoluntaryExitPropertyTest {
   @Property
-  void roundTrip(@ForAll("signedVoluntaryExit") final SignedVoluntaryExit signedVoluntaryExit)
+  void roundTrip(
+      @ForAll(supplier = SignedVoluntaryExitSupplier.class)
+          final SignedVoluntaryExit signedVoluntaryExit)
       throws JsonProcessingException {
     final SignedVoluntaryExit.SignedVoluntaryExitSchema schema = signedVoluntaryExit.getSchema();
     final DeserializableTypeDefinition<SignedVoluntaryExit> typeDefinition =
@@ -48,15 +41,5 @@ public class SignedVoluntaryExitPropertyTest {
     final String json = JsonUtil.serialize(signedVoluntaryExit, typeDefinition);
     final SignedVoluntaryExit fromJson = JsonUtil.parse(json, typeDefinition);
     assertThat(fromJson).isEqualTo(signedVoluntaryExit);
-  }
-
-  @Provide
-  Arbitrary<SignedVoluntaryExit> signedVoluntaryExit() {
-    Arbitrary<Integer> seed = Arbitraries.integers();
-    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
-    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
-    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
-    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
-    return dsu.map(DataStructureUtil::randomSignedVoluntaryExit);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SignedVoluntaryExitSupplier.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SignedVoluntaryExitSupplier.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.operations;
+
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.ArbitrarySupplier;
+import net.jqwik.api.Combinators;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class SignedVoluntaryExitSupplier implements ArbitrarySupplier<SignedVoluntaryExit> {
+  @Override
+  public Arbitrary<SignedVoluntaryExit> get() {
+    Arbitrary<Integer> seed = Arbitraries.integers();
+    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
+    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
+    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
+    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
+    return dsu.map(DataStructureUtil::randomSignedVoluntaryExit);
+  }
+}

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SyncAggregatorSelectionDataPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SyncAggregatorSelectionDataPropertyTest.java
@@ -16,27 +16,18 @@ package tech.pegasys.teku.spec.datastructures.operations;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.Combinators;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import net.jqwik.api.Provide;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
-import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncAggregatorSelectionData;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncAggregatorSelectionDataSchema;
-import tech.pegasys.teku.spec.networks.Eth2Network;
-import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class SyncAggregatorSelectionDataPropertyTest {
   @Property
   void roundTrip(
-      @ForAll("syncAggregatorSelectionData")
+      @ForAll(supplier = SyncAggregatorSelectionDataSupplier.class)
           final SyncAggregatorSelectionData syncAggregatorSelectionData)
       throws JsonProcessingException {
     final SyncAggregatorSelectionDataSchema schema = syncAggregatorSelectionData.getSchema();
@@ -52,17 +43,5 @@ public class SyncAggregatorSelectionDataPropertyTest {
     final String json = JsonUtil.serialize(syncAggregatorSelectionData, typeDefinition);
     final SyncAggregatorSelectionData fromJson = JsonUtil.parse(json, typeDefinition);
     assertThat(fromJson).isEqualTo(syncAggregatorSelectionData);
-  }
-
-  @Provide
-  Arbitrary<SyncAggregatorSelectionData> syncAggregatorSelectionData() {
-    Arbitrary<Integer> seed = Arbitraries.integers();
-    Arbitrary<SpecMilestone> milestone =
-        Arbitraries.of(SpecMilestone.class)
-            .filter(m -> m.isGreaterThanOrEqualTo(SpecMilestone.ALTAIR));
-    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
-    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
-    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
-    return dsu.map(DataStructureUtil::randomSyncAggregatorSelectionData);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SyncAggregatorSelectionDataSupplier.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SyncAggregatorSelectionDataSupplier.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.operations;
+
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.ArbitrarySupplier;
+import net.jqwik.api.Combinators;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncAggregatorSelectionData;
+import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class SyncAggregatorSelectionDataSupplier
+    implements ArbitrarySupplier<SyncAggregatorSelectionData> {
+  @Override
+  public Arbitrary<SyncAggregatorSelectionData> get() {
+    Arbitrary<Integer> seed = Arbitraries.integers();
+    Arbitrary<SpecMilestone> milestone =
+        Arbitraries.of(SpecMilestone.class)
+            .filter(m -> m.isGreaterThanOrEqualTo(SpecMilestone.ALTAIR));
+    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
+    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
+    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
+    return dsu.map(DataStructureUtil::randomSyncAggregatorSelectionData);
+  }
+}

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SyncCommitteeContributionPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SyncCommitteeContributionPropertyTest.java
@@ -21,6 +21,7 @@ import net.jqwik.api.Arbitrary;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
 import net.jqwik.api.Provide;
+import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -28,6 +29,7 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeContribution;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeContributionSchema;
 import tech.pegasys.teku.spec.networks.Eth2Network;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
@@ -43,16 +45,24 @@ public class SyncCommitteeContributionPropertyTest {
     final DataStructureUtil dataStructureUtil = new DataStructureUtil(seed, spec);
     final SyncCommitteeContribution syncCommitteeContribution =
         dataStructureUtil.randomSyncCommitteeContribution(UInt64.fromLongBits(slot));
-    final DeserializableTypeDefinition<SyncCommitteeContribution> typeDefinition =
+    final SyncCommitteeContributionSchema schema =
         spec.forMilestone(specMilestone)
             .getSchemaDefinitions()
             .toVersionAltair()
             .orElseThrow()
-            .getSyncCommitteeContributionSchema()
-            .getJsonTypeDefinition();
+            .getSyncCommitteeContributionSchema();
+    final DeserializableTypeDefinition<SyncCommitteeContribution> typeDefinition =
+        schema.getJsonTypeDefinition();
+
+    // Round-trip SSZ serialization.
+    final Bytes ssz = syncCommitteeContribution.sszSerialize();
+    final SyncCommitteeContribution fromSsz = schema.sszDeserialize(ssz);
+    assertThat(fromSsz).isEqualTo(syncCommitteeContribution);
+
+    // Round-trip JSON serialization.
     final String json = JsonUtil.serialize(syncCommitteeContribution, typeDefinition);
-    final SyncCommitteeContribution result = JsonUtil.parse(json, typeDefinition);
-    assertThat(result).isEqualTo(syncCommitteeContribution);
+    final SyncCommitteeContribution fromJson = JsonUtil.parse(json, typeDefinition);
+    assertThat(fromJson).isEqualTo(syncCommitteeContribution);
   }
 
   @Provide

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SyncCommitteeContributionPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SyncCommitteeContributionPropertyTest.java
@@ -16,27 +16,18 @@ package tech.pegasys.teku.spec.datastructures.operations;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.Combinators;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import net.jqwik.api.Provide;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
-import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeContribution;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeContributionSchema;
-import tech.pegasys.teku.spec.networks.Eth2Network;
-import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class SyncCommitteeContributionPropertyTest {
   @Property
   void roundTrip(
-      @ForAll("syncCommitteeContribution")
+      @ForAll(supplier = SyncCommitteeContributionSupplier.class)
           final SyncCommitteeContribution syncCommitteeContribution)
       throws JsonProcessingException {
     final SyncCommitteeContributionSchema schema = syncCommitteeContribution.getSchema();
@@ -52,17 +43,5 @@ public class SyncCommitteeContributionPropertyTest {
     final String json = JsonUtil.serialize(syncCommitteeContribution, typeDefinition);
     final SyncCommitteeContribution fromJson = JsonUtil.parse(json, typeDefinition);
     assertThat(fromJson).isEqualTo(syncCommitteeContribution);
-  }
-
-  @Provide
-  Arbitrary<SyncCommitteeContribution> syncCommitteeContribution() {
-    Arbitrary<Integer> seed = Arbitraries.integers();
-    Arbitrary<SpecMilestone> milestone =
-        Arbitraries.of(SpecMilestone.class)
-            .filter(m -> m.isGreaterThanOrEqualTo(SpecMilestone.ALTAIR));
-    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
-    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
-    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
-    return dsu.map(DataStructureUtil::randomSyncCommitteeContribution);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SyncCommitteeContributionSupplier.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SyncCommitteeContributionSupplier.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.operations;
+
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.ArbitrarySupplier;
+import net.jqwik.api.Combinators;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeContribution;
+import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class SyncCommitteeContributionSupplier
+    implements ArbitrarySupplier<SyncCommitteeContribution> {
+  @Override
+  public Arbitrary<SyncCommitteeContribution> get() {
+    Arbitrary<Integer> seed = Arbitraries.integers();
+    Arbitrary<SpecMilestone> milestone =
+        Arbitraries.of(SpecMilestone.class)
+            .filter(m -> m.isGreaterThanOrEqualTo(SpecMilestone.ALTAIR));
+    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
+    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
+    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
+    return dsu.map(DataStructureUtil::randomSyncCommitteeContribution);
+  }
+}

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SyncCommitteeMessagePropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SyncCommitteeMessagePropertyTest.java
@@ -18,6 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import net.jqwik.api.Arbitraries;
 import net.jqwik.api.Arbitrary;
+import net.jqwik.api.Combinators;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
 import net.jqwik.api.Provide;
@@ -34,21 +35,9 @@ import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class SyncCommitteeMessagePropertyTest {
   @Property
-  void roundTrip(
-      @ForAll final int seed,
-      @ForAll("milestone") final SpecMilestone specMilestone,
-      @ForAll final Eth2Network network)
+  void roundTrip(@ForAll("syncCommitteeMessage") final SyncCommitteeMessage syncCommitteeMessage)
       throws JsonProcessingException {
-    final Spec spec = TestSpecFactory.create(specMilestone, network);
-    final DataStructureUtil dataStructureUtil = new DataStructureUtil(seed, spec);
-    final SyncCommitteeMessage syncCommitteeMessage =
-        dataStructureUtil.randomSyncCommitteeMessage();
-    final SyncCommitteeMessageSchema schema =
-        spec.forMilestone(specMilestone)
-            .getSchemaDefinitions()
-            .toVersionAltair()
-            .orElseThrow()
-            .getSyncCommitteeMessageSchema();
+    final SyncCommitteeMessageSchema schema = syncCommitteeMessage.getSchema();
     final DeserializableTypeDefinition<SyncCommitteeMessage> typeDefinition =
         schema.getJsonTypeDefinition();
 
@@ -64,8 +53,14 @@ public class SyncCommitteeMessagePropertyTest {
   }
 
   @Provide
-  Arbitrary<SpecMilestone> milestone() {
-    return Arbitraries.of(SpecMilestone.class)
-        .filter(m -> m.isGreaterThanOrEqualTo(SpecMilestone.ALTAIR));
+  Arbitrary<SyncCommitteeMessage> syncCommitteeMessage() {
+    Arbitrary<Integer> seed = Arbitraries.integers();
+    Arbitrary<SpecMilestone> milestone =
+        Arbitraries.of(SpecMilestone.class)
+            .filter(m -> m.isGreaterThanOrEqualTo(SpecMilestone.ALTAIR));
+    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
+    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
+    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
+    return dsu.map(DataStructureUtil::randomSyncCommitteeMessage);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SyncCommitteeMessageSupplier.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SyncCommitteeMessageSupplier.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.operations;
+
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.ArbitrarySupplier;
+import net.jqwik.api.Combinators;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeMessage;
+import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class SyncCommitteeMessageSupplier implements ArbitrarySupplier<SyncCommitteeMessage> {
+  @Override
+  public Arbitrary<SyncCommitteeMessage> get() {
+    Arbitrary<Integer> seed = Arbitraries.integers();
+    Arbitrary<SpecMilestone> milestone =
+        Arbitraries.of(SpecMilestone.class)
+            .filter(m -> m.isGreaterThanOrEqualTo(SpecMilestone.ALTAIR));
+    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
+    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
+    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
+    return dsu.map(DataStructureUtil::randomSyncCommitteeMessage);
+  }
+}

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/VoluntaryExitPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/VoluntaryExitPropertyTest.java
@@ -16,24 +16,15 @@ package tech.pegasys.teku.spec.datastructures.operations;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.Combinators;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import net.jqwik.api.Provide;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
-import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.networks.Eth2Network;
-import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class VoluntaryExitPropertyTest {
   @Property
-  void roundTrip(@ForAll("voluntaryExit") final VoluntaryExit voluntaryExit)
+  void roundTrip(@ForAll(supplier = VoluntaryExitSupplier.class) final VoluntaryExit voluntaryExit)
       throws JsonProcessingException {
     final VoluntaryExit.VoluntaryExitSchema schema = voluntaryExit.getSchema();
     final DeserializableTypeDefinition<VoluntaryExit> typeDefinition =
@@ -48,15 +39,5 @@ public class VoluntaryExitPropertyTest {
     final String json = JsonUtil.serialize(voluntaryExit, typeDefinition);
     final VoluntaryExit fromJson = JsonUtil.parse(json, typeDefinition);
     assertThat(fromJson).isEqualTo(voluntaryExit);
-  }
-
-  @Provide
-  Arbitrary<VoluntaryExit> voluntaryExit() {
-    Arbitrary<Integer> seed = Arbitraries.integers();
-    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
-    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
-    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
-    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
-    return dsu.map(DataStructureUtil::randomVoluntaryExit);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/VoluntaryExitPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/VoluntaryExitPropertyTest.java
@@ -16,8 +16,12 @@ package tech.pegasys.teku.spec.datastructures.operations;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.Combinators;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
@@ -29,14 +33,8 @@ import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class VoluntaryExitPropertyTest {
   @Property
-  void roundTrip(
-      @ForAll final int seed,
-      @ForAll final SpecMilestone specMilestone,
-      @ForAll final Eth2Network network)
+  void roundTrip(@ForAll("voluntaryExit") final VoluntaryExit voluntaryExit)
       throws JsonProcessingException {
-    final Spec spec = TestSpecFactory.create(specMilestone, network);
-    final DataStructureUtil dataStructureUtil = new DataStructureUtil(seed, spec);
-    final VoluntaryExit voluntaryExit = dataStructureUtil.randomVoluntaryExit();
     final VoluntaryExit.VoluntaryExitSchema schema = voluntaryExit.getSchema();
     final DeserializableTypeDefinition<VoluntaryExit> typeDefinition =
         schema.getJsonTypeDefinition();
@@ -50,5 +48,15 @@ public class VoluntaryExitPropertyTest {
     final String json = JsonUtil.serialize(voluntaryExit, typeDefinition);
     final VoluntaryExit fromJson = JsonUtil.parse(json, typeDefinition);
     assertThat(fromJson).isEqualTo(voluntaryExit);
+  }
+
+  @Provide
+  Arbitrary<VoluntaryExit> voluntaryExit() {
+    Arbitrary<Integer> seed = Arbitraries.integers();
+    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
+    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
+    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
+    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
+    return dsu.map(DataStructureUtil::randomVoluntaryExit);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/VoluntaryExitSupplier.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/VoluntaryExitSupplier.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.operations;
+
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.ArbitrarySupplier;
+import net.jqwik.api.Combinators;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class VoluntaryExitSupplier implements ArbitrarySupplier<VoluntaryExit> {
+  @Override
+  public Arbitrary<VoluntaryExit> get() {
+    Arbitrary<Integer> seed = Arbitraries.integers();
+    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
+    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
+    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
+    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
+    return dsu.map(DataStructureUtil::randomVoluntaryExit);
+  }
+}

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/state/BeaconStatePropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/state/BeaconStatePropertyTest.java
@@ -16,27 +16,19 @@ package tech.pegasys.teku.spec.datastructures.state;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.Combinators;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import net.jqwik.api.Provide;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
-import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchema;
-import tech.pegasys.teku.spec.networks.Eth2Network;
-import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class BeaconStatePropertyTest {
   @Property(tries = 100)
   @SuppressWarnings("unchecked")
-  void roundTrip(@ForAll("beaconState") final BeaconState state) throws JsonProcessingException {
+  void roundTrip(@ForAll(supplier = BeaconStateSupplier.class) final BeaconState state)
+      throws JsonProcessingException {
     final BeaconStateSchema<?, ?> schema = state.getBeaconStateSchema();
     final DeserializableTypeDefinition<BeaconState> typeDefinition =
         (DeserializableTypeDefinition<BeaconState>) schema.getJsonTypeDefinition();
@@ -50,15 +42,5 @@ public class BeaconStatePropertyTest {
     final String json = JsonUtil.serialize(state, typeDefinition);
     final BeaconState fromJson = JsonUtil.parse(json, typeDefinition);
     assertThat(fromJson).isEqualTo(state);
-  }
-
-  @Provide
-  Arbitrary<BeaconState> beaconState() {
-    Arbitrary<Integer> seed = Arbitraries.integers();
-    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
-    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
-    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
-    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
-    return dsu.map(DataStructureUtil::randomBeaconState);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/state/BeaconStatePropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/state/BeaconStatePropertyTest.java
@@ -18,12 +18,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
+import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchema;
 import tech.pegasys.teku.spec.networks.Eth2Network;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
@@ -38,14 +40,19 @@ public class BeaconStatePropertyTest {
     final Spec spec = TestSpecFactory.create(specMilestone, network);
     final DataStructureUtil dataStructureUtil = new DataStructureUtil(seed, spec);
     final BeaconState state = dataStructureUtil.randomBeaconState();
+    final BeaconStateSchema<?, ?> schema =
+        spec.forMilestone(specMilestone).getSchemaDefinitions().getBeaconStateSchema();
     final DeserializableTypeDefinition<BeaconState> typeDefinition =
-        (DeserializableTypeDefinition<BeaconState>)
-            spec.forMilestone(specMilestone)
-                .getSchemaDefinitions()
-                .getBeaconStateSchema()
-                .getJsonTypeDefinition();
+        (DeserializableTypeDefinition<BeaconState>) schema.getJsonTypeDefinition();
+
+    // Round-trip SSZ serialization.
+    final Bytes ssz = state.sszSerialize();
+    final BeaconState fromSsz = schema.sszDeserialize(ssz);
+    assertThat(fromSsz).isEqualTo(state);
+
+    // Round-trip JSON serialization.
     final String json = JsonUtil.serialize(state, typeDefinition);
-    final BeaconState result = JsonUtil.parse(json, typeDefinition);
-    assertThat(result).isEqualTo(state);
+    final BeaconState fromJson = JsonUtil.parse(json, typeDefinition);
+    assertThat(fromJson).isEqualTo(state);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/state/BeaconStateSupplier.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/state/BeaconStateSupplier.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.state;
+
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.ArbitrarySupplier;
+import net.jqwik.api.Combinators;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class BeaconStateSupplier implements ArbitrarySupplier<BeaconState> {
+  @Override
+  public Arbitrary<BeaconState> get() {
+    Arbitrary<Integer> seed = Arbitraries.integers();
+    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
+    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
+    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
+    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
+    return dsu.map(DataStructureUtil::randomBeaconState);
+  }
+}

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/type/SszPublicKeyPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/type/SszPublicKeyPropertyTest.java
@@ -16,24 +16,16 @@ package tech.pegasys.teku.spec.datastructures.type;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.Combinators;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import net.jqwik.api.Provide;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
-import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.networks.Eth2Network;
-import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class SszPublicKeyPropertyTest {
   @Property
-  void roundTrip(@ForAll("sszPublicKey") final SszPublicKey key) throws JsonProcessingException {
+  void roundTrip(@ForAll(supplier = SszPublicKeySupplier.class) final SszPublicKey key)
+      throws JsonProcessingException {
     final SszPublicKeySchema schema = key.getSchema();
     final DeserializableTypeDefinition<SszPublicKey> typeDefinition =
         schema.getJsonTypeDefinition();
@@ -47,15 +39,5 @@ public class SszPublicKeyPropertyTest {
     final String json = JsonUtil.serialize(key, typeDefinition);
     final SszPublicKey fromJson = JsonUtil.parse(json, typeDefinition);
     assertThat(fromJson).isEqualTo(key);
-  }
-
-  @Provide
-  Arbitrary<SszPublicKey> sszPublicKey() {
-    Arbitrary<Integer> seed = Arbitraries.integers();
-    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
-    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
-    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
-    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
-    return dsu.map(DataStructureUtil::randomPublicKey).map(SszPublicKey::new);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/type/SszPublicKeyPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/type/SszPublicKeyPropertyTest.java
@@ -18,6 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
+import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 import tech.pegasys.teku.spec.Spec;
@@ -36,10 +37,18 @@ public class SszPublicKeyPropertyTest {
     final Spec spec = TestSpecFactory.create(specMilestone, network);
     final DataStructureUtil dataStructureUtil = new DataStructureUtil(seed, spec);
     final SszPublicKey key = new SszPublicKey(dataStructureUtil.randomPublicKey());
+    final SszPublicKeySchema schema = key.getSchema();
     final DeserializableTypeDefinition<SszPublicKey> typeDefinition =
-        key.getSchema().getJsonTypeDefinition();
+        schema.getJsonTypeDefinition();
+
+    // Round-trip SSZ serialization.
+    final Bytes ssz = key.sszSerialize();
+    final SszPublicKey fromSsz = schema.sszDeserialize(ssz);
+    assertThat(fromSsz).isEqualTo(key);
+
+    // Round-trip JSON serialization.
     final String json = JsonUtil.serialize(key, typeDefinition);
-    final SszPublicKey result = JsonUtil.parse(json, typeDefinition);
-    assertThat(result).isEqualTo(key);
+    final SszPublicKey fromJson = JsonUtil.parse(json, typeDefinition);
+    assertThat(fromJson).isEqualTo(key);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/type/SszPublicKeySupplier.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/type/SszPublicKeySupplier.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.type;
+
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.ArbitrarySupplier;
+import net.jqwik.api.Combinators;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class SszPublicKeySupplier implements ArbitrarySupplier<SszPublicKey> {
+  @Override
+  public Arbitrary<SszPublicKey> get() {
+    Arbitrary<Integer> seed = Arbitraries.integers();
+    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
+    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
+    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
+    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
+    return dsu.map(DataStructureUtil::randomPublicKey).map(SszPublicKey::new);
+  }
+}

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/type/SszSignaturePropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/type/SszSignaturePropertyTest.java
@@ -16,24 +16,15 @@ package tech.pegasys.teku.spec.datastructures.type;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.Combinators;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import net.jqwik.api.Provide;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
-import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.networks.Eth2Network;
-import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class SszSignaturePropertyTest {
   @Property
-  void roundTrip(@ForAll("sszSignature") final SszSignature signature)
+  void roundTrip(@ForAll(supplier = SszSignatureSupplier.class) final SszSignature signature)
       throws JsonProcessingException {
     final SszSignatureSchema schema = signature.getSchema();
     final DeserializableTypeDefinition<SszSignature> typeDefinition =
@@ -48,15 +39,5 @@ public class SszSignaturePropertyTest {
     final String json = JsonUtil.serialize(signature, typeDefinition);
     final SszSignature fromJson = JsonUtil.parse(json, typeDefinition);
     assertThat(fromJson).isEqualTo(signature);
-  }
-
-  @Provide
-  Arbitrary<SszSignature> sszSignature() {
-    Arbitrary<Integer> seed = Arbitraries.integers();
-    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
-    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
-    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
-    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
-    return dsu.map(DataStructureUtil::randomSignature).map(SszSignature::new);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/type/SszSignaturePropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/type/SszSignaturePropertyTest.java
@@ -16,8 +16,12 @@ package tech.pegasys.teku.spec.datastructures.type;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.Combinators;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
@@ -29,14 +33,8 @@ import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class SszSignaturePropertyTest {
   @Property
-  void roundTrip(
-      @ForAll final int seed,
-      @ForAll final SpecMilestone specMilestone,
-      @ForAll final Eth2Network network)
+  void roundTrip(@ForAll("sszSignature") final SszSignature signature)
       throws JsonProcessingException {
-    final Spec spec = TestSpecFactory.create(specMilestone, network);
-    final DataStructureUtil dataStructureUtil = new DataStructureUtil(seed, spec);
-    final SszSignature signature = new SszSignature(dataStructureUtil.randomSignature());
     final SszSignatureSchema schema = signature.getSchema();
     final DeserializableTypeDefinition<SszSignature> typeDefinition =
         schema.getJsonTypeDefinition();
@@ -50,5 +48,15 @@ public class SszSignaturePropertyTest {
     final String json = JsonUtil.serialize(signature, typeDefinition);
     final SszSignature fromJson = JsonUtil.parse(json, typeDefinition);
     assertThat(fromJson).isEqualTo(signature);
+  }
+
+  @Provide
+  Arbitrary<SszSignature> sszSignature() {
+    Arbitrary<Integer> seed = Arbitraries.integers();
+    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
+    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
+    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
+    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
+    return dsu.map(DataStructureUtil::randomSignature).map(SszSignature::new);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/type/SszSignatureSupplier.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/type/SszSignatureSupplier.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.type;
+
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.ArbitrarySupplier;
+import net.jqwik.api.Combinators;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class SszSignatureSupplier implements ArbitrarySupplier<SszSignature> {
+  @Override
+  public Arbitrary<SszSignature> get() {
+    Arbitrary<Integer> seed = Arbitraries.integers();
+    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
+    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
+    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
+    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
+    return dsu.map(DataStructureUtil::randomSignature).map(SszSignature::new);
+  }
+}

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -1431,6 +1431,10 @@ public final class DataStructureUtil {
     return AnchorPoint.create(spec, anchorCheckpoint, signedAnchorBlock, anchorState);
   }
 
+  public SignedContributionAndProof randomSignedContributionAndProof() {
+    return randomSignedContributionAndProof(randomUInt64(), randomBytes32());
+  }
+
   public SignedContributionAndProof randomSignedContributionAndProof(final long slot) {
     return randomSignedContributionAndProof(slot, randomBytes32());
   }
@@ -1449,6 +1453,10 @@ public final class DataStructureUtil {
         .create(contributionAndProof, randomSignature());
   }
 
+  public ContributionAndProof randomContributionAndProof() {
+    return randomContributionAndProof(randomUInt64(), randomBytes32());
+  }
+
   public ContributionAndProof randomContributionAndProof(
       final UInt64 slot, final Bytes32 beaconBlockRoot) {
     return getAltairSchemaDefinitions(slot)
@@ -1457,6 +1465,10 @@ public final class DataStructureUtil {
             randomUInt64(),
             randomSyncCommitteeContribution(slot, beaconBlockRoot),
             randomSignature());
+  }
+
+  public SyncCommitteeContribution randomSyncCommitteeContribution() {
+    return randomSyncCommitteeContribution(randomUInt64(), randomBytes32());
   }
 
   public SyncCommitteeContribution randomSyncCommitteeContribution(final UInt64 slot) {

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -703,6 +703,10 @@ public final class DataStructureUtil {
     return signedBlock(beaconBlock);
   }
 
+  public SignedBeaconBlock randomSignedBeaconBlock() {
+    return randomSignedBeaconBlock(randomUInt64());
+  }
+
   public SignedBeaconBlock randomSignedBeaconBlock(long slotNum) {
     return randomSignedBeaconBlock(UInt64.valueOf(slotNum));
   }
@@ -749,6 +753,10 @@ public final class DataStructureUtil {
     return new BeaconBlockBuilder(specVersion, this);
   }
 
+  public BeaconBlock randomBeaconBlock() {
+    return randomBeaconBlock(randomUInt64());
+  }
+
   public BeaconBlock randomBeaconBlock(long slotNum) {
     return randomBeaconBlock(UInt64.valueOf(slotNum));
   }
@@ -766,6 +774,10 @@ public final class DataStructureUtil {
         previousRoot,
         stateRoot,
         body);
+  }
+
+  public BeaconBlock randomBlindedBeaconBlock() {
+    return randomBlindedBeaconBlock(randomUInt64());
   }
 
   public BeaconBlock randomBlindedBeaconBlock(long slotNum) {
@@ -891,6 +903,10 @@ public final class DataStructureUtil {
   public BeaconBlockHeader randomBeaconBlockHeader(final UInt64 slot, final UInt64 proposerIndex) {
     return new BeaconBlockHeader(
         slot, proposerIndex, randomBytes32(), randomBytes32(), randomBytes32());
+  }
+
+  public BeaconBlockBody randomBlindedBeaconBlockBody() {
+    return randomBlindedBeaconBlockBody(randomUInt64());
   }
 
   public BeaconBlockBody randomBlindedBeaconBlockBody(UInt64 slotNum) {


### PR DESCRIPTION
## PR Description

This PR adds round-trip SSZ serialization property tests (essentially fuzzing) to the existing `roundTrip` test methods. Previously, this method only tested JSON serialization/deserialization. The extra overhead in adding this is pretty minimal as generating the random data structures is the time consuming part of the test. No bugs were found. This functionality is already very well tested, but it may help catch a regression in the future. Who knows 🤷

* Add some new methods to `DataStructureUtil` that take zero arguments.
* Add overridden `getSchema` methods for some types that were missing it.
* Add new `Supplier` classes for each data type.
  * This looks cleaner & makes it way easier to add more tests in the future.

It may be easier to review these changes in an IDE.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
