### PR TITLE
Upgrade jackson-databind to 2.13.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ For information on changes in released versions of Teku, see the [releases page]
 
 ### Additions and Improvements
 - Enabled new framework for REST API with better performance and less memory usage. The new framework does not cause any breaking changes, however if needed the old version can be restored with `--Xrest-api-migrated-enabled=false`
+- Updated jackson-databind library to version 2.13.4.2 addressing [CVE-2022-42003](https://nvd.nist.gov/vuln/detail/CVE-2022-42003)
 
 ### Bug Fixes
 - Fix issue where /readiness endpoint returned 200 when Execution Client was not available.

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -1,6 +1,6 @@
 dependencyManagement {
   dependencies {
-    dependency 'com.fasterxml.jackson.core:jackson-databind:2.13.4'
+    dependency 'com.fasterxml.jackson.core:jackson-databind:2.13.4.2'
     dependency 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.4'
     dependency 'com.fasterxml.jackson.dataformat:jackson-dataformat-toml:2.13.4'
     dependency 'com.fasterxml.jackson.module:jackson-module-kotlin:2.13.4'


### PR DESCRIPTION
## PR Description

Updated jackson-databind library to version 2.13.4.2 addressing [CVE-2022-42003](https://nvd.nist.gov/vuln/detail/CVE-2022-42003)
