### PR TITLE
Readiness api returning 'unavailable' when EL isn't available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,3 +31,4 @@ For information on changes in released versions of Teku, see the [releases page]
 - Filter out unknown validators when sending validator registrations to the builder network
 - Fix issue which could cause locally produced aggregates to not be gossiped
 - Fix issue where the sync module could cause `Unexpected rejected execution due to full task queue in nioEventLoopGroup` log messages and high CPU usage
+- Fix issue where /readiness endpoint returned 200 when Execution Client was not available.

--- a/data/beaconrestapi/build.gradle
+++ b/data/beaconrestapi/build.gradle
@@ -3,6 +3,7 @@ dependencies {
     implementation project(':ethereum:pow:api')
     implementation project(':data:provider')
     implementation project(':data:serializer')
+    implementation project(':ethereum:executionclient')
     implementation project(':ethereum:execution-types')
     implementation project(':ethereum:spec')
     implementation project(':ethereum:statetransition')

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/AbstractDataBackedRestAPIIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/AbstractDataBackedRestAPIIntegrationTest.java
@@ -36,6 +36,7 @@ import okhttp3.RequestBody;
 import okhttp3.Response;
 import org.junit.jupiter.api.AfterEach;
 import tech.pegasys.teku.api.DataProvider;
+import tech.pegasys.teku.api.ExecutionClientDataProvider;
 import tech.pegasys.teku.beacon.sync.SyncService;
 import tech.pegasys.teku.bls.BLSKeyGenerator;
 import tech.pegasys.teku.bls.BLSKeyPair;
@@ -127,6 +128,9 @@ public abstract class AbstractDataBackedRestAPIIntegrationTest {
   protected final ProposersDataManager proposersDataManager = mock(ProposersDataManager.class);
   protected final Eth1DataProvider eth1DataProvider = mock(Eth1DataProvider.class);
 
+  protected final ExecutionClientDataProvider executionClientDataProvider =
+      mock(ExecutionClientDataProvider.class);
+
   private StorageSystem storageSystem;
 
   protected RecentChainData recentChainData;
@@ -212,6 +216,7 @@ public abstract class AbstractDataBackedRestAPIIntegrationTest {
                 eventChannels,
                 SyncAsyncRunner.SYNC_RUNNER,
                 StubTimeProvider.withTimeInMillis(1000),
+                executionClientDataProvider,
                 spec)
             : new ReflectionBasedBeaconRestApi(
                 dataProvider,
@@ -220,6 +225,7 @@ public abstract class AbstractDataBackedRestAPIIntegrationTest {
                 eventChannels,
                 SyncAsyncRunner.SYNC_RUNNER,
                 StubTimeProvider.withTimeInMillis(1000),
+                executionClientDataProvider,
                 spec);
     assertThat(beaconRestApi.start()).isCompleted();
     client = new OkHttpClient.Builder().readTimeout(0, TimeUnit.SECONDS).build();

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/JsonTypeDefinitionBeaconRestApi.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/JsonTypeDefinitionBeaconRestApi.java
@@ -19,6 +19,7 @@ import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_UNSUPPORT
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.apache.commons.lang3.StringUtils;
 import tech.pegasys.teku.api.DataProvider;
+import tech.pegasys.teku.api.ExecutionClientDataProvider;
 import tech.pegasys.teku.api.exceptions.BadRequestException;
 import tech.pegasys.teku.api.exceptions.ServiceUnavailableException;
 import tech.pegasys.teku.beaconrestapi.handlers.tekuv1.admin.Liveness;
@@ -109,6 +110,7 @@ import tech.pegasys.teku.validator.coordinator.Eth1DataProvider;
 import tech.pegasys.teku.validator.coordinator.MissingDepositsException;
 
 public class JsonTypeDefinitionBeaconRestApi implements BeaconRestApi {
+
   private final RestApi restApi;
 
   public JsonTypeDefinitionBeaconRestApi(
@@ -118,10 +120,18 @@ public class JsonTypeDefinitionBeaconRestApi implements BeaconRestApi {
       final EventChannels eventChannels,
       final AsyncRunner asyncRunner,
       final TimeProvider timeProvider,
+      final ExecutionClientDataProvider executionClientDataProvider,
       final Spec spec) {
     restApi =
         create(
-            config, dataProvider, eth1DataProvider, eventChannels, asyncRunner, timeProvider, spec);
+            config,
+            dataProvider,
+            eth1DataProvider,
+            eventChannels,
+            asyncRunner,
+            timeProvider,
+            executionClientDataProvider,
+            spec);
   }
 
   @Override
@@ -146,6 +156,7 @@ public class JsonTypeDefinitionBeaconRestApi implements BeaconRestApi {
       final EventChannels eventChannels,
       final AsyncRunner asyncRunner,
       final TimeProvider timeProvider,
+      final ExecutionClientDataProvider executionClientDataProvider,
       final Spec spec) {
     final SchemaDefinitionCache schemaCache = new SchemaDefinitionCache(spec);
     return new RestApiBuilder()
@@ -269,7 +280,7 @@ public class JsonTypeDefinitionBeaconRestApi implements BeaconRestApi {
         .endpoint(new PutLogLevel())
         .endpoint(new GetStateByBlockRoot(dataProvider, spec))
         .endpoint(new Liveness(dataProvider))
-        .endpoint(new Readiness(dataProvider))
+        .endpoint(new Readiness(dataProvider, executionClientDataProvider))
         .endpoint(new GetAllBlocksAtSlot(dataProvider, schemaCache))
         .endpoint(new GetPeersScore(dataProvider))
         .endpoint(new GetProtoArray(dataProvider))

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/AbstractMigratedBeaconHandlerTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/AbstractMigratedBeaconHandlerTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.mock;
 
 import java.util.function.IntSupplier;
 import tech.pegasys.teku.api.ChainDataProvider;
+import tech.pegasys.teku.api.ExecutionClientDataProvider;
 import tech.pegasys.teku.api.NetworkDataProvider;
 import tech.pegasys.teku.api.SyncDataProvider;
 import tech.pegasys.teku.api.ValidatorDataProvider;
@@ -49,6 +50,8 @@ public abstract class AbstractMigratedBeaconHandlerTest {
 
   protected ChainDataProvider chainDataProvider = mock(ChainDataProvider.class);
   protected final ValidatorDataProvider validatorDataProvider = mock(ValidatorDataProvider.class);
+  protected final ExecutionClientDataProvider executionClientDataProvider =
+      mock(ExecutionClientDataProvider.class);
 
   // Getting a NullPointerException from this? Call setHandler as the first thing you do. :)
   protected StubRestApiRequest request;

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/ReflectionBasedBeaconRestApiTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/ReflectionBasedBeaconRestApiTest.java
@@ -26,6 +26,7 @@ import io.javalin.jetty.JettyServer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.api.DataProvider;
+import tech.pegasys.teku.api.ExecutionClientDataProvider;
 import tech.pegasys.teku.beacon.sync.SyncService;
 import tech.pegasys.teku.ethereum.execution.types.Eth1Address;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
@@ -72,6 +73,9 @@ class ReflectionBasedBeaconRestApiTest {
   private final DepositProvider depositProvider = mock(DepositProvider.class);
   private final Eth1DataCache eth1DataCache = mock(Eth1DataCache.class);
 
+  private final ExecutionClientDataProvider executionClientDataProvider =
+      mock(ExecutionClientDataProvider.class);
+
   @BeforeEach
   public void setup() {
     BeaconRestApiConfig beaconRestApiConfig =
@@ -109,6 +113,7 @@ class ReflectionBasedBeaconRestApiTest {
         eventChannels,
         new StubAsyncRunner(),
         StubTimeProvider.withTimeInMillis(1000),
+        executionClientDataProvider,
         app,
         storageClient.getSpec());
   }

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/ReflectionBasedBeaconRestApiV1Test.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/ReflectionBasedBeaconRestApiV1Test.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import tech.pegasys.teku.api.DataProvider;
+import tech.pegasys.teku.api.ExecutionClientDataProvider;
 import tech.pegasys.teku.beacon.sync.SyncService;
 import tech.pegasys.teku.beaconrestapi.handlers.tekuv1.admin.Liveness;
 import tech.pegasys.teku.beaconrestapi.handlers.tekuv1.admin.PutLogLevel;
@@ -126,6 +127,8 @@ public class ReflectionBasedBeaconRestApiV1Test {
   private final ProposersDataManager proposersDataManager = mock(ProposersDataManager.class);
   private final DepositProvider depositProvider = mock(DepositProvider.class);
   private final Eth1DataCache eth1DataCache = mock(Eth1DataCache.class);
+  private final ExecutionClientDataProvider executionClientDataProvider =
+      mock(ExecutionClientDataProvider.class);
 
   @BeforeEach
   public void setup() {
@@ -165,6 +168,7 @@ public class ReflectionBasedBeaconRestApiV1Test {
         eventChannels,
         new StubAsyncRunner(),
         StubTimeProvider.withTimeInMillis(1000),
+        executionClientDataProvider,
         app,
         storageClient.getSpec());
   }

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/admin/ReadinessTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/admin/ReadinessTest.java
@@ -37,13 +37,15 @@ public class ReadinessTest extends AbstractMigratedBeaconHandlerTest {
 
   @BeforeEach
   void setup() {
-    setHandler(new Readiness(syncDataProvider, chainDataProvider, network));
+    setHandler(
+        new Readiness(syncDataProvider, chainDataProvider, network, executionClientDataProvider));
   }
 
   @Test
   public void shouldReturnOkWhenInSyncAndReady() throws Exception {
     when(chainDataProvider.isStoreAvailable()).thenReturn(true);
     when(syncService.getCurrentSyncState()).thenReturn(SyncState.IN_SYNC);
+    when(executionClientDataProvider.isExecutionClientAvailable()).thenReturn(true);
 
     handler.handleRequest(request);
 
@@ -57,6 +59,7 @@ public class ReadinessTest extends AbstractMigratedBeaconHandlerTest {
     final Eth2Peer peer1 = mock(Eth2Peer.class);
     when(chainDataProvider.isStoreAvailable()).thenReturn(true);
     when(syncService.getCurrentSyncState()).thenReturn(SyncState.IN_SYNC);
+    when(executionClientDataProvider.isExecutionClientAvailable()).thenReturn(true);
     when(eth2P2PNetwork.streamPeers())
         .thenReturn(Stream.of(peer1, peer1))
         .thenReturn(Stream.of(peer1, peer1));
@@ -119,6 +122,18 @@ public class ReadinessTest extends AbstractMigratedBeaconHandlerTest {
     when(chainDataProvider.isStoreAvailable()).thenReturn(true);
     when(syncService.getCurrentSyncState()).thenReturn(SyncState.IN_SYNC);
     when(eth2P2PNetwork.streamPeers()).thenReturn(Stream.of(peer1)).thenReturn(Stream.of(peer1));
+
+    handler.handleRequest(request);
+
+    assertThat(request.getResponseCode()).isEqualTo(SC_SERVICE_UNAVAILABLE);
+    assertThat(request.getResponseBody()).isNull();
+  }
+
+  @Test
+  public void shouldReturnUnavailableWhenExecutionClientIsNotAvailable() throws Exception {
+    when(chainDataProvider.isStoreAvailable()).thenReturn(true);
+    when(syncService.getCurrentSyncState()).thenReturn(SyncState.IN_SYNC);
+    when(executionClientDataProvider.isExecutionClientAvailable()).thenReturn(false);
 
     handler.handleRequest(request);
 

--- a/data/provider/build.gradle
+++ b/data/provider/build.gradle
@@ -2,6 +2,7 @@ dependencies {
     api project(':ethereum:spec')
 
     implementation project(':data:serializer')
+    implementation project(':ethereum:executionclient')
     implementation project(':ethereum:spec')
     implementation project(':ethereum:statetransition')
     implementation project(':infrastructure:async')

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ExecutionClientDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ExecutionClientDataProvider.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.api;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import tech.pegasys.teku.ethereum.executionclient.events.ExecutionClientEventsChannel;
+
+public class ExecutionClientDataProvider implements ExecutionClientEventsChannel {
+
+  private final AtomicBoolean isExecutionClientAvailable = new AtomicBoolean(false);
+
+  @Override
+  public void onAvailabilityUpdated(final boolean isAvailable) {
+    isExecutionClientAvailable.set(isAvailable);
+  }
+
+  public boolean isExecutionClientAvailable() {
+    return isExecutionClientAvailable.get();
+  }
+}

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JClient.java
@@ -117,10 +117,11 @@ public abstract class Web3JClient {
     final long lastErrorTime = lastError.getAndUpdate(x -> NO_ERROR_TIME);
     if (lastErrorTime == STARTUP_LAST_ERROR_TIME) {
       eventLog.executionClientIsOnline();
+      executionClientEventsPublisher.onAvailabilityUpdated(true);
     } else if (lastErrorTime != NO_ERROR_TIME) {
       eventLog.executionClientRecovered();
+      executionClientEventsPublisher.onAvailabilityUpdated(true);
     }
-    executionClientEventsPublisher.onAvailabilityUpdated(true);
   }
 
   public synchronized Web3jService getWeb3jService() {

--- a/services/beaconchain/build.gradle
+++ b/services/beaconchain/build.gradle
@@ -6,6 +6,7 @@ dependencies {
   implementation project(':infrastructure:metrics')
   implementation project(':data:provider')
   implementation project(':ethereum:events')
+  implementation project(':ethereum:executionclient')
   implementation project(':ethereum:execution-types')
   implementation project(':ethereum:networks')
   implementation project(':ethereum:pow:api')

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -38,6 +38,7 @@ import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.api.ChainDataProvider;
 import tech.pegasys.teku.api.DataProvider;
+import tech.pegasys.teku.api.ExecutionClientDataProvider;
 import tech.pegasys.teku.beacon.sync.DefaultSyncServiceFactory;
 import tech.pegasys.teku.beacon.sync.SyncService;
 import tech.pegasys.teku.beacon.sync.SyncServiceFactory;
@@ -47,6 +48,7 @@ import tech.pegasys.teku.beaconrestapi.JsonTypeDefinitionBeaconRestApi;
 import tech.pegasys.teku.beaconrestapi.ReflectionBasedBeaconRestApi;
 import tech.pegasys.teku.ethereum.events.SlotEventsChannel;
 import tech.pegasys.teku.ethereum.execution.types.Eth1Address;
+import tech.pegasys.teku.ethereum.executionclient.events.ExecutionClientEventsChannel;
 import tech.pegasys.teku.ethereum.pow.api.Eth1EventsChannel;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.AsyncRunnerFactory;
@@ -861,6 +863,10 @@ public class BeaconChainController extends Service implements BeaconChainControl
     }
     final Eth1DataProvider eth1DataProvider = new Eth1DataProvider(eth1DataCache, depositProvider);
 
+    final ExecutionClientDataProvider executionClientDataProvider =
+        new ExecutionClientDataProvider();
+    eventChannels.subscribe(ExecutionClientEventsChannel.class, executionClientDataProvider);
+
     final BeaconRestApi api =
         beaconConfig.beaconRestApiConfig().isEnableMigratedRestApi()
             ? new JsonTypeDefinitionBeaconRestApi(
@@ -870,6 +876,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
                 eventChannels,
                 eventAsyncRunner,
                 timeProvider,
+                executionClientDataProvider,
                 spec)
             : new ReflectionBasedBeaconRestApi(
                 dataProvider,
@@ -878,6 +885,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
                 eventChannels,
                 eventAsyncRunner,
                 timeProvider,
+                executionClientDataProvider,
                 spec);
     beaconRestAPI = Optional.of(api);
 


### PR DESCRIPTION
## PR Description

`/readiness` endpoint now will check if EL client is available. If EL is not available, it returns a 503 status code.

`ExecutionClientDataProvider` subscribes to `ExecutionClientEventsChannel` to listen to EL online/offline events.

## Fixed Issue(s)
fixes #6236 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
