### PR TITLE
Fixed interop of capella data

### DIFF
--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/ExecutionPayloadV2.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/ExecutionPayloadV2.java
@@ -92,6 +92,9 @@ public class ExecutionPayloadV2 extends ExecutionPayloadV1 {
   @Override
   public ExecutionPayload asInternalExecutionPayload(
       ExecutionPayloadSchema<?> executionPayloadSchema) {
+    if (withdrawals == null) {
+      return super.asInternalExecutionPayload(executionPayloadSchema);
+    }
     return executionPayloadSchema
         .toVersionCapella()
         .orElseThrow()

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/CapellaExecutionClientHandler.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/CapellaExecutionClientHandler.java
@@ -30,7 +30,7 @@ import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
 import tech.pegasys.teku.spec.executionlayer.ForkChoiceState;
 import tech.pegasys.teku.spec.executionlayer.PayloadBuildingAttributes;
 import tech.pegasys.teku.spec.executionlayer.PayloadStatus;
-import tech.pegasys.teku.spec.schemas.SchemaDefinitionsCapella;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsBellatrix;
 
 public class CapellaExecutionClientHandler extends BellatrixExecutionClientHandler
     implements ExecutionClientHandler {
@@ -54,7 +54,7 @@ public class CapellaExecutionClientHandler extends BellatrixExecutionClientHandl
         .thenCombine(
             SafeFuture.of(
                 () ->
-                    SchemaDefinitionsCapella.required(spec.atSlot(slot).getSchemaDefinitions())
+                    SchemaDefinitionsBellatrix.required(spec.atSlot(slot).getSchemaDefinitions())
                         .getExecutionPayloadSchema()),
             ExecutionPayloadV2::asInternalExecutionPayload)
         .thenPeek(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
@@ -207,28 +207,55 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
     final HeadAndAttributes headAndAttrs = maybeHeadAndAttrs.get();
     final PayloadBuildingAttributes payloadAttributes = headAndAttrs.attributes;
 
-    final ExecutionPayload executionPayload =
-        schemaDefinitionsBellatrix
-            .get()
-            .getExecutionPayloadSchema()
-            .toVersionBellatrix()
-            .orElseThrow()
-            .create(
-                headAndAttrs.head,
-                payloadAttributes.getFeeRecipient(),
-                Bytes32.ZERO,
-                Bytes32.ZERO,
-                Bytes.random(256),
-                payloadAttributes.getPrevRandao(),
-                UInt64.valueOf(payloadIdCounter.get()),
-                UInt64.ONE,
-                UInt64.ZERO,
-                payloadAttributes.getTimestamp(),
-                Bytes.EMPTY,
-                UInt256.ONE,
-                Bytes32.random(),
-                List.of(Bytes.fromHexString("0x0edf"), Bytes.fromHexString("0xedf0")));
-
+    final ExecutionPayload executionPayload;
+    if (spec.atSlot(slot).getMilestone().isGreaterThanOrEqualTo(SpecMilestone.CAPELLA)) {
+      executionPayload =
+          spec.atSlot(slot)
+              .getSchemaDefinitions()
+              .toVersionCapella()
+              .orElseThrow()
+              .getExecutionPayloadSchema()
+              .toVersionCapella()
+              .orElseThrow()
+              .create(
+                  headAndAttrs.head,
+                  payloadAttributes.getFeeRecipient(),
+                  Bytes32.ZERO,
+                  Bytes32.ZERO,
+                  Bytes.random(256),
+                  payloadAttributes.getPrevRandao(),
+                  UInt64.valueOf(payloadIdCounter.get()),
+                  UInt64.ONE,
+                  UInt64.ZERO,
+                  payloadAttributes.getTimestamp(),
+                  Bytes.EMPTY,
+                  UInt256.ONE,
+                  Bytes32.random(),
+                  List.of(Bytes.fromHexString("0x0edf"), Bytes.fromHexString("0xedf0")),
+                  List.of());
+    } else {
+      executionPayload =
+          schemaDefinitionsBellatrix
+              .get()
+              .getExecutionPayloadSchema()
+              .toVersionBellatrix()
+              .orElseThrow()
+              .create(
+                  headAndAttrs.head,
+                  payloadAttributes.getFeeRecipient(),
+                  Bytes32.ZERO,
+                  Bytes32.ZERO,
+                  Bytes.random(256),
+                  payloadAttributes.getPrevRandao(),
+                  UInt64.valueOf(payloadIdCounter.get()),
+                  UInt64.ONE,
+                  UInt64.ZERO,
+                  payloadAttributes.getTimestamp(),
+                  Bytes.EMPTY,
+                  UInt256.ONE,
+                  Bytes32.random(),
+                  List.of(Bytes.fromHexString("0x0edf"), Bytes.fromHexString("0xedf0")));
+    }
     // we assume all blocks are produced locally
     lastValidBlock =
         Optional.of(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/SpecLogicCapella.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/SpecLogicCapella.java
@@ -40,6 +40,7 @@ import tech.pegasys.teku.spec.schemas.SchemaDefinitionsCapella;
 
 public class SpecLogicCapella extends AbstractSpecLogic {
   private final Optional<SyncCommitteeUtil> syncCommitteeUtil;
+  private final BellatrixTransitionHelpers bellatrixTransitionHelpers;
 
   private SpecLogicCapella(
       final Predicates predicates,
@@ -58,7 +59,8 @@ public class SpecLogicCapella extends AbstractSpecLogic {
       final BlockProposalUtil blockProposalUtil,
       final BlindBlockUtil blindBlockUtil,
       final SyncCommitteeUtil syncCommitteeUtil,
-      final CapellaStateUpgrade stateUpgrade) {
+      final CapellaStateUpgrade stateUpgrade,
+      final BellatrixTransitionHelpers bellatrixTransitionHelpers) {
     super(
         predicates,
         miscHelpers,
@@ -77,6 +79,7 @@ public class SpecLogicCapella extends AbstractSpecLogic {
         Optional.of(blindBlockUtil),
         Optional.of(stateUpgrade));
     this.syncCommitteeUtil = Optional.of(syncCommitteeUtil);
+    this.bellatrixTransitionHelpers = bellatrixTransitionHelpers;
   }
 
   public static SpecLogicCapella create(
@@ -151,6 +154,9 @@ public class SpecLogicCapella extends AbstractSpecLogic {
     final CapellaStateUpgrade stateUpgrade =
         new CapellaStateUpgrade(config, schemaDefinitions, beaconStateAccessors);
 
+    final BellatrixTransitionHelpers bellatrixTransitionHelpers =
+        new BellatrixTransitionHelpers(config, miscHelpers);
+
     return new SpecLogicCapella(
         predicates,
         miscHelpers,
@@ -168,7 +174,8 @@ public class SpecLogicCapella extends AbstractSpecLogic {
         blockProposalUtil,
         blindBlockUtil,
         syncCommitteeUtil,
-        stateUpgrade);
+        stateUpgrade,
+        bellatrixTransitionHelpers);
   }
 
   @Override
@@ -178,6 +185,6 @@ public class SpecLogicCapella extends AbstractSpecLogic {
 
   @Override
   public Optional<BellatrixTransitionHelpers> getBellatrixTransitionHelpers() {
-    return Optional.empty();
+    return Optional.of(bellatrixTransitionHelpers);
   }
 }


### PR DESCRIPTION
 - Capella needed BellatrixTransitionHelpers

 - Can now start at capella on epoch 0, and sync with a second BN with stubbed EL.

 - fixed a problem where engineGetPayload was requiring capella spec, and potentially has bellatrix.

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
