### PR TITLE
Increased the operation pool size for bls changes

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/OperationPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/OperationPool.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.statetransition;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -23,8 +24,6 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
-
-import com.google.common.annotations.VisibleForTesting;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.plugin.services.metrics.Counter;
 import org.hyperledger.besu.plugin.services.metrics.LabelledMetric;

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/OperationPoolTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/OperationPoolTest.java
@@ -37,6 +37,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszBytes4;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszListSchema;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
@@ -78,6 +79,22 @@ public class OperationPoolTest {
             beaconBlockSchemaSupplier.andThen(BeaconBlockBodySchema::getProposerSlashingsSchema),
             validator);
     assertThat(pool.getItemsForBlock(state)).isEmpty();
+  }
+
+  @Test
+  void shouldAddMaxItemsInBigPool() {
+    final int largePoolSize = 300_000;
+    OperationValidator<SszBytes4> validator = mock(OperationValidator.class);
+    OperationPool<SszBytes4> pool =
+        new OperationPool<>("Bytes4Pool", metricsSystem, (a) -> null, validator, largePoolSize);
+    when(validator.validateForGossip(any())).thenReturn(completedFuture(ACCEPT));
+    final int loopSanityCounter = largePoolSize + 10_000;
+    // because the loop de-duplicates, we can require more than the pool size of adds, so
+    // the sanity counter will ensure we can go past the loop limit without going too far
+    for (int i = 0; pool.size() < largePoolSize && i < loopSanityCounter; i++) {
+      pool.addLocal(SszBytes4.of(dataStructureUtil.randomBytes4()));
+    }
+    assertThat(pool.size()).isEqualTo(largePoolSize);
   }
 
   @Test

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -540,7 +540,8 @@ public class BeaconChainController extends Service implements BeaconChainControl
                 .andThen(BeaconBlockBodySchema::toVersionCapella)
                 .andThen(Optional::orElseThrow)
                 .andThen(BeaconBlockBodySchemaCapella::getBlsToExecutionChangesSchema),
-            validator);
+            validator,
+            300_000);
   }
 
   protected void initDataProvider() {


### PR DESCRIPTION
This is ultimately likely to be a short term change, as this pool can be reduced once capella has been made active.

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
