### PR TITLE
Implement forward multipeer sync for EIP-4844

### DIFF
--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/DefaultSyncServiceFactory.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/DefaultSyncServiceFactory.java
@@ -159,6 +159,7 @@ public class DefaultSyncServiceFactory implements SyncServiceFactory {
               pendingBlocks,
               p2pNetwork,
               blockImporter,
+              blobsSidecarManager,
               spec);
     } else {
       LOG.info("Using single peer sync");

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/BatchImporter.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/BatchImporter.java
@@ -16,27 +16,37 @@ package tech.pegasys.teku.beacon.sync.forward.multipeer;
 import static com.google.common.base.Preconditions.checkState;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.beacon.sync.forward.multipeer.batches.Batch;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.peers.SyncSource;
 import tech.pegasys.teku.networking.p2p.peer.DisconnectReason;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.execution.versions.eip4844.BlobsSidecar;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
+import tech.pegasys.teku.statetransition.blobs.BlobsSidecarManager;
 import tech.pegasys.teku.statetransition.block.BlockImporter;
 
 public class BatchImporter {
   private static final Logger LOG = LogManager.getLogger();
 
   private final BlockImporter blockImporter;
+  private final BlobsSidecarManager blobsSidecarManager;
   private final AsyncRunner asyncRunner;
 
-  public BatchImporter(final BlockImporter blockImporter, final AsyncRunner asyncRunner) {
+  public BatchImporter(
+      final BlockImporter blockImporter,
+      final BlobsSidecarManager blobsSidecarManager,
+      final AsyncRunner asyncRunner) {
     this.blockImporter = blockImporter;
+    this.blobsSidecarManager = blobsSidecarManager;
     this.asyncRunner = asyncRunner;
   }
 
@@ -51,20 +61,29 @@ public class BatchImporter {
   public SafeFuture<BatchImportResult> importBatch(final Batch batch) {
     // Copy the data from batch as we're going to use them from off the event thread.
     final List<SignedBeaconBlock> blocks = new ArrayList<>(batch.getBlocks());
+    final Map<UInt64, BlobsSidecar> blobsSidecarsBySlot =
+        new HashMap<>(batch.getBlobsSidecarsBySlot());
     final Optional<SyncSource> source = batch.getSource();
 
     checkState(!blocks.isEmpty(), "Batch has no blocks to import");
     return asyncRunner.runAsync(
         () -> {
+          final SignedBeaconBlock firstBlock = blocks.get(0);
           SafeFuture<BlockImportResult> importResult =
-              importBlock(blocks.get(0), source.orElseThrow());
+              storeBlobsSidecarAndImportBlock(
+                  Optional.ofNullable(blobsSidecarsBySlot.get(firstBlock.getSlot())),
+                  firstBlock,
+                  source.orElseThrow());
           for (int i = 1; i < blocks.size(); i++) {
             final SignedBeaconBlock block = blocks.get(i);
             importResult =
                 importResult.thenCompose(
                     previousResult -> {
                       if (previousResult.isSuccessful()) {
-                        return importBlock(block, source.orElseThrow());
+                        return storeBlobsSidecarAndImportBlock(
+                            Optional.ofNullable(blobsSidecarsBySlot.get(block.getSlot())),
+                            block,
+                            source.orElseThrow());
                       } else {
                         return SafeFuture.completedFuture(previousResult);
                       }
@@ -87,8 +106,11 @@ public class BatchImporter {
         });
   }
 
-  private SafeFuture<BlockImportResult> importBlock(
-      final SignedBeaconBlock block, final SyncSource source) {
+  private SafeFuture<BlockImportResult> storeBlobsSidecarAndImportBlock(
+      final Optional<BlobsSidecar> blobsSidecar,
+      final SignedBeaconBlock block,
+      final SyncSource source) {
+    blobsSidecar.ifPresent(blobsSidecarManager::storeUnconfirmedBlobsSidecar);
     return blockImporter
         .importBlock(block)
         .thenApply(

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/MultipeerSyncService.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/MultipeerSyncService.java
@@ -37,6 +37,7 @@ import tech.pegasys.teku.service.serviceutils.Service;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.config.Constants;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.statetransition.blobs.BlobsSidecarManager;
 import tech.pegasys.teku.statetransition.block.BlockImporter;
 import tech.pegasys.teku.statetransition.util.PendingPool;
 import tech.pegasys.teku.storage.client.RecentChainData;
@@ -70,6 +71,7 @@ public class MultipeerSyncService extends Service implements ForwardSyncService 
       final PendingPool<SignedBeaconBlock> pendingBlocks,
       final P2PNetwork<Eth2Peer> p2pNetwork,
       final BlockImporter blockImporter,
+      final BlobsSidecarManager blobsSidecarManager,
       final Spec spec) {
     final EventThread eventThread = new AsyncRunnerEventThread("sync", asyncRunnerFactory);
     final SettableLabelledGauge targetChainCountGauge =
@@ -87,8 +89,9 @@ public class MultipeerSyncService extends Service implements ForwardSyncService 
             eventThread,
             asyncRunner,
             recentChainData,
-            new BatchImporter(blockImporter, asyncRunner),
-            new BatchFactory(eventThread, new PeerScoringConflictResolutionStrategy()),
+            new BatchImporter(blockImporter, blobsSidecarManager, asyncRunner),
+            new BatchFactory(
+                eventThread, new PeerScoringConflictResolutionStrategy(), blobsSidecarManager),
             Constants.SYNC_BATCH_SIZE,
             MultipeerCommonAncestorFinder.create(recentChainData, eventThread, spec),
             timeProvider);

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/Batch.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/Batch.java
@@ -14,11 +14,13 @@
 package tech.pegasys.teku.beacon.sync.forward.multipeer.batches;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import tech.pegasys.teku.beacon.sync.forward.multipeer.chains.TargetChain;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.peers.SyncSource;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.execution.versions.eip4844.BlobsSidecar;
 
 /** A section of a particular target chain that can be downloaded in parallel. */
 public interface Batch {
@@ -33,6 +35,8 @@ public interface Batch {
   Optional<SignedBeaconBlock> getLastBlock();
 
   List<SignedBeaconBlock> getBlocks();
+
+  Map<UInt64, BlobsSidecar> getBlobsSidecarsBySlot();
 
   Optional<SyncSource> getSource();
 

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/BatchFactory.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/BatchFactory.java
@@ -16,15 +16,21 @@ package tech.pegasys.teku.beacon.sync.forward.multipeer.batches;
 import tech.pegasys.teku.beacon.sync.forward.multipeer.chains.TargetChain;
 import tech.pegasys.teku.infrastructure.async.eventthread.EventThread;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.statetransition.blobs.BlobsSidecarManager;
 
 public class BatchFactory {
+
   private final EventThread eventThread;
   private final ConflictResolutionStrategy conflictResolutionStrategy;
+  private final BlobsSidecarManager blobsSidecarManager;
 
   public BatchFactory(
-      final EventThread eventThread, final ConflictResolutionStrategy conflictResolutionStrategy) {
+      final EventThread eventThread,
+      final ConflictResolutionStrategy conflictResolutionStrategy,
+      final BlobsSidecarManager blobsSidecarManager) {
     this.eventThread = eventThread;
     this.conflictResolutionStrategy = conflictResolutionStrategy;
+    this.blobsSidecarManager = blobsSidecarManager;
   }
 
   public Batch createBatch(final TargetChain chain, final UInt64 start, final UInt64 count) {
@@ -33,6 +39,12 @@ public class BatchFactory {
     return new EventThreadOnlyBatch(
         eventThread,
         new SyncSourceBatch(
-            eventThread, syncSourceProvider, conflictResolutionStrategy, chain, start, count));
+            eventThread,
+            syncSourceProvider,
+            conflictResolutionStrategy,
+            chain,
+            blobsSidecarManager,
+            start,
+            count));
   }
 }

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/EventThreadOnlyBatch.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/EventThreadOnlyBatch.java
@@ -15,12 +15,14 @@ package tech.pegasys.teku.beacon.sync.forward.multipeer.batches;
 
 import com.google.common.base.MoreObjects;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import tech.pegasys.teku.beacon.sync.forward.multipeer.chains.TargetChain;
 import tech.pegasys.teku.infrastructure.async.eventthread.EventThread;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.peers.SyncSource;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.execution.versions.eip4844.BlobsSidecar;
 
 public class EventThreadOnlyBatch implements Batch {
   private final EventThread eventThread;
@@ -65,6 +67,12 @@ public class EventThreadOnlyBatch implements Batch {
   public List<SignedBeaconBlock> getBlocks() {
     eventThread.checkOnEventThread();
     return delegate.getBlocks();
+  }
+
+  @Override
+  public Map<UInt64, BlobsSidecar> getBlobsSidecarsBySlot() {
+    eventThread.checkOnEventThread();
+    return delegate.getBlobsSidecarsBySlot();
   }
 
   @Override

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/SyncSourceBatch.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/SyncSourceBatch.java
@@ -214,16 +214,20 @@ public class SyncSourceBatch implements Batch {
     }
     awaitingBlocks = true;
     final SyncSource syncSource = currentSyncSource.orElseThrow();
+
     LOG.debug(
-        "Requesting {} slots starting at {} from peer {}", remainingSlots, startSlot, syncSource);
+        "Requesting blocks for {} slots starting at {} from peer {}",
+        remainingSlots,
+        startSlot,
+        syncSource);
 
     final SafeFuture<Void> blocksRequest =
         syncSource.requestBlocksByRange(startSlot, remainingSlots, blockRequestHandler);
 
     final SafeFuture<Void> blobsSidecarsRequest;
     if (blobsSidecarManager.isStorageOfBlobsSidecarRequired(lastSlot)) {
-      LOG.trace(
-          "Requesting {} blobs sidecars starting at {} from peer {}",
+      LOG.debug(
+          "Requesting blobs sidecars for {} slots starting at {} from peer {}",
           remainingSlots,
           startSlot,
           syncSource);

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/BatchImporterTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/BatchImporterTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.async.FutureUtil.ignoreFuture;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -38,21 +39,25 @@ import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.statetransition.blobs.BlobsSidecarManager;
 import tech.pegasys.teku.statetransition.block.BlockImporter;
 
 class BatchImporterTest {
   private final DataStructureUtil dataStructureUtil =
       new DataStructureUtil(TestSpecFactory.createDefault());
   private final BlockImporter blockImporter = mock(BlockImporter.class);
+  private final BlobsSidecarManager blobsSidecarManager = mock(BlobsSidecarManager.class);
   private final StubAsyncRunner asyncRunner = new StubAsyncRunner();
   private final Batch batch = mock(Batch.class);
   final SyncSource syncSource = mock(SyncSource.class);
 
-  private final BatchImporter importer = new BatchImporter(blockImporter, asyncRunner);
+  private final BatchImporter importer =
+      new BatchImporter(blockImporter, blobsSidecarManager, asyncRunner);
 
   @BeforeEach
   public void setup() {
     when(batch.getSource()).thenReturn(Optional.of(syncSource));
+    when(batch.getBlobsSidecarsBySlot()).thenReturn(Collections.emptyMap());
   }
 
   @Test
@@ -74,8 +79,10 @@ class BatchImporterTest {
     // Should not be started on the calling thread
     verifyNoInteractions(blockImporter);
 
-    // We should have copied the blocks to avoid accessing the Batch data from other threads
+    // We should have copied the blocks and blobs sidecars to avoid accessing the Batch data from
+    // other threads
     verify(batch).getBlocks();
+    verify(batch).getBlobsSidecarsBySlot();
     verify(batch).getSource();
     blocks.clear();
 

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/SyncSourceBatchTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/SyncSourceBatchTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.beacon.sync.forward.multipeer.batches.BatchAssert.assertThatBatch;
 import static tech.pegasys.teku.beacon.sync.forward.multipeer.chains.TargetChainTestUtil.chainWith;
 
@@ -30,6 +31,7 @@ import java.util.Map;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import tech.pegasys.teku.beacon.sync.forward.multipeer.chains.TargetChain;
 import tech.pegasys.teku.infrastructure.async.eventthread.InlineEventThread;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -40,13 +42,14 @@ import tech.pegasys.teku.networking.p2p.peer.PeerDisconnectedException;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
+import tech.pegasys.teku.spec.datastructures.execution.versions.eip4844.BlobsSidecar;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.blobs.BlobsSidecarManager;
 
 public class SyncSourceBatchTest {
 
   private final DataStructureUtil dataStructureUtil =
-      new DataStructureUtil(TestSpecFactory.createDefault());
+      new DataStructureUtil(TestSpecFactory.createMinimalEip4844());
   private final TargetChain targetChain =
       chainWith(new SlotAndBlockRoot(UInt64.valueOf(1000), Bytes32.ZERO));
   private final InlineEventThread eventThread = new InlineEventThread();
@@ -119,6 +122,43 @@ public class SyncSourceBatchTest {
     final StubSyncSource secondSyncSource = getSyncSource(batch);
     assertThat(secondSyncSource).isNotSameAs(firstSyncSource);
     secondSyncSource.assertRequestedBlocks(70, 50);
+  }
+
+  @Test
+  void requestMoreBlocks_shouldRequestSidecarsIfRequired() {
+    final Runnable callback = mock(Runnable.class);
+    final ArgumentCaptor<UInt64> lastSlotArgumentCaptor = ArgumentCaptor.forClass(UInt64.class);
+    when(blobsSidecarManager.isStorageOfBlobsSidecarRequired(lastSlotArgumentCaptor.capture()))
+        .thenReturn(true);
+
+    final Batch batch = createBatch(70, 50);
+
+    batch.requestMoreBlocks(callback);
+    verifyNoInteractions(callback);
+
+    final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(75);
+    final BlobsSidecar blobsSidecar = dataStructureUtil.randomBlobsSidecarForBlock(block);
+
+    receiveBlocks(batch, block);
+    receiveBlobsSidecars(batch, blobsSidecar);
+
+    verify(callback).run();
+    batch.markFirstBlockConfirmed();
+    batch.markAsContested();
+
+    final Map<UInt64, BlobsSidecar> blobsSidecars = batch.getBlobsSidecarsBySlot();
+
+    // verify sidecars are cached
+    assertThat(blobsSidecars).hasSize(1);
+    assertThat(blobsSidecars.get(UInt64.valueOf(75))).isEqualTo(blobsSidecar);
+    assertThat(batch.getBlocks()).containsExactly(block);
+
+    batch.requestMoreBlocks(callback);
+    getSyncSource(batch).assertRequestedBlocks(76, 44);
+    getSyncSource(batch).assertRequestedBlobsSidecars(76, 44);
+
+    assertThat(lastSlotArgumentCaptor.getAllValues())
+        .containsExactly(UInt64.valueOf(119), UInt64.valueOf(119));
   }
 
   @Test
@@ -234,6 +274,10 @@ public class SyncSourceBatchTest {
 
   protected void receiveBlocks(final Batch batch, final SignedBeaconBlock... blocks) {
     getSyncSource(batch).receiveBlocks(blocks);
+  }
+
+  protected void receiveBlobsSidecars(final Batch batch, final BlobsSidecar... blobsSidecars) {
+    getSyncSource(batch).receiveBlobsSidecars(blobsSidecars);
   }
 
   protected void requestError(final Batch batch, final Throwable error) {

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/SyncSourceBatchTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/SyncSourceBatchTest.java
@@ -41,6 +41,7 @@ import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.statetransition.blobs.BlobsSidecarManager;
 
 public class SyncSourceBatchTest {
 
@@ -51,6 +52,7 @@ public class SyncSourceBatchTest {
   private final InlineEventThread eventThread = new InlineEventThread();
   private final ConflictResolutionStrategy conflictResolutionStrategy =
       mock(ConflictResolutionStrategy.class);
+  private final BlobsSidecarManager blobsSidecarManager = mock(BlobsSidecarManager.class);
   private final Map<Batch, List<StubSyncSource>> syncSources = new HashMap<>();
 
   @Test
@@ -194,6 +196,7 @@ public class SyncSourceBatchTest {
             emptySourceSelector,
             conflictResolutionStrategy,
             targetChain,
+            blobsSidecarManager,
             UInt64.ONE,
             UInt64.ONE);
 
@@ -222,6 +225,7 @@ public class SyncSourceBatchTest {
             syncSourceProvider,
             conflictResolutionStrategy,
             targetChain,
+            blobsSidecarManager,
             UInt64.valueOf(startSlot),
             UInt64.valueOf(count));
     this.syncSources.put(batch, syncSources);

--- a/beacon/sync/src/testFixtures/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/StubBatchFactory.java
+++ b/beacon/sync/src/testFixtures/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/StubBatchFactory.java
@@ -29,6 +29,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.peers.StubSyncSource;
 import tech.pegasys.teku.networking.eth2.peers.SyncSource;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.statetransition.blobs.BlobsSidecarManager;
 
 public class StubBatchFactory extends BatchFactory implements Iterable<Batch> {
   private final List<Batch> batches = new ArrayList<>();
@@ -37,8 +38,8 @@ public class StubBatchFactory extends BatchFactory implements Iterable<Batch> {
   private final EventThread eventThread;
   private final boolean enforceEventThread;
 
-  public StubBatchFactory(final EventThread eventThread, final boolean enforceEventThread) {
-    super(eventThread, null);
+  public StubBatchFactory(final EventThread eventThread, boolean enforceEventThread) {
+    super(eventThread, null, BlobsSidecarManager.NOOP);
     this.eventThread = eventThread;
     this.enforceEventThread = enforceEventThread;
   }
@@ -121,7 +122,9 @@ public class StubBatchFactory extends BatchFactory implements Iterable<Batch> {
         final TargetChain chain,
         final UInt64 start,
         final UInt64 count) {
-      batch = new SyncSourceBatch(eventThread, this, this, chain, start, count);
+      batch =
+          new SyncSourceBatch(
+              eventThread, this, this, chain, BlobsSidecarManager.NOOP, start, count);
       eventThreadOnlyBatch = new EventThreadOnlyBatch(eventThread, batch);
     }
 


### PR DESCRIPTION
## PR Description

- Modified `SyncSourceBatch` to cache the blobs sidecars for a batch
- Modified `BatchImported` to store blobs sidecars ahead of block import

Tested syncing to mainnet with stub EL, so current flow seems not affected.

## Fixed Issue(s)
fixes #6669 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
