### PR TITLE
Batch Block Pruning

### DIFF
--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/AsyncRunner.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/AsyncRunner.java
@@ -64,10 +64,29 @@ public interface AsyncRunner {
       final ExceptionThrowingRunnable runnable,
       final Duration delay,
       final Consumer<Throwable> exceptionHandler) {
+    return runWithFixedDelay(runnable, delay, delay, exceptionHandler);
+  }
+
+  /**
+   * Schedules the recurrent task which will be repeatedly executed with the specified delay. The
+   * first run will occur after {@code initialDelay}.
+   *
+   * <p>The returned instance can be used to cancel the task. Note that {@link Cancellable#cancel()}
+   * doesn't interrupt already running task.
+   *
+   * <p>Whenever the {@code runnable} throws exception it is notified to the {@code
+   * exceptionHandler} and the task recurring executions are not interrupted
+   */
+  default Cancellable runWithFixedDelay(
+      final ExceptionThrowingRunnable runnable,
+      final Duration initialDelay,
+      final Duration delay,
+      final Consumer<Throwable> exceptionHandler) {
     Preconditions.checkNotNull(exceptionHandler);
 
     Cancellable cancellable = FutureUtil.createCancellable();
-    FutureUtil.runWithFixedDelay(this, runnable, cancellable, delay, exceptionHandler);
+    FutureUtil.runWithFixedDelay(
+        this, runnable, cancellable, initialDelay, delay, exceptionHandler);
     return cancellable;
   }
 

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/FutureUtil.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/FutureUtil.java
@@ -28,6 +28,7 @@ public class FutureUtil {
       AsyncRunner runner,
       ExceptionThrowingRunnable runnable,
       Cancellable task,
+      final Duration initialDelay,
       final Duration duration,
       Consumer<Throwable> exceptionHandler) {
 
@@ -44,11 +45,11 @@ public class FutureUtil {
                     LOG.warn("Exception in exception handler", e);
                   }
                 } finally {
-                  runWithFixedDelay(runner, runnable, task, duration, exceptionHandler);
+                  runWithFixedDelay(runner, runnable, task, duration, duration, exceptionHandler);
                 }
               }
             },
-            duration)
+            initialDelay)
         .finish(() -> {}, exceptionHandler);
   }
 

