### PR TITLE
Don't fail the entire registration flow when a signing fails

### DIFF
--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
@@ -212,9 +212,7 @@ public class SafeFuture<T> extends CompletableFuture<T> {
     final Stream<SafeFuture<Optional<T>>> optionalFutures =
         futures.map(future -> future.thenApply(Optional::of).exceptionally(__ -> Optional.empty()));
     return collectAll(optionalFutures)
-        .thenApply(
-            results ->
-                results.stream().filter(Optional::isPresent).map(Optional::get).collect(toList()));
+        .thenApply(results -> results.stream().flatMap(Optional::stream).collect(toList()));
   }
 
   /**

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
@@ -18,6 +18,7 @@ import static java.util.stream.Collectors.toList;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
@@ -190,6 +191,30 @@ public class SafeFuture<T> extends CompletableFuture<T> {
   public static <T> SafeFuture<List<T>> collectAll(final SafeFuture<T>... futures) {
     return allOf(futures)
         .thenApply(__ -> Stream.of(futures).map(SafeFuture::join).collect(toList()));
+  }
+
+  /**
+   * Waits for all the supplied futures to complete then returns a single future that combines all
+   * the successful results.
+   *
+   * <p>If all the futures complete successfully the returned future completes with a {@link List}
+   * of each result in the same order as the futures were given.
+   *
+   * <p>If any futures complete exceptionally the returned future completes with a {@link List} of
+   * each result in the same order as the futures were given filtering out the exceptionally
+   * completed futures.
+   *
+   * @param futures the futures to collect results from
+   * @param <T> the result type to collect
+   * @return a new future that completes when all the supplied futures complete
+   */
+  public static <T> SafeFuture<List<T>> collectAllSuccessful(final Stream<SafeFuture<T>> futures) {
+    final Stream<SafeFuture<Optional<T>>> optionalFutures =
+        futures.map(future -> future.thenApply(Optional::of).exceptionally(__ -> Optional.empty()));
+    return collectAll(optionalFutures)
+        .thenApply(
+            results ->
+                results.stream().filter(Optional::isPresent).map(Optional::get).collect(toList()));
   }
 
   /**

--- a/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/SafeFutureTest.java
+++ b/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/SafeFutureTest.java
@@ -1129,7 +1129,13 @@ public class SafeFutureTest {
   }
 
   @Test
-  public void collectAllSuccessful_getsSuccessfulResultsWhenSomeFuturesCompleteExceptionally() {
+  void collectAllSuccessful_completeWithEmptyListWhenNoFuturesSupplied() {
+    assertThat(SafeFuture.collectAllSuccessful(Stream.empty()))
+        .isCompletedWithValue(Collections.emptyList());
+  }
+
+  @Test
+  public void collectAllSuccessful_completesWithListOfResultsEvenIfSomeFuturesFail() {
     final SafeFuture<String> fooFuture = SafeFuture.completedFuture("foo");
     final SafeFuture<String> barFuture = SafeFuture.completedFuture("bar");
     final SafeFuture<String> failedFuture = SafeFuture.failedFuture(new IllegalStateException());

--- a/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/SafeFutureTest.java
+++ b/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/SafeFutureTest.java
@@ -32,6 +32,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.async.SafeFuture.Interruptor;
@@ -1125,6 +1126,20 @@ public class SafeFutureTest {
     SafeFutureAssert.assertThatSafeFuture(result)
         .isCompletedExceptionallyWith(IllegalStateException.class)
         .hasMessage("oopsy");
+  }
+
+  @Test
+  public void collectAllSuccessful_getsSuccessfulResultsWhenSomeFuturesCompleteExceptionally() {
+    final SafeFuture<String> fooFuture = SafeFuture.completedFuture("foo");
+    final SafeFuture<String> barFuture = SafeFuture.completedFuture("bar");
+    final SafeFuture<String> failedFuture = SafeFuture.failedFuture(new IllegalStateException());
+
+    final SafeFuture<List<String>> futureResult =
+        SafeFuture.collectAllSuccessful(Stream.of(fooFuture, failedFuture, barFuture));
+
+    final List<String> result = SafeFutureAssert.safeJoin(futureResult);
+
+    assertThat(result).containsExactly("foo", "bar");
   }
 
   private List<Throwable> collectUncaughtExceptions() {

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrator.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrator.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
@@ -189,15 +190,36 @@ public class ValidatorRegistrator implements ValidatorTimingChannel {
         .thenCompose(
             maybeProposerConfig -> {
               final Stream<SafeFuture<SignedValidatorRegistration>> validatorRegistrationsFutures =
-                  validators.stream()
-                      .map(
-                          validator ->
-                              createSignedValidatorRegistration(maybeProposerConfig, validator))
-                      .flatMap(Optional::stream);
-
+                  createValidatorRegistrations(validators, maybeProposerConfig);
               return SafeFuture.collectAllSuccessful(validatorRegistrationsFutures)
                   .thenCompose(validatorRegistrationBatchSender::sendInBatches);
             });
+  }
+
+  private Stream<SafeFuture<SignedValidatorRegistration>> createValidatorRegistrations(
+      final List<Validator> validators, final Optional<ProposerConfig> maybeProposerConfig) {
+    return validators.stream()
+        .map(
+            validator ->
+                createSignedValidatorRegistration(
+                    maybeProposerConfig,
+                    validator,
+                    throwable -> {
+                      final String errorMessage =
+                          String.format(
+                              "Exception while creating a validator registration for %s. Creation will be attempted again next epoch.",
+                              validator.getPublicKey());
+                      LOG.warn(errorMessage, throwable);
+                    }))
+        .flatMap(Optional::stream);
+  }
+
+  private Optional<SafeFuture<SignedValidatorRegistration>> createSignedValidatorRegistration(
+      final Optional<ProposerConfig> maybeProposerConfig,
+      final Validator validator,
+      final Consumer<Throwable> errorHandler) {
+    return createSignedValidatorRegistration(maybeProposerConfig, validator)
+        .map(registrationFuture -> registrationFuture.whenException(errorHandler));
   }
 
   private Optional<SafeFuture<SignedValidatorRegistration>> createSignedValidatorRegistration(
@@ -297,14 +319,6 @@ public class ValidatorRegistrator implements ValidatorTimingChannel {
       final Signer signer) {
     return signer
         .signValidatorRegistration(validatorRegistration)
-        .whenException(
-            throwable -> {
-              final String errorMessage =
-                  String.format(
-                      "Exception while signing validator registration for %s. Signing will be attempted again next epoch.",
-                      cacheKey);
-              LOG.warn(errorMessage, throwable);
-            })
         .thenApply(
             signature -> {
               final SignedValidatorRegistration signedValidatorRegistration =

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorRegistratorTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorRegistratorTest.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.validator.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -54,8 +55,6 @@ import tech.pegasys.teku.validator.client.proposerconfig.ProposerConfigProvider;
 
 @TestSpecContext(milestone = SpecMilestone.BELLATRIX)
 class ValidatorRegistratorTest {
-
-  private static final UInt64 TWO = UInt64.valueOf(2);
 
   private final OwnedValidators ownedValidators = mock(OwnedValidators.class);
   private final ProposerConfigProvider proposerConfigProvider = mock(ProposerConfigProvider.class);
@@ -123,7 +122,7 @@ class ValidatorRegistratorTest {
   void doesNotRegisterValidators_ifNotReady() {
     when(validatorRegistrationPropertiesProvider.isReadyToProvideProperties()).thenReturn(false);
 
-    runRegistrationFlowForSlot(TWO);
+    runRegistrationFlowForEpoch(0);
 
     verifyNoInteractions(ownedValidators, validatorRegistrationBatchSender, signer);
   }
@@ -148,8 +147,8 @@ class ValidatorRegistratorTest {
   void registersValidators_threeSlotsInTheEpoch() {
     setActiveValidators(validator1, validator2, validator3);
 
-    runRegistrationFlowForSlot(TWO);
-    runRegistrationFlowForSlot(UInt64.valueOf(slotsPerEpoch).plus(TWO));
+    runRegistrationFlowForEpoch(0);
+    runRegistrationFlowForEpoch(1);
 
     final List<List<SignedValidatorRegistration>> registrationCalls = captureRegistrationCalls(2);
 
@@ -170,8 +169,8 @@ class ValidatorRegistratorTest {
 
     setActiveValidators(validator1);
 
-    runRegistrationFlowForSlot(TWO);
-    runRegistrationFlowForSlot(UInt64.valueOf(slotsPerEpoch).plus(TWO));
+    runRegistrationFlowForEpoch(0);
+    runRegistrationFlowForEpoch(1);
 
     final List<List<SignedValidatorRegistration>> registrationCalls = captureRegistrationCalls(2);
 
@@ -191,8 +190,8 @@ class ValidatorRegistratorTest {
 
     setActiveValidators(validator1);
 
-    runRegistrationFlowForSlot(TWO);
-    runRegistrationFlowForSlot(UInt64.valueOf(slotsPerEpoch).plus(TWO));
+    runRegistrationFlowForEpoch(0);
+    runRegistrationFlowForEpoch(1);
 
     final List<List<SignedValidatorRegistration>> registrationCalls = captureRegistrationCalls(2);
 
@@ -221,8 +220,8 @@ class ValidatorRegistratorTest {
 
     setActiveValidators(validator1);
 
-    runRegistrationFlowForSlot(TWO);
-    runRegistrationFlowForSlot(UInt64.valueOf(slotsPerEpoch).plus(TWO));
+    runRegistrationFlowForEpoch(0);
+    runRegistrationFlowForEpoch(1);
 
     final List<List<SignedValidatorRegistration>> registrationCalls = captureRegistrationCalls(2);
 
@@ -247,8 +246,8 @@ class ValidatorRegistratorTest {
 
     setActiveValidators(validator1, validator2);
 
-    runRegistrationFlowForSlot(TWO);
-    runRegistrationFlowForSlot(UInt64.valueOf(slotsPerEpoch).plus(TWO));
+    runRegistrationFlowForEpoch(0);
+    runRegistrationFlowForEpoch(1);
 
     final List<List<SignedValidatorRegistration>> registrationCalls = captureRegistrationCalls(2);
 
@@ -278,8 +277,8 @@ class ValidatorRegistratorTest {
 
     setActiveValidators(validator1, validator2);
 
-    runRegistrationFlowForSlot(TWO);
-    runRegistrationFlowForSlot(UInt64.valueOf(slotsPerEpoch).plus(TWO));
+    runRegistrationFlowForEpoch(0);
+    runRegistrationFlowForEpoch(1);
 
     final List<List<SignedValidatorRegistration>> registrationCalls = captureRegistrationCalls(2);
 
@@ -301,14 +300,14 @@ class ValidatorRegistratorTest {
   void cleanupsCache_ifValidatorIsNoLongerActive() {
     setActiveValidators(validator1, validator2, validator3);
 
-    runRegistrationFlowForSlot(TWO);
+    runRegistrationFlowForEpoch(0);
 
     assertThat(validatorRegistrator.getNumberOfCachedRegistrations()).isEqualTo(3);
 
     // validator1 not active anymore
     setActiveValidators(validator2, validator3);
 
-    runRegistrationFlowForSlot(UInt64.valueOf(slotsPerEpoch).plus(TWO));
+    runRegistrationFlowForEpoch(1);
 
     assertThat(validatorRegistrator.getNumberOfCachedRegistrations()).isEqualTo(2);
   }
@@ -322,7 +321,7 @@ class ValidatorRegistratorTest {
 
     setActiveValidators(validator1, validator2, validator3, validator4, validator5);
 
-    runRegistrationFlowForSlot(TWO);
+    runRegistrationFlowForEpoch(0);
 
     final Eth1Address otherEth1Address = dataStructureUtil.randomEth1Address();
     final UInt64 otherGasLimit = dataStructureUtil.randomUInt64();
@@ -345,7 +344,7 @@ class ValidatorRegistratorTest {
     when(proposerConfig.getBuilderRegistrationOverrides(validator5.getPublicKey()))
         .thenReturn(Optional.of(new RegistrationOverrides(otherTimestamp, null)));
 
-    runRegistrationFlowForSlot(UInt64.valueOf(slotsPerEpoch).plus(TWO));
+    runRegistrationFlowForEpoch(1);
 
     final List<List<SignedValidatorRegistration>> registrationCalls = captureRegistrationCalls(2);
 
@@ -403,7 +402,7 @@ class ValidatorRegistratorTest {
   void registersNewlyAddedValidators() {
     setActiveValidators(validator1);
 
-    runRegistrationFlowForSlot(TWO);
+    runRegistrationFlowForEpoch(0);
 
     // new validators are added
     setActiveValidators(validator1, validator2, validator3);
@@ -434,7 +433,7 @@ class ValidatorRegistratorTest {
         .thenReturn(Optional.empty());
     when(validatorConfig.isBuilderRegistrationDefaultEnabled()).thenReturn(false);
 
-    runRegistrationFlowForSlot(TWO);
+    runRegistrationFlowForEpoch(0);
 
     final List<SignedValidatorRegistration> registrationCalls = captureRegistrationCall();
     verifyRegistrations(registrationCalls, List.of(validator1));
@@ -455,7 +454,7 @@ class ValidatorRegistratorTest {
         .thenReturn(Optional.empty());
     when(validatorConfig.getBuilderRegistrationDefaultGasLimit()).thenReturn(defaultGasLimit);
 
-    runRegistrationFlowForSlot(TWO);
+    runRegistrationFlowForEpoch(0);
 
     final List<SignedValidatorRegistration> registrationCalls = captureRegistrationCall();
 
@@ -488,10 +487,32 @@ class ValidatorRegistratorTest {
     when(validatorRegistrationPropertiesProvider.getFeeRecipient(validator2.getPublicKey()))
         .thenReturn(Optional.empty());
 
-    runRegistrationFlowForSlot(TWO);
+    runRegistrationFlowForEpoch(0);
 
     final List<SignedValidatorRegistration> registrationCalls = captureRegistrationCall();
     verifyRegistrations(registrationCalls, List.of(validator1));
+  }
+
+  @TestTemplate
+  void registerValidatorsEvenIfOneRegistrationSigningFails() {
+    setActiveValidators(validator1, validator2, validator3);
+
+    when(signer.signValidatorRegistration(
+            argThat(
+                validatorRegistration ->
+                    validatorRegistration.getPublicKey().equals(validator2.getPublicKey()))))
+        // signing initially fails for validator2
+        .thenReturn(SafeFuture.failedFuture(new IllegalStateException("oopsy")))
+        // then it succeeds
+        .thenReturn(SafeFuture.completedFuture(dataStructureUtil.randomSignature()));
+
+    runRegistrationFlowForEpoch(0);
+    runRegistrationFlowForEpoch(1);
+
+    final List<List<SignedValidatorRegistration>> registrationCalls = captureRegistrationCalls(2);
+
+    verifyRegistrations(registrationCalls.get(0), List.of(validator1, validator3));
+    verifyRegistrations(registrationCalls.get(1), List.of(validator1, validator2, validator3));
   }
 
   private void setActiveValidators(final Validator... validators) {
@@ -500,6 +521,12 @@ class ValidatorRegistratorTest {
   }
 
   private void runRegistrationFlowForSlot(final UInt64 slot) {
+    validatorRegistrator.onSlot(slot);
+  }
+
+  private void runRegistrationFlowForEpoch(final int epoch) {
+    // third slot in the epoch
+    final UInt64 slot = UInt64.valueOf(epoch).times(slotsPerEpoch).plus(2);
     validatorRegistrator.onSlot(slot);
   }
 


### PR DESCRIPTION
## PR Description
**Before:**
if there is a signing error for one validator, the entire registration flow fails.
**After the change in this PR:**
If there is a signing error for one or more validator, those validators won't be registered and signing will be retried next epoch. All successful signed registrations will be sent.

## Fixed Issue(s)
capturing Improvement 2 of #6289 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
