### PR TITLE
Change error message when registering validators and no builder is configured

### DIFF
--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionBuilderModule.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionBuilderModule.java
@@ -46,6 +46,7 @@ import tech.pegasys.teku.spec.datastructures.execution.HeaderWithFallbackData;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 
 public class ExecutionBuilderModule {
+
   private static final Logger LOG = LogManager.getLogger();
 
   private final Spec spec;
@@ -200,8 +201,14 @@ public class ExecutionBuilderModule {
         signedValidatorRegistrations);
 
     if (!isBuilderAvailable()) {
+      final String reason;
+      if (builderClient.isEmpty()) {
+        reason = "builder not configured";
+      } else {
+        reason = "builder not available";
+      }
       return SafeFuture.failedFuture(
-          new RuntimeException("Unable to register validators: builder not available"));
+          new RuntimeException("Unable to register validators: " + reason));
     }
 
     return builderClient


### PR DESCRIPTION
## PR Description
Better error message when the VC tries to register validators, but the builder endpoint is not configured on the BN side.

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
