### PR TITLE
Fix event stream failover when primary node is syncing

### DIFF
--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/eventsource/EventSourceBeaconChainEventAdapter.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/eventsource/EventSourceBeaconChainEventAdapter.java
@@ -18,7 +18,6 @@ import static java.util.Collections.emptyMap;
 import com.google.common.base.Preconditions;
 import com.launchdarkly.eventsource.ConnectionErrorHandler.Action;
 import com.launchdarkly.eventsource.EventSource;
-import com.launchdarkly.eventsource.ReadyState;
 import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
@@ -160,7 +159,7 @@ public class EventSourceBeaconChainEventAdapter
   }
 
   private void switchToFailoverEventStream(final RemoteValidatorApiChannel beaconNodeApi) {
-    if (alreadyFailedOver(beaconNodeApi)) {
+    if (currentEventStreamHasSameEndpoint(beaconNodeApi)) {
       return;
     }
     eventSource.close();
@@ -176,11 +175,6 @@ public class EventSourceBeaconChainEventAdapter
     currentBeaconNodeUsedForEventStreaming = primaryBeaconNodeApi;
     validatorLogger.switchingBackToPrimaryBeaconNodeForEventStreaming();
     eventSource.start();
-  }
-
-  private boolean alreadyFailedOver(final RemoteValidatorApiChannel beaconNodeApi) {
-    return currentEventStreamHasSameEndpoint(beaconNodeApi)
-        || eventSource.getState().equals(ReadyState.OPEN);
   }
 
   private boolean currentEventStreamHasSameEndpoint(final RemoteValidatorApiChannel beaconNodeApi) {


### PR DESCRIPTION
## PR Description
Removing additional check `eventSource.getState().equals(ReadyState.OPEN)` since the state could be OPEN even if the node is syncing.

## Fixed Issue(s)
fixes #6345 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
