### PR TITLE
Add Capella to api types

### DIFF
--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/interfaces/SignedBlindedBlock.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/interfaces/SignedBlindedBlock.java
@@ -16,12 +16,14 @@ package tech.pegasys.teku.api.schema.interfaces;
 import io.swagger.v3.oas.annotations.media.Schema;
 import tech.pegasys.teku.api.schema.altair.SignedBeaconBlockAltair;
 import tech.pegasys.teku.api.schema.bellatrix.SignedBlindedBeaconBlockBellatrix;
+import tech.pegasys.teku.api.schema.capella.SignedBlindedBeaconBlockCapella;
 import tech.pegasys.teku.api.schema.phase0.SignedBeaconBlockPhase0;
 
 @Schema(
     oneOf = {
       SignedBeaconBlockPhase0.class,
       SignedBeaconBlockAltair.class,
-      SignedBlindedBeaconBlockBellatrix.class
+      SignedBlindedBeaconBlockBellatrix.class,
+      SignedBlindedBeaconBlockCapella.class
     })
 public interface SignedBlindedBlock {}

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/interfaces/SignedBlock.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/interfaces/SignedBlock.java
@@ -16,12 +16,14 @@ package tech.pegasys.teku.api.schema.interfaces;
 import io.swagger.v3.oas.annotations.media.Schema;
 import tech.pegasys.teku.api.schema.altair.SignedBeaconBlockAltair;
 import tech.pegasys.teku.api.schema.bellatrix.SignedBeaconBlockBellatrix;
+import tech.pegasys.teku.api.schema.capella.SignedBeaconBlockCapella;
 import tech.pegasys.teku.api.schema.phase0.SignedBeaconBlockPhase0;
 
 @Schema(
     oneOf = {
       SignedBeaconBlockPhase0.class,
       SignedBeaconBlockAltair.class,
-      SignedBeaconBlockBellatrix.class
+      SignedBeaconBlockBellatrix.class,
+      SignedBeaconBlockCapella.class
     })
 public interface SignedBlock {}

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/interfaces/State.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/interfaces/State.java
@@ -16,7 +16,14 @@ package tech.pegasys.teku.api.schema.interfaces;
 import io.swagger.v3.oas.annotations.media.Schema;
 import tech.pegasys.teku.api.schema.altair.BeaconStateAltair;
 import tech.pegasys.teku.api.schema.bellatrix.BeaconStateBellatrix;
+import tech.pegasys.teku.api.schema.capella.BeaconStateCapella;
 import tech.pegasys.teku.api.schema.phase0.BeaconStatePhase0;
 
-@Schema(oneOf = {BeaconStatePhase0.class, BeaconStateAltair.class, BeaconStateBellatrix.class})
+@Schema(
+    oneOf = {
+      BeaconStatePhase0.class,
+      BeaconStateAltair.class,
+      BeaconStateBellatrix.class,
+      BeaconStateCapella.class
+    })
 public interface State {}

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/interfaces/UnsignedBlindedBlock.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/interfaces/UnsignedBlindedBlock.java
@@ -16,7 +16,14 @@ package tech.pegasys.teku.api.schema.interfaces;
 import io.swagger.v3.oas.annotations.media.Schema;
 import tech.pegasys.teku.api.schema.altair.BeaconBlockAltair;
 import tech.pegasys.teku.api.schema.bellatrix.BlindedBlockBellatrix;
+import tech.pegasys.teku.api.schema.capella.BlindedBlockCapella;
 import tech.pegasys.teku.api.schema.phase0.BeaconBlockPhase0;
 
-@Schema(oneOf = {BeaconBlockPhase0.class, BeaconBlockAltair.class, BlindedBlockBellatrix.class})
+@Schema(
+    oneOf = {
+      BeaconBlockPhase0.class,
+      BeaconBlockAltair.class,
+      BlindedBlockBellatrix.class,
+      BlindedBlockCapella.class
+    })
 public interface UnsignedBlindedBlock {}

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/interfaces/UnsignedBlock.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/interfaces/UnsignedBlock.java
@@ -16,7 +16,14 @@ package tech.pegasys.teku.api.schema.interfaces;
 import io.swagger.v3.oas.annotations.media.Schema;
 import tech.pegasys.teku.api.schema.altair.BeaconBlockAltair;
 import tech.pegasys.teku.api.schema.bellatrix.BeaconBlockBellatrix;
+import tech.pegasys.teku.api.schema.capella.BeaconBlockCapella;
 import tech.pegasys.teku.api.schema.phase0.BeaconBlockPhase0;
 
-@Schema(oneOf = {BeaconBlockPhase0.class, BeaconBlockAltair.class, BeaconBlockBellatrix.class})
+@Schema(
+    oneOf = {
+      BeaconBlockPhase0.class,
+      BeaconBlockAltair.class,
+      BeaconBlockBellatrix.class,
+      BeaconBlockCapella.class
+    })
 public interface UnsignedBlock {}


### PR DESCRIPTION
## PR Description
Adds capella as an option for the various block and state interfaces used in reflection based parsing. These are no longer used for OpenAPI definitions so we don't need to worry about it showing up there.

fixes #6410 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
