### PR TITLE
Update errorprone to 2.17.0

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -8,7 +8,7 @@ dependencyManagement {
 
     dependency 'com.google.auto.service:auto-service:1.0-rc7'
 
-    dependencySet(group: 'com.google.errorprone', version: '2.16') {
+    dependencySet(group: 'com.google.errorprone', version: '2.17.0') {
       entry 'error_prone_annotation'
       entry 'error_prone_check_api'
       entry 'error_prone_core'


### PR DESCRIPTION
## PR Description

This PR updates errorprone to 2.17.0 (see [the release notes](https://github.com/google/error-prone/releases/tag/v2.17.0)). There are a few new checks & no new findings.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
