### PR TITLE
Updated PostBlsToExecutionChanges to reject changes prior to capella.

### DIFF
--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/JsonTypeDefinitionBeaconRestApi.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/JsonTypeDefinitionBeaconRestApi.java
@@ -235,8 +235,8 @@ public class JsonTypeDefinitionBeaconRestApi implements BeaconRestApi {
         .endpoint(new PostVoluntaryExit(dataProvider))
         .endpoint(new PostSyncCommittees(dataProvider))
         .endpoint(new PostValidatorLiveness(dataProvider))
-        .endpoint(new PostBlsToExecutionChanges(dataProvider.getNodeDataProvider(), schemaCache))
-        .endpoint(new GetBlsToExecutionChanges(dataProvider.getNodeDataProvider(), schemaCache))
+        .endpoint(new PostBlsToExecutionChanges(dataProvider, schemaCache))
+        .endpoint(new GetBlsToExecutionChanges(dataProvider, schemaCache))
         // Event Handler
         .endpoint(
             new GetEvents(

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetBlsToExecutionChanges.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetBlsToExecutionChanges.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import io.javalin.http.Header;
 import java.util.List;
 import java.util.function.Function;
+import tech.pegasys.teku.api.DataProvider;
 import tech.pegasys.teku.api.NodeDataProvider;
 import tech.pegasys.teku.infrastructure.json.types.SerializableTypeDefinition;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.EndpointMetadata;
@@ -36,6 +37,11 @@ public class GetBlsToExecutionChanges extends RestApiEndpoint {
   public static final String ROUTE = "/eth/v1/beacon/pool/bls_to_execution_changes";
 
   private final NodeDataProvider nodeDataProvider;
+
+  public GetBlsToExecutionChanges(
+      final DataProvider dataProvider, final SchemaDefinitionCache schemaCache) {
+    this(dataProvider.getNodeDataProvider(), schemaCache);
+  }
 
   public GetBlsToExecutionChanges(
       final NodeDataProvider nodeDataProvider, final SchemaDefinitionCache schemaCache) {

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
@@ -523,6 +523,10 @@ public class ChainDataProvider {
                 .map(SignedBeaconBlock::getRoot));
   }
 
+  public SpecMilestone getMilestoneAtHead() {
+    return spec.atSlot(recentChainData.getHeadSlot()).getMilestone();
+  }
+
   private <T> SafeFuture<Optional<ObjectAndMetaData<T>>> fromBlock(
       final String slotParameter, final Function<SignedBeaconBlock, T> mapper) {
     return defaultBlockSelectorFactory


### PR DESCRIPTION
Accepting a bellatrix bls_to_execution_change would lead to bad UX, because the user would have a good faith expectation that the change can be made (given that it was accepted), but in reality the change cannot be made even though it is valid pre-capella, because the signed object is no longer valid once Capella occurs and the signature is invalidated by the fork transition.

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
