### PR TITLE
Expose validate method in the BlobsSidecarAvailabilityChecker

### DIFF
--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/singlepeer/PeerSyncTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/singlepeer/PeerSyncTest.java
@@ -130,7 +130,8 @@ public class PeerSyncTest extends AbstractSyncTest {
   @Test
   void sync_failedImport_failedBlobsAvailabilityChecks() {
     when(blobsSidecarManager.isStorageOfBlobsSidecarRequired(any())).thenReturn(true);
-    testFailedBlockImport(() -> BlockImportResult.FAILED_BLOBS_AVAILABILITY_CHECK, true, true);
+    testFailedBlockImport(
+        () -> BlockImportResult.failedBlobsAvailabilityCheck(Optional.empty()), true, true);
   }
 
   void testFailedBlockImport(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/results/BlockImportResult.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/results/BlockImportResult.java
@@ -34,8 +34,9 @@ public interface BlockImportResult {
   BlockImportResult FAILED_DESCENDANT_OF_INVALID_BLOCK =
       new FailedBlockImportResult(FailureReason.DESCENDANT_OF_INVALID_BLOCK, Optional.empty());
 
-  BlockImportResult FAILED_BLOBS_AVAILABILITY_CHECK =
-      new FailedBlockImportResult(FailureReason.FAILED_BLOBS_AVAILABILITY_CHECK, Optional.empty());
+  static BlockImportResult failedBlobsAvailabilityCheck(final Optional<Throwable> cause) {
+    return new FailedBlockImportResult(FailureReason.FAILED_BLOBS_AVAILABILITY_CHECK, cause);
+  }
 
   static BlockImportResult failedExecutionPayloadExecution(final Throwable cause) {
     return new FailedBlockImportResult(
@@ -79,10 +80,14 @@ public interface BlockImportResult {
 
   boolean isSuccessful();
 
-  /** @return If successful, returns a {@code SignedBeaconBlock}, otherwise returns null. */
+  /**
+   * @return If successful, returns a {@code SignedBeaconBlock}, otherwise returns null.
+   */
   SignedBeaconBlock getBlock();
 
-  /** @return If failed, returns a non-null failure reason, otherwise returns null. */
+  /**
+   * @return If failed, returns a non-null failure reason, otherwise returns null.
+   */
   FailureReason getFailureReason();
 
   /**

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/results/BlockImportResult.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/results/BlockImportResult.java
@@ -80,14 +80,10 @@ public interface BlockImportResult {
 
   boolean isSuccessful();
 
-  /**
-   * @return If successful, returns a {@code SignedBeaconBlock}, otherwise returns null.
-   */
+  /** @return If successful, returns a {@code SignedBeaconBlock}, otherwise returns null. */
   SignedBeaconBlock getBlock();
 
-  /**
-   * @return If failed, returns a non-null failure reason, otherwise returns null.
-   */
+  /** @return If failed, returns a non-null failure reason, otherwise returns null. */
   FailureReason getFailureReason();
 
   /**

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/eip4844/blobs/BlobsSidecarAvailabilityChecker.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/eip4844/blobs/BlobsSidecarAvailabilityChecker.java
@@ -37,7 +37,8 @@ public interface BlobsSidecarAvailabilityChecker {
         }
 
         @Override
-        public SafeFuture<BlobsSidecarAndValidationResult> validate(BlobsSidecar blobsSidecar) {
+        public SafeFuture<BlobsSidecarAndValidationResult> validate(
+            final BlobsSidecar blobsSidecar) {
           return NOT_REQUIRED_RESULT_FUTURE;
         }
       };

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/eip4844/blobs/BlobsSidecarAvailabilityChecker.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/eip4844/blobs/BlobsSidecarAvailabilityChecker.java
@@ -35,23 +35,37 @@ public interface BlobsSidecarAvailabilityChecker {
         public SafeFuture<BlobsSidecarAndValidationResult> getAvailabilityCheckResult() {
           return NOT_REQUIRED_RESULT_FUTURE;
         }
+
+        @Override
+        public SafeFuture<BlobsSidecarAndValidationResult> validate(BlobsSidecar blobsSidecar) {
+          return NOT_REQUIRED_RESULT_FUTURE;
+        }
       };
 
   BlobsSidecarAvailabilityChecker NOT_REQUIRED = NOOP;
 
   Function<BlobsSidecar, BlobsSidecarAvailabilityChecker> ALREADY_CHECKED =
-      (blobsSidecar) ->
-          new BlobsSidecarAvailabilityChecker() {
-            @Override
-            public boolean initiateDataAvailabilityCheck() {
-              return true;
-            }
+      (blobsSidecar) -> {
+        final SafeFuture<BlobsSidecarAndValidationResult> blobsSidecarValidResult =
+            SafeFuture.completedFuture(validResult(blobsSidecar));
+        return new BlobsSidecarAvailabilityChecker() {
+          @Override
+          public boolean initiateDataAvailabilityCheck() {
+            return true;
+          }
 
-            @Override
-            public SafeFuture<BlobsSidecarAndValidationResult> getAvailabilityCheckResult() {
-              return SafeFuture.completedFuture(validResult(blobsSidecar));
-            }
-          };
+          @Override
+          public SafeFuture<BlobsSidecarAndValidationResult> getAvailabilityCheckResult() {
+            return blobsSidecarValidResult;
+          }
+
+          @Override
+          public SafeFuture<BlobsSidecarAndValidationResult> validate(
+              final BlobsSidecar blobsSidecar) {
+            return blobsSidecarValidResult;
+          }
+        };
+      };
 
   /**
    * Similar to {@link
@@ -64,6 +78,8 @@ public interface BlobsSidecarAvailabilityChecker {
   boolean initiateDataAvailabilityCheck();
 
   SafeFuture<BlobsSidecarAndValidationResult> getAvailabilityCheckResult();
+
+  SafeFuture<BlobsSidecarAndValidationResult> validate(BlobsSidecar blobsSidecar);
 
   enum BlobsSidecarValidationResult {
     NOT_REQUIRED,

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -378,7 +378,8 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
       LOG.error(
           "blobsSidecar validation result: {}",
           blobsSidecarAndValidationResult.getValidationResult());
-      return BlockImportResult.FAILED_BLOBS_AVAILABILITY_CHECK;
+      return BlockImportResult.failedBlobsAvailabilityCheck(
+          blobsSidecarAndValidationResult.getCause());
     } else if (blobsSidecarAndValidationResult.isNotRequired()) {
       LOG.debug(
           "blobsSidecar validation result: {}",

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceBlobsSidecarAvailabilityChecker.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceBlobsSidecarAvailabilityChecker.java
@@ -64,13 +64,7 @@ public class ForkChoiceBlobsSidecarAvailabilityChecker implements BlobsSidecarAv
 
   @Override
   public SafeFuture<BlobsSidecarAndValidationResult> validate(final BlobsSidecar blobsSidecar) {
-    return SafeFuture.of(
-        () -> {
-          if (!isBlockInDataAvailabilityWindow()) {
-            return BlobsSidecarAndValidationResult.NOT_REQUIRED;
-          }
-          return validateBlobsSidecar(blobsSidecar);
-        });
+    return SafeFuture.of(() -> validateBlobsSidecar(blobsSidecar));
   }
 
   private BlobsSidecarAndValidationResult validateBlobsSidecar(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceBlobsSidecarAvailabilityChecker.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceBlobsSidecarAvailabilityChecker.java
@@ -20,7 +20,6 @@ import java.util.stream.Collectors;
 import tech.pegasys.teku.dataproviders.lookup.BlobsSidecarProvider;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.kzg.KZGException;
 import tech.pegasys.teku.spec.SpecVersion;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
@@ -63,13 +62,24 @@ public class ForkChoiceBlobsSidecarAvailabilityChecker implements BlobsSidecarAv
     return validationResult.orElse(NOT_REQUIRED_RESULT_FUTURE);
   }
 
+  @Override
+  public SafeFuture<BlobsSidecarAndValidationResult> validate(final BlobsSidecar blobsSidecar) {
+    return SafeFuture.of(
+        () -> {
+          if (!isBlockInDataAvailabilityWindow()) {
+            return BlobsSidecarAndValidationResult.NOT_REQUIRED;
+          }
+          return validateBlobsSidecar(blobsSidecar);
+        });
+  }
+
   private BlobsSidecarAndValidationResult validateBlobsSidecar(
       final Optional<BlobsSidecar> blobsSidecar) {
 
     // in the current 4844 specs, the blobsSidecar is immediately available with the block
     // so if we have it we do want to validate it regardless
     if (blobsSidecar.isPresent()) {
-      return validate(blobsSidecar.get());
+      return validateBlobsSidecar(blobsSidecar.get());
     }
 
     // when blobs are not available, we check if it is ok to not have them based on
@@ -82,14 +92,13 @@ public class ForkChoiceBlobsSidecarAvailabilityChecker implements BlobsSidecarAv
     return BlobsSidecarAndValidationResult.NOT_REQUIRED;
   }
 
-  private BlobsSidecarAndValidationResult validate(final BlobsSidecar blobsSidecar) {
+  private BlobsSidecarAndValidationResult validateBlobsSidecar(final BlobsSidecar blobsSidecar) {
     final BeaconBlockBodyEip4844 blockBody =
         block
             .getBeaconBlock()
             .map(BeaconBlock::getBody)
             .flatMap(BeaconBlockBody::toVersionEip4844)
             .orElseThrow();
-
     try {
       if (!specVersion
           .miscHelpers()
@@ -102,7 +111,7 @@ public class ForkChoiceBlobsSidecarAvailabilityChecker implements BlobsSidecarAv
               blobsSidecar)) {
         return BlobsSidecarAndValidationResult.invalidResult(blobsSidecar);
       }
-    } catch (KZGException ex) {
+    } catch (final Exception ex) {
       return BlobsSidecarAndValidationResult.invalidResult(blobsSidecar, ex);
     }
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceBlobsSidecarAvailabilityCheckerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceBlobsSidecarAvailabilityCheckerTest.java
@@ -66,7 +66,6 @@ public class ForkChoiceBlobsSidecarAvailabilityCheckerTest {
 
     assertThat(blobsSidecarAvailabilityChecker.initiateDataAvailabilityCheck()).isTrue();
     assertNotRequired(blobsSidecarAvailabilityChecker.getAvailabilityCheckResult());
-    assertNotRequired(blobsSidecarAvailabilityChecker.validate(blobsSidecar));
   }
 
   @Test


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

- Add a validate method to the `BlobsSidecarAvailabilityChecker`
- Propagate the failed validation result exception to the `BlockImportResult`

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
