### PR TITLE
Slot based solution for execution client data switches

### DIFF
--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ExecutionEngineClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ExecutionEngineClient.java
@@ -17,12 +17,10 @@ import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.ethereum.executionclient.schema.BlobsBundleV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV1;
-import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV2;
 import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceStateV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceUpdatedResult;
 import tech.pegasys.teku.ethereum.executionclient.schema.GetPayloadV2Response;
 import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV1;
-import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV2;
 import tech.pegasys.teku.ethereum.executionclient.schema.PayloadStatusV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.Response;
 import tech.pegasys.teku.ethereum.executionclient.schema.TransitionConfigurationV1;
@@ -45,13 +43,13 @@ public interface ExecutionEngineClient {
 
   SafeFuture<Response<PayloadStatusV1>> newPayloadV1(ExecutionPayloadV1 executionPayload);
 
-  SafeFuture<Response<PayloadStatusV1>> newPayloadV2(ExecutionPayloadV2 executionPayload);
+  SafeFuture<Response<PayloadStatusV1>> newPayloadV2(ExecutionPayloadV1 executionPayload);
 
   SafeFuture<Response<ForkChoiceUpdatedResult>> forkChoiceUpdatedV1(
       ForkChoiceStateV1 forkChoiceState, Optional<PayloadAttributesV1> payloadAttributes);
 
   SafeFuture<Response<ForkChoiceUpdatedResult>> forkChoiceUpdatedV2(
-      ForkChoiceStateV1 forkChoiceState, Optional<PayloadAttributesV2> payloadAttributes);
+      ForkChoiceStateV1 forkChoiceState, Optional<PayloadAttributesV1> payloadAttributes);
 
   SafeFuture<Response<TransitionConfigurationV1>> exchangeTransitionConfiguration(
       TransitionConfigurationV1 transitionConfiguration);

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ThrottlingExecutionEngineClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ThrottlingExecutionEngineClient.java
@@ -18,12 +18,10 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.ethereum.executionclient.schema.BlobsBundleV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV1;
-import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV2;
 import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceStateV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceUpdatedResult;
 import tech.pegasys.teku.ethereum.executionclient.schema.GetPayloadV2Response;
 import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV1;
-import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV2;
 import tech.pegasys.teku.ethereum.executionclient.schema.PayloadStatusV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.Response;
 import tech.pegasys.teku.ethereum.executionclient.schema.TransitionConfigurationV1;
