### PR TITLE
Better handling sse sendComment error

### DIFF
--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriber.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriber.java
@@ -156,8 +156,7 @@ public class EventSubscriber {
                 final Throwable rootException = Throwables.getRootCause(throwable);
                 if (rootException instanceof IllegalStateException) {
                   // this might fail due to https://github.com/eclipse/jetty.project/issues/4461 but
-                  // ultimately
-                  // isn't important because it has a retry mechanism
+                  // ultimately isn't important because it has a retry mechanism
                   LOG.warn(
                       "Error sending keep-alive SSE comment. Retrying in {} seconds.",
                       retryInSeconds);

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriber.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriber.java
@@ -157,7 +157,7 @@ public class EventSubscriber {
                 if (rootException instanceof IllegalStateException) {
                   // this might fail due to https://github.com/eclipse/jetty.project/issues/4461 but
                   // ultimately isn't important because it has a retry mechanism
-                  LOG.warn(
+                  LOG.debug(
                       "Error sending keep-alive SSE comment. Retrying in {} seconds.",
                       retryInSeconds);
                   return null;

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriber.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriber.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.beaconrestapi.handlers.v1.events;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.base.Throwables;
 import io.javalin.http.sse.SseClient;
 import java.io.ByteArrayInputStream;
 import java.time.Duration;
@@ -138,6 +139,7 @@ public class EventSubscriber {
   }
 
   private void keepAlive() {
+    final int retryInSeconds = 30;
     if (!stopped.get()) {
       asyncRunner
           .runAfterDelay(
@@ -147,9 +149,28 @@ public class EventSubscriber {
                   sseClient.sendComment("");
                 }
               },
-              Duration.ofSeconds(30))
+              Duration.ofSeconds(retryInSeconds))
           .alwaysRun(this::keepAlive)
-          .ifExceptionGetsHereRaiseABug();
+          .exceptionally(
+              throwable -> {
+                final Throwable rootException = Throwables.getRootCause(throwable);
+                if (rootException instanceof IllegalStateException) {
+                  // this might fail due to https://github.com/eclipse/jetty.project/issues/4461 but
+                  // ultimately
+                  // isn't important because it has a retry mechanism
+                  LOG.warn(
+                      "Error sending keep-alive SSE comment. Retrying in {} seconds.",
+                      retryInSeconds);
+                  return null;
+                }
+
+                if (throwable instanceof RuntimeException) {
+                  throw (RuntimeException) throwable;
+                } else {
+                  throw new RuntimeException(
+                      "Unexpected error when sending keep-alive SSE comment.", throwable);
+                }
+              });
     }
   }
 

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriber.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriber.java
@@ -138,6 +138,7 @@ public class EventSubscriber {
                     "Failed to process event queue for client " + sseClient.hashCode(), error));
   }
 
+  @SuppressWarnings("FutureReturnValueIgnored")
   private void keepAlive() {
     final int retryInSeconds = 30;
     if (!stopped.get()) {


### PR DESCRIPTION
## PR Description

Ignoring IllegalStateException potentially caused by https://github.com/eclipse/jetty.project/issues/4461
This happens on our SSE sendComment for keep-alive, that has a retry mechanism.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
fixes #6654 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
