### PR TITLE
Acceptance tests for Sentry Nodes feature

### DIFF
--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/SentryNodesAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/SentryNodesAcceptanceTest.java
@@ -13,11 +13,6 @@
 
 package tech.pegasys.teku.test.acceptance;
 
-import static tech.pegasys.teku.test.acceptance.dsl.metrics.MetricConditions.withLabelsContaining;
-import static tech.pegasys.teku.test.acceptance.dsl.metrics.MetricConditions.withNameEqualsTo;
-import static tech.pegasys.teku.test.acceptance.dsl.metrics.MetricConditions.withValueGreaterThan;
-
-import java.util.Map;
 import java.util.function.Consumer;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -49,46 +44,9 @@ public class SentryNodesAcceptanceTest extends AcceptanceTestBase {
             config -> config.withInteropValidators(0, 32).withSentryNodes(sentryNodesConfig));
     remoteValidator.start();
 
-    waitForRemoteValidatorGettingProposerDutiesFromBeaconNode(remoteValidator, dutiesProviderNode);
-    waitForRemoteValidatorPublishingAttestationToBeaconNode(
-        remoteValidator, attestationPublisherNode);
-    waitForRemoteValidatorPublishingBlockToBeaconNode(remoteValidator, blockHandlerNode);
-  }
-
-  private void waitForRemoteValidatorGettingProposerDutiesFromBeaconNode(
-      final TekuValidatorNode remoteValidator, final TekuNode beaconNode) {
-    remoteValidator.waitForMetric(
-        withNameEqualsTo("validator_remote_beacon_nodes_requests_total"),
-        withLabelsContaining(
-            Map.of(
-                "endpoint", beaconNode.getBeaconRestApiUrl() + "/",
-                "method", "get_proposer_duties",
-                "outcome", "success")),
-        withValueGreaterThan(0));
-  }
-
-  private void waitForRemoteValidatorPublishingBlockToBeaconNode(
-      final TekuValidatorNode remoteValidator, final TekuNode beaconNode) {
-    remoteValidator.waitForMetric(
-        withNameEqualsTo("validator_remote_beacon_nodes_requests_total"),
-        withLabelsContaining(
-            Map.of(
-                "endpoint", beaconNode.getBeaconRestApiUrl() + "/",
-                "method", "publish_block",
-                "outcome", "success")),
-        withValueGreaterThan(0));
-  }
-
-  private void waitForRemoteValidatorPublishingAttestationToBeaconNode(
-      final TekuValidatorNode remoteValidator, final TekuNode beaconNode) {
-    remoteValidator.waitForMetric(
-        withNameEqualsTo("validator_remote_beacon_nodes_requests_total"),
-        withLabelsContaining(
-            Map.of(
-                "endpoint", beaconNode.getBeaconRestApiUrl() + "/",
-                "method", "publish_attestation",
-                "outcome", "success")),
-        withValueGreaterThan(0));
+    remoteValidator.waitForDutiesRequestedFrom(dutiesProviderNode);
+    remoteValidator.waitForAttestationPublishedTo(attestationPublisherNode);
+    remoteValidator.waitForBlockPublishedTo(blockHandlerNode);
   }
 
   private TekuNode createAndStartPeerBeaconNode(

--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/SentryNodesAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/SentryNodesAcceptanceTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.test.acceptance;
+
+import static tech.pegasys.teku.test.acceptance.dsl.metrics.MetricConditions.withLabelsContaining;
+import static tech.pegasys.teku.test.acceptance.dsl.metrics.MetricConditions.withNameEqualsTo;
+import static tech.pegasys.teku.test.acceptance.dsl.metrics.MetricConditions.withValueGreaterThan;
+
+import java.util.Map;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.test.acceptance.dsl.AcceptanceTestBase;
+import tech.pegasys.teku.test.acceptance.dsl.SentryNodesConfig;
+import tech.pegasys.teku.test.acceptance.dsl.TekuNode;
+import tech.pegasys.teku.test.acceptance.dsl.TekuNode.Config;
+import tech.pegasys.teku.test.acceptance.dsl.TekuValidatorNode;
+
+public class SentryNodesAcceptanceTest extends AcceptanceTestBase {
+
+  @Test
+  void sentryBeaconNodesSetup() throws Exception {
+    final TekuNode dutiesProviderNode = createAndStartBootstrapBeaconNode();
+    final TekuNode attestationPublisherNode =
+        createAndStartPeerBeaconNode(dutiesProviderNode, dutiesProviderNode.getGenesisTime());
+    final TekuNode blockHandlerNode =
+        createAndStartPeerBeaconNode(dutiesProviderNode, dutiesProviderNode.getGenesisTime());
+
+    final SentryNodesConfig sentryNodesConfig =
+        new SentryNodesConfig.Builder()
+            .withDutiesProviders(dutiesProviderNode)
+            .withAttestationPublisher(attestationPublisherNode)
+            .withBlockHandlers(blockHandlerNode)
+            .build();
+
+    final TekuValidatorNode remoteValidator =
+        createValidatorNode(
+            config -> config.withInteropValidators(0, 32).withSentryNodes(sentryNodesConfig));
+    remoteValidator.start();
+
+    waitForRemoteValidatorGettingProposerDutiesFromBeaconNode(remoteValidator, dutiesProviderNode);
+    waitForRemoteValidatorPublishingAttestationToBeaconNode(
+        remoteValidator, attestationPublisherNode);
+    waitForRemoteValidatorPublishingBlockToBeaconNode(remoteValidator, blockHandlerNode);
+  }
+
+  private void waitForRemoteValidatorGettingProposerDutiesFromBeaconNode(
+      final TekuValidatorNode remoteValidator, final TekuNode beaconNode) {
+    remoteValidator.waitForMetric(
+        withNameEqualsTo("validator_remote_beacon_nodes_requests_total"),
+        withLabelsContaining(
+            Map.of(
+                "endpoint", beaconNode.getBeaconRestApiUrl() + "/",
+                "method", "get_proposer_duties",
+                "outcome", "success")),
+        withValueGreaterThan(0));
+  }
+
+  private void waitForRemoteValidatorPublishingBlockToBeaconNode(
+      final TekuValidatorNode remoteValidator, final TekuNode beaconNode) {
+    remoteValidator.waitForMetric(
+        withNameEqualsTo("validator_remote_beacon_nodes_requests_total"),
+        withLabelsContaining(
+            Map.of(
+                "endpoint", beaconNode.getBeaconRestApiUrl() + "/",
+                "method", "publish_block",
+                "outcome", "success")),
+        withValueGreaterThan(0));
+  }
+
+  private void waitForRemoteValidatorPublishingAttestationToBeaconNode(
+      final TekuValidatorNode remoteValidator, final TekuNode beaconNode) {
+    remoteValidator.waitForMetric(
+        withNameEqualsTo("validator_remote_beacon_nodes_requests_total"),
+        withLabelsContaining(
+            Map.of(
+                "endpoint", beaconNode.getBeaconRestApiUrl() + "/",
+                "method", "publish_attestation",
+                "outcome", "success")),
+        withValueGreaterThan(0));
+  }
+
+  private TekuNode createAndStartPeerBeaconNode(
+      final TekuNode dutiesProviderNode, final UInt64 genesisTime) throws Exception {
+    final TekuNode blockHandlerNode =
+        createTekuNode(configureLateJoiningNode(dutiesProviderNode, genesisTime.intValue()));
+    blockHandlerNode.start();
+    return blockHandlerNode;
+  }
+
+  private TekuNode createAndStartBootstrapBeaconNode() throws Exception {
+    final TekuNode dutiesProviderNode =
+        createTekuNode(
+            c -> {
+              c.withRealNetwork();
+              c.withNetwork("minimal");
+              c.withInteropNumberOfValidators(64);
+              c.withInteropValidators(32, 32);
+            });
+    dutiesProviderNode.start();
+    return dutiesProviderNode;
+  }
+
+  private Consumer<Config> configureLateJoiningNode(
+      final TekuNode primaryNode, final int genesisTime) {
+    return c ->
+        c.withGenesisTime(genesisTime)
+            .withRealNetwork()
+            .withNetwork("minimal")
+            .withPeers(primaryNode)
+            .withInteropValidators(0, 0);
+  }
+}

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/BesuNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/BesuNode.java
@@ -118,8 +118,8 @@ public class BesuNode extends Node {
   private String fetchEnodeUrl() throws Exception {
     final URI baseUri = new URI(getExternalJsonRpcUrl());
     final String response =
-        httpClient.post(baseUri, "", jsonProvider.objectToJSON(new Request("admin_nodeInfo")));
-    final ObjectMapper objectMapper = jsonProvider.getObjectMapper();
+        httpClient.post(baseUri, "", JSON_PROVIDER.objectToJSON(new Request("admin_nodeInfo")));
+    final ObjectMapper objectMapper = JSON_PROVIDER.getObjectMapper();
     final JavaType nodeInfoResponseType =
         objectMapper
             .getTypeFactory()
@@ -134,8 +134,8 @@ public class BesuNode extends Node {
     final URI baseUri = new URI(getExternalJsonRpcUrl());
     final String response =
         httpClient.post(
-            baseUri, "", jsonProvider.objectToJSON(new Request("admin_addPeer", enode)));
-    final ObjectMapper objectMapper = jsonProvider.getObjectMapper();
+            baseUri, "", JSON_PROVIDER.objectToJSON(new Request("admin_addPeer", enode)));
+    final ObjectMapper objectMapper = JSON_PROVIDER.getObjectMapper();
     final JavaType removePeerResponseType =
         objectMapper.getTypeFactory().constructParametricType(Response.class, Boolean.class);
     final Response<Boolean> removePeerResponse =

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/ExternalMetricNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/ExternalMetricNode.java
@@ -71,7 +71,7 @@ public class ExternalMetricNode extends Node {
   private List<Map<String, Object>> getPublishedObjects() throws URISyntaxException, IOException {
     String response = getResponse();
     LOG.debug("Metric data was published " + response);
-    final ObjectMapper mapper = jsonProvider.getObjectMapper();
+    final ObjectMapper mapper = JSON_PROVIDER.getObjectMapper();
     JsonNode node = mapper.readTree(response);
     final List<Map<String, Object>> result = new ArrayList<>();
     assertThat(node.isArray()).isTrue();

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/Node.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/Node.java
@@ -140,18 +140,18 @@ public abstract class Node {
     waitFor(() -> assertThat(getFilteredOutput(filter)).isNotEmpty(), 2, TimeUnit.MINUTES);
   }
 
-  public void waitForMetricWithValue(final String metricName, final double value) {
+  protected void waitForMetricWithValue(final String metricName, final double value) {
     waitForMetric(withNameEqualsTo(metricName), withAnyLabels(), withValueEqualTo(value));
   }
 
-  public void waitForMetric(
+  protected void waitForMetric(
       final MetricNameCondition nameCondition,
       final MetricLabelsCondition labelsCondition,
       final MetricValuesCondition valueCondition) {
     waitForMetric(nameCondition, labelsCondition, valueCondition, 5, TimeUnit.MINUTES);
   }
 
-  public void waitForMetric(
+  protected void waitForMetric(
       final MetricNameCondition nameCondition,
       final MetricLabelsCondition labelsCondition,
       final MetricValuesCondition valueCondition,

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/Node.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/Node.java
@@ -165,6 +165,7 @@ public abstract class Node {
           assertThat(
                   MetricMatcher.anyMatching(
                       metrics, nameCondition, labelsCondition, valueCondition))
+              .withFailMessage("No matching metric")
               .isPresent();
         },
         timeoutAmount,

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/Node.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/Node.java
@@ -55,15 +55,15 @@ public abstract class Node {
 
   private static final Logger LOG = LogManager.getLogger();
   public static final String TEKU_DOCKER_IMAGE_NAME = "consensys/teku";
+  protected static final JsonProvider JSON_PROVIDER = new JsonProvider();
   protected final SimpleHttpClient httpClient = new SimpleHttpClient();
-  protected final JsonProvider jsonProvider = new JsonProvider();
-
   protected static final int REST_API_PORT = 9051;
   protected static final int METRICS_PORT = 8008;
   protected static final String CONFIG_FILE_PATH = "/config.yaml";
   protected static final String NETWORK_FILE_PATH = "/network.yaml";
   protected static final String PRIVATE_KEY_FILE_PATH = "/private-key.txt";
   protected static final String JWT_SECRET_FILE_PATH = "/jwt-secret.hex";
+  protected static final String SENTRY_NODE_CONFIG_FILE_PATH = "/sentry-node-config.json";
   protected static final String WORKING_DIRECTORY = "/opt/teku/";
   protected static final String DATA_PATH = WORKING_DIRECTORY + "data/";
   protected static final int P2P_PORT = 9000;

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/SentryNodesConfig.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/SentryNodesConfig.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.test.acceptance.dsl;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import tech.pegasys.teku.provider.JsonProvider;
+
+public class SentryNodesConfig {
+
+  private final List<String> dutiesProviderNodes;
+  private final List<String> blockHandlerNodes;
+  private final List<String> attestationPublisherNodes;
+
+  private SentryNodesConfig(
+      final List<String> dutiesProviderNodes,
+      final List<String> blockHandlerNodes,
+      final List<String> attestationPublisherNodes) {
+    this.dutiesProviderNodes = dutiesProviderNodes;
+    this.blockHandlerNodes = blockHandlerNodes;
+    this.attestationPublisherNodes = attestationPublisherNodes;
+  }
+
+  public String toJson(final JsonProvider jsonProvider) throws JsonProcessingException {
+    final HashMap<String, Object> config = new HashMap<>();
+
+    final Map<String, Object> beaconNodes = new HashMap<>();
+    if (dutiesProviderNodes != null && !dutiesProviderNodes.isEmpty()) {
+      beaconNodes.put("duties_provider", Map.of("endpoints", dutiesProviderNodes));
+    }
+
+    if (blockHandlerNodes != null && !blockHandlerNodes.isEmpty()) {
+      beaconNodes.put("block_handler", Map.of("endpoints", blockHandlerNodes));
+    }
+
+    if (attestationPublisherNodes != null && !attestationPublisherNodes.isEmpty()) {
+      beaconNodes.put("attestation_publisher", Map.of("endpoints", attestationPublisherNodes));
+    }
+
+    config.put("beacon_nodes", beaconNodes);
+
+    return jsonProvider.objectToJSON(config);
+  }
+
+  public static class Builder {
+
+    private List<String> dutiesProviderNodes = new ArrayList<>();
+    private List<String> blockHandlerNodes = new ArrayList<>();
+    private List<String> attestationPublisherNodes = new ArrayList<>();
+
+    public Builder withDutiesProviders(TekuNode... nodes) {
+      dutiesProviderNodes =
+          Arrays.stream(nodes).map(TekuNode::getBeaconRestApiUrl).collect(Collectors.toList());
+      return this;
+    }
+
+    public Builder withBlockHandlers(TekuNode... nodes) {
+      blockHandlerNodes =
+          Arrays.stream(nodes).map(TekuNode::getBeaconRestApiUrl).collect(Collectors.toList());
+      return this;
+    }
+
+    public Builder withAttestationPublisher(TekuNode... nodes) {
+      attestationPublisherNodes =
+          Arrays.stream(nodes).map(TekuNode::getBeaconRestApiUrl).collect(Collectors.toList());
+      return this;
+    }
+
+    public SentryNodesConfig build() {
+      return new SentryNodesConfig(
+          dutiesProviderNodes, blockHandlerNodes, attestationPublisherNodes);
+    }
+  }
+}

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNode.java
@@ -184,7 +184,7 @@ public class TekuNode extends Node {
       final Eth2EventHandler.PackedMessage packedMessage) {
     try {
       return Optional.of(
-          jsonProvider.jsonToObject(
+          JSON_PROVIDER.jsonToObject(
               packedMessage.getMessageEvent().getData(), SignedContributionAndProof.class));
     } catch (JsonProcessingException e) {
       return Optional.empty();
@@ -221,7 +221,7 @@ public class TekuNode extends Node {
       final Eth2EventHandler.PackedMessage packedMessage) {
     try {
       return Optional.of(
-          jsonProvider.jsonToObject(packedMessage.getMessageEvent().getData(), HeadEvent.class)
+          JSON_PROVIDER.jsonToObject(packedMessage.getMessageEvent().getData(), HeadEvent.class)
               .slot);
     } catch (JsonProcessingException e) {
       LOG.error("Failed to process head event", e);
@@ -249,9 +249,9 @@ public class TekuNode extends Node {
     final ValidatorLivenessRequest request = new ValidatorLivenessRequest(epoch, validators);
     final String response =
         httpClient.post(
-            getRestApiUrl(), "/eth/v1/validator/liveness", jsonProvider.objectToJSON(request));
+            getRestApiUrl(), "/eth/v1/validator/liveness", JSON_PROVIDER.objectToJSON(request));
     final PostValidatorLivenessResponse livenessResponse =
-        jsonProvider.jsonToObject(response, PostValidatorLivenessResponse.class);
+        JSON_PROVIDER.jsonToObject(response, PostValidatorLivenessResponse.class);
     final Object2BooleanMap<UInt64> output = new Object2BooleanOpenHashMap<UInt64>();
     for (ValidatorLivenessAtEpoch entry : livenessResponse.data) {
       output.put(entry.index, entry.isLive);
@@ -275,7 +275,7 @@ public class TekuNode extends Node {
   private UInt64 fetchGenesisTime() throws IOException {
     String genesisTime = httpClient.get(getRestApiUrl(), "/eth/v1/beacon/genesis");
     final GetGenesisResponse response =
-        jsonProvider.jsonToObject(genesisTime, GetGenesisResponse.class);
+        JSON_PROVIDER.jsonToObject(genesisTime, GetGenesisResponse.class);
     return response.data.genesisTime;
   }
 
@@ -403,7 +403,7 @@ public class TekuNode extends Node {
     }
 
     final GetBlockRootResponse response =
-        jsonProvider.jsonToObject(result, GetBlockRootResponse.class);
+        JSON_PROVIDER.jsonToObject(result, GetBlockRootResponse.class);
 
     return Optional.of(Pair.of(response.data.root, response.execution_optimistic));
   }
@@ -433,7 +433,7 @@ public class TekuNode extends Node {
       return Optional.empty();
     }
     final GetStateFinalityCheckpointsResponse response =
-        jsonProvider.jsonToObject(result, GetStateFinalityCheckpointsResponse.class);
+        JSON_PROVIDER.jsonToObject(result, GetStateFinalityCheckpointsResponse.class);
     return Optional.of(response.data);
   }
 
@@ -442,7 +442,7 @@ public class TekuNode extends Node {
     if (result.isEmpty()) {
       return Optional.empty();
     } else {
-      return Optional.of(jsonProvider.jsonToObject(result, GetBlockResponseV2.class).data);
+      return Optional.of(JSON_PROVIDER.jsonToObject(result, GetBlockResponseV2.class).data);
     }
   }
 

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuValidatorNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuValidatorNode.java
@@ -58,8 +58,9 @@ public class TekuValidatorNode extends Node {
     super(network, TEKU_DOCKER_IMAGE_NAME, version, LOG);
     this.config = config;
     if (config.configMap.containsKey("validator-api-enabled")) {
-      container.withExposedPorts(VALIDATOR_API_PORT);
+      container.addExposedPort(VALIDATOR_API_PORT);
     }
+    container.addExposedPort(METRICS_PORT);
 
     container
         .withWorkingDirectory(WORKING_DIRECTORY)
@@ -159,6 +160,10 @@ public class TekuValidatorNode extends Node {
       configMap.put("data-path", DATA_PATH);
       configMap.put("log-destination", "console");
       configMap.put("beacon-node-api-endpoint", "http://notvalid.restapi.com");
+      configMap.put("metrics-enabled", true);
+      configMap.put("metrics-port", METRICS_PORT);
+      configMap.put("metrics-interface", "0.0.0.0");
+      configMap.put("metrics-host-allowlist", "*");
     }
 
     public TekuValidatorNode.Config withInteropModeDisabled() {

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuValidatorNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuValidatorNode.java
@@ -14,6 +14,9 @@
 package tech.pegasys.teku.test.acceptance.dsl;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.test.acceptance.dsl.metrics.MetricConditions.withLabelsContaining;
+import static tech.pegasys.teku.test.acceptance.dsl.metrics.MetricConditions.withNameEqualsTo;
+import static tech.pegasys.teku.test.acceptance.dsl.metrics.MetricConditions.withValueGreaterThan;
 
 import com.google.common.io.Resources;
 import java.io.File;
@@ -42,6 +45,7 @@ import tech.pegasys.teku.test.acceptance.dsl.tools.ValidatorKeysApi;
 import tech.pegasys.teku.test.acceptance.dsl.tools.deposits.ValidatorKeystores;
 
 public class TekuValidatorNode extends Node {
+
   private static final Logger LOG = LogManager.getLogger();
   private static final int VALIDATOR_API_PORT = 9052;
   protected static final String VALIDATOR_PATH = DATA_PATH + "validator/";
@@ -141,7 +145,41 @@ public class TekuValidatorNode extends Node {
         in -> IOUtils.toString(in, StandardCharsets.UTF_8));
   }
 
+  public void waitForDutiesRequestedFrom(final TekuNode node) {
+    waitForMetric(
+        withNameEqualsTo("validator_remote_beacon_nodes_requests_total"),
+        withLabelsContaining(
+            Map.of(
+                "endpoint", node.getBeaconRestApiUrl() + "/",
+                "method", "get_proposer_duties",
+                "outcome", "success")),
+        withValueGreaterThan(0));
+  }
+
+  public void waitForAttestationPublishedTo(final TekuNode node) {
+    waitForMetric(
+        withNameEqualsTo("validator_remote_beacon_nodes_requests_total"),
+        withLabelsContaining(
+            Map.of(
+                "endpoint", node.getBeaconRestApiUrl() + "/",
+                "method", "publish_attestation",
+                "outcome", "success")),
+        withValueGreaterThan(0));
+  }
+
+  public void waitForBlockPublishedTo(final TekuNode node) {
+    waitForMetric(
+        withNameEqualsTo("validator_remote_beacon_nodes_requests_total"),
+        withLabelsContaining(
+            Map.of(
+                "endpoint", node.getBeaconRestApiUrl() + "/",
+                "method", "publish_block",
+                "outcome", "success")),
+        withValueGreaterThan(0));
+  }
+
   public static class Config {
+
     private static final int DEFAULT_VALIDATOR_COUNT = 64;
 
     private Map<String, Object> configMap = new HashMap<>();


### PR DESCRIPTION
## PR Description

Running a remote validator using 3 beacon nodes, one per role. Verifies that each beacon node is being used for their designated purpose.

## Fixed Issue(s)
Related to #5929 