### PR TITLE
Add deserializeMutated test for datastructures

### DIFF
--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/BeaconBlockBodyPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/BeaconBlockBodyPropertyTest.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.datastructures.blocks;
 
+import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertDeserializeMutatedThrowsExpected;
 import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -26,5 +27,12 @@ public class BeaconBlockBodyPropertyTest {
       @ForAll(supplier = BeaconBlockBodySupplier.class) final BeaconBlockBody beaconBlockBody)
       throws JsonProcessingException {
     assertRoundTrip(beaconBlockBody);
+  }
+
+  @Property
+  void deserializeMutated(
+      @ForAll(supplier = BeaconBlockBodySupplier.class) final BeaconBlockBody beaconBlockBody,
+      @ForAll final int seed) {
+    assertDeserializeMutatedThrowsExpected(beaconBlockBody, seed);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/BeaconBlockHeaderPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/BeaconBlockHeaderPropertyTest.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.datastructures.blocks;
 
+import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertDeserializeMutatedThrowsExpected;
 import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -25,5 +26,12 @@ public class BeaconBlockHeaderPropertyTest {
       @ForAll(supplier = BeaconBlockHeaderSupplier.class) final BeaconBlockHeader beaconBlockHeader)
       throws JsonProcessingException {
     assertRoundTrip(beaconBlockHeader);
+  }
+
+  @Property
+  void deserializeMutated(
+      @ForAll(supplier = BeaconBlockHeaderSupplier.class) final BeaconBlockHeader beaconBlockHeader,
+      @ForAll final int seed) {
+    assertDeserializeMutatedThrowsExpected(beaconBlockHeader, seed);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/BeaconBlockPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/BeaconBlockPropertyTest.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.datastructures.blocks;
 
+import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertDeserializeMutatedThrowsExpected;
 import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -24,5 +25,12 @@ public class BeaconBlockPropertyTest {
   void roundTrip(@ForAll(supplier = BeaconBlockSupplier.class) final BeaconBlock beaconBlock)
       throws JsonProcessingException {
     assertRoundTrip(beaconBlock);
+  }
+
+  @Property
+  void deserializeMutated(
+      @ForAll(supplier = BeaconBlockSupplier.class) final BeaconBlock beaconBlock,
+      @ForAll final int seed) {
+    assertDeserializeMutatedThrowsExpected(beaconBlock, seed);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/BlindedBeaconBlockBodyPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/BlindedBeaconBlockBodyPropertyTest.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.datastructures.blocks;
 
+import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertDeserializeMutatedThrowsExpected;
 import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -27,5 +28,13 @@ public class BlindedBeaconBlockBodyPropertyTest {
           final BeaconBlockBody beaconBlockBody)
       throws JsonProcessingException {
     assertRoundTrip(beaconBlockBody);
+  }
+
+  @Property
+  void deserializeMutated(
+      @ForAll(supplier = BlindedBeaconBlockBodySupplier.class)
+          final BeaconBlockBody beaconBlockBody,
+      @ForAll final int seed) {
+    assertDeserializeMutatedThrowsExpected(beaconBlockBody, seed);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/BlindedBeaconBlockPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/BlindedBeaconBlockPropertyTest.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.datastructures.blocks;
 
+import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertDeserializeMutatedThrowsExpected;
 import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -24,5 +25,12 @@ public class BlindedBeaconBlockPropertyTest {
   void roundTrip(@ForAll(supplier = BlindedBeaconBlockSupplier.class) final BeaconBlock beaconBlock)
       throws JsonProcessingException {
     assertRoundTrip(beaconBlock);
+  }
+
+  @Property
+  void deserializeMutated(
+      @ForAll(supplier = BlindedBeaconBlockSupplier.class) final BeaconBlock beaconBlock,
+      @ForAll final int seed) {
+    assertDeserializeMutatedThrowsExpected(beaconBlock, seed);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/Eth1DataPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/Eth1DataPropertyTest.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.datastructures.blocks;
 
+import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertDeserializeMutatedThrowsExpected;
 import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -24,5 +25,11 @@ public class Eth1DataPropertyTest {
   void roundTrip(@ForAll(supplier = Eth1DataSupplier.class) final Eth1Data eth1Data)
       throws JsonProcessingException {
     assertRoundTrip(eth1Data);
+  }
+
+  @Property
+  void deserializeMutated(
+      @ForAll(supplier = Eth1DataSupplier.class) final Eth1Data eth1Data, @ForAll final int seed) {
+    assertDeserializeMutatedThrowsExpected(eth1Data, seed);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBeaconBlockHeaderPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBeaconBlockHeaderPropertyTest.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.datastructures.blocks;
 
+import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertDeserializeMutatedThrowsExpected;
 import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -26,5 +27,13 @@ public class SignedBeaconBlockHeaderPropertyTest {
           final SignedBeaconBlockHeader signedBeaconBlockHeader)
       throws JsonProcessingException {
     assertRoundTrip(signedBeaconBlockHeader);
+  }
+
+  @Property
+  void deserializeMutated(
+      @ForAll(supplier = SignedBeaconBlockHeaderSupplier.class)
+          final SignedBeaconBlockHeader signedBeaconBlockHeader,
+      @ForAll final int seed) {
+    assertDeserializeMutatedThrowsExpected(signedBeaconBlockHeader, seed);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBeaconBlockPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBeaconBlockPropertyTest.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.datastructures.blocks;
 
+import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertDeserializeMutatedThrowsExpected;
 import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -25,5 +26,12 @@ public class SignedBeaconBlockPropertyTest {
       @ForAll(supplier = SignedBeaconBlockSupplier.class) final SignedBeaconBlock signedBeaconBlock)
       throws JsonProcessingException {
     assertRoundTrip(signedBeaconBlock);
+  }
+
+  @Property
+  void deserializeMutated(
+      @ForAll(supplier = SignedBeaconBlockSupplier.class) final SignedBeaconBlock signedBeaconBlock,
+      @ForAll final int seed) {
+    assertDeserializeMutatedThrowsExpected(signedBeaconBlock, seed);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/SyncAggregatePropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blocks/SyncAggregatePropertyTest.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.datastructures.blocks;
 
+import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertDeserializeMutatedThrowsExpected;
 import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -25,5 +26,12 @@ public class SyncAggregatePropertyTest {
   void roundTrip(@ForAll(supplier = SyncAggregateSupplier.class) final SyncAggregate syncAggregate)
       throws JsonProcessingException {
     assertRoundTrip(syncAggregate);
+  }
+
+  @Property
+  void deserializeMutated(
+      @ForAll(supplier = SyncAggregateSupplier.class) final SyncAggregate syncAggregate,
+      @ForAll final int seed) {
+    assertDeserializeMutatedThrowsExpected(syncAggregate, seed);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/builder/BuilderBidPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/builder/BuilderBidPropertyTest.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.datastructures.builder;
 
+import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertDeserializeMutatedThrowsExpected;
 import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -24,5 +25,12 @@ public class BuilderBidPropertyTest {
   void roundTrip(@ForAll(supplier = BuilderBidSupplier.class) final BuilderBid builderBid)
       throws JsonProcessingException {
     assertRoundTrip(builderBid);
+  }
+
+  @Property
+  void deserializeMutated(
+      @ForAll(supplier = BuilderBidSupplier.class) final BuilderBid builderBid,
+      @ForAll final int seed) {
+    assertDeserializeMutatedThrowsExpected(builderBid, seed);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/builder/SignedBuilderBidPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/builder/SignedBuilderBidPropertyTest.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.datastructures.builder;
 
+import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertDeserializeMutatedThrowsExpected;
 import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -25,5 +26,12 @@ public class SignedBuilderBidPropertyTest {
       @ForAll(supplier = SignedBuilderBidSupplier.class) final SignedBuilderBid signedBuilderBid)
       throws JsonProcessingException {
     assertRoundTrip(signedBuilderBid);
+  }
+
+  @Property
+  void deserializeMutated(
+      @ForAll(supplier = SignedBuilderBidSupplier.class) final SignedBuilderBid signedBuilderBid,
+      @ForAll final int seed) {
+    assertDeserializeMutatedThrowsExpected(signedBuilderBid, seed);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/builder/SignedValidatorRegistrationPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/builder/SignedValidatorRegistrationPropertyTest.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.datastructures.builder;
 
+import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertDeserializeMutatedThrowsExpected;
 import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -26,5 +27,13 @@ public class SignedValidatorRegistrationPropertyTest {
           final SignedValidatorRegistration signedValidatorRegistration)
       throws JsonProcessingException {
     assertRoundTrip(signedValidatorRegistration);
+  }
+
+  @Property
+  void deserializeMutated(
+      @ForAll(supplier = SignedValidatorRegistrationSupplier.class)
+          final SignedValidatorRegistration signedValidatorRegistration,
+      @ForAll final int seed) {
+    assertDeserializeMutatedThrowsExpected(signedValidatorRegistration, seed);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/builder/ValidatorRegistrationPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/builder/ValidatorRegistrationPropertyTest.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.datastructures.builder;
 
+import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertDeserializeMutatedThrowsExpected;
 import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -26,5 +27,13 @@ public class ValidatorRegistrationPropertyTest {
           final ValidatorRegistration validatorRegistration)
       throws JsonProcessingException {
     assertRoundTrip(validatorRegistration);
+  }
+
+  @Property
+  void deserializeMutated(
+      @ForAll(supplier = ValidatorRegistrationSupplier.class)
+          final ValidatorRegistration validatorRegistration,
+      @ForAll final int seed) {
+    assertDeserializeMutatedThrowsExpected(validatorRegistration, seed);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadHeaderPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadHeaderPropertyTest.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.datastructures.execution;
 
+import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertDeserializeMutatedThrowsExpected;
 import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -26,5 +27,13 @@ public class ExecutionPayloadHeaderPropertyTest {
           ExecutionPayloadHeader executionPayloadHeader)
       throws JsonProcessingException {
     assertRoundTrip(executionPayloadHeader);
+  }
+
+  @Property
+  void deserializeMutated(
+      @ForAll(supplier = ExecutionPayloadHeaderSupplier.class)
+          ExecutionPayloadHeader executionPayloadHeader,
+      @ForAll final int seed) {
+    assertDeserializeMutatedThrowsExpected(executionPayloadHeader, seed);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadPropertyTest.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.datastructures.execution;
 
+import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertDeserializeMutatedThrowsExpected;
 import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -25,5 +26,12 @@ public class ExecutionPayloadPropertyTest {
       @ForAll(supplier = ExecutionPayloadSupplier.class) final ExecutionPayload executionPayload)
       throws JsonProcessingException {
     assertRoundTrip(executionPayload);
+  }
+
+  @Property
+  void deserializeMutated(
+      @ForAll(supplier = ExecutionPayloadSupplier.class) final ExecutionPayload executionPayload,
+      @ForAll final int seed) {
+    assertDeserializeMutatedThrowsExpected(executionPayload, seed);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/execution/TransactionPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/execution/TransactionPropertyTest.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.datastructures.execution;
 
+import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertDeserializeMutatedThrowsExpected;
 import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -24,5 +25,12 @@ public class TransactionPropertyTest {
   void roundTrip(@ForAll(supplier = TransactionSupplier.class) final Transaction transaction)
       throws JsonProcessingException {
     assertRoundTrip(transaction);
+  }
+
+  @Property
+  void deserializeMutated(
+      @ForAll(supplier = TransactionSupplier.class) final Transaction transaction,
+      @ForAll final int seed) {
+    assertDeserializeMutatedThrowsExpected(transaction, seed);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/AggregateAndProofPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/AggregateAndProofPropertyTest.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.datastructures.operations;
 
+import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertDeserializeMutatedThrowsExpected;
 import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -25,5 +26,12 @@ public class AggregateAndProofPropertyTest {
       @ForAll(supplier = AggregateAndProofSupplier.class) final AggregateAndProof aggregateAndProof)
       throws JsonProcessingException {
     assertRoundTrip(aggregateAndProof);
+  }
+
+  @Property
+  void deserializeMutated(
+      @ForAll(supplier = AggregateAndProofSupplier.class) final AggregateAndProof aggregateAndProof,
+      @ForAll final int seed) {
+    assertDeserializeMutatedThrowsExpected(aggregateAndProof, seed);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/AttestationDataPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/AttestationDataPropertyTest.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.datastructures.operations;
 
+import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertDeserializeMutatedThrowsExpected;
 import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -25,5 +26,12 @@ public class AttestationDataPropertyTest {
       @ForAll(supplier = AttestationDataSupplier.class) final AttestationData attestationData)
       throws JsonProcessingException {
     assertRoundTrip(attestationData);
+  }
+
+  @Property
+  void deserializeMutated(
+      @ForAll(supplier = AttestationDataSupplier.class) final AttestationData attestationData,
+      @ForAll final int seed) {
+    assertDeserializeMutatedThrowsExpected(attestationData, seed);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/AttestationPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/AttestationPropertyTest.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.datastructures.operations;
 
+import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertDeserializeMutatedThrowsExpected;
 import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -24,5 +25,12 @@ public class AttestationPropertyTest {
   void roundTrip(@ForAll(supplier = AttestationSupplier.class) final Attestation attestation)
       throws JsonProcessingException {
     assertRoundTrip(attestation);
+  }
+
+  @Property
+  void deserializeMutated(
+      @ForAll(supplier = AttestationSupplier.class) final Attestation attestation,
+      @ForAll final int seed) {
+    assertDeserializeMutatedThrowsExpected(attestation, seed);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/AttesterSlashingPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/AttesterSlashingPropertyTest.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.datastructures.operations;
 
+import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertDeserializeMutatedThrowsExpected;
 import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -25,5 +26,12 @@ public class AttesterSlashingPropertyTest {
       @ForAll(supplier = AttesterSlashingSupplier.class) final AttesterSlashing attesterSlashing)
       throws JsonProcessingException {
     assertRoundTrip(attesterSlashing);
+  }
+
+  @Property
+  void deserializeMutated(
+      @ForAll(supplier = AttesterSlashingSupplier.class) final AttesterSlashing attesterSlashing,
+      @ForAll final int seed) {
+    assertDeserializeMutatedThrowsExpected(attesterSlashing, seed);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/ContributionAndProofPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/ContributionAndProofPropertyTest.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.datastructures.operations;
 
+import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertDeserializeMutatedThrowsExpected;
 import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -27,5 +28,13 @@ public class ContributionAndProofPropertyTest {
           final ContributionAndProof contributionAndProof)
       throws JsonProcessingException {
     assertRoundTrip(contributionAndProof);
+  }
+
+  @Property
+  void deserializeMutated(
+      @ForAll(supplier = ContributionAndProofSupplier.class)
+          final ContributionAndProof contributionAndProof,
+      @ForAll final int seed) {
+    assertDeserializeMutatedThrowsExpected(contributionAndProof, seed);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/DepositMessagePropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/DepositMessagePropertyTest.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.datastructures.operations;
 
+import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertDeserializeMutatedThrowsExpected;
 import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -25,5 +26,12 @@ public class DepositMessagePropertyTest {
       @ForAll(supplier = DepositMessageSupplier.class) final DepositMessage depositMessage)
       throws JsonProcessingException {
     assertRoundTrip(depositMessage);
+  }
+
+  @Property
+  void deserializeMutated(
+      @ForAll(supplier = DepositMessageSupplier.class) final DepositMessage depositMessage,
+      @ForAll final int seed) {
+    assertDeserializeMutatedThrowsExpected(depositMessage, seed);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/DepositPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/DepositPropertyTest.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.datastructures.operations;
 
+import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertDeserializeMutatedThrowsExpected;
 import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -24,5 +25,11 @@ public class DepositPropertyTest {
   void roundTrip(@ForAll(supplier = DepositSupplier.class) final Deposit deposit)
       throws JsonProcessingException {
     assertRoundTrip(deposit);
+  }
+
+  @Property
+  void deserializeMutated(
+      @ForAll(supplier = DepositSupplier.class) final Deposit deposit, @ForAll final int seed) {
+    assertDeserializeMutatedThrowsExpected(deposit, seed);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/IndexedAttestationPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/IndexedAttestationPropertyTest.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.datastructures.operations;
 
+import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertDeserializeMutatedThrowsExpected;
 import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -26,5 +27,13 @@ public class IndexedAttestationPropertyTest {
           final IndexedAttestation indexedAttestation)
       throws JsonProcessingException {
     assertRoundTrip(indexedAttestation);
+  }
+
+  @Property
+  void deserializeMutated(
+      @ForAll(supplier = IndexedAttestationSupplier.class)
+          final IndexedAttestation indexedAttestation,
+      @ForAll final int seed) {
+    assertDeserializeMutatedThrowsExpected(indexedAttestation, seed);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/ProposerSlashingPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/ProposerSlashingPropertyTest.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.datastructures.operations;
 
+import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertDeserializeMutatedThrowsExpected;
 import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -25,5 +26,12 @@ public class ProposerSlashingPropertyTest {
       @ForAll(supplier = ProposerSlashingSupplier.class) final ProposerSlashing proposerSlashing)
       throws JsonProcessingException {
     assertRoundTrip(proposerSlashing);
+  }
+
+  @Property
+  void deserializeMutated(
+      @ForAll(supplier = ProposerSlashingSupplier.class) final ProposerSlashing proposerSlashing,
+      @ForAll final int seed) {
+    assertDeserializeMutatedThrowsExpected(proposerSlashing, seed);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SignedAggregateAndProofPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SignedAggregateAndProofPropertyTest.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.datastructures.operations;
 
+import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertDeserializeMutatedThrowsExpected;
 import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -26,5 +27,13 @@ public class SignedAggregateAndProofPropertyTest {
           final SignedAggregateAndProof signedAggregateAndProof)
       throws JsonProcessingException {
     assertRoundTrip(signedAggregateAndProof);
+  }
+
+  @Property
+  void deserializeMutated(
+      @ForAll(supplier = SignedAggregateAndProofSupplier.class)
+          final SignedAggregateAndProof signedAggregateAndProof,
+      @ForAll final int seed) {
+    assertDeserializeMutatedThrowsExpected(signedAggregateAndProof, seed);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SignedContributionAndProofPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SignedContributionAndProofPropertyTest.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.datastructures.operations;
 
+import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertDeserializeMutatedThrowsExpected;
 import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -27,5 +28,13 @@ public class SignedContributionAndProofPropertyTest {
           final SignedContributionAndProof signedContributionAndProof)
       throws JsonProcessingException {
     assertRoundTrip(signedContributionAndProof);
+  }
+
+  @Property
+  void deserializeMutated(
+      @ForAll(supplier = SignedContributionAndProofSupplier.class)
+          final SignedContributionAndProof signedContributionAndProof,
+      @ForAll final int seed) {
+    assertDeserializeMutatedThrowsExpected(signedContributionAndProof, seed);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SignedVoluntaryExitPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SignedVoluntaryExitPropertyTest.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.datastructures.operations;
 
+import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertDeserializeMutatedThrowsExpected;
 import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -26,5 +27,13 @@ public class SignedVoluntaryExitPropertyTest {
           final SignedVoluntaryExit signedVoluntaryExit)
       throws JsonProcessingException {
     assertRoundTrip(signedVoluntaryExit);
+  }
+
+  @Property
+  void deserializeMutated(
+      @ForAll(supplier = SignedVoluntaryExitSupplier.class)
+          final SignedVoluntaryExit signedVoluntaryExit,
+      @ForAll final int seed) {
+    assertDeserializeMutatedThrowsExpected(signedVoluntaryExit, seed);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SyncAggregatorSelectionDataPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SyncAggregatorSelectionDataPropertyTest.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.datastructures.operations;
 
+import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertDeserializeMutatedThrowsExpected;
 import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -27,5 +28,13 @@ public class SyncAggregatorSelectionDataPropertyTest {
           final SyncAggregatorSelectionData syncAggregatorSelectionData)
       throws JsonProcessingException {
     assertRoundTrip(syncAggregatorSelectionData);
+  }
+
+  @Property
+  void deserializeMutated(
+      @ForAll(supplier = SyncAggregatorSelectionDataSupplier.class)
+          final SyncAggregatorSelectionData syncAggregatorSelectionData,
+      @ForAll final int seed) {
+    assertDeserializeMutatedThrowsExpected(syncAggregatorSelectionData, seed);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SyncCommitteeContributionPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SyncCommitteeContributionPropertyTest.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.datastructures.operations;
 
+import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertDeserializeMutatedThrowsExpected;
 import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -27,5 +28,13 @@ public class SyncCommitteeContributionPropertyTest {
           final SyncCommitteeContribution syncCommitteeContribution)
       throws JsonProcessingException {
     assertRoundTrip(syncCommitteeContribution);
+  }
+
+  @Property
+  void deserializeMutated(
+      @ForAll(supplier = SyncCommitteeContributionSupplier.class)
+          final SyncCommitteeContribution syncCommitteeContribution,
+      @ForAll final int seed) {
+    assertDeserializeMutatedThrowsExpected(syncCommitteeContribution, seed);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SyncCommitteeMessagePropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/SyncCommitteeMessagePropertyTest.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.datastructures.operations;
 
+import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertDeserializeMutatedThrowsExpected;
 import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -27,5 +28,13 @@ public class SyncCommitteeMessagePropertyTest {
           final SyncCommitteeMessage syncCommitteeMessage)
       throws JsonProcessingException {
     assertRoundTrip(syncCommitteeMessage);
+  }
+
+  @Property
+  void deserializeMutated(
+      @ForAll(supplier = SyncCommitteeMessageSupplier.class)
+          final SyncCommitteeMessage syncCommitteeMessage,
+      @ForAll final int seed) {
+    assertDeserializeMutatedThrowsExpected(syncCommitteeMessage, seed);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/VoluntaryExitPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/operations/VoluntaryExitPropertyTest.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.datastructures.operations;
 
+import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertDeserializeMutatedThrowsExpected;
 import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -24,5 +25,12 @@ public class VoluntaryExitPropertyTest {
   void roundTrip(@ForAll(supplier = VoluntaryExitSupplier.class) final VoluntaryExit voluntaryExit)
       throws JsonProcessingException {
     assertRoundTrip(voluntaryExit);
+  }
+
+  @Property
+  void deserializeMutated(
+      @ForAll(supplier = VoluntaryExitSupplier.class) final VoluntaryExit voluntaryExit,
+      @ForAll final int seed) {
+    assertDeserializeMutatedThrowsExpected(voluntaryExit, seed);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/state/BeaconStatePropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/state/BeaconStatePropertyTest.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.datastructures.state;
 
+import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertDeserializeMutatedThrowsExpected;
 import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -22,9 +23,15 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 
 public class BeaconStatePropertyTest {
   @Property(tries = 100)
-  @SuppressWarnings("unchecked")
   void roundTrip(@ForAll(supplier = BeaconStateSupplier.class) final BeaconState beaconState)
       throws JsonProcessingException {
     assertRoundTrip(beaconState);
+  }
+
+  @Property(tries = 100)
+  void deserializeMutated(
+      @ForAll(supplier = BeaconStateSupplier.class) final BeaconState beaconState,
+      @ForAll final int seed) {
+    assertDeserializeMutatedThrowsExpected(beaconState, seed);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/type/SszPublicKeyPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/type/SszPublicKeyPropertyTest.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.datastructures.type;
 
+import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertDeserializeMutatedThrowsExpected;
 import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -24,5 +25,12 @@ public class SszPublicKeyPropertyTest {
   void roundTrip(@ForAll(supplier = SszPublicKeySupplier.class) final SszPublicKey sszPublicKey)
       throws JsonProcessingException {
     assertRoundTrip(sszPublicKey);
+  }
+
+  @Property
+  void deserializeMutated(
+      @ForAll(supplier = SszPublicKeySupplier.class) final SszPublicKey sszPublicKey,
+      @ForAll final int seed) {
+    assertDeserializeMutatedThrowsExpected(sszPublicKey, seed);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/type/SszSignaturePropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/type/SszSignaturePropertyTest.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.datastructures.type;
 
+import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertDeserializeMutatedThrowsExpected;
 import static tech.pegasys.teku.spec.datastructures.util.PropertyTestHelper.assertRoundTrip;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -24,5 +25,12 @@ public class SszSignaturePropertyTest {
   void roundTrip(@ForAll(supplier = SszSignatureSupplier.class) final SszSignature sszSignature)
       throws JsonProcessingException {
     assertRoundTrip(sszSignature);
+  }
+
+  @Property
+  void deserializeMutated(
+      @ForAll(supplier = SszSignatureSupplier.class) final SszSignature sszSignature,
+      @ForAll final int seed) {
+    assertDeserializeMutatedThrowsExpected(sszSignature, seed);
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/util/Mutator.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/util/Mutator.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import org.apache.tuweni.bytes.Bytes;
+
+public class Mutator {
+  /** The types of mutations that can occur. */
+  private enum Mutation {
+    REPLACE,
+    ADD_BEFORE,
+    ADD_AFTER,
+    DELETE
+  }
+
+  /** Likelihood that a specific mutation will happen. */
+  private static final Map<Mutation, Double> MUTATION_PROBABILITIES =
+      Map.of(
+          Mutation.REPLACE, 0.01,
+          Mutation.ADD_BEFORE, 0.001,
+          Mutation.ADD_AFTER, 0.001,
+          Mutation.DELETE, 0.001);
+
+  /** The total probability that a mutation of any kind will happen. */
+  private static final double MUTATION_PROBABILITY =
+      MUTATION_PROBABILITIES.values().stream().reduce(0.0, Double::sum);
+
+  /** If a random number falls in this range, that mutation should happen. */
+  private static final Map<Mutation, Range> RANGE_MAP = new HashMap<>();
+
+  static {
+    // Make a map of non-overlapping ranges. The range reflects the probability of that mutation.
+    // When fuzzing, a random number will be chosen. To determine which mutation should occur, we
+    // check which of these ranges the random number falls into. For example, you could expect this
+    // map to look something like:
+    //
+    // {
+    //    REPLACE: Range(0, 0.01),
+    //    ADD_BEFORE: Range(0.01, 0.011),
+    //    ADD_AFTER: Range(0.011, 0.012),
+    //    DELETE: Range(0.012, 0.013)
+    // }
+    double start = 0.0;
+    for (Map.Entry<Mutation, Double> entry : MUTATION_PROBABILITIES.entrySet()) {
+      RANGE_MAP.put(entry.getKey(), new Range(start, start + entry.getValue()));
+      start += entry.getValue();
+    }
+  }
+
+  /**
+   * A helper function for generating random input data. Instead of blinding making data, start with
+   * a known valid data and slightly mutate that. By default, you can expect a ~1% mutation rate.
+   *
+   * @param input The bytes to mutate, should resemble valid data.
+   * @param seed The seed that should be used for randomness, for reproducibility.
+   * @return A mutated version of the input.
+   */
+  public static Bytes mutate(final Bytes input, final int seed) {
+    final Random random = new Random(seed);
+    final List<Bytes> sections = new ArrayList<>();
+
+    for (final byte b : input.toArray()) {
+      final double randomNumber = Math.abs(random.nextGaussian());
+      if (randomNumber <= MUTATION_PROBABILITY) {
+
+        Mutation op = null;
+        for (final Map.Entry<Mutation, Range> entry : RANGE_MAP.entrySet()) {
+          if (entry.getValue().contains(randomNumber)) {
+            op = entry.getKey();
+            break;
+          }
+        }
+        assertThat(op).isNotNull();
+
+        switch (op) {
+          case ADD_BEFORE:
+            final byte before = (byte) random.nextInt();
+            sections.add(Bytes.of(before, b));
+            break;
+          case ADD_AFTER:
+            final byte after = (byte) random.nextInt();
+            sections.add(Bytes.of(b, after));
+            break;
+          case REPLACE:
+            final byte replace = (byte) random.nextInt();
+            sections.add(Bytes.of(replace));
+            break;
+          case DELETE:
+            break;
+        }
+      } else {
+        sections.add(Bytes.of(b));
+      }
+    }
+    return Bytes.concatenate(sections);
+  }
+
+  private static class Range {
+    private final double a;
+    private final double b;
+
+    public Range(final double a, final double b) {
+      assertThat(a).isLessThanOrEqualTo(b);
+      this.a = a;
+      this.b = b;
+    }
+
+    /** Does the value fall into the exclusive [a, b) range. */
+    public boolean contains(final double value) {
+      return a <= value && value < b;
+    }
+  }
+}

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/util/Mutator.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/util/Mutator.java
@@ -13,8 +13,7 @@
 
 package tech.pegasys.teku.spec.datastructures.util;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.io.ByteArrayOutputStream;
 import java.util.Map;
 import java.util.Random;
 import java.util.TreeMap;
@@ -71,7 +70,7 @@ public class Mutator {
    */
   public static Bytes mutate(final Bytes input, final int seed) {
     final Random random = new Random(seed);
-    final List<Bytes> sections = new ArrayList<>();
+    final ByteArrayOutputStream out = new ByteArrayOutputStream(input.size());
 
     for (final byte b : input.toArray()) {
       final double randomNumber = random.nextDouble();
@@ -80,23 +79,25 @@ public class Mutator {
         switch (entry.getValue()) {
           case ADD_BEFORE:
             final byte before = (byte) random.nextInt();
-            sections.add(Bytes.of(before, b));
+            out.write(before);
+            out.write(b);
             break;
           case ADD_AFTER:
             final byte after = (byte) random.nextInt();
-            sections.add(Bytes.of(b, after));
+            out.write(b);
+            out.write(after);
             break;
           case REPLACE:
             final byte replace = (byte) random.nextInt();
-            sections.add(Bytes.of(replace));
+            out.write(replace);
             break;
           case DELETE:
             break;
         }
       } else {
-        sections.add(Bytes.of(b));
+        out.write(b);
       }
     }
-    return Bytes.concatenate(sections);
+    return Bytes.wrap(out.toByteArray());
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/util/Mutator.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/util/Mutator.java
@@ -79,7 +79,7 @@ public class Mutator {
 
     for (final byte b : input.toArray()) {
       final double randomNumber = Math.abs(random.nextGaussian());
-      if (randomNumber <= MUTATION_PROBABILITY) {
+      if (randomNumber < MUTATION_PROBABILITY) {
 
         Mutation op = null;
         for (final Map.Entry<Mutation, Range> entry : RANGE_MAP.entrySet()) {

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/util/PropertyTestHelper.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/util/PropertyTestHelper.java
@@ -21,6 +21,7 @@ import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 import tech.pegasys.teku.infrastructure.ssz.SszData;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszSchema;
+import tech.pegasys.teku.infrastructure.ssz.sos.SszDeserializeException;
 
 public class PropertyTestHelper {
   @SuppressWarnings("unchecked")
@@ -38,5 +39,19 @@ public class PropertyTestHelper {
     final String json = JsonUtil.serialize(data, typeDefinition);
     final T fromJson = JsonUtil.parse(json, typeDefinition);
     assertThat(fromJson).isEqualTo(data);
+  }
+
+  @SuppressWarnings("unchecked")
+  public static <T extends SszData, S extends SszSchema<T>>
+      void assertDeserializeMutatedThrowsExpected(final T data, final int seed) {
+    final S schema = (S) data.getSchema();
+    final Bytes ssz = data.sszSerialize();
+    final Bytes mutated = Mutator.mutate(ssz, seed);
+
+    try {
+      schema.sszDeserialize(mutated);
+    } catch (Exception e) {
+      assertThat(e).isInstanceOfAny(SszDeserializeException.class, IllegalArgumentException.class);
+    }
   }
 }


### PR DESCRIPTION
## PR Description

The current property tests deserialize input that should be deserializable. This PR adds tests that deserialize data structures that have been slightly mutated. I believe this is smarter than deserializing random bytes. This PR is focussed on SSZ deserialization; we could do the same thing for JSON deserialization, but it would be a bit more difficult.

Overview of changes:

* Add new `Mutator` class with a static `mutate` method.
* Add new `deserializeMutated` method to each data structure property test file.
* Add new `assertDeserializeMutatedThrowsExpected` method to `PropertyTestHelper`.
  * Expected exceptions are `SszDeserializeException` and `IllegalArgumentException`.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
