### PR TITLE
Add metric to report the number of peers subscribed to each attestation and sync committee subnet

### DIFF
--- a/networking/eth2/build.gradle
+++ b/networking/eth2/build.gradle
@@ -46,6 +46,7 @@ dependencies {
   testFixturesImplementation testFixtures(project(':infrastructure:async'))
   testFixturesImplementation project(':infrastructure:bytes')
   testFixturesImplementation testFixtures(project(':infrastructure:events'))
+  testFixturesImplementation testFixtures(project(':infrastructure:metrics'))
   testFixturesImplementation testFixtures(project(':infrastructure:time'))
   testFixturesImplementation testFixtures(project(':storage'))
   testFixturesImplementation project(':infrastructure:subscribers')

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkBuilder.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkBuilder.java
@@ -29,6 +29,8 @@ import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.events.EventChannels;
+import tech.pegasys.teku.infrastructure.metrics.SettableLabelledGauge;
+import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
 import tech.pegasys.teku.networking.eth2.gossip.forks.GossipForkManager;
@@ -327,6 +329,13 @@ public class Eth2P2PNetworkBuilder {
             discoConfig.getMinRandomlySelectedPeers());
     final SchemaDefinitionsSupplier currentSchemaDefinitions =
         () -> recentChainData.getCurrentSpec().getSchemaDefinitions();
+    final SettableLabelledGauge subnetPeerCountGauge =
+        SettableLabelledGauge.create(
+            metricsSystem,
+            TekuMetricCategory.NETWORK,
+            "subnet_peer_count",
+            "Number of currently connected peers subscribed to each subnet",
+            "subnet");
     return createDiscoveryNetworkBuilder()
         .metricsSystem(metricsSystem)
         .asyncRunner(asyncRunner)
@@ -342,7 +351,8 @@ public class Eth2P2PNetworkBuilder {
                         attestationSubnetTopicProvider,
                         syncCommitteeSubnetTopicProvider,
                         syncCommitteeSubnetService,
-                        config.getTargetSubnetSubscriberCount()),
+                        config.getTargetSubnetSubscriberCount(),
+                        subnetPeerCountGauge),
                 reputationManager,
                 Collections::shuffle))
         .discoveryConfig(discoConfig)

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/subnets/PeerSubnetSubscriptionsTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/subnets/PeerSubnetSubscriptionsTest.java
@@ -30,6 +30,7 @@ import java.util.Set;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.metrics.SettableLabelledGauge;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszBitvector;
 import tech.pegasys.teku.networking.eth2.SubnetSubscriptionService;
 import tech.pegasys.teku.networking.p2p.gossip.GossipNetwork;
@@ -46,6 +47,7 @@ class PeerSubnetSubscriptionsTest {
   private static final int TARGET_SUBSCRIBER_COUNT = 2;
 
   private final Spec spec = TestSpecFactory.createMinimalAltair();
+  private final SettableLabelledGauge subnetPeerCountGauge = mock(SettableLabelledGauge.class);
   private final SchemaDefinitionsSupplier currentSchemaDefinitions =
       spec::getGenesisSchemaDefinitions;
   private final GossipNetwork gossipNetwork = mock(GossipNetwork.class);
@@ -201,7 +203,8 @@ class PeerSubnetSubscriptionsTest {
         attestationTopicProvider,
         syncCommitteeTopicProvider,
         syncnetSubscriptions,
-        TARGET_SUBSCRIBER_COUNT);
+        TARGET_SUBSCRIBER_COUNT,
+        subnetPeerCountGauge);
   }
 
   private void withSubscriberCountForAllSubnets(int subscriberCount) {

--- a/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkFactory.java
+++ b/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkFactory.java
@@ -40,6 +40,8 @@ import tech.pegasys.teku.infrastructure.async.DelayedExecutorAsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.Waiter;
 import tech.pegasys.teku.infrastructure.events.EventChannels;
+import tech.pegasys.teku.infrastructure.metrics.SettableLabelledGauge;
+import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.subscribers.Subscribers;
 import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -228,6 +230,13 @@ public class Eth2P2PNetworkFactory {
                 discoConfig.getMinRandomlySelectedPeers());
         final SchemaDefinitionsSupplier currentSchemaDefinitions =
             () -> config.getSpec().getGenesisSchemaDefinitions();
+        final SettableLabelledGauge subnetPeerCountGauge =
+            SettableLabelledGauge.create(
+                metricsSystem,
+                TekuMetricCategory.NETWORK,
+                "subnet_peer_count",
+                "Number of currently connected peers subscribed to each subnet",
+                "subnet");
         final DiscoveryNetwork<?> network =
             DiscoveryNetworkBuilder.create()
                 .metricsSystem(metricsSystem)
@@ -257,7 +266,8 @@ public class Eth2P2PNetworkFactory {
                                 attestationSubnetTopicProvider,
                                 syncCommitteeTopicProvider,
                                 syncCommitteeSubnetService,
-                                config.getTargetSubnetSubscriberCount()),
+                                config.getTargetSubnetSubscriberCount(),
+                                subnetPeerCountGauge),
                         reputationManager,
                         Collections::shuffle))
                 .discoveryConfig(config.getDiscoveryConfig())


### PR DESCRIPTION
## PR Description
Add metric to report the number of peers subscribed to each attestation and sync committee subnet.

## Fixed Issue(s)
Will provide some insight into how much coverage of each topic we have is for #6527 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
