### PR TITLE
Add assertRoundTrip helper for deduplication

### DIFF
--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/BeaconBlockBodyPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/BeaconBlockBodyPropertyTest.java
@@ -13,34 +13,18 @@
 
 package tech.pegasys.teku.spec.datastructures.blocks;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import org.apache.tuweni.bytes.Bytes;
-import tech.pegasys.teku.infrastructure.json.JsonUtil;
-import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
-import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodySchema;
 
 public class BeaconBlockBodyPropertyTest {
   @Property
-  @SuppressWarnings("unchecked")
-  void roundTrip(@ForAll(supplier = BeaconBlockBodySupplier.class) final BeaconBlockBody body)
+  void roundTrip(
+      @ForAll(supplier = BeaconBlockBodySupplier.class) final BeaconBlockBody beaconBlockBody)
       throws JsonProcessingException {
-    final BeaconBlockBodySchema<?> schema = body.getSchema();
-    final DeserializableTypeDefinition<BeaconBlockBody> typeDefinition =
-        (DeserializableTypeDefinition<BeaconBlockBody>) schema.getJsonTypeDefinition();
-
-    // Round-trip SSZ serialization.
-    final Bytes ssz = body.sszSerialize();
-    final BeaconBlockBody fromSsz = schema.sszDeserialize(ssz);
-    assertThat(fromSsz).isEqualTo(body);
-
-    // Round-trip JSON serialization.
-    final String json = JsonUtil.serialize(body, typeDefinition);
-    final BeaconBlockBody fromJson = JsonUtil.parse(json, typeDefinition);
-    assertThat(fromJson).isEqualTo(body);
+    assertRoundTrip(beaconBlockBody);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/BeaconBlockHeaderPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/BeaconBlockHeaderPropertyTest.java
@@ -13,31 +13,17 @@
 
 package tech.pegasys.teku.spec.datastructures.blocks;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import org.apache.tuweni.bytes.Bytes;
-import tech.pegasys.teku.infrastructure.json.JsonUtil;
-import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 
 public class BeaconBlockHeaderPropertyTest {
   @Property
-  void roundTrip(@ForAll(supplier = BeaconBlockHeaderSupplier.class) final BeaconBlockHeader header)
+  void roundTrip(
+      @ForAll(supplier = BeaconBlockHeaderSupplier.class) final BeaconBlockHeader beaconBlockHeader)
       throws JsonProcessingException {
-    final BeaconBlockHeader.BeaconBlockHeaderSchema schema = header.getSchema();
-    final DeserializableTypeDefinition<BeaconBlockHeader> typeDefinition =
-        schema.getJsonTypeDefinition();
-
-    // Round-trip SSZ serialization.
-    final Bytes ssz = header.sszSerialize();
-    final BeaconBlockHeader fromSsz = schema.sszDeserialize(ssz);
-    assertThat(fromSsz).isEqualTo(header);
-
-    // Round-trip JSON serialization.
-    final String json = JsonUtil.serialize(header, typeDefinition);
-    final BeaconBlockHeader fromJson = JsonUtil.parse(json, typeDefinition);
-    assertThat(fromJson).isEqualTo(header);
+    assertRoundTrip(beaconBlockHeader);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/BeaconBlockPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/BeaconBlockPropertyTest.java
@@ -13,30 +13,16 @@
 
 package tech.pegasys.teku.spec.datastructures.blocks;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import org.apache.tuweni.bytes.Bytes;
-import tech.pegasys.teku.infrastructure.json.JsonUtil;
-import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 
 public class BeaconBlockPropertyTest {
   @Property
-  void roundTrip(@ForAll(supplier = BeaconBlockSupplier.class) final BeaconBlock block)
+  void roundTrip(@ForAll(supplier = BeaconBlockSupplier.class) final BeaconBlock beaconBlock)
       throws JsonProcessingException {
-    final BeaconBlockSchema schema = block.getSchema();
-    final DeserializableTypeDefinition<BeaconBlock> typeDefinition = schema.getJsonTypeDefinition();
-
-    // Round-trip SSZ serialization.
-    final Bytes ssz = block.sszSerialize();
-    final BeaconBlock fromSsz = schema.sszDeserialize(ssz);
-    assertThat(fromSsz).isEqualTo(block);
-
-    // Round-trip JSON serialization.
-    final String json = JsonUtil.serialize(block, typeDefinition);
-    final BeaconBlock fromJson = JsonUtil.parse(json, typeDefinition);
-    assertThat(fromJson).isEqualTo(block);
+    assertRoundTrip(beaconBlock);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/BlindedBeaconBlockBodyPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/BlindedBeaconBlockBodyPropertyTest.java
@@ -13,34 +13,19 @@
 
 package tech.pegasys.teku.spec.datastructures.blocks;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import org.apache.tuweni.bytes.Bytes;
-import tech.pegasys.teku.infrastructure.json.JsonUtil;
-import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
-import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodySchema;
 
 public class BlindedBeaconBlockBodyPropertyTest {
   @Property
-  @SuppressWarnings("unchecked")
-  void roundTrip(@ForAll(supplier = BeaconBlockBodySupplier.class) final BeaconBlockBody body)
+  void roundTrip(
+      @ForAll(supplier = BlindedBeaconBlockBodySupplier.class)
+          final BeaconBlockBody beaconBlockBody)
       throws JsonProcessingException {
-    final BeaconBlockBodySchema<?> schema = body.getSchema();
-    final DeserializableTypeDefinition<BeaconBlockBody> typeDefinition =
-        (DeserializableTypeDefinition<BeaconBlockBody>) schema.getJsonTypeDefinition();
-
-    // Round-trip SSZ serialization.
-    final Bytes ssz = body.sszSerialize();
-    final BeaconBlockBody fromSsz = schema.sszDeserialize(ssz);
-    assertThat(fromSsz).isEqualTo(body);
-
-    // Round-trip JSON serialization.
-    final String json = JsonUtil.serialize(body, typeDefinition);
-    final BeaconBlockBody fromJson = JsonUtil.parse(json, typeDefinition);
-    assertThat(fromJson).isEqualTo(body);
+    assertRoundTrip(beaconBlockBody);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/BlindedBeaconBlockPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/BlindedBeaconBlockPropertyTest.java
@@ -13,30 +13,16 @@
 
 package tech.pegasys.teku.spec.datastructures.blocks;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import org.apache.tuweni.bytes.Bytes;
-import tech.pegasys.teku.infrastructure.json.JsonUtil;
-import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 
 public class BlindedBeaconBlockPropertyTest {
   @Property
-  void roundTrip(@ForAll(supplier = BeaconBlockSupplier.class) final BeaconBlock block)
+  void roundTrip(@ForAll(supplier = BeaconBlockSupplier.class) final BeaconBlock beaconBlock)
       throws JsonProcessingException {
-    final BeaconBlockSchema schema = block.getSchema();
-    final DeserializableTypeDefinition<BeaconBlock> typeDefinition = schema.getJsonTypeDefinition();
-
-    // Round-trip SSZ serialization.
-    final Bytes ssz = block.sszSerialize();
-    final BeaconBlock fromSsz = schema.sszDeserialize(ssz);
-    assertThat(fromSsz).isEqualTo(block);
-
-    // Round-trip JSON serialization.
-    final String json = JsonUtil.serialize(block, typeDefinition);
-    final BeaconBlock fromJson = JsonUtil.parse(json, typeDefinition);
-    assertThat(fromJson).isEqualTo(block);
+    assertRoundTrip(beaconBlock);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/Eth1DataPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/Eth1DataPropertyTest.java
@@ -13,30 +13,16 @@
 
 package tech.pegasys.teku.spec.datastructures.blocks;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import org.apache.tuweni.bytes.Bytes;
-import tech.pegasys.teku.infrastructure.json.JsonUtil;
-import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 
 public class Eth1DataPropertyTest {
   @Property
-  void roundTrip(@ForAll(supplier = Eth1DataSupplier.class) final Eth1Data data)
+  void roundTrip(@ForAll(supplier = Eth1DataSupplier.class) final Eth1Data eth1Data)
       throws JsonProcessingException {
-    final Eth1Data.Eth1DataSchema schema = data.getSchema();
-    final DeserializableTypeDefinition<Eth1Data> typeDefinition = schema.getJsonTypeDefinition();
-
-    // Round-trip SSZ serialization.
-    final Bytes ssz = data.sszSerialize();
-    final Eth1Data fromSsz = schema.sszDeserialize(ssz);
-    assertThat(fromSsz).isEqualTo(data);
-
-    // Round-trip JSON serialization.
-    final String json = JsonUtil.serialize(data, typeDefinition);
-    final Eth1Data fromJson = JsonUtil.parse(json, typeDefinition);
-    assertThat(fromJson).isEqualTo(data);
+    assertRoundTrip(eth1Data);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBeaconBlockHeaderPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBeaconBlockHeaderPropertyTest.java
@@ -13,33 +13,18 @@
 
 package tech.pegasys.teku.spec.datastructures.blocks;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import org.apache.tuweni.bytes.Bytes;
-import tech.pegasys.teku.infrastructure.json.JsonUtil;
-import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 
 public class SignedBeaconBlockHeaderPropertyTest {
   @Property
   void roundTrip(
       @ForAll(supplier = SignedBeaconBlockHeaderSupplier.class)
-          final SignedBeaconBlockHeader header)
+          final SignedBeaconBlockHeader signedBeaconBlockHeader)
       throws JsonProcessingException {
-    final SignedBeaconBlockHeader.SignedBeaconBlockHeaderSchema schema = header.getSchema();
-    final DeserializableTypeDefinition<SignedBeaconBlockHeader> typeDefinition =
-        schema.getJsonTypeDefinition();
-
-    // Round-trip SSZ serialization.
-    final Bytes ssz = header.sszSerialize();
-    final SignedBeaconBlockHeader fromSsz = schema.sszDeserialize(ssz);
-    assertThat(fromSsz).isEqualTo(header);
-
-    // Round-trip JSON serialization.
-    final String json = JsonUtil.serialize(header, typeDefinition);
-    final SignedBeaconBlockHeader fromJson = JsonUtil.parse(json, typeDefinition);
-    assertThat(fromJson).isEqualTo(header);
+    assertRoundTrip(signedBeaconBlockHeader);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBeaconBlockPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBeaconBlockPropertyTest.java
@@ -13,31 +13,17 @@
 
 package tech.pegasys.teku.spec.datastructures.blocks;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import org.apache.tuweni.bytes.Bytes;
-import tech.pegasys.teku.infrastructure.json.JsonUtil;
-import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 
 public class SignedBeaconBlockPropertyTest {
   @Property
-  void roundTrip(@ForAll(supplier = SignedBeaconBlockProvider.class) final SignedBeaconBlock block)
+  void roundTrip(
+      @ForAll(supplier = SignedBeaconBlockProvider.class) final SignedBeaconBlock signedBeaconBlock)
       throws JsonProcessingException {
-    final SignedBeaconBlockSchema schema = block.getSchema();
-    final DeserializableTypeDefinition<SignedBeaconBlock> typeDefinition =
-        schema.getJsonTypeDefinition();
-
-    // Round-trip SSZ serialization.
-    final Bytes ssz = block.sszSerialize();
-    final SignedBeaconBlock fromSsz = schema.sszDeserialize(ssz);
-    assertThat(fromSsz).isEqualTo(block);
-
-    // Round-trip JSON serialization.
-    final String json = JsonUtil.serialize(block, typeDefinition);
-    final SignedBeaconBlock result = JsonUtil.parse(json, typeDefinition);
-    assertThat(result).isEqualTo(block);
+    assertRoundTrip(signedBeaconBlock);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/SyncAggregatePropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/SyncAggregatePropertyTest.java
@@ -13,33 +13,17 @@
 
 package tech.pegasys.teku.spec.datastructures.blocks;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import org.apache.tuweni.bytes.Bytes;
-import tech.pegasys.teku.infrastructure.json.JsonUtil;
-import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregate;
-import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregateSchema;
 
 public class SyncAggregatePropertyTest {
   @Property
   void roundTrip(@ForAll(supplier = SyncAggregateSupplier.class) final SyncAggregate syncAggregate)
       throws JsonProcessingException {
-    final SyncAggregateSchema schema = syncAggregate.getSchema();
-    final DeserializableTypeDefinition<SyncAggregate> typeDefinition =
-        schema.getJsonTypeDefinition();
-
-    // Round-trip SSZ serialization.
-    final Bytes ssz = syncAggregate.sszSerialize();
-    final SyncAggregate fromSsz = schema.sszDeserialize(ssz);
-    assertThat(fromSsz).isEqualTo(syncAggregate);
-
-    // Round-trip JSON serialization.
-    final String json = JsonUtil.serialize(syncAggregate, typeDefinition);
-    final SyncAggregate fromJson = JsonUtil.parse(json, typeDefinition);
-    assertThat(fromJson).isEqualTo(syncAggregate);
+    assertRoundTrip(syncAggregate);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/builder/BuilderBidPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/builder/BuilderBidPropertyTest.java
@@ -13,30 +13,16 @@
 
 package tech.pegasys.teku.spec.datastructures.builder;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import org.apache.tuweni.bytes.Bytes;
-import tech.pegasys.teku.infrastructure.json.JsonUtil;
-import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 
 public class BuilderBidPropertyTest {
   @Property
-  void roundTrip(@ForAll(supplier = BuilderBidSupplier.class) final BuilderBid bid)
+  void roundTrip(@ForAll(supplier = BuilderBidSupplier.class) final BuilderBid builderBid)
       throws JsonProcessingException {
-    final BuilderBidSchema schema = bid.getSchema();
-    final DeserializableTypeDefinition<BuilderBid> typeDefinition = schema.getJsonTypeDefinition();
-
-    // Round-trip SSZ serialization.
-    final Bytes ssz = bid.sszSerialize();
-    final BuilderBid fromSsz = schema.sszDeserialize(ssz);
-    assertThat(fromSsz).isEqualTo(bid);
-
-    // Round-trip JSON serialization.
-    final String json = JsonUtil.serialize(bid, typeDefinition);
-    final BuilderBid fromJson = JsonUtil.parse(json, typeDefinition);
-    assertThat(fromJson).isEqualTo(bid);
+    assertRoundTrip(builderBid);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/builder/SignedBuilderBidPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/builder/SignedBuilderBidPropertyTest.java
@@ -13,31 +13,17 @@
 
 package tech.pegasys.teku.spec.datastructures.builder;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import org.apache.tuweni.bytes.Bytes;
-import tech.pegasys.teku.infrastructure.json.JsonUtil;
-import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 
 public class SignedBuilderBidPropertyTest {
   @Property
-  void roundTrip(@ForAll(supplier = SignedBuilderBidSupplier.class) final SignedBuilderBid bid)
+  void roundTrip(
+      @ForAll(supplier = SignedBuilderBidSupplier.class) final SignedBuilderBid signedBuilderBid)
       throws JsonProcessingException {
-    final SignedBuilderBidSchema schema = bid.getSchema();
-    final DeserializableTypeDefinition<SignedBuilderBid> typeDefinition =
-        schema.getJsonTypeDefinition();
-
-    // Round-trip SSZ serialization.
-    final Bytes ssz = bid.sszSerialize();
-    final SignedBuilderBid fromSsz = schema.sszDeserialize(ssz);
-    assertThat(fromSsz).isEqualTo(bid);
-
-    // Round-trip JSON serialization.
-    final String json = JsonUtil.serialize(bid, typeDefinition);
-    final SignedBuilderBid fromJson = JsonUtil.parse(json, typeDefinition);
-    assertThat(fromJson).isEqualTo(bid);
+    assertRoundTrip(signedBuilderBid);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/builder/SignedValidatorRegistrationPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/builder/SignedValidatorRegistrationPropertyTest.java
@@ -13,33 +13,18 @@
 
 package tech.pegasys.teku.spec.datastructures.builder;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import org.apache.tuweni.bytes.Bytes;
-import tech.pegasys.teku.infrastructure.json.JsonUtil;
-import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 
 public class SignedValidatorRegistrationPropertyTest {
   @Property
   void roundTrip(
       @ForAll(supplier = SignedValidatorRegistrationSupplier.class)
-          final SignedValidatorRegistration registration)
+          final SignedValidatorRegistration signedValidatorRegistration)
       throws JsonProcessingException {
-    final SignedValidatorRegistrationSchema schema = registration.getSchema();
-    final DeserializableTypeDefinition<SignedValidatorRegistration> typeDefinition =
-        schema.getJsonTypeDefinition();
-
-    // Round-trip SSZ serialization.
-    final Bytes ssz = registration.sszSerialize();
-    final SignedValidatorRegistration fromSsz = schema.sszDeserialize(ssz);
-    assertThat(fromSsz).isEqualTo(registration);
-
-    // Round-trip JSON serialization.
-    final String json = JsonUtil.serialize(registration, typeDefinition);
-    final SignedValidatorRegistration fromJson = JsonUtil.parse(json, typeDefinition);
-    assertThat(fromJson).isEqualTo(registration);
+    assertRoundTrip(signedValidatorRegistration);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/builder/ValidatorRegistrationPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/builder/ValidatorRegistrationPropertyTest.java
@@ -13,33 +13,18 @@
 
 package tech.pegasys.teku.spec.datastructures.builder;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import org.apache.tuweni.bytes.Bytes;
-import tech.pegasys.teku.infrastructure.json.JsonUtil;
-import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 
 public class ValidatorRegistrationPropertyTest {
   @Property
   void roundTrip(
       @ForAll(supplier = ValidatorRegistrationSupplier.class)
-          final ValidatorRegistration registration)
+          final ValidatorRegistration validatorRegistration)
       throws JsonProcessingException {
-    final ValidatorRegistrationSchema schema = registration.getSchema();
-    final DeserializableTypeDefinition<ValidatorRegistration> typeDefinition =
-        schema.getJsonTypeDefinition();
-
-    // Round-trip SSZ serialization.
-    final Bytes ssz = registration.sszSerialize();
-    final ValidatorRegistration fromSsz = schema.sszDeserialize(ssz);
-    assertThat(fromSsz).isEqualTo(registration);
-
-    // Round-trip JSON serialization.
-    final String json = JsonUtil.serialize(registration, typeDefinition);
-    final ValidatorRegistration fromJson = JsonUtil.parse(json, typeDefinition);
-    assertThat(fromJson).isEqualTo(registration);
+    assertRoundTrip(validatorRegistration);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadHeaderPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadHeaderPropertyTest.java
@@ -13,32 +13,18 @@
 
 package tech.pegasys.teku.spec.datastructures.execution;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import org.apache.tuweni.bytes.Bytes;
-import tech.pegasys.teku.infrastructure.json.JsonUtil;
-import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 
 public class ExecutionPayloadHeaderPropertyTest {
   @Property
   void roundTrip(
-      @ForAll(supplier = ExecutionPayloadHeaderSupplier.class) ExecutionPayloadHeader header)
+      @ForAll(supplier = ExecutionPayloadHeaderSupplier.class)
+          ExecutionPayloadHeader executionPayloadHeader)
       throws JsonProcessingException {
-    final ExecutionPayloadHeaderSchema schema = header.getSchema();
-    final DeserializableTypeDefinition<ExecutionPayloadHeader> typeDefinition =
-        schema.getJsonTypeDefinition();
-
-    // Round-trip SSZ serialization.
-    final Bytes ssz = header.sszSerialize();
-    final ExecutionPayloadHeader fromSsz = schema.sszDeserialize(ssz);
-    assertThat(fromSsz).isEqualTo(header);
-
-    // Round-trip JSON serialization.
-    final String json = JsonUtil.serialize(header, typeDefinition);
-    final ExecutionPayloadHeader fromJson = JsonUtil.parse(json, typeDefinition);
-    assertThat(fromJson).isEqualTo(header);
+    assertRoundTrip(executionPayloadHeader);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadPropertyTest.java
@@ -13,31 +13,17 @@
 
 package tech.pegasys.teku.spec.datastructures.execution;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import org.apache.tuweni.bytes.Bytes;
-import tech.pegasys.teku.infrastructure.json.JsonUtil;
-import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 
 public class ExecutionPayloadPropertyTest {
   @Property
-  void roundTrip(@ForAll(supplier = ExecutionPayloadSupplier.class) final ExecutionPayload payload)
+  void roundTrip(
+      @ForAll(supplier = ExecutionPayloadSupplier.class) final ExecutionPayload executionPayload)
       throws JsonProcessingException {
-    final ExecutionPayloadSchema schema = payload.getSchema();
-    final DeserializableTypeDefinition<ExecutionPayload> typeDefinition =
-        schema.getJsonTypeDefinition();
-
-    // Round-trip SSZ serialization.
-    final Bytes ssz = payload.sszSerialize();
-    final ExecutionPayload fromSsz = schema.sszDeserialize(ssz);
-    assertThat(fromSsz).isEqualTo(payload);
-
-    // Round-trip JSON serialization.
-    final String json = JsonUtil.serialize(payload, typeDefinition);
-    final ExecutionPayload fromJson = JsonUtil.parse(json, typeDefinition);
-    assertThat(fromJson).isEqualTo(payload);
+    assertRoundTrip(executionPayload);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/execution/TransactionPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/execution/TransactionPropertyTest.java
@@ -13,30 +13,16 @@
 
 package tech.pegasys.teku.spec.datastructures.execution;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import org.apache.tuweni.bytes.Bytes;
-import tech.pegasys.teku.infrastructure.json.JsonUtil;
-import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 
 public class TransactionPropertyTest {
   @Property
   void roundTrip(@ForAll(supplier = TransactionSupplier.class) final Transaction transaction)
       throws JsonProcessingException {
-    final TransactionSchema schema = transaction.getSchema();
-    final DeserializableTypeDefinition<Transaction> typeDefinition = schema.getJsonTypeDefinition();
-
-    // Round-trip SSZ serialization.
-    final Bytes ssz = transaction.sszSerialize();
-    final Transaction fromSsz = schema.sszDeserialize(ssz);
-    assertThat(fromSsz).isEqualTo(transaction);
-
-    // Round-trip JSON serialization.
-    final String json = JsonUtil.serialize(transaction, typeDefinition);
-    final Transaction fromJson = JsonUtil.parse(json, typeDefinition);
-    assertThat(fromJson).isEqualTo(transaction);
+    assertRoundTrip(transaction);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/AggregateAndProofPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/AggregateAndProofPropertyTest.java
@@ -13,32 +13,17 @@
 
 package tech.pegasys.teku.spec.datastructures.operations;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import org.apache.tuweni.bytes.Bytes;
-import tech.pegasys.teku.infrastructure.json.JsonUtil;
-import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 
 public class AggregateAndProofPropertyTest {
   @Property
   void roundTrip(
       @ForAll(supplier = AggregateAndProofSupplier.class) final AggregateAndProof aggregateAndProof)
       throws JsonProcessingException {
-    final AggregateAndProof.AggregateAndProofSchema schema = aggregateAndProof.getSchema();
-    final DeserializableTypeDefinition<AggregateAndProof> typeDefinition =
-        schema.getJsonTypeDefinition();
-
-    // Round-trip SSZ serialization.
-    final Bytes ssz = aggregateAndProof.sszSerialize();
-    final AggregateAndProof fromSsz = schema.sszDeserialize(ssz);
-    assertThat(fromSsz).isEqualTo(aggregateAndProof);
-
-    // Round-trip JSON serialization.
-    final String json = JsonUtil.serialize(aggregateAndProof, typeDefinition);
-    final AggregateAndProof fromJson = JsonUtil.parse(json, typeDefinition);
-    assertThat(fromJson).isEqualTo(aggregateAndProof);
+    assertRoundTrip(aggregateAndProof);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/AttestationDataPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/AttestationDataPropertyTest.java
@@ -13,32 +13,17 @@
 
 package tech.pegasys.teku.spec.datastructures.operations;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import org.apache.tuweni.bytes.Bytes;
-import tech.pegasys.teku.infrastructure.json.JsonUtil;
-import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 
 public class AttestationDataPropertyTest {
   @Property
   void roundTrip(
       @ForAll(supplier = AttestationDataSupplier.class) final AttestationData attestationData)
       throws JsonProcessingException {
-    final AttestationData.AttestationDataSchema schema = attestationData.getSchema();
-    final DeserializableTypeDefinition<AttestationData> typeDefinition =
-        schema.getJsonTypeDefinition();
-
-    // Round-trip SSZ serialization.
-    final Bytes ssz = attestationData.sszSerialize();
-    final AttestationData fromSsz = schema.sszDeserialize(ssz);
-    assertThat(fromSsz).isEqualTo(attestationData);
-
-    // Round-trip JSON serialization.
-    final String json = JsonUtil.serialize(attestationData, typeDefinition);
-    final AttestationData fromJson = JsonUtil.parse(json, typeDefinition);
-    assertThat(fromJson).isEqualTo(attestationData);
+    assertRoundTrip(attestationData);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/AttestationPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/AttestationPropertyTest.java
@@ -13,30 +13,16 @@
 
 package tech.pegasys.teku.spec.datastructures.operations;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import org.apache.tuweni.bytes.Bytes;
-import tech.pegasys.teku.infrastructure.json.JsonUtil;
-import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 
 public class AttestationPropertyTest {
   @Property
   void roundTrip(@ForAll(supplier = AttestationSupplier.class) final Attestation attestation)
       throws JsonProcessingException {
-    final Attestation.AttestationSchema schema = attestation.getSchema();
-    final DeserializableTypeDefinition<Attestation> typeDefinition = schema.getJsonTypeDefinition();
-
-    // Round-trip SSZ serialization.
-    final Bytes ssz = attestation.sszSerialize();
-    final Attestation fromSsz = schema.sszDeserialize(ssz);
-    assertThat(fromSsz).isEqualTo(attestation);
-
-    // Round-trip JSON serialization.
-    final String json = JsonUtil.serialize(attestation, typeDefinition);
-    final Attestation fromJson = JsonUtil.parse(json, typeDefinition);
-    assertThat(fromJson).isEqualTo(attestation);
+    assertRoundTrip(attestation);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/AttesterSlashingPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/AttesterSlashingPropertyTest.java
@@ -13,32 +13,17 @@
 
 package tech.pegasys.teku.spec.datastructures.operations;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import org.apache.tuweni.bytes.Bytes;
-import tech.pegasys.teku.infrastructure.json.JsonUtil;
-import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 
 public class AttesterSlashingPropertyTest {
   @Property
   void roundTrip(
       @ForAll(supplier = AttesterSlashingSupplier.class) final AttesterSlashing attesterSlashing)
       throws JsonProcessingException {
-    final AttesterSlashing.AttesterSlashingSchema schema = attesterSlashing.getSchema();
-    final DeserializableTypeDefinition<AttesterSlashing> typeDefinition =
-        schema.getJsonTypeDefinition();
-
-    // Round-trip SSZ serialization.
-    final Bytes ssz = attesterSlashing.sszSerialize();
-    final AttesterSlashing fromSsz = schema.sszDeserialize(ssz);
-    assertThat(fromSsz).isEqualTo(attesterSlashing);
-
-    // Round-trip JSON serialization.
-    final String json = JsonUtil.serialize(attesterSlashing, typeDefinition);
-    final AttesterSlashing fromJson = JsonUtil.parse(json, typeDefinition);
-    assertThat(fromJson).isEqualTo(attesterSlashing);
+    assertRoundTrip(attesterSlashing);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/ContributionAndProofPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/ContributionAndProofPropertyTest.java
@@ -13,16 +13,12 @@
 
 package tech.pegasys.teku.spec.datastructures.operations;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import org.apache.tuweni.bytes.Bytes;
-import tech.pegasys.teku.infrastructure.json.JsonUtil;
-import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.ContributionAndProof;
-import tech.pegasys.teku.spec.datastructures.operations.versions.altair.ContributionAndProofSchema;
 
 public class ContributionAndProofPropertyTest {
   @Property
@@ -30,18 +26,6 @@ public class ContributionAndProofPropertyTest {
       @ForAll(supplier = ContributionAndProofSupplier.class)
           final ContributionAndProof contributionAndProof)
       throws JsonProcessingException {
-    final ContributionAndProofSchema schema = contributionAndProof.getSchema();
-    final DeserializableTypeDefinition<ContributionAndProof> typeDefinition =
-        schema.getJsonTypeDefinition();
-
-    // Round-trip SSZ serialization.
-    final Bytes ssz = contributionAndProof.sszSerialize();
-    final ContributionAndProof fromSsz = schema.sszDeserialize(ssz);
-    assertThat(fromSsz).isEqualTo(contributionAndProof);
-
-    // Round-trip JSON serialization.
-    final String json = JsonUtil.serialize(contributionAndProof, typeDefinition);
-    final ContributionAndProof fromJson = JsonUtil.parse(json, typeDefinition);
-    assertThat(fromJson).isEqualTo(contributionAndProof);
+    assertRoundTrip(contributionAndProof);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/DepositMessagePropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/DepositMessagePropertyTest.java
@@ -13,32 +13,17 @@
 
 package tech.pegasys.teku.spec.datastructures.operations;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import org.apache.tuweni.bytes.Bytes;
-import tech.pegasys.teku.infrastructure.json.JsonUtil;
-import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 
 public class DepositMessagePropertyTest {
   @Property
   void roundTrip(
       @ForAll(supplier = DepositMessageSupplier.class) final DepositMessage depositMessage)
       throws JsonProcessingException {
-    final DepositMessage.DepositMessageSchema schema = depositMessage.getSchema();
-    final DeserializableTypeDefinition<DepositMessage> typeDefinition =
-        schema.getJsonTypeDefinition();
-
-    // Round-trip SSZ serialization.
-    final Bytes ssz = depositMessage.sszSerialize();
-    final DepositMessage fromSsz = schema.sszDeserialize(ssz);
-    assertThat(fromSsz).isEqualTo(depositMessage);
-
-    // Round-trip JSON serialization.
-    final String json = JsonUtil.serialize(depositMessage, typeDefinition);
-    final DepositMessage fromJson = JsonUtil.parse(json, typeDefinition);
-    assertThat(fromJson).isEqualTo(depositMessage);
+    assertRoundTrip(depositMessage);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/DepositPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/DepositPropertyTest.java
@@ -13,30 +13,16 @@
 
 package tech.pegasys.teku.spec.datastructures.operations;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import org.apache.tuweni.bytes.Bytes;
-import tech.pegasys.teku.infrastructure.json.JsonUtil;
-import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 
 public class DepositPropertyTest {
   @Property
   void roundTrip(@ForAll(supplier = DepositSupplier.class) final Deposit deposit)
       throws JsonProcessingException {
-    final Deposit.DepositSchema schema = deposit.getSchema();
-    final DeserializableTypeDefinition<Deposit> typeDefinition = schema.getJsonTypeDefinition();
-
-    // Round-trip SSZ serialization.
-    final Bytes ssz = deposit.sszSerialize();
-    final Deposit fromSsz = schema.sszDeserialize(ssz);
-    assertThat(fromSsz).isEqualTo(deposit);
-
-    // Round-trip JSON serialization.
-    final String json = JsonUtil.serialize(deposit, typeDefinition);
-    final Deposit fromJson = JsonUtil.parse(json, typeDefinition);
-    assertThat(fromJson).isEqualTo(deposit);
+    assertRoundTrip(deposit);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/IndexedAttestationPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/IndexedAttestationPropertyTest.java
@@ -13,14 +13,11 @@
 
 package tech.pegasys.teku.spec.datastructures.operations;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import org.apache.tuweni.bytes.Bytes;
-import tech.pegasys.teku.infrastructure.json.JsonUtil;
-import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 
 public class IndexedAttestationPropertyTest {
   @Property
@@ -28,18 +25,6 @@ public class IndexedAttestationPropertyTest {
       @ForAll(supplier = IndexedAttestationSupplier.class)
           final IndexedAttestation indexedAttestation)
       throws JsonProcessingException {
-    final IndexedAttestation.IndexedAttestationSchema schema = indexedAttestation.getSchema();
-    final DeserializableTypeDefinition<IndexedAttestation> typeDefinition =
-        schema.getJsonTypeDefinition();
-
-    // Round-trip SSZ serialization.
-    final Bytes ssz = indexedAttestation.sszSerialize();
-    final IndexedAttestation fromSsz = schema.sszDeserialize(ssz);
-    assertThat(fromSsz).isEqualTo(indexedAttestation);
-
-    // Round-trip JSON serialization.
-    final String json = JsonUtil.serialize(indexedAttestation, typeDefinition);
-    final IndexedAttestation fromJson = JsonUtil.parse(json, typeDefinition);
-    assertThat(fromJson).isEqualTo(indexedAttestation);
+    assertRoundTrip(indexedAttestation);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/ProposerSlashingPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/ProposerSlashingPropertyTest.java
@@ -13,32 +13,17 @@
 
 package tech.pegasys.teku.spec.datastructures.operations;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import org.apache.tuweni.bytes.Bytes;
-import tech.pegasys.teku.infrastructure.json.JsonUtil;
-import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 
 public class ProposerSlashingPropertyTest {
   @Property
   void roundTrip(
       @ForAll(supplier = ProposerSlashingSupplier.class) final ProposerSlashing proposerSlashing)
       throws JsonProcessingException {
-    final ProposerSlashing.ProposerSlashingSchema schema = proposerSlashing.getSchema();
-    final DeserializableTypeDefinition<ProposerSlashing> typeDefinition =
-        schema.getJsonTypeDefinition();
-
-    // Round-trip SSZ serialization.
-    final Bytes ssz = proposerSlashing.sszSerialize();
-    final ProposerSlashing fromSsz = schema.sszDeserialize(ssz);
-    assertThat(fromSsz).isEqualTo(proposerSlashing);
-
-    // Round-trip JSON serialization.
-    final String json = JsonUtil.serialize(proposerSlashing, typeDefinition);
-    final ProposerSlashing fromJson = JsonUtil.parse(json, typeDefinition);
-    assertThat(fromJson).isEqualTo(proposerSlashing);
+    assertRoundTrip(proposerSlashing);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SignedAggregateAndProofPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SignedAggregateAndProofPropertyTest.java
@@ -13,14 +13,11 @@
 
 package tech.pegasys.teku.spec.datastructures.operations;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import org.apache.tuweni.bytes.Bytes;
-import tech.pegasys.teku.infrastructure.json.JsonUtil;
-import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 
 public class SignedAggregateAndProofPropertyTest {
   @Property
@@ -28,19 +25,6 @@ public class SignedAggregateAndProofPropertyTest {
       @ForAll(supplier = SignedAggregateAndProofSupplier.class)
           final SignedAggregateAndProof signedAggregateAndProof)
       throws JsonProcessingException {
-    final SignedAggregateAndProof.SignedAggregateAndProofSchema schema =
-        signedAggregateAndProof.getSchema();
-    final DeserializableTypeDefinition<SignedAggregateAndProof> typeDefinition =
-        schema.getJsonTypeDefinition();
-
-    // Round-trip SSZ serialization.
-    final Bytes ssz = signedAggregateAndProof.sszSerialize();
-    final SignedAggregateAndProof fromSsz = schema.sszDeserialize(ssz);
-    assertThat(fromSsz).isEqualTo(signedAggregateAndProof);
-
-    // Round-trip JSON serialization.
-    final String json = JsonUtil.serialize(signedAggregateAndProof, typeDefinition);
-    final SignedAggregateAndProof fromJson = JsonUtil.parse(json, typeDefinition);
-    assertThat(fromJson).isEqualTo(signedAggregateAndProof);
+    assertRoundTrip(signedAggregateAndProof);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SignedContributionAndProofPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SignedContributionAndProofPropertyTest.java
@@ -13,16 +13,12 @@
 
 package tech.pegasys.teku.spec.datastructures.operations;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import org.apache.tuweni.bytes.Bytes;
-import tech.pegasys.teku.infrastructure.json.JsonUtil;
-import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SignedContributionAndProof;
-import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SignedContributionAndProofSchema;
 
 public class SignedContributionAndProofPropertyTest {
   @Property
@@ -30,18 +26,6 @@ public class SignedContributionAndProofPropertyTest {
       @ForAll(supplier = SignedContributionAndProofSupplier.class)
           final SignedContributionAndProof signedContributionAndProof)
       throws JsonProcessingException {
-    final SignedContributionAndProofSchema schema = signedContributionAndProof.getSchema();
-    final DeserializableTypeDefinition<SignedContributionAndProof> typeDefinition =
-        schema.getJsonTypeDefinition();
-
-    // Round-trip SSZ serialization.
-    final Bytes ssz = signedContributionAndProof.sszSerialize();
-    final SignedContributionAndProof fromSsz = schema.sszDeserialize(ssz);
-    assertThat(fromSsz).isEqualTo(signedContributionAndProof);
-
-    // Round-trip JSON serialization.
-    final String json = JsonUtil.serialize(signedContributionAndProof, typeDefinition);
-    final SignedContributionAndProof fromJson = JsonUtil.parse(json, typeDefinition);
-    assertThat(fromJson).isEqualTo(signedContributionAndProof);
+    assertRoundTrip(signedContributionAndProof);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SignedVoluntaryExitPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SignedVoluntaryExitPropertyTest.java
@@ -13,14 +13,11 @@
 
 package tech.pegasys.teku.spec.datastructures.operations;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import org.apache.tuweni.bytes.Bytes;
-import tech.pegasys.teku.infrastructure.json.JsonUtil;
-import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 
 public class SignedVoluntaryExitPropertyTest {
   @Property
@@ -28,18 +25,6 @@ public class SignedVoluntaryExitPropertyTest {
       @ForAll(supplier = SignedVoluntaryExitSupplier.class)
           final SignedVoluntaryExit signedVoluntaryExit)
       throws JsonProcessingException {
-    final SignedVoluntaryExit.SignedVoluntaryExitSchema schema = signedVoluntaryExit.getSchema();
-    final DeserializableTypeDefinition<SignedVoluntaryExit> typeDefinition =
-        schema.getJsonTypeDefinition();
-
-    // Round-trip SSZ serialization.
-    final Bytes ssz = signedVoluntaryExit.sszSerialize();
-    final SignedVoluntaryExit fromSsz = schema.sszDeserialize(ssz);
-    assertThat(fromSsz).isEqualTo(signedVoluntaryExit);
-
-    // Round-trip JSON serialization.
-    final String json = JsonUtil.serialize(signedVoluntaryExit, typeDefinition);
-    final SignedVoluntaryExit fromJson = JsonUtil.parse(json, typeDefinition);
-    assertThat(fromJson).isEqualTo(signedVoluntaryExit);
+    assertRoundTrip(signedVoluntaryExit);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SyncAggregatorSelectionDataPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SyncAggregatorSelectionDataPropertyTest.java
@@ -13,16 +13,12 @@
 
 package tech.pegasys.teku.spec.datastructures.operations;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import org.apache.tuweni.bytes.Bytes;
-import tech.pegasys.teku.infrastructure.json.JsonUtil;
-import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncAggregatorSelectionData;
-import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncAggregatorSelectionDataSchema;
 
 public class SyncAggregatorSelectionDataPropertyTest {
   @Property
@@ -30,18 +26,6 @@ public class SyncAggregatorSelectionDataPropertyTest {
       @ForAll(supplier = SyncAggregatorSelectionDataSupplier.class)
           final SyncAggregatorSelectionData syncAggregatorSelectionData)
       throws JsonProcessingException {
-    final SyncAggregatorSelectionDataSchema schema = syncAggregatorSelectionData.getSchema();
-    final DeserializableTypeDefinition<SyncAggregatorSelectionData> typeDefinition =
-        schema.getJsonTypeDefinition();
-
-    // Round-trip SSZ serialization.
-    final Bytes ssz = syncAggregatorSelectionData.sszSerialize();
-    final SyncAggregatorSelectionData fromSsz = schema.sszDeserialize(ssz);
-    assertThat(fromSsz).isEqualTo(syncAggregatorSelectionData);
-
-    // Round-trip JSON serialization.
-    final String json = JsonUtil.serialize(syncAggregatorSelectionData, typeDefinition);
-    final SyncAggregatorSelectionData fromJson = JsonUtil.parse(json, typeDefinition);
-    assertThat(fromJson).isEqualTo(syncAggregatorSelectionData);
+    assertRoundTrip(syncAggregatorSelectionData);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SyncCommitteeContributionPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SyncCommitteeContributionPropertyTest.java
@@ -13,16 +13,12 @@
 
 package tech.pegasys.teku.spec.datastructures.operations;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import org.apache.tuweni.bytes.Bytes;
-import tech.pegasys.teku.infrastructure.json.JsonUtil;
-import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeContribution;
-import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeContributionSchema;
 
 public class SyncCommitteeContributionPropertyTest {
   @Property
@@ -30,18 +26,6 @@ public class SyncCommitteeContributionPropertyTest {
       @ForAll(supplier = SyncCommitteeContributionSupplier.class)
           final SyncCommitteeContribution syncCommitteeContribution)
       throws JsonProcessingException {
-    final SyncCommitteeContributionSchema schema = syncCommitteeContribution.getSchema();
-    final DeserializableTypeDefinition<SyncCommitteeContribution> typeDefinition =
-        schema.getJsonTypeDefinition();
-
-    // Round-trip SSZ serialization.
-    final Bytes ssz = syncCommitteeContribution.sszSerialize();
-    final SyncCommitteeContribution fromSsz = schema.sszDeserialize(ssz);
-    assertThat(fromSsz).isEqualTo(syncCommitteeContribution);
-
-    // Round-trip JSON serialization.
-    final String json = JsonUtil.serialize(syncCommitteeContribution, typeDefinition);
-    final SyncCommitteeContribution fromJson = JsonUtil.parse(json, typeDefinition);
-    assertThat(fromJson).isEqualTo(syncCommitteeContribution);
+    assertRoundTrip(syncCommitteeContribution);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SyncCommitteeMessagePropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SyncCommitteeMessagePropertyTest.java
@@ -13,16 +13,12 @@
 
 package tech.pegasys.teku.spec.datastructures.operations;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import org.apache.tuweni.bytes.Bytes;
-import tech.pegasys.teku.infrastructure.json.JsonUtil;
-import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeMessage;
-import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeMessageSchema;
 
 public class SyncCommitteeMessagePropertyTest {
   @Property
@@ -30,18 +26,6 @@ public class SyncCommitteeMessagePropertyTest {
       @ForAll(supplier = SyncCommitteeMessageSupplier.class)
           final SyncCommitteeMessage syncCommitteeMessage)
       throws JsonProcessingException {
-    final SyncCommitteeMessageSchema schema = syncCommitteeMessage.getSchema();
-    final DeserializableTypeDefinition<SyncCommitteeMessage> typeDefinition =
-        schema.getJsonTypeDefinition();
-
-    // Round-trip SSZ serialization.
-    final Bytes ssz = syncCommitteeMessage.sszSerialize();
-    final SyncCommitteeMessage fromSsz = schema.sszDeserialize(ssz);
-    assertThat(fromSsz).isEqualTo(syncCommitteeMessage);
-
-    // Round-trip JSON serialization.
-    final String json = JsonUtil.serialize(syncCommitteeMessage, typeDefinition);
-    final SyncCommitteeMessage fromJson = JsonUtil.parse(json, typeDefinition);
-    assertThat(fromJson).isEqualTo(syncCommitteeMessage);
+    assertRoundTrip(syncCommitteeMessage);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/VoluntaryExitPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/VoluntaryExitPropertyTest.java
@@ -13,31 +13,16 @@
 
 package tech.pegasys.teku.spec.datastructures.operations;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import org.apache.tuweni.bytes.Bytes;
-import tech.pegasys.teku.infrastructure.json.JsonUtil;
-import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 
 public class VoluntaryExitPropertyTest {
   @Property
   void roundTrip(@ForAll(supplier = VoluntaryExitSupplier.class) final VoluntaryExit voluntaryExit)
       throws JsonProcessingException {
-    final VoluntaryExit.VoluntaryExitSchema schema = voluntaryExit.getSchema();
-    final DeserializableTypeDefinition<VoluntaryExit> typeDefinition =
-        schema.getJsonTypeDefinition();
-
-    // Round-trip SSZ serialization.
-    final Bytes ssz = voluntaryExit.sszSerialize();
-    final VoluntaryExit fromSsz = schema.sszDeserialize(ssz);
-    assertThat(fromSsz).isEqualTo(voluntaryExit);
-
-    // Round-trip JSON serialization.
-    final String json = JsonUtil.serialize(voluntaryExit, typeDefinition);
-    final VoluntaryExit fromJson = JsonUtil.parse(json, typeDefinition);
-    assertThat(fromJson).isEqualTo(voluntaryExit);
+    assertRoundTrip(voluntaryExit);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/state/BeaconStatePropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/state/BeaconStatePropertyTest.java
@@ -13,34 +13,18 @@
 
 package tech.pegasys.teku.spec.datastructures.state;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import org.apache.tuweni.bytes.Bytes;
-import tech.pegasys.teku.infrastructure.json.JsonUtil;
-import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchema;
 
 public class BeaconStatePropertyTest {
   @Property(tries = 100)
   @SuppressWarnings("unchecked")
-  void roundTrip(@ForAll(supplier = BeaconStateSupplier.class) final BeaconState state)
+  void roundTrip(@ForAll(supplier = BeaconStateSupplier.class) final BeaconState beaconState)
       throws JsonProcessingException {
-    final BeaconStateSchema<?, ?> schema = state.getBeaconStateSchema();
-    final DeserializableTypeDefinition<BeaconState> typeDefinition =
-        (DeserializableTypeDefinition<BeaconState>) schema.getJsonTypeDefinition();
-
-    // Round-trip SSZ serialization.
-    final Bytes ssz = state.sszSerialize();
-    final BeaconState fromSsz = schema.sszDeserialize(ssz);
-    assertThat(fromSsz).isEqualTo(state);
-
-    // Round-trip JSON serialization.
-    final String json = JsonUtil.serialize(state, typeDefinition);
-    final BeaconState fromJson = JsonUtil.parse(json, typeDefinition);
-    assertThat(fromJson).isEqualTo(state);
+    assertRoundTrip(beaconState);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/type/SszPublicKeyPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/type/SszPublicKeyPropertyTest.java
@@ -13,31 +13,16 @@
 
 package tech.pegasys.teku.spec.datastructures.type;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import org.apache.tuweni.bytes.Bytes;
-import tech.pegasys.teku.infrastructure.json.JsonUtil;
-import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 
 public class SszPublicKeyPropertyTest {
   @Property
-  void roundTrip(@ForAll(supplier = SszPublicKeySupplier.class) final SszPublicKey key)
+  void roundTrip(@ForAll(supplier = SszPublicKeySupplier.class) final SszPublicKey sszPublicKey)
       throws JsonProcessingException {
-    final SszPublicKeySchema schema = key.getSchema();
-    final DeserializableTypeDefinition<SszPublicKey> typeDefinition =
-        schema.getJsonTypeDefinition();
-
-    // Round-trip SSZ serialization.
-    final Bytes ssz = key.sszSerialize();
-    final SszPublicKey fromSsz = schema.sszDeserialize(ssz);
-    assertThat(fromSsz).isEqualTo(key);
-
-    // Round-trip JSON serialization.
-    final String json = JsonUtil.serialize(key, typeDefinition);
-    final SszPublicKey fromJson = JsonUtil.parse(json, typeDefinition);
-    assertThat(fromJson).isEqualTo(key);
+    assertRoundTrip(sszPublicKey);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/type/SszSignaturePropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/type/SszSignaturePropertyTest.java
@@ -13,31 +13,16 @@
 
 package tech.pegasys.teku.spec.datastructures.type;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import org.apache.tuweni.bytes.Bytes;
-import tech.pegasys.teku.infrastructure.json.JsonUtil;
-import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 
 public class SszSignaturePropertyTest {
   @Property
-  void roundTrip(@ForAll(supplier = SszSignatureSupplier.class) final SszSignature signature)
+  void roundTrip(@ForAll(supplier = SszSignatureSupplier.class) final SszSignature sszSignature)
       throws JsonProcessingException {
-    final SszSignatureSchema schema = signature.getSchema();
-    final DeserializableTypeDefinition<SszSignature> typeDefinition =
-        schema.getJsonTypeDefinition();
-
-    // Round-trip SSZ serialization.
-    final Bytes ssz = signature.sszSerialize();
-    final SszSignature fromSsz = schema.sszDeserialize(ssz);
-    assertThat(fromSsz).isEqualTo(signature);
-
-    // Round-trip JSON serialization.
-    final String json = JsonUtil.serialize(signature, typeDefinition);
-    final SszSignature fromJson = JsonUtil.parse(json, typeDefinition);
-    assertThat(fromJson).isEqualTo(signature);
+    assertRoundTrip(sszSignature);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/util/PropertyTestHelper.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/util/PropertyTestHelper.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.tuweni.bytes.Bytes;
+import tech.pegasys.teku.infrastructure.json.JsonUtil;
+import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
+import tech.pegasys.teku.infrastructure.ssz.SszData;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszSchema;
+
+public class PropertyTestHelper {
+  @SuppressWarnings("unchecked")
+  public static <T extends SszData, S extends SszSchema<T>> void assertRoundTrip(final T data)
+      throws JsonProcessingException {
+    final S schema = (S) data.getSchema();
+
+    // Round-trip SSZ serialization.
+    final Bytes ssz = data.sszSerialize();
+    final T fromSsz = schema.sszDeserialize(ssz);
+    assertThat(fromSsz).isEqualTo(data);
+
+    // Round-trip JSON serialization.
+    final DeserializableTypeDefinition<T> typeDefinition = schema.getJsonTypeDefinition();
+    final String json = JsonUtil.serialize(data, typeDefinition);
+    final T fromJson = JsonUtil.parse(json, typeDefinition);
+    assertThat(fromJson).isEqualTo(data);
+  }
+}


### PR DESCRIPTION
## PR Description

Thanks for the suggestions, @ajsutton! This is a lot nicer to read. He's the PR for the first one.

* Made a new `PropertyTestHelper` class in a new `util` directory.
* Added a new `assertRoundTrip` helper to that class.
* Replaced the bodies of all the `roundTrip` methods with a call to that helper.
* Renamed some variables (*e.g.,* `header` to `beaconBlockHeader`) for consistency.
* For blinded beacon blocks, use `BlindedBeaconBlockBodySupplier` instead of `BeaconBlockBodySupplier`.
  * This was a minor issue I didn't notice in the original PR.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
