### PR TITLE
Increase parallelism for reference tests as they're the slowest part of the build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -386,7 +386,7 @@ jobs:
             - ./eth-reference-tests/
 
   referenceTests:
-    parallelism: 4
+    parallelism: 6
     executor: large_executor
     steps:
       - prepare


### PR DESCRIPTION
## PR Description
With all the new tests being added for capella and 4844, reference tests can use some more parallelism to avoid being the slowest part of the build.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
