### PR TITLE
Complete builder registration filtering

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -28,7 +28,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiFunction;
@@ -821,7 +820,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
                       signedValidatorRegistration.getMessage().getPublicKey();
                   final boolean unknownOrHasExited =
                       Optional.ofNullable(validatorStatuses.get(validatorIdentifier))
-                          .map(this::validatorHasExited)
+                          .map(ValidatorStatus::hasExited)
                           .orElse(true);
                   if (unknownOrHasExited) {
                     LOG.debug(
@@ -835,11 +834,6 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
       return validatorRegistrations;
     }
     return validatorRegistrations.getSchema().createFromElements(applicableValidatorRegistrations);
-  }
-
-  private boolean validatorHasExited(final ValidatorStatus validatorStatus) {
-    return Objects.equals(validatorStatus, ValidatorStatus.exited_slashed)
-        || Objects.equals(validatorStatus, ValidatorStatus.exited_unslashed);
   }
 
   private static <A, B, R> Optional<R> combine(

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/beacon/ValidatorStatus.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/beacon/ValidatorStatus.java
@@ -18,13 +18,23 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @SuppressWarnings("JavaCase")
 @Schema(description = "[Validator status specification](https://hackmd.io/ofFJ5gOmQpu1jjHilHbdQQ)")
 public enum ValidatorStatus {
-  pending_initialized,
-  pending_queued,
-  active_ongoing,
-  active_exiting,
-  active_slashed,
-  exited_unslashed,
-  exited_slashed,
-  withdrawal_possible,
-  withdrawal_done
+  pending_initialized(false),
+  pending_queued(false),
+  active_ongoing(false),
+  active_exiting(false),
+  active_slashed(false),
+  exited_unslashed(true),
+  exited_slashed(true),
+  withdrawal_possible(true),
+  withdrawal_done(true);
+
+  private final boolean hasExited;
+
+  ValidatorStatus(final boolean hasExited) {
+    this.hasExited = hasExited;
+  }
+
+  public boolean hasExited() {
+    return hasExited;
+  }
 }


### PR DESCRIPTION
implements a more exhaustive filtering on validator statuses when we are about to send them to the builder endpoint.

We don't want to send unknown or exited validators.

## Fixed Issue(s)

fixes #6312 

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
