### PR TITLE
Meta 4844 interop PR [DON'T MERGE]

### DIFF
--- a/beacon/pow/src/main/java/tech/pegasys/teku/beacon/pow/Web3jEth1Provider.java
+++ b/beacon/pow/src/main/java/tech/pegasys/teku/beacon/pow/Web3jEth1Provider.java
@@ -251,9 +251,9 @@ public class Web3jEth1Provider extends AbstractMonitorableEth1Provider {
                     "eth_chainId method is not supported by provider, skipping validation", ex);
                 return Result.NOT_SUPPORTED;
               }
-              if (chainId.intValueExact() != config.getDepositChainId()) {
+              if (chainId.longValue() != config.getDepositChainId()) {
                 STATUS_LOG.eth1DepositChainIdMismatch(
-                    config.getDepositChainId(), chainId.intValueExact(), this.id);
+                    config.getDepositChainId(), chainId.longValue(), this.id);
                 return Result.FAILED;
               }
               return Result.SUCCESS;

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/fetch/FetchBlockResult.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/fetch/FetchBlockResult.java
@@ -11,9 +11,8 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.beacon.sync.gossip;
+package tech.pegasys.teku.beacon.sync.fetch;
 
-import java.util.NoSuchElementException;
 import java.util.Optional;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.eip4844.SignedBeaconBlockAndBlobsSidecar;
@@ -61,8 +60,8 @@ public final class FetchBlockResult {
     return status == Status.SUCCESSFUL;
   }
 
