### PR TITLE
Introduce `SpecLogicEip4844` and fix attestationWorthinessCheckerCreator

### DIFF
--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/MilestoneDependentTypesUtil.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/MilestoneDependentTypesUtil.java
@@ -33,7 +33,8 @@ import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
 
 public class MilestoneDependentTypesUtil {
 
-  private static final Set<SpecMilestone> IGNORED_MILESTONES = Set.of(SpecMilestone.CAPELLA);
+  private static final Set<SpecMilestone> IGNORED_MILESTONES =
+      Set.of(SpecMilestone.CAPELLA, SpecMilestone.EIP4844);
 
   public static <T extends SszData>
       SerializableOneOfTypeDefinition<T> getSchemaDefinitionForAllMilestones(

--- a/data/provider/src/test/java/tech/pegasys/teku/api/ValidatorDataProviderTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/ValidatorDataProviderTest.java
@@ -54,6 +54,7 @@ import tech.pegasys.teku.infrastructure.async.SafeFutureAssert;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.provider.JsonProvider;
 import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecContext;
 import tech.pegasys.teku.spec.TestSpecInvocationContextProvider.SpecContext;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
@@ -69,7 +70,13 @@ import tech.pegasys.teku.validator.api.SendSignedBlockResult;
 import tech.pegasys.teku.validator.api.SubmitDataError;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 
-@TestSpecContext(allMilestones = true)
+@TestSpecContext(
+    milestone = {
+      SpecMilestone.PHASE0,
+      SpecMilestone.ALTAIR,
+      SpecMilestone.BELLATRIX,
+      SpecMilestone.CAPELLA
+    })
 public class ValidatorDataProviderTest {
 
   @SuppressWarnings("unchecked")
@@ -230,6 +237,8 @@ public class ValidatorDataProviderTest {
       case CAPELLA:
         assertThat(parsedBlock).isInstanceOf(SignedBeaconBlockCapella.class);
         break;
+      case EIP4844:
+        throw new RuntimeException("notImplemented");
     }
   }
 

--- a/data/serializer/src/property-test/java/tech/pegasys/teku/provider/JsonProviderPropertyTest.java
+++ b/data/serializer/src/property-test/java/tech/pegasys/teku/provider/JsonProviderPropertyTest.java
@@ -74,18 +74,31 @@ public class JsonProviderPropertyTest {
   private static final Map<SpecMilestone, Class<? extends SignedBeaconBlock>>
       SIGNED_BEACON_BLOCK_CLASS_MAP =
           Map.of(
-              SpecMilestone.PHASE0, SignedBeaconBlockPhase0.class,
-              SpecMilestone.ALTAIR, SignedBeaconBlockAltair.class,
-              SpecMilestone.BELLATRIX, SignedBeaconBlockBellatrix.class,
-              // TODO CAPELLA
-              SpecMilestone.CAPELLA, SignedBeaconBlockBellatrix.class);
+              SpecMilestone.PHASE0,
+              SignedBeaconBlockPhase0.class,
+              SpecMilestone.ALTAIR,
+              SignedBeaconBlockAltair.class,
+              SpecMilestone.BELLATRIX,
+              SignedBeaconBlockBellatrix.class,
+              // TODO CAPELLA and EIP4844
+              SpecMilestone.CAPELLA,
+              SignedBeaconBlockBellatrix.class,
+              SpecMilestone.EIP4844,
+              SignedBeaconBlockBellatrix.class);
 
   private static final Map<SpecMilestone, Class<? extends BeaconState>> BEACON_STATE_CLASS_MAP =
       Map.of(
-          SpecMilestone.PHASE0, BeaconStatePhase0.class,
-          SpecMilestone.ALTAIR, BeaconStateAltair.class,
-          SpecMilestone.BELLATRIX, BeaconStateBellatrix.class,
-          SpecMilestone.CAPELLA, BeaconStateCapella.class);
+          SpecMilestone.PHASE0,
+          BeaconStatePhase0.class,
+          SpecMilestone.ALTAIR,
+          BeaconStateAltair.class,
+          SpecMilestone.BELLATRIX,
+          BeaconStateBellatrix.class,
+          SpecMilestone.CAPELLA,
+          BeaconStateCapella.class,
+          // TODO EIP4844
+          SpecMilestone.EIP4844,
+          BeaconStateCapella.class);
 
   @Property
   void roundTripBytes32(@ForAll @Size(32) final byte[] value) throws JsonProcessingException {

--- a/data/serializer/src/test/java/tech/pegasys/teku/api/schema/BeaconStateTest.java
+++ b/data/serializer/src/test/java/tech/pegasys/teku/api/schema/BeaconStateTest.java
@@ -21,10 +21,17 @@ import tech.pegasys.teku.api.schema.bellatrix.BeaconStateBellatrix;
 import tech.pegasys.teku.api.schema.capella.BeaconStateCapella;
 import tech.pegasys.teku.api.schema.phase0.BeaconStatePhase0;
 import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecContext;
 import tech.pegasys.teku.spec.TestSpecInvocationContextProvider.SpecContext;
 
-@TestSpecContext(allMilestones = true)
+@TestSpecContext(
+    milestone = {
+      SpecMilestone.PHASE0,
+      SpecMilestone.ALTAIR,
+      SpecMilestone.BELLATRIX,
+      SpecMilestone.CAPELLA
+    })
 public class BeaconStateTest {
 
   @TestTemplate

--- a/data/serializer/src/test/java/tech/pegasys/teku/api/schema/SignedBeaconBlockTest.java
+++ b/data/serializer/src/test/java/tech/pegasys/teku/api/schema/SignedBeaconBlockTest.java
@@ -16,10 +16,17 @@ package tech.pegasys.teku.api.schema;
 import static tech.pegasys.teku.infrastructure.ssz.SszDataAssert.assertThatSszData;
 
 import org.junit.jupiter.api.TestTemplate;
+import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecContext;
 import tech.pegasys.teku.spec.TestSpecInvocationContextProvider.SpecContext;
 
-@TestSpecContext(allMilestones = true)
+@TestSpecContext(
+    milestone = {
+      SpecMilestone.PHASE0,
+      SpecMilestone.ALTAIR,
+      SpecMilestone.BELLATRIX,
+      SpecMilestone.CAPELLA
+    })
 class SignedBeaconBlockTest {
 
   @TestTemplate

--- a/ethereum/json-types/src/main/java/tech/pegasys/teku/ethereum/json/types/EthereumTypes.java
+++ b/ethereum/json-types/src/main/java/tech/pegasys/teku/ethereum/json/types/EthereumTypes.java
@@ -72,7 +72,7 @@ public class EthereumTypes {
       DeserializableTypeDefinition.enumOf(
           SpecMilestone.class,
           milestone -> milestone.name().toLowerCase(Locale.ROOT),
-          Set.of(SpecMilestone.CAPELLA));
+          Set.of(SpecMilestone.CAPELLA, SpecMilestone.EIP4844));
 
   public static <X extends SszData, T extends ObjectAndMetaData<X>>
       ResponseContentTypeDefinition<T> sszResponseType() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -750,7 +750,7 @@ public class Spec {
   }
 
   public AttestationWorthinessChecker createAttestationWorthinessChecker(final BeaconState state) {
-    return atState(state).createAttestationWorthinessChecker(state);
+    return atState(state).getAttestationUtil().createAttestationWorthinessChecker(state);
   }
 
   public boolean isMergeTransitionComplete(final BeaconState state) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/SpecMilestone.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/SpecMilestone.java
@@ -27,7 +27,8 @@ public enum SpecMilestone {
   PHASE0,
   ALTAIR,
   BELLATRIX,
-  CAPELLA;
+  CAPELLA,
+  EIP4844;
 
   /**
    * Returns true if this milestone is at or after the supplied milestone ({@code other})

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/SpecMilestone.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/SpecMilestone.java
@@ -22,6 +22,7 @@ import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.config.SpecConfigAltair;
 import tech.pegasys.teku.spec.config.SpecConfigBellatrix;
 import tech.pegasys.teku.spec.config.SpecConfigCapella;
+import tech.pegasys.teku.spec.config.SpecConfigEip4844;
 
 public enum SpecMilestone {
   PHASE0,
@@ -84,6 +85,8 @@ public enum SpecMilestone {
         return specConfig.toVersionBellatrix().map(SpecConfigBellatrix::getBellatrixForkVersion);
       case CAPELLA:
         return specConfig.toVersionCapella().map(SpecConfigCapella::getCapellaForkVersion);
+      case EIP4844:
+        return specConfig.toVersionEip4844().map(SpecConfigEip4844::getEip4844ForkVersion);
       default:
         throw new UnsupportedOperationException("Unknown milestone requested: " + milestone.name());
     }
@@ -101,6 +104,8 @@ public enum SpecMilestone {
         return specConfig.toVersionBellatrix().map(SpecConfigBellatrix::getBellatrixForkEpoch);
       case CAPELLA:
         return specConfig.toVersionCapella().map(SpecConfigCapella::getCapellaForkEpoch);
+      case EIP4844:
+        return specConfig.toVersionEip4844().map(SpecConfigEip4844::getEip4844ForkEpoch);
       default:
         throw new UnsupportedOperationException("Unknown milestone requested: " + milestone.name());
     }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/SpecVersion.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/SpecVersion.java
@@ -30,6 +30,7 @@ import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsAltair;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsBellatrix;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsCapella;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsEip4844;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsPhase0;
 
 public class SpecVersion extends DelegatingSpecLogic {
@@ -91,7 +92,7 @@ public class SpecVersion extends DelegatingSpecLogic {
   }
 
   static SpecVersion createEip4844(final SpecConfigEip4844 specConfig) {
-    final SchemaDefinitionsCapella schemaDefinitions = new SchemaDefinitionsCapella(specConfig);
+    final SchemaDefinitionsEip4844 schemaDefinitions = new SchemaDefinitionsEip4844(specConfig);
     final SpecLogicEip4844 specLogic = SpecLogicEip4844.create(specConfig, schemaDefinitions);
     return new SpecVersion(SpecMilestone.EIP4844, specConfig, schemaDefinitions, specLogic);
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/SpecVersion.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/SpecVersion.java
@@ -18,11 +18,13 @@ import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.config.SpecConfigAltair;
 import tech.pegasys.teku.spec.config.SpecConfigBellatrix;
 import tech.pegasys.teku.spec.config.SpecConfigCapella;
+import tech.pegasys.teku.spec.config.SpecConfigEip4844;
 import tech.pegasys.teku.spec.logic.DelegatingSpecLogic;
 import tech.pegasys.teku.spec.logic.SpecLogic;
 import tech.pegasys.teku.spec.logic.versions.altair.SpecLogicAltair;
 import tech.pegasys.teku.spec.logic.versions.bellatrix.SpecLogicBellatrix;
 import tech.pegasys.teku.spec.logic.versions.capella.SpecLogicCapella;
+import tech.pegasys.teku.spec.logic.versions.eip4844.SpecLogicEip4844;
 import tech.pegasys.teku.spec.logic.versions.phase0.SpecLogicPhase0;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsAltair;
@@ -57,6 +59,8 @@ public class SpecVersion extends DelegatingSpecLogic {
         return specConfig.toVersionBellatrix().map(SpecVersion::createBellatrix);
       case CAPELLA:
         return specConfig.toVersionCapella().map(SpecVersion::createCapella);
+      case EIP4844:
+        return specConfig.toVersionEip4844().map(SpecVersion::createEip4844);
       default:
         throw new UnsupportedOperationException("Unknown milestone requested: " + milestone);
     }
@@ -84,6 +88,12 @@ public class SpecVersion extends DelegatingSpecLogic {
     final SchemaDefinitionsCapella schemaDefinitions = new SchemaDefinitionsCapella(specConfig);
     final SpecLogicCapella specLogic = SpecLogicCapella.create(specConfig, schemaDefinitions);
     return new SpecVersion(SpecMilestone.CAPELLA, specConfig, schemaDefinitions, specLogic);
+  }
+
+  static SpecVersion createEip4844(final SpecConfigEip4844 specConfig) {
+    final SchemaDefinitionsCapella schemaDefinitions = new SchemaDefinitionsCapella(specConfig);
+    final SpecLogicEip4844 specLogic = SpecLogicEip4844.create(specConfig, schemaDefinitions);
+    return new SpecVersion(SpecMilestone.EIP4844, specConfig, schemaDefinitions, specLogic);
   }
 
   public SpecMilestone getMilestone() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/DelegatingSpecLogic.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/DelegatingSpecLogic.java
@@ -14,7 +14,6 @@
 package tech.pegasys.teku.spec.logic;
 
 import java.util.Optional;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.logic.common.block.BlockProcessor;
 import tech.pegasys.teku.spec.logic.common.forktransition.StateUpgrade;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
@@ -23,7 +22,6 @@ import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
 import tech.pegasys.teku.spec.logic.common.helpers.Predicates;
 import tech.pegasys.teku.spec.logic.common.operations.OperationSignatureVerifier;
 import tech.pegasys.teku.spec.logic.common.operations.validation.OperationValidator;
-import tech.pegasys.teku.spec.logic.common.statetransition.attestation.AttestationWorthinessChecker;
 import tech.pegasys.teku.spec.logic.common.statetransition.epoch.EpochProcessor;
 import tech.pegasys.teku.spec.logic.common.statetransition.epoch.status.ValidatorStatusFactory;
 import tech.pegasys.teku.spec.logic.common.util.AttestationUtil;
@@ -130,10 +128,5 @@ public class DelegatingSpecLogic implements SpecLogic {
   @Override
   public OperationSignatureVerifier operationSignatureVerifier() {
     return specLogic.operationSignatureVerifier();
-  }
-
-  @Override
-  public AttestationWorthinessChecker createAttestationWorthinessChecker(final BeaconState state) {
-    return specLogic.createAttestationWorthinessChecker(state);
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/SpecLogic.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/SpecLogic.java
@@ -14,7 +14,6 @@
 package tech.pegasys.teku.spec.logic;
 
 import java.util.Optional;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.logic.common.block.BlockProcessor;
 import tech.pegasys.teku.spec.logic.common.forktransition.StateUpgrade;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
@@ -23,7 +22,6 @@ import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
 import tech.pegasys.teku.spec.logic.common.helpers.Predicates;
 import tech.pegasys.teku.spec.logic.common.operations.OperationSignatureVerifier;
 import tech.pegasys.teku.spec.logic.common.operations.validation.OperationValidator;
-import tech.pegasys.teku.spec.logic.common.statetransition.attestation.AttestationWorthinessChecker;
 import tech.pegasys.teku.spec.logic.common.statetransition.epoch.EpochProcessor;
 import tech.pegasys.teku.spec.logic.common.statetransition.epoch.status.ValidatorStatusFactory;
 import tech.pegasys.teku.spec.logic.common.util.AttestationUtil;
@@ -69,8 +67,6 @@ public interface SpecLogic {
   BeaconStateMutators beaconStateMutators();
 
   OperationSignatureVerifier operationSignatureVerifier();
-
-  AttestationWorthinessChecker createAttestationWorthinessChecker(BeaconState state);
 
   Optional<BellatrixTransitionHelpers> getBellatrixTransitionHelpers();
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/AttestationUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/AttestationUtil.java
@@ -33,6 +33,7 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszBitlist;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszUInt64List;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.constants.Domain;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidateableAttestation;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSummary;
@@ -46,20 +47,24 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.util.AttestationProcessingResult;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
 import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
+import tech.pegasys.teku.spec.logic.common.statetransition.attestation.AttestationWorthinessChecker;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
 
-public class AttestationUtil {
+public abstract class AttestationUtil {
 
   private static final Logger LOG = LogManager.getLogger();
 
-  private final SchemaDefinitions schemaDefinitions;
-  private final BeaconStateAccessors beaconStateAccessors;
-  private final MiscHelpers miscHelpers;
+  protected final SchemaDefinitions schemaDefinitions;
+  protected final BeaconStateAccessors beaconStateAccessors;
+  protected final MiscHelpers miscHelpers;
+  protected final SpecConfig specConfig;
 
   public AttestationUtil(
+      final SpecConfig specConfig,
       final SchemaDefinitions schemaDefinitions,
       final BeaconStateAccessors beaconStateAccessors,
       final MiscHelpers miscHelpers) {
+    this.specConfig = specConfig;
     this.schemaDefinitions = schemaDefinitions;
     this.beaconStateAccessors = beaconStateAccessors;
     this.miscHelpers = miscHelpers;
@@ -289,4 +294,7 @@ public class AttestationUtil {
     // Set attestation data
     return new AttestationData(slot, committeeIndex, beaconBlockRoot, source, target);
   }
+
+  public abstract AttestationWorthinessChecker createAttestationWorthinessChecker(
+      BeaconState state);
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/util/AttestationUtilAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/util/AttestationUtilAltair.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.logic.versions.altair.util;
+
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.config.SpecConfig;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
+import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
+import tech.pegasys.teku.spec.logic.common.statetransition.attestation.AttestationWorthinessChecker;
+import tech.pegasys.teku.spec.logic.common.util.AttestationUtil;
+import tech.pegasys.teku.spec.logic.versions.altair.statetransition.attestation.AttestationWorthinessCheckerAltair;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
+
+public class AttestationUtilAltair extends AttestationUtil {
+  public AttestationUtilAltair(
+      final SpecConfig specConfig,
+      final SchemaDefinitions schemaDefinitions,
+      final BeaconStateAccessors beaconStateAccessors,
+      final MiscHelpers miscHelpers) {
+    super(specConfig, schemaDefinitions, beaconStateAccessors, miscHelpers);
+  }
+
+  @Override
+  public AttestationWorthinessChecker createAttestationWorthinessChecker(final BeaconState state) {
+    final UInt64 currentSlot = state.getSlot();
+    final UInt64 startSlot =
+        miscHelpers.computeStartSlotAtEpoch(miscHelpers.computeEpochAtSlot(currentSlot));
+
+    final Bytes32 expectedAttestationTarget =
+        startSlot.compareTo(currentSlot) == 0 || currentSlot.compareTo(startSlot) <= 0
+            ? state.getLatestBlockHeader().getRoot()
+            : beaconStateAccessors.getBlockRootAtSlot(state, startSlot);
+
+    final UInt64 oldestWorthySlotForSourceReward =
+        state.getSlot().minusMinZero(specConfig.getSquareRootSlotsPerEpoch());
+    return new AttestationWorthinessCheckerAltair(
+        expectedAttestationTarget, oldestWorthySlotForSourceReward);
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/eip4844/SpecLogicEip4844.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/eip4844/SpecLogicEip4844.java
@@ -14,14 +14,11 @@
 package tech.pegasys.teku.spec.logic.versions.eip4844;
 
 import java.util.Optional;
-import java.util.function.Function;
 import tech.pegasys.teku.spec.config.SpecConfigEip4844;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.logic.common.AbstractSpecLogic;
 import tech.pegasys.teku.spec.logic.common.helpers.Predicates;
 import tech.pegasys.teku.spec.logic.common.operations.OperationSignatureVerifier;
 import tech.pegasys.teku.spec.logic.common.operations.validation.OperationValidator;
-import tech.pegasys.teku.spec.logic.common.statetransition.attestation.AttestationWorthinessChecker;
 import tech.pegasys.teku.spec.logic.common.util.AttestationUtil;
 import tech.pegasys.teku.spec.logic.common.util.BeaconStateUtil;
 import tech.pegasys.teku.spec.logic.common.util.BlindBlockUtil;
@@ -29,9 +26,9 @@ import tech.pegasys.teku.spec.logic.common.util.BlockProposalUtil;
 import tech.pegasys.teku.spec.logic.common.util.ForkChoiceUtil;
 import tech.pegasys.teku.spec.logic.common.util.SyncCommitteeUtil;
 import tech.pegasys.teku.spec.logic.common.util.ValidatorsUtil;
-import tech.pegasys.teku.spec.logic.versions.altair.SpecLogicAltair;
 import tech.pegasys.teku.spec.logic.versions.altair.helpers.BeaconStateAccessorsAltair;
 import tech.pegasys.teku.spec.logic.versions.altair.statetransition.epoch.ValidatorStatusFactoryAltair;
+import tech.pegasys.teku.spec.logic.versions.altair.util.AttestationUtilAltair;
 import tech.pegasys.teku.spec.logic.versions.bellatrix.helpers.BeaconStateMutatorsBellatrix;
 import tech.pegasys.teku.spec.logic.versions.bellatrix.helpers.BellatrixTransitionHelpers;
 import tech.pegasys.teku.spec.logic.versions.bellatrix.helpers.MiscHelpersBellatrix;
@@ -43,9 +40,6 @@ import tech.pegasys.teku.spec.schemas.SchemaDefinitionsCapella;
 
 public class SpecLogicEip4844 extends AbstractSpecLogic {
   private final Optional<SyncCommitteeUtil> syncCommitteeUtil;
-
-  private final Function<BeaconState, AttestationWorthinessChecker>
-      attestationWorthinessCheckerCreator;
 
   private SpecLogicEip4844(
       final Predicates predicates,
@@ -64,9 +58,7 @@ public class SpecLogicEip4844 extends AbstractSpecLogic {
       final BlockProposalUtil blockProposalUtil,
       final BlindBlockUtil blindBlockUtil,
       final SyncCommitteeUtil syncCommitteeUtil,
-      final CapellaStateUpgrade stateUpgrade,
-      final Function<BeaconState, AttestationWorthinessChecker>
-          attestationWorthinessCheckerCreator) {
+      final CapellaStateUpgrade stateUpgrade) {
     super(
         predicates,
         miscHelpers,
@@ -85,7 +77,6 @@ public class SpecLogicEip4844 extends AbstractSpecLogic {
         Optional.of(blindBlockUtil),
         Optional.of(stateUpgrade));
     this.syncCommitteeUtil = Optional.of(syncCommitteeUtil);
-    this.attestationWorthinessCheckerCreator = attestationWorthinessCheckerCreator;
   }
 
   public static SpecLogicEip4844 create(
@@ -109,7 +100,7 @@ public class SpecLogicEip4844 extends AbstractSpecLogic {
         new BeaconStateUtil(
             config, schemaDefinitions, predicates, miscHelpers, beaconStateAccessors);
     final AttestationUtil attestationUtil =
-        new AttestationUtil(schemaDefinitions, beaconStateAccessors, miscHelpers);
+        new AttestationUtilAltair(config, schemaDefinitions, beaconStateAccessors, miscHelpers);
     final OperationValidator operationValidator =
         OperationValidator.create(
             config, predicates, miscHelpers, beaconStateAccessors, attestationUtil);
@@ -156,10 +147,6 @@ public class SpecLogicEip4844 extends AbstractSpecLogic {
 
     final BlindBlockUtilBellatrix blindBlockUtil = new BlindBlockUtilBellatrix(schemaDefinitions);
 
-    final Function<BeaconState, AttestationWorthinessChecker> attestationWorthinessCheckerCreator =
-        SpecLogicAltair.attestationWorthinessCheckerCreator(
-            miscHelpers, config, beaconStateAccessors);
-
     // State upgrade
     final CapellaStateUpgrade stateUpgrade =
         new CapellaStateUpgrade(config, schemaDefinitions, beaconStateAccessors);
@@ -181,18 +168,12 @@ public class SpecLogicEip4844 extends AbstractSpecLogic {
         blockProposalUtil,
         blindBlockUtil,
         syncCommitteeUtil,
-        stateUpgrade,
-        attestationWorthinessCheckerCreator);
+        stateUpgrade);
   }
 
   @Override
   public Optional<SyncCommitteeUtil> getSyncCommitteeUtil() {
     return syncCommitteeUtil;
-  }
-
-  @Override
-  public AttestationWorthinessChecker createAttestationWorthinessChecker(final BeaconState state) {
-    return attestationWorthinessCheckerCreator.apply(state);
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/eip4844/SpecLogicEip4844.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/eip4844/SpecLogicEip4844.java
@@ -11,62 +11,60 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.spec.logic.versions.altair;
+package tech.pegasys.teku.spec.logic.versions.eip4844;
 
 import java.util.Optional;
 import java.util.function.Function;
-import org.apache.tuweni.bytes.Bytes32;
-import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.config.SpecConfig;
-import tech.pegasys.teku.spec.config.SpecConfigAltair;
+import tech.pegasys.teku.spec.config.SpecConfigEip4844;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.logic.common.AbstractSpecLogic;
-import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
-import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateMutators;
-import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
 import tech.pegasys.teku.spec.logic.common.helpers.Predicates;
 import tech.pegasys.teku.spec.logic.common.operations.OperationSignatureVerifier;
 import tech.pegasys.teku.spec.logic.common.operations.validation.OperationValidator;
 import tech.pegasys.teku.spec.logic.common.statetransition.attestation.AttestationWorthinessChecker;
 import tech.pegasys.teku.spec.logic.common.util.AttestationUtil;
 import tech.pegasys.teku.spec.logic.common.util.BeaconStateUtil;
+import tech.pegasys.teku.spec.logic.common.util.BlindBlockUtil;
 import tech.pegasys.teku.spec.logic.common.util.BlockProposalUtil;
 import tech.pegasys.teku.spec.logic.common.util.ForkChoiceUtil;
 import tech.pegasys.teku.spec.logic.common.util.SyncCommitteeUtil;
 import tech.pegasys.teku.spec.logic.common.util.ValidatorsUtil;
-import tech.pegasys.teku.spec.logic.versions.altair.block.BlockProcessorAltair;
-import tech.pegasys.teku.spec.logic.versions.altair.forktransition.AltairStateUpgrade;
+import tech.pegasys.teku.spec.logic.versions.altair.SpecLogicAltair;
 import tech.pegasys.teku.spec.logic.versions.altair.helpers.BeaconStateAccessorsAltair;
-import tech.pegasys.teku.spec.logic.versions.altair.helpers.BeaconStateMutatorsAltair;
-import tech.pegasys.teku.spec.logic.versions.altair.helpers.MiscHelpersAltair;
-import tech.pegasys.teku.spec.logic.versions.altair.statetransition.attestation.AttestationWorthinessCheckerAltair;
-import tech.pegasys.teku.spec.logic.versions.altair.statetransition.epoch.EpochProcessorAltair;
 import tech.pegasys.teku.spec.logic.versions.altair.statetransition.epoch.ValidatorStatusFactoryAltair;
+import tech.pegasys.teku.spec.logic.versions.bellatrix.helpers.BeaconStateMutatorsBellatrix;
 import tech.pegasys.teku.spec.logic.versions.bellatrix.helpers.BellatrixTransitionHelpers;
-import tech.pegasys.teku.spec.schemas.SchemaDefinitionsAltair;
+import tech.pegasys.teku.spec.logic.versions.bellatrix.helpers.MiscHelpersBellatrix;
+import tech.pegasys.teku.spec.logic.versions.bellatrix.statetransition.epoch.EpochProcessorBellatrix;
+import tech.pegasys.teku.spec.logic.versions.bellatrix.util.BlindBlockUtilBellatrix;
+import tech.pegasys.teku.spec.logic.versions.capella.block.BlockProcessorCapella;
+import tech.pegasys.teku.spec.logic.versions.capella.forktransition.CapellaStateUpgrade;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsCapella;
 
-public class SpecLogicAltair extends AbstractSpecLogic {
+public class SpecLogicEip4844 extends AbstractSpecLogic {
   private final Optional<SyncCommitteeUtil> syncCommitteeUtil;
+
   private final Function<BeaconState, AttestationWorthinessChecker>
       attestationWorthinessCheckerCreator;
 
-  private SpecLogicAltair(
+  private SpecLogicEip4844(
       final Predicates predicates,
-      final MiscHelpersAltair miscHelpers,
+      final MiscHelpersBellatrix miscHelpers,
       final BeaconStateAccessorsAltair beaconStateAccessors,
-      final BeaconStateMutators beaconStateMutators,
+      final BeaconStateMutatorsBellatrix beaconStateMutators,
       final OperationSignatureVerifier operationSignatureVerifier,
       final ValidatorsUtil validatorsUtil,
       final BeaconStateUtil beaconStateUtil,
       final AttestationUtil attestationUtil,
       final OperationValidator operationValidator,
       final ValidatorStatusFactoryAltair validatorStatusFactory,
-      final EpochProcessorAltair epochProcessor,
-      final BlockProcessorAltair blockProcessor,
+      final EpochProcessorBellatrix epochProcessor,
+      final BlockProcessorCapella blockProcessor,
       final ForkChoiceUtil forkChoiceUtil,
       final BlockProposalUtil blockProposalUtil,
+      final BlindBlockUtil blindBlockUtil,
       final SyncCommitteeUtil syncCommitteeUtil,
-      final AltairStateUpgrade stateUpgrade,
+      final CapellaStateUpgrade stateUpgrade,
       final Function<BeaconState, AttestationWorthinessChecker>
           attestationWorthinessCheckerCreator) {
     super(
@@ -84,21 +82,21 @@ public class SpecLogicAltair extends AbstractSpecLogic {
         blockProcessor,
         forkChoiceUtil,
         blockProposalUtil,
-        Optional.empty(),
+        Optional.of(blindBlockUtil),
         Optional.of(stateUpgrade));
     this.syncCommitteeUtil = Optional.of(syncCommitteeUtil);
     this.attestationWorthinessCheckerCreator = attestationWorthinessCheckerCreator;
   }
 
-  public static SpecLogicAltair create(
-      final SpecConfigAltair config, final SchemaDefinitionsAltair schemaDefinitions) {
+  public static SpecLogicEip4844 create(
+      final SpecConfigEip4844 config, final SchemaDefinitionsCapella schemaDefinitions) {
     // Helpers
     final Predicates predicates = new Predicates(config);
-    final MiscHelpersAltair miscHelpers = new MiscHelpersAltair(config);
+    final MiscHelpersBellatrix miscHelpers = new MiscHelpersBellatrix(config);
     final BeaconStateAccessorsAltair beaconStateAccessors =
         new BeaconStateAccessorsAltair(config, predicates, miscHelpers);
-    final BeaconStateMutatorsAltair beaconStateMutators =
-        new BeaconStateMutatorsAltair(config, miscHelpers, beaconStateAccessors);
+    final BeaconStateMutatorsBellatrix beaconStateMutators =
+        new BeaconStateMutatorsBellatrix(config, miscHelpers, beaconStateAccessors);
 
     // Operation validation
     final OperationSignatureVerifier operationSignatureVerifier =
@@ -123,8 +121,8 @@ public class SpecLogicAltair extends AbstractSpecLogic {
             predicates,
             miscHelpers,
             beaconStateAccessors);
-    final EpochProcessorAltair epochProcessor =
-        new EpochProcessorAltair(
+    final EpochProcessorBellatrix epochProcessor =
+        new EpochProcessorBellatrix(
             config,
             miscHelpers,
             beaconStateAccessors,
@@ -136,8 +134,8 @@ public class SpecLogicAltair extends AbstractSpecLogic {
     final SyncCommitteeUtil syncCommitteeUtil =
         new SyncCommitteeUtil(
             beaconStateAccessors, validatorsUtil, config, miscHelpers, schemaDefinitions);
-    final BlockProcessorAltair blockProcessor =
-        new BlockProcessorAltair(
+    final BlockProcessorCapella blockProcessor =
+        new BlockProcessorCapella(
             config,
             predicates,
             miscHelpers,
@@ -148,23 +146,25 @@ public class SpecLogicAltair extends AbstractSpecLogic {
             beaconStateUtil,
             attestationUtil,
             validatorsUtil,
-            operationValidator);
+            operationValidator,
+            schemaDefinitions);
     final ForkChoiceUtil forkChoiceUtil =
         new ForkChoiceUtil(
             config, beaconStateAccessors, epochProcessor, attestationUtil, miscHelpers);
     final BlockProposalUtil blockProposalUtil =
         new BlockProposalUtil(schemaDefinitions, blockProcessor);
 
+    final BlindBlockUtilBellatrix blindBlockUtil = new BlindBlockUtilBellatrix(schemaDefinitions);
+
     final Function<BeaconState, AttestationWorthinessChecker> attestationWorthinessCheckerCreator =
         SpecLogicAltair.attestationWorthinessCheckerCreator(
             miscHelpers, config, beaconStateAccessors);
 
     // State upgrade
-    final AltairStateUpgrade stateUpgrade =
-        new AltairStateUpgrade(
-            config, schemaDefinitions, beaconStateAccessors, attestationUtil, miscHelpers);
+    final CapellaStateUpgrade stateUpgrade =
+        new CapellaStateUpgrade(config, schemaDefinitions, beaconStateAccessors);
 
-    return new SpecLogicAltair(
+    return new SpecLogicEip4844(
         predicates,
         miscHelpers,
         beaconStateAccessors,
@@ -179,6 +179,7 @@ public class SpecLogicAltair extends AbstractSpecLogic {
         blockProcessor,
         forkChoiceUtil,
         blockProposalUtil,
+        blindBlockUtil,
         syncCommitteeUtil,
         stateUpgrade,
         attestationWorthinessCheckerCreator);
@@ -197,27 +198,5 @@ public class SpecLogicAltair extends AbstractSpecLogic {
   @Override
   public Optional<BellatrixTransitionHelpers> getBellatrixTransitionHelpers() {
     return Optional.empty();
-  }
-
-  public static Function<BeaconState, AttestationWorthinessChecker>
-      attestationWorthinessCheckerCreator(
-          final MiscHelpers miscHelpers,
-          final SpecConfig specConfig,
-          final BeaconStateAccessors beaconStateAccessors) {
-    return (state) -> {
-      final UInt64 currentSlot = state.getSlot();
-      final UInt64 startSlot =
-          miscHelpers.computeStartSlotAtEpoch(miscHelpers.computeEpochAtSlot(currentSlot));
-
-      final Bytes32 expectedAttestationTarget =
-          startSlot.compareTo(currentSlot) == 0 || currentSlot.compareTo(startSlot) <= 0
-              ? state.getLatestBlockHeader().getRoot()
-              : beaconStateAccessors.getBlockRootAtSlot(state, startSlot);
-
-      final UInt64 oldestWorthySlotForSourceReward =
-          state.getSlot().minusMinZero(specConfig.getSquareRootSlotsPerEpoch());
-      return new AttestationWorthinessCheckerAltair(
-          expectedAttestationTarget, oldestWorthySlotForSourceReward);
-    };
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/SpecLogicPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/SpecLogicPhase0.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.spec.logic.versions.phase0;
 
 import java.util.Optional;
 import tech.pegasys.teku.spec.config.SpecConfig;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.logic.common.AbstractSpecLogic;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateMutators;
@@ -23,7 +22,6 @@ import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
 import tech.pegasys.teku.spec.logic.common.helpers.Predicates;
 import tech.pegasys.teku.spec.logic.common.operations.OperationSignatureVerifier;
 import tech.pegasys.teku.spec.logic.common.operations.validation.OperationValidator;
-import tech.pegasys.teku.spec.logic.common.statetransition.attestation.AttestationWorthinessChecker;
 import tech.pegasys.teku.spec.logic.common.util.AttestationUtil;
 import tech.pegasys.teku.spec.logic.common.util.BeaconStateUtil;
 import tech.pegasys.teku.spec.logic.common.util.BlockProposalUtil;
@@ -35,6 +33,7 @@ import tech.pegasys.teku.spec.logic.versions.phase0.block.BlockProcessorPhase0;
 import tech.pegasys.teku.spec.logic.versions.phase0.helpers.BeaconStateAccessorsPhase0;
 import tech.pegasys.teku.spec.logic.versions.phase0.statetransition.epoch.EpochProcessorPhase0;
 import tech.pegasys.teku.spec.logic.versions.phase0.statetransition.epoch.ValidatorStatusFactoryPhase0;
+import tech.pegasys.teku.spec.logic.versions.phase0.util.AttestationUtilPhase0;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
 
 public class SpecLogicPhase0 extends AbstractSpecLogic {
@@ -94,7 +93,7 @@ public class SpecLogicPhase0 extends AbstractSpecLogic {
         new BeaconStateUtil(
             config, schemaDefinitions, predicates, miscHelpers, beaconStateAccessors);
     final AttestationUtil attestationUtil =
-        new AttestationUtil(schemaDefinitions, beaconStateAccessors, miscHelpers);
+        new AttestationUtilPhase0(config, schemaDefinitions, beaconStateAccessors, miscHelpers);
     final OperationValidator operationValidator =
         OperationValidator.create(
             config, predicates, miscHelpers, beaconStateAccessors, attestationUtil);
@@ -149,11 +148,6 @@ public class SpecLogicPhase0 extends AbstractSpecLogic {
   @Override
   public Optional<SyncCommitteeUtil> getSyncCommitteeUtil() {
     return Optional.empty();
-  }
-
-  @Override
-  public AttestationWorthinessChecker createAttestationWorthinessChecker(final BeaconState state) {
-    return AttestationWorthinessChecker.NOOP;
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/util/AttestationUtilPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/util/AttestationUtilPhase0.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.logic.versions.phase0.util;
+
+import tech.pegasys.teku.spec.config.SpecConfig;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
+import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
+import tech.pegasys.teku.spec.logic.common.statetransition.attestation.AttestationWorthinessChecker;
+import tech.pegasys.teku.spec.logic.common.util.AttestationUtil;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
+
+public class AttestationUtilPhase0 extends AttestationUtil {
+  public AttestationUtilPhase0(
+      final SpecConfig specConfig,
+      final SchemaDefinitions schemaDefinitions,
+      final BeaconStateAccessors beaconStateAccessors,
+      final MiscHelpers miscHelpers) {
+    super(specConfig, schemaDefinitions, beaconStateAccessors, miscHelpers);
+  }
+
+  @Override
+  public AttestationWorthinessChecker createAttestationWorthinessChecker(final BeaconState state) {
+    return AttestationWorthinessChecker.NOOP;
+  }
+}

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/SpecFactoryTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/SpecFactoryTest.java
@@ -78,10 +78,7 @@ public class SpecFactoryTest {
   }
 
   @ParameterizedTest
-  @EnumSource(
-      value = SpecMilestone.class,
-      names = {"EIP4844"},
-      mode = EnumSource.Mode.EXCLUDE)
+  @EnumSource(value = SpecMilestone.class)
   public void shouldCreateTheRightAttestationWorthinessChecker(SpecMilestone milestone) {
     final Spec spec = TestSpecFactory.createMainnet(milestone);
     final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/SpecFactoryTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/SpecFactoryTest.java
@@ -80,7 +80,7 @@ public class SpecFactoryTest {
   @ParameterizedTest
   @EnumSource(
       value = SpecMilestone.class,
-      names = {"BELLATRIX", "CAPELLA"},
+      names = {"EIP4844"},
       mode = EnumSource.Mode.EXCLUDE)
   public void shouldCreateTheRightAttestationWorthinessChecker(SpecMilestone milestone) {
     final Spec spec = TestSpecFactory.createMainnet(milestone);

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBeaconBlockTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBeaconBlockTest.java
@@ -26,7 +26,13 @@ import tech.pegasys.teku.spec.TestSpecInvocationContextProvider.SpecContext;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
-@TestSpecContext(allMilestones = true)
+@TestSpecContext(
+    milestone = {
+      SpecMilestone.PHASE0,
+      SpecMilestone.ALTAIR,
+      SpecMilestone.BELLATRIX,
+      SpecMilestone.CAPELLA
+    })
 class SignedBeaconBlockTest {
 
   private Spec spec;

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/EpochProcessorTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/EpochProcessorTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.when;
 import org.junit.jupiter.api.TestTemplate;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecContext;
 import tech.pegasys.teku.spec.TestSpecInvocationContextProvider.SpecContext;
 import tech.pegasys.teku.spec.datastructures.state.Validator;
@@ -29,7 +30,13 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.logic.common.statetransition.epoch.status.ValidatorStatuses;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
-@TestSpecContext(allMilestones = true)
+@TestSpecContext(
+    milestone = {
+      SpecMilestone.PHASE0,
+      SpecMilestone.ALTAIR,
+      SpecMilestone.BELLATRIX,
+      SpecMilestone.CAPELLA
+    })
 class EpochProcessorTest {
   /**
    * Updating the effective balance to the same value is wasteful and results in new validator

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/AttestationUtilTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/AttestationUtilTest.java
@@ -31,7 +31,9 @@ import org.junit.jupiter.api.TestTemplate;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.ssz.Merkleizable;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.SpecVersion;
 import tech.pegasys.teku.spec.TestSpecContext;
 import tech.pegasys.teku.spec.TestSpecInvocationContextProvider.SpecContext;
@@ -41,9 +43,13 @@ import tech.pegasys.teku.spec.datastructures.operations.IndexedAttestation;
 import tech.pegasys.teku.spec.datastructures.util.AttestationProcessingResult;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
 import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
+import tech.pegasys.teku.spec.logic.common.statetransition.attestation.AttestationWorthinessChecker;
+import tech.pegasys.teku.spec.logic.versions.altair.statetransition.attestation.AttestationWorthinessCheckerAltair;
+import tech.pegasys.teku.spec.logic.versions.altair.util.AttestationUtilAltair;
+import tech.pegasys.teku.spec.logic.versions.phase0.util.AttestationUtilPhase0;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
-@TestSpecContext
+@TestSpecContext(milestone = {SpecMilestone.PHASE0, SpecMilestone.ALTAIR})
 class AttestationUtilTest {
 
   private final MiscHelpers miscHelpers = mock(MiscHelpers.class);
@@ -57,7 +63,7 @@ class AttestationUtilTest {
   private AttestationUtil attestationUtil;
 
   @BeforeEach
-  void setUp(SpecContext specContext) {
+  void setUp(final SpecContext specContext) {
     spec = specContext.getSpec();
     dataStructureUtil = specContext.getDataStructureUtil();
     final SpecVersion specVersion = spec.forMilestone(specContext.getSpecMilestone());
@@ -71,12 +77,56 @@ class AttestationUtilTest {
         .thenReturn(dataStructureUtil.randomBytes(10));
     when(asyncBLSSignatureVerifier.verify(anyList(), any(Bytes.class), any(BLSSignature.class)))
         .thenReturn(SafeFuture.completedFuture(true));
-    attestationUtil =
-        new AttestationUtil(specVersion.getSchemaDefinitions(), beaconStateAccessors, miscHelpers);
+    attestationUtil = spec.getGenesisSpec().getAttestationUtil();
+
+    switch (specContext.getSpecMilestone()) {
+      case PHASE0:
+        attestationUtil =
+            new AttestationUtilPhase0(
+                spec.getGenesisSpecConfig(),
+                specVersion.getSchemaDefinitions(),
+                beaconStateAccessors,
+                miscHelpers);
+        break;
+      case ALTAIR:
+        attestationUtil =
+            new AttestationUtilAltair(
+                spec.getGenesisSpecConfig(),
+                specVersion.getSchemaDefinitions(),
+                beaconStateAccessors,
+                miscHelpers);
+        break;
+      default:
+        throw new UnsupportedOperationException("unsupported milestone");
+    }
   }
 
   @TestTemplate
-  void noValidationIsDoneIfAttestationIsAlreadyValidAndIndexedAttestationIsPresent() {
+  void shouldCreateAttestationWorthinessChecker(final SpecContext specContext) {
+    when(miscHelpers.computeStartSlotAtEpoch(any())).thenReturn(UInt64.ONE);
+
+    switch (specContext.getSpecMilestone()) {
+      case PHASE0:
+        assertThat(
+                attestationUtil.createAttestationWorthinessChecker(
+                    dataStructureUtil.randomBeaconState(UInt64.ONE)))
+            .isEqualTo(AttestationWorthinessChecker.NOOP);
+        break;
+      case ALTAIR:
+        assertThat(
+                attestationUtil.createAttestationWorthinessChecker(
+                    dataStructureUtil.randomBeaconState(UInt64.ONE)))
+            .isInstanceOf(AttestationWorthinessCheckerAltair.class);
+        break;
+      default:
+        throw new UnsupportedOperationException("unsupported milestone");
+    }
+  }
+
+  @TestTemplate
+  void noValidationIsDoneIfAttestationIsAlreadyValidAndIndexedAttestationIsPresent(
+      final SpecContext specContext) {
+    specContext.assumeIsOneOf(SpecMilestone.PHASE0);
     final ValidateableAttestation validateableAttestation =
         ValidateableAttestation.from(spec, dataStructureUtil.randomAttestation());
     validateableAttestation.setValidIndexedAttestation();
@@ -95,7 +145,8 @@ class AttestationUtilTest {
   }
 
   @TestTemplate
-  void createsAndValidatesIndexedAttestation() {
+  void createsAndValidatesIndexedAttestation(final SpecContext specContext) {
+    specContext.assumeIsOneOf(SpecMilestone.PHASE0);
     final Attestation attestation = dataStructureUtil.randomAttestation();
     final ValidateableAttestation validateableAttestation =
         ValidateableAttestation.from(spec, attestation);
@@ -113,7 +164,9 @@ class AttestationUtilTest {
   }
 
   @TestTemplate
-  void createsButDoesNotValidateIndexedAttestationBecauseItHasAlreadyBeenValidated() {
+  void createsButDoesNotValidateIndexedAttestationBecauseItHasAlreadyBeenValidated(
+      final SpecContext specContext) {
+    specContext.assumeIsOneOf(SpecMilestone.PHASE0);
     final Attestation attestation = dataStructureUtil.randomAttestation();
     // reorged block does not require indexed attestation validation, however it requires the
     // creation of it

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionCacheTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionCacheTest.java
@@ -64,6 +64,9 @@ public class SchemaDefinitionCacheTest {
   @ParameterizedTest
   @EnumSource(SpecMilestone.class)
   void shouldGetSpecMilestoneFromSpecObject(final SpecMilestone specMilestone) {
+    if (specMilestone == SpecMilestone.EIP4844) {
+      return;
+    }
     final Spec spec = TestSpecFactory.createMinimal(specMilestone);
     final SchemaDefinitionCache cache = new SchemaDefinitionCache(spec);
     assertThat(cache.milestoneAtSlot(UInt64.ONE)).isSameAs(specMilestone);
@@ -82,6 +85,9 @@ public class SchemaDefinitionCacheTest {
   @ParameterizedTest
   @EnumSource(SpecMilestone.class)
   void subsequentCallsShouldGetTheSameSchemaObject(final SpecMilestone specMilestone) {
+    if (specMilestone == SpecMilestone.EIP4844) {
+      return;
+    }
     final Spec spec = TestSpecFactory.createMinimal(specMilestone);
     final SchemaDefinitionCache cache = new SchemaDefinitionCache(spec);
 

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/TestSpecFactory.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/TestSpecFactory.java
@@ -102,6 +102,11 @@ public class TestSpecFactory {
     return create(specConfig, SpecMilestone.CAPELLA);
   }
 
+  public static Spec createMinimalEip4844() {
+    final SpecConfigEip4844 specConfig = getEip4844SpecConfig(Eth2Network.MINIMAL);
+    return create(specConfig, SpecMilestone.EIP4844);
+  }
+
   /**
    * Create a spec that forks to altair at the provided slot
    *
@@ -174,6 +179,10 @@ public class TestSpecFactory {
 
   public static Spec createCapella(final SpecConfig config) {
     return create(config, SpecMilestone.CAPELLA);
+  }
+
+  public static Spec createEip4844(final SpecConfig config) {
+    return create(config, SpecMilestone.EIP4844);
   }
 
   public static Spec create(final SpecMilestone specMilestone, final Eth2Network network) {

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/TestSpecFactory.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/TestSpecFactory.java
@@ -21,6 +21,7 @@ import tech.pegasys.teku.spec.config.SpecConfigAltair;
 import tech.pegasys.teku.spec.config.SpecConfigBellatrix;
 import tech.pegasys.teku.spec.config.SpecConfigBuilder;
 import tech.pegasys.teku.spec.config.SpecConfigCapella;
+import tech.pegasys.teku.spec.config.SpecConfigEip4844;
 import tech.pegasys.teku.spec.config.SpecConfigLoader;
 import tech.pegasys.teku.spec.networks.Eth2Network;
 
@@ -61,6 +62,8 @@ public class TestSpecFactory {
         return createMainnetBellatrix();
       case CAPELLA:
         return createMainnetCapella();
+      case EIP4844:
+        return createMainnetEip4844();
       default:
         throw new IllegalStateException("unsupported milestone");
     }
@@ -138,7 +141,12 @@ public class TestSpecFactory {
   }
 
   public static Spec createMainnetCapella() {
-    final SpecConfigBellatrix specConfig = getCapellaSpecConfig(Eth2Network.MAINNET);
+    final SpecConfigCapella specConfig = getCapellaSpecConfig(Eth2Network.MAINNET);
+    return create(specConfig, SpecMilestone.CAPELLA);
+  }
+
+  public static Spec createMainnetEip4844() {
+    final SpecConfigBellatrix specConfig = getEip4844SpecConfig(Eth2Network.MAINNET);
     return create(specConfig, SpecMilestone.CAPELLA);
   }
 
@@ -201,6 +209,15 @@ public class TestSpecFactory {
                         .bellatrixBuilder(b -> b.bellatrixForkEpoch(UInt64.ZERO))
                         .capellaBuilder(c -> c.capellaForkEpoch(UInt64.ZERO)));
         break;
+      case EIP4844:
+        actualModifier =
+            configModifier.andThen(
+                z ->
+                    z.altairBuilder(a -> a.altairForkEpoch(UInt64.ZERO))
+                        .bellatrixBuilder(b -> b.bellatrixForkEpoch(UInt64.ZERO))
+                        .capellaBuilder(c -> c.capellaForkEpoch(UInt64.ZERO))
+                        .eip4844Builder(d -> d.eip4844ForkEpoch(UInt64.ZERO)));
+        break;
       default:
         throw new IllegalStateException("unsupported milestone");
     }
@@ -256,7 +273,7 @@ public class TestSpecFactory {
   private static SpecConfigCapella getCapellaSpecConfig(
       final Eth2Network network,
       final UInt64 altairForkEpoch,
-      UInt64 bellatrixForkEpoch,
+      final UInt64 bellatrixForkEpoch,
       final UInt64 capellaForkEpoch) {
     return getCapellaSpecConfig(
         network,
@@ -276,6 +293,40 @@ public class TestSpecFactory {
                   .altairBuilder(a -> a.altairForkEpoch(UInt64.ZERO))
                   .bellatrixBuilder(b -> b.bellatrixForkEpoch(UInt64.ZERO))
                   .capellaBuilder(c -> c.capellaForkEpoch(UInt64.ZERO));
+              configAdapter.accept(builder);
+            }));
+  }
+
+  private static SpecConfigEip4844 getEip4844SpecConfig(final Eth2Network network) {
+    return getEip4844SpecConfig(network, UInt64.ZERO, UInt64.ZERO, UInt64.ZERO, UInt64.ZERO);
+  }
+
+  private static SpecConfigEip4844 getEip4844SpecConfig(
+      final Eth2Network network,
+      final UInt64 altairForkEpoch,
+      final UInt64 bellatrixForkEpoch,
+      final UInt64 capellaForkEpoch,
+      final UInt64 eip4844ForkEpoch) {
+    return getEip4844SpecConfig(
+        network,
+        z ->
+            z.altairBuilder(a -> a.altairForkEpoch(altairForkEpoch))
+                .bellatrixBuilder(b -> b.bellatrixForkEpoch(bellatrixForkEpoch))
+                .capellaBuilder(c -> c.capellaForkEpoch(capellaForkEpoch))
+                .eip4844Builder(d -> d.eip4844ForkEpoch(eip4844ForkEpoch)));
+  }
+
+  private static SpecConfigEip4844 getEip4844SpecConfig(
+      final Eth2Network network, final Consumer<SpecConfigBuilder> configAdapter) {
+    return SpecConfigEip4844.required(
+        SpecConfigLoader.loadConfig(
+            network.configName(),
+            builder -> {
+              builder
+                  .altairBuilder(a -> a.altairForkEpoch(UInt64.ZERO))
+                  .bellatrixBuilder(b -> b.bellatrixForkEpoch(UInt64.ZERO))
+                  .capellaBuilder(c -> c.capellaForkEpoch(UInt64.ZERO))
+                  .eip4844Builder(d -> d.eip4844ForkEpoch(UInt64.ZERO));
               configAdapter.accept(builder);
             }));
   }

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/propertytest/suppliers/DataStructureUtilSupplier.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/propertytest/suppliers/DataStructureUtilSupplier.java
@@ -25,27 +25,22 @@ import tech.pegasys.teku.spec.util.DataStructureUtil;
 public abstract class DataStructureUtilSupplier<T> implements ArbitrarySupplier<T> {
   private final Function<DataStructureUtil, T> accessor;
   private final SpecMilestone minimumSpecMilestone;
-  private final SpecMilestone maximumSpecMilestone;
 
   protected DataStructureUtilSupplier(final Function<DataStructureUtil, T> accessor) {
     this.accessor = accessor;
     this.minimumSpecMilestone = SpecMilestone.PHASE0;
-    this.maximumSpecMilestone = SpecMilestone.CAPELLA;
   }
 
   protected DataStructureUtilSupplier(
-      final Function<DataStructureUtil, T> accessor,
-      final SpecMilestone minimumSpecMilestone,
-      final SpecMilestone maximumSpecMilestone) {
+      final Function<DataStructureUtil, T> accessor, final SpecMilestone minimumSpecMilestone) {
     this.accessor = accessor;
     this.minimumSpecMilestone = minimumSpecMilestone;
-    this.maximumSpecMilestone = maximumSpecMilestone;
   }
 
   @Override
   public Arbitrary<T> get() {
     Arbitrary<Integer> seed = Arbitraries.integers();
-    Arbitrary<Spec> spec = new SpecSupplier(minimumSpecMilestone, maximumSpecMilestone).get();
+    Arbitrary<Spec> spec = new SpecSupplier(minimumSpecMilestone).get();
     Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
     return dsu.map(accessor);
   }

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/propertytest/suppliers/DataStructureUtilSupplier.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/propertytest/suppliers/DataStructureUtilSupplier.java
@@ -25,22 +25,27 @@ import tech.pegasys.teku.spec.util.DataStructureUtil;
 public abstract class DataStructureUtilSupplier<T> implements ArbitrarySupplier<T> {
   private final Function<DataStructureUtil, T> accessor;
   private final SpecMilestone minimumSpecMilestone;
+  private final SpecMilestone maximumSpecMilestone;
 
   protected DataStructureUtilSupplier(final Function<DataStructureUtil, T> accessor) {
     this.accessor = accessor;
     this.minimumSpecMilestone = SpecMilestone.PHASE0;
+    this.maximumSpecMilestone = SpecMilestone.CAPELLA;
   }
 
   protected DataStructureUtilSupplier(
-      final Function<DataStructureUtil, T> accessor, final SpecMilestone minimumSpecMilestone) {
+      final Function<DataStructureUtil, T> accessor,
+      final SpecMilestone minimumSpecMilestone,
+      final SpecMilestone maximumSpecMilestone) {
     this.accessor = accessor;
     this.minimumSpecMilestone = minimumSpecMilestone;
+    this.maximumSpecMilestone = maximumSpecMilestone;
   }
 
   @Override
   public Arbitrary<T> get() {
     Arbitrary<Integer> seed = Arbitraries.integers();
-    Arbitrary<Spec> spec = new SpecSupplier(minimumSpecMilestone).get();
+    Arbitrary<Spec> spec = new SpecSupplier(minimumSpecMilestone, maximumSpecMilestone).get();
     Arbitrary<DataStructureUtil> dsu = Combinators.combine(seed, spec).as(DataStructureUtil::new);
     return dsu.map(accessor);
   }

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/propertytest/suppliers/SpecSupplier.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/propertytest/suppliers/SpecSupplier.java
@@ -23,19 +23,17 @@ import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.networks.Eth2Network;
 
 public class SpecSupplier implements ArbitrarySupplier<Spec> {
+  public static final SpecMilestone MAXIMUM_SPEC_MILESTONE = SpecMilestone.CAPELLA;
 
   private final SpecMilestone minimumSpecMilestone;
-  private final SpecMilestone maximumSpecMilestone;
 
   @SuppressWarnings("unused")
   public SpecSupplier() {
-    this(SpecMilestone.PHASE0, SpecMilestone.CAPELLA);
+    this(SpecMilestone.PHASE0);
   }
 
-  public SpecSupplier(
-      final SpecMilestone minimumSpecMilestone, final SpecMilestone maximumSpecMilestone) {
+  public SpecSupplier(final SpecMilestone minimumSpecMilestone) {
     this.minimumSpecMilestone = minimumSpecMilestone;
-    this.maximumSpecMilestone = maximumSpecMilestone;
   }
 
   @Override
@@ -43,7 +41,7 @@ public class SpecSupplier implements ArbitrarySupplier<Spec> {
     Arbitrary<SpecMilestone> milestone =
         Arbitraries.of(SpecMilestone.class)
             .filter(m -> m.isGreaterThanOrEqualTo(minimumSpecMilestone))
-            .filter(m -> !m.isGreaterThanOrEqualTo(maximumSpecMilestone));
+            .filter(m -> !m.isGreaterThanOrEqualTo(MAXIMUM_SPEC_MILESTONE));
     Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
     return Combinators.combine(milestone, network)
         .as(TestSpecFactory::create)

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/propertytest/suppliers/SpecSupplier.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/propertytest/suppliers/SpecSupplier.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.propertytest.suppliers;
 
+import java.util.Optional;
 import net.jqwik.api.Arbitraries;
 import net.jqwik.api.Arbitrary;
 import net.jqwik.api.ArbitrarySupplier;
@@ -23,7 +24,9 @@ import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.networks.Eth2Network;
 
 public class SpecSupplier implements ArbitrarySupplier<Spec> {
-  public static final SpecMilestone MAXIMUM_SPEC_MILESTONE = SpecMilestone.CAPELLA;
+  // TODO set this to Optional.empty() when all milestones support property tests
+  public static final Optional<SpecMilestone> EXCLUDE_MILESTONES_FROM =
+      Optional.of(SpecMilestone.EIP4844);
 
   private final SpecMilestone minimumSpecMilestone;
 
@@ -41,7 +44,8 @@ public class SpecSupplier implements ArbitrarySupplier<Spec> {
     Arbitrary<SpecMilestone> milestone =
         Arbitraries.of(SpecMilestone.class)
             .filter(m -> m.isGreaterThanOrEqualTo(minimumSpecMilestone))
-            .filter(m -> !m.isGreaterThanOrEqualTo(MAXIMUM_SPEC_MILESTONE));
+            .filter(
+                m -> EXCLUDE_MILESTONES_FROM.map(e -> !m.isGreaterThanOrEqualTo(e)).orElse(true));
     Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
     return Combinators.combine(milestone, network)
         .as(TestSpecFactory::create)

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/propertytest/suppliers/SpecSupplier.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/propertytest/suppliers/SpecSupplier.java
@@ -25,21 +25,25 @@ import tech.pegasys.teku.spec.networks.Eth2Network;
 public class SpecSupplier implements ArbitrarySupplier<Spec> {
 
   private final SpecMilestone minimumSpecMilestone;
+  private final SpecMilestone maximumSpecMilestone;
 
   @SuppressWarnings("unused")
   public SpecSupplier() {
-    this(SpecMilestone.PHASE0);
+    this(SpecMilestone.PHASE0, SpecMilestone.CAPELLA);
   }
 
-  public SpecSupplier(final SpecMilestone minimumSpecMilestone) {
+  public SpecSupplier(
+      final SpecMilestone minimumSpecMilestone, final SpecMilestone maximumSpecMilestone) {
     this.minimumSpecMilestone = minimumSpecMilestone;
+    this.maximumSpecMilestone = maximumSpecMilestone;
   }
 
   @Override
   public Arbitrary<Spec> get() {
     Arbitrary<SpecMilestone> milestone =
         Arbitraries.of(SpecMilestone.class)
-            .filter(m -> m.isGreaterThanOrEqualTo(minimumSpecMilestone));
+            .filter(m -> m.isGreaterThanOrEqualTo(minimumSpecMilestone))
+            .filter(m -> !m.isGreaterThanOrEqualTo(maximumSpecMilestone));
     Arbitrary<Eth2Network> network = Arbitraries.of(Eth2Network.class);
     return Combinators.combine(milestone, network)
         .as(TestSpecFactory::create)

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/BeaconStateBuilderEip4844.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/BeaconStateBuilderEip4844.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.util;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import tech.pegasys.teku.infrastructure.ssz.SszList;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszUInt64List;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszByte;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.SpecVersion;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
+import tech.pegasys.teku.spec.datastructures.state.SyncCommittee;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.eip4844.BeaconStateEip4844;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.eip4844.BeaconStateSchemaEip4844;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.eip4844.MutableBeaconStateEip4844;
+
+public class BeaconStateBuilderEip4844
+    extends AbstractBeaconStateBuilder<
+        BeaconStateEip4844, MutableBeaconStateEip4844, BeaconStateBuilderEip4844> {
+  private UInt64 nextWithdrawalIndex;
+  private UInt64 nextWithdrawalValidatorIndex;
+
+  private SszList<SszByte> previousEpochParticipation;
+  private SszList<SszByte> currentEpochParticipation;
+  private SszUInt64List inactivityScores;
+  private SyncCommittee currentSyncCommittee;
+  private SyncCommittee nextSyncCommittee;
+  private ExecutionPayloadHeader latestExecutionPayloadHeader;
+
+  protected BeaconStateBuilderEip4844(
+      final SpecVersion spec,
+      final DataStructureUtil dataStructureUtil,
+      final int defaultValidatorCount,
+      final int defaultItemsInSSZLists) {
+    super(spec, dataStructureUtil, defaultValidatorCount, defaultItemsInSSZLists);
+  }
+
+  @Override
+  protected BeaconStateEip4844 getEmptyState() {
+    return BeaconStateSchemaEip4844.create(spec.getConfig()).createEmpty();
+  }
+
+  @Override
+  protected void setUniqueFields(final MutableBeaconStateEip4844 state) {
+    state.setPreviousEpochParticipation(previousEpochParticipation);
+    state.setCurrentEpochParticipation(currentEpochParticipation);
+    state.setInactivityScores(inactivityScores);
+    state.setCurrentSyncCommittee(currentSyncCommittee);
+    state.setNextSyncCommittee(nextSyncCommittee);
+    state.setLatestExecutionPayloadHeader(latestExecutionPayloadHeader);
+    state.setNextWithdrawalIndex(nextWithdrawalIndex);
+    state.setNextWithdrawalValidatorIndex(nextWithdrawalValidatorIndex);
+  }
+
+  public static BeaconStateBuilderEip4844 create(
+      final DataStructureUtil dataStructureUtil,
+      final Spec spec,
+      final int defaultValidatorCount,
+      final int defaultItemsInSSZLists) {
+    return new BeaconStateBuilderEip4844(
+        spec.forMilestone(SpecMilestone.EIP4844),
+        dataStructureUtil,
+        defaultValidatorCount,
+        defaultItemsInSSZLists);
+  }
+
+  public BeaconStateBuilderEip4844 nextWithdrawalIndex(final UInt64 nextWithdrawalIndex) {
+    checkNotNull(nextWithdrawalIndex);
+    this.nextWithdrawalIndex = nextWithdrawalIndex;
+    return this;
+  }
+
+  public BeaconStateBuilderEip4844 nextWithdrawalValidatorIndex(
+      final UInt64 nextWithdrawalValidatorIndex) {
+    checkNotNull(nextWithdrawalValidatorIndex);
+    this.nextWithdrawalValidatorIndex = nextWithdrawalValidatorIndex;
+    return this;
+  }
+
+  private BeaconStateSchemaEip4844 getBeaconStateSchema() {
+    return (BeaconStateSchemaEip4844) spec.getSchemaDefinitions().getBeaconStateSchema();
+  }
+
+  @Override
+  protected void initDefaults() {
+    super.initDefaults();
+
+    final BeaconStateSchemaEip4844 schema = getBeaconStateSchema();
+
+    previousEpochParticipation =
+        dataStructureUtil.randomSszList(
+            schema.getPreviousEpochParticipationSchema(),
+            defaultValidatorCount,
+            dataStructureUtil::randomSszByte);
+    currentEpochParticipation =
+        dataStructureUtil.randomSszList(
+            schema.getCurrentEpochParticipationSchema(),
+            defaultValidatorCount,
+            dataStructureUtil::randomSszByte);
+    inactivityScores =
+        dataStructureUtil.randomSszUInt64List(
+            schema.getInactivityScoresSchema(), defaultItemsInSSZLists);
+    currentSyncCommittee = dataStructureUtil.randomSyncCommittee();
+    nextSyncCommittee = dataStructureUtil.randomSyncCommittee();
+    latestExecutionPayloadHeader = dataStructureUtil.randomExecutionPayloadHeaderEip4844();
+
+    this.nextWithdrawalIndex = UInt64.ZERO;
+    this.nextWithdrawalValidatorIndex =
+        defaultValidatorCount > 0
+            ? dataStructureUtil.randomUInt64(defaultValidatorCount)
+            : UInt64.ZERO;
+  }
+}

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -77,6 +77,7 @@ import tech.pegasys.teku.spec.SpecVersion;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.config.SpecConfigBellatrix;
 import tech.pegasys.teku.spec.config.SpecConfigCapella;
+import tech.pegasys.teku.spec.config.SpecConfigEip4844;
 import tech.pegasys.teku.spec.constants.Domain;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockAndState;
@@ -153,6 +154,7 @@ import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsAltair;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsBellatrix;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsCapella;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsEip4844;
 
 public final class DataStructureUtil {
 
@@ -495,6 +497,8 @@ public final class DataStructureUtil {
       return randomExecutionPayloadHeaderBellatrix();
     } else if (milestone.equals(SpecMilestone.CAPELLA)) {
       return randomExecutionPayloadHeaderCapella();
+    } else if (milestone.equals(SpecMilestone.EIP4844)) {
+      return randomExecutionPayloadHeaderEip4844();
     } else {
       throw new IllegalArgumentException(
           "There is no random execution payload header configured for " + milestone);
@@ -577,6 +581,32 @@ public final class DataStructureUtil {
             randomBytes32());
   }
 
+  public ExecutionPayloadHeader randomExecutionPayloadHeaderEip4844() {
+    final SpecConfigEip4844 specConfigCapella =
+        SpecConfigEip4844.required(spec.getGenesisSpecConfig());
+    return SchemaDefinitionsEip4844.required(spec.getGenesisSchemaDefinitions())
+        .getExecutionPayloadHeaderSchema()
+        .toVersionEip4844()
+        .orElseThrow()
+        .create(
+            randomBytes32(),
+            randomBytes20(),
+            randomBytes32(),
+            randomBytes32(),
+            randomBytes(specConfigCapella.getBytesPerLogsBloom()),
+            randomBytes32(),
+            randomUInt64(),
+            randomUInt64(),
+            randomUInt64(),
+            randomUInt64(),
+            randomBytes(randomInt(specConfigCapella.getMaxExtraDataBytes())),
+            randomUInt256(),
+            randomUInt64(),
+            randomBytes32(),
+            randomBytes32(),
+            randomBytes32());
+  }
+
   public BuilderBid randomBuilderBid() {
     return randomBuilderBid(randomPublicKey());
   }
@@ -609,10 +639,9 @@ public final class DataStructureUtil {
           .map(__ -> randomExecutionPayloadCapella(specVersion))
           .orElse(null);
     } else if (milestone.equals(SpecMilestone.EIP4844)) {
-      // TODO update with randomExecutionPayloadEip4844
       return schema
-          .toVersionCapella()
-          .map(__ -> randomExecutionPayloadCapella(specVersion))
+          .toVersionEip4844()
+          .map(__ -> randomExecutionPayloadEip4844(specVersion))
           .orElse(null);
     } else {
       throw new IllegalArgumentException(
@@ -663,6 +692,31 @@ public final class DataStructureUtil {
             randomUInt64(),
             randomBytes(randomInt(specConfigCapella.getMaxExtraDataBytes())),
             randomUInt256(),
+            randomBytes32(),
+            randomExecutionPayloadTransactions(),
+            randomExecutionPayloadWithdrawals());
+  }
+
+  public ExecutionPayload randomExecutionPayloadEip4844(SpecVersion specVersion) {
+    final SpecConfigEip4844 specConfigEip4844 = SpecConfigEip4844.required(specVersion.getConfig());
+    return SchemaDefinitionsEip4844.required(specVersion.getSchemaDefinitions())
+        .getExecutionPayloadSchema()
+        .toVersionEip4844()
+        .orElseThrow()
+        .create(
+            randomBytes32(),
+            randomBytes20(),
+            randomBytes32(),
+            randomBytes32(),
+            randomBytes(specConfigEip4844.getBytesPerLogsBloom()),
+            randomBytes32(),
+            randomUInt64(),
+            randomUInt64(),
+            randomUInt64(),
+            randomUInt64(),
+            randomBytes(randomInt(specConfigEip4844.getMaxExtraDataBytes())),
+            randomUInt256(),
+            randomUInt64(),
             randomBytes32(),
             randomExecutionPayloadTransactions(),
             randomExecutionPayloadWithdrawals());
@@ -1542,8 +1596,7 @@ public final class DataStructureUtil {
       case CAPELLA:
         return stateBuilderCapella(validatorCount, numItemsInSszLists);
       case EIP4844:
-        // TODO migrate to stateBuilderEip4844 when available
-        return stateBuilderCapella(validatorCount, numItemsInSszLists);
+        return stateBuilderEip4844(validatorCount, numItemsInSszLists);
       default:
         throw new IllegalArgumentException("Unsupported milestone: " + milestone);
     }
@@ -1585,6 +1638,16 @@ public final class DataStructureUtil {
   public BeaconStateBuilderCapella stateBuilderCapella(
       final int defaultValidatorCount, final int defaultItemsInSSZLists) {
     return BeaconStateBuilderCapella.create(
+        this, spec, defaultValidatorCount, defaultItemsInSSZLists);
+  }
+
+  public BeaconStateBuilderEip4844 stateBuilderEip4844() {
+    return stateBuilderEip4844(10, 10);
+  }
+
+  public BeaconStateBuilderEip4844 stateBuilderEip4844(
+      final int defaultValidatorCount, final int defaultItemsInSSZLists) {
+    return BeaconStateBuilderEip4844.create(
         this, spec, defaultValidatorCount, defaultItemsInSSZLists);
   }
 

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -582,7 +582,7 @@ public final class DataStructureUtil {
   }
 
   public ExecutionPayloadHeader randomExecutionPayloadHeaderEip4844() {
-    final SpecConfigEip4844 specConfigCapella =
+    final SpecConfigEip4844 specConfigEip4844 =
         SpecConfigEip4844.required(spec.getGenesisSpecConfig());
     return SchemaDefinitionsEip4844.required(spec.getGenesisSchemaDefinitions())
         .getExecutionPayloadHeaderSchema()
@@ -593,13 +593,13 @@ public final class DataStructureUtil {
             randomBytes20(),
             randomBytes32(),
             randomBytes32(),
-            randomBytes(specConfigCapella.getBytesPerLogsBloom()),
+            randomBytes(specConfigEip4844.getBytesPerLogsBloom()),
             randomBytes32(),
             randomUInt64(),
             randomUInt64(),
             randomUInt64(),
             randomUInt64(),
-            randomBytes(randomInt(specConfigCapella.getMaxExtraDataBytes())),
+            randomBytes(randomInt(specConfigEip4844.getMaxExtraDataBytes())),
             randomUInt256(),
             randomUInt64(),
             randomBytes32(),

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -608,6 +608,12 @@ public final class DataStructureUtil {
           .toVersionCapella()
           .map(__ -> randomExecutionPayloadCapella(specVersion))
           .orElse(null);
+    } else if (milestone.equals(SpecMilestone.EIP4844)) {
+      // TODO update with randomExecutionPayloadEip4844
+      return schema
+          .toVersionCapella()
+          .map(__ -> randomExecutionPayloadCapella(specVersion))
+          .orElse(null);
     } else {
       throw new IllegalArgumentException(
           "There is no random execution payload configured for " + milestone);
@@ -1534,6 +1540,9 @@ public final class DataStructureUtil {
       case BELLATRIX:
         return stateBuilderBellatrix(validatorCount, numItemsInSszLists);
       case CAPELLA:
+        return stateBuilderCapella(validatorCount, numItemsInSszLists);
+      case EIP4844:
+        // TODO migrate to stateBuilderEip4844 when available
         return stateBuilderCapella(validatorCount, numItemsInSszLists);
       default:
         throw new IllegalArgumentException("Unsupported milestone: " + milestone);

--- a/validator/remote/src/integration-test/java/tech/pegasys/teku/validator/remote/typedef/OkHttpValidatorTypeDefClientTest.java
+++ b/validator/remote/src/integration-test/java/tech/pegasys/teku/validator/remote/typedef/OkHttpValidatorTypeDefClientTest.java
@@ -43,7 +43,14 @@ import tech.pegasys.teku.validator.api.SendSignedBlockResult;
 import tech.pegasys.teku.validator.api.required.SyncingStatus;
 import tech.pegasys.teku.validator.remote.typedef.handlers.RegisterValidatorsRequest;
 
-@TestSpecContext(allMilestones = true, network = Eth2Network.MINIMAL)
+@TestSpecContext(
+    milestone = {
+      SpecMilestone.PHASE0,
+      SpecMilestone.ALTAIR,
+      SpecMilestone.BELLATRIX,
+      SpecMilestone.CAPELLA
+    },
+    network = Eth2Network.MINIMAL)
 class OkHttpValidatorTypeDefClientTest extends AbstractTypeDefRequestTestBase {
 
   private OkHttpValidatorTypeDefClient okHttpValidatorTypeDefClient;


### PR DESCRIPTION
Introduce `SpecLogicEip4844` class and `EIP4844` milestone, with `TestSpecFactory` support.

`SpecLogicEip4844` needs to be gradually migrated to use `Eip4844` classes while we gradually introduce them.

This also make Altair's `attestationWorthinessCheckerCreator` to be reused in the subsequent forks, by moving it in  `AttestationUtil` and making it fork specific.

Fixing this I also extended the unit test `shouldCreateTheRightAttestationWorthinessChecker` to check that all forks create the expected checker (which now is checked for all milestones)

Several tests have been disabled. Tracking them on #6422.

related to: #6440

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
