### PR TITLE
teku-6320 Capella helper functions

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/Validator.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/Validator.java
@@ -235,4 +235,16 @@ public class Validator
         getExitEpoch(),
         withdrawableEpoch);
   }
+
+  public Validator withWithdrawalCredentials(final Bytes32 withdrawalCredentials) {
+    return new Validator(
+        getPubkeyBytes(),
+        withdrawalCredentials,
+        getEffectiveBalance(),
+        isSlashed(),
+        getActivationEligibilityEpoch(),
+        getActivationEpoch(),
+        getExitEpoch(),
+        getWithdrawableEpoch());
+  }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/SpecLogicCapella.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/SpecLogicCapella.java
@@ -32,11 +32,11 @@ import tech.pegasys.teku.spec.logic.versions.altair.helpers.BeaconStateAccessors
 import tech.pegasys.teku.spec.logic.versions.altair.statetransition.epoch.ValidatorStatusFactoryAltair;
 import tech.pegasys.teku.spec.logic.versions.bellatrix.helpers.BeaconStateMutatorsBellatrix;
 import tech.pegasys.teku.spec.logic.versions.bellatrix.helpers.BellatrixTransitionHelpers;
-import tech.pegasys.teku.spec.logic.versions.bellatrix.helpers.MiscHelpersBellatrix;
 import tech.pegasys.teku.spec.logic.versions.bellatrix.statetransition.epoch.EpochProcessorBellatrix;
 import tech.pegasys.teku.spec.logic.versions.bellatrix.util.BlindBlockUtilBellatrix;
 import tech.pegasys.teku.spec.logic.versions.capella.block.BlockProcessorCapella;
 import tech.pegasys.teku.spec.logic.versions.capella.forktransition.CapellaStateUpgrade;
