### PR TITLE
Blobs sidecar storage counters metrics

### DIFF
--- a/infrastructure/metrics/src/main/java/tech/pegasys/teku/infrastructure/metrics/MetricsConfig.java
+++ b/infrastructure/metrics/src/main/java/tech/pegasys/teku/infrastructure/metrics/MetricsConfig.java
@@ -40,6 +40,7 @@ public class MetricsConfig {
   public static final int DEFAULT_METRICS_PUBLICATION_INTERVAL = 60;
   public static final boolean DEFAULT_BLOCK_PERFORMANCE_ENABLED = true;
   public static final boolean DEFAULT_TICK_PERFORMANCE_ENABLED = false;
+  public static final boolean DEFAULT_BLOBS_SIDECAR_STORAGE_ENABLED = false;
 
   private final boolean metricsEnabled;
   private final int metricsPort;
@@ -51,6 +52,7 @@ public class MetricsConfig {
   private final int idleTimeoutSeconds;
   private final boolean blockPerformanceEnabled;
   private final boolean tickPerformanceEnabled;
+  private final boolean blobsSidecarStorageEnabled;
 
   private MetricsConfig(
       final boolean metricsEnabled,
@@ -62,7 +64,8 @@ public class MetricsConfig {
       final int publicationInterval,
       final int idleTimeoutSeconds,
       final boolean blockPerformanceEnabled,
-      final boolean tickPerformanceEnabled) {
+      final boolean tickPerformanceEnabled,
+      final boolean blobsSidecarStorageEnabled) {
     this.metricsEnabled = metricsEnabled;
     this.metricsPort = metricsPort;
     this.metricsInterface = metricsInterface;
@@ -73,6 +76,7 @@ public class MetricsConfig {
     this.idleTimeoutSeconds = idleTimeoutSeconds;
     this.blockPerformanceEnabled = blockPerformanceEnabled;
     this.tickPerformanceEnabled = tickPerformanceEnabled;
+    this.blobsSidecarStorageEnabled = blobsSidecarStorageEnabled;
   }
 
   public static MetricsConfigBuilder builder() {
@@ -119,6 +123,10 @@ public class MetricsConfig {
     return tickPerformanceEnabled;
   }
 
+  public boolean isBlobsSidecarStorageEnabled() {
+    return blobsSidecarStorageEnabled;
+  }
+
   public static final class MetricsConfigBuilder {
 
     private boolean metricsEnabled = false;
@@ -131,6 +139,7 @@ public class MetricsConfig {
     private int idleTimeoutSeconds = DEFAULT_IDLE_TIMEOUT_SECONDS;
     private boolean blockPerformanceEnabled = DEFAULT_BLOCK_PERFORMANCE_ENABLED;
     private boolean tickPerformanceEnabled = DEFAULT_TICK_PERFORMANCE_ENABLED;
+    private boolean blobsSidecarStorageEnabled = DEFAULT_BLOBS_SIDECAR_STORAGE_ENABLED;
 
     private MetricsConfigBuilder() {}
 
@@ -196,6 +205,12 @@ public class MetricsConfig {
       return this;
     }
 
+    public MetricsConfigBuilder blobsSidecarStorageEnabled(
+        final boolean blobsSidecarStorageEnabled) {
+      this.blobsSidecarStorageEnabled = blobsSidecarStorageEnabled;
+      return this;
+    }
+
     public MetricsConfig build() {
       return new MetricsConfig(
           metricsEnabled,
@@ -207,7 +222,8 @@ public class MetricsConfig {
           metricsPublishInterval,
           idleTimeoutSeconds,
           blockPerformanceEnabled,
-          tickPerformanceEnabled);
+          tickPerformanceEnabled,
+          blobsSidecarStorageEnabled);
     }
   }
 }

--- a/infrastructure/metrics/src/main/java/tech/pegasys/teku/infrastructure/metrics/MetricsConfig.java
+++ b/infrastructure/metrics/src/main/java/tech/pegasys/teku/infrastructure/metrics/MetricsConfig.java
@@ -40,7 +40,7 @@ public class MetricsConfig {
   public static final int DEFAULT_METRICS_PUBLICATION_INTERVAL = 60;
   public static final boolean DEFAULT_BLOCK_PERFORMANCE_ENABLED = true;
   public static final boolean DEFAULT_TICK_PERFORMANCE_ENABLED = false;
-  public static final boolean DEFAULT_BLOBS_SIDECAR_STORAGE_ENABLED = false;
+  public static final boolean DEFAULT_BLOBS_SIDECAR_STORAGE_COUNTERS_ENABLED = false;
 
   private final boolean metricsEnabled;
   private final int metricsPort;
@@ -52,7 +52,7 @@ public class MetricsConfig {
   private final int idleTimeoutSeconds;
   private final boolean blockPerformanceEnabled;
   private final boolean tickPerformanceEnabled;
-  private final boolean blobsSidecarStorageEnabled;
+  private final boolean blobsSidecarStorageCountersEnabled;
 
   private MetricsConfig(
       final boolean metricsEnabled,
@@ -65,7 +65,7 @@ public class MetricsConfig {
       final int idleTimeoutSeconds,
       final boolean blockPerformanceEnabled,
       final boolean tickPerformanceEnabled,
-      final boolean blobsSidecarStorageEnabled) {
+      final boolean blobsSidecarStorageCountersEnabled) {
     this.metricsEnabled = metricsEnabled;
     this.metricsPort = metricsPort;
     this.metricsInterface = metricsInterface;
@@ -76,7 +76,7 @@ public class MetricsConfig {
     this.idleTimeoutSeconds = idleTimeoutSeconds;
     this.blockPerformanceEnabled = blockPerformanceEnabled;
     this.tickPerformanceEnabled = tickPerformanceEnabled;
-    this.blobsSidecarStorageEnabled = blobsSidecarStorageEnabled;
+    this.blobsSidecarStorageCountersEnabled = blobsSidecarStorageCountersEnabled;
   }
 
   public static MetricsConfigBuilder builder() {
@@ -123,8 +123,8 @@ public class MetricsConfig {
     return tickPerformanceEnabled;
   }
 
-  public boolean isBlobsSidecarStorageEnabled() {
-    return blobsSidecarStorageEnabled;
+  public boolean isBlobsSidecarStorageCountersEnabled() {
+    return blobsSidecarStorageCountersEnabled;
   }
 
   public static final class MetricsConfigBuilder {
@@ -139,7 +139,8 @@ public class MetricsConfig {
     private int idleTimeoutSeconds = DEFAULT_IDLE_TIMEOUT_SECONDS;
     private boolean blockPerformanceEnabled = DEFAULT_BLOCK_PERFORMANCE_ENABLED;
     private boolean tickPerformanceEnabled = DEFAULT_TICK_PERFORMANCE_ENABLED;
-    private boolean blobsSidecarStorageEnabled = DEFAULT_BLOBS_SIDECAR_STORAGE_ENABLED;
+    private boolean blobsSidecarStorageCountersEnabled =
+        DEFAULT_BLOBS_SIDECAR_STORAGE_COUNTERS_ENABLED;
 
     private MetricsConfigBuilder() {}
 
@@ -205,9 +206,9 @@ public class MetricsConfig {
       return this;
     }
 
-    public MetricsConfigBuilder blobsSidecarStorageEnabled(
-        final boolean blobsSidecarStorageEnabled) {
-      this.blobsSidecarStorageEnabled = blobsSidecarStorageEnabled;
+    public MetricsConfigBuilder blobsSidecarStorageCountersEnabled(
+        final boolean blobsSidecarStorageCountersEnabled) {
+      this.blobsSidecarStorageCountersEnabled = blobsSidecarStorageCountersEnabled;
       return this;
     }
 
@@ -223,7 +224,7 @@ public class MetricsConfig {
           idleTimeoutSeconds,
           blockPerformanceEnabled,
           tickPerformanceEnabled,
-          blobsSidecarStorageEnabled);
+          blobsSidecarStorageCountersEnabled);
     }
   }
 }

--- a/services/chainstorage/src/main/java/tech/pegasys/teku/services/chainstorage/StorageService.java
+++ b/services/chainstorage/src/main/java/tech/pegasys/teku/services/chainstorage/StorageService.java
@@ -49,14 +49,17 @@ public class StorageService extends Service implements StorageServiceFacade {
   private volatile Optional<BlockPruner> blockPruner = Optional.empty();
   private volatile Optional<BlobsSidecarPruner> blobsPruner = Optional.empty();
   private final boolean depositSnapshotStorageEnabled;
+  private final boolean blobsSidecarStorageEnabled;
 
   public StorageService(
       final ServiceConfig serviceConfig,
       final StorageConfiguration storageConfiguration,
-      final boolean depositSnapshotStorageEnabled) {
+      final boolean depositSnapshotStorageEnabled,
+      final boolean blobsSidecarStorageEnabled) {
     this.serviceConfig = serviceConfig;
     this.config = storageConfiguration;
     this.depositSnapshotStorageEnabled = depositSnapshotStorageEnabled;
+    this.blobsSidecarStorageEnabled = blobsSidecarStorageEnabled;
   }
 
   @Override
@@ -97,7 +100,8 @@ public class StorageService extends Service implements StorageServiceFacade {
                             storagePrunerAsyncRunner,
                             serviceConfig.getTimeProvider(),
                             config.getBlobsPruningInterval(),
-                            config.getBlobsPruningLimit()));
+                            config.getBlobsPruningLimit(),
+                            blobsSidecarStorageEnabled));
               }
               final EventChannels eventChannels = serviceConfig.getEventChannels();
               chainStorage = ChainStorage.create(database, config.getSpec());

--- a/services/chainstorage/src/main/java/tech/pegasys/teku/services/chainstorage/StorageService.java
+++ b/services/chainstorage/src/main/java/tech/pegasys/teku/services/chainstorage/StorageService.java
@@ -49,17 +49,17 @@ public class StorageService extends Service implements StorageServiceFacade {
   private volatile Optional<BlockPruner> blockPruner = Optional.empty();
   private volatile Optional<BlobsSidecarPruner> blobsPruner = Optional.empty();
   private final boolean depositSnapshotStorageEnabled;
-  private final boolean blobsSidecarStorageEnabled;
+  private final boolean blobsSidecarStorageCountersEnabled;
 
   public StorageService(
       final ServiceConfig serviceConfig,
       final StorageConfiguration storageConfiguration,
       final boolean depositSnapshotStorageEnabled,
-      final boolean blobsSidecarStorageEnabled) {
+      final boolean blobsSidecarStorageCountersEnabled) {
     this.serviceConfig = serviceConfig;
     this.config = storageConfiguration;
     this.depositSnapshotStorageEnabled = depositSnapshotStorageEnabled;
-    this.blobsSidecarStorageEnabled = blobsSidecarStorageEnabled;
+    this.blobsSidecarStorageCountersEnabled = blobsSidecarStorageCountersEnabled;
   }
 
   @Override
@@ -101,7 +101,7 @@ public class StorageService extends Service implements StorageServiceFacade {
                             serviceConfig.getTimeProvider(),
                             config.getBlobsPruningInterval(),
                             config.getBlobsPruningLimit(),
-                            blobsSidecarStorageEnabled));
+                            blobsSidecarStorageCountersEnabled));
               }
               final EventChannels eventChannels = serviceConfig.getEventChannels();
               chainStorage = ChainStorage.create(database, config.getSpec());

--- a/services/chainstorage/src/main/java/tech/pegasys/teku/services/chainstorage/StorageService.java
+++ b/services/chainstorage/src/main/java/tech/pegasys/teku/services/chainstorage/StorageService.java
@@ -93,6 +93,7 @@ public class StorageService extends Service implements StorageServiceFacade {
                         new BlobsSidecarPruner(
                             config.getSpec(),
                             database,
+                            serviceConfig.getMetricsSystem(),
                             storagePrunerAsyncRunner,
                             serviceConfig.getTimeProvider(),
                             config.getBlobsPruningInterval(),

--- a/storage/src/integration-test/java/tech/pegasys/teku/storage/server/kvstore/DatabaseTest.java
+++ b/storage/src/integration-test/java/tech/pegasys/teku/storage/server/kvstore/DatabaseTest.java
@@ -94,7 +94,7 @@ import tech.pegasys.teku.storage.store.UpdatableStore;
 import tech.pegasys.teku.storage.store.UpdatableStore.StoreTransaction;
 
 @TestDatabaseContext
-@Execution(ExecutionMode.SAME_THREAD)
+@Execution(ExecutionMode.CONCURRENT)
 public class DatabaseTest {
 
   private static final List<BLSKeyPair> VALIDATOR_KEYS = BLSKeyGenerator.generateKeyPairs(3);

--- a/storage/src/integration-test/java/tech/pegasys/teku/storage/server/kvstore/DatabaseTest.java
+++ b/storage/src/integration-test/java/tech/pegasys/teku/storage/server/kvstore/DatabaseTest.java
@@ -94,7 +94,7 @@ import tech.pegasys.teku.storage.store.UpdatableStore;
 import tech.pegasys.teku.storage.store.UpdatableStore.StoreTransaction;
 
 @TestDatabaseContext
-@Execution(ExecutionMode.CONCURRENT)
+@Execution(ExecutionMode.SAME_THREAD)
 public class DatabaseTest {
 
   private static final List<BLSKeyPair> VALIDATOR_KEYS = BLSKeyGenerator.generateKeyPairs(3);
@@ -210,6 +210,12 @@ public class DatabaseTest {
     database.storeUnconfirmedBlobsSidecar(blobsSidecar4);
     database.storeUnconfirmedBlobsSidecar(blobsSidecar3);
 
+    assertThat(database.getBlobsSidecarColumnCounts())
+        .containsExactlyInAnyOrderEntriesOf(
+            Map.of(
+                "UNCONFIRMED_BLOBS_SIDECAR_BY_SLOT_AND_BLOCK_ROOT", 5L,
+                "BLOBS_SIDECAR_BY_SLOT_AND_BLOCK_ROOT", 5L));
+
     assertThat(database.getEarliestBlobsSidecarSlot()).contains(ONE);
 
     // all added blobs must be there
@@ -239,6 +245,12 @@ public class DatabaseTest {
         blobsSidecarToSlotAndBlockRoot(blobsSidecar4));
 
     database.confirmBlobsSidecar(blobsSidecarToSlotAndBlockRoot(blobsSidecar4));
+
+    assertThat(database.getBlobsSidecarColumnCounts())
+        .containsExactlyInAnyOrderEntriesOf(
+            Map.of(
+                "UNCONFIRMED_BLOBS_SIDECAR_BY_SLOT_AND_BLOCK_ROOT", 4L,
+                "BLOBS_SIDECAR_BY_SLOT_AND_BLOCK_ROOT", 5L));
 
     // only 1 and 3 blobs must be unconfirmed
     assertUnconfirmedBlobsStream(
@@ -282,6 +294,12 @@ public class DatabaseTest {
     // all empty now
     assertUnconfirmedBlobsStream();
     assertBlobsStream();
+
+    assertThat(database.getBlobsSidecarColumnCounts())
+        .containsExactlyInAnyOrderEntriesOf(
+            Map.of(
+                "UNCONFIRMED_BLOBS_SIDECAR_BY_SLOT_AND_BLOCK_ROOT", 0L,
+                "BLOBS_SIDECAR_BY_SLOT_AND_BLOCK_ROOT", 0L));
   }
 
   @TestTemplate

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
@@ -205,6 +205,8 @@ public interface Database extends AutoCloseable {
 
   Map<String, Long> getColumnCounts();
 
+  Map<String, Long> getBlobsSidecarColumnCounts();
+
   void migrate();
 
   Optional<Checkpoint> getAnchor();

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreAccessor.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreAccessor.java
@@ -79,6 +79,9 @@ public interface KvStoreAccessor extends AutoCloseable {
   @MustBeClosed
   Stream<ColumnEntry<Bytes, Bytes>> streamRaw(KvStoreColumn<?, ?> column);
 
+  @MustBeClosed
+  Stream<Bytes> streamKeysRaw(final KvStoreColumn<?, ?> column);
+
   /**
    * WARNING: should only be used to migrate data between tables
    *

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
@@ -324,6 +324,11 @@ public class KvStoreDatabase implements Database {
   }
 
   @Override
+  public Map<String, Long> getBlobsSidecarColumnCounts() {
+    return dao.getBlobsSidecarColumnCounts();
+  }
+
+  @Override
   public void migrate() {}
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
@@ -384,7 +384,11 @@ public class CombinedKvStoreDao<S extends SchemaCombined>
 
     schema.getColumnMap().entrySet().stream()
         .filter(
-            stringKvStoreColumnEntry -> stringKvStoreColumnEntry.getKey().contains("BLOBS_SIDECAR"))
+            stringKvStoreColumnEntry ->
+                List.of(
+                        "UNCONFIRMED_BLOBS_SIDECAR_BY_SLOT_AND_BLOCK_ROOT",
+                        "BLOBS_SIDECAR_BY_SLOT_AND_BLOCK_ROOT")
+                    .contains(stringKvStoreColumnEntry.getKey()))
         .collect(Collectors.toMap(Entry::getKey, Entry::getValue))
         .forEach((k, v) -> columnCounts.put(k, db.size(v)));
     return columnCounts;

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
@@ -379,6 +379,18 @@ public class CombinedKvStoreDao<S extends SchemaCombined>
   }
 
   @Override
+  public Map<String, Long> getBlobsSidecarColumnCounts() {
+    final Map<String, Long> columnCounts = new LinkedHashMap<>();
+
+    schema.getColumnMap().entrySet().stream()
+        .filter(
+            stringKvStoreColumnEntry -> stringKvStoreColumnEntry.getKey().contains("BLOBS_SIDECAR"))
+        .collect(Collectors.toMap(Entry::getKey, Entry::getValue))
+        .forEach((k, v) -> columnCounts.put(k, db.size(v)));
+    return columnCounts;
+  }
+
+  @Override
   @MustBeClosed
   public Stream<UInt64> streamFinalizedStateSlots(final UInt64 startSlot, final UInt64 endSlot) {
     return stateStorageLogic.streamFinalizedStateSlots(db, schema, startSlot, endSlot);

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDao.java
@@ -139,6 +139,8 @@ public interface KvStoreCombinedDao extends AutoCloseable {
 
   Map<String, Long> getColumnCounts();
 
+  Map<String, Long> getBlobsSidecarColumnCounts();
+
   @MustBeClosed
   Stream<UInt64> streamFinalizedStateSlots(final UInt64 startSlot, final UInt64 endSlot);
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoAdapter.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoAdapter.java
@@ -217,6 +217,11 @@ public class KvStoreCombinedDaoAdapter implements KvStoreCombinedDao, V4Migratab
   }
 
   @Override
+  public Map<String, Long> getBlobsSidecarColumnCounts() {
+    return new LinkedHashMap<>(finalizedDao.getBlobsSidecarColumnCounts());
+  }
+
+  @Override
   @MustBeClosed
   public Stream<UInt64> streamFinalizedStateSlots(final UInt64 startSlot, final UInt64 endSlot) {
     return finalizedDao.streamFinalizedStateSlots(startSlot, endSlot);

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4FinalizedKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4FinalizedKvStoreDao.java
@@ -20,8 +20,10 @@ import com.google.errorprone.annotations.MustBeClosed;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -202,6 +204,17 @@ public class V4FinalizedKvStoreDao {
   public Map<String, Long> getColumnCounts() {
     final Map<String, Long> columnCounts = new HashMap<>();
     schema.getColumnMap().forEach((k, v) -> columnCounts.put(k, db.size(v)));
+    return columnCounts;
+  }
+
+  public Map<String, Long> getBlobsSidecarColumnCounts() {
+    final Map<String, Long> columnCounts = new LinkedHashMap<>();
+
+    schema.getColumnMap().entrySet().stream()
+        .filter(
+            stringKvStoreColumnEntry -> stringKvStoreColumnEntry.getKey().contains("BLOBS_SIDECAR"))
+        .collect(Collectors.toMap(Entry::getKey, Entry::getValue))
+        .forEach((k, v) -> columnCounts.put(k, db.size(v)));
     return columnCounts;
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4FinalizedKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4FinalizedKvStoreDao.java
@@ -212,7 +212,11 @@ public class V4FinalizedKvStoreDao {
 
     schema.getColumnMap().entrySet().stream()
         .filter(
-            stringKvStoreColumnEntry -> stringKvStoreColumnEntry.getKey().contains("BLOBS_SIDECAR"))
+            stringKvStoreColumnEntry ->
+                List.of(
+                        "UNCONFIRMED_BLOBS_SIDECAR_BY_SLOT_AND_BLOCK_ROOT",
+                        "BLOBS_SIDECAR_BY_SLOT_AND_BLOCK_ROOT")
+                    .contains(stringKvStoreColumnEntry.getKey()))
         .collect(Collectors.toMap(Entry::getKey, Entry::getValue))
         .forEach((k, v) -> columnCounts.put(k, db.size(v)));
     return columnCounts;

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/leveldb/LevelDbInstance.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/leveldb/LevelDbInstance.java
@@ -113,7 +113,7 @@ public class LevelDbInstance implements KvStoreAccessor {
   @Override
   public long size(final KvStoreColumn<?, ?> column) {
     assertOpen();
-    try (final Stream<?> rawStream = streamRaw(column)) {
+    try (final Stream<?> rawStream = streamKeysRaw(column)) {
       return rawStream.count();
     }
   }
@@ -241,6 +241,13 @@ public class LevelDbInstance implements KvStoreAccessor {
   public Stream<ColumnEntry<Bytes, Bytes>> streamRaw(final KvStoreColumn<?, ?> column) {
     return streamRaw(column, column.getId().toArrayUnsafe(), getKeyAfterColumn(column))
         .map(entry -> ColumnEntry.create(Bytes.wrap(entry.getKey()), Bytes.wrap(entry.getValue())));
+  }
+
+  @Override
+  @MustBeClosed
+  public Stream<Bytes> streamKeysRaw(final KvStoreColumn<?, ?> column) {
+    return streamKeysRaw(column, column.getId().toArrayUnsafe(), getKeyAfterColumn(column))
+        .map(Bytes::wrap);
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
@@ -247,6 +247,11 @@ public class NoOpDatabase implements Database {
   }
 
   @Override
+  public Map<String, Long> getBlobsSidecarColumnCounts() {
+    return new HashMap<>();
+  }
+
+  @Override
   public void migrate() {}
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/pruner/BlobsSidecarPruner.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/pruner/BlobsSidecarPruner.java
@@ -47,7 +47,7 @@ public class BlobsSidecarPruner extends Service implements FinalizedCheckpointCh
   private final Duration pruneInterval;
   private int pruneLimit;
   private final TimeProvider timeProvider;
-  private final boolean blobsSidecarStorageEnabled;
+  private final boolean blobsSidecarStorageCountersEnabled;
 
   private Optional<Cancellable> scheduledPruner = Optional.empty();
   private Optional<UInt64> genesisTime = Optional.empty();
@@ -65,16 +65,16 @@ public class BlobsSidecarPruner extends Service implements FinalizedCheckpointCh
       final TimeProvider timeProvider,
       final Duration pruneInterval,
       final int pruneLimit,
-      final boolean blobsSidecarStorageEnabled) {
+      final boolean blobsSidecarStorageCountersEnabled) {
     this.spec = spec;
     this.database = database;
     this.asyncRunner = asyncRunner;
     this.pruneInterval = pruneInterval;
     this.pruneLimit = pruneLimit;
     this.timeProvider = timeProvider;
-    this.blobsSidecarStorageEnabled = blobsSidecarStorageEnabled;
+    this.blobsSidecarStorageCountersEnabled = blobsSidecarStorageCountersEnabled;
 
-    if (blobsSidecarStorageEnabled) {
+    if (blobsSidecarStorageCountersEnabled) {
       LabelledGauge labelledGauge =
           metricsSystem.createLabelledGauge(
               TekuMetricCategory.STORAGE,
@@ -118,7 +118,7 @@ public class BlobsSidecarPruner extends Service implements FinalizedCheckpointCh
     pruneBlobsPriorToAvailabilityWindow();
     pruneUnconfirmedBlobs();
 
-    if (blobsSidecarStorageEnabled) {
+    if (blobsSidecarStorageCountersEnabled) {
       blobsColumnsSize.putAll(database.getBlobsSidecarColumnCounts());
     }
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbInstance.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/rocksdb/RocksDbInstance.java
@@ -157,6 +157,12 @@ public class RocksDbInstance implements KvStoreAccessor {
   }
 
   @Override
+  @MustBeClosed
+  public Stream<Bytes> streamKeysRaw(final KvStoreColumn<?, ?> column) {
+    return createStreamKeyRaw(column, RocksIterator::seekToFirst, key -> true).map(Bytes::wrap);
+  }
+
+  @Override
   public <K, V> Optional<Bytes> getRaw(final KvStoreColumn<K, V> column, final K key) {
     assertOpen();
     final ColumnFamilyHandle handle = columnHandles.get(column);

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/pruner/BlobsSidecarPrunerTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/pruner/BlobsSidecarPrunerTest.java
@@ -28,6 +28,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
+import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
@@ -50,10 +51,17 @@ public class BlobsSidecarPrunerTest {
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
   private final StubAsyncRunner asyncRunner = new StubAsyncRunner(timeProvider);
   private final Database database = mock(Database.class);
+  private final StubMetricsSystem stubMetricsSystem = new StubMetricsSystem();
 
   private final BlobsSidecarPruner blobsPruner =
       new BlobsSidecarPruner(
-          spec, database, asyncRunner, timeProvider, PRUNE_INTERVAL, PRUNE_LIMIT);
+          spec,
+          database,
+          stubMetricsSystem,
+          asyncRunner,
+          timeProvider,
+          PRUNE_INTERVAL,
+          PRUNE_LIMIT);
 
   @BeforeEach
   void setUp() {

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/pruner/BlobsSidecarPrunerTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/pruner/BlobsSidecarPrunerTest.java
@@ -61,7 +61,8 @@ public class BlobsSidecarPrunerTest {
           asyncRunner,
           timeProvider,
           PRUNE_INTERVAL,
-          PRUNE_LIMIT);
+          PRUNE_LIMIT,
+          false);
 
   @BeforeEach
   void setUp() {

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/server/kvstore/MockKvStoreInstance.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/server/kvstore/MockKvStoreInstance.java
@@ -149,7 +149,7 @@ public class MockKvStoreInstance implements KvStoreAccessor {
 
   @Override
   public <K, V> Stream<K> streamKeys(KvStoreColumn<K, V> column) {
-    return streamKeyRaw(column)
+    return streamKeysRaw(column)
         .map(entry -> column.getKeySerializer().deserialize(entry.toArrayUnsafe()));
   }
 
@@ -162,7 +162,8 @@ public class MockKvStoreInstance implements KvStoreAccessor {
         .map(entry -> columnEntry(entry));
   }
 
-  public Stream<Bytes> streamKeyRaw(final KvStoreColumn<?, ?> column) {
+  @Override
+  public Stream<Bytes> streamKeysRaw(KvStoreColumn<?, ?> column) {
     assertOpen();
     assertValidColumn(column);
     return columnData.get(column).keySet().stream();

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/MetricsOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/MetricsOptions.java
@@ -111,6 +111,15 @@ public class MetricsOptions {
       arity = "0..1")
   private boolean tickPerformanceEnabled = MetricsConfig.DEFAULT_TICK_PERFORMANCE_ENABLED;
 
+  @Option(
+      names = {"--Xmetrics-blobs-sidecar-storage-enabled"},
+      showDefaultValue = Visibility.ALWAYS,
+      paramLabel = "<BOOLEAN>",
+      description = "Whether blobs sidecar storage metrics are reported",
+      fallbackValue = "true",
+      arity = "0..1")
+  private boolean blobsSidecarStorageEnabled = MetricsConfig.DEFAULT_BLOBS_SIDECAR_STORAGE_ENABLED;
+
   public void configure(TekuConfiguration.Builder builder) {
     builder.metrics(
         b ->
@@ -123,7 +132,8 @@ public class MetricsOptions {
                 .metricsPublishInterval(metricsPublicationInterval)
                 .idleTimeoutSeconds(idleTimeoutSeconds)
                 .blockPerformanceEnabled(blockPerformanceEnabled)
-                .tickPerformanceEnabled(tickPerformanceEnabled));
+                .tickPerformanceEnabled(tickPerformanceEnabled)
+                .blobsSidecarStorageEnabled(blobsSidecarStorageEnabled));
   }
 
   private URL parseMetricsEndpointUrl() {

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/MetricsOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/MetricsOptions.java
@@ -113,12 +113,14 @@ public class MetricsOptions {
 
   @Option(
       names = {"--Xmetrics-blobs-sidecar-storage-enabled"},
+      hidden = true,
       showDefaultValue = Visibility.ALWAYS,
       paramLabel = "<BOOLEAN>",
       description = "Whether blobs sidecar storage metrics are reported",
       fallbackValue = "true",
       arity = "0..1")
-  private boolean blobsSidecarStorageEnabled = MetricsConfig.DEFAULT_BLOBS_SIDECAR_STORAGE_ENABLED;
+  private boolean blobsSidecarStorageCountersEnabled =
+      MetricsConfig.DEFAULT_BLOBS_SIDECAR_STORAGE_COUNTERS_ENABLED;
 
   public void configure(TekuConfiguration.Builder builder) {
     builder.metrics(
@@ -133,7 +135,7 @@ public class MetricsOptions {
                 .idleTimeoutSeconds(idleTimeoutSeconds)
                 .blockPerformanceEnabled(blockPerformanceEnabled)
                 .tickPerformanceEnabled(tickPerformanceEnabled)
-                .blobsSidecarStorageEnabled(blobsSidecarStorageEnabled));
+                .blobsSidecarStorageCountersEnabled(blobsSidecarStorageCountersEnabled));
   }
 
   private URL parseMetricsEndpointUrl() {

--- a/teku/src/main/java/tech/pegasys/teku/services/BeaconNodeServiceController.java
+++ b/teku/src/main/java/tech/pegasys/teku/services/BeaconNodeServiceController.java
@@ -34,7 +34,8 @@ public class BeaconNodeServiceController extends ServiceController {
         new StorageService(
             serviceConfig,
             tekuConfig.storageConfiguration(),
-            tekuConfig.powchain().isDepositSnapshotEnabled()));
+            tekuConfig.powchain().isDepositSnapshotEnabled(),
+            tekuConfig.metricsConfig().isBlobsSidecarStorageEnabled()));
     Optional<ExecutionWeb3jClientProvider> maybeExecutionWeb3jClientProvider = Optional.empty();
     if (tekuConfig.executionLayer().isEnabled()) {
       // Need to make sure the execution engine is listening before starting the beacon chain

--- a/teku/src/main/java/tech/pegasys/teku/services/BeaconNodeServiceController.java
+++ b/teku/src/main/java/tech/pegasys/teku/services/BeaconNodeServiceController.java
@@ -35,7 +35,7 @@ public class BeaconNodeServiceController extends ServiceController {
             serviceConfig,
             tekuConfig.storageConfiguration(),
             tekuConfig.powchain().isDepositSnapshotEnabled(),
-            tekuConfig.metricsConfig().isBlobsSidecarStorageEnabled()));
+            tekuConfig.metricsConfig().isBlobsSidecarStorageCountersEnabled()));
     Optional<ExecutionWeb3jClientProvider> maybeExecutionWeb3jClientProvider = Optional.empty();
     if (tekuConfig.executionLayer().isEnabled()) {
       // Need to make sure the execution engine is listening before starting the beacon chain


### PR DESCRIPTION
Introduces `--Xmetrics-blobs-sidecar-storage-enabled` (disabled by default) to expose number of blobs sidecars and unconfirmed blobs sidecars currently stored.

To implement it I used the previously introduced `streamKeysRaw` function to stream keys only, ignoring values.


## Fixed Issue(s)
one of the PRs in migrating https://github.com/ConsenSys/teku/pull/6728 to master

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
