### PR TITLE
SSZ serialization of LightClientUpdate

### DIFF
--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_beacon_light_client_updates.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_beacon_light_client_updates.json
@@ -51,6 +51,12 @@
                 }
               }
             }
+          },
+          "application/octet-stream" : {
+            "schema" : {
+              "type" : "string",
+              "format" : "binary"
+            }
           }
         }
       },

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/lightclient/GetLightClientUpdatesByRangeTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/lightclient/GetLightClientUpdatesByRangeTest.java
@@ -19,6 +19,7 @@ import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_INTERNAL_
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_NOT_ACCEPTABLE;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_NOT_IMPLEMENTED;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
+import static tech.pegasys.teku.infrastructure.restapi.MetadataTestUtil.getResponseSszFromMetadata;
 import static tech.pegasys.teku.infrastructure.restapi.MetadataTestUtil.getResponseStringFromMetadata;
 import static tech.pegasys.teku.infrastructure.restapi.MetadataTestUtil.verifyMetadataErrorResponse;
 
@@ -34,6 +35,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.lightclient.LightClientUpdate;
+import tech.pegasys.teku.spec.datastructures.lightclient.LightClientUpdateResponse;
 import tech.pegasys.teku.spec.datastructures.metadata.ObjectAndMetaData;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
@@ -48,7 +50,7 @@ public class GetLightClientUpdatesByRangeTest extends AbstractMigratedBeaconHand
   }
 
   @Test
-  void metadata_shouldHandle200() throws IOException {
+  void metadata_shouldHandleJson200() throws IOException {
     LightClientUpdate lightClientUpdate = dataStructureUtil.randomLightClientUpdate(UInt64.ONE);
     ObjectAndMetaData<LightClientUpdate> responseData =
         new ObjectAndMetaData<>(lightClientUpdate, SpecMilestone.ALTAIR, false, true, false);
@@ -61,6 +63,18 @@ public class GetLightClientUpdatesByRangeTest extends AbstractMigratedBeaconHand
                 GetLightClientBootstrapTest.class, "getLightClientUpdatesByRange.json"),
             StandardCharsets.UTF_8);
     assertThat(data).isEqualTo(expected);
