### PR TITLE
Allow other users to read the /opt/teku dir when using docker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 ## Upcoming Breaking Changes
 - The `--Xmetrics-block-timing-tracking-enabled` option has been renamed to `--metrics-block-timing-tracking-enabled` and enabled by default. The `--X` version will be removed in a future release.
-- The `/eth/v1/debug/beacon/states/:state_id` endpoint has been deprecated in favor of the v2 Altair endpoint `/eth/v2/debug/beacon/states/:state_id`.
-- The `/eth/v1/beacon/blocks/:block_id` endpoint has been deprecated in favor of the v2 Altair endpoint `/eth/v2/beacon/blocks/:block_id`.
-- The `/eth/v1/validator/blocks/:slot` endpoint has been deprecated in favor of the v2 Altair endpoint `/eth/v2/validator/blocks/:slot`.
-- The `/eth/v1/debug/beacon/heads` endpoint has been deprecated in favor of the v2 Bellatrix endpoint `/eth/v2/debug/beacon/heads`.
+- The `/eth/v1/debug/beacon/states/:state_id` endpoint has been deprecated in favor of the v2 Altair endpoint `/eth/v2/debug/beacon/states/:state_id`
+- The `/eth/v1/beacon/blocks/:block_id` endpoint has been deprecated in favor of the v2 Altair endpoint `/eth/v2/beacon/blocks/:block_id`
+- The `/eth/v1/validator/blocks/:slot` endpoint has been deprecated in favor of the v2 Altair endpoint `/eth/v2/validator/blocks/:slot`
+- The `/eth/v1/debug/beacon/heads` endpoint has been deprecated in favor of the v2 Bellatrix endpoint `/eth/v2/debug/beacon/heads`
 - The commandline option `--network` of the `validator-client` subcommand has been undeprecated and can be used to select a network for standalone validator clients. When set to `auto`, it automatically
   fetches network configuration information from the configured beacon node endpoint.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 ## Upcoming Breaking Changes
 - The `--Xmetrics-block-timing-tracking-enabled` option has been renamed to `--metrics-block-timing-tracking-enabled` and enabled by default. The `--X` version will be removed in a future release.
-- The `/eth/v1/debug/beacon/states/:state_id` endpoint has been deprecated in favor of the v2 Altair endpoint `/eth/v2/debug/beacon/states/:state_id`
-- The `/eth/v1/beacon/blocks/:block_id` endpoint has been deprecated in favor of the v2 Altair endpoint `/eth/v2/beacon/blocks/:block_id`
-- The `/eth/v1/validator/blocks/:slot` endpoint has been deprecated in favor of the v2 Altair endpoint `/eth/v2/validator/blocks/:slot`
-- The `/eth/v1/debug/beacon/heads` endpoint has been deprecated in favor of the v2 Bellatrix endpoint `/eth/v2/debug/beacon/heads`
+- The `/eth/v1/debug/beacon/states/:state_id` endpoint has been deprecated in favor of the v2 Altair endpoint `/eth/v2/debug/beacon/states/:state_id`.
+- The `/eth/v1/beacon/blocks/:block_id` endpoint has been deprecated in favor of the v2 Altair endpoint `/eth/v2/beacon/blocks/:block_id`.
+- The `/eth/v1/validator/blocks/:slot` endpoint has been deprecated in favor of the v2 Altair endpoint `/eth/v2/validator/blocks/:slot`.
+- The `/eth/v1/debug/beacon/heads` endpoint has been deprecated in favor of the v2 Bellatrix endpoint `/eth/v2/debug/beacon/heads`.
 - The commandline option `--network` of the `validator-client` subcommand has been undeprecated and can be used to select a network for standalone validator clients. When set to `auto`, it automatically
   fetches network configuration information from the configured beacon node endpoint.
 

--- a/docker/jdk16/Dockerfile
+++ b/docker/jdk16/Dockerfile
@@ -17,7 +17,8 @@ COPY --from=jre-build /javaruntime $JAVA_HOME
 RUN apt-get -y update && apt-get -y upgrade && apt-get -y install curl
 RUN rm -rf /var/lib/api/lists/*
 RUN adduser --disabled-password --gecos "" --home /opt/teku teku && \
-    chown teku:teku /opt/teku
+    chown teku:teku /opt/teku && \
+    chmod 0775 /opt/teku
 
 USER teku
 WORKDIR /opt/teku

--- a/docker/jdk16/Dockerfile
+++ b/docker/jdk16/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get -y update && apt-get -y upgrade && apt-get -y install curl
 RUN rm -rf /var/lib/api/lists/*
 RUN adduser --disabled-password --gecos "" --home /opt/teku teku && \
     chown teku:teku /opt/teku && \
-    chmod 0775 /opt/teku
+    chmod 0755 /opt/teku
 
 USER teku
 WORKDIR /opt/teku

--- a/docker/jdk17/Dockerfile
+++ b/docker/jdk17/Dockerfile
@@ -17,7 +17,8 @@ COPY --from=jre-build /javaruntime $JAVA_HOME
 RUN apt-get -y update && apt-get -y upgrade && apt-get -y install curl
 RUN rm -rf /var/lib/api/lists/*
 RUN adduser --disabled-password --gecos "" --home /opt/teku teku && \
-    chown teku:teku /opt/teku
+    chown teku:teku /opt/teku && \
+    chmod 0775 /opt/teku
 
 USER teku
 WORKDIR /opt/teku

--- a/docker/jdk17/Dockerfile
+++ b/docker/jdk17/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get -y update && apt-get -y upgrade && apt-get -y install curl
 RUN rm -rf /var/lib/api/lists/*
 RUN adduser --disabled-password --gecos "" --home /opt/teku teku && \
     chown teku:teku /opt/teku && \
-    chmod 0775 /opt/teku
+    chmod 0755 /opt/teku
 
 USER teku
 WORKDIR /opt/teku


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

The problem is that if we try to run the teku container with any other user that has a differen uid than `1000`, we won't be able to execute the teku binary due to the permissions of the working dir ( `/opt/teku` ) being too strict 0770. I'm changing the permissions to 0775 so that other users can also read the directory and execute the teku binary.

Example on how this fails currently with other users than 1000

```sh
$ docker pull consensys/teku 
$ docker run --rm -it --entrypoint ls --user=1000 consensys/teku 
LICENSE  bin  lib  licenses  teku.autocomplete.sh
$ docker run --rm -it --entrypoint ls --user=1003 consensys/teku 
ls: cannot open directory '.': Permission denied
```

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
