### PR TITLE
Introduce `BlobsSidecar` storage

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -311,7 +311,7 @@ public class Spec {
         .getSchemaDefinitions()
         .toVersionEip4844()
         .orElseThrow(
-            () -> new RuntimeException("Bellatrix milestone is required to load execution payload"))
+            () -> new RuntimeException("Eip4844 milestone is required to load execution payload"))
         .getBlobsSidecarSchema()
         .sszDeserialize(serializedBlobsSidecar);
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -57,6 +57,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodyBui
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
 import tech.pegasys.teku.spec.datastructures.execution.versions.capella.Withdrawal;
+import tech.pegasys.teku.spec.datastructures.execution.versions.eip4844.BlobsSidecar;
 import tech.pegasys.teku.spec.datastructures.forkchoice.MutableStore;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrategy;
 import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyStore;
@@ -302,6 +303,17 @@ public class Spec {
             () -> new RuntimeException("Bellatrix milestone is required to load execution payload"))
         .getExecutionPayloadSchema()
         .sszDeserialize(serializedPayload);
+  }
+
+  public BlobsSidecar deserializeBlobsSidecar(
+      final Bytes serializedBlobsSidecar, final UInt64 slot) {
+    return atSlot(slot)
+        .getSchemaDefinitions()
+        .toVersionEip4844()
+        .orElseThrow(
+            () -> new RuntimeException("Bellatrix milestone is required to load execution payload"))
+        .getBlobsSidecarSchema()
+        .sszDeserialize(serializedBlobsSidecar);
   }
 
   public ExecutionPayloadHeader deserializeJsonExecutionPayloadHeader(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/SlotAndBlockRoot.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/SlotAndBlockRoot.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.spec.datastructures.blocks;
 
 import com.google.common.base.MoreObjects;
+import java.util.Comparator;
 import java.util.Objects;
 import org.apache.tuweni.bytes.Bytes32;
 import org.jetbrains.annotations.NotNull;
@@ -55,12 +56,9 @@ public class SlotAndBlockRoot implements Comparable<SlotAndBlockRoot> {
 
   @Override
   public int compareTo(@NotNull SlotAndBlockRoot o) {
-    int slotComparison = this.slot.compareTo(o.slot);
-    if (slotComparison != 0) {
-      return slotComparison;
-    }
-
-    return this.blockRoot.compareTo(o.blockRoot);
+    return Comparator.comparing(SlotAndBlockRoot::getSlot)
+        .thenComparing(SlotAndBlockRoot::getBlockRoot)
+        .compare(this, o);
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/SlotAndBlockRoot.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/SlotAndBlockRoot.java
@@ -16,10 +16,11 @@ package tech.pegasys.teku.spec.datastructures.blocks;
 import com.google.common.base.MoreObjects;
 import java.util.Objects;
 import org.apache.tuweni.bytes.Bytes32;
+import org.jetbrains.annotations.NotNull;
 import tech.pegasys.teku.infrastructure.logging.LogFormatter;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
-public class SlotAndBlockRoot {
+public class SlotAndBlockRoot implements Comparable<SlotAndBlockRoot> {
   private final UInt64 slot;
   private final Bytes32 blockRoot;
 
@@ -50,6 +51,16 @@ public class SlotAndBlockRoot {
     }
     final SlotAndBlockRoot that = (SlotAndBlockRoot) o;
     return Objects.equals(slot, that.slot) && Objects.equals(blockRoot, that.blockRoot);
+  }
+
+  @Override
+  public int compareTo(@NotNull SlotAndBlockRoot o) {
+    int slotComparison = this.slot.compareTo(o.slot);
+    if (slotComparison != 0) {
+      return slotComparison;
+    }
+
+    return this.blockRoot.compareTo(o.blockRoot);
   }
 
   @Override

--- a/storage/api/src/main/java/tech/pegasys/teku/storage/api/StorageQueryChannel.java
+++ b/storage/api/src/main/java/tech/pegasys/teku/storage/api/StorageQueryChannel.java
@@ -26,6 +26,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
+import tech.pegasys.teku.spec.datastructures.execution.versions.eip4844.BlobsSidecar;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 
@@ -76,4 +77,6 @@ public interface StorageQueryChannel extends ChannelInterface {
   SafeFuture<Optional<Checkpoint>> getAnchor();
 
   SafeFuture<Optional<DepositTreeSnapshot>> getFinalizedDepositSnapshot();
+
+  SafeFuture<Optional<BlobsSidecar>> getBlobsSidecar(final SlotAndBlockRoot slotAndBlockRoot);
 }

--- a/storage/api/src/main/java/tech/pegasys/teku/storage/api/StorageUpdateChannel.java
+++ b/storage/api/src/main/java/tech/pegasys/teku/storage/api/StorageUpdateChannel.java
@@ -18,7 +18,10 @@ import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.ethereum.pow.api.DepositTreeSnapshot;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.events.ChannelInterface;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
+import tech.pegasys.teku.spec.datastructures.execution.versions.eip4844.BlobsSidecar;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 
@@ -35,6 +38,14 @@ public interface StorageUpdateChannel extends ChannelInterface {
   SafeFuture<Void> onWeakSubjectivityUpdate(WeakSubjectivityUpdate weakSubjectivityUpdate);
 
   SafeFuture<Void> onFinalizedDepositSnapshot(DepositTreeSnapshot depositTreeSnapshot);
+
+  SafeFuture<Void> onBlobsSidecar(BlobsSidecar blobsSidecar);
+
+  SafeFuture<Void> onBlobsSidecarRemoval(SlotAndBlockRoot blobsSidecar);
+
+  SafeFuture<Void> onBlobsSidecarPruning(UInt64 endSlot, int pruneLimit);
+
+  SafeFuture<Void> onUnconfirmedBlobsSidecarPruning(UInt64 endSlot, int pruneLimit);
 
   void onChainInitialized(AnchorPoint initialAnchor);
 }

--- a/storage/api/src/main/java/tech/pegasys/teku/storage/api/StorageUpdateChannel.java
+++ b/storage/api/src/main/java/tech/pegasys/teku/storage/api/StorageUpdateChannel.java
@@ -41,7 +41,7 @@ public interface StorageUpdateChannel extends ChannelInterface {
 
   SafeFuture<Void> onBlobsSidecar(BlobsSidecar blobsSidecar);
 
-  SafeFuture<Void> onBlobsSidecarRemoval(SlotAndBlockRoot blobsSidecar);
+  SafeFuture<Void> onBlobsSidecarRemoval(SlotAndBlockRoot blobsSidecarKey);
 
   SafeFuture<Void> onBlobsSidecarPruning(UInt64 endSlot, int pruneLimit);
 

--- a/storage/src/integration-test/java/tech/pegasys/teku/storage/server/kvstore/DatabaseTest.java
+++ b/storage/src/integration-test/java/tech/pegasys/teku/storage/server/kvstore/DatabaseTest.java
@@ -249,7 +249,7 @@ public class DatabaseTest {
     assertBlobsStream(blobsSidecar1, blobsSidecar2, blobsSidecar2bis, blobsSidecar3, blobsSidecar4);
 
     // let's prune unconfirmed with limit to 1
-    database.pruneOldestUnconfirmedBlobsSidecar(UInt64.MAX_VALUE, 1);
+    assertThat(database.pruneOldestUnconfirmedBlobsSidecar(UInt64.MAX_VALUE, 1)).isTrue();
     assertUnconfirmedBlobsStream(
         blobsSidecarToSlotAndBlockRoot(blobsSidecar2),
         blobsSidecarToSlotAndBlockRoot(blobsSidecar2bis),
@@ -258,7 +258,7 @@ public class DatabaseTest {
     assertBlobsStream(blobsSidecar2, blobsSidecar2bis, blobsSidecar3, blobsSidecar4);
 
     // let's prune unconfirmed up to slot 1 (nothing will be pruned)
-    database.pruneOldestUnconfirmedBlobsSidecar(ONE, 10);
+    assertThat(database.pruneOldestUnconfirmedBlobsSidecar(ONE, 10)).isFalse();
     assertUnconfirmedBlobsStream(
         blobsSidecarToSlotAndBlockRoot(blobsSidecar2),
         blobsSidecarToSlotAndBlockRoot(blobsSidecar2bis),
@@ -267,17 +267,17 @@ public class DatabaseTest {
     assertBlobsStream(blobsSidecar2, blobsSidecar2bis, blobsSidecar3, blobsSidecar4);
 
     // let's prune all unconfirmed
-    database.pruneOldestUnconfirmedBlobsSidecar(UInt64.valueOf(3), 10);
+    assertThat(database.pruneOldestUnconfirmedBlobsSidecar(UInt64.valueOf(3), 10)).isFalse();
     assertUnconfirmedBlobsStream();
     // we have blobsSidecar4
     assertBlobsStream(blobsSidecar4);
 
     // let's prune all up to a too old slot (nothing will be pruned)
-    database.pruneOldestBlobsSidecar(UInt64.valueOf(3), 10);
+    assertThat(database.pruneOldestBlobsSidecar(UInt64.valueOf(3), 10)).isFalse();
     assertBlobsStream(blobsSidecar4);
 
     // let's prune all up slot 4
-    database.pruneOldestBlobsSidecar(UInt64.valueOf(4), 1);
+    assertThat(database.pruneOldestBlobsSidecar(UInt64.valueOf(4), 1)).isTrue();
     // all empty now
     assertUnconfirmedBlobsStream();
     assertBlobsStream();
@@ -306,13 +306,13 @@ public class DatabaseTest {
     database.storeUnconfirmedBlobsSidecar(blobsSidecar4);
     database.storeUnconfirmedBlobsSidecar(blobsSidecar3);
 
-    database.pruneOldestBlobsSidecar(UInt64.MAX_VALUE, 2);
+    assertThat(database.pruneOldestBlobsSidecar(UInt64.MAX_VALUE, 2)).isTrue();
     assertUnconfirmedBlobsStream(
         blobsSidecarToSlotAndBlockRoot(blobsSidecar3),
         blobsSidecarToSlotAndBlockRoot(blobsSidecar4));
     assertBlobsStream(blobsSidecar3, blobsSidecar4);
 
-    database.pruneOldestBlobsSidecar(UInt64.MAX_VALUE, 100);
+    assertThat(database.pruneOldestBlobsSidecar(UInt64.MAX_VALUE, 100)).isFalse();
     assertUnconfirmedBlobsStream();
     assertBlobsStream();
   }

--- a/storage/src/integration-test/java/tech/pegasys/teku/storage/server/kvstore/DatabaseTest.java
+++ b/storage/src/integration-test/java/tech/pegasys/teku/storage/server/kvstore/DatabaseTest.java
@@ -254,7 +254,7 @@ public class DatabaseTest {
         blobsSidecarToSlotAndBlockRoot(blobsSidecar2),
         blobsSidecarToSlotAndBlockRoot(blobsSidecar2bis),
         blobsSidecarToSlotAndBlockRoot(blobsSidecar3));
-    // we all blobs except the first
+    // we have all blobs except the first
     assertBlobsStream(blobsSidecar2, blobsSidecar2bis, blobsSidecar3, blobsSidecar4);
 
     // let's prune unconfirmed up to slot 1 (nothing will be pruned)
@@ -263,13 +263,13 @@ public class DatabaseTest {
         blobsSidecarToSlotAndBlockRoot(blobsSidecar2),
         blobsSidecarToSlotAndBlockRoot(blobsSidecar2bis),
         blobsSidecarToSlotAndBlockRoot(blobsSidecar3));
-    // we all blobs except the first
+    // we still have all blobs except the first
     assertBlobsStream(blobsSidecar2, blobsSidecar2bis, blobsSidecar3, blobsSidecar4);
 
     // let's prune all unconfirmed
     database.pruneOldestUnconfirmedBlobsSidecar(UInt64.valueOf(3), 10);
     assertUnconfirmedBlobsStream();
-    // we still have blobsSidecar4
+    // we have blobsSidecar4
     assertBlobsStream(blobsSidecar4);
 
     // let's prune all up to a too old slot (nothing will be pruned)

--- a/storage/src/integration-test/java/tech/pegasys/teku/storage/server/kvstore/DatabaseTest.java
+++ b/storage/src/integration-test/java/tech/pegasys/teku/storage/server/kvstore/DatabaseTest.java
@@ -66,6 +66,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.SlotAndExecutionPayloadSummary;
+import tech.pegasys.teku.spec.datastructures.execution.versions.eip4844.BlobsSidecar;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
@@ -97,7 +98,7 @@ public class DatabaseTest {
 
   private static final List<BLSKeyPair> VALIDATOR_KEYS = BLSKeyGenerator.generateKeyPairs(3);
 
-  protected final Spec spec = TestSpecFactory.createMinimalBellatrix();
+  protected final Spec spec = TestSpecFactory.createMinimalEip4844();
   final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
   private final ChainBuilder chainBuilder = ChainBuilder.create(spec, VALIDATOR_KEYS);
   private final ChainProperties chainProperties = new ChainProperties(spec);
@@ -180,6 +181,140 @@ public class DatabaseTest {
     database.updateWeakSubjectivityState(update);
 
     assertThat(database.getWeakSubjectivityState().getCheckpoint()).contains(checkpoint);
+  }
+
+  @TestTemplate
+  public void verifyBlobsLifecycle(final DatabaseContext context) throws IOException {
+    initialize(context);
+
+    // no blobs, no early slot
+    assertThat(database.getEarliestBlobsSidecarSlot()).isEmpty();
+
+    final BlobsSidecar blobsSidecar1 =
+        dataStructureUtil.randomBlobsSidecar(dataStructureUtil.randomBytes32(), UInt64.valueOf(1));
+    final BlobsSidecar blobsSidecar2 =
+        dataStructureUtil.randomBlobsSidecar(Bytes32.ZERO, UInt64.valueOf(2));
+    final BlobsSidecar blobsSidecar2bis =
+        dataStructureUtil.randomBlobsSidecar(Bytes32.fromHexString("0x01"), UInt64.valueOf(2));
+    final BlobsSidecar blobsSidecar3 =
+        dataStructureUtil.randomBlobsSidecar(dataStructureUtil.randomBytes32(), UInt64.valueOf(3));
+    final BlobsSidecar blobsSidecar4 =
+        dataStructureUtil.randomBlobsSidecar(dataStructureUtil.randomBytes32(), UInt64.valueOf(4));
+    final BlobsSidecar blobsSidecarNotAdded = dataStructureUtil.randomBlobsSidecar();
+
+    // add blobs out of order
+    database.storeUnconfirmedBlobsSidecar(blobsSidecar2);
+    database.storeUnconfirmedBlobsSidecar(blobsSidecar1);
+    database.storeUnconfirmedBlobsSidecar(blobsSidecar2bis);
+    database.storeUnconfirmedBlobsSidecar(blobsSidecar4);
+    database.storeUnconfirmedBlobsSidecar(blobsSidecar3);
+
+    assertThat(database.getEarliestBlobsSidecarSlot()).contains(ONE);
+
+    // all added blobs must be there
+    List.of(blobsSidecar1, blobsSidecar2, blobsSidecar2bis, blobsSidecar3, blobsSidecar4)
+        .forEach(
+            blobsSidecar ->
+                assertThat(database.getBlobsSidecar(blobsSidecarToSlotAndBlockRoot(blobsSidecar)))
+                    .contains(blobsSidecar));
+
+    // non added blobs must not be there
+    assertThat(database.getBlobsSidecar(blobsSidecarToSlotAndBlockRoot(blobsSidecarNotAdded)))
+        .isEmpty();
+
+    // all blobs must be streamed ordered by slot
+    assertBlobsStream(blobsSidecar1, blobsSidecar2, blobsSidecar2bis, blobsSidecar3, blobsSidecar4);
+
+    // a subset of blobs must be streamed ordered by slot
+    assertBlobsStream(
+        UInt64.valueOf(2), UInt64.valueOf(3), blobsSidecar2, blobsSidecar2bis, blobsSidecar3);
+
+    // all blobs must be unconfirmed
+    assertUnconfirmedBlobsStream(
+        blobsSidecarToSlotAndBlockRoot(blobsSidecar1),
+        blobsSidecarToSlotAndBlockRoot(blobsSidecar2),
+        blobsSidecarToSlotAndBlockRoot(blobsSidecar2bis),
+        blobsSidecarToSlotAndBlockRoot(blobsSidecar3),
+        blobsSidecarToSlotAndBlockRoot(blobsSidecar4));
+
+    database.confirmBlobsSidecar(blobsSidecarToSlotAndBlockRoot(blobsSidecar4));
+
+    // only 1 and 3 blobs must be unconfirmed
+    assertUnconfirmedBlobsStream(
+        blobsSidecarToSlotAndBlockRoot(blobsSidecar1),
+        blobsSidecarToSlotAndBlockRoot(blobsSidecar2),
+        blobsSidecarToSlotAndBlockRoot(blobsSidecar2bis),
+        blobsSidecarToSlotAndBlockRoot(blobsSidecar3));
+    // we still have all blobs
+    assertBlobsStream(blobsSidecar1, blobsSidecar2, blobsSidecar2bis, blobsSidecar3, blobsSidecar4);
+
+    // let's prune unconfirmed with limit to 1
+    database.pruneOldestUnconfirmedBlobsSidecar(UInt64.MAX_VALUE, 1);
+    assertUnconfirmedBlobsStream(
+        blobsSidecarToSlotAndBlockRoot(blobsSidecar2),
+        blobsSidecarToSlotAndBlockRoot(blobsSidecar2bis),
+        blobsSidecarToSlotAndBlockRoot(blobsSidecar3));
+    // we all blobs except the first
+    assertBlobsStream(blobsSidecar2, blobsSidecar2bis, blobsSidecar3, blobsSidecar4);
+
+    // let's prune unconfirmed up to slot 1 (nothing will be pruned)
+    database.pruneOldestUnconfirmedBlobsSidecar(ONE, 10);
+    assertUnconfirmedBlobsStream(
+        blobsSidecarToSlotAndBlockRoot(blobsSidecar2),
+        blobsSidecarToSlotAndBlockRoot(blobsSidecar2bis),
+        blobsSidecarToSlotAndBlockRoot(blobsSidecar3));
+    // we all blobs except the first
+    assertBlobsStream(blobsSidecar2, blobsSidecar2bis, blobsSidecar3, blobsSidecar4);
+
+    // let's prune all unconfirmed
+    database.pruneOldestUnconfirmedBlobsSidecar(UInt64.valueOf(3), 10);
+    assertUnconfirmedBlobsStream();
+    // we still have blobsSidecar4
+    assertBlobsStream(blobsSidecar4);
+
+    // let's prune all up to a too old slot (nothing will be pruned)
+    database.pruneOldestBlobsSidecar(UInt64.valueOf(3), 10);
+    assertBlobsStream(blobsSidecar4);
+
+    // let's prune all up slot 4
+    database.pruneOldestBlobsSidecar(UInt64.valueOf(4), 1);
+    // all empty now
+    assertUnconfirmedBlobsStream();
+    assertBlobsStream();
+  }
+
+  @TestTemplate
+  void pruneOldestBlobsSidecar_shouldPruneUnconfirmedBlobsToo(final DatabaseContext context)
+      throws IOException {
+    initialize(context);
+
+    // no blobs, no early slot
+    assertThat(database.getEarliestBlobsSidecarSlot()).isEmpty();
+
+    final BlobsSidecar blobsSidecar1 =
+        dataStructureUtil.randomBlobsSidecar(dataStructureUtil.randomBytes32(), UInt64.valueOf(1));
+    final BlobsSidecar blobsSidecar2 =
+        dataStructureUtil.randomBlobsSidecar(dataStructureUtil.randomBytes32(), UInt64.valueOf(2));
+    final BlobsSidecar blobsSidecar3 =
+        dataStructureUtil.randomBlobsSidecar(dataStructureUtil.randomBytes32(), UInt64.valueOf(3));
+    final BlobsSidecar blobsSidecar4 =
+        dataStructureUtil.randomBlobsSidecar(dataStructureUtil.randomBytes32(), UInt64.valueOf(4));
+
+    // add unconfirmed blobs
+    database.storeUnconfirmedBlobsSidecar(blobsSidecar2);
+    database.storeUnconfirmedBlobsSidecar(blobsSidecar1);
+    database.storeUnconfirmedBlobsSidecar(blobsSidecar4);
+    database.storeUnconfirmedBlobsSidecar(blobsSidecar3);
+
+    database.pruneOldestBlobsSidecar(UInt64.MAX_VALUE, 2);
+    assertUnconfirmedBlobsStream(
+        blobsSidecarToSlotAndBlockRoot(blobsSidecar3),
+        blobsSidecarToSlotAndBlockRoot(blobsSidecar4));
+    assertBlobsStream(blobsSidecar3, blobsSidecar4);
+
+    database.pruneOldestBlobsSidecar(UInt64.MAX_VALUE, 100);
+    assertUnconfirmedBlobsStream();
+    assertBlobsStream();
   }
 
   @TestTemplate
@@ -2127,6 +2262,31 @@ public class DatabaseTest {
     storageSystems.add(storageSystem);
   }
 
+  private void assertUnconfirmedBlobsStream(SlotAndBlockRoot... slotAndBlockRoots) {
+    assertUnconfirmedBlobsStream(ZERO, UInt64.MAX_VALUE, slotAndBlockRoots);
+  }
+
+  private void assertUnconfirmedBlobsStream(
+      UInt64 startSlot, UInt64 endSlot, SlotAndBlockRoot... slotAndBlockRoots) {
+    try (Stream<SlotAndBlockRoot> blobsSidecarStream =
+        database.streamUnconfirmedBlobsSidecar(startSlot, endSlot)) {
+      final List<SlotAndBlockRoot> allSlotAndBlockRoots = blobsSidecarStream.collect(toList());
+      assertThat(allSlotAndBlockRoots).containsExactly(slotAndBlockRoots);
+    }
+  }
+
+  private void assertBlobsStream(BlobsSidecar... blobsSidecars) {
+    assertBlobsStream(ZERO, UInt64.MAX_VALUE, blobsSidecars);
+  }
+
+  private void assertBlobsStream(UInt64 startSlot, UInt64 endSlot, BlobsSidecar... blobsSidecars) {
+    try (Stream<BlobsSidecar> blobsSidecarStream =
+        database.streamBlobsSidecar(startSlot, endSlot)) {
+      final List<BlobsSidecar> allBlobs = blobsSidecarStream.collect(toList());
+      assertThat(allBlobs).containsExactly(blobsSidecars);
+    }
+  }
+
   public static class CreateForkChainResult {
     private final ChainBuilder forkChain;
     private final UInt64 firstHotBlockSlot;
@@ -2143,5 +2303,10 @@ public class DatabaseTest {
     public UInt64 getFirstHotBlockSlot() {
       return firstHotBlockSlot;
     }
+  }
+
+  private static SlotAndBlockRoot blobsSidecarToSlotAndBlockRoot(final BlobsSidecar blobsSidecar) {
+    return new SlotAndBlockRoot(
+        blobsSidecar.getBeaconBlockSlot(), blobsSidecar.getBeaconBlockRoot());
   }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/ChainStorage.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/ChainStorage.java
@@ -184,10 +184,10 @@ public class ChainStorage
   }
 
   @Override
-  public SafeFuture<Void> onBlobsSidecarRemoval(final SlotAndBlockRoot blobsSidecar) {
+  public SafeFuture<Void> onBlobsSidecarRemoval(final SlotAndBlockRoot blobsSidecarKey) {
     return SafeFuture.of(
         () -> {
-          database.removeBlobsSidecar(blobsSidecar);
+          database.removeBlobsSidecar(blobsSidecarKey);
           return null;
         });
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/ChainStorage.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/ChainStorage.java
@@ -175,7 +175,7 @@ public class ChainStorage
   }
 
   @Override
-  public SafeFuture<Void> onBlobsSidecar(BlobsSidecar blobsSidecar) {
+  public SafeFuture<Void> onBlobsSidecar(final BlobsSidecar blobsSidecar) {
     return SafeFuture.of(
         () -> {
           database.storeUnconfirmedBlobsSidecar(blobsSidecar);
@@ -184,7 +184,7 @@ public class ChainStorage
   }
 
   @Override
-  public SafeFuture<Void> onBlobsSidecarRemoval(SlotAndBlockRoot blobsSidecar) {
+  public SafeFuture<Void> onBlobsSidecarRemoval(final SlotAndBlockRoot blobsSidecar) {
     return SafeFuture.of(
         () -> {
           database.removeBlobsSidecar(blobsSidecar);
@@ -193,7 +193,7 @@ public class ChainStorage
   }
 
   @Override
-  public SafeFuture<Void> onBlobsSidecarPruning(UInt64 endSlot, int pruneLimit) {
+  public SafeFuture<Void> onBlobsSidecarPruning(final UInt64 endSlot, final int pruneLimit) {
     return SafeFuture.of(
         () -> {
           database.pruneOldestBlobsSidecar(endSlot, pruneLimit);
@@ -202,7 +202,8 @@ public class ChainStorage
   }
 
   @Override
-  public SafeFuture<Void> onUnconfirmedBlobsSidecarPruning(UInt64 endSlot, int pruneLimit) {
+  public SafeFuture<Void> onUnconfirmedBlobsSidecarPruning(
+      final UInt64 endSlot, final int pruneLimit) {
     return SafeFuture.of(
         () -> {
           database.pruneOldestUnconfirmedBlobsSidecar(endSlot, pruneLimit);

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/ChainStorage.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/ChainStorage.java
@@ -33,6 +33,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSummary;
+import tech.pegasys.teku.spec.datastructures.execution.versions.eip4844.BlobsSidecar;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
@@ -171,6 +172,42 @@ public class ChainStorage
   public SafeFuture<Optional<SignedBeaconBlock>> getFinalizedBlockAtSlot(final UInt64 slot) {
     return SafeFuture.of(() -> database.getFinalizedBlockAtSlot(slot))
         .thenCompose(this::unblindBlock);
+  }
+
+  @Override
+  public SafeFuture<Void> onBlobsSidecar(BlobsSidecar blobsSidecar) {
+    return SafeFuture.of(
+        () -> {
+          database.storeUnconfirmedBlobsSidecar(blobsSidecar);
+          return null;
+        });
+  }
+
+  @Override
+  public SafeFuture<Void> onBlobsSidecarRemoval(SlotAndBlockRoot blobsSidecar) {
+    return SafeFuture.of(
+        () -> {
+          database.removeBlobsSidecar(blobsSidecar);
+          return null;
+        });
+  }
+
+  @Override
+  public SafeFuture<Void> onBlobsSidecarPruning(UInt64 endSlot, int pruneLimit) {
+    return SafeFuture.of(
+        () -> {
+          database.pruneOldestBlobsSidecar(endSlot, pruneLimit);
+          return null;
+        });
+  }
+
+  @Override
+  public SafeFuture<Void> onUnconfirmedBlobsSidecarPruning(UInt64 endSlot, int pruneLimit) {
+    return SafeFuture.of(
+        () -> {
+          database.pruneOldestUnconfirmedBlobsSidecar(endSlot, pruneLimit);
+          return null;
+        });
   }
 
   private SafeFuture<Optional<SignedBeaconBlock>> unblindBlock(
@@ -317,5 +354,11 @@ public class ChainStorage
   @Override
   public SafeFuture<Optional<DepositTreeSnapshot>> getFinalizedDepositSnapshot() {
     return SafeFuture.of(database::getFinalizedDepositSnapshot);
+  }
+
+  @Override
+  public SafeFuture<Optional<BlobsSidecar>> getBlobsSidecar(
+      final SlotAndBlockRoot slotAndBlockRoot) {
+    return SafeFuture.of(() -> database.getBlobsSidecar(slotAndBlockRoot));
   }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/CombinedStorageChannelSplitter.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/CombinedStorageChannelSplitter.java
@@ -107,8 +107,8 @@ public class CombinedStorageChannelSplitter implements CombinedStorageChannel {
   }
 
   @Override
-  public SafeFuture<Void> onBlobsSidecarRemoval(final SlotAndBlockRoot blobsSidecar) {
-    return updateDelegate.onBlobsSidecarRemoval(blobsSidecar);
+  public SafeFuture<Void> onBlobsSidecarRemoval(final SlotAndBlockRoot blobsSidecarKey) {
+    return updateDelegate.onBlobsSidecarRemoval(blobsSidecarKey);
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/CombinedStorageChannelSplitter.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/CombinedStorageChannelSplitter.java
@@ -102,22 +102,23 @@ public class CombinedStorageChannelSplitter implements CombinedStorageChannel {
   }
 
   @Override
-  public SafeFuture<Void> onBlobsSidecar(BlobsSidecar blobsSidecar) {
+  public SafeFuture<Void> onBlobsSidecar(final BlobsSidecar blobsSidecar) {
     return updateDelegate.onBlobsSidecar(blobsSidecar);
   }
 
   @Override
-  public SafeFuture<Void> onBlobsSidecarRemoval(SlotAndBlockRoot blobsSidecar) {
+  public SafeFuture<Void> onBlobsSidecarRemoval(final SlotAndBlockRoot blobsSidecar) {
     return updateDelegate.onBlobsSidecarRemoval(blobsSidecar);
   }
 
   @Override
-  public SafeFuture<Void> onBlobsSidecarPruning(UInt64 endSlot, int pruneLimit) {
+  public SafeFuture<Void> onBlobsSidecarPruning(final UInt64 endSlot, final int pruneLimit) {
     return updateDelegate.onBlobsSidecarPruning(endSlot, pruneLimit);
   }
 
   @Override
-  public SafeFuture<Void> onUnconfirmedBlobsSidecarPruning(UInt64 endSlot, int pruneLimit) {
+  public SafeFuture<Void> onUnconfirmedBlobsSidecarPruning(
+      final UInt64 endSlot, final int pruneLimit) {
     return updateDelegate.onUnconfirmedBlobsSidecarPruning(endSlot, pruneLimit);
   }
 
@@ -187,7 +188,7 @@ public class CombinedStorageChannelSplitter implements CombinedStorageChannel {
   }
 
   @Override
-  public SafeFuture<Optional<BeaconState>> getLatestAvailableFinalizedState(UInt64 slot) {
+  public SafeFuture<Optional<BeaconState>> getLatestAvailableFinalizedState(final UInt64 slot) {
     return asyncRunner.runAsync(() -> queryDelegate.getLatestAvailableFinalizedState(slot));
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/CombinedStorageChannelSplitter.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/CombinedStorageChannelSplitter.java
@@ -27,6 +27,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
+import tech.pegasys.teku.spec.datastructures.execution.versions.eip4844.BlobsSidecar;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
@@ -98,6 +99,26 @@ public class CombinedStorageChannelSplitter implements CombinedStorageChannel {
   @Override
   public void onChainInitialized(final AnchorPoint initialAnchor) {
     updateDelegate.onChainInitialized(initialAnchor);
+  }
+
+  @Override
+  public SafeFuture<Void> onBlobsSidecar(BlobsSidecar blobsSidecar) {
+    return updateDelegate.onBlobsSidecar(blobsSidecar);
+  }
+
+  @Override
+  public SafeFuture<Void> onBlobsSidecarRemoval(SlotAndBlockRoot blobsSidecar) {
+    return updateDelegate.onBlobsSidecarRemoval(blobsSidecar);
+  }
+
+  @Override
+  public SafeFuture<Void> onBlobsSidecarPruning(UInt64 endSlot, int pruneLimit) {
+    return updateDelegate.onBlobsSidecarPruning(endSlot, pruneLimit);
+  }
+
+  @Override
+  public SafeFuture<Void> onUnconfirmedBlobsSidecarPruning(UInt64 endSlot, int pruneLimit) {
+    return updateDelegate.onUnconfirmedBlobsSidecarPruning(endSlot, pruneLimit);
   }
 
   @Override
@@ -193,5 +214,11 @@ public class CombinedStorageChannelSplitter implements CombinedStorageChannel {
   @Override
   public SafeFuture<Optional<DepositTreeSnapshot>> getFinalizedDepositSnapshot() {
     return asyncRunner.runAsync(queryDelegate::getFinalizedDepositSnapshot);
+  }
+
+  @Override
+  public SafeFuture<Optional<BlobsSidecar>> getBlobsSidecar(
+      final SlotAndBlockRoot slotAndBlockRoot) {
+    return asyncRunner.runAsync(() -> queryDelegate.getBlobsSidecar(slotAndBlockRoot));
   }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
@@ -30,6 +30,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
+import tech.pegasys.teku.spec.datastructures.execution.versions.eip4844.BlobsSidecar;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
@@ -53,6 +54,26 @@ public interface Database extends AutoCloseable {
   void storeReconstructedFinalizedState(BeaconState state, Bytes32 blockRoot);
 
   void updateWeakSubjectivityState(WeakSubjectivityUpdate weakSubjectivityUpdate);
+
+  void storeUnconfirmedBlobsSidecar(BlobsSidecar blobsSidecar);
+
+  void confirmBlobsSidecar(SlotAndBlockRoot slotAndBlockRoot);
+
+  Optional<BlobsSidecar> getBlobsSidecar(SlotAndBlockRoot slotAndBlockRoot);
+
+  void removeBlobsSidecar(SlotAndBlockRoot slotAndBlockRoot);
+
+  void pruneOldestBlobsSidecar(UInt64 endSlot, int pruneLimit);
+
+  void pruneOldestUnconfirmedBlobsSidecar(UInt64 endSlot, int pruneLimit);
+
+  @MustBeClosed
+  Stream<BlobsSidecar> streamBlobsSidecar(UInt64 startSlot, UInt64 endSlot);
+
+  @MustBeClosed
+  Stream<SlotAndBlockRoot> streamUnconfirmedBlobsSidecar(UInt64 startSlot, UInt64 endSlot);
+
+  Optional<UInt64> getEarliestBlobsSidecarSlot();
 
   Optional<OnDiskStoreData> createMemoryStore();
 
@@ -84,7 +105,7 @@ public interface Database extends AutoCloseable {
 
   Optional<Bytes32> getFinalizedBlockRootBySlot(UInt64 slot);
 
-  Optional<ExecutionPayload> getExecutionPayload(Bytes32 blockRoot, final UInt64 slot);
+  Optional<ExecutionPayload> getExecutionPayload(Bytes32 blockRoot, UInt64 slot);
 
   /**
    * Returns the latest finalized block at or prior to the given slot

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
@@ -63,9 +63,27 @@ public interface Database extends AutoCloseable {
 
   void removeBlobsSidecar(SlotAndBlockRoot slotAndBlockRoot);
 
-  void pruneOldestBlobsSidecar(UInt64 endSlot, int pruneLimit);
+  /**
+   * this prune method will delete BlobsSidecars (including the unconfirmed ones) starting from the
+   * oldest BlobsSidecars (by slot) up to BlobsSidecars at {@code endSlot} (inclusive). The pruning
+   * process will be limited to maximum {@code pruneLimit} BlobsSidecars
+   *
+   * @param endSlot
+   * @param pruneLimit
+   * @return true if number of pruned blobs reached the pruneLimit, false otherwise
+   */
+  boolean pruneOldestBlobsSidecar(UInt64 endSlot, int pruneLimit);
 
-  void pruneOldestUnconfirmedBlobsSidecar(UInt64 endSlot, int pruneLimit);
+  /**
+   * this prune method will delete unconfirmed BlobsSidecars starting from the oldest BlobsSidecars
+   * (by slot) up to BlobsSidecars at {@code endSlot} (inclusive). The pruning process will be
+   * limited to maximum {@code pruneLimit} BlobsSidecars
+   *
+   * @param endSlot
+   * @param pruneLimit
+   * @return true if number of pruned blobs reached the pruneLimit, false otherwise
+   */
+  boolean pruneOldestUnconfirmedBlobsSidecar(UInt64 endSlot, int pruneLimit);
 
   @MustBeClosed
   Stream<BlobsSidecar> streamBlobsSidecar(UInt64 startSlot, UInt64 endSlot);

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
@@ -65,25 +65,25 @@ public interface Database extends AutoCloseable {
 
   /**
    * this prune method will delete BlobsSidecars (including the unconfirmed ones) starting from the
-   * oldest BlobsSidecars (by slot) up to BlobsSidecars at {@code endSlot} (inclusive). The pruning
-   * process will be limited to maximum {@code pruneLimit} BlobsSidecars
+   * oldest BlobsSidecars (by slot) up to BlobsSidecars at {@code lastSlotToPrune} (inclusive). The
+   * pruning process will be limited to maximum {@code pruneLimit} BlobsSidecars
    *
-   * @param endSlot
+   * @param lastSlotToPrune
    * @param pruneLimit
    * @return true if number of pruned blobs reached the pruneLimit, false otherwise
    */
-  boolean pruneOldestBlobsSidecar(UInt64 endSlot, int pruneLimit);
+  boolean pruneOldestBlobsSidecar(UInt64 lastSlotToPrune, int pruneLimit);
 
   /**
    * this prune method will delete unconfirmed BlobsSidecars starting from the oldest BlobsSidecars
-   * (by slot) up to BlobsSidecars at {@code endSlot} (inclusive). The pruning process will be
-   * limited to maximum {@code pruneLimit} BlobsSidecars
+   * (by slot) up to BlobsSidecars at {@code lastSlotToPrune} (inclusive). The pruning process will
+   * be limited to maximum {@code pruneLimit} BlobsSidecars
    *
-   * @param endSlot
+   * @param lastSlotToPrune
    * @param pruneLimit
    * @return true if number of pruned blobs reached the pruneLimit, false otherwise
    */
-  boolean pruneOldestUnconfirmedBlobsSidecar(UInt64 endSlot, int pruneLimit);
+  boolean pruneOldestUnconfirmedBlobsSidecar(UInt64 lastSlotToPrune, int pruneLimit);
 
   @MustBeClosed
   Stream<BlobsSidecar> streamBlobsSidecar(UInt64 startSlot, UInt64 endSlot);

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/RetryingStorageUpdateChannel.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/RetryingStorageUpdateChannel.java
@@ -128,8 +128,8 @@ public class RetryingStorageUpdateChannel implements StorageUpdateChannel {
   }
 
   @Override
-  public SafeFuture<Void> onBlobsSidecarRemoval(final SlotAndBlockRoot blobsSidecar) {
-    return retry(() -> delegate.onBlobsSidecarRemoval(blobsSidecar));
+  public SafeFuture<Void> onBlobsSidecarRemoval(final SlotAndBlockRoot blobsSidecarKey) {
+    return retry(() -> delegate.onBlobsSidecarRemoval(blobsSidecarKey));
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/RetryingStorageUpdateChannel.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/RetryingStorageUpdateChannel.java
@@ -96,7 +96,7 @@ public class RetryingStorageUpdateChannel implements StorageUpdateChannel {
 
   @Override
   public SafeFuture<Void> onReconstructedFinalizedState(
-      BeaconState finalizedState, Bytes32 blockRoot) {
+      final BeaconState finalizedState, final Bytes32 blockRoot) {
     return this.retry(() -> delegate.onReconstructedFinalizedState(finalizedState, blockRoot));
   }
 
@@ -123,22 +123,23 @@ public class RetryingStorageUpdateChannel implements StorageUpdateChannel {
   }
 
   @Override
-  public SafeFuture<Void> onBlobsSidecar(BlobsSidecar blobsSidecar) {
+  public SafeFuture<Void> onBlobsSidecar(final BlobsSidecar blobsSidecar) {
     return retry(() -> delegate.onBlobsSidecar(blobsSidecar));
   }
 
   @Override
-  public SafeFuture<Void> onBlobsSidecarRemoval(SlotAndBlockRoot blobsSidecar) {
+  public SafeFuture<Void> onBlobsSidecarRemoval(final SlotAndBlockRoot blobsSidecar) {
     return retry(() -> delegate.onBlobsSidecarRemoval(blobsSidecar));
   }
 
   @Override
-  public SafeFuture<Void> onBlobsSidecarPruning(UInt64 endSlot, int pruneLimit) {
+  public SafeFuture<Void> onBlobsSidecarPruning(final UInt64 endSlot, final int pruneLimit) {
     return retry(() -> delegate.onBlobsSidecarPruning(endSlot, pruneLimit));
   }
 
   @Override
-  public SafeFuture<Void> onUnconfirmedBlobsSidecarPruning(UInt64 endSlot, int pruneLimit) {
+  public SafeFuture<Void> onUnconfirmedBlobsSidecarPruning(
+      final UInt64 endSlot, final int pruneLimit) {
     return retry(() -> delegate.onUnconfirmedBlobsSidecarPruning(endSlot, pruneLimit));
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
@@ -35,6 +35,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.dataproviders.lookup.BlockProvider;
@@ -53,6 +54,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
 import tech.pegasys.teku.spec.datastructures.execution.SlotAndExecutionPayloadSummary;
+import tech.pegasys.teku.spec.datastructures.execution.versions.eip4844.BlobsSidecar;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.spec.datastructures.hashtree.HashTree;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
@@ -533,6 +535,95 @@ public abstract class KvStoreDatabase<
       blockNumbers.forEach(updater::removeDepositsFromBlockEvent);
       updater.commit();
     }
+  }
+
+  @Override
+  public void storeUnconfirmedBlobsSidecar(final BlobsSidecar blobsSidecar) {
+    try (final FinalizedUpdaterT updater = finalizedUpdater()) {
+      updater.addBlobsSidecar(blobsSidecar);
+      updater.addUnconfirmedBlobsSidecar(blobsSidecar);
+      updater.commit();
+    }
+  }
+
+  @Override
+  public void confirmBlobsSidecar(SlotAndBlockRoot slotAndBlockRoot) {
+    try (final FinalizedUpdaterT updater = finalizedUpdater()) {
+      updater.removeUnconfirmedBlobsSidecar(slotAndBlockRoot);
+      updater.commit();
+    }
+  }
+
+  @Override
+  public Optional<BlobsSidecar> getBlobsSidecar(SlotAndBlockRoot slotAndBlockRoot) {
+    final Optional<Bytes> maybePayload = dao.getBlobsSidecar(slotAndBlockRoot);
+    return maybePayload.map(
+        payload -> spec.deserializeBlobsSidecar(payload, slotAndBlockRoot.getSlot()));
+  }
+
+  @Override
+  public void removeBlobsSidecar(SlotAndBlockRoot slotAndBlockRoot) {
+    try (final FinalizedUpdaterT updater = finalizedUpdater()) {
+      updater.removeBlobsSidecar(slotAndBlockRoot);
+      updater.removeUnconfirmedBlobsSidecar(slotAndBlockRoot);
+      updater.commit();
+    }
+  }
+
+  @Override
+  public void pruneOldestBlobsSidecar(UInt64 endSlot, int pruneLimit) {
+    try (final Stream<BlobsSidecar> prunableBlobs = streamBlobsSidecar(UInt64.ZERO, endSlot);
+        final FinalizedUpdaterT updater = finalizedUpdater()) {
+      prunableBlobs
+          .limit(pruneLimit)
+          .forEach(
+              blobsSidecar -> {
+                final SlotAndBlockRoot slotAndBlockRoot =
+                    new SlotAndBlockRoot(
+                        blobsSidecar.getBeaconBlockSlot(), blobsSidecar.getBeaconBlockRoot());
+                updater.removeBlobsSidecar(slotAndBlockRoot);
+                updater.removeUnconfirmedBlobsSidecar(slotAndBlockRoot);
+              });
+      updater.commit();
+    }
+  }
+
+  @Override
+  public void pruneOldestUnconfirmedBlobsSidecar(UInt64 endSlot, int pruneLimit) {
+    try (final Stream<SlotAndBlockRoot> prunableUnconfirmed =
+            streamUnconfirmedBlobsSidecar(UInt64.ZERO, endSlot);
+        final FinalizedUpdaterT updater = finalizedUpdater()) {
+      prunableUnconfirmed
+          .limit(pruneLimit)
+          .forEach(
+              slotAndBlockRoot -> {
+                updater.removeBlobsSidecar(slotAndBlockRoot);
+                updater.removeUnconfirmedBlobsSidecar(slotAndBlockRoot);
+              });
+      updater.commit();
+    }
+  }
+
+  @MustBeClosed
+  @Override
+  public Stream<BlobsSidecar> streamBlobsSidecar(UInt64 startSlot, UInt64 endSlot) {
+    return dao.streamBlobsSidecar(startSlot, endSlot)
+        .map(
+            slotAndBlockRootBytesEntry ->
+                spec.deserializeBlobsSidecar(
+                    slotAndBlockRootBytesEntry.getValue(),
+                    slotAndBlockRootBytesEntry.getKey().getSlot()));
+  }
+
+  @MustBeClosed
+  @Override
+  public Stream<SlotAndBlockRoot> streamUnconfirmedBlobsSidecar(UInt64 startSlot, UInt64 endSlot) {
+    return dao.streamUnconfirmedBlobsSidecar(startSlot, endSlot);
+  }
+
+  @Override
+  public Optional<UInt64> getEarliestBlobsSidecarSlot() {
+    return dao.getEarliestBlobsSidecarSlot();
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
@@ -547,7 +547,7 @@ public abstract class KvStoreDatabase<
   }
 
   @Override
-  public void confirmBlobsSidecar(SlotAndBlockRoot slotAndBlockRoot) {
+  public void confirmBlobsSidecar(final SlotAndBlockRoot slotAndBlockRoot) {
     try (final FinalizedUpdaterT updater = finalizedUpdater()) {
       updater.removeUnconfirmedBlobsSidecar(slotAndBlockRoot);
       updater.commit();
@@ -555,14 +555,14 @@ public abstract class KvStoreDatabase<
   }
 
   @Override
-  public Optional<BlobsSidecar> getBlobsSidecar(SlotAndBlockRoot slotAndBlockRoot) {
+  public Optional<BlobsSidecar> getBlobsSidecar(final SlotAndBlockRoot slotAndBlockRoot) {
     final Optional<Bytes> maybePayload = dao.getBlobsSidecar(slotAndBlockRoot);
     return maybePayload.map(
         payload -> spec.deserializeBlobsSidecar(payload, slotAndBlockRoot.getSlot()));
   }
 
   @Override
-  public void removeBlobsSidecar(SlotAndBlockRoot slotAndBlockRoot) {
+  public void removeBlobsSidecar(final SlotAndBlockRoot slotAndBlockRoot) {
     try (final FinalizedUpdaterT updater = finalizedUpdater()) {
       updater.removeBlobsSidecar(slotAndBlockRoot);
       updater.removeUnconfirmedBlobsSidecar(slotAndBlockRoot);
@@ -571,7 +571,7 @@ public abstract class KvStoreDatabase<
   }
 
   @Override
-  public void pruneOldestBlobsSidecar(UInt64 endSlot, int pruneLimit) {
+  public void pruneOldestBlobsSidecar(final UInt64 endSlot, final int pruneLimit) {
     try (final Stream<BlobsSidecar> prunableBlobs = streamBlobsSidecar(UInt64.ZERO, endSlot);
         final FinalizedUpdaterT updater = finalizedUpdater()) {
       prunableBlobs
@@ -589,7 +589,7 @@ public abstract class KvStoreDatabase<
   }
 
   @Override
-  public void pruneOldestUnconfirmedBlobsSidecar(UInt64 endSlot, int pruneLimit) {
+  public void pruneOldestUnconfirmedBlobsSidecar(final UInt64 endSlot, final int pruneLimit) {
     try (final Stream<SlotAndBlockRoot> prunableUnconfirmed =
             streamUnconfirmedBlobsSidecar(UInt64.ZERO, endSlot);
         final FinalizedUpdaterT updater = finalizedUpdater()) {
@@ -606,7 +606,7 @@ public abstract class KvStoreDatabase<
 
   @MustBeClosed
   @Override
-  public Stream<BlobsSidecar> streamBlobsSidecar(UInt64 startSlot, UInt64 endSlot) {
+  public Stream<BlobsSidecar> streamBlobsSidecar(final UInt64 startSlot, final UInt64 endSlot) {
     return dao.streamBlobsSidecar(startSlot, endSlot)
         .map(
             slotAndBlockRootBytesEntry ->
@@ -617,7 +617,8 @@ public abstract class KvStoreDatabase<
 
   @MustBeClosed
   @Override
-  public Stream<SlotAndBlockRoot> streamUnconfirmedBlobsSidecar(UInt64 startSlot, UInt64 endSlot) {
+  public Stream<SlotAndBlockRoot> streamUnconfirmedBlobsSidecar(
+      final UInt64 startSlot, final UInt64 endSlot) {
     return dao.streamUnconfirmedBlobsSidecar(startSlot, endSlot);
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
@@ -571,8 +571,9 @@ public abstract class KvStoreDatabase<
   }
 
   @Override
-  public boolean pruneOldestBlobsSidecar(final UInt64 endSlot, final int pruneLimit) {
-    try (final Stream<BlobsSidecar> prunableBlobs = streamBlobsSidecar(UInt64.ZERO, endSlot);
+  public boolean pruneOldestBlobsSidecar(final UInt64 lastSlotToPrune, final int pruneLimit) {
+    try (final Stream<BlobsSidecar> prunableBlobs =
+            streamBlobsSidecar(UInt64.ZERO, lastSlotToPrune);
         final FinalizedUpdaterT updater = finalizedUpdater()) {
       final long pruned =
           prunableBlobs
@@ -593,9 +594,10 @@ public abstract class KvStoreDatabase<
   }
 
   @Override
-  public boolean pruneOldestUnconfirmedBlobsSidecar(final UInt64 endSlot, final int pruneLimit) {
+  public boolean pruneOldestUnconfirmedBlobsSidecar(
+      final UInt64 lastSlotToPrune, final int pruneLimit) {
     try (final Stream<SlotAndBlockRoot> prunableUnconfirmed =
-            streamUnconfirmedBlobsSidecar(UInt64.ZERO, endSlot);
+            streamUnconfirmedBlobsSidecar(UInt64.ZERO, lastSlotToPrune);
         final FinalizedUpdaterT updater = finalizedUpdater()) {
       final long pruned =
           prunableUnconfirmed

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
@@ -421,14 +421,14 @@ public class CombinedKvStoreDao<S extends SchemaCombined>
   }
 
   @Override
-  public Optional<Bytes> getBlobsSidecar(SlotAndBlockRoot slotAndBlockRoot) {
+  public Optional<Bytes> getBlobsSidecar(final SlotAndBlockRoot slotAndBlockRoot) {
     return db.get(schema.getColumnBlobsSidecarBySlotAndBlockRoot(), slotAndBlockRoot);
   }
 
   @MustBeClosed
   @Override
   public Stream<Entry<SlotAndBlockRoot, Bytes>> streamBlobsSidecar(
-      UInt64 startSlot, UInt64 endSlot) {
+      final UInt64 startSlot, final UInt64 endSlot) {
     return db.stream(
             schema.getColumnBlobsSidecarBySlotAndBlockRoot(),
             new SlotAndBlockRoot(startSlot, Bytes32.ZERO),
@@ -438,7 +438,8 @@ public class CombinedKvStoreDao<S extends SchemaCombined>
 
   @MustBeClosed
   @Override
-  public Stream<SlotAndBlockRoot> streamUnconfirmedBlobsSidecar(UInt64 startSlot, UInt64 endSlot) {
+  public Stream<SlotAndBlockRoot> streamUnconfirmedBlobsSidecar(
+      final UInt64 startSlot, final UInt64 endSlot) {
     return db.stream(
             schema.getColumnUnconfirmedBlobsSidecarBySlotAndBlockRoot(),
             new SlotAndBlockRoot(startSlot, Bytes32.ZERO),
@@ -866,7 +867,7 @@ public class CombinedKvStoreDao<S extends SchemaCombined>
     }
 
     @Override
-    public void addBlobsSidecar(BlobsSidecar blobsSidecar) {
+    public void addBlobsSidecar(final BlobsSidecar blobsSidecar) {
       transaction.put(
           schema.getColumnBlobsSidecarBySlotAndBlockRoot(),
           new SlotAndBlockRoot(
@@ -875,7 +876,7 @@ public class CombinedKvStoreDao<S extends SchemaCombined>
     }
 
     @Override
-    public void addUnconfirmedBlobsSidecar(BlobsSidecar blobsSidecar) {
+    public void addUnconfirmedBlobsSidecar(final BlobsSidecar blobsSidecar) {
       transaction.put(
           schema.getColumnUnconfirmedBlobsSidecarBySlotAndBlockRoot(),
           new SlotAndBlockRoot(
@@ -884,12 +885,12 @@ public class CombinedKvStoreDao<S extends SchemaCombined>
     }
 
     @Override
-    public void removeBlobsSidecar(SlotAndBlockRoot slotAndBlockRoot) {
+    public void removeBlobsSidecar(final SlotAndBlockRoot slotAndBlockRoot) {
       transaction.delete(schema.getColumnBlobsSidecarBySlotAndBlockRoot(), slotAndBlockRoot);
     }
 
     @Override
-    public void removeUnconfirmedBlobsSidecar(SlotAndBlockRoot slotAndBlockRoot) {
+    public void removeUnconfirmedBlobsSidecar(final SlotAndBlockRoot slotAndBlockRoot) {
       transaction.delete(
           schema.getColumnUnconfirmedBlobsSidecarBySlotAndBlockRoot(), slotAndBlockRoot);
     }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
@@ -29,7 +29,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
-import org.apache.tuweni.units.bigints.UInt256;
 import org.jetbrains.annotations.NotNull;
 import tech.pegasys.teku.ethereum.pow.api.DepositTreeSnapshot;
 import tech.pegasys.teku.ethereum.pow.api.DepositsFromBlockEvent;
@@ -431,8 +430,8 @@ public class CombinedKvStoreDao<S extends SchemaCombined>
       final UInt64 startSlot, final UInt64 endSlot) {
     return db.stream(
             schema.getColumnBlobsSidecarBySlotAndBlockRoot(),
-            new SlotAndBlockRoot(startSlot, Bytes32.ZERO),
-            new SlotAndBlockRoot(endSlot, UInt256.MAX_VALUE))
+            new SlotAndBlockRoot(startSlot, MIN_BLOCK_ROOT),
+            new SlotAndBlockRoot(endSlot, MAX_BLOCK_ROOT))
         .map(entry -> entry);
   }
 
@@ -442,8 +441,8 @@ public class CombinedKvStoreDao<S extends SchemaCombined>
       final UInt64 startSlot, final UInt64 endSlot) {
     return db.stream(
             schema.getColumnUnconfirmedBlobsSidecarBySlotAndBlockRoot(),
-            new SlotAndBlockRoot(startSlot, Bytes32.ZERO),
-            new SlotAndBlockRoot(endSlot, UInt256.MAX_VALUE))
+            new SlotAndBlockRoot(startSlot, MIN_BLOCK_ROOT),
+            new SlotAndBlockRoot(endSlot, MAX_BLOCK_ROOT))
         .map(ColumnEntry::getKey);
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoAdapter.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoAdapter.java
@@ -308,20 +308,21 @@ public class KvStoreCombinedDaoAdapter
   }
 
   @Override
-  public Optional<Bytes> getBlobsSidecar(SlotAndBlockRoot slotAndBlockRoot) {
+  public Optional<Bytes> getBlobsSidecar(final SlotAndBlockRoot slotAndBlockRoot) {
     return finalizedDao.getBlobsSidecar(slotAndBlockRoot);
   }
 
   @Override
   @MustBeClosed
   public Stream<Map.Entry<SlotAndBlockRoot, Bytes>> streamBlobsSidecar(
-      UInt64 startSlot, UInt64 endSlot) {
+      final UInt64 startSlot, final UInt64 endSlot) {
     return finalizedDao.streamBlobsSidecar(startSlot, endSlot);
   }
 
   @Override
   @MustBeClosed
-  public Stream<SlotAndBlockRoot> streamUnconfirmedBlobsSidecar(UInt64 startSlot, UInt64 endSlot) {
+  public Stream<SlotAndBlockRoot> streamUnconfirmedBlobsSidecar(
+      final UInt64 startSlot, final UInt64 endSlot) {
     return finalizedDao.streamUnconfirmedBlobsSidecar(startSlot, endSlot);
   }
 
@@ -517,22 +518,22 @@ public class KvStoreCombinedDaoAdapter
     }
 
     @Override
-    public void addBlobsSidecar(BlobsSidecar blobsSidecar) {
+    public void addBlobsSidecar(final BlobsSidecar blobsSidecar) {
       finalizedUpdater.addBlobsSidecar(blobsSidecar);
     }
 
     @Override
-    public void addUnconfirmedBlobsSidecar(BlobsSidecar blobsSidecar) {
+    public void addUnconfirmedBlobsSidecar(final BlobsSidecar blobsSidecar) {
       finalizedUpdater.addUnconfirmedBlobsSidecar(blobsSidecar);
     }
 
     @Override
-    public void removeBlobsSidecar(SlotAndBlockRoot slotAndBlockRoot) {
+    public void removeBlobsSidecar(final SlotAndBlockRoot slotAndBlockRoot) {
       finalizedUpdater.removeBlobsSidecar(slotAndBlockRoot);
     }
 
     @Override
-    public void removeUnconfirmedBlobsSidecar(SlotAndBlockRoot slotAndBlockRoot) {
+    public void removeUnconfirmedBlobsSidecar(final SlotAndBlockRoot slotAndBlockRoot) {
       finalizedUpdater.removeUnconfirmedBlobsSidecar(slotAndBlockRoot);
     }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoAdapter.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoAdapter.java
@@ -34,6 +34,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
+import tech.pegasys.teku.spec.datastructures.execution.versions.eip4844.BlobsSidecar;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
@@ -307,6 +308,29 @@ public class KvStoreCombinedDaoAdapter
   }
 
   @Override
+  public Optional<Bytes> getBlobsSidecar(SlotAndBlockRoot slotAndBlockRoot) {
+    return finalizedDao.getBlobsSidecar(slotAndBlockRoot);
+  }
+
+  @Override
+  @MustBeClosed
+  public Stream<Map.Entry<SlotAndBlockRoot, Bytes>> streamBlobsSidecar(
+      UInt64 startSlot, UInt64 endSlot) {
+    return finalizedDao.streamBlobsSidecar(startSlot, endSlot);
+  }
+
+  @Override
+  @MustBeClosed
+  public Stream<SlotAndBlockRoot> streamUnconfirmedBlobsSidecar(UInt64 startSlot, UInt64 endSlot) {
+    return finalizedDao.streamUnconfirmedBlobsSidecar(startSlot, endSlot);
+  }
+
+  @Override
+  public Optional<UInt64> getEarliestBlobsSidecarSlot() {
+    return finalizedDao.getEarliestBlobsSidecarSlot();
+  }
+
+  @Override
   @MustBeClosed
   public Stream<Bytes32> streamFinalizedBlockRoots(final UInt64 startSlot, final UInt64 endSlot) {
     return finalizedDao.streamFinalizedBlockRoots(startSlot, endSlot);
@@ -490,6 +514,26 @@ public class KvStoreCombinedDaoAdapter
     @Override
     public void addHotBlock(final BlockAndCheckpoints blockAndCheckpoints) {
       hotUpdater.addHotBlock(blockAndCheckpoints);
+    }
+
+    @Override
+    public void addBlobsSidecar(BlobsSidecar blobsSidecar) {
+      finalizedUpdater.addBlobsSidecar(blobsSidecar);
+    }
+
+    @Override
+    public void addUnconfirmedBlobsSidecar(BlobsSidecar blobsSidecar) {
+      finalizedUpdater.addUnconfirmedBlobsSidecar(blobsSidecar);
+    }
+
+    @Override
+    public void removeBlobsSidecar(SlotAndBlockRoot slotAndBlockRoot) {
+      finalizedUpdater.removeBlobsSidecar(slotAndBlockRoot);
+    }
+
+    @Override
+    public void removeUnconfirmedBlobsSidecar(SlotAndBlockRoot slotAndBlockRoot) {
+      finalizedUpdater.removeUnconfirmedBlobsSidecar(slotAndBlockRoot);
     }
 
     @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoCommon.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoCommon.java
@@ -35,6 +35,8 @@ import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 
 public interface KvStoreCombinedDaoCommon extends AutoCloseable {
+  Bytes32 MIN_BLOCK_ROOT = Bytes32.ZERO;
+  Bytes32 MAX_BLOCK_ROOT = Bytes32.ZERO.not();
 
   void ingest(KvStoreCombinedDaoCommon dao, int batchSize, Consumer<String> logger);
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoCommon.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoCommon.java
@@ -16,10 +16,12 @@ package tech.pegasys.teku.storage.server.kvstore.dataaccess;
 import com.google.errorprone.annotations.MustBeClosed;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
+import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.ethereum.pow.api.DepositTreeSnapshot;
 import tech.pegasys.teku.ethereum.pow.api.DepositsFromBlockEvent;
@@ -27,6 +29,7 @@ import tech.pegasys.teku.ethereum.pow.api.MinGenesisTimeBlockEvent;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
+import tech.pegasys.teku.spec.datastructures.execution.versions.eip4844.BlobsSidecar;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
@@ -80,6 +83,16 @@ public interface KvStoreCombinedDaoCommon extends AutoCloseable {
   long countNonCanonicalSlots();
 
   Optional<UInt64> getOptimisticTransitionBlockSlot();
+
+  Optional<Bytes> getBlobsSidecar(SlotAndBlockRoot slotAndBlockRoot);
+
+  @MustBeClosed
+  Stream<Entry<SlotAndBlockRoot, Bytes>> streamBlobsSidecar(UInt64 startSlot, UInt64 endSlot);
+
+  @MustBeClosed
+  Stream<SlotAndBlockRoot> streamUnconfirmedBlobsSidecar(UInt64 startSlot, UInt64 endSlot);
+
+  Optional<UInt64> getEarliestBlobsSidecarSlot();
 
   Map<String, Long> getColumnCounts();
 
@@ -149,6 +162,14 @@ public interface KvStoreCombinedDaoCommon extends AutoCloseable {
     void setOptimisticTransitionBlockSlot(final Optional<UInt64> transitionBlockSlot);
 
     void addNonCanonicalRootAtSlot(final UInt64 slot, final Set<Bytes32> blockRoots);
+
+    void addBlobsSidecar(BlobsSidecar blobsSidecar);
+
+    void addUnconfirmedBlobsSidecar(BlobsSidecar blobsSidecar);
+
+    void removeBlobsSidecar(SlotAndBlockRoot slotAndBlockRoot);
+
+    void removeUnconfirmedBlobsSidecar(SlotAndBlockRoot slotAndBlockRoot);
 
     void commit();
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4FinalizedKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4FinalizedKvStoreDao.java
@@ -169,7 +169,7 @@ public class V4FinalizedKvStoreDao {
     return db.get(schema.getColumnNonCanonicalBlocksByRoot(), root);
   }
 
-  public Optional<Bytes> getBlobsSidecar(SlotAndBlockRoot slotAndBlockRoot) {
+  public Optional<Bytes> getBlobsSidecar(final SlotAndBlockRoot slotAndBlockRoot) {
     return db.get(schema.getColumnBlobsSidecarBySlotAndBlockRoot(), slotAndBlockRoot);
   }
 
@@ -429,7 +429,7 @@ public class V4FinalizedKvStoreDao {
     }
 
     @Override
-    public void addReconstructedFinalizedState(Bytes32 blockRoot, BeaconState state) {
+    public void addReconstructedFinalizedState(final Bytes32 blockRoot, final BeaconState state) {
       stateStorageUpdater.addReconstructedFinalizedState(db, transaction, schema, state);
     }
 
@@ -457,7 +457,7 @@ public class V4FinalizedKvStoreDao {
     }
 
     @Override
-    public void addUnconfirmedBlobsSidecar(BlobsSidecar blobsSidecar) {
+    public void addUnconfirmedBlobsSidecar(final BlobsSidecar blobsSidecar) {
       transaction.put(
           schema.getColumnUnconfirmedBlobsSidecarBySlotAndBlockRoot(),
           new SlotAndBlockRoot(
@@ -466,12 +466,12 @@ public class V4FinalizedKvStoreDao {
     }
 
     @Override
-    public void removeBlobsSidecar(SlotAndBlockRoot slotAndBlockRoot) {
+    public void removeBlobsSidecar(final SlotAndBlockRoot slotAndBlockRoot) {
       transaction.delete(schema.getColumnBlobsSidecarBySlotAndBlockRoot(), slotAndBlockRoot);
     }
 
     @Override
-    public void removeUnconfirmedBlobsSidecar(SlotAndBlockRoot slotAndBlockRoot) {
+    public void removeUnconfirmedBlobsSidecar(final SlotAndBlockRoot slotAndBlockRoot) {
       transaction.delete(
           schema.getColumnUnconfirmedBlobsSidecarBySlotAndBlockRoot(), slotAndBlockRoot);
     }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4FinalizedKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4FinalizedKvStoreDao.java
@@ -13,6 +13,9 @@
 
 package tech.pegasys.teku.storage.server.kvstore.dataaccess;
 
+import static tech.pegasys.teku.storage.server.kvstore.dataaccess.KvStoreCombinedDaoCommon.MAX_BLOCK_ROOT;
+import static tech.pegasys.teku.storage.server.kvstore.dataaccess.KvStoreCombinedDaoCommon.MIN_BLOCK_ROOT;
+
 import com.google.errorprone.annotations.MustBeClosed;
 import java.util.Collection;
 import java.util.HashMap;
@@ -25,7 +28,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
-import org.apache.tuweni.units.bigints.UInt256;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
@@ -178,8 +180,8 @@ public class V4FinalizedKvStoreDao {
       final UInt64 startSlot, final UInt64 endSlot) {
     return db.stream(
             schema.getColumnBlobsSidecarBySlotAndBlockRoot(),
-            new SlotAndBlockRoot(startSlot, Bytes32.ZERO),
-            new SlotAndBlockRoot(endSlot, UInt256.MAX_VALUE))
+            new SlotAndBlockRoot(startSlot, MIN_BLOCK_ROOT),
+            new SlotAndBlockRoot(endSlot, MAX_BLOCK_ROOT))
         .map(entry -> entry);
   }
 
@@ -188,8 +190,8 @@ public class V4FinalizedKvStoreDao {
       final UInt64 startSlot, final UInt64 endSlot) {
     return db.stream(
             schema.getColumnUnconfirmedBlobsSidecarBySlotAndBlockRoot(),
-            new SlotAndBlockRoot(startSlot, Bytes32.ZERO),
-            new SlotAndBlockRoot(endSlot, UInt256.MAX_VALUE))
+            new SlotAndBlockRoot(startSlot, MIN_BLOCK_ROOT),
+            new SlotAndBlockRoot(endSlot, MAX_BLOCK_ROOT))
         .map(ColumnEntry::getKey);
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/SchemaCombined.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/SchemaCombined.java
@@ -60,6 +60,10 @@ public interface SchemaCombined extends Schema {
 
   KvStoreColumn<Bytes32, Bytes> getColumnExecutionPayloadByBlockRoot();
 
+  KvStoreColumn<SlotAndBlockRoot, Bytes> getColumnBlobsSidecarBySlotAndBlockRoot();
+
+  KvStoreColumn<SlotAndBlockRoot, Void> getColumnUnconfirmedBlobsSidecarBySlotAndBlockRoot();
+
   KvStoreColumn<UInt64, Bytes32> getColumnFinalizedBlockRootBySlot();
   // Variables
   KvStoreVariable<UInt64> getVariableGenesisTime();

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/SchemaFinalizedSnapshotStateAdapter.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/SchemaFinalizedSnapshotStateAdapter.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.storage.server.kvstore.schema;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
@@ -20,6 +21,7 @@ import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 
 public class SchemaFinalizedSnapshotStateAdapter implements SchemaFinalizedSnapshotState {
@@ -49,17 +51,31 @@ public class SchemaFinalizedSnapshotStateAdapter implements SchemaFinalizedSnaps
     return delegate.getColumnExecutionPayloadByBlockRoot();
   }
 
+  public KvStoreColumn<SlotAndBlockRoot, Bytes> getColumnBlobsSidecarBySlotAndBlockRoot() {
+    return delegate.getColumnBlobsSidecarBySlotAndBlockRoot();
+  }
+
+  public KvStoreColumn<SlotAndBlockRoot, Void>
+      getColumnUnconfirmedBlobsSidecarBySlotAndBlockRoot() {
+    return delegate.getColumnUnconfirmedBlobsSidecarBySlotAndBlockRoot();
+  }
+
   public Map<String, KvStoreColumn<?, ?>> getColumnMap() {
-    return Map.of(
-        "SLOTS_BY_FINALIZED_ROOT", getColumnSlotsByFinalizedRoot(),
-        "FINALIZED_BLOCKS_BY_SLOT", getColumnFinalizedBlocksBySlot(),
-        "FINALIZED_STATES_BY_SLOT", getColumnFinalizedStatesBySlot(),
-        "SLOTS_BY_FINALIZED_STATE_ROOT", getColumnSlotsByFinalizedStateRoot(),
-        "NON_CANONICAL_BLOCKS_BY_ROOT", getColumnNonCanonicalBlocksByRoot(),
-        "NON_CANONICAL_BLOCK_ROOTS_BY_SLOT", getColumnNonCanonicalRootsBySlot(),
-        "BLINDED_BLOCKS_BY_ROOT", getColumnBlindedBlocksByRoot(),
-        "EXECUTION_PAYLOAD_BY_BLOCK_ROOT", getColumnExecutionPayloadByBlockRoot(),
-        "FINALIZED_BLOCK_ROOT_BY_SLOT", getColumnFinalizedBlockRootBySlot());
+    return ImmutableMap.<String, KvStoreColumn<?, ?>>builder()
+        .put("SLOTS_BY_FINALIZED_ROOT", getColumnSlotsByFinalizedRoot())
+        .put("FINALIZED_BLOCKS_BY_SLOT", getColumnFinalizedBlocksBySlot())
+        .put("FINALIZED_STATES_BY_SLOT", getColumnFinalizedStatesBySlot())
+        .put("SLOTS_BY_FINALIZED_STATE_ROOT", getColumnSlotsByFinalizedStateRoot())
+        .put("NON_CANONICAL_BLOCKS_BY_ROOT", getColumnNonCanonicalBlocksByRoot())
+        .put("NON_CANONICAL_BLOCK_ROOTS_BY_SLOT", getColumnNonCanonicalRootsBySlot())
+        .put("BLINDED_BLOCKS_BY_ROOT", getColumnBlindedBlocksByRoot())
+        .put("EXECUTION_PAYLOAD_BY_BLOCK_ROOT", getColumnExecutionPayloadByBlockRoot())
+        .put("FINALIZED_BLOCK_ROOT_BY_SLOT", getColumnFinalizedBlockRootBySlot())
+        .put("BLOBS_SIDECAR_BY_SLOT_AND_BLOCK_ROOT", getColumnBlobsSidecarBySlotAndBlockRoot())
+        .put(
+            "UNCONFIRMED_BLOBS_SIDECAR_BY_SLOT_AND_BLOCK_ROOT",
+            getColumnUnconfirmedBlobsSidecarBySlotAndBlockRoot())
+        .build();
   }
 
   public Collection<KvStoreColumn<?, ?>> getAllColumns() {

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/V6SchemaCombined.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/V6SchemaCombined.java
@@ -49,6 +49,7 @@ public abstract class V6SchemaCombined implements SchemaCombined {
   protected final int finalizedOffset;
 
   private final KvStoreColumn<Bytes32, SignedBeaconBlock> hotBlocksByRoot;
+
   // Checkpoint states are no longer stored, keeping only for backwards compatibility.
   private final KvStoreColumn<Checkpoint, BeaconState> checkpointStates;
   private final KvStoreColumn<UInt64, VoteTracker> votes;
@@ -202,6 +203,10 @@ public abstract class V6SchemaCombined implements SchemaCombined {
         .put("BLINDED_BLOCKS_BY_ROOT", getColumnBlindedBlocksByRoot())
         .put("EXECUTION_PAYLOAD_BY_BLOCK_ROOT", getColumnExecutionPayloadByBlockRoot())
         .put("FINALIZED_BLOCK_ROOT_BY_SLOT", getColumnFinalizedBlockRootBySlot())
+        .put("BLOBS_SIDECAR_BY_SLOT_AND_BLOCK_ROOT", getColumnBlobsSidecarBySlotAndBlockRoot())
+        .put(
+            "UNCONFIRMED_BLOBS_SIDECAR_BY_SLOT_AND_BLOCK_ROOT",
+            getColumnUnconfirmedBlobsSidecarBySlotAndBlockRoot())
         .build();
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/serialization/KvStoreSerializer.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/serialization/KvStoreSerializer.java
@@ -49,6 +49,10 @@ public interface KvStoreSerializer<T> {
       new CompressedBranchInfoSerializer();
   KvStoreSerializer<VoteTracker> VOTE_TRACKER_SERIALIZER = new VoteTrackerSerializer();
 
+  KvStoreSerializer<Void> VOID_SERIALIZER = new VoidSerializer();
+  KvStoreSerializer<SlotAndBlockRoot> SLOT_AND_BLOCK_ROOT_KEY_SERIALIZER =
+      new SlotAndBlockRootKeySerializer();
+
   static KvStoreSerializer<BeaconState> createStateSerializer(final Spec spec) {
     return new BeaconStateSerializer(spec);
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/serialization/SlotAndBlockRootKeySerializer.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/serialization/SlotAndBlockRootKeySerializer.java
@@ -19,6 +19,11 @@ import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 
+/**
+ * This serializer is intended to be used as a Key so that it preserve slot ordering when we stream
+ * data. This is useful for values that are always looked up by root and slot, giving us the ability
+ * to quickly lookup most recent\oldest values by slot as well as perform pruning based on slot
+ */
 class SlotAndBlockRootKeySerializer implements KvStoreSerializer<SlotAndBlockRoot> {
   @Override
   public SlotAndBlockRoot deserialize(final byte[] data) {

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/serialization/SlotAndBlockRootKeySerializer.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/serialization/SlotAndBlockRootKeySerializer.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.server.kvstore.serialization;
+
+import com.google.common.primitives.Longs;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
+
+class SlotAndBlockRootKeySerializer implements KvStoreSerializer<SlotAndBlockRoot> {
+  @Override
+  public SlotAndBlockRoot deserialize(final byte[] data) {
+    return new SlotAndBlockRoot(
+        UInt64.fromLongBits(
+            Longs.fromBytes(
+                data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7])),
+        Bytes32.wrap(data, 8));
+  }
+
+  @Override
+  public byte[] serialize(final SlotAndBlockRoot value) {
+
+    return Bytes.concatenate(
+            Bytes.wrap(Longs.toByteArray(value.getSlot().longValue())), value.getBlockRoot())
+        .toArrayUnsafe();
+  }
+}

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/serialization/VoidSerializer.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/serialization/VoidSerializer.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.server.kvstore.serialization;
+
+public class VoidSerializer implements KvStoreSerializer<Void> {
+
+  private static final byte[] VOID_VALUE = new byte[0];
+
+  @Override
+  public Void deserialize(byte[] data) {
+    return null;
+  }
+
+  @Override
+  public byte[] serialize(Void value) {
+    return VOID_VALUE;
+  }
+}

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
@@ -33,6 +33,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
+import tech.pegasys.teku.spec.datastructures.execution.versions.eip4844.BlobsSidecar;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
@@ -265,6 +266,41 @@ public class NoOpDatabase implements Database {
 
   @Override
   public void deleteHotBlocks(final Set<Bytes32> blockRootsToDelete) {}
+
+  @Override
+  public void storeUnconfirmedBlobsSidecar(BlobsSidecar blobsSidecar) {}
+
+  @Override
+  public void confirmBlobsSidecar(SlotAndBlockRoot slotAndBlockRoot) {}
+
+  @Override
+  public Optional<BlobsSidecar> getBlobsSidecar(SlotAndBlockRoot slotAndBlockRoot) {
+    return Optional.empty();
+  }
+
+  @Override
+  public void removeBlobsSidecar(SlotAndBlockRoot slotAndBlockRoot) {}
+
+  @Override
+  public Stream<BlobsSidecar> streamBlobsSidecar(UInt64 startSlot, UInt64 endSlot) {
+    return Stream.empty();
+  }
+
+  @Override
+  public Optional<UInt64> getEarliestBlobsSidecarSlot() {
+    return Optional.empty();
+  }
+
+  @Override
+  public void pruneOldestBlobsSidecar(UInt64 endSlot, int pruneLimit) {}
+
+  @Override
+  public Stream<SlotAndBlockRoot> streamUnconfirmedBlobsSidecar(UInt64 startSlot, UInt64 endSlot) {
+    return Stream.empty();
+  }
+
+  @Override
+  public void pruneOldestUnconfirmedBlobsSidecar(UInt64 endSlot, int pruneLimit) {}
 
   @Override
   public void close() {}

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
@@ -292,7 +292,7 @@ public class NoOpDatabase implements Database {
   }
 
   @Override
-  public boolean pruneOldestBlobsSidecar(final UInt64 endSlot, final int pruneLimit) {
+  public boolean pruneOldestBlobsSidecar(final UInt64 lastSlotToPrune, final int pruneLimit) {
     return false;
   }
 
@@ -303,7 +303,8 @@ public class NoOpDatabase implements Database {
   }
 
   @Override
-  public boolean pruneOldestUnconfirmedBlobsSidecar(final UInt64 endSlot, final int pruneLimit) {
+  public boolean pruneOldestUnconfirmedBlobsSidecar(
+      final UInt64 lastSlotToPrune, final int pruneLimit) {
     return false;
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
@@ -292,7 +292,9 @@ public class NoOpDatabase implements Database {
   }
 
   @Override
-  public void pruneOldestBlobsSidecar(final UInt64 endSlot, final int pruneLimit) {}
+  public boolean pruneOldestBlobsSidecar(final UInt64 endSlot, final int pruneLimit) {
+    return false;
+  }
 
   @Override
   public Stream<SlotAndBlockRoot> streamUnconfirmedBlobsSidecar(
@@ -301,7 +303,9 @@ public class NoOpDatabase implements Database {
   }
 
   @Override
-  public void pruneOldestUnconfirmedBlobsSidecar(final UInt64 endSlot, final int pruneLimit) {}
+  public boolean pruneOldestUnconfirmedBlobsSidecar(final UInt64 endSlot, final int pruneLimit) {
+    return false;
+  }
 
   @Override
   public void close() {}

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
@@ -268,21 +268,21 @@ public class NoOpDatabase implements Database {
   public void deleteHotBlocks(final Set<Bytes32> blockRootsToDelete) {}
 
   @Override
-  public void storeUnconfirmedBlobsSidecar(BlobsSidecar blobsSidecar) {}
+  public void storeUnconfirmedBlobsSidecar(final BlobsSidecar blobsSidecar) {}
 
   @Override
-  public void confirmBlobsSidecar(SlotAndBlockRoot slotAndBlockRoot) {}
+  public void confirmBlobsSidecar(final SlotAndBlockRoot slotAndBlockRoot) {}
 
   @Override
-  public Optional<BlobsSidecar> getBlobsSidecar(SlotAndBlockRoot slotAndBlockRoot) {
+  public Optional<BlobsSidecar> getBlobsSidecar(final SlotAndBlockRoot slotAndBlockRoot) {
     return Optional.empty();
   }
 
   @Override
-  public void removeBlobsSidecar(SlotAndBlockRoot slotAndBlockRoot) {}
+  public void removeBlobsSidecar(final SlotAndBlockRoot slotAndBlockRoot) {}
 
   @Override
-  public Stream<BlobsSidecar> streamBlobsSidecar(UInt64 startSlot, UInt64 endSlot) {
+  public Stream<BlobsSidecar> streamBlobsSidecar(final UInt64 startSlot, final UInt64 endSlot) {
     return Stream.empty();
   }
 
@@ -292,15 +292,16 @@ public class NoOpDatabase implements Database {
   }
 
   @Override
-  public void pruneOldestBlobsSidecar(UInt64 endSlot, int pruneLimit) {}
+  public void pruneOldestBlobsSidecar(final UInt64 endSlot, final int pruneLimit) {}
 
   @Override
-  public Stream<SlotAndBlockRoot> streamUnconfirmedBlobsSidecar(UInt64 startSlot, UInt64 endSlot) {
+  public Stream<SlotAndBlockRoot> streamUnconfirmedBlobsSidecar(
+      final UInt64 startSlot, final UInt64 endSlot) {
     return Stream.empty();
   }
 
   @Override
-  public void pruneOldestUnconfirmedBlobsSidecar(UInt64 endSlot, int pruneLimit) {}
+  public void pruneOldestUnconfirmedBlobsSidecar(final UInt64 endSlot, final int pruneLimit) {}
 
   @Override
   public void close() {}

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageQueryChannel.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageQueryChannel.java
@@ -27,6 +27,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
+import tech.pegasys.teku.spec.datastructures.execution.versions.eip4844.BlobsSidecar;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 
@@ -123,6 +124,11 @@ public class StubStorageQueryChannel implements StorageQueryChannel {
 
   @Override
   public SafeFuture<Optional<DepositTreeSnapshot>> getFinalizedDepositSnapshot() {
+    return SafeFuture.completedFuture(Optional.empty());
+  }
+
+  @Override
+  public SafeFuture<Optional<BlobsSidecar>> getBlobsSidecar(SlotAndBlockRoot slotAndBlockRoot) {
     return SafeFuture.completedFuture(Optional.empty());
   }
 }

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageQueryChannel.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageQueryChannel.java
@@ -128,7 +128,8 @@ public class StubStorageQueryChannel implements StorageQueryChannel {
   }
 
   @Override
-  public SafeFuture<Optional<BlobsSidecar>> getBlobsSidecar(SlotAndBlockRoot slotAndBlockRoot) {
+  public SafeFuture<Optional<BlobsSidecar>> getBlobsSidecar(
+      final SlotAndBlockRoot slotAndBlockRoot) {
     return SafeFuture.completedFuture(Optional.empty());
   }
 }

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageUpdateChannel.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageUpdateChannel.java
@@ -66,7 +66,7 @@ public class StubStorageUpdateChannel implements StorageUpdateChannel {
   }
 
   @Override
-  public SafeFuture<Void> onBlobsSidecarRemoval(final SlotAndBlockRoot blobsSidecar) {
+  public SafeFuture<Void> onBlobsSidecarRemoval(final SlotAndBlockRoot blobsSidecarKey) {
     return SafeFuture.COMPLETE;
   }
 

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageUpdateChannel.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageUpdateChannel.java
@@ -17,7 +17,10 @@ import java.util.Collection;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.ethereum.pow.api.DepositTreeSnapshot;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
+import tech.pegasys.teku.spec.datastructures.execution.versions.eip4844.BlobsSidecar;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 
@@ -51,6 +54,26 @@ public class StubStorageUpdateChannel implements StorageUpdateChannel {
 
   @Override
   public SafeFuture<Void> onFinalizedDepositSnapshot(DepositTreeSnapshot depositTreeSnapshot) {
+    return SafeFuture.COMPLETE;
+  }
+
+  @Override
+  public SafeFuture<Void> onBlobsSidecar(BlobsSidecar blobsSidecar) {
+    return SafeFuture.COMPLETE;
+  }
+
+  @Override
+  public SafeFuture<Void> onBlobsSidecarRemoval(SlotAndBlockRoot blobsSidecar) {
+    return SafeFuture.COMPLETE;
+  }
+
+  @Override
+  public SafeFuture<Void> onBlobsSidecarPruning(UInt64 endSlot, int pruneLimit) {
+    return SafeFuture.COMPLETE;
+  }
+
+  @Override
+  public SafeFuture<Void> onUnconfirmedBlobsSidecarPruning(UInt64 endSlot, int pruneLimit) {
     return SafeFuture.COMPLETE;
   }
 

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageUpdateChannel.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageUpdateChannel.java
@@ -27,7 +27,7 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 public class StubStorageUpdateChannel implements StorageUpdateChannel {
 
   @Override
-  public SafeFuture<UpdateResult> onStorageUpdate(StorageUpdate event) {
+  public SafeFuture<UpdateResult> onStorageUpdate(final StorageUpdate event) {
     return SafeFuture.completedFuture(UpdateResult.EMPTY);
   }
 
@@ -37,46 +37,50 @@ public class StubStorageUpdateChannel implements StorageUpdateChannel {
   }
 
   @Override
-  public SafeFuture<Void> onFinalizedState(BeaconState finalizedState, Bytes32 blockRoot) {
+  public SafeFuture<Void> onFinalizedState(
+      final BeaconState finalizedState, final Bytes32 blockRoot) {
     return SafeFuture.COMPLETE;
   }
 
   @Override
   public SafeFuture<Void> onReconstructedFinalizedState(
-      BeaconState finalizedState, Bytes32 blockRoot) {
+      final BeaconState finalizedState, final Bytes32 blockRoot) {
     return SafeFuture.COMPLETE;
   }
 
   @Override
-  public SafeFuture<Void> onWeakSubjectivityUpdate(WeakSubjectivityUpdate weakSubjectivityUpdate) {
+  public SafeFuture<Void> onWeakSubjectivityUpdate(
+      final WeakSubjectivityUpdate weakSubjectivityUpdate) {
     return SafeFuture.COMPLETE;
   }
 
   @Override
-  public SafeFuture<Void> onFinalizedDepositSnapshot(DepositTreeSnapshot depositTreeSnapshot) {
+  public SafeFuture<Void> onFinalizedDepositSnapshot(
+      final DepositTreeSnapshot depositTreeSnapshot) {
     return SafeFuture.COMPLETE;
   }
 
   @Override
-  public SafeFuture<Void> onBlobsSidecar(BlobsSidecar blobsSidecar) {
+  public SafeFuture<Void> onBlobsSidecar(final BlobsSidecar blobsSidecar) {
     return SafeFuture.COMPLETE;
   }
 
   @Override
-  public SafeFuture<Void> onBlobsSidecarRemoval(SlotAndBlockRoot blobsSidecar) {
+  public SafeFuture<Void> onBlobsSidecarRemoval(final SlotAndBlockRoot blobsSidecar) {
     return SafeFuture.COMPLETE;
   }
 
   @Override
-  public SafeFuture<Void> onBlobsSidecarPruning(UInt64 endSlot, int pruneLimit) {
+  public SafeFuture<Void> onBlobsSidecarPruning(final UInt64 endSlot, final int pruneLimit) {
     return SafeFuture.COMPLETE;
   }
 
   @Override
-  public SafeFuture<Void> onUnconfirmedBlobsSidecarPruning(UInt64 endSlot, int pruneLimit) {
+  public SafeFuture<Void> onUnconfirmedBlobsSidecarPruning(
+      final UInt64 endSlot, final int pruneLimit) {
     return SafeFuture.COMPLETE;
   }
 
   @Override
-  public void onChainInitialized(AnchorPoint initialAnchor) {}
+  public void onChainInitialized(final AnchorPoint initialAnchor) {}
 }

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageUpdateChannelWithDelays.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageUpdateChannelWithDelays.java
@@ -72,7 +72,7 @@ public class StubStorageUpdateChannelWithDelays implements StorageUpdateChannel 
   }
 
   @Override
-  public SafeFuture<Void> onBlobsSidecarRemoval(final SlotAndBlockRoot blobsSidecar) {
+  public SafeFuture<Void> onBlobsSidecarRemoval(final SlotAndBlockRoot blobsSidecarKey) {
     return asyncRunner.runAsync(() -> SafeFuture.COMPLETE);
   }
 

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageUpdateChannelWithDelays.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageUpdateChannelWithDelays.java
@@ -33,7 +33,7 @@ public class StubStorageUpdateChannelWithDelays implements StorageUpdateChannel 
   }
 
   @Override
-  public SafeFuture<UpdateResult> onStorageUpdate(StorageUpdate event) {
+  public SafeFuture<UpdateResult> onStorageUpdate(final StorageUpdate event) {
     return asyncRunner.runAsync(() -> SafeFuture.completedFuture(UpdateResult.EMPTY));
   }
 
@@ -43,46 +43,50 @@ public class StubStorageUpdateChannelWithDelays implements StorageUpdateChannel 
   }
 
   @Override
-  public SafeFuture<Void> onFinalizedState(BeaconState finalizedState, Bytes32 blockRoot) {
+  public SafeFuture<Void> onFinalizedState(
+      final BeaconState finalizedState, final Bytes32 blockRoot) {
     return asyncRunner.runAsync(() -> SafeFuture.COMPLETE);
   }
 
   @Override
   public SafeFuture<Void> onReconstructedFinalizedState(
-      BeaconState finalizedState, Bytes32 blockRoot) {
+      final BeaconState finalizedState, final Bytes32 blockRoot) {
     return asyncRunner.runAsync(() -> SafeFuture.COMPLETE);
   }
 
   @Override
-  public SafeFuture<Void> onWeakSubjectivityUpdate(WeakSubjectivityUpdate weakSubjectivityUpdate) {
+  public SafeFuture<Void> onWeakSubjectivityUpdate(
+      final WeakSubjectivityUpdate weakSubjectivityUpdate) {
     return asyncRunner.runAsync(() -> SafeFuture.COMPLETE);
   }
 
   @Override
-  public SafeFuture<Void> onFinalizedDepositSnapshot(DepositTreeSnapshot depositTreeSnapshot) {
+  public SafeFuture<Void> onFinalizedDepositSnapshot(
+      final DepositTreeSnapshot depositTreeSnapshot) {
     return asyncRunner.runAsync(() -> SafeFuture.COMPLETE);
   }
 
   @Override
-  public SafeFuture<Void> onBlobsSidecar(BlobsSidecar blobsSidecar) {
+  public SafeFuture<Void> onBlobsSidecar(final BlobsSidecar blobsSidecar) {
     return asyncRunner.runAsync(() -> SafeFuture.COMPLETE);
   }
 
   @Override
-  public SafeFuture<Void> onBlobsSidecarRemoval(SlotAndBlockRoot blobsSidecar) {
+  public SafeFuture<Void> onBlobsSidecarRemoval(final SlotAndBlockRoot blobsSidecar) {
     return asyncRunner.runAsync(() -> SafeFuture.COMPLETE);
   }
 
   @Override
-  public SafeFuture<Void> onBlobsSidecarPruning(UInt64 endSlot, int pruneLimit) {
+  public SafeFuture<Void> onBlobsSidecarPruning(final UInt64 endSlot, final int pruneLimit) {
     return asyncRunner.runAsync(() -> SafeFuture.COMPLETE);
   }
 
   @Override
-  public SafeFuture<Void> onUnconfirmedBlobsSidecarPruning(UInt64 endSlot, int pruneLimit) {
+  public SafeFuture<Void> onUnconfirmedBlobsSidecarPruning(
+      final UInt64 endSlot, final int pruneLimit) {
     return asyncRunner.runAsync(() -> SafeFuture.COMPLETE);
   }
 
   @Override
-  public void onChainInitialized(AnchorPoint initialAnchor) {}
+  public void onChainInitialized(final AnchorPoint initialAnchor) {}
 }

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageUpdateChannelWithDelays.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageUpdateChannelWithDelays.java
@@ -18,7 +18,10 @@ import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.ethereum.pow.api.DepositTreeSnapshot;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
+import tech.pegasys.teku.spec.datastructures.execution.versions.eip4844.BlobsSidecar;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 
@@ -57,6 +60,26 @@ public class StubStorageUpdateChannelWithDelays implements StorageUpdateChannel 
 
   @Override
   public SafeFuture<Void> onFinalizedDepositSnapshot(DepositTreeSnapshot depositTreeSnapshot) {
+    return asyncRunner.runAsync(() -> SafeFuture.COMPLETE);
+  }
+
+  @Override
+  public SafeFuture<Void> onBlobsSidecar(BlobsSidecar blobsSidecar) {
+    return asyncRunner.runAsync(() -> SafeFuture.COMPLETE);
+  }
+
+  @Override
+  public SafeFuture<Void> onBlobsSidecarRemoval(SlotAndBlockRoot blobsSidecar) {
+    return asyncRunner.runAsync(() -> SafeFuture.COMPLETE);
+  }
+
+  @Override
+  public SafeFuture<Void> onBlobsSidecarPruning(UInt64 endSlot, int pruneLimit) {
+    return asyncRunner.runAsync(() -> SafeFuture.COMPLETE);
+  }
+
+  @Override
+  public SafeFuture<Void> onUnconfirmedBlobsSidecarPruning(UInt64 endSlot, int pruneLimit) {
     return asyncRunner.runAsync(() -> SafeFuture.COMPLETE);
   }
 

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/server/kvstore/MockKvStoreInstance.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/server/kvstore/MockKvStoreInstance.java
@@ -121,8 +121,10 @@ public class MockKvStoreInstance implements KvStoreAccessor {
   public <K, V> Optional<ColumnEntry<K, V>> getFirstEntry(final KvStoreColumn<K, V> column) {
     assertOpen();
     assertValidColumn(column);
-    return Optional.ofNullable(columnData.get(column).firstEntry())
-        .map(e -> columnEntry(column, e));
+    final NavigableMap<Bytes, Bytes> values = columnData.get(column);
+    return values.isEmpty()
+        ? Optional.empty()
+        : Optional.of(values.firstEntry()).map(e -> columnEntry(column, e));
   }
 
   @Override
@@ -192,7 +194,7 @@ public class MockKvStoreInstance implements KvStoreAccessor {
   private <K, V> ColumnEntry<K, V> columnEntry(
       final KvStoreColumn<K, V> column, final Map.Entry<Bytes, Bytes> entry) {
     final K key = columnKey(column, entry.getKey());
-    final V value = columnValue(column, entry.getValue()).get();
+    final V value = columnValue(column, entry.getValue()).orElse(null);
     return ColumnEntry.create(key, value);
   }
 


### PR DESCRIPTION
Introduces two new columns:

1. blobsSidecar column: store blobs for the entire lifecycle
<Slot,BlockRoot> -> BlobsSidecar 

2. unconfirmed blobsSidecar column: tracks which blobsSidecar conteined in the previous column is yet to be confirmed (which happens when the block is fully validated and imported)
<Slot,BlockRoot> -> Void

Allows blobs to be streamed ordered by slot (ascending)

Introduces two pruning methods.
 - One for unconfirmed blobs (will be used to prune unconfirmed blobs referring to finalized slots).
 - Another for all (confirmed and unconfirmed) to be used to prune blobs outside our availability window (`MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUESTS`)

## Fixed Issue(s)
fixes #6586

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
