### PR TITLE
Handle blinded block failover scenarios plus CLI option for sending duties to failovers

### DIFF
--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
@@ -613,7 +613,7 @@ public class SafeFuture<T> extends CompletableFuture<T> {
   }
 
   /**
-   * Returns the future which completes with the same result or exception The consumer is invoked if
+   * Returns the future which completes with the same result or exception. The consumer is invoked if
    * this future completes exceptionally
    */
   public SafeFuture<T> whenException(final Consumer<Throwable> action) {
@@ -627,7 +627,7 @@ public class SafeFuture<T> extends CompletableFuture<T> {
   }
 
   /**
-   * Returns the future which completes with the same result or exception The action is run if this
+   * Returns the future which completes with the same result or exception. The action is run if this
    * future completes successfully
    */
   public SafeFuture<T> whenSuccess(final Runnable action) {

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
@@ -627,6 +627,20 @@ public class SafeFuture<T> extends CompletableFuture<T> {
   }
 
   /**
+   * Returns the future which completes with the same result or exception The action is run if this
+   * future completes successfully
+   */
+  public SafeFuture<T> whenSuccess(final Runnable action) {
+    return (SafeFuture<T>)
+        super.whenComplete(
+            (r, t) -> {
+              if (t == null) {
+                action.run();
+              }
+            });
+  }
+
+  /**
    * Returns a void future that completes successfully with null result. The consumer is invoked if
    * this future completes exceptions and the returned future only completes once the consumer
    * returns.

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
@@ -613,8 +613,8 @@ public class SafeFuture<T> extends CompletableFuture<T> {
   }
 
   /**
-   * Returns the future which completes with the same result or exception. The consumer is invoked if
-   * this future completes exceptionally
+   * Returns the future which completes with the same result or exception. The consumer is invoked
+   * if this future completes exceptionally
    */
   public SafeFuture<T> whenException(final Consumer<Throwable> action) {
     return (SafeFuture<T>)

--- a/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/SafeFutureTest.java
+++ b/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/SafeFutureTest.java
@@ -28,6 +28,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -1146,6 +1147,14 @@ public class SafeFutureTest {
     final List<String> result = SafeFutureAssert.safeJoin(futureResult);
 
     assertThat(result).containsExactly("foo", "bar");
+  }
+
+  @Test
+  public void whenSuccessActionIsExecutedWhenFutureIsCompleted() {
+    final AtomicBoolean flag = new AtomicBoolean(false);
+    final SafeFuture<String> future = new SafeFuture<String>().whenSuccess(() -> flag.set(true));
+    future.complete("foobar");
+    Waiter.waitFor(flag::get, 100, TimeUnit.MILLISECONDS);
   }
 
   private List<Throwable> collectUncaughtExceptions() {

--- a/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/SafeFutureTest.java
+++ b/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/SafeFutureTest.java
@@ -1151,10 +1151,20 @@ public class SafeFutureTest {
   @Test
   public void whenSuccessActionIsExecutedWhenFutureIsCompleted() {
     final AtomicBoolean flag = new AtomicBoolean(false);
-    SafeFuture<String> future =
+    final SafeFuture<String> future =
         SafeFuture.completedFuture("foobar").whenSuccess(() -> flag.set(true));
     assertThat(future).isCompleted();
     assertThat(flag).isTrue();
+  }
+
+  @Test
+  public void whenSuccessActionIsNotExecutedWhenFutureCompletesExceptionally() {
+    final AtomicBoolean flag = new AtomicBoolean(false);
+    final SafeFuture<Object> future =
+        SafeFuture.failedFuture(new IllegalStateException("oopsy"))
+            .whenSuccess(() -> flag.set(true));
+    assertThat(future).isCompletedExceptionally();
+    assertThat(flag).isFalse();
   }
 
   private List<Throwable> collectUncaughtExceptions() {

--- a/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/SafeFutureTest.java
+++ b/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/SafeFutureTest.java
@@ -1151,7 +1151,9 @@ public class SafeFutureTest {
   @Test
   public void whenSuccessActionIsExecutedWhenFutureIsCompleted() {
     final AtomicBoolean flag = new AtomicBoolean(false);
-    SafeFuture.completedFuture("foobar").whenSuccess(() -> flag.set(true));
+    SafeFuture<String> future =
+        SafeFuture.completedFuture("foobar").whenSuccess(() -> flag.set(true));
+    assertThat(future).isCompleted();
     assertThat(flag).isTrue();
   }
 

--- a/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/SafeFutureTest.java
+++ b/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/SafeFutureTest.java
@@ -28,7 +28,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -1152,9 +1151,8 @@ public class SafeFutureTest {
   @Test
   public void whenSuccessActionIsExecutedWhenFutureIsCompleted() {
     final AtomicBoolean flag = new AtomicBoolean(false);
-    final SafeFuture<String> future = new SafeFuture<String>().whenSuccess(() -> flag.set(true));
-    future.complete("foobar");
-    Waiter.waitFor(flag::get, 100, TimeUnit.MILLISECONDS);
+    SafeFuture.completedFuture("foobar").whenSuccess(() -> flag.set(true));
+    assertThat(flag).isTrue();
   }
 
   private List<Throwable> collectUncaughtExceptions() {

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorClientOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorClientOptions.java
@@ -44,6 +44,18 @@ public class ValidatorClientOptions {
       ValidatorConfig.DEFAULT_FAILOVERS_SEND_SUBNET_SUBSCRIPTIONS_ENABLED;
 
   @Option(
+      names = {"--Xfailovers-send-signed-duties-enabled"},
+      paramLabel = "<BOOLEAN>",
+      description =
+          "Send signed duties (blocks, attestations, aggregations, ...) to beacon nodes which are used as failovers",
+      hidden = true,
+      showDefaultValue = CommandLine.Help.Visibility.ALWAYS,
+      arity = "0..1",
+      fallbackValue = "true")
+  private boolean failoversSendSignedDutiesEnabled =
+      ValidatorConfig.DEFAULT_FAILOVERS_SEND_SIGNED_DUTIES_ENABLED;
+
+  @Option(
       names = {"--Xbeacon-node-ssz-blocks-enabled"},
       paramLabel = "<BOOLEAN>",
       description = "Use SSZ encoding for API block requests",
@@ -62,6 +74,7 @@ public class ValidatorClientOptions {
                 .beaconNodeApiEndpoints(getBeaconNodeApiEndpoints())
                 .validatorClientUseSszBlocksEnabled(validatorClientSszBlocksEnabled)
                 .failoversSendSubnetSubscriptionsEnabled(failoversSendSubnetSubscriptionsEnabled)
+                .failoversSendSignedDutiesEnabled(failoversSendSignedDutiesEnabled)
                 .sentryNodeConfigurationFile(exclusiveParams.sentryConfigFile));
   }
 

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorClientOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorClientOptions.java
@@ -35,7 +35,8 @@ public class ValidatorClientOptions {
   @Option(
       names = {"--Xfailovers-send-subnet-subscriptions-enabled"},
       paramLabel = "<BOOLEAN>",
-      description = "Send subnet subscriptions to beacon nodes which are used as failovers",
+      description =
+          "Send subnet subscriptions to failover beacon nodes in addition to the primary node",
       hidden = true,
       showDefaultValue = CommandLine.Help.Visibility.ALWAYS,
       arity = "0..1",
@@ -44,16 +45,16 @@ public class ValidatorClientOptions {
       ValidatorConfig.DEFAULT_FAILOVERS_SEND_SUBNET_SUBSCRIPTIONS_ENABLED;
 
   @Option(
-      names = {"--Xfailovers-send-signed-duties-enabled"},
+      names = {"--Xfailovers-publish-signed-duties-enabled"},
       paramLabel = "<BOOLEAN>",
       description =
-          "Send signed duties (blocks, attestations, aggregations, ...) to beacon nodes which are used as failovers",
+          "Publish signed duties (blocks, attestations, aggregations, ...) to failover beacon nodes in addition to the primary node",
       hidden = true,
       showDefaultValue = CommandLine.Help.Visibility.ALWAYS,
       arity = "0..1",
       fallbackValue = "true")
-  private boolean failoversSendSignedDutiesEnabled =
-      ValidatorConfig.DEFAULT_FAILOVERS_SEND_SIGNED_DUTIES_ENABLED;
+  private boolean failoversPublishSignedDutiesEnabled =
+      ValidatorConfig.DEFAULT_FAILOVERS_PUBLISH_SIGNED_DUTIES_ENABLED;
 
   @Option(
       names = {"--Xbeacon-node-ssz-blocks-enabled"},
@@ -74,7 +75,7 @@ public class ValidatorClientOptions {
                 .beaconNodeApiEndpoints(getBeaconNodeApiEndpoints())
                 .validatorClientUseSszBlocksEnabled(validatorClientSszBlocksEnabled)
                 .failoversSendSubnetSubscriptionsEnabled(failoversSendSubnetSubscriptionsEnabled)
-                .failoversSendSignedDutiesEnabled(failoversSendSignedDutiesEnabled)
+                .failoversPublishSignedDutiesEnabled(failoversPublishSignedDutiesEnabled)
                 .sentryNodeConfigurationFile(exclusiveParams.sentryConfigFile));
   }
 

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorClientOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorClientOptions.java
@@ -36,7 +36,7 @@ public class ValidatorClientOptions {
       names = {"--Xfailovers-send-subnet-subscriptions-enabled"},
       paramLabel = "<BOOLEAN>",
       description =
-          "Send subnet subscriptions to failover beacon nodes in addition to the primary node",
+          "Send subnet subscriptions to the configured failover beacon nodes in addition to the primary node",
       hidden = true,
       showDefaultValue = CommandLine.Help.Visibility.ALWAYS,
       arity = "0..1",
@@ -48,7 +48,7 @@ public class ValidatorClientOptions {
       names = {"--Xfailovers-publish-signed-duties-enabled"},
       paramLabel = "<BOOLEAN>",
       description =
-          "Publish signed duties (blocks, attestations, aggregations, ...) to failover beacon nodes in addition to the primary node",
+          "Publish signed duties (blocks, attestations, aggregations, ...) to the configured failover beacon nodes in addition to the primary node",
       hidden = true,
       showDefaultValue = CommandLine.Help.Visibility.ALWAYS,
       arity = "0..1",

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
@@ -40,6 +40,7 @@ public class ValidatorConfig {
   public static final List<URI> DEFAULT_BEACON_NODE_API_ENDPOINTS =
       List.of(URI.create("http://127.0.0.1:" + DEFAULT_REST_API_PORT));
   public static final boolean DEFAULT_FAILOVERS_SEND_SUBNET_SUBSCRIPTIONS_ENABLED = true;
+  public static final boolean DEFAULT_FAILOVERS_SEND_SIGNED_DUTIES_ENABLED = true;
   public static final boolean DEFAULT_VALIDATOR_CLIENT_SSZ_BLOCKS_ENABLED = false;
   public static final boolean DEFAULT_DOPPELGANGER_DETECTION_ENABLED = false;
   public static final int DEFAULT_EXECUTOR_MAX_QUEUE_SIZE = 20_000;
@@ -78,6 +79,7 @@ public class ValidatorConfig {
   private final boolean validatorClientUseSszBlocksEnabled;
   private final boolean doppelgangerDetectionEnabled;
   private final boolean failoversSendSubnetSubscriptionsEnabled;
+  private final boolean failoversSendSignedDutiesEnabled;
   private final UInt64 builderRegistrationDefaultGasLimit;
   private final int builderRegistrationSendingBatchSize;
   private final Optional<UInt64> builderRegistrationTimestampOverride;
@@ -109,6 +111,7 @@ public class ValidatorConfig {
       final boolean validatorClientUseSszBlocksEnabled,
       final boolean doppelgangerDetectionEnabled,
       final boolean failoversSendSubnetSubscriptionsEnabled,
+      final boolean failoversSendSignedDutiesEnabled,
       final UInt64 builderRegistrationDefaultGasLimit,
       final int builderRegistrationSendingBatchSize,
       final Optional<UInt64> builderRegistrationTimestampOverride,
@@ -141,6 +144,7 @@ public class ValidatorConfig {
     this.validatorClientUseSszBlocksEnabled = validatorClientUseSszBlocksEnabled;
     this.doppelgangerDetectionEnabled = doppelgangerDetectionEnabled;
     this.failoversSendSubnetSubscriptionsEnabled = failoversSendSubnetSubscriptionsEnabled;
+    this.failoversSendSignedDutiesEnabled = failoversSendSignedDutiesEnabled;
     this.builderRegistrationDefaultGasLimit = builderRegistrationDefaultGasLimit;
     this.builderRegistrationSendingBatchSize = builderRegistrationSendingBatchSize;
     this.builderRegistrationTimestampOverride = builderRegistrationTimestampOverride;
@@ -256,6 +260,10 @@ public class ValidatorConfig {
     return failoversSendSubnetSubscriptionsEnabled;
   }
 
+  public boolean isFailoversSendSignedDutiesEnabled() {
+    return failoversSendSignedDutiesEnabled;
+  }
+
   public boolean isBuilderRegistrationDefaultEnabled() {
     return builderRegistrationDefaultEnabled;
   }
@@ -308,6 +316,7 @@ public class ValidatorConfig {
     private boolean doppelgangerDetectionEnabled = DEFAULT_DOPPELGANGER_DETECTION_ENABLED;
     private boolean failoversSendSubnetSubscriptionsEnabled =
         DEFAULT_FAILOVERS_SEND_SUBNET_SUBSCRIPTIONS_ENABLED;
+    private boolean failoversSendSignedDutiesEnabled = DEFAULT_FAILOVERS_SEND_SIGNED_DUTIES_ENABLED;
     private UInt64 builderRegistrationDefaultGasLimit = DEFAULT_BUILDER_REGISTRATION_GAS_LIMIT;
     private int builderRegistrationSendingBatchSize =
         DEFAULT_VALIDATOR_REGISTRATION_SENDING_BATCH_SIZE;
@@ -468,6 +477,12 @@ public class ValidatorConfig {
       return this;
     }
 
+    public Builder failoversSendSignedDutiesEnabled(
+        final boolean failoversSendSignedDutiesEnabled) {
+      this.failoversSendSignedDutiesEnabled = failoversSendSignedDutiesEnabled;
+      return this;
+    }
+
     public Builder builderRegistrationDefaultGasLimit(
         final UInt64 builderRegistrationDefaultGasLimit) {
       this.builderRegistrationDefaultGasLimit = builderRegistrationDefaultGasLimit;
@@ -535,6 +550,7 @@ public class ValidatorConfig {
           validatorClientSszBlocksEnabled,
           doppelgangerDetectionEnabled,
           failoversSendSubnetSubscriptionsEnabled,
+          failoversSendSignedDutiesEnabled,
           builderRegistrationDefaultGasLimit,
           builderRegistrationSendingBatchSize,
           builderRegistrationTimestampOverride,

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
@@ -40,7 +40,7 @@ public class ValidatorConfig {
   public static final List<URI> DEFAULT_BEACON_NODE_API_ENDPOINTS =
       List.of(URI.create("http://127.0.0.1:" + DEFAULT_REST_API_PORT));
   public static final boolean DEFAULT_FAILOVERS_SEND_SUBNET_SUBSCRIPTIONS_ENABLED = true;
-  public static final boolean DEFAULT_FAILOVERS_SEND_SIGNED_DUTIES_ENABLED = true;
+  public static final boolean DEFAULT_FAILOVERS_PUBLISH_SIGNED_DUTIES_ENABLED = true;
   public static final boolean DEFAULT_VALIDATOR_CLIENT_SSZ_BLOCKS_ENABLED = false;
   public static final boolean DEFAULT_DOPPELGANGER_DETECTION_ENABLED = false;
   public static final int DEFAULT_EXECUTOR_MAX_QUEUE_SIZE = 20_000;
@@ -79,7 +79,7 @@ public class ValidatorConfig {
   private final boolean validatorClientUseSszBlocksEnabled;
   private final boolean doppelgangerDetectionEnabled;
   private final boolean failoversSendSubnetSubscriptionsEnabled;
-  private final boolean failoversSendSignedDutiesEnabled;
+  private final boolean failoversPublishSignedDutiesEnabled;
   private final UInt64 builderRegistrationDefaultGasLimit;
   private final int builderRegistrationSendingBatchSize;
   private final Optional<UInt64> builderRegistrationTimestampOverride;
@@ -111,7 +111,7 @@ public class ValidatorConfig {
       final boolean validatorClientUseSszBlocksEnabled,
       final boolean doppelgangerDetectionEnabled,
       final boolean failoversSendSubnetSubscriptionsEnabled,
-      final boolean failoversSendSignedDutiesEnabled,
+      final boolean failoversPublishSignedDutiesEnabled,
       final UInt64 builderRegistrationDefaultGasLimit,
       final int builderRegistrationSendingBatchSize,
       final Optional<UInt64> builderRegistrationTimestampOverride,
@@ -144,7 +144,7 @@ public class ValidatorConfig {
     this.validatorClientUseSszBlocksEnabled = validatorClientUseSszBlocksEnabled;
     this.doppelgangerDetectionEnabled = doppelgangerDetectionEnabled;
     this.failoversSendSubnetSubscriptionsEnabled = failoversSendSubnetSubscriptionsEnabled;
-    this.failoversSendSignedDutiesEnabled = failoversSendSignedDutiesEnabled;
+    this.failoversPublishSignedDutiesEnabled = failoversPublishSignedDutiesEnabled;
     this.builderRegistrationDefaultGasLimit = builderRegistrationDefaultGasLimit;
     this.builderRegistrationSendingBatchSize = builderRegistrationSendingBatchSize;
     this.builderRegistrationTimestampOverride = builderRegistrationTimestampOverride;
@@ -260,8 +260,8 @@ public class ValidatorConfig {
     return failoversSendSubnetSubscriptionsEnabled;
   }
 
-  public boolean isFailoversSendSignedDutiesEnabled() {
-    return failoversSendSignedDutiesEnabled;
+  public boolean isFailoversPublishSignedDutiesEnabled() {
+    return failoversPublishSignedDutiesEnabled;
   }
 
   public boolean isBuilderRegistrationDefaultEnabled() {
@@ -316,7 +316,7 @@ public class ValidatorConfig {
     private boolean doppelgangerDetectionEnabled = DEFAULT_DOPPELGANGER_DETECTION_ENABLED;
     private boolean failoversSendSubnetSubscriptionsEnabled =
         DEFAULT_FAILOVERS_SEND_SUBNET_SUBSCRIPTIONS_ENABLED;
-    private boolean failoversSendSignedDutiesEnabled = DEFAULT_FAILOVERS_SEND_SIGNED_DUTIES_ENABLED;
+    private boolean failoversPublishSignedDutiesEnabled = DEFAULT_FAILOVERS_PUBLISH_SIGNED_DUTIES_ENABLED;
     private UInt64 builderRegistrationDefaultGasLimit = DEFAULT_BUILDER_REGISTRATION_GAS_LIMIT;
     private int builderRegistrationSendingBatchSize =
         DEFAULT_VALIDATOR_REGISTRATION_SENDING_BATCH_SIZE;
@@ -477,9 +477,9 @@ public class ValidatorConfig {
       return this;
     }
 
-    public Builder failoversSendSignedDutiesEnabled(
-        final boolean failoversSendSignedDutiesEnabled) {
-      this.failoversSendSignedDutiesEnabled = failoversSendSignedDutiesEnabled;
+    public Builder failoversPublishSignedDutiesEnabled(
+        final boolean failoversPublishSignedDutiesEnabled) {
+      this.failoversPublishSignedDutiesEnabled = failoversPublishSignedDutiesEnabled;
       return this;
     }
 
@@ -550,7 +550,7 @@ public class ValidatorConfig {
           validatorClientSszBlocksEnabled,
           doppelgangerDetectionEnabled,
           failoversSendSubnetSubscriptionsEnabled,
-          failoversSendSignedDutiesEnabled,
+          failoversPublishSignedDutiesEnabled,
           builderRegistrationDefaultGasLimit,
           builderRegistrationSendingBatchSize,
           builderRegistrationTimestampOverride,

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
@@ -316,7 +316,8 @@ public class ValidatorConfig {
     private boolean doppelgangerDetectionEnabled = DEFAULT_DOPPELGANGER_DETECTION_ENABLED;
     private boolean failoversSendSubnetSubscriptionsEnabled =
         DEFAULT_FAILOVERS_SEND_SUBNET_SUBSCRIPTIONS_ENABLED;
-    private boolean failoversPublishSignedDutiesEnabled = DEFAULT_FAILOVERS_PUBLISH_SIGNED_DUTIES_ENABLED;
+    private boolean failoversPublishSignedDutiesEnabled =
+        DEFAULT_FAILOVERS_PUBLISH_SIGNED_DUTIES_ENABLED;
     private UInt64 builderRegistrationDefaultGasLimit = DEFAULT_BUILDER_REGISTRATION_GAS_LIMIT;
     private int builderRegistrationSendingBatchSize =
         DEFAULT_VALIDATOR_REGISTRATION_SENDING_BATCH_SIZE;

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandler.java
@@ -70,7 +70,7 @@ public class FailoverValidatorApiHandler implements ValidatorApiChannel {
       "remote_beacon_nodes_requests_total";
 
   private final Map<UInt64, ValidatorApiChannel> blindedBlockCreatorCache =
-      LimitedMap.createNonSynchronized(2);
+      LimitedMap.createSynchronized(2);
 
   private final BeaconNodeReadinessManager beaconNodeReadinessManager;
   private final RemoteValidatorApiChannel primaryDelegate;

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApi.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApi.java
@@ -126,6 +126,7 @@ public class RemoteBeaconNodeApi implements BeaconNodeApi {
                 primaryValidatorApi,
                 failoverValidatorApis,
                 validatorConfig.isFailoversSendSubnetSubscriptionsEnabled(),
+                validatorConfig.isFailoversSendSignedDutiesEnabled(),
                 metricsSystem));
 
     final EventSourceBeaconChainEventAdapter beaconChainEventAdapter =

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApi.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApi.java
@@ -126,7 +126,7 @@ public class RemoteBeaconNodeApi implements BeaconNodeApi {
                 primaryValidatorApi,
                 failoverValidatorApis,
                 validatorConfig.isFailoversSendSubnetSubscriptionsEnabled(),
-                validatorConfig.isFailoversSendSignedDutiesEnabled(),
+                validatorConfig.isFailoversPublishSignedDutiesEnabled(),
                 metricsSystem));
 
     final EventSourceBeaconChainEventAdapter beaconChainEventAdapter =

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/sentry/SentryBeaconNodeApi.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/sentry/SentryBeaconNodeApi.java
@@ -107,6 +107,7 @@ public class SentryBeaconNodeApi implements BeaconNodeApi {
                 dutiesProviderPrimaryValidatorApiChannel,
                 dutiesProviderFailoverValidatorApiChannel,
                 validatorConfig.isFailoversSendSubnetSubscriptionsEnabled(),
+                validatorConfig.isFailoversSendSignedDutiesEnabled(),
                 serviceConfig.getMetricsSystem()));
 
     final Optional<ValidatorApiChannel> blockHandlerValidatorApi =
@@ -229,6 +230,7 @@ public class SentryBeaconNodeApi implements BeaconNodeApi {
             primaryValidatorApi,
             failoverValidatorApis,
             validatorConfig.isFailoversSendSubnetSubscriptionsEnabled(),
+            validatorConfig.isFailoversSendSignedDutiesEnabled(),
             metricsSystem));
   }
 

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/sentry/SentryBeaconNodeApi.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/sentry/SentryBeaconNodeApi.java
@@ -107,7 +107,7 @@ public class SentryBeaconNodeApi implements BeaconNodeApi {
                 dutiesProviderPrimaryValidatorApiChannel,
                 dutiesProviderFailoverValidatorApiChannel,
                 validatorConfig.isFailoversSendSubnetSubscriptionsEnabled(),
-                validatorConfig.isFailoversSendSignedDutiesEnabled(),
+                validatorConfig.isFailoversPublishSignedDutiesEnabled(),
                 serviceConfig.getMetricsSystem()));
 
     final Optional<ValidatorApiChannel> blockHandlerValidatorApi =
@@ -230,7 +230,7 @@ public class SentryBeaconNodeApi implements BeaconNodeApi {
             primaryValidatorApi,
             failoverValidatorApis,
             validatorConfig.isFailoversSendSubnetSubscriptionsEnabled(),
-            validatorConfig.isFailoversSendSignedDutiesEnabled(),
+            validatorConfig.isFailoversPublishSignedDutiesEnabled(),
             metricsSystem));
   }
 

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandlerTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandlerTest.java
@@ -300,8 +300,8 @@ class FailoverValidatorApiHandlerTest {
   }
 
   @ParameterizedTest(name = "{0}")
-  @MethodSource("getSendSignedDutiesRequests")
-  <T> void requestIsNotRelayedToFailoversIfFailoversSendSignedDutiesIsDisabled(
+  @MethodSource("getPublishSignedDutiesRequests")
+  <T> void requestIsNotRelayedToFailoversIfFailoversPublishSignedDutiesIsDisabled(
       final ValidatorApiChannelRequest<T> request,
       final Consumer<ValidatorApiChannel> verifyCallIsMade,
       final String methodLabel,
@@ -707,7 +707,7 @@ class FailoverValidatorApiHandlerTest {
 
     return Streams.concat(
         getSubscriptionRequests(),
-        getSendSignedDutiesRequests(),
+        getPublishSignedDutiesRequests(),
         Stream.of(
             getArguments(
                 "prepareBeaconProposer",
@@ -724,7 +724,7 @@ class FailoverValidatorApiHandlerTest {
                 null)));
   }
 
-  private static Stream<Arguments> getSendSignedDutiesRequests() {
+  private static Stream<Arguments> getPublishSignedDutiesRequests() {
     final Attestation attestation = DATA_STRUCTURE_UTIL.randomAttestation();
     final SubmitDataError submitDataError =
         new SubmitDataError(DATA_STRUCTURE_UTIL.randomUInt64(), "foo");

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandlerTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandlerTest.java
@@ -17,6 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -38,9 +39,11 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Named;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import tech.pegasys.teku.api.migrated.ValidatorLivenessAtEpoch;
 import tech.pegasys.teku.api.response.v1.beacon.ValidatorStatus;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.bls.BLSSignature;
@@ -62,6 +65,7 @@ import tech.pegasys.teku.spec.datastructures.operations.SignedAggregateAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SignedContributionAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeContribution;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeMessage;
+import tech.pegasys.teku.spec.datastructures.operations.versions.bellatrix.BeaconPreparableProposer;
 import tech.pegasys.teku.spec.datastructures.validator.SubnetSubscription;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.validator.api.AttesterDuties;
@@ -78,7 +82,7 @@ import tech.pegasys.teku.validator.remote.FailoverValidatorApiHandler.ValidatorA
 
 class FailoverValidatorApiHandlerTest {
 
-  private static final Spec SPEC = TestSpecFactory.createMinimalAltair();
+  private static final Spec SPEC = TestSpecFactory.createMinimalBellatrix();
   private static final DataStructureUtil DATA_STRUCTURE_UTIL = new DataStructureUtil(SPEC);
 
   private final StubMetricsSystem stubMetricsSystem = new StubMetricsSystem();
@@ -117,6 +121,7 @@ class FailoverValidatorApiHandlerTest {
             beaconNodeReadinessManager,
             primaryApiChannel,
             failoverDelegates,
+            true,
             true,
             stubMetricsSystem);
   }
@@ -231,7 +236,12 @@ class FailoverValidatorApiHandlerTest {
 
     failoverApiHandler =
         new FailoverValidatorApiHandler(
-            beaconNodeReadinessManager, primaryApiChannel, List.of(), true, stubMetricsSystem);
+            beaconNodeReadinessManager,
+            primaryApiChannel,
+            List.of(),
+            true,
+            true,
+            stubMetricsSystem);
 
     // readiness is ignored
     when(beaconNodeReadinessManager.isReady(primaryApiChannel)).thenReturn(false);
@@ -262,6 +272,47 @@ class FailoverValidatorApiHandlerTest {
             beaconNodeReadinessManager,
             primaryApiChannel,
             List.of(failoverApiChannel1, failoverApiChannel2),
+            false,
+            true,
+            stubMetricsSystem);
+
+    setupSuccesses(request, response, primaryApiChannel);
+
+    final SafeFuture<T> result = request.run(failoverApiHandler);
+
+    assertThat(result).isCompletedWithValue(response);
+    verifyCallIsMade.accept(primaryApiChannel);
+
+    verifyNoInteractions(failoverApiChannel1, failoverApiChannel2);
+
+    verifyRequestCounters(
+        primaryApiChannel,
+        methodLabel,
+        Map.of(RequestOutcome.SUCCESS, 1L, RequestOutcome.ERROR, 0L));
+    verifyRequestCounters(
+        failoverApiChannel1,
+        methodLabel,
+        Map.of(RequestOutcome.SUCCESS, 0L, RequestOutcome.ERROR, 0L));
+    verifyRequestCounters(
+        failoverApiChannel2,
+        methodLabel,
+        Map.of(RequestOutcome.SUCCESS, 0L, RequestOutcome.ERROR, 0L));
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("getSendSignedDutiesRequests")
+  <T> void requestIsNotRelayedToFailoversIfFailoversSendSignedDutiesIsDisabled(
+      final ValidatorApiChannelRequest<T> request,
+      final Consumer<ValidatorApiChannel> verifyCallIsMade,
+      final String methodLabel,
+      final T response) {
+
+    failoverApiHandler =
+        new FailoverValidatorApiHandler(
+            beaconNodeReadinessManager,
+            primaryApiChannel,
+            List.of(failoverApiChannel1, failoverApiChannel2),
+            true,
             false,
             stubMetricsSystem);
 
@@ -330,7 +381,12 @@ class FailoverValidatorApiHandlerTest {
 
     failoverApiHandler =
         new FailoverValidatorApiHandler(
-            beaconNodeReadinessManager, primaryApiChannel, List.of(), true, stubMetricsSystem);
+            beaconNodeReadinessManager,
+            primaryApiChannel,
+            List.of(),
+            true,
+            true,
+            stubMetricsSystem);
 
     // readiness is ignored
     when(beaconNodeReadinessManager.isReady(primaryApiChannel)).thenReturn(false);
@@ -515,6 +571,40 @@ class FailoverValidatorApiHandlerTest {
         Map.of(RequestOutcome.SUCCESS, 0L, RequestOutcome.ERROR, 1L));
   }
 
+  @Test
+  public void publishesBlindedBlockOnlyToTheBeaconNodeWhichCreatedIt() {
+    final UInt64 slot = UInt64.ONE;
+    final BLSSignature randaoReveal = DATA_STRUCTURE_UTIL.randomSignature();
+
+    final ValidatorApiChannelRequest<Optional<BeaconBlock>> creationRequest =
+        apiChannel -> apiChannel.createUnsignedBlock(slot, randaoReveal, Optional.empty(), true);
+
+    setupFailures(creationRequest, primaryApiChannel);
+    setupSuccesses(creationRequest, Optional.of(mock(BeaconBlock.class)), failoverApiChannel1);
+
+    SafeFutureAssert.assertThatSafeFuture(creationRequest.run(failoverApiHandler)).isCompleted();
+
+    final SignedBeaconBlock blindedBlock =
+        DATA_STRUCTURE_UTIL.randomSignedBlindedBeaconBlock(UInt64.ONE);
+
+    final ValidatorApiChannelRequest<SendSignedBlockResult> publishingRequest =
+        apiChannel -> apiChannel.sendSignedBlock(blindedBlock);
+
+    setupSuccesses(
+        publishingRequest,
+        mock(SendSignedBlockResult.class),
+        primaryApiChannel,
+        failoverApiChannel1,
+        failoverApiChannel2);
+
+    SafeFutureAssert.assertThatSafeFuture(publishingRequest.run(failoverApiHandler)).isCompleted();
+
+    verify(failoverApiChannel1).sendSignedBlock(blindedBlock);
+
+    verify(primaryApiChannel, never()).sendSignedBlock(blindedBlock);
+    verify(failoverApiChannel2, never()).sendSignedBlock(blindedBlock);
+  }
+
   private <T> void setupSuccesses(
       final ValidatorApiChannelRequest<T> request,
       final T response,
@@ -547,6 +637,8 @@ class FailoverValidatorApiHandlerTest {
     final UInt64 epoch = DATA_STRUCTURE_UTIL.randomUInt64();
     final Bytes32 randomBytes32 = DATA_STRUCTURE_UTIL.randomBytes32();
     final Attestation attestation = DATA_STRUCTURE_UTIL.randomAttestation();
+    final ValidatorLivenessAtEpoch validatorLivenessAtEpoch =
+        new ValidatorLivenessAtEpoch(UInt64.ZERO, UInt64.ZERO, false);
 
     return Stream.of(
         getArguments(
@@ -582,7 +674,7 @@ class FailoverValidatorApiHandlerTest {
         getArguments(
             "createUnsignedBlock",
             apiChannel ->
-                apiChannel.createUnsignedBlock(slot, randaoReveal, Optional.empty(), true),
+                apiChannel.createUnsignedBlock(slot, randaoReveal, Optional.empty(), false),
             BeaconNodeRequestLabels.CREATE_UNSIGNED_BLOCK_METHOD,
             Optional.of(mock(BeaconBlock.class))),
         getArguments(
@@ -599,10 +691,40 @@ class FailoverValidatorApiHandlerTest {
             "createSyncCommitteeContribution",
             apiChannel -> apiChannel.createSyncCommitteeContribution(slot, 0, randomBytes32),
             BeaconNodeRequestLabels.CREATE_SYNC_COMMITTEE_CONTRIBUTION_METHOD,
-            Optional.of(mock(SyncCommitteeContribution.class))));
+            Optional.of(mock(SyncCommitteeContribution.class))),
+        getArguments(
+            "checkValidatorsDoppelganger",
+            apiChannel -> apiChannel.checkValidatorsDoppelganger(List.of(UInt64.ZERO), epoch),
+            BeaconNodeRequestLabels.CHECK_VALIDATORS_DOPPELGANGER_METHOD,
+            Optional.of(List.of(validatorLivenessAtEpoch))));
   }
 
   private static Stream<Arguments> getRelayRequests() {
+    final SszList<SignedValidatorRegistration> validatorRegistrations =
+        DATA_STRUCTURE_UTIL.randomSignedValidatorRegistrations(3);
+    final BeaconPreparableProposer beaconPreparableProposer =
+        DATA_STRUCTURE_UTIL.randomBeaconPreparableProposer();
+
+    return Streams.concat(
+        getSubscriptionRequests(),
+        getSendSignedDutiesRequests(),
+        Stream.of(
+            getArguments(
+                "prepareBeaconProposer",
+                apiChannel -> apiChannel.prepareBeaconProposer(List.of(beaconPreparableProposer)),
+                apiChannel ->
+                    verify(apiChannel).prepareBeaconProposer(List.of(beaconPreparableProposer)),
+                BeaconNodeRequestLabels.PREPARE_BEACON_PROPOSERS_METHOD,
+                null),
+            getArguments(
+                "registerValidators",
+                apiChannel -> apiChannel.registerValidators(validatorRegistrations),
+                apiChannel -> verify(apiChannel).registerValidators(validatorRegistrations),
+                BeaconNodeRequestLabels.REGISTER_VALIDATORS_METHOD,
+                null)));
+  }
+
+  private static Stream<Arguments> getSendSignedDutiesRequests() {
     final Attestation attestation = DATA_STRUCTURE_UTIL.randomAttestation();
     final SubmitDataError submitDataError =
         new SubmitDataError(DATA_STRUCTURE_UTIL.randomUInt64(), "foo");
@@ -614,53 +736,43 @@ class FailoverValidatorApiHandlerTest {
         DATA_STRUCTURE_UTIL.randomSyncCommitteeMessage();
     final SignedContributionAndProof signedContributionAndProof =
         DATA_STRUCTURE_UTIL.randomSignedContributionAndProof(2);
-    final SszList<SignedValidatorRegistration> validatorRegistrations =
-        DATA_STRUCTURE_UTIL.randomSignedValidatorRegistrations(3);
 
-    return Streams.concat(
-        getSubscriptionRequests(),
-        Stream.of(
-            getArguments(
-                "sendSignedAttestations",
-                apiChannel -> apiChannel.sendSignedAttestations(List.of(attestation)),
-                apiChannel -> verify(apiChannel).sendSignedAttestations(List.of(attestation)),
-                BeaconNodeRequestLabels.PUBLISH_ATTESTATION_METHOD,
-                List.of(submitDataError)),
-            getArguments(
-                "sendAggregateAndProofs",
-                apiChannel -> apiChannel.sendAggregateAndProofs(List.of(signedAggregateAndProof)),
-                apiChannel ->
-                    verify(apiChannel).sendAggregateAndProofs(List.of(signedAggregateAndProof)),
-                BeaconNodeRequestLabels.PUBLISH_AGGREGATE_AND_PROOFS_METHOD,
-                List.of(submitDataError)),
-            getArguments(
-                "sendSignedBlock",
-                apiChannel -> apiChannel.sendSignedBlock(signedBeaconBlock),
-                apiChannel -> verify(apiChannel).sendSignedBlock(signedBeaconBlock),
-                BeaconNodeRequestLabels.PUBLISH_BLOCK_METHOD,
-                mock(SendSignedBlockResult.class)),
-            getArguments(
-                "sendSyncCommitteeMessages",
-                apiChannel -> apiChannel.sendSyncCommitteeMessages(List.of(syncCommitteeMessage)),
-                apiChannel ->
-                    verify(apiChannel).sendSyncCommitteeMessages(List.of(syncCommitteeMessage)),
-                BeaconNodeRequestLabels.SEND_SYNC_COMMITTEE_MESSAGES_METHOD,
-                List.of(submitDataError)),
-            getArguments(
-                "sendSignedContributionAndProofs",
-                apiChannel ->
-                    apiChannel.sendSignedContributionAndProofs(List.of(signedContributionAndProof)),
-                apiChannel ->
-                    verify(apiChannel)
-                        .sendSignedContributionAndProofs(List.of(signedContributionAndProof)),
-                BeaconNodeRequestLabels.SEND_CONTRIBUTIONS_AND_PROOFS_METHOD,
-                null),
-            getArguments(
-                "registerValidators",
-                apiChannel -> apiChannel.registerValidators(validatorRegistrations),
-                apiChannel -> verify(apiChannel).registerValidators(validatorRegistrations),
-                BeaconNodeRequestLabels.REGISTER_VALIDATORS_METHOD,
-                null)));
+    return Stream.of(
+        getArguments(
+            "sendSignedAttestations",
+            apiChannel -> apiChannel.sendSignedAttestations(List.of(attestation)),
+            apiChannel -> verify(apiChannel).sendSignedAttestations(List.of(attestation)),
+            BeaconNodeRequestLabels.PUBLISH_ATTESTATION_METHOD,
+            List.of(submitDataError)),
+        getArguments(
+            "sendAggregateAndProofs",
+            apiChannel -> apiChannel.sendAggregateAndProofs(List.of(signedAggregateAndProof)),
+            apiChannel ->
+                verify(apiChannel).sendAggregateAndProofs(List.of(signedAggregateAndProof)),
+            BeaconNodeRequestLabels.PUBLISH_AGGREGATE_AND_PROOFS_METHOD,
+            List.of(submitDataError)),
+        getArguments(
+            "sendSignedBlock",
+            apiChannel -> apiChannel.sendSignedBlock(signedBeaconBlock),
+            apiChannel -> verify(apiChannel).sendSignedBlock(signedBeaconBlock),
+            BeaconNodeRequestLabels.PUBLISH_BLOCK_METHOD,
+            mock(SendSignedBlockResult.class)),
+        getArguments(
+            "sendSyncCommitteeMessages",
+            apiChannel -> apiChannel.sendSyncCommitteeMessages(List.of(syncCommitteeMessage)),
+            apiChannel ->
+                verify(apiChannel).sendSyncCommitteeMessages(List.of(syncCommitteeMessage)),
+            BeaconNodeRequestLabels.SEND_SYNC_COMMITTEE_MESSAGES_METHOD,
+            List.of(submitDataError)),
+        getArguments(
+            "sendSignedContributionAndProofs",
+            apiChannel ->
+                apiChannel.sendSignedContributionAndProofs(List.of(signedContributionAndProof)),
+            apiChannel ->
+                verify(apiChannel)
+                    .sendSignedContributionAndProofs(List.of(signedContributionAndProof)),
+            BeaconNodeRequestLabels.SEND_CONTRIBUTIONS_AND_PROOFS_METHOD,
+            null));
   }
 
   private static Stream<Arguments> getSubscriptionRequests() {
@@ -747,8 +859,7 @@ class FailoverValidatorApiHandlerTest {
   }
 
   private String getExceptionMessageForEndpoint(final HttpUrl endpoint) {
-    return String.format(
-        "%s: java.lang.IllegalStateException: Request failed for %s", endpoint, endpoint);
+    return String.format("java.lang.IllegalStateException: Request failed for %s", endpoint);
   }
 
   private long getFailoverCounterValue(


### PR DESCRIPTION
## PR Description

- When failovers are configured and we are to publish a blinded block, the VC will send it to only the BN which created the block.
- Introduced new CLI option `--Xfailovers-publish-signed-duties-enabled` which can enable/disable publishing blocks/attestations/aggregation/sync committee messages/contribution and proofs to failovers.
- Changed `checkValidatorsDoppelganger` to use `tryRequestUntilSuccess` instead of `relayRequest`

## Fixed Issue(s)
fixes #6342 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
