### PR TITLE
Fix issue which could cause locally produced aggregates to not be gossiped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,3 +27,4 @@ For information on changes in released versions of Teku, see the [releases page]
 
 ### Bug Fixes
 - Filter out unknown validators when sending validator registrations to the builder network
+- Fix issue which could cause locally produced aggregates to not be gossiped

--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/AttestationGossipAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/AttestationGossipAcceptanceTest.java
@@ -40,5 +40,9 @@ public class AttestationGossipAcceptanceTest extends AcceptanceTestBase {
     node2.start();
 
     node2.waitForAttestationBeingGossiped(32, 64);
+
+    // Check aggregate gossip is also being received by both nodes.
+    node1.waitForAggregateGossipReceived();
+    node2.waitForAggregateGossipReceived();
   }
 }

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNode.java
@@ -19,6 +19,9 @@ import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static tech.pegasys.teku.test.acceptance.dsl.metrics.MetricConditions.withLabelValueSubstring;
+import static tech.pegasys.teku.test.acceptance.dsl.metrics.MetricConditions.withNameEqualsTo;
+import static tech.pegasys.teku.test.acceptance.dsl.metrics.MetricConditions.withValueGreaterThan;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.libp2p.core.PeerId;
@@ -599,6 +602,13 @@ public class TekuNode extends Node {
       // Can't capture artifacts if it's not running but then it probably didn't cause the failure
       LOG.debug("Not capturing artifacts from {} because it is not running", nodeAlias);
     }
+  }
+
+  public void waitForAggregateGossipReceived() {
+    waitForMetric(
+        withNameEqualsTo("libp2p_gossip_messages_total"),
+        withLabelValueSubstring("topic", "beacon_aggregate_and_proof"),
+        withValueGreaterThan(0));
   }
 
   public static class Config {

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/metrics/MetricConditions.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/metrics/MetricConditions.java
@@ -59,6 +59,14 @@ public class MetricConditions {
                         && actualLabels.get(entry.getKey()).equals(entry.getValue()));
   }
 
+  public static MetricLabelsCondition withLabelValueSubstring(
+      final String labelName, final String labelValueSubstring) {
+    return actualLabels -> {
+      final String actual = actualLabels.get(labelName);
+      return actual != null && actual.contains(labelValueSubstring);
+    };
+  }
+
   public static MetricValuesCondition withValueEqualTo(double value) {
     return (actualValue) -> DoubleMath.fuzzyEquals(actualValue, value, DOUBLE_COMPARE_TOLERANCE);
   }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AttestationManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AttestationManager.java
@@ -115,7 +115,7 @@ public class AttestationManager extends Service
   }
 
   private void validateForGossipAndNotifySendSubscribers(ValidateableAttestation attestation) {
-    if (attestation.isAggregate()) {
+    if (attestation.isAggregate() && !attestation.isAcceptedAsGossip()) {
       // We know the Attestation is valid, but need to validate the SignedAggregateAndProof wrapper
       aggregateValidator
           .validate(attestation)


### PR DESCRIPTION
## PR Description
Ensures that locally produced aggregates aren't validated twice and ignored as duplicates.

Update AT to specifically check aggregate gossip counts, not just individual attestations in the full configuration.


## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
