### PR TITLE
Include information about why publishing the attestation failed in response

### DIFF
--- a/beacon/validator/build.gradle
+++ b/beacon/validator/build.gradle
@@ -25,6 +25,7 @@ dependencies {
   implementation project(':data:serializer')
   implementation project(':data:provider')
   implementation project(':infrastructure:events')
+  implementation project(':infrastructure:exceptions')
   implementation project(':infrastructure:metrics')
 
   implementation 'it.unimi.dsi:fastutil'

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -494,7 +494,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
             })
         .exceptionally(
             error -> {
-              LOG.debug(
+              LOG.error(
                   "Failed to send signed attestation for slot {}, block {}",
                   attestation.getData().getSlot(),
                   attestation.getData().getBeaconBlockRoot(),

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.validator.coordinator;
 
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
+import static tech.pegasys.teku.infrastructure.exceptions.ExceptionUtil.getMessageOrSimpleName;
 import static tech.pegasys.teku.infrastructure.logging.ValidatorLogger.VALIDATOR_LOGGER;
 import static tech.pegasys.teku.spec.config.SpecConfig.GENESIS_SLOT;
 
@@ -31,7 +32,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiFunction;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
@@ -504,7 +504,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
                   "Failed to send signed attestation for slot %s, block %s: %s",
                   attestation.getData().getSlot(),
                   attestation.getData().getBeaconBlockRoot(),
-                  ExceptionUtils.getMessage(error));
+                  getMessageOrSimpleName(error));
             });
   }
 

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -493,10 +493,18 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
               }
             })
         .exceptionally(
-            error ->
-                InternalValidationResult.reject(
-                    "Failed to send signed attestation for slot %s, block %s",
-                    attestation.getData().getSlot(), attestation.getData().getBeaconBlockRoot()));
+            error -> {
+              LOG.debug(
+                  "Failed to send signed attestation for slot {}, block {}",
+                  attestation.getData().getSlot(),
+                  attestation.getData().getBeaconBlockRoot(),
+                  error);
+              return InternalValidationResult.reject(
+                  "Failed to send signed attestation for slot %s, block %s: %s",
+                  attestation.getData().getSlot(),
+                  attestation.getData().getBeaconBlockRoot(),
+                  error.getMessage());
+            });
   }
 
   private List<SubmitDataError> convertAttestationProcessingResultsToErrorList(

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiFunction;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
@@ -503,7 +504,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
                   "Failed to send signed attestation for slot %s, block %s: %s",
                   attestation.getData().getSlot(),
                   attestation.getData().getBeaconBlockRoot(),
-                  error.getMessage());
+                  ExceptionUtils.getMessage(error));
             });
   }
 


### PR DESCRIPTION
## PR Description
Provide information about why publishing the attestation failed in the error response instead of just a generic description that it failed.  Since we shouldn't get exceptions (should just return a rejected result), it also logs it as an error on the beacon node.


## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
