### PR TITLE
[EIP-4844] Blobs pruning

### DIFF
--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/AsyncRunnerFactory.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/AsyncRunnerFactory.java
@@ -18,6 +18,7 @@ import java.util.regex.Pattern;
 public interface AsyncRunnerFactory {
 
   int DEFAULT_MAX_QUEUE_SIZE = 5000;
+  int DEFAULT_THREAD_PRIORITY = Thread.NORM_PRIORITY;
   Pattern ASYNC_RUNNER_NAME_PATTERN = Pattern.compile("[a-zA-Z][a-zA-Z0-9_]*");
 
   default AsyncRunner create(String name, int maxThreads) {
@@ -34,7 +35,11 @@ public interface AsyncRunnerFactory {
     }
   }
 
-  AsyncRunner create(String name, int maxThreads, int maxQueueSize);
+  default AsyncRunner create(String name, int maxThreads, int maxQueueSize) {
+    return create(name, maxThreads, maxQueueSize, DEFAULT_THREAD_PRIORITY);
+  }
+
+  AsyncRunner create(String name, int maxThreads, int maxQueueSize, int threadPriority);
 
   void shutdown();
 

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/DefaultAsyncRunnerFactory.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/DefaultAsyncRunnerFactory.java
@@ -26,10 +26,12 @@ public class DefaultAsyncRunnerFactory implements AsyncRunnerFactory {
   }
 
   @Override
-  public AsyncRunner create(final String name, final int maxThreads, final int maxQueueSize) {
+  public AsyncRunner create(
+      final String name, final int maxThreads, final int maxQueueSize, final int threadPriority) {
     validateAsyncRunnerName(name);
     final AsyncRunner asyncRunner =
-        ScheduledExecutorAsyncRunner.create(name, maxThreads, maxQueueSize, executorFactory);
+        ScheduledExecutorAsyncRunner.create(
+            name, maxThreads, maxQueueSize, threadPriority, executorFactory);
     asyncRunners.add(asyncRunner);
     return asyncRunner;
   }

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/ScheduledExecutorAsyncRunner.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/ScheduledExecutorAsyncRunner.java
@@ -40,6 +40,7 @@ public class ScheduledExecutorAsyncRunner implements AsyncRunner {
       final String name,
       final int maxThreads,
       final int maxQueueSize,
+      final int threadPriority,
       final MetricTrackingExecutorFactory executorFactory) {
     final ScheduledExecutorService scheduler =
         Executors.newSingleThreadScheduledExecutor(
@@ -52,7 +53,11 @@ public class ScheduledExecutorAsyncRunner implements AsyncRunner {
             name,
             maxThreads,
             maxQueueSize,
-            new ThreadFactoryBuilder().setNameFormat(name + "-async-%d").setDaemon(false).build());
+            new ThreadFactoryBuilder()
+                .setNameFormat(name + "-async-%d")
+                .setDaemon(false)
+                .setPriority(threadPriority)
+                .build());
 
     return new ScheduledExecutorAsyncRunner(scheduler, workerPool);
   }

--- a/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/AsyncRunnerFactoryTest.java
+++ b/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/AsyncRunnerFactoryTest.java
@@ -22,7 +22,8 @@ class AsyncRunnerFactoryTest {
   private AsyncRunnerFactory asyncRunnerFactory =
       new AsyncRunnerFactory() {
         @Override
-        public AsyncRunner create(String name, int maxThreads, int maxQueueSize) {
+        public AsyncRunner create(
+            String name, int maxThreads, int maxQueueSize, int threadPriority) {
           return null;
         }
 

--- a/infrastructure/async/src/testFixtures/java/tech/pegasys/teku/infrastructure/async/StubAsyncRunnerFactory.java
+++ b/infrastructure/async/src/testFixtures/java/tech/pegasys/teku/infrastructure/async/StubAsyncRunnerFactory.java
@@ -20,7 +20,8 @@ public class StubAsyncRunnerFactory implements AsyncRunnerFactory {
   private final List<StubAsyncRunner> runners = new ArrayList<>();
 
   @Override
-  public AsyncRunner create(final String name, final int maxThreads, final int maxQueueSize) {
+  public AsyncRunner create(
+      final String name, final int maxThreads, final int maxQueueSize, final int threadPriority) {
     validateAsyncRunnerName(name);
     final StubAsyncRunner asyncRunner = new StubAsyncRunner();
     runners.add(asyncRunner);

--- a/infrastructure/serviceutils/src/main/java/tech/pegasys/teku/service/serviceutils/ServiceConfig.java
+++ b/infrastructure/serviceutils/src/main/java/tech/pegasys/teku/service/serviceutils/ServiceConfig.java
@@ -83,6 +83,11 @@ public class ServiceConfig {
     return asyncRunnerFactory.create(name, maxThreads, maxQueueSize);
   }
 
+  public AsyncRunner createAsyncRunner(
+      final String name, final int maxThreads, final int maxQueueSize, final int threadPriority) {
+    return asyncRunnerFactory.create(name, maxThreads, maxQueueSize, threadPriority);
+  }
+
   public AsyncRunnerFactory getAsyncRunnerFactory() {
     return asyncRunnerFactory;
   }

--- a/services/chainstorage/src/main/java/tech/pegasys/teku/services/chainstorage/StorageService.java
+++ b/services/chainstorage/src/main/java/tech/pegasys/teku/services/chainstorage/StorageService.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.services.chainstorage;
 
+import static tech.pegasys.teku.infrastructure.async.AsyncRunnerFactory.DEFAULT_MAX_QUEUE_SIZE;
 import static tech.pegasys.teku.spec.config.Constants.STORAGE_QUERY_CHANNEL_PARALLELISM;
 
 import java.util.Optional;
@@ -62,7 +63,11 @@ public class StorageService extends Service implements StorageServiceFacade {
     return SafeFuture.fromRunnable(
             () -> {
               final AsyncRunner storagePrunerAsyncRunner =
-                  serviceConfig.createAsyncRunner("storagePrunerAsyncRunner", 1);
+                  serviceConfig.createAsyncRunner(
+                      "storagePrunerAsyncRunner",
+                      1,
+                      DEFAULT_MAX_QUEUE_SIZE,
+                      Thread.NORM_PRIORITY - 1);
               final VersionedDatabaseFactory dbFactory =
                   new VersionedDatabaseFactory(
                       serviceConfig.getMetricsSystem(),

--- a/services/chainstorage/src/main/java/tech/pegasys/teku/services/chainstorage/StorageService.java
+++ b/services/chainstorage/src/main/java/tech/pegasys/teku/services/chainstorage/StorageService.java
@@ -27,6 +27,7 @@ import tech.pegasys.teku.service.serviceutils.ServiceConfig;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.storage.api.CombinedStorageChannel;
 import tech.pegasys.teku.storage.api.Eth1DepositStorageChannel;
+import tech.pegasys.teku.storage.api.FinalizedCheckpointChannel;
 import tech.pegasys.teku.storage.api.VoteUpdateChannel;
 import tech.pegasys.teku.storage.server.BatchingVoteUpdateChannel;
 import tech.pegasys.teku.storage.server.ChainStorage;
@@ -124,6 +125,8 @@ public class StorageService extends Service implements StorageServiceFacade {
                   .subscribe(Eth1DepositStorageChannel.class, depositStorage)
                   .subscribe(Eth1EventsChannel.class, depositStorage)
                   .subscribe(VoteUpdateChannel.class, batchingVoteUpdateChannel);
+              blobsPruner.ifPresent(
+                  pruner -> eventChannels.subscribe(FinalizedCheckpointChannel.class, pruner));
             })
         .thenCompose(
             __ ->

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
@@ -90,6 +90,9 @@ public interface Database extends AutoCloseable {
   Stream<BlobsSidecar> streamBlobsSidecar(UInt64 startSlot, UInt64 endSlot);
 
   @MustBeClosed
+  Stream<SlotAndBlockRoot> streamBlobsSidecarKeys(UInt64 startSlot, UInt64 endSlot);
+
+  @MustBeClosed
   Stream<SlotAndBlockRoot> streamUnconfirmedBlobsSidecar(UInt64 startSlot, UInt64 endSlot);
 
   Optional<UInt64> getEarliestBlobsSidecarSlot();

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
@@ -136,6 +136,8 @@ public interface Database extends AutoCloseable {
 
   Optional<BeaconState> getHotState(Bytes32 root);
 
+  Optional<UInt64> getGenesisTime();
+
   /**
    * Returns latest finalized block or any known blocks that descend from the latest finalized block
    *

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/StorageConfiguration.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/StorageConfiguration.java
@@ -25,6 +25,8 @@ public class StorageConfiguration {
   public static final long DEFAULT_STORAGE_FREQUENCY = 2048L;
   public static final int DEFAULT_MAX_KNOWN_NODE_CACHE_SIZE = 100_000;
   public static final Duration DEFAULT_BLOCK_PRUNING_INTERVAL = Duration.ofHours(1);
+  public static final Duration DEFAULT_BLOBS_PRUNING_INTERVAL = Duration.ofMinutes(1);
+  public static final int DEFAULT_BLOBS_PRUNING_LIMIT = 32;
 
   private final Eth1Address eth1DepositContract;
 
@@ -35,6 +37,8 @@ public class StorageConfiguration {
   private final boolean storeNonCanonicalBlocks;
   private final int maxKnownNodeCacheSize;
   private final Duration blockPruningInterval;
+  private final Duration blobsPruningInterval;
+  private final int blobsPruningLimit;
 
   private StorageConfiguration(
       final Eth1Address eth1DepositContract,
@@ -44,6 +48,8 @@ public class StorageConfiguration {
       final boolean storeNonCanonicalBlocks,
       final int maxKnownNodeCacheSize,
       final Duration blockPruningInterval,
+      final Duration blobsPruningInterval,
+      final int blobsPruningLimit,
       final Spec spec) {
     this.eth1DepositContract = eth1DepositContract;
     this.dataStorageMode = dataStorageMode;
@@ -52,6 +58,8 @@ public class StorageConfiguration {
     this.storeNonCanonicalBlocks = storeNonCanonicalBlocks;
     this.maxKnownNodeCacheSize = maxKnownNodeCacheSize;
     this.blockPruningInterval = blockPruningInterval;
+    this.blobsPruningInterval = blobsPruningInterval;
+    this.blobsPruningLimit = blobsPruningLimit;
     this.spec = spec;
   }
 
@@ -87,6 +95,14 @@ public class StorageConfiguration {
     return blockPruningInterval;
   }
 
+  public Duration getBlobsPruningInterval() {
+    return blobsPruningInterval;
+  }
+
+  public int getBlobsPruningLimit() {
+    return blobsPruningLimit;
+  }
+
   public Spec getSpec() {
     return spec;
   }
@@ -101,6 +117,8 @@ public class StorageConfiguration {
     private boolean storeNonCanonicalBlocks = DEFAULT_STORE_NON_CANONICAL_BLOCKS_ENABLED;
     private int maxKnownNodeCacheSize = DEFAULT_MAX_KNOWN_NODE_CACHE_SIZE;
     private Duration blockPruningInterval = DEFAULT_BLOCK_PRUNING_INTERVAL;
+    private Duration blobsPruningInterval = DEFAULT_BLOBS_PRUNING_INTERVAL;
+    private int blobsPruningLimit = DEFAULT_BLOBS_PRUNING_LIMIT;
 
     private Builder() {}
 
@@ -162,6 +180,23 @@ public class StorageConfiguration {
       return this;
     }
 
+    public Builder blobsPruningInterval(final Duration blobsPruningInterval) {
+      if (blobsPruningInterval.isNegative() || blobsPruningInterval.isZero()) {
+        throw new InvalidConfigurationException("Blobs pruning interval must be positive");
+      }
+      this.blobsPruningInterval = blobsPruningInterval;
+      return this;
+    }
+
+    public Builder blobsPruningLimit(final int blobsPruningLimit) {
+      if (blobsPruningLimit < 0) {
+        throw new InvalidConfigurationException(
+            String.format("Invalid blobsPruningLimit: %d", blobsPruningLimit));
+      }
+      this.blobsPruningLimit = blobsPruningLimit;
+      return this;
+    }
+
     public StorageConfiguration build() {
       return new StorageConfiguration(
           eth1DepositContract,
@@ -171,6 +206,8 @@ public class StorageConfiguration {
           storeNonCanonicalBlocks,
           maxKnownNodeCacheSize,
           blockPruningInterval,
+          blobsPruningInterval,
+          blobsPruningLimit,
           spec);
     }
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreAccessor.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreAccessor.java
@@ -67,6 +67,9 @@ public interface KvStoreAccessor extends AutoCloseable {
   @MustBeClosed
   <K, V> Stream<ColumnEntry<K, V>> stream(KvStoreColumn<K, V> column);
 
+  @MustBeClosed
+  <K, V> Stream<K> streamKeys(KvStoreColumn<K, V> column);
+
   /**
    * WARNING: should only be used to migrate data between database instances
    *
@@ -98,6 +101,9 @@ public interface KvStoreAccessor extends AutoCloseable {
   @MustBeClosed
   <K extends Comparable<K>, V> Stream<ColumnEntry<K, V>> stream(
       KvStoreColumn<K, V> column, K from, K to);
+
+  @MustBeClosed
+  <K extends Comparable<K>, V> Stream<K> streamKeys(KvStoreColumn<K, V> column, K from, K to);
 
   KvStoreTransaction startTransaction();
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
@@ -626,6 +626,11 @@ public class KvStoreDatabase implements Database {
   }
 
   @Override
+  public Optional<UInt64> getGenesisTime() {
+    return dao.getGenesisTime();
+  }
+
+  @Override
   public void pruneHotStateRoots(final List<Bytes32> stateRoots) {
     try (final HotUpdater updater = hotUpdater()) {
       updater.pruneHotStateRoots(stateRoots);

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
@@ -347,13 +347,22 @@ public class CombinedKvStoreDao<S extends SchemaCombined>
 
   @MustBeClosed
   @Override
+  public Stream<SlotAndBlockRoot> streamBlobsSidecarKeys(
+      final UInt64 startSlot, final UInt64 endSlot) {
+    return db.streamKeys(
+        schema.getColumnBlobsSidecarBySlotAndBlockRoot(),
+        new SlotAndBlockRoot(startSlot, MIN_BLOCK_ROOT),
+        new SlotAndBlockRoot(endSlot, MAX_BLOCK_ROOT));
+  }
+
+  @MustBeClosed
+  @Override
   public Stream<SlotAndBlockRoot> streamUnconfirmedBlobsSidecar(
       final UInt64 startSlot, final UInt64 endSlot) {
-    return db.stream(
-            schema.getColumnUnconfirmedBlobsSidecarBySlotAndBlockRoot(),
-            new SlotAndBlockRoot(startSlot, MIN_BLOCK_ROOT),
-            new SlotAndBlockRoot(endSlot, MAX_BLOCK_ROOT))
-        .map(ColumnEntry::getKey);
+    return db.streamKeys(
+        schema.getColumnUnconfirmedBlobsSidecarBySlotAndBlockRoot(),
+        new SlotAndBlockRoot(startSlot, MIN_BLOCK_ROOT),
+        new SlotAndBlockRoot(endSlot, MAX_BLOCK_ROOT));
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDao.java
@@ -130,6 +130,9 @@ public interface KvStoreCombinedDao extends AutoCloseable {
   Stream<Entry<SlotAndBlockRoot, Bytes>> streamBlobsSidecar(UInt64 startSlot, UInt64 endSlot);
 
   @MustBeClosed
+  Stream<SlotAndBlockRoot> streamBlobsSidecarKeys(UInt64 startSlot, UInt64 endSlot);
+
+  @MustBeClosed
   Stream<SlotAndBlockRoot> streamUnconfirmedBlobsSidecar(UInt64 startSlot, UInt64 endSlot);
 
   Optional<UInt64> getEarliestBlobsSidecarSlot();

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoAdapter.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoAdapter.java
@@ -241,6 +241,13 @@ public class KvStoreCombinedDaoAdapter implements KvStoreCombinedDao, V4Migratab
 
   @Override
   @MustBeClosed
+  public Stream<SlotAndBlockRoot> streamBlobsSidecarKeys(
+      final UInt64 startSlot, final UInt64 endSlot) {
+    return finalizedDao.streamBlobsSidecarKeys(startSlot, endSlot);
+  }
+
+  @Override
+  @MustBeClosed
   public Stream<SlotAndBlockRoot> streamUnconfirmedBlobsSidecar(
       final UInt64 startSlot, final UInt64 endSlot) {
     return finalizedDao.streamUnconfirmedBlobsSidecar(startSlot, endSlot);

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4FinalizedKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4FinalizedKvStoreDao.java
@@ -135,13 +135,21 @@ public class V4FinalizedKvStoreDao {
   }
 
   @MustBeClosed
+  public Stream<SlotAndBlockRoot> streamBlobsSidecarKeys(
+      final UInt64 startSlot, final UInt64 endSlot) {
+    return db.streamKeys(
+        schema.getColumnBlobsSidecarBySlotAndBlockRoot(),
+        new SlotAndBlockRoot(startSlot, MIN_BLOCK_ROOT),
+        new SlotAndBlockRoot(endSlot, MAX_BLOCK_ROOT));
+  }
+
+  @MustBeClosed
   public Stream<SlotAndBlockRoot> streamUnconfirmedBlobsSidecar(
       final UInt64 startSlot, final UInt64 endSlot) {
-    return db.stream(
-            schema.getColumnUnconfirmedBlobsSidecarBySlotAndBlockRoot(),
-            new SlotAndBlockRoot(startSlot, MIN_BLOCK_ROOT),
-            new SlotAndBlockRoot(endSlot, MAX_BLOCK_ROOT))
-        .map(ColumnEntry::getKey);
+    return db.streamKeys(
+        schema.getColumnUnconfirmedBlobsSidecarBySlotAndBlockRoot(),
+        new SlotAndBlockRoot(startSlot, MIN_BLOCK_ROOT),
+        new SlotAndBlockRoot(endSlot, MAX_BLOCK_ROOT));
   }
 
   public Optional<UInt64> getEarliestBlobsSidecarSlot() {

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/leveldb/LevelDbKeyIterator.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/leveldb/LevelDbKeyIterator.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.server.leveldb;
+
+import static tech.pegasys.teku.storage.server.leveldb.LevelDbUtils.isFromColumn;
+import static tech.pegasys.teku.storage.server.leveldb.LevelDbUtils.removeKeyPrefix;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+import org.iq80.leveldb.DBIterator;
+import tech.pegasys.teku.storage.server.kvstore.schema.KvStoreColumn;
+
+public class LevelDbKeyIterator<K, V> implements Iterator<byte[]> {
+
+  private final LevelDbInstance dbInstance;
+  private final DBIterator iterator;
+  private final KvStoreColumn<K, V> column;
+  private final byte[] lastKey;
+
+  public LevelDbKeyIterator(
+      final LevelDbInstance dbInstance,
+      final DBIterator iterator,
+      final KvStoreColumn<K, V> column,
+      final byte[] lastKey) {
+    this.dbInstance = dbInstance;
+    this.iterator = iterator;
+    this.column = column;
+    this.lastKey = lastKey;
+  }
+
+  @Override
+  public boolean hasNext() {
+    synchronized (dbInstance) {
+      dbInstance.assertOpen();
+      return iterator.hasNext() && isValidKey();
+    }
+  }
+
+  private boolean isValidKey() {
+    final byte[] nextKey = iterator.peekNext().getKey();
+    return isFromColumn(column, nextKey) && Arrays.compareUnsigned(nextKey, lastKey) <= 0;
+  }
+
+  @Override
+  public byte[] next() {
+    synchronized (dbInstance) {
+      dbInstance.assertOpen();
+      return removeKeyPrefix(column, iterator.next().getKey());
+    }
+  }
+
+  public Stream<byte[]> toStream() {
+    final Spliterator<byte[]> split =
+        Spliterators.spliteratorUnknownSize(
+            this,
+            Spliterator.IMMUTABLE
+                | Spliterator.DISTINCT
+                | Spliterator.NONNULL
+                | Spliterator.ORDERED
+                | Spliterator.SORTED);
+
+    return StreamSupport.stream(split, false);
+  }
+}

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
@@ -279,6 +279,11 @@ public class NoOpDatabase implements Database {
   }
 
   @Override
+  public Stream<SlotAndBlockRoot> streamBlobsSidecarKeys(UInt64 startSlot, UInt64 endSlot) {
+    return Stream.empty();
+  }
+
+  @Override
   public Optional<UInt64> getEarliestBlobsSidecarSlot() {
     return Optional.empty();
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
@@ -158,6 +158,11 @@ public class NoOpDatabase implements Database {
   }
 
   @Override
+  public Optional<UInt64> getGenesisTime() {
+    return Optional.empty();
+  }
+
+  @Override
   public Stream<Map.Entry<Bytes32, BlockCheckpoints>> streamBlockCheckpoints() {
     return Stream.empty();
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbKeyIterator.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbKeyIterator.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.server.rocksdb;
+
+import com.google.errorprone.annotations.MustBeClosed;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.rocksdb.RocksDBException;
+import org.rocksdb.RocksIterator;
+import tech.pegasys.teku.storage.server.ShuttingDownException;
+import tech.pegasys.teku.storage.server.kvstore.schema.KvStoreColumn;
+
+class RocksDbKeyIterator<TKey, TValue> implements Iterator<byte[]>, AutoCloseable {
+  private static final Logger LOG = LogManager.getLogger();
+
+  private final KvStoreColumn<TKey, TValue> column;
+  private final RocksIterator rocksIterator;
+  private final AtomicBoolean closed = new AtomicBoolean(false);
+  private final Predicate<TKey> continueTest;
+  private final Supplier<Boolean> isDatabaseClosed;
+
+  private RocksDbKeyIterator(
+      final KvStoreColumn<TKey, TValue> column,
+      final RocksIterator rocksIterator,
+      final Predicate<TKey> continueTest,
+      final Supplier<Boolean> isDatabaseClosed) {
+    this.column = column;
+    this.rocksIterator = rocksIterator;
+    this.continueTest = continueTest;
+    this.isDatabaseClosed = isDatabaseClosed;
+  }
+
+  @MustBeClosed
+  public static <K, V> RocksDbKeyIterator<K, V> create(
+      final KvStoreColumn<K, V> column,
+      final RocksIterator rocksIt,
+      final Predicate<K> continueTest,
+      final Supplier<Boolean> isDatabaseClosed) {
+    return new RocksDbKeyIterator<>(column, rocksIt, continueTest, isDatabaseClosed);
+  }
+
+  @Override
+  public boolean hasNext() {
+    assertOpen();
+    return rocksIterator.isValid()
+        && continueTest.test(column.getKeySerializer().deserialize(rocksIterator.key()));
+  }
+
+  @Override
+  public byte[] next() {
+    assertOpen();
+    try {
+      rocksIterator.status();
+    } catch (final RocksDBException e) {
+      LOG.error("RocksDbEntryIterator encountered a problem while iterating.", e);
+    }
+    if (!hasNext()) {
+      throw new NoSuchElementException();
+    }
+    final byte[] entry = rocksIterator.key();
+    rocksIterator.next();
+    return entry;
+  }
+
+  @MustBeClosed
+  public Stream<byte[]> toStream() {
+    assertOpen();
+    final Spliterator<byte[]> split =
+        Spliterators.spliteratorUnknownSize(
+            this,
+            Spliterator.IMMUTABLE
+                | Spliterator.DISTINCT
+                | Spliterator.NONNULL
+                | Spliterator.ORDERED
+                | Spliterator.SORTED);
+
+    return StreamSupport.stream(split, false).onClose(this::close);
+  }
+
+  private void assertOpen() {
+    if (this.isDatabaseClosed.get()) {
+      throw new ShuttingDownException();
+    }
+    if (closed.get()) {
+      throw new IllegalStateException(
+          "Attempt to update a closed " + this.getClass().getSimpleName());
+    }
+  }
+
+  @Override
+  public void close() {
+    if (closed.compareAndSet(false, true)) {
+      rocksIterator.close();
+    }
+  }
+}

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/pruner/BlobsPrunerTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/pruner/BlobsPrunerTest.java
@@ -75,15 +75,15 @@ public class BlobsPrunerTest {
 
   @Test
   void shouldPrune() {
-    // set current time to 2 slots after the MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUESTS window
+    // set current time to MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUESTS window + 2 slots
     final UInt64 currentSlot =
         UInt64.valueOf(MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUESTS)
             .times(spec.getGenesisSpecConfig().getSlotsPerEpoch())
             .plus(2);
-    final UInt64 time =
+    final UInt64 currentTime =
         currentSlot.times(spec.getGenesisSpecConfig().getSecondsPerSlot()).plus(genesisTime);
 
-    timeProvider.advanceTimeBy(Duration.ofSeconds(time.longValue()));
+    timeProvider.advanceTimeBy(Duration.ofSeconds(currentTime.longValue()));
 
     when(database.getGenesisTime()).thenReturn(Optional.of(genesisTime));
 

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/pruner/BlobsPrunerTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/pruner/BlobsPrunerTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.server.pruner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.spec.config.Constants.MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUESTS;
+
+import java.time.Duration;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
+import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.storage.server.Database;
+
+public class BlobsPrunerTest {
+  public static final Duration PRUNE_INTERVAL = Duration.ofSeconds(5);
+  public static final int PRUNE_LIMIT = 10;
+
+  private final Spec spec = TestSpecFactory.createMinimalEip4844();
+
+  private UInt64 genesisTime = UInt64.valueOf(100);
+
+  private final StubTimeProvider timeProvider = StubTimeProvider.withTimeInSeconds(0);
+  private final StubAsyncRunner asyncRunner = new StubAsyncRunner(timeProvider);
+  private final Database database = mock(Database.class);
+
+  private final BlobsPruner blobsPruner =
+      new BlobsPruner(spec, database, asyncRunner, timeProvider, PRUNE_INTERVAL, PRUNE_LIMIT);
+
+  @BeforeEach
+  void setUp() {
+    assertThat(blobsPruner.start()).isCompleted();
+  }
+
+  @Test
+  void shouldNotPruneWhenGenesisNotAvailable() {
+    when(database.getGenesisTime()).thenReturn(Optional.empty());
+
+    asyncRunner.executeDueActions();
+
+    verify(database).getGenesisTime();
+    verify(database, never()).pruneOldestBlobsSidecar(any(), anyInt());
+  }
+
+  @Test
+  void shouldNotPrunePriorGenesis() {
+    when(database.getGenesisTime()).thenReturn(Optional.of(genesisTime));
+
+    asyncRunner.executeDueActions();
+
+    verify(database).getGenesisTime();
+    verify(database, never()).pruneOldestBlobsSidecar(any(), anyInt());
+  }
+
+  @Test
+  void shouldPrune() {
+    // set current time to 2 slots after the MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUESTS window
+    final UInt64 currentSlot =
+        UInt64.valueOf(MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUESTS)
+            .times(spec.getGenesisSpecConfig().getSlotsPerEpoch())
+            .plus(2);
+    final UInt64 time =
+        currentSlot.times(spec.getGenesisSpecConfig().getSecondsPerSlot()).plus(genesisTime);
+
+    timeProvider.advanceTimeBy(Duration.ofSeconds(time.longValue()));
+
+    when(database.getGenesisTime()).thenReturn(Optional.of(genesisTime));
+
+    asyncRunner.executeDueActions();
+    verify(database).pruneOldestBlobsSidecar(UInt64.valueOf(2), PRUNE_LIMIT);
+  }
+}

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/BeaconNodeDataOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/BeaconNodeDataOptions.java
@@ -106,6 +106,28 @@ public class BeaconNodeDataOptions extends ValidatorClientDataOptions {
   private long blockPruningIntervalSeconds =
       StorageConfiguration.DEFAULT_BLOCK_PRUNING_INTERVAL.toSeconds();
 
+  @CommandLine.Option(
+      names = {"--Xdata-storage-blobs-pruning-interval"},
+      hidden = true,
+      paramLabel = "<INTEGER>",
+      description = "Interval in seconds between blobs sidecars pruning",
+      fallbackValue = "true",
+      showDefaultValue = Visibility.ALWAYS,
+      arity = "0..1")
+  private long blobsSidecarsPruningIntervalSeconds =
+      StorageConfiguration.DEFAULT_BLOBS_PRUNING_INTERVAL.toSeconds();
+
+  @CommandLine.Option(
+      names = {"--Xdata-storage-blobs-pruning-limit"},
+      hidden = true,
+      paramLabel = "<INTEGER>",
+      description =
+          "Maximum number of blobs sidecars that can be pruned in in each pruning session",
+      fallbackValue = "true",
+      showDefaultValue = Visibility.ALWAYS,
+      arity = "0..1")
+  private int blobsSidecarsPruningLimit = StorageConfiguration.DEFAULT_BLOBS_PRUNING_LIMIT;
+
   @Override
   protected DataConfig.Builder configureDataConfig(final DataConfig.Builder config) {
     return super.configureDataConfig(config).beaconDataPath(dataBeaconPath);
@@ -121,7 +143,9 @@ public class BeaconNodeDataOptions extends ValidatorClientDataOptions {
                 .dataStorageCreateDbVersion(parseDatabaseVersion())
                 .storeNonCanonicalBlocks(storeNonCanonicalBlocksEnabled)
                 .maxKnownNodeCacheSize(maxKnownNodeCacheSize)
-                .blockPruningInterval(Duration.ofSeconds(blockPruningIntervalSeconds)));
+                .blockPruningInterval(Duration.ofSeconds(blockPruningIntervalSeconds))
+                .blobsPruningInterval(Duration.ofSeconds(blobsSidecarsPruningIntervalSeconds))
+                .blobsPruningLimit(blobsSidecarsPruningLimit));
     builder.sync(
         b ->
             b.fetchAllHistoricBlocks(dataStorageMode.storesAllBlocks())

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/BeaconNodeDataOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/BeaconNodeDataOptionsTest.java
@@ -222,6 +222,23 @@ public class BeaconNodeDataOptionsTest extends AbstractBeaconNodeCommandTest {
   }
 
   @Test
+  void shouldSetBlobsPruningOptions() {
+    final TekuConfiguration config =
+        getTekuConfigurationFromArguments(
+            "--Xdata-storage-blobs-pruning-interval=55", "--Xdata-storage-blobs-pruning-limit=10");
+    assertThat(config.storageConfiguration().getBlobsPruningInterval())
+        .isEqualTo(Duration.ofSeconds(55));
+    assertThat(config.storageConfiguration().getBlobsPruningLimit()).isEqualTo(10);
+    assertThat(
+            createConfigBuilder()
+                .storageConfiguration(
+                    b -> b.blobsPruningInterval(Duration.ofSeconds(55)).blobsPruningLimit(10))
+                .build())
+        .usingRecursiveComparison()
+        .isEqualTo(config);
+  }
+
+  @Test
   void shouldNotAllowPruningBlocksAndReconstructingStates() {
     assertThatThrownBy(
             () ->


### PR DESCRIPTION
Blocks and Blobs pruning work slightly different.

Blocks jobs run every 1h and always prune all "prunable" blocks (that's why the first time you switch MINIMAL on, takes a while to complete).

Blobs pruning are designed to run frequently and with an hard cap on the `BlobsSidecar`s that can be pruned. Currently configured to run every minute and prune maximum of 32 blobs. Under finalization, with mainnet config, we are supposed to create 5 BlobsSidecar each minute, so 32 is able to catch up relatively quickly.

The idea is to avoid those pruning jobs to overlap, so we limit the CPU\Disk pressure while node is doing its main work that's why I configured `storagePrunerAsyncRunner` to be single-threaded.

I also lowered down the thread priority.

I added the unconfirmed blobs pruning, which make sure that unconfirmed blobs (blobs its block has been received but never imported (remaining in FutureItems or in PendingPool)) are removed from DB once we finalize those slots. It shares the same prune limit (32)

Improved pruning by adding the ability to stream keys only from the KV store, so value doesn't need to be read\deserialized.

related to #6629

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
