### PR TITLE
teku-6236 Added event channel for execution client availability report

### DIFF
--- a/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JExecutionEngineClientTest.java
+++ b/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JExecutionEngineClientTest.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.ethereum.executionclient.web3j;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.InstanceOfAssertFactories.INTEGER;
 import static org.assertj.core.api.InstanceOfAssertFactories.STRING;
+import static org.mockito.Mockito.mock;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
@@ -35,6 +36,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
+import tech.pegasys.teku.ethereum.executionclient.events.ExecutionClientEventsChannel;
 import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceStateV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceUpdatedResult;
 import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV1;
@@ -56,6 +58,8 @@ public class Web3JExecutionEngineClientTest {
   private static final Duration DEFAULT_TIMEOUT = Duration.ofMinutes(1);
   private final MockWebServer mockWebServer = new MockWebServer();
   private final StubTimeProvider timeProvider = StubTimeProvider.withTimeInSeconds(0);
+  private final ExecutionClientEventsChannel executionClientEventsPublisher =
+      mock(ExecutionClientEventsChannel.class);
 
   Writer jsonWriter;
   JsonGenerator jsonGenerator;
@@ -80,6 +84,7 @@ public class Web3JExecutionEngineClientTest {
             .timeout(DEFAULT_TIMEOUT)
             .jwtConfigOpt(Optional.empty())
             .timeProvider(timeProvider)
+            .executionClientEventsPublisher(executionClientEventsPublisher)
             .build();
     eeClient = new Web3JExecutionEngineClient(web3JClient);
   }

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/events/ExecutionClientEventsChannel.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/events/ExecutionClientEventsChannel.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionclient.events;
+
+import tech.pegasys.teku.infrastructure.events.VoidReturningChannelInterface;
+
+public interface ExecutionClientEventsChannel extends VoidReturningChannelInterface {
+
+  void onAvailabilityUpdated(boolean isAvailable);
+}

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/DefaultExecutionWeb3jClientProvider.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/DefaultExecutionWeb3jClientProvider.java
@@ -19,6 +19,7 @@ import java.time.Duration;
 import java.util.Optional;
 import org.web3j.protocol.Web3j;
 import tech.pegasys.teku.ethereum.executionclient.auth.JwtConfig;
+import tech.pegasys.teku.ethereum.executionclient.events.ExecutionClientEventsChannel;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 
 public class DefaultExecutionWeb3jClientProvider implements ExecutionWeb3jClientProvider {
@@ -26,6 +27,7 @@ public class DefaultExecutionWeb3jClientProvider implements ExecutionWeb3jClient
   private final Duration timeout;
   private final Optional<JwtConfig> jwtConfig;
   private final TimeProvider timeProvider;
+  private final ExecutionClientEventsChannel executionClientEventsPublisher;
 
   private boolean alreadyBuilt = false;
   private Web3JClient web3JClient;
@@ -34,12 +36,14 @@ public class DefaultExecutionWeb3jClientProvider implements ExecutionWeb3jClient
       final String eeEndpoint,
       final Duration timeout,
       final Optional<JwtConfig> jwtConfig,
-      final TimeProvider timeProvider) {
+      final TimeProvider timeProvider,
+      final ExecutionClientEventsChannel executionClientEventsPublisher) {
     checkNotNull(eeEndpoint);
     this.eeEndpoint = eeEndpoint;
     this.timeout = timeout;
     this.jwtConfig = jwtConfig;
     this.timeProvider = timeProvider;
+    this.executionClientEventsPublisher = executionClientEventsPublisher;
   }
 
   private synchronized void buildClient() {
@@ -53,6 +57,7 @@ public class DefaultExecutionWeb3jClientProvider implements ExecutionWeb3jClient
             .timeout(timeout)
             .jwtConfigOpt(jwtConfig)
             .timeProvider(timeProvider)
+            .executionClientEventsPublisher(executionClientEventsPublisher)
             .build();
     this.alreadyBuilt = true;
   }

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/ExecutionWeb3jClientProvider.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/ExecutionWeb3jClientProvider.java
@@ -21,6 +21,7 @@ import java.time.Duration;
 import java.util.Optional;
 import org.web3j.protocol.Web3j;
 import tech.pegasys.teku.ethereum.executionclient.auth.JwtConfig;
+import tech.pegasys.teku.ethereum.executionclient.events.ExecutionClientEventsChannel;
 import tech.pegasys.teku.infrastructure.exceptions.InvalidConfigurationException;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 
@@ -54,7 +55,8 @@ public interface ExecutionWeb3jClientProvider {
       final boolean jwtSupported,
       final Optional<String> jwtSecretFile,
       final Path beaconDataDirectory,
-      final TimeProvider timeProvider) {
+      final TimeProvider timeProvider,
+      final ExecutionClientEventsChannel executionClientEventsPublisher) {
     if (endpoint.startsWith(PREVIOUS_STUB_ENDPOINT_PREFIX)) {
       throw new InvalidConfigurationException(
           "Using the stub execution engine is unsafe. This is only designed for testing. Please use a real execution client.");
@@ -63,7 +65,8 @@ public interface ExecutionWeb3jClientProvider {
     } else {
       final Optional<JwtConfig> jwtConfig =
           JwtConfig.createIfNeeded(jwtSupported, jwtSecretFile, beaconDataDirectory);
-      return new DefaultExecutionWeb3jClientProvider(endpoint, timeout, jwtConfig, timeProvider);
+      return new DefaultExecutionWeb3jClientProvider(
+          endpoint, timeout, jwtConfig, timeProvider, executionClientEventsPublisher);
     }
   }
 

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3jHttpClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3jHttpClient.java
@@ -23,6 +23,7 @@ import org.web3j.protocol.Web3jService;
 import org.web3j.protocol.http.HttpService;
 import tech.pegasys.teku.ethereum.executionclient.OkHttpClientCreator;
 import tech.pegasys.teku.ethereum.executionclient.auth.JwtConfig;
+import tech.pegasys.teku.ethereum.executionclient.events.ExecutionClientEventsChannel;
 import tech.pegasys.teku.infrastructure.logging.EventLogger;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 
@@ -34,8 +35,9 @@ class Web3jHttpClient extends Web3JClient {
       final URI endpoint,
       final TimeProvider timeProvider,
       final Duration timeout,
-      final Optional<JwtConfig> jwtConfig) {
-    super(eventLog, timeProvider);
+      final Optional<JwtConfig> jwtConfig,
+      final ExecutionClientEventsChannel executionClientEventsPublisher) {
+    super(eventLog, timeProvider, executionClientEventsPublisher);
     final OkHttpClient okHttpClient =
         OkHttpClientCreator.create(timeout, LOG, jwtConfig, timeProvider);
     final Web3jService httpService = new HttpService(endpoint.toString(), okHttpClient);

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3jIpcClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3jIpcClient.java
@@ -23,6 +23,7 @@ import org.web3j.protocol.ipc.IpcService;
 import org.web3j.protocol.ipc.UnixIpcService;
 import org.web3j.protocol.ipc.WindowsIpcService;
 import tech.pegasys.teku.ethereum.executionclient.auth.JwtConfig;
+import tech.pegasys.teku.ethereum.executionclient.events.ExecutionClientEventsChannel;
 import tech.pegasys.teku.infrastructure.exceptions.InvalidConfigurationException;
 import tech.pegasys.teku.infrastructure.logging.EventLogger;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
@@ -34,8 +35,9 @@ class Web3jIpcClient extends Web3JClient {
       final EventLogger eventLog,
       final URI endpoint,
       final TimeProvider timeProvider,
-      final Optional<JwtConfig> jwtConfig) {
-    super(eventLog, timeProvider);
+      final Optional<JwtConfig> jwtConfig,
+      final ExecutionClientEventsChannel executionClientEventsPublisher) {
+    super(eventLog, timeProvider, executionClientEventsPublisher);
     if (jwtConfig.isPresent()) {
       LOG.warn("JWT configuration is ignored with IPC endpoint URI");
     }

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3jWebsocketClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3jWebsocketClient.java
@@ -23,6 +23,7 @@ import org.web3j.protocol.websocket.WebSocketClient;
 import org.web3j.protocol.websocket.WebSocketService;
 import tech.pegasys.teku.ethereum.executionclient.auth.JwtAuthWebsocketHelper;
 import tech.pegasys.teku.ethereum.executionclient.auth.JwtConfig;
+import tech.pegasys.teku.ethereum.executionclient.events.ExecutionClientEventsChannel;
 import tech.pegasys.teku.ethereum.executionclient.schema.Response;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.logging.EventLogger;
@@ -37,8 +38,9 @@ class Web3jWebsocketClient extends Web3JClient {
       final EventLogger eventLog,
       final URI endpoint,
       final TimeProvider timeProvider,
-      final Optional<JwtConfig> jwtConfig) {
-    super(eventLog, timeProvider);
+      final Optional<JwtConfig> jwtConfig,
+      final ExecutionClientEventsChannel executionClientEventsPublisher) {
+    super(eventLog, timeProvider, executionClientEventsPublisher);
     this.webSocketClient = new WebSocketClient(endpoint);
     final WebSocketService webSocketService = new WebSocketService(webSocketClient, false);
     initWeb3jService(webSocketService);

--- a/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JClientTest.java
+++ b/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JClientTest.java
@@ -209,27 +209,6 @@ public class Web3JClientTest {
     verify(executionClientEventsPublisher).onAvailabilityUpdated(eq(false));
   }
 
-  @ParameterizedTest
-  @MethodSource("getClientInstances")
-  void shouldNotUpdateAvailabilityAfterSubsequentsFailedRequests(final ClientFactory clientFactory)
-      throws Exception {
-    final Web3JClient client = clientFactory.create(eventLog, executionClientEventsPublisher);
-    Request<Void, VoidResponse> request = createRequest(client);
-    when(client.getWeb3jService().sendAsync(request, VoidResponse.class))
-        .thenReturn(SafeFuture.completedFuture(new VoidResponse()))
-        .thenReturn(SafeFuture.failedFuture(new IllegalStateException("oopsy")))
-        .thenReturn(SafeFuture.failedFuture(new IllegalStateException("oopsy")));
-
-    Waiter.waitFor(client.doRequest(request, DEFAULT_TIMEOUT));
-    verify(executionClientEventsPublisher).onAvailabilityUpdated(eq(true));
-
-    Waiter.waitFor(client.doRequest(request, DEFAULT_TIMEOUT));
-    verify(executionClientEventsPublisher).onAvailabilityUpdated(eq(false));
-
-    Waiter.waitFor(client.doRequest(request, DEFAULT_TIMEOUT));
-    verifyNoMoreInteractions(executionClientEventsPublisher);
-  }
-
   private static Request<Void, VoidResponse> createRequest(final Web3JClient client) {
     return new Request<>("test", new ArrayList<>(), client.getWeb3jService(), VoidResponse.class);
   }

--- a/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3jClientBuilderTest.java
+++ b/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3jClientBuilderTest.java
@@ -19,108 +19,156 @@ import static org.mockito.Mockito.mock;
 
 import java.time.Duration;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.ethereum.executionclient.events.ExecutionClientEventsChannel;
 import tech.pegasys.teku.infrastructure.exceptions.InvalidConfigurationException;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 
 public class Web3jClientBuilderTest {
-  private static final Duration DEFAULT_TIMEOUT = Duration.ofMinutes(1);
+
+  private final String endpoint = "http://localhost";
+  private final TimeProvider timeProvider = mock(TimeProvider.class);
+  private final Duration timeout = Duration.ofMinutes(1);
+  private final ExecutionClientEventsChannel executionClientEventsPublisher =
+      mock(ExecutionClientEventsChannel.class);
 
   @Test
   public void shouldFailSettingBadEndpoint() {
-    Web3jClientBuilder builder = new Web3jClientBuilder();
-    assertThatThrownBy(() -> builder.endpoint("http://^"))
+    assertThatThrownBy(() -> new Web3jClientBuilder().endpoint("http://^"))
         .isInstanceOf(InvalidConfigurationException.class);
   }
 
   @Test
   public void shouldFailBuildPreconditionCheckWithNoEndpoint() {
-    Web3jClientBuilder builder = new Web3jClientBuilder();
+    Web3jClientBuilder builder =
+        new Web3jClientBuilder()
+            .timeProvider(timeProvider)
+            .timeout(timeout)
+            .executionClientEventsPublisher(executionClientEventsPublisher);
+
     assertThatThrownBy(builder::build).isInstanceOf(NullPointerException.class);
   }
 
   @Test
   public void shouldFailBuildPreconditionCheckWithNoTimeout() {
-    Web3jClientBuilder builder = new Web3jClientBuilder();
-    builder.timeProvider(mock(TimeProvider.class)).endpoint("http://localhost");
+    Web3jClientBuilder builder =
+        new Web3jClientBuilder()
+            .timeProvider(timeProvider)
+            .endpoint(endpoint)
+            .executionClientEventsPublisher(executionClientEventsPublisher);
+
     assertThatThrownBy(builder::build).isInstanceOf(NullPointerException.class);
   }
 
   @Test
   public void shouldFailBuildPreconditionCheckWithNoTimeprovider() {
-    Web3jClientBuilder builder = new Web3jClientBuilder();
-    builder.timeout(DEFAULT_TIMEOUT).endpoint("http://localhost");
+    Web3jClientBuilder builder =
+        new Web3jClientBuilder()
+            .endpoint(endpoint)
+            .timeout(timeout)
+            .executionClientEventsPublisher(executionClientEventsPublisher);
+
+    assertThatThrownBy(builder::build).isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  public void shouldFailBuildPreconditionCheckWithNoExecutionClientEventPublisher() {
+    Web3jClientBuilder builder =
+        new Web3jClientBuilder().timeProvider(timeProvider).endpoint(endpoint).timeout(timeout);
+
     assertThatThrownBy(builder::build).isInstanceOf(NullPointerException.class);
   }
 
   @Test
   public void shouldFailBuildWithUnsupportedEndpointScheme() {
-    Web3jClientBuilder builder = new Web3jClientBuilder();
-    builder
-        .timeProvider(mock(TimeProvider.class))
-        .timeout(DEFAULT_TIMEOUT)
-        .endpoint("abc://localhost");
+    Web3jClientBuilder builder =
+        new Web3jClientBuilder()
+            .timeProvider(timeProvider)
+            .endpoint("abc://localhost")
+            .timeout(timeout)
+            .executionClientEventsPublisher(executionClientEventsPublisher);
+
     assertThatThrownBy(builder::build).isInstanceOf(InvalidConfigurationException.class);
   }
 
   @Test
   public void shouldFailBuildWithNullEndpointScheme() {
-    Web3jClientBuilder builder = new Web3jClientBuilder();
-    builder.timeProvider(mock(TimeProvider.class)).timeout(DEFAULT_TIMEOUT).endpoint("localhost");
+    Web3jClientBuilder builder =
+        new Web3jClientBuilder()
+            .timeProvider(timeProvider)
+            .endpoint("localhost")
+            .timeout(timeout)
+            .executionClientEventsPublisher(executionClientEventsPublisher);
+
     assertThatThrownBy(builder::build).hasMessageContaining("scheme is not supported");
   }
 
   @Test
   public void shouldBuildHttpClientWithHttpEndpoint() {
-    Web3jClientBuilder builder = new Web3jClientBuilder();
-    builder
-        .timeProvider(mock(TimeProvider.class))
-        .timeout(DEFAULT_TIMEOUT)
-        .endpoint("http://localhost");
+    Web3jClientBuilder builder =
+        new Web3jClientBuilder()
+            .timeProvider(mock(TimeProvider.class))
+            .endpoint("http://localhost")
+            .timeout(timeout)
+            .executionClientEventsPublisher(executionClientEventsPublisher);
+
     Web3JClient client = builder.build();
+
     assertThat(client).isInstanceOf(Web3jHttpClient.class);
   }
 
   @Test
   public void shouldBuildHttpClientWithHttpsEndpoint() {
-    Web3jClientBuilder builder = new Web3jClientBuilder();
-    builder
-        .timeProvider(mock(TimeProvider.class))
-        .timeout(DEFAULT_TIMEOUT)
-        .endpoint("https://localhost");
+    Web3jClientBuilder builder =
+        new Web3jClientBuilder()
+            .timeProvider(mock(TimeProvider.class))
+            .endpoint("https://localhost")
+            .timeout(timeout)
+            .executionClientEventsPublisher(executionClientEventsPublisher);
+
     Web3JClient client = builder.build();
+
     assertThat(client).isInstanceOf(Web3jHttpClient.class);
   }
 
   @Test
   public void shouldBuildWebsocketClientWithWsEndpoint() {
-    Web3jClientBuilder builder = new Web3jClientBuilder();
-    builder
-        .timeProvider(mock(TimeProvider.class))
-        .timeout(DEFAULT_TIMEOUT)
-        .endpoint("ws://localhost");
+    Web3jClientBuilder builder =
+        new Web3jClientBuilder()
+            .timeProvider(mock(TimeProvider.class))
+            .endpoint("ws://localhost")
+            .timeout(timeout)
+            .executionClientEventsPublisher(executionClientEventsPublisher);
+
     Web3JClient client = builder.build();
+
     assertThat(client).isInstanceOf(Web3jWebsocketClient.class);
   }
 
   @Test
   public void shouldBuildWebsocketClientWithWssEndpoint() {
-    Web3jClientBuilder builder = new Web3jClientBuilder();
-    builder
-        .timeProvider(mock(TimeProvider.class))
-        .timeout(DEFAULT_TIMEOUT)
-        .endpoint("wss://localhost");
+    Web3jClientBuilder builder =
+        new Web3jClientBuilder()
+            .timeProvider(mock(TimeProvider.class))
+            .endpoint("wss://localhost")
+            .timeout(timeout)
+            .executionClientEventsPublisher(executionClientEventsPublisher);
+
     Web3JClient client = builder.build();
+
     assertThat(client).isInstanceOf(Web3jWebsocketClient.class);
   }
 
   @Test
   public void shouldBuildIpcClientWithFileEndpoint() {
-    Web3jClientBuilder builder = new Web3jClientBuilder();
-    builder
-        .timeProvider(mock(TimeProvider.class))
-        .timeout(DEFAULT_TIMEOUT)
-        .endpoint("file:/some/path");
+    Web3jClientBuilder builder =
+        new Web3jClientBuilder()
+            .timeProvider(mock(TimeProvider.class))
+            .endpoint("file:/some/path")
+            .timeout(timeout)
+            .executionClientEventsPublisher(executionClientEventsPublisher);
+
     Web3JClient client = builder.build();
+
     assertThat(client).isInstanceOf(Web3jIpcClient.class);
   }
 }

--- a/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3jWebsocketClientTest.java
+++ b/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3jWebsocketClientTest.java
@@ -35,14 +35,18 @@ import org.junit.jupiter.api.Test;
 import org.web3j.protocol.core.Request;
 import org.web3j.protocol.core.methods.response.VoidResponse;
 import org.web3j.protocol.websocket.WebSocketService;
+import tech.pegasys.teku.ethereum.executionclient.events.ExecutionClientEventsChannel;
 import tech.pegasys.teku.ethereum.executionclient.schema.Response;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 
 public class Web3jWebsocketClientTest {
+
   private static final Duration TIMEOUT = Duration.ofSeconds(10000000);
   private final TimeProvider timeProvider = StubTimeProvider.withTimeInSeconds(1000);
+  private final ExecutionClientEventsChannel executionClientEventsPublisher =
+      mock(ExecutionClientEventsChannel.class);
   private final WebSocketService webSocketService = mock(WebSocketService.class);
   private final URI endpoint = URI.create("");
   private Web3jWebsocketClient web3jWebsocketClient;
@@ -50,7 +54,8 @@ public class Web3jWebsocketClientTest {
   @BeforeEach
   public void setup() {
     this.web3jWebsocketClient =
-        new Web3jWebsocketClient(EVENT_LOG, endpoint, timeProvider, Optional.empty());
+        new Web3jWebsocketClient(
+            EVENT_LOG, endpoint, timeProvider, Optional.empty(), executionClientEventsPublisher);
     web3jWebsocketClient.initWeb3jService(webSocketService);
   }
 

--- a/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerService.java
+++ b/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerService.java
@@ -28,6 +28,7 @@ import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.ethereum.events.SlotEventsChannel;
 import tech.pegasys.teku.ethereum.executionclient.BuilderClient;
 import tech.pegasys.teku.ethereum.executionclient.ExecutionEngineClient;
+import tech.pegasys.teku.ethereum.executionclient.events.ExecutionClientEventsChannel;
 import tech.pegasys.teku.ethereum.executionclient.rest.RestClientProvider;
 import tech.pegasys.teku.ethereum.executionclient.web3j.ExecutionWeb3jClientProvider;
 import tech.pegasys.teku.ethereum.executionlayer.BuilderBidValidatorImpl;
@@ -57,6 +58,9 @@ public class ExecutionLayerService extends Service {
     final Path beaconDataDirectory = serviceConfig.getDataDirLayout().getBeaconDataDirectory();
     final TimeProvider timeProvider = serviceConfig.getTimeProvider();
 
+    final ExecutionClientEventsChannel executionClientEventsPublisher =
+        serviceConfig.getEventChannels().getPublisher(ExecutionClientEventsChannel.class);
+
     final ExecutionWeb3jClientProvider engineWeb3jClientProvider =
         ExecutionWeb3jClientProvider.create(
             config.getEngineEndpoint(),
@@ -64,7 +68,8 @@ public class ExecutionLayerService extends Service {
             true,
             config.getEngineJwtSecretFile(),
             beaconDataDirectory,
-            timeProvider);
+            timeProvider,
+            executionClientEventsPublisher);
 
     final Optional<RestClientProvider> builderRestClientProvider =
         config


### PR DESCRIPTION
Created a new interface `ExecutionClientEventsChannel` for any ExecutionClient event. Atm it only has a `onAvailabilityUpdated(bool)` method.

Updated `Web3JClient` to keep track of the EL's availability and publish an event when it changes.

Before any requests to the EL, we assume the its availability = false.