### PR TITLE
Cleanup workarounds for calling v1 endpoints

### DIFF
--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/CapellaExecutionClientHandler.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/CapellaExecutionClientHandler.java
@@ -25,7 +25,6 @@ import tech.pegasys.teku.ethereum.executionclient.schema.PayloadStatusV1;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSchema;
@@ -46,9 +45,6 @@ public class CapellaExecutionClientHandler extends BellatrixExecutionClientHandl
   @Override
   public SafeFuture<ExecutionPayloadWithValue> engineGetPayload(
       final ExecutionPayloadContext executionPayloadContext, final UInt64 slot) {
-    if (!spec.atSlot(slot).getMilestone().isGreaterThanOrEqualTo(SpecMilestone.CAPELLA)) {
-      return super.engineGetPayload(executionPayloadContext, slot);
-    }
     LOG.trace(
         "calling engineGetPayloadV2(payloadId={}, slot={})",
         executionPayloadContext.getPayloadId(),
@@ -79,12 +75,6 @@ public class CapellaExecutionClientHandler extends BellatrixExecutionClientHandl
       engineForkChoiceUpdated(
           final ForkChoiceState forkChoiceState,
           final Optional<PayloadBuildingAttributes> payloadBuildingAttributes) {
-
-    if (!spec.atSlot(forkChoiceState.getHeadBlockSlot().increment())
-        .getMilestone()
-        .isGreaterThanOrEqualTo(SpecMilestone.CAPELLA)) {
-      return super.engineForkChoiceUpdated(forkChoiceState, payloadBuildingAttributes);
-    }
     LOG.trace(
         "calling engineForkChoiceUpdatedV2(forkChoiceState={}, payloadAttributes={})",
         forkChoiceState,
@@ -106,9 +96,6 @@ public class CapellaExecutionClientHandler extends BellatrixExecutionClientHandl
 
   @Override
   public SafeFuture<PayloadStatus> engineNewPayload(final ExecutionPayload executionPayload) {
-    if (executionPayload.getOptionalWithdrawals().isEmpty()) {
-      return super.engineNewPayload(executionPayload);
-    }
     LOG.trace("calling engineNewPayloadV2(executionPayload={})", executionPayload);
     return executionEngineClient
         .newPayloadV2(ExecutionPayloadV2.fromInternalExecutionPayload(executionPayload))

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/AbstractBlockProcessor.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/AbstractBlockProcessor.java
@@ -279,8 +279,10 @@ public abstract class AbstractBlockProcessor implements BlockProcessor {
           "Block state root does NOT match the calculated state root!\n"
               + "Block state root: "
               + block.getMessage().getStateRoot().toHexString()
-              + "New state root: "
-              + postState.hashTreeRoot().toHexString());
+              + "\n  New state root: "
+              + postState.hashTreeRoot().toHexString()
+              + "\n block proposer: "
+              + block.getProposerIndex());
     } else {
       return BlockValidationResult.SUCCESSFUL;
     }

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/TransitionCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/TransitionCommand.java
@@ -190,7 +190,13 @@ public class TransitionCommand implements Runnable {
   }
 
   private SignedBeaconBlock readBlock(final Spec spec, final String path) throws IOException {
-    final byte[] blockDataBytesArray = Files.readAllBytes(Path.of(path));
+    final byte[] blockDataBytesArray;
+    if (path.endsWith(".hex")) {
+      final String str = Files.readString(Path.of(path)).trim();
+      blockDataBytesArray = Bytes.fromHexString(str).toArrayUnsafe();
+    } else {
+      blockDataBytesArray = Files.readAllBytes(Path.of(path));
+    }
     try {
       return spec.deserializeSignedBeaconBlock(Bytes.wrap(blockDataBytesArray));
     } catch (final RuntimeException e) {


### PR DESCRIPTION
 - add functionality to read a block from hex using the transition command.

 - fix log message for state root mismatch, and add block proposer to that message for context.

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
