### PR TITLE
Replace reference comparison with isNotSameAs in test

### DIFF
--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/AbstractBeaconStateTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/AbstractBeaconStateTest.java
@@ -76,7 +76,7 @@ public abstract class AbstractBeaconStateTest<
     final T state = randomState();
     final Object stateCopy = state.getSchema().createFromBackingNode(state.getBackingNode());
 
-    assertThat(state == stateCopy).isFalse();
+    assertThat(state).isNotSameAs(stateCopy);
     assertThat(state).isEqualTo(stateCopy);
     assertThat(state.hashCode()).isEqualTo(stateCopy.hashCode());
   }
@@ -87,7 +87,7 @@ public abstract class AbstractBeaconStateTest<
     final T state = randomState();
     final T stateCopy = (T) state.updated(s -> s.setSlot(s.getSlot().plus(1)));
 
-    assertThat(state == stateCopy).isFalse();
+    assertThat(state).isNotSameAs(stateCopy);
     assertThat(state).isNotEqualTo(stateCopy);
     assertThat(state.hashCode()).isNotEqualTo(stateCopy.hashCode());
   }


### PR DESCRIPTION
## PR Description

Minor change. Use the `assertThat#isNotSameAs` method instead of doing a reference comparison. To be clear, there was nothing wrong before, this is just easier to read and probably provides a better message in the event of a problem.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
