### PR TITLE
Use value comparison for validator sync committee indices

### DIFF
--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/SyncCommitteeDuty.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/SyncCommitteeDuty.java
@@ -55,7 +55,7 @@ public class SyncCommitteeDuty {
     }
     final SyncCommitteeDuty that = (SyncCommitteeDuty) o;
     return validatorIndex == that.validatorIndex
-        && validatorSyncCommitteeIndices == that.validatorSyncCommitteeIndices
+        && Objects.equals(validatorSyncCommitteeIndices, that.validatorSyncCommitteeIndices)
         && Objects.equals(publicKey, that.publicKey);
   }
 


### PR DESCRIPTION
## PR Description

So `validatorSyncCommitteeIndices` is an `IntSet` and should be compared with `Objects.equals`, right?

For a little backstory... last week, I noticed this fix:

```diff
-      if (withdrawalCredentials.slice(1)
-           != Hash.sha256(addressChange.getFromBlsPubkey().toBytesCompressed()).slice(1)) {
+       if (!withdrawalCredentials
+           .slice(1)
+           .equals(Hash.sha256(addressChange.getFromBlsPubkey().toBytesCompressed()).slice(1))) {
```

Link: https://github.com/consensys/teku/commit/1292eee92ce1b638ccbfe7b73e1068602a8cffb8#diff-87b45febe4cdb42f6503c505eb76fc3efe53b77caa61d7f8cf578968da70a63cL297-R293

It was a reference comparison when it should have been a value comparison. I would have expected [ErrorProne's ReferenceEquality](http://errorprone.info/bugpattern/ReferenceEquality) bug-pattern to spot this, but it doesn't seem to work the way I would expect. With that in mind, I wrote a new bug-pattern that works as I expect and it found this. I'll publish that soon, still needs some work.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
