### PR TITLE
Speed up ATs by using a custom genesis state rather than processing deposits

### DIFF
--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/AddValidatorsAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/AddValidatorsAcceptanceTest.java
@@ -15,7 +15,7 @@ package tech.pegasys.teku.test.acceptance;
 
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.test.acceptance.dsl.AcceptanceTestBase;
-import tech.pegasys.teku.test.acceptance.dsl.BesuNode;
+import tech.pegasys.teku.test.acceptance.dsl.GenesisGenerator.InitialStateData;
 import tech.pegasys.teku.test.acceptance.dsl.TekuNode;
 import tech.pegasys.teku.test.acceptance.dsl.tools.deposits.ValidatorKeystores;
 
@@ -24,21 +24,25 @@ public class AddValidatorsAcceptanceTest extends AcceptanceTestBase {
   @Test
   void shouldLoadAdditionalValidatorsWithoutRestart() throws Exception {
     final String networkName = "less-swift";
-    final BesuNode eth1Node = createBesuNode(config -> config.withMiningEnabled(true));
-    eth1Node.start();
 
     final ValidatorKeystores initialKeystores =
-        createTekuDepositSender(networkName).sendValidatorDeposits(eth1Node, 2);
+        createTekuDepositSender(networkName).generateValidatorKeys(2);
 
     final ValidatorKeystores additionalKeystores =
-        createTekuDepositSender(networkName).sendValidatorDeposits(eth1Node, 2);
+        createTekuDepositSender(networkName).generateValidatorKeys(2);
+
+    final InitialStateData genesis =
+        createGenesisGenerator()
+            .network(networkName)
+            .validatorKeys(initialKeystores, additionalKeystores)
+            .generate();
 
     final TekuNode node =
         createTekuNode(
             config ->
                 config
                     .withNetwork(networkName)
-                    .withDepositsFrom(eth1Node)
+                    .withInitialState(genesis)
                     .withValidatorKeystores(initialKeystores));
     node.start();
 
@@ -53,7 +57,7 @@ public class AddValidatorsAcceptanceTest extends AcceptanceTestBase {
 
     // Check loading new validators a second time still works and that they don't have to be active
     final ValidatorKeystores evenMoreKeystores =
-        createTekuDepositSender(networkName).sendValidatorDeposits(eth1Node, 1);
+        createTekuDepositSender(networkName).generateValidatorKeys(1);
     node.addValidators(evenMoreKeystores);
     node.waitForOwnedValidatorCount(5);
   }

--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/LocalValidatorKeysAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/LocalValidatorKeysAcceptanceTest.java
@@ -21,7 +21,7 @@ import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.ethereum.execution.types.Eth1Address;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.test.acceptance.dsl.AcceptanceTestBase;
-import tech.pegasys.teku.test.acceptance.dsl.BesuNode;
+import tech.pegasys.teku.test.acceptance.dsl.GenesisGenerator.InitialStateData;
 import tech.pegasys.teku.test.acceptance.dsl.TekuNode;
 import tech.pegasys.teku.test.acceptance.dsl.TekuValidatorNode;
 import tech.pegasys.teku.test.acceptance.dsl.tools.ValidatorKeysApi;
@@ -33,20 +33,19 @@ public class LocalValidatorKeysAcceptanceTest extends AcceptanceTestBase {
   @Test
   void shouldMaintainValidatorsInMutableClient() throws Exception {
     final String networkName = "less-swift";
-    final BesuNode eth1Node =
-        createBesuNode(
-            config ->
-                config
-                    .withMiningEnabled(true)
-                    .withMergeSupport(true)
-                    .withGenesisFile("besu/preMergeGenesis.json")
-                    .withJwtTokenAuthorization(JWT_FILE));
-    eth1Node.start();
 
     final ValidatorKeystores validatorKeystores =
-        createTekuDepositSender(networkName).sendValidatorDeposits(eth1Node, 8);
+        createTekuDepositSender(networkName).generateValidatorKeys(8);
     final ValidatorKeystores extraKeys =
-        createTekuDepositSender(networkName).sendValidatorDeposits(eth1Node, 1);
+        createTekuDepositSender(networkName).generateValidatorKeys(1);
+
+    final InitialStateData genesis =
+        createGenesisGenerator()
+            .network(networkName)
+            .withAltairEpoch(UInt64.ZERO)
+            .withBellatrixEpoch(UInt64.ZERO)
+            .validatorKeys(validatorKeystores, extraKeys)
+            .generate();
 
     final String defaultFeeRecipient = "0xFE3B557E8Fb62b89F4916B721be55cEb828dBd73";
     final TekuNode beaconNode =
@@ -54,11 +53,11 @@ public class LocalValidatorKeysAcceptanceTest extends AcceptanceTestBase {
             config ->
                 config
                     .withNetwork(networkName)
-                    .withDepositsFrom(eth1Node)
-                    .withBellatrixEpoch(UInt64.ONE)
-                    .withTotalTerminalDifficulty(10001)
+                    .withInitialState(genesis)
+                    .withAltairEpoch(UInt64.ZERO)
+                    .withBellatrixEpoch(UInt64.ZERO)
+                    .withStubExecutionEngine()
                     .withValidatorProposerDefaultFeeRecipient(defaultFeeRecipient)
-                    .withExecutionEngine(eth1Node)
                     .withJwtSecretFile(JWT_FILE));
 
     final TekuValidatorNode validatorClient =
@@ -118,10 +117,5 @@ public class LocalValidatorKeysAcceptanceTest extends AcceptanceTestBase {
 
     // remove the same validator again
     api.removeLocalValidatorAndCheckStatus(removedPubkey, "not_active");
-
-    validatorClient.stop();
-
-    beaconNode.stop();
-    eth1Node.stop();
   }
 }

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/GenesisGenerator.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/GenesisGenerator.java
@@ -16,8 +16,10 @@ package tech.pegasys.teku.test.acceptance.dsl;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.Collections;
 import java.util.Optional;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 import org.apache.tuweni.units.bigints.UInt256;
 import tech.pegasys.teku.infrastructure.time.SystemTimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -83,8 +85,10 @@ public class GenesisGenerator {
     return this;
   }
 
-  public GenesisGenerator validatorKeys(final ValidatorKeystores validatorKeys) {
-    this.validatorKeys = validatorKeys;
+  public GenesisGenerator validatorKeys(final ValidatorKeystores... validatorKeys) {
+    this.validatorKeys =
+        Stream.of(validatorKeys)
+            .reduce(new ValidatorKeystores(Collections.emptyList()), ValidatorKeystores::add);
     return this;
   }
 

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/SimpleHttpClient.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/SimpleHttpClient.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.test.acceptance.dsl;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.io.IOException;
 import java.net.URI;
@@ -62,12 +63,12 @@ public class SimpleHttpClient {
     final Request.Builder builder = new Request.Builder().url(baseUrl.resolve(path).toURL()).get();
     headers.forEach(builder::header);
     final Response response = httpClient.newCall(builder.build()).execute();
-    assertThat(response.isSuccessful())
-        .describedAs(
-            "Received unsuccessful response from %s: %s %s",
-            url, response.code(), response.message())
-        .isTrue();
     final ResponseBody body = response.body();
+    if (!response.isSuccessful()) {
+      fail(
+          "Received unsuccessful response from %s: %s %s %s",
+          url, response.code(), response.message(), body != null ? body.string() : "null");
+    }
     assertThat(body).isNotNull();
     return body;
   }

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuValidatorNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuValidatorNode.java
@@ -255,12 +255,6 @@ public class TekuValidatorNode extends Node {
       return this;
     }
 
-    public TekuValidatorNode.Config withNetwork(final InputStream stream) {
-      this.maybeNetworkYaml = Optional.of(stream);
-      configMap.put("network", NETWORK_FILE_PATH);
-      return this;
-    }
-
     public TekuValidatorNode.Config withInteropValidators(
         final int startIndex, final int validatorCount) {
       configMap.put("Xinterop-owned-validator-start-index", startIndex);

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/Web3SignerNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/Web3SignerNode.java
@@ -17,10 +17,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.net.URI;
-import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 import org.apache.logging.log4j.LogManager;
@@ -114,7 +112,6 @@ public class Web3SignerNode extends Node {
   public static class Config {
     private Map<String, Object> configMap = new HashMap<>();
     private final Map<File, String> configFileMap = new HashMap<>();
-    private Optional<URL> maybeNetworkYaml = Optional.empty();
 
     public Config() {
       configMap.put("logging", "debug");
@@ -124,10 +121,8 @@ public class Web3SignerNode extends Node {
       configMap.put("eth2.key-manager-api-enabled", true);
     }
 
-    public Web3SignerNode.Config withNetwork(final URL yamlUrl) {
-      // TODO just specify less-swift rather than NETWORK_FILE_PATH
-      this.maybeNetworkYaml = Optional.of(yamlUrl);
-      configMap.put("eth2.network", NETWORK_FILE_PATH);
+    public Web3SignerNode.Config withNetwork(final String network) {
+      configMap.put("eth2.network", network);
       return this;
     }
 
@@ -141,10 +136,6 @@ public class Web3SignerNode extends Node {
       configFile.deleteOnExit();
       writeConfigFileTo(configFile);
       configFileMap.put(configFile, CONFIG_FILE_PATH);
-      if (maybeNetworkYaml.isPresent()) {
-        final File networkFile = copyToTmpFile(maybeNetworkYaml.get());
-        configFileMap.put(networkFile, NETWORK_FILE_PATH);
-      }
     }
 
     private void writeConfigFileTo(final File configFile) throws Exception {

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/tools/deposits/ValidatorKeystores.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/tools/deposits/ValidatorKeystores.java
@@ -59,6 +59,12 @@ public class ValidatorKeystores {
     this.validatorKeys = validatorKeys;
   }
 
+  public static ValidatorKeystores add(final ValidatorKeystores a, final ValidatorKeystores b) {
+    final List<ValidatorKeys> combinedKeys = new ArrayList<>(a.validatorKeys);
+    combinedKeys.addAll(b.validatorKeys);
+    return new ValidatorKeystores(combinedKeys);
+  }
+
   public List<String> getKeystores(final Path tempDir) {
     return validatorKeys.stream()
         .map(


### PR DESCRIPTION
## PR Description
For ATs that need real validator keys but aren't actually testing the deposit contract interactions, switch to using a custom genesis state instead of having to spin up a besu instance and processing deposits.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
