### PR TITLE
Add default proposer config builder unit test

### DIFF
--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorRegistratorTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorRegistratorTest.java
@@ -163,6 +163,26 @@ class ValidatorRegistratorTest {
   }
 
   @TestTemplate
+  void registersValidators_shouldRegisterIfDefaultBuilderIsEnabledAndNoSpecificBuilderConfig() {
+    when(proposerConfig.isBuilderEnabledForPubKey(validator1.getPublicKey()))
+        .thenReturn(Optional.empty());
+    when(validatorConfig.isBuilderRegistrationDefaultEnabled()).thenReturn(true);
+
+    setActiveValidators(validator1);
+
+    runRegistrationFlowForSlot(TWO);
+    runRegistrationFlowForSlot(UInt64.valueOf(slotsPerEpoch).plus(TWO));
+
+    final List<List<SignedValidatorRegistration>> registrationCalls = captureRegistrationCalls(2);
+
+    registrationCalls.forEach(
+        registrationCall ->
+            verifyRegistrations(registrationCall, List.of(validator1), Optional.empty()));
+
+    verify(signer, times(1)).signValidatorRegistration(any());
+  }
+
+  @TestTemplate
   void registersValidators_shouldRegisterWithTimestampOverride() {
     final UInt64 timestampOverride = dataStructureUtil.randomUInt64();
 


### PR DESCRIPTION
Added a test to ensure that when proposerConfig default config has `builder` set to `true` and the validator has no `builder` config set, the default builder enabled is used.

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
