### PR TITLE
Add config options to prune historic blocks.

### DIFF
--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/DefaultSyncServiceFactory.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/DefaultSyncServiceFactory.java
@@ -127,7 +127,8 @@ public class DefaultSyncServiceFactory implements SyncServiceFactory {
         signatureVerifier,
         syncStateProvider,
         syncConfig.isReconstructHistoricStatesEnabled(),
-        genesisStateResource);
+        genesisStateResource,
+        syncConfig.fetchAllHistoricBlocks());
   }
 
   protected SyncStateTracker createSyncStateTracker(final ForwardSync forwardSync) {

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/SyncConfig.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/SyncConfig.java
@@ -19,18 +19,22 @@ public class SyncConfig {
 
   public static final boolean DEFAULT_MULTI_PEER_SYNC_ENABLED = true;
   public static final boolean DEFAULT_RECONSTRUCT_HISTORIC_STATES_ENABLED = false;
+  public static final boolean DEFAULT_FETCH_ALL_HISTORIC_BLOCKS = true;
 
   private final boolean isEnabled;
   private final boolean isMultiPeerSyncEnabled;
   private final boolean reconstructHistoricStatesEnabled;
+  private final boolean fetchAllHistoricBlocks;
 
   private SyncConfig(
       final boolean isEnabled,
       final boolean isMultiPeerSyncEnabled,
-      final boolean reconstructHistoricStatesEnabled) {
+      final boolean reconstructHistoricStatesEnabled,
+      final boolean fetchAllHistoricBlocks) {
     this.isEnabled = isEnabled;
     this.isMultiPeerSyncEnabled = isMultiPeerSyncEnabled;
     this.reconstructHistoricStatesEnabled = reconstructHistoricStatesEnabled;
+    this.fetchAllHistoricBlocks = fetchAllHistoricBlocks;
   }
 
   public static Builder builder() {
@@ -49,16 +53,25 @@ public class SyncConfig {
     return reconstructHistoricStatesEnabled;
   }
 
+  public boolean fetchAllHistoricBlocks() {
+    return fetchAllHistoricBlocks;
+  }
+
   public static class Builder {
     private Boolean isEnabled;
     private Boolean isMultiPeerSyncEnabled = DEFAULT_MULTI_PEER_SYNC_ENABLED;
     private Boolean reconstructHistoricStatesEnabled = DEFAULT_RECONSTRUCT_HISTORIC_STATES_ENABLED;
+    private boolean fetchAllHistoricBlocks = DEFAULT_FETCH_ALL_HISTORIC_BLOCKS;
 
     private Builder() {}
 
     public SyncConfig build() {
       initMissingDefaults();
-      return new SyncConfig(isEnabled, isMultiPeerSyncEnabled, reconstructHistoricStatesEnabled);
+      return new SyncConfig(
+          isEnabled,
+          isMultiPeerSyncEnabled,
+          reconstructHistoricStatesEnabled,
+          fetchAllHistoricBlocks);
     }
 
     private void initMissingDefaults() {
@@ -86,10 +99,15 @@ public class SyncConfig {
       return this;
     }
 
-    public Builder isReconstructHistoricStatesEnabled(
+    public Builder reconstructHistoricStatesEnabled(
         final Boolean reconstructHistoricStatesEnabled) {
       checkNotNull(reconstructHistoricStatesEnabled);
       this.reconstructHistoricStatesEnabled = reconstructHistoricStatesEnabled;
+      return this;
+    }
+
+    public Builder fetchAllHistoricBlocks(final boolean fetchAllHistoricBlocks) {
+      this.fetchAllHistoricBlocks = fetchAllHistoricBlocks;
       return this;
     }
   }

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/historical/HistoricalBlockSyncServiceTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/historical/HistoricalBlockSyncServiceTest.java
@@ -93,7 +93,8 @@ public class HistoricalBlockSyncServiceTest {
           syncStateProvider,
           signatureVerificationService,
           batchSize,
-          Optional.of(reconstructHistoricalStatesService));
+          Optional.of(reconstructHistoricalStatesService),
+          false);
   private final Subscribers<SyncStateProvider.SyncStateSubscriber> syncStateSubscribers =
       Subscribers.create(false);
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfig.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfig.java
@@ -144,6 +144,10 @@ public interface SpecConfig {
 
   ProgressiveBalancesMode getProgressiveBalancesMode();
 
+  default int getMinEpochsForBlockRequests() {
+    return getMinValidatorWithdrawabilityDelay() + getChurnLimitQuotient() / 2;
+  }
+
   default Optional<SpecConfigAltair> toVersionAltair() {
     return Optional.empty();
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/StorageConfiguration.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/StorageConfiguration.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.storage.server;
 
+import java.time.Duration;
 import tech.pegasys.teku.ethereum.execution.types.Eth1Address;
 import tech.pegasys.teku.infrastructure.exceptions.InvalidConfigurationException;
 import tech.pegasys.teku.spec.Spec;
@@ -26,6 +27,8 @@ public class StorageConfiguration {
   public static final int DEFAULT_MAX_KNOWN_NODE_CACHE_SIZE = 100_000;
   public static final int DEFAULT_BLOCK_MIGRATION_BATCH_SIZE = 25;
   public static final int DEFAULT_BLOCK_MIGRATION_BATCH_DELAY_MS = 100;
+  public static final boolean DEFAULT_BLOCK_PRUNING_ENABLED = false;
+  public static final Duration DEFAULT_BLOCK_PRUNING_INTERVAL = Duration.ofHours(1);
 
   private final Eth1Address eth1DepositContract;
 
@@ -38,6 +41,8 @@ public class StorageConfiguration {
   private final Spec spec;
   private final boolean storeNonCanonicalBlocks;
   private final int maxKnownNodeCacheSize;
+  private final boolean blockPruningEnabled;
+  private final Duration blockPruningInterval;
 
   private StorageConfiguration(
       final Eth1Address eth1DepositContract,
@@ -49,6 +54,8 @@ public class StorageConfiguration {
       final boolean storeBlockExecutionPayloadSeparately,
       final int blockMigrationBatchSize,
       final int blockMigrationBatchDelay,
+      final boolean blockPruningEnabled,
+      final Duration blockPruningInterval,
       final Spec spec) {
     this.eth1DepositContract = eth1DepositContract;
     this.dataStorageMode = dataStorageMode;
@@ -59,6 +66,8 @@ public class StorageConfiguration {
     this.storeBlockExecutionPayloadSeparately = storeBlockExecutionPayloadSeparately;
     this.blockMigrationBatchSize = blockMigrationBatchSize;
     this.blockMigrationBatchDelay = blockMigrationBatchDelay;
+    this.blockPruningEnabled = blockPruningEnabled;
+    this.blockPruningInterval = blockPruningInterval;
     this.spec = spec;
   }
 
@@ -102,6 +111,14 @@ public class StorageConfiguration {
     return blockMigrationBatchDelay;
   }
 
+  public boolean isBlockPruningEnabled() {
+    return blockPruningEnabled;
+  }
+
+  public Duration getBlockPruningInterval() {
+    return blockPruningInterval;
+  }
+
   public Spec getSpec() {
     return spec;
   }
@@ -118,6 +135,8 @@ public class StorageConfiguration {
     private boolean storeBlockExecutionPayloadSeparately = DEFAULT_STORE_BLOCK_PAYLOAD_SEPARATELY;
     private int blockMigrationBatchSize = DEFAULT_BLOCK_MIGRATION_BATCH_SIZE;
     private int blockMigrationBatchDelay = DEFAULT_BLOCK_MIGRATION_BATCH_DELAY_MS;
+    private boolean blockPruningEnabled = DEFAULT_BLOCK_PRUNING_ENABLED;
+    private Duration blockPruningInterval = DEFAULT_BLOCK_PRUNING_INTERVAL;
 
     private Builder() {}
 
@@ -171,6 +190,19 @@ public class StorageConfiguration {
       return this;
     }
 
+    public Builder blockPruningEnabled(final boolean blockPruningEnabled) {
+      this.blockPruningEnabled = blockPruningEnabled;
+      return this;
+    }
+
+    public Builder blockPruningInterval(final Duration blockPruningInterval) {
+      if (blockPruningInterval.isNegative() || blockPruningInterval.isZero()) {
+        throw new InvalidConfigurationException("Block pruning interval must be positive");
+      }
+      this.blockPruningInterval = blockPruningInterval;
+      return this;
+    }
+
     public StorageConfiguration build() {
       return new StorageConfiguration(
           eth1DepositContract,
@@ -182,6 +214,8 @@ public class StorageConfiguration {
           storeBlockExecutionPayloadSeparately,
           blockMigrationBatchSize,
           blockMigrationBatchDelay,
+          blockPruningEnabled,
+          blockPruningInterval,
           spec);
     }
 

--- a/teku/src/main/java/tech/pegasys/teku/config/TekuConfiguration.java
+++ b/teku/src/main/java/tech/pegasys/teku/config/TekuConfiguration.java
@@ -239,10 +239,19 @@ public class TekuConfiguration {
             "Genesis state required when reconstructing historic states");
       }
 
-      if (syncConfig.isReconstructHistoricStatesEnabled()
-          && PRUNE.equals(storageConfiguration.getDataStorageMode())) {
+      if (syncConfig.isReconstructHistoricStatesEnabled()) {
+        if (PRUNE.equals(storageConfiguration.getDataStorageMode())) {
+          throw new InvalidConfigurationException(
+              "Cannot reconstruct historic states when using prune data storage mode");
+        }
+        if (storageConfiguration.isBlockPruningEnabled()) {
+          throw new InvalidConfigurationException(
+              "Cannot reconstruct historic states when block pruning is enabled");
+        }
+      }
+      if (storageConfiguration.isBlockPruningEnabled() == syncConfig.fetchAllHistoricBlocks()) {
         throw new InvalidConfigurationException(
-            "Cannot reconstruct historic states when using prune data storage mode");
+            "Cannot download all historic blocks with block pruning enabled");
       }
 
       return new TekuConfiguration(


### PR DESCRIPTION
## PR Description
Add config options to prune historic blocks.

Currently only stops backfilling historic blocks sooner - follow up PR will add a pruner to delete no longer required blocks.

Slightly awkward that this will wind up changing behaviour in two quite separate components - storage and sync, so the config winds up needing to be in two separate config objects with validation that they make sense together (and it interacts with the historic backfill which can't be enabled when pruning). It works and it seems good to keep the service configuration separate, but it's a bit uglier than I'd have liked.

## Fixed Issue(s)
#6576 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