@@ -83,7 +81,7 @@ public class ThrottlingExecutionEngineClient implements ExecutionEngineClient {
 
   @Override
   public SafeFuture<Response<PayloadStatusV1>> newPayloadV2(
-      final ExecutionPayloadV2 executionPayload) {
+      final ExecutionPayloadV1 executionPayload) {
     return taskQueue.queueTask(() -> delegate.newPayloadV2(executionPayload));
   }
 
@@ -98,7 +96,7 @@ public class ThrottlingExecutionEngineClient implements ExecutionEngineClient {
   @Override
   public SafeFuture<Response<ForkChoiceUpdatedResult>> forkChoiceUpdatedV2(
       final ForkChoiceStateV1 forkChoiceState,
-      final Optional<PayloadAttributesV2> payloadAttributes) {
+      final Optional<PayloadAttributesV1> payloadAttributes) {
     return taskQueue.queueTask(
         () -> delegate.forkChoiceUpdatedV2(forkChoiceState, payloadAttributes));
   }

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/metrics/MetricRecordingExecutionEngineClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/metrics/MetricRecordingExecutionEngineClient.java
@@ -21,12 +21,10 @@ import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.ethereum.executionclient.ExecutionEngineClient;
 import tech.pegasys.teku.ethereum.executionclient.schema.BlobsBundleV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV1;
-import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV2;
 import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceStateV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceUpdatedResult;
 import tech.pegasys.teku.ethereum.executionclient.schema.GetPayloadV2Response;
 import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV1;
-import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV2;
 import tech.pegasys.teku.ethereum.executionclient.schema.PayloadStatusV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.Response;
 import tech.pegasys.teku.ethereum.executionclient.schema.TransitionConfigurationV1;
@@ -105,7 +103,7 @@ public class MetricRecordingExecutionEngineClient extends MetricRecordingAbstrac
 
   @Override
   public SafeFuture<Response<PayloadStatusV1>> newPayloadV2(
-      final ExecutionPayloadV2 executionPayload) {
+      final ExecutionPayloadV1 executionPayload) {
     return countRequest(() -> delegate.newPayloadV2(executionPayload), NEW_PAYLOAD_V2_METHOD);
   }
 
@@ -123,7 +121,7 @@ public class MetricRecordingExecutionEngineClient extends MetricRecordingAbstrac
   @Override
   public SafeFuture<Response<ForkChoiceUpdatedResult>> forkChoiceUpdatedV2(
       final ForkChoiceStateV1 forkChoiceState,
-      final Optional<PayloadAttributesV2> payloadAttributes) {
+      final Optional<PayloadAttributesV1> payloadAttributes) {
     return countRequest(
         () -> delegate.forkChoiceUpdatedV2(forkChoiceState, payloadAttributes),
         payloadAttributes.isPresent()

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/GetPayloadV2Response.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/GetPayloadV2Response.java
@@ -21,14 +21,14 @@ import tech.pegasys.teku.ethereum.executionclient.serialization.UInt256AsHexDese
 import tech.pegasys.teku.ethereum.executionclient.serialization.UInt256AsHexSerializer;
 
 public class GetPayloadV2Response {
-  public final ExecutionPayloadV1 executionPayload;
+  public final ExecutionPayloadV2 executionPayload;
 
   @JsonSerialize(using = UInt256AsHexSerializer.class)
   @JsonDeserialize(using = UInt256AsHexDeserializer.class)
   public final UInt256 blockValue;
 
   public GetPayloadV2Response(
-      @JsonProperty("executionPayload") final ExecutionPayloadV1 executionPayload,
+      @JsonProperty("executionPayload") final ExecutionPayloadV2 executionPayload,
       @JsonProperty("blockValue") final UInt256 blockValue) {
     this.executionPayload = executionPayload;
     this.blockValue = blockValue;

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/GetPayloadV2Response.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/GetPayloadV2Response.java
@@ -21,14 +21,14 @@ import tech.pegasys.teku.ethereum.executionclient.serialization.UInt256AsHexDese
 import tech.pegasys.teku.ethereum.executionclient.serialization.UInt256AsHexSerializer;
 
 public class GetPayloadV2Response {
-  public final ExecutionPayloadV2 executionPayload;
+  public final ExecutionPayloadV1 executionPayload;
 
   @JsonSerialize(using = UInt256AsHexSerializer.class)
   @JsonDeserialize(using = UInt256AsHexDeserializer.class)
   public final UInt256 blockValue;
 
   public GetPayloadV2Response(
-      @JsonProperty("executionPayload") final ExecutionPayloadV2 executionPayload,
+      @JsonProperty("executionPayload") final ExecutionPayloadV1 executionPayload,
       @JsonProperty("blockValue") final UInt256 blockValue) {
     this.executionPayload = executionPayload;
     this.blockValue = blockValue;

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/PayloadAttributesV2.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/PayloadAttributesV2.java
@@ -37,7 +37,7 @@ public class PayloadAttributesV2 extends PayloadAttributesV1 {
     this.withdrawals = withdrawals;
   }
 
-  public static Optional<PayloadAttributesV2> fromInternalPayloadBuildingAttributesV2(
+  public static Optional<PayloadAttributesV1> fromInternalPayloadBuildingAttributesV2(
       Optional<PayloadBuildingAttributes> payloadBuildingAttributes) {
     return payloadBuildingAttributes.map(
         (payloadAttributes) ->

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JExecutionEngineClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JExecutionEngineClient.java
@@ -29,12 +29,10 @@ import org.web3j.protocol.core.methods.response.EthBlock;
 import tech.pegasys.teku.ethereum.executionclient.ExecutionEngineClient;
 import tech.pegasys.teku.ethereum.executionclient.schema.BlobsBundleV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV1;
-import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV2;
 import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceStateV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceUpdatedResult;
 import tech.pegasys.teku.ethereum.executionclient.schema.GetPayloadV2Response;
 import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV1;
-import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV2;
 import tech.pegasys.teku.ethereum.executionclient.schema.PayloadStatusV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.Response;
 import tech.pegasys.teku.ethereum.executionclient.schema.TransitionConfigurationV1;
@@ -130,7 +128,7 @@ public class Web3JExecutionEngineClient implements ExecutionEngineClient {
 
   @Override
   public SafeFuture<Response<PayloadStatusV1>> newPayloadV2(
-      final ExecutionPayloadV2 executionPayload) {
+      final ExecutionPayloadV1 executionPayload) {
     Request<?, PayloadStatusV1Web3jResponse> web3jRequest =
         new Request<>(
             "engine_newPayloadV2",
@@ -155,7 +153,7 @@ public class Web3JExecutionEngineClient implements ExecutionEngineClient {
   @Override
   public SafeFuture<Response<ForkChoiceUpdatedResult>> forkChoiceUpdatedV2(
       final ForkChoiceStateV1 forkChoiceState,
-      final Optional<PayloadAttributesV2> payloadAttributes) {
+      final Optional<PayloadAttributesV1> payloadAttributes) {
     Request<?, ForkChoiceUpdatedResultWeb3jResponse> web3jRequest =
         new Request<>(
             "engine_forkchoiceUpdatedV2",
@@ -182,9 +180,6 @@ public class Web3JExecutionEngineClient implements ExecutionEngineClient {
 
   static class GetPayloadV2Web3jResponse
       extends org.web3j.protocol.core.Response<GetPayloadV2Response> {}
-
-  static class ExecutionPayloadV2Web3jResponse
-      extends org.web3j.protocol.core.Response<ExecutionPayloadV2> {}
 
   static class BlobsBundleV1Web3jResponse extends org.web3j.protocol.core.Response<BlobsBundleV1> {}
 

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/CapellaExecutionClientHandler.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/CapellaExecutionClientHandler.java
@@ -21,7 +21,6 @@ import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV2;
 import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceStateV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceUpdatedResult;
-import tech.pegasys.teku.ethereum.executionclient.schema.GetPayloadV2Response;
 import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV2;
 import tech.pegasys.teku.ethereum.executionclient.schema.PayloadStatusV1;
@@ -56,7 +55,15 @@ public class CapellaExecutionClientHandler extends BellatrixExecutionClientHandl
     return executionEngineClient
         .getPayloadV2(executionPayloadContext.getPayloadId())
         .thenApply(ResponseUnwrapper::unwrapExecutionClientResponseOrThrow)
-        .thenApply(response -> getExecutionPayloadWithValue(response, slot))
+        .thenApply(
+            response -> {
+              final ExecutionPayloadSchema<?> payloadSchema =
+                  SchemaDefinitionsBellatrix.required(spec.atSlot(slot).getSchemaDefinitions())
+                      .getExecutionPayloadSchema();
+              return new ExecutionPayloadWithValue(
+                  response.executionPayload.asInternalExecutionPayload(payloadSchema),
+                  response.blockValue);
+            })
         .thenPeek(
             payloadAndValue ->
                 LOG.trace(
@@ -64,20 +71,6 @@ public class CapellaExecutionClientHandler extends BellatrixExecutionClientHandl
                     executionPayloadContext.getPayloadId(),
                     slot,
                     payloadAndValue));
-  }
-
-  private ExecutionPayloadWithValue getExecutionPayloadWithValue(
-      final GetPayloadV2Response response, final UInt64 slot) {
-    final ExecutionPayloadSchema<?> payloadSchema =
-        SchemaDefinitionsBellatrix.required(spec.atSlot(slot).getSchemaDefinitions())
-            .getExecutionPayloadSchema();
-
-    if (spec.atSlot(slot).getMilestone().isGreaterThanOrEqualTo(SpecMilestone.CAPELLA)) {
-      return new ExecutionPayloadWithValue(
-          response.executionPayload.asInternalExecutionPayload(payloadSchema), response.blockValue);
-    }
-    return new ExecutionPayloadWithValue(
-        response.executionPayload.asInternalExecutionPayload(payloadSchema), response.blockValue);
   }
 
   @Override

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/CapellaExecutionClientHandler.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/CapellaExecutionClientHandler.java
@@ -48,9 +48,6 @@ public class CapellaExecutionClientHandler extends BellatrixExecutionClientHandl
   @Override
   public SafeFuture<ExecutionPayloadWithValue> engineGetPayload(
       final ExecutionPayloadContext executionPayloadContext, final UInt64 slot) {
-    if (!spec.atSlot(slot).getMilestone().isGreaterThanOrEqualTo(SpecMilestone.CAPELLA)) {
-      return super.engineGetPayload(executionPayloadContext, slot);
-    }
     LOG.trace(
         "calling engineGetPayloadV2(payloadId={}, slot={})",
         executionPayloadContext.getPayloadId(),

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/BellatrixExecutionClientHandlerTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/BellatrixExecutionClientHandlerTest.java
@@ -93,7 +93,8 @@ class BellatrixExecutionClientHandlerTest extends ExecutionHandlerClientTest {
             dataStructureUtil.randomBytes32(),
             dataStructureUtil.randomEth1Address(),
             Optional.empty(),
-            Optional.empty());
+            Optional.empty(),
+            dataStructureUtil.randomUInt64());
     final Optional<PayloadAttributesV1> payloadAttributes =
         PayloadAttributesV1.fromInternalPayloadBuildingAttributes(Optional.of(attributes));
     final SafeFuture<Response<ForkChoiceUpdatedResult>> dummyResponse =

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/CapellaExecutionClientHandlerTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/CapellaExecutionClientHandlerTest.java
@@ -25,6 +25,7 @@ import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV2;
 import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceStateV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceUpdatedResult;
 import tech.pegasys.teku.ethereum.executionclient.schema.GetPayloadV2Response;
+import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV2;
 import tech.pegasys.teku.ethereum.executionclient.schema.PayloadStatusV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.Response;
@@ -99,8 +100,9 @@ public class CapellaExecutionClientHandlerTest extends ExecutionHandlerClientTes
             dataStructureUtil.randomBytes32(),
             dataStructureUtil.randomEth1Address(),
             Optional.empty(),
-            Optional.of(List.of()));
-    final Optional<PayloadAttributesV2> payloadAttributes =
+            Optional.of(List.of()),
+            dataStructureUtil.randomUInt64());
+    final Optional<PayloadAttributesV1> payloadAttributes =
         PayloadAttributesV2.fromInternalPayloadBuildingAttributesV2(Optional.of(attributes));
     final SafeFuture<Response<ForkChoiceUpdatedResult>> dummyResponse =
         SafeFuture.completedFuture(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/PayloadBuildingAttributes.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/PayloadBuildingAttributes.java
@@ -32,17 +32,21 @@ public class PayloadBuildingAttributes {
 
   private final Optional<List<Withdrawal>> maybeWithdrawals;
 
+  private final UInt64 blockSlot;
+
   public PayloadBuildingAttributes(
       final UInt64 timestamp,
       final Bytes32 prevRandao,
       final Eth1Address feeRecipient,
       final Optional<SignedValidatorRegistration> validatorRegistration,
-      final Optional<List<Withdrawal>> maybeWithdrawals) {
+      final Optional<List<Withdrawal>> maybeWithdrawals,
+      final UInt64 blockSlot) {
     this.timestamp = timestamp;
     this.prevRandao = prevRandao;
     this.feeRecipient = feeRecipient;
     this.validatorRegistration = validatorRegistration;
     this.maybeWithdrawals = maybeWithdrawals;
+    this.blockSlot = blockSlot;
   }
 
   public UInt64 getTimestamp() {
@@ -55,6 +59,10 @@ public class PayloadBuildingAttributes {
 
   public Eth1Address getFeeRecipient() {
     return feeRecipient;
+  }
+
+  public UInt64 getBlockSlot() {
+    return blockSlot;
   }
 
   public Optional<SignedValidatorRegistration> getValidatorRegistration() {

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -1436,7 +1436,8 @@ public final class DataStructureUtil {
         withValidatorRegistration
             ? Optional.of(randomSignedValidatorRegistration())
             : Optional.empty(),
-        randomWithdrawalList());
+        randomWithdrawalList(),
+        randomUInt64());
   }
 
   public BeaconPreparableProposer randomBeaconPreparableProposer() {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ProposersDataManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ProposersDataManager.java
@@ -232,7 +232,8 @@ public class ProposersDataManager implements SlotEventsChannel {
             random,
             getFeeRecipient(proposerInfo, blockSlot),
             validatorRegistration,
-            spec.getExpectedWithdrawals(state)));
+            spec.getExpectedWithdrawals(state),
+            blockSlot));
   }
 
   // this function MUST return a fee recipient.

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
@@ -954,7 +954,8 @@ class ForkChoiceNotifierTest {
         random,
         feeRecipient,
         validatorRegistration,
-        dataStructureUtil.randomWithdrawalList());
+        dataStructureUtil.randomWithdrawalList(),
+        blockSlot);
   }
 
   private ForkChoiceState getCurrentForkChoiceState() {


### PR DESCRIPTION
Basically if capella is active, we can call FcU and newPayloadV2 straight away, just with v1 structures.  This is much simpler than falling back to v1 functions, requiring less context about genesis time etc.

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
