### PR TITLE
Add DataStructureUtilSupplier to reduce duplication

### DIFF
--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/BeaconBlockBodySupplier.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/BeaconBlockBodySupplier.java
@@ -13,25 +13,12 @@
 
 package tech.pegasys.teku.spec.datastructures.blocks;
 
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.ArbitrarySupplier;
-import net.jqwik.api.Combinators;
-import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
-import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.datastructures.util.DataStructureUtilSupplier;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
-public class BeaconBlockBodySupplier implements ArbitrarySupplier<BeaconBlockBody> {
-  @Override
-  public Arbitrary<BeaconBlockBody> get() {
-    Arbitrary<Integer> seed = Arbitraries.integers();
-    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
-    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
-    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
-    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
-    return dsu.map(DataStructureUtil::randomBeaconBlockBody);
+public class BeaconBlockBodySupplier extends DataStructureUtilSupplier<BeaconBlockBody> {
+  public BeaconBlockBodySupplier() {
+    super(DataStructureUtil::randomBeaconBlockBody);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/BeaconBlockHeaderSupplier.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/BeaconBlockHeaderSupplier.java
@@ -13,24 +13,11 @@
 
 package tech.pegasys.teku.spec.datastructures.blocks;
 
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.ArbitrarySupplier;
-import net.jqwik.api.Combinators;
-import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.datastructures.util.DataStructureUtilSupplier;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
-public class BeaconBlockHeaderSupplier implements ArbitrarySupplier<BeaconBlockHeader> {
-  @Override
-  public Arbitrary<BeaconBlockHeader> get() {
-    Arbitrary<Integer> seed = Arbitraries.integers();
-    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
-    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
-    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
-    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
-    return dsu.map(DataStructureUtil::randomBeaconBlockHeader);
+public class BeaconBlockHeaderSupplier extends DataStructureUtilSupplier<BeaconBlockHeader> {
+  public BeaconBlockHeaderSupplier() {
+    super(DataStructureUtil::randomBeaconBlockHeader);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/BeaconBlockSupplier.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/BeaconBlockSupplier.java
@@ -13,24 +13,11 @@
 
 package tech.pegasys.teku.spec.datastructures.blocks;
 
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.ArbitrarySupplier;
-import net.jqwik.api.Combinators;
-import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.datastructures.util.DataStructureUtilSupplier;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
-public class BeaconBlockSupplier implements ArbitrarySupplier<BeaconBlock> {
-  @Override
-  public Arbitrary<BeaconBlock> get() {
-    Arbitrary<Integer> seed = Arbitraries.integers();
-    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
-    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
-    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
-    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
-    return dsu.map(DataStructureUtil::randomBeaconBlock);
+public class BeaconBlockSupplier extends DataStructureUtilSupplier<BeaconBlock> {
+  public BeaconBlockSupplier() {
+    super(DataStructureUtil::randomBeaconBlock);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/BlindedBeaconBlockBodyPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/BlindedBeaconBlockBodyPropertyTest.java
@@ -27,7 +27,8 @@ import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodySch
 public class BlindedBeaconBlockBodyPropertyTest {
   @Property
   @SuppressWarnings("unchecked")
-  void roundTrip(@ForAll(supplier = BeaconBlockBodySupplier.class) final BeaconBlockBody body)
+  void roundTrip(
+      @ForAll(supplier = BlindedBeaconBlockBodySupplier.class) final BeaconBlockBody body)
       throws JsonProcessingException {
     final BeaconBlockBodySchema<?> schema = body.getSchema();
     final DeserializableTypeDefinition<BeaconBlockBody> typeDefinition =

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/BlindedBeaconBlockBodySupplier.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/BlindedBeaconBlockBodySupplier.java
@@ -13,25 +13,12 @@
 
 package tech.pegasys.teku.spec.datastructures.blocks;
 
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.ArbitrarySupplier;
-import net.jqwik.api.Combinators;
-import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
-import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.datastructures.util.DataStructureUtilSupplier;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
-public class BlindedBeaconBlockBodySupplier implements ArbitrarySupplier<BeaconBlockBody> {
-  @Override
-  public Arbitrary<BeaconBlockBody> get() {
-    Arbitrary<Integer> seed = Arbitraries.integers();
-    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
-    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
-    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
-    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
-    return dsu.map(DataStructureUtil::randomBlindedBeaconBlockBody);
+public class BlindedBeaconBlockBodySupplier extends DataStructureUtilSupplier<BeaconBlockBody> {
+  public BlindedBeaconBlockBodySupplier() {
+    super(DataStructureUtil::randomBlindedBeaconBlockBody);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/BlindedBeaconBlockPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/BlindedBeaconBlockPropertyTest.java
@@ -24,7 +24,7 @@ import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 
 public class BlindedBeaconBlockPropertyTest {
   @Property
-  void roundTrip(@ForAll(supplier = BeaconBlockSupplier.class) final BeaconBlock block)
+  void roundTrip(@ForAll(supplier = BlindedBeaconBlockSupplier.class) final BeaconBlock block)
       throws JsonProcessingException {
     final BeaconBlockSchema schema = block.getSchema();
     final DeserializableTypeDefinition<BeaconBlock> typeDefinition = schema.getJsonTypeDefinition();

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/BlindedBeaconBlockSupplier.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/BlindedBeaconBlockSupplier.java
@@ -13,24 +13,11 @@
 
 package tech.pegasys.teku.spec.datastructures.blocks;
 
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.ArbitrarySupplier;
-import net.jqwik.api.Combinators;
-import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.datastructures.util.DataStructureUtilSupplier;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
-public class BlindedBeaconBlockSupplier implements ArbitrarySupplier<BeaconBlock> {
-  @Override
-  public Arbitrary<BeaconBlock> get() {
-    Arbitrary<Integer> seed = Arbitraries.integers();
-    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
-    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
-    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
-    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
-    return dsu.map(DataStructureUtil::randomBlindedBeaconBlock);
+public class BlindedBeaconBlockSupplier extends DataStructureUtilSupplier<BeaconBlock> {
+  public BlindedBeaconBlockSupplier() {
+    super(DataStructureUtil::randomBlindedBeaconBlock);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/Eth1DataSupplier.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/Eth1DataSupplier.java
@@ -13,24 +13,11 @@
 
 package tech.pegasys.teku.spec.datastructures.blocks;
 
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.ArbitrarySupplier;
-import net.jqwik.api.Combinators;
-import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.datastructures.util.DataStructureUtilSupplier;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
-public class Eth1DataSupplier implements ArbitrarySupplier<Eth1Data> {
-  @Override
-  public Arbitrary<Eth1Data> get() {
-    Arbitrary<Integer> seed = Arbitraries.integers();
-    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
-    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
-    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
-    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
-    return dsu.map(DataStructureUtil::randomEth1Data);
+public class Eth1DataSupplier extends DataStructureUtilSupplier<Eth1Data> {
+  public Eth1DataSupplier() {
+    super(DataStructureUtil::randomEth1Data);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBeaconBlockHeaderSupplier.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBeaconBlockHeaderSupplier.java
@@ -13,24 +13,12 @@
 
 package tech.pegasys.teku.spec.datastructures.blocks;
 
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.ArbitrarySupplier;
-import net.jqwik.api.Combinators;
-import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.datastructures.util.DataStructureUtilSupplier;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
-public class SignedBeaconBlockHeaderSupplier implements ArbitrarySupplier<SignedBeaconBlockHeader> {
-  @Override
-  public Arbitrary<SignedBeaconBlockHeader> get() {
-    Arbitrary<Integer> seed = Arbitraries.integers();
-    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
-    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
-    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
-    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
-    return dsu.map(DataStructureUtil::randomSignedBeaconBlockHeader);
+public class SignedBeaconBlockHeaderSupplier
+    extends DataStructureUtilSupplier<SignedBeaconBlockHeader> {
+  public SignedBeaconBlockHeaderSupplier() {
+    super(DataStructureUtil::randomSignedBeaconBlockHeader);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBeaconBlockPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBeaconBlockPropertyTest.java
@@ -24,7 +24,7 @@ import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 
 public class SignedBeaconBlockPropertyTest {
   @Property
-  void roundTrip(@ForAll(supplier = SignedBeaconBlockProvider.class) final SignedBeaconBlock block)
+  void roundTrip(@ForAll(supplier = SignedBeaconBlockSupplier.class) final SignedBeaconBlock block)
       throws JsonProcessingException {
     final SignedBeaconBlockSchema schema = block.getSchema();
     final DeserializableTypeDefinition<SignedBeaconBlock> typeDefinition =

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBeaconBlockSupplier.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBeaconBlockSupplier.java
@@ -11,13 +11,13 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.spec.datastructures.operations;
+package tech.pegasys.teku.spec.datastructures.blocks;
 
 import tech.pegasys.teku.spec.datastructures.util.DataStructureUtilSupplier;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
-public class ProposerSlashingSupplier extends DataStructureUtilSupplier<ProposerSlashing> {
-  public ProposerSlashingSupplier() {
-    super(DataStructureUtil::randomProposerSlashing);
+public class SignedBeaconBlockSupplier extends DataStructureUtilSupplier<SignedBeaconBlock> {
+  public SignedBeaconBlockSupplier() {
+    super(DataStructureUtil::randomSignedBeaconBlock);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/SyncAggregateSupplier.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/SyncAggregateSupplier.java
@@ -13,27 +13,13 @@
 
 package tech.pegasys.teku.spec.datastructures.blocks;
 
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.ArbitrarySupplier;
-import net.jqwik.api.Combinators;
-import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregate;
-import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.datastructures.util.DataStructureUtilSupplier;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
-public class SyncAggregateSupplier implements ArbitrarySupplier<SyncAggregate> {
-  @Override
-  public Arbitrary<SyncAggregate> get() {
-    Arbitrary<Integer> seed = Arbitraries.integers();
-    Arbitrary<SpecMilestone> milestone =
-        Arbitraries.of(SpecMilestone.class)
-            .filter(m -> m.isGreaterThanOrEqualTo(SpecMilestone.ALTAIR));
-    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
-    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
-    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
-    return dsu.map(DataStructureUtil::randomSyncAggregate);
+public class SyncAggregateSupplier extends DataStructureUtilSupplier<SyncAggregate> {
+  public SyncAggregateSupplier() {
+    super(DataStructureUtil::randomSyncAggregate, SpecMilestone.ALTAIR);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/builder/BuilderBidSupplier.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/builder/BuilderBidSupplier.java
@@ -13,26 +13,12 @@
 
 package tech.pegasys.teku.spec.datastructures.builder;
 
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.ArbitrarySupplier;
-import net.jqwik.api.Combinators;
-import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.datastructures.util.DataStructureUtilSupplier;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
-public class BuilderBidSupplier implements ArbitrarySupplier<BuilderBid> {
-  @Override
-  public Arbitrary<BuilderBid> get() {
-    Arbitrary<Integer> seed = Arbitraries.integers();
-    Arbitrary<SpecMilestone> milestone =
-        Arbitraries.of(SpecMilestone.class)
-            .filter(m -> m.isGreaterThanOrEqualTo(SpecMilestone.BELLATRIX));
-    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
-    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
-    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
-    return dsu.map(DataStructureUtil::randomBuilderBid);
+public class BuilderBidSupplier extends DataStructureUtilSupplier<BuilderBid> {
+  public BuilderBidSupplier() {
+    super(DataStructureUtil::randomBuilderBid, SpecMilestone.BELLATRIX);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/builder/SignedBuilderBidSupplier.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/builder/SignedBuilderBidSupplier.java
@@ -13,26 +13,12 @@
 
 package tech.pegasys.teku.spec.datastructures.builder;
 
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.ArbitrarySupplier;
-import net.jqwik.api.Combinators;
-import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.datastructures.util.DataStructureUtilSupplier;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
-public class SignedBuilderBidSupplier implements ArbitrarySupplier<SignedBuilderBid> {
-  @Override
-  public Arbitrary<SignedBuilderBid> get() {
-    Arbitrary<Integer> seed = Arbitraries.integers();
-    Arbitrary<SpecMilestone> milestone =
-        Arbitraries.of(SpecMilestone.class)
-            .filter(m -> m.isGreaterThanOrEqualTo(SpecMilestone.BELLATRIX));
-    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
-    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
-    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
-    return dsu.map(DataStructureUtil::randomSignedBuilderBid);
+public class SignedBuilderBidSupplier extends DataStructureUtilSupplier<SignedBuilderBid> {
+  public SignedBuilderBidSupplier() {
+    super(DataStructureUtil::randomSignedBuilderBid, SpecMilestone.BELLATRIX);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/builder/SignedValidatorRegistrationSupplier.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/builder/SignedValidatorRegistrationSupplier.java
@@ -13,27 +13,13 @@
 
 package tech.pegasys.teku.spec.datastructures.builder;
 
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.ArbitrarySupplier;
-import net.jqwik.api.Combinators;
-import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.datastructures.util.DataStructureUtilSupplier;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class SignedValidatorRegistrationSupplier
-    implements ArbitrarySupplier<SignedValidatorRegistration> {
-  @Override
-  public Arbitrary<SignedValidatorRegistration> get() {
-    Arbitrary<Integer> seed = Arbitraries.integers();
-    Arbitrary<SpecMilestone> milestone =
-        Arbitraries.of(SpecMilestone.class)
-            .filter(m -> m.isGreaterThanOrEqualTo(SpecMilestone.BELLATRIX));
-    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
-    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
-    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
-    return dsu.map(DataStructureUtil::randomSignedValidatorRegistration);
+    extends DataStructureUtilSupplier<SignedValidatorRegistration> {
+  public SignedValidatorRegistrationSupplier() {
+    super(DataStructureUtil::randomSignedValidatorRegistration, SpecMilestone.BELLATRIX);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/builder/ValidatorRegistrationSupplier.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/builder/ValidatorRegistrationSupplier.java
@@ -13,26 +13,13 @@
 
 package tech.pegasys.teku.spec.datastructures.builder;
 
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.ArbitrarySupplier;
-import net.jqwik.api.Combinators;
-import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.datastructures.util.DataStructureUtilSupplier;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
-public class ValidatorRegistrationSupplier implements ArbitrarySupplier<ValidatorRegistration> {
-  @Override
-  public Arbitrary<ValidatorRegistration> get() {
-    Arbitrary<Integer> seed = Arbitraries.integers();
-    Arbitrary<SpecMilestone> milestone =
-        Arbitraries.of(SpecMilestone.class)
-            .filter(m -> m.isGreaterThanOrEqualTo(SpecMilestone.BELLATRIX));
-    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
-    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
-    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
-    return dsu.map(DataStructureUtil::randomValidatorRegistration);
+public class ValidatorRegistrationSupplier
+    extends DataStructureUtilSupplier<ValidatorRegistration> {
+  public ValidatorRegistrationSupplier() {
+    super(DataStructureUtil::randomValidatorRegistration, SpecMilestone.BELLATRIX);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadHeaderSupplier.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadHeaderSupplier.java
@@ -13,26 +13,13 @@
 
 package tech.pegasys.teku.spec.datastructures.execution;
 
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.ArbitrarySupplier;
-import net.jqwik.api.Combinators;
-import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.datastructures.util.DataStructureUtilSupplier;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
-public class ExecutionPayloadHeaderSupplier implements ArbitrarySupplier<ExecutionPayloadHeader> {
-  @Override
-  public Arbitrary<ExecutionPayloadHeader> get() {
-    Arbitrary<Integer> seed = Arbitraries.integers();
-    Arbitrary<SpecMilestone> milestone =
-        Arbitraries.of(SpecMilestone.class)
-            .filter(m -> m.isGreaterThanOrEqualTo(SpecMilestone.BELLATRIX));
-    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
-    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
-    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
-    return dsu.map(DataStructureUtil::randomExecutionPayloadHeader);
+public class ExecutionPayloadHeaderSupplier
+    extends DataStructureUtilSupplier<ExecutionPayloadHeader> {
+  public ExecutionPayloadHeaderSupplier() {
+    super(DataStructureUtil::randomExecutionPayloadHeader, SpecMilestone.BELLATRIX);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadSupplier.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadSupplier.java
@@ -13,26 +13,12 @@
 
 package tech.pegasys.teku.spec.datastructures.execution;
 
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.ArbitrarySupplier;
-import net.jqwik.api.Combinators;
-import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.datastructures.util.DataStructureUtilSupplier;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
-public class ExecutionPayloadSupplier implements ArbitrarySupplier<ExecutionPayload> {
-  @Override
-  public Arbitrary<ExecutionPayload> get() {
-    Arbitrary<Integer> seed = Arbitraries.integers();
-    Arbitrary<SpecMilestone> milestone =
-        Arbitraries.of(SpecMilestone.class)
-            .filter(m -> m.isGreaterThanOrEqualTo(SpecMilestone.BELLATRIX));
-    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
-    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
-    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
-    return dsu.map(DataStructureUtil::randomExecutionPayload);
+public class ExecutionPayloadSupplier extends DataStructureUtilSupplier<ExecutionPayload> {
+  public ExecutionPayloadSupplier() {
+    super(DataStructureUtil::randomExecutionPayload, SpecMilestone.BELLATRIX);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/execution/TransactionSupplier.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/execution/TransactionSupplier.java
@@ -13,26 +13,12 @@
 
 package tech.pegasys.teku.spec.datastructures.execution;
 
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.ArbitrarySupplier;
-import net.jqwik.api.Combinators;
-import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.datastructures.util.DataStructureUtilSupplier;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
-public class TransactionSupplier implements ArbitrarySupplier<Transaction> {
-  @Override
-  public Arbitrary<Transaction> get() {
-    Arbitrary<Integer> seed = Arbitraries.integers();
-    Arbitrary<SpecMilestone> milestone =
-        Arbitraries.of(SpecMilestone.class)
-            .filter(m -> m.isGreaterThanOrEqualTo(SpecMilestone.BELLATRIX));
-    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
-    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
-    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
-    return dsu.map(DataStructureUtil::randomExecutionPayloadTransaction);
+public class TransactionSupplier extends DataStructureUtilSupplier<Transaction> {
+  public TransactionSupplier() {
+    super(DataStructureUtil::randomExecutionPayloadTransaction, SpecMilestone.BELLATRIX);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/AggregateAndProofSupplier.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/AggregateAndProofSupplier.java
@@ -13,24 +13,11 @@
 
 package tech.pegasys.teku.spec.datastructures.operations;
 
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.ArbitrarySupplier;
-import net.jqwik.api.Combinators;
-import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.datastructures.util.DataStructureUtilSupplier;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
-public class AggregateAndProofSupplier implements ArbitrarySupplier<AggregateAndProof> {
-  @Override
-  public Arbitrary<AggregateAndProof> get() {
-    Arbitrary<Integer> seed = Arbitraries.integers();
-    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
-    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
-    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
-    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
-    return dsu.map(DataStructureUtil::randomAggregateAndProof);
+public class AggregateAndProofSupplier extends DataStructureUtilSupplier<AggregateAndProof> {
+  public AggregateAndProofSupplier() {
+    super(DataStructureUtil::randomAggregateAndProof);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/AttestationDataSupplier.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/AttestationDataSupplier.java
@@ -13,24 +13,11 @@
 
 package tech.pegasys.teku.spec.datastructures.operations;
 
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.ArbitrarySupplier;
-import net.jqwik.api.Combinators;
-import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.datastructures.util.DataStructureUtilSupplier;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
-public class AttestationDataSupplier implements ArbitrarySupplier<AttestationData> {
-  @Override
-  public Arbitrary<AttestationData> get() {
-    Arbitrary<Integer> seed = Arbitraries.integers();
-    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
-    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
-    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
-    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
-    return dsu.map(DataStructureUtil::randomAttestationData);
+public class AttestationDataSupplier extends DataStructureUtilSupplier<AttestationData> {
+  public AttestationDataSupplier() {
+    super(DataStructureUtil::randomAttestationData);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/AttestationSupplier.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/AttestationSupplier.java
@@ -13,24 +13,11 @@
 
 package tech.pegasys.teku.spec.datastructures.operations;
 
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.ArbitrarySupplier;
-import net.jqwik.api.Combinators;
-import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.datastructures.util.DataStructureUtilSupplier;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
-public class AttestationSupplier implements ArbitrarySupplier<Attestation> {
-  @Override
-  public Arbitrary<Attestation> get() {
-    Arbitrary<Integer> seed = Arbitraries.integers();
-    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
-    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
-    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
-    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
-    return dsu.map(DataStructureUtil::randomAttestation);
+public class AttestationSupplier extends DataStructureUtilSupplier<Attestation> {
+  public AttestationSupplier() {
+    super(DataStructureUtil::randomAttestation);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/AttesterSlashingSupplier.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/AttesterSlashingSupplier.java
@@ -13,24 +13,11 @@
 
 package tech.pegasys.teku.spec.datastructures.operations;
 
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.ArbitrarySupplier;
-import net.jqwik.api.Combinators;
-import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.datastructures.util.DataStructureUtilSupplier;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
-public class AttesterSlashingSupplier implements ArbitrarySupplier<AttesterSlashing> {
-  @Override
-  public Arbitrary<AttesterSlashing> get() {
-    Arbitrary<Integer> seed = Arbitraries.integers();
-    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
-    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
-    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
-    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
-    return dsu.map(DataStructureUtil::randomAttesterSlashing);
+public class AttesterSlashingSupplier extends DataStructureUtilSupplier<AttesterSlashing> {
+  public AttesterSlashingSupplier() {
+    super(DataStructureUtil::randomAttesterSlashing);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/ContributionAndProofSupplier.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/ContributionAndProofSupplier.java
@@ -13,27 +13,13 @@
 
 package tech.pegasys.teku.spec.datastructures.operations;
 
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.ArbitrarySupplier;
-import net.jqwik.api.Combinators;
-import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.ContributionAndProof;
-import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.datastructures.util.DataStructureUtilSupplier;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
-public class ContributionAndProofSupplier implements ArbitrarySupplier<ContributionAndProof> {
-  @Override
-  public Arbitrary<ContributionAndProof> get() {
-    Arbitrary<Integer> seed = Arbitraries.integers();
-    Arbitrary<SpecMilestone> milestone =
-        Arbitraries.of(SpecMilestone.class)
-            .filter(m -> m.isGreaterThanOrEqualTo(SpecMilestone.ALTAIR));
-    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
-    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
-    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
-    return dsu.map(DataStructureUtil::randomContributionAndProof);
+public class ContributionAndProofSupplier extends DataStructureUtilSupplier<ContributionAndProof> {
+  public ContributionAndProofSupplier() {
+    super(DataStructureUtil::randomContributionAndProof, SpecMilestone.ALTAIR);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/DepositMessageSupplier.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/DepositMessageSupplier.java
@@ -13,24 +13,11 @@
 
 package tech.pegasys.teku.spec.datastructures.operations;
 
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.ArbitrarySupplier;
-import net.jqwik.api.Combinators;
-import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.datastructures.util.DataStructureUtilSupplier;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
-public class DepositMessageSupplier implements ArbitrarySupplier<DepositMessage> {
-  @Override
-  public Arbitrary<DepositMessage> get() {
-    Arbitrary<Integer> seed = Arbitraries.integers();
-    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
-    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
-    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
-    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
-    return dsu.map(DataStructureUtil::randomDepositMessage);
+public class DepositMessageSupplier extends DataStructureUtilSupplier<DepositMessage> {
+  public DepositMessageSupplier() {
+    super(DataStructureUtil::randomDepositMessage);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/DepositSupplier.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/DepositSupplier.java
@@ -13,24 +13,11 @@
 
 package tech.pegasys.teku.spec.datastructures.operations;
 
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.ArbitrarySupplier;
-import net.jqwik.api.Combinators;
-import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.datastructures.util.DataStructureUtilSupplier;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
-public class DepositSupplier implements ArbitrarySupplier<Deposit> {
-  @Override
-  public Arbitrary<Deposit> get() {
-    Arbitrary<Integer> seed = Arbitraries.integers();
-    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
-    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
-    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
-    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
-    return dsu.map(DataStructureUtil::randomDeposit);
+public class DepositSupplier extends DataStructureUtilSupplier<Deposit> {
+  public DepositSupplier() {
+    super(DataStructureUtil::randomDeposit);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/IndexedAttestationSupplier.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/IndexedAttestationSupplier.java
@@ -13,24 +13,11 @@
 
 package tech.pegasys.teku.spec.datastructures.operations;
 
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.ArbitrarySupplier;
-import net.jqwik.api.Combinators;
-import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.datastructures.util.DataStructureUtilSupplier;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
-public class IndexedAttestationSupplier implements ArbitrarySupplier<IndexedAttestation> {
-  @Override
-  public Arbitrary<IndexedAttestation> get() {
-    Arbitrary<Integer> seed = Arbitraries.integers();
-    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
-    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
-    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
-    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
-    return dsu.map(DataStructureUtil::randomIndexedAttestation);
+public class IndexedAttestationSupplier extends DataStructureUtilSupplier<IndexedAttestation> {
+  public IndexedAttestationSupplier() {
+    super(DataStructureUtil::randomIndexedAttestation);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SignedAggregateAndProofSupplier.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SignedAggregateAndProofSupplier.java
@@ -13,24 +13,12 @@
 
 package tech.pegasys.teku.spec.datastructures.operations;
 
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.ArbitrarySupplier;
-import net.jqwik.api.Combinators;
-import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.datastructures.util.DataStructureUtilSupplier;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
-public class SignedAggregateAndProofSupplier implements ArbitrarySupplier<SignedAggregateAndProof> {
-  @Override
-  public Arbitrary<SignedAggregateAndProof> get() {
-    Arbitrary<Integer> seed = Arbitraries.integers();
-    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
-    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
-    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
-    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
-    return dsu.map(DataStructureUtil::randomSignedAggregateAndProof);
+public class SignedAggregateAndProofSupplier
+    extends DataStructureUtilSupplier<SignedAggregateAndProof> {
+  public SignedAggregateAndProofSupplier() {
+    super(DataStructureUtil::randomSignedAggregateAndProof);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SignedContributionAndProofSupplier.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SignedContributionAndProofSupplier.java
@@ -13,28 +13,14 @@
 
 package tech.pegasys.teku.spec.datastructures.operations;
 
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.ArbitrarySupplier;
-import net.jqwik.api.Combinators;
-import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SignedContributionAndProof;
-import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.datastructures.util.DataStructureUtilSupplier;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class SignedContributionAndProofSupplier
-    implements ArbitrarySupplier<SignedContributionAndProof> {
-  @Override
-  public Arbitrary<SignedContributionAndProof> get() {
-    Arbitrary<Integer> seed = Arbitraries.integers();
-    Arbitrary<SpecMilestone> milestone =
-        Arbitraries.of(SpecMilestone.class)
-            .filter(m -> m.isGreaterThanOrEqualTo(SpecMilestone.ALTAIR));
-    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
-    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
-    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
-    return dsu.map(DataStructureUtil::randomSignedContributionAndProof);
+    extends DataStructureUtilSupplier<SignedContributionAndProof> {
+  public SignedContributionAndProofSupplier() {
+    super(DataStructureUtil::randomSignedContributionAndProof, SpecMilestone.ALTAIR);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SignedVoluntaryExitSupplier.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SignedVoluntaryExitSupplier.java
@@ -13,24 +13,11 @@
 
 package tech.pegasys.teku.spec.datastructures.operations;
 
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.ArbitrarySupplier;
-import net.jqwik.api.Combinators;
-import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.datastructures.util.DataStructureUtilSupplier;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
-public class SignedVoluntaryExitSupplier implements ArbitrarySupplier<SignedVoluntaryExit> {
-  @Override
-  public Arbitrary<SignedVoluntaryExit> get() {
-    Arbitrary<Integer> seed = Arbitraries.integers();
-    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
-    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
-    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
-    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
-    return dsu.map(DataStructureUtil::randomSignedVoluntaryExit);
+public class SignedVoluntaryExitSupplier extends DataStructureUtilSupplier<SignedVoluntaryExit> {
+  public SignedVoluntaryExitSupplier() {
+    super(DataStructureUtil::randomSignedVoluntaryExit);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SyncAggregatorSelectionDataSupplier.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SyncAggregatorSelectionDataSupplier.java
@@ -13,28 +13,14 @@
 
 package tech.pegasys.teku.spec.datastructures.operations;
 
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.ArbitrarySupplier;
-import net.jqwik.api.Combinators;
-import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncAggregatorSelectionData;
-import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.datastructures.util.DataStructureUtilSupplier;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class SyncAggregatorSelectionDataSupplier
-    implements ArbitrarySupplier<SyncAggregatorSelectionData> {
-  @Override
-  public Arbitrary<SyncAggregatorSelectionData> get() {
-    Arbitrary<Integer> seed = Arbitraries.integers();
-    Arbitrary<SpecMilestone> milestone =
-        Arbitraries.of(SpecMilestone.class)
-            .filter(m -> m.isGreaterThanOrEqualTo(SpecMilestone.ALTAIR));
-    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
-    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
-    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
-    return dsu.map(DataStructureUtil::randomSyncAggregatorSelectionData);
+    extends DataStructureUtilSupplier<SyncAggregatorSelectionData> {
+  public SyncAggregatorSelectionDataSupplier() {
+    super(DataStructureUtil::randomSyncAggregatorSelectionData, SpecMilestone.ALTAIR);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SyncCommitteeContributionSupplier.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SyncCommitteeContributionSupplier.java
@@ -13,28 +13,14 @@
 
 package tech.pegasys.teku.spec.datastructures.operations;
 
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.ArbitrarySupplier;
-import net.jqwik.api.Combinators;
-import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeContribution;
-import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.datastructures.util.DataStructureUtilSupplier;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class SyncCommitteeContributionSupplier
-    implements ArbitrarySupplier<SyncCommitteeContribution> {
-  @Override
-  public Arbitrary<SyncCommitteeContribution> get() {
-    Arbitrary<Integer> seed = Arbitraries.integers();
-    Arbitrary<SpecMilestone> milestone =
-        Arbitraries.of(SpecMilestone.class)
-            .filter(m -> m.isGreaterThanOrEqualTo(SpecMilestone.ALTAIR));
-    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
-    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
-    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
-    return dsu.map(DataStructureUtil::randomSyncCommitteeContribution);
+    extends DataStructureUtilSupplier<SyncCommitteeContribution> {
+  public SyncCommitteeContributionSupplier() {
+    super(DataStructureUtil::randomSyncCommitteeContribution, SpecMilestone.ALTAIR);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SyncCommitteeMessageSupplier.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SyncCommitteeMessageSupplier.java
@@ -13,27 +13,13 @@
 
 package tech.pegasys.teku.spec.datastructures.operations;
 
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.ArbitrarySupplier;
-import net.jqwik.api.Combinators;
-import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeMessage;
-import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.datastructures.util.DataStructureUtilSupplier;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
-public class SyncCommitteeMessageSupplier implements ArbitrarySupplier<SyncCommitteeMessage> {
-  @Override
-  public Arbitrary<SyncCommitteeMessage> get() {
-    Arbitrary<Integer> seed = Arbitraries.integers();
-    Arbitrary<SpecMilestone> milestone =
-        Arbitraries.of(SpecMilestone.class)
-            .filter(m -> m.isGreaterThanOrEqualTo(SpecMilestone.ALTAIR));
-    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
-    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
-    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
-    return dsu.map(DataStructureUtil::randomSyncCommitteeMessage);
+public class SyncCommitteeMessageSupplier extends DataStructureUtilSupplier<SyncCommitteeMessage> {
+  public SyncCommitteeMessageSupplier() {
+    super(DataStructureUtil::randomSyncCommitteeMessage, SpecMilestone.ALTAIR);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/VoluntaryExitSupplier.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/VoluntaryExitSupplier.java
@@ -13,24 +13,11 @@
 
 package tech.pegasys.teku.spec.datastructures.operations;
 
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.ArbitrarySupplier;
-import net.jqwik.api.Combinators;
-import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.datastructures.util.DataStructureUtilSupplier;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
-public class VoluntaryExitSupplier implements ArbitrarySupplier<VoluntaryExit> {
-  @Override
-  public Arbitrary<VoluntaryExit> get() {
-    Arbitrary<Integer> seed = Arbitraries.integers();
-    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
-    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
-    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
-    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
-    return dsu.map(DataStructureUtil::randomVoluntaryExit);
+public class VoluntaryExitSupplier extends DataStructureUtilSupplier<VoluntaryExit> {
+  public VoluntaryExitSupplier() {
+    super(DataStructureUtil::randomVoluntaryExit);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/state/BeaconStateSupplier.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/state/BeaconStateSupplier.java
@@ -13,25 +13,12 @@
 
 package tech.pegasys.teku.spec.datastructures.state;
 
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.ArbitrarySupplier;
-import net.jqwik.api.Combinators;
-import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
-import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.datastructures.util.DataStructureUtilSupplier;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
-public class BeaconStateSupplier implements ArbitrarySupplier<BeaconState> {
-  @Override
-  public Arbitrary<BeaconState> get() {
-    Arbitrary<Integer> seed = Arbitraries.integers();
-    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
-    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
-    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
-    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
-    return dsu.map(DataStructureUtil::randomBeaconState);
+public class BeaconStateSupplier extends DataStructureUtilSupplier<BeaconState> {
+  public BeaconStateSupplier() {
+    super(DataStructureUtil::randomBeaconState);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/type/SszPublicKeySupplier.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/type/SszPublicKeySupplier.java
@@ -13,24 +13,11 @@
 
 package tech.pegasys.teku.spec.datastructures.type;
 
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.ArbitrarySupplier;
-import net.jqwik.api.Combinators;
-import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.datastructures.util.DataStructureUtilSupplier;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
-public class SszPublicKeySupplier implements ArbitrarySupplier<SszPublicKey> {
-  @Override
-  public Arbitrary<SszPublicKey> get() {
-    Arbitrary<Integer> seed = Arbitraries.integers();
-    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
-    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
-    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
-    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
-    return dsu.map(DataStructureUtil::randomPublicKey).map(SszPublicKey::new);
+public class SszPublicKeySupplier extends DataStructureUtilSupplier<SszPublicKey> {
+  public SszPublicKeySupplier() {
+    super(DataStructureUtil::randomSszPublicKey);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/type/SszSignatureSupplier.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/type/SszSignatureSupplier.java
@@ -13,24 +13,11 @@
 
 package tech.pegasys.teku.spec.datastructures.type;
 
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.ArbitrarySupplier;
-import net.jqwik.api.Combinators;
-import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.networks.Eth2Network;
+import tech.pegasys.teku.spec.datastructures.util.DataStructureUtilSupplier;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
-public class SszSignatureSupplier implements ArbitrarySupplier<SszSignature> {
-  @Override
-  public Arbitrary<SszSignature> get() {
-    Arbitrary<Integer> seed = Arbitraries.integers();
-    Arbitrary<SpecMilestone> milestone = Arbitraries.of(SpecMilestone.class);
-    Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
-    Arbitrary<Spec> spec = Combinators.combine(milestone, network).as(TestSpecFactory::create);
-    Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
-    return dsu.map(DataStructureUtil::randomSignature).map(SszSignature::new);
+public class SszSignatureSupplier extends DataStructureUtilSupplier<SszSignature> {
+  public SszSignatureSupplier() {
+    super(DataStructureUtil::randomSszSignature);
   }
 }

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -132,6 +132,7 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconStat
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.altair.BeaconStateSchemaAltair;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.phase0.BeaconStateSchemaPhase0;
 import tech.pegasys.teku.spec.datastructures.type.SszPublicKey;
+import tech.pegasys.teku.spec.datastructures.type.SszSignature;
 import tech.pegasys.teku.spec.datastructures.util.DepositGenerator;
 import tech.pegasys.teku.spec.executionlayer.ForkChoiceState;
 import tech.pegasys.teku.spec.executionlayer.PayloadBuildingAttributes;
@@ -232,6 +233,10 @@ public final class DataStructureUtil {
     return BLSTestUtil.randomSignature(nextSeed());
   }
 
+  public SszSignature randomSszSignature() {
+    return new SszSignature(randomSignature());
+  }
+
   public <T extends SszData> SszList<T> randomSszList(
       SszListSchema<T, ?> schema, Supplier<T> valueGenerator, long numItems) {
     return randomSszList(schema, numItems, valueGenerator);
@@ -327,6 +332,10 @@ public final class DataStructureUtil {
 
   public BLSPublicKey randomPublicKey() {
     return pubKeyGenerator.get();
+  }
+
+  public SszPublicKey randomSszPublicKey() {
+    return new SszPublicKey(randomPublicKey());
   }
 
   public Bytes48 randomPublicKeyBytes() {


### PR DESCRIPTION
## PR Description

Thanks again, @ajsutton! This looks a lot better.

* Added new abstract `DataStructureUtilSupplier` class.
  * Takes a DSU method that provides some random data structure.
  * Optionally, you can provide the milestone at which the structure was introduced.
  * Really helps cut down in code duplication.
* Added new `randomSszPublicKey` and `randomSszSignature` methods to the DSU.
  * Previously these were mapped in `get`.
* Renamed `SignedBeaconBlockProvider.java` to `SignedBeaconBlockSupplier.java`.
  * Used the wrong word in the original PR.
* Fixed a couple instances of blinded block tests using the non-blinded block suppliers.
  * I did this in another PR, but I just want to be certain it gets fixed.
  * I think I missed one in the other PR.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
