### PR TITLE
Implement historical blocks syncing for EIP-4844

### DIFF
--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/fetch/FetchBlockResult.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/fetch/FetchBlockResult.java
@@ -11,9 +11,8 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.beacon.sync.gossip;
+package tech.pegasys.teku.beacon.sync.fetch;
 
-import java.util.NoSuchElementException;
 import java.util.Optional;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.eip4844.SignedBeaconBlockAndBlobsSidecar;
@@ -61,8 +60,8 @@ public final class FetchBlockResult {
     return status == Status.SUCCESSFUL;
   }
 
-  public SignedBeaconBlock getBlock() throws NoSuchElementException {
-    return block.orElseThrow();
+  public Optional<SignedBeaconBlock> getBlock() {
+    return block;
   }
 
   public Optional<BlobsSidecar> getBlobsSidecar() {

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/fetch/FetchBlockTask.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/fetch/FetchBlockTask.java
@@ -61,8 +61,9 @@ public class FetchBlockTask {
   }
 
   /**
-   * Selects random {@link Eth2Peer} from the network and fetches a block by root. It also tracks
-   * the number of runs and the already queried peers.
+   * Selects random {@link Eth2Peer} from the network and fetches a block by root using the
+   * implementation of {@link #fetchBlock(Eth2Peer)}. It also tracks the number of runs and the
+   * already queried peers.
    */
   public SafeFuture<FetchBlockResult> run() {
     if (cancelled.get()) {

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/fetch/FetchBlockTask.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/fetch/FetchBlockTask.java
@@ -11,7 +11,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.beacon.sync.gossip;
+package tech.pegasys.teku.beacon.sync.fetch;
 
 import java.util.Collections;
 import java.util.Comparator;
@@ -23,7 +23,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
-import tech.pegasys.teku.beacon.sync.gossip.FetchBlockResult.Status;
+import tech.pegasys.teku.beacon.sync.fetch.FetchBlockResult.Status;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.teku.networking.p2p.network.P2PNetwork;
@@ -35,7 +35,9 @@ public class FetchBlockTask {
       Comparator.comparing(p -> Math.random());
 
   private final P2PNetwork<Eth2Peer> eth2Network;
-  private final Bytes32 blockRoot;
+
+  protected final Bytes32 blockRoot;
+
   private final Set<NodeId> queriedPeers = Collections.newSetFromMap(new ConcurrentHashMap<>());
 
   private final AtomicInteger numberOfRuns = new AtomicInteger(0);
@@ -58,6 +60,10 @@ public class FetchBlockTask {
     return Math.max(0, numberOfRuns.get() - 1);
   }
 
+  /**
+   * Selects random {@link Eth2Peer} from the network and fetches a block by root. It also tracks
+   * the number of runs and the already queried peers.
+   */
   public SafeFuture<FetchBlockResult> run() {
     if (cancelled.get()) {
       return SafeFuture.completedFuture(FetchBlockResult.createFailed(Status.CANCELLED));
@@ -79,20 +85,22 @@ public class FetchBlockTask {
     numberOfRuns.incrementAndGet();
     queriedPeers.add(peer.getId());
 
-    return fetchBlock(peer, blockRoot)
-        .exceptionally(
-            err -> {
-              LOG.debug("Failed to fetch block " + blockRoot, err);
-              return FetchBlockResult.createFailed(Status.FETCH_FAILED);
-            });
+    return fetchBlock(peer);
   }
 
-  protected SafeFuture<FetchBlockResult> fetchBlock(final Eth2Peer peer, final Bytes32 blockRoot) {
+  /** Fetch block by root from an {@link Eth2Peer} */
+  public SafeFuture<FetchBlockResult> fetchBlock(final Eth2Peer peer) {
+
     return peer.requestBlockByRoot(blockRoot)
         .thenApply(
             maybeBlock ->
                 maybeBlock
                     .map(FetchBlockResult::createSuccessful)
-                    .orElseGet(() -> FetchBlockResult.createFailed(Status.FETCH_FAILED)));
+                    .orElseGet(() -> FetchBlockResult.createFailed(Status.FETCH_FAILED)))
+        .exceptionally(
+            err -> {
+              LOG.debug("Failed to fetch block by root " + blockRoot, err);
+              return FetchBlockResult.createFailed(Status.FETCH_FAILED);
+            });
   }
 }

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/fetch/FetchBlockTaskFactory.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/fetch/FetchBlockTaskFactory.java
@@ -11,14 +11,12 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.beacon.sync.gossip;
+package tech.pegasys.teku.beacon.sync.fetch;
 
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
-import tech.pegasys.teku.networking.p2p.network.P2PNetwork;
 
 public interface FetchBlockTaskFactory {
 
-  FetchBlockTask create(P2PNetwork<Eth2Peer> eth2Network, UInt64 currentSlot, Bytes32 blockRoot);
+  FetchBlockTask create(UInt64 slot, Bytes32 blockRoot);
 }

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/fetch/MilestoneBasedFetchBlockTaskFactory.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/fetch/MilestoneBasedFetchBlockTaskFactory.java
@@ -57,8 +57,8 @@ public class MilestoneBasedFetchBlockTaskFactory implements FetchBlockTaskFactor
   }
 
   @Override
-  public FetchBlockTask create(final UInt64 currentSlot, final Bytes32 blockRoot) {
-    final SpecMilestone currentMilestone = spec.atSlot(currentSlot).getMilestone();
-    return registeredFetchBlockTaskFactories.get(currentMilestone).create(currentSlot, blockRoot);
+  public FetchBlockTask create(final UInt64 slot, final Bytes32 blockRoot) {
+    final SpecMilestone currentMilestone = spec.atSlot(slot).getMilestone();
+    return registeredFetchBlockTaskFactories.get(currentMilestone).create(slot, blockRoot);
   }
 }

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/fetch/MilestoneBasedFetchBlockTaskFactory.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/fetch/MilestoneBasedFetchBlockTaskFactory.java
@@ -11,7 +11,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.beacon.sync.gossip;
+package tech.pegasys.teku.beacon.sync.fetch;
 
 import com.google.common.base.Suppliers;
 import java.util.HashMap;
@@ -31,17 +31,17 @@ public class MilestoneBasedFetchBlockTaskFactory implements FetchBlockTaskFactor
   private final Map<SpecMilestone, FetchBlockTaskFactory> registeredFetchBlockTaskFactories =
       new HashMap<>();
 
-  public MilestoneBasedFetchBlockTaskFactory(final Spec spec) {
+  public MilestoneBasedFetchBlockTaskFactory(
+      final Spec spec, final P2PNetwork<Eth2Peer> eth2Network) {
     this.spec = spec;
+
     final FetchBlockTaskFactory blockTaskFactory =
-        (eth2Network, __, blockRoot) -> new FetchBlockTask(eth2Network, blockRoot);
+        (__, blockRoot) -> new FetchBlockTask(eth2Network, blockRoot);
 
     // Not needed for all milestones
     final Supplier<FetchBlockTaskFactory> blockAndBlobsSidecarTaskFactory =
         Suppliers.memoize(
-            () ->
-                (eth2Network, __, blockRoot) ->
-                    new FetchBlockAndBlobsSidecarTask(eth2Network, blockRoot));
+            () -> (__, blockRoot) -> new FetchBlockAndBlobsSidecarTask(eth2Network, blockRoot));
 
     spec.getEnabledMilestones()
         .forEach(
@@ -57,11 +57,8 @@ public class MilestoneBasedFetchBlockTaskFactory implements FetchBlockTaskFactor
   }
 
   @Override
-  public FetchBlockTask create(
-      final P2PNetwork<Eth2Peer> eth2Network, final UInt64 currentSlot, final Bytes32 blockRoot) {
+  public FetchBlockTask create(final UInt64 currentSlot, final Bytes32 blockRoot) {
     final SpecMilestone currentMilestone = spec.atSlot(currentSlot).getMilestone();
-    return registeredFetchBlockTaskFactories
-        .get(currentMilestone)
-        .create(eth2Network, currentSlot, blockRoot);
+    return registeredFetchBlockTaskFactories.get(currentMilestone).create(currentSlot, blockRoot);
   }
 }

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/historical/HistoricalBatchFetcher.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/historical/HistoricalBatchFetcher.java
@@ -385,8 +385,8 @@ public class HistoricalBatchFetcher {
     blobsSidecarAndValidationResult
         .getCause()
         .ifPresentOrElse(
-            throwable -> {
-              throw new IllegalArgumentException(exceptionMessage, throwable);
+            cause -> {
+              throw new IllegalArgumentException(exceptionMessage, cause);
             },
             () -> {
               throw new IllegalArgumentException(exceptionMessage);

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/historical/HistoricalBatchFetcher.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/historical/HistoricalBatchFetcher.java
@@ -366,7 +366,7 @@ public class HistoricalBatchFetcher {
                       .thenAccept(
                           blobsSidecarAndValidationResult -> {
                             if (blobsSidecarAndValidationResult.isFailure()) {
-                              throw new IllegalStateException(
+                              throw new IllegalArgumentException(
                                   String.format(
                                       "Blobs sidecar for slot %s received from peer %s has failed the validation check: %s",
                                       slot,
@@ -382,7 +382,7 @@ public class HistoricalBatchFetcher {
   private SafeFuture<Void> handleNotReceivedBlobsSidecar(final UInt64 slot) {
     if (blobsSidecarManager.isStorageOfBlobsSidecarRequired(slot)) {
       return SafeFuture.failedFuture(
-          new IllegalStateException(
+          new IllegalArgumentException(
               String.format(
                   "Blobs sidecar for slot %s was not received from peer %s", slot, peer.getId())));
     }

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/historical/HistoricalBatchFetcher.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/historical/HistoricalBatchFetcher.java
@@ -265,29 +265,26 @@ public class HistoricalBatchFetcher {
   }
 
   private SafeFuture<Void> importBatch() {
-    final SignedBeaconBlock newEarliestBlock = blocksToImport.getFirst();
-
     // send to signature verification and blobs sidecars validation and only store blocks and blobs
     // sidecars if all checks pass, or if one fails we reject the entire response
     return batchVerifyHistoricalBlockSignatures(blocksToImport)
-        .thenCompose(__ -> validateBlobsSidecars(blocksToImport, blobsSidecarsBySlotToImport))
         .thenCompose(
             __ -> {
-              final Stream<SafeFuture<?>> blobsSidecarsImporting =
-                  blobsSidecarsBySlotToImport.values().stream()
-                      .map(storageUpdateChannel::onBlobsSidecar);
-              return SafeFuture.allOfFailFast(blobsSidecarsImporting);
+              final UInt64 latestSlotInBatch = blocksToImport.getLast().getSlot();
+              return validateBlobsSidecars(
+                  latestSlotInBatch, blocksToImport, blobsSidecarsBySlotToImport);
             })
         .thenCompose(
-            __ ->
-                storageUpdateChannel
-                    .onFinalizedBlocks(blocksToImport)
-                    .thenRun(
-                        () -> {
-                          LOG.trace(
-                              "Earliest block is now from slot {}", newEarliestBlock.getSlot());
-                          future.complete(newEarliestBlock);
-                        }))
+            __ -> {
+              final SignedBeaconBlock newEarliestBlock = blocksToImport.getFirst();
+              return storageUpdateChannel
+                  .onFinalizedBlocks(blocksToImport, blobsSidecarsBySlotToImport)
+                  .thenRun(
+                      () -> {
+                        LOG.trace("Earliest block is now from slot {}", newEarliestBlock.getSlot());
+                        future.complete(newEarliestBlock);
+                      });
+            })
         // always clear the blobs sidecars batch cache
         .alwaysRun(blobsSidecarsBySlotToImport::clear);
   }
@@ -340,9 +337,16 @@ public class HistoricalBatchFetcher {
   }
 
   private SafeFuture<Void> validateBlobsSidecars(
+      final UInt64 latestSlotInBatch,
       final Collection<SignedBeaconBlock> blocks,
       final Map<UInt64, BlobsSidecar> blobsSidecarsBySlot) {
-    final Stream<SafeFuture<?>> validatingAndImportingBlobsSidecars =
+    if (!blobsSidecarManager.isStorageOfBlobsSidecarRequired(latestSlotInBatch)) {
+      LOG.trace(
+          "Latest slot in batch does not require blobs sidecars to be available. No validation is needed.");
+      return SafeFuture.COMPLETE;
+    }
+    LOG.trace("Validating blobs sidecars for a batch");
+    final Stream<SafeFuture<?>> validatingBlobsSidecars =
         blocks.stream()
             .map(
                 signedBlock -> {
@@ -372,7 +376,7 @@ public class HistoricalBatchFetcher {
                           });
                 });
 
-    return SafeFuture.allOfFailFast(validatingAndImportingBlobsSidecars);
+    return SafeFuture.allOfFailFast(validatingBlobsSidecars);
   }
 
   private SafeFuture<Void> handleNotReceivedBlobsSidecar(final UInt64 slot) {

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/historical/HistoricalBatchFetcher.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/historical/HistoricalBatchFetcher.java
@@ -285,7 +285,7 @@ public class HistoricalBatchFetcher {
                         future.complete(newEarliestBlock);
                       });
             })
-        // always clear the blobs sidecars batch cache
+        // always clear the blobs sidecars
         .alwaysRun(blobsSidecarsBySlotToImport::clear);
   }
 
@@ -300,9 +300,9 @@ public class HistoricalBatchFetcher {
 
   private SafeFuture<Void> batchVerifyHistoricalBlockSignature(
       final Collection<SignedBeaconBlock> blocks, final BeaconState bestState) {
-    List<BLSSignature> signatures = new ArrayList<>();
-    List<Bytes> signingRoots = new ArrayList<>();
-    List<List<BLSPublicKey>> proposerPublicKeys = new ArrayList<>();
+    final List<BLSSignature> signatures = new ArrayList<>();
+    final List<Bytes> signingRoots = new ArrayList<>();
+    final List<List<BLSPublicKey>> proposerPublicKeys = new ArrayList<>();
 
     final Bytes32 genesisValidatorsRoot = bestState.getForkInfo().getGenesisValidatorsRoot();
 
@@ -316,7 +316,7 @@ public class HistoricalBatchFetcher {
                 spec.getDomain(Domain.BEACON_PROPOSER, epoch, fork, genesisValidatorsRoot);
             signatures.add(signedBlock.getSignature());
             signingRoots.add(spec.computeSigningRoot(block, domain));
-            BLSPublicKey proposerPublicKey =
+            final BLSPublicKey proposerPublicKey =
                 spec.getValidatorPubKey(bestState, block.getProposerIndex())
                     .orElseThrow(
                         () ->
@@ -407,14 +407,14 @@ public class HistoricalBatchFetcher {
     return Optional.ofNullable(blocksToImport.peekLast());
   }
 
-  private boolean latestBlockCompletesBatch(Optional<SignedBeaconBlock> latestBlock) {
+  private boolean latestBlockCompletesBatch(final Optional<SignedBeaconBlock> latestBlock) {
     return latestBlock
         .map(SignedBeaconBlock::getRoot)
         .map(r -> r.equals(lastBlockRoot))
         .orElse(false);
   }
 
-  private boolean latestBlockShouldCompleteBatch(Optional<SignedBeaconBlock> latestBlock) {
+  private boolean latestBlockShouldCompleteBatch(final Optional<SignedBeaconBlock> latestBlock) {
     return latestBlock
         .map(SignedBeaconBlock::getSlot)
         .map(s -> s.isGreaterThanOrEqualTo(maxSlot))

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/historical/HistoricalBatchFetcher.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/historical/HistoricalBatchFetcher.java
@@ -267,8 +267,8 @@ public class HistoricalBatchFetcher {
   private SafeFuture<Void> importBatch() {
     final SignedBeaconBlock newEarliestBlock = blocksToImport.getFirst();
 
-    // send to signature and blobs sidecars verification then store blobs sidecars and blocks if all
-    // pass, or if one fails we reject the entire response
+    // send to signature verification and blobs sidecars validation and only store blocks and blobs
+    // sidecars if all checks pass, or if one fails we reject the entire response
     return batchVerifyHistoricalBlockSignatures(blocksToImport)
         .thenCompose(__ -> validateBlobsSidecars(blocksToImport, blobsSidecarsBySlotToImport))
         .thenCompose(

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/historical/HistoricalBlockSyncService.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/historical/HistoricalBlockSyncService.java
@@ -223,9 +223,9 @@ public class HistoricalBlockSyncService extends Service {
   }
 
   private void updateSyncMetrics() {
-    if (earliestBlock.getBeaconBlock().isPresent()) {
-      historicSyncGauge.set(earliestBlock.getSlot().doubleValue());
-    }
+    earliestBlock
+        .getBeaconBlock()
+        .ifPresent(__ -> historicSyncGauge.set(earliestBlock.getSlot().doubleValue()));
   }
 
   private void fetchBlocks() {
@@ -308,7 +308,7 @@ public class HistoricalBlockSyncService extends Service {
   private boolean isSyncDone() {
     return earliestBlock
         .getBeaconBlock()
-        .map(b -> b.getSlot().isLessThanOrEqualTo(getTerminalSlot()))
+        .map(block -> block.getSlot().isLessThanOrEqualTo(getTerminalSlot()))
         .orElse(false);
   }
 

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/fetch/AbstractFetchBlockTask.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/fetch/AbstractFetchBlockTask.java
@@ -11,7 +11,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.beacon.sync.gossip;
+package tech.pegasys.teku.beacon.sync.fetch;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/fetch/FetchBlockAndBlobsSidecarTaskTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/fetch/FetchBlockAndBlobsSidecarTaskTest.java
@@ -11,7 +11,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.beacon.sync.gossip;
+package tech.pegasys.teku.beacon.sync.fetch;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
@@ -19,7 +19,7 @@ import static org.mockito.Mockito.when;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
-import tech.pegasys.teku.beacon.sync.gossip.FetchBlockResult.Status;
+import tech.pegasys.teku.beacon.sync.fetch.FetchBlockResult.Status;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
@@ -53,7 +53,7 @@ public class FetchBlockAndBlobsSidecarTaskTest extends AbstractFetchBlockTask {
     assertThat(result).isDone();
     final FetchBlockResult fetchBlockResult = result.getNow(null);
     assertThat(fetchBlockResult.isSuccessful()).isTrue();
-    assertThat(fetchBlockResult.getBlock()).isEqualTo(block);
+    assertThat(fetchBlockResult.getBlock()).hasValue(block);
     assertThat(fetchBlockResult.getBlobsSidecar()).hasValue(blobsSidecar);
   }
 
@@ -100,7 +100,7 @@ public class FetchBlockAndBlobsSidecarTaskTest extends AbstractFetchBlockTask {
     assertThat(result).isDone();
     final FetchBlockResult fetchBlockResult = result.getNow(null);
     assertThat(fetchBlockResult.isSuccessful()).isTrue();
-    assertThat(fetchBlockResult.getBlock()).isEqualTo(block);
+    assertThat(fetchBlockResult.getBlock()).hasValue(block);
     assertThat(fetchBlockResult.getBlobsSidecar()).isEmpty();
   }
 }

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/fetch/FetchBlockTaskTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/fetch/FetchBlockTaskTest.java
@@ -11,7 +11,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.beacon.sync.gossip;
+package tech.pegasys.teku.beacon.sync.fetch;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
@@ -19,7 +19,7 @@ import static org.mockito.Mockito.when;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
-import tech.pegasys.teku.beacon.sync.gossip.FetchBlockResult.Status;
+import tech.pegasys.teku.beacon.sync.fetch.FetchBlockResult.Status;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
@@ -41,7 +41,7 @@ public class FetchBlockTaskTest extends AbstractFetchBlockTask {
     assertThat(result).isDone();
     final FetchBlockResult fetchBlockResult = result.getNow(null);
     assertThat(fetchBlockResult.isSuccessful()).isTrue();
-    assertThat(fetchBlockResult.getBlock()).isEqualTo(block);
+    assertThat(fetchBlockResult.getBlock()).hasValue(block);
     assertThat(fetchBlockResult.getBlobsSidecar()).isEmpty();
   }
 
@@ -111,7 +111,7 @@ public class FetchBlockTaskTest extends AbstractFetchBlockTask {
     assertThat(result).isDone();
     final FetchBlockResult fetchBlockResult2 = result2.getNow(null);
     assertThat(fetchBlockResult2.isSuccessful()).isTrue();
-    assertThat(fetchBlockResult2.getBlock()).isEqualTo(block);
+    assertThat(fetchBlockResult2.getBlock()).hasValue(block);
     assertThat(fetchBlockResult2.getBlobsSidecar()).isEmpty();
     assertThat(task.getNumberOfRetries()).isEqualTo(1);
   }
@@ -137,7 +137,7 @@ public class FetchBlockTaskTest extends AbstractFetchBlockTask {
     assertThat(result).isDone();
     final FetchBlockResult fetchBlockResult = result.getNow(null);
     assertThat(fetchBlockResult.isSuccessful()).isTrue();
-    assertThat(fetchBlockResult.getBlock()).isEqualTo(block);
+    assertThat(fetchBlockResult.getBlock()).hasValue(block);
     assertThat(fetchBlockResult.getBlobsSidecar()).isEmpty();
   }
 

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/fetch/MilestoneBasedFetchBlockTaskFactoryTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/fetch/MilestoneBasedFetchBlockTaskFactoryTest.java
@@ -11,7 +11,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.beacon.sync.gossip;
+package tech.pegasys.teku.beacon.sync.fetch;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -32,26 +32,25 @@ public class MilestoneBasedFetchBlockTaskFactoryTest {
 
   private final int slotsPerEpoch = spec.getSlotsPerEpoch(UInt64.ZERO);
 
-  private final MilestoneBasedFetchBlockTaskFactory milestoneBasedFetchBlockTaskFactory =
-      new MilestoneBasedFetchBlockTaskFactory(spec);
-
   @SuppressWarnings("unchecked")
   private final P2PNetwork<Eth2Peer> eth2Network = mock(P2PNetwork.class);
+
+  private final MilestoneBasedFetchBlockTaskFactory milestoneBasedFetchBlockTaskFactory =
+      new MilestoneBasedFetchBlockTaskFactory(spec, eth2Network);
 
   @Test
   public void createsFetchBlockTaskForMilestonesBeforeDeneb() {
     final FetchBlockTask task =
-        milestoneBasedFetchBlockTaskFactory.create(
-            eth2Network, UInt64.ONE, dataStructureUtil.randomBytes32());
+        milestoneBasedFetchBlockTaskFactory.create(UInt64.ONE, dataStructureUtil.randomBytes32());
 
     assertThat(task).isExactlyInstanceOf(FetchBlockTask.class);
   }
 
   @Test
-  public void createsFetchBlockTaskForMilestonesAfterDeneb() {
+  public void createsFetchBlockAndBlobsSidecarTaskForMilestonesAfterDeneb() {
     final FetchBlockTask task =
         milestoneBasedFetchBlockTaskFactory.create(
-            eth2Network, UInt64.ONE.plus(slotsPerEpoch), dataStructureUtil.randomBytes32());
+            UInt64.ONE.plus(slotsPerEpoch), dataStructureUtil.randomBytes32());
 
     assertThat(task).isExactlyInstanceOf(FetchBlockAndBlobsSidecarTask.class);
   }

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/historical/HistoricalBatchFetcherTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/historical/HistoricalBatchFetcherTest.java
@@ -158,7 +158,7 @@ public class HistoricalBatchFetcherTest {
     peer.completePendingRequests();
     assertThat(peer.getOutstandingRequests()).isEqualTo(0);
     assertThat(future).isCompletedWithValue(firstBlockInBatch);
-
+    // finalizedBlobsSidecar assertion is done in mockBlockAndBlobsSidecarsRelatedMethods()
     verify(storageUpdateChannel).onFinalizedBlocks(blockCaptor.capture(), anyMap());
     assertThat(blockCaptor.getValue()).containsExactlyElementsOf(blockBatch);
     // verify no availability checker is triggered

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/historical/HistoricalBatchFetcherTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/historical/HistoricalBatchFetcherTest.java
@@ -219,7 +219,7 @@ public class HistoricalBatchFetcherTest {
   public void run_failingOnBlobsSidecarNotReceived() {
     mockBlockAndBlobsSidecarsRelatedMethods(true);
 
-    // discard sidecar for slot 20
+    // discard sidecar for slot 20 (with kzg commitments)
     chainBuilder.discardBlobsSidecar(UInt64.valueOf(20));
 
     final SafeFuture<BeaconBlockSummary> future = fetcher.run();

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/historical/HistoricalBlockSyncServiceTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/historical/HistoricalBlockSyncServiceTest.java
@@ -120,7 +120,7 @@ public class HistoricalBlockSyncServiceTest {
   @SuppressWarnings("unchecked")
   @BeforeEach
   public void setup() {
-    when(storageUpdateChannel.onFinalizedBlocks(any())).thenReturn(SafeFuture.COMPLETE);
+    when(storageUpdateChannel.onFinalizedBlocks(any(), any())).thenReturn(SafeFuture.COMPLETE);
     when(syncStateProvider.subscribeToSyncStateChanges(any()))
         .thenAnswer((i) -> syncStateSubscribers.subscribe(i.getArgument(0)));
     when(syncStateProvider.unsubscribeFromSyncStateChanges(anyLong()))
@@ -144,7 +144,7 @@ public class HistoricalBlockSyncServiceTest {
 
     // Service should complete immediately
     assertServiceFinished();
-    verify(storageUpdateChannel, never()).onFinalizedBlocks(any());
+    verify(storageUpdateChannel, never()).onFinalizedBlocks(any(), any());
   }
 
   @Test
@@ -175,7 +175,7 @@ public class HistoricalBlockSyncServiceTest {
 
     // We should be waiting to actually start the historic sync
     assertServiceNotActive(peer);
-    verify(storageUpdateChannel, never()).onFinalizedBlocks(any());
+    verify(storageUpdateChannel, never()).onFinalizedBlocks(any(), any());
 
     // When we switch to in sync, the service should run and complete
     updateSyncState(SyncState.IN_SYNC);
@@ -210,7 +210,7 @@ public class HistoricalBlockSyncServiceTest {
 
     // We should be waiting to actually start the historic sync
     assertServiceIsWaitingForPeers(peer);
-    verify(storageUpdateChannel, never()).onFinalizedBlocks(any());
+    verify(storageUpdateChannel, never()).onFinalizedBlocks(any(), any());
 
     // When should succeed on the next retry
     assertThat(asyncRunner.countDelayedActions()).isEqualTo(1);
@@ -398,7 +398,7 @@ public class HistoricalBlockSyncServiceTest {
   }
 
   private void assertBlocksSaved(final List<SignedBeaconBlock> expectedBlocks) {
-    verify(storageUpdateChannel, atLeastOnce()).onFinalizedBlocks(blockCaptor.capture());
+    verify(storageUpdateChannel, atLeastOnce()).onFinalizedBlocks(blockCaptor.capture(), any());
     final List<SignedBeaconBlock> allBlocks =
         blockCaptor.getAllValues().stream()
             .flatMap(Collection::stream)

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/historical/HistoricalBlockSyncServiceTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/historical/HistoricalBlockSyncServiceTest.java
@@ -36,6 +36,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import tech.pegasys.teku.beacon.sync.events.SyncState;
 import tech.pegasys.teku.beacon.sync.events.SyncStateProvider;
+import tech.pegasys.teku.beacon.sync.fetch.FetchBlockTaskFactory;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
@@ -52,6 +53,8 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
+import tech.pegasys.teku.spec.logic.versions.eip4844.blobs.BlobsSidecarAvailabilityChecker;
+import tech.pegasys.teku.statetransition.blobs.BlobsSidecarManager;
 import tech.pegasys.teku.statetransition.validation.signatures.SignatureVerificationService;
 import tech.pegasys.teku.storage.api.StorageUpdateChannel;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
@@ -75,6 +78,11 @@ public class HistoricalBlockSyncServiceTest {
   private final SyncStateProvider syncStateProvider = mock(SyncStateProvider.class);
 
   private final CombinedChainDataClient chainData = mock(CombinedChainDataClient.class);
+
+  private final FetchBlockTaskFactory fetchBlockTaskFactory = mock(FetchBlockTaskFactory.class);
+
+  private final BlobsSidecarManager blobsSidecarManager = mock(BlobsSidecarManager.class);
+
   private final Optional<String> genesisStateResource =
       Optional.of("https://example.com/state.ssz");
   private final ReconstructHistoricalStatesService reconstructHistoricalStatesService =
@@ -94,7 +102,9 @@ public class HistoricalBlockSyncServiceTest {
           signatureVerificationService,
           batchSize,
           Optional.of(reconstructHistoricalStatesService),
-          false);
+          false,
+          fetchBlockTaskFactory,
+          blobsSidecarManager);
   private final Subscribers<SyncStateProvider.SyncStateSubscriber> syncStateSubscribers =
       Subscribers.create(false);
 
@@ -118,6 +128,8 @@ public class HistoricalBlockSyncServiceTest {
     when(syncStateProvider.getCurrentSyncState()).thenAnswer(i -> currentSyncState.get());
     when(signatureVerificationService.verify(any(), any(), (List<BLSSignature>) any()))
         .thenReturn(SafeFuture.completedFuture(true));
+    when(blobsSidecarManager.createAvailabilityChecker(any()))
+        .thenReturn(BlobsSidecarAvailabilityChecker.NOT_REQUIRED);
   }
 
   @Test

--- a/beacon/sync/src/testFixtures/java/tech/pegasys/teku/beacon/sync/SyncingNodeManager.java
+++ b/beacon/sync/src/testFixtures/java/tech/pegasys/teku/beacon/sync/SyncingNodeManager.java
@@ -21,13 +21,13 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
+import tech.pegasys.teku.beacon.sync.fetch.FetchBlockTaskFactory;
+import tech.pegasys.teku.beacon.sync.fetch.MilestoneBasedFetchBlockTaskFactory;
 import tech.pegasys.teku.beacon.sync.forward.ForwardSync;
 import tech.pegasys.teku.beacon.sync.forward.ForwardSyncService;
 import tech.pegasys.teku.beacon.sync.forward.singlepeer.SinglePeerSyncService;
 import tech.pegasys.teku.beacon.sync.forward.singlepeer.SyncManager;
-import tech.pegasys.teku.beacon.sync.gossip.FetchBlockTaskFactory;
 import tech.pegasys.teku.beacon.sync.gossip.FetchRecentBlocksService;
-import tech.pegasys.teku.beacon.sync.gossip.MilestoneBasedFetchBlockTaskFactory;
 import tech.pegasys.teku.bls.BLSKeyPair;
 import tech.pegasys.teku.ethereum.events.SlotEventsChannel;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
@@ -170,11 +170,11 @@ public class SyncingNodeManager {
     ForwardSyncService syncService = new SinglePeerSyncService(syncManager, recentChainData);
 
     final FetchBlockTaskFactory fetchBlockTaskFactory =
-        new MilestoneBasedFetchBlockTaskFactory(spec);
+        new MilestoneBasedFetchBlockTaskFactory(spec, eth2P2PNetwork);
 
     final FetchRecentBlocksService recentBlockFetcher =
         FetchRecentBlocksService.create(
-            asyncRunner, eth2P2PNetwork, pendingBlocks, syncService, fetchBlockTaskFactory);
+            asyncRunner, pendingBlocks, syncService, fetchBlockTaskFactory);
     recentBlockFetcher.subscribeBlockFetched(blockManager::importBlock);
     blockManager.subscribeToReceivedBlocks(
         (block, executionOptimistic) ->

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/eip4844/blobs/BlobsSidecarAvailabilityChecker.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/eip4844/blobs/BlobsSidecarAvailabilityChecker.java
@@ -39,7 +39,7 @@ public interface BlobsSidecarAvailabilityChecker {
 
         @Override
         public SafeFuture<BlobsSidecarAndValidationResult> validate(
-            final BlobsSidecar blobsSidecar) {
+            final Optional<BlobsSidecar> blobsSidecar) {
           return NOT_REQUIRED_RESULT_FUTURE;
         }
       };
@@ -63,7 +63,7 @@ public interface BlobsSidecarAvailabilityChecker {
 
           @Override
           public SafeFuture<BlobsSidecarAndValidationResult> validate(
-              final BlobsSidecar blobsSidecar) {
+              final Optional<BlobsSidecar> blobsSidecar) {
             return blobsSidecarValidResult;
           }
         };
@@ -82,7 +82,7 @@ public interface BlobsSidecarAvailabilityChecker {
   SafeFuture<BlobsSidecarAndValidationResult> getAvailabilityCheckResult();
 
   /** Only perform the {@link MiscHelpersEip4844#isDataAvailable} check */
-  SafeFuture<BlobsSidecarAndValidationResult> validate(BlobsSidecar blobsSidecar);
+  SafeFuture<BlobsSidecarAndValidationResult> validate(Optional<BlobsSidecar> blobsSidecar);
 
   enum BlobsSidecarValidationResult {
     NOT_REQUIRED,
@@ -144,17 +144,24 @@ public interface BlobsSidecarAvailabilityChecker {
       return validationResult.equals(BlobsSidecarValidationResult.VALID);
     }
 
+    public boolean isNotRequired() {
+      return validationResult.equals(BlobsSidecarValidationResult.NOT_REQUIRED);
+    }
+
+    public boolean isInvalid() {
+      return validationResult.equals(BlobsSidecarValidationResult.INVALID);
+    }
+
+    public boolean isNotAvailable() {
+      return validationResult.equals(BlobsSidecarValidationResult.NOT_AVAILABLE);
+    }
+
     public boolean isFailure() {
-      return validationResult.equals(BlobsSidecarValidationResult.INVALID)
-          || validationResult.equals(BlobsSidecarValidationResult.NOT_AVAILABLE);
+      return isInvalid() || isNotAvailable();
     }
 
     public Optional<Throwable> getCause() {
       return cause;
-    }
-
-    public boolean isNotRequired() {
-      return validationResult.equals(BlobsSidecarValidationResult.NOT_REQUIRED);
     }
 
     @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/eip4844/blobs/BlobsSidecarAvailabilityChecker.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/eip4844/blobs/BlobsSidecarAvailabilityChecker.java
@@ -22,6 +22,7 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
 import tech.pegasys.teku.spec.datastructures.execution.versions.eip4844.BlobsSidecar;
+import tech.pegasys.teku.spec.logic.versions.eip4844.helpers.MiscHelpersEip4844;
 
 public interface BlobsSidecarAvailabilityChecker {
   BlobsSidecarAvailabilityChecker NOOP =
@@ -80,6 +81,7 @@ public interface BlobsSidecarAvailabilityChecker {
 
   SafeFuture<BlobsSidecarAndValidationResult> getAvailabilityCheckResult();
 
+  /** Only perform the {@link MiscHelpersEip4844#isDataAvailable} check */
   SafeFuture<BlobsSidecarAndValidationResult> validate(BlobsSidecar blobsSidecar);
 
   enum BlobsSidecarValidationResult {

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/ChainBuilder.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/ChainBuilder.java
@@ -232,16 +232,12 @@ public class ChainBuilder {
     return Optional.ofNullable(blocks.lastEntry()).map(Map.Entry::getValue).orElse(null);
   }
 
-  public BlobsSidecar getLatestBlobsSidecar() {
-    return Optional.ofNullable(blobsSidecars.lastEntry()).map(Map.Entry::getValue).orElse(null);
-  }
-
   public SignedBlockAndState getBlockAndStateAtSlot(final long slot) {
     return getBlockAndStateAtSlot(UInt64.valueOf(slot));
   }
 
   public SignedBlockAndState getBlockAndStateAtSlot(final UInt64 slot) {
-    return Optional.ofNullable(blocks.get(slot)).orElse(null);
+    return blocks.get(slot);
   }
 
   public SignedBeaconBlock getBlockAtSlot(final long slot) {

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/ChainBuilder.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/ChainBuilder.java
@@ -323,6 +323,19 @@ public class ChainBuilder {
 
     final SignedBlockAndState blockAndState = new SignedBlockAndState(signedBlock, genesisState);
     trackBlock(blockAndState);
+
+    // add an empty blobs sidecar to the genesis block if genesis is in the EIP-4844 milestone
+    spec.getGenesisSchemaDefinitions()
+        .toVersionEip4844()
+        .ifPresent(
+            schemaDefinitions -> {
+              final BlobsSidecarSchema blobsSidecarSchema =
+                  schemaDefinitions.getBlobsSidecarSchema();
+              final BlobsSidecar blobsSidecar =
+                  blobsSidecarSchema.createEmpty(blockAndState.getRoot(), blockAndState.getSlot());
+              trackBlobsSidecar(blobsSidecar);
+            });
+
     return blockAndState;
   }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceBlobsSidecarAvailabilityChecker.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceBlobsSidecarAvailabilityChecker.java
@@ -63,7 +63,8 @@ public class ForkChoiceBlobsSidecarAvailabilityChecker implements BlobsSidecarAv
   }
 
   @Override
-  public SafeFuture<BlobsSidecarAndValidationResult> validate(final BlobsSidecar blobsSidecar) {
+  public SafeFuture<BlobsSidecarAndValidationResult> validate(
+      final Optional<BlobsSidecar> blobsSidecar) {
     return SafeFuture.of(() -> validateBlobsSidecar(blobsSidecar));
   }
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceBlobsSidecarAvailabilityCheckerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceBlobsSidecarAvailabilityCheckerTest.java
@@ -66,6 +66,7 @@ public class ForkChoiceBlobsSidecarAvailabilityCheckerTest {
 
     assertThat(blobsSidecarAvailabilityChecker.initiateDataAvailabilityCheck()).isTrue();
     assertNotRequired(blobsSidecarAvailabilityChecker.getAvailabilityCheckResult());
+    assertNotRequired(blobsSidecarAvailabilityChecker.validate(Optional.empty()));
   }
 
   @Test
@@ -74,6 +75,7 @@ public class ForkChoiceBlobsSidecarAvailabilityCheckerTest {
 
     assertThat(blobsSidecarAvailabilityChecker.initiateDataAvailabilityCheck()).isTrue();
     assertNotAvailable(blobsSidecarAvailabilityChecker.getAvailabilityCheckResult());
+    assertNotAvailable(blobsSidecarAvailabilityChecker.validate(Optional.empty()));
   }
 
   @Test
@@ -82,7 +84,8 @@ public class ForkChoiceBlobsSidecarAvailabilityCheckerTest {
 
     assertThat(blobsSidecarAvailabilityChecker.initiateDataAvailabilityCheck()).isTrue();
     assertInvalid(blobsSidecarAvailabilityChecker.getAvailabilityCheckResult(), Optional.empty());
-    assertInvalid(blobsSidecarAvailabilityChecker.validate(blobsSidecar), Optional.empty());
+    assertInvalid(
+        blobsSidecarAvailabilityChecker.validate(Optional.of(blobsSidecar)), Optional.empty());
   }
 
   @Test
@@ -100,7 +103,8 @@ public class ForkChoiceBlobsSidecarAvailabilityCheckerTest {
 
     assertThat(blobsSidecarAvailabilityChecker.initiateDataAvailabilityCheck()).isTrue();
     assertInvalid(blobsSidecarAvailabilityChecker.getAvailabilityCheckResult(), Optional.of(cause));
-    assertInvalid(blobsSidecarAvailabilityChecker.validate(blobsSidecar), Optional.of(cause));
+    assertInvalid(
+        blobsSidecarAvailabilityChecker.validate(Optional.of(blobsSidecar)), Optional.of(cause));
   }
 
   @Test
@@ -116,7 +120,7 @@ public class ForkChoiceBlobsSidecarAvailabilityCheckerTest {
 
     assertThat(blobsSidecarAvailabilityChecker.initiateDataAvailabilityCheck()).isTrue();
     assertAvailable(blobsSidecarAvailabilityChecker.getAvailabilityCheckResult());
-    assertAvailable(blobsSidecarAvailabilityChecker.validate(blobsSidecar));
+    assertAvailable(blobsSidecarAvailabilityChecker.validate(Optional.of(blobsSidecar)));
   }
 
   @Test

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
@@ -262,6 +262,10 @@ public class SafeFuture<T> extends CompletableFuture<T> {
     return complete;
   }
 
+  public static SafeFuture<Void> allOfFailFast(final Stream<SafeFuture<?>> futures) {
+    return allOfFailFast(futures.toArray(SafeFuture[]::new));
+  }
+
   /**
    * Returns a new {@link SafeFuture} with the result of the first successful future from the given
    * futures. If all futures complete exceptionally, the returned {@link SafeFuture} will complete

--- a/storage/api/src/main/java/tech/pegasys/teku/storage/api/StorageUpdateChannel.java
+++ b/storage/api/src/main/java/tech/pegasys/teku/storage/api/StorageUpdateChannel.java
@@ -14,10 +14,12 @@
 package tech.pegasys.teku.storage.api;
 
 import java.util.Collection;
+import java.util.Map;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.ethereum.pow.api.DepositTreeSnapshot;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.events.ChannelInterface;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.execution.versions.eip4844.BlobsSidecar;
@@ -28,7 +30,9 @@ public interface StorageUpdateChannel extends ChannelInterface {
 
   SafeFuture<UpdateResult> onStorageUpdate(StorageUpdate event);
 
-  SafeFuture<Void> onFinalizedBlocks(Collection<SignedBeaconBlock> finalizedBlocks);
+  SafeFuture<Void> onFinalizedBlocks(
+      Collection<SignedBeaconBlock> finalizedBlocks,
+      Map<UInt64, BlobsSidecar> finalizedBlobsSidecar);
 
   SafeFuture<Void> onFinalizedState(BeaconState finalizedState, Bytes32 blockRoot);
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/ChainStorage.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/ChainStorage.java
@@ -103,8 +103,11 @@ public class ChainStorage
   }
 
   @Override
-  public SafeFuture<Void> onFinalizedBlocks(final Collection<SignedBeaconBlock> finalizedBlocks) {
-    return SafeFuture.fromRunnable(() -> database.storeFinalizedBlocks(finalizedBlocks));
+  public SafeFuture<Void> onFinalizedBlocks(
+      final Collection<SignedBeaconBlock> finalizedBlocks,
+      final Map<UInt64, BlobsSidecar> finalizedBlobsSidecar) {
+    return SafeFuture.fromRunnable(
+        () -> database.storeFinalizedBlocks(finalizedBlocks, finalizedBlobsSidecar));
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/CombinedStorageChannelSplitter.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/CombinedStorageChannelSplitter.java
@@ -68,8 +68,10 @@ public class CombinedStorageChannelSplitter implements CombinedStorageChannel {
   }
 
   @Override
-  public SafeFuture<Void> onFinalizedBlocks(final Collection<SignedBeaconBlock> finalizedBlocks) {
-    return updateDelegate.onFinalizedBlocks(finalizedBlocks);
+  public SafeFuture<Void> onFinalizedBlocks(
+      final Collection<SignedBeaconBlock> finalizedBlocks,
+      final Map<UInt64, BlobsSidecar> blobsSidecarBySlot) {
+    return updateDelegate.onFinalizedBlocks(finalizedBlocks, blobsSidecarBySlot);
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
@@ -48,7 +48,8 @@ public interface Database extends AutoCloseable {
 
   UpdateResult update(StorageUpdate event);
 
-  void storeFinalizedBlocks(Collection<SignedBeaconBlock> blocks);
+  void storeFinalizedBlocks(
+      Collection<SignedBeaconBlock> blocks, Map<UInt64, BlobsSidecar> blobsSidecarBySlot);
 
   void storeFinalizedState(BeaconState state, Bytes32 blockRoot);
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/RetryingStorageUpdateChannel.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/RetryingStorageUpdateChannel.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.storage.server;
 import com.google.common.annotations.VisibleForTesting;
 import java.time.Duration;
 import java.util.Collection;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 import org.apache.logging.log4j.LogManager;
@@ -84,8 +85,10 @@ public class RetryingStorageUpdateChannel implements StorageUpdateChannel {
   }
 
   @Override
-  public SafeFuture<Void> onFinalizedBlocks(final Collection<SignedBeaconBlock> finalizedBlocks) {
-    return retry(() -> delegate.onFinalizedBlocks(finalizedBlocks));
+  public SafeFuture<Void> onFinalizedBlocks(
+      final Collection<SignedBeaconBlock> finalizedBlocks,
+      final Map<UInt64, BlobsSidecar> blobsSidecarBySlot) {
+    return retry(() -> delegate.onFinalizedBlocks(finalizedBlocks, blobsSidecarBySlot));
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
@@ -300,9 +300,16 @@ public class KvStoreDatabase implements Database {
     return dao.getNonCanonicalBlocksAtSlot(slot);
   }
 
-  protected void storeFinalizedBlocksToDao(final Collection<SignedBeaconBlock> blocks) {
+  protected void storeFinalizedBlocksToDao(
+      final Collection<SignedBeaconBlock> blocks,
+      final Map<UInt64, BlobsSidecar> blobsSidecarBySlot) {
     try (final FinalizedUpdater updater = finalizedUpdater()) {
-      blocks.forEach(updater::addFinalizedBlock);
+      blocks.forEach(
+          block -> {
+            updater.addFinalizedBlock(block);
+            Optional.ofNullable(blobsSidecarBySlot.get(block.getSlot()))
+                .ifPresent(updater::addBlobsSidecar);
+          });
       updater.commit();
     }
   }
@@ -438,7 +445,9 @@ public class KvStoreDatabase implements Database {
   }
 
   @Override
-  public void storeFinalizedBlocks(final Collection<SignedBeaconBlock> blocks) {
+  public void storeFinalizedBlocks(
+      final Collection<SignedBeaconBlock> blocks,
+      final Map<UInt64, BlobsSidecar> blobsSidecarBySlot) {
     if (blocks.isEmpty()) {
       return;
     }
@@ -463,7 +472,7 @@ public class KvStoreDatabase implements Database {
       expectedRoot = block.getParentRoot();
     }
 
-    storeFinalizedBlocksToDao(blocks);
+    storeFinalizedBlocksToDao(blocks, blobsSidecarBySlot);
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
@@ -56,7 +56,9 @@ public class NoOpDatabase implements Database {
   }
 
   @Override
-  public void storeFinalizedBlocks(final Collection<SignedBeaconBlock> blocks) {}
+  public void storeFinalizedBlocks(
+      final Collection<SignedBeaconBlock> blocks,
+      final Map<UInt64, BlobsSidecar> blobsSidecarBySlot) {}
 
   @Override
   public void storeFinalizedState(BeaconState state, Bytes32 blockRoot) {}

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/ChainStorageTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/ChainStorageTest.java
@@ -21,6 +21,7 @@ import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 import com.google.common.collect.Lists;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.AfterEach;
@@ -137,10 +138,12 @@ public class ChainStorageTest {
           Lists.partition(missingHistoricalBlocks, batchSize);
       for (int i = batches.size() - 1; i >= 0; i--) {
         final List<SignedBeaconBlock> batch = batches.get(i);
-        chainStorage.onFinalizedBlocks(batch).ifExceptionGetsHereRaiseABug();
+        chainStorage.onFinalizedBlocks(batch, Map.of()).ifExceptionGetsHereRaiseABug();
       }
     } else {
-      chainStorage.onFinalizedBlocks(missingHistoricalBlocks).ifExceptionGetsHereRaiseABug();
+      chainStorage
+          .onFinalizedBlocks(missingHistoricalBlocks, Map.of())
+          .ifExceptionGetsHereRaiseABug();
     }
 
     // Verify blocks are now available
@@ -186,7 +189,7 @@ public class ChainStorageTest {
             .streamBlocksAndStates(0, firstMissingBlockSlot)
             .map(SignedBlockAndState::getBlock)
             .collect(Collectors.toList());
-    final SafeFuture<Void> result = chainStorage.onFinalizedBlocks(invalidBlocks);
+    final SafeFuture<Void> result = chainStorage.onFinalizedBlocks(invalidBlocks, Map.of());
     assertThat(result).isCompletedExceptionally();
     assertThatThrownBy(result::get)
         .hasCauseInstanceOf(IllegalArgumentException.class)
@@ -225,7 +228,7 @@ public class ChainStorageTest {
     // Remove a block from the middle
     blocks.remove(blocks.size() / 2);
 
-    final SafeFuture<Void> result = chainStorage.onFinalizedBlocks(blocks);
+    final SafeFuture<Void> result = chainStorage.onFinalizedBlocks(blocks, Map.of());
     assertThat(result).isCompletedExceptionally();
     assertThatThrownBy(result::get)
         .hasCauseInstanceOf(IllegalArgumentException.class)
@@ -264,7 +267,7 @@ public class ChainStorageTest {
     // Remove a block from the end
     blocks.remove(blocks.size() - 1);
 
-    final SafeFuture<Void> result = chainStorage.onFinalizedBlocks(blocks);
+    final SafeFuture<Void> result = chainStorage.onFinalizedBlocks(blocks, Map.of());
     assertThat(result).isCompletedExceptionally();
     assertThatThrownBy(result::get)
         .hasCauseInstanceOf(IllegalArgumentException.class)

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageUpdateChannel.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageUpdateChannel.java
@@ -14,9 +14,11 @@
 package tech.pegasys.teku.storage.api;
 
 import java.util.Collection;
+import java.util.Map;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.ethereum.pow.api.DepositTreeSnapshot;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.execution.versions.eip4844.BlobsSidecar;
@@ -31,7 +33,9 @@ public class StubStorageUpdateChannel implements StorageUpdateChannel {
   }
 
   @Override
-  public SafeFuture<Void> onFinalizedBlocks(final Collection<SignedBeaconBlock> finalizedBlocks) {
+  public SafeFuture<Void> onFinalizedBlocks(
+      final Collection<SignedBeaconBlock> finalizedBlocks,
+      final Map<UInt64, BlobsSidecar> blobsSidecarBySlot) {
     return SafeFuture.COMPLETE;
   }
 

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageUpdateChannelWithDelays.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageUpdateChannelWithDelays.java
@@ -14,10 +14,12 @@
 package tech.pegasys.teku.storage.api;
 
 import java.util.Collection;
+import java.util.Map;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.ethereum.pow.api.DepositTreeSnapshot;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.execution.versions.eip4844.BlobsSidecar;
@@ -37,7 +39,9 @@ public class StubStorageUpdateChannelWithDelays implements StorageUpdateChannel 
   }
 
   @Override
-  public SafeFuture<Void> onFinalizedBlocks(final Collection<SignedBeaconBlock> finalizedBlocks) {
+  public SafeFuture<Void> onFinalizedBlocks(
+      final Collection<SignedBeaconBlock> finalizedBlocks,
+      final Map<UInt64, BlobsSidecar> blobsSidecarBySlot) {
     return asyncRunner.runAsync(() -> SafeFuture.COMPLETE);
   }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

- Changed `HistoricalBatchFetcher` to import blobs sidecars if required
- Tested historical fetching with current mainnet to ensure the current workflow is not affected.
- Moved `FetchBlockTask` and all its related classses to a different package to be reused by the `HistoricalBatchFetcher`
- changed `onFinalizedBlocks` method to accept blobs sidecars

## Fixed Issue(s)


## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