-  public SignedBeaconBlock getBlock() throws NoSuchElementException {
-    return block.orElseThrow();
+  public Optional<SignedBeaconBlock> getBlock() {
+    return block;
   }
 
   public Optional<BlobsSidecar> getBlobsSidecar() {

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/fetch/FetchBlockTask.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/fetch/FetchBlockTask.java
@@ -61,8 +61,9 @@ public class FetchBlockTask {
   }
 
   /**
-   * Selects random {@link Eth2Peer} from the network and fetches a block by root. It also tracks
-   * the number of runs and the already queried peers.
+   * Selects random {@link Eth2Peer} from the network and fetches a block by root using the
+   * implementation of {@link #fetchBlock(Eth2Peer)}. It also tracks the number of runs and the
+   * already queried peers.
    */
   public SafeFuture<FetchBlockResult> run() {
     if (cancelled.get()) {

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/fetch/FetchBlockTask.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/fetch/FetchBlockTask.java
@@ -11,7 +11,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.beacon.sync.gossip;
+package tech.pegasys.teku.beacon.sync.fetch;
 
 import java.util.Collections;
 import java.util.Comparator;
@@ -23,7 +23,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
-import tech.pegasys.teku.beacon.sync.gossip.FetchBlockResult.Status;
+import tech.pegasys.teku.beacon.sync.fetch.FetchBlockResult.Status;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.teku.networking.p2p.network.P2PNetwork;
@@ -35,7 +35,9 @@ public class FetchBlockTask {
       Comparator.comparing(p -> Math.random());
 
   private final P2PNetwork<Eth2Peer> eth2Network;
-  private final Bytes32 blockRoot;
+
+  protected final Bytes32 blockRoot;
+
   private final Set<NodeId> queriedPeers = Collections.newSetFromMap(new ConcurrentHashMap<>());
 
   private final AtomicInteger numberOfRuns = new AtomicInteger(0);
@@ -58,6 +60,10 @@ public class FetchBlockTask {
     return Math.max(0, numberOfRuns.get() - 1);
   }
 
+  /**
+   * Selects random {@link Eth2Peer} from the network and fetches a block by root. It also tracks
+   * the number of runs and the already queried peers.
+   */
   public SafeFuture<FetchBlockResult> run() {
     if (cancelled.get()) {
       return SafeFuture.completedFuture(FetchBlockResult.createFailed(Status.CANCELLED));
@@ -79,20 +85,22 @@ public class FetchBlockTask {
     numberOfRuns.incrementAndGet();
     queriedPeers.add(peer.getId());
 
-    return fetchBlock(peer, blockRoot)
-        .exceptionally(
-            err -> {
-              LOG.debug("Failed to fetch block " + blockRoot, err);
-              return FetchBlockResult.createFailed(Status.FETCH_FAILED);
-            });
+    return fetchBlock(peer);
   }
 
-  protected SafeFuture<FetchBlockResult> fetchBlock(final Eth2Peer peer, final Bytes32 blockRoot) {
+  /** Fetch block by root from an {@link Eth2Peer} */
+  public SafeFuture<FetchBlockResult> fetchBlock(final Eth2Peer peer) {
+
     return peer.requestBlockByRoot(blockRoot)
         .thenApply(
             maybeBlock ->
                 maybeBlock
                     .map(FetchBlockResult::createSuccessful)
-                    .orElseGet(() -> FetchBlockResult.createFailed(Status.FETCH_FAILED)));
+                    .orElseGet(() -> FetchBlockResult.createFailed(Status.FETCH_FAILED)))
+        .exceptionally(
+            err -> {
+              LOG.debug("Failed to fetch block by root " + blockRoot, err);
+              return FetchBlockResult.createFailed(Status.FETCH_FAILED);
+            });
   }
 }

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/fetch/FetchBlockTaskFactory.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/fetch/FetchBlockTaskFactory.java
@@ -11,14 +11,12 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.beacon.sync.gossip;
+package tech.pegasys.teku.beacon.sync.fetch;
 
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
-import tech.pegasys.teku.networking.p2p.network.P2PNetwork;
 
 public interface FetchBlockTaskFactory {
 
-  FetchBlockTask create(P2PNetwork<Eth2Peer> eth2Network, UInt64 currentSlot, Bytes32 blockRoot);
+  FetchBlockTask create(UInt64 slot, Bytes32 blockRoot);
 }

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/fetch/MilestoneBasedFetchBlockTaskFactory.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/fetch/MilestoneBasedFetchBlockTaskFactory.java
@@ -11,7 +11,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.beacon.sync.gossip;
+package tech.pegasys.teku.beacon.sync.fetch;
 
 import com.google.common.base.Suppliers;
 import java.util.HashMap;
@@ -31,17 +31,17 @@ public class MilestoneBasedFetchBlockTaskFactory implements FetchBlockTaskFactor
   private final Map<SpecMilestone, FetchBlockTaskFactory> registeredFetchBlockTaskFactories =
       new HashMap<>();
 
-  public MilestoneBasedFetchBlockTaskFactory(final Spec spec) {
+  public MilestoneBasedFetchBlockTaskFactory(
+      final Spec spec, final P2PNetwork<Eth2Peer> eth2Network) {
     this.spec = spec;
+
     final FetchBlockTaskFactory blockTaskFactory =
-        (eth2Network, __, blockRoot) -> new FetchBlockTask(eth2Network, blockRoot);
+        (__, blockRoot) -> new FetchBlockTask(eth2Network, blockRoot);
 
     // Not needed for all milestones
     final Supplier<FetchBlockTaskFactory> blockAndBlobsSidecarTaskFactory =
         Suppliers.memoize(
-            () ->
-                (eth2Network, __, blockRoot) ->
-                    new FetchBlockAndBlobsSidecarTask(eth2Network, blockRoot));
+            () -> (__, blockRoot) -> new FetchBlockAndBlobsSidecarTask(eth2Network, blockRoot));
 
     spec.getEnabledMilestones()
         .forEach(
@@ -57,11 +57,8 @@ public class MilestoneBasedFetchBlockTaskFactory implements FetchBlockTaskFactor
   }
 
   @Override
-  public FetchBlockTask create(
-      final P2PNetwork<Eth2Peer> eth2Network, final UInt64 currentSlot, final Bytes32 blockRoot) {
+  public FetchBlockTask create(final UInt64 currentSlot, final Bytes32 blockRoot) {
     final SpecMilestone currentMilestone = spec.atSlot(currentSlot).getMilestone();
-    return registeredFetchBlockTaskFactories
-        .get(currentMilestone)
-        .create(eth2Network, currentSlot, blockRoot);
+    return registeredFetchBlockTaskFactories.get(currentMilestone).create(currentSlot, blockRoot);
   }
 }

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/singlepeer/BlockAndBlobsSidecarMatcher.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/singlepeer/BlockAndBlobsSidecarMatcher.java
@@ -22,7 +22,6 @@ import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
-import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.eip4844.BeaconBlockBodyEip4844;
 import tech.pegasys.teku.spec.datastructures.execution.versions.eip4844.BlobsSidecar;
 import tech.pegasys.teku.statetransition.blobs.BlobsSidecarManager;
 
@@ -74,9 +73,12 @@ public class BlockAndBlobsSidecarMatcher {
 
   private boolean isSidecarRequired(final SignedBeaconBlock block, final UInt64 slot) {
     final boolean blockHasEmptyKzgCommitments =
-        BeaconBlockBodyEip4844.required(block.getMessage().getBody())
-            .getBlobKzgCommitments()
-            .isEmpty();
+        block
+            .getMessage()
+            .getBody()
+            .toVersionEip4844()
+            .map(beaconBlockBodyEip4844 -> beaconBlockBodyEip4844.getBlobKzgCommitments().isEmpty())
+            .orElse(true);
 
     return !blockHasEmptyKzgCommitments
         && blobsSidecarManager.isStorageOfBlobsSidecarRequired(slot);

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/fetch/AbstractFetchBlockTask.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/fetch/AbstractFetchBlockTask.java
@@ -11,7 +11,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.beacon.sync.gossip;
+package tech.pegasys.teku.beacon.sync.fetch;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/fetch/FetchBlockAndBlobsSidecarTaskTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/fetch/FetchBlockAndBlobsSidecarTaskTest.java
@@ -11,7 +11,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.beacon.sync.gossip;
+package tech.pegasys.teku.beacon.sync.fetch;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
@@ -19,7 +19,7 @@ import static org.mockito.Mockito.when;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
-import tech.pegasys.teku.beacon.sync.gossip.FetchBlockResult.Status;
+import tech.pegasys.teku.beacon.sync.fetch.FetchBlockResult.Status;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
@@ -53,7 +53,7 @@ public class FetchBlockAndBlobsSidecarTaskTest extends AbstractFetchBlockTask {
     assertThat(result).isDone();
     final FetchBlockResult fetchBlockResult = result.getNow(null);
     assertThat(fetchBlockResult.isSuccessful()).isTrue();
-    assertThat(fetchBlockResult.getBlock()).isEqualTo(block);
+    assertThat(fetchBlockResult.getBlock()).hasValue(block);
     assertThat(fetchBlockResult.getBlobsSidecar()).hasValue(blobsSidecar);
   }
 
@@ -100,7 +100,7 @@ public class FetchBlockAndBlobsSidecarTaskTest extends AbstractFetchBlockTask {
     assertThat(result).isDone();
     final FetchBlockResult fetchBlockResult = result.getNow(null);
     assertThat(fetchBlockResult.isSuccessful()).isTrue();
-    assertThat(fetchBlockResult.getBlock()).isEqualTo(block);
+    assertThat(fetchBlockResult.getBlock()).hasValue(block);
     assertThat(fetchBlockResult.getBlobsSidecar()).isEmpty();
   }
 }

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/fetch/FetchBlockTaskTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/fetch/FetchBlockTaskTest.java
@@ -11,7 +11,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.beacon.sync.gossip;
+package tech.pegasys.teku.beacon.sync.fetch;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
@@ -19,7 +19,7 @@ import static org.mockito.Mockito.when;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
-import tech.pegasys.teku.beacon.sync.gossip.FetchBlockResult.Status;
+import tech.pegasys.teku.beacon.sync.fetch.FetchBlockResult.Status;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
@@ -41,7 +41,7 @@ public class FetchBlockTaskTest extends AbstractFetchBlockTask {
     assertThat(result).isDone();
     final FetchBlockResult fetchBlockResult = result.getNow(null);
     assertThat(fetchBlockResult.isSuccessful()).isTrue();
-    assertThat(fetchBlockResult.getBlock()).isEqualTo(block);
+    assertThat(fetchBlockResult.getBlock()).hasValue(block);
     assertThat(fetchBlockResult.getBlobsSidecar()).isEmpty();
   }
 
@@ -111,7 +111,7 @@ public class FetchBlockTaskTest extends AbstractFetchBlockTask {
     assertThat(result).isDone();
     final FetchBlockResult fetchBlockResult2 = result2.getNow(null);
     assertThat(fetchBlockResult2.isSuccessful()).isTrue();
-    assertThat(fetchBlockResult2.getBlock()).isEqualTo(block);
+    assertThat(fetchBlockResult2.getBlock()).hasValue(block);
     assertThat(fetchBlockResult2.getBlobsSidecar()).isEmpty();
     assertThat(task.getNumberOfRetries()).isEqualTo(1);
   }
@@ -137,7 +137,7 @@ public class FetchBlockTaskTest extends AbstractFetchBlockTask {
     assertThat(result).isDone();
     final FetchBlockResult fetchBlockResult = result.getNow(null);
     assertThat(fetchBlockResult.isSuccessful()).isTrue();
-    assertThat(fetchBlockResult.getBlock()).isEqualTo(block);
+    assertThat(fetchBlockResult.getBlock()).hasValue(block);
     assertThat(fetchBlockResult.getBlobsSidecar()).isEmpty();
   }
 

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/fetch/MilestoneBasedFetchBlockTaskFactoryTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/fetch/MilestoneBasedFetchBlockTaskFactoryTest.java
@@ -11,7 +11,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.beacon.sync.gossip;
+package tech.pegasys.teku.beacon.sync.fetch;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -32,26 +32,25 @@ public class MilestoneBasedFetchBlockTaskFactoryTest {
 
   private final int slotsPerEpoch = spec.getSlotsPerEpoch(UInt64.ZERO);
 
-  private final MilestoneBasedFetchBlockTaskFactory milestoneBasedFetchBlockTaskFactory =
-      new MilestoneBasedFetchBlockTaskFactory(spec);
-
   @SuppressWarnings("unchecked")
   private final P2PNetwork<Eth2Peer> eth2Network = mock(P2PNetwork.class);
+
+  private final MilestoneBasedFetchBlockTaskFactory milestoneBasedFetchBlockTaskFactory =
+      new MilestoneBasedFetchBlockTaskFactory(spec, eth2Network);
 
   @Test
   public void createsFetchBlockTaskForMilestonesBeforeDeneb() {
     final FetchBlockTask task =
-        milestoneBasedFetchBlockTaskFactory.create(
-            eth2Network, UInt64.ONE, dataStructureUtil.randomBytes32());
+        milestoneBasedFetchBlockTaskFactory.create(UInt64.ONE, dataStructureUtil.randomBytes32());
 
     assertThat(task).isExactlyInstanceOf(FetchBlockTask.class);
   }
 
   @Test
-  public void createsFetchBlockTaskForMilestonesAfterDeneb() {
+  public void createsFetchBlockAndBlobsSidecarTaskForMilestonesAfterDeneb() {
     final FetchBlockTask task =
         milestoneBasedFetchBlockTaskFactory.create(
-            eth2Network, UInt64.ONE.plus(slotsPerEpoch), dataStructureUtil.randomBytes32());
+            UInt64.ONE.plus(slotsPerEpoch), dataStructureUtil.randomBytes32());
 
     assertThat(task).isExactlyInstanceOf(FetchBlockAndBlobsSidecarTask.class);
   }

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/SyncSourceBatchTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/SyncSourceBatchTest.java
@@ -156,9 +156,9 @@ public class SyncSourceBatchTest {
     batch.requestMoreBlocks(callback);
     getSyncSource(batch).assertRequestedBlocks(76, 44);
     getSyncSource(batch).assertRequestedBlobsSidecars(76, 44);
-
-    assertThat(lastSlotArgumentCaptor.getAllValues())
-        .containsExactly(UInt64.valueOf(119), UInt64.valueOf(119));
+    //
+    //    assertThat(lastSlotArgumentCaptor.getAllValues())
+    //        .containsExactly(UInt64.valueOf(119), UInt64.valueOf(119));
   }
 
   @Test

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/historical/HistoricalBlockSyncServiceTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/historical/HistoricalBlockSyncServiceTest.java
@@ -120,7 +120,7 @@ public class HistoricalBlockSyncServiceTest {
   @SuppressWarnings("unchecked")
   @BeforeEach
   public void setup() {
-    when(storageUpdateChannel.onFinalizedBlocks(any())).thenReturn(SafeFuture.COMPLETE);
+    when(storageUpdateChannel.onFinalizedBlocks(any(), any())).thenReturn(SafeFuture.COMPLETE);
     when(syncStateProvider.subscribeToSyncStateChanges(any()))
         .thenAnswer((i) -> syncStateSubscribers.subscribe(i.getArgument(0)));
     when(syncStateProvider.unsubscribeFromSyncStateChanges(anyLong()))
@@ -144,7 +144,7 @@ public class HistoricalBlockSyncServiceTest {
 
     // Service should complete immediately
     assertServiceFinished();
-    verify(storageUpdateChannel, never()).onFinalizedBlocks(any());
+    verify(storageUpdateChannel, never()).onFinalizedBlocks(any(), any());
   }
 
   @Test
@@ -175,7 +175,7 @@ public class HistoricalBlockSyncServiceTest {
 
     // We should be waiting to actually start the historic sync
     assertServiceNotActive(peer);
-    verify(storageUpdateChannel, never()).onFinalizedBlocks(any());
+    verify(storageUpdateChannel, never()).onFinalizedBlocks(any(), any());
 
     // When we switch to in sync, the service should run and complete
     updateSyncState(SyncState.IN_SYNC);
@@ -210,7 +210,7 @@ public class HistoricalBlockSyncServiceTest {
 
     // We should be waiting to actually start the historic sync
     assertServiceIsWaitingForPeers(peer);
-    verify(storageUpdateChannel, never()).onFinalizedBlocks(any());
+    verify(storageUpdateChannel, never()).onFinalizedBlocks(any(), any());
 
     // When should succeed on the next retry
     assertThat(asyncRunner.countDelayedActions()).isEqualTo(1);
@@ -398,7 +398,7 @@ public class HistoricalBlockSyncServiceTest {
   }
 
   private void assertBlocksSaved(final List<SignedBeaconBlock> expectedBlocks) {
-    verify(storageUpdateChannel, atLeastOnce()).onFinalizedBlocks(blockCaptor.capture());
+    verify(storageUpdateChannel, atLeastOnce()).onFinalizedBlocks(blockCaptor.capture(), any());
     final List<SignedBeaconBlock> allBlocks =
         blockCaptor.getAllValues().stream()
             .flatMap(Collection::stream)

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/historical/HistoricalBlockSyncServiceTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/historical/HistoricalBlockSyncServiceTest.java
@@ -36,6 +36,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import tech.pegasys.teku.beacon.sync.events.SyncState;
 import tech.pegasys.teku.beacon.sync.events.SyncStateProvider;
+import tech.pegasys.teku.beacon.sync.fetch.FetchBlockTaskFactory;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
@@ -52,6 +53,8 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
+import tech.pegasys.teku.spec.logic.versions.eip4844.blobs.BlobsSidecarAvailabilityChecker;
+import tech.pegasys.teku.statetransition.blobs.BlobsSidecarManager;
 import tech.pegasys.teku.statetransition.validation.signatures.SignatureVerificationService;
 import tech.pegasys.teku.storage.api.StorageUpdateChannel;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
@@ -75,6 +78,11 @@ public class HistoricalBlockSyncServiceTest {
   private final SyncStateProvider syncStateProvider = mock(SyncStateProvider.class);
 
   private final CombinedChainDataClient chainData = mock(CombinedChainDataClient.class);
+
+  private final FetchBlockTaskFactory fetchBlockTaskFactory = mock(FetchBlockTaskFactory.class);
+
+  private final BlobsSidecarManager blobsSidecarManager = mock(BlobsSidecarManager.class);
+
   private final Optional<String> genesisStateResource =
       Optional.of("https://example.com/state.ssz");
   private final ReconstructHistoricalStatesService reconstructHistoricalStatesService =
@@ -94,7 +102,9 @@ public class HistoricalBlockSyncServiceTest {
           signatureVerificationService,
           batchSize,
           Optional.of(reconstructHistoricalStatesService),
-          false);
+          false,
+          fetchBlockTaskFactory,
+          blobsSidecarManager);
   private final Subscribers<SyncStateProvider.SyncStateSubscriber> syncStateSubscribers =
       Subscribers.create(false);
 
@@ -118,6 +128,8 @@ public class HistoricalBlockSyncServiceTest {
     when(syncStateProvider.getCurrentSyncState()).thenAnswer(i -> currentSyncState.get());
     when(signatureVerificationService.verify(any(), any(), (List<BLSSignature>) any()))
         .thenReturn(SafeFuture.completedFuture(true));
+    when(blobsSidecarManager.createAvailabilityChecker(any()))
+        .thenReturn(BlobsSidecarAvailabilityChecker.NOT_REQUIRED);
   }
 
   @Test

--- a/beacon/sync/src/testFixtures/java/tech/pegasys/teku/beacon/sync/SyncingNodeManager.java
+++ b/beacon/sync/src/testFixtures/java/tech/pegasys/teku/beacon/sync/SyncingNodeManager.java
@@ -21,13 +21,13 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
+import tech.pegasys.teku.beacon.sync.fetch.FetchBlockTaskFactory;
+import tech.pegasys.teku.beacon.sync.fetch.MilestoneBasedFetchBlockTaskFactory;
 import tech.pegasys.teku.beacon.sync.forward.ForwardSync;
 import tech.pegasys.teku.beacon.sync.forward.ForwardSyncService;
 import tech.pegasys.teku.beacon.sync.forward.singlepeer.SinglePeerSyncService;
 import tech.pegasys.teku.beacon.sync.forward.singlepeer.SyncManager;
-import tech.pegasys.teku.beacon.sync.gossip.FetchBlockTaskFactory;
 import tech.pegasys.teku.beacon.sync.gossip.FetchRecentBlocksService;
-import tech.pegasys.teku.beacon.sync.gossip.MilestoneBasedFetchBlockTaskFactory;
 import tech.pegasys.teku.bls.BLSKeyPair;
 import tech.pegasys.teku.ethereum.events.SlotEventsChannel;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
@@ -170,11 +170,11 @@ public class SyncingNodeManager {
     ForwardSyncService syncService = new SinglePeerSyncService(syncManager, recentChainData);
 
     final FetchBlockTaskFactory fetchBlockTaskFactory =
-        new MilestoneBasedFetchBlockTaskFactory(spec);
+        new MilestoneBasedFetchBlockTaskFactory(spec, eth2P2PNetwork);
 
     final FetchRecentBlocksService recentBlockFetcher =
         FetchRecentBlocksService.create(
-            asyncRunner, eth2P2PNetwork, pendingBlocks, syncService, fetchBlockTaskFactory);
+            asyncRunner, pendingBlocks, syncService, fetchBlockTaskFactory);
     recentBlockFetcher.subscribeBlockFetched(blockManager::importBlock);
     blockManager.subscribeToReceivedBlocks(
         (block, executionOptimistic) ->

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/config/GetDepositContract.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/config/GetDepositContract.java
@@ -65,7 +65,7 @@ public class GetDepositContract extends RestApiEndpoint {
 
   @Override
   public void handleRequest(RestApiRequest request) throws JsonProcessingException {
-    final int depositChainId = configProvider.getGenesisSpecConfig().getDepositChainId();
+    final long depositChainId = configProvider.getGenesisSpecConfig().getDepositChainId();
     request.respondOk(new DepositContractData(depositChainId, depositContractAddress));
   }
 
@@ -73,7 +73,7 @@ public class GetDepositContract extends RestApiEndpoint {
     final UInt64 chainId;
     final Eth1Address address;
 
-    DepositContractData(int chainId, Eth1Address address) {
+    DepositContractData(long chainId, Eth1Address address) {
       this.chainId = UInt64.valueOf(chainId);
       this.address = address;
     }

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/config/GetDepositContractTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/config/GetDepositContractTest.java
@@ -29,7 +29,7 @@ import tech.pegasys.teku.ethereum.execution.types.Eth1Address;
 
 class GetDepositContractTest extends AbstractMigratedBeaconHandlerTest {
   final Eth1Address eth1Address = dataStructureUtil.randomEth1Address();
-  final int chainId = spec.getGenesisSpecConfig().getDepositChainId();
+  final long chainId = spec.getGenesisSpecConfig().getDepositChainId();
   private final GetDepositContract.DepositContractData contractData =
       new GetDepositContract.DepositContractData(chainId, eth1Address);
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,39 @@
+FROM eclipse-temurin:17 as jre-build
+
+# Create a custom Java runtime
+RUN JAVA_TOOL_OPTIONS="-Djdk.lang.Process.launchMechanism=vfork" $JAVA_HOME/bin/jlink \
+         --add-modules ALL-MODULE-PATH \
+         --strip-debug \
+         --no-man-pages \
+         --no-header-files \
+         --compress=2 \
+         --output /javaruntime
+
+FROM ubuntu:22.04
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH "${JAVA_HOME}/bin:${PATH}"
+COPY --from=jre-build /javaruntime $JAVA_HOME
+
+RUN apt-get -y update && apt-get -y upgrade && apt-get -y install curl git jq docker
+RUN rm -rf /var/lib/api/lists/*
+RUN adduser --disabled-password --gecos "" --home /opt/teku teku && \
+    chown teku:teku /opt/teku
+
+RUN git clone --depth 1 https://github.com/ConsenSys/teku.git --branch 4844-interop && \
+    (cd teku && ./gradlew installDist)
+
+# Default to UTF-8 locale
+ENV LANG C.UTF-8
+
+ENV TEKU_REST_API_INTERFACE="0.0.0.0"
+ENV TEKU_VALIDATOR_API_INTERFACE="0.0.0.0"
+ENV TEKU_METRICS_INTERFACE="0.0.0.0"
+
+# List Exposed Ports
+# Metrics, Rest API, LibP2P, Discv5
+EXPOSE 8008 5051 9000 9000/udp
+
+USER teku
+
+# specify default command
+ENTRYPOINT ["/teku/build/install/teku/bin/teku"]

--- a/docker/jdk16/Dockerfile
+++ b/docker/jdk16/Dockerfile
@@ -17,7 +17,8 @@ COPY --from=jre-build /javaruntime $JAVA_HOME
 RUN apt-get -y update && apt-get -y upgrade && apt-get -y install curl
 RUN rm -rf /var/lib/api/lists/*
 RUN adduser --disabled-password --gecos "" --home /opt/teku teku && \
-    chown teku:teku /opt/teku
+    chown teku:teku /opt/teku && \
+    chmod 0755 /opt/teku
 
 USER teku
 WORKDIR /opt/teku

--- a/docker/jdk17/Dockerfile
+++ b/docker/jdk17/Dockerfile
@@ -17,7 +17,8 @@ COPY --from=jre-build /javaruntime $JAVA_HOME
 RUN apt-get -y update && apt-get -y upgrade && apt-get -y install curl
 RUN rm -rf /var/lib/api/lists/*
 RUN adduser --disabled-password --gecos "" --home /opt/teku teku && \
-    chown teku:teku /opt/teku
+    chown teku:teku /opt/teku && \
+    chmod 0755 /opt/teku
 
 USER teku
 WORKDIR /opt/teku

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/DelegatingSpecConfig.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/DelegatingSpecConfig.java
@@ -282,7 +282,7 @@ public class DelegatingSpecConfig implements SpecConfig {
   }
 
   @Override
-  public int getDepositChainId() {
+  public long getDepositChainId() {
     return specConfig.getDepositChainId();
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/DelegatingSpecConfig.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/DelegatingSpecConfig.java
@@ -287,7 +287,7 @@ public class DelegatingSpecConfig implements SpecConfig {
   }
 
   @Override
-  public int getDepositNetworkId() {
+  public long getDepositNetworkId() {
     return specConfig.getDepositNetworkId();
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfig.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfig.java
@@ -138,7 +138,7 @@ public interface SpecConfig {
 
   long getDepositChainId();
 
-  int getDepositNetworkId();
+  long getDepositNetworkId();
 
   Eth1Address getDepositContractAddress();
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfig.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfig.java
@@ -136,7 +136,7 @@ public interface SpecConfig {
 
   int getProposerScoreBoost();
 
-  int getDepositChainId();
+  long getDepositChainId();
 
   int getDepositNetworkId();
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigPhase0.java
@@ -97,7 +97,7 @@ public class SpecConfigPhase0 implements SpecConfig {
 
   // Deposit Contract
   private final long depositChainId;
-  private final int depositNetworkId;
+  private final long depositNetworkId;
   private final Eth1Address depositContractAddress;
 
   private final ProgressiveBalancesMode progressiveBalancesMode;
@@ -151,7 +151,7 @@ public class SpecConfigPhase0 implements SpecConfig {
       final int safeSlotsToUpdateJustified,
       final int proposerScoreBoost,
       final long depositChainId,
-      final int depositNetworkId,
+      final long depositNetworkId,
       final Eth1Address depositContractAddress,
       final ProgressiveBalancesMode progressiveBalancesMode) {
     this.rawConfig = rawConfig;
@@ -474,7 +474,7 @@ public class SpecConfigPhase0 implements SpecConfig {
   }
 
   @Override
-  public int getDepositNetworkId() {
+  public long getDepositNetworkId() {
     return depositNetworkId;
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigPhase0.java
@@ -96,7 +96,7 @@ public class SpecConfigPhase0 implements SpecConfig {
   private final int proposerScoreBoost;
 
   // Deposit Contract
-  private final int depositChainId;
+  private final long depositChainId;
   private final int depositNetworkId;
   private final Eth1Address depositContractAddress;
 
@@ -150,7 +150,7 @@ public class SpecConfigPhase0 implements SpecConfig {
       final int secondsPerEth1Block,
       final int safeSlotsToUpdateJustified,
       final int proposerScoreBoost,
-      final int depositChainId,
+      final long depositChainId,
       final int depositNetworkId,
       final Eth1Address depositContractAddress,
       final ProgressiveBalancesMode progressiveBalancesMode) {
@@ -469,7 +469,7 @@ public class SpecConfigPhase0 implements SpecConfig {
   }
 
   @Override
-  public int getDepositChainId() {
+  public long getDepositChainId() {
     return depositChainId;
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/builder/SpecConfigBuilder.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/builder/SpecConfigBuilder.java
@@ -98,7 +98,7 @@ public class SpecConfigBuilder {
   private int proposerScoreBoost = 0;
 
   // Deposit Contract
-  private Integer depositChainId;
+  private Long depositChainId;
   private Integer depositNetworkId;
   private Eth1Address depositContractAddress;
 
@@ -518,7 +518,7 @@ public class SpecConfigBuilder {
     return this;
   }
 
-  public SpecConfigBuilder depositChainId(final Integer depositChainId) {
+  public SpecConfigBuilder depositChainId(final Long depositChainId) {
     checkNotNull(depositChainId);
     this.depositChainId = depositChainId;
     return this;

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/builder/SpecConfigBuilder.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/builder/SpecConfigBuilder.java
@@ -99,7 +99,7 @@ public class SpecConfigBuilder {
 
   // Deposit Contract
   private Long depositChainId;
-  private Integer depositNetworkId;
+  private Long depositNetworkId;
   private Eth1Address depositContractAddress;
 
   private ProgressiveBalancesMode progressiveBalancesMode = ProgressiveBalancesMode.USED;
@@ -524,7 +524,7 @@ public class SpecConfigBuilder {
     return this;
   }
 
-  public SpecConfigBuilder depositNetworkId(final Integer depositNetworkId) {
+  public SpecConfigBuilder depositNetworkId(final Long depositNetworkId) {
     checkNotNull(depositNetworkId);
     this.depositNetworkId = depositNetworkId;
     return this;

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
@@ -333,7 +333,7 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
             headAndAttrs.currentKzgCommitments.orElseThrow(),
             headAndAttrs.currentBlobs.orElseThrow());
 
-    LOG.info("getBlobsBundle: slot: {} -> blobsBundle: {}", slot, blobsBundle);
+    LOG.info("getBlobsBundle: slot: {} -> blobsBundle: {}", slot, blobsBundle.toBriefBlobsString());
 
     return SafeFuture.completedFuture(blobsBundle);
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/eip4844/blobs/BlobsSidecarAvailabilityChecker.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/eip4844/blobs/BlobsSidecarAvailabilityChecker.java
@@ -22,6 +22,7 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
 import tech.pegasys.teku.spec.datastructures.execution.versions.eip4844.BlobsSidecar;
+import tech.pegasys.teku.spec.logic.versions.eip4844.helpers.MiscHelpersEip4844;
 
 public interface BlobsSidecarAvailabilityChecker {
   BlobsSidecarAvailabilityChecker NOOP =
@@ -80,6 +81,7 @@ public interface BlobsSidecarAvailabilityChecker {
 
   SafeFuture<BlobsSidecarAndValidationResult> getAvailabilityCheckResult();
 
+  /** Only perform the {@link MiscHelpersEip4844#isDataAvailable} check */
   SafeFuture<BlobsSidecarAndValidationResult> validate(BlobsSidecar blobsSidecar);
 
   enum BlobsSidecarValidationResult {

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/ChainBuilder.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/ChainBuilder.java
@@ -216,6 +216,10 @@ public class ChainBuilder {
         .filter(s -> s.getBeaconBlockSlot().isLessThanOrEqualTo(toSlot));
   }
 
+  public Stream<BlobsSidecar> streamBlobsSidecars() {
+    return blobsSidecars.values().stream();
+  }
+
   public void discardBlobsSidecar(final UInt64 slot) {
     blobsSidecars.remove(slot);
   }

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/ChainBuilder.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/ChainBuilder.java
@@ -216,6 +216,10 @@ public class ChainBuilder {
         .filter(s -> s.getBeaconBlockSlot().isLessThanOrEqualTo(toSlot));
   }
 
+  public void discardBlobsSidecar(final UInt64 slot) {
+    blobsSidecars.remove(slot);
+  }
+
   public SignedBlockAndState getGenesis() {
     return Optional.ofNullable(blocks.firstEntry()).map(Map.Entry::getValue).orElse(null);
   }

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
@@ -262,6 +262,10 @@ public class SafeFuture<T> extends CompletableFuture<T> {
     return complete;
   }
 
+  public static SafeFuture<Void> allOfFailFast(final Stream<SafeFuture<?>> futures) {
+    return allOfFailFast(futures.toArray(SafeFuture[]::new));
+  }
+
   /**
    * Returns a new {@link SafeFuture} with the result of the first successful future from the given
    * futures. If all futures complete exceptionally, the returned {@link SafeFuture} will complete

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
@@ -382,7 +382,7 @@ public class StatusLogger {
     log.info(performance);
   }
 
-  public void eth1DepositChainIdMismatch(int expectedChainId, int eth1ChainId, String endpointId) {
+  public void eth1DepositChainIdMismatch(long expectedChainId, int eth1ChainId, String endpointId) {
     log.log(
         Level.ERROR,
         "PLEASE CHECK YOUR ETH1 NODE (endpoint {})| Wrong Eth1 chain id (expected={}, actual={})",

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
@@ -382,7 +382,8 @@ public class StatusLogger {
     log.info(performance);
   }
 
-  public void eth1DepositChainIdMismatch(long expectedChainId, int eth1ChainId, String endpointId) {
+  public void eth1DepositChainIdMismatch(
+      long expectedChainId, long eth1ChainId, String endpointId) {
     log.log(
         Level.ERROR,
         "PLEASE CHECK YOUR ETH1 NODE (endpoint {})| Wrong Eth1 chain id (expected={}, actual={})",

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/BeaconChainMethods.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/BeaconChainMethods.java
@@ -50,7 +50,6 @@ import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlockSchema;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.eip4844.SignedBeaconBlockAndBlobsSidecar;
-import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.eip4844.SignedBeaconBlockAndBlobsSidecarSchema;
 import tech.pegasys.teku.spec.datastructures.execution.versions.eip4844.BlobsSidecar;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BeaconBlockAndBlobsSidecarByRootRequestMessage;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BeaconBlockAndBlobsSidecarByRootRequestMessage.BeaconBlockAndBlobsSidecarByRootRequestMessageSchema;
@@ -66,7 +65,6 @@ import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.GoodbyeMessag
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.PingMessage;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.StatusMessage;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.metadata.MetadataMessage;
-import tech.pegasys.teku.spec.schemas.SchemaDefinitionsEip4844;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
@@ -231,7 +229,7 @@ public class BeaconChainMethods {
     if (spec.isMilestoneSupported(SpecMilestone.ALTAIR)) {
       final RpcContextCodec<Bytes4, SignedBeaconBlock> forkDigestContextCodec =
           RpcContextCodec.forkDigest(
-              spec, recentChainData, ForkDigestPayloadContext.SIGNED_BEACONBLOCK);
+              spec, recentChainData, ForkDigestPayloadContext.SIGNED_BEACON_BLOCK);
 
       final SingleProtocolEth2RpcMethod<BeaconBlocksByRootRequestMessage, SignedBeaconBlock>
           v2Method =
@@ -292,7 +290,7 @@ public class BeaconChainMethods {
     if (spec.isMilestoneSupported(SpecMilestone.ALTAIR)) {
       final RpcContextCodec<Bytes4, SignedBeaconBlock> forkDigestContextCodec =
           RpcContextCodec.forkDigest(
-              spec, recentChainData, ForkDigestPayloadContext.SIGNED_BEACONBLOCK);
+              spec, recentChainData, ForkDigestPayloadContext.SIGNED_BEACON_BLOCK);
 
       final SingleProtocolEth2RpcMethod<BeaconBlocksByRangeRequestMessage, SignedBeaconBlock>
           v2Method =
@@ -331,13 +329,9 @@ public class BeaconChainMethods {
     final BeaconBlockAndBlobsSidecarByRootRequestMessageSchema requestType =
         BeaconBlockAndBlobsSidecarByRootRequestMessage.SSZ_SCHEMA;
 
-    final SignedBeaconBlockAndBlobsSidecarSchema beaconBlockAndBlobsSidecarSchema =
-        SchemaDefinitionsEip4844.required(
-                spec.forMilestone(SpecMilestone.EIP4844).getSchemaDefinitions())
-            .getSignedBeaconBlockAndBlobsSidecarSchema();
-
-    final RpcContextCodec<Bytes, SignedBeaconBlockAndBlobsSidecar> noContextCodec =
-        RpcContextCodec.noop(beaconBlockAndBlobsSidecarSchema);
+    final RpcContextCodec<Bytes4, SignedBeaconBlockAndBlobsSidecar> forkDigestContextCodec =
+        RpcContextCodec.forkDigest(
+            spec, recentChainData, ForkDigestPayloadContext.SIGNED_BEACON_BLOCK_AND_BLOBS_SIDECAR);
 
     final BeaconBlockAndBlobsSidecarByRootMessageHandler messageHandler =
         new BeaconBlockAndBlobsSidecarByRootMessageHandler(
@@ -351,7 +345,7 @@ public class BeaconChainMethods {
             rpcEncoding,
             requestType,
             true,
-            noContextCodec,
+            forkDigestContextCodec,
             messageHandler,
             peerLookup));
   }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/encodings/context/ForkDigestPayloadContext.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/encodings/context/ForkDigestPayloadContext.java
@@ -17,12 +17,13 @@ import tech.pegasys.teku.infrastructure.ssz.SszData;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszSchema;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.eip4844.SignedBeaconBlockAndBlobsSidecar;
 import tech.pegasys.teku.spec.datastructures.execution.versions.eip4844.BlobsSidecar;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
 
 public interface ForkDigestPayloadContext<TPayload extends SszData> {
 
-  ForkDigestPayloadContext<SignedBeaconBlock> SIGNED_BEACONBLOCK =
+  ForkDigestPayloadContext<SignedBeaconBlock> SIGNED_BEACON_BLOCK =
       new ForkDigestPayloadContext<>() {
         @Override
         public UInt64 getSlotFromPayload(final SignedBeaconBlock responsePayload) {
@@ -47,6 +48,23 @@ public interface ForkDigestPayloadContext<TPayload extends SszData> {
         public SszSchema<BlobsSidecar> getSchemaFromSchemaDefinitions(
             final SchemaDefinitions schemaDefinitions) {
           return schemaDefinitions.toVersionEip4844().orElseThrow().getBlobsSidecarSchema();
+        }
+      };
+
+  ForkDigestPayloadContext<SignedBeaconBlockAndBlobsSidecar> SIGNED_BEACON_BLOCK_AND_BLOBS_SIDECAR =
+      new ForkDigestPayloadContext<>() {
+        @Override
+        public UInt64 getSlotFromPayload(final SignedBeaconBlockAndBlobsSidecar responsePayload) {
+          return responsePayload.getSignedBeaconBlock().getSlot();
+        }
+
+        @Override
+        public SszSchema<SignedBeaconBlockAndBlobsSidecar> getSchemaFromSchemaDefinitions(
+            final SchemaDefinitions schemaDefinitions) {
+          return schemaDefinitions
+              .toVersionEip4844()
+              .orElseThrow()
+              .getSignedBeaconBlockAndBlobsSidecarSchema();
         }
       };
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/encodings/context/ForkDigestPayloadContext.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/encodings/context/ForkDigestPayloadContext.java
@@ -17,6 +17,7 @@ import tech.pegasys.teku.infrastructure.ssz.SszData;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszSchema;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.execution.versions.eip4844.BlobsSidecar;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
 
 public interface ForkDigestPayloadContext<TPayload extends SszData> {
@@ -32,6 +33,20 @@ public interface ForkDigestPayloadContext<TPayload extends SszData> {
         public SszSchema<SignedBeaconBlock> getSchemaFromSchemaDefinitions(
             final SchemaDefinitions schemaDefinitions) {
           return schemaDefinitions.getSignedBeaconBlockSchema();
+        }
+      };
+
+  ForkDigestPayloadContext<BlobsSidecar> BLOBS_SIDECAR =
+      new ForkDigestPayloadContext<>() {
+        @Override
+        public UInt64 getSlotFromPayload(final BlobsSidecar responsePayload) {
+          return responsePayload.getBeaconBlockSlot();
+        }
+
+        @Override
+        public SszSchema<BlobsSidecar> getSchemaFromSchemaDefinitions(
+            final SchemaDefinitions schemaDefinitions) {
+          return schemaDefinitions.toVersionEip4844().orElseThrow().getBlobsSidecarSchema();
         }
       };
 

--- a/services/chainstorage/src/main/java/tech/pegasys/teku/services/chainstorage/StorageService.java
+++ b/services/chainstorage/src/main/java/tech/pegasys/teku/services/chainstorage/StorageService.java
@@ -37,7 +37,7 @@ import tech.pegasys.teku.storage.server.DepositStorage;
 import tech.pegasys.teku.storage.server.RetryingStorageUpdateChannel;
 import tech.pegasys.teku.storage.server.StorageConfiguration;
 import tech.pegasys.teku.storage.server.VersionedDatabaseFactory;
-import tech.pegasys.teku.storage.server.pruner.BlobsPruner;
+import tech.pegasys.teku.storage.server.pruner.BlobsSidecarPruner;
 import tech.pegasys.teku.storage.server.pruner.BlockPruner;
 
 public class StorageService extends Service implements StorageServiceFacade {
@@ -47,7 +47,7 @@ public class StorageService extends Service implements StorageServiceFacade {
   private volatile Database database;
   private volatile BatchingVoteUpdateChannel batchingVoteUpdateChannel;
   private volatile Optional<BlockPruner> blockPruner = Optional.empty();
-  private volatile Optional<BlobsPruner> blobsPruner = Optional.empty();
+  private volatile Optional<BlobsSidecarPruner> blobsPruner = Optional.empty();
   private final boolean depositSnapshotStorageEnabled;
 
   public StorageService(
@@ -90,7 +90,7 @@ public class StorageService extends Service implements StorageServiceFacade {
               if (config.getSpec().isMilestoneSupported(SpecMilestone.EIP4844)) {
                 blobsPruner =
                     Optional.of(
-                        new BlobsPruner(
+                        new BlobsSidecarPruner(
                             config.getSpec(),
                             database,
                             storagePrunerAsyncRunner,
@@ -136,7 +136,7 @@ public class StorageService extends Service implements StorageServiceFacade {
         .thenCompose(
             __ ->
                 blobsPruner
-                    .map(BlobsPruner::start)
+                    .map(BlobsSidecarPruner::start)
                     .orElseGet(() -> SafeFuture.completedFuture(null)));
   }
 

--- a/services/chainstorage/src/main/java/tech/pegasys/teku/services/chainstorage/StorageService.java
+++ b/services/chainstorage/src/main/java/tech/pegasys/teku/services/chainstorage/StorageService.java
@@ -93,6 +93,7 @@ public class StorageService extends Service implements StorageServiceFacade {
                         new BlobsSidecarPruner(
                             config.getSpec(),
                             database,
+                            serviceConfig.getMetricsSystem(),
                             storagePrunerAsyncRunner,
                             serviceConfig.getTimeProvider(),
                             config.getBlobsPruningInterval(),

--- a/storage/api/src/main/java/tech/pegasys/teku/storage/api/StorageUpdateChannel.java
+++ b/storage/api/src/main/java/tech/pegasys/teku/storage/api/StorageUpdateChannel.java
@@ -14,10 +14,12 @@
 package tech.pegasys.teku.storage.api;
 
 import java.util.Collection;
+import java.util.Map;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.ethereum.pow.api.DepositTreeSnapshot;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.events.ChannelInterface;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.execution.versions.eip4844.BlobsSidecar;
@@ -28,7 +30,9 @@ public interface StorageUpdateChannel extends ChannelInterface {
 
   SafeFuture<UpdateResult> onStorageUpdate(StorageUpdate event);
 
-  SafeFuture<Void> onFinalizedBlocks(Collection<SignedBeaconBlock> finalizedBlocks);
+  SafeFuture<Void> onFinalizedBlocks(
+      Collection<SignedBeaconBlock> finalizedBlocks,
+      Map<UInt64, BlobsSidecar> finalizedBlobsSidecar);
 
   SafeFuture<Void> onFinalizedState(BeaconState finalizedState, Bytes32 blockRoot);
 

--- a/storage/src/integration-test/java/tech/pegasys/teku/storage/server/kvstore/DatabaseTest.java
+++ b/storage/src/integration-test/java/tech/pegasys/teku/storage/server/kvstore/DatabaseTest.java
@@ -250,7 +250,7 @@ public class DatabaseTest {
     assertBlobsStream(blobsSidecar1, blobsSidecar2, blobsSidecar2bis, blobsSidecar3, blobsSidecar4);
 
     // let's prune unconfirmed with limit to 1
-    assertThat(database.pruneOldestUnconfirmedBlobsSidecar(UInt64.MAX_VALUE, 1)).isTrue();
+    assertThat(database.pruneOldestUnconfirmedBlobsSidecars(UInt64.MAX_VALUE, 1)).isTrue();
     assertUnconfirmedBlobsStream(
         blobsSidecarToSlotAndBlockRoot(blobsSidecar2),
         blobsSidecarToSlotAndBlockRoot(blobsSidecar2bis),
@@ -259,7 +259,7 @@ public class DatabaseTest {
     assertBlobsStream(blobsSidecar2, blobsSidecar2bis, blobsSidecar3, blobsSidecar4);
 
     // let's prune unconfirmed up to slot 1 (nothing will be pruned)
-    assertThat(database.pruneOldestUnconfirmedBlobsSidecar(ONE, 10)).isFalse();
+    assertThat(database.pruneOldestUnconfirmedBlobsSidecars(ONE, 10)).isFalse();
     assertUnconfirmedBlobsStream(
         blobsSidecarToSlotAndBlockRoot(blobsSidecar2),
         blobsSidecarToSlotAndBlockRoot(blobsSidecar2bis),
@@ -268,7 +268,7 @@ public class DatabaseTest {
     assertBlobsStream(blobsSidecar2, blobsSidecar2bis, blobsSidecar3, blobsSidecar4);
 
     // let's prune all unconfirmed
-    assertThat(database.pruneOldestUnconfirmedBlobsSidecar(UInt64.valueOf(3), 10)).isFalse();
+    assertThat(database.pruneOldestUnconfirmedBlobsSidecars(UInt64.valueOf(3), 10)).isFalse();
     assertUnconfirmedBlobsStream();
     // we have blobsSidecar4
     assertBlobsStream(blobsSidecar4);
@@ -2275,7 +2275,7 @@ public class DatabaseTest {
   private void assertUnconfirmedBlobsStream(
       UInt64 startSlot, UInt64 endSlot, SlotAndBlockRoot... slotAndBlockRoots) {
     try (Stream<SlotAndBlockRoot> blobsSidecarStream =
-        database.streamUnconfirmedBlobsSidecar(startSlot, endSlot)) {
+        database.streamUnconfirmedBlobsSidecars(startSlot, endSlot)) {
       final List<SlotAndBlockRoot> allSlotAndBlockRoots = blobsSidecarStream.collect(toList());
       assertThat(allSlotAndBlockRoots).containsExactly(slotAndBlockRoots);
     }
@@ -2287,7 +2287,7 @@ public class DatabaseTest {
 
   private void assertBlobsStream(UInt64 startSlot, UInt64 endSlot, BlobsSidecar... blobsSidecars) {
     try (Stream<BlobsSidecar> blobsSidecarStream =
-        database.streamBlobsSidecar(startSlot, endSlot)) {
+        database.streamBlobsSidecars(startSlot, endSlot)) {
       final List<BlobsSidecar> allBlobs = blobsSidecarStream.collect(toList());
       assertThat(allBlobs).containsExactly(blobsSidecars);
     }

--- a/storage/src/integration-test/java/tech/pegasys/teku/storage/server/kvstore/DatabaseTest.java
+++ b/storage/src/integration-test/java/tech/pegasys/teku/storage/server/kvstore/DatabaseTest.java
@@ -370,6 +370,9 @@ public class DatabaseTest {
     // Add base blocks
     addBlocks(chainBuilder.streamBlocksAndStates().collect(toList()));
 
+    // add blobs sidecars
+    addBlobsSidecars(chainBuilder.streamBlobsSidecars().collect(toList()));
+
     // Set target slot at which to create duplicate blocks
     // and generate block options to make each block unique
     final List<BlockOptions> blockOptions =
@@ -392,6 +395,11 @@ public class DatabaseTest {
     add(List.of(blockB));
     add(List.of(blockC));
 
+    // Add corresponding blobs sidecars
+    addBlobsSidecars(List.of(forkA.getBlobsSidecar(blockA.getRoot()).orElseThrow()));
+    addBlobsSidecars(List.of(forkB.getBlobsSidecar(blockB.getRoot()).orElseThrow()));
+    addBlobsSidecars(List.of(chainBuilder.getBlobsSidecar(blockC.getRoot()).orElseThrow()));
+
     // Verify all blocks are available
     assertThat(store.retrieveBlock(blockA.getRoot()))
         .isCompletedWithValue(Optional.of(blockA.getBlock().getMessage()));
@@ -400,9 +408,23 @@ public class DatabaseTest {
     assertThat(store.retrieveBlock(blockC.getRoot()))
         .isCompletedWithValue(Optional.of(blockC.getBlock().getMessage()));
 
+    // verify we have all blobs sidecar are available
+    final List<SignedBeaconBlock> blocksWithAvailableSidecars =
+        Stream.concat(
+                Stream.concat(
+                    chainBuilder.streamBlocksAndStates(ONE),
+                    forkA.streamBlocksAndStates(targetSlot)),
+                forkB.streamBlocksAndStates(targetSlot))
+            .map(SignedBlockAndState::getBlock)
+            .collect(Collectors.toList());
+
+    assertBlobsSidecarAvailabilityExceptPruned(blocksWithAvailableSidecars, List.of());
+
     // Finalize subsequent block to prune blocks a, b, and c
     final SignedBlockAndState finalBlock = chainBuilder.generateNextBlock();
     add(List.of(finalBlock));
+    addBlobsSidecars(List.of(chainBuilder.getBlobsSidecar(finalBlock.getRoot()).orElseThrow()));
+
     final UInt64 finalEpoch = chainBuilder.getLatestEpoch().plus(ONE);
     final SignedBlockAndState finalizedBlock =
         chainBuilder.getLatestBlockAndStateAtEpochBoundary(finalEpoch);
@@ -413,6 +435,17 @@ public class DatabaseTest {
     rootsToPrune.add(genesisBlockAndState.getRoot());
     // Check that all blocks at slot 10 were pruned
     assertRecentDataWasPruned(store, rootsToPrune);
+
+    // verify we have all canonical and finalized sidecars and blockA and blockB sidecars have been
+    // pruned
+    final List<SignedBeaconBlock> canonicalBlocksWithAvailableSidecars =
+        chainBuilder
+            .streamBlocksAndStates(ONE)
+            .map(SignedBlockAndState::getBlock)
+            .collect(toList());
+
+    assertBlobsSidecarAvailabilityExceptPruned(
+        canonicalBlocksWithAvailableSidecars, List.of(blockA.getBlock(), blockB.getBlock()));
   }
 
   @TestTemplate
@@ -2150,6 +2183,23 @@ public class DatabaseTest {
     }
   }
 
+  private void assertBlobsSidecarAvailabilityExceptPruned(
+      final Collection<SignedBeaconBlock> availableBlocksSidecars,
+      final Collection<SignedBeaconBlock> prunedBlocksSidecars) {
+    availableBlocksSidecars.forEach(
+        block ->
+            assertThat(
+                    database.getBlobsSidecar(
+                        new SlotAndBlockRoot(block.getSlot(), block.getRoot())))
+                .isPresent());
+    prunedBlocksSidecars.forEach(
+        block ->
+            assertThat(
+                    database.getBlobsSidecar(
+                        new SlotAndBlockRoot(block.getSlot(), block.getRoot())))
+                .isEmpty());
+  }
+
   private void addBlocks(final SignedBlockAndState... blocks) {
     addBlocks(Arrays.asList(blocks));
   }
@@ -2160,6 +2210,16 @@ public class DatabaseTest {
       transaction.putBlockAndState(block, spec.calculateBlockCheckpoints(block.getState()));
     }
     commit(transaction);
+  }
+
+  private void addBlobsSidecars(final List<BlobsSidecar> blobsSidecars) {
+    blobsSidecars.forEach(
+        blobsSidecar -> {
+          database.storeUnconfirmedBlobsSidecar(blobsSidecar);
+          database.confirmBlobsSidecar(
+              new SlotAndBlockRoot(
+                  blobsSidecar.getBeaconBlockSlot(), blobsSidecar.getBeaconBlockRoot()));
+        });
   }
 
   private void add(final Collection<SignedBlockAndState> blocks) {

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/ChainStorage.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/ChainStorage.java
@@ -103,8 +103,11 @@ public class ChainStorage
   }
 
   @Override
-  public SafeFuture<Void> onFinalizedBlocks(final Collection<SignedBeaconBlock> finalizedBlocks) {
-    return SafeFuture.fromRunnable(() -> database.storeFinalizedBlocks(finalizedBlocks));
+  public SafeFuture<Void> onFinalizedBlocks(
+      final Collection<SignedBeaconBlock> finalizedBlocks,
+      final Map<UInt64, BlobsSidecar> finalizedBlobsSidecar) {
+    return SafeFuture.fromRunnable(
+        () -> database.storeFinalizedBlocks(finalizedBlocks, finalizedBlobsSidecar));
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/CombinedStorageChannelSplitter.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/CombinedStorageChannelSplitter.java
@@ -68,8 +68,10 @@ public class CombinedStorageChannelSplitter implements CombinedStorageChannel {
   }
 
   @Override
-  public SafeFuture<Void> onFinalizedBlocks(final Collection<SignedBeaconBlock> finalizedBlocks) {
-    return updateDelegate.onFinalizedBlocks(finalizedBlocks);
+  public SafeFuture<Void> onFinalizedBlocks(
+      final Collection<SignedBeaconBlock> finalizedBlocks,
+      final Map<UInt64, BlobsSidecar> blobsSidecarBySlot) {
+    return updateDelegate.onFinalizedBlocks(finalizedBlocks, blobsSidecarBySlot);
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
@@ -84,16 +84,20 @@ public interface Database extends AutoCloseable {
    * @param pruneLimit
    * @return true if number of pruned blobs reached the pruneLimit, false otherwise
    */
-  boolean pruneOldestUnconfirmedBlobsSidecar(UInt64 lastSlotToPrune, int pruneLimit);
+  boolean pruneOldestUnconfirmedBlobsSidecars(UInt64 lastSlotToPrune, int pruneLimit);
 
   @MustBeClosed
-  Stream<BlobsSidecar> streamBlobsSidecar(UInt64 startSlot, UInt64 endSlot);
+  Stream<BlobsSidecar> streamBlobsSidecars(UInt64 startSlot, UInt64 endSlot);
+
+  @MustBeClosed
+  Stream<Map.Entry<SlotAndBlockRoot, Bytes>> streamBlobsSidecarsAsSsz(
+      UInt64 startSlot, UInt64 endSlot);
 
   @MustBeClosed
   Stream<SlotAndBlockRoot> streamBlobsSidecarKeys(UInt64 startSlot, UInt64 endSlot);
 
   @MustBeClosed
-  Stream<SlotAndBlockRoot> streamUnconfirmedBlobsSidecar(UInt64 startSlot, UInt64 endSlot);
+  Stream<SlotAndBlockRoot> streamUnconfirmedBlobsSidecars(UInt64 startSlot, UInt64 endSlot);
 
   Optional<UInt64> getEarliestBlobsSidecarSlot();
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
@@ -48,7 +48,8 @@ public interface Database extends AutoCloseable {
 
   UpdateResult update(StorageUpdate event);
 
-  void storeFinalizedBlocks(Collection<SignedBeaconBlock> blocks);
+  void storeFinalizedBlocks(
+      Collection<SignedBeaconBlock> blocks, Map<UInt64, BlobsSidecar> blobsSidecarBySlot);
 
   void storeFinalizedState(BeaconState state, Bytes32 blockRoot);
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
@@ -205,6 +205,8 @@ public interface Database extends AutoCloseable {
 
   Map<String, Long> getColumnCounts();
 
+  Map<String, Long> getBlobsSidecarColumnCounts();
+
   void migrate();
 
   Optional<Checkpoint> getAnchor();

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/RetryingStorageUpdateChannel.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/RetryingStorageUpdateChannel.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.storage.server;
 import com.google.common.annotations.VisibleForTesting;
 import java.time.Duration;
 import java.util.Collection;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 import org.apache.logging.log4j.LogManager;
@@ -84,8 +85,10 @@ public class RetryingStorageUpdateChannel implements StorageUpdateChannel {
   }
 
   @Override
-  public SafeFuture<Void> onFinalizedBlocks(final Collection<SignedBeaconBlock> finalizedBlocks) {
-    return retry(() -> delegate.onFinalizedBlocks(finalizedBlocks));
+  public SafeFuture<Void> onFinalizedBlocks(
+      final Collection<SignedBeaconBlock> finalizedBlocks,
+      final Map<UInt64, BlobsSidecar> blobsSidecarBySlot) {
+    return retry(() -> delegate.onFinalizedBlocks(finalizedBlocks, blobsSidecarBySlot));
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreAccessor.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreAccessor.java
@@ -79,6 +79,9 @@ public interface KvStoreAccessor extends AutoCloseable {
   @MustBeClosed
   Stream<ColumnEntry<Bytes, Bytes>> streamRaw(KvStoreColumn<?, ?> column);
 
+  @MustBeClosed
+  Stream<Bytes> streamKeysRaw(final KvStoreColumn<?, ?> column);
+
   /**
    * WARNING: should only be used to migrate data between tables
    *

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
@@ -324,6 +324,11 @@ public class KvStoreDatabase implements Database {
   }
 
   @Override
+  public Map<String, Long> getBlobsSidecarColumnCounts() {
+    return dao.getBlobsSidecarColumnCounts();
+  }
+
+  @Override
   public void migrate() {}
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
@@ -461,6 +461,11 @@ public class KvStoreDatabase implements Database {
             "Blocks must be contiguous with the earliest known block.");
       }
       expectedRoot = block.getParentRoot();
+      final SlotAndBlockRoot slotAndBlockRoot =
+          new SlotAndBlockRoot(block.getSlot(), block.getRoot());
+      // we only store finalized blocks when we have validated the sidecar and stored it as
+      // unconfirmed, so we can safely confirm it now
+      confirmBlobsSidecar(slotAndBlockRoot);
     }
 
     storeFinalizedBlocksToDao(blocks);

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
@@ -738,10 +738,10 @@ public class KvStoreDatabase implements Database {
   }
 
   @Override
-  public boolean pruneOldestUnconfirmedBlobsSidecar(
+  public boolean pruneOldestUnconfirmedBlobsSidecars(
       final UInt64 lastSlotToPrune, final int pruneLimit) {
     try (final Stream<SlotAndBlockRoot> prunableUnconfirmed =
-            streamUnconfirmedBlobsSidecar(UInt64.ZERO, lastSlotToPrune);
+            streamUnconfirmedBlobsSidecars(UInt64.ZERO, lastSlotToPrune);
         final FinalizedUpdater updater = finalizedUpdater()) {
       final long pruned =
           prunableUnconfirmed
@@ -760,13 +760,20 @@ public class KvStoreDatabase implements Database {
 
   @MustBeClosed
   @Override
-  public Stream<BlobsSidecar> streamBlobsSidecar(final UInt64 startSlot, final UInt64 endSlot) {
+  public Stream<BlobsSidecar> streamBlobsSidecars(final UInt64 startSlot, final UInt64 endSlot) {
     return dao.streamBlobsSidecar(startSlot, endSlot)
         .map(
             slotAndBlockRootBytesEntry ->
                 spec.deserializeBlobsSidecar(
                     slotAndBlockRootBytesEntry.getValue(),
                     slotAndBlockRootBytesEntry.getKey().getSlot()));
+  }
+
+  @MustBeClosed
+  @Override
+  public Stream<Map.Entry<SlotAndBlockRoot, Bytes>> streamBlobsSidecarsAsSsz(
+      final UInt64 startSlot, final UInt64 endSlot) {
+    return dao.streamBlobsSidecar(startSlot, endSlot);
   }
 
   @MustBeClosed
@@ -778,7 +785,7 @@ public class KvStoreDatabase implements Database {
 
   @MustBeClosed
   @Override
-  public Stream<SlotAndBlockRoot> streamUnconfirmedBlobsSidecar(
+  public Stream<SlotAndBlockRoot> streamUnconfirmedBlobsSidecars(
       final UInt64 startSlot, final UInt64 endSlot) {
     return dao.streamUnconfirmedBlobsSidecar(startSlot, endSlot);
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
@@ -853,7 +853,8 @@ public class KvStoreDatabase implements Database {
             update.getOptimisticTransitionBlockRoot());
 
     if (update.isBlobsSidecarEnabled()) {
-      updateBlobsSidecars(update.getHotBlocks(), update.getDeletedHotBlocks());
+      updateBlobsSidecars(
+          update.getHotBlocks(), update.getFinalizedBlocks(), update.getDeletedHotBlocks());
     }
 
     LOG.trace("Applying hot updates");
@@ -938,6 +939,7 @@ public class KvStoreDatabase implements Database {
 
   private void updateBlobsSidecars(
       final Map<Bytes32, BlockAndCheckpoints> hotBlocks,
+      final Map<Bytes32, SignedBeaconBlock> finalizedBlocks,
       final Map<Bytes32, UInt64> deletedHotBlocks) {
     try (final FinalizedUpdater updater = finalizedUpdater()) {
       LOG.trace("Confirming blobs sidecars for new hot blocks");
@@ -948,8 +950,11 @@ public class KvStoreDatabase implements Database {
                       blockAndCheckpoints.getSlot(), blockAndCheckpoints.getRoot()))
           .forEach(updater::confirmBlobsSidecar);
 
+      final Set<Bytes32> finalizedBlockRoots = finalizedBlocks.keySet();
+
       LOG.trace("Removing blobs sidecars for deleted hot blocks");
       deletedHotBlocks.entrySet().stream()
+          .filter(entry -> !finalizedBlockRoots.contains(entry.getKey()))
           .map(entry -> new SlotAndBlockRoot(entry.getValue(), entry.getKey()))
           .forEach(updater::removeBlobsSidecar);
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
@@ -379,6 +379,18 @@ public class CombinedKvStoreDao<S extends SchemaCombined>
   }
 
   @Override
+  public Map<String, Long> getBlobsSidecarColumnCounts() {
+    final Map<String, Long> columnCounts = new LinkedHashMap<>();
+
+    schema.getColumnMap().entrySet().stream()
+        .filter(
+            stringKvStoreColumnEntry -> stringKvStoreColumnEntry.getKey().contains("BLOBS_SIDECAR"))
+        .collect(Collectors.toMap(Entry::getKey, Entry::getValue))
+        .forEach((k, v) -> columnCounts.put(k, db.size(v)));
+    return columnCounts;
+  }
+
+  @Override
   @MustBeClosed
   public Stream<UInt64> streamFinalizedStateSlots(final UInt64 startSlot, final UInt64 endSlot) {
     return stateStorageLogic.streamFinalizedStateSlots(db, schema, startSlot, endSlot);

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDao.java
@@ -139,6 +139,8 @@ public interface KvStoreCombinedDao extends AutoCloseable {
 
   Map<String, Long> getColumnCounts();
 
+  Map<String, Long> getBlobsSidecarColumnCounts();
+
   @MustBeClosed
   Stream<UInt64> streamFinalizedStateSlots(final UInt64 startSlot, final UInt64 endSlot);
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoAdapter.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoAdapter.java
@@ -217,6 +217,11 @@ public class KvStoreCombinedDaoAdapter implements KvStoreCombinedDao, V4Migratab
   }
 
   @Override
+  public Map<String, Long> getBlobsSidecarColumnCounts() {
+    return new LinkedHashMap<>(finalizedDao.getBlobsSidecarColumnCounts());
+  }
+
+  @Override
   @MustBeClosed
   public Stream<UInt64> streamFinalizedStateSlots(final UInt64 startSlot, final UInt64 endSlot) {
     return finalizedDao.streamFinalizedStateSlots(startSlot, endSlot);

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4FinalizedKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4FinalizedKvStoreDao.java
@@ -20,8 +20,10 @@ import com.google.errorprone.annotations.MustBeClosed;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -202,6 +204,17 @@ public class V4FinalizedKvStoreDao {
   public Map<String, Long> getColumnCounts() {
     final Map<String, Long> columnCounts = new HashMap<>();
     schema.getColumnMap().forEach((k, v) -> columnCounts.put(k, db.size(v)));
+    return columnCounts;
+  }
+
+  public Map<String, Long> getBlobsSidecarColumnCounts() {
+    final Map<String, Long> columnCounts = new LinkedHashMap<>();
+
+    schema.getColumnMap().entrySet().stream()
+        .filter(
+            stringKvStoreColumnEntry -> stringKvStoreColumnEntry.getKey().contains("BLOBS_SIDECAR"))
+        .collect(Collectors.toMap(Entry::getKey, Entry::getValue))
+        .forEach((k, v) -> columnCounts.put(k, db.size(v)));
     return columnCounts;
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/leveldb/LevelDbInstance.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/leveldb/LevelDbInstance.java
@@ -113,7 +113,7 @@ public class LevelDbInstance implements KvStoreAccessor {
   @Override
   public long size(final KvStoreColumn<?, ?> column) {
     assertOpen();
-    try (final Stream<?> rawStream = streamRaw(column)) {
+    try (final Stream<?> rawStream = streamKeysRaw(column)) {
       return rawStream.count();
     }
   }
@@ -241,6 +241,13 @@ public class LevelDbInstance implements KvStoreAccessor {
   public Stream<ColumnEntry<Bytes, Bytes>> streamRaw(final KvStoreColumn<?, ?> column) {
     return streamRaw(column, column.getId().toArrayUnsafe(), getKeyAfterColumn(column))
         .map(entry -> ColumnEntry.create(Bytes.wrap(entry.getKey()), Bytes.wrap(entry.getValue())));
+  }
+
+  @Override
+  @MustBeClosed
+  public Stream<Bytes> streamKeysRaw(final KvStoreColumn<?, ?> column) {
+    return streamKeysRaw(column, column.getId().toArrayUnsafe(), getKeyAfterColumn(column))
+        .map(Bytes::wrap);
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -274,7 +275,13 @@ public class NoOpDatabase implements Database {
   public void removeBlobsSidecar(final SlotAndBlockRoot slotAndBlockRoot) {}
 
   @Override
-  public Stream<BlobsSidecar> streamBlobsSidecar(final UInt64 startSlot, final UInt64 endSlot) {
+  public Stream<BlobsSidecar> streamBlobsSidecars(final UInt64 startSlot, final UInt64 endSlot) {
+    return Stream.empty();
+  }
+
+  @Override
+  public Stream<Entry<SlotAndBlockRoot, Bytes>> streamBlobsSidecarsAsSsz(
+      final UInt64 startSlot, final UInt64 endSlot) {
     return Stream.empty();
   }
 
@@ -294,13 +301,13 @@ public class NoOpDatabase implements Database {
   }
 
   @Override
-  public Stream<SlotAndBlockRoot> streamUnconfirmedBlobsSidecar(
+  public Stream<SlotAndBlockRoot> streamUnconfirmedBlobsSidecars(
       final UInt64 startSlot, final UInt64 endSlot) {
     return Stream.empty();
   }
 
   @Override
-  public boolean pruneOldestUnconfirmedBlobsSidecar(
+  public boolean pruneOldestUnconfirmedBlobsSidecars(
       final UInt64 lastSlotToPrune, final int pruneLimit) {
     return false;
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
@@ -56,7 +56,9 @@ public class NoOpDatabase implements Database {
   }
 
   @Override
-  public void storeFinalizedBlocks(final Collection<SignedBeaconBlock> blocks) {}
+  public void storeFinalizedBlocks(
+      final Collection<SignedBeaconBlock> blocks,
+      final Map<UInt64, BlobsSidecar> blobsSidecarBySlot) {}
 
   @Override
   public void storeFinalizedState(BeaconState state, Bytes32 blockRoot) {}

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
@@ -247,6 +247,11 @@ public class NoOpDatabase implements Database {
   }
 
   @Override
+  public Map<String, Long> getBlobsSidecarColumnCounts() {
+    return new HashMap<>();
+  }
+
+  @Override
   public void migrate() {}
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/pruner/BlobsSidecarPruner.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/pruner/BlobsSidecarPruner.java
@@ -33,7 +33,7 @@ import tech.pegasys.teku.storage.api.FinalizedCheckpointChannel;
 import tech.pegasys.teku.storage.server.Database;
 import tech.pegasys.teku.storage.server.ShuttingDownException;
 
-public class BlobsPruner extends Service implements FinalizedCheckpointChannel {
+public class BlobsSidecarPruner extends Service implements FinalizedCheckpointChannel {
   private static final Logger LOG = LogManager.getLogger();
 
   private final Spec spec;
@@ -49,7 +49,7 @@ public class BlobsPruner extends Service implements FinalizedCheckpointChannel {
   private AtomicReference<Optional<UInt64>> latestFinalizedSlot =
       new AtomicReference<>(Optional.empty());
 
-  public BlobsPruner(
+  public BlobsSidecarPruner(
       final Spec spec,
       final Database database,
       final AsyncRunner asyncRunner,
@@ -102,7 +102,7 @@ public class BlobsPruner extends Service implements FinalizedCheckpointChannel {
     try {
       final long start = System.currentTimeMillis();
       final boolean limitReached =
-          database.pruneOldestUnconfirmedBlobsSidecar(maybeLatestFinalizedSlot.get(), pruneLimit);
+          database.pruneOldestUnconfirmedBlobsSidecars(maybeLatestFinalizedSlot.get(), pruneLimit);
       LOG.debug(
           "Unconfirmed blobs pruning finished in {} ms. Limit reached: {}",
           () -> System.currentTimeMillis() - start,

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/pruner/BlobsSidecarPruner.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/pruner/BlobsSidecarPruner.java
@@ -151,17 +151,16 @@ public class BlobsSidecarPruner extends Service implements FinalizedCheckpointCh
     final UInt64 currentSlot =
         spec.getCurrentSlot(timeProvider.getTimeInSeconds(), genesisTime.get());
 
-    final UInt64 earliestPrunableSlot = getEarliestPrunableSlot(currentSlot);
+    final UInt64 latestPrunableSlot = getLatestPrunableSlot(currentSlot);
 
-    if (earliestPrunableSlot.isZero()) {
+    if (latestPrunableSlot.isZero()) {
       LOG.debug("Not pruning as slots to keep includes genesis.");
       return;
     }
-    LOG.debug("Pruning blobs up to slot {}, limit {}", earliestPrunableSlot, pruneLimit);
+    LOG.debug("Pruning blobs up to slot {}, limit {}", latestPrunableSlot, pruneLimit);
     try {
       final long start = System.currentTimeMillis();
-      final boolean limitReached =
-          database.pruneOldestBlobsSidecar(earliestPrunableSlot, pruneLimit);
+      final boolean limitReached = database.pruneOldestBlobsSidecar(latestPrunableSlot, pruneLimit);
       LOG.debug(
           "Blobs pruning finished in {} ms. Limit reached: {}",
           () -> System.currentTimeMillis() - start,
@@ -185,9 +184,30 @@ public class BlobsSidecarPruner extends Service implements FinalizedCheckpointCh
     return genesisTime;
   }
 
-  private UInt64 getEarliestPrunableSlot(final UInt64 currentSlot) {
-    final int slotsPerEpoch = spec.getSlotsPerEpoch(currentSlot);
+  private UInt64 getLatestPrunableSlot(final UInt64 currentSlot) {
+    // we have to guarantee that current epoch data is fully available,
+    // moreover we want to gradually delete blobs at each iteration
 
-    return currentSlot.minusMinZero((long) MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUESTS * slotsPerEpoch);
+    // MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUESTS = 1
+    //    (5)
+    //  latest                        (70)
+    //  prunable   DA boundary          current_slot
+    //     |       |                    |
+    // 0 ----- 31 // 32 ---- 63 // 64 ---- 95 // 96
+
+    // edge case 1 (only 1 slot of tolerance to support slight client timing differences):
+    //   current_slot = 95
+    //   DA_boundary: 32
+    //   latest_prunable_slot = 30
+
+    // edge case 2 (1 entire epoch of extra data):
+    //   current_slot = 96
+    //   DA_boundary: 64
+    //   latest_prunable_slot = 31
+
+    return currentSlot.minusMinZero(
+        ((long) (MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUESTS + 1)
+                * spec.atSlot(currentSlot).getSlotsPerEpoch())
+            + 1);
   }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbInstance.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbInstance.java
@@ -157,6 +157,12 @@ public class RocksDbInstance implements KvStoreAccessor {
   }
 
   @Override
+  @MustBeClosed
+  public Stream<Bytes> streamKeysRaw(final KvStoreColumn<?, ?> column) {
+    return createStreamKeyRaw(column, RocksIterator::seekToFirst, key -> true).map(Bytes::wrap);
+  }
+
+  @Override
   public <K, V> Optional<Bytes> getRaw(final KvStoreColumn<K, V> column, final K key) {
     assertOpen();
     final ColumnFamilyHandle handle = columnHandles.get(column);

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/ChainStorageTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/ChainStorageTest.java
@@ -21,6 +21,7 @@ import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 import com.google.common.collect.Lists;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.AfterEach;
@@ -137,10 +138,12 @@ public class ChainStorageTest {
           Lists.partition(missingHistoricalBlocks, batchSize);
       for (int i = batches.size() - 1; i >= 0; i--) {
         final List<SignedBeaconBlock> batch = batches.get(i);
-        chainStorage.onFinalizedBlocks(batch).ifExceptionGetsHereRaiseABug();
+        chainStorage.onFinalizedBlocks(batch, Map.of()).ifExceptionGetsHereRaiseABug();
       }
     } else {
-      chainStorage.onFinalizedBlocks(missingHistoricalBlocks).ifExceptionGetsHereRaiseABug();
+      chainStorage
+          .onFinalizedBlocks(missingHistoricalBlocks, Map.of())
+          .ifExceptionGetsHereRaiseABug();
     }
 
     // Verify blocks are now available
@@ -186,7 +189,7 @@ public class ChainStorageTest {
             .streamBlocksAndStates(0, firstMissingBlockSlot)
             .map(SignedBlockAndState::getBlock)
             .collect(Collectors.toList());
-    final SafeFuture<Void> result = chainStorage.onFinalizedBlocks(invalidBlocks);
+    final SafeFuture<Void> result = chainStorage.onFinalizedBlocks(invalidBlocks, Map.of());
     assertThat(result).isCompletedExceptionally();
     assertThatThrownBy(result::get)
         .hasCauseInstanceOf(IllegalArgumentException.class)
@@ -225,7 +228,7 @@ public class ChainStorageTest {
     // Remove a block from the middle
     blocks.remove(blocks.size() / 2);
 
-    final SafeFuture<Void> result = chainStorage.onFinalizedBlocks(blocks);
+    final SafeFuture<Void> result = chainStorage.onFinalizedBlocks(blocks, Map.of());
     assertThat(result).isCompletedExceptionally();
     assertThatThrownBy(result::get)
         .hasCauseInstanceOf(IllegalArgumentException.class)
@@ -264,7 +267,7 @@ public class ChainStorageTest {
     // Remove a block from the end
     blocks.remove(blocks.size() - 1);
 
-    final SafeFuture<Void> result = chainStorage.onFinalizedBlocks(blocks);
+    final SafeFuture<Void> result = chainStorage.onFinalizedBlocks(blocks, Map.of());
     assertThat(result).isCompletedExceptionally();
     assertThatThrownBy(result::get)
         .hasCauseInstanceOf(IllegalArgumentException.class)

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/pruner/BlobsSidecarPrunerTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/pruner/BlobsSidecarPrunerTest.java
@@ -28,6 +28,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
+import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
@@ -47,10 +48,17 @@ public class BlobsSidecarPrunerTest {
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
   private final StubAsyncRunner asyncRunner = new StubAsyncRunner(timeProvider);
   private final Database database = mock(Database.class);
+  private final StubMetricsSystem stubMetricsSystem = new StubMetricsSystem();
 
   private final BlobsSidecarPruner blobsPruner =
       new BlobsSidecarPruner(
-          spec, database, asyncRunner, timeProvider, PRUNE_INTERVAL, PRUNE_LIMIT);
+          spec,
+          database,
+          stubMetricsSystem,
+          asyncRunner,
+          timeProvider,
+          PRUNE_INTERVAL,
+          PRUNE_LIMIT);
 
   @BeforeEach
   void setUp() {

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/pruner/BlobsSidecarPrunerTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/pruner/BlobsSidecarPrunerTest.java
@@ -35,7 +35,7 @@ import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.storage.server.Database;
 
-public class BlobsPrunerTest {
+public class BlobsSidecarPrunerTest {
   public static final Duration PRUNE_INTERVAL = Duration.ofSeconds(5);
   public static final int PRUNE_LIMIT = 10;
 
@@ -48,8 +48,9 @@ public class BlobsPrunerTest {
   private final StubAsyncRunner asyncRunner = new StubAsyncRunner(timeProvider);
   private final Database database = mock(Database.class);
 
-  private final BlobsPruner blobsPruner =
-      new BlobsPruner(spec, database, asyncRunner, timeProvider, PRUNE_INTERVAL, PRUNE_LIMIT);
+  private final BlobsSidecarPruner blobsPruner =
+      new BlobsSidecarPruner(
+          spec, database, asyncRunner, timeProvider, PRUNE_INTERVAL, PRUNE_LIMIT);
 
   @BeforeEach
   void setUp() {
@@ -95,7 +96,7 @@ public class BlobsPrunerTest {
   void shouldNotPruneUnconfirmedBlobsWithoutFinalizedCheckpoint() {
     asyncRunner.executeDueActions();
 
-    verify(database, never()).pruneOldestUnconfirmedBlobsSidecar(any(), anyInt());
+    verify(database, never()).pruneOldestUnconfirmedBlobsSidecars(any(), anyInt());
   }
 
   @Test
@@ -106,12 +107,12 @@ public class BlobsPrunerTest {
     final UInt64 expectedLastSlotToPrune =
         UInt64.valueOf(spec.getGenesisSpecConfig().getSlotsPerEpoch());
 
-    verify(database).pruneOldestUnconfirmedBlobsSidecar(expectedLastSlotToPrune, PRUNE_LIMIT);
+    verify(database).pruneOldestUnconfirmedBlobsSidecars(expectedLastSlotToPrune, PRUNE_LIMIT);
 
     timeProvider.advanceTimeBy(PRUNE_INTERVAL);
     asyncRunner.executeDueActions();
 
     verify(database, times(1))
-        .pruneOldestUnconfirmedBlobsSidecar(expectedLastSlotToPrune, PRUNE_LIMIT);
+        .pruneOldestUnconfirmedBlobsSidecars(expectedLastSlotToPrune, PRUNE_LIMIT);
   }
 }

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageUpdateChannel.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageUpdateChannel.java
@@ -14,9 +14,11 @@
 package tech.pegasys.teku.storage.api;
 
 import java.util.Collection;
+import java.util.Map;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.ethereum.pow.api.DepositTreeSnapshot;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.execution.versions.eip4844.BlobsSidecar;
@@ -31,7 +33,9 @@ public class StubStorageUpdateChannel implements StorageUpdateChannel {
   }
 
   @Override
-  public SafeFuture<Void> onFinalizedBlocks(final Collection<SignedBeaconBlock> finalizedBlocks) {
+  public SafeFuture<Void> onFinalizedBlocks(
+      final Collection<SignedBeaconBlock> finalizedBlocks,
+      final Map<UInt64, BlobsSidecar> blobsSidecarBySlot) {
     return SafeFuture.COMPLETE;
   }
 

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageUpdateChannelWithDelays.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageUpdateChannelWithDelays.java
@@ -14,10 +14,12 @@
 package tech.pegasys.teku.storage.api;
 
 import java.util.Collection;
+import java.util.Map;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.ethereum.pow.api.DepositTreeSnapshot;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.execution.versions.eip4844.BlobsSidecar;
@@ -37,7 +39,9 @@ public class StubStorageUpdateChannelWithDelays implements StorageUpdateChannel 
   }
 
   @Override
-  public SafeFuture<Void> onFinalizedBlocks(final Collection<SignedBeaconBlock> finalizedBlocks) {
+  public SafeFuture<Void> onFinalizedBlocks(
+      final Collection<SignedBeaconBlock> finalizedBlocks,
+      final Map<UInt64, BlobsSidecar> blobsSidecarBySlot) {
     return asyncRunner.runAsync(() -> SafeFuture.COMPLETE);
   }
 

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/server/kvstore/MockKvStoreInstance.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/server/kvstore/MockKvStoreInstance.java
@@ -149,7 +149,7 @@ public class MockKvStoreInstance implements KvStoreAccessor {
 
   @Override
   public <K, V> Stream<K> streamKeys(KvStoreColumn<K, V> column) {
-    return streamKeyRaw(column)
+    return streamKeysRaw(column)
         .map(entry -> column.getKeySerializer().deserialize(entry.toArrayUnsafe()));
   }
 
@@ -162,7 +162,8 @@ public class MockKvStoreInstance implements KvStoreAccessor {
         .map(entry -> columnEntry(entry));
   }
 
-  public Stream<Bytes> streamKeyRaw(final KvStoreColumn<?, ?> column) {
+  @Override
+  public Stream<Bytes> streamKeysRaw(KvStoreColumn<?, ?> column) {
     assertOpen();
     assertValidColumn(column);
     return columnData.get(column).keySet().stream();


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
This branch includes all changes we do during interop event. It's a mess currently and most of them should be reworked in separate PRs after the event. Once a certain task is merged to `master` please tick the box.

- [x] Implemented historical block sync for EIP-4844 https://github.com/ConsenSys/teku/commit/8ed7a2ac4e9c57d04c2c0c0778fbb64b49740676 https://github.com/ConsenSys/teku/commit/f2f9355e17b121c104686d90374ae3937a4de809 https://github.com/ConsenSys/teku/commit/dd02ff50ad97c3c5934e92fa5fe0d6acd005cb30  (covered entirely by https://github.com/ConsenSys/teku/pull/6712) 
- [x] Fixes block casting to EIP-4844 on other forks https://github.com/ConsenSys/teku/commit/c482f043fc2914819b756ac4c138ff01a0c29aa1
- [x] Don't request `BlobsSidecars` in non EIP-4844 epochs. Say, our current is 50 slot and we have a fork on 64. Previously we requested sidecars starting from 51 to 101, instead we should request only 64-101. It's fixed with https://github.com/ConsenSys/teku/commit/f849d2dbf5673fc4144920dc9a6c91854bb88ff8
- [x] Command to dump `BlobsSidecars` from DB to zip-file https://github.com/ConsenSys/teku/commit/0de1f1383cea7217086692052eb0c87166e01cf3
- [x] Use long for a chainId,networkId instead of integer https://github.com/ConsenSys/teku/commit/8ec33baf3eb193c97be2b9f1f647d06aea62aa6d https://github.com/ConsenSys/teku/commit/1bec77b3c5be438b9b812a69c0ff7b3b1f6f1a58 https://github.com/ConsenSys/teku/commit/df0b6cf18bcbd254a08794754d227b7a153e2dc9
- [x] Using ForkDigestCodec instead of noContextCodec https://github.com/ConsenSys/teku/commit/ba9566d2f42c3f5605fc3c5ebdb590a485c83e5f https://github.com/ConsenSys/teku/commit/86495dd05aac257d1e59644b31654b3e634660b3
- [x] blobs storage metrics https://github.com/ConsenSys/teku/pull/6755
- [x] blobs pruner fix https://github.com/ConsenSys/teku/pull/6746
- [x] fix pruning of finalized blobs sidecar https://github.com/ConsenSys/teku/pull/6754

No longer needed:
- https://github.com/ConsenSys/teku/pull/6728/commits/92c0e71a1a3963390c0418305cb81f763d5e4b41 (superceeded by https://github.com/ConsenSys/teku/commit/8ed7a2ac4e9c57d04c2c0c0778fbb64b49740676)

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
