### PR TITLE
Allow other users to read the /opt/teku dir when using docker

### DIFF
--- a/docker/jdk16/Dockerfile
+++ b/docker/jdk16/Dockerfile
@@ -17,7 +17,8 @@ COPY --from=jre-build /javaruntime $JAVA_HOME
 RUN apt-get -y update && apt-get -y upgrade && apt-get -y install curl
 RUN rm -rf /var/lib/api/lists/*
 RUN adduser --disabled-password --gecos "" --home /opt/teku teku && \
-    chown teku:teku /opt/teku
+    chown teku:teku /opt/teku && \
+    chmod 0775 /opt/teku
 
 USER teku
 WORKDIR /opt/teku

--- a/docker/jdk17/Dockerfile
+++ b/docker/jdk17/Dockerfile
@@ -17,7 +17,8 @@ COPY --from=jre-build /javaruntime $JAVA_HOME
 RUN apt-get -y update && apt-get -y upgrade && apt-get -y install curl
 RUN rm -rf /var/lib/api/lists/*
 RUN adduser --disabled-password --gecos "" --home /opt/teku teku && \
-    chown teku:teku /opt/teku
+    chown teku:teku /opt/teku && \
+    chmod 0775 /opt/teku
 
 USER teku
 WORKDIR /opt/teku


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

The problem is that if we try to run the teku container with any other user that has a differen uid than `1000`, we won't be able to execute the teku binary due to the permissions of the working dir ( `/opt/teku` ) being too strict 0770. I'm changing the permissions to 0775 so that other users can also read the directory and execute the teku binary.

Example on how this fails currently with other users than 1000

```sh
$ docker pull consensys/teku 
$ docker run --rm -it --entrypoint ls --user=1000 consensys/teku 
LICENSE  bin  lib  licenses  teku.autocomplete.sh
$ docker run --rm -it --entrypoint ls --user=1003 consensys/teku 
ls: cannot open directory '.': Permission denied
```

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
