### PR TITLE
Use long for Chain ID and Network ID

### DIFF
--- a/beacon/pow/src/main/java/tech/pegasys/teku/beacon/pow/Web3jEth1Provider.java
+++ b/beacon/pow/src/main/java/tech/pegasys/teku/beacon/pow/Web3jEth1Provider.java
@@ -251,9 +251,9 @@ public class Web3jEth1Provider extends AbstractMonitorableEth1Provider {
                     "eth_chainId method is not supported by provider, skipping validation", ex);
                 return Result.NOT_SUPPORTED;
               }
-              if (chainId.intValueExact() != config.getDepositChainId()) {
+              if (chainId.longValue() != config.getDepositChainId()) {
                 STATUS_LOG.eth1DepositChainIdMismatch(
-                    config.getDepositChainId(), chainId.intValueExact(), this.id);
+                    config.getDepositChainId(), chainId.longValue(), this.id);
                 return Result.FAILED;
               }
               return Result.SUCCESS;

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/config/GetDepositContract.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/config/GetDepositContract.java
@@ -65,7 +65,7 @@ public class GetDepositContract extends RestApiEndpoint {
 
   @Override
   public void handleRequest(RestApiRequest request) throws JsonProcessingException {
-    final int depositChainId = configProvider.getGenesisSpecConfig().getDepositChainId();
+    final long depositChainId = configProvider.getGenesisSpecConfig().getDepositChainId();
     request.respondOk(new DepositContractData(depositChainId, depositContractAddress));
   }
 
@@ -73,7 +73,7 @@ public class GetDepositContract extends RestApiEndpoint {
     final UInt64 chainId;
     final Eth1Address address;
 
-    DepositContractData(int chainId, Eth1Address address) {
+    DepositContractData(long chainId, Eth1Address address) {
       this.chainId = UInt64.valueOf(chainId);
       this.address = address;
     }

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/config/GetDepositContractTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/config/GetDepositContractTest.java
@@ -29,7 +29,7 @@ import tech.pegasys.teku.ethereum.execution.types.Eth1Address;
 
 class GetDepositContractTest extends AbstractMigratedBeaconHandlerTest {
   final Eth1Address eth1Address = dataStructureUtil.randomEth1Address();
-  final int chainId = spec.getGenesisSpecConfig().getDepositChainId();
+  final long chainId = spec.getGenesisSpecConfig().getDepositChainId();
   private final GetDepositContract.DepositContractData contractData =
       new GetDepositContract.DepositContractData(chainId, eth1Address);
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/DelegatingSpecConfig.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/DelegatingSpecConfig.java
@@ -282,12 +282,12 @@ public class DelegatingSpecConfig implements SpecConfig {
   }
 
   @Override
-  public int getDepositChainId() {
+  public long getDepositChainId() {
     return specConfig.getDepositChainId();
   }
 
   @Override
-  public int getDepositNetworkId() {
+  public long getDepositNetworkId() {
     return specConfig.getDepositNetworkId();
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfig.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfig.java
@@ -136,9 +136,9 @@ public interface SpecConfig {
 
   int getProposerScoreBoost();
 
-  int getDepositChainId();
+  long getDepositChainId();
 
-  int getDepositNetworkId();
+  long getDepositNetworkId();
 
   Eth1Address getDepositContractAddress();
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigPhase0.java
@@ -96,8 +96,8 @@ public class SpecConfigPhase0 implements SpecConfig {
   private final int proposerScoreBoost;
 
   // Deposit Contract
-  private final int depositChainId;
-  private final int depositNetworkId;
+  private final long depositChainId;
+  private final long depositNetworkId;
   private final Eth1Address depositContractAddress;
 
   private final ProgressiveBalancesMode progressiveBalancesMode;
@@ -150,8 +150,8 @@ public class SpecConfigPhase0 implements SpecConfig {
       final int secondsPerEth1Block,
       final int safeSlotsToUpdateJustified,
       final int proposerScoreBoost,
-      final int depositChainId,
-      final int depositNetworkId,
+      final long depositChainId,
+      final long depositNetworkId,
       final Eth1Address depositContractAddress,
       final ProgressiveBalancesMode progressiveBalancesMode) {
     this.rawConfig = rawConfig;
@@ -469,12 +469,12 @@ public class SpecConfigPhase0 implements SpecConfig {
   }
 
   @Override
-  public int getDepositChainId() {
+  public long getDepositChainId() {
     return depositChainId;
   }
 
   @Override
-  public int getDepositNetworkId() {
+  public long getDepositNetworkId() {
     return depositNetworkId;
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/builder/SpecConfigBuilder.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/builder/SpecConfigBuilder.java
@@ -98,8 +98,8 @@ public class SpecConfigBuilder {
   private int proposerScoreBoost = 0;
 
   // Deposit Contract
-  private Integer depositChainId;
-  private Integer depositNetworkId;
+  private Long depositChainId;
+  private Long depositNetworkId;
   private Eth1Address depositContractAddress;
 
   private ProgressiveBalancesMode progressiveBalancesMode = ProgressiveBalancesMode.USED;
@@ -518,13 +518,13 @@ public class SpecConfigBuilder {
     return this;
   }
 
-  public SpecConfigBuilder depositChainId(final Integer depositChainId) {
+  public SpecConfigBuilder depositChainId(final Long depositChainId) {
     checkNotNull(depositChainId);
     this.depositChainId = depositChainId;
     return this;
   }
 
-  public SpecConfigBuilder depositNetworkId(final Integer depositNetworkId) {
+  public SpecConfigBuilder depositNetworkId(final Long depositNetworkId) {
     checkNotNull(depositNetworkId);
     this.depositNetworkId = depositNetworkId;
     return this;

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
@@ -387,7 +387,8 @@ public class StatusLogger {
     log.info(performance);
   }
 
-  public void eth1DepositChainIdMismatch(int expectedChainId, int eth1ChainId, String endpointId) {
+  public void eth1DepositChainIdMismatch(
+      long expectedChainId, long eth1ChainId, String endpointId) {
     log.log(
         Level.ERROR,
         "PLEASE CHECK YOUR ETH1 NODE (endpoint {})| Wrong Eth1 chain id (expected={}, actual={})",


### PR DESCRIPTION
## PR Description
EIP-4844 devnet had a config for DEPOSIT_CHAIN_ID and DEPOSIT_NETWORK_ID larger than what int can contain: `4844001004`. It's better to use a long to cater for such cases even though they will apply to mostly testnets.

## Fixed Issue(s)
will apply few of the commits in https://github.com/ConsenSys/teku/pull/6728 to master

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
