### PR TITLE
Adds override for async runner threads in VC service

### DIFF
--- a/infrastructure/serviceutils/src/main/java/tech/pegasys/teku/service/serviceutils/ServiceConfig.java
+++ b/infrastructure/serviceutils/src/main/java/tech/pegasys/teku/service/serviceutils/ServiceConfig.java
@@ -30,8 +30,7 @@ public class ServiceConfig {
   private final DataDirLayout dataDirLayout;
 
   private final IntSupplier rejectedExecutionsSupplier;
-
-  private final int runnerThreadNum;
+  private final IntSupplier runnerThreadNum;
 
   public ServiceConfig(
       final AsyncRunnerFactory asyncRunnerFactory,
@@ -40,7 +39,7 @@ public class ServiceConfig {
       final MetricsSystem metricsSystem,
       final DataDirLayout dataDirLayout,
       final IntSupplier rejectedExecutionsSupplier,
-      final int runnerThreadNum) {
+      final IntSupplier runnerThreadNum) {
     this.asyncRunnerFactory = asyncRunnerFactory;
     this.timeProvider = timeProvider;
     this.eventChannels = eventChannels;
@@ -99,6 +98,6 @@ public class ServiceConfig {
   private int calculateMaxThreads() {
     // We use a bunch of blocking calls so need to ensure the thread pool is reasonably large
     // as many threads may be blocked.
-    return Math.max(Runtime.getRuntime().availableProcessors(), runnerThreadNum);
+    return Math.max(Runtime.getRuntime().availableProcessors(), runnerThreadNum.getAsInt());
   }
 }

--- a/infrastructure/serviceutils/src/main/java/tech/pegasys/teku/service/serviceutils/ServiceConfig.java
+++ b/infrastructure/serviceutils/src/main/java/tech/pegasys/teku/service/serviceutils/ServiceConfig.java
@@ -31,19 +31,23 @@ public class ServiceConfig {
 
   private final IntSupplier rejectedExecutionsSupplier;
 
+  private final int runnerThreadNum;
+
   public ServiceConfig(
       final AsyncRunnerFactory asyncRunnerFactory,
       final TimeProvider timeProvider,
       final EventChannels eventChannels,
       final MetricsSystem metricsSystem,
       final DataDirLayout dataDirLayout,
-      final IntSupplier rejectedExecutionsSupplier) {
+      final IntSupplier rejectedExecutionsSupplier,
+      final int runnerThreadNum) {
     this.asyncRunnerFactory = asyncRunnerFactory;
     this.timeProvider = timeProvider;
     this.eventChannels = eventChannels;
     this.metricsSystem = metricsSystem;
     this.dataDirLayout = dataDirLayout;
     this.rejectedExecutionsSupplier = rejectedExecutionsSupplier;
+    this.runnerThreadNum = runnerThreadNum;
   }
 
   public TimeProvider getTimeProvider() {
@@ -95,6 +99,6 @@ public class ServiceConfig {
   private int calculateMaxThreads() {
     // We use a bunch of blocking calls so need to ensure the thread pool is reasonably large
     // as many threads may be blocked.
-    return Math.max(Runtime.getRuntime().availableProcessors(), 5);
+    return Math.max(Runtime.getRuntime().availableProcessors(), runnerThreadNum);
   }
 }

--- a/infrastructure/serviceutils/src/main/java/tech/pegasys/teku/service/serviceutils/ServiceConfig.java
+++ b/infrastructure/serviceutils/src/main/java/tech/pegasys/teku/service/serviceutils/ServiceConfig.java
@@ -30,7 +30,7 @@ public class ServiceConfig {
   private final DataDirLayout dataDirLayout;
 
   private final IntSupplier rejectedExecutionsSupplier;
-  private final IntSupplier runnerThreadNum;
+  private final IntSupplier executorThreads;
 
   public ServiceConfig(
       final AsyncRunnerFactory asyncRunnerFactory,
@@ -39,14 +39,14 @@ public class ServiceConfig {
       final MetricsSystem metricsSystem,
       final DataDirLayout dataDirLayout,
       final IntSupplier rejectedExecutionsSupplier,
-      final IntSupplier runnerThreadNum) {
+      final IntSupplier executorThreads) {
     this.asyncRunnerFactory = asyncRunnerFactory;
     this.timeProvider = timeProvider;
     this.eventChannels = eventChannels;
     this.metricsSystem = metricsSystem;
     this.dataDirLayout = dataDirLayout;
     this.rejectedExecutionsSupplier = rejectedExecutionsSupplier;
-    this.runnerThreadNum = runnerThreadNum;
+    this.executorThreads = executorThreads;
   }
 
   public TimeProvider getTimeProvider() {
@@ -98,6 +98,6 @@ public class ServiceConfig {
   private int calculateMaxThreads() {
     // We use a bunch of blocking calls so need to ensure the thread pool is reasonably large
     // as many threads may be blocked.
-    return Math.max(Runtime.getRuntime().availableProcessors(), runnerThreadNum.getAsInt());
+    return Math.max(Runtime.getRuntime().availableProcessors(), executorThreads.getAsInt());
   }
 }

--- a/teku/src/main/java/tech/pegasys/teku/AbstractNode.java
+++ b/teku/src/main/java/tech/pegasys/teku/AbstractNode.java
@@ -39,6 +39,7 @@ import tech.pegasys.teku.service.serviceutils.ServiceConfig;
 import tech.pegasys.teku.service.serviceutils.layout.DataDirLayout;
 import tech.pegasys.teku.services.ServiceController;
 import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.validator.api.ValidatorConfig;
 
 public abstract class AbstractNode implements Node {
   private static final Logger LOG = LogManager.getLogger();
@@ -71,6 +72,8 @@ public abstract class AbstractNode implements Node {
         AsyncRunnerFactory.createDefault(
             new MetricTrackingExecutorFactory(metricsSystem, rejectedExecutionCounter));
     final DataDirLayout dataDirLayout = DataDirLayout.createFrom(tekuConfig.dataConfig());
+    ValidatorConfig validatorConfig = tekuConfig.validatorClient().getValidatorConfig();
+
     serviceConfig =
         new ServiceConfig(
             asyncRunnerFactory,
@@ -78,7 +81,8 @@ public abstract class AbstractNode implements Node {
             eventChannels,
             metricsSystem,
             dataDirLayout,
-            rejectedExecutionCounter::getTotalCount);
+            rejectedExecutionCounter::getTotalCount,
+            validatorConfig.getRunnerThreadNum());
     this.metricsPublisher =
         new MetricsPublisherManager(
             asyncRunnerFactory,

--- a/teku/src/main/java/tech/pegasys/teku/AbstractNode.java
+++ b/teku/src/main/java/tech/pegasys/teku/AbstractNode.java
@@ -82,7 +82,7 @@ public abstract class AbstractNode implements Node {
             metricsSystem,
             dataDirLayout,
             rejectedExecutionCounter::getTotalCount,
-            validatorConfig.getRunnerThreadNum());
+            validatorConfig::getRunnerThreadNum);
     this.metricsPublisher =
         new MetricsPublisherManager(
             asyncRunnerFactory,

--- a/teku/src/main/java/tech/pegasys/teku/AbstractNode.java
+++ b/teku/src/main/java/tech/pegasys/teku/AbstractNode.java
@@ -82,7 +82,7 @@ public abstract class AbstractNode implements Node {
             metricsSystem,
             dataDirLayout,
             rejectedExecutionCounter::getTotalCount,
-            validatorConfig::getRunnerThreadNum);
+            validatorConfig::getexecutorThreads);
     this.metricsPublisher =
         new MetricsPublisherManager(
             asyncRunnerFactory,

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
@@ -111,6 +111,15 @@ public class ValidatorOptions {
       fallbackValue = "true")
   private boolean doppelgangerDetectionEnabled = DEFAULT_DOPPELGANGER_DETECTION_ENABLED;
 
+  @Option(
+      names = {"--Xvalidator-client-runner-threads"},
+      paramLabel = "<INTEGER>",
+      showDefaultValue = Visibility.ALWAYS,
+      description = "Set the number of threads for the validator runner",
+      hidden = true,
+      arity = "1")
+  private int runnerThreadNum = ValidatorConfig.DEFAULT_RUNNER_THREAD_NUM;
+
   public void configure(TekuConfiguration.Builder builder) {
     builder.validator(
         config ->
@@ -124,7 +133,8 @@ public class ValidatorOptions {
                         Optional.ofNullable(graffiti), Optional.ofNullable(graffitiFile)))
                 .generateEarlyAttestations(generateEarlyAttestations)
                 .executorMaxQueueSize(executorMaxQueueSize)
-                .doppelgangerDetectionEnabled(doppelgangerDetectionEnabled));
+                .doppelgangerDetectionEnabled(doppelgangerDetectionEnabled)
+                .runnerThreadNum(runnerThreadNum));
     validatorProposerOptions.configure(builder);
     validatorKeysOptions.configure(builder);
   }

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
@@ -112,13 +112,13 @@ public class ValidatorOptions {
   private boolean doppelgangerDetectionEnabled = DEFAULT_DOPPELGANGER_DETECTION_ENABLED;
 
   @Option(
-      names = {"--Xvalidator-client-runner-threads"},
+      names = {"--Xvalidator-client-executor-threads"},
       paramLabel = "<INTEGER>",
       showDefaultValue = Visibility.ALWAYS,
-      description = "Set the number of threads for the validator runner",
+      description = "Set the number of threads for the validator executor",
       hidden = true,
       arity = "1")
-  private int runnerThreadNum = ValidatorConfig.DEFAULT_RUNNER_THREAD_NUM;
+  private int executorThreads = ValidatorConfig.DEFAULT_EXECUTOR_THREADS;
 
   public void configure(TekuConfiguration.Builder builder) {
     builder.validator(
@@ -134,7 +134,7 @@ public class ValidatorOptions {
                 .generateEarlyAttestations(generateEarlyAttestations)
                 .executorMaxQueueSize(executorMaxQueueSize)
                 .doppelgangerDetectionEnabled(doppelgangerDetectionEnabled)
-                .runnerThreadNum(runnerThreadNum));
+                .executorThreads(executorThreads));
     validatorProposerOptions.configure(builder);
     validatorKeysOptions.configure(builder);
   }

--- a/teku/src/test/java/tech/pegasys/teku/cli/subcommand/ValidatorClientCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/subcommand/ValidatorClientCommandTest.java
@@ -174,26 +174,40 @@ public class ValidatorClientCommandTest extends AbstractBeaconNodeCommandTest {
   }
 
   @Test
-  public void clientRunnerThreadsShouldBeDefaultValue() {
+  public void clientExecutorThreadsShouldBeDefaultValue() {
 
     final String[] args = {"vc", "--network", "minimal"};
 
     final TekuConfiguration tekuConfig = getTekuConfigurationFromArguments(args);
 
-    assertThat(tekuConfig.validatorClient().getValidatorConfig().getRunnerThreadNum()).isEqualTo(5);
+    assertThat(tekuConfig.validatorClient().getValidatorConfig().getexecutorThreads()).isEqualTo(5);
   }
 
   @Test
-  public void clientRunnerThreadsShouldBeSetValue() {
+  public void clientExecutorThreadsShouldBeSetValue() {
 
     final String[] args = {
-      "vc", "--network", "minimal", "--Xvalidator-client-runner-threads", "1000"
+      "vc", "--network", "minimal", "--Xvalidator-client-executor-threads", "1000"
     };
 
     final TekuConfiguration tekuConfig = getTekuConfigurationFromArguments(args);
 
-    assertThat(tekuConfig.validatorClient().getValidatorConfig().getRunnerThreadNum())
+    assertThat(tekuConfig.validatorClient().getValidatorConfig().getexecutorThreads())
         .isEqualTo(1000);
+  }
+
+  @Test
+  public void clientExecutorThreadsShouldThrowOverLimit() {
+    final String[] args = {
+      "vc", "--network", "minimal", "--Xvalidator-client-executor-threads", "6000"
+    };
+
+    int parseResult = beaconNodeCommand.parse(args);
+    assertThat(parseResult).isEqualTo(1);
+    String cmdOutput = getCommandLineOutput();
+    assertThat(cmdOutput)
+        .contains(
+            "--Xvalidator-client-executor-threads must be greater than 0 and less than 5000.");
   }
 
   private String pathFor(final String filename) {

--- a/teku/src/test/java/tech/pegasys/teku/cli/subcommand/ValidatorClientCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/subcommand/ValidatorClientCommandTest.java
@@ -150,30 +150,6 @@ public class ValidatorClientCommandTest extends AbstractBeaconNodeCommandTest {
   }
 
   @Test
-  public void executorThreadsShouldBeDefaultValue() {
-
-    final String[] args = {"vc", "--network", "minimal"};
-
-    final TekuConfiguration tekuConfig = getTekuConfigurationFromArguments(args);
-
-    assertThat(tekuConfig.validatorClient().getValidatorConfig().getRunnerThreadNum())
-            .isEqualTo(5);
-  }
-
-  @Test
-  public void executorThreadsShouldBeSetValue() {
-
-    final String[] args = {
-            "vc", "--network", "minimal", "--Xvalidator-client-runner-threads", "1000"
-    };
-
-    final TekuConfiguration tekuConfig = getTekuConfigurationFromArguments(args);
-
-    assertThat(tekuConfig.validatorClient().getValidatorConfig().getRunnerThreadNum())
-            .isEqualTo(1000);
-  }
-
-  @Test
   public void doppelgangerDetectionShouldBeDisabledByDefault() {
 
     final String[] args = {"vc", "--network", "minimal"};
@@ -195,6 +171,29 @@ public class ValidatorClientCommandTest extends AbstractBeaconNodeCommandTest {
 
     assertThat(tekuConfig.validatorClient().getValidatorConfig().isDoppelgangerDetectionEnabled())
         .isTrue();
+  }
+
+  @Test
+  public void executorThreadsShouldBeDefaultValue() {
+
+    final String[] args = {"vc", "--network", "minimal"};
+
+    final TekuConfiguration tekuConfig = getTekuConfigurationFromArguments(args);
+
+    assertThat(tekuConfig.validatorClient().getValidatorConfig().getRunnerThreadNum()).isEqualTo(5);
+  }
+
+  @Test
+  public void executorThreadsShouldBeSetValue() {
+
+    final String[] args = {
+      "vc", "--network", "minimal", "--Xvalidator-client-runner-threads", "1000"
+    };
+
+    final TekuConfiguration tekuConfig = getTekuConfigurationFromArguments(args);
+
+    assertThat(tekuConfig.validatorClient().getValidatorConfig().getRunnerThreadNum())
+        .isEqualTo(1000);
   }
 
   private String pathFor(final String filename) {

--- a/teku/src/test/java/tech/pegasys/teku/cli/subcommand/ValidatorClientCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/subcommand/ValidatorClientCommandTest.java
@@ -174,7 +174,7 @@ public class ValidatorClientCommandTest extends AbstractBeaconNodeCommandTest {
   }
 
   @Test
-  public void executorThreadsShouldBeDefaultValue() {
+  public void clientRunnerThreadsShouldBeDefaultValue() {
 
     final String[] args = {"vc", "--network", "minimal"};
 
@@ -184,7 +184,7 @@ public class ValidatorClientCommandTest extends AbstractBeaconNodeCommandTest {
   }
 
   @Test
-  public void executorThreadsShouldBeSetValue() {
+  public void clientRunnerThreadsShouldBeSetValue() {
 
     final String[] args = {
       "vc", "--network", "minimal", "--Xvalidator-client-runner-threads", "1000"

--- a/teku/src/test/java/tech/pegasys/teku/cli/subcommand/ValidatorClientCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/subcommand/ValidatorClientCommandTest.java
@@ -150,6 +150,30 @@ public class ValidatorClientCommandTest extends AbstractBeaconNodeCommandTest {
   }
 
   @Test
+  public void executorThreadsShouldBeDefaultValue() {
+
+    final String[] args = {"vc", "--network", "minimal"};
+
+    final TekuConfiguration tekuConfig = getTekuConfigurationFromArguments(args);
+
+    assertThat(tekuConfig.validatorClient().getValidatorConfig().getRunnerThreadNum())
+            .isEqualTo(5);
+  }
+
+  @Test
+  public void executorThreadsShouldBeSetValue() {
+
+    final String[] args = {
+            "vc", "--network", "minimal", "--Xvalidator-client-runner-threads", "1000"
+    };
+
+    final TekuConfiguration tekuConfig = getTekuConfigurationFromArguments(args);
+
+    assertThat(tekuConfig.validatorClient().getValidatorConfig().getRunnerThreadNum())
+            .isEqualTo(1000);
+  }
+
+  @Test
   public void doppelgangerDetectionShouldBeDisabledByDefault() {
 
     final String[] args = {"vc", "--network", "minimal"};

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
@@ -121,8 +121,8 @@ public class ValidatorConfig {
       final Optional<UInt64> builderRegistrationTimestampOverride,
       final Optional<BLSPublicKey> builderRegistrationPublicKeyOverride,
       final int executorMaxQueueSize,
-      final Optional<String> sentryNodeConfigurationFile,
-      final int runnerThreadNum) {
+      final int runnerThreadNum,
+      final Optional<String> sentryNodeConfigurationFile) {
     this.validatorKeys = validatorKeys;
     this.validatorExternalSignerPublicKeySources = validatorExternalSignerPublicKeySources;
     this.validatorExternalSignerUrl = validatorExternalSignerUrl;
@@ -155,8 +155,8 @@ public class ValidatorConfig {
     this.builderRegistrationTimestampOverride = builderRegistrationTimestampOverride;
     this.builderRegistrationPublicKeyOverride = builderRegistrationPublicKeyOverride;
     this.executorMaxQueueSize = executorMaxQueueSize;
-    this.sentryNodeConfigurationFile = sentryNodeConfigurationFile;
     this.runnerThreadNum = runnerThreadNum;
+    this.sentryNodeConfigurationFile = sentryNodeConfigurationFile;
   }
 
   public static Builder builder() {
@@ -278,12 +278,12 @@ public class ValidatorConfig {
     return executorMaxQueueSize;
   }
 
-  public Optional<String> getSentryNodeConfigurationFile() {
-    return sentryNodeConfigurationFile;
-  }
-
   public int getRunnerThreadNum() {
     return runnerThreadNum;
+  }
+
+  public Optional<String> getSentryNodeConfigurationFile() {
+    return sentryNodeConfigurationFile;
   }
 
   private void validateProposerDefaultFeeRecipientOrProposerConfigSource() {
@@ -574,8 +574,8 @@ public class ValidatorConfig {
           builderRegistrationTimestampOverride,
           builderRegistrationPublicKeyOverride,
           executorMaxQueueSize,
-          sentryNodeConfigurationFile,
-          runnerThreadNum);
+          runnerThreadNum,
+          sentryNodeConfigurationFile);
     }
 
     private void validateExternalSignerUrlAndPublicKeys() {

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
@@ -56,7 +56,7 @@ public class ValidatorConfig {
   public static final int DEFAULT_VALIDATOR_REGISTRATION_SENDING_BATCH_SIZE = 100;
   public static final UInt64 DEFAULT_BUILDER_REGISTRATION_GAS_LIMIT = UInt64.valueOf(30_000_000);
 
-  public static final int DEFAULT_RUNNER_THREAD_NUM = 5;
+  public static final int DEFAULT_EXECUTOR_THREADS = 5;
 
   private final List<String> validatorKeys;
   private final List<String> validatorExternalSignerPublicKeySources;
@@ -89,7 +89,7 @@ public class ValidatorConfig {
   private final int executorMaxQueueSize;
   private final Optional<String> sentryNodeConfigurationFile;
 
-  private final int runnerThreadNum;
+  private final int executorThreads;
 
   private ValidatorConfig(
       final List<String> validatorKeys,
@@ -121,7 +121,7 @@ public class ValidatorConfig {
       final Optional<UInt64> builderRegistrationTimestampOverride,
       final Optional<BLSPublicKey> builderRegistrationPublicKeyOverride,
       final int executorMaxQueueSize,
-      final int runnerThreadNum,
+      final int executorThreads,
       final Optional<String> sentryNodeConfigurationFile) {
     this.validatorKeys = validatorKeys;
     this.validatorExternalSignerPublicKeySources = validatorExternalSignerPublicKeySources;
@@ -155,7 +155,7 @@ public class ValidatorConfig {
     this.builderRegistrationTimestampOverride = builderRegistrationTimestampOverride;
     this.builderRegistrationPublicKeyOverride = builderRegistrationPublicKeyOverride;
     this.executorMaxQueueSize = executorMaxQueueSize;
-    this.runnerThreadNum = runnerThreadNum;
+    this.executorThreads = executorThreads;
     this.sentryNodeConfigurationFile = sentryNodeConfigurationFile;
   }
 
@@ -278,8 +278,8 @@ public class ValidatorConfig {
     return executorMaxQueueSize;
   }
 
-  public int getRunnerThreadNum() {
-    return runnerThreadNum;
+  public int getexecutorThreads() {
+    return executorThreads;
   }
 
   public Optional<String> getSentryNodeConfigurationFile() {
@@ -336,7 +336,7 @@ public class ValidatorConfig {
     private int executorMaxQueueSize = DEFAULT_EXECUTOR_MAX_QUEUE_SIZE;
     private Optional<String> sentryNodeConfigurationFile = Optional.empty();
 
-    private int runnerThreadNum = DEFAULT_RUNNER_THREAD_NUM;
+    private int executorThreads = DEFAULT_EXECUTOR_THREADS;
 
     private Builder() {}
 
@@ -484,8 +484,13 @@ public class ValidatorConfig {
       return this;
     }
 
-    public Builder runnerThreadNum(final int runnerThreadNum) {
-      this.runnerThreadNum = runnerThreadNum;
+    public Builder executorThreads(final int executorThreads) {
+      if (executorThreads < 1 || executorThreads > 5_000) {
+        throw new InvalidConfigurationException(
+            "Invalid configuration. --Xvalidator-client-executor-threads must be greater than 0 and less than 5000.");
+      }
+
+      this.executorThreads = executorThreads;
       return this;
     }
 
@@ -574,7 +579,7 @@ public class ValidatorConfig {
           builderRegistrationTimestampOverride,
           builderRegistrationPublicKeyOverride,
           executorMaxQueueSize,
-          runnerThreadNum,
+          executorThreads,
           sentryNodeConfigurationFile);
     }
 

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
@@ -56,6 +56,8 @@ public class ValidatorConfig {
   public static final int DEFAULT_VALIDATOR_REGISTRATION_SENDING_BATCH_SIZE = 100;
   public static final UInt64 DEFAULT_BUILDER_REGISTRATION_GAS_LIMIT = UInt64.valueOf(30_000_000);
 
+  public static final int DEFAULT_RUNNER_THREAD_NUM = 5;
+
   private final List<String> validatorKeys;
   private final List<String> validatorExternalSignerPublicKeySources;
   private final boolean validatorExternalSignerSlashingProtectionEnabled;
@@ -87,6 +89,8 @@ public class ValidatorConfig {
   private final int executorMaxQueueSize;
   private final Optional<String> sentryNodeConfigurationFile;
 
+  private final int runnerThreadNum;
+
   private ValidatorConfig(
       final List<String> validatorKeys,
       final List<String> validatorExternalSignerPublicKeySources,
@@ -117,7 +121,8 @@ public class ValidatorConfig {
       final Optional<UInt64> builderRegistrationTimestampOverride,
       final Optional<BLSPublicKey> builderRegistrationPublicKeyOverride,
       final int executorMaxQueueSize,
-      final Optional<String> sentryNodeConfigurationFile) {
+      final Optional<String> sentryNodeConfigurationFile,
+      final int runnerThreadNum) {
     this.validatorKeys = validatorKeys;
     this.validatorExternalSignerPublicKeySources = validatorExternalSignerPublicKeySources;
     this.validatorExternalSignerUrl = validatorExternalSignerUrl;
@@ -151,6 +156,7 @@ public class ValidatorConfig {
     this.builderRegistrationPublicKeyOverride = builderRegistrationPublicKeyOverride;
     this.executorMaxQueueSize = executorMaxQueueSize;
     this.sentryNodeConfigurationFile = sentryNodeConfigurationFile;
+    this.runnerThreadNum = runnerThreadNum;
   }
 
   public static Builder builder() {
@@ -276,6 +282,10 @@ public class ValidatorConfig {
     return sentryNodeConfigurationFile;
   }
 
+  public int getRunnerThreadNum() {
+    return runnerThreadNum;
+  }
+
   private void validateProposerDefaultFeeRecipientOrProposerConfigSource() {
     if (proposerDefaultFeeRecipient.isEmpty()
         && proposerConfigSource.isEmpty()
@@ -325,6 +335,8 @@ public class ValidatorConfig {
     private Optional<BLSPublicKey> builderRegistrationPublicKeyOverride = Optional.empty();
     private int executorMaxQueueSize = DEFAULT_EXECUTOR_MAX_QUEUE_SIZE;
     private Optional<String> sentryNodeConfigurationFile = Optional.empty();
+
+    private int runnerThreadNum = DEFAULT_RUNNER_THREAD_NUM;
 
     private Builder() {}
 
@@ -472,6 +484,11 @@ public class ValidatorConfig {
       return this;
     }
 
+    public Builder runnerThreadNum(final int runnerThreadNum) {
+      this.runnerThreadNum = runnerThreadNum;
+      return this;
+    }
+
     public Builder failoversSendSubnetSubscriptionsEnabled(
         final boolean failoversSendSubnetSubscriptionsEnabled) {
       this.failoversSendSubnetSubscriptionsEnabled = failoversSendSubnetSubscriptionsEnabled;
@@ -557,7 +574,8 @@ public class ValidatorConfig {
           builderRegistrationTimestampOverride,
           builderRegistrationPublicKeyOverride,
           executorMaxQueueSize,
-          sentryNodeConfigurationFile);
+          sentryNodeConfigurationFile,
+          runnerThreadNum);
     }
 
     private void validateExternalSignerUrlAndPublicKeys() {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

This pr adds a flag `--Xvalidator-client-runner-threads` that can be used to set the number of asynchronous runner threads used in the validator client service. This will allow for a greater number of concurrent blocking requests to a BN as is required in DVT.

As suggested in the linked issue, we have built and tested a version of this with a higher configured thread count and this has resolved our issue. We are running a Teku VC as part of 1000 validator DVT cluster with no `unexpected delay in slot processing` errors.

## Fixed Issue(s)
Addresses https://github.com/ConsenSys/teku/issues/6667

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
