### PR TITLE
gradle: replace deprecated classifier property

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -976,3 +976,4 @@ task cloudsmithUpload {
     }
   }
 }
+

--- a/build.gradle
+++ b/build.gradle
@@ -124,7 +124,7 @@ allprojects {
   version = rootProject.version
 
   task sourcesJar(type: Jar, dependsOn: classes) {
-    classifier = 'sources'
+    archiveClassifier = 'sources'
     from sourceSets.main.allSource
     jar.reproducibleFileOrder = true
     jar.preserveFileTimestamps = false
@@ -976,4 +976,3 @@ task cloudsmithUpload {
     }
   }
 }
-


### PR DESCRIPTION
The `classifier` property of `Jar` has been deprecated few major versions back, and no longer supported in the newest Gradle 8.0. Replace `classifier` with `archiveClassifier` as suggested in docs: https://docs.gradle.org/7.6/dsl/org.gradle.api.tasks.bundling.Jar.html#org.gradle.api.tasks.bundling.Jar:classifier

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

## Fixed Issue(s)

Fixes #6825

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

This does not look applicable.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

This is not a breaking change so I did not consider this necessary; please let me know if this is needed.
