### PR TITLE
Refactored operations validators to have fork versions

### DIFF
--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryTest.java
@@ -56,10 +56,10 @@ import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SignedCo
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannel;
-import tech.pegasys.teku.spec.logic.common.operations.validation.AttesterSlashingValidator.AttesterSlashingInvalidReason;
-import tech.pegasys.teku.spec.logic.common.operations.validation.BlsToExecutionChangesValidator.BlsToExecutionChangeInvalidReason;
-import tech.pegasys.teku.spec.logic.common.operations.validation.ProposerSlashingValidator.ProposerSlashingInvalidReason;
-import tech.pegasys.teku.spec.logic.common.operations.validation.VoluntaryExitValidator.ExitInvalidReason;
+import tech.pegasys.teku.spec.logic.versions.capella.operations.validation.BlsToExecutionChangesValidator.BlsToExecutionChangeInvalidReason;
+import tech.pegasys.teku.spec.logic.versions.phase0.operations.validation.AttesterSlashingValidator.AttesterSlashingInvalidReason;
+import tech.pegasys.teku.spec.logic.versions.phase0.operations.validation.ProposerSlashingValidator.ProposerSlashingInvalidReason;
+import tech.pegasys.teku.spec.logic.versions.phase0.operations.validation.VoluntaryExitValidator.ExitInvalidReason;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsBellatrix;
 import tech.pegasys.teku.spec.util.DataStructureUtil;

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/operations/validation/OperationValidator.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/operations/validation/OperationValidator.java
@@ -14,7 +14,6 @@
 package tech.pegasys.teku.spec.logic.common.operations.validation;
 
 import java.util.Optional;
-import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.BlsToExecutionChange;
@@ -22,88 +21,27 @@ import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
-import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
-import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
-import tech.pegasys.teku.spec.logic.common.helpers.Predicates;
-import tech.pegasys.teku.spec.logic.common.operations.validation.AttesterSlashingValidator.SlashedIndicesCaptor;
-import tech.pegasys.teku.spec.logic.common.util.AttestationUtil;
+import tech.pegasys.teku.spec.logic.versions.phase0.operations.validation.AttesterSlashingValidator;
 
