### PR TITLE
Prefer nodes in sync when making failover requests which are not sent to all nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ For information on changes in released versions of Teku, see the [releases page]
 
 ### Additions and Improvements
 - Improve Execution Layer error logging
+- Add new validator client metric `validator_remote_beacon_nodes_requests_total` which tracks the requests made to remote beacon nodes (useful when there are failovers configured)
 - The `voluntary-exit` subcommand can restrict the exit to a specific list of validators public keys using the option `--validator-public-keys`.
   Example: `teku voluntary-exit --beacon-node-api-endpoint=<ENDPOINT>[,<ENDPOINT>...]... --data-validator-path=<PATH> --include-keymanager-keys=<BOOLEAN> --validator-keys=<KEY_DIR>:<PASS_DIR> | <KEY_FILE>:<PASS_FILE> --validator-public-keys=<PUBKEY>[,<PUBKEY>...]...`
   To include validator keys managed via keymanager APIs, the option `--include-keymanager-keys` could be set to `true` (The default value is set to `false`)

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/ValidatorLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/ValidatorLogger.java
@@ -98,7 +98,7 @@ public class ValidatorLogger {
     log.info(
         ColorConsolePrinter.print(
             String.format(
-                "%sThe%s beacon node is back and ready to accept requests now",
+                "%sThe%s beacon node is back in sync and ready to accept requests now",
                 PREFIX, failoversConfigured ? " primary" : ""),
             Color.GREEN));
   }

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessManager.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessManager.java
@@ -14,6 +14,8 @@
 package tech.pegasys.teku.validator.remote;
 
 import com.google.common.collect.Maps;
