### PR TITLE
Retrieve signed block and blobs sidecar implementation

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
@@ -363,7 +363,7 @@ public class BlockOperationSelectorFactory {
       final Bytes32 beaconBlockRoot,
       final List<Blob> blobs) {
     final MiscHelpersEip4844 miscHelpers =
-        (MiscHelpersEip4844) spec.forMilestone(SpecMilestone.EIP4844).miscHelpers();
+        spec.forMilestone(SpecMilestone.EIP4844).miscHelpers().toVersionEip4844().orElseThrow();
     return new BlobsSidecar(
         schemaDefinitionsEip4844.getBlobsSidecarSchema(),
         beaconBlockRoot,

--- a/ethereum/dataproviders/src/main/java/tech/pegasys/teku/dataproviders/lookup/BlobsSidecarProvider.java
+++ b/ethereum/dataproviders/src/main/java/tech/pegasys/teku/dataproviders/lookup/BlobsSidecarProvider.java
@@ -21,6 +21,7 @@ import tech.pegasys.teku.spec.datastructures.execution.versions.eip4844.BlobsSid
 
 @FunctionalInterface
 public interface BlobsSidecarProvider {
+  BlobsSidecarProvider NOOP = (block) -> SafeFuture.completedFuture(Optional.empty());
 
   default SafeFuture<Optional<BlobsSidecar>> getBlobsSidecar(SignedBeaconBlock block) {
     return getBlobsSidecar(new SlotAndBlockRoot(block.getSlot(), block.getRoot()));

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/eip4844/BlobsSidecarSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/eip4844/BlobsSidecarSchema.java
@@ -69,6 +69,10 @@ public class BlobsSidecarSchema
         KZGProof.fromBytesCompressed(kzgAggregatedProof));
   }
 
+  public BlobsSidecar createEmpty(final Bytes32 beaconBlockRoot, final UInt64 beaconBlockSlot) {
+    return new BlobsSidecar(this, beaconBlockRoot, beaconBlockSlot, List.of(), KZGProof.INFINITY);
+  }
+
   public static BlobsSidecarSchema create(
       final SpecConfigEip4844 specConfig, final BlobSchema blobSchema) {
     return new BlobsSidecarSchema(specConfig, blobSchema);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/SyncCommitteeUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/SyncCommitteeUtil.java
@@ -379,7 +379,7 @@ public class SyncCommitteeUtil {
     final MutableBeaconStateAltair stateAltair = MutableBeaconStateAltair.required(state);
 
     // avoid failures in case of empty validators
-    if(state.getValidators().size() == 0) {
+    if (state.getValidators().size() == 0) {
       return;
     }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/SyncCommitteeUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/SyncCommitteeUtil.java
@@ -378,6 +378,11 @@ public class SyncCommitteeUtil {
   public void setGenesisStateSyncCommittees(final MutableBeaconState state) {
     final MutableBeaconStateAltair stateAltair = MutableBeaconStateAltair.required(state);
 
+    // avoid failures in case of empty validators
+    if(state.getValidators().size() == 0) {
+      return;
+    }
+
     // Note: A duplicate committee is assigned for the current and next committee at the fork
     // boundary
     final SyncCommittee syncCommittee = beaconStateAccessors.getNextSyncCommittee(state);

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/BlockProposalTestUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/BlockProposalTestUtil.java
@@ -348,7 +348,7 @@ public class BlockProposalTestUtil {
     final UInt64 newEpoch = spec.computeEpochAtSlot(newSlot);
 
     final MiscHelpersEip4844 miscHelpers =
-        (MiscHelpersEip4844) spec.forMilestone(SpecMilestone.EIP4844).miscHelpers();
+        spec.forMilestone(SpecMilestone.EIP4844).miscHelpers().toVersionEip4844().orElseThrow();
     List<KZGCommitment> generatedBlobsKzgCommitments =
         blobs.stream().map(miscHelpers::blobToKzgCommitment).collect(Collectors.toList());
 

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/ChainBuilder.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/ChainBuilder.java
@@ -559,7 +559,7 @@ public class ChainBuilder {
             nextBlockAndState.getRoot(),
             slot,
             options.getBlobs().orElse(List.of()),
-            options.getKzgProof().orElse(KZGProof.infinity()));
+            options.getKzgProof().orElse(KZGProof.INFINITY));
 
     trackBlobsSidecar(blobsSidecar);
     return nextBlockAndState;
@@ -599,7 +599,7 @@ public class ChainBuilder {
         spec.getGenesisSchemaDefinitions().toVersionEip4844().orElseThrow().getBlobsSidecarSchema();
 
     final MiscHelpersEip4844 miscHelpers =
-        (MiscHelpersEip4844) spec.forMilestone(SpecMilestone.EIP4844).miscHelpers();
+        spec.forMilestone(SpecMilestone.EIP4844).miscHelpers().toVersionEip4844().orElseThrow();
     KZGProof kzgProof =
         miscHelpers.computeAggregatedKzgProof(
             randomBlobs.stream().map(Blob::getBytes).collect(Collectors.toList()));

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/ChainBuilder.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/ChainBuilder.java
@@ -553,15 +553,19 @@ public class ChainBuilder {
     final BlobsSidecarSchema blobsSidecarSchema =
         spec.getGenesisSchemaDefinitions().toVersionEip4844().orElseThrow().getBlobsSidecarSchema();
 
-    BlobsSidecar blobsSidecar =
-        new BlobsSidecar(
-            blobsSidecarSchema,
-            nextBlockAndState.getRoot(),
-            slot,
-            options.getBlobs().orElse(List.of()),
-            options.getKzgProof().orElse(KZGProof.INFINITY));
+    if (options.isStoreBlobsSidecarEnabled()) {
+      final BlobsSidecar blobsSidecar =
+          options.blobsSidecar.orElseGet(
+              () ->
+                  new BlobsSidecar(
+                      blobsSidecarSchema,
+                      nextBlockAndState.getRoot(),
+                      slot,
+                      options.getBlobs().orElse(List.of()),
+                      options.getKzgProof().orElse(KZGProof.INFINITY)));
+      trackBlobsSidecar(blobsSidecar);
+    }
 
-    trackBlobsSidecar(blobsSidecar);
     return nextBlockAndState;
   }
 
@@ -604,11 +608,13 @@ public class ChainBuilder {
         miscHelpers.computeAggregatedKzgProof(
             randomBlobs.stream().map(Blob::getBytes).collect(Collectors.toList()));
 
-    BlobsSidecar blobsSidecar =
-        new BlobsSidecar(
-            blobsSidecarSchema, nextBlockAndState.getRoot(), slot, randomBlobs, kzgProof);
+    if (options.isStoreBlobsSidecarEnabled()) {
+      final BlobsSidecar blobsSidecar =
+          new BlobsSidecar(
+              blobsSidecarSchema, nextBlockAndState.getRoot(), slot, randomBlobs, kzgProof);
 
-    trackBlobsSidecar(blobsSidecar);
+      trackBlobsSidecar(blobsSidecar);
+    }
     return nextBlockAndState;
   }
 
@@ -732,7 +738,9 @@ public class ChainBuilder {
     private Optional<SszList<SszKZGCommitment>> kzgCommitments = Optional.empty();
     private Optional<List<Blob>> blobs = Optional.empty();
     private Optional<KZGProof> kzgProof = Optional.empty();
+    private Optional<BlobsSidecar> blobsSidecar = Optional.empty();
     private boolean generateRandomBlobs = false;
+    private boolean storeBlobsSidecar = true;
     private boolean skipStateTransition = false;
     private boolean wrongProposer = false;
 
@@ -773,6 +781,21 @@ public class ChainBuilder {
       return this;
     }
 
+    public BlockOptions setBlobs(final List<Blob> blobs) {
+      this.blobs = Optional.of(blobs);
+      return this;
+    }
+
+    public BlockOptions setKzgProof(final KZGProof kzgProof) {
+      this.kzgProof = Optional.of(kzgProof);
+      return this;
+    }
+
+    public BlockOptions setBlobsSidecar(final BlobsSidecar blobsSidecar) {
+      this.blobsSidecar = Optional.of(blobsSidecar);
+      return this;
+    }
+
     public BlockOptions setKzgCommitments(final SszList<SszKZGCommitment> kzgCommitments) {
       this.kzgCommitments = Optional.of(kzgCommitments);
       return this;
@@ -780,6 +803,11 @@ public class ChainBuilder {
 
     public BlockOptions setGenerateRandomBlobs(final boolean generateRandomBlobs) {
       this.generateRandomBlobs = generateRandomBlobs;
+      return this;
+    }
+
+    public BlockOptions setStoreBlobsSidecar(final boolean storeBlobsSidecar) {
+      this.storeBlobsSidecar = storeBlobsSidecar;
       return this;
     }
 
@@ -828,6 +856,14 @@ public class ChainBuilder {
 
     public Optional<List<Blob>> getBlobs() {
       return blobs;
+    }
+
+    public Optional<BlobsSidecar> getBlobsSidecar() {
+      return blobsSidecar;
+    }
+
+    public boolean isStoreBlobsSidecarEnabled() {
+      return storeBlobsSidecar;
     }
 
     public Optional<KZGProof> getKzgProof() {

--- a/infrastructure/kzg/src/main/java/tech/pegasys/teku/kzg/KZG.java
+++ b/infrastructure/kzg/src/main/java/tech/pegasys/teku/kzg/KZG.java
@@ -32,7 +32,7 @@ public interface KZG {
 
         @Override
         public KZGProof computeAggregateKzgProof(final List<Bytes> blobs) throws KZGException {
-          return KZGProof.infinity();
+          return KZGProof.INFINITY;
         }
 
         @Override

--- a/infrastructure/kzg/src/main/java/tech/pegasys/teku/kzg/KZGProof.java
+++ b/infrastructure/kzg/src/main/java/tech/pegasys/teku/kzg/KZGProof.java
@@ -23,15 +23,8 @@ import org.apache.tuweni.ssz.SSZ;
 public final class KZGProof {
 
   public static final int KZG_PROOF_SIZE = 48;
-
-  /**
-   * Creates 0x00..00 for point-at-infinity
-   *
-   * @return point-at-infinity as per the Eth2 spec
-   */
-  public static KZGProof infinity() {
-    return KZGProof.fromBytesCompressed(Bytes48.ZERO);
-  }
+  /** Creates 0x00..00 for point-at-infinity */
+  public static final KZGProof INFINITY = KZGProof.fromBytesCompressed(Bytes48.ZERO);
 
   public static KZGProof fromHexString(final String hexString) {
     return KZGProof.fromBytesCompressed(Bytes48.fromHexString(hexString));

--- a/infrastructure/kzg/src/test/java/tech/pegasys/teku/kzg/KZGTest.java
+++ b/infrastructure/kzg/src/test/java/tech/pegasys/teku/kzg/KZGTest.java
@@ -95,7 +95,7 @@ public final class KZGTest {
                 KZGException.class,
                 () ->
                     kzg.verifyAggregateKzgProof(
-                        Collections.emptyList(), Collections.emptyList(), KZGProof.infinity())),
+                        Collections.emptyList(), Collections.emptyList(), KZGProof.INFINITY)),
             assertThrows(KZGException.class, () -> kzg.blobToKzgCommitment(Bytes.EMPTY)),
             assertThrows(
                 KZGException.class, () -> kzg.computeAggregateKzgProof(Collections.emptyList())));

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
@@ -28,6 +28,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.plugin.services.metrics.Counter;
+import tech.pegasys.teku.dataproviders.lookup.BlobsSidecarProvider;
 import tech.pegasys.teku.dataproviders.lookup.BlockProvider;
 import tech.pegasys.teku.dataproviders.lookup.StateAndBlockSummaryProvider;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
@@ -73,6 +74,7 @@ public abstract class RecentChainData implements StoreUpdateHandler {
   private static final Logger LOG = LogManager.getLogger();
 
   private final BlockProvider blockProvider;
+  private final BlobsSidecarProvider blobsSidecarProvider;
   private final StateAndBlockSummaryProvider stateProvider;
   protected final FinalizedCheckpointChannel finalizedCheckpointChannel;
   protected final StorageUpdateChannel storageUpdateChannel;
@@ -100,6 +102,7 @@ public abstract class RecentChainData implements StoreUpdateHandler {
       final MetricsSystem metricsSystem,
       final StoreConfig storeConfig,
       final BlockProvider blockProvider,
+      final BlobsSidecarProvider blobsSidecarProvider,
       final StateAndBlockSummaryProvider stateProvider,
       final StorageUpdateChannel storageUpdateChannel,
       final VoteUpdateChannel voteUpdateChannel,
@@ -110,6 +113,7 @@ public abstract class RecentChainData implements StoreUpdateHandler {
     this.metricsSystem = metricsSystem;
     this.storeConfig = storeConfig;
     this.blockProvider = blockProvider;
+    this.blobsSidecarProvider = blobsSidecarProvider;
     this.stateProvider = stateProvider;
     this.voteUpdateChannel = voteUpdateChannel;
     this.chainHeadChannel = chainHeadChannel;
@@ -144,6 +148,7 @@ public abstract class RecentChainData implements StoreUpdateHandler {
             .metricsSystem(metricsSystem)
             .specProvider(spec)
             .blockProvider(blockProvider)
+            .blobsSidecarProvider(blobsSidecarProvider)
             .stateProvider(stateProvider)
             .storeConfig(storeConfig)
             .build();

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/StorageBackedRecentChainData.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/StorageBackedRecentChainData.java
@@ -22,6 +22,7 @@ import java.util.concurrent.TimeoutException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
+import tech.pegasys.teku.dataproviders.lookup.BlobsSidecarProvider;
 import tech.pegasys.teku.dataproviders.lookup.BlockProvider;
 import tech.pegasys.teku.dataproviders.lookup.StateAndBlockSummaryProvider;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
@@ -41,6 +42,7 @@ import tech.pegasys.teku.storage.store.UpdatableStore;
 public class StorageBackedRecentChainData extends RecentChainData {
   private static final Logger LOG = LogManager.getLogger();
   private final BlockProvider blockProvider;
+  private final BlobsSidecarProvider blobsSidecarProvider;
   private final StateAndBlockSummaryProvider stateProvider;
   private final StorageQueryChannel storageQueryChannel;
   private final StoreConfig storeConfig;
@@ -60,6 +62,7 @@ public class StorageBackedRecentChainData extends RecentChainData {
         metricsSystem,
         storeConfig,
         storageQueryChannel::getHotBlocksByRoot,
+        storageQueryChannel::getBlobsSidecar,
         storageQueryChannel::getHotStateAndBlockSummaryByBlockRoot,
         storageUpdateChannel,
         voteUpdateChannel,
@@ -70,6 +73,7 @@ public class StorageBackedRecentChainData extends RecentChainData {
     this.storageQueryChannel = storageQueryChannel;
     this.blockProvider = storageQueryChannel::getHotBlocksByRoot;
     this.stateProvider = storageQueryChannel::getHotStateAndBlockSummaryByBlockRoot;
+    this.blobsSidecarProvider = storageQueryChannel::getBlobsSidecar;
   }
 
   public static SafeFuture<RecentChainData> create(
@@ -152,6 +156,7 @@ public class StorageBackedRecentChainData extends RecentChainData {
                   .onDiskStoreData(data)
                   .asyncRunner(asyncRunner)
                   .blockProvider(blockProvider)
+                  .blobsSidecarProvider(blobsSidecarProvider)
                   .stateProvider(stateProvider)
                   .storeConfig(storeConfig)
                   .build();

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
@@ -497,16 +497,21 @@ class Store implements UpdatableStore {
   private SignedBeaconBlockAndBlobsSidecar createSignedBeaconBlockAndBlobsSidecar(
       final SignedBeaconBlock signedBeaconBlock, final Optional<BlobsSidecar> maybeBlobsSidecar) {
     checkState(
-        maybeBlobsSidecar.map(BlobsSidecar::getBlobs).map(List::size).orElse(0)
-            == signedBeaconBlock
-                .getBeaconBlock()
-                .orElseThrow()
-                .getBody()
-                .toVersionEip4844()
-                .orElseThrow()
-                .getBlobKzgCommitments()
-                .size(),
-        "Inconsistent number of blobs from sidecar and commitments from block");
+        maybeBlobsSidecar
+            .map(
+                blobsSidecar ->
+                    blobsSidecar.getBeaconBlockRoot().equals(signedBeaconBlock.getRoot()))
+            .orElseGet(
+                () ->
+                    signedBeaconBlock
+                        .getBeaconBlock()
+                        .orElseThrow()
+                        .getBody()
+                        .toVersionEip4844()
+                        .orElseThrow()
+                        .getBlobKzgCommitments()
+                        .isEmpty()),
+        "BlobsSidecar is inconsistent with the BeaconBlock");
 
     final SchemaDefinitionsEip4844 schemaDefinitionsEip4844 =
         spec.atSlot(signedBeaconBlock.getSlot())

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
@@ -496,22 +496,22 @@ class Store implements UpdatableStore {
 
   private SignedBeaconBlockAndBlobsSidecar createSignedBeaconBlockAndBlobsSidecar(
       final SignedBeaconBlock signedBeaconBlock, final Optional<BlobsSidecar> maybeBlobsSidecar) {
-    checkState(
-        maybeBlobsSidecar
-            .map(
-                blobsSidecar ->
-                    blobsSidecar.getBeaconBlockRoot().equals(signedBeaconBlock.getRoot()))
-            .orElseGet(
-                () ->
-                    signedBeaconBlock
-                        .getBeaconBlock()
-                        .orElseThrow()
-                        .getBody()
-                        .toVersionEip4844()
-                        .orElseThrow()
-                        .getBlobKzgCommitments()
-                        .isEmpty()),
-        "BlobsSidecar is inconsistent with the BeaconBlock");
+    if (maybeBlobsSidecar.isPresent()) {
+      checkState(
+          maybeBlobsSidecar.get().getBeaconBlockRoot().equals(signedBeaconBlock.getRoot()),
+          "BlobsSidecar belongs to a different BeaconBlock");
+    } else {
+      checkState(
+          signedBeaconBlock
+              .getBeaconBlock()
+              .orElseThrow()
+              .getBody()
+              .toVersionEip4844()
+              .orElseThrow()
+              .getBlobKzgCommitments()
+              .isEmpty(),
+          "BeaconBlock KzgCommitments must be empty when BlobsSidecar is not present");
+    }
 
     final SchemaDefinitionsEip4844 schemaDefinitionsEip4844 =
         spec.atSlot(signedBeaconBlock.getSlot())

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
@@ -510,7 +510,7 @@ class Store implements UpdatableStore {
               .orElseThrow()
               .getBlobKzgCommitments()
               .isEmpty(),
-          "BeaconBlock KzgCommitments must be empty when BlobsSidecar is not present");
+          "BeaconBlock contains kzg commitments but BlobsSidecar is not present");
     }
 
     final SchemaDefinitionsEip4844 schemaDefinitionsEip4844 =

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreBuilder.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreBuilder.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
+import tech.pegasys.teku.dataproviders.lookup.BlobsSidecarProvider;
 import tech.pegasys.teku.dataproviders.lookup.BlockProvider;
 import tech.pegasys.teku.dataproviders.lookup.StateAndBlockSummaryProvider;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
@@ -38,6 +39,7 @@ public class StoreBuilder {
   private MetricsSystem metricsSystem;
   private Spec spec;
   private BlockProvider blockProvider;
+  private BlobsSidecarProvider blobsSidecarProvider;
   private StateAndBlockSummaryProvider stateAndBlockProvider;
   private StoreConfig storeConfig = StoreConfig.createDefault();
 
@@ -107,6 +109,7 @@ public class StoreBuilder {
         metricsSystem,
         spec,
         blockProvider,
+        blobsSidecarProvider,
         stateAndBlockProvider,
         anchor,
         time,
@@ -161,6 +164,12 @@ public class StoreBuilder {
   public StoreBuilder blockProvider(final BlockProvider blockProvider) {
     checkNotNull(blockProvider);
     this.blockProvider = blockProvider;
+    return this;
+  }
+
+  public StoreBuilder blobsSidecarProvider(final BlobsSidecarProvider blobsSidecarProvider) {
+    checkNotNull(blobsSidecarProvider);
+    this.blobsSidecarProvider = blobsSidecarProvider;
     return this;
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransaction.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransaction.java
@@ -334,7 +334,7 @@ class StoreTransaction implements UpdatableStore.StoreTransaction {
   @Override
   public SafeFuture<Optional<SignedBeaconBlockAndBlobsSidecar>> retrieveSignedBlockAndBlobsSidecar(
       Bytes32 blockRoot) {
-    return SafeFuture.failedFuture(new UnsupportedOperationException("Not yet implemented"));
+    return store.retrieveSignedBlockAndBlobsSidecar(blockRoot);
   }
 
   @Override

--- a/storage/src/test/java/tech/pegasys/teku/storage/client/StorageBackedRecentChainDataTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/client/StorageBackedRecentChainDataTest.java
@@ -26,6 +26,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.dataproviders.lookup.BlobsSidecarProvider;
 import tech.pegasys.teku.dataproviders.lookup.BlockProvider;
 import tech.pegasys.teku.dataproviders.lookup.StateAndBlockSummaryProvider;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -104,6 +105,7 @@ public class StorageBackedRecentChainDataTest {
             .metricsSystem(new StubMetricsSystem())
             .specProvider(spec)
             .blockProvider(BlockProvider.NOOP)
+            .blobsSidecarProvider(BlobsSidecarProvider.NOOP)
             .stateProvider(StateAndBlockSummaryProvider.NOOP)
             .storeConfig(storeConfig)
             .build();
@@ -151,6 +153,7 @@ public class StorageBackedRecentChainDataTest {
             .metricsSystem(new StubMetricsSystem())
             .specProvider(spec)
             .blockProvider(BlockProvider.NOOP)
+            .blobsSidecarProvider(BlobsSidecarProvider.NOOP)
             .stateProvider(StateAndBlockSummaryProvider.NOOP)
             .storeConfig(storeConfig)
             .build();

--- a/storage/src/test/java/tech/pegasys/teku/storage/store/AbstractStoreTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/store/AbstractStoreTest.java
@@ -140,6 +140,7 @@ public abstract class AbstractStoreTest {
         .metricsSystem(new StubMetricsSystem())
         .specProvider(spec)
         .blockProvider(blockProviderFromChainBuilder())
+        .blobsSidecarProvider(blobsSidecarFromChainBuilder())
         .stateProvider(StateAndBlockSummaryProvider.NOOP)
         .anchor(Optional.empty())
         .genesisTime(genesis.getState().getGenesisTime())

--- a/storage/src/test/java/tech/pegasys/teku/storage/store/AbstractStoreTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/store/AbstractStoreTest.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import tech.pegasys.teku.dataproviders.lookup.BlobsSidecarProvider;
 import tech.pegasys.teku.dataproviders.lookup.BlockProvider;
 import tech.pegasys.teku.dataproviders.lookup.StateAndBlockSummaryProvider;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -42,7 +43,7 @@ import tech.pegasys.teku.storage.api.StoredBlockMetadata;
 import tech.pegasys.teku.storage.api.StubStorageUpdateChannel;
 
 public abstract class AbstractStoreTest {
-  protected final Spec spec = TestSpecFactory.createMinimalPhase0();
+  protected final Spec spec = TestSpecFactory.createMinimalEip4844();
   protected final StorageUpdateChannel storageUpdateChannel = new StubStorageUpdateChannel();
   protected final ChainBuilder chainBuilder = ChainBuilder.create(spec);
 
@@ -168,5 +169,10 @@ public abstract class AbstractStoreTest {
                 .map(chainBuilder::getBlock)
                 .flatMap(Optional::stream)
                 .collect(Collectors.toMap(SignedBeaconBlock::getRoot, Function.identity())));
+  }
+
+  protected BlobsSidecarProvider blobsSidecarFromChainBuilder() {
+    return (block) ->
+        SafeFuture.completedFuture(chainBuilder.getBlobsSidecar(block.getBlockRoot()));
   }
 }

--- a/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTest.java
@@ -56,6 +56,7 @@ class StoreTest extends AbstractStoreTest {
                     new StubMetricsSystem(),
                     spec,
                     blockProviderFromChainBuilder(),
+                    blobsSidecarFromChainBuilder(),
                     StateAndBlockSummaryProvider.NOOP,
                     Optional.empty(),
                     genesisTime.minus(1),
@@ -123,6 +124,13 @@ class StoreTest extends AbstractStoreTest {
               .describedAs("State at %s", blockAndState.getSlot())
               .isCompletedWithValue(Optional.of(blockAndState.getState()));
         });
+  }
+
+  @Test
+  public void retrieveSignedBlockAndBlobsSidecar() {
+    final UpdatableStore store = createGenesisStore();
+    final SignedBlockAndState finalizedBlockAndState =
+            chainBuilder.generateBlockAtSlot(spec.slotsPerEpoch(UInt64.ZERO) - 1);
   }
 
   @Test

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/client/MemoryOnlyRecentChainData.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/client/MemoryOnlyRecentChainData.java
@@ -18,6 +18,7 @@ import static tech.pegasys.teku.infrastructure.async.SyncAsyncRunner.SYNC_RUNNER
 
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
+import tech.pegasys.teku.dataproviders.lookup.BlobsSidecarProvider;
 import tech.pegasys.teku.dataproviders.lookup.BlockProvider;
 import tech.pegasys.teku.dataproviders.lookup.StateAndBlockSummaryProvider;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
@@ -48,6 +49,7 @@ public class MemoryOnlyRecentChainData extends RecentChainData {
         metricsSystem,
         storeConfig,
         BlockProvider.NOOP,
+        BlobsSidecarProvider.NOOP,
         StateAndBlockSummaryProvider.NOOP,
         storageUpdateChannel,
         voteUpdateChannel,

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/store/StoreAssertions.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/store/StoreAssertions.java
@@ -31,6 +31,7 @@ public class StoreAssertions {
             "lock",
             "readLock",
             "blockProvider",
+            "blobsSidecarProvider",
             "blocks",
             "blockMetadata",
             "stateRequestCachedCounter",


### PR DESCRIPTION
Introduces `retrieveSignedBlockAndBlobsSidecar` method in `Store` used in the BeaconBlockAndBlobsSidecarByRoot rpc method

## Fixed Issue(s)

fixes #6633

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