-public class OperationValidator {
+public interface OperationValidator {
+  Optional<OperationInvalidReason> validateAttestationData(
+      Fork fork, BeaconState state, AttestationData data);
 
-  private final AttestationDataValidator attestationDataValidator;
-  private final AttesterSlashingValidator attesterSlashingValidator;
-  private final ProposerSlashingValidator proposerSlashingValidator;
-  private final VoluntaryExitValidator voluntaryExitValidator;
+  Optional<OperationInvalidReason> validateAttesterSlashing(
+      Fork fork, BeaconState state, AttesterSlashing attesterSlashing);
 
-  private final BlsToExecutionChangesValidator blsToExecutionChangesValidator;
+  Optional<OperationInvalidReason> validateAttesterSlashing(
+      Fork fork,
+      BeaconState state,
+      AttesterSlashing attesterSlashing,
+      AttesterSlashingValidator.SlashedIndicesCaptor slashedIndicesCaptor);
 
-  private OperationValidator(
-      final AttestationDataValidator attestationDataValidator,
-      final AttesterSlashingValidator attesterSlashingValidator,
-      final ProposerSlashingValidator proposerSlashingValidator,
-      final VoluntaryExitValidator voluntaryExitValidator,
-      final BlsToExecutionChangesValidator blsToExecutionChangesValidator) {
-    this.attestationDataValidator = attestationDataValidator;
-    this.attesterSlashingValidator = attesterSlashingValidator;
-    this.proposerSlashingValidator = proposerSlashingValidator;
-    this.voluntaryExitValidator = voluntaryExitValidator;
-    this.blsToExecutionChangesValidator = blsToExecutionChangesValidator;
-  }
+  Optional<OperationInvalidReason> validateProposerSlashing(
+      Fork fork, BeaconState state, ProposerSlashing proposerSlashing);
 
-  public static OperationValidator create(
-      final SpecConfig specConfig,
-      final Predicates predicates,
-      final MiscHelpers miscHelpers,
-      final BeaconStateAccessors beaconStateAccessors,
-      final AttestationUtil attestationUtil) {
-    final AttestationDataValidator attestationDataValidator =
-        new AttestationDataValidator(specConfig, miscHelpers, beaconStateAccessors);
-    final AttesterSlashingValidator attesterSlashingValidator =
-        new AttesterSlashingValidator(predicates, beaconStateAccessors, attestationUtil);
-    final ProposerSlashingValidator proposerSlashingValidator =
-        new ProposerSlashingValidator(predicates, beaconStateAccessors);
-    final VoluntaryExitValidator voluntaryExitValidator =
-        new VoluntaryExitValidator(specConfig, predicates, beaconStateAccessors);
-    final BlsToExecutionChangesValidator blsToExecutionChangesValidator =
-        new BlsToExecutionChangesValidator();
-    return new OperationValidator(
-        attestationDataValidator,
-        attesterSlashingValidator,
-        proposerSlashingValidator,
-        voluntaryExitValidator,
-        blsToExecutionChangesValidator);
-  }
+  Optional<OperationInvalidReason> validateVoluntaryExit(
+      Fork fork, BeaconState state, SignedVoluntaryExit signedExit);
 
-  public Optional<OperationInvalidReason> validateAttestationData(
-      final Fork fork, final BeaconState state, final AttestationData data) {
-    return attestationDataValidator.validate(fork, state, data);
-  }
-
-  public Optional<OperationInvalidReason> validateAttesterSlashing(
-      final Fork fork, final BeaconState state, final AttesterSlashing attesterSlashing) {
-    return attesterSlashingValidator.validate(fork, state, attesterSlashing);
-  }
-
-  public Optional<OperationInvalidReason> validateAttesterSlashing(
-      final Fork fork,
-      final BeaconState state,
-      final AttesterSlashing attesterSlashing,
-      SlashedIndicesCaptor slashedIndicesCaptor) {
-    return attesterSlashingValidator.validate(fork, state, attesterSlashing, slashedIndicesCaptor);
-  }
-
-  public Optional<OperationInvalidReason> validateProposerSlashing(
-      final Fork fork, final BeaconState state, final ProposerSlashing proposerSlashing) {
-    return proposerSlashingValidator.validate(fork, state, proposerSlashing);
-  }
-
-  public Optional<OperationInvalidReason> validateVoluntaryExit(
-      final Fork fork, final BeaconState state, final SignedVoluntaryExit signedExit) {
-    return voluntaryExitValidator.validate(fork, state, signedExit);
-  }
-
-  public Optional<OperationInvalidReason> validateBlsToExecutionChange(
-      final Fork fork, final BeaconState state, final BlsToExecutionChange blsToExecutionChange) {
-    return blsToExecutionChangesValidator.validate(fork, state, blsToExecutionChange);
-  }
+  Optional<OperationInvalidReason> validateBlsToExecutionChange(
+      Fork fork, BeaconState state, BlsToExecutionChange blsToExecutionChange);
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/SpecLogicAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/SpecLogicAltair.java
@@ -35,6 +35,7 @@ import tech.pegasys.teku.spec.logic.versions.altair.statetransition.epoch.EpochP
 import tech.pegasys.teku.spec.logic.versions.altair.statetransition.epoch.ValidatorStatusFactoryAltair;
 import tech.pegasys.teku.spec.logic.versions.altair.util.AttestationUtilAltair;
 import tech.pegasys.teku.spec.logic.versions.bellatrix.helpers.BellatrixTransitionHelpers;
+import tech.pegasys.teku.spec.logic.versions.phase0.operations.validation.OperationValidatorPhase0;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsAltair;
 
 public class SpecLogicAltair extends AbstractSpecLogic {
@@ -99,8 +100,10 @@ public class SpecLogicAltair extends AbstractSpecLogic {
             config, schemaDefinitions, predicates, miscHelpers, beaconStateAccessors);
     final AttestationUtil attestationUtil =
         new AttestationUtilAltair(config, schemaDefinitions, beaconStateAccessors, miscHelpers);
+    // specific operation validator from spec so that things can hapepn like rejecting bls to
+    // execution change
     final OperationValidator operationValidator =
-        OperationValidator.create(
+        new OperationValidatorPhase0(
             config, predicates, miscHelpers, beaconStateAccessors, attestationUtil);
     final ValidatorStatusFactoryAltair validatorStatusFactory =
         new ValidatorStatusFactoryAltair(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/bellatrix/SpecLogicBellatrix.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/bellatrix/SpecLogicBellatrix.java
@@ -36,6 +36,7 @@ import tech.pegasys.teku.spec.logic.versions.bellatrix.helpers.BellatrixTransiti
 import tech.pegasys.teku.spec.logic.versions.bellatrix.helpers.MiscHelpersBellatrix;
 import tech.pegasys.teku.spec.logic.versions.bellatrix.statetransition.epoch.EpochProcessorBellatrix;
 import tech.pegasys.teku.spec.logic.versions.bellatrix.util.BlindBlockUtilBellatrix;
+import tech.pegasys.teku.spec.logic.versions.phase0.operations.validation.OperationValidatorPhase0;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsBellatrix;
 
 public class SpecLogicBellatrix extends AbstractSpecLogic {
@@ -106,7 +107,7 @@ public class SpecLogicBellatrix extends AbstractSpecLogic {
     final AttestationUtil attestationUtil =
         new AttestationUtilAltair(config, schemaDefinitions, beaconStateAccessors, miscHelpers);
     final OperationValidator operationValidator =
-        OperationValidator.create(
+        new OperationValidatorPhase0(
             config, predicates, miscHelpers, beaconStateAccessors, attestationUtil);
     final ValidatorStatusFactoryAltair validatorStatusFactory =
         new ValidatorStatusFactoryAltair(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/SpecLogicCapella.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/SpecLogicCapella.java
@@ -36,6 +36,7 @@ import tech.pegasys.teku.spec.logic.versions.bellatrix.statetransition.epoch.Epo
 import tech.pegasys.teku.spec.logic.versions.bellatrix.util.BlindBlockUtilBellatrix;
 import tech.pegasys.teku.spec.logic.versions.capella.block.BlockProcessorCapella;
 import tech.pegasys.teku.spec.logic.versions.capella.forktransition.CapellaStateUpgrade;
+import tech.pegasys.teku.spec.logic.versions.capella.operations.validation.OperationValidatorCapella;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsCapella;
 
 public class SpecLogicCapella extends AbstractSpecLogic {
@@ -105,7 +106,7 @@ public class SpecLogicCapella extends AbstractSpecLogic {
     final AttestationUtil attestationUtil =
         new AttestationUtilAltair(config, schemaDefinitions, beaconStateAccessors, miscHelpers);
     final OperationValidator operationValidator =
-        OperationValidator.create(
+        new OperationValidatorCapella(
             config, predicates, miscHelpers, beaconStateAccessors, attestationUtil);
     final ValidatorStatusFactoryAltair validatorStatusFactory =
         new ValidatorStatusFactoryAltair(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/operations/validation/BlsToExecutionChangesValidator.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/operations/validation/BlsToExecutionChangesValidator.java
@@ -11,13 +11,13 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.spec.logic.common.operations.validation;
+package tech.pegasys.teku.spec.logic.versions.capella.operations.validation;
 
-import static tech.pegasys.teku.spec.logic.common.operations.validation.BlsToExecutionChangesValidator.BlsToExecutionChangeInvalidReason.invalidValidatorIndex;
-import static tech.pegasys.teku.spec.logic.common.operations.validation.BlsToExecutionChangesValidator.BlsToExecutionChangeInvalidReason.publicKeyNotMatchingCredentials;
-import static tech.pegasys.teku.spec.logic.common.operations.validation.BlsToExecutionChangesValidator.BlsToExecutionChangeInvalidReason.validatorWithoutWithdrawalCredentials;
 import static tech.pegasys.teku.spec.logic.common.operations.validation.OperationInvalidReason.check;
 import static tech.pegasys.teku.spec.logic.common.operations.validation.OperationInvalidReason.firstOf;
+import static tech.pegasys.teku.spec.logic.versions.capella.operations.validation.BlsToExecutionChangesValidator.BlsToExecutionChangeInvalidReason.invalidValidatorIndex;
+import static tech.pegasys.teku.spec.logic.versions.capella.operations.validation.BlsToExecutionChangesValidator.BlsToExecutionChangeInvalidReason.publicKeyNotMatchingCredentials;
+import static tech.pegasys.teku.spec.logic.versions.capella.operations.validation.BlsToExecutionChangesValidator.BlsToExecutionChangeInvalidReason.validatorWithoutWithdrawalCredentials;
 
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
@@ -26,6 +26,8 @@ import tech.pegasys.teku.spec.constants.WithdrawalPrefixes;
 import tech.pegasys.teku.spec.datastructures.operations.BlsToExecutionChange;
 import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.logic.common.operations.validation.OperationInvalidReason;
+import tech.pegasys.teku.spec.logic.common.operations.validation.OperationStateTransitionValidator;
 
 public class BlsToExecutionChangesValidator
     implements OperationStateTransitionValidator<BlsToExecutionChange> {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/operations/validation/OperationValidatorCapella.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/operations/validation/OperationValidatorCapella.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.logic.versions.capella.operations.validation;
+
+import java.util.Optional;
+import tech.pegasys.teku.spec.config.SpecConfig;
+import tech.pegasys.teku.spec.datastructures.operations.BlsToExecutionChange;
+import tech.pegasys.teku.spec.datastructures.state.Fork;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
+import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
+import tech.pegasys.teku.spec.logic.common.helpers.Predicates;
+import tech.pegasys.teku.spec.logic.common.operations.validation.OperationInvalidReason;
+import tech.pegasys.teku.spec.logic.common.util.AttestationUtil;
+import tech.pegasys.teku.spec.logic.versions.phase0.operations.validation.OperationValidatorPhase0;
+
+public class OperationValidatorCapella extends OperationValidatorPhase0 {
+
+  private final BlsToExecutionChangesValidator blsToExecutionChangesValidator =
+      new BlsToExecutionChangesValidator();
+
+  public OperationValidatorCapella(
+      final SpecConfig specConfig,
+      final Predicates predicates,
+      final MiscHelpers miscHelpers,
+      final BeaconStateAccessors beaconStateAccessors,
+      final AttestationUtil attestationUtil) {
+    super(specConfig, predicates, miscHelpers, beaconStateAccessors, attestationUtil);
+  }
+
+  @Override
+  public Optional<OperationInvalidReason> validateBlsToExecutionChange(
+      final Fork fork, final BeaconState state, final BlsToExecutionChange blsToExecutionChange) {
+    return blsToExecutionChangesValidator.validate(fork, state, blsToExecutionChange);
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/eip4844/SpecLogicEip4844.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/eip4844/SpecLogicEip4844.java
@@ -34,6 +34,7 @@ import tech.pegasys.teku.spec.logic.versions.bellatrix.helpers.BellatrixTransiti
 import tech.pegasys.teku.spec.logic.versions.bellatrix.statetransition.epoch.EpochProcessorBellatrix;
 import tech.pegasys.teku.spec.logic.versions.bellatrix.util.BlindBlockUtilBellatrix;
 import tech.pegasys.teku.spec.logic.versions.capella.block.BlockProcessorCapella;
+import tech.pegasys.teku.spec.logic.versions.capella.operations.validation.OperationValidatorCapella;
 import tech.pegasys.teku.spec.logic.versions.eip4844.block.BlockProcessorEip4844;
 import tech.pegasys.teku.spec.logic.versions.eip4844.forktransition.Eip4844StateUpgrade;
 import tech.pegasys.teku.spec.logic.versions.eip4844.helpers.MiscHelpersEip4844;
@@ -103,7 +104,7 @@ public class SpecLogicEip4844 extends AbstractSpecLogic {
     final AttestationUtil attestationUtil =
         new AttestationUtilAltair(config, schemaDefinitions, beaconStateAccessors, miscHelpers);
     final OperationValidator operationValidator =
-        OperationValidator.create(
+        new OperationValidatorCapella(
             config, predicates, miscHelpers, beaconStateAccessors, attestationUtil);
     final ValidatorStatusFactoryAltair validatorStatusFactory =
         new ValidatorStatusFactoryAltair(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/SpecLogicPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/SpecLogicPhase0.java
@@ -31,6 +31,7 @@ import tech.pegasys.teku.spec.logic.common.util.ValidatorsUtil;
 import tech.pegasys.teku.spec.logic.versions.bellatrix.helpers.BellatrixTransitionHelpers;
 import tech.pegasys.teku.spec.logic.versions.phase0.block.BlockProcessorPhase0;
 import tech.pegasys.teku.spec.logic.versions.phase0.helpers.BeaconStateAccessorsPhase0;
+import tech.pegasys.teku.spec.logic.versions.phase0.operations.validation.OperationValidatorPhase0;
 import tech.pegasys.teku.spec.logic.versions.phase0.statetransition.epoch.EpochProcessorPhase0;
 import tech.pegasys.teku.spec.logic.versions.phase0.statetransition.epoch.ValidatorStatusFactoryPhase0;
 import tech.pegasys.teku.spec.logic.versions.phase0.util.AttestationUtilPhase0;
@@ -95,7 +96,7 @@ public class SpecLogicPhase0 extends AbstractSpecLogic {
     final AttestationUtil attestationUtil =
         new AttestationUtilPhase0(config, schemaDefinitions, beaconStateAccessors, miscHelpers);
     final OperationValidator operationValidator =
-        OperationValidator.create(
+        new OperationValidatorPhase0(
             config, predicates, miscHelpers, beaconStateAccessors, attestationUtil);
     final ValidatorStatusFactoryPhase0 validatorStatusFactory =
         new ValidatorStatusFactoryPhase0(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/operations/validation/AttestationDataValidator.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/operations/validation/AttestationDataValidator.java
@@ -11,7 +11,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.spec.logic.common.operations.validation;
+package tech.pegasys.teku.spec.logic.versions.phase0.operations.validation;
 
 import static tech.pegasys.teku.spec.logic.common.operations.validation.OperationInvalidReason.check;
 import static tech.pegasys.teku.spec.logic.common.operations.validation.OperationInvalidReason.firstOf;
@@ -23,6 +23,8 @@ import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
 import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
+import tech.pegasys.teku.spec.logic.common.operations.validation.OperationInvalidReason;
+import tech.pegasys.teku.spec.logic.common.operations.validation.OperationStateTransitionValidator;
 
 public class AttestationDataValidator
     implements OperationStateTransitionValidator<AttestationData> {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/operations/validation/AttesterSlashingValidator.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/operations/validation/AttesterSlashingValidator.java
@@ -11,7 +11,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.spec.logic.common.operations.validation;
+package tech.pegasys.teku.spec.logic.versions.phase0.operations.validation;
 
 import static java.lang.Math.toIntExact;
 import static tech.pegasys.teku.spec.logic.common.operations.validation.OperationInvalidReason.check;
@@ -26,6 +26,8 @@ import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
 import tech.pegasys.teku.spec.logic.common.helpers.Predicates;
+import tech.pegasys.teku.spec.logic.common.operations.validation.OperationInvalidReason;
+import tech.pegasys.teku.spec.logic.common.operations.validation.OperationStateTransitionValidator;
 import tech.pegasys.teku.spec.logic.common.util.AttestationUtil;
 
 public class AttesterSlashingValidator

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/operations/validation/OperationValidatorPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/operations/validation/OperationValidatorPhase0.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.logic.versions.phase0.operations.validation;
+
+import java.util.Optional;
+import tech.pegasys.teku.spec.config.SpecConfig;
+import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
+import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
+import tech.pegasys.teku.spec.datastructures.operations.BlsToExecutionChange;
+import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
+import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
+import tech.pegasys.teku.spec.datastructures.state.Fork;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
+import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
+import tech.pegasys.teku.spec.logic.common.helpers.Predicates;
+import tech.pegasys.teku.spec.logic.common.operations.validation.OperationInvalidReason;
+import tech.pegasys.teku.spec.logic.common.operations.validation.OperationValidator;
+import tech.pegasys.teku.spec.logic.common.util.AttestationUtil;
+import tech.pegasys.teku.spec.logic.versions.phase0.operations.validation.AttesterSlashingValidator.SlashedIndicesCaptor;
+
+public class OperationValidatorPhase0 implements OperationValidator {
+
+  private final AttestationDataValidator attestationDataValidator;
+  private final AttesterSlashingValidator attesterSlashingValidator;
+  private final ProposerSlashingValidator proposerSlashingValidator;
+  private final VoluntaryExitValidator voluntaryExitValidator;
+
+  public OperationValidatorPhase0(
+      final SpecConfig specConfig,
+      final Predicates predicates,
+      final MiscHelpers miscHelpers,
+      final BeaconStateAccessors beaconStateAccessors,
+      final AttestationUtil attestationUtil) {
+    this.attestationDataValidator =
+        new AttestationDataValidator(specConfig, miscHelpers, beaconStateAccessors);
+    this.attesterSlashingValidator =
+        new AttesterSlashingValidator(predicates, beaconStateAccessors, attestationUtil);
+    this.proposerSlashingValidator =
+        new ProposerSlashingValidator(predicates, beaconStateAccessors);
+    this.voluntaryExitValidator =
+        new VoluntaryExitValidator(specConfig, predicates, beaconStateAccessors);
+  }
+
+  @Override
+  public Optional<OperationInvalidReason> validateAttestationData(
+      final Fork fork, final BeaconState state, final AttestationData data) {
+    return attestationDataValidator.validate(fork, state, data);
+  }
+
+  @Override
+  public Optional<OperationInvalidReason> validateAttesterSlashing(
+      final Fork fork, final BeaconState state, final AttesterSlashing attesterSlashing) {
+    return attesterSlashingValidator.validate(fork, state, attesterSlashing);
+  }
+
+  @Override
+  public Optional<OperationInvalidReason> validateAttesterSlashing(
+      final Fork fork,
+      final BeaconState state,
+      final AttesterSlashing attesterSlashing,
+      SlashedIndicesCaptor slashedIndicesCaptor) {
+    return attesterSlashingValidator.validate(fork, state, attesterSlashing, slashedIndicesCaptor);
+  }
+
+  @Override
+  public Optional<OperationInvalidReason> validateProposerSlashing(
+      final Fork fork, final BeaconState state, final ProposerSlashing proposerSlashing) {
+    return proposerSlashingValidator.validate(fork, state, proposerSlashing);
+  }
+
+  @Override
+  public Optional<OperationInvalidReason> validateVoluntaryExit(
+      final Fork fork, final BeaconState state, final SignedVoluntaryExit signedExit) {
+    return voluntaryExitValidator.validate(fork, state, signedExit);
+  }
+
+  @Override
+  public Optional<OperationInvalidReason> validateBlsToExecutionChange(
+      final Fork fork, final BeaconState state, final BlsToExecutionChange blsToExecutionChange) {
+    return Optional.of(() -> "Bls to execution changes are not valid before Capella fork");
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/operations/validation/ProposerSlashingValidator.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/operations/validation/ProposerSlashingValidator.java
@@ -11,7 +11,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.spec.logic.common.operations.validation;
+package tech.pegasys.teku.spec.logic.versions.phase0.operations.validation;
 
 import static java.lang.Math.toIntExact;
 import static tech.pegasys.teku.spec.logic.common.operations.validation.OperationInvalidReason.check;
@@ -26,6 +26,8 @@ import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
 import tech.pegasys.teku.spec.logic.common.helpers.Predicates;
+import tech.pegasys.teku.spec.logic.common.operations.validation.OperationInvalidReason;
+import tech.pegasys.teku.spec.logic.common.operations.validation.OperationStateTransitionValidator;
 
 public class ProposerSlashingValidator
     implements OperationStateTransitionValidator<ProposerSlashing> {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/operations/validation/VoluntaryExitValidator.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/operations/validation/VoluntaryExitValidator.java
@@ -11,7 +11,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.spec.logic.common.operations.validation;
+package tech.pegasys.teku.spec.logic.versions.phase0.operations.validation;
 
 import static java.lang.Math.toIntExact;
 import static tech.pegasys.teku.spec.config.SpecConfig.FAR_FUTURE_EPOCH;
@@ -28,6 +28,8 @@ import tech.pegasys.teku.spec.datastructures.state.Validator;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
 import tech.pegasys.teku.spec.logic.common.helpers.Predicates;
+import tech.pegasys.teku.spec.logic.common.operations.validation.OperationInvalidReason;
+import tech.pegasys.teku.spec.logic.common.operations.validation.OperationStateTransitionValidator;
 
 public class VoluntaryExitValidator
     implements OperationStateTransitionValidator<SignedVoluntaryExit> {

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/phase0/operations/validation/OperationValidatorPhase0Test.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/phase0/operations/validation/OperationValidatorPhase0Test.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.logic.versions.phase0.operations.validation;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.spec.config.SpecConfig;
+import tech.pegasys.teku.spec.datastructures.operations.BlsToExecutionChange;
+import tech.pegasys.teku.spec.datastructures.state.Fork;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
+import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
+import tech.pegasys.teku.spec.logic.common.helpers.Predicates;
+import tech.pegasys.teku.spec.logic.common.operations.validation.OperationInvalidReason;
+import tech.pegasys.teku.spec.logic.common.operations.validation.OperationValidator;
+import tech.pegasys.teku.spec.logic.common.util.AttestationUtil;
+
+public class OperationValidatorPhase0Test {
+
+  @Test
+  void shouldRejectBlsOperationsPhase0() {
+    final SpecConfig specConfig = mock(SpecConfig.class);
+    final Predicates predicates = mock(Predicates.class);
+    final MiscHelpers miscHelpers = mock(MiscHelpers.class);
+    final BeaconStateAccessors beaconStateAccessors = mock(BeaconStateAccessors.class);
+    final AttestationUtil attestationUtil = mock(AttestationUtil.class);
+    final OperationValidator operationValidator =
+        new OperationValidatorPhase0(
+            specConfig, predicates, miscHelpers, beaconStateAccessors, attestationUtil);
+
+    assertThat(
+            operationValidator.validateBlsToExecutionChange(
+                mock(Fork.class), mock(BeaconState.class), mock(BlsToExecutionChange.class)))
+        .containsInstanceOf(OperationInvalidReason.class);
+    verifyNoInteractions(specConfig);
+    verifyNoInteractions(predicates);
+    verifyNoInteractions(miscHelpers);
+    verifyNoInteractions(beaconStateAccessors);
+    verifyNoInteractions(attestationUtil);
+  }
+}

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ProposerSlashingValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/ProposerSlashingValidator.java
@@ -27,7 +27,7 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.logic.common.operations.validation.OperationInvalidReason;
-import tech.pegasys.teku.spec.logic.common.operations.validation.ProposerSlashingValidator.ProposerSlashingInvalidReason;
+import tech.pegasys.teku.spec.logic.versions.phase0.operations.validation.ProposerSlashingValidator.ProposerSlashingInvalidReason;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
 public class ProposerSlashingValidator implements OperationValidator<ProposerSlashing> {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/VoluntaryExitValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/VoluntaryExitValidator.java
@@ -28,7 +28,7 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.logic.common.operations.validation.OperationInvalidReason;
-import tech.pegasys.teku.spec.logic.common.operations.validation.VoluntaryExitValidator.ExitInvalidReason;
+import tech.pegasys.teku.spec.logic.versions.phase0.operations.validation.VoluntaryExitValidator.ExitInvalidReason;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
 public class VoluntaryExitValidator implements OperationValidator<SignedVoluntaryExit> {

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/OperationPoolTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/OperationPoolTest.java
@@ -46,7 +46,7 @@ import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
-import tech.pegasys.teku.spec.logic.common.operations.validation.VoluntaryExitValidator.ExitInvalidReason;
+import tech.pegasys.teku.spec.logic.versions.phase0.operations.validation.VoluntaryExitValidator.ExitInvalidReason;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.OperationPool.OperationAddedSubscriber;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolTest.java
@@ -40,8 +40,8 @@ import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation.AttestationSchema;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
-import tech.pegasys.teku.spec.logic.common.operations.validation.AttestationDataValidator.AttestationInvalidReason;
 import tech.pegasys.teku.spec.logic.common.statetransition.attestation.AttestationWorthinessChecker;
+import tech.pegasys.teku.spec.logic.versions.phase0.operations.validation.AttestationDataValidator.AttestationInvalidReason;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 class AggregatingAttestationPoolTest {

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/AttesterSlashingValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/AttesterSlashingValidatorTest.java
@@ -27,7 +27,7 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
-import tech.pegasys.teku.spec.logic.common.operations.validation.AttesterSlashingValidator.AttesterSlashingInvalidReason;
+import tech.pegasys.teku.spec.logic.versions.phase0.operations.validation.AttesterSlashingValidator.AttesterSlashingInvalidReason;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.storage.client.RecentChainData;
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/ProposerSlashingValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/ProposerSlashingValidatorTest.java
@@ -36,7 +36,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlockHeader;
 import tech.pegasys.teku.spec.datastructures.interop.MockStartValidatorKeyPairFactory;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
-import tech.pegasys.teku.spec.logic.common.operations.validation.ProposerSlashingValidator.ProposerSlashingInvalidReason;
+import tech.pegasys.teku.spec.logic.versions.phase0.operations.validation.ProposerSlashingValidator.ProposerSlashingInvalidReason;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.BeaconChainUtil;
 import tech.pegasys.teku.storage.client.MemoryOnlyRecentChainData;

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/VoluntaryExitValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/VoluntaryExitValidatorTest.java
@@ -34,7 +34,7 @@ import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.interop.MockStartValidatorKeyPairFactory;
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
-import tech.pegasys.teku.spec.logic.common.operations.validation.VoluntaryExitValidator.ExitInvalidReason;
+import tech.pegasys.teku.spec.logic.versions.phase0.operations.validation.VoluntaryExitValidator.ExitInvalidReason;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.BeaconChainUtil;
 import tech.pegasys.teku.storage.client.MemoryOnlyRecentChainData;


### PR DESCRIPTION
 - Previously bls_to_execution_change would have been accepted as an operation before capella

 - had to remove create method to make the structure a little cleaner.

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
