### PR TITLE
Calculate sync committee duties and subscribe at most SYNC_COMMITTEE_SUBNET_COUNT ahead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,3 +30,4 @@ For information on changes in released versions of Teku, see the [releases page]
 ### Bug Fixes
  - Fix missing status filters (active, pending, exited, withdrawal) for the `/eth/v1/beacon/states/{state_id}/validators` endpoint
  - Fixed issue which could lead to duplicate processing of some events when gossip is stopped and restarted.
+ - Fixed issue which could cause sync committee duties to be calculated too early, potentially causing duties to be missed if the scheduling was changed by a reorg.

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/SyncCommitteeScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/SyncCommitteeScheduler.java
@@ -21,7 +21,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.config.SpecConfigAltair;
+import tech.pegasys.teku.spec.constants.NetworkConstants;
 import tech.pegasys.teku.spec.logic.common.util.SyncCommitteeUtil;
 import tech.pegasys.teku.validator.api.ValidatorTimingChannel;
 import tech.pegasys.teku.validator.client.duties.synccommittee.SyncCommitteeScheduledDuties;
@@ -67,7 +67,6 @@ public class SyncCommitteeScheduler implements ValidatorTimingChannel {
     }
     final SyncCommitteeUtil syncCommitteeUtil = maybeUtils.get();
     final UInt64 dutiesEpoch = syncCommitteeUtil.getEpochForDutiesAtSlot(slot);
-    final SpecConfigAltair specConfig = SpecConfigAltair.required(spec.getSpecConfig(dutiesEpoch));
     if (currentSyncCommitteePeriod.isEmpty()) {
       final SyncCommitteePeriod committeePeriod =
           createSyncCommitteePeriod(
@@ -82,7 +81,7 @@ public class SyncCommitteeScheduler implements ValidatorTimingChannel {
       final UInt64 firstEpochOfNextSyncCommitteePeriod =
           syncCommitteeUtil.computeFirstEpochOfNextSyncCommitteePeriod(dutiesEpoch);
       final int subscribeEpochsPriorToNextSyncPeriod =
-          earlySubscribeRandomSource.randomEpochCount(specConfig.getEpochsPerSyncCommitteePeriod());
+          earlySubscribeRandomSource.randomEpochCount(NetworkConstants.SYNC_COMMITTEE_SUBNET_COUNT);
       nextSyncCommitteePeriod =
           Optional.of(
               createSyncCommitteePeriod(

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/SyncCommitteeSchedulerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/SyncCommitteeSchedulerTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.spec.constants.NetworkConstants.SYNC_COMMITTEE_SUBNET_COUNT;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -141,7 +142,7 @@ class SyncCommitteeSchedulerTest {
 
   @Test
   void shouldCalculateNextSyncPeriodDutiesRandomNumberOfEpochsPriorToStart() {
-    when(earlySubscribeRandomSource.randomEpochCount(epochsPerSyncCommitteePeriod)).thenReturn(4);
+    when(earlySubscribeRandomSource.randomEpochCount(SYNC_COMMITTEE_SUBNET_COUNT)).thenReturn(4);
     final UInt64 nextSyncCommitteePeriodStartEpoch =
         syncCommitteeUtil.computeFirstEpochOfNextSyncCommitteePeriod(UInt64.ZERO);
     final UInt64 subscribeEpoch = nextSyncCommitteePeriodStartEpoch.minus(4);
@@ -155,10 +156,10 @@ class SyncCommitteeSchedulerTest {
 
   @Test
   void shouldNotSelectNewRandomNumberEachSlot() {
-    when(earlySubscribeRandomSource.randomEpochCount(epochsPerSyncCommitteePeriod)).thenReturn(4);
+    when(earlySubscribeRandomSource.randomEpochCount(SYNC_COMMITTEE_SUBNET_COUNT)).thenReturn(4);
 
     scheduler.onSlot(UInt64.ONE);
-    verify(earlySubscribeRandomSource).randomEpochCount(epochsPerSyncCommitteePeriod);
+    verify(earlySubscribeRandomSource).randomEpochCount(SYNC_COMMITTEE_SUBNET_COUNT);
 
     // Already picked a random epoch to subscribe, so don't pick again
     scheduler.onSlot(UInt64.valueOf(2));
@@ -167,7 +168,7 @@ class SyncCommitteeSchedulerTest {
 
   @Test
   void shouldNotRecalculateDutiesEverySlot() {
-    when(earlySubscribeRandomSource.randomEpochCount(epochsPerSyncCommitteePeriod)).thenReturn(4);
+    when(earlySubscribeRandomSource.randomEpochCount(SYNC_COMMITTEE_SUBNET_COUNT)).thenReturn(4);
     final UInt64 nextSyncCommitteePeriodStartEpoch =
         syncCommitteeUtil.computeFirstEpochOfNextSyncCommitteePeriod(UInt64.ZERO);
     final UInt64 subscribeEpoch = nextSyncCommitteePeriodStartEpoch.minus(4);
@@ -188,7 +189,7 @@ class SyncCommitteeSchedulerTest {
 
   @Test
   void shouldSwitchToNextCommitteePeriodWhenLastSlotOfSyncCommitteePeriodReached() {
-    when(earlySubscribeRandomSource.randomEpochCount(epochsPerSyncCommitteePeriod)).thenReturn(5);
+    when(earlySubscribeRandomSource.randomEpochCount(SYNC_COMMITTEE_SUBNET_COUNT)).thenReturn(5);
     final UInt64 nextSyncCommitteePeriodStartEpoch =
         syncCommitteeUtil.computeFirstEpochOfNextSyncCommitteePeriod(UInt64.ZERO);
     final UInt64 subscribeEpoch = nextSyncCommitteePeriodStartEpoch.minus(5);
@@ -222,7 +223,7 @@ class SyncCommitteeSchedulerTest {
    */
   @Test
   void shouldUseNextPeriodForDutiesWhenOnSlotNotYetCalled() {
-    when(earlySubscribeRandomSource.randomEpochCount(epochsPerSyncCommitteePeriod)).thenReturn(5);
+    when(earlySubscribeRandomSource.randomEpochCount(SYNC_COMMITTEE_SUBNET_COUNT)).thenReturn(5);
     final UInt64 nextSyncCommitteePeriodStartEpoch =
         syncCommitteeUtil.computeFirstEpochOfNextSyncCommitteePeriod(UInt64.ZERO);
     final UInt64 subscribeEpoch = nextSyncCommitteePeriodStartEpoch.minus(5);


### PR DESCRIPTION
## PR Description
Calculate sync committee duties and subscribe at most SYNC_COMMITTEE_SUBNET_COUNT ahead not EPOCHS_PER_SYNC_COMMITTEE_PERIOD ahead. Otherwise if the random number of epochs ahead we wind up picking is close to or equal to `EPOCHS_PER_SYNC_COMMITTEE_PERIOD` a reorg or late block may cause the sync committee duties to change.

Since sync committees are very stable, the REST API doesn't provide information on dependentRoots for sync committee duties and the validator client doesn't invalidate them. So in the case where we calculate duties too early and they are affected by a reorg, the validator client will fail to perform the correct duties leading to 0% inclusion rate.

## Fixed Issue(s)
fixes #6212 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