+import tech.pegasys.teku.spec.logic.versions.capella.helpers.MiscHelpersCapella;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsCapella;
 
 public class SpecLogicCapella extends AbstractSpecLogic {
@@ -46,7 +46,7 @@ public class SpecLogicCapella extends AbstractSpecLogic {
   private SpecLogicCapella(
       final SpecConfigCapella specConfig,
       final Predicates predicates,
-      final MiscHelpersBellatrix miscHelpers,
+      final MiscHelpersCapella miscHelpers,
       final BeaconStateAccessorsAltair beaconStateAccessors,
       final BeaconStateMutatorsBellatrix beaconStateMutators,
       final OperationSignatureVerifier operationSignatureVerifier,
@@ -87,7 +87,7 @@ public class SpecLogicCapella extends AbstractSpecLogic {
       final SpecConfigCapella config, final SchemaDefinitionsCapella schemaDefinitions) {
     // Helpers
     final Predicates predicates = new Predicates();
-    final MiscHelpersBellatrix miscHelpers = new MiscHelpersBellatrix(config);
+    final MiscHelpersCapella miscHelpers = new MiscHelpersCapella(config);
     final BeaconStateAccessorsAltair beaconStateAccessors =
         new BeaconStateAccessorsAltair(config, predicates, miscHelpers);
     final BeaconStateMutatorsBellatrix beaconStateMutators =

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/block/BlockProcessorCapella.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/block/BlockProcessorCapella.java
@@ -24,14 +24,14 @@ import tech.pegasys.teku.spec.logic.common.util.SyncCommitteeUtil;
 import tech.pegasys.teku.spec.logic.common.util.ValidatorsUtil;
 import tech.pegasys.teku.spec.logic.versions.altair.helpers.BeaconStateAccessorsAltair;
 import tech.pegasys.teku.spec.logic.versions.bellatrix.block.BlockProcessorBellatrix;
-import tech.pegasys.teku.spec.logic.versions.bellatrix.helpers.MiscHelpersBellatrix;
+import tech.pegasys.teku.spec.logic.versions.capella.helpers.MiscHelpersCapella;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsBellatrix;
 
 public class BlockProcessorCapella extends BlockProcessorBellatrix {
   public BlockProcessorCapella(
       final SpecConfigBellatrix specConfig,
       final Predicates predicates,
-      final MiscHelpersBellatrix miscHelpers,
+      final MiscHelpersCapella miscHelpers,
       final SyncCommitteeUtil syncCommitteeUtil,
       final BeaconStateAccessorsAltair beaconStateAccessors,
       final BeaconStateMutators beaconStateMutators,

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/helpers/MiscHelpersCapella.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/helpers/MiscHelpersCapella.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.logic.versions.capella.helpers;
+
+import org.apache.tuweni.bytes.Bytes;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.config.SpecConfig;
+import tech.pegasys.teku.spec.datastructures.state.Validator;
+import tech.pegasys.teku.spec.logic.versions.bellatrix.helpers.MiscHelpersBellatrix;
+
+public class MiscHelpersCapella extends MiscHelpersBellatrix {
+
+  public static final Bytes ETH1_WITHDRAWAL_PREFIX = Bytes.fromHexString("0x01");
+
+  public MiscHelpersCapella(final SpecConfig specConfig) {
+    super(specConfig);
+  }
+
+  /**
+   * Implementation of <b>has_eth1_withdrawal_credential</b> Capella Helper function. <br>
+   * Checks if validator has a 0x01 prefixed "eth1" withdrawal credential.
+   *
+   * @param validator the validator being checked
+   * @return true if the validator has an "eth1" withdrawal credential, false otherwise
+   */
+  public boolean hasEth1WithdrawalCredential(final Validator validator) {
+    return validator.getWithdrawalCredentials().slice(0, 1).equals(ETH1_WITHDRAWAL_PREFIX);
+  }
+
+  /**
+   * Implementation of <b>is_fully_withdrawable_validator</b> Capella helper function. <br>
+   * Checks if validator is fully withdrawable.
+   *
+   * @param validator the validator being checked
+   * @param balance the validator's balance
+   * @param epoch the current epoch
+   * @return true if the validator can fully withdraw their funds, false otherwise
+   */
+  public boolean isFullyWithdrawableValidator(
+      final Validator validator, final UInt64 balance, final UInt64 epoch) {
+    return hasEth1WithdrawalCredential(validator)
+        && validator.getWithdrawableEpoch().isLessThanOrEqualTo(epoch)
+        && balance.isGreaterThan(UInt64.ZERO);
+  }
+
+  /**
+   * Implementation of <b>is_partially_withdrawable_validator</b> Capella helper function. <br>
+   * Checks if validator is partially withdrawable.
+   *
+   * @param validator the validator being checked
+   * @param balance the validator's balance
+   * @return true if the validator can partially withdraw their funds, false otherwise
+   */
+  public boolean isPartiallyWithdrawableValidator(final Validator validator, final UInt64 balance) {
+    final UInt64 maxEffectiveBalance = specConfig.getMaxEffectiveBalance();
+    final boolean hasMaxEffectiveBalance =
+        validator.getEffectiveBalance().equals(maxEffectiveBalance);
+    final boolean hasExcessBalance = balance.isGreaterThan(maxEffectiveBalance);
+
+    return hasEth1WithdrawalCredential(validator) && hasMaxEffectiveBalance && hasExcessBalance;
+  }
+}

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/capella/helpers/MiscHelpersCapellaTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/capella/helpers/MiscHelpersCapellaTest.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.logic.versions.capella.helpers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.config.SpecConfigCapella;
+import tech.pegasys.teku.spec.datastructures.state.Validator;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+class MiscHelpersCapellaTest {
+
+  private SpecConfigCapella specConfigCapella;
+  private DataStructureUtil dataStructureUtil;
+  private MiscHelpersCapella miscHelpersCapella;
+  private Bytes32 eth1WithdrawalsCredentials;
+  private Bytes32 blsWithdrawalsCredentials;
+
+  @BeforeEach
+  public void before() {
+    final Spec spec = TestSpecFactory.createMainnet(SpecMilestone.CAPELLA);
+    this.specConfigCapella = spec.getGenesisSpecConfig().toVersionCapella().orElseThrow();
+    this.dataStructureUtil = new DataStructureUtil(spec);
+    this.miscHelpersCapella = new MiscHelpersCapella(specConfigCapella);
+    this.eth1WithdrawalsCredentials = dataStructureUtil.randomEth1WithdrawalCredentials();
+    this.blsWithdrawalsCredentials = dataStructureUtil.randomBlsWithdrawalCredentials();
+  }
+
+  @Test
+  public void isFullyWithdrawableValidatorShouldReturnTrueForEligibleValidator() {
+    final Validator validator =
+        dataStructureUtil
+            .randomValidator()
+            .withWithdrawalCredentials(eth1WithdrawalsCredentials)
+            .withWithdrawableEpoch(UInt64.ZERO);
+
+    final UInt64 balance = UInt64.ONE;
+    final UInt64 epoch = UInt64.ONE;
+
+    assertThat(miscHelpersCapella.isFullyWithdrawableValidator(validator, balance, epoch)).isTrue();
+  }
+
+  @Test
+  public void isFullyWithdrawableValidatorShouldReturnFalseForNonEth1Credentials() {
+    final Validator validator =
+        dataStructureUtil
+            .randomValidator()
+            .withWithdrawalCredentials(blsWithdrawalsCredentials)
+            .withWithdrawableEpoch(UInt64.ZERO);
+
+    final UInt64 balance = UInt64.ONE;
+    final UInt64 epoch = UInt64.ONE;
+
+    assertThat(miscHelpersCapella.isFullyWithdrawableValidator(validator, balance, epoch))
+        .isFalse();
+  }
+
+  @Test
+  public void isFullyWithdrawableValidatorShouldReturnFalseForZeroBalance() {
+    final Validator validator =
+        dataStructureUtil
+            .randomValidator()
+            .withWithdrawalCredentials(eth1WithdrawalsCredentials)
+            .withWithdrawableEpoch(UInt64.ZERO);
+
+    final UInt64 balance = UInt64.ZERO;
+    final UInt64 epoch = UInt64.ONE;
+
+    assertThat(miscHelpersCapella.isFullyWithdrawableValidator(validator, balance, epoch))
+        .isFalse();
+  }
+
+  @Test
+  public void isFullyWithdrawableValidatorShouldReturnFalseForWithdrawableEpochInTheFuture() {
+    final Validator validator =
+        dataStructureUtil
+            .randomValidator()
+            .withWithdrawalCredentials(eth1WithdrawalsCredentials)
+            .withWithdrawableEpoch(UInt64.MAX_VALUE);
+
+    final UInt64 balance = UInt64.ZERO;
+    final UInt64 epoch = UInt64.ONE;
+
+    assertThat(miscHelpersCapella.isFullyWithdrawableValidator(validator, balance, epoch))
+        .isFalse();
+  }
+
+  @Test
+  public void isPartiallyWithdrawableValidatorShouldReturnTrueForEligibleValidator() {
+    final Validator validator =
+        dataStructureUtil
+            .randomValidator()
+            .withWithdrawalCredentials(eth1WithdrawalsCredentials)
+            .withEffectiveBalance(specConfigCapella.getMaxEffectiveBalance());
+
+    final UInt64 balance = specConfigCapella.getMaxEffectiveBalance().plus(UInt64.ONE);
+
+    assertThat(miscHelpersCapella.isPartiallyWithdrawableValidator(validator, balance)).isTrue();
+  }
+
+  @Test
+  public void isPartiallyWithdrawableValidatorShouldReturnFalseForNonEth1Credentials() {
+    final Validator validator =
+        dataStructureUtil
+            .randomValidator()
+            .withWithdrawalCredentials(blsWithdrawalsCredentials)
+            .withEffectiveBalance(specConfigCapella.getMaxEffectiveBalance());
+
+    final UInt64 balance = specConfigCapella.getMaxEffectiveBalance().plus(UInt64.ONE);
+
+    assertThat(miscHelpersCapella.isPartiallyWithdrawableValidator(validator, balance)).isFalse();
+  }
+
+  @Test
+  public void
+      isPartiallyWithdrawableValidatorShouldReturnFalseForEffectiveBalanceLessThanMaxEffectiveBalance() {
+    final Validator validator =
+        dataStructureUtil
+            .randomValidator()
+            .withWithdrawalCredentials(eth1WithdrawalsCredentials)
+            .withEffectiveBalance(specConfigCapella.getMaxEffectiveBalance().minus(UInt64.ONE));
+
+    final UInt64 balance = specConfigCapella.getMaxEffectiveBalance().plus(UInt64.ONE);
+
+    assertThat(miscHelpersCapella.isPartiallyWithdrawableValidator(validator, balance)).isFalse();
+  }
+
+  @Test
+  public void
+      isPartiallyWithdrawableValidatorShouldReturnFalseForBalanceLowerThanMaxEffectiveBalance() {
+    final Validator validator =
+        dataStructureUtil
+            .randomValidator()
+            .withWithdrawalCredentials(eth1WithdrawalsCredentials)
+            .withEffectiveBalance(specConfigCapella.getMaxEffectiveBalance());
+
+    final UInt64 balance = specConfigCapella.getMaxEffectiveBalance().minus(UInt64.ONE);
+
+    assertThat(miscHelpersCapella.isPartiallyWithdrawableValidator(validator, balance)).isFalse();
+  }
+
+  @Test
+  public void
+      isPartiallyWithdrawableValidatorShouldReturnFalseForBalanceEqualToMaxEffectiveBalance() {
+    final Validator validator =
+        dataStructureUtil
+            .randomValidator()
+            .withWithdrawalCredentials(eth1WithdrawalsCredentials)
+            .withEffectiveBalance(specConfigCapella.getMaxEffectiveBalance());
+
+    final UInt64 balance = specConfigCapella.getMaxEffectiveBalance();
+
+    assertThat(miscHelpersCapella.isPartiallyWithdrawableValidator(validator, balance)).isFalse();
+  }
+}

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -1587,6 +1587,16 @@ public final class DataStructureUtil {
         .create(randomBlsToExecutionChange(), randomSignature());
   }
 
+  public Bytes32 randomBlsWithdrawalCredentials() {
+    return Bytes32.wrap(
+        Bytes.concatenate(Bytes.fromHexString("0x00"), randomBytes32().slice(0, 31)));
+  }
+
+  public Bytes32 randomEth1WithdrawalCredentials() {
+    return Bytes32.wrap(
+        Bytes.concatenate(Bytes.fromHexString("0x01"), randomBytes32().slice(0, 31)));
+  }
+
   private int randomInt(final int bound) {
     return new Random(nextSeed()).nextInt(bound);
   }


### PR DESCRIPTION
## PR Description

Implemented helper predicate functions:
- has_eth1_withdrawal_credential
- has_eth1_withdrawal_credential
- is_partially_withdrawable_validator

Reference: [Cappella beacon chain spec](https://github.com/ethereum/consensus-specs/blob/dev/specs/capella/beacon-chain.md#predicates)

## Fixed Issue(s)
fixes #6320

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
