### PR TITLE
Fixed block building for capella

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
@@ -25,15 +25,18 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.SpecVersion;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.Eth1Data;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlockUnblinder;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodyBuilder;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.capella.BeaconBlockBodySchemaCapella;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
+import tech.pegasys.teku.spec.datastructures.operations.SignedBlsToExecutionChange;
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannel;
@@ -135,6 +138,14 @@ public class BlockOperationSelectorFactory {
 
       final SpecVersion specVersion = spec.atSlot(blockSlotState.getSlot());
 
+      if (specVersion.getMilestone().isGreaterThanOrEqualTo(SpecMilestone.CAPELLA)) {
+        final SszList<SignedBlsToExecutionChange> blsToExecutionChanges =
+            BeaconBlockBodySchemaCapella.required(
+                    specVersion.getSchemaDefinitions().getBeaconBlockBodySchema())
+                .getBlsToExecutionChangesSchema()
+                .getDefault();
+        bodyBuilder.blsToExecutionChanges(() -> blsToExecutionChanges);
+      }
       // execution payload handling
       if (bodyBuilder.isBlinded()) {
         // an execution payload header is required

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryTest.java
@@ -60,7 +60,6 @@ import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannel;
 import tech.pegasys.teku.spec.logic.common.block.AbstractBlockProcessor;
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.StateTransitionException;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsBellatrix;
-import tech.pegasys.teku.spec.schemas.SchemaDefinitionsCapella;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.OperationPool;
 import tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPool;
@@ -418,26 +417,14 @@ class BlockFactoryTest {
   }
 
   private void prepareDefaultPayload(final Spec spec) {
-    if (spec.isMilestoneSupported(SpecMilestone.CAPELLA)) {
-      executionPayload =
-          SchemaDefinitionsCapella.required(spec.getGenesisSpec().getSchemaDefinitions())
-              .getExecutionPayloadSchema()
-              .getDefault();
+    executionPayload =
+        SchemaDefinitionsBellatrix.required(spec.getGenesisSpec().getSchemaDefinitions())
+            .getExecutionPayloadSchema()
+            .getDefault();
 
-      executionPayloadHeader =
-          SchemaDefinitionsCapella.required(spec.getGenesisSpec().getSchemaDefinitions())
-              .getExecutionPayloadHeaderSchema()
-              .getHeaderOfDefaultPayload();
-    } else {
-      executionPayload =
-          SchemaDefinitionsBellatrix.required(spec.getGenesisSpec().getSchemaDefinitions())
-              .getExecutionPayloadSchema()
-              .getDefault();
-
-      executionPayloadHeader =
-          SchemaDefinitionsBellatrix.required(spec.getGenesisSpec().getSchemaDefinitions())
-              .getExecutionPayloadHeaderSchema()
-              .getHeaderOfDefaultPayload();
-    }
+    executionPayloadHeader =
+        SchemaDefinitionsBellatrix.required(spec.getGenesisSpec().getSchemaDefinitions())
+            .getExecutionPayloadHeaderSchema()
+            .getHeaderOfDefaultPayload();
   }
 }


### PR DESCRIPTION
Currently an empty list is added for BlsToExecutionChanges, that'll ultimately come from a pool.

After this change, Capella minimal network is able to progress.

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
