### PR TITLE
teku-6768 add a development cli flag for disabling listening to bls change topic

### DIFF
--- a/data/provider/src/main/java/tech/pegasys/teku/api/DataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/DataProvider.java
@@ -18,6 +18,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.util.function.IntSupplier;
 import tech.pegasys.teku.beacon.sync.SyncService;
 import tech.pegasys.teku.networking.eth2.Eth2P2PNetwork;
+import tech.pegasys.teku.networking.eth2.P2PConfig;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
@@ -104,8 +105,9 @@ public class DataProvider {
     private OperationPool<SignedBlsToExecutionChange> blsToExecutionChangePool;
     private SyncCommitteeContributionPool syncCommitteeContributionPool;
     private ProposersDataManager proposersDataManager;
-
     private boolean isLivenessTrackingEnabled = true;
+    private boolean acceptBlsToExecutionMessages =
+        P2PConfig.DEFAULT_BLS_TO_EXECUTION_CHANGES_SUBNET_ENABLED;
     private IntSupplier rejectedExecutionSupplier;
 
     public Builder recentChainData(final RecentChainData recentChainData) {
@@ -150,6 +152,11 @@ public class DataProvider {
 
     public Builder isLivenessTrackingEnabled(final boolean isLivenessTrackingEnabled) {
       this.isLivenessTrackingEnabled = isLivenessTrackingEnabled;
+      return this;
+    }
+
+    public Builder acceptBlsToExecutionMessages(final boolean acceptBlsToExecutionMessages) {
+      this.acceptBlsToExecutionMessages = acceptBlsToExecutionMessages;
       return this;
     }
 
@@ -212,7 +219,8 @@ public class DataProvider {
               attestationManager,
               isLivenessTrackingEnabled,
               activeValidatorChannel,
-              proposersDataManager);
+              proposersDataManager,
+              acceptBlsToExecutionMessages);
       final ChainDataProvider chainDataProvider =
           new ChainDataProvider(spec, recentChainData, combinedChainDataClient);
       final SyncDataProvider syncDataProvider =

--- a/data/provider/src/main/java/tech/pegasys/teku/api/NodeDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/NodeDataProvider.java
@@ -61,6 +61,7 @@ public class NodeDataProvider {
   private final ActiveValidatorChannel activeValidatorChannel;
   private final boolean isLivenessTrackingEnabled;
   private final ProposersDataManager proposersDataManager;
+  private final boolean acceptBlsToExecutionMessages;
 
   public NodeDataProvider(
       final AggregatingAttestationPool attestationPool,
@@ -73,7 +74,8 @@ public class NodeDataProvider {
       final AttestationManager attestationManager,
       final boolean isLivenessTrackingEnabled,
       final ActiveValidatorChannel activeValidatorChannel,
-      final ProposersDataManager proposersDataManager) {
+      final ProposersDataManager proposersDataManager,
+      final boolean acceptBlsToExecutionMessages) {
     this.attestationPool = attestationPool;
     this.attesterSlashingPool = attesterSlashingsPool;
     this.proposerSlashingPool = proposerSlashingPool;
@@ -85,6 +87,7 @@ public class NodeDataProvider {
     this.activeValidatorChannel = activeValidatorChannel;
     this.isLivenessTrackingEnabled = isLivenessTrackingEnabled;
     this.proposersDataManager = proposersDataManager;
+    this.acceptBlsToExecutionMessages = acceptBlsToExecutionMessages;
   }
 
   public List<Attestation> getAttestations(
@@ -122,6 +125,13 @@ public class NodeDataProvider {
 
   public SafeFuture<List<SubmitDataError>> postBlsToExecutionChanges(
       final List<SignedBlsToExecutionChange> blsToExecutionChanges) {
+    if (!acceptBlsToExecutionMessages) {
+      return SafeFuture.failedFuture(
+          new BadRequestException(
+              "Beacon node is not subscribed to the bls_to_execution_changes subnet. This behaviour can be changed "
+                  + "with the CLI option --Xbls-to-execution-changes-subnet-enabled"));
+    }
+
     final List<SafeFuture<Optional<SubmitDataError>>> maybeFutureErrors = new ArrayList<>();
 
     for (int i = 0; i < blsToExecutionChanges.size(); i++) {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkBuilder.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkBuilder.java
@@ -251,6 +251,7 @@ public class Eth2P2PNetworkBuilder {
         return new GossipForkSubscriptionsCapella(
             forkAndSpecMilestone.getFork(),
             spec,
+            config,
             asyncRunner,
             metricsSystem,
             network,
@@ -269,6 +270,7 @@ public class Eth2P2PNetworkBuilder {
         return new GossipForkSubscriptionsDeneb(
             forkAndSpecMilestone.getFork(),
             spec,
+            config,
             asyncRunner,
             metricsSystem,
             network,

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/P2PConfig.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/P2PConfig.java
@@ -37,6 +37,7 @@ public class P2PConfig {
   public static final int DEFAULT_BATCH_VERIFY_QUEUE_CAPACITY = 15_000;
   public static final int DEFAULT_BATCH_VERIFY_MAX_BATCH_SIZE = 250;
   public static final boolean DEFAULT_BATCH_VERIFY_STRICT_THREAD_LIMIT_ENABLED = false;
+  public static final boolean DEFAULT_BLS_TO_EXECUTION_CHANGES_SUBNET_ENABLED = true;
 
   private final Spec spec;
   private final NetworkConfig networkConfig;
@@ -53,6 +54,7 @@ public class P2PConfig {
   private final int batchVerifyQueueCapacity;
   private final int batchVerifyMaxBatchSize;
   private final boolean batchVerifyStrictThreadLimitEnabled;
+  private final boolean blsToExecutionChangesSubnetEnabled;
 
   private P2PConfig(
       final Spec spec,
@@ -68,7 +70,8 @@ public class P2PConfig {
       final int batchVerifyMaxThreads,
       final int batchVerifyQueueCapacity,
       final int batchVerifyMaxBatchSize,
-      final boolean batchVerifyStrictThreadLimitEnabled) {
+      final boolean batchVerifyStrictThreadLimitEnabled,
+      final boolean blsToExecutionChangesSubnetEnabled) {
     this.spec = spec;
     this.networkConfig = networkConfig;
     this.discoveryConfig = discoveryConfig;
@@ -83,6 +86,7 @@ public class P2PConfig {
     this.batchVerifyQueueCapacity = batchVerifyQueueCapacity;
     this.batchVerifyMaxBatchSize = batchVerifyMaxBatchSize;
     this.batchVerifyStrictThreadLimitEnabled = batchVerifyStrictThreadLimitEnabled;
+    this.blsToExecutionChangesSubnetEnabled = blsToExecutionChangesSubnetEnabled;
   }
 
   public static Builder builder() {
@@ -145,6 +149,10 @@ public class P2PConfig {
     return batchVerifyStrictThreadLimitEnabled;
   }
 
+  public boolean isBlsToExecutionChangesSubnetEnabled() {
+    return blsToExecutionChangesSubnetEnabled;
+  }
+
   public static class Builder {
     private final NetworkConfig.Builder networkConfig = NetworkConfig.builder();
     private final DiscoveryConfig.Builder discoveryConfig = DiscoveryConfig.builder();
@@ -162,6 +170,8 @@ public class P2PConfig {
     private int batchVerifyMaxBatchSize = DEFAULT_BATCH_VERIFY_MAX_BATCH_SIZE;
     private boolean batchVerifyStrictThreadLimitEnabled =
         DEFAULT_BATCH_VERIFY_STRICT_THREAD_LIMIT_ENABLED;
+    private boolean blsToExecutionChangesSubnetEnabled =
+        DEFAULT_BLS_TO_EXECUTION_CHANGES_SUBNET_ENABLED;
 
     private Builder() {}
 
@@ -197,7 +207,8 @@ public class P2PConfig {
           batchVerifyMaxThreads,
           batchVerifyQueueCapacity,
           batchVerifyMaxBatchSize,
-          batchVerifyStrictThreadLimitEnabled);
+          batchVerifyStrictThreadLimitEnabled,
+          blsToExecutionChangesSubnetEnabled);
     }
 
     private void validate() {
@@ -302,6 +313,12 @@ public class P2PConfig {
     public Builder batchVerifyStrictThreadLimitEnabled(
         final boolean batchVerifyStrictThreadLimitEnabled) {
       this.batchVerifyStrictThreadLimitEnabled = batchVerifyStrictThreadLimitEnabled;
+      return this;
+    }
+
+    public Builder blsToExecutionChangesSubnetEnabled(
+        final boolean blsToExecutionChangesSubnetEnabled) {
+      this.blsToExecutionChangesSubnetEnabled = blsToExecutionChangesSubnetEnabled;
       return this;
     }
   }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/forks/versions/GossipForkSubscriptionsDeneb.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/forks/versions/GossipForkSubscriptionsDeneb.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.networking.eth2.gossip.forks.versions;
 
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
+import tech.pegasys.teku.networking.eth2.P2PConfig;
 import tech.pegasys.teku.networking.eth2.gossip.BlockAndBlobsSidecarGossipManager;
 import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
 import tech.pegasys.teku.networking.eth2.gossip.topics.OperationProcessor;
@@ -42,6 +43,7 @@ public class GossipForkSubscriptionsDeneb extends GossipForkSubscriptionsCapella
   public GossipForkSubscriptionsDeneb(
       final Fork fork,
       final Spec spec,
+      final P2PConfig config,
       final AsyncRunner asyncRunner,
       final MetricsSystem metricsSystem,
       final DiscoveryNetwork<?> discoveryNetwork,
@@ -63,6 +65,7 @@ public class GossipForkSubscriptionsDeneb extends GossipForkSubscriptionsCapella
     super(
         fork,
         spec,
+        config,
         asyncRunner,
         metricsSystem,
         discoveryNetwork,

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/forks/versions/GossipForkSubscriptionsCapellaTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/forks/versions/GossipForkSubscriptionsCapellaTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright ConsenSys Software Inc., 2023
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.networking.eth2.gossip.forks.versions;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
+import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.networking.eth2.P2PConfig;
+import tech.pegasys.teku.networking.eth2.gossip.SignedBlsToExecutionChangeGossipManager;
+import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
+import tech.pegasys.teku.networking.eth2.gossip.topics.OperationProcessor;
+import tech.pegasys.teku.networking.p2p.discovery.DiscoveryNetwork;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.operations.SignedBlsToExecutionChange;
+import tech.pegasys.teku.spec.datastructures.state.Fork;
+import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.storage.client.MemoryOnlyRecentChainData;
+import tech.pegasys.teku.storage.client.RecentChainData;
+
+@SuppressWarnings({"unchecked", "rawtypes"})
+class GossipForkSubscriptionsCapellaTest {
+
+  private final Spec spec = TestSpecFactory.createMinimalCapella();
+  final Fork fork = spec.getForkSchedule().getFork(UInt64.ZERO);
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+  private final P2PConfig p2pConfig = mock(P2PConfig.class);
+
+  private GossipForkSubscriptionsCapella gossipForkSubscriptions;
+
+  @Test
+  public void shouldAddBlsToExecutionChangesGossipManagerIfEnabled() {
+    when(p2pConfig.isBlsToExecutionChangesSubnetEnabled()).thenReturn(true);
+    gossipForkSubscriptions = spy(createGossipForkSubscriptionCapella());
+
+    gossipForkSubscriptions.addSignedBlsToExecutionChangeGossipManager(forkInfo());
+
+    assertThat(gossipForkSubscriptions.getSignedBlsToExecutionChangeGossipManager()).isNotEmpty();
+    verify(gossipForkSubscriptions, times(1))
+        .addGossipManager(any(SignedBlsToExecutionChangeGossipManager.class));
+  }
+
+  @Test
+  public void shouldNotAddBlsToExecutionChangesGossipManagerIfDisabled() {
+    when(p2pConfig.isBlsToExecutionChangesSubnetEnabled()).thenReturn(false);
+    gossipForkSubscriptions = spy(createGossipForkSubscriptionCapella());
+
+    gossipForkSubscriptions.addSignedBlsToExecutionChangeGossipManager(forkInfo());
+
+    assertThat(gossipForkSubscriptions.getSignedBlsToExecutionChangeGossipManager()).isEmpty();
+    verify(gossipForkSubscriptions, times(0)).addGossipManager(any());
+  }
+
+  @Test
+  public void shouldPublishBlsToExecutionChangeMessageIfGossipManagerIsPresent() {
+    gossipForkSubscriptions = createGossipForkSubscriptionCapella();
+
+    // the actual gossip manager is created within the class, we are injecting a mock here to test
+    // the isPresent() logic
+    final SignedBlsToExecutionChangeGossipManager blsGossipManager =
+        mock(SignedBlsToExecutionChangeGossipManager.class);
+    gossipForkSubscriptions.setSignedBlsToExecutionChangeGossipManager(
+        Optional.of(blsGossipManager));
+
+    final SignedBlsToExecutionChange message = dataStructureUtil.randomSignedBlsToExecutionChange();
+    gossipForkSubscriptions.publishSignedBlsToExecutionChangeMessage(message);
+
+    verify(blsGossipManager).publish(eq(message));
+  }
+
+  private ForkInfo forkInfo() {
+    return new ForkInfo(fork, dataStructureUtil.randomBytes32());
+  }
+
+  private GossipForkSubscriptionsCapella createGossipForkSubscriptionCapella() {
+    final DiscoveryNetwork discoveryNetwork = mock(DiscoveryNetwork.class);
+    final RecentChainData recentChainData = MemoryOnlyRecentChainData.create(spec);
+    final GossipEncoding gossipEncoding = mock(GossipEncoding.class);
+    final OperationProcessor noopOperationProcessor = OperationProcessor.NOOP;
+
+    return new GossipForkSubscriptionsCapella(
+        fork,
+        spec,
+        p2pConfig,
+        new StubAsyncRunner(),
+        new StubMetricsSystem(),
+        discoveryNetwork,
+        recentChainData,
+        gossipEncoding,
+        noopOperationProcessor,
+        noopOperationProcessor,
+        noopOperationProcessor,
+        noopOperationProcessor,
+        noopOperationProcessor,
+        noopOperationProcessor,
+        noopOperationProcessor,
+        noopOperationProcessor,
+        noopOperationProcessor);
+  }
+}

--- a/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkFactory.java
+++ b/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkFactory.java
@@ -284,6 +284,7 @@ public class Eth2P2PNetworkFactory {
               new GossipForkSubscriptionsCapella(
                   spec.getForkSchedule().getFork(UInt64.ZERO),
                   spec,
+                  config,
                   asyncRunner,
                   metricsSystem,
                   network,

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -561,6 +561,8 @@ public class BeaconChainController extends Service implements BeaconChainControl
             .attestationManager(attestationManager)
             .isLivenessTrackingEnabled(
                 beaconConfig.beaconRestApiConfig().isBeaconLivenessTrackingEnabled())
+            .acceptBlsToExecutionMessages(
+                beaconConfig.p2pConfig().isBlsToExecutionChangesSubnetEnabled())
             .activeValidatorChannel(
                 eventChannels.getPublisher(ActiveValidatorChannel.class, beaconAsyncRunner))
             .attesterSlashingPool(attesterSlashingPool)

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
@@ -250,6 +250,17 @@ public class P2POptions {
       fallbackValue = "true")
   private boolean siteLocalAddressesEnabled = DiscoveryConfig.DEFAULT_SITE_LOCAL_ADDRESSES_ENABLED;
 
+  @Option(
+      names = {"--Xbls-to-execution-changes-subnet-enabled"},
+      paramLabel = "<BOOLEAN>",
+      showDefaultValue = Visibility.ALWAYS,
+      description = "Whether this node will subscribe to the bls_to_execution_changes subnet",
+      arity = "0..1",
+      hidden = true,
+      fallbackValue = "true")
+  private boolean blsToExecutionChangesSubnetEnabled =
+      P2PConfig.DEFAULT_BLS_TO_EXECUTION_CHANGES_SUBNET_ENABLED;
+
   private int getP2pLowerBound() {
     if (p2pLowerBound > p2pUpperBound) {
       STATUS_LOG.adjustingP2pLowerBoundToUpperBound(p2pUpperBound);
@@ -281,7 +292,8 @@ public class P2POptions {
                     .targetSubnetSubscriberCount(p2pTargetSubnetSubscriberCount)
                     .isGossipScoringEnabled(gossipScoringEnabled)
                     .peerRateLimit(peerRateLimit)
-                    .peerRequestLimit(peerRequestLimit))
+                    .peerRequestLimit(peerRequestLimit)
+                    .blsToExecutionChangesSubnetEnabled(blsToExecutionChangesSubnetEnabled))
         .discovery(
             d -> {
               if (p2pDiscoveryBootnodes != null) {

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/P2POptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/P2POptionsTest.java
@@ -285,4 +285,19 @@ public class P2POptionsTest extends AbstractBeaconNodeCommandTest {
         .isInstanceOf(InvalidConfigurationException.class)
         .hasMessage("Invalid minimumSubnetSubscriptions: -1");
   }
+
+  @Test
+  public void subscribeToBlsToExecutionChangesOption_shouldDefaultToTrue() {
+    final TekuConfiguration tekuConfiguration = getTekuConfigurationFromArguments();
+    final P2PConfig config = tekuConfiguration.p2p();
+    assertThat(config.isBlsToExecutionChangesSubnetEnabled()).isTrue();
+  }
+
+  @Test
+  public void subscribeToBlsToExecutionChangesOption_shouldOverrideDefault() {
+    final TekuConfiguration tekuConfiguration =
+        getTekuConfigurationFromArguments("--Xbls-to-execution-changes-subnet-enabled", "false");
+    final P2PConfig config = tekuConfiguration.p2p();
+    assertThat(config.isBlsToExecutionChangesSubnetEnabled()).isFalse();
+  }
 }


### PR DESCRIPTION
## PR Description
- Adds `--Xbls-to-execution-changes-subnet-enabled` option (default to true)
- When disabled, beacon node won't connect to bls_to_execution_changes subnet
- When disabled, beacon node API won't accept publishing bls_to_execution_changes messages

## Fixed Issue(s)
fixes #6768 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
  - Did not update changelog because this is a developer option.