--- a/storage/src/integration-test/java/tech/pegasys/teku/storage/server/kvstore/DatabaseTest.java
+++ b/storage/src/integration-test/java/tech/pegasys/teku/storage/server/kvstore/DatabaseTest.java
@@ -1708,11 +1708,16 @@ public class DatabaseTest {
     justifyAndFinalizeEpoch(
         spec.computeEpochAtSlot(finalizedBlock.getSlot()).plus(1), finalizedBlock);
     assertThat(database.getFinalizedBlockAtSlot(UInt64.valueOf(6))).isPresent();
-    database.pruneFinalizedBlocks(UInt64.valueOf(2), UInt64.valueOf(5));
-    assertThat(database.getFinalizedBlockAtSlot(UInt64.valueOf(0))).isPresent();
-    assertThat(database.getFinalizedBlockAtSlot(UInt64.valueOf(1))).isPresent();
+    database.pruneFinalizedBlocks(UInt64.valueOf(3));
+    assertThat(database.getFinalizedBlockAtSlot(UInt64.valueOf(0))).isEmpty();
+    assertThat(database.getFinalizedBlockAtSlot(UInt64.valueOf(1))).isEmpty();
     assertThat(database.getFinalizedBlockAtSlot(UInt64.valueOf(2))).isEmpty();
     assertThat(database.getFinalizedBlockAtSlot(UInt64.valueOf(3))).isEmpty();
+    assertThat(database.getFinalizedBlockAtSlot(UInt64.valueOf(4))).isPresent();
+    assertThat(database.getFinalizedBlockAtSlot(UInt64.valueOf(5))).isPresent();
+    assertThat(database.getFinalizedBlockAtSlot(UInt64.valueOf(6))).isPresent();
+
+    database.pruneFinalizedBlocks(UInt64.valueOf(5));
     assertThat(database.getFinalizedBlockAtSlot(UInt64.valueOf(4))).isEmpty();
     assertThat(database.getFinalizedBlockAtSlot(UInt64.valueOf(5))).isEmpty();
     assertThat(database.getFinalizedBlockAtSlot(UInt64.valueOf(6))).isPresent();

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
@@ -42,6 +42,8 @@ import tech.pegasys.teku.storage.api.WeakSubjectivityUpdate;
 
 public interface Database extends AutoCloseable {
 
+  int PRUNE_BATCH_SIZE = 10000;
+
   void storeInitialAnchor(AnchorPoint genesis);
 
   UpdateResult update(StorageUpdate event);
@@ -172,5 +174,5 @@ public interface Database extends AutoCloseable {
 
   void setFinalizedDepositSnapshot(DepositTreeSnapshot finalizedDepositSnapshot);
 
-  void pruneFinalizedBlocks(UInt64 firstSlotToPrune, UInt64 lastSlotToPrune);
+  void pruneFinalizedBlocks(UInt64 lastSlotToPrune);
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
@@ -225,7 +225,7 @@ public class NoOpDatabase implements Database {
   public void setFinalizedDepositSnapshot(DepositTreeSnapshot finalizedDepositSnapshot) {}
 
   @Override
-  public void pruneFinalizedBlocks(final UInt64 firstSlotToPrune, final UInt64 lastSlotToPrune) {}
+  public void pruneFinalizedBlocks(final UInt64 lastSlotToPrune) {}
 
   @Override
   public void addMinGenesisTimeBlock(final MinGenesisTimeBlockEvent event) {}

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/pruner/BlockPruner.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/pruner/BlockPruner.java
@@ -53,6 +53,7 @@ public class BlockPruner extends Service {
         Optional.of(
             asyncRunner.runWithFixedDelay(
                 this::pruneBlocks,
+                Duration.ZERO,
                 pruneInterval,
                 error -> LOG.error("Failed to prune old blocks", error)));
     return SafeFuture.COMPLETE;

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/pruner/BlockPruner.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/pruner/BlockPruner.java
@@ -78,7 +78,7 @@ public class BlockPruner extends Service {
       return;
     }
     LOG.info("Pruning finalized blocks before slot {}", earliestSlotToKeep);
-    database.pruneFinalizedBlocks(UInt64.ZERO, earliestSlotToKeep.decrement());
+    database.pruneFinalizedBlocks(earliestSlotToKeep.decrement());
   }
 
   private int getEpochsToKeep(final UInt64 finalizedEpoch) {

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/pruner/BlockPrunerTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/pruner/BlockPrunerTest.java
@@ -60,6 +60,11 @@ class BlockPrunerTest {
   }
 
   @Test
+  void shouldPruneWhenFirstStarted() {
+
+  }
+
+  @Test
   void shouldNotPruneWhenFinalizedCheckpointNotSet() {
     when(database.getFinalizedCheckpoint()).thenReturn(Optional.empty());
     triggerNextPruning();

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/pruner/BlockPrunerTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/pruner/BlockPrunerTest.java
@@ -61,7 +61,22 @@ class BlockPrunerTest {
 
   @Test
   void shouldPruneWhenFirstStarted() {
+    when(database.getFinalizedCheckpoint())
+        .thenReturn(Optional.of(dataStructureUtil.randomCheckpoint(UInt64.valueOf(50))));
+    asyncRunner.executeDueActions();
+    verify(database).pruneFinalizedBlocks(any());
+  }
 
+  @Test
+  void shouldPruneAfterInterval() {
+    when(database.getFinalizedCheckpoint()).thenReturn(Optional.empty());
+    asyncRunner.executeDueActions();
+    verify(database, never()).pruneFinalizedBlocks(any());
+
+    when(database.getFinalizedCheckpoint())
+        .thenReturn(Optional.of(dataStructureUtil.randomCheckpoint(UInt64.valueOf(52))));
+    triggerNextPruning();
+    verify(database).pruneFinalizedBlocks(any());
   }
 
   @Test

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/pruner/BlockPrunerTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/pruner/BlockPrunerTest.java
@@ -63,7 +63,7 @@ class BlockPrunerTest {
   void shouldNotPruneWhenFinalizedCheckpointNotSet() {
     when(database.getFinalizedCheckpoint()).thenReturn(Optional.empty());
     triggerNextPruning();
-    verify(database, never()).pruneFinalizedBlocks(any(), any());
+    verify(database, never()).pruneFinalizedBlocks(any());
   }
 
   @Test
@@ -71,7 +71,7 @@ class BlockPrunerTest {
     when(database.getFinalizedCheckpoint())
         .thenReturn(Optional.of(dataStructureUtil.randomCheckpoint(epochsToKeep)));
     triggerNextPruning();
-    verify(database, never()).pruneFinalizedBlocks(any(), any());
+    verify(database, never()).pruneFinalizedBlocks(any());
   }
 
   @Test
@@ -83,7 +83,7 @@ class BlockPrunerTest {
     // SlotToKeep = FinalizedEpoch (50) * SlotsPerEpoch(10) - EpochsToKeep(5) * SlotsPerEpoch(10)
     // = 500 - 50 = 450, last slot to prune = 550 - 1 = 449.
     final UInt64 lastSlotToPrune = UInt64.valueOf(449);
-    verify(database).pruneFinalizedBlocks(UInt64.ZERO, lastSlotToPrune);
+    verify(database).pruneFinalizedBlocks(lastSlotToPrune);
   }
 
   @Test
@@ -94,7 +94,7 @@ class BlockPrunerTest {
     triggerNextPruning();
     // Should prune all blocks in the first epoch (ie blocks 0 - 9)
     final UInt64 lastSlotToPrune = UInt64.valueOf(SLOTS_PER_EPOCH - 1);
-    verify(database).pruneFinalizedBlocks(UInt64.ZERO, lastSlotToPrune);
+    verify(database).pruneFinalizedBlocks(lastSlotToPrune);
   }
 
   private void triggerNextPruning() {


### PR DESCRIPTION
## PR Description
Be defensive and prune blocks in batches rather than always using a single transaction to delete all pruneable blocks.

## Fixed Issue(s)
#6582 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
