### PR TITLE
Implemented a BlsToExecutionOperationPool

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/BlsToExecutionOperationPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/BlsToExecutionOperationPool.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright ConsenSys Software Inc., 2023
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition;
+
+import static tech.pegasys.teku.statetransition.validation.ValidationResultCode.IGNORE;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.hyperledger.besu.plugin.services.MetricsSystem;
+import org.hyperledger.besu.plugin.services.metrics.Counter;
+import org.hyperledger.besu.plugin.services.metrics.LabelledMetric;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.collections.LimitedMap;
+import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
+import tech.pegasys.teku.infrastructure.ssz.SszCollection;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszListSchema;
+import tech.pegasys.teku.infrastructure.subscribers.Subscribers;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.operations.SignedBlsToExecutionChange;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
+import tech.pegasys.teku.statetransition.validation.OperationValidator;
+import tech.pegasys.teku.statetransition.validation.SignedBlsToExecutionChangeValidator;
+import tech.pegasys.teku.statetransition.validation.ValidationResultCode;
+
+public class BlsToExecutionOperationPool implements OperationPool<SignedBlsToExecutionChange> {
+  private static final Logger LOG = LogManager.getLogger();
+  private static final int DEFAULT_OPERATION_POOL_SIZE = 50_000;
+  final Map<UInt64, SignedBlsToExecutionChange> operations;
+  private final Function<UInt64, SszListSchema<SignedBlsToExecutionChange, ?>>
+      slotToSszListSchemaSupplier;
+  private final OperationValidator<SignedBlsToExecutionChange> operationValidator;
+  private final Subscribers<OperationAddedSubscriber<SignedBlsToExecutionChange>> subscribers =
+      Subscribers.create(true);
+  private final LabelledMetric<Counter> validationReasonCounter;
+
+  public BlsToExecutionOperationPool(
+      final String metricType,
+      final MetricsSystem metricsSystem,
+      final Function<UInt64, SszListSchema<SignedBlsToExecutionChange, ?>>
+          slotToSszListSchemaSupplier,
+      final SignedBlsToExecutionChangeValidator operationValidator) {
+
+    this.slotToSszListSchemaSupplier = slotToSszListSchemaSupplier;
+    this.operations = LimitedMap.createSynchronized(DEFAULT_OPERATION_POOL_SIZE);
+    this.operationValidator = operationValidator;
+    metricsSystem.createIntegerGauge(
+        TekuMetricCategory.BEACON,
+        OPERATION_POOL_SIZE_METRIC + metricType,
+        "Current number of operations in the pool",
+        this::size);
+    validationReasonCounter =
+        metricsSystem.createLabelledCounter(
+            TekuMetricCategory.BEACON,
+            OPERATION_POOL_SIZE_VALIDATION_REASON + metricType,
+            "Total number of attempts to add an operation to the pool, broken down by validation result",
+            "result");
+  }
+
+  private static InternalValidationResult rejectForDuplicatedMessage(final UInt64 validatorIndex) {
+    final String logMessage =
+        String.format(
+            "BlsToExecutionChange is not the first one for validator %s.", validatorIndex);
+    LOG.trace(logMessage);
+    return InternalValidationResult.create(IGNORE, logMessage);
+  }
+
+  @Override
+  public void subscribeOperationAdded(
+      final OperationAddedSubscriber<SignedBlsToExecutionChange> subscriber) {
+    this.subscribers.subscribe(subscriber);
+  }
+
+  @Override
+  public SszList<SignedBlsToExecutionChange> getItemsForBlock(final BeaconState stateAtBlockSlot) {
+    return getItemsForBlock(stateAtBlockSlot, operation -> true, operation -> {});
+  }
+
+  @Override
+  public SszList<SignedBlsToExecutionChange> getItemsForBlock(
+      final BeaconState stateAtBlockSlot,
+      final Predicate<SignedBlsToExecutionChange> filter,
+      final Consumer<SignedBlsToExecutionChange> includedItemConsumer) {
+    final SszListSchema<SignedBlsToExecutionChange, ?> schema =
+        slotToSszListSchemaSupplier.apply(stateAtBlockSlot.getSlot());
+
+    // Note that iterating through all items does not affect their access time so we are effectively
+    // evicting the oldest entries when the size is exceeded as we only ever access via iteration.
+    final Collection<SignedBlsToExecutionChange> sortedViableOperations = operations.values();
+    final List<SignedBlsToExecutionChange> selected = new ArrayList<>();
+    for (final SignedBlsToExecutionChange item : sortedViableOperations) {
+      if (!filter.test(item)) {
+        continue;
+      }
+      final UInt64 validatorIndex = item.getMessage().getValidatorIndex();
+      if (operationValidator.validateForBlockInclusion(stateAtBlockSlot, item).isEmpty()) {
+        LOG.trace("ADD " + validatorIndex);
+        selected.add(item);
+        includedItemConsumer.accept(item);
+        if (selected.size() == schema.getMaxLength()) {
+          break;
+        }
+      } else {
+        // The item is no longer valid to be included in a block so remove it from the pool.
+        LOG.trace("PRUNE " + validatorIndex);
+        operations.remove(validatorIndex);
+      }
+    }
+    return schema.createFromElements(selected);
+  }
+
+  @Override
+  public SafeFuture<InternalValidationResult> addLocal(final SignedBlsToExecutionChange item) {
+    final UInt64 validatorIndex = item.getMessage().getValidatorIndex();
+    if (operations.containsKey(validatorIndex)) {
+      return SafeFuture.completedFuture(rejectForDuplicatedMessage(validatorIndex))
+          .thenPeek(result -> validationReasonCounter.labels(result.code().toString()).inc());
+    }
+    return add(item, false);
+  }
+
+  @Override
+  public SafeFuture<InternalValidationResult> addRemote(final SignedBlsToExecutionChange item) {
+    final UInt64 validatorIndex = item.getMessage().getValidatorIndex();
+    if (operations.containsKey(validatorIndex)) {
+      return SafeFuture.completedFuture(rejectForDuplicatedMessage(validatorIndex))
+          .thenPeek(result -> validationReasonCounter.labels(result.code().toString()).inc());
+    }
+    return add(item, true);
+  }
+
+  @Override
+  public void addAll(final SszCollection<SignedBlsToExecutionChange> items) {
+    items.forEach(
+        item -> {
+          final UInt64 validatorIndex = item.getMessage().getValidatorIndex();
+          LOG.trace("ADD ALL " + validatorIndex);
+          operations.putIfAbsent(validatorIndex, item);
+        });
+  }
+
+  @Override
+  public void removeAll(final SszCollection<SignedBlsToExecutionChange> items) {
+    items.forEach(
+        item -> {
+          final UInt64 validatorIndex = item.getMessage().getValidatorIndex();
+          LOG.trace("REMOVE ALL " + validatorIndex);
+          operations.remove(validatorIndex);
+        });
+  }
+
+  @Override
+  public Set<SignedBlsToExecutionChange> getAll() {
+    return Set.copyOf(operations.values());
+  }
+
+  @Override
+  public int size() {
+    return operations.size();
+  }
+
+  private SafeFuture<InternalValidationResult> add(
+      SignedBlsToExecutionChange item, boolean fromNetwork) {
+    final UInt64 validatorIndex = item.getMessage().getValidatorIndex();
+    return operationValidator
+        .validateForGossip(item)
+        .thenApply(
+            result -> {
+              validationReasonCounter.labels(result.code().toString()).inc();
+              if (result.code().equals(ValidationResultCode.ACCEPT)
+                  || result.code().equals(ValidationResultCode.SAVE_FOR_FUTURE)) {
+                operations.put(validatorIndex, item);
+                subscribers.forEach(s -> s.onOperationAdded(item, result, fromNetwork));
+              }
+              return result;
+            });
+  }
+}

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/OperationPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/OperationPool.java
@@ -25,6 +25,10 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
 
 public interface OperationPool<T extends SszData> {
+
+  String OPERATION_POOL_SIZE_METRIC = "operation_pool_size_";
+  String OPERATION_POOL_SIZE_VALIDATION_REASON = "operation_pool_validation_";
+
   void subscribeOperationAdded(OperationAddedSubscriber<T> subscriber);
 
   SszList<T> getItemsForBlock(BeaconState stateAtBlockSlot);

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/SimpleOperationPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/SimpleOperationPool.java
@@ -43,8 +43,6 @@ import tech.pegasys.teku.statetransition.validation.ValidationResultCode;
 
 public class SimpleOperationPool<T extends SszData> implements OperationPool<T> {
   private static final int DEFAULT_OPERATION_POOL_SIZE = 1000;
-  private static final String OPERATION_POOL_SIZE_METRIC = "operation_pool_size_";
-  private static final String OPERATION_POOL_SIZE_VALIDATION_REASON = "operation_pool_validation_";
   private final Set<T> operations;
   private final Function<UInt64, SszListSchema<T, ?>> slotToSszListSchemaSupplier;
   private final OperationValidator<T> operationValidator;

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/BlsToExecutionOperationPoolTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/BlsToExecutionOperationPoolTest.java
@@ -1,0 +1,265 @@
+/*
+ * Copyright ConsenSys Software Inc., 2023
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.infrastructure.async.SafeFuture.completedFuture;
+import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.ACCEPT;
+import static tech.pegasys.teku.statetransition.validation.InternalValidationResult.IGNORE;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Function;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszListSchema;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodySchema;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.capella.BeaconBlockBodySchemaCapella;
+import tech.pegasys.teku.spec.datastructures.operations.SignedBlsToExecutionChange;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.logic.common.operations.validation.OperationInvalidReason;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
+import tech.pegasys.teku.statetransition.validation.SignedBlsToExecutionChangeValidator;
+
+public class BlsToExecutionOperationPoolTest {
+
+  private final Spec spec = TestSpecFactory.createMinimalCapella();
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+  private final Function<UInt64, BeaconBlockBodySchema<?>> beaconBlockSchemaSupplier =
+      slot -> spec.atSlot(slot).getSchemaDefinitions().getBeaconBlockBodySchema();
+  private final BeaconState state = mock(BeaconState.class);
+  private final StubMetricsSystem metricsSystem = new StubMetricsSystem();
+  private final SignedBlsToExecutionChangeValidator validator =
+      mock(SignedBlsToExecutionChangeValidator.class);
+  private final Function<UInt64, SszListSchema<SignedBlsToExecutionChange, ?>>
+      blsToExecutionSchemaSupplier =
+          beaconBlockSchemaSupplier
+              .andThen(BeaconBlockBodySchema::toVersionCapella)
+              .andThen(Optional::orElseThrow)
+              .andThen(BeaconBlockBodySchemaCapella::getBlsToExecutionChangesSchema);
+  private final OperationPool<SignedBlsToExecutionChange> pool =
+      new BlsToExecutionOperationPool(
+          "BlsToExecutionOperationPool", metricsSystem, blsToExecutionSchemaSupplier, validator);
+
+  @BeforeEach
+  void init() {
+    when(state.getSlot()).thenReturn(UInt64.ZERO);
+  }
+
+  @Test
+  void emptyPoolShouldReturnEmptyList() {
+    assertThat(pool.getItemsForBlock(state)).isEmpty();
+  }
+
+  @Test
+  void shouldAddEntryToPool() {
+    when(validator.validateForGossip(any()))
+        .thenReturn(SafeFuture.completedFuture(InternalValidationResult.ACCEPT));
+    final SignedBlsToExecutionChange item = dataStructureUtil.randomSignedBlsToExecutionChange();
+    final SafeFuture<?> future = pool.addLocal(item);
+    assertThat(future.isCompletedNormally()).isTrue();
+    assertThat(pool.size()).isEqualTo(1);
+    assertThat(pool.getAll()).containsExactly(item);
+  }
+
+  @Test
+  void shouldRejectDuplicateEntryFromPool() throws ExecutionException, InterruptedException {
+    final SignedBlsToExecutionChange item = initPoolWithSingleItem();
+
+    final SafeFuture<InternalValidationResult> future2 = pool.addLocal(item);
+    assertThat(future2.get().code()).isEqualTo(InternalValidationResult.IGNORE.code());
+  }
+
+  @Test
+  void shouldRemoveEntryFromPool() {
+    final SignedBlsToExecutionChange item = initPoolWithSingleItem();
+    pool.removeAll(
+        blsToExecutionSchemaSupplier
+            .apply(UInt64.ZERO)
+            .createFromElements(
+                List.of(item, dataStructureUtil.randomSignedBlsToExecutionChange(), item)));
+    assertThat(pool.size()).isEqualTo(0);
+  }
+
+  @Test
+  void shouldAddEntriesToPool() {
+    final SignedBlsToExecutionChange item = initPoolWithSingleItem();
+    final SignedBlsToExecutionChange item2 = dataStructureUtil.randomSignedBlsToExecutionChange();
+    pool.addAll(
+        blsToExecutionSchemaSupplier.apply(UInt64.ZERO).createFromElements(List.of(item, item2)));
+    assertThat(pool.size()).isEqualTo(2);
+    assertThat(pool.getAll()).containsExactlyInAnyOrder(item, item2);
+  }
+
+  private SignedBlsToExecutionChange initPoolWithSingleItem() {
+    when(validator.validateForGossip(any()))
+        .thenReturn(SafeFuture.completedFuture(InternalValidationResult.ACCEPT));
+    final SignedBlsToExecutionChange item = dataStructureUtil.randomSignedBlsToExecutionChange();
+    final SafeFuture<InternalValidationResult> future = pool.addLocal(item);
+    assertThat(future.isCompletedNormally()).isTrue();
+    assertThat(pool.size()).isEqualTo(1);
+    return item;
+  }
+
+  @Test
+  void shouldAddMaxItemsToPool() {
+    final SignedBlsToExecutionChange item = initPoolWithSingleItem();
+    when(validator.validateForGossip(any())).thenReturn(completedFuture(ACCEPT));
+    when(validator.validateForBlockInclusion(any(), any())).thenReturn(Optional.empty());
+    final int maxBlsToExecutionChanges =
+        spec.getGenesisSpecConfig().toVersionCapella().orElseThrow().getMaxBlsToExecutionChanges();
+    while (pool.size() < maxBlsToExecutionChanges) {
+      assertThat(pool.addLocal(dataStructureUtil.randomSignedBlsToExecutionChange())).isCompleted();
+    }
+
+    assertThat(pool.getItemsForBlock(state)).hasSize(maxBlsToExecutionChanges);
+    assertThat(pool.size()).isEqualTo(maxBlsToExecutionChanges);
+    assertThat(pool.getItemsForBlock(state)).contains(item);
+  }
+
+  @Test
+  void shouldPruneFromPoolIfNoLongerValid() {
+    when(validator.validateForGossip(any())).thenReturn(completedFuture(ACCEPT));
+    when(validator.validateForBlockInclusion(any(), any()))
+        .thenReturn(Optional.of(mock(OperationInvalidReason.class)));
+
+    initPoolWithSingleItem();
+    assertThat(pool.size()).isEqualTo(1);
+
+    assertThat(pool.getItemsForBlock(state)).isEmpty();
+    assertThat(pool.size()).isEqualTo(0);
+  }
+
+  @ParameterizedTest(name = "fromNetwork={0}")
+  @ValueSource(booleans = {true, false})
+  void subscribeOperationAddedSuccessfully(final boolean isFromNetwork) {
+    final Subscription subscription = new Subscription();
+    final OperationAddedSubscriber<SignedBlsToExecutionChange> subscriber =
+        (key, value, fromNetwork) -> {
+          subscription.setFromNetwork(fromNetwork);
+          subscription.setBlsToExecutionChange(key);
+          subscription.setInternalValidationResult(value);
+        };
+    pool.subscribeOperationAdded(subscriber);
+    final SignedBlsToExecutionChange item = dataStructureUtil.randomSignedBlsToExecutionChange();
+    when(validator.validateForGossip(item)).thenReturn(completedFuture(ACCEPT));
+
+    if (isFromNetwork) {
+      assertThat(pool.addRemote(item)).isCompleted();
+    } else {
+      assertThat(pool.addLocal(item)).isCompleted();
+    }
+    assertThat(subscription.getBlsToExecutionChange()).contains(item);
+    assertThat(subscription.getInternalValidationResult()).contains(ACCEPT);
+    assertThat(subscription.getFromNetwork()).contains(isFromNetwork);
+  }
+
+  @ParameterizedTest(name = "fromNetwork={0}")
+  @ValueSource(booleans = {true, false})
+  void subscribeOperationIgnored(final boolean isFromNetwork) {
+    final Subscription subscription = new Subscription();
+    final OperationAddedSubscriber<SignedBlsToExecutionChange> subscriber =
+        (key, value, fromNetwork) -> {
+          subscription.setFromNetwork(fromNetwork);
+          subscription.setBlsToExecutionChange(key);
+          subscription.setInternalValidationResult(value);
+        };
+    pool.subscribeOperationAdded(subscriber);
+    final SignedBlsToExecutionChange item = dataStructureUtil.randomSignedBlsToExecutionChange();
+    when(validator.validateForGossip(item)).thenReturn(completedFuture(IGNORE));
+
+    if (isFromNetwork) {
+      assertThat(pool.addRemote(item)).isCompleted();
+    } else {
+      assertThat(pool.addLocal(item)).isCompleted();
+    }
+    assertThat(subscription.getBlsToExecutionChange()).isEmpty();
+    assertThat(subscription.getInternalValidationResult()).isEmpty();
+    assertThat(subscription.getFromNetwork()).isEmpty();
+  }
+
+  @ParameterizedTest(name = "fromNetwork={0}")
+  @ValueSource(booleans = {true, false})
+  void subscribeOperationIgnoredDuplicate(final boolean isFromNetwork)
+      throws ExecutionException, InterruptedException {
+    final SignedBlsToExecutionChange item = dataStructureUtil.randomSignedBlsToExecutionChange();
+    when(validator.validateForGossip(item)).thenReturn(completedFuture(ACCEPT));
+    // pre-populate cache
+    assertThat(pool.addRemote(item)).isCompleted();
+
+    final Subscription subscription = new Subscription();
+    final OperationAddedSubscriber<SignedBlsToExecutionChange> subscriber =
+        (key, value, fromNetwork) -> {
+          subscription.setFromNetwork(fromNetwork);
+          subscription.setBlsToExecutionChange(key);
+          subscription.setInternalValidationResult(value);
+        };
+    pool.subscribeOperationAdded(subscriber);
+
+    final SafeFuture<InternalValidationResult> future;
+    if (isFromNetwork) {
+      // pre-populate cache, then try to add a second time.
+      future = pool.addRemote(item);
+    } else {
+      future = pool.addLocal(item);
+    }
+    assertThat(future).isCompleted();
+    assertThat(future.get().code()).isEqualTo(IGNORE.code());
+    assertThat(subscription.getBlsToExecutionChange()).isEmpty();
+    assertThat(subscription.getInternalValidationResult()).isEmpty();
+    assertThat(subscription.getFromNetwork()).isEmpty();
+  }
+
+  private static class Subscription {
+    private Optional<Boolean> fromNetwork = Optional.empty();
+    private Optional<SignedBlsToExecutionChange> blsToExecutionChange = Optional.empty();
+    private Optional<InternalValidationResult> internalValidationResult = Optional.empty();
+
+    public void setFromNetwork(final boolean fromNetwork) {
+      this.fromNetwork = Optional.of(fromNetwork);
+    }
+
+    public void setBlsToExecutionChange(final SignedBlsToExecutionChange change) {
+      this.blsToExecutionChange = Optional.of(change);
+    }
+
+    public void setInternalValidationResult(final InternalValidationResult result) {
+      this.internalValidationResult = Optional.of(result);
+    }
+
+    public Optional<Boolean> getFromNetwork() {
+      return fromNetwork;
+    }
+
+    public Optional<SignedBlsToExecutionChange> getBlsToExecutionChange() {
+      return blsToExecutionChange;
+    }
+
+    public Optional<InternalValidationResult> getInternalValidationResult() {
+      return internalValidationResult;
+    }
+  }
+}

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/SimpleOperationPoolTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/SimpleOperationPoolTest.java
@@ -53,7 +53,7 @@ import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
 import tech.pegasys.teku.statetransition.validation.OperationValidator;
 
 @SuppressWarnings({"unchecked", "FutureReturnValueIgnored"})
-public class OperationPoolTest {
+public class SimpleOperationPoolTest {
 
   Spec spec = TestSpecFactory.createMinimalPhase0();
   DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/SignedBlsToExecutionChangeValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/SignedBlsToExecutionChangeValidatorTest.java
@@ -84,24 +84,6 @@ class SignedBlsToExecutionChangeValidatorTest {
   }
 
   @Test
-  public void validateFullyShouldIgnoreSubsequentMessagesForSameValidator() {
-    final SignedBlsToExecutionChange message = dataStructureUtil.randomSignedBlsToExecutionChange();
-    mockSpecValidationSucceeded(spec);
-    mockSignatureVerificationSucceeded(spec);
-
-    final SafeFuture<InternalValidationResult> firstValidationResult =
-        validator.validateForGossip(message);
-    final SafeFuture<InternalValidationResult> secondValidationResult =
-        validator.validateForGossip(message);
-
-    assertValidationResult(firstValidationResult, ValidationResultCode.ACCEPT);
-    assertValidationResult(
-        secondValidationResult,
-        ValidationResultCode.IGNORE,
-        "BlsToExecutionChange is not the first one for validator");
-  }
-
-  @Test
   public void validateFullyShouldRejectMessageIfSpecValidationFails() {
     final SignedBlsToExecutionChange signedBlsToExecutionChange =
         dataStructureUtil.randomSignedBlsToExecutionChange();

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -93,6 +93,7 @@ import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.executionlayer.ExecutionLayerBlockProductionManager;
 import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannel;
+import tech.pegasys.teku.statetransition.BlsToExecutionOperationPool;
 import tech.pegasys.teku.statetransition.EpochCachePrimer;
 import tech.pegasys.teku.statetransition.LocalOperationAcceptedFilter;
 import tech.pegasys.teku.statetransition.OperationPool;
@@ -535,15 +536,14 @@ public class BeaconChainController extends Service implements BeaconChainControl
             spec, timeProvider, recentChainData, signatureVerificationService);
 
     blsToExecutionChangePool =
-        new SimpleOperationPool<>(
+        new BlsToExecutionOperationPool(
             "SignedBlsToExecutionChangePool",
             metricsSystem,
             beaconBlockSchemaSupplier
                 .andThen(BeaconBlockBodySchema::toVersionCapella)
                 .andThen(Optional::orElseThrow)
                 .andThen(BeaconBlockBodySchemaCapella::getBlsToExecutionChangesSchema),
-            validator,
-            16_384);
+            validator);
   }
 
   protected void initDataProvider() {


### PR DESCRIPTION
 - Moved the 'duplicate' handling into the pool itself, out of the validator to reduce complexity

 - added a new suite of tests for the new cache, though the logic is very similar to the SimpleOperationPool.

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
