### PR TITLE
Add doppelganger option to the beacon node command

### DIFF
--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorClientOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorClientOptions.java
@@ -13,7 +13,6 @@
 
 package tech.pegasys.teku.cli.options;
 
-import static tech.pegasys.teku.validator.api.ValidatorConfig.DEFAULT_DOPPELGANGER_DETECTION_ENABLED;
 import static tech.pegasys.teku.validator.api.ValidatorConfig.DEFAULT_VALIDATOR_CLIENT_SSZ_BLOCKS_ENABLED;
 
 import java.net.URI;
@@ -54,16 +53,6 @@ public class ValidatorClientOptions {
       fallbackValue = "true")
   private boolean validatorClientSszBlocksEnabled = DEFAULT_VALIDATOR_CLIENT_SSZ_BLOCKS_ENABLED;
 
-  @Option(
-      names = {"--Xdoppelganger-detection-enabled"},
-      paramLabel = "<BOOLEAN>",
-      description = "Enable validators doppelganger detection",
-      hidden = true,
-      showDefaultValue = CommandLine.Help.Visibility.ALWAYS,
-      arity = "0..1",
-      fallbackValue = "true")
-  private boolean doppelgangerDetectionEnabled = DEFAULT_DOPPELGANGER_DETECTION_ENABLED;
-
   public void configure(TekuConfiguration.Builder builder) {
     configureBeaconNodeApiEndpoints();
 
@@ -72,7 +61,6 @@ public class ValidatorClientOptions {
             config
                 .beaconNodeApiEndpoints(getBeaconNodeApiEndpoints())
                 .validatorClientUseSszBlocksEnabled(validatorClientSszBlocksEnabled)
-                .doppelgangerDetectionEnabled(doppelgangerDetectionEnabled)
                 .failoversSendSubnetSubscriptionsEnabled(failoversSendSubnetSubscriptionsEnabled)
                 .sentryNodeConfigurationFile(exclusiveParams.sentryConfigFile));
   }

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.teku.cli.options;
 
+import static tech.pegasys.teku.validator.api.ValidatorConfig.DEFAULT_DOPPELGANGER_DETECTION_ENABLED;
+
 import java.nio.file.Path;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
@@ -100,6 +102,16 @@ public class ValidatorOptions {
       arity = "1")
   private int executorMaxQueueSize = ValidatorConfig.DEFAULT_EXECUTOR_MAX_QUEUE_SIZE;
 
+  @Option(
+      names = {"--Xdoppelganger-detection-enabled"},
+      paramLabel = "<BOOLEAN>",
+      description = "Enable validators doppelganger detection",
+      hidden = true,
+      showDefaultValue = CommandLine.Help.Visibility.ALWAYS,
+      arity = "0..1",
+      fallbackValue = "true")
+  private boolean doppelgangerDetectionEnabled = DEFAULT_DOPPELGANGER_DETECTION_ENABLED;
+
   public void configure(TekuConfiguration.Builder builder) {
     builder.validator(
         config ->
@@ -112,7 +124,8 @@ public class ValidatorOptions {
                     new FileBackedGraffitiProvider(
                         Optional.ofNullable(graffiti), Optional.ofNullable(graffitiFile)))
                 .generateEarlyAttestations(generateEarlyAttestations)
-                .executorMaxQueueSize(executorMaxQueueSize));
+                .executorMaxQueueSize(executorMaxQueueSize)
+                .doppelgangerDetectionEnabled(doppelgangerDetectionEnabled));
     validatorProposerOptions.configure(builder);
     validatorKeysOptions.configure(builder);
   }

