### PR TITLE
Enable block timing metrics by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Upcoming Breaking Changes
+- The `--Xmetrics-block-timing-tracking-enabled` option has been renamed to `--metrics-block-timing-tracking-enabled` and enabled by default. The `--X` version will be removed in a future release. 
 - The `validator_beacon_node_published_attestation_total`, `validator_beacon_node_published_aggregate_total`,
   `validator_beacon_node_send_sync_committee_messages_total`, `validator_beacon_node_send_sync_committee_contributions_total`
   and `validator_beacon_node_published_block_total` metrics have been deprecated in favour of the new `validator_beacon_node_requests_total` metric.
@@ -10,7 +11,7 @@
 - The `/eth/v1/validator/blocks/:slot` endpoint has been deprecated in favor of the v2 Altair endpoint `/eth/v2/validator/blocks/:slot`
 - The `/eth/v1/debug/beacon/heads` endpoint has been deprecated in favor of the v2 Bellatrix endpoint `/eth/v2/debug/beacon/heads`
 - The commandline option `--network` of the `validator-client` subcommand has been undeprecated and can be used to select a network for standalone validator clients. When set to `auto`, it automatically
-  fetches network configuration information from the configured beacon node endpoint.  
+  fetches network configuration information from the configured beacon node endpoint.
 
 ## Current Releases
 For information on changes in released versions of Teku, see the [releases page](https://github.com/ConsenSys/teku/releases).
@@ -26,6 +27,7 @@ For information on changes in released versions of Teku, see the [releases page]
  - Improved discv5 compliance
  - Changed the builder `is online\is offline` logs to `is available\is not available`
  - Added `/eth/v1/beacon/states/{state_id}/randao` to beacon-api.
+ - Block timing tracking is now enabled by default. The `--Xmetrics-block-timing-tracking-enabled` option has been renamed to `--metrics-block-timing-tracking-enabled`.
 
 ### Bug Fixes
  - Fix missing status filters (active, pending, exited, withdrawal) for the `/eth/v1/beacon/states/{state_id}/validators` endpoint

--- a/infrastructure/metrics/src/main/java/tech/pegasys/teku/infrastructure/metrics/MetricsConfig.java
+++ b/infrastructure/metrics/src/main/java/tech/pegasys/teku/infrastructure/metrics/MetricsConfig.java
@@ -38,7 +38,7 @@ public class MetricsConfig {
       Arrays.asList("127.0.0.1", "localhost");
   public static final int DEFAULT_IDLE_TIMEOUT_SECONDS = 60;
   public static final int DEFAULT_METRICS_PUBLICATION_INTERVAL = 60;
-  public static final boolean DEFAULT_BLOCK_PERFORMANCE_ENABLED = false;
+  public static final boolean DEFAULT_BLOCK_PERFORMANCE_ENABLED = true;
   public static final boolean DEFAULT_TICK_PERFORMANCE_ENABLED = false;
 
   private final boolean metricsEnabled;

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/MetricsOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/MetricsOptions.java
@@ -90,8 +90,10 @@ public class MetricsOptions {
   private int metricsPublicationInterval = MetricsConfig.DEFAULT_METRICS_PUBLICATION_INTERVAL;
 
   @Option(
-      names = {"--Xmetrics-block-timing-tracking-enabled"},
-      hidden = true,
+      names = {
+        "--metrics-block-timing-tracking-enabled",
+        "--Xmetrics-block-timing-tracking-enabled"
+      },
       showDefaultValue = Visibility.ALWAYS,
       paramLabel = "<BOOLEAN>",
       description = "Whether block timing metrics are tracked and reported",

--- a/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
@@ -148,6 +148,9 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
 
     beaconNodeCommand.parse(args);
     String str = getCommandLineOutput();
+    // --Xmetrics-block-timing-tracking-enabled is being supported as an alias for the supported
+    // version because of the significant number of people using it
+    str = str.replace("--Xmetrics-block-timing-tracking-enabled", "");
     assertThat(str).doesNotContain("--X");
   }
 


### PR DESCRIPTION
## PR Description
Enables block timing metrics by default and unhides the option to enable/disable it. The `--X` version is still supported as an alias because there's quite a few people using it.

## Fixed Issue(s)
fixes #6300 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
