### PR TITLE
Failover when BN is in optimistic sync mode

### DIFF
--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessManager.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessManager.java
@@ -114,7 +114,8 @@ public class BeaconNodeReadinessManager implements ValidatorTimingChannel {
         .getSyncingStatus()
         .thenApply(
             syncingStatus -> {
-              if (syncingStatus.isSyncing()) {
+              // Consider node not ready if it is still syncing or is in optimistic sync mode
+              if (syncingStatus.isSyncing() || syncingStatus.getIsOptimistic().orElse(false)) {
                 LOG.debug(
                     "{} is not ready to accept requests because it is not in sync",
                     beaconNodeApiEndpoint);

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessManager.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessManager.java
@@ -114,14 +114,14 @@ public class BeaconNodeReadinessManager implements ValidatorTimingChannel {
         .getSyncingStatus()
         .thenApply(
             syncingStatus -> {
-              if (!syncingStatus.isSyncing() || syncingStatus.getIsOptimistic().orElse(false)) {
-                LOG.debug("{} is in sync and ready to accept requests", beaconNodeApiEndpoint);
-                return true;
+              if (syncingStatus.isSyncing()) {
+                LOG.debug(
+                    "{} is not ready to accept requests because it is not in sync",
+                    beaconNodeApiEndpoint);
+                return false;
               }
-              LOG.debug(
-                  "{} is not ready to accept requests because it is not in sync",
-                  beaconNodeApiEndpoint);
-              return false;
+              LOG.debug("{} is in sync and ready to accept requests", beaconNodeApiEndpoint);
+              return true;
             })
         .exceptionally(
             throwable -> {

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessManagerTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessManagerTest.java
@@ -37,7 +37,7 @@ public class BeaconNodeReadinessManagerTest {
       new SyncingStatus(UInt64.ONE, UInt64.ZERO, true, Optional.empty());
 
   private static final SyncingStatus OPTIMISTICALLY_SYNCING_STATUS =
-      new SyncingStatus(UInt64.ONE, UInt64.ZERO, true, Optional.of(true));
+      new SyncingStatus(UInt64.ONE, UInt64.ZERO, false, Optional.of(true));
 
   private final RemoteValidatorApiChannel beaconNodeApi = mock(RemoteValidatorApiChannel.class);
   private final RemoteValidatorApiChannel failoverBeaconNodeApi =


### PR DESCRIPTION
## PR Description
Consider BN not ready if in optimistic sync mode (means will failover to other BN if configured)

## Fixed Issue(s)
fixes #6655 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
