### PR TITLE
Update Capella beacon state to include latest_withdrawal_validator_index

### DIFF
--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/altair/BeaconStateAltair.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/altair/BeaconStateAltair.java
@@ -39,6 +39,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.state.SyncCommittee.SyncCommitteeSchema;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.altair.BeaconStateSchemaAltair;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.altair.MutableBeaconStateAltair;
 
 @SuppressWarnings("JavaCase")
 public class BeaconStateAltair extends BeaconState implements State {
@@ -129,26 +130,33 @@ public class BeaconStateAltair extends BeaconState implements State {
               final SyncCommitteeSchema syncCommitteeSchema =
                   BeaconStateSchemaAltair.required(beaconStateAltair.getBeaconStateSchema())
                       .getCurrentSyncCommitteeSchema();
-              final SszList<SszByte> previousEpochParticipation =
-                  beaconStateAltair
-                      .getPreviousEpochParticipation()
-                      .getSchema()
-                      .sszDeserialize(Bytes.wrap(this.previous_epoch_participation));
-              final SszList<SszByte> currentEpochParticipation =
-                  beaconStateAltair
-                      .getCurrentEpochParticipation()
-                      .getSchema()
-                      .sszDeserialize(Bytes.wrap(this.current_epoch_participation));
-
-              beaconStateAltair.setPreviousEpochParticipation(previousEpochParticipation);
-              beaconStateAltair.setCurrentEpochParticipation(currentEpochParticipation);
-              beaconStateAltair.getInactivityScores().setAllElements(inactivity_scores);
-
-              beaconStateAltair.setCurrentSyncCommittee(
-                  current_sync_committee.asInternalSyncCommittee(syncCommitteeSchema));
-              beaconStateAltair.setNextSyncCommittee(
-                  next_sync_committee.asInternalSyncCommittee(syncCommitteeSchema));
+              applyAltairFields(beaconStateAltair, syncCommitteeSchema, this);
             });
+  }
+
+  public static void applyAltairFields(
+      MutableBeaconStateAltair state,
+      SyncCommitteeSchema syncCommitteeSchema,
+      BeaconStateAltair instance) {
+    final SszList<SszByte> previousEpochParticipation =
+        state
+            .getPreviousEpochParticipation()
+            .getSchema()
+            .sszDeserialize(Bytes.wrap(instance.previous_epoch_participation));
+    final SszList<SszByte> currentEpochParticipation =
+        state
+            .getCurrentEpochParticipation()
+            .getSchema()
+            .sszDeserialize(Bytes.wrap(instance.current_epoch_participation));
+
+    state.setPreviousEpochParticipation(previousEpochParticipation);
+    state.setCurrentEpochParticipation(currentEpochParticipation);
+    state.getInactivityScores().setAllElements(instance.inactivity_scores);
+
+    state.setCurrentSyncCommittee(
+        instance.current_sync_committee.asInternalSyncCommittee(syncCommitteeSchema));
+    state.setNextSyncCommittee(
+        instance.next_sync_committee.asInternalSyncCommittee(syncCommitteeSchema));
   }
 
   @Override

--- a/data/serializer/src/property-test/java/tech/pegasys/teku/provider/JsonProviderPropertyTest.java
+++ b/data/serializer/src/property-test/java/tech/pegasys/teku/provider/JsonProviderPropertyTest.java
@@ -52,6 +52,7 @@ import tech.pegasys.teku.api.schema.altair.BeaconStateAltair;
 import tech.pegasys.teku.api.schema.altair.SignedBeaconBlockAltair;
 import tech.pegasys.teku.api.schema.bellatrix.BeaconStateBellatrix;
 import tech.pegasys.teku.api.schema.bellatrix.SignedBeaconBlockBellatrix;
+import tech.pegasys.teku.api.schema.capella.BeaconStateCapella;
 import tech.pegasys.teku.api.schema.phase0.BeaconStatePhase0;
 import tech.pegasys.teku.api.schema.phase0.SignedBeaconBlockPhase0;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
