### PR TITLE
fix pruning of finalized blobs sidecars

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
@@ -333,7 +333,7 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
             headAndAttrs.currentKzgCommitments.orElseThrow(),
             headAndAttrs.currentBlobs.orElseThrow());
 
-    LOG.info("getBlobsBundle: slot: {} -> blobsBundle: {}", slot, blobsBundle);
+    LOG.info("getBlobsBundle: slot: {} -> blobsBundle: {}", slot, blobsBundle.toBriefBlobsString());
 
     return SafeFuture.completedFuture(blobsBundle);
   }

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/ChainBuilder.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/ChainBuilder.java
@@ -216,6 +216,10 @@ public class ChainBuilder {
         .filter(s -> s.getBeaconBlockSlot().isLessThanOrEqualTo(toSlot));
   }
 
+  public Stream<BlobsSidecar> streamBlobsSidecars() {
+    return blobsSidecars.values().stream();
+  }
+
   public void discardBlobsSidecar(final UInt64 slot) {
     blobsSidecars.remove(slot);
   }

--- a/storage/src/integration-test/java/tech/pegasys/teku/storage/server/kvstore/DatabaseTest.java
+++ b/storage/src/integration-test/java/tech/pegasys/teku/storage/server/kvstore/DatabaseTest.java
@@ -370,6 +370,9 @@ public class DatabaseTest {
     // Add base blocks
     addBlocks(chainBuilder.streamBlocksAndStates().collect(toList()));
 
+    // add blobs sidecars
+    addBlobsSidecars(chainBuilder.streamBlobsSidecars().collect(toList()));
+
     // Set target slot at which to create duplicate blocks
     // and generate block options to make each block unique
     final List<BlockOptions> blockOptions =
@@ -392,6 +395,11 @@ public class DatabaseTest {
     add(List.of(blockB));
     add(List.of(blockC));
 
+    // Add corresponding blobs sidecars
+    addBlobsSidecars(List.of(forkA.getBlobsSidecar(blockA.getRoot()).orElseThrow()));
+    addBlobsSidecars(List.of(forkB.getBlobsSidecar(blockB.getRoot()).orElseThrow()));
+    addBlobsSidecars(List.of(chainBuilder.getBlobsSidecar(blockC.getRoot()).orElseThrow()));
+
     // Verify all blocks are available
     assertThat(store.retrieveBlock(blockA.getRoot()))
         .isCompletedWithValue(Optional.of(blockA.getBlock().getMessage()));
@@ -400,9 +408,23 @@ public class DatabaseTest {
     assertThat(store.retrieveBlock(blockC.getRoot()))
         .isCompletedWithValue(Optional.of(blockC.getBlock().getMessage()));
 
+    // verify we have all blobs sidecar are available
+    final List<SignedBeaconBlock> blocksWithAvailableSidecars =
+        Stream.concat(
+                Stream.concat(
+                    chainBuilder.streamBlocksAndStates(ONE),
+                    forkA.streamBlocksAndStates(targetSlot)),
+                forkB.streamBlocksAndStates(targetSlot))
+            .map(SignedBlockAndState::getBlock)
+            .collect(Collectors.toList());
+
+    assertBlobsSidecarAvailabilityExceptPruned(blocksWithAvailableSidecars, List.of());
+
     // Finalize subsequent block to prune blocks a, b, and c
     final SignedBlockAndState finalBlock = chainBuilder.generateNextBlock();
     add(List.of(finalBlock));
+    addBlobsSidecars(List.of(chainBuilder.getBlobsSidecar(finalBlock.getRoot()).orElseThrow()));
+
     final UInt64 finalEpoch = chainBuilder.getLatestEpoch().plus(ONE);
     final SignedBlockAndState finalizedBlock =
         chainBuilder.getLatestBlockAndStateAtEpochBoundary(finalEpoch);
@@ -413,6 +435,17 @@ public class DatabaseTest {
     rootsToPrune.add(genesisBlockAndState.getRoot());
     // Check that all blocks at slot 10 were pruned
     assertRecentDataWasPruned(store, rootsToPrune);
+
+    // verify we have all canonical and finalized sidecars and blockA and blockB sidecars have been
+    // pruned
+    final List<SignedBeaconBlock> canonicalBlocksWithAvailableSidecars =
+        chainBuilder
+            .streamBlocksAndStates(ONE)
+            .map(SignedBlockAndState::getBlock)
+            .collect(toList());
+
+    assertBlobsSidecarAvailabilityExceptPruned(
+        canonicalBlocksWithAvailableSidecars, List.of(blockA.getBlock(), blockB.getBlock()));
   }
 
   @TestTemplate
@@ -2150,6 +2183,23 @@ public class DatabaseTest {
     }
   }
 
+  private void assertBlobsSidecarAvailabilityExceptPruned(
+      final Collection<SignedBeaconBlock> availableBlocksSidecars,
+      final Collection<SignedBeaconBlock> prunedBlocksSidecars) {
+    availableBlocksSidecars.forEach(
+        block ->
+            assertThat(
+                    database.getBlobsSidecar(
+                        new SlotAndBlockRoot(block.getSlot(), block.getRoot())))
+                .isPresent());
+    prunedBlocksSidecars.forEach(
+        block ->
+            assertThat(
+                    database.getBlobsSidecar(
+                        new SlotAndBlockRoot(block.getSlot(), block.getRoot())))
+                .isEmpty());
+  }
+
   private void addBlocks(final SignedBlockAndState... blocks) {
     addBlocks(Arrays.asList(blocks));
   }
@@ -2160,6 +2210,16 @@ public class DatabaseTest {
       transaction.putBlockAndState(block, spec.calculateBlockCheckpoints(block.getState()));
     }
     commit(transaction);
+  }
+
+  private void addBlobsSidecars(final List<BlobsSidecar> blobsSidecars) {
+    blobsSidecars.forEach(
+        blobsSidecar -> {
+          database.storeUnconfirmedBlobsSidecar(blobsSidecar);
+          database.confirmBlobsSidecar(
+              new SlotAndBlockRoot(
+                  blobsSidecar.getBeaconBlockSlot(), blobsSidecar.getBeaconBlockRoot()));
+        });
   }
 
   private void add(final Collection<SignedBlockAndState> blocks) {

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
@@ -853,7 +853,8 @@ public class KvStoreDatabase implements Database {
             update.getOptimisticTransitionBlockRoot());
 
     if (update.isBlobsSidecarEnabled()) {
-      updateBlobsSidecars(update.getHotBlocks(), update.getDeletedHotBlocks());
+      updateBlobsSidecars(
+          update.getHotBlocks(), update.getFinalizedBlocks(), update.getDeletedHotBlocks());
     }
 
     LOG.trace("Applying hot updates");
@@ -938,6 +939,7 @@ public class KvStoreDatabase implements Database {
 
   private void updateBlobsSidecars(
       final Map<Bytes32, BlockAndCheckpoints> hotBlocks,
+      final Map<Bytes32, SignedBeaconBlock> finalizedBlocks,
       final Map<Bytes32, UInt64> deletedHotBlocks) {
     try (final FinalizedUpdater updater = finalizedUpdater()) {
       LOG.trace("Confirming blobs sidecars for new hot blocks");
@@ -948,8 +950,11 @@ public class KvStoreDatabase implements Database {
                       blockAndCheckpoints.getSlot(), blockAndCheckpoints.getRoot()))
           .forEach(updater::confirmBlobsSidecar);
 
+      final Set<Bytes32> finalizedBlockRoots = finalizedBlocks.keySet();
+
       LOG.trace("Removing blobs sidecars for deleted hot blocks");
       deletedHotBlocks.entrySet().stream()
+          .filter(entry -> !finalizedBlockRoots.contains(entry.getKey()))
           .map(entry -> new SlotAndBlockRoot(entry.getValue(), entry.getKey()))
           .forEach(updater::removeBlobsSidecar);
 


### PR DESCRIPTION
We were pruning finalized sidecars when performing Storage transaction.

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
