### PR TITLE
Eip4844 Execution Layer Stub + bugfix  + BlockPublisher improvements

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/AbstractBlockPublisher.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/AbstractBlockPublisher.java
@@ -50,7 +50,8 @@ public abstract class AbstractBlockPublisher implements BlockPublisher {
   public SafeFuture<SendSignedBlockResult> sendSignedBlock(SignedBeaconBlock maybeBlindedBlock) {
     return blockFactory
         .unblindSignedBeaconBlockIfBlinded(maybeBlindedBlock)
-        .thenCompose(this::importUnblindedSignedBlock)
+        .thenPeek(performanceTracker::saveProducedBlock)
+        .thenCompose(this::gossipAndImportUnblindedSignedBlock)
         .thenApply(
             result -> {
               if (result.isSuccessful()) {
@@ -76,5 +77,6 @@ public abstract class AbstractBlockPublisher implements BlockPublisher {
             });
   }
 
-  abstract SafeFuture<BlockImportResult> importUnblindedSignedBlock(final SignedBeaconBlock block);
+  abstract SafeFuture<BlockImportResult> gossipAndImportUnblindedSignedBlock(
+      final SignedBeaconBlock block);
 }

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisherEip4844.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisherEip4844.java
@@ -38,9 +38,8 @@ public class BlockPublisherEip4844 extends AbstractBlockPublisher {
   }
 
   @Override
-  protected SafeFuture<BlockImportResult> importUnblindedSignedBlock(
+  protected SafeFuture<BlockImportResult> gossipAndImportUnblindedSignedBlock(
       final SignedBeaconBlock block) {
-    performanceTracker.saveProducedBlock(block);
     final SafeFuture<SignedBeaconBlockAndBlobsSidecar> blockAndBlobsSidecarSafeFuture =
         blockFactory.supplementBlockWithSidecar(block);
     return blockAndBlobsSidecarSafeFuture

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisherPhase0.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisherPhase0.java
@@ -37,9 +37,8 @@ public class BlockPublisherPhase0 extends AbstractBlockPublisher {
   }
 
   @Override
-  protected SafeFuture<BlockImportResult> importUnblindedSignedBlock(
+  protected SafeFuture<BlockImportResult> gossipAndImportUnblindedSignedBlock(
       final SignedBeaconBlock block) {
-    performanceTracker.saveProducedBlock(block);
     blockGossipChannel.publishBlock(block);
     return blockImportChannel.importBlock(block, Optional.empty());
   }

--- a/ethereum/spec/build.gradle
+++ b/ethereum/spec/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     implementation 'org.apache.tuweni:tuweni-ssz'
     implementation 'org.apache.tuweni:tuweni-ssz'
     implementation 'org.apache.tuweni:tuweni-units'
+    implementation 'tech.pegasys:jc-kzg-4844'
     implementation project(':ethereum:execution-types')
     implementation project(':ethereum:pow:api')
     implementation project(':ethereum:signingrecord')

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/util/BlobsUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/util/BlobsUtil.java
@@ -26,16 +26,18 @@ import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt256;
 import tech.pegasys.teku.infrastructure.crypto.Hash;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.kzg.KZGCommitment;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.execution.versions.eip4844.Blob;
 import tech.pegasys.teku.spec.datastructures.execution.versions.eip4844.BlobSchema;
+import tech.pegasys.teku.spec.logic.versions.eip4844.helpers.MiscHelpersEip4844;
 
 public class BlobsUtil {
   private static final int RANDOM_SEED = 5566;
   private static final Random RND = new Random(RANDOM_SEED);
 
+  // the following are raw bytes of a SignedBlobTransaction ssz object. These bytes precede the
+  // actual list of versioned hashes representing the commitments
   private static final Bytes MAGIC_BLOB_TRANSACTION_PREFIX =
       Bytes.fromHexString(
           "0x05450000000000000000000000000000000000000000000000000000000000000000"
@@ -69,12 +71,10 @@ public class BlobsUtil {
   }
 
   public List<KZGCommitment> blobsToKzgCommitments(final UInt64 slot, final List<Blob> blobs) {
-    final KZG kzg = spec.atSlot(slot).miscHelpers().getKzg().orElseThrow();
+    final MiscHelpersEip4844 miscHelpersEip4844 =
+        spec.atSlot(slot).miscHelpers().toVersionEip4844().orElseThrow();
 
-    return blobs.stream()
-        .map(Blob::getBytes)
-        .map(kzg::blobToKzgCommitment)
-        .collect(Collectors.toList());
+    return blobs.stream().map(miscHelpersEip4844::blobToKzgCommitment).collect(Collectors.toList());
   }
 
   public List<Blob> generateBlobs(final UInt64 slot, final int count) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/util/BlobsUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/util/BlobsUtil.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright ConsenSys Software Inc., 2023
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.util;
+
+import static ethereum.ckzg4844.CKZG4844JNI.BLS_MODULUS;
+import static tech.pegasys.teku.spec.config.SpecConfigEip4844.VERSIONED_HASH_VERSION_KZG;
+
+import java.math.BigInteger;
+import java.nio.ByteOrder;
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.units.bigints.UInt256;
+import tech.pegasys.teku.infrastructure.crypto.Hash;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.kzg.KZG;
+import tech.pegasys.teku.kzg.KZGCommitment;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.datastructures.execution.versions.eip4844.Blob;
+import tech.pegasys.teku.spec.datastructures.execution.versions.eip4844.BlobSchema;
+
+public class BlobsUtil {
+  private static final int RANDOM_SEED = 5566;
+  private static final Random RND = new Random(RANDOM_SEED);
+
+  private static final Bytes MAGIC_BLOB_TRANSACTION_PREFIX =
+      Bytes.fromHexString(
+          "0x05450000000000000000000000000000000000000000000000000000000000000000"
+              + "0000000000000000000000000000000000000000000000000000000000000000000000"
+              + "0000000000000000000000000000000000000000000000000000000000000000000000"
+              + "0000000000000000000000000000000000000000000000000000000000000000000000"
+              + "0000000000000000000000000000000000000000000000000000000000000000000000"
+              + "0000000000000000c00000000000000000000000000000000000000000000000000000"
+              + "000000000000000000c1000000c1000000000000000000000000000000000000000000"
+              + "0000000000000000000000000000c100000000");
+
+  private final Spec spec;
+
+  public BlobsUtil(final Spec spec) {
+    this.spec = spec;
+  }
+
+  public Bytes generateRawBlobTransactionFromKzgCommitments(
+      final List<KZGCommitment> kzgCommitments) {
+
+    Bytes blobTransaction = MAGIC_BLOB_TRANSACTION_PREFIX;
+
+    for (final KZGCommitment kzgCommitment : kzgCommitments) {
+      blobTransaction =
+          Bytes.concatenate(
+              blobTransaction,
+              VERSIONED_HASH_VERSION_KZG,
+              Hash.sha256(kzgCommitment.getBytesCompressed()).slice(1));
+    }
+    return blobTransaction;
+  }
+
+  public List<KZGCommitment> blobsToKzgCommitments(final UInt64 slot, final List<Blob> blobs) {
+    final KZG kzg = spec.atSlot(slot).miscHelpers().getKzg().orElseThrow();
+
+    return blobs.stream()
+        .map(Blob::getBytes)
+        .map(kzg::blobToKzgCommitment)
+        .collect(Collectors.toList());
+  }
+
+  public List<Blob> generateBlobs(final UInt64 slot, final int count) {
+    return IntStream.range(0, count)
+        .mapToObj(__ -> generateBlob(slot))
+        .collect(Collectors.toList());
+  }
+
+  private Blob generateBlob(final UInt64 slot) {
+    final int fieldElementsPerBlob = getFieldElementsPerBlob(slot);
+    final Bytes rawBlob =
+        IntStream.range(0, fieldElementsPerBlob)
+            .mapToObj(__ -> randomBLSFieldElement())
+            .map(fieldElement -> Bytes.wrap(fieldElement.toArray(ByteOrder.LITTLE_ENDIAN)))
+            .reduce(Bytes::wrap)
+            .orElse(Bytes.EMPTY);
+
+    return getBlobSchema(slot).create(rawBlob);
+  }
+
+  private static UInt256 randomBLSFieldElement() {
+    while (true) {
+      final BigInteger attempt = new BigInteger(BLS_MODULUS.bitLength(), RND);
+      if (attempt.compareTo(BLS_MODULUS) < 0) {
+        return UInt256.valueOf(attempt);
+      }
+    }
+  }
+
+  private int getFieldElementsPerBlob(final UInt64 slot) {
+    return spec.atSlot(slot).getConfig().toVersionEip4844().orElseThrow().getFieldElementsPerBlob();
+  }
+
+  private BlobSchema getBlobSchema(final UInt64 slot) {
+    return spec.atSlot(slot)
+        .getSchemaDefinitions()
+        .toVersionEip4844()
+        .orElseThrow()
+        .getBlobSchema();
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
@@ -21,6 +21,7 @@ import static tech.pegasys.teku.spec.logic.common.helpers.MathHelpers.uintToByte
 import com.google.common.primitives.UnsignedBytes;
 import it.unimi.dsi.fastutil.ints.IntList;
 import java.util.List;
+import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.bytes.Bytes4;
@@ -29,6 +30,7 @@ import tech.pegasys.teku.infrastructure.ssz.Merkleizable;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszByteVector;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.kzg.KZGCommitment;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.datastructures.execution.Transaction;
@@ -276,5 +278,9 @@ public class MiscHelpers {
   public boolean verifyKZGCommitmentsAgainstTransactions(
       final List<Transaction> transactions, final List<KZGCommitment> kzgCommitments) {
     return false;
+  }
+
+  public Optional<KZG> getKzg() {
+    return Optional.empty();
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
@@ -30,7 +30,6 @@ import tech.pegasys.teku.infrastructure.ssz.Merkleizable;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszByteVector;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.kzg.KZGCommitment;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.datastructures.execution.Transaction;
@@ -39,6 +38,7 @@ import tech.pegasys.teku.spec.datastructures.state.ForkData;
 import tech.pegasys.teku.spec.datastructures.state.SigningData;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateCache;
+import tech.pegasys.teku.spec.logic.versions.eip4844.helpers.MiscHelpersEip4844;
 
 public class MiscHelpers {
 
@@ -280,7 +280,7 @@ public class MiscHelpers {
     return false;
   }
 
-  public Optional<KZG> getKzg() {
+  public Optional<MiscHelpersEip4844> toVersionEip4844() {
     return Optional.empty();
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/eip4844/helpers/MiscHelpersEip4844.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/eip4844/helpers/MiscHelpersEip4844.java
@@ -151,7 +151,7 @@ public class MiscHelpersEip4844 extends MiscHelpersBellatrix {
   }
 
   @Override
-  public Optional<KZG> getKzg() {
-    return Optional.of(kzg);
+  public Optional<MiscHelpersEip4844> toVersionEip4844() {
+    return Optional.of(this);
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/eip4844/helpers/MiscHelpersEip4844.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/eip4844/helpers/MiscHelpersEip4844.java
@@ -21,6 +21,7 @@ import com.google.common.annotations.VisibleForTesting;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
@@ -149,7 +150,8 @@ public class MiscHelpersEip4844 extends MiscHelpersBellatrix {
     return kzg.computeAggregateKzgProof(blobs);
   }
 
-  public KZG getKzg() {
-    return kzg;
+  @Override
+  public Optional<KZG> getKzg() {
+    return Optional.of(kzg);
   }
 }

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -1898,7 +1898,12 @@ public final class DataStructureUtil {
   }
 
   public SignedBeaconBlockAndBlobsSidecar randomConsistentSignedBeaconBlockAndBlobsSidecar() {
-    final SignedBeaconBlock randomBlock = randomSignedBeaconBlock();
+    return randomConsistentSignedBeaconBlockAndBlobsSidecar(randomUInt64());
+  }
+
+  public SignedBeaconBlockAndBlobsSidecar randomConsistentSignedBeaconBlockAndBlobsSidecar(
+      final UInt64 slot) {
+    final SignedBeaconBlock randomBlock = randomSignedBeaconBlock(slot);
     return SchemaDefinitionsEip4844.required(spec.getGenesisSchemaDefinitions())
         .getSignedBeaconBlockAndBlobsSidecarSchema()
         .create(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceBlobsSidecarAvailabilityChecker.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceBlobsSidecarAvailabilityChecker.java
@@ -95,7 +95,7 @@ public class ForkChoiceBlobsSidecarAvailabilityChecker implements BlobsSidecarAv
           .miscHelpers()
           .isDataAvailable(
               block.getSlot(),
-              block.getBodyRoot(),
+              block.getRoot(),
               blockBody.getBlobKzgCommitments().stream()
                   .map(SszKZGCommitment::getKZGCommitment)
                   .collect(Collectors.toUnmodifiableList()),


### PR DESCRIPTION
## PR Description

- provides `BlobsUtil` which can generate blobs and blobs transaction
- extends `ExecutionLayerChannelStub` to support 4844 blobs generation
- bug fix a bug in `ForkChoiceBlobsSidecarAvailabilityChecker`
- improves `AbstractBlockPublisher` class

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
