### PR TITLE
Ignore status updates from disconnected peers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,3 +29,4 @@ For information on changes in released versions of Teku, see the [releases page]
 ### Bug Fixes
 - Filter out unknown validators when sending validator registrations to the builder network
 - Fix issue which could cause locally produced aggregates to not be gossiped
+- Fix issue where the sync module could cause `Unexpected rejected execution due to full task queue in nioEventLoopGroup` log messages and high CPU usage

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/chains/PeerChainTracker.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/chains/PeerChainTracker.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.teku.beacon.sync.forward.multipeer.chains;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.infrastructure.async.eventthread.EventThread;
 import tech.pegasys.teku.infrastructure.subscribers.Subscribers;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
@@ -27,6 +29,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
  * non-finalized chains.
  */
 public class PeerChainTracker {
+  private static final Logger LOG = LogManager.getLogger();
   private final Spec spec;
   private final EventThread eventThread;
   private final P2PNetwork<Eth2Peer> p2pNetwork;
@@ -81,6 +84,10 @@ public class PeerChainTracker {
 
   private void onPeerStatusUpdate(final Eth2Peer peer, final PeerStatus status) {
     eventThread.checkOnEventThread();
+    if (!peer.isConnected()) {
+      LOG.debug("Ignoring update from disconnected peer");
+      return;
+    }
     final SyncSource syncSource = syncSourceFactory.getOrCreateSyncSource(peer);
     final SlotAndBlockRoot finalizedChainHead =
         new SlotAndBlockRoot(


### PR DESCRIPTION
## PR Description
Sync target chain tracking now ignores status updates from disconnected peers. This fixes a race condition where when a status message is received just before a client disconnects, the disconnection even may be processed by the sync module before the status message leading to a disconnected peer being kept in the set of target chains.

## Fixed Issue(s)
fixes #6200 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
