### PR TITLE
Improve logging in case of execution client or builder errors

### DIFF
--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/BuilderBidValidationException.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/BuilderBidValidationException.java
@@ -14,11 +14,11 @@
 package tech.pegasys.teku.ethereum.executionlayer;
 
 public class BuilderBidValidationException extends Exception {
-  public BuilderBidValidationException(String message) {
+  public BuilderBidValidationException(final String message) {
     super(message);
   }
 
-  public BuilderBidValidationException(String message, Throwable cause) {
+  public BuilderBidValidationException(final String message, final Throwable cause) {
     super(message, cause);
   }
 }

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
@@ -511,7 +511,7 @@ public class ExecutionLayerManagerImpl implements ExecutionLayerManager {
   private static <K> K unwrapResponseOrThrow(
       final RemoteService remoteService, final Response<K> response) {
     if (response.isFailure()) {
-      String errorMessage =
+      final String errorMessage =
           String.format(
               "Invalid remote response from the %s: %s",
               remoteService.displayName, response.getErrorMessage());

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
@@ -228,7 +228,7 @@ public class ExecutionLayerManagerImpl implements ExecutionLayerManager {
         .forkChoiceUpdated(
             ForkChoiceStateV1.fromInternalForkChoiceState(forkChoiceState),
             PayloadAttributesV1.fromInternalPayloadBuildingAttributes(payloadBuildingAttributes))
-        .thenApply(ExecutionLayerManagerImpl::unwrapResponseOrThrow)
+        .thenApply(ExecutionLayerManagerImpl::unwrapExecutionClientResponseOrThrow)
         .thenApply(ForkChoiceUpdatedResult::asInternalExecutionPayload)
         .thenPeek(
             forkChoiceUpdatedResult ->
@@ -263,7 +263,7 @@ public class ExecutionLayerManagerImpl implements ExecutionLayerManager {
 
     return executionEngineClient
         .getPayload(executionPayloadContext.getPayloadId())
-        .thenApply(ExecutionLayerManagerImpl::unwrapResponseOrThrow)
+        .thenApply(ExecutionLayerManagerImpl::unwrapExecutionClientResponseOrThrow)
         .thenCombine(
             SafeFuture.of(
                 () ->
@@ -285,7 +285,7 @@ public class ExecutionLayerManagerImpl implements ExecutionLayerManager {
 
     return executionEngineClient
         .newPayload(ExecutionPayloadV1.fromInternalExecutionPayload(executionPayload))
-        .thenApply(ExecutionLayerManagerImpl::unwrapResponseOrThrow)
+        .thenApply(ExecutionLayerManagerImpl::unwrapExecutionClientResponseOrThrow)
         .thenApply(PayloadStatusV1::asInternalExecutionPayload)
         .thenPeek(
             payloadStatus ->
@@ -304,7 +304,7 @@ public class ExecutionLayerManagerImpl implements ExecutionLayerManager {
     return executionEngineClient
         .exchangeTransitionConfiguration(
             TransitionConfigurationV1.fromInternalTransitionConfiguration(transitionConfiguration))
-        .thenApply(ExecutionLayerManagerImpl::unwrapResponseOrThrow)
+        .thenApply(ExecutionLayerManagerImpl::unwrapExecutionClientResponseOrThrow)
         .thenApply(TransitionConfigurationV1::asInternalTransitionConfiguration)
         .thenPeek(
             remoteTransitionConfiguration ->
@@ -330,7 +330,7 @@ public class ExecutionLayerManagerImpl implements ExecutionLayerManager {
     return builderClient
         .orElseThrow()
         .registerValidators(slot, signedValidatorRegistrations)
-        .thenApply(ExecutionLayerManagerImpl::unwrapResponseOrThrow)
+        .thenApply(ExecutionLayerManagerImpl::unwrapBuilderResponseOrThrow)
         .thenPeek(
             __ ->
                 LOG.trace(
@@ -383,7 +383,7 @@ public class ExecutionLayerManagerImpl implements ExecutionLayerManager {
     return builderClient
         .orElseThrow()
         .getHeader(slot, validatorPublicKey, executionPayloadContext.getParentHash())
-        .thenApply(ExecutionLayerManagerImpl::unwrapResponseOrThrow)
+        .thenApply(ExecutionLayerManagerImpl::unwrapBuilderResponseOrThrow)
         .thenPeek(
             signedBuilderBidMaybe ->
                 LOG.trace(
@@ -474,7 +474,7 @@ public class ExecutionLayerManagerImpl implements ExecutionLayerManager {
                 new RuntimeException(
                     "Unable to get payload from builder: builder endpoint not available"))
         .getPayload(signedBlindedBeaconBlock)
-        .thenApply(ExecutionLayerManagerImpl::unwrapResponseOrThrow)
+        .thenApply(ExecutionLayerManagerImpl::unwrapBuilderResponseOrThrow)
         .thenPeek(
             executionPayload -> {
               logReceivedBuilderExecutionPayload(executionPayload);
@@ -500,8 +500,23 @@ public class ExecutionLayerManagerImpl implements ExecutionLayerManager {
     return latestBuilderAvailability.get();
   }
 
-  private static <K> K unwrapResponseOrThrow(final Response<K> response) {
-    checkArgument(response.isSuccess(), "Invalid remote response: %s", response.getErrorMessage());
+  private static <K> K unwrapExecutionClientResponseOrThrow(final Response<K> response) {
+    return unwrapResponseOrThrow(RemoteService.EXECUTION_CLIENT, response);
+  }
+
+  private static <K> K unwrapBuilderResponseOrThrow(final Response<K> response) {
+    return unwrapResponseOrThrow(RemoteService.BUILDER, response);
+  }
+
+  private static <K> K unwrapResponseOrThrow(
+      final RemoteService remoteService, final Response<K> response) {
+    if (response.isFailure()) {
+      String errorMessage =
+          String.format(
+              "Invalid remote response from the %s: %s",
+              remoteService.displayName, response.getErrorMessage());
+      throw new InvalidRemoteResponseException(errorMessage);
+    }
     return response.getPayload();
   }
 
@@ -589,6 +604,17 @@ public class ExecutionLayerManagerImpl implements ExecutionLayerManager {
     public FallbackData(final ExecutionPayload executionPayload, final FallbackReason reason) {
       this.executionPayload = executionPayload;
       this.reason = reason;
+    }
+  }
+
+  private enum RemoteService {
+    EXECUTION_CLIENT("execution client"),
+    BUILDER("builder");
+
+    private final String displayName;
+
+    RemoteService(final String displayName) {
+      this.displayName = displayName;
     }
   }
 

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/InvalidRemoteResponseException.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/InvalidRemoteResponseException.java
@@ -1,0 +1,8 @@
+package tech.pegasys.teku.ethereum.executionlayer;
+
+public class InvalidRemoteResponseException extends RuntimeException {
+
+  public InvalidRemoteResponseException(final String message) {
+    super(message);
+  }
+}

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/InvalidRemoteResponseException.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/InvalidRemoteResponseException.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package tech.pegasys.teku.ethereum.executionlayer;
 
 public class InvalidRemoteResponseException extends RuntimeException {


### PR DESCRIPTION
## PR Description

- Create `InvalidRemoteServiceException` (seems better than `IllegalArgumentException`)
- Specify whether execution client or builder error (both use the same unwrap method)

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
