### PR TITLE
Add test to check EIP-4844 support for BeaconBlocksByRange v2

### DIFF
--- a/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/AbstractRpcMethodIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/AbstractRpcMethodIntegrationTest.java
@@ -63,6 +63,17 @@ public abstract class AbstractRpcMethodIntegrationTest {
     return createRemotePeerAndNetwork(enableAltairLocally, enableAltairRemotely).getPeer();
   }
 
+  /**
+   * Create and connect 2 networks, return an Eth2Peer representing the remote network to which we
+   * can send requests.
+   *
+   * @param spec The spec which the "local" and remote peer will use
+   * @return An Eth2Peer to which we can send requests
+   */
+  protected Eth2Peer createPeer(final Spec spec) {
+    return createRemotePeerAndNetwork(spec, spec).getPeer();
+  }
+
   protected PeerAndNetwork createRemotePeerAndNetwork() {
     return createRemotePeerAndNetwork(false, false);
   }
@@ -77,15 +88,26 @@ public abstract class AbstractRpcMethodIntegrationTest {
    */
   protected PeerAndNetwork createRemotePeerAndNetwork(
       final boolean enableAltairLocally, final boolean enableAltairRemotely) {
-    // Set up remote peer storage
+    final Spec localSpec = enableAltairLocally ? altairEnabledSpec : phase0Spec;
     final Spec remoteSpec = enableAltairRemotely ? altairEnabledSpec : phase0Spec;
+    return createRemotePeerAndNetwork(localSpec, remoteSpec);
+  }
+
+  /**
+   * Create and connect 2 networks, return an Eth2Peer representing the remote network to which we
+   * can send requests along with the corresponding remote Eth2P2PNetwork.
+   *
+   * @param localSpec The spec which the "local" node will use
+   * @param remoteSpec The spec which the remote peer will use
+   * @return An Eth2Peer to which we can send requests along with its corresponding Eth2P2PNetwork
+   */
+  protected PeerAndNetwork createRemotePeerAndNetwork(final Spec localSpec, final Spec remoteSpec) {
+    // Set up remote peer storage
     if (peerStorage == null) {
       peerStorage = InMemoryStorageSystemBuilder.create().specProvider(remoteSpec).build();
       peerStorage.chainUpdater().initializeGenesis();
     }
-
     // Set up local storage
-    final Spec localSpec = enableAltairLocally ? altairEnabledSpec : phase0Spec;
     final StorageSystem localStorage =
         InMemoryStorageSystemBuilder.create().specProvider(localSpec).build();
     localStorage.chainUpdater().initializeGenesis();

--- a/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/BeaconBlocksByRangeIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/BeaconBlocksByRangeIntegrationTest.java
@@ -36,9 +36,11 @@ import tech.pegasys.teku.networking.eth2.rpc.core.RpcException.DeserializationFa
 import tech.pegasys.teku.networking.p2p.peer.DisconnectReason;
 import tech.pegasys.teku.networking.p2p.peer.PeerDisconnectedException;
 import tech.pegasys.teku.networking.p2p.rpc.RpcResponseListener;
+import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.BeaconBlockBodyAltair;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.eip4844.BeaconBlockBodyEip4844;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.phase0.BeaconBlockBodyPhase0;
 
 public class BeaconBlocksByRangeIntegrationTest extends AbstractRpcMethodIntegrationTest {
@@ -214,6 +216,32 @@ public class BeaconBlocksByRangeIntegrationTest extends AbstractRpcMethodIntegra
       assertThat(res).isCompletedExceptionally();
       assertThatThrownBy(res::get).hasCauseInstanceOf(DeserializationFailedException.class);
     }
+  }
+
+  @Test
+  public void testRequestingEip4844Blocks() {
+    final Eth2Peer peer = createPeer(TestSpecFactory.createMinimalEip4844());
+    // Create blocks
+    final SignedBlockAndState block1 = peerStorage.chainUpdater().advanceChain();
+    final SignedBlockAndState block2 = peerStorage.chainUpdater().advanceChain();
+
+    peerStorage.chainUpdater().updateBestBlock(block2);
+
+    final List<SignedBeaconBlock> blocks = new ArrayList<>();
+    final SafeFuture<Void> res =
+        peer.requestBlocksByRange(
+            block1.getSlot(), UInt64.valueOf(2), RpcResponseListener.from(blocks::add));
+
+    waitFor(() -> assertThat(res).isDone());
+    assertThat(peer.getOutstandingRequests()).isEqualTo(0);
+
+    assertThat(res).isCompleted();
+    assertThat(blocks)
+        .containsExactly(block1.getBlock(), block2.getBlock())
+        .allSatisfy(
+            block ->
+                assertThat(block.getMessage().getBody())
+                    .isInstanceOf(BeaconBlockBodyEip4844.class));
   }
 
   public static Stream<Arguments> altairVersioningOptions() {

--- a/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/BeaconBlocksByRangeIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/BeaconBlocksByRangeIntegrationTest.java
@@ -219,7 +219,7 @@ public class BeaconBlocksByRangeIntegrationTest extends AbstractRpcMethodIntegra
   }
 
   @Test
-  public void testRequestingEip4844Blocks() {
+  public void testRequestingBlocksByRangeForEip4844() {
     final Eth2Peer peer = createPeer(TestSpecFactory.createMinimalEip4844());
     // Create blocks
     final SignedBlockAndState block1 = peerStorage.chainUpdater().advanceChain();


### PR DESCRIPTION
## PR Description
Added test to check EIP-4844 support for the `BeaconBlocksByRange v2` req/resp method
Added helper methods in `AbstractRpcMethodIntegrationTest` to create networks based on a specific `Spec`

## Fixed Issue(s)
will ensure the task `Implement BeaconBlocksByRange v2` in the epic issue is done

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