@@ -84,8 +85,7 @@ public class JsonProviderPropertyTest {
           SpecMilestone.PHASE0, BeaconStatePhase0.class,
           SpecMilestone.ALTAIR, BeaconStateAltair.class,
           SpecMilestone.BELLATRIX, BeaconStateBellatrix.class,
-          // TODO CAPELLA
-          SpecMilestone.CAPELLA, BeaconStateBellatrix.class);
+          SpecMilestone.CAPELLA, BeaconStateCapella.class);
 
   @Property
   void roundTripBytes32(@ForAll @Size(32) final byte[] value) throws JsonProcessingException {

--- a/data/serializer/src/test/java/tech/pegasys/teku/api/schema/BeaconStateTest.java
+++ b/data/serializer/src/test/java/tech/pegasys/teku/api/schema/BeaconStateTest.java
@@ -18,6 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.TestTemplate;
 import tech.pegasys.teku.api.schema.altair.BeaconStateAltair;
 import tech.pegasys.teku.api.schema.bellatrix.BeaconStateBellatrix;
+import tech.pegasys.teku.api.schema.capella.BeaconStateCapella;
 import tech.pegasys.teku.api.schema.phase0.BeaconStatePhase0;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecContext;
@@ -41,8 +42,10 @@ public class BeaconStateTest {
         beaconState = new BeaconStateAltair(beaconStateInternal);
         break;
       case BELLATRIX:
-      case CAPELLA: // TODO CAPELLA
         beaconState = new BeaconStateBellatrix(beaconStateInternal);
+        break;
+      case CAPELLA:
+        beaconState = new BeaconStateCapella(beaconStateInternal);
         break;
       default:
         throw new IllegalStateException("Unsupported milestone");

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigBuilder.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigBuilder.java
@@ -876,10 +876,6 @@ public class SpecConfigBuilder {
     private Bytes4 capellaForkVersion;
     private UInt64 capellaForkEpoch;
 
-    private UInt64 maxPartialWithdrawalsPerEpoch;
-
-    private UInt64 withdrawalQueueLimit;
-
     private UInt64 maxBlsToExecutionChanges;
 
     private UInt64 maxWithdrawalsPerPayload;
@@ -891,8 +887,6 @@ public class SpecConfigBuilder {
           specConfig,
           capellaForkVersion,
           capellaForkEpoch,
-          maxPartialWithdrawalsPerEpoch,
-          withdrawalQueueLimit,
           maxBlsToExecutionChanges,
           maxWithdrawalsPerPayload);
     }
@@ -913,19 +907,6 @@ public class SpecConfigBuilder {
       return this;
     }
 
-    public CapellaBuilder maxPartialWithdrawalsPerEpoch(
-        final UInt64 maxPartialWithdrawalsPerEpoch) {
-      checkNotNull(maxPartialWithdrawalsPerEpoch);
-      this.maxPartialWithdrawalsPerEpoch = maxPartialWithdrawalsPerEpoch;
-      return this;
-    }
-
-    public CapellaBuilder withdrawalQueueLimit(final UInt64 withdrawalQueueLimit) {
-      checkNotNull(withdrawalQueueLimit);
-      this.withdrawalQueueLimit = withdrawalQueueLimit;
-      return this;
-    }
-
     public CapellaBuilder maxBlsToExecutionChanges(final UInt64 maxBlsToExecutionChanges) {
       checkNotNull(maxBlsToExecutionChanges);
       this.maxBlsToExecutionChanges = maxBlsToExecutionChanges;
@@ -941,8 +922,6 @@ public class SpecConfigBuilder {
     public void validate() {
       validateConstant("capellaForkVersion", capellaForkVersion);
       validateConstant("capellaForkEpoch", capellaForkEpoch);
-      validateConstant("maxPartialWithdrawalsPerEpoch", maxPartialWithdrawalsPerEpoch);
-      validateConstant("withdrawalQueueLimit", withdrawalQueueLimit);
       validateConstant("maxBlsToExecutionChanges", maxBlsToExecutionChanges);
       validateConstant("maxWithdrawalsPerPayload", maxWithdrawalsPerPayload);
     }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigBuilder.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigBuilder.java
@@ -876,9 +876,9 @@ public class SpecConfigBuilder {
     private Bytes4 capellaForkVersion;
     private UInt64 capellaForkEpoch;
 
-    private UInt64 maxBlsToExecutionChanges;
+    private int maxBlsToExecutionChanges;
 
-    private UInt64 maxWithdrawalsPerPayload;
+    private int maxWithdrawalsPerPayload;
 
     private CapellaBuilder() {}
 
@@ -907,14 +907,12 @@ public class SpecConfigBuilder {
       return this;
     }
 
-    public CapellaBuilder maxBlsToExecutionChanges(final UInt64 maxBlsToExecutionChanges) {
-      checkNotNull(maxBlsToExecutionChanges);
+    public CapellaBuilder maxBlsToExecutionChanges(final int maxBlsToExecutionChanges) {
       this.maxBlsToExecutionChanges = maxBlsToExecutionChanges;
       return this;
     }
 
-    public CapellaBuilder maxWithdrawalsPerPayload(final UInt64 maxWithdrawalsPerPayload) {
-      checkNotNull(maxWithdrawalsPerPayload);
+    public CapellaBuilder maxWithdrawalsPerPayload(final int maxWithdrawalsPerPayload) {
       this.maxWithdrawalsPerPayload = maxWithdrawalsPerPayload;
       return this;
     }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigCapella.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigCapella.java
@@ -36,7 +36,7 @@ public interface SpecConfigCapella extends SpecConfigBellatrix {
   @Override
   Optional<SpecConfigCapella> toVersionCapella();
 
-  UInt64 getMaxWithdrawalsPerPayload();
+  int getMaxWithdrawalsPerPayload();
 
-  UInt64 getMaxBlsToExecutionChanges();
+  int getMaxBlsToExecutionChanges();
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigCapella.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigCapella.java
@@ -35,4 +35,8 @@ public interface SpecConfigCapella extends SpecConfigBellatrix {
 
   @Override
   Optional<SpecConfigCapella> toVersionCapella();
+
+  UInt64 getMaxWithdrawalsPerPayload();
+
+  UInt64 getMaxBlsToExecutionChanges();
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigCapellaImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigCapellaImpl.java
@@ -24,10 +24,6 @@ public class SpecConfigCapellaImpl extends DelegatingSpecConfigBellatrix
   private final Bytes4 capellaForkVersion;
   private final UInt64 capellaForkEpoch;
 
-  private final UInt64 maxPartialWithdrawalsPerEpoch;
-
-  private final UInt64 withdrawalQueueLimit;
-
   private final UInt64 maxBlsToExecutionChanges;
 
   private final UInt64 maxWithdrawalsPerPayload;
@@ -36,15 +32,11 @@ public class SpecConfigCapellaImpl extends DelegatingSpecConfigBellatrix
       final SpecConfigBellatrix specConfig,
       final Bytes4 capellaForkVersion,
       final UInt64 capellaForkEpoch,
-      final UInt64 maxPartialWithdrawalsPerEpoch,
-      final UInt64 withdrawalQueueLimit,
       final UInt64 maxBlsToExecutionChanges,
       final UInt64 maxWithdrawalsPerPayload) {
     super(specConfig);
     this.capellaForkVersion = capellaForkVersion;
     this.capellaForkEpoch = capellaForkEpoch;
-    this.maxPartialWithdrawalsPerEpoch = maxPartialWithdrawalsPerEpoch;
-    this.withdrawalQueueLimit = withdrawalQueueLimit;
     this.maxBlsToExecutionChanges = maxBlsToExecutionChanges;
     this.maxWithdrawalsPerPayload = maxWithdrawalsPerPayload;
   }
@@ -71,8 +63,6 @@ public class SpecConfigCapellaImpl extends DelegatingSpecConfigBellatrix
     return Objects.equals(specConfig, that.specConfig)
         && Objects.equals(capellaForkVersion, that.capellaForkVersion)
         && Objects.equals(capellaForkEpoch, that.capellaForkEpoch)
-        && Objects.equals(maxPartialWithdrawalsPerEpoch, that.maxPartialWithdrawalsPerEpoch)
-        && Objects.equals(withdrawalQueueLimit, that.withdrawalQueueLimit)
         && Objects.equals(maxBlsToExecutionChanges, that.maxBlsToExecutionChanges)
         && Objects.equals(maxWithdrawalsPerPayload, that.maxWithdrawalsPerPayload);
   }
@@ -83,24 +73,16 @@ public class SpecConfigCapellaImpl extends DelegatingSpecConfigBellatrix
         specConfig,
         capellaForkVersion,
         capellaForkEpoch,
-        maxPartialWithdrawalsPerEpoch,
-        withdrawalQueueLimit,
         maxBlsToExecutionChanges,
         maxWithdrawalsPerPayload);
   }
 
-  public UInt64 getMaxPartialWithdrawalsPerEpoch() {
-    return maxPartialWithdrawalsPerEpoch;
-  }
-
-  public UInt64 getWithdrawalQueueLimit() {
-    return withdrawalQueueLimit;
-  }
-
+  @Override
   public UInt64 getMaxBlsToExecutionChanges() {
     return maxBlsToExecutionChanges;
   }
 
+  @Override
   public UInt64 getMaxWithdrawalsPerPayload() {
     return maxWithdrawalsPerPayload;
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigCapellaImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigCapellaImpl.java
@@ -24,16 +24,16 @@ public class SpecConfigCapellaImpl extends DelegatingSpecConfigBellatrix
   private final Bytes4 capellaForkVersion;
   private final UInt64 capellaForkEpoch;
 
-  private final UInt64 maxBlsToExecutionChanges;
+  private final int maxBlsToExecutionChanges;
 
-  private final UInt64 maxWithdrawalsPerPayload;
+  private final int maxWithdrawalsPerPayload;
 
   public SpecConfigCapellaImpl(
       final SpecConfigBellatrix specConfig,
       final Bytes4 capellaForkVersion,
       final UInt64 capellaForkEpoch,
-      final UInt64 maxBlsToExecutionChanges,
-      final UInt64 maxWithdrawalsPerPayload) {
+      final int maxBlsToExecutionChanges,
+      final int maxWithdrawalsPerPayload) {
     super(specConfig);
     this.capellaForkVersion = capellaForkVersion;
     this.capellaForkEpoch = capellaForkEpoch;
@@ -63,8 +63,8 @@ public class SpecConfigCapellaImpl extends DelegatingSpecConfigBellatrix
     return Objects.equals(specConfig, that.specConfig)
         && Objects.equals(capellaForkVersion, that.capellaForkVersion)
         && Objects.equals(capellaForkEpoch, that.capellaForkEpoch)
-        && Objects.equals(maxBlsToExecutionChanges, that.maxBlsToExecutionChanges)
-        && Objects.equals(maxWithdrawalsPerPayload, that.maxWithdrawalsPerPayload);
+        && maxBlsToExecutionChanges == that.maxBlsToExecutionChanges
+        && maxWithdrawalsPerPayload == that.maxWithdrawalsPerPayload;
   }
 
   @Override
@@ -78,12 +78,12 @@ public class SpecConfigCapellaImpl extends DelegatingSpecConfigBellatrix
   }
 
   @Override
-  public UInt64 getMaxBlsToExecutionChanges() {
+  public int getMaxBlsToExecutionChanges() {
     return maxBlsToExecutionChanges;
   }
 
   @Override
-  public UInt64 getMaxWithdrawalsPerPayload() {
+  public int getMaxWithdrawalsPerPayload() {
     return maxWithdrawalsPerPayload;
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/BeaconStateFields.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/BeaconStateFields.java
@@ -64,7 +64,9 @@ public enum BeaconStateFields implements SszFieldName {
   CURRENT_SYNC_COMMITTEE,
   NEXT_SYNC_COMMITTEE,
   // Bellatrix fields
-  LATEST_EXECUTION_PAYLOAD_HEADER;
+  LATEST_EXECUTION_PAYLOAD_HEADER,
+  // Capella fields
+  LATEST_WITHDRAWAL_VALIDATOR_INDEX;
 
   private final String sszFieldName;
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/bellatrix/BeaconStateSchemaBellatrix.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/bellatrix/BeaconStateSchemaBellatrix.java
@@ -36,7 +36,7 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.altair.B
 public class BeaconStateSchemaBellatrix
     extends AbstractBeaconStateSchema<BeaconStateBellatrix, MutableBeaconStateBellatrix> {
 
-  public static final int LATEST_EXECUTION_PAYLOAD_HEADER_FIELD_INDEX = 24;
+  private static final int LATEST_EXECUTION_PAYLOAD_HEADER_FIELD_INDEX = 24;
 
   @VisibleForTesting
   BeaconStateSchemaBellatrix(final SpecConfig specConfig) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/bellatrix/BeaconStateSchemaBellatrix.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/bellatrix/BeaconStateSchemaBellatrix.java
@@ -36,7 +36,7 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.altair.B
 public class BeaconStateSchemaBellatrix
     extends AbstractBeaconStateSchema<BeaconStateBellatrix, MutableBeaconStateBellatrix> {
 
-  private static final int LATEST_EXECUTION_PAYLOAD_HEADER_FIELD_INDEX = 24;
+  public static final int LATEST_EXECUTION_PAYLOAD_HEADER_FIELD_INDEX = 24;
 
   @VisibleForTesting
   BeaconStateSchemaBellatrix(final SpecConfig specConfig) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/capella/BeaconStateCapella.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/capella/BeaconStateCapella.java
@@ -13,8 +13,12 @@
 
 package tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.capella;
 
+import static tech.pegasys.teku.spec.datastructures.state.beaconstate.common.BeaconStateFields.LATEST_WITHDRAWAL_VALIDATOR_INDEX;
+
 import com.google.common.base.MoreObjects;
 import java.util.Optional;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.bellatrix.BeaconStateBellatrix;
 
@@ -31,10 +35,17 @@ public interface BeaconStateCapella extends BeaconStateBellatrix {
   static void describeCustomCapellaFields(
       MoreObjects.ToStringHelper stringBuilder, BeaconStateCapella state) {
     BeaconStateBellatrix.describeCustomBellatrixFields(stringBuilder, state);
+    stringBuilder.add(
+        "latest_withdrawal_validator_index", state.getLatestWithdrawalValidatorIndex());
   }
 
   @Override
   default Optional<BeaconStateCapella> toVersionCapella() {
     return Optional.of(this);
+  }
+
+  default UInt64 getLatestWithdrawalValidatorIndex() {
+    final int index = getSchema().getFieldIndex(LATEST_WITHDRAWAL_VALIDATOR_INDEX);
+    return ((SszUInt64) get(index)).get();
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/capella/BeaconStateCapellaImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/capella/BeaconStateCapellaImpl.java
@@ -25,15 +25,13 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchema
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.AbstractBeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.TransitionCaches;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.altair.ValidatorStatsAltair;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.bellatrix.BeaconStateBellatrix;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.bellatrix.BeaconStateSchemaBellatrix;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.bellatrix.MutableBeaconStateBellatrix;
 
 public class BeaconStateCapellaImpl extends AbstractBeaconState<MutableBeaconStateCapella>
     implements BeaconStateCapella, BeaconStateCache, ValidatorStatsAltair {
 
   BeaconStateCapellaImpl(
-      final BeaconStateSchema<BeaconStateBellatrix, MutableBeaconStateBellatrix> schema) {
+      final BeaconStateSchema<BeaconStateCapella, MutableBeaconStateCapella> schema) {
     super(schema);
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/capella/BeaconStateSchemaCapella.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/capella/BeaconStateSchemaCapella.java
@@ -13,31 +13,95 @@
 
 package tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.capella;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.google.common.annotations.VisibleForTesting;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszByte;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
+import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszPrimitiveListSchema;
+import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszUInt64ListSchema;
 import tech.pegasys.teku.infrastructure.ssz.sos.SszField;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.spec.config.SpecConfig;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeaderSchema;
+import tech.pegasys.teku.spec.datastructures.state.SyncCommittee;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchema;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.AbstractBeaconStateSchema;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.bellatrix.BeaconStateBellatrix;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.BeaconStateFields;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.bellatrix.BeaconStateSchemaBellatrix;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.bellatrix.MutableBeaconStateBellatrix;
 
 public class BeaconStateSchemaCapella
-    extends AbstractBeaconStateSchema<BeaconStateBellatrix, MutableBeaconStateBellatrix> {
+    extends AbstractBeaconStateSchema<BeaconStateCapella, MutableBeaconStateCapella> {
+  private static final int LATEST_WITHDRAWAL_VALIDATOR_INDEX =
+      BeaconStateSchemaBellatrix.LATEST_EXECUTION_PAYLOAD_HEADER_FIELD_INDEX + 1;
 
   @VisibleForTesting
   BeaconStateSchemaCapella(final SpecConfig specConfig) {
-    super("BeaconStateBellatrix", getUniqueFields(specConfig), specConfig);
+    super("BeaconStateCapella", getUniqueFields(specConfig), specConfig);
   }
 
   private static List<SszField> getUniqueFields(final SpecConfig specConfig) {
-    return BeaconStateSchemaBellatrix.getUniqueFields(specConfig);
+    final SszField latestWithdrawalValidatorIndexField =
+        new SszField(
+            LATEST_WITHDRAWAL_VALIDATOR_INDEX,
+            BeaconStateFields.LATEST_WITHDRAWAL_VALIDATOR_INDEX,
+            () -> SszPrimitiveSchemas.UINT64_SCHEMA);
+    return Stream.concat(
+            BeaconStateSchemaBellatrix.getUniqueFields(specConfig).stream(),
+            Stream.of(latestWithdrawalValidatorIndexField))
+        .collect(Collectors.toList());
+  }
+
+  @SuppressWarnings("unchecked")
+  public SszPrimitiveListSchema<Byte, SszByte, ?> getPreviousEpochParticipationSchema() {
+    return (SszPrimitiveListSchema<Byte, SszByte, ?>)
+        getChildSchema(getFieldIndex(BeaconStateFields.PREVIOUS_EPOCH_PARTICIPATION));
+  }
+
+  @SuppressWarnings("unchecked")
+  public SszPrimitiveListSchema<Byte, SszByte, ?> getCurrentEpochParticipationSchema() {
+    return (SszPrimitiveListSchema<Byte, SszByte, ?>)
+        getChildSchema(getFieldIndex(BeaconStateFields.CURRENT_EPOCH_PARTICIPATION));
+  }
+
+  public SszUInt64ListSchema<?> getInactivityScoresSchema() {
+    return (SszUInt64ListSchema<?>)
+        getChildSchema(getFieldIndex(BeaconStateFields.INACTIVITY_SCORES));
+  }
+
+  public SyncCommittee.SyncCommitteeSchema getCurrentSyncCommitteeSchema() {
+    return (SyncCommittee.SyncCommitteeSchema)
+        getChildSchema(getFieldIndex(BeaconStateFields.CURRENT_SYNC_COMMITTEE));
+  }
+
+  public SyncCommittee.SyncCommitteeSchema getNextSyncCommitteeSchema() {
+    return (SyncCommittee.SyncCommitteeSchema)
+        getChildSchema(getFieldIndex(BeaconStateFields.NEXT_SYNC_COMMITTEE));
+  }
+
+  public ExecutionPayloadHeaderSchema getLastExecutionPayloadHeaderSchema() {
+    return (ExecutionPayloadHeaderSchema)
+        getChildSchema(getFieldIndex(BeaconStateFields.LATEST_EXECUTION_PAYLOAD_HEADER));
   }
 
   @Override
-  public MutableBeaconStateBellatrix createBuilder() {
+  public MutableBeaconStateCapella createBuilder() {
     return new MutableBeaconStateCapellaImpl(createEmptyBeaconStateImpl(), true);
+  }
+
+  public static BeaconStateSchemaCapella create(final SpecConfig specConfig) {
+    return new BeaconStateSchemaCapella(specConfig);
+  }
+
+  public static BeaconStateSchemaCapella required(final BeaconStateSchema<?, ?> schema) {
+    checkArgument(
+        schema instanceof BeaconStateSchemaCapella,
+        "Expected a BeaconStateSchemaCapella but was %s",
+        schema.getClass());
+    return (BeaconStateSchemaCapella) schema;
   }
 
   @Override
@@ -50,7 +114,7 @@ public class BeaconStateSchemaCapella
   }
 
   @Override
-  public BeaconStateBellatrix createFromBackingNode(TreeNode node) {
+  public BeaconStateCapella createFromBackingNode(TreeNode node) {
     return new BeaconStateCapellaImpl(this, node);
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/capella/BeaconStateSchemaCapella.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/capella/BeaconStateSchemaCapella.java
@@ -35,8 +35,7 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.bellatri
 
 public class BeaconStateSchemaCapella
     extends AbstractBeaconStateSchema<BeaconStateCapella, MutableBeaconStateCapella> {
-  private static final int LATEST_WITHDRAWAL_VALIDATOR_INDEX =
-      BeaconStateSchemaBellatrix.LATEST_EXECUTION_PAYLOAD_HEADER_FIELD_INDEX + 1;
+  private static final int LATEST_WITHDRAWAL_VALIDATOR_INDEX = 25;
 
   @VisibleForTesting
   BeaconStateSchemaCapella(final SpecConfig specConfig) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/capella/MutableBeaconStateCapella.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/capella/MutableBeaconStateCapella.java
@@ -14,7 +14,10 @@
 package tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.capella;
 
 import java.util.Optional;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.BeaconStateFields;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.bellatrix.MutableBeaconStateBellatrix;
 
 public interface MutableBeaconStateCapella extends MutableBeaconStateBellatrix, BeaconStateCapella {
@@ -29,6 +32,12 @@ public interface MutableBeaconStateCapella extends MutableBeaconStateBellatrix, 
 
   @Override
   BeaconStateCapella commitChanges();
+
+  default void setLatestWithdrawalValidatorIndex(UInt64 latestWithdrawalValidatorIndex) {
+    final int fieldIndex =
+        getSchema().getFieldIndex(BeaconStateFields.LATEST_WITHDRAWAL_VALIDATOR_INDEX);
+    set(fieldIndex, SszUInt64.of(latestWithdrawalValidatorIndex));
+  }
 
   @Override
   default Optional<MutableBeaconStateCapella> toMutableVersionCapella() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/capella/MutableBeaconStateCapellaImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/capella/MutableBeaconStateCapellaImpl.java
@@ -49,11 +49,6 @@ public class MutableBeaconStateCapellaImpl
     BeaconStateCapella.describeCustomCapellaFields(stringBuilder, this);
   }
 
-  static void describeCustomFields(
-      MoreObjects.ToStringHelper stringBuilder, final BeaconStateBellatrix state) {
-    stringBuilder.add("execution_payload_header", state.getLatestExecutionPayloadHeader());
-  }
-
   @Override
   public BeaconStateCapella commitChanges() {
     return (BeaconStateCapella) super.commitChanges();

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsCapella.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsCapella.java
@@ -20,9 +20,14 @@ import tech.pegasys.teku.spec.config.SpecConfigCapella;
 import tech.pegasys.teku.spec.datastructures.execution.versions.capella.WithdrawalSchema;
 import tech.pegasys.teku.spec.datastructures.operations.BlsToExecutionChangeSchema;
 import tech.pegasys.teku.spec.datastructures.operations.SignedBlsToExecutionChangeSchema;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchema;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.capella.BeaconStateCapella;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.capella.BeaconStateSchemaCapella;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.capella.MutableBeaconStateCapella;
 
 public class SchemaDefinitionsCapella extends SchemaDefinitionsBellatrix {
 
+  private final BeaconStateSchemaCapella beaconStateSchema;
   private final WithdrawalSchema withdrawalSchema;
 
   private final BlsToExecutionChangeSchema blsToExecutionChangeSchema;
@@ -31,6 +36,7 @@ public class SchemaDefinitionsCapella extends SchemaDefinitionsBellatrix {
 
   public SchemaDefinitionsCapella(final SpecConfigCapella specConfig) {
     super(specConfig.toVersionCapella().orElseThrow());
+    this.beaconStateSchema = BeaconStateSchemaCapella.create(specConfig);
     this.withdrawalSchema = new WithdrawalSchema();
     this.blsToExecutionChangeSchema = new BlsToExecutionChangeSchema();
     this.signedBlsToExecutionChangeSchema = new SignedBlsToExecutionChangeSchema();
@@ -43,6 +49,12 @@ public class SchemaDefinitionsCapella extends SchemaDefinitionsBellatrix {
         SchemaDefinitionsCapella.class,
         schemaDefinitions.getClass());
     return (SchemaDefinitionsCapella) schemaDefinitions;
+  }
+
+  @Override
+  public BeaconStateSchema<? extends BeaconStateCapella, ? extends MutableBeaconStateCapella>
+      getBeaconStateSchema() {
+    return beaconStateSchema;
   }
 
   public WithdrawalSchema getWithdrawalSchema() {

--- a/ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/gnosis/capella.yaml
+++ b/ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/gnosis/capella.yaml
@@ -1,17 +1,5 @@
 # Mainnet preset - Capella
 
-# Misc
-# ---------------------------------------------------------------
-# 2**8 (= 256) withdrawals
-MAX_PARTIAL_WITHDRAWALS_PER_EPOCH: 256
-
-
-# State list lengths
-# ---------------------------------------------------------------
-# 2**40 (= 1,099,511,627,776) withdrawals
-WITHDRAWAL_QUEUE_LIMIT: 1099511627776
-
-
 # Max operations per block
 # ---------------------------------------------------------------
 # 2**4 (= 16)

--- a/ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/capella.yaml
+++ b/ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/capella.yaml
@@ -1,17 +1,5 @@
 # Mainnet preset - Capella
 
-# Misc
-# ---------------------------------------------------------------
-# 2**8 (= 256) withdrawals
-MAX_PARTIAL_WITHDRAWALS_PER_EPOCH: 256
-
-
-# State list lengths
-# ---------------------------------------------------------------
-# 2**40 (= 1,099,511,627,776) withdrawals
-WITHDRAWAL_QUEUE_LIMIT: 1099511627776
-
-
 # Max operations per block
 # ---------------------------------------------------------------
 # 2**4 (= 16)

--- a/ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/minimal/capella.yaml
+++ b/ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/minimal/capella.yaml
@@ -2,18 +2,6 @@
 
 # Minimal preset - Capella
 
-# Misc
-# ---------------------------------------------------------------
-# [customized] 16 for more interesting tests at low validator count
-MAX_PARTIAL_WITHDRAWALS_PER_EPOCH: 16
-
-
-# State list lengths
-# ---------------------------------------------------------------
-# 2**40 (= 1,099,511,627,776) withdrawals
-WITHDRAWAL_QUEUE_LIMIT: 1099511627776
-
-
 # Max operations per block
 # ---------------------------------------------------------------
 # 2**4 (= 16)
@@ -22,5 +10,5 @@ MAX_BLS_TO_EXECUTION_CHANGES: 16
 
 # Execution
 # ---------------------------------------------------------------
-# [customized] Lower than MAX_PARTIAL_WITHDRAWALS_PER_EPOCH so not all processed in one block
-MAX_WITHDRAWALS_PER_PAYLOAD: 8
+# 2**2 (= 4)
+MAX_WITHDRAWALS_PER_PAYLOAD: 4

--- a/ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/swift/capella.yaml
+++ b/ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/swift/capella.yaml
@@ -1,17 +1,5 @@
 # Minimal preset - Capella
 
-# Misc
-# ---------------------------------------------------------------
-# [customized] 16 for more interesting tests at low validator count
-MAX_PARTIAL_WITHDRAWALS_PER_EPOCH: 16
-
-
-# State list lengths
-# ---------------------------------------------------------------
-# 2**40 (= 1,099,511,627,776) withdrawals
-WITHDRAWAL_QUEUE_LIMIT: 1099511627776
-
-
 # Max operations per block
 # ---------------------------------------------------------------
 # 2**4 (= 16)
@@ -20,5 +8,5 @@ MAX_BLS_TO_EXECUTION_CHANGES: 16
 
 # Execution
 # ---------------------------------------------------------------
-# [customized] Lower than MAX_PARTIAL_WITHDRAWALS_PER_EPOCH so not all processed in one block
-MAX_WITHDRAWALS_PER_PAYLOAD: 8
+# 2**2 (= 4)
+MAX_WITHDRAWALS_PER_PAYLOAD: 4

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/config/SpecConfigCapellaTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/config/SpecConfigCapellaTest.java
@@ -87,7 +87,7 @@ public class SpecConfigCapellaTest {
         bellatrixConfig,
         dataStructureUtil.randomBytes4(),
         dataStructureUtil.randomUInt64(),
-        dataStructureUtil.randomUInt64(),
-        dataStructureUtil.randomUInt64());
+        dataStructureUtil.randomPositiveInt(),
+        dataStructureUtil.randomPositiveInt());
   }
 }

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/config/SpecConfigCapellaTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/config/SpecConfigCapellaTest.java
@@ -88,8 +88,6 @@ public class SpecConfigCapellaTest {
         dataStructureUtil.randomBytes4(),
         dataStructureUtil.randomUInt64(),
         dataStructureUtil.randomUInt64(),
-        dataStructureUtil.randomUInt64(),
-        dataStructureUtil.randomUInt64(),
         dataStructureUtil.randomUInt64());
   }
 }

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/capella/BeaconStateCapellaTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/capella/BeaconStateCapellaTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.capella;
+
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.config.SpecConfig;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchema;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.AbstractBeaconStateTest;
+
+public class BeaconStateCapellaTest
+    extends AbstractBeaconStateTest<BeaconStateCapella, MutableBeaconStateCapella> {
+  @Override
+  protected Spec createSpec() {
+    return TestSpecFactory.createMinimalCapella();
+  }
+
+  @Override
+  protected BeaconStateSchema<BeaconStateCapella, MutableBeaconStateCapella> getSchema(
+      final SpecConfig specConfig) {
+    return BeaconStateSchemaCapella.create(specConfig);
+  }
+
+  @Override
+  protected BeaconStateCapella randomState() {
+    return dataStructureUtil.stateBuilderCapella().build();
+  }
+}

--- a/ethereum/spec/src/test/resources/tech/pegasys/teku/spec/config/standard/presets/mainnet/capella.yaml
+++ b/ethereum/spec/src/test/resources/tech/pegasys/teku/spec/config/standard/presets/mainnet/capella.yaml
@@ -1,17 +1,5 @@
 # Mainnet preset - Capella
 
-# Misc
-# ---------------------------------------------------------------
-# 2**8 (= 256) withdrawals
-MAX_PARTIAL_WITHDRAWALS_PER_EPOCH: 256
-
-
-# State list lengths
-# ---------------------------------------------------------------
-# 2**40 (= 1,099,511,627,776) withdrawals
-WITHDRAWAL_QUEUE_LIMIT: 1099511627776
-
-
 # Max operations per block
 # ---------------------------------------------------------------
 # 2**4 (= 16)

--- a/ethereum/spec/src/test/resources/tech/pegasys/teku/spec/config/standard/presets/minimal/capella.yaml
+++ b/ethereum/spec/src/test/resources/tech/pegasys/teku/spec/config/standard/presets/minimal/capella.yaml
@@ -1,17 +1,5 @@
 # Minimal preset - Capella
 
-# Misc
-# ---------------------------------------------------------------
-# [customized] 16 for more interesting tests at low validator count
-MAX_PARTIAL_WITHDRAWALS_PER_EPOCH: 16
-
-
-# State list lengths
-# ---------------------------------------------------------------
-# 2**40 (= 1,099,511,627,776) withdrawals
-WITHDRAWAL_QUEUE_LIMIT: 1099511627776
-
-
 # Max operations per block
 # ---------------------------------------------------------------
 # 2**4 (= 16)
@@ -20,5 +8,5 @@ MAX_BLS_TO_EXECUTION_CHANGES: 16
 
 # Execution
 # ---------------------------------------------------------------
-# [customized] Lower than MAX_PARTIAL_WITHDRAWALS_PER_EPOCH so not all processed in one block
-MAX_WITHDRAWALS_PER_PAYLOAD: 8
+# 2**2 (= 4)
+MAX_WITHDRAWALS_PER_PAYLOAD: 4

--- a/ethereum/spec/src/test/resources/tech/pegasys/teku/spec/config/standard/presets/swift/capella.yaml
+++ b/ethereum/spec/src/test/resources/tech/pegasys/teku/spec/config/standard/presets/swift/capella.yaml
@@ -1,17 +1,5 @@
 # Minimal preset - Capella
 
-# Misc
-# ---------------------------------------------------------------
-# [customized] 16 for more interesting tests at low validator count
-MAX_PARTIAL_WITHDRAWALS_PER_EPOCH: 16
-
-
-# State list lengths
-# ---------------------------------------------------------------
-# 2**40 (= 1,099,511,627,776) withdrawals
-WITHDRAWAL_QUEUE_LIMIT: 1099511627776
-
-
 # Max operations per block
 # ---------------------------------------------------------------
 # 2**4 (= 16)
@@ -20,5 +8,5 @@ MAX_BLS_TO_EXECUTION_CHANGES: 16
 
 # Execution
 # ---------------------------------------------------------------
-# [customized] Lower than MAX_PARTIAL_WITHDRAWALS_PER_EPOCH so not all processed in one block
-MAX_WITHDRAWALS_PER_PAYLOAD: 8
+# 2**2 (= 4)
+MAX_WITHDRAWALS_PER_PAYLOAD: 4

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/BeaconStateBuilderCapella.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/BeaconStateBuilderCapella.java
@@ -110,6 +110,9 @@ public class BeaconStateBuilderCapella
     nextSyncCommittee = dataStructureUtil.randomSyncCommittee();
     latestExecutionPayloadHeader = dataStructureUtil.randomExecutionPayloadHeader();
 
-    this.latestWithdrawalValidatorIndex = dataStructureUtil.randomUInt64(defaultValidatorCount);
+    this.latestWithdrawalValidatorIndex =
+        defaultValidatorCount > 0
+            ? dataStructureUtil.randomUInt64(defaultValidatorCount)
+            : UInt64.ZERO;
   }
 }

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/BeaconStateBuilderCapella.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/BeaconStateBuilderCapella.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.util;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import tech.pegasys.teku.infrastructure.ssz.SszList;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszUInt64List;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszByte;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.SpecVersion;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
+import tech.pegasys.teku.spec.datastructures.state.SyncCommittee;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.capella.BeaconStateCapella;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.capella.BeaconStateSchemaCapella;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.capella.MutableBeaconStateCapella;
+
+public class BeaconStateBuilderCapella
+    extends AbstractBeaconStateBuilder<
+        BeaconStateCapella, MutableBeaconStateCapella, BeaconStateBuilderCapella> {
+  private UInt64 latestWithdrawalValidatorIndex;
+
+  private SszList<SszByte> previousEpochParticipation;
+  private SszList<SszByte> currentEpochParticipation;
+  private SszUInt64List inactivityScores;
+  private SyncCommittee currentSyncCommittee;
+  private SyncCommittee nextSyncCommittee;
+  private ExecutionPayloadHeader latestExecutionPayloadHeader;
+
+  protected BeaconStateBuilderCapella(
+      final SpecVersion spec,
+      final DataStructureUtil dataStructureUtil,
+      final int defaultValidatorCount,
+      final int defaultItemsInSSZLists) {
+    super(spec, dataStructureUtil, defaultValidatorCount, defaultItemsInSSZLists);
+  }
+
+  @Override
+  protected BeaconStateCapella getEmptyState() {
+    return BeaconStateSchemaCapella.create(spec.getConfig()).createEmpty();
+  }
+
+  @Override
+  protected void setUniqueFields(final MutableBeaconStateCapella state) {
+    state.setPreviousEpochParticipation(previousEpochParticipation);
+    state.setCurrentEpochParticipation(currentEpochParticipation);
+    state.setInactivityScores(inactivityScores);
+    state.setCurrentSyncCommittee(currentSyncCommittee);
+    state.setNextSyncCommittee(nextSyncCommittee);
+    state.setLatestExecutionPayloadHeader(latestExecutionPayloadHeader);
+    state.setLatestWithdrawalValidatorIndex(latestWithdrawalValidatorIndex);
+  }
+
+  public static BeaconStateBuilderCapella create(
+      final DataStructureUtil dataStructureUtil,
+      final Spec spec,
+      final int defaultValidatorCount,
+      final int defaultItemsInSSZLists) {
+    return new BeaconStateBuilderCapella(
+        spec.forMilestone(SpecMilestone.CAPELLA),
+        dataStructureUtil,
+        defaultValidatorCount,
+        defaultItemsInSSZLists);
+  }
+
+  public BeaconStateBuilderCapella latestWithdrawalValidatorIndex(
+      final UInt64 latestWithdrawalValidatorIndex) {
+    checkNotNull(latestWithdrawalValidatorIndex);
+    this.latestWithdrawalValidatorIndex = latestWithdrawalValidatorIndex;
+    return this;
+  }
+
+  private BeaconStateSchemaCapella getBeaconStateSchema() {
+    return (BeaconStateSchemaCapella) spec.getSchemaDefinitions().getBeaconStateSchema();
+  }
+
+  @Override
+  protected void initDefaults() {
+    super.initDefaults();
+
+    final BeaconStateSchemaCapella schema = getBeaconStateSchema();
+
+    previousEpochParticipation =
+        dataStructureUtil.randomSszList(
+            schema.getPreviousEpochParticipationSchema(),
+            defaultValidatorCount,
+            dataStructureUtil::randomSszByte);
+    currentEpochParticipation =
+        dataStructureUtil.randomSszList(
+            schema.getCurrentEpochParticipationSchema(),
+            defaultValidatorCount,
+            dataStructureUtil::randomSszByte);
+    inactivityScores =
+        dataStructureUtil.randomSszUInt64List(
+            schema.getInactivityScoresSchema(), defaultItemsInSSZLists);
+    currentSyncCommittee = dataStructureUtil.randomSyncCommittee();
+    nextSyncCommittee = dataStructureUtil.randomSyncCommittee();
+    latestExecutionPayloadHeader = dataStructureUtil.randomExecutionPayloadHeader();
+
+    this.latestWithdrawalValidatorIndex = dataStructureUtil.randomUInt64(defaultValidatorCount);
+  }
+}

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -1368,8 +1368,9 @@ public final class DataStructureUtil {
       case ALTAIR:
         return stateBuilderAltair(validatorCount, numItemsInSszLists);
       case BELLATRIX:
-      case CAPELLA: // TODO CAPELLA
         return stateBuilderBellatrix(validatorCount, numItemsInSszLists);
+      case CAPELLA:
+        return stateBuilderCapella(validatorCount, numItemsInSszLists);
       default:
         throw new IllegalArgumentException("Unsupported milestone: " + milestone);
     }
@@ -1401,6 +1402,16 @@ public final class DataStructureUtil {
   public BeaconStateBuilderBellatrix stateBuilderBellatrix(
       final int defaultValidatorCount, final int defaultItemsInSSZLists) {
     return BeaconStateBuilderBellatrix.create(
+        this, spec, defaultValidatorCount, defaultItemsInSSZLists);
+  }
+
+  public BeaconStateBuilderCapella stateBuilderCapella() {
+    return stateBuilderCapella(10, 10);
+  }
+
+  public BeaconStateBuilderCapella stateBuilderCapella(
+      final int defaultValidatorCount, final int defaultItemsInSSZLists) {
+    return BeaconStateBuilderCapella.create(
         this, spec, defaultValidatorCount, defaultItemsInSSZLists);
   }
 


### PR DESCRIPTION
- removed withdrawal_queue_limit and max_partial_withdrawals_per_epoch from the configuration, as they're not needed in the latest spec updates

 - BeaconState can now be created and copied through accessors.

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