+  }
+
+  @Test
+  void metadata_shouldHandleSsz200() throws IOException {
+    LightClientUpdateResponse responseData =
+        dataStructureUtil.randomLightClientUpdateResponse(UInt64.ONE);
+    List<LightClientUpdateResponse> response = List.of(responseData);
+
+    final byte[] actual = getResponseSszFromMetadata(handler, SC_OK, response);
+    final byte[] expected = responseData.sszSerialize().toArray();
+
+    assertThat(actual).isEqualTo(expected);
   }
 
   @Test

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/lightclient/LightClientUpdateResponse.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/lightclient/LightClientUpdateResponse.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright ConsenSys Software Inc., 2023
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.lightclient;
+
+import tech.pegasys.teku.infrastructure.ssz.containers.Container3;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszBytes4;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+
+public class LightClientUpdateResponse
+    extends Container3<LightClientUpdateResponse, SszUInt64, SszBytes4, LightClientUpdate> {
+
+  public LightClientUpdateResponse(
+      final LightClientUpdateResponseSchema schema,
+      final SszUInt64 responseChunkLen,
+      final SszBytes4 context,
+      final LightClientUpdate lightClientUpdate) {
+    super(schema, responseChunkLen, context, lightClientUpdate);
+  }
+
+  protected LightClientUpdateResponse(
+      final LightClientUpdateResponseSchema type, final TreeNode backingNode) {
+    super(type, backingNode);
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/lightclient/LightClientUpdateResponse.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/lightclient/LightClientUpdateResponse.java
@@ -25,8 +25,8 @@ public class LightClientUpdateResponse
       final LightClientUpdateResponseSchema schema,
       final SszUInt64 responseChunkLen,
       final SszBytes4 context,
-      final LightClientUpdate lightClientUpdate) {
-    super(schema, responseChunkLen, context, lightClientUpdate);
+      final LightClientUpdate payload) {
+    super(schema, responseChunkLen, context, payload);
   }
 
   protected LightClientUpdateResponse(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/lightclient/LightClientUpdateResponseSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/lightclient/LightClientUpdateResponseSchema.java
@@ -32,8 +32,8 @@ public class LightClientUpdateResponseSchema
   }
 
   public LightClientUpdateResponse create(
-      SszUInt64 responseChunkLen, SszBytes4 context, LightClientUpdate lightClientUpdate) {
-    return new LightClientUpdateResponse(this, responseChunkLen, context, lightClientUpdate);
+      SszUInt64 responseChunkLen, SszBytes4 context, LightClientUpdate payload) {
+    return new LightClientUpdateResponse(this, responseChunkLen, context, payload);
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/lightclient/LightClientUpdateResponseSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/lightclient/LightClientUpdateResponseSchema.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright ConsenSys Software Inc., 2023
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.lightclient;
+
+import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema3;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszBytes4;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+import tech.pegasys.teku.spec.config.SpecConfigAltair;
+
+public class LightClientUpdateResponseSchema
+    extends ContainerSchema3<LightClientUpdateResponse, SszUInt64, SszBytes4, LightClientUpdate> {
+
+  public LightClientUpdateResponseSchema(final SpecConfigAltair specConfigAltair) {
+    super(
+        "LightClientUpdateResponse",
+        namedSchema("response_chunk_len", SszPrimitiveSchemas.UINT64_SCHEMA),
+        namedSchema("context", SszPrimitiveSchemas.BYTES4_SCHEMA),
+        namedSchema("payload", new LightClientUpdateSchema(specConfigAltair)));
+  }
+
+  public LightClientUpdateResponse create(
+      SszUInt64 responseChunkLen, SszBytes4 context, LightClientUpdate lightClientUpdate) {
+    return new LightClientUpdateResponse(this, responseChunkLen, context, lightClientUpdate);
+  }
+
+  @Override
+  public LightClientUpdateResponse createFromBackingNode(TreeNode node) {
+    return new LightClientUpdateResponse(this, node);
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsAltair.java
@@ -23,6 +23,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.Be
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.BeaconBlockBodySchemaAltairImpl;
 import tech.pegasys.teku.spec.datastructures.lightclient.LightClientBootstrapSchema;
 import tech.pegasys.teku.spec.datastructures.lightclient.LightClientHeaderSchema;
+import tech.pegasys.teku.spec.datastructures.lightclient.LightClientUpdateResponseSchema;
 import tech.pegasys.teku.spec.datastructures.lightclient.LightClientUpdateSchema;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.metadata.versions.altair.MetadataMessageSchemaAltair;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.ContributionAndProofSchema;
@@ -47,6 +48,7 @@ public class SchemaDefinitionsAltair extends AbstractSchemaDefinitions {
   private final LightClientHeaderSchema lightClientHeaderSchema;
   private final LightClientBootstrapSchema lightClientBootstrapSchema;
   private final LightClientUpdateSchema lightClientUpdateSchema;
+  private final LightClientUpdateResponseSchema lightClientUpdateResponseSchema;
 
   public SchemaDefinitionsAltair(final SpecConfigAltair specConfig) {
     super(specConfig);
@@ -66,6 +68,7 @@ public class SchemaDefinitionsAltair extends AbstractSchemaDefinitions {
     this.lightClientHeaderSchema = new LightClientHeaderSchema();
     this.lightClientBootstrapSchema = new LightClientBootstrapSchema(specConfig);
     this.lightClientUpdateSchema = new LightClientUpdateSchema(specConfig);
+    this.lightClientUpdateResponseSchema = new LightClientUpdateResponseSchema(specConfig);
   }
 
   public static SchemaDefinitionsAltair required(final SchemaDefinitions schemaDefinitions) {
@@ -153,5 +156,9 @@ public class SchemaDefinitionsAltair extends AbstractSchemaDefinitions {
 
   public LightClientUpdateSchema getLightClientUpdateSchema() {
     return lightClientUpdateSchema;
+  }
+
+  public LightClientUpdateResponseSchema getLightClientUpdateResponseSchema() {
+    return lightClientUpdateResponseSchema;
   }
 }

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -61,6 +61,7 @@ import tech.pegasys.teku.infrastructure.ssz.collections.SszPrimitiveVector;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszUInt64List;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszByte;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszBytes32;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszBytes4;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszListSchema;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszVectorSchema;
@@ -115,6 +116,8 @@ import tech.pegasys.teku.spec.datastructures.lightclient.LightClientBootstrap;
 import tech.pegasys.teku.spec.datastructures.lightclient.LightClientBootstrapSchema;
 import tech.pegasys.teku.spec.datastructures.lightclient.LightClientHeaderSchema;
 import tech.pegasys.teku.spec.datastructures.lightclient.LightClientUpdate;
+import tech.pegasys.teku.spec.datastructures.lightclient.LightClientUpdateResponse;
+import tech.pegasys.teku.spec.datastructures.lightclient.LightClientUpdateResponseSchema;
 import tech.pegasys.teku.spec.datastructures.lightclient.LightClientUpdateSchema;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.EnrForkId;
 import tech.pegasys.teku.spec.datastructures.operations.AggregateAndProof;
@@ -1747,6 +1750,14 @@ public final class DataStructureUtil {
         randomSszBytes32Vector(schema.getFinalityBranchSchema(), this::randomBytes32),
         randomSyncAggregate(),
         SszUInt64.of(randomUInt64()));
+  }
+
+  public LightClientUpdateResponse randomLightClientUpdateResponse(final UInt64 slot) {
+    LightClientUpdateResponseSchema schema =
+        getAltairSchemaDefinitions(slot).getLightClientUpdateResponseSchema();
+
+    return schema.create(
+        SszUInt64.of(randomUInt64()), SszBytes4.of(randomBytes4()), randomLightClientUpdate(slot));
   }
 
   public Withdrawal randomWithdrawal() {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
The SSZ serialization of the endpoint `GetLightClientUpdatesByRange` has a custom octet encoding defined [here](https://github.com/ethereum/beacon-APIs/blob/master/apis/beacon/light_client/updates.yaml#L37). This PR implements the serialization.

Note that the SSZ object is simply used for convenience, and the field names are irrelevant as it should only be used for the `application/octet-stream` response type.

## Fixed Issue(s)
partially addresses #4230 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
