### PR TITLE
Fix REST API tried to get cache of not-enabled fork

### DIFF
--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/MilestoneDependentTypesUtil.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/MilestoneDependentTypesUtil.java
@@ -44,7 +44,8 @@ public class MilestoneDependentTypesUtil {
     final SerializableOneOfTypeDefinitionBuilder<T> builder =
         new SerializableOneOfTypeDefinitionBuilder<T>().title(title);
     for (SpecMilestone milestone : SpecMilestone.values()) {
-      if (IGNORED_MILESTONES.contains(milestone)) {
+      if (!schemaDefinitionCache.getEnabledMilestones().contains(milestone)
+          || IGNORED_MILESTONES.contains(milestone)) {
         continue;
       }
       final DeserializableTypeDefinition<? extends T> jsonTypeDefinition =

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/MilestoneDependentTypesUtilTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/MilestoneDependentTypesUtilTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.beaconrestapi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.MilestoneDependentTypesUtil.getSchemaDefinitionForAllMilestones;
+
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.json.types.SerializableOneOfTypeDefinition;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.config.SpecConfigLoader;
+import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
+import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSchema;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionCache;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
+
+public class MilestoneDependentTypesUtilTest {
+
+  @Test
+  public void shouldNotThrowExceptionWithSpecUnderHighestSupported() {
+    final Spec spec = TestSpecFactory.createBellatrix(SpecConfigLoader.loadConfig("prater"));
+    final SchemaDefinitionCache schemaDefinitionCache = new SchemaDefinitionCache(spec);
+    SerializableOneOfTypeDefinition<BeaconBlock> blockType =
+        getSchemaDefinitionForAllMilestones(
+            schemaDefinitionCache,
+            "BeaconBlockPhase0",
+            SchemaDefinitions::getBeaconBlockSchema,
+            (beaconBlock, milestone) ->
+                schemaDefinitionCache.milestoneAtSlot(beaconBlock.getSlot()).equals(milestone));
+    final BeaconBlockSchema schema = spec.getGenesisSchemaDefinitions().getBeaconBlockSchema();
+    assertThat(schema.getContainerName()).isEqualTo("BeaconBlockPhase0");
+    assertThat(blockType.isEquivalentToDeserializableType(schema.getJsonTypeDefinition())).isTrue();
+  }
+
+  @Test
+  public void shouldSupportHighestSupportedMilestone() {
+    final Spec spec = TestSpecFactory.createMainnetCapella();
+    final SchemaDefinitionCache schemaDefinitionCache = new SchemaDefinitionCache(spec);
+    SerializableOneOfTypeDefinition<BeaconBlock> blindedBlockType =
+        getSchemaDefinitionForAllMilestones(
+            schemaDefinitionCache,
+            "BlindedBlock",
+            SchemaDefinitions::getBlindedBeaconBlockSchema,
+            (beaconBlock, milestone) ->
+                schemaDefinitionCache.milestoneAtSlot(beaconBlock.getSlot()).equals(milestone));
+    final BeaconBlockSchema schema =
+        spec.getGenesisSchemaDefinitions().getBlindedBeaconBlockSchema();
+    assertThat(schema.getContainerName()).isEqualTo("BlindedBlockCapella");
+    assertThat(blindedBlockType.isEquivalentToDeserializableType(schema.getJsonTypeDefinition()))
+        .isTrue();
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionCache.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionCache.java
@@ -26,11 +26,11 @@ import tech.pegasys.teku.spec.datastructures.util.ForkAndSpecMilestone;
 public class SchemaDefinitionCache {
   private final Spec spec;
   private final Map<SpecMilestone, SchemaDefinitions> schemas = new ConcurrentHashMap<>();
-  private final Set<SpecMilestone> supportedMilestones;
+  private final Set<SpecMilestone> enabledMilestones;
 
   public SchemaDefinitionCache(final Spec spec) {
     this.spec = spec;
-    this.supportedMilestones =
+    this.enabledMilestones =
         spec.getEnabledMilestones().stream()
             .map(ForkAndSpecMilestone::getSpecMilestone)
             .collect(Collectors.toSet());
@@ -64,6 +64,6 @@ public class SchemaDefinitionCache {
   }
 
   public Set<SpecMilestone> getEnabledMilestones() {
-    return supportedMilestones;
+    return enabledMilestones;
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionCache.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionCache.java
@@ -14,18 +14,26 @@
 package tech.pegasys.teku.spec.schemas;
 
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.SpecVersion;
+import tech.pegasys.teku.spec.datastructures.util.ForkAndSpecMilestone;
 
 public class SchemaDefinitionCache {
   private final Spec spec;
   private final Map<SpecMilestone, SchemaDefinitions> schemas = new ConcurrentHashMap<>();
+  private final Set<SpecMilestone> supportedMilestones;
 
   public SchemaDefinitionCache(final Spec spec) {
     this.spec = spec;
+    this.supportedMilestones =
+        spec.getEnabledMilestones().stream()
+            .map(ForkAndSpecMilestone::getSpecMilestone)
+            .collect(Collectors.toSet());
   }
 
   public SchemaDefinitions getSchemaDefinition(final SpecMilestone milestone) {
@@ -53,5 +61,9 @@ public class SchemaDefinitionCache {
                         + milestone.name()
                         + ". Ensure network config includes all required options."))
         .getSchemaDefinitions();
+  }
+
+  public Set<SpecMilestone> getEnabledMilestones() {
+    return supportedMilestones;
   }
 }

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionCacheTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionCacheTest.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.spec.schemas;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionCacheTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionCacheTest.java
@@ -15,7 +15,9 @@ package tech.pegasys.teku.spec.schemas;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -58,6 +60,7 @@ public class SchemaDefinitionCacheTest {
     verify(spec).forMilestone(eq(SpecMilestone.ALTAIR));
 
     assertThat(cache.getSchemaDefinition(SpecMilestone.ALTAIR)).isNotNull();
+    verify(spec, times(1)).getEnabledMilestones();
     verifyNoMoreInteractions(spec);
   }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Currently when Teku starts on Goerli/Prater with Rest API enabled, it fails to start with following error:
```
21:51:33.353 INFO  - PreGenesis Local ENR: enr:-I24QKzxNnTb0DWsbGrTz-nl-ntrNIOLtb9f2x7BT2Gww5oWeO5yimQaVN0OIv-LF6hrC8CepsglvEj9TKLOvWFKABSCAWqEZXRoMpDkvpOTAAAQIP__________gmlkgnY0iXNlY3AyNTZrMaECDWbqPskoP4hjA2RGl4EL-hvAXE0k-VfmtGYT65US_xU
Teku failed to start: java.lang.IllegalArgumentException: Unable to create spec for milestone CAPELLA. Ensure network config includes all required options.

To display full help:
teku [COMMAND] --help

> Task :teku:Teku.main() FAILED
```
So it has `SpecConfigBellatrixImpl` because Capella fork is not defined on Goerli, but Rest API tries to get caches for all milestones including Capella. This PR fixes it
I don't like that test is based on `prater` config which could be changed in future but have not found simple way to create `SpecConfigBellatrix`. We could remove Capella from `less-swift` or create a new config

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
