### PR TITLE
Throttle validator registration external signing requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ For information on changes in released versions of Teku, see the [releases page]
 - The `voluntary-exit` subcommand can restrict the exit to a specific list of validators public keys using the option `--validator-public-keys`.
   Example: `teku voluntary-exit --beacon-node-api-endpoint=<ENDPOINT>[,<ENDPOINT>...]... --data-validator-path=<PATH> --include-keymanager-keys=<BOOLEAN> --validator-keys=<KEY_DIR>:<PASS_DIR> | <KEY_FILE>:<PASS_FILE> --validator-public-keys=<PUBKEY>[,<PUBKEY>...]...`
   To include validator keys managed via keymanager APIs, the option `--include-keymanager-keys` could be set to `true` (The default value is set to `false`)
+- Throttle signing of validator registrations when using an external signer
 
 ### Bug Fixes
 - Filter out unknown validators when sending validator registrations to the builder network

--- a/beacon/pow/src/main/java/tech/pegasys/teku/beacon/pow/ThrottlingEth1Provider.java
+++ b/beacon/pow/src/main/java/tech/pegasys/teku/beacon/pow/ThrottlingEth1Provider.java
@@ -38,7 +38,7 @@ public class ThrottlingEth1Provider implements Eth1Provider {
       final MetricsSystem metricsSystem) {
     this.delegate = delegate;
     taskQueue =
-        new ThrottlingTaskQueue(
+        ThrottlingTaskQueue.create(
             maximumConcurrentRequests,
             metricsSystem,
             TekuMetricCategory.BEACON,

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ThrottlingBuilderClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ThrottlingBuilderClient.java
@@ -38,7 +38,7 @@ public class ThrottlingBuilderClient implements BuilderClient {
       final MetricsSystem metricsSystem) {
     this.delegate = delegate;
     taskQueue =
-        new ThrottlingTaskQueue(
+        ThrottlingTaskQueue.create(
             maximumConcurrentRequests,
             metricsSystem,
             TekuMetricCategory.BEACON,

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ThrottlingExecutionEngineClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ThrottlingExecutionEngineClient.java
@@ -39,7 +39,7 @@ public class ThrottlingExecutionEngineClient implements ExecutionEngineClient {
       final MetricsSystem metricsSystem) {
     this.delegate = delegate;
     taskQueue =
-        new ThrottlingTaskQueue(
+        ThrottlingTaskQueue.create(
             maximumConcurrentRequests,
             metricsSystem,
             TekuMetricCategory.BEACON,

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/ThrottlingTaskQueue.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/ThrottlingTaskQueue.java
@@ -33,13 +33,10 @@ public class ThrottlingTaskQueue {
       final MetricsSystem metricsSystem,
       final TekuMetricCategory metricCategory,
       final String metricName) {
-    final ThrottlingTaskQueue throttlingTaskQueue = new ThrottlingTaskQueue(maximumConcurrentTasks);
+    final ThrottlingTaskQueue taskQueue = new ThrottlingTaskQueue(maximumConcurrentTasks);
     metricsSystem.createGauge(
-        metricCategory,
-        metricName,
-        "Number of tasks queued",
-        throttlingTaskQueue::getQueuedTasksCount);
-    return throttlingTaskQueue;
+        metricCategory, metricName, "Number of tasks queued", taskQueue.queuedTasks::size);
+    return taskQueue;
   }
 
   protected ThrottlingTaskQueue(final int maximumConcurrentTasks) {

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/ThrottlingTaskQueue.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/ThrottlingTaskQueue.java
@@ -37,7 +37,7 @@ public class ThrottlingTaskQueue {
     this.maximumConcurrentTasks = maximumConcurrentTasks;
 
     metricsSystem.createGauge(
-        metricCategory, metricName, "Number of tasks queued", queuedTasks::size);
+        metricCategory, metricName, "Number of tasks queued", this::getQueuedTasksCount);
   }
 
   public <T> SafeFuture<T> queueTask(

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/ThrottlingTaskQueue.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/ThrottlingTaskQueue.java
@@ -28,14 +28,22 @@ public class ThrottlingTaskQueue {
 
   private int inflightTaskCount = 0;
 
-  public ThrottlingTaskQueue(
+  public static ThrottlingTaskQueue create(
       final int maximumConcurrentTasks,
       final MetricsSystem metricsSystem,
       final TekuMetricCategory metricCategory,
       final String metricName) {
-    this.maximumConcurrentTasks = maximumConcurrentTasks;
+    final ThrottlingTaskQueue throttlingTaskQueue = new ThrottlingTaskQueue(maximumConcurrentTasks);
     metricsSystem.createGauge(
-        metricCategory, metricName, "Number of tasks queued", this::getQueuedTasksCount);
+        metricCategory,
+        metricName,
+        "Number of tasks queued",
+        throttlingTaskQueue::getQueuedTasksCount);
+    return throttlingTaskQueue;
+  }
+
+  protected ThrottlingTaskQueue(final int maximumConcurrentTasks) {
+    this.maximumConcurrentTasks = maximumConcurrentTasks;
   }
 
   public <T> SafeFuture<T> queueTask(final Supplier<SafeFuture<T>> request) {

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/ThrottlingTaskQueueWithPriority.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/ThrottlingTaskQueueWithPriority.java
@@ -17,6 +17,7 @@ import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.function.Supplier;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
+import org.hyperledger.besu.plugin.services.metrics.LabelledGauge;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 
 public class ThrottlingTaskQueueWithPriority extends ThrottlingTaskQueue {
@@ -30,8 +31,11 @@ public class ThrottlingTaskQueueWithPriority extends ThrottlingTaskQueue {
       final String metricName) {
     final ThrottlingTaskQueueWithPriority taskQueue =
         new ThrottlingTaskQueueWithPriority(maximumConcurrentTasks);
-    metricsSystem.createGauge(
-        metricCategory, metricName, "Number of tasks queued", taskQueue::getQueuedTasksCount);
+    final LabelledGauge taskQueueGauge =
+        metricsSystem.createLabelledGauge(
+            metricCategory, metricName, "Number of tasks queued", "priority");
+    taskQueueGauge.labels(taskQueue.queuedTasks::size, "normal");
+    taskQueueGauge.labels(taskQueue.queuedPrioritizedTasks::size, "high");
     return taskQueue;
   }
 

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/ThrottlingTaskQueueWithPriority.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/ThrottlingTaskQueueWithPriority.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.async;
+
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.function.Supplier;
+import org.hyperledger.besu.plugin.services.MetricsSystem;
+import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
+
+public class ThrottlingTaskQueueWithPriority extends ThrottlingTaskQueue {
+
+  private final Queue<Runnable> queuedPrioritizedTasks = new ConcurrentLinkedQueue<>();
+
+  public ThrottlingTaskQueueWithPriority(
+      final int maximumConcurrentTasks,
+      final MetricsSystem metricsSystem,
+      final TekuMetricCategory metricCategory,
+      final String metricName) {
+    super(maximumConcurrentTasks, metricsSystem, metricCategory, metricName);
+  }
+
+  public <T> SafeFuture<T> queueTask(
+      final Supplier<SafeFuture<T>> request, final boolean prioritize) {
+    if (!prioritize) {
+      return queueTask(request);
+    }
+    final SafeFuture<T> target = new SafeFuture<>();
+    final Runnable taskToQueue = getTaskToQueue(request, target);
+    queuedPrioritizedTasks.add(taskToQueue);
+    processQueuedTasks();
+    return target;
+  }
+
+  @Override
+  protected Runnable getTaskToRun() {
+    return !queuedPrioritizedTasks.isEmpty()
+        ? queuedPrioritizedTasks.remove()
+        : queuedTasks.remove();
+  }
+
+  @Override
+  protected int getQueuedTasksCount() {
+    return queuedTasks.size() + queuedPrioritizedTasks.size();
+  }
+}

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/ThrottlingTaskQueueWithPriority.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/ThrottlingTaskQueueWithPriority.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.teku.infrastructure.async;
 
+import java.util.Collection;
+import java.util.Optional;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.function.Supplier;
@@ -52,6 +54,7 @@ public class ThrottlingTaskQueueWithPriority extends ThrottlingTaskQueue {
 
   @Override
   protected int getQueuedTasksCount() {
-    return queuedTasks.size() + queuedPrioritizedTasks.size();
+    return queuedTasks.size()
+        + Optional.ofNullable(queuedPrioritizedTasks).map(Collection::size).orElse(0);
   }
 }

--- a/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/ThrottlingTaskQueueTest.java
+++ b/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/ThrottlingTaskQueueTest.java
@@ -53,6 +53,7 @@ public class ThrottlingTaskQueueTest {
   }
 
   @Test
+  @SuppressWarnings("FutureReturnValueIgnored")
   public void prioritizesRequests() {
     final SafeFuture<Void> initialRequest = new SafeFuture<>();
     final SafeFuture<Void> prioritizedRequest = new SafeFuture<>();

--- a/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/ThrottlingTaskQueueTest.java
+++ b/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/ThrottlingTaskQueueTest.java
@@ -31,7 +31,7 @@ public class ThrottlingTaskQueueTest {
   private final StubAsyncRunner stubAsyncRunner = new StubAsyncRunner();
 
   private final ThrottlingTaskQueue taskQueue =
-      new ThrottlingTaskQueue(
+      ThrottlingTaskQueue.create(
           MAXIMUM_CONCURRENT_TASKS, stubMetricsSystem, TekuMetricCategory.BEACON, "test_metric");
 
   @Test

--- a/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/ThrottlingTaskQueueTest.java
+++ b/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/ThrottlingTaskQueueTest.java
@@ -38,13 +38,15 @@ public class ThrottlingTaskQueueTest {
     final List<SafeFuture<Void>> requests =
         IntStream.range(0, 100)
             .mapToObj(
-                __ ->
-                    stubAsyncRunner.runAsync(
-                        () -> {
-                          assertThat(throttlingTaskQueue.getInflightTaskCount())
-                              .isLessThanOrEqualTo(MAXIMUM_CONCURRENT_TASKS);
-                        }))
-            .peek(request -> throttlingTaskQueue.queueTask(() -> request))
+                __ -> {
+                  final SafeFuture<Void> request =
+                      stubAsyncRunner.runAsync(
+                          () -> {
+                            assertThat(throttlingTaskQueue.getInflightTaskCount())
+                                .isLessThanOrEqualTo(MAXIMUM_CONCURRENT_TASKS);
+                          });
+                  return throttlingTaskQueue.queueTask(() -> request);
+                })
             .collect(Collectors.toList());
 
     stubAsyncRunner.executeQueuedActions();

--- a/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/ThrottlingTaskQueueTest.java
+++ b/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/ThrottlingTaskQueueTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.async;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
+import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
+
+public class ThrottlingTaskQueueTest {
+
+  private static final int MAXIMUM_CONCURRENT_TASKS = 3;
+
+  private final StubAsyncRunner stubAsyncRunner = new StubAsyncRunner();
+
+  private final ThrottlingTaskQueue throttlingTaskQueue =
+      new ThrottlingTaskQueue(
+          MAXIMUM_CONCURRENT_TASKS, new StubMetricsSystem(), TekuMetricCategory.BEACON, "test");
+
+  @Test
+  public void throttlesRequests() {
+    final List<SafeFuture<Void>> requests =
+        IntStream.range(0, 100)
+            .mapToObj(
+                __ ->
+                    stubAsyncRunner.runAsync(
+                        () -> {
+                          assertThat(throttlingTaskQueue.getInflightTaskCount())
+                              .isLessThanOrEqualTo(MAXIMUM_CONCURRENT_TASKS);
+                        }))
+            .peek(request -> throttlingTaskQueue.queueTask(() -> request))
+            .collect(Collectors.toList());
+
+    stubAsyncRunner.executeQueuedActions();
+
+    requests.forEach(request -> assertThat(request).isCompleted());
+  }
+
+  @Test
+  public void prioritizesRequests() {
+    final SafeFuture<Void> initialRequest = new SafeFuture<>();
+    final SafeFuture<Void> prioritizedRequest = new SafeFuture<>();
+    final SafeFuture<Void> normalRequest = new SafeFuture<>();
+
+    final AtomicBoolean priorityFirst = new AtomicBoolean(false);
+
+    // fill queue
+    IntStream.range(0, MAXIMUM_CONCURRENT_TASKS)
+        .forEach(__ -> throttlingTaskQueue.queueTask(() -> initialRequest));
+    final SafeFuture<Void> assertion =
+        throttlingTaskQueue.queueTask(
+            () -> {
+              // make sure the prioritized request is ran first
+              // even though It has been queued after this one
+              assertThat(priorityFirst).isTrue();
+              return normalRequest;
+            });
+    throttlingTaskQueue.queueTask(
+        () -> {
+          priorityFirst.set(true);
+          return prioritizedRequest;
+        },
+        true);
+
+    initialRequest.complete(null);
+    normalRequest.complete(null);
+    prioritizedRequest.complete(null);
+
+    assertThat(assertion).isCompleted();
+  }
+}

--- a/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/ThrottlingTaskQueueTest.java
+++ b/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/ThrottlingTaskQueueTest.java
@@ -38,14 +38,16 @@ public class ThrottlingTaskQueueTest {
     final List<SafeFuture<Void>> requests =
         IntStream.range(0, 100)
             .mapToObj(
-                __ -> {
+                element -> {
                   final SafeFuture<Void> request =
                       stubAsyncRunner.runAsync(
                           () -> {
                             assertThat(throttlingTaskQueue.getInflightTaskCount())
                                 .isLessThanOrEqualTo(MAXIMUM_CONCURRENT_TASKS);
                           });
-                  return throttlingTaskQueue.queueTask(() -> request);
+                  // prioritize 1/3 of requests
+                  final boolean prioritize = element % 3 == 0;
+                  return throttlingTaskQueue.queueTask(() -> request, prioritize);
                 })
             .collect(Collectors.toList());
 

--- a/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/ThrottlingTaskQueueTest.java
+++ b/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/ThrottlingTaskQueueTest.java
@@ -50,7 +50,7 @@ public class ThrottlingTaskQueueTest {
                 })
             .collect(Collectors.toList());
 
-    assertThat(getNumberOfQueuedTasksMetric()).isEqualTo(97);
+    assertThat(getQueuedTasksGaugeValue()).isEqualTo(97);
     assertThat(taskQueue.getInflightTaskCount()).isEqualTo(3);
 
     stubAsyncRunner.executeQueuedActions();
@@ -58,7 +58,7 @@ public class ThrottlingTaskQueueTest {
     requests.forEach(request -> assertThat(request).isCompleted());
   }
 
-  private double getNumberOfQueuedTasksMetric() {
+  private double getQueuedTasksGaugeValue() {
     return stubMetricsSystem.getGauge(TekuMetricCategory.BEACON, "test_metric").getValue();
   }
 }

--- a/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/ThrottlingTaskQueueWithPriorityTest.java
+++ b/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/ThrottlingTaskQueueWithPriorityTest.java
@@ -55,7 +55,8 @@ public class ThrottlingTaskQueueWithPriorityTest {
                 })
             .collect(Collectors.toList());
 
-    assertThat(getNumberOfQueuedTasksMetric()).isEqualTo(97);
+    assertThat(getQueuedTasksGaugeValue(true)).isEqualTo(33);
+    assertThat(getQueuedTasksGaugeValue(false)).isEqualTo(64);
     assertThat(taskQueue.getInflightTaskCount()).isEqualTo(3);
 
     stubAsyncRunner.executeQueuedActions();
@@ -90,7 +91,8 @@ public class ThrottlingTaskQueueWithPriorityTest {
         },
         true);
 
-    assertThat(getNumberOfQueuedTasksMetric()).isEqualTo(2);
+    assertThat(getQueuedTasksGaugeValue(true)).isEqualTo(1);
+    assertThat(getQueuedTasksGaugeValue(false)).isEqualTo(1);
     assertThat(taskQueue.getInflightTaskCount()).isEqualTo(3);
 
     initialRequest.complete(null);
@@ -100,7 +102,10 @@ public class ThrottlingTaskQueueWithPriorityTest {
     assertThat(assertion).isCompleted();
   }
 
-  private double getNumberOfQueuedTasksMetric() {
-    return stubMetricsSystem.getGauge(TekuMetricCategory.BEACON, "test_metric").getValue();
+  private double getQueuedTasksGaugeValue(final boolean priority) {
+    return stubMetricsSystem
+        .getLabelledGauge(TekuMetricCategory.BEACON, "test_metric")
+        .getValue(priority ? "high" : "normal")
+        .orElseThrow();
   }
 }

--- a/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/ThrottlingTaskQueueWithPriorityTest.java
+++ b/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/ThrottlingTaskQueueWithPriorityTest.java
@@ -32,7 +32,7 @@ public class ThrottlingTaskQueueWithPriorityTest {
   private final StubAsyncRunner stubAsyncRunner = new StubAsyncRunner();
 
   private final ThrottlingTaskQueueWithPriority taskQueue =
-      new ThrottlingTaskQueueWithPriority(
+      ThrottlingTaskQueueWithPriority.create(
           MAXIMUM_CONCURRENT_TASKS, stubMetricsSystem, TekuMetricCategory.BEACON, "test_metric");
 
   @Test

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorKeysOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorKeysOptions.java
@@ -98,7 +98,8 @@ public class ValidatorKeysOptions {
   @CommandLine.Option(
       names = {"--Xvalidators-external-signer-concurrent-limit"},
       paramLabel = "<INTEGER>",
-      description = "The maximum number of concurrent background requests to make to the signer.",
+      description =
+          "The maximum number of concurrent background requests to make to the signer. This only applies for aggregation slot and validator registration requests.",
       hidden = true,
       arity = "1")
   private int validatorExternalSignerConcurrentRequestLimit =

--- a/validator/client/src/integration-test/java/tech/pegasys/teku/validator/client/signer/ExternalSignerAltairIntegrationTest.java
+++ b/validator/client/src/integration-test/java/tech/pegasys/teku/validator/client/signer/ExternalSignerAltairIntegrationTest.java
@@ -39,7 +39,7 @@ import tech.pegasys.teku.bls.BLSKeyPair;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.bls.BLSTestUtil;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
-import tech.pegasys.teku.infrastructure.async.ThrottlingTaskQueue;
+import tech.pegasys.teku.infrastructure.async.ThrottlingTaskQueueWithPriority;
 import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -82,8 +82,9 @@ public class ExternalSignerAltairIntegrationTest {
   private final ForkInfo forkInfo = dataStructureUtil.randomForkInfo();
   private static final BLSKeyPair KEYPAIR = BLSTestUtil.randomKeyPair(1234);
   private final StubMetricsSystem metricsSystem = new StubMetricsSystem();
-  private final ThrottlingTaskQueue queue =
-      new ThrottlingTaskQueue(8, metricsSystem, TekuMetricCategory.VALIDATOR, "externalSignerTest");
+  private final ThrottlingTaskQueueWithPriority queue =
+      new ThrottlingTaskQueueWithPriority(
+          8, metricsSystem, TekuMetricCategory.VALIDATOR, "externalSignerTest");
 
   private ClientAndServer client;
   private ExternalSigner externalSigner;

--- a/validator/client/src/integration-test/java/tech/pegasys/teku/validator/client/signer/ExternalSignerAltairIntegrationTest.java
+++ b/validator/client/src/integration-test/java/tech/pegasys/teku/validator/client/signer/ExternalSignerAltairIntegrationTest.java
@@ -83,7 +83,7 @@ public class ExternalSignerAltairIntegrationTest {
   private static final BLSKeyPair KEYPAIR = BLSTestUtil.randomKeyPair(1234);
   private final StubMetricsSystem metricsSystem = new StubMetricsSystem();
   private final ThrottlingTaskQueueWithPriority queue =
-      new ThrottlingTaskQueueWithPriority(
+      ThrottlingTaskQueueWithPriority.create(
           8, metricsSystem, TekuMetricCategory.VALIDATOR, "externalSignerTest");
 
   private ClientAndServer client;

--- a/validator/client/src/integration-test/java/tech/pegasys/teku/validator/client/signer/ExternalSignerBellatrixBlockSigningIntegrationTest.java
+++ b/validator/client/src/integration-test/java/tech/pegasys/teku/validator/client/signer/ExternalSignerBellatrixBlockSigningIntegrationTest.java
@@ -35,7 +35,7 @@ import org.mockserver.junit.jupiter.MockServerExtension;
 import tech.pegasys.teku.bls.BLSKeyPair;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.bls.BLSTestUtil;
-import tech.pegasys.teku.infrastructure.async.ThrottlingTaskQueue;
+import tech.pegasys.teku.infrastructure.async.ThrottlingTaskQueueWithPriority;
 import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.spec.Spec;
@@ -57,8 +57,9 @@ public class ExternalSignerBellatrixBlockSigningIntegrationTest {
   private final ForkInfo fork = dataStructureUtil.randomForkInfo();
   private static final BLSKeyPair KEYPAIR = BLSTestUtil.randomKeyPair(1234);
   private final StubMetricsSystem metricsSystem = new StubMetricsSystem();
-  private final ThrottlingTaskQueue queue =
-      new ThrottlingTaskQueue(8, metricsSystem, TekuMetricCategory.VALIDATOR, "externalSignerTest");
+  private final ThrottlingTaskQueueWithPriority queue =
+      new ThrottlingTaskQueueWithPriority(
+          8, metricsSystem, TekuMetricCategory.VALIDATOR, "externalSignerTest");
 
   private ClientAndServer client;
   private ExternalSigner externalSigner;

--- a/validator/client/src/integration-test/java/tech/pegasys/teku/validator/client/signer/ExternalSignerBellatrixBlockSigningIntegrationTest.java
+++ b/validator/client/src/integration-test/java/tech/pegasys/teku/validator/client/signer/ExternalSignerBellatrixBlockSigningIntegrationTest.java
@@ -58,7 +58,7 @@ public class ExternalSignerBellatrixBlockSigningIntegrationTest {
   private static final BLSKeyPair KEYPAIR = BLSTestUtil.randomKeyPair(1234);
   private final StubMetricsSystem metricsSystem = new StubMetricsSystem();
   private final ThrottlingTaskQueueWithPriority queue =
-      new ThrottlingTaskQueueWithPriority(
+      ThrottlingTaskQueueWithPriority.create(
           8, metricsSystem, TekuMetricCategory.VALIDATOR, "externalSignerTest");
 
   private ClientAndServer client;

--- a/validator/client/src/integration-test/java/tech/pegasys/teku/validator/client/signer/ExternalSignerIntegrationTest.java
+++ b/validator/client/src/integration-test/java/tech/pegasys/teku/validator/client/signer/ExternalSignerIntegrationTest.java
@@ -69,7 +69,7 @@ public class ExternalSignerIntegrationTest {
   private final ForkInfo fork = dataStructureUtil.randomForkInfo();
   private final StubMetricsSystem metricsSystem = new StubMetricsSystem();
   private final ThrottlingTaskQueueWithPriority queue =
-      new ThrottlingTaskQueueWithPriority(
+      ThrottlingTaskQueueWithPriority.create(
           8, metricsSystem, TekuMetricCategory.VALIDATOR, "externalSignerTest");
   private final SigningRootUtil signingRootUtil = new SigningRootUtil(spec);
 

--- a/validator/client/src/integration-test/java/tech/pegasys/teku/validator/client/signer/ExternalSignerIntegrationTest.java
+++ b/validator/client/src/integration-test/java/tech/pegasys/teku/validator/client/signer/ExternalSignerIntegrationTest.java
@@ -43,7 +43,7 @@ import tech.pegasys.teku.bls.BLSKeyPair;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.bls.BLSTestUtil;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
-import tech.pegasys.teku.infrastructure.async.ThrottlingTaskQueue;
+import tech.pegasys.teku.infrastructure.async.ThrottlingTaskQueueWithPriority;
 import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -68,8 +68,9 @@ public class ExternalSignerIntegrationTest {
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
   private final ForkInfo fork = dataStructureUtil.randomForkInfo();
   private final StubMetricsSystem metricsSystem = new StubMetricsSystem();
-  private final ThrottlingTaskQueue queue =
-      new ThrottlingTaskQueue(8, metricsSystem, TekuMetricCategory.VALIDATOR, "externalSignerTest");
+  private final ThrottlingTaskQueueWithPriority queue =
+      new ThrottlingTaskQueueWithPriority(
+          8, metricsSystem, TekuMetricCategory.VALIDATOR, "externalSignerTest");
   private final SigningRootUtil signingRootUtil = new SigningRootUtil(spec);
 
   private ClientAndServer client;

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/ExternalValidatorProvider.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/ExternalValidatorProvider.java
@@ -20,7 +20,7 @@ import java.time.Duration;
 import java.util.function.Supplier;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.bls.BLSPublicKey;
-import tech.pegasys.teku.infrastructure.async.ThrottlingTaskQueue;
+import tech.pegasys.teku.infrastructure.async.ThrottlingTaskQueueWithPriority;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.signatures.Signer;
 import tech.pegasys.teku.validator.client.signer.ExternalSigner;
@@ -32,7 +32,7 @@ class ExternalValidatorProvider implements ValidatorSource.ValidatorProvider {
   private final URL externalSignerUrl;
   private final BLSPublicKey publicKey;
   private final Duration externalSignerTimeout;
-  private final ThrottlingTaskQueue externalSignerTaskQueue;
+  private final ThrottlingTaskQueueWithPriority externalSignerTaskQueue;
   private final MetricsSystem metricsSystem;
   private final boolean readOnly;
 
@@ -42,7 +42,7 @@ class ExternalValidatorProvider implements ValidatorSource.ValidatorProvider {
       final URL externalSignerUrl,
       final BLSPublicKey publicKey,
       final Duration externalSignerTimeout,
-      final ThrottlingTaskQueue externalSignerTaskQueue,
+      final ThrottlingTaskQueueWithPriority externalSignerTaskQueue,
       final MetricsSystem metricsSystem,
       final boolean readOnly) {
     this.spec = spec;

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/ExternalValidatorSource.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/ExternalValidatorSource.java
@@ -35,7 +35,7 @@ import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.signers.bls.keystore.model.KeyStoreData;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
-import tech.pegasys.teku.infrastructure.async.ThrottlingTaskQueue;
+import tech.pegasys.teku.infrastructure.async.ThrottlingTaskQueueWithPriority;
 import tech.pegasys.teku.infrastructure.exceptions.InvalidConfigurationException;
 import tech.pegasys.teku.service.serviceutils.layout.DataDirLayout;
 import tech.pegasys.teku.spec.Spec;
@@ -54,7 +54,7 @@ public class ExternalValidatorSource extends AbstractValidatorSource implements 
   private final ValidatorConfig config;
   private final Supplier<HttpClient> externalSignerHttpClientFactory;
   private final PublicKeyLoader publicKeyLoader;
-  private final ThrottlingTaskQueue externalSignerTaskQueue;
+  private final ThrottlingTaskQueueWithPriority externalSignerTaskQueue;
   private final MetricsSystem metricsSystem;
   private final Map<BLSPublicKey, URL> externalValidatorSourceMap = new ConcurrentHashMap<>();
 
@@ -63,7 +63,7 @@ public class ExternalValidatorSource extends AbstractValidatorSource implements 
       final ValidatorConfig config,
       final Supplier<HttpClient> externalSignerHttpClientFactory,
       final PublicKeyLoader publicKeyLoader,
-      final ThrottlingTaskQueue externalSignerTaskQueue,
+      final ThrottlingTaskQueueWithPriority externalSignerTaskQueue,
       final MetricsSystem metricsSystem,
       final boolean readOnly,
       final Optional<DataDirLayout> maybeDataDirLayout) {
@@ -84,7 +84,7 @@ public class ExternalValidatorSource extends AbstractValidatorSource implements 
       final PublicKeyLoader publicKeyLoader,
       final AsyncRunner asyncRunner,
       final boolean readOnly,
-      final ThrottlingTaskQueue externalSignerTaskQueue,
+      final ThrottlingTaskQueueWithPriority externalSignerTaskQueue,
       final Optional<DataDirLayout> maybeDataDirLayout) {
     setupExternalSignerStatusLogging(config, externalSignerHttpClientFactory, asyncRunner);
     return new ExternalValidatorSource(

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/ValidatorSourceFactory.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/ValidatorSourceFactory.java
@@ -220,7 +220,7 @@ public class ValidatorSourceFactory {
   private ThrottlingTaskQueueWithPriority initializeExternalSignerTaskQueue() {
     if (externalSignerTaskQueue == null) {
       externalSignerTaskQueue =
-          new ThrottlingTaskQueueWithPriority(
+          ThrottlingTaskQueueWithPriority.create(
               config.getValidatorExternalSignerConcurrentRequestLimit(),
               metricsSystem,
               TekuMetricCategory.VALIDATOR,

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/ValidatorSourceFactory.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/ValidatorSourceFactory.java
@@ -24,7 +24,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
-import tech.pegasys.teku.infrastructure.async.ThrottlingTaskQueue;
+import tech.pegasys.teku.infrastructure.async.ThrottlingTaskQueueWithPriority;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.service.serviceutils.layout.DataDirLayout;
 import tech.pegasys.teku.spec.Spec;
@@ -73,7 +73,7 @@ public class ValidatorSourceFactory {
   private final Optional<DataDirLayout> maybeDataDir;
   private Optional<ValidatorSource> mutableLocalValidatorSource = Optional.empty();
   private Optional<ValidatorSource> mutableExternalValidatorSource = Optional.empty();
-  private ThrottlingTaskQueue externalSignerTaskQueue;
+  private ThrottlingTaskQueueWithPriority externalSignerTaskQueue;
 
   public ValidatorSourceFactory(
       final Spec spec,
@@ -217,10 +217,10 @@ public class ValidatorSourceFactory {
     return new SlashingProtectedValidatorSource(validatorSource, slashingProtector);
   }
 
-  private ThrottlingTaskQueue initializeExternalSignerTaskQueue() {
+  private ThrottlingTaskQueueWithPriority initializeExternalSignerTaskQueue() {
     if (externalSignerTaskQueue == null) {
       externalSignerTaskQueue =
-          new ThrottlingTaskQueue(
+          new ThrottlingTaskQueueWithPriority(
               config.getValidatorExternalSignerConcurrentRequestLimit(),
               metricsSystem,
               TekuMetricCategory.VALIDATOR,

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/signer/ExternalSigner.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/signer/ExternalSigner.java
@@ -41,7 +41,7 @@ import tech.pegasys.teku.api.schema.Fork;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
-import tech.pegasys.teku.infrastructure.async.ThrottlingTaskQueue;
+import tech.pegasys.teku.infrastructure.async.ThrottlingTaskQueueWithPriority;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.provider.JsonProvider;
@@ -67,7 +67,7 @@ public class ExternalSigner implements Signer {
   private final Duration timeout;
   private final Spec spec;
   private final HttpClient httpClient;
-  private final ThrottlingTaskQueue taskQueue;
+  private final ThrottlingTaskQueueWithPriority taskQueue;
   private final SigningRootUtil signingRootUtil;
 
   private final Counter successCounter;
@@ -80,7 +80,7 @@ public class ExternalSigner implements Signer {
       final URL signingServiceUrl,
       final BLSPublicKey blsPublicKey,
       final Duration timeout,
-      final ThrottlingTaskQueue taskQueue,
+      final ThrottlingTaskQueueWithPriority taskQueue,
       final MetricsSystem metricsSystem) {
     this.spec = spec;
     this.httpClient = httpClient;

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/signer/ExternalSigner.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/signer/ExternalSigner.java
@@ -159,7 +159,8 @@ public class ExternalSigner implements Signer {
                 signingRootUtil.signingRootForSignAggregationSlot(slot, forkInfo),
                 SignType.AGGREGATION_SLOT,
                 Map.of("aggregation_slot", Map.of("slot", slot), FORK_INFO, forkInfo(forkInfo)),
-                slashableGenericMessage("aggregation slot")));
+                slashableGenericMessage("aggregation slot")),
+        true);
   }
 
   @Override
@@ -257,21 +258,23 @@ public class ExternalSigner implements Signer {
   @Override
   public SafeFuture<BLSSignature> signValidatorRegistration(
       final ValidatorRegistration validatorRegistration) {
-    return sign(
-        signingRootUtil.signingRootForValidatorRegistration(validatorRegistration),
-        SignType.VALIDATOR_REGISTRATION,
-        Map.of(
-            "validator_registration",
-            Map.of(
-                "fee_recipient",
-                validatorRegistration.getFeeRecipient().toHexString(),
-                "gas_limit",
-                validatorRegistration.getGasLimit(),
-                "timestamp",
-                validatorRegistration.getTimestamp(),
-                "pubkey",
-                validatorRegistration.getPublicKey().toString())),
-        slashableGenericMessage("validator registration"));
+    return taskQueue.queueTask(
+        () ->
+            sign(
+                signingRootUtil.signingRootForValidatorRegistration(validatorRegistration),
+                SignType.VALIDATOR_REGISTRATION,
+                Map.of(
+                    "validator_registration",
+                    Map.of(
+                        "fee_recipient",
+                        validatorRegistration.getFeeRecipient().toHexString(),
+                        "gas_limit",
+                        validatorRegistration.getGasLimit(),
+                        "timestamp",
+                        validatorRegistration.getTimestamp(),
+                        "pubkey",
+                        validatorRegistration.getPublicKey().toString())),
+                slashableGenericMessage("validator registration")));
   }
 
   @Override

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/ExternalValidatorSourceTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/ExternalValidatorSourceTest.java
@@ -43,7 +43,7 @@ import tech.pegasys.techu.service.serviceutils.layout.SimpleDataDirLayout;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
-import tech.pegasys.teku.infrastructure.async.ThrottlingTaskQueue;
+import tech.pegasys.teku.infrastructure.async.ThrottlingTaskQueueWithPriority;
 import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.service.serviceutils.layout.DataDirLayout;
@@ -65,7 +65,7 @@ public class ExternalValidatorSourceTest {
   private final HttpClient httpClient = mock(HttpClient.class);
   private final MetricsSystem metricsSystem = new StubMetricsSystem();
   private final AsyncRunner asyncRunner = new StubAsyncRunner();
-  private ThrottlingTaskQueue externalSignerTaskQueue;
+  private ThrottlingTaskQueueWithPriority externalSignerTaskQueue;
 
   private final Supplier<HttpClient> httpClientFactory = () -> httpClient;
 
@@ -84,7 +84,7 @@ public class ExternalValidatorSourceTest {
             .validatorExternalSignerUrl(new URL("http://localhost:9000"))
             .build();
     externalSignerTaskQueue =
-        new ThrottlingTaskQueue(
+        new ThrottlingTaskQueueWithPriority(
             config.getValidatorExternalSignerConcurrentRequestLimit(),
             metricsSystem,
             TekuMetricCategory.VALIDATOR,

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/ExternalValidatorSourceTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/ExternalValidatorSourceTest.java
@@ -84,7 +84,7 @@ public class ExternalValidatorSourceTest {
             .validatorExternalSignerUrl(new URL("http://localhost:9000"))
             .build();
     externalSignerTaskQueue =
-        new ThrottlingTaskQueueWithPriority(
+        ThrottlingTaskQueueWithPriority.create(
             config.getValidatorExternalSignerConcurrentRequestLimit(),
             metricsSystem,
             TekuMetricCategory.VALIDATOR,

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/SlashingProtectionLoggerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/SlashingProtectionLoggerTest.java
@@ -36,7 +36,7 @@ import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.ethereum.signingrecord.ValidatorSigningRecord;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
-import tech.pegasys.teku.infrastructure.async.ThrottlingTaskQueue;
+import tech.pegasys.teku.infrastructure.async.ThrottlingTaskQueueWithPriority;
 import tech.pegasys.teku.infrastructure.logging.ValidatorLogger;
 import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -164,7 +164,7 @@ public class SlashingProtectionLoggerTest {
               new URL("http://127.0.0.1/"),
               publicKey,
               TIMEOUT,
-              mock(ThrottlingTaskQueue.class),
+              mock(ThrottlingTaskQueueWithPriority.class),
               metricsSystem);
     } catch (MalformedURLException e) {
       throw new RuntimeException(e);


### PR DESCRIPTION
## PR Description

- Use the existing throttler in ExternalSigner for validator registrations.
- Prioritize aggregation slot signing to ensure validator duties flow is not affected.

## Fixed Issue(s)
fixes #6289 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
