### PR TITLE
Add metric to report total number of tracked target chains

### DIFF
--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/DefaultSyncServiceFactory.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/DefaultSyncServiceFactory.java
@@ -139,6 +139,7 @@ public class DefaultSyncServiceFactory implements SyncServiceFactory {
     if (syncConfig.isMultiPeerSyncEnabled()) {
       forwardSync =
           MultipeerSyncService.create(
+              metrics,
               asyncRunnerFactory,
               asyncRunner,
               timeProvider,

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/BatchSyncTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/BatchSyncTest.java
@@ -40,6 +40,7 @@ import tech.pegasys.teku.beacon.sync.forward.multipeer.chains.TargetChains;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
 import tech.pegasys.teku.infrastructure.async.eventthread.InlineEventThread;
+import tech.pegasys.teku.infrastructure.metrics.SettableLabelledGauge;
 import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.peers.SyncSource;
@@ -168,7 +169,7 @@ class BatchSyncTest {
 
   @Test
   void shouldFailSyncWhenTargetChainHasNoPeersAndThereAreNoOutstandingRequests() {
-    final TargetChains targetChains = new TargetChains();
+    final TargetChains targetChains = new TargetChains(mock(SettableLabelledGauge.class), "target");
     targetChains.onPeerStatusUpdated(syncSource, targetChain.getChainHead());
     targetChain = targetChains.streamChains().findFirst().orElseThrow();
 

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/SyncTargetSelectorTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/SyncTargetSelectorTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.beacon.sync.forward.multipeer.chains.TargetChain;
 import tech.pegasys.teku.beacon.sync.forward.multipeer.chains.TargetChains;
+import tech.pegasys.teku.infrastructure.metrics.SettableLabelledGauge;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.peers.SyncSource;
 import tech.pegasys.teku.spec.TestSpecFactory;
@@ -44,8 +45,10 @@ class SyncTargetSelectorTest {
   @SuppressWarnings("unchecked")
   private final PendingPool<SignedBeaconBlock> pendingBlocks = mock(PendingPool.class);
 
-  private final TargetChains finalizedChains = new TargetChains();
-  private final TargetChains nonfinalizedChains = new TargetChains();
+  private final TargetChains finalizedChains =
+      new TargetChains(mock(SettableLabelledGauge.class), "finalized");
+  private final TargetChains nonfinalizedChains =
+      new TargetChains(mock(SettableLabelledGauge.class), "nonfinalized");
 
   private final SyncTargetSelector selector =
       new SyncTargetSelector(

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/chains/PeerChainTrackerTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/chains/PeerChainTrackerTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import tech.pegasys.teku.infrastructure.async.eventthread.EventThread;
 import tech.pegasys.teku.infrastructure.async.eventthread.InlineEventThread;
+import tech.pegasys.teku.infrastructure.metrics.SettableLabelledGauge;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer.PeerStatusSubscriber;
 import tech.pegasys.teku.networking.eth2.peers.PeerStatus;
@@ -49,8 +50,10 @@ class PeerChainTrackerTest {
   private final SyncSource syncSource = mock(SyncSource.class);
   private final SyncSourceFactory syncSourceFactory = mock(SyncSourceFactory.class);
 
-  private final TargetChains finalizedChains = new TargetChains();
-  private final TargetChains nonfinalizedChains = new TargetChains();
+  private final TargetChains finalizedChains =
+      new TargetChains(mock(SettableLabelledGauge.class), "finalized");
+  private final TargetChains nonfinalizedChains =
+      new TargetChains(mock(SettableLabelledGauge.class), "nonfinalized");
   private final EventThread eventThread = new InlineEventThread();
   private final PeerStatus status =
       new PeerStatus(

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/chains/TargetChainsTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/chains/TargetChainsTest.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.mock;
 import static tech.pegasys.teku.beacon.sync.forward.multipeer.chains.TargetChainTestUtil.chainWith;
 
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.metrics.SettableLabelledGauge;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.peers.SyncSource;
 import tech.pegasys.teku.spec.TestSpecFactory;
@@ -27,7 +28,8 @@ import tech.pegasys.teku.spec.util.DataStructureUtil;
 class TargetChainsTest {
   private final DataStructureUtil dataStructureUtil =
       new DataStructureUtil(TestSpecFactory.createDefault());
-  private final TargetChains targetChains = new TargetChains();
+  private final TargetChains targetChains =
+      new TargetChains(mock(SettableLabelledGauge.class), "chains");
   private final SyncSource peer1 = mock(SyncSource.class);
   private final SyncSource peer2 = mock(SyncSource.class);
 


### PR DESCRIPTION
## PR Description
Add a metric gauge to report the current number of "target chains" the sync system is tracking.

## Fixed Issue(s)
Provides additional info to help with #6200 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
