### PR TITLE
Temporary independent Dockerfile to run 4844-interop branch

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,39 @@
+FROM eclipse-temurin:17 as jre-build
+
+# Create a custom Java runtime
+RUN JAVA_TOOL_OPTIONS="-Djdk.lang.Process.launchMechanism=vfork" $JAVA_HOME/bin/jlink \
+         --add-modules ALL-MODULE-PATH \
+         --strip-debug \
+         --no-man-pages \
+         --no-header-files \
+         --compress=2 \
+         --output /javaruntime
+
+FROM ubuntu:22.04
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH "${JAVA_HOME}/bin:${PATH}"
+COPY --from=jre-build /javaruntime $JAVA_HOME
+
+RUN apt-get -y update && apt-get -y upgrade && apt-get -y install curl git jq docker
+RUN rm -rf /var/lib/api/lists/*
+RUN adduser --disabled-password --gecos "" --home /opt/teku teku && \
+    chown teku:teku /opt/teku
+
+RUN git clone --depth 1 https://github.com/ConsenSys/teku.git --branch 4844-interop && \
+    (cd teku && ./gradlew dockerDistUntar)
+
+# Default to UTF-8 locale
+ENV LANG C.UTF-8
+
+ENV TEKU_REST_API_INTERFACE="0.0.0.0"
+ENV TEKU_VALIDATOR_API_INTERFACE="0.0.0.0"
+ENV TEKU_METRICS_INTERFACE="0.0.0.0"
+
+# List Exposed Ports
+# Metrics, Rest API, LibP2P, Discv5
+EXPOSE 8008 5051 9000 9000/udp
+
+USER teku
+
+# specify default command
+ENTRYPOINT ["/teku/build/docker-teku/teku/bin/teku"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,7 +20,7 @@ RUN adduser --disabled-password --gecos "" --home /opt/teku teku && \
     chown teku:teku /opt/teku
 
 RUN git clone --depth 1 https://github.com/ConsenSys/teku.git --branch 4844-interop && \
-    (cd teku && ./gradlew dockerDistUntar)
+    (cd teku && ./gradlew installDist)
 
 # Default to UTF-8 locale
 ENV LANG C.UTF-8
@@ -36,4 +36,4 @@ EXPOSE 8008 5051 9000 9000/udp
 USER teku
 
 # specify default command
-ENTRYPOINT ["/teku/build/docker-teku/teku/bin/teku"]
+ENTRYPOINT ["/teku/build/install/teku/bin/teku"]


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Adding independent Teku dockerfile for #6728 to simplify usage of Teku by other teams. To use, build [this Dockerfile](https://github.com/zilm13/teku/blob/7f10cb9b7689cc4a5c1034b7dba1f56329a17ee8/docker/Dockerfile) and run Teku from it:
```
# build Dockerfile
docker build -q Dockerfile
```

```
# run image
docker run 
--network=host \ # only needed in separate docker, will be in the same network if used in docker compose
-v /home/zilm/.lighthouse/local-testnet/geth_datadir1/geth/jwtsecret:/jwtsecret \ # share EL jwt (change left)
-v /home/zilm/interop/teku2:/data \ # directory for logs and DB (change left)
-v /home/zilm/projects/teku/ethereum/networks/src/main/resources/tech/pegasys/teku/networks/mainnet-trusted-setup.txt:/trusted_setup.txt \ # mainnet trusted setup file (change left)
-v /home/zilm/.lighthouse/local-testnet/testnet/genesis.ssz:/genesis.ssz \ # genesis file (change left)
-v /home/zilm/.lighthouse/local-testnet/testnet/config.yaml:/config.yaml \ # testnet config (change left)
-it 1b452d0f8ea743e910ca324537f0a5d19484d47505ad399ebbe99316cd0b149d \ #image
--data-path /data \
--ee-jwt-secret-file=/jwtsecret \
--initial-state=/genesis.ssz \ 
--Xtrusted-setup=trusted_setup.txt \
--network=/config.yaml \
--ee-endpoint=http://localhost:8001 \ # change to actual EL endpoint
--p2p-discovery-bootnodes="enr:-Ly4QMsyb23OCy6r9XyriLqI5t_07JInbVw58AzXsdtIVlOIXSt2eurMQwvnydVAbfSSv2KQi3sm_opLqEUrvXBqoagBh2F0dG5ldHOIAAAAAAAAAACEZXRoMpCq8mMKQkJCQv__________gmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQMkhVqy2zFrCP5KeaycvsKFRjqdjshgVhB8oDo0EaXLvohzeW5jbmV0cwCDdGNwghCSg3VkcIIQkg"  # change to actual bootnode ENR
```
## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
