### PR TITLE
Add bls_to_execution_changes to event stream

### DIFF
--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/BlsToExecutionChangeAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/BlsToExecutionChangeAcceptanceTest.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.test.acceptance;
 
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.api.response.v1.EventType;
 import tech.pegasys.teku.bls.BLSKeyPair;
 import tech.pegasys.teku.ethereum.execution.types.Eth1Address;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -40,14 +41,19 @@ public class BlsToExecutionChangeAcceptanceTest extends AcceptanceTestBase {
 
     final TekuNode primaryNode = createPrimaryNode(executionAddress, capellaActivationEpoch);
     primaryNode.start();
+    primaryNode.startEventListener(List.of(EventType.bls_to_execution_change));
 
     final TekuNode lateJoiningNode =
         createLateJoiningNode(capellaActivationEpoch, primaryNode, primaryNode.getGenesisTime());
     lateJoiningNode.start();
     lateJoiningNode.waitUntilInSyncWith(primaryNode);
+    lateJoiningNode.startEventListener(List.of(EventType.bls_to_execution_change));
 
     lateJoiningNode.submitBlsToExecutionChange(validatorIndex, validatorKeyPair, executionAddress);
     lateJoiningNode.waitForValidatorWithCredentials(validatorIndex, executionAddress);
+
+    primaryNode.waitForBlsToExecutionChangeEventForValidator(0);
+    lateJoiningNode.waitForBlsToExecutionChangeEventForValidator(0);
   }
 
   private TekuNode createPrimaryNode(

--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/BlsToExecutionChangeAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/BlsToExecutionChangeAcceptanceTest.java
@@ -41,13 +41,13 @@ public class BlsToExecutionChangeAcceptanceTest extends AcceptanceTestBase {
 
     final TekuNode primaryNode = createPrimaryNode(executionAddress, capellaActivationEpoch);
     primaryNode.start();
-    primaryNode.startEventListener(List.of(EventType.bls_to_execution_change));
+    primaryNode.startEventListener(EventType.bls_to_execution_change);
 
     final TekuNode lateJoiningNode =
         createLateJoiningNode(capellaActivationEpoch, primaryNode, primaryNode.getGenesisTime());
     lateJoiningNode.start();
     lateJoiningNode.waitUntilInSyncWith(primaryNode);
-    lateJoiningNode.startEventListener(List.of(EventType.bls_to_execution_change));
+    lateJoiningNode.startEventListener(EventType.bls_to_execution_change);
 
     lateJoiningNode.submitBlsToExecutionChange(validatorIndex, validatorKeyPair, executionAddress);
     lateJoiningNode.waitForValidatorWithCredentials(validatorIndex, executionAddress);

--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/SyncCommitteeGossipAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/SyncCommitteeGossipAcceptanceTest.java
@@ -13,7 +13,6 @@
 
 package tech.pegasys.teku.test.acceptance;
 
-import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.api.response.v1.EventType;
@@ -69,7 +68,7 @@ public class SyncCommitteeGossipAcceptanceTest extends AcceptanceTestBase {
     secondaryNode.start();
     validatorClient.start();
     watcherNode.start();
-    watcherNode.startEventListener(List.of(EventType.contribution_and_proof));
+    watcherNode.startEventListener(EventType.contribution_and_proof);
 
     primaryNode.waitForEpochAtOrAbove(1);
 

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNode.java
@@ -19,6 +19,7 @@ import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 import static tech.pegasys.teku.test.acceptance.dsl.metrics.MetricConditions.withLabelValueSubstring;
 import static tech.pegasys.teku.test.acceptance.dsl.metrics.MetricConditions.withNameEqualsTo;
 import static tech.pegasys.teku.test.acceptance.dsl.metrics.MetricConditions.withValueGreaterThan;
@@ -154,8 +155,9 @@ public class TekuNode extends Node {
     container.start();
   }
 
-  public void startEventListener(final List<EventType> eventTypes) {
-    maybeEventStreamListener = Optional.of(new EventStreamListener(getEventUrl(eventTypes)));
+  public void startEventListener(final EventType... eventTypes) {
+    maybeEventStreamListener =
+        Optional.of(new EventStreamListener(getEventUrl(List.of(eventTypes))));
   }
 
   public void waitForContributionAndProofEvent() {
@@ -294,7 +296,8 @@ public class TekuNode extends Node {
 
   public void waitForBlsToExecutionChangeEventForValidator(int validatorIndex) {
     if (maybeEventStreamListener.isEmpty()) {
-      startEventListener(List.of(EventType.bls_to_execution_change));
+      fail(
+          "Must start listening to events before waiting for them... Try calling TekuNode.startEventListener(..)!");
     }
 
     waitFor(

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNode.java
@@ -207,7 +207,7 @@ public class TekuNode extends Node {
 
   public void waitForBlockAtOrAfterSlot(final long slot) {
     if (maybeEventStreamListener.isEmpty()) {
-      startEventListener(List.of(EventType.head));
+      startEventListener(EventType.head);
     }
     waitFor(
         () ->

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNode.java
@@ -307,7 +307,7 @@ public class TekuNode extends Node {
           final Optional<tech.pegasys.teku.api.schema.capella.SignedBlsToExecutionChange>
               eventForValidator =
                   blsToExecutionChanges.stream()
-                      .filter(m -> m.message.validatorIndex == UInt64.valueOf(validatorIndex))
+                      .filter(m -> UInt64.valueOf(validatorIndex).equals(m.message.validatorIndex))
                       .findFirst();
           assertThat(eventForValidator).isPresent();
         });

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/BlsToExecutionChangeEvent.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/BlsToExecutionChangeEvent.java
@@ -11,24 +11,13 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.api.response.v1;
+package tech.pegasys.teku.beaconrestapi.handlers.v1.events;
 
-import java.util.List;
-import java.util.stream.Collectors;
+import tech.pegasys.teku.spec.datastructures.operations.SignedBlsToExecutionChange;
 
-@SuppressWarnings("JavaCase")
-public enum EventType {
-  head,
-  block,
-  attestation,
-  voluntary_exit,
-  finalized_checkpoint,
-  chain_reorg,
-  sync_state,
-  contribution_and_proof,
-  bls_to_execution_change;
+public class BlsToExecutionChangeEvent extends Event<SignedBlsToExecutionChange> {
 
-  public static List<EventType> getTopics(List<String> topics) {
-    return topics.stream().map(EventType::valueOf).collect(Collectors.toList());
+  BlsToExecutionChangeEvent(final SignedBlsToExecutionChange blsToExecutionChange) {
+    super(blsToExecutionChange.getSchema().getJsonTypeDefinition(), blsToExecutionChange);
   }
 }

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManager.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManager.java
@@ -40,6 +40,7 @@ import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidateableAttestation;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.operations.SignedBlsToExecutionChange;
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SignedContributionAndProof;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
@@ -81,6 +82,7 @@ public class EventSubscriptionManager implements ChainHeadChannel, FinalizedChec
     nodeDataProvider.subscribeToValidAttestations(this::onNewAttestation);
     nodeDataProvider.subscribeToNewVoluntaryExits(this::onNewVoluntaryExit);
     nodeDataProvider.subscribeToSyncCommitteeContributions(this::onSyncCommitteeContribution);
+    nodeDataProvider.subscribeToNewBlsToExecutionChanges(this::onNewBlsToExecutionChange);
   }
 
   public void registerClient(final SseClient sseClient) {
@@ -145,6 +147,17 @@ public class EventSubscriptionManager implements ChainHeadChannel, FinalizedChec
       final boolean fromNetwork) {
     final VoluntaryExitEvent voluntaryExitEvent = new VoluntaryExitEvent(exit);
     notifySubscribersOfEvent(EventType.voluntary_exit, voluntaryExitEvent);
+  }
+
+  protected void onNewBlsToExecutionChange(
+      final SignedBlsToExecutionChange blsToExecutionChange,
+      final InternalValidationResult result,
+      final boolean fromNetwork) {
+    if (result.isAccept()) {
+      final BlsToExecutionChangeEvent blsToExecutionChangeEvent =
+          new BlsToExecutionChangeEvent(blsToExecutionChange);
+      notifySubscribersOfEvent(EventType.bls_to_execution_change, blsToExecutionChangeEvent);
+    }
   }
 
   protected void onSyncCommitteeContribution(

--- a/data/provider/src/main/java/tech/pegasys/teku/api/NodeDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/NodeDataProvider.java
@@ -133,6 +133,11 @@ public class NodeDataProvider {
     voluntaryExitPool.subscribeOperationAdded(listener);
   }
 
+  public void subscribeToNewBlsToExecutionChanges(
+      OperationPool.OperationAddedSubscriber<SignedBlsToExecutionChange> listener) {
+    blsToExecutionChangePool.subscribeOperationAdded(listener);
+  }
+
   public void subscribeToSyncCommitteeContributions(
       OperationPool.OperationAddedSubscriber<SignedContributionAndProof> listener) {
     syncCommitteeContributionPool.subscribeOperationAdded(listener);


### PR DESCRIPTION
Users that are subscribed to bls_to_executoin_change events should receive events upon valid new bls_to_execution_changes operations being received by the node (either via RPC or Gossip).

## Fixed Issue(s)
fixes #6529

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
