### PR TITLE
Using json-based definitions for API methods by default

### DIFF
--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/AbstractDataBackedRestAPIIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/AbstractDataBackedRestAPIIntegrationTest.java
@@ -96,6 +96,7 @@ public abstract class AbstractDataBackedRestAPIIntegrationTest {
           .restApiCorsAllowedOrigins(new ArrayList<>())
           .beaconLivenessTrackingEnabled(true)
           .eth1DepositContractAddress(Eth1Address.ZERO)
+          .enableMigratedRestApi(false)
           .build();
   private static final BeaconRestApiConfig MIGRATED_CONFIG =
       BeaconRestApiConfig.builder()

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApiConfig.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApiConfig.java
@@ -31,7 +31,7 @@ public class BeaconRestApiConfig {
   public static final List<String> DEFAULT_REST_API_CORS_ALLOWED_ORIGINS = new ArrayList<>();
   public static final boolean DEFAULT_BEACON_LIVENESS_TRACKING_ENABLED = false;
   public static final int DEFAULT_SUBSCRIBE_THREADS_COUNT = 1;
-  public static final boolean DEFAULT_ENABLE_MIGRATED_BEACON_REST_API = false;
+  public static final boolean DEFAULT_ENABLE_MIGRATED_BEACON_REST_API = true;
 
   // Beacon REST API
   private final int restApiPort;


### PR DESCRIPTION
## PR Description

Updates default value of `--Xrest-api-migrated-enabled` to `true`.

This change should not require any changes for the users and should be completely transparent. To revert to the previous behaviour run your node with `--Xrest-api-migrated-enabled=false`.

This toggle chooses between `JsonTypeDefinitionBeaconRestApi` (new default) or `ReflectionBasedBeaconRestApi` (previous default). In the future, the `--Xrest-api-migrated-enabled` option will be deprecated in favour of always using the updated `JsonTypeDefinitionBeaconRestApi`.