### PR TITLE
Add light client support flag

### DIFF
--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/AbstractDataBackedRestAPIIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/AbstractDataBackedRestAPIIntegrationTest.java
@@ -94,6 +94,7 @@ public abstract class AbstractDataBackedRestAPIIntegrationTest {
       BeaconRestApiConfig.builder()
           .restApiPort(0)
           .restApiEnabled(true)
+          .restApiLightClientEnabled(true)
           .restApiDocsEnabled(true)
           .restApiHostAllowlist(List.of("127.0.0.1", "localhost"))
           .restApiCorsAllowedOrigins(new ArrayList<>())

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApiConfig.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApiConfig.java
@@ -36,6 +36,7 @@ public class BeaconRestApiConfig {
   private final int restApiPort;
   private final boolean restApiDocsEnabled;
   private final boolean restApiEnabled;
+  private final boolean restApiLightClientEnabled;
   private final boolean beaconLivenessTrackingEnabled;
   private final String restApiInterface;
   private final List<String> restApiHostAllowlist;
@@ -49,6 +50,7 @@ public class BeaconRestApiConfig {
       final int restApiPort,
       final boolean restApiDocsEnabled,
       final boolean restApiEnabled,
+      final boolean restApiLightClientEnabled,
       final String restApiInterface,
       final List<String> restApiHostAllowlist,
       final List<String> restApiCorsAllowedOrigins,
@@ -60,6 +62,7 @@ public class BeaconRestApiConfig {
     this.restApiPort = restApiPort;
     this.restApiDocsEnabled = restApiDocsEnabled;
     this.restApiEnabled = restApiEnabled;
+    this.restApiLightClientEnabled = restApiLightClientEnabled;
     this.restApiInterface = restApiInterface;
     this.restApiHostAllowlist = restApiHostAllowlist;
     this.restApiCorsAllowedOrigins = restApiCorsAllowedOrigins;
@@ -80,6 +83,10 @@ public class BeaconRestApiConfig {
 
   public boolean isRestApiEnabled() {
     return restApiEnabled;
+  }
+
+  public boolean isRestApiLightClientEnabled() {
+    return restApiLightClientEnabled;
   }
 
   public boolean isBeaconLivenessTrackingEnabled() {
@@ -123,6 +130,7 @@ public class BeaconRestApiConfig {
     private int restApiPort = DEFAULT_REST_API_PORT;
     private boolean restApiDocsEnabled = false;
     private boolean restApiEnabled = false;
+    private boolean restApiLightClientEnabled = false;
     private boolean beaconLivenessTrackingEnabled = DEFAULT_BEACON_LIVENESS_TRACKING_ENABLED;
     private String restApiInterface = DEFAULT_REST_API_INTERFACE;
     private List<String> restApiHostAllowlist = DEFAULT_REST_API_HOST_ALLOWLIST;
@@ -150,6 +158,12 @@ public class BeaconRestApiConfig {
 
     public BeaconRestApiConfigBuilder restApiEnabled(final boolean restApiEnabled) {
       this.restApiEnabled = restApiEnabled;
+      return this;
+    }
+
+    public BeaconRestApiConfigBuilder restApiLightClientEnabled(
+        final boolean restApiLightClientEnabled) {
+      this.restApiLightClientEnabled = restApiLightClientEnabled;
       return this;
     }
 
@@ -214,6 +228,7 @@ public class BeaconRestApiConfig {
           restApiPort,
           restApiDocsEnabled,
           restApiEnabled,
+          restApiLightClientEnabled,
           restApiInterface,
           restApiHostAllowlist,
           restApiCorsAllowedOrigins,

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/JsonTypeDefinitionBeaconRestApi.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/JsonTypeDefinitionBeaconRestApi.java
@@ -165,145 +165,154 @@ public class JsonTypeDefinitionBeaconRestApi implements BeaconRestApi {
       final ExecutionClientDataProvider executionClientDataProvider,
       final Spec spec) {
     final SchemaDefinitionCache schemaCache = new SchemaDefinitionCache(spec);
-    return new RestApiBuilder()
-        .openApiInfo(
-            openApi ->
-                openApi
-                    .title(StringUtils.capitalize(VersionProvider.CLIENT_IDENTITY))
-                    .version(VersionProvider.IMPLEMENTATION_VERSION)
-                    .description(
-                        "A minimal API specification for the beacon node, which enables a validator "
-                            + "to connect and perform its obligations on the Ethereum beacon chain.")
-                    .license("Apache 2.0", "https://www.apache.org/licenses/LICENSE-2.0.html"))
-        .openApiDocsEnabled(config.isRestApiDocsEnabled())
-        .listenAddress(config.getRestApiInterface())
-        .port(config.getRestApiPort())
-        .maxUrlLength(config.getMaxUrlLength())
-        .corsAllowedOrigins(config.getRestApiCorsAllowedOrigins())
-        .hostAllowlist(config.getRestApiHostAllowlist())
-        .exceptionHandler(
-            ChainDataUnavailableException.class, (throwable) -> HttpErrorResponse.noContent())
-        .exceptionHandler(
-            NodeSyncingException.class, (throwable) -> HttpErrorResponse.serviceUnavailable())
-        .exceptionHandler(
-            ServiceUnavailableException.class,
-            (throwable) -> HttpErrorResponse.serviceUnavailable())
-        .exceptionHandler(
-            ContentTypeNotSupportedException.class,
-            (throwable) -> new HttpErrorResponse(SC_UNSUPPORTED_MEDIA_TYPE, throwable.getMessage()))
-        .exceptionHandler(
-            MissingDepositsException.class,
-            (throwable) -> new HttpErrorResponse(SC_INTERNAL_SERVER_ERROR, throwable.getMessage()))
-        .exceptionHandler(
-            BadRequestException.class,
-            (throwable) -> HttpErrorResponse.badRequest(throwable.getMessage()))
-        .exceptionHandler(
-            JsonProcessingException.class,
-            (throwable) -> HttpErrorResponse.badRequest(throwable.getMessage()))
-        .exceptionHandler(
-            IllegalArgumentException.class,
-            (throwable) -> HttpErrorResponse.badRequest(throwable.getMessage()))
-        // Beacon Handlers
-        .endpoint(new GetGenesis(dataProvider))
-        .endpoint(new GetStateRoot(dataProvider))
-        .endpoint(new GetStateFork(dataProvider))
-        .endpoint(new GetStateFinalityCheckpoints(dataProvider))
-        .endpoint(new GetStateValidators(dataProvider))
-        .endpoint(new GetStateValidator(dataProvider))
-        .endpoint(new GetStateValidatorBalances(dataProvider))
-        .endpoint(new GetStateCommittees(dataProvider))
-        .endpoint(new GetStateSyncCommittees(dataProvider))
-        .endpoint(new GetStateRandao(dataProvider))
-        .endpoint(new GetBlockHeaders(dataProvider))
-        .endpoint(new GetBlockHeader(dataProvider))
-        .endpoint(new PostBlock(dataProvider, spec, schemaCache))
-        .endpoint(new PostBlindedBlock(dataProvider, spec, schemaCache))
-        .endpoint(new GetBlock(dataProvider, schemaCache))
-        .endpoint(
-            new tech.pegasys.teku.beaconrestapi.handlers.v2.beacon.GetBlock(
-                dataProvider, schemaCache))
-        .endpoint(new GetBlindedBlock(dataProvider, schemaCache))
-        .endpoint(new GetFinalizedCheckpointState(dataProvider, spec))
-        .endpoint(new GetBlockRoot(dataProvider))
-        .endpoint(new GetFinalizedBlockRoot(dataProvider))
-        .endpoint(new GetLightClientBootstrap(dataProvider, schemaCache))
-        .endpoint(new GetLightClientUpdatesByRange(schemaCache))
-        .endpoint(new GetBlockAttestations(dataProvider, spec))
-        .endpoint(new GetAttestations(dataProvider, spec))
-        .endpoint(new PostAttestation(dataProvider, schemaCache))
-        .endpoint(new GetAttesterSlashings(dataProvider, spec))
-        .endpoint(new PostAttesterSlashing(dataProvider, spec))
-        .endpoint(new GetProposerSlashings(dataProvider))
-        .endpoint(new PostProposerSlashing(dataProvider))
-        .endpoint(new GetVoluntaryExits(dataProvider))
-        .endpoint(new PostVoluntaryExit(dataProvider))
-        .endpoint(new PostSyncCommittees(dataProvider))
-        .endpoint(new PostValidatorLiveness(dataProvider))
-        .endpoint(new PostBlsToExecutionChanges(dataProvider, schemaCache))
-        .endpoint(new GetBlsToExecutionChanges(dataProvider, schemaCache))
-        // Event Handler
-        .endpoint(
-            new GetEvents(
-                dataProvider,
-                eventChannels,
-                asyncRunner,
-                timeProvider,
-                config.getMaxPendingEvents()))
-        // Node Handlers
-        .endpoint(new GetHealth(dataProvider))
-        .endpoint(new GetIdentity(dataProvider))
-        .endpoint(new GetPeers(dataProvider))
-        .endpoint(new GetPeerCount(dataProvider))
-        .endpoint(new GetPeerById(dataProvider))
-        .endpoint(new GetSyncing(dataProvider))
-        .endpoint(new GetVersion())
-        // Validator Handlers
-        .endpoint(new PostAttesterDuties(dataProvider))
-        .endpoint(new GetProposerDuties(dataProvider))
-        .endpoint(
-            new tech.pegasys.teku.beaconrestapi.handlers.v1.validator.GetNewBlock(
-                dataProvider, schemaCache))
-        .endpoint(new GetNewBlock(dataProvider, spec, schemaCache))
-        .endpoint(new GetNewBlindedBlock(dataProvider, spec, schemaCache))
-        .endpoint(new GetAttestationData(dataProvider))
-        .endpoint(new GetAggregateAttestation(dataProvider, spec))
-        .endpoint(new PostAggregateAndProofs(dataProvider, spec.getGenesisSchemaDefinitions()))
-        .endpoint(new PostSubscribeToBeaconCommitteeSubnet(dataProvider))
-        .endpoint(new PostSyncDuties(dataProvider))
-        .endpoint(new GetSyncCommitteeContribution(dataProvider, schemaCache))
-        .endpoint(new PostSyncCommitteeSubscriptions(dataProvider))
-        .endpoint(new PostContributionAndProofs(dataProvider, schemaCache))
-        .endpoint(new PostPrepareBeaconProposer(dataProvider))
-        .endpoint(new PostRegisterValidator(dataProvider))
-        // Config Handlers
-        .endpoint(
-            new GetDepositContract(
-                config.getEth1DepositContractAddress(), dataProvider.getConfigProvider()))
-        .endpoint(new GetForkSchedule(dataProvider))
-        .endpoint(new GetSpec(dataProvider))
-        // Debug Handlers
-        .endpoint(new GetChainHeadsV1(dataProvider))
-        .endpoint(new GetChainHeadsV2(dataProvider))
-        .endpoint(
-            new tech.pegasys.teku.beaconrestapi.handlers.v1.debug.GetState(
-                dataProvider, spec, schemaCache))
-        .endpoint(new GetState(dataProvider, schemaCache))
-        .endpoint(new GetForkChoice(dataProvider))
-        // Teku Specific Handlers
-        .endpoint(new PutLogLevel())
-        .endpoint(new GetStateByBlockRoot(dataProvider, spec))
-        .endpoint(new Liveness(dataProvider))
-        .endpoint(new Readiness(dataProvider, executionClientDataProvider))
-        .endpoint(new GetAllBlocksAtSlot(dataProvider, schemaCache))
-        .endpoint(new GetPeersScore(dataProvider))
-        .endpoint(new GetProposersData(dataProvider))
-        .endpoint(new GetDeposits(eth1DataProvider))
-        .endpoint(new GetEth1Data(dataProvider, eth1DataProvider))
-        .endpoint(new GetEth1DataCache(eth1DataProvider))
-        .endpoint(new GetEth1VotingSummary(dataProvider, eth1DataProvider))
-        .endpoint(new GetDepositSnapshot(eth1DataProvider))
-        .endpoint(new GetGlobalValidatorInclusion(dataProvider))
-        .endpoint(new GetValidatorInclusion(dataProvider))
-        .build();
+    RestApiBuilder builder =
+        new RestApiBuilder()
+            .openApiInfo(
+                openApi ->
+                    openApi
+                        .title(StringUtils.capitalize(VersionProvider.CLIENT_IDENTITY))
+                        .version(VersionProvider.IMPLEMENTATION_VERSION)
+                        .description(
+                            "A minimal API specification for the beacon node, which enables a validator "
+                                + "to connect and perform its obligations on the Ethereum beacon chain.")
+                        .license("Apache 2.0", "https://www.apache.org/licenses/LICENSE-2.0.html"))
+            .openApiDocsEnabled(config.isRestApiDocsEnabled())
+            .listenAddress(config.getRestApiInterface())
+            .port(config.getRestApiPort())
+            .maxUrlLength(config.getMaxUrlLength())
+            .corsAllowedOrigins(config.getRestApiCorsAllowedOrigins())
+            .hostAllowlist(config.getRestApiHostAllowlist())
+            .exceptionHandler(
+                ChainDataUnavailableException.class, (throwable) -> HttpErrorResponse.noContent())
+            .exceptionHandler(
+                NodeSyncingException.class, (throwable) -> HttpErrorResponse.serviceUnavailable())
+            .exceptionHandler(
+                ServiceUnavailableException.class,
+                (throwable) -> HttpErrorResponse.serviceUnavailable())
+            .exceptionHandler(
+                ContentTypeNotSupportedException.class,
+                (throwable) ->
+                    new HttpErrorResponse(SC_UNSUPPORTED_MEDIA_TYPE, throwable.getMessage()))
+            .exceptionHandler(
+                MissingDepositsException.class,
+                (throwable) ->
+                    new HttpErrorResponse(SC_INTERNAL_SERVER_ERROR, throwable.getMessage()))
+            .exceptionHandler(
+                BadRequestException.class,
+                (throwable) -> HttpErrorResponse.badRequest(throwable.getMessage()))
+            .exceptionHandler(
+                JsonProcessingException.class,
+                (throwable) -> HttpErrorResponse.badRequest(throwable.getMessage()))
+            .exceptionHandler(
+                IllegalArgumentException.class,
+                (throwable) -> HttpErrorResponse.badRequest(throwable.getMessage()))
+            // Beacon Handlers
+            .endpoint(new GetGenesis(dataProvider))
+            .endpoint(new GetStateRoot(dataProvider))
+            .endpoint(new GetStateFork(dataProvider))
+            .endpoint(new GetStateFinalityCheckpoints(dataProvider))
+            .endpoint(new GetStateValidators(dataProvider))
+            .endpoint(new GetStateValidator(dataProvider))
+            .endpoint(new GetStateValidatorBalances(dataProvider))
+            .endpoint(new GetStateCommittees(dataProvider))
+            .endpoint(new GetStateSyncCommittees(dataProvider))
+            .endpoint(new GetStateRandao(dataProvider))
+            .endpoint(new GetBlockHeaders(dataProvider))
+            .endpoint(new GetBlockHeader(dataProvider))
+            .endpoint(new PostBlock(dataProvider, spec, schemaCache))
+            .endpoint(new PostBlindedBlock(dataProvider, spec, schemaCache))
+            .endpoint(new GetBlock(dataProvider, schemaCache))
+            .endpoint(
+                new tech.pegasys.teku.beaconrestapi.handlers.v2.beacon.GetBlock(
+                    dataProvider, schemaCache))
+            .endpoint(new GetBlindedBlock(dataProvider, schemaCache))
+            .endpoint(new GetFinalizedCheckpointState(dataProvider, spec))
+            .endpoint(new GetBlockRoot(dataProvider))
+            .endpoint(new GetFinalizedBlockRoot(dataProvider))
+            .endpoint(new GetBlockAttestations(dataProvider, spec))
+            .endpoint(new GetAttestations(dataProvider, spec))
+            .endpoint(new PostAttestation(dataProvider, schemaCache))
+            .endpoint(new GetAttesterSlashings(dataProvider, spec))
+            .endpoint(new PostAttesterSlashing(dataProvider, spec))
+            .endpoint(new GetProposerSlashings(dataProvider))
+            .endpoint(new PostProposerSlashing(dataProvider))
+            .endpoint(new GetVoluntaryExits(dataProvider))
+            .endpoint(new PostVoluntaryExit(dataProvider))
+            .endpoint(new PostSyncCommittees(dataProvider))
+            .endpoint(new PostValidatorLiveness(dataProvider))
+            .endpoint(new PostBlsToExecutionChanges(dataProvider, schemaCache))
+            .endpoint(new GetBlsToExecutionChanges(dataProvider, schemaCache))
+            // Event Handler
+            .endpoint(
+                new GetEvents(
+                    dataProvider,
+                    eventChannels,
+                    asyncRunner,
+                    timeProvider,
+                    config.getMaxPendingEvents()))
+            // Node Handlers
+            .endpoint(new GetHealth(dataProvider))
+            .endpoint(new GetIdentity(dataProvider))
+            .endpoint(new GetPeers(dataProvider))
+            .endpoint(new GetPeerCount(dataProvider))
+            .endpoint(new GetPeerById(dataProvider))
+            .endpoint(new GetSyncing(dataProvider))
+            .endpoint(new GetVersion())
+            // Validator Handlers
+            .endpoint(new PostAttesterDuties(dataProvider))
+            .endpoint(new GetProposerDuties(dataProvider))
+            .endpoint(
+                new tech.pegasys.teku.beaconrestapi.handlers.v1.validator.GetNewBlock(
+                    dataProvider, schemaCache))
+            .endpoint(new GetNewBlock(dataProvider, spec, schemaCache))
+            .endpoint(new GetNewBlindedBlock(dataProvider, spec, schemaCache))
+            .endpoint(new GetAttestationData(dataProvider))
+            .endpoint(new GetAggregateAttestation(dataProvider, spec))
+            .endpoint(new PostAggregateAndProofs(dataProvider, spec.getGenesisSchemaDefinitions()))
+            .endpoint(new PostSubscribeToBeaconCommitteeSubnet(dataProvider))
+            .endpoint(new PostSyncDuties(dataProvider))
+            .endpoint(new GetSyncCommitteeContribution(dataProvider, schemaCache))
+            .endpoint(new PostSyncCommitteeSubscriptions(dataProvider))
+            .endpoint(new PostContributionAndProofs(dataProvider, schemaCache))
+            .endpoint(new PostPrepareBeaconProposer(dataProvider))
+            .endpoint(new PostRegisterValidator(dataProvider))
+            // Config Handlers
+            .endpoint(
+                new GetDepositContract(
+                    config.getEth1DepositContractAddress(), dataProvider.getConfigProvider()))
+            .endpoint(new GetForkSchedule(dataProvider))
+            .endpoint(new GetSpec(dataProvider))
+            // Debug Handlers
+            .endpoint(new GetChainHeadsV1(dataProvider))
+            .endpoint(new GetChainHeadsV2(dataProvider))
+            .endpoint(
+                new tech.pegasys.teku.beaconrestapi.handlers.v1.debug.GetState(
+                    dataProvider, spec, schemaCache))
+            .endpoint(new GetState(dataProvider, schemaCache))
+            .endpoint(new GetForkChoice(dataProvider))
+            // Teku Specific Handlers
+            .endpoint(new PutLogLevel())
+            .endpoint(new GetStateByBlockRoot(dataProvider, spec))
+            .endpoint(new Liveness(dataProvider))
+            .endpoint(new Readiness(dataProvider, executionClientDataProvider))
+            .endpoint(new GetAllBlocksAtSlot(dataProvider, schemaCache))
+            .endpoint(new GetPeersScore(dataProvider))
+            .endpoint(new GetProposersData(dataProvider))
+            .endpoint(new GetDeposits(eth1DataProvider))
+            .endpoint(new GetEth1Data(dataProvider, eth1DataProvider))
+            .endpoint(new GetEth1DataCache(eth1DataProvider))
+            .endpoint(new GetEth1VotingSummary(dataProvider, eth1DataProvider))
+            .endpoint(new GetDepositSnapshot(eth1DataProvider))
+            .endpoint(new GetGlobalValidatorInclusion(dataProvider))
+            .endpoint(new GetValidatorInclusion(dataProvider));
+
+    if (config.isRestApiLightClientEnabled()) {
+      builder =
+          builder
+              .endpoint(new GetLightClientBootstrap(dataProvider, schemaCache))
+              .endpoint(new GetLightClientUpdatesByRange(schemaCache));
+    }
+
+    return builder.build();
   }
 }

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/BeaconRestApiOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/BeaconRestApiOptions.java
@@ -52,6 +52,16 @@ public class BeaconRestApiOptions {
   private boolean restApiEnabled = false;
 
   @Option(
+      names = {"--rest-api-light-client-enabled"},
+      paramLabel = "<BOOLEAN>",
+      showDefaultValue = Visibility.ALWAYS,
+      description =
+          "Enables Beacon Rest API light client endpoints and storage of light client data.",
+      fallbackValue = "true",
+      arity = "0..1")
+  private boolean restApiLightClientEnabled = false;
+
+  @Option(
       names = {"--rest-api-interface"},
       paramLabel = "<NETWORK>",
       description = "Interface of Beacon Rest API",
@@ -125,6 +135,7 @@ public class BeaconRestApiOptions {
         restApiBuilder ->
             restApiBuilder
                 .restApiEnabled(restApiEnabled)
+                .restApiLightClientEnabled(restApiLightClientEnabled)
                 .restApiDocsEnabled(restApiDocsEnabled)
                 .restApiPort(restApiPort)
                 .restApiInterface(restApiInterface)

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/BeaconRestApiOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/BeaconRestApiOptions.java
@@ -52,16 +52,6 @@ public class BeaconRestApiOptions {
   private boolean restApiEnabled = false;
 
   @Option(
-      names = {"--rest-api-light-client-enabled"},
-      paramLabel = "<BOOLEAN>",
-      showDefaultValue = Visibility.ALWAYS,
-      description =
-          "Enables Beacon Rest API light client endpoints and storage of light client data.",
-      fallbackValue = "true",
-      arity = "0..1")
-  private boolean restApiLightClientEnabled = false;
-
-  @Option(
       names = {"--rest-api-interface"},
       paramLabel = "<NETWORK>",
       description = "Interface of Beacon Rest API",
@@ -85,6 +75,17 @@ public class BeaconRestApiOptions {
       arity = "0..*")
   private final List<String> restApiCorsAllowedOrigins =
       BeaconRestApiConfig.DEFAULT_REST_API_CORS_ALLOWED_ORIGINS;
+
+  @Option(
+      names = {"--Xrest-api-light-client-enabled"},
+      paramLabel = "<BOOLEAN>",
+      showDefaultValue = Visibility.ALWAYS,
+      description =
+          "Enables Beacon Rest API light client endpoints and storage of light client data.",
+      fallbackValue = "true",
+      arity = "0..1",
+      hidden = true)
+  private boolean restApiLightClientEnabled = false;
 
   @Option(
       names = {"--Xrest-api-max-pending-events"},

--- a/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
@@ -444,7 +444,7 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
       "false",
       "--rest-api-enabled",
       "false",
-      "--rest-api-light-client-enabled",
+      "--Xrest-api-light-client-enabled",
       "false",
       "--rest-api-interface",
       "127.0.0.1",

--- a/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
@@ -444,6 +444,8 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
       "false",
       "--rest-api-enabled",
       "false",
+      "--rest-api-light-client-enabled",
+      "false",
       "--rest-api-interface",
       "127.0.0.1",
       "--Xrest-api-max-url-length",
@@ -540,6 +542,7 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
                 b.restApiPort(5051)
                     .restApiDocsEnabled(false)
                     .restApiEnabled(false)
+                    .restApiLightClientEnabled(false)
                     .restApiInterface("127.0.0.1")
                     .restApiHostAllowlist(List.of("127.0.0.1", "localhost"))
                     .restApiCorsAllowedOrigins(new ArrayList<>())

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/ReflectionBasedBeaconRestApiOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/ReflectionBasedBeaconRestApiOptionsTest.java
@@ -68,7 +68,7 @@ public class ReflectionBasedBeaconRestApiOptionsTest extends AbstractBeaconNodeC
   @Test
   public void restApiLightClientEnabled_shouldNotRequireAValue() {
     TekuConfiguration tekuConfiguration =
-        getTekuConfigurationFromArguments("--rest-api-light-client-enabled");
+        getTekuConfigurationFromArguments("--Xrest-api-light-client-enabled");
     final BeaconRestApiConfig config = getConfig(tekuConfiguration);
     assertThat(config.isRestApiLightClientEnabled()).isTrue();
     assertThat(createConfigBuilder().restApi(b -> b.restApiLightClientEnabled(true)).build())

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/ReflectionBasedBeaconRestApiOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/ReflectionBasedBeaconRestApiOptionsTest.java
@@ -37,6 +37,7 @@ public class ReflectionBasedBeaconRestApiOptionsTest extends AbstractBeaconNodeC
     assertThat(config.getRestApiPort()).isEqualTo(5055);
     assertThat(config.isRestApiDocsEnabled()).isTrue();
     assertThat(config.isRestApiEnabled()).isTrue();
+    assertThat(config.isRestApiLightClientEnabled()).isTrue();
     assertThat(config.getRestApiHostAllowlist()).containsExactly("test.domain.com", "11.12.13.14");
     assertThat(config.getRestApiCorsAllowedOrigins())
         .containsExactly("127.1.2.3", "origin.allowed.com");
@@ -60,6 +61,17 @@ public class ReflectionBasedBeaconRestApiOptionsTest extends AbstractBeaconNodeC
     final BeaconRestApiConfig config = getConfig(tekuConfiguration);
     assertThat(config.isRestApiEnabled()).isTrue();
     assertThat(createConfigBuilder().restApi(b -> b.restApiEnabled(true)).build())
+        .usingRecursiveComparison()
+        .isEqualTo(tekuConfiguration);
+  }
+
+  @Test
+  public void restApiLightClientEnabled_shouldNotRequireAValue() {
+    TekuConfiguration tekuConfiguration =
+        getTekuConfigurationFromArguments("--rest-api-light-client-enabled");
+    final BeaconRestApiConfig config = getConfig(tekuConfiguration);
+    assertThat(config.isRestApiLightClientEnabled()).isTrue();
+    assertThat(createConfigBuilder().restApi(b -> b.restApiLightClientEnabled(true)).build())
         .usingRecursiveComparison()
         .isEqualTo(tekuConfiguration);
   }

--- a/teku/src/test/resources/beaconRestApiOptions_config.yaml
+++ b/teku/src/test/resources/beaconRestApiOptions_config.yaml
@@ -2,6 +2,7 @@
 rest-api-port: 5055
 rest-api-docs-enabled: True
 rest-api-enabled: True
+rest-api-light-client-enabled: True
 rest-api-interface: "127.100.0.1"
 rest-api-host-allowlist: ["test.domain.com", "11.12.13.14"]
 rest-api-cors-origins: ["127.1.2.3", "origin.allowed.com"]

--- a/teku/src/test/resources/beaconRestApiOptions_config.yaml
+++ b/teku/src/test/resources/beaconRestApiOptions_config.yaml
@@ -2,7 +2,7 @@
 rest-api-port: 5055
 rest-api-docs-enabled: True
 rest-api-enabled: True
-rest-api-light-client-enabled: True
 rest-api-interface: "127.100.0.1"
 rest-api-host-allowlist: ["test.domain.com", "11.12.13.14"]
 rest-api-cors-origins: ["127.1.2.3", "origin.allowed.com"]
+Xrest-api-light-client-enabled: True


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Adds a flag enabling/disabling the light client endpoints in the Beacon REST API. Useful for clients who elect not to serve light client data. In the future a flag value of `false` will also imply that the client is not _storing_ the light client data (in local cache).

## Fixed Issue(s)
partially addresses #4230 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

Although this is a CLI change, we can avoid updating docs until the light client APIs are stable to minimize confusion.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
