### PR TITLE
Fix client version regexp in `ExternalMetricNode` AT class

### DIFF
--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/ExternalMetricNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/ExternalMetricNode.java
@@ -190,7 +190,7 @@ public class ExternalMetricNode extends Node {
     assertThat(publishedData.get("client_name")).isEqualTo("teku");
 
     assertThat((String) publishedData.get("client_version"))
-        .matches(Pattern.compile("^\\d\\d\\.\\d\\.\\d.*"));
+        .matches(Pattern.compile("^\\d\\d\\.\\d{1,2}\\.\\d.*"));
     assertThat(publishedData.get("client_build")).isEqualTo(0L);
     assertThat(publishedData.get("sync_eth2_fallback_configured")).isEqualTo(false);
     assertThat(publishedData.get("sync_eth2_fallback_connected")).isEqualTo(false);


### PR DESCRIPTION
Regexp in `ExternalMetricNode` checking client version seems not supporting Q4 teku versions

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
