### PR TITLE
Increase trivy timeout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -243,7 +243,7 @@ jobs:
             for FILE in $(ls docker)
             do
               docker pull -q "consensys/teku:develop-$FILE"
-              trivy -q image --exit-code 1 --no-progress --severity HIGH,CRITICAL --ignorefile "gradle/trivyignore.txt" "consensys/teku:develop-$FILE" 
+              trivy -q image --exit-code 1 --no-progress --severity HIGH,CRITICAL --ignorefile "gradle/trivyignore.txt" --timeout 10m "consensys/teku:develop-$FILE" 
             done
       - notify
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Often, there is a dockerScan error in CI: 
```
FATAL	image scan error: scan error: scan failed: failed analysis: analyze error: timeout: context deadline exceeded
```
Seems to be related to trivy https://github.com/aquasecurity/trivy/issues/802. Increasing the timeout (default is 5m) to 10m seems to help few of the users, so it's worth trying.

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
