### PR TITLE
Strip whitespace from response error messages

### DIFF
--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/Response.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/Response.java
@@ -67,7 +67,10 @@ public class Response<T> {
   }
 
   public String getErrorMessage() {
-    return errorMessage;
+    if (errorMessage != null) {
+      return errorMessage.strip();
+    }
+    return null;
   }
 
   public boolean isSuccess() {


### PR DESCRIPTION
## PR Description

I'm hesitant to make this PR because I feel like it's a problem on the sender's side, but the error response from a builder (mev-boost) contains a newline at the end. This causes the log to get split into two lines.

```
2022-11-15 00:59:47.955-06:00 | OkHttp http://mev:18550/... | WARN  | teku-event-log | The builder is not available: {"code":503,"message":"all relays are unavailable"}
. Block production will fallback to the execution engine.
```

https://github.com/ConsenSys/teku/blob/c4837e18e73487e980bb13496a5f0420fe0cf936/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java#L162

To fix this, I called `strip` on the error message in its getter method. This could be done outside of the class, on an individual basis, but I don't think this hurts anything.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
