### PR TITLE
Logging improvements and higher timeout for exchangeTransitionConfigurationV1

### DIFF
--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/paths/_eth_v1_validator_register_validator.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/migrated/paths/_eth_v1_validator_register_validator.json
@@ -3,7 +3,7 @@
     "tags" : [ "Validator", "Validator Required Api" ],
     "operationId" : "registerValidator",
     "summary" : "Register validators with builder",
-    "description" : "Prepares the beacon node for engaging with external builders. The information will be sent by the beacon node to the builder network. It is expected that the validator client will send this information periodically to ensure the beacon node has correct and timely registration information to provide to builders. The validator client should not sign blinded beacon blocks that do not adhere to their latest fee recipient and gas limit preferences.",
+    "description" : "Prepares the beacon node for engaging with external builders. The information must be sent by the beacon node to the builder network. It is expected that the validator client will send this information periodically to ensure the beacon node has correct and timely registration information to provide to builders. The validator client should not sign blinded beacon blocks that do not adhere to their latest fee recipient and gas limit preferences.",
     "requestBody" : {
       "content" : {
         "application/octet-stream" : {

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_validator_register_validator.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_validator_register_validator.json
@@ -1,33 +1,30 @@
 {
-  "post": {
-    "tags": [
-      "Validator",
-      "Validator Required Api"
-    ],
-    "summary": "Register validators with builder",
-    "description": "Prepares the beacon node for engaging with external builders. The information must be sent by the beacon node to the builder network. The information supplied for each validator is considered persistent until overwritten by new information for the given validator, or until the beacon node restarts.\n\nNote that because the information is not persistent across beacon node restarts it is recommended that either the beacon node is monitored for restarts or this information is refreshed by resending this request periodically (for example, each epoch).\n\nAlso note that only registrations for active or pending validators must be sent to the builder network. Registrations for unknown or exited validators must be filtered out and not sent to the builder network.",
-    "operationId": "postEthV1ValidatorRegister_validator",
-    "requestBody": {
-      "content": {
-        "application/json": {
-          "schema": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PostRegisterValidatorRequest"
+  "post" : {
+    "tags" : [ "Validator", "Validator Required Api" ],
+    "summary" : "Register validators with builder",
+    "description" : "Prepares the beacon node for engaging with external builders. The information must be sent by the beacon node to the builder network. The information supplied for each validator is considered persistent until overwritten by new information for the given validator, or until the beacon node restarts.\n\nNote that because the information is not persistent across beacon node restarts it is recommended that either the beacon node is monitored for restarts or this information is refreshed by resending this request periodically (for example, each epoch).\n\nAlso note that only registrations for active or pending validators must be sent to the builder network. Registrations for unknown or exited validators must be filtered out and not sent to the builder network.",
+    "operationId" : "postEthV1ValidatorRegister_validator",
+    "requestBody" : {
+      "content" : {
+        "application/json" : {
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PostRegisterValidatorRequest"
             }
           }
         }
       }
     },
-    "responses": {
-      "200": {
-        "description": "Registration information has been received."
+    "responses" : {
+      "200" : {
+        "description" : "Registration information has been received."
       },
-      "400": {
-        "description": "Invalid parameter supplied."
+      "400" : {
+        "description" : "Invalid parameter supplied."
       },
-      "500": {
-        "description": "Beacon node internal error."
+      "500" : {
+        "description" : "Beacon node internal error."
       }
     }
   }

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_validator_register_validator.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_validator_register_validator.json
@@ -1,30 +1,33 @@
 {
-  "post" : {
-    "tags" : [ "Validator", "Validator Required Api" ],
-    "summary" : "Register validators with builder",
-    "description" : "Prepares the beacon node for potential proposers by supplying information required when proposing blocks for the given validators. The information supplied for each validator index is considered persistent until overwritten by new information for the given validator index, or until the beacon node restarts.\n\nNote that because the information is not persistent across beacon node restarts it is recommended that either the beacon node is monitored for restarts or this information is refreshed by resending this request periodically (for example, each epoch).\n\nAlso note that only registrations for active or pending validators will be sent to the builder network. Registrations for unknown or exited validators will be filtered out and not sent to the builder network.",
-    "operationId" : "postEthV1ValidatorRegister_validator",
-    "requestBody" : {
-      "content" : {
-        "application/json" : {
-          "schema" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/PostRegisterValidatorRequest"
+  "post": {
+    "tags": [
+      "Validator",
+      "Validator Required Api"
+    ],
+    "summary": "Register validators with builder",
+    "description": "Prepares the beacon node for engaging with external builders. The information must be sent by the beacon node to the builder network. The information supplied for each validator is considered persistent until overwritten by new information for the given validator, or until the beacon node restarts.\n\nNote that because the information is not persistent across beacon node restarts it is recommended that either the beacon node is monitored for restarts or this information is refreshed by resending this request periodically (for example, each epoch).\n\nAlso note that only registrations for active or pending validators must be sent to the builder network. Registrations for unknown or exited validators must be filtered out and not sent to the builder network.",
+    "operationId": "postEthV1ValidatorRegister_validator",
+    "requestBody": {
+      "content": {
+        "application/json": {
+          "schema": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PostRegisterValidatorRequest"
             }
           }
         }
       }
     },
-    "responses" : {
-      "200" : {
-        "description" : "Preparation information has been received."
+    "responses": {
+      "200": {
+        "description": "Registration information has been received."
       },
-      "400" : {
-        "description" : "Invalid parameter supplied."
+      "400": {
+        "description": "Invalid parameter supplied."
       },
-      "500" : {
-        "description" : "Beacon node internal error."
+      "500": {
+        "description": "Beacon node internal error."
       }
     }
   }

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostRegisterValidator.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostRegisterValidator.java
@@ -53,7 +53,7 @@ public class PostRegisterValidator extends MigratingEndpointAdapter {
             .summary("Register validators with builder")
             .description(
                 "Prepares the beacon node for engaging with external builders."
-                    + " The information will be sent by the beacon node to the builder network."
+                    + " The information must be sent by the beacon node to the builder network."
                     + " It is expected that the validator client will send this information periodically"
                     + " to ensure the beacon node has correct and timely registration information"
                     + " to provide to builders. The validator client should not sign blinded beacon"
@@ -82,7 +82,7 @@ public class PostRegisterValidator extends MigratingEndpointAdapter {
       description =
           "Prepares the beacon node for potential proposers by supplying information required when proposing blocks for the given validators. The information supplied for each validator index is considered persistent until overwritten by new information for the given validator index, or until the beacon node restarts.\n\n"
               + "Note that because the information is not persistent across beacon node restarts it is recommended that either the beacon node is monitored for restarts or this information is refreshed by resending this request periodically (for example, each epoch).\n\n"
-              + "Also note that only registrations for active or pending validators will be sent to the builder network. Registrations for unknown or exited validators will be filtered out and not sent to the builder network.",
+              + "Also note that only registrations for active or pending validators must be sent to the builder network. Registrations for unknown or exited validators must be filtered out and not sent to the builder network.",
       responses = {
         @OpenApiResponse(
             status = RES_OK,

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostRegisterValidator.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostRegisterValidator.java
@@ -80,13 +80,13 @@ public class PostRegisterValidator extends MigratingEndpointAdapter {
           @OpenApiRequestBody(
               content = {@OpenApiContent(from = PostRegisterValidatorRequest[].class)}),
       description =
-          "Prepares the beacon node for potential proposers by supplying information required when proposing blocks for the given validators. The information supplied for each validator index is considered persistent until overwritten by new information for the given validator index, or until the beacon node restarts.\n\n"
+          "Prepares the beacon node for engaging with external builders. The information must be sent by the beacon node to the builder network. The information supplied for each validator is considered persistent until overwritten by new information for the given validator, or until the beacon node restarts.\n\n"
               + "Note that because the information is not persistent across beacon node restarts it is recommended that either the beacon node is monitored for restarts or this information is refreshed by resending this request periodically (for example, each epoch).\n\n"
               + "Also note that only registrations for active or pending validators must be sent to the builder network. Registrations for unknown or exited validators must be filtered out and not sent to the builder network.",
       responses = {
         @OpenApiResponse(
             status = RES_OK,
-            description = "Preparation information has been received."),
+            description = "Registration information has been received."),
         @OpenApiResponse(status = RES_BAD_REQUEST, description = "Invalid parameter supplied."),
         @OpenApiResponse(status = RES_INTERNAL_ERROR, description = "Beacon node internal error.")
       })

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JExecutionEngineClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JExecutionEngineClient.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.ethereum.executionclient.web3j;
 import static tech.pegasys.teku.spec.config.Constants.EL_ENGINE_BLOCK_EXECUTION_TIMEOUT;
 import static tech.pegasys.teku.spec.config.Constants.EL_ENGINE_NON_BLOCK_EXECUTION_TIMEOUT;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -39,6 +40,9 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.execution.PowBlock;
 
 public class Web3JExecutionEngineClient implements ExecutionEngineClient {
+
+  private static final Duration EXCHANGE_TRANSITION_CONFIGURATION_TIMEOUT = Duration.ofSeconds(8);
+
   private final Web3JClient web3JClient;
 
   public Web3JExecutionEngineClient(final Web3JClient web3JClient) {
@@ -119,7 +123,7 @@ public class Web3JExecutionEngineClient implements ExecutionEngineClient {
             Collections.singletonList(transitionConfiguration),
             web3JClient.getWeb3jService(),
             TransitionConfigurationV1Web3jResponse.class);
-    return web3JClient.doRequest(web3jRequest, EL_ENGINE_NON_BLOCK_EXECUTION_TIMEOUT);
+    return web3JClient.doRequest(web3jRequest, EXCHANGE_TRANSITION_CONFIGURATION_TIMEOUT);
   }
 
   static class ExecutionPayloadV1Web3jResponse

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/ValidatorLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/ValidatorLogger.java
@@ -239,6 +239,15 @@ public class ValidatorLogger {
     log.error(ColorConsolePrinter.print(errorString, Color.RED), error);
   }
 
+  public void validatorRegistrationsSentToTheBuilderNetwork(
+      final int successfullySentRegistrations, final int totalRegistrations) {
+    final String infoString =
+        String.format(
+            "%s%s out of %s validator(s) registrations were successfully sent to the builder network via the Beacon Node.",
+            PREFIX, successfullySentRegistrations, totalRegistrations);
+    log.info(ColorConsolePrinter.print(infoString, Color.GREEN));
+  }
+
   public void registeringValidatorsFailed(final Throwable error) {
     final String errorString =
         String.format(

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/BeaconProposerPreparer.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/BeaconProposerPreparer.java
@@ -243,7 +243,7 @@ public class BeaconProposerPreparer
                     .thenApply(__ -> beaconPreparableProposers))
         .finish(
             beaconPreparableProposers -> {
-              LOG.info(
+              LOG.debug(
                   "Information about {} proposers has been processed successfully by the Beacon Node.",
                   beaconPreparableProposers.size());
               sentProposersAtLeastOnce.compareAndSet(false, true);

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrationBatchSender.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrationBatchSender.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.teku.validator.client;
 
+import static tech.pegasys.teku.infrastructure.logging.ValidatorLogger.VALIDATOR_LOGGER;
+
 import com.google.common.collect.Lists;
 import java.util.Iterator;
 import java.util.List;
@@ -81,10 +83,8 @@ public class ValidatorRegistrationBatchSender {
             })
         .alwaysRun(
             () ->
-                LOG.info(
-                    "{} out of {} validator(s) registrations were successfully sent to the builder network via the Beacon Node.",
-                    successfullySentRegistrations.get(),
-                    validatorRegistrations.size()));
+                VALIDATOR_LOGGER.validatorRegistrationsSentToTheBuilderNetwork(
+                    successfullySentRegistrations.get(), validatorRegistrations.size()));
   }
 
   private SafeFuture<Void> sendBatch(


### PR DESCRIPTION
## PR Description

- Increase timeout for engine_exchangeTransitionConfigurationV1 since noticing there are few timeouts from users 
- Improve logging in other places
- Change description of `register_validator` endpoint as per latest spec

## Fixed Issue(s)
fixes #6249 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
