### PR TITLE
BlobsSidecarAvailabilityChecker return not_required when availability check is not initiated

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/results/BlockImportResult.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/results/BlockImportResult.java
@@ -34,6 +34,9 @@ public interface BlockImportResult {
   BlockImportResult FAILED_DESCENDANT_OF_INVALID_BLOCK =
       new FailedBlockImportResult(FailureReason.DESCENDANT_OF_INVALID_BLOCK, Optional.empty());
 
+  BlockImportResult FAILED_BLOBS_AVAILABILITY_CHECK =
+      new FailedBlockImportResult(FailureReason.FAILED_BLOBS_AVAILABILITY_CHECK, Optional.empty());
+
   static BlockImportResult failedExecutionPayloadExecution(final Throwable cause) {
     return new FailedBlockImportResult(
         FailureReason.FAILED_EXECUTION_PAYLOAD_EXECUTION, Optional.of(cause));
@@ -70,6 +73,7 @@ public interface BlockImportResult {
     FAILED_EXECUTION_PAYLOAD_EXECUTION,
     FAILED_EXECUTION_PAYLOAD_EXECUTION_SYNCING,
     DESCENDANT_OF_INVALID_BLOCK,
+    FAILED_BLOBS_AVAILABILITY_CHECK,
     INTERNAL_ERROR // A catch-all category for unexpected errors (bugs)
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/eip4844/blobs/BlobsSidecarAvailabilityChecker.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/eip4844/blobs/BlobsSidecarAvailabilityChecker.java
@@ -29,7 +29,7 @@ public interface BlobsSidecarAvailabilityChecker {
 
         @Override
         public SafeFuture<BlobsSidecarAndValidationResult> getAvailabilityCheckResult() {
-          return NOT_AVAILABLE_RESULT_FUTURE;
+          return NOT_REQUIRED_RESULT_FUTURE;
         }
       };
 
@@ -52,8 +52,8 @@ public interface BlobsSidecarAvailabilityChecker {
     VALID
   }
 
-  SafeFuture<BlobsSidecarAndValidationResult> NOT_AVAILABLE_RESULT_FUTURE =
-      SafeFuture.completedFuture(BlobsSidecarAndValidationResult.NOT_AVAILABLE);
+  SafeFuture<BlobsSidecarAndValidationResult> NOT_REQUIRED_RESULT_FUTURE =
+      SafeFuture.completedFuture(BlobsSidecarAndValidationResult.NOT_REQUIRED);
 
   class BlobsSidecarAndValidationResult {
     private final BlobsSidecarValidationResult validationResult;

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/BlockManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/BlockManager.java
@@ -277,9 +277,10 @@ public class BlockManager extends Service
                         FailedPayloadExecutionSubscriber::onPayloadExecutionFailed, block);
                     break;
                   case FAILED_BLOBS_AVAILABILITY_CHECK:
-                    // TODO: we cannot invalidate the block root since it passed the checks
-                    // we should maintain a set of invalid BlobsSidecar root OR
-                    // SignedBeaconBlockAndBlobsSidecar root
+                    // TODO:
+                    //  Trigger the fetcher in the case the coupled BeaconBlockAndBlobsSidecar
+                    //  contains a valid block but the BlobsSidecar validation fails.
+                    //  Should be similar to what we do with pendingBlocks.
                     break;
                   default:
                     LOG.trace(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/BlockManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/BlockManager.java
@@ -276,6 +276,11 @@ public class BlockManager extends Service
                     failedPayloadExecutionSubscribers.deliver(
                         FailedPayloadExecutionSubscriber::onPayloadExecutionFailed, block);
                     break;
+                  case FAILED_BLOBS_AVAILABILITY_CHECK:
+                    // TODO: we cannot invalidate the block root since it passed the checks
+                    // we should maintain a set of invalid BlobsSidecar root OR
+                    // SignedBeaconBlockAndBlobsSidecar root
+                    break;
                   default:
                     LOG.trace(
                         "Unable to import block for reason {}: {}",

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -35,7 +35,6 @@ import tech.pegasys.teku.infrastructure.exceptions.FatalServiceFailureException;
 import tech.pegasys.teku.infrastructure.subscribers.Subscribers;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.SpecVersion;
 import tech.pegasys.teku.spec.cache.CapturingIndexedAttestationCache;
 import tech.pegasys.teku.spec.cache.IndexedAttestationCache;
@@ -374,16 +373,20 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
           payloadResult.getFailureCause().orElseThrow());
     }
 
-    if (spec.isMilestoneSupported(SpecMilestone.EIP4844)) {
-      if (blobsSidecarAndValidationResult.isFailure()) {
-        LOG.error("blobs are " + blobsSidecarAndValidationResult.getValidationResult());
-        // TODO: fail block import
-      } else if (blobsSidecarAndValidationResult.isNotRequired()) {
-        LOG.debug("blobs are " + blobsSidecarAndValidationResult.getValidationResult());
-      } else if (blobsSidecarAndValidationResult.isValid()) {
-        LOG.debug("blobs are " + blobsSidecarAndValidationResult.getValidationResult());
-        // TODO: store blobs
-      }
+    if (blobsSidecarAndValidationResult.isFailure()) {
+      LOG.error(
+          "blobsSidecar validation result: {}",
+          blobsSidecarAndValidationResult.getValidationResult());
+      return BlockImportResult.FAILED_BLOBS_AVAILABILITY_CHECK;
+    } else if (blobsSidecarAndValidationResult.isNotRequired()) {
+      LOG.debug(
+          "blobsSidecar validation result: {}",
+          blobsSidecarAndValidationResult.getValidationResult());
+    } else if (blobsSidecarAndValidationResult.isValid()) {
+      LOG.debug(
+          "blobsSidecar validation result: {}",
+          blobsSidecarAndValidationResult.getValidationResult());
+      // TODO: store blobs
     }
 
     final ForkChoiceStrategy forkChoiceStrategy = getForkChoiceStrategy();

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceBlobsSidecarAvailabilityChecker.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceBlobsSidecarAvailabilityChecker.java
@@ -56,7 +56,7 @@ public class ForkChoiceBlobsSidecarAvailabilityChecker implements BlobsSidecarAv
 
   @Override
   public SafeFuture<BlobsSidecarAndValidationResult> getAvailabilityCheckResult() {
-    return validationResult.orElse(NOT_AVAILABLE_RESULT_FUTURE);
+    return validationResult.orElse(NOT_REQUIRED_RESULT_FUTURE);
   }
 
   private BlobsSidecarAndValidationResult validateBlobsSidecar() {

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockManagerTest.java
@@ -81,7 +81,7 @@ import tech.pegasys.teku.weaksubjectivity.WeakSubjectivityFactory;
 public class BlockManagerTest {
   private final StubTimeProvider timeProvider = StubTimeProvider.withTimeInSeconds(0);
   private final EventLogger eventLogger = mock(EventLogger.class);
-  private final Spec spec = TestSpecFactory.createMinimalEip4844();
+  private final Spec spec = TestSpecFactory.createMinimalBellatrix();
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
   private final BlockImportNotifications blockImportNotifications =
       mock(BlockImportNotifications.class);

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceBlobsSidecarAvailabilityCheckerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceBlobsSidecarAvailabilityCheckerTest.java
@@ -101,10 +101,10 @@ public class ForkChoiceBlobsSidecarAvailabilityCheckerTest {
   }
 
   @Test
-  void shouldReturnNotAvailableWhenNotDataAvailabilityCheckNotInitiated() {
+  void shouldReturnNotRequiredWhenNotDataAvailabilityCheckNotInitiated() {
     prepareBlockAndBlobInAvailabilityWindow(true);
 
-    assertNotAvailable(blobsSidecarAvailabilityChecker.getAvailabilityCheckResult());
+    assertNotRequired(blobsSidecarAvailabilityChecker.getAvailabilityCheckResult());
   }
 
   private void assertNotRequired(SafeFuture<BlobsSidecarAndValidationResult> availabilityCheck) {


### PR DESCRIPTION
An alternative to this is to put the checker in the spec logic.
This solution follows the `ForkChoicePayloadExecutor` pattern, essentially acting as a NOOP if not engaged during block import.

related to #6522

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
