### PR TITLE
Check if block contains more than 1 BlsToExecutionChange for the same validator

### DIFF
--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/sanity/SanityBlocksTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/sanity/SanityBlocksTestExecutor.java
@@ -39,7 +39,7 @@ public class SanityBlocksTestExecutor implements TestExecutor {
 
   private static final String EXPECTED_STATE_FILENAME = "post.ssz_snappy";
   private static final String STATE_ROOT_MISMATCH_ERROR_MESSAGE =
-      "Block state root does NOT match the calculated " + "state root";
+      "Block state root does NOT match the calculated state root";
 
   @Override
   public void runTest(final TestDefinition testDefinition) throws Exception {

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/block/BlockProcessorTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/block/BlockProcessorTest.java
@@ -48,7 +48,7 @@ import tech.pegasys.teku.spec.util.DataStructureUtil;
 @ExtendWith(BouncyCastleExtension.class)
 public abstract class BlockProcessorTest {
   protected final Spec spec = createSpec();
-  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+  protected final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
 
   private final SpecVersion genesisSpec = spec.getGenesisSpec();
   private final SpecConfig specConfig = genesisSpec.getConfig();

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/capella/block/BlockProcessorCapellaTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/capella/block/BlockProcessorCapellaTest.java
@@ -20,20 +20,28 @@ import java.util.List;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.infrastructure.bytes.Bytes20;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.execution.versions.capella.Withdrawal;
+import tech.pegasys.teku.spec.datastructures.operations.BlsToExecutionChange;
+import tech.pegasys.teku.spec.datastructures.operations.SignedBlsToExecutionChange;
 import tech.pegasys.teku.spec.datastructures.state.Validator;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.generator.ChainBuilder;
+import tech.pegasys.teku.spec.logic.common.statetransition.blockvalidator.BlockValidationResult;
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.StateTransitionException;
 import tech.pegasys.teku.spec.logic.versions.bellatrix.BlockProcessorBellatrixTest;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsCapella;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class BlockProcessorCapellaTest extends BlockProcessorBellatrixTest {
+
   @Override
   protected Spec createSpec() {
     return TestSpecFactory.createMainnetCapella();
@@ -95,5 +103,63 @@ public class BlockProcessorCapellaTest extends BlockProcessorBellatrixTest {
     assertThat(BlockProcessorCapella.incrementValidatorIndex(9, 10)).isEqualTo(0);
     assertThat(BlockProcessorCapella.incrementValidatorIndex(8, 10)).isEqualTo(9);
     assertThat(BlockProcessorCapella.incrementValidatorIndex(0, 10)).isEqualTo(1);
+  }
+
+  @Test
+  public void shouldRejectBlockWithMoreThanOneBlsExecutionChangesForSameValidator() {
+    final int validatorIndex = 0;
+    final ChainBuilder chain = ChainBuilder.create(spec);
+    chain.generateGenesis();
+
+    final BeaconState state = chain.getGenesis().getState();
+    final BLSPublicKey validatorPubKey = chain.getValidatorKeys().get(0).getPublicKey();
+
+    final SignedBlsToExecutionChange signedBlsToExecutionChange1 =
+        createSignedBlsToExecutionChange(validatorIndex, validatorPubKey);
+    final SignedBlsToExecutionChange signedBlsToExecutionChange2 =
+        createSignedBlsToExecutionChange(validatorIndex, validatorPubKey);
+
+    final SszList<SignedBlsToExecutionChange> blsToExecutionChangesListWithDuplicate =
+        createBlsToExecutionChangeList(signedBlsToExecutionChange1, signedBlsToExecutionChange2);
+
+    final BlockProcessorCapella capellaBlockProcessor =
+        ((BlockProcessorCapella) spec.getGenesisSpec().getBlockProcessor());
+
+    final BlockValidationResult validationResult =
+        capellaBlockProcessor.verifyBlsToExecutionChangesPreProcessing(
+            state, blsToExecutionChangesListWithDuplicate, BLSSignatureVerifier.NO_OP);
+
+    assertThat(validationResult.isValid()).isFalse();
+    assertThat(validationResult.getFailureReason())
+        .contains("Duplicated BlsToExecutionChange for validator " + validatorIndex);
+  }
+
+  private SignedBlsToExecutionChange createSignedBlsToExecutionChange(
+      final int validatorIndex, final BLSPublicKey validatorPubKey) {
+    final SchemaDefinitionsCapella capellaSchema =
+        SchemaDefinitionsCapella.required(spec.getGenesisSchemaDefinitions());
+
+    final BlsToExecutionChange blsToExecutionChange =
+        capellaSchema
+            .getBlsToExecutionChangeSchema()
+            .create(
+                UInt64.valueOf(validatorIndex),
+                validatorPubKey,
+                dataStructureUtil.randomEth1Address());
+
+    return capellaSchema
+        .getSignedBlsToExecutionChangeSchema()
+        .create(blsToExecutionChange, dataStructureUtil.randomSignature());
+  }
+
+  private SszList<SignedBlsToExecutionChange> createBlsToExecutionChangeList(
+      final SignedBlsToExecutionChange... signedBlsToExecutionChanges) {
+    return SchemaDefinitionsCapella.required(spec.getGenesisSchemaDefinitions())
+        .getBeaconBlockSchema()
+        .getBodySchema()
+        .toVersionCapella()
+        .orElseThrow()
+        .getBlsToExecutionChangesSchema()
+        .of(signedBlsToExecutionChanges);
   }
 }


### PR DESCRIPTION
## PR Description
- Include fix for multiple operations for same validator in block
- Updates `ManualReferenceTestRunner` with logic to check the type of error on block processing (need to revisit this approach after https://github.com/ethereum/consensus-specs/issues/3122)

## Fixed Issue(s)
fixes #6445