### PR TITLE
force `TimerService` to run the handler in alignment with the beginning of the second

### DIFF
--- a/services/timer/src/main/java/tech/pegasys/teku/services/timer/TimerService.java
+++ b/services/timer/src/main/java/tech/pegasys/teku/services/timer/TimerService.java
@@ -88,7 +88,7 @@ public class TimerService extends Service {
                       // contention), then just skip it and fire the next event when it is due
                       .withMisfireHandlingInstructionNextWithRemainingCount()
                       .repeatForever())
-              .startAt(Date.from(Instant.now().truncatedTo(ChronoUnit.SECONDS).minusSeconds(1)))
+              .startAt(Date.from(Instant.now().truncatedTo(ChronoUnit.SECONDS)))
               .build();
       sched.scheduleJob(job, trigger);
       sched.start();

--- a/services/timer/src/main/java/tech/pegasys/teku/services/timer/TimerService.java
+++ b/services/timer/src/main/java/tech/pegasys/teku/services/timer/TimerService.java
@@ -88,7 +88,7 @@ public class TimerService extends Service {
                       // contention), then just skip it and fire the next event when it is due
                       .withMisfireHandlingInstructionNextWithRemainingCount()
                       .repeatForever())
-              .startAt(Date.from(Instant.now().truncatedTo(ChronoUnit.SECONDS).plusSeconds(1)))
+              .startAt(Date.from(Instant.now().truncatedTo(ChronoUnit.SECONDS).minusSeconds(1)))
               .build();
       sched.scheduleJob(job, trigger);
       sched.start();

--- a/services/timer/src/main/java/tech/pegasys/teku/services/timer/TimerService.java
+++ b/services/timer/src/main/java/tech/pegasys/teku/services/timer/TimerService.java
@@ -17,6 +17,9 @@ import static org.quartz.JobBuilder.newJob;
 import static org.quartz.SimpleScheduleBuilder.simpleSchedule;
 import static org.quartz.TriggerBuilder.newTrigger;
 
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.quartz.JobDetail;
@@ -85,6 +88,7 @@ public class TimerService extends Service {
                       // contention), then just skip it and fire the next event when it is due
                       .withMisfireHandlingInstructionNextWithRemainingCount()
                       .repeatForever())
+              .startAt(Date.from(Instant.now().truncatedTo(ChronoUnit.SECONDS).plusSeconds(1)))
               .build();
       sched.scheduleJob(job, trigger);
       sched.start();


### PR DESCRIPTION
as discussed here: https://github.com/ConsenSys/teku/pull/6245#issuecomment-1268053355

as per my checks, time drift is always corrected back to be close to the tick of the second

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
