### PR TITLE
Add timeout when fetching initial state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ For information on changes in released versions of Teku, see the [releases page]
 - Support for the `/eth/v1/beacon/blinded_blocks/{block_id}` REST API
 - Added `finalized` metadata field to applicable REST API responses
 - Use SSZ encoding for external validator client block creation requests by default. Can be disabled with `--beacon-node-ssz-blocks-enabled=false`.
+- Added a timeout (5 minutes) when attempting to load the initial state from a URL
 
 ### Bug Fixes
 - Fixed issue which could cause command line options to be parsed incorrectly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ For information on changes in released versions of Teku, see the [releases page]
 - Support for the `/eth/v1/beacon/blinded_blocks/{block_id}` REST API
 - Added `finalized` metadata field to applicable REST API responses
 - Use SSZ encoding for external validator client block creation requests by default. Can be disabled with `--beacon-node-ssz-blocks-enabled=false`.
-- Added a timeout (5 minutes) when attempting to load the initial state from a URL
+- Added a timeout (2 minutes) when attempting to load the initial state from a URL
 
 ### Bug Fixes
 - Fixed issue which could cause command line options to be parsed incorrectly

--- a/infrastructure/io/src/integration-test/java/tech/pegasys/teku/infrastructure/io/resource/URLResourceLoaderIntegrationTest.java
+++ b/infrastructure/io/src/integration-test/java/tech/pegasys/teku/infrastructure/io/resource/URLResourceLoaderIntegrationTest.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package tech.pegasys.teku.infrastructure.io.resource;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/infrastructure/io/src/integration-test/java/tech/pegasys/teku/infrastructure/io/resource/URLResourceLoaderIntegrationTest.java
+++ b/infrastructure/io/src/integration-test/java/tech/pegasys/teku/infrastructure/io/resource/URLResourceLoaderIntegrationTest.java
@@ -1,0 +1,29 @@
+package tech.pegasys.teku.infrastructure.io.resource;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.SocketTimeoutException;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+public class URLResourceLoaderIntegrationTest {
+
+  @Test
+  void shouldThrowConnectExceptionWhenConnectionTimesOut() throws Exception {
+    // Create a socket on any available port that never responds
+    final InetAddress loopbackAddress = InetAddress.getLoopbackAddress();
+    try (final ServerSocket serverSocket = new ServerSocket(0, 1, loopbackAddress)) {
+      final ResourceLoader loader = new URLResourceLoader(Optional.empty(), __ -> true, 1);
+      assertThatThrownBy(
+              () ->
+                  loader.loadSource(
+                      "http://"
+                          + loopbackAddress.getHostAddress()
+                          + ":"
+                          + serverSocket.getLocalPort()))
+          .isInstanceOf(SocketTimeoutException.class);
+    }
+  }
+}

--- a/infrastructure/io/src/main/java/tech/pegasys/teku/infrastructure/io/resource/URLResourceLoader.java
+++ b/infrastructure/io/src/main/java/tech/pegasys/teku/infrastructure/io/resource/URLResourceLoader.java
@@ -31,7 +31,7 @@ import org.apache.logging.log4j.Logger;
 public class URLResourceLoader extends ResourceLoader {
 
   private static final Logger LOG = LogManager.getLogger();
-  public static final int DEFAULT_TIMEOUT_MS = (int) TimeUnit.MINUTES.toMillis(5);
+  public static final int DEFAULT_TIMEOUT_MS = (int) TimeUnit.MINUTES.toMillis(2);
   private final Optional<String> acceptHeader;
   private final int timeoutMillis;
 

--- a/infrastructure/io/src/main/java/tech/pegasys/teku/infrastructure/io/resource/URLResourceLoader.java
+++ b/infrastructure/io/src/main/java/tech/pegasys/teku/infrastructure/io/resource/URLResourceLoader.java
@@ -23,6 +23,7 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.util.Base64;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -30,7 +31,7 @@ import org.apache.logging.log4j.Logger;
 public class URLResourceLoader extends ResourceLoader {
 
   private static final Logger LOG = LogManager.getLogger();
-  public static final int DEFAULT_TIMEOUT_MS = 120_000;
+  public static final int DEFAULT_TIMEOUT_MS = (int) TimeUnit.MINUTES.toMillis(5);
   private final Optional<String> acceptHeader;
   private final int timeoutMillis;
 


### PR DESCRIPTION
## PR Description
When loading the initial state, apply a 2 minute timeout to requests so Teku doesn't hang silently forever.  The timeout is still fairly long because regenerating historic states can take a long time with some nodes. This isn't an issue when requesting the latest finalized state which is quickly available, but is when starting from a specific slot state.

We also now report an accurate error message when downloading from a URL fails.

## Fixed Issue(s)
fixes #6594 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
