### PR TITLE
Fix typo in blsToExecutionChangePool setter

### DIFF
--- a/data/provider/src/main/java/tech/pegasys/teku/api/DataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/DataProvider.java
@@ -176,8 +176,8 @@ public class DataProvider {
     }
 
     public Builder blsToExecutionChangePool(
-        final OperationPool<SignedBlsToExecutionChange> blsToExecutionChangePoolExitPool) {
-      this.blsToExecutionChangePool = blsToExecutionChangePoolExitPool;
+        final OperationPool<SignedBlsToExecutionChange> blsToExecutionChangePool) {
+      this.blsToExecutionChangePool = blsToExecutionChangePool;
       return this;
     }
 


### PR DESCRIPTION
## PR Description

Real minor nit. This is a copy-paste typo from `VoluntaryExitPool`.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
