### PR TITLE
Added capella types to rest api

### DIFF
--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_beacon_blinded_blocks.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_beacon_blinded_blocks.json
@@ -22,6 +22,8 @@
               "$ref" : "#/components/schemas/SignedBeaconBlockAltair"
             }, {
               "$ref" : "#/components/schemas/SignedBlindedBlockBellatrix"
+            }, {
+              "$ref" : "#/components/schemas/SignedBlindedBlockCapella"
             } ]
           }
         }

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_beacon_blocks.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_beacon_blocks.json
@@ -22,6 +22,8 @@
               "$ref" : "#/components/schemas/SignedBeaconBlockAltair"
             }, {
               "$ref" : "#/components/schemas/SignedBeaconBlockBellatrix"
+            }, {
+              "$ref" : "#/components/schemas/SignedBeaconBlockCapella"
             } ]
           }
         }

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/BLSToExecutionChange.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/BLSToExecutionChange.json
@@ -1,0 +1,25 @@
+{
+  "title" : "BLSToExecutionChange",
+  "type" : "object",
+  "required" : [ "validator_index", "from_bls_pubkey", "to_execution_address" ],
+  "properties" : {
+    "validator_index" : {
+      "type" : "string",
+      "description" : "unsigned 64 bit integer",
+      "example" : "1",
+      "format" : "uint64"
+    },
+    "from_bls_pubkey" : {
+      "type" : "string",
+      "pattern" : "^0x[a-fA-F0-9]{2,}$",
+      "description" : "Bytes48 hexadecimal",
+      "format" : "bytes"
+    },
+    "to_execution_address" : {
+      "type" : "string",
+      "pattern" : "^0x[a-fA-F0-9]{2,}$",
+      "description" : "SSZ hexadecimal",
+      "format" : "bytes"
+    }
+  }
+}

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/BeaconBlockBodyCapella.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/BeaconBlockBodyCapella.json
@@ -1,0 +1,64 @@
+{
+  "title" : "BeaconBlockBodyCapella",
+  "type" : "object",
+  "required" : [ "randao_reveal", "eth1_data", "graffiti", "proposer_slashings", "attester_slashings", "attestations", "deposits", "voluntary_exits", "sync_aggregate", "execution_payload", "bls_to_execution_changes" ],
+  "properties" : {
+    "randao_reveal" : {
+      "type" : "string",
+      "pattern" : "^0x[a-fA-F0-9]{2,}$",
+      "description" : "SSZ hexadecimal",
+      "format" : "bytes"
+    },
+    "eth1_data" : {
+      "$ref" : "#/components/schemas/Eth1Data"
+    },
+    "graffiti" : {
+      "type" : "string",
+      "description" : "Bytes32 hexadecimal",
+      "example" : "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+      "format" : "byte"
+    },
+    "proposer_slashings" : {
+      "type" : "array",
+      "items" : {
+        "$ref" : "#/components/schemas/ProposerSlashing"
+      }
+    },
+    "attester_slashings" : {
+      "type" : "array",
+      "items" : {
+        "$ref" : "#/components/schemas/AttesterSlashing"
+      }
+    },
+    "attestations" : {
+      "type" : "array",
+      "items" : {
+        "$ref" : "#/components/schemas/Attestation"
+      }
+    },
+    "deposits" : {
+      "type" : "array",
+      "items" : {
+        "$ref" : "#/components/schemas/Deposit"
+      }
+    },
+    "voluntary_exits" : {
+      "type" : "array",
+      "items" : {
+        "$ref" : "#/components/schemas/SignedVoluntaryExit"
+      }
+    },
+    "sync_aggregate" : {
+      "$ref" : "#/components/schemas/SyncAggregate"
+    },
+    "execution_payload" : {
+      "$ref" : "#/components/schemas/ExecutionPayloadCapella"
+    },
+    "bls_to_execution_changes" : {
+      "type" : "array",
+      "items" : {
+        "$ref" : "#/components/schemas/SignedBLSToExecutionChange"
+      }
+    }
+  }
+}

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/BeaconBlockCapella.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/BeaconBlockCapella.json
@@ -1,0 +1,34 @@
+{
+  "title" : "BeaconBlockCapella",
+  "type" : "object",
+  "required" : [ "slot", "proposer_index", "parent_root", "state_root", "body" ],
+  "properties" : {
+    "slot" : {
+      "type" : "string",
+      "description" : "unsigned 64 bit integer",
+      "example" : "1",
+      "format" : "uint64"
+    },
+    "proposer_index" : {
+      "type" : "string",
+      "description" : "unsigned 64 bit integer",
+      "example" : "1",
+      "format" : "uint64"
+    },
+    "parent_root" : {
+      "type" : "string",
+      "description" : "Bytes32 hexadecimal",
+      "example" : "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+      "format" : "byte"
+    },
+    "state_root" : {
+      "type" : "string",
+      "description" : "Bytes32 hexadecimal",
+      "example" : "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+      "format" : "byte"
+    },
+    "body" : {
+      "$ref" : "#/components/schemas/BeaconBlockBodyCapella"
+    }
+  }
+}

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/BeaconStateCapella.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/BeaconStateCapella.json
@@ -1,0 +1,169 @@
+{
+  "title" : "BeaconStateCapella",
+  "type" : "object",
+  "required" : [ "genesis_time", "genesis_validators_root", "slot", "fork", "latest_block_header", "block_roots", "state_roots", "historical_roots", "eth1_data", "eth1_data_votes", "eth1_deposit_index", "validators", "balances", "randao_mixes", "slashings", "previous_epoch_participation", "current_epoch_participation", "justification_bits", "previous_justified_checkpoint", "current_justified_checkpoint", "finalized_checkpoint", "inactivity_scores", "current_sync_committee", "next_sync_committee", "latest_execution_payload_header", "next_withdrawal_index", "next_withdrawal_validator_index" ],
+  "properties" : {
+    "genesis_time" : {
+      "type" : "string",
+      "description" : "unsigned 64 bit integer",
+      "example" : "1",
+      "format" : "uint64"
+    },
+    "genesis_validators_root" : {
+      "type" : "string",
+      "description" : "Bytes32 hexadecimal",
+      "example" : "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+      "format" : "byte"
+    },
+    "slot" : {
+      "type" : "string",
+      "description" : "unsigned 64 bit integer",
+      "example" : "1",
+      "format" : "uint64"
+    },
+    "fork" : {
+      "$ref" : "#/components/schemas/Fork"
+    },
+    "latest_block_header" : {
+      "$ref" : "#/components/schemas/BeaconBlockHeader"
+    },
+    "block_roots" : {
+      "type" : "array",
+      "items" : {
+        "type" : "string",
+        "description" : "Bytes32 hexadecimal",
+        "example" : "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+        "format" : "byte"
+      }
+    },
+    "state_roots" : {
+      "type" : "array",
+      "items" : {
+        "type" : "string",
+        "description" : "Bytes32 hexadecimal",
+        "example" : "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+        "format" : "byte"
+      }
+    },
+    "historical_roots" : {
+      "type" : "array",
+      "items" : {
+        "type" : "string",
+        "description" : "Bytes32 hexadecimal",
+        "example" : "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+        "format" : "byte"
+      }
+    },
+    "eth1_data" : {
+      "$ref" : "#/components/schemas/Eth1Data"
+    },
+    "eth1_data_votes" : {
+      "type" : "array",
+      "items" : {
+        "$ref" : "#/components/schemas/Eth1Data"
+      }
+    },
+    "eth1_deposit_index" : {
+      "type" : "string",
+      "description" : "unsigned 64 bit integer",
+      "example" : "1",
+      "format" : "uint64"
+    },
+    "validators" : {
+      "type" : "array",
+      "items" : {
+        "$ref" : "#/components/schemas/Validator"
+      }
+    },
+    "balances" : {
+      "type" : "array",
+      "items" : {
+        "type" : "string",
+        "description" : "unsigned 64 bit integer",
+        "example" : "1",
+        "format" : "uint64"
+      }
+    },
+    "randao_mixes" : {
+      "type" : "array",
+      "items" : {
+        "type" : "string",
+        "description" : "Bytes32 hexadecimal",
+        "example" : "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+        "format" : "byte"
+      }
+    },
+    "slashings" : {
+      "type" : "array",
+      "items" : {
+        "type" : "string",
+        "description" : "unsigned 64 bit integer",
+        "example" : "1",
+        "format" : "uint64"
+      }
+    },
+    "previous_epoch_participation" : {
+      "type" : "array",
+      "items" : {
+        "type" : "string",
+        "example" : "1",
+        "description" : "unsigned 8 bit integer, max value 255",
+        "format" : "uint8"
+      }
+    },
+    "current_epoch_participation" : {
+      "type" : "array",
+      "items" : {
+        "type" : "string",
+        "example" : "1",
+        "description" : "unsigned 8 bit integer, max value 255",
+        "format" : "uint8"
+      }
+    },
+    "justification_bits" : {
+      "type" : "string",
+      "pattern" : "^0x[a-fA-F0-9]{2,}$",
+      "description" : "SSZ hexadecimal",
+      "format" : "bytes"
+    },
+    "previous_justified_checkpoint" : {
+      "$ref" : "#/components/schemas/Checkpoint"
+    },
+    "current_justified_checkpoint" : {
+      "$ref" : "#/components/schemas/Checkpoint"
+    },
+    "finalized_checkpoint" : {
+      "$ref" : "#/components/schemas/Checkpoint"
+    },
+    "inactivity_scores" : {
+      "type" : "array",
+      "items" : {
+        "type" : "string",
+        "description" : "unsigned 64 bit integer",
+        "example" : "1",
+        "format" : "uint64"
+      }
+    },
+    "current_sync_committee" : {
+      "$ref" : "#/components/schemas/SyncCommittee"
+    },
+    "next_sync_committee" : {
+      "$ref" : "#/components/schemas/SyncCommittee"
+    },
+    "latest_execution_payload_header" : {
+      "$ref" : "#/components/schemas/ExecutionPayloadHeaderCapella"
+    },
+    "next_withdrawal_index" : {
+      "type" : "string",
+      "description" : "unsigned 64 bit integer",
+      "example" : "1",
+      "format" : "uint64"
+    },
+    "next_withdrawal_validator_index" : {
+      "type" : "string",
+      "description" : "unsigned 64 bit integer",
+      "example" : "1",
+      "format" : "uint64"
+    }
+  }
+}

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/BlindedBlockBodyCapella.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/BlindedBlockBodyCapella.json
@@ -1,0 +1,64 @@
+{
+  "title" : "BlindedBlockBodyCapella",
+  "type" : "object",
+  "required" : [ "randao_reveal", "eth1_data", "graffiti", "proposer_slashings", "attester_slashings", "attestations", "deposits", "voluntary_exits", "sync_aggregate", "execution_payload_header", "bls_to_execution_changes" ],
+  "properties" : {
+    "randao_reveal" : {
+      "type" : "string",
+      "pattern" : "^0x[a-fA-F0-9]{2,}$",
+      "description" : "SSZ hexadecimal",
+      "format" : "bytes"
+    },
+    "eth1_data" : {
+      "$ref" : "#/components/schemas/Eth1Data"
+    },
+    "graffiti" : {
+      "type" : "string",
+      "description" : "Bytes32 hexadecimal",
+      "example" : "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+      "format" : "byte"
+    },
+    "proposer_slashings" : {
+      "type" : "array",
+      "items" : {
+        "$ref" : "#/components/schemas/ProposerSlashing"
+      }
+    },
+    "attester_slashings" : {
+      "type" : "array",
+      "items" : {
+        "$ref" : "#/components/schemas/AttesterSlashing"
+      }
+    },
+    "attestations" : {
+      "type" : "array",
+      "items" : {
+        "$ref" : "#/components/schemas/Attestation"
+      }
+    },
+    "deposits" : {
+      "type" : "array",
+      "items" : {
+        "$ref" : "#/components/schemas/Deposit"
+      }
+    },
+    "voluntary_exits" : {
+      "type" : "array",
+      "items" : {
+        "$ref" : "#/components/schemas/SignedVoluntaryExit"
+      }
+    },
+    "sync_aggregate" : {
+      "$ref" : "#/components/schemas/SyncAggregate"
+    },
+    "execution_payload_header" : {
+      "$ref" : "#/components/schemas/ExecutionPayloadHeaderCapella"
+    },
+    "bls_to_execution_changes" : {
+      "type" : "array",
+      "items" : {
+        "$ref" : "#/components/schemas/SignedBLSToExecutionChange"
+      }
+    }
+  }
+}

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/BlindedBlockCapella.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/BlindedBlockCapella.json
@@ -1,0 +1,34 @@
+{
+  "title" : "BlindedBlockCapella",
+  "type" : "object",
+  "required" : [ "slot", "proposer_index", "parent_root", "state_root", "body" ],
+  "properties" : {
+    "slot" : {
+      "type" : "string",
+      "description" : "unsigned 64 bit integer",
+      "example" : "1",
+      "format" : "uint64"
+    },
+    "proposer_index" : {
+      "type" : "string",
+      "description" : "unsigned 64 bit integer",
+      "example" : "1",
+      "format" : "uint64"
+    },
+    "parent_root" : {
+      "type" : "string",
+      "description" : "Bytes32 hexadecimal",
+      "example" : "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+      "format" : "byte"
+    },
+    "state_root" : {
+      "type" : "string",
+      "description" : "Bytes32 hexadecimal",
+      "example" : "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+      "format" : "byte"
+    },
+    "body" : {
+      "$ref" : "#/components/schemas/BlindedBlockBodyCapella"
+    }
+  }
+}

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/ExecutionPayloadCapella.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/ExecutionPayloadCapella.json
@@ -1,0 +1,100 @@
+{
+  "title" : "ExecutionPayloadCapella",
+  "type" : "object",
+  "required" : [ "parent_hash", "fee_recipient", "state_root", "receipts_root", "logs_bloom", "prev_randao", "block_number", "gas_limit", "gas_used", "timestamp", "extra_data", "base_fee_per_gas", "block_hash", "transactions", "withdrawals" ],
+  "properties" : {
+    "parent_hash" : {
+      "type" : "string",
+      "description" : "Bytes32 hexadecimal",
+      "example" : "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+      "format" : "byte"
+    },
+    "fee_recipient" : {
+      "type" : "string",
+      "pattern" : "^0x[a-fA-F0-9]{2,}$",
+      "description" : "SSZ hexadecimal",
+      "format" : "bytes"
+    },
+    "state_root" : {
+      "type" : "string",
+      "description" : "Bytes32 hexadecimal",
+      "example" : "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+      "format" : "byte"
+    },
+    "receipts_root" : {
+      "type" : "string",
+      "description" : "Bytes32 hexadecimal",
+      "example" : "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+      "format" : "byte"
+    },
+    "logs_bloom" : {
+      "type" : "string",
+      "pattern" : "^0x[a-fA-F0-9]{2,}$",
+      "description" : "SSZ hexadecimal",
+      "format" : "bytes"
+    },
+    "prev_randao" : {
+      "type" : "string",
+      "description" : "Bytes32 hexadecimal",
+      "example" : "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+      "format" : "byte"
+    },
+    "block_number" : {
+      "type" : "string",
+      "description" : "unsigned 64 bit integer",
+      "example" : "1",
+      "format" : "uint64"
+    },
+    "gas_limit" : {
+      "type" : "string",
+      "description" : "unsigned 64 bit integer",
+      "example" : "1",
+      "format" : "uint64"
+    },
+    "gas_used" : {
+      "type" : "string",
+      "description" : "unsigned 64 bit integer",
+      "example" : "1",
+      "format" : "uint64"
+    },
+    "timestamp" : {
+      "type" : "string",
+      "description" : "unsigned 64 bit integer",
+      "example" : "1",
+      "format" : "uint64"
+    },
+    "extra_data" : {
+      "type" : "string",
+      "pattern" : "^0x[a-fA-F0-9]{2,}$",
+      "description" : "SSZ encoded byte list",
+      "format" : "bytes"
+    },
+    "base_fee_per_gas" : {
+      "type" : "string",
+      "description" : "unsigned 256 bit integer",
+      "example" : "1",
+      "format" : "uint256"
+    },
+    "block_hash" : {
+      "type" : "string",
+      "description" : "Bytes32 hexadecimal",
+      "example" : "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+      "format" : "byte"
+    },
+    "transactions" : {
+      "type" : "array",
+      "items" : {
+        "type" : "string",
+        "pattern" : "^0x[a-fA-F0-9]{2,}$",
+        "description" : "SSZ encoded byte list",
+        "format" : "bytes"
+      }
+    },
+    "withdrawals" : {
+      "type" : "array",
+      "items" : {
+        "$ref" : "#/components/schemas/Withdrawal"
+      }
+    }
+  }
+}

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/ExecutionPayloadHeaderCapella.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/ExecutionPayloadHeaderCapella.json
@@ -1,0 +1,97 @@
+{
+  "title" : "ExecutionPayloadHeaderCapella",
+  "type" : "object",
+  "required" : [ "parent_hash", "fee_recipient", "state_root", "receipts_root", "logs_bloom", "prev_randao", "block_number", "gas_limit", "gas_used", "timestamp", "extra_data", "base_fee_per_gas", "block_hash", "transactions_root", "withdrawals_root" ],
+  "properties" : {
+    "parent_hash" : {
+      "type" : "string",
+      "description" : "Bytes32 hexadecimal",
+      "example" : "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+      "format" : "byte"
+    },
+    "fee_recipient" : {
+      "type" : "string",
+      "pattern" : "^0x[a-fA-F0-9]{2,}$",
+      "description" : "SSZ hexadecimal",
+      "format" : "bytes"
+    },
+    "state_root" : {
+      "type" : "string",
+      "description" : "Bytes32 hexadecimal",
+      "example" : "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+      "format" : "byte"
+    },
+    "receipts_root" : {
+      "type" : "string",
+      "description" : "Bytes32 hexadecimal",
+      "example" : "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+      "format" : "byte"
+    },
+    "logs_bloom" : {
+      "type" : "string",
+      "pattern" : "^0x[a-fA-F0-9]{2,}$",
+      "description" : "SSZ hexadecimal",
+      "format" : "bytes"
+    },
+    "prev_randao" : {
+      "type" : "string",
+      "description" : "Bytes32 hexadecimal",
+      "example" : "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+      "format" : "byte"
+    },
+    "block_number" : {
+      "type" : "string",
+      "description" : "unsigned 64 bit integer",
+      "example" : "1",
+      "format" : "uint64"
+    },
+    "gas_limit" : {
+      "type" : "string",
+      "description" : "unsigned 64 bit integer",
+      "example" : "1",
+      "format" : "uint64"
+    },
+    "gas_used" : {
+      "type" : "string",
+      "description" : "unsigned 64 bit integer",
+      "example" : "1",
+      "format" : "uint64"
+    },
+    "timestamp" : {
+      "type" : "string",
+      "description" : "unsigned 64 bit integer",
+      "example" : "1",
+      "format" : "uint64"
+    },
+    "extra_data" : {
+      "type" : "string",
+      "pattern" : "^0x[a-fA-F0-9]{2,}$",
+      "description" : "SSZ encoded byte list",
+      "format" : "bytes"
+    },
+    "base_fee_per_gas" : {
+      "type" : "string",
+      "description" : "unsigned 256 bit integer",
+      "example" : "1",
+      "format" : "uint256"
+    },
+    "block_hash" : {
+      "type" : "string",
+      "description" : "Bytes32 hexadecimal",
+      "example" : "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+      "format" : "byte"
+    },
+    "transactions_root" : {
+      "type" : "string",
+      "description" : "Bytes32 hexadecimal",
+      "example" : "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+      "format" : "byte"
+    },
+    "withdrawals_root" : {
+      "type" : "string",
+      "description" : "Bytes32 hexadecimal",
+      "example" : "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+      "format" : "byte"
+    }
+  }
+}

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/GetAllBlocksAtSlotResponse.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/GetAllBlocksAtSlotResponse.json
@@ -5,7 +5,7 @@
   "properties" : {
     "version" : {
       "type" : "string",
-      "enum" : [ "phase0", "altair", "bellatrix" ]
+      "enum" : [ "phase0", "altair", "bellatrix", "capella" ]
     },
     "data" : {
       "type" : "array",
@@ -22,6 +22,8 @@
               "$ref" : "#/components/schemas/BeaconBlockAltair"
             }, {
               "$ref" : "#/components/schemas/BeaconBlockBellatrix"
+            }, {
+              "$ref" : "#/components/schemas/BeaconBlockCapella"
             } ]
           },
           "signature" : {

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/GetBlockV2Response.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/GetBlockV2Response.json
@@ -5,7 +5,7 @@
   "properties" : {
     "version" : {
       "type" : "string",
-      "enum" : [ "phase0", "altair", "bellatrix" ]
+      "enum" : [ "phase0", "altair", "bellatrix", "capella" ]
     },
     "execution_optimistic" : {
       "type" : "boolean"
@@ -19,6 +19,8 @@
         "$ref" : "#/components/schemas/SignedBeaconBlockAltair"
       }, {
         "$ref" : "#/components/schemas/SignedBeaconBlockBellatrix"
+      }, {
+        "$ref" : "#/components/schemas/SignedBeaconBlockCapella"
       } ]
     }
   }

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/GetLightClientBootstrapResponse.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/GetLightClientBootstrapResponse.json
@@ -5,10 +5,10 @@
   "properties" : {
     "version" : {
       "type" : "string",
-      "enum" : [ "phase0", "altair", "bellatrix" ]
+      "enum" : [ "phase0", "altair", "bellatrix", "capella" ]
     },
     "data" : {
-      "$ref": "#/components/schemas/LightClientBootstrap"
+      "$ref" : "#/components/schemas/LightClientBootstrap"
     }
   }
 }

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/GetNewBlindedBlockResponse.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/GetNewBlindedBlockResponse.json
@@ -12,11 +12,13 @@
         "$ref" : "#/components/schemas/BeaconBlockAltair"
       }, {
         "$ref" : "#/components/schemas/BlindedBlockBellatrix"
+      }, {
+        "$ref" : "#/components/schemas/BlindedBlockCapella"
       } ]
     },
     "version" : {
       "type" : "string",
-      "enum" : [ "phase0", "altair", "bellatrix" ]
+      "enum" : [ "phase0", "altair", "bellatrix", "capella" ]
     }
   }
 }

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/GetStateV2Response.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/GetStateV2Response.json
@@ -5,7 +5,7 @@
   "properties" : {
     "version" : {
       "type" : "string",
-      "enum" : [ "phase0", "altair", "bellatrix" ]
+      "enum" : [ "phase0", "altair", "bellatrix", "capella" ]
     },
     "execution_optimistic" : {
       "type" : "boolean"
@@ -19,6 +19,8 @@
         "$ref" : "#/components/schemas/BeaconStateAltair"
       }, {
         "$ref" : "#/components/schemas/BeaconStateBellatrix"
+      }, {
+        "$ref" : "#/components/schemas/BeaconStateCapella"
       } ]
     }
   }

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/ProduceBlockResponse.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/ProduceBlockResponse.json
@@ -12,7 +12,9 @@
         "$ref" : "#/components/schemas/BeaconBlockAltair"
       }, {
         "$ref" : "#/components/schemas/BeaconBlockBellatrix"
-      } ]
+      }, {
+        "$ref" : "#/components/schemas/BeaconBlockCapella"
+      }  ]
     }
   }
 }

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/ProduceBlockV2Response.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/ProduceBlockV2Response.json
@@ -12,11 +12,13 @@
         "$ref" : "#/components/schemas/BeaconBlockAltair"
       }, {
         "$ref" : "#/components/schemas/BeaconBlockBellatrix"
-      } ]
+      }, {
+        "$ref" : "#/components/schemas/BeaconBlockCapella"
+      }  ]
     },
     "version" : {
       "type" : "string",
-      "enum" : [ "phase0", "altair", "bellatrix" ]
+      "enum" : [ "phase0", "altair", "bellatrix", "capella" ]
     }
   }
 }

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/SignedBLSToExecutionChange.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/SignedBLSToExecutionChange.json
@@ -1,0 +1,16 @@
+{
+  "title" : "SignedBLSToExecutionChange",
+  "type" : "object",
+  "required" : [ "message", "signature" ],
+  "properties" : {
+    "message" : {
+      "$ref" : "#/components/schemas/BLSToExecutionChange"
+    },
+    "signature" : {
+      "type" : "string",
+      "pattern" : "^0x[a-fA-F0-9]{2,}$",
+      "description" : "SSZ hexadecimal",
+      "format" : "bytes"
+    }
+  }
+}

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/SignedBeaconBlockCapella.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/SignedBeaconBlockCapella.json
@@ -1,0 +1,16 @@
+{
+  "title" : "SignedBeaconBlockCapella",
+  "type" : "object",
+  "required" : [ "message", "signature" ],
+  "properties" : {
+    "message" : {
+      "$ref" : "#/components/schemas/BeaconBlockCapella"
+    },
+    "signature" : {
+      "type" : "string",
+      "pattern" : "^0x[a-fA-F0-9]{2,}$",
+      "description" : "SSZ hexadecimal",
+      "format" : "bytes"
+    }
+  }
+}

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/SignedBlindedBlockCapella.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/SignedBlindedBlockCapella.json
@@ -1,0 +1,16 @@
+{
+  "title" : "SignedBlindedBlockCapella",
+  "type" : "object",
+  "required" : [ "message", "signature" ],
+  "properties" : {
+    "message" : {
+      "$ref" : "#/components/schemas/BlindedBlockCapella"
+    },
+    "signature" : {
+      "type" : "string",
+      "pattern" : "^0x[a-fA-F0-9]{2,}$",
+      "description" : "SSZ hexadecimal",
+      "format" : "bytes"
+    }
+  }
+}

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/Withdrawal.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/Withdrawal.json
@@ -1,0 +1,31 @@
+{
+  "title" : "Withdrawal",
+  "type" : "object",
+  "required" : [ "index", "validator_index", "address", "amount" ],
+  "properties" : {
+    "index" : {
+      "type" : "string",
+      "description" : "unsigned 64 bit integer",
+      "example" : "1",
+      "format" : "uint64"
+    },
+    "validator_index" : {
+      "type" : "string",
+      "description" : "unsigned 64 bit integer",
+      "example" : "1",
+      "format" : "uint64"
+    },
+    "address" : {
+      "type" : "string",
+      "pattern" : "^0x[a-fA-F0-9]{2,}$",
+      "description" : "SSZ hexadecimal",
+      "format" : "bytes"
+    },
+    "amount" : {
+      "type" : "string",
+      "description" : "unsigned 64 bit integer",
+      "example" : "1",
+      "format" : "uint64"
+    }
+  }
+}

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/MilestoneDependentTypesUtil.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/MilestoneDependentTypesUtil.java
@@ -33,8 +33,7 @@ import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
 
 public class MilestoneDependentTypesUtil {
 
-  private static final Set<SpecMilestone> IGNORED_MILESTONES =
-      Set.of(SpecMilestone.CAPELLA, SpecMilestone.EIP4844);
+  private static final Set<SpecMilestone> IGNORED_MILESTONES = Set.of(SpecMilestone.EIP4844);
 
   public static <T extends SszData>
       SerializableOneOfTypeDefinition<T> getSchemaDefinitionForAllMilestones(

--- a/ethereum/json-types/src/main/java/tech/pegasys/teku/ethereum/json/types/EthereumTypes.java
+++ b/ethereum/json-types/src/main/java/tech/pegasys/teku/ethereum/json/types/EthereumTypes.java
@@ -72,7 +72,7 @@ public class EthereumTypes {
       DeserializableTypeDefinition.enumOf(
           SpecMilestone.class,
           milestone -> milestone.name().toLowerCase(Locale.ROOT),
-          Set.of(SpecMilestone.CAPELLA, SpecMilestone.EIP4844));
+          Set.of(SpecMilestone.EIP4844));
 
   public static <X extends SszData, T extends ObjectAndMetaData<X>>
       ResponseContentTypeDefinition<T> sszResponseType() {


### PR DESCRIPTION
This is needed for beacon-api to be able to respond with capella structures.

partially addresses #6357

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