+import java.util.Comparator;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -54,6 +56,12 @@ public class BeaconNodeReadinessManager implements ValidatorTimingChannel {
 
   public boolean isReady(final RemoteValidatorApiChannel beaconNodeApi) {
     return readinessStatusCache.getOrDefault(beaconNodeApi, true);
+  }
+
+  public Iterator<RemoteValidatorApiChannel> getFailoversInOrderOfReadiness() {
+    return failoverBeaconNodeApis.stream()
+        .sorted(Comparator.comparing(this::isReady).reversed())
+        .iterator();
   }
 
   @Override

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverRequestException.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverRequestException.java
@@ -15,23 +15,22 @@ package tech.pegasys.teku.validator.remote;
 
 import java.util.Map;
 import java.util.stream.Collectors;
-import okhttp3.HttpUrl;
 
 public class FailoverRequestException extends RuntimeException {
 
   public FailoverRequestException(
-      final String method, final Map<HttpUrl, Throwable> capturedExceptions) {
+      final String method, final Map<RemoteValidatorApiChannel, Throwable> capturedExceptions) {
     super(createErrorMessage(method, capturedExceptions));
   }
 
   private static String createErrorMessage(
-      final String method, final Map<HttpUrl, Throwable> capturedExceptions) {
+      final String method, final Map<RemoteValidatorApiChannel, Throwable> capturedExceptions) {
     final String prefix =
         String.format(
             "Remote request (%s) failed on all configured Beacon Node endpoints%n", method);
     final String errorSummary =
         capturedExceptions.entrySet().stream()
-            .map(entry -> entry.getKey() + ": " + entry.getValue())
+            .map(entry -> entry.getKey().getEndpoint() + ": " + entry.getValue())
             .collect(Collectors.joining(System.lineSeparator()));
     return prefix + errorSummary;
   }

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandler.java
@@ -24,7 +24,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
-import okhttp3.HttpUrl;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
@@ -262,7 +261,9 @@ public class FailoverValidatorApiHandler implements ValidatorApiChannel {
 
   /**
    * Relays the given request to the primary Beacon Node along with all failover Beacon Node
-   * endpoints if relayRequestToFailovers flag is true. The returned {@link SafeFuture} will
+   * endpoints if relayRequestToFailovers flag is true. If there are failovers configured, the
+   * request to the primary Beacon Node will fail immediately if the {@link
+   * BeaconNodeReadinessManager} marked it as not ready.The returned {@link SafeFuture} will
    * complete with the response from the primary Beacon Node or in case in failure, it will complete
    * with the first successful response from a failover node. The returned {@link SafeFuture} will
    * only complete exceptionally when the request to the primary Beacon Node and all the requests to
@@ -277,23 +278,21 @@ public class FailoverValidatorApiHandler implements ValidatorApiChannel {
       return runPrimaryRequestWithNoFailovers(request, method);
     }
     final SafeFuture<T> primaryResponse = runPrimaryRequestWithConfiguredFailovers(request, method);
-    final Map<HttpUrl, Throwable> capturedExceptions = new ConcurrentHashMap<>();
+    final Map<RemoteValidatorApiChannel, Throwable> capturedExceptions = new ConcurrentHashMap<>();
     final List<SafeFuture<T>> failoversResponses =
         failoverDelegates.stream()
             .map(
                 failover ->
                     runFailoverRequest(failover, request, method)
-                        .catchAndRethrow(
-                            throwable -> capturedExceptions.put(failover.getEndpoint(), throwable)))
+                        .catchAndRethrow(throwable -> capturedExceptions.put(failover, throwable)))
             .collect(Collectors.toList());
     return primaryResponse.exceptionallyCompose(
         primaryThrowable -> {
-          final HttpUrl primaryEndpoint = primaryDelegate.getEndpoint();
-          capturedExceptions.put(primaryEndpoint, primaryThrowable);
+          capturedExceptions.put(primaryDelegate, primaryThrowable);
           LOG.debug(
               "Remote request ({}) which is sent to all configured Beacon Node endpoints failed on the primary Beacon Node {}. Will try to use a response from a failover.",
               method,
-              primaryEndpoint);
+              primaryDelegate.getEndpoint());
           return SafeFuture.firstSuccess(failoversResponses)
               .exceptionallyCompose(
                   __ -> {
@@ -305,8 +304,11 @@ public class FailoverValidatorApiHandler implements ValidatorApiChannel {
   }
 
   /**
-   * Tries the given request first with the primary Beacon Node. If it fails, it will retry the
-   * request against each failover Beacon Node in order until there is a successful response. In
+   * Tries the given request first with the primary Beacon Node. If there are failovers configured,
+   * the request to the primary Beacon Node will fail immediately if the {@link
+   * BeaconNodeReadinessManager} marked it as not ready. If the request to the primary Beacon Node
+   * fails, the request will be retried against each failover Beacon Node in order of readiness
+   * determined by the {@link BeaconNodeReadinessManager} until there is a successful response. In
    * case all the requests fail, the returned {@link SafeFuture} will complete exceptionally with a
    * {@link FailoverRequestException}.
    */
@@ -315,37 +317,41 @@ public class FailoverValidatorApiHandler implements ValidatorApiChannel {
     if (failoverDelegates.isEmpty()) {
       return runPrimaryRequestWithNoFailovers(request, method);
     }
-    return makeFailoverRequest(
-        primaryDelegate, failoverDelegates.iterator(), request, method, new HashMap<>());
+    return runPrimaryRequestWithConfiguredFailovers(request, method)
+        .exceptionallyCompose(
+            throwable -> {
+              final Map<RemoteValidatorApiChannel, Throwable> capturedExceptions = new HashMap<>();
+              capturedExceptions.put(primaryDelegate, throwable);
+              final Iterator<RemoteValidatorApiChannel> failoverDelegates =
+                  beaconNodeReadinessManager.getFailoversInOrderOfReadiness();
+              return makeFailoverRequestUntilSuccess(
+                  failoverDelegates.next(), failoverDelegates, request, method, capturedExceptions);
+            });
   }
 
-  private <T> SafeFuture<T> makeFailoverRequest(
-      final RemoteValidatorApiChannel currentDelegate,
+  private <T> SafeFuture<T> makeFailoverRequestUntilSuccess(
+      final RemoteValidatorApiChannel currentFailoverDelegate,
       final Iterator<RemoteValidatorApiChannel> failoverDelegates,
       final ValidatorApiChannelRequest<T> request,
       final String method,
-      final Map<HttpUrl, Throwable> capturedExceptions) {
-    final SafeFuture<T> response =
-        currentDelegate.equals(primaryDelegate)
-            ? runPrimaryRequestWithConfiguredFailovers(request, method)
-            : runFailoverRequest(currentDelegate, request, method);
+      final Map<RemoteValidatorApiChannel, Throwable> capturedExceptions) {
+    final SafeFuture<T> response = runFailoverRequest(currentFailoverDelegate, request, method);
     return response.exceptionallyCompose(
         throwable -> {
-          final HttpUrl failedEndpoint = currentDelegate.getEndpoint();
-          capturedExceptions.put(failedEndpoint, throwable);
+          capturedExceptions.put(currentFailoverDelegate, throwable);
           if (!failoverDelegates.hasNext()) {
             final FailoverRequestException failoverRequestException =
                 new FailoverRequestException(method, capturedExceptions);
             return SafeFuture.failedFuture(failoverRequestException);
           }
-          final RemoteValidatorApiChannel nextDelegate = failoverDelegates.next();
+          final RemoteValidatorApiChannel nextFailoverDelegate = failoverDelegates.next();
           LOG.debug(
-              "Remote request ({}) to Beacon Node {} failed. Will try sending request to failover {}",
+              "Remote request ({}) to a failover Beacon Node {} failed. Will try sending request to another failover {}",
               method,
-              failedEndpoint,
-              nextDelegate.getEndpoint());
-          return makeFailoverRequest(
-              nextDelegate, failoverDelegates, request, method, capturedExceptions);
+              currentFailoverDelegate.getEndpoint(),
+              nextFailoverDelegate.getEndpoint());
+          return makeFailoverRequestUntilSuccess(
+              nextFailoverDelegate, failoverDelegates, request, method, capturedExceptions);
         });
   }
 
@@ -360,10 +366,10 @@ public class FailoverValidatorApiHandler implements ValidatorApiChannel {
   }
 
   private <T> SafeFuture<T> runFailoverRequest(
-      final RemoteValidatorApiChannel delegate,
+      final RemoteValidatorApiChannel failoverDelegate,
       final ValidatorApiChannelRequest<T> request,
       final String method) {
-    return runRequest(delegate, request, false, method);
+    return runRequest(failoverDelegate, request, false, method);
   }
 
   private <T> SafeFuture<T> runRequest(
@@ -378,7 +384,8 @@ public class FailoverValidatorApiHandler implements ValidatorApiChannel {
       final RemoteServiceNotAvailableException exception =
           new RemoteServiceNotAvailableException(
               String.format(
-                  "Beacon node %s was not ready to accept requests", delegate.getEndpoint()));
+                  "Beacon node %s was marked as not ready to accept requests",
+                  delegate.getEndpoint()));
       futureResponse = SafeFuture.failedFuture(exception);
     }
     return futureResponse.handleComposed(

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandlerTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandlerTest.java
@@ -101,7 +101,12 @@ class FailoverValidatorApiHandlerTest {
     final Supplier<HttpUrl> randomHttpUrlGenerator =
         () -> HttpUrl.get("http://" + DATA_STRUCTURE_UTIL.randomBytes4().toHexString() + ".com");
 
+    final List<RemoteValidatorApiChannel> failoverDelegates =
+        List.of(failoverApiChannel1, failoverApiChannel2);
+
     when(beaconNodeReadinessManager.isReady(any())).thenReturn(true);
+    when(beaconNodeReadinessManager.getFailoversInOrderOfReadiness())
+        .thenReturn(failoverDelegates.iterator());
 
     when(primaryApiChannel.getEndpoint()).thenReturn(randomHttpUrlGenerator.get());
     when(failoverApiChannel1.getEndpoint()).thenReturn(randomHttpUrlGenerator.get());
@@ -111,7 +116,7 @@ class FailoverValidatorApiHandlerTest {
         new FailoverValidatorApiHandler(
             beaconNodeReadinessManager,
             primaryApiChannel,
-            List.of(failoverApiChannel1, failoverApiChannel2),
+            failoverDelegates,
             true,
             stubMetricsSystem);
   }


### PR DESCRIPTION
## PR Description
For VC requests which are not relayed to all the nodes, if the primary Beacon Node is not in sync or the request fails then:
**Before**
The same request will be tried by each failover in order of configuration regardless of their syncing status.
**Now**
The request will be tried by each failover but they will be ordered by their readiness status.

## Fixed Issue(s)
improvement related to #6174 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
