### PR TITLE
Waiting for ready comment on SSE channel to mark connection as ready

### DIFF
--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/Eth2EventHandler.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/Eth2EventHandler.java
@@ -31,12 +31,12 @@ public class Eth2EventHandler implements EventHandler {
   public void onClosed() {}
 
   @Override
-  public void onMessage(final String event, final MessageEvent messageEvent) {
+  public synchronized void onMessage(final String event, final MessageEvent messageEvent) {
     eventList.add(new PackedMessage(event, messageEvent));
   }
 
-  public List<PackedMessage> getMessages() {
-    return eventList;
+  public synchronized List<PackedMessage> getMessages() {
+    return List.copyOf(eventList);
   }
 
   @Override

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/Eth2EventHandler.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/Eth2EventHandler.java
@@ -21,6 +21,9 @@ import java.util.List;
 public class Eth2EventHandler implements EventHandler {
   private final List<PackedMessage> eventList = new ArrayList<>();
 
+  // Using this as a way to assert that our EventSubscriber is ready
+  private boolean hasReceivedReadyComment = false;
+
   @Override
   public void onOpen() {}
 
@@ -37,7 +40,15 @@ public class Eth2EventHandler implements EventHandler {
   }
 
   @Override
-  public void onComment(final String comment) {}
+  public void onComment(final String comment) {
+    if (!hasReceivedReadyComment) {
+      hasReceivedReadyComment = comment.equals("ready");
+    }
+  }
+
+  public boolean hasReceivedComment() {
+    return hasReceivedReadyComment;
+  }
 
   @Override
   public void onError(final Throwable t) {}

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/EventStreamListener.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/EventStreamListener.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.test.acceptance.dsl;
 
 import com.launchdarkly.eventsource.EventSource;
+import com.launchdarkly.eventsource.ReadyState;
 import java.net.URI;
 import java.util.List;
 
@@ -28,6 +29,10 @@ public class EventStreamListener {
 
   public List<Eth2EventHandler.PackedMessage> getMessages() {
     return handler.getMessages();
+  }
+
+  public boolean isReady() {
+    return eventSource.getState() == ReadyState.OPEN && handler.hasReceivedComment();
   }
 
   public void close() {

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNode.java
@@ -158,6 +158,7 @@ public class TekuNode extends Node {
   public void startEventListener(final EventType... eventTypes) {
     maybeEventStreamListener =
         Optional.of(new EventStreamListener(getEventUrl(List.of(eventTypes))));
+    waitFor(() -> assertThat(maybeEventStreamListener.get().isReady()).isTrue());
   }
 
   public void waitForContributionAndProofEvent() {

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriber.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriber.java
@@ -152,4 +152,13 @@ public class EventSubscriber {
           .ifExceptionGetsHereRaiseABug();
     }
   }
+
+  /*
+   Using this as a way of notifying clients that our EventSubscriber is ready and they should start receiving events
+  */
+  public void sendReadyComment() {
+    if (!stopped.get()) {
+      asyncRunner.runAsync(() -> sseClient.sendComment("ready")).ifExceptionGetsHereRaiseABug();
+    }
+  }
 }

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManager.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManager.java
@@ -86,7 +86,7 @@ public class EventSubscriptionManager implements ChainHeadChannel, FinalizedChec
   }
 
   public void registerClient(final SseClient sseClient) {
-    LOG.trace("connected " + sseClient.hashCode());
+    LOG.trace("SSE client connected " + sseClient.hashCode());
     final List<String> allTopicsInContext =
         ListQueryParameterUtils.getParameterAsStringList(sseClient.ctx().queryParamMap(), TOPICS);
     final EventSubscriber subscriber =
@@ -101,6 +101,7 @@ public class EventSubscriptionManager implements ChainHeadChannel, FinalizedChec
             timeProvider,
             maxPendingEvents);
     eventSubscribers.add(subscriber);
+    subscriber.sendReadyComment();
   }
 
   @Override

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/TestServletOutputStream.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/TestServletOutputStream.java
@@ -15,9 +15,9 @@ package tech.pegasys.teku.beaconrestapi.handlers.v1.events;
 
 import jakarta.servlet.ServletOutputStream;
 import jakarta.servlet.WriteListener;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 
 public class TestServletOutputStream extends ServletOutputStream {
@@ -55,11 +55,9 @@ public class TestServletOutputStream extends ServletOutputStream {
   }
 
   public List<String> getEvents() {
-    final List<String> result = new ArrayList<>();
-    String[] splits = StringUtils.splitByWholeSeparator(getString(), "event: ");
-    for (String s : splits) {
-      result.add(String.format("event: %s", s));
-    }
-    return result;
+    return Arrays.stream(StringUtils.splitByWholeSeparator(getString(), "event: "))
+        .filter(s -> !s.startsWith(": ")) // remove SSE comments
+        .map(s -> String.format("event: %s", s))
+        .collect(Collectors.toList());
   }
 }


### PR DESCRIPTION
## PR Description
- EventSubscriber now sends an SSE comment with "ready" to notify the client it is ready to send events
- On ATs, we wait for "ready" comment on SSE channel before continuing

## Fixed Issue(s)
N/A

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
