### PR TITLE
Fix SSZ definition for Withdrawal

### DIFF
--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_static/SszTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_static/SszTestExecutor.java
@@ -44,6 +44,7 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.phase0.B
 import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsAltair;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsBellatrix;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsCapella;
 
 public class SszTestExecutor<T extends SszData> implements TestExecutor {
   private final SchemaProvider<T> sszType;
@@ -148,6 +149,23 @@ public class SszTestExecutor<T extends SszData> implements TestExecutor {
                   schemas ->
                       SchemaDefinitionsBellatrix.required(schemas).getExecutionPayloadSchema()))
           .put("ssz_static/PowBlock", IGNORE_TESTS)
+
+          // Capella Types
+          .put(
+              "ssz_static/SignedBLSToExecutionChange",
+              new SszTestExecutor<>(
+                  schemas ->
+                      SchemaDefinitionsCapella.required(schemas)
+                          .getSignedBlsToExecutionChangeSchema()))
+          .put(
+              "ssz_static/BLSToExecutionChange",
+              new SszTestExecutor<>(
+                  schemas ->
+                      SchemaDefinitionsCapella.required(schemas).getBlsToExecutionChangeSchema()))
+          .put(
+              "ssz_static/Withdrawal",
+              new SszTestExecutor<>(
+                  schemas -> SchemaDefinitionsCapella.required(schemas).getWithdrawalSchema()))
 
           // Legacy Schemas (Not yet migrated to SchemaDefinitions)
           .put(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/capella/Withdrawal.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/capella/Withdrawal.java
@@ -13,27 +13,25 @@
 
 package tech.pegasys.teku.spec.datastructures.execution.versions.capella;
 
-import org.apache.tuweni.units.bigints.UInt256;
 import tech.pegasys.teku.infrastructure.bytes.Bytes20;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszByteVector;
 import tech.pegasys.teku.infrastructure.ssz.containers.Container4;
-import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt256;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 public class Withdrawal
-    extends Container4<Withdrawal, SszUInt256, SszUInt64, SszByteVector, SszUInt64> {
+    extends Container4<Withdrawal, SszUInt64, SszUInt64, SszByteVector, SszUInt64> {
 
   Withdrawal(
       final WithdrawalSchema schema,
-      final UInt256 index,
+      final UInt64 index,
       final UInt64 validatorIndex,
       final Bytes20 address,
       final UInt64 amount) {
     super(
         schema,
-        SszUInt256.of(index),
+        SszUInt64.of(index),
         SszUInt64.of(validatorIndex),
         SszByteVector.fromBytes(address.getWrappedBytes()),
         SszUInt64.of(amount));
@@ -43,7 +41,7 @@ public class Withdrawal
     super(type, backingNode);
   }
 
-  public UInt256 getIndex() {
+  public UInt64 getIndex() {
     return getField0().get();
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/capella/WithdrawalSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/capella/WithdrawalSchema.java
@@ -13,11 +13,9 @@
 
 package tech.pegasys.teku.spec.datastructures.execution.versions.capella;
 
-import org.apache.tuweni.units.bigints.UInt256;
 import tech.pegasys.teku.infrastructure.bytes.Bytes20;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszByteVector;
 import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema4;
-import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt256;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
 import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszByteVectorSchema;
@@ -25,22 +23,19 @@ import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 public class WithdrawalSchema
-    extends ContainerSchema4<Withdrawal, SszUInt256, SszUInt64, SszByteVector, SszUInt64> {
+    extends ContainerSchema4<Withdrawal, SszUInt64, SszUInt64, SszByteVector, SszUInt64> {
 
   public WithdrawalSchema() {
     super(
         "Withdrawal",
-        namedSchema("index", SszPrimitiveSchemas.UINT256_SCHEMA),
+        namedSchema("index", SszPrimitiveSchemas.UINT64_SCHEMA),
         namedSchema("validator_index", SszPrimitiveSchemas.UINT64_SCHEMA),
         namedSchema("address", SszByteVectorSchema.create(Bytes20.SIZE)),
         namedSchema("amount", SszPrimitiveSchemas.UINT64_SCHEMA));
   }
 
   public Withdrawal create(
-      final UInt256 index,
-      final UInt64 validatorIndex,
-      final Bytes20 address,
-      final UInt64 amount) {
+      final UInt64 index, final UInt64 validatorIndex, final Bytes20 address, final UInt64 amount) {
     return new Withdrawal(this, index, validatorIndex, address, amount);
   }
 

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/execution/versions/capella/WithdrawalTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/execution/versions/capella/WithdrawalTest.java
@@ -16,7 +16,6 @@ package tech.pegasys.teku.spec.datastructures.execution.versions.capella;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.tuweni.bytes.Bytes;
-import org.apache.tuweni.units.bigints.UInt256;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.bytes.Bytes20;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -30,7 +29,7 @@ class WithdrawalTest {
       new DataStructureUtil(TestSpecFactory.createMinimal(SpecMilestone.CAPELLA));
   private final WithdrawalSchema withdrawalSchema = new WithdrawalSchema();
 
-  private final UInt256 index = dataStructureUtil.randomUInt256();
+  private final UInt64 index = dataStructureUtil.randomUInt64();
   private final UInt64 validatorIndex = dataStructureUtil.randomUInt64();
   private final Bytes20 address = dataStructureUtil.randomBytes20();
   private final UInt64 amount = dataStructureUtil.randomUInt64();

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -1645,7 +1645,7 @@ public final class DataStructureUtil {
   public Withdrawal randomWithdrawal() {
     return SchemaDefinitionsCapella.required(spec.getGenesisSchemaDefinitions())
         .getWithdrawalSchema()
-        .create(randomUInt256(), randomUInt64(), randomBytes20(), randomUInt64());
+        .create(randomUInt64(), randomUInt64(), randomBytes20(), randomUInt64());
   }
 
   public BlsToExecutionChange randomBlsToExecutionChange() {


### PR DESCRIPTION
## PR Description
Fix Withdrawal definition. index should be UInt64 not UInt256.

Setup ssz_static test executors for Capella types.


## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
