### PR TITLE
Use correct fork when validating sync committee messages/contributions

### DIFF
--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/ChainBuilder.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/ChainBuilder.java
@@ -553,10 +553,11 @@ public class ChainBuilder {
       final BeaconStateAltair state,
       final BLSPublicKey validatorPublicKey) {
     final int validatorIndex = spec.getValidatorIndex(state, validatorPublicKey).orElseThrow();
+
+    final UInt64 epoch = spec.getSyncCommitteeUtilRequired(slot).getEpochForDutiesAtSlot(slot);
+    final ForkInfo forkInfo = new ForkInfo(spec.fork(epoch), state.getGenesisValidatorsRoot());
     final BLSSignature signature =
-        getSigner(validatorIndex)
-            .signSyncCommitteeMessage(slot, blockRoot, state.getForkInfo())
-            .join();
+        getSigner(validatorIndex).signSyncCommitteeMessage(slot, blockRoot, forkInfo).join();
     return SchemaDefinitionsAltair.required(spec.atSlot(slot).getSchemaDefinitions())
         .getSyncCommitteeMessageSchema()
         .create(slot, blockRoot, UInt64.valueOf(validatorIndex), signature);

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/ChainBuilder.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/ChainBuilder.java
@@ -54,6 +54,7 @@ import tech.pegasys.teku.spec.datastructures.operations.SignedBlsToExecutionChan
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncAggregatorSelectionData;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeMessage;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
+import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.altair.BeaconStateAltair;
 import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
@@ -509,11 +510,11 @@ public class ChainBuilder {
         final SyncAggregatorSelectionData syncAggregatorSelectionData =
             syncCommitteeUtil.createSyncAggregatorSelectionData(
                 slot, UInt64.valueOf(subcommitteeIndex));
+        final ForkInfo forkInfo =
+            new ForkInfo(
+                spec.fork(epoch), latestBlockAndState.getState().getGenesisValidatorsRoot());
         final BLSSignature proof =
-            signer
-                .signSyncCommitteeSelectionProof(
-                    syncAggregatorSelectionData, latestBlockAndState.getState().getForkInfo())
-                .join();
+            signer.signSyncCommitteeSelectionProof(syncAggregatorSelectionData, forkInfo).join();
         if (syncCommitteeUtil.isSyncCommitteeAggregator(proof)) {
           return new SignedContributionAndProofTestBuilder()
               .signerProvider(this::getSigner)

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SignedContributionAndProofValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SignedContributionAndProofValidator.java
@@ -39,6 +39,7 @@ import tech.pegasys.teku.spec.config.SpecConfigAltair;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.ContributionAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SignedContributionAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeContribution;
+import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
 import tech.pegasys.teku.spec.datastructures.state.SyncCommittee;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.altair.BeaconStateAltair;
@@ -202,7 +203,7 @@ public class SignedContributionAndProofValidator {
         syncCommitteeUtil.getSyncAggregatorSelectionDataSigningRoot(
             syncCommitteeUtil.createSyncAggregatorSelectionData(
                 contribution.getSlot(), contribution.getSubcommitteeIndex()),
-            state.getForkInfo());
+            new ForkInfo(spec.fork(contributionEpoch), state.getGenesisValidatorsRoot()));
     if (!signatureVerifier.verify(
         aggregatorPublicKey.get(), signingRoot, contributionAndProof.getSelectionProof())) {
       return futureFailureResult(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeMessageValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeMessageValidator.java
@@ -35,6 +35,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeMessage;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.ValidateableSyncCommitteeMessage;
+import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.altair.BeaconStateAltair;
 import tech.pegasys.teku.spec.datastructures.util.SyncSubcommitteeAssignments;
 import tech.pegasys.teku.spec.logic.common.util.AsyncBLSSignatureVerifier;
@@ -179,9 +180,11 @@ public class SyncCommitteeMessageValidator {
 
     // [REJECT] The message is valid for the message beacon_block_root for the validator
     // referenced by validator_index.
+    final ForkInfo forkInfo =
+        new ForkInfo(spec.fork(messageEpoch), state.getGenesisValidatorsRoot());
     final Bytes32 signingRoot =
         syncCommitteeUtil.getSyncCommitteeMessageSigningRoot(
-            message.getBeaconBlockRoot(), messageEpoch, state.getForkInfo());
+            message.getBeaconBlockRoot(), messageEpoch, forkInfo);
     return signatureVerifier
         .verify(maybeValidatorPublicKey.get(), signingRoot, message.getSignature())
         .thenApply(


### PR DESCRIPTION
## PR Description
Handle the case where sync committee gossip is received for slots after a milestone activates but the head state is still from the previous milestone due to empty slots. The fork from the state in that case won't include the new milestone information (it only has current and previous) so we need to ensure we get the fork from the spec fork schedule.

## Fixed Issue(s)
fixes #6499

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
