### PR TITLE
TimeBasedEth1HeadTracker needs an eth1 block to complete its initiali…

### DIFF
--- a/beacon/pow/src/main/java/tech/pegasys/teku/beacon/pow/TimeBasedEth1HeadTracker.java
+++ b/beacon/pow/src/main/java/tech/pegasys/teku/beacon/pow/TimeBasedEth1HeadTracker.java
@@ -70,7 +70,7 @@ public class TimeBasedEth1HeadTracker implements Eth1HeadTracker, RunLoopLogic {
   @Override
   public SafeFuture<Void> init() {
     return eth1Provider
-        .getLatestEth1Block()
+        .getGuaranteedLatestEth1Block()
         .thenCompose(
             headBlock -> {
               if (isOldEnough(headBlock)) {

--- a/beacon/pow/src/test/java/tech/pegasys/teku/beacon/pow/TimeBasedEth1HeadTrackerTest.java
+++ b/beacon/pow/src/test/java/tech/pegasys/teku/beacon/pow/TimeBasedEth1HeadTrackerTest.java
@@ -77,7 +77,7 @@ class TimeBasedEth1HeadTrackerTest {
     timeProvider.advanceTimeBySeconds(FOLLOW_TIME);
     withBlockTimestamps(5, 10, 15);
     assertThat(headTracker.init()).isCompleted();
-    verify(eth1Provider).getLatestEth1Block();
+    verify(eth1Provider).getGuaranteedLatestEth1Block();
     verify(eth1Provider).getEth1Block(UInt64.ZERO);
     verifyNoInteractions(subscriber);
 
@@ -91,7 +91,7 @@ class TimeBasedEth1HeadTrackerTest {
     withBlockTimestamps(5, 10, 100);
     assertThat(headTracker.init()).isCompleted();
 
-    verify(eth1Provider).getLatestEth1Block();
+    verify(eth1Provider).getGuaranteedLatestEth1Block();
     verify(subscriber).onValueChanged(UInt64.valueOf(2));
   }
 
@@ -102,7 +102,7 @@ class TimeBasedEth1HeadTrackerTest {
         withBlockTimestamps(1, 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 1100);
     assertThat(headTracker.init()).isCompleted();
 
-    verify(eth1Provider).getLatestEth1Block();
+    verify(eth1Provider).getGuaranteedLatestEth1Block();
     final int followDistanceBlockNumber = blocks.size() - FOLLOW_DISTANCE - 1;
     verifyBlockRequested(followDistanceBlockNumber);
     verify(subscriber).onValueChanged(UInt64.valueOf(followDistanceBlockNumber));
@@ -269,7 +269,7 @@ class TimeBasedEth1HeadTrackerTest {
     withBlockTimestamps(5, 10, 100);
     assertThat(headTracker.init()).isCompleted();
 
-    verify(eth1Provider).getLatestEth1Block();
+    verify(eth1Provider).getGuaranteedLatestEth1Block();
     verify(subscriber).onValueChanged(UInt64.valueOf(2));
 
     final ValueObserver<UInt64> subscriber2 = mock(ValueObserver.class);
@@ -296,7 +296,7 @@ class TimeBasedEth1HeadTrackerTest {
     final AtomicReference<UInt64> firstHead = new AtomicReference<>();
     headTracker.subscribe(firstHead::set);
     assertThat(headTracker.init()).isCompleted();
-    verify(eth1Provider).getLatestEth1Block();
+    verify(eth1Provider).getGuaranteedLatestEth1Block();
     while (firstHead.get() == null) {
       assertThat(headTracker.advance()).isCompleted();
     }
@@ -325,7 +325,7 @@ class TimeBasedEth1HeadTrackerTest {
       blocks.add(block);
     }
 
-    when(eth1Provider.getLatestEth1Block())
+    when(eth1Provider.getGuaranteedLatestEth1Block())
         .thenReturn(SafeFuture.completedFuture(blocks.get(blocks.size() - 1)));
     return blocks;
   }


### PR DESCRIPTION
…sation

We are using a `getGuaranteedLatestEth1Block` elsewhere, and that will fix the problem in the init also.

Basically we can only really keep retrying until we get something but otherwise the init need not complete, as it's tracking the head block and none has been returned.

This was a problem on a devnet, causing an NPE constantly and filling up logs.

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
