### PR TITLE
Update plurality for registration messages

### DIFF
--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/ValidatorLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/ValidatorLogger.java
@@ -243,7 +243,7 @@ public class ValidatorLogger {
       final int successfullySentRegistrations, final int totalRegistrations) {
     final String infoString =
         String.format(
-            "%s%s out of %s validator(s) registrations were successfully sent to the builder network via the Beacon Node.",
+            "%s%s out of %s validator registration(s) were successfully sent to the builder network via the Beacon Node.",
             PREFIX, successfullySentRegistrations, totalRegistrations);
     log.info(ColorConsolePrinter.print(infoString, Color.GREEN));
   }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrationBatchSender.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrationBatchSender.java
@@ -51,7 +51,7 @@ public class ValidatorRegistrationBatchSender {
         Lists.partition(validatorRegistrations, batchSize);
 
     LOG.debug(
-        "Going to send {} validator(s) registrations to the Beacon Node in {} batch(es)",
+        "Going to send {} validator registration(s) to the Beacon Node in {} batch(es)",
         validatorRegistrations.size(),
         batchedRegistrations.size());
 

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrator.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrator.java
@@ -154,7 +154,7 @@ public class ValidatorRegistrator implements ValidatorTimingChannel {
             .equals(SLOT_IN_THE_EPOCH_TO_RUN_REGISTRATION.minus(1));
     if (slotIsApplicable && registrationInProgress.get()) {
       LOG.warn(
-          "Validator(s) registration for epoch {} is still in progress. Will skip registration for the current epoch {}.",
+          "Validator registration(s) for epoch {} is still in progress. Will skip registration for the current epoch {}.",
           lastRunEpoch.get(),
           currentEpoch);
       return false;

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrator.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorRegistrator.java
@@ -154,7 +154,7 @@ public class ValidatorRegistrator implements ValidatorTimingChannel {
             .equals(SLOT_IN_THE_EPOCH_TO_RUN_REGISTRATION.minus(1));
     if (slotIsApplicable && registrationInProgress.get()) {
       LOG.warn(
-          "Validator registration(s) for epoch {} is still in progress. Will skip registration for the current epoch {}.",
+          "Validator registration(s) for epoch {} is still in progress. Will skip registration(s) for the current epoch {}.",
           lastRunEpoch.get(),
           currentEpoch);
       return false;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

Small nit that I've been meaning to fix for a while.

To me, these three log sentences are a bit weird. I think the "(s)" should be on "registration" not "validator". And because each validator only has one registration, "validators" should not be plural.

```diff
- validator(s) registrations
+ validator registration(s)
```

Thoughts?

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