--- a/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
@@ -365,11 +365,11 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
     beaconNodeCommand.parse(args);
     assertThat(
             beaconNodeCommand
-                    .tekuConfiguration()
-                    .validatorClient()
-                    .getValidatorConfig()
-                    .isDoppelgangerDetectionEnabled())
-            .isFalse();
+                .tekuConfiguration()
+                .validatorClient()
+                .getValidatorConfig()
+                .isDoppelgangerDetectionEnabled())
+        .isFalse();
   }
 
   private Path createConfigFile() throws IOException {

--- a/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
@@ -335,6 +335,19 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
 
   @Test
   public void doppelgangerDetectionShouldBeDisabledByDefault() {
+    final String[] args = {};
+    beaconNodeCommand.parse(args);
+    assertThat(
+            beaconNodeCommand
+                .tekuConfiguration()
+                .validatorClient()
+                .getValidatorConfig()
+                .isDoppelgangerDetectionEnabled())
+        .isFalse();
+  }
+
+  @Test
+  public void shouldEnableDoppelgangerDetection() {
     final String[] args = {"--Xdoppelganger-detection-enabled", "true"};
     beaconNodeCommand.parse(args);
     assertThat(
@@ -347,16 +360,16 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
   }
 
   @Test
-  public void shouldSetDoppelgangerDetection() {
-    final String[] args = {"--Xdoppelganger-detection-enabled", "true"};
+  public void shouldDisableDoppelgangerDetection() {
+    final String[] args = {"--Xdoppelganger-detection-enabled", "false"};
     beaconNodeCommand.parse(args);
     assertThat(
             beaconNodeCommand
-                .tekuConfiguration()
-                .validatorClient()
-                .getValidatorConfig()
-                .isDoppelgangerDetectionEnabled())
-        .isTrue();
+                    .tekuConfiguration()
+                    .validatorClient()
+                    .getValidatorConfig()
+                    .isDoppelgangerDetectionEnabled())
+            .isFalse();
   }
 
   private Path createConfigFile() throws IOException {

--- a/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
@@ -62,6 +62,7 @@ import tech.pegasys.teku.storage.server.DatabaseVersion;
 import tech.pegasys.teku.storage.server.StorageConfiguration;
 import tech.pegasys.teku.validator.api.FileBackedGraffitiProvider;
 import tech.pegasys.teku.validator.api.InteropConfig;
+import tech.pegasys.teku.validator.api.ValidatorConfig;
 import tech.pegasys.teku.validator.api.ValidatorPerformanceTrackingMode;
 
 public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
@@ -332,6 +333,32 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
         .isEqualTo(NatMethod.UPNP);
   }
 
+  @Test
+  public void doppelgangerDetectionShouldBeDisabledByDefault() {
+    final String[] args = {"--Xdoppelganger-detection-enabled", "true"};
+    beaconNodeCommand.parse(args);
+    assertThat(
+            beaconNodeCommand
+                .tekuConfiguration()
+                .validatorClient()
+                .getValidatorConfig()
+                .isDoppelgangerDetectionEnabled())
+        .isTrue();
+  }
+
+  @Test
+  public void shouldSetDoppelgangerDetection() {
+    final String[] args = {"--Xdoppelganger-detection-enabled", "true"};
+    beaconNodeCommand.parse(args);
+    assertThat(
+            beaconNodeCommand
+                .tekuConfiguration()
+                .validatorClient()
+                .getValidatorConfig()
+                .isDoppelgangerDetectionEnabled())
+        .isTrue();
+  }
+
   private Path createConfigFile() throws IOException {
     final URL configFile = BeaconNodeCommandTest.class.getResource("/complete_config.yaml");
     final String updatedConfig =
@@ -523,7 +550,9 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
                     .validatorKeystoreLockingEnabled(true)
                     .validatorPerformanceTrackingMode(ValidatorPerformanceTrackingMode.ALL)
                     .graffitiProvider(new FileBackedGraffitiProvider())
-                    .generateEarlyAttestations(true))
+                    .generateEarlyAttestations(true)
+                    .doppelgangerDetectionEnabled(
+                        ValidatorConfig.DEFAULT_DOPPELGANGER_DETECTION_ENABLED))
         .metrics(
             b ->
                 b.metricsEnabled(false)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

Move the doppelganger detection enabling option from the `ValidatorClientOptions` to the the `ValidatorOptions` to make it available to the Beacon Node command (Otherwise will only be available when the VC is run in a separate process from the BN).

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
https://github.com/ConsenSys/teku/issues/3493

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
