### PR TITLE
Remove unnecessary validation in BlobsSidecarsByRange

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/BeaconChainMethods.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/BeaconChainMethods.java
@@ -325,11 +325,7 @@ public class BeaconChainMethods {
 
     final BlobsSidecarsByRangeMessageHandler blobsSidecarsByRangeHandler =
         new BlobsSidecarsByRangeMessageHandler(
-            spec,
-            eip4844ForkEpoch,
-            metricsSystem,
-            combinedChainDataClient,
-            MAX_REQUEST_BLOBS_SIDECARS);
+            eip4844ForkEpoch, metricsSystem, combinedChainDataClient, MAX_REQUEST_BLOBS_SIDECARS);
 
     return Optional.of(
         new SingleProtocolEth2RpcMethod<>(

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobsSidecarsByRangeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobsSidecarsByRangeMessageHandler.java
@@ -110,7 +110,7 @@ public class BlobsSidecarsByRangeMessageHandler
               if (!verifyBlobsSidecarsAreAvailable(earliestAvailableEpoch, currentEpoch)) {
                 return SafeFuture.failedFuture(
                     new ResourceUnavailableException(
-                        "Blobs sidecars are not available in the MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUESTS epoch range."));
+                        "Blobs sidecars are not available within the MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUESTS epoch range."));
               }
               final RequestState initialState =
                   new RequestState(

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobsSidecarsByRangeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobsSidecarsByRangeMessageHandler.java
@@ -35,7 +35,6 @@ import tech.pegasys.teku.networking.eth2.rpc.core.ResponseCallback;
 import tech.pegasys.teku.networking.eth2.rpc.core.RpcException;
 import tech.pegasys.teku.networking.eth2.rpc.core.RpcException.ResourceUnavailableException;
 import tech.pegasys.teku.networking.p2p.rpc.StreamClosedException;
-import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.execution.versions.eip4844.BlobsSidecar;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BlobsSidecarsByRangeRequestMessage;
@@ -46,7 +45,6 @@ public class BlobsSidecarsByRangeMessageHandler
 
   private static final Logger LOG = LogManager.getLogger();
 
-  private final Spec spec;
   private final UInt64 eip4844ForkEpoch;
   private final CombinedChainDataClient combinedChainDataClient;
   private final UInt64 maxRequestSize;
@@ -54,12 +52,10 @@ public class BlobsSidecarsByRangeMessageHandler
   private final Counter totalBlobsSidecarsRequestedCounter;
 
   public BlobsSidecarsByRangeMessageHandler(
-      final Spec spec,
       final UInt64 eip4844ForkEpoch,
       final MetricsSystem metricsSystem,
       final CombinedChainDataClient combinedChainDataClient,
       final UInt64 maxRequestSize) {
-    this.spec = spec;
     this.eip4844ForkEpoch = eip4844ForkEpoch;
     this.combinedChainDataClient = combinedChainDataClient;
     this.maxRequestSize = maxRequestSize;

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobsSidecarsByRangeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobsSidecarsByRangeMessageHandler.java
@@ -13,7 +13,6 @@
 
 package tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods;
 
-import static tech.pegasys.teku.networking.eth2.rpc.core.RpcResponseStatus.INVALID_REQUEST_CODE;
 import static tech.pegasys.teku.spec.config.Constants.MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUESTS;
 
 import com.google.common.base.Throwables;
@@ -37,7 +36,6 @@ import tech.pegasys.teku.networking.eth2.rpc.core.RpcException;
 import tech.pegasys.teku.networking.eth2.rpc.core.RpcException.ResourceUnavailableException;
 import tech.pegasys.teku.networking.p2p.rpc.StreamClosedException;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.execution.versions.eip4844.BlobsSidecar;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BlobsSidecarsByRangeRequestMessage;
@@ -79,21 +77,6 @@ public class BlobsSidecarsByRangeMessageHandler
   }
 
   @Override
-  public Optional<RpcException> validateRequest(
-      final String protocolId, final BlobsSidecarsByRangeRequestMessage request) {
-    final UInt64 maxSlotRequested = request.getMaxSlot();
-    final SpecMilestone specMilestone =
-        spec.getForkSchedule().getSpecMilestoneAtSlot(maxSlotRequested);
-    if (!specMilestone.isGreaterThanOrEqualTo(SpecMilestone.EIP4844)) {
-      return Optional.of(
-          new RpcException(
-              INVALID_REQUEST_CODE,
-              "Can't request blobs sidecars for slots before the EIP-4844 fork"));
-    }
-    return Optional.empty();
-  }
-
-  @Override
   protected void onIncomingMessage(
       final String protocolId,
       final Eth2Peer peer,
@@ -111,6 +94,7 @@ public class BlobsSidecarsByRangeMessageHandler
       requestCounter.labels("rate_limited").inc();
       return;
     }
+
     requestCounter.labels("ok").inc();
     totalBlobsSidecarsRequestedCounter.inc(message.getCount().longValue());
 

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobsSidecarsByRangeMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobsSidecarsByRangeMessageHandlerTest.java
@@ -89,7 +89,7 @@ public class BlobsSidecarsByRangeMessageHandlerTest {
 
   private final BlobsSidecarsByRangeMessageHandler handler =
       new BlobsSidecarsByRangeMessageHandler(
-          spec, eip4844ForkEpoch, metricsSystem, combinedChainDataClient, maxRequestSize);
+          eip4844ForkEpoch, metricsSystem, combinedChainDataClient, maxRequestSize);
 
   @BeforeEach
   public void setUp() {
@@ -126,11 +126,6 @@ public class BlobsSidecarsByRangeMessageHandlerTest {
 
   @Test
   public void shouldSendResourcesUnavailableWhenPreEip4844() {
-    final Spec spec = TestSpecFactory.createMinimalWithEip4844ForkEpoch(ONE);
-    final BlobsSidecarsByRangeMessageHandler handler =
-        new BlobsSidecarsByRangeMessageHandler(
-            spec, eip4844ForkEpoch, metricsSystem, combinedChainDataClient, maxRequestSize);
-
     when(combinedChainDataClient.getBestBlockRoot())
         .thenReturn(Optional.of(dataStructureUtil.randomBytes32()));
     // no sidecars in database
@@ -138,7 +133,6 @@ public class BlobsSidecarsByRangeMessageHandlerTest {
         .thenReturn(SafeFuture.completedFuture(Optional.empty()));
     // current epoch before EIP-4844
     when(combinedChainDataClient.getCurrentEpoch()).thenReturn(eip4844ForkEpoch.minus(1));
-    when(listener.respond(any())).thenReturn(SafeFuture.COMPLETE);
 
     final BlobsSidecarsByRangeRequestMessage request =
         new BlobsSidecarsByRangeRequestMessage(ONE, ONE.plus(1));

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobsSidecarsByRangeMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobsSidecarsByRangeMessageHandlerTest.java
@@ -58,7 +58,7 @@ public class BlobsSidecarsByRangeMessageHandlerTest {
 
   private static final RpcException RESOURCE_UNAVAILABLE_EXCEPTION =
       new ResourceUnavailableException(
-          "Blobs sidecars are not available in the MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUESTS epoch range.");
+          "Blobs sidecars are not available within the MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUESTS epoch range.");
 
   private final Spec spec = TestSpecFactory.createMinimalEip4844();
 


### PR DESCRIPTION
## PR Description
Pre-EIP 4844 requests are covered by `Blobs sidecars are not available in the MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUESTS epoch range.` exception so no need to validate requests

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
