### PR TITLE
Use `.equals` for SszSchema comparisons

### DIFF
--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/SszPrimitiveListSchema.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/SszPrimitiveListSchema.java
@@ -38,13 +38,13 @@ public interface SszPrimitiveListSchema<
   static <PrimT, SszPrimT extends SszPrimitive<PrimT, SszPrimT>>
       SszPrimitiveListSchema<PrimT, SszPrimT, ?> create(
           SszPrimitiveSchema<PrimT, SszPrimT> elementSchema, long maxLength, SszSchemaHints hints) {
-    if (elementSchema == SszPrimitiveSchemas.BIT_SCHEMA) {
+    if (elementSchema.equals(SszPrimitiveSchemas.BIT_SCHEMA)) {
       return (SszPrimitiveListSchema<PrimT, SszPrimT, ?>) SszBitlistSchema.create(maxLength);
-    } else if (elementSchema == SszPrimitiveSchemas.UINT64_SCHEMA) {
+    } else if (elementSchema.equals(SszPrimitiveSchemas.UINT64_SCHEMA)) {
       return (SszPrimitiveListSchema<PrimT, SszPrimT, ?>) SszUInt64ListSchema.create(maxLength);
-    } else if (elementSchema == SszPrimitiveSchemas.BYTE_SCHEMA) {
+    } else if (elementSchema.equals(SszPrimitiveSchemas.BYTE_SCHEMA)) {
       return (SszPrimitiveListSchema<PrimT, SszPrimT, ?>) SszByteListSchema.create(maxLength);
-    } else if (elementSchema == SszPrimitiveSchemas.UINT8_SCHEMA) {
+    } else if (elementSchema.equals(SszPrimitiveSchemas.UINT8_SCHEMA)) {
       return (SszPrimitiveListSchema<PrimT, SszPrimT, ?>) SszByteListSchema.createUInt8(maxLength);
     } else {
       return new SszPrimitiveListSchemaImpl<>(elementSchema, maxLength);

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/SszPrimitiveVectorSchema.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/SszPrimitiveVectorSchema.java
@@ -38,15 +38,15 @@ public interface SszPrimitiveVectorSchema<
   static <PrimT, SszPrimT extends SszPrimitive<PrimT, SszPrimT>>
       SszPrimitiveVectorSchema<PrimT, SszPrimT, ?> create(
           SszPrimitiveSchema<PrimT, SszPrimT> elementSchema, long length, SszSchemaHints hints) {
-    if (elementSchema == SszPrimitiveSchemas.BIT_SCHEMA) {
+    if (elementSchema.equals(SszPrimitiveSchemas.BIT_SCHEMA)) {
       return (SszPrimitiveVectorSchema<PrimT, SszPrimT, ?>) SszBitvectorSchema.create(length);
-    } else if (elementSchema == SszPrimitiveSchemas.BYTE_SCHEMA) {
+    } else if (elementSchema.equals(SszPrimitiveSchemas.BYTE_SCHEMA)) {
       return (SszPrimitiveVectorSchema<PrimT, SszPrimT, ?>)
           SszByteVectorSchema.create((int) length);
-    } else if (elementSchema == SszPrimitiveSchemas.UINT8_SCHEMA) {
+    } else if (elementSchema.equals(SszPrimitiveSchemas.UINT8_SCHEMA)) {
       return (SszPrimitiveVectorSchema<PrimT, SszPrimT, ?>)
           SszByteVectorSchema.createUInt8((int) length);
-    } else if (elementSchema == SszPrimitiveSchemas.BYTES32_SCHEMA) {
+    } else if (elementSchema.equals(SszPrimitiveSchemas.BYTES32_SCHEMA)) {
       return (SszPrimitiveVectorSchema<PrimT, SszPrimT, ?>)
           SszBytes32VectorSchema.create((int) length);
     } else {

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/impl/SszByteListSchemaImpl.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/impl/SszByteListSchemaImpl.java
@@ -38,7 +38,7 @@ public class SszByteListSchemaImpl<SszListT extends SszByteList>
       final SszPrimitiveSchema<Byte, SszByte> elementSchema, final long maxLength) {
     super(elementSchema, maxLength);
     this.jsonTypeDefinition =
-        elementSchema == SszPrimitiveSchemas.BYTE_SCHEMA
+        elementSchema.equals(SszPrimitiveSchemas.BYTE_SCHEMA)
             ? SszPrimitiveTypeDefinitions.sszSerializedType(this, "SSZ encoded byte list")
             : new DeserializableArrayTypeDefinition<>(
                 getElementSchema().getJsonTypeDefinition(), this::createFromElements);

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/impl/SszByteVectorSchemaImpl.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/collections/impl/SszByteVectorSchemaImpl.java
@@ -40,7 +40,7 @@ public class SszByteVectorSchemaImpl<SszVectorT extends SszByteVector>
 
   @Override
   protected DeserializableTypeDefinition<SszVectorT> createTypeDefinition() {
-    return getElementSchema() == SszPrimitiveSchemas.BYTE_SCHEMA
+    return getElementSchema().equals(SszPrimitiveSchemas.BYTE_SCHEMA)
         ? sszSerializedType(this, "SSZ hexadecimal")
         : super.createTypeDefinition();
   }

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/impl/AbstractSszListSchema.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/impl/AbstractSszListSchema.java
@@ -123,7 +123,7 @@ public abstract class AbstractSszListSchema<
   @Override
   public int sszSerializeTree(TreeNode node, SszWriter writer) {
     int elementsCount = getLength(node);
-    if (getElementSchema() == SszPrimitiveSchemas.BIT_SCHEMA) {
+    if (getElementSchema().equals(SszPrimitiveSchemas.BIT_SCHEMA)) {
       throw new UnsupportedOperationException(
           "BitlistImpl serialization is only supported by SszBitlistSchema");
     } else {
@@ -134,7 +134,7 @@ public abstract class AbstractSszListSchema<
 
   @Override
   public TreeNode sszDeserializeTree(SszReader reader) {
-    if (getElementSchema() == SszPrimitiveSchemas.BIT_SCHEMA) {
+    if (getElementSchema().equals(SszPrimitiveSchemas.BIT_SCHEMA)) {
       throw new UnsupportedOperationException(
           "BitlistImpl deserialization is only supported by SszBitlistSchema");
     } else {
@@ -313,7 +313,7 @@ public abstract class AbstractSszListSchema<
         SszLengthBounds.ofBits(0, elementAndOffsetLengthBounds.mul(maxLength).getMaxBits());
     // adding 1 boundary bit for BitlistImpl
     return maxLenBounds
-        .addBits(elementSchema == SszPrimitiveSchemas.BIT_SCHEMA ? 1 : 0)
+        .addBits(elementSchema.equals(SszPrimitiveSchemas.BIT_SCHEMA) ? 1 : 0)
         .ceilToBytes();
   }
 

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/impl/AbstractSszVectorSchema.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/impl/AbstractSszVectorSchema.java
@@ -167,7 +167,7 @@ public abstract class AbstractSszVectorSchema<
 
   @Override
   public TreeNode sszDeserializeTree(SszReader reader) {
-    if (getElementSchema() == SszPrimitiveSchemas.BIT_SCHEMA) {
+    if (getElementSchema().equals(SszPrimitiveSchemas.BIT_SCHEMA)) {
       throw new UnsupportedOperationException(
           "Bitvector deserialization is only supported by SszBitvectorSchema");
     }

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/impl/SszUnionSchemaImpl.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/schema/impl/SszUnionSchemaImpl.java
@@ -79,7 +79,7 @@ public abstract class SszUnionSchemaImpl<SszUnionT extends SszUnion>
     checkArgument(
         childrenSchemas.stream()
             .skip(1)
-            .allMatch(schema -> schema != SszPrimitiveSchemas.NONE_SCHEMA),
+            .allMatch(schema -> !schema.equals(SszPrimitiveSchemas.NONE_SCHEMA)),
         "None is allowed for zero selector only");
     this.childrenSchemas = childrenSchemas;
     defaultTree =

--- a/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/SszListTestBase.java
+++ b/infrastructure/ssz/src/test/java/tech/pegasys/teku/infrastructure/ssz/SszListTestBase.java
@@ -30,7 +30,8 @@ public interface SszListTestBase extends SszCollectionTestBase {
   @ParameterizedTest
   default void sszSerialize_emptyNonBitListShouldResultInEmptySsz(SszList<?> data) {
     Assumptions.assumeTrue(data.isEmpty());
-    Assumptions.assumeTrue(data.getSchema().getElementSchema() != SszPrimitiveSchemas.BIT_SCHEMA);
+    Assumptions.assumeTrue(
+        !data.getSchema().getElementSchema().equals(SszPrimitiveSchemas.BIT_SCHEMA));
     assertThat(data.sszSerialize()).isEqualTo(Bytes.EMPTY);
   }
 

--- a/infrastructure/ssz/src/testFixtures/java/tech/pegasys/teku/infrastructure/ssz/RandomSszDataGenerator.java
+++ b/infrastructure/ssz/src/testFixtures/java/tech/pegasys/teku/infrastructure/ssz/RandomSszDataGenerator.java
@@ -75,19 +75,19 @@ public class RandomSszDataGenerator {
   @SuppressWarnings("unchecked")
   public <T extends SszData> Stream<T> randomDataStream(SszSchema<T> schema) {
     if (schema instanceof AbstractSszPrimitiveSchema) {
-      if (schema == SszPrimitiveSchemas.NONE_SCHEMA) {
+      if (schema.equals(SszPrimitiveSchemas.NONE_SCHEMA)) {
         return (Stream<T>) Stream.generate(() -> SszNone.INSTANCE);
-      } else if (schema == SszPrimitiveSchemas.BIT_SCHEMA) {
+      } else if (schema.equals(SszPrimitiveSchemas.BIT_SCHEMA)) {
         return (Stream<T>) Stream.generate(bitSupplier);
-      } else if (schema == SszPrimitiveSchemas.BYTE_SCHEMA) {
+      } else if (schema.equals(SszPrimitiveSchemas.BYTE_SCHEMA)) {
         return (Stream<T>) Stream.generate(byteSupplier);
-      } else if (schema == SszPrimitiveSchemas.UINT64_SCHEMA) {
+      } else if (schema.equals(SszPrimitiveSchemas.UINT64_SCHEMA)) {
         return (Stream<T>) Stream.generate(uintSupplier);
-      } else if (schema == SszPrimitiveSchemas.UINT256_SCHEMA) {
+      } else if (schema.equals(SszPrimitiveSchemas.UINT256_SCHEMA)) {
         return (Stream<T>) Stream.generate(uint256Supplier);
-      } else if (schema == SszPrimitiveSchemas.BYTES4_SCHEMA) {
+      } else if (schema.equals(SszPrimitiveSchemas.BYTES4_SCHEMA)) {
         return (Stream<T>) Stream.generate(bytes4Supplier);
-      } else if (schema == SszPrimitiveSchemas.BYTES32_SCHEMA) {
+      } else if (schema.equals(SszPrimitiveSchemas.BYTES32_SCHEMA)) {
         return (Stream<T>) Stream.generate(bytes32Supplier);
       } else {
         throw new IllegalArgumentException("Unknown primitive schema: " + schema);


### PR DESCRIPTION
## PR Description

Associated with this potentially new check in errorprone-checks:

* https://github.com/ConsenSys/errorprone-checks/pull/11

Where this was said:

> The `SszPrimitiveSchemas` ones are more interesting because `==` is definitely safe to use because they're all defined, slightly oddly, as anonymous inner classes and only one instance is ever going to exist for them. May need to investigate which benchmarks cover that code to see if there is actually a performance benefit.

So there isn't a problem with how things are, but it is a bit strange. I'm not really sure that I like this PR, because in my opinion the `==` comparison is better; this PR fixes the false positives from that check. Under the hood, the `.equals` method should use the `==` comparison. Is there an alternative way to "fix" these findings?

Additionally, something to keep in mind, if the schema variable is null, it could result in a `NullPointerException`. This isn't a problem in the current way things are done, with reference comparisons.

Regarding performance, I made a simple benchmark:

```java
static final SszUInt64 sszUint64 = SszUInt64.ZERO;

@Benchmark()
@BenchmarkMode(Mode.Throughput)
@Warmup(iterations = 5, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
@Measurement(iterations = 10, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
public void schemaComparison(Blackhole bh) {
  bh.consume(sszUint64.getSchema() == SszPrimitiveSchemas.UINT64_SCHEMA);
}
```

```
Benchmark                               Mode  Cnt    Score    Error   Units
BeaconBlockBenchmark.schemaComparison  thrpt   50  596.444 ± 14.337  ops/us
```

When changed from `==` to `.equals` its performance stayed just about the same:

```java
public void schemaComparison(Blackhole bh) {
  bh.consume(sszUint64.getSchema().equals(SszPrimitiveSchemas.UINT64_SCHEMA));
}
```

```
Benchmark                               Mode  Cnt    Score    Error   Units
BeaconBlockBenchmark.schemaComparison  thrpt   50  592.575 ± 20.353  ops/us
```

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
