### PR TITLE
Added method objects for engine_forkChoiceUpdatedV1/V2

### DIFF
--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/methods/AbstractEngineJsonRpcMethod.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/methods/AbstractEngineJsonRpcMethod.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright ConsenSys Software Inc., 2023
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionclient.methods;
+
+import tech.pegasys.teku.ethereum.executionclient.ExecutionEngineClient;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+
+public abstract class AbstractEngineJsonRpcMethod<T> implements EngineJsonRpcMethod<T> {
+
+  protected final ExecutionEngineClient executionEngineClient;
+
+  public AbstractEngineJsonRpcMethod(final ExecutionEngineClient executionEngineClient) {
+    this.executionEngineClient = executionEngineClient;
+  }
+
+  @Override
+  public abstract String getName();
+
+  @Override
+  public abstract int getVersion();
+  ;
+
+  @Override
+  public final String getVersionedName() {
+    return getName() + "V" + getVersion();
+  }
+
+  @Override
+  public abstract SafeFuture<T> execute(JsonRpcRequestParams params);
+}

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineForkChoiceUpdatedV1.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineForkChoiceUpdatedV1.java
@@ -56,6 +56,7 @@ public class EngineForkChoiceUpdatedV1
         "calling engineForkChoiceUpdatedV1(forkChoiceState={}, payloadAttributes={})",
         forkChoiceState,
         payloadBuildingAttributes);
+
     return executionEngineClient
         .forkChoiceUpdatedV1(
             ForkChoiceStateV1.fromInternalForkChoiceState(forkChoiceState),

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineForkChoiceUpdatedV1.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineForkChoiceUpdatedV1.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright ConsenSys Software Inc., 2023
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionclient.methods;
+
+import java.util.Optional;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import tech.pegasys.teku.ethereum.executionclient.ExecutionEngineClient;
+import tech.pegasys.teku.ethereum.executionclient.response.ResponseUnwrapper;
+import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceStateV1;
+import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceUpdatedResult;
+import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV1;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.spec.executionlayer.ForkChoiceState;
+import tech.pegasys.teku.spec.executionlayer.PayloadBuildingAttributes;
+
+public class EngineForkChoiceUpdatedV1
+    extends AbstractEngineJsonRpcMethod<
+        tech.pegasys.teku.spec.executionlayer.ForkChoiceUpdatedResult> {
+
+  private static final Logger LOG = LogManager.getLogger();
+
+  public EngineForkChoiceUpdatedV1(final ExecutionEngineClient executionEngineClient) {
+    super(executionEngineClient);
+  }
+
+  @Override
+  public String getName() {
+    return "engine_forkChoiceUpdated";
+  }
+
+  @Override
+  public int getVersion() {
+    return 1;
+  }
+
+  @Override
+  public SafeFuture<tech.pegasys.teku.spec.executionlayer.ForkChoiceUpdatedResult> execute(
+      final JsonRpcRequestParams params) {
+    final ForkChoiceState forkChoiceState = params.getRequiredParameter(0, ForkChoiceState.class);
+    final Optional<PayloadBuildingAttributes> payloadBuildingAttributes =
+        params.getOptionalParameter(1, PayloadBuildingAttributes.class);
+
+    LOG.trace(
+        "calling engineForkChoiceUpdatedV1(forkChoiceState={}, payloadAttributes={})",
+        forkChoiceState,
+        payloadBuildingAttributes);
+    return executionEngineClient
+        .forkChoiceUpdatedV1(
+            ForkChoiceStateV1.fromInternalForkChoiceState(forkChoiceState),
+            PayloadAttributesV1.fromInternalPayloadBuildingAttributes(payloadBuildingAttributes))
+        .thenApply(ResponseUnwrapper::unwrapExecutionClientResponseOrThrow)
+        .thenApply(ForkChoiceUpdatedResult::asInternalExecutionPayload)
+        .thenPeek(
+            forkChoiceUpdatedResult ->
+                LOG.trace(
+                    "engineForkChoiceUpdatedV1(forkChoiceState={}, payloadAttributes={}) -> {}",
+                    forkChoiceState,
+                    payloadBuildingAttributes,
+                    forkChoiceUpdatedResult));
+  }
+}

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineForkChoiceUpdatedV2.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineForkChoiceUpdatedV2.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright ConsenSys Software Inc., 2023
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionclient.methods;
+
+import java.util.Optional;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import tech.pegasys.teku.ethereum.executionclient.ExecutionEngineClient;
+import tech.pegasys.teku.ethereum.executionclient.response.ResponseUnwrapper;
+import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceStateV1;
+import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceUpdatedResult;
+import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV1;
+import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV2;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.executionlayer.ForkChoiceState;
+import tech.pegasys.teku.spec.executionlayer.PayloadBuildingAttributes;
+
+public class EngineForkChoiceUpdatedV2
+    extends AbstractEngineJsonRpcMethod<
+        tech.pegasys.teku.spec.executionlayer.ForkChoiceUpdatedResult> {
+
+  private static final Logger LOG = LogManager.getLogger();
+  private final Spec spec;
+
+  public EngineForkChoiceUpdatedV2(
+      final ExecutionEngineClient executionEngineClient, final Spec spec) {
+    super(executionEngineClient);
+    this.spec = spec;
+  }
+
+  @Override
+  public String getName() {
+    return "engine_forkChoiceUpdated";
+  }
+
+  @Override
+  public int getVersion() {
+    return 2;
+  }
+
+  @Override
+  public SafeFuture<tech.pegasys.teku.spec.executionlayer.ForkChoiceUpdatedResult> execute(
+      final JsonRpcRequestParams params) {
+    final ForkChoiceState forkChoiceState = params.getRequiredParameter(0, ForkChoiceState.class);
+    final Optional<PayloadBuildingAttributes> payloadBuildingAttributes =
+        params.getOptionalParameter(1, PayloadBuildingAttributes.class);
+
+    LOG.trace(
+        "calling engineForkChoiceUpdatedV1(forkChoiceState={}, payloadAttributes={})",
+        forkChoiceState,
+        payloadBuildingAttributes);
+
+    final Optional<PayloadAttributesV1> maybePayloadAttributes =
+        payloadBuildingAttributes.flatMap(
+            attributes ->
+                spec.atSlot(attributes.getBlockSlot())
+                        .getMilestone()
+                        .isGreaterThanOrEqualTo(SpecMilestone.CAPELLA)
+                    ? PayloadAttributesV2.fromInternalPayloadBuildingAttributesV2(
+                        payloadBuildingAttributes)
+                    : PayloadAttributesV1.fromInternalPayloadBuildingAttributes(
+                        payloadBuildingAttributes));
+    LOG.trace(
+        "calling engineForkChoiceUpdatedV2(forkChoiceState={}, payloadAttributes={})",
+        forkChoiceState,
+        maybePayloadAttributes);
+    return executionEngineClient
+        .forkChoiceUpdatedV2(
+            ForkChoiceStateV1.fromInternalForkChoiceState(forkChoiceState), maybePayloadAttributes)
+        .thenApply(ResponseUnwrapper::unwrapExecutionClientResponseOrThrow)
+        .thenApply(ForkChoiceUpdatedResult::asInternalExecutionPayload)
+        .thenPeek(
+            forkChoiceUpdatedResult ->
+                LOG.trace(
+                    "engineForkChoiceUpdatedV2(forkChoiceState={}, payloadAttributes={}) -> {}",
+                    forkChoiceState,
+                    payloadBuildingAttributes,
+                    forkChoiceUpdatedResult));
+  }
+}

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineForkChoiceUpdatedV2.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineForkChoiceUpdatedV2.java
@@ -59,7 +59,7 @@ public class EngineForkChoiceUpdatedV2
         params.getOptionalParameter(1, PayloadBuildingAttributes.class);
 
     LOG.trace(
-        "calling engineForkChoiceUpdatedV1(forkChoiceState={}, payloadAttributes={})",
+        "calling engineForkChoiceUpdatedV2(forkChoiceState={}, payloadAttributes={})",
         forkChoiceState,
         payloadBuildingAttributes);
 
@@ -73,10 +73,7 @@ public class EngineForkChoiceUpdatedV2
                         payloadBuildingAttributes)
                     : PayloadAttributesV1.fromInternalPayloadBuildingAttributes(
                         payloadBuildingAttributes));
-    LOG.trace(
-        "calling engineForkChoiceUpdatedV2(forkChoiceState={}, payloadAttributes={})",
-        forkChoiceState,
-        maybePayloadAttributes);
+
     return executionEngineClient
         .forkChoiceUpdatedV2(
             ForkChoiceStateV1.fromInternalForkChoiceState(forkChoiceState), maybePayloadAttributes)

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineJsonRpcMethod.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineJsonRpcMethod.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright ConsenSys Software Inc., 2023
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionclient.methods;
+
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+
+public interface EngineJsonRpcMethod<T> {
+
+  String getName();
+
+  int getVersion();
+
+  String getVersionedName();
+
+  SafeFuture<T> execute(JsonRpcRequestParams params);
+}

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/methods/JsonRpcRequestParams.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/methods/JsonRpcRequestParams.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright ConsenSys Software Inc., 2023
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionclient.methods;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+public class JsonRpcRequestParams {
+
+  private final List<Object> params;
+
+  private JsonRpcRequestParams(final List<Object> params) {
+    this.params = params;
+  }
+
+  public <T> T getRequiredParameter(final int index, final Class<T> paramClass) {
+    return getOptionalParameter(index, paramClass)
+        .orElseThrow(
+            () -> new IllegalArgumentException("Missing required parameter at index " + index));
+  }
+
+  @SuppressWarnings("unchecked")
+  public <T> Optional<T> getOptionalParameter(final int index, final Class<T> paramClass) {
+    if (params == null || params.isEmpty() || params.size() <= index || params.get(index) == null) {
+      return Optional.empty();
+    }
+
+    final Object param = params.get(index);
+
+    if (!paramClass.isAssignableFrom(param.getClass())) {
+      throw new IllegalArgumentException(
+          "Invalid type " + paramClass.getSimpleName() + " for parameter at index " + index);
+    }
+
+    return Optional.of((T) param);
+  }
+
+  public static final JsonRpcRequestParams NO_PARAMS =
+      new JsonRpcRequestParams(Collections.emptyList());
+
+  public static class Builder {
+
+    private final List<Object> params = new ArrayList<>();
+
+    public Builder add(Object param) {
+      this.params.add(param);
+      return this;
+    }
+
+    public Builder add(int index, Object param) {
+      if (params.get(index) != null) {
+        params.remove(index);
+      }
+
+      this.params.add(index, param);
+
+      return this;
+    }
+
+    public Builder addOptional(Optional<?> param) {
+      param.ifPresent(this::add);
+      return this;
+    }
+
+    public Builder addOptional(int index, Optional<?> param) {
+      param.ifPresent(
+          p -> {
+            if (params.get(index) != null) {
+              params.remove(index);
+            }
+
+            params.add(index, p);
+          });
+      return this;
+    }
+
+    public JsonRpcRequestParams build() {
+      return new JsonRpcRequestParams(params);
+    }
+  }
+}

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/methods/JsonRpcRequestParams.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/methods/JsonRpcRequestParams.java
@@ -20,6 +20,9 @@ import java.util.Optional;
 
 public class JsonRpcRequestParams {
 
+  public static final JsonRpcRequestParams NO_PARAMS =
+      new JsonRpcRequestParams(Collections.emptyList());
+
   private final List<Object> params;
 
   private JsonRpcRequestParams(final List<Object> params) {
@@ -47,9 +50,6 @@ public class JsonRpcRequestParams {
 
     return Optional.of((T) param);
   }
-
-  public static final JsonRpcRequestParams NO_PARAMS =
-      new JsonRpcRequestParams(Collections.emptyList());
 
   public static class Builder {
 

--- a/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineForkChoiceUpdatedV1Test.java
+++ b/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineForkChoiceUpdatedV1Test.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright ConsenSys Software Inc., 2023
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionclient.methods;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.ethereum.executionclient.ExecutionEngineClient;
+import tech.pegasys.teku.ethereum.executionclient.response.InvalidRemoteResponseException;
+import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceStateV1;
+import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceUpdatedResult;
+import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV1;
+import tech.pegasys.teku.ethereum.executionclient.schema.PayloadStatusV1;
+import tech.pegasys.teku.ethereum.executionclient.schema.Response;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.executionlayer.ExecutionPayloadStatus;
+import tech.pegasys.teku.spec.executionlayer.ForkChoiceState;
+import tech.pegasys.teku.spec.executionlayer.PayloadBuildingAttributes;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+class EngineForkChoiceUpdatedV1Test {
+
+  private final Spec spec = TestSpecFactory.createMinimalBellatrix();
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+  private final ExecutionEngineClient executionEngineClient = mock(ExecutionEngineClient.class);
+  private EngineForkChoiceUpdatedV1 jsonRpcMethod;
+
+  @BeforeEach
+  public void setUp() {
+    jsonRpcMethod = new EngineForkChoiceUpdatedV1(executionEngineClient);
+  }
+
+  @Test
+  public void shouldReturnExpectedNameAndVersion() {
+    assertThat(jsonRpcMethod.getName()).isEqualTo("engine_forkChoiceUpdated");
+    assertThat(jsonRpcMethod.getVersion()).isEqualTo(1);
+    assertThat(jsonRpcMethod.getVersionedName()).isEqualTo("engine_forkChoiceUpdatedV1");
+  }
+
+  @Test
+  public void forkChoiceStateParamIsRequired() {
+    final JsonRpcRequestParams params = new JsonRpcRequestParams.Builder().build();
+
+    assertThatThrownBy(() -> jsonRpcMethod.execute(params))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Missing required parameter at index 0");
+
+    verifyNoInteractions(executionEngineClient);
+  }
+
+  @Test
+  public void payloadBuildingAttributesParamIsOptional() {
+    final ForkChoiceState forkChoiceState = dataStructureUtil.randomForkChoiceState(false);
+
+    when(executionEngineClient.forkChoiceUpdatedV1(any(), eq(Optional.empty())))
+        .thenReturn(dummySuccessfulResponse());
+
+    final JsonRpcRequestParams params =
+        new JsonRpcRequestParams.Builder().add(forkChoiceState).build();
+
+    assertThat(jsonRpcMethod.execute(params)).isCompleted();
+
+    verify(executionEngineClient).forkChoiceUpdatedV1(any(), eq(Optional.empty()));
+  }
+
+  @Test
+  public void shouldReturnFailedFutureWithMessageWhenEngineClientRequestFails() {
+    final ForkChoiceState forkChoiceState = dataStructureUtil.randomForkChoiceState(false);
+    final String errorResponseFromClient = "error!";
+
+    when(executionEngineClient.forkChoiceUpdatedV1(any(), any()))
+        .thenReturn(dummyFailedResponse(errorResponseFromClient));
+
+    final JsonRpcRequestParams params =
+        new JsonRpcRequestParams.Builder().add(forkChoiceState).build();
+
+    assertThat(jsonRpcMethod.execute(params))
+        .failsWithin(1, TimeUnit.SECONDS)
+        .withThrowableOfType(ExecutionException.class)
+        .withRootCauseInstanceOf(InvalidRemoteResponseException.class)
+        .withMessageContaining(
+            "Invalid remote response from the execution client: %s", errorResponseFromClient);
+  }
+
+  @Test
+  public void shouldCallExecutionEngineClientForkChoiceUpdateV1() {
+    final ForkChoiceState forkChoiceState = dataStructureUtil.randomForkChoiceState(false);
+    final PayloadBuildingAttributes payloadBuildingAttributes =
+        dataStructureUtil.randomPayloadBuildingAttributes(false);
+    final ForkChoiceStateV1 forkChoiceStateV1 =
+        ForkChoiceStateV1.fromInternalForkChoiceState(forkChoiceState);
+    final Optional<PayloadAttributesV1> payloadAttributesV1 =
+        PayloadAttributesV1.fromInternalPayloadBuildingAttributes(
+            Optional.of(payloadBuildingAttributes));
+
+    when(executionEngineClient.forkChoiceUpdatedV1(forkChoiceStateV1, payloadAttributesV1))
+        .thenReturn(dummySuccessfulResponse());
+
+    final JsonRpcRequestParams params =
+        new JsonRpcRequestParams.Builder()
+            .add(forkChoiceState)
+            .add(payloadBuildingAttributes)
+            .build();
+
+    assertThat(jsonRpcMethod.execute(params)).isCompleted();
+
+    verify(executionEngineClient).forkChoiceUpdatedV1(forkChoiceStateV1, payloadAttributesV1);
+  }
+
+  private SafeFuture<Response<ForkChoiceUpdatedResult>> dummySuccessfulResponse() {
+    return SafeFuture.completedFuture(
+        new Response<>(
+            new ForkChoiceUpdatedResult(
+                new PayloadStatusV1(
+                    ExecutionPayloadStatus.ACCEPTED, dataStructureUtil.randomBytes32(), ""),
+                dataStructureUtil.randomBytes8())));
+  }
+
+  private SafeFuture<Response<ForkChoiceUpdatedResult>> dummyFailedResponse(final String errorMsg) {
+    return SafeFuture.completedFuture(Response.withErrorMessage(errorMsg));
+  }
+}

--- a/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineForkChoiceUpdatedV1Test.java
+++ b/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineForkChoiceUpdatedV1Test.java
@@ -140,7 +140,8 @@ class EngineForkChoiceUpdatedV1Test {
                 dataStructureUtil.randomBytes8())));
   }
 
-  private SafeFuture<Response<ForkChoiceUpdatedResult>> dummyFailedResponse(final String errorMsg) {
-    return SafeFuture.completedFuture(Response.withErrorMessage(errorMsg));
+  private SafeFuture<Response<ForkChoiceUpdatedResult>> dummyFailedResponse(
+      final String errorMessage) {
+    return SafeFuture.completedFuture(Response.withErrorMessage(errorMessage));
   }
 }

--- a/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineForkChoiceUpdatedV2Test.java
+++ b/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineForkChoiceUpdatedV2Test.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright ConsenSys Software Inc., 2023
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionclient.methods;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.ethereum.executionclient.ExecutionEngineClient;
+import tech.pegasys.teku.ethereum.executionclient.response.InvalidRemoteResponseException;
+import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceStateV1;
+import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceUpdatedResult;
+import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV1;
+import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV2;
+import tech.pegasys.teku.ethereum.executionclient.schema.PayloadStatusV1;
+import tech.pegasys.teku.ethereum.executionclient.schema.Response;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.executionlayer.ExecutionPayloadStatus;
+import tech.pegasys.teku.spec.executionlayer.ForkChoiceState;
+import tech.pegasys.teku.spec.executionlayer.PayloadBuildingAttributes;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+class EngineForkChoiceUpdatedV2Test {
+
+  private final Spec spec = TestSpecFactory.createMinimalCapella();
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+  private final ExecutionEngineClient executionEngineClient = mock(ExecutionEngineClient.class);
+  private EngineForkChoiceUpdatedV2 jsonRpcMethod;
+
+  @BeforeEach
+  public void setUp() {
+    jsonRpcMethod = new EngineForkChoiceUpdatedV2(executionEngineClient, spec);
+  }
+
+  @Test
+  public void shouldReturnExpectedNameAndVersion() {
+    assertThat(jsonRpcMethod.getName()).isEqualTo("engine_forkChoiceUpdated");
+    assertThat(jsonRpcMethod.getVersion()).isEqualTo(2);
+    assertThat(jsonRpcMethod.getVersionedName()).isEqualTo("engine_forkChoiceUpdatedV2");
+  }
+
+  @Test
+  public void forkChoiceStateParamIsRequired() {
+    final JsonRpcRequestParams params = new JsonRpcRequestParams.Builder().build();
+
+    assertThatThrownBy(() -> jsonRpcMethod.execute(params))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Missing required parameter at index 0");
+
+    verifyNoInteractions(executionEngineClient);
+  }
+
+  @Test
+  public void payloadBuildingAttributesParamIsOptional() {
+    final ForkChoiceState forkChoiceState = dataStructureUtil.randomForkChoiceState(false);
+
+    when(executionEngineClient.forkChoiceUpdatedV2(any(), eq(Optional.empty())))
+        .thenReturn(dummySuccessfulResponse());
+
+    final JsonRpcRequestParams params =
+        new JsonRpcRequestParams.Builder().add(forkChoiceState).build();
+
+    assertThat(jsonRpcMethod.execute(params)).isCompleted();
+
+    verify(executionEngineClient).forkChoiceUpdatedV2(any(), eq(Optional.empty()));
+  }
+
+  @Test
+  public void shouldReturnFailedFutureWithMessageWhenEngineClientRequestFails() {
+    final ForkChoiceState forkChoiceState = dataStructureUtil.randomForkChoiceState(false);
+    final String errorResponseFromClient = "error!";
+
+    when(executionEngineClient.forkChoiceUpdatedV2(any(), any()))
+        .thenReturn(dummyFailedResponse(errorResponseFromClient));
+
+    final JsonRpcRequestParams params =
+        new JsonRpcRequestParams.Builder().add(forkChoiceState).build();
+
+    assertThat(jsonRpcMethod.execute(params))
+        .failsWithin(1, TimeUnit.SECONDS)
+        .withThrowableOfType(ExecutionException.class)
+        .withRootCauseInstanceOf(InvalidRemoteResponseException.class)
+        .withMessageContaining(
+            "Invalid remote response from the execution client: %s", errorResponseFromClient);
+  }
+
+  @Test
+  public void shouldCallForkChoiceUpdateV2WithPayloadAttributesV1WhenInBellatrix() {
+    final Spec bellatrixSpec = TestSpecFactory.createMinimalBellatrix();
+    final DataStructureUtil dataStructureUtilBellatrix = new DataStructureUtil(bellatrixSpec);
+
+    final ForkChoiceState forkChoiceState = dataStructureUtilBellatrix.randomForkChoiceState(false);
+    final PayloadBuildingAttributes payloadBuildingAttributes =
+        dataStructureUtilBellatrix.randomPayloadBuildingAttributes(false);
+    final ForkChoiceStateV1 forkChoiceStateV1 =
+        ForkChoiceStateV1.fromInternalForkChoiceState(forkChoiceState);
+    final Optional<PayloadAttributesV1> payloadAttributesV1 =
+        PayloadAttributesV1.fromInternalPayloadBuildingAttributes(
+            Optional.of(payloadBuildingAttributes));
+    assertThat(payloadAttributesV1).get().isExactlyInstanceOf(PayloadAttributesV1.class);
+
+    jsonRpcMethod = new EngineForkChoiceUpdatedV2(executionEngineClient, bellatrixSpec);
+
+    when(executionEngineClient.forkChoiceUpdatedV2(forkChoiceStateV1, payloadAttributesV1))
+        .thenReturn(dummySuccessfulResponse());
+
+    final JsonRpcRequestParams params =
+        new JsonRpcRequestParams.Builder()
+            .add(forkChoiceState)
+            .add(payloadBuildingAttributes)
+            .build();
+
+    assertThat(jsonRpcMethod.execute(params)).isCompleted();
+
+    verify(executionEngineClient).forkChoiceUpdatedV2(forkChoiceStateV1, payloadAttributesV1);
+  }
+
+  @Test
+  public void shouldCallForkChoiceUpdateV2WithPayloadAttributesV2WhenInCapella() {
+    final Spec capellaSpec = TestSpecFactory.createMinimalCapella();
+    final DataStructureUtil dataStructureUtilCapella = new DataStructureUtil(capellaSpec);
+
+    final ForkChoiceState forkChoiceState = dataStructureUtilCapella.randomForkChoiceState(false);
+    final PayloadBuildingAttributes payloadBuildingAttributes =
+        dataStructureUtilCapella.randomPayloadBuildingAttributes(false);
+    final ForkChoiceStateV1 forkChoiceStateV1 =
+        ForkChoiceStateV1.fromInternalForkChoiceState(forkChoiceState);
+    final Optional<PayloadAttributesV1> payloadAttributesV2 =
+        PayloadAttributesV2.fromInternalPayloadBuildingAttributesV2(
+            Optional.of(payloadBuildingAttributes));
+    // PayloadAttributesV2 extends PayloadAttributesV1, we want to ensure we are using V2 in this
+    // call
+    assertThat(payloadAttributesV2).get().isExactlyInstanceOf(PayloadAttributesV2.class);
+
+    jsonRpcMethod = new EngineForkChoiceUpdatedV2(executionEngineClient, capellaSpec);
+
+    when(executionEngineClient.forkChoiceUpdatedV2(forkChoiceStateV1, payloadAttributesV2))
+        .thenReturn(dummySuccessfulResponse());
+
+    final JsonRpcRequestParams params =
+        new JsonRpcRequestParams.Builder()
+            .add(forkChoiceState)
+            .add(payloadBuildingAttributes)
+            .build();
+
+    assertThat(jsonRpcMethod.execute(params)).isCompleted();
+
+    verify(executionEngineClient).forkChoiceUpdatedV2(forkChoiceStateV1, payloadAttributesV2);
+  }
+
+  private SafeFuture<Response<ForkChoiceUpdatedResult>> dummySuccessfulResponse() {
+    return SafeFuture.completedFuture(
+        new Response<>(
+            new ForkChoiceUpdatedResult(
+                new PayloadStatusV1(
+                    ExecutionPayloadStatus.ACCEPTED, dataStructureUtil.randomBytes32(), ""),
+                dataStructureUtil.randomBytes8())));
+  }
+
+  private SafeFuture<Response<ForkChoiceUpdatedResult>> dummyFailedResponse(final String errorMsg) {
+    return SafeFuture.completedFuture(Response.withErrorMessage(errorMsg));
+  }
+}

--- a/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineForkChoiceUpdatedV2Test.java
+++ b/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineForkChoiceUpdatedV2Test.java
@@ -180,7 +180,8 @@ class EngineForkChoiceUpdatedV2Test {
                 dataStructureUtil.randomBytes8())));
   }
 
-  private SafeFuture<Response<ForkChoiceUpdatedResult>> dummyFailedResponse(final String errorMsg) {
-    return SafeFuture.completedFuture(Response.withErrorMessage(errorMsg));
+  private SafeFuture<Response<ForkChoiceUpdatedResult>> dummyFailedResponse(
+      final String errorMessage) {
+    return SafeFuture.completedFuture(Response.withErrorMessage(errorMessage));
   }
 }

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/BellatrixExecutionClientHandler.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/BellatrixExecutionClientHandler.java
@@ -33,6 +33,7 @@ import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSchema;
 import tech.pegasys.teku.spec.datastructures.execution.PowBlock;
+import tech.pegasys.teku.spec.executionlayer.ExecutionPayloadWithValue;
 import tech.pegasys.teku.spec.executionlayer.ForkChoiceState;
 import tech.pegasys.teku.spec.executionlayer.PayloadBuildingAttributes;
 import tech.pegasys.teku.spec.executionlayer.PayloadStatus;

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/BellatrixExecutionClientHandler.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/BellatrixExecutionClientHandler.java
@@ -19,11 +19,10 @@ import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
 import tech.pegasys.teku.ethereum.executionclient.ExecutionEngineClient;
+import tech.pegasys.teku.ethereum.executionclient.methods.EngineForkChoiceUpdatedV1;
+import tech.pegasys.teku.ethereum.executionclient.methods.JsonRpcRequestParams;
 import tech.pegasys.teku.ethereum.executionclient.response.ResponseUnwrapper;
 import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV1;
-import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceStateV1;
-import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceUpdatedResult;
-import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.PayloadStatusV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.TransitionConfigurationV1;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -35,6 +34,7 @@ import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSchema;
 import tech.pegasys.teku.spec.datastructures.execution.PowBlock;
 import tech.pegasys.teku.spec.executionlayer.ExecutionPayloadWithValue;
 import tech.pegasys.teku.spec.executionlayer.ForkChoiceState;
+import tech.pegasys.teku.spec.executionlayer.ForkChoiceUpdatedResult;
 import tech.pegasys.teku.spec.executionlayer.PayloadBuildingAttributes;
 import tech.pegasys.teku.spec.executionlayer.PayloadStatus;
 import tech.pegasys.teku.spec.executionlayer.TransitionConfiguration;
@@ -69,28 +69,17 @@ class BellatrixExecutionClientHandler implements ExecutionClientHandler {
   }
 
   @Override
-  public SafeFuture<tech.pegasys.teku.spec.executionlayer.ForkChoiceUpdatedResult>
-      engineForkChoiceUpdated(
-          final ForkChoiceState forkChoiceState,
-          final Optional<PayloadBuildingAttributes> payloadBuildingAttributes) {
+  public SafeFuture<ForkChoiceUpdatedResult> engineForkChoiceUpdated(
+      final ForkChoiceState forkChoiceState,
+      final Optional<PayloadBuildingAttributes> payloadBuildingAttributes) {
 
-    LOG.trace(
-        "calling engineForkChoiceUpdatedV1(forkChoiceState={}, payloadAttributes={})",
-        forkChoiceState,
-        payloadBuildingAttributes);
-    return executionEngineClient
-        .forkChoiceUpdatedV1(
-            ForkChoiceStateV1.fromInternalForkChoiceState(forkChoiceState),
-            PayloadAttributesV1.fromInternalPayloadBuildingAttributes(payloadBuildingAttributes))
-        .thenApply(ResponseUnwrapper::unwrapExecutionClientResponseOrThrow)
-        .thenApply(ForkChoiceUpdatedResult::asInternalExecutionPayload)
-        .thenPeek(
-            forkChoiceUpdatedResult ->
-                LOG.trace(
-                    "engineForkChoiceUpdatedV1(forkChoiceState={}, payloadAttributes={}) -> {}",
-                    forkChoiceState,
-                    payloadBuildingAttributes,
-                    forkChoiceUpdatedResult));
+    final JsonRpcRequestParams params =
+        new JsonRpcRequestParams.Builder()
+            .add(forkChoiceState)
+            .addOptional(payloadBuildingAttributes)
+            .build();
+
+    return new EngineForkChoiceUpdatedV1(executionEngineClient).execute(params);
   }
 
   @Override

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/CapellaExecutionClientHandler.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/CapellaExecutionClientHandler.java
@@ -32,6 +32,7 @@ import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSchema;
+import tech.pegasys.teku.spec.executionlayer.ExecutionPayloadWithValue;
 import tech.pegasys.teku.spec.executionlayer.ForkChoiceState;
 import tech.pegasys.teku.spec.executionlayer.PayloadBuildingAttributes;
 import tech.pegasys.teku.spec.executionlayer.PayloadStatus;

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/CapellaExecutionClientHandler.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/CapellaExecutionClientHandler.java
@@ -17,23 +17,21 @@ import java.util.Optional;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.ethereum.executionclient.ExecutionEngineClient;
+import tech.pegasys.teku.ethereum.executionclient.methods.EngineForkChoiceUpdatedV2;
+import tech.pegasys.teku.ethereum.executionclient.methods.JsonRpcRequestParams;
 import tech.pegasys.teku.ethereum.executionclient.response.ResponseUnwrapper;
 import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV2;
-import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceStateV1;
-import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceUpdatedResult;
-import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV1;
-import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV2;
 import tech.pegasys.teku.ethereum.executionclient.schema.PayloadStatusV1;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSchema;
 import tech.pegasys.teku.spec.executionlayer.ExecutionPayloadWithValue;
 import tech.pegasys.teku.spec.executionlayer.ForkChoiceState;
+import tech.pegasys.teku.spec.executionlayer.ForkChoiceUpdatedResult;
 import tech.pegasys.teku.spec.executionlayer.PayloadBuildingAttributes;
 import tech.pegasys.teku.spec.executionlayer.PayloadStatus;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsBellatrix;
@@ -76,37 +74,17 @@ public class CapellaExecutionClientHandler extends BellatrixExecutionClientHandl
   }
 
   @Override
-  public SafeFuture<tech.pegasys.teku.spec.executionlayer.ForkChoiceUpdatedResult>
-      engineForkChoiceUpdated(
-          final ForkChoiceState forkChoiceState,
-          final Optional<PayloadBuildingAttributes> payloadBuildingAttributes) {
+  public SafeFuture<ForkChoiceUpdatedResult> engineForkChoiceUpdated(
+      final ForkChoiceState forkChoiceState,
+      final Optional<PayloadBuildingAttributes> payloadBuildingAttributes) {
 
-    final Optional<PayloadAttributesV1> maybePayloadAttributes =
-        payloadBuildingAttributes.flatMap(
-            attributes ->
-                spec.atSlot(attributes.getBlockSlot())
-                        .getMilestone()
-                        .isGreaterThanOrEqualTo(SpecMilestone.CAPELLA)
-                    ? PayloadAttributesV2.fromInternalPayloadBuildingAttributesV2(
-                        payloadBuildingAttributes)
-                    : PayloadAttributesV1.fromInternalPayloadBuildingAttributes(
-                        payloadBuildingAttributes));
-    LOG.trace(
-        "calling engineForkChoiceUpdatedV2(forkChoiceState={}, payloadAttributes={})",
-        forkChoiceState,
-        maybePayloadAttributes);
-    return executionEngineClient
-        .forkChoiceUpdatedV2(
-            ForkChoiceStateV1.fromInternalForkChoiceState(forkChoiceState), maybePayloadAttributes)
-        .thenApply(ResponseUnwrapper::unwrapExecutionClientResponseOrThrow)
-        .thenApply(ForkChoiceUpdatedResult::asInternalExecutionPayload)
-        .thenPeek(
-            forkChoiceUpdatedResult ->
-                LOG.trace(
-                    "engineForkChoiceUpdatedV2(forkChoiceState={}, payloadAttributes={}) -> {}",
-                    forkChoiceState,
-                    payloadBuildingAttributes,
-                    forkChoiceUpdatedResult));
+    final JsonRpcRequestParams params =
+        new JsonRpcRequestParams.Builder()
+            .add(forkChoiceState)
+            .addOptional(payloadBuildingAttributes)
+            .build();
+
+    return new EngineForkChoiceUpdatedV2(executionEngineClient, spec).execute(params);
   }
 
   @Override

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/DenebExecutionClientHandler.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/DenebExecutionClientHandler.java
@@ -31,6 +31,7 @@ import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSchema;
 import tech.pegasys.teku.spec.datastructures.execution.versions.deneb.BlobsBundle;
+import tech.pegasys.teku.spec.executionlayer.ExecutionPayloadWithValue;
 import tech.pegasys.teku.spec.executionlayer.PayloadStatus;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsBellatrix;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsDeneb;

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionBuilderModule.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionBuilderModule.java
@@ -45,6 +45,7 @@ import tech.pegasys.teku.spec.datastructures.execution.FallbackData;
 import tech.pegasys.teku.spec.datastructures.execution.FallbackReason;
 import tech.pegasys.teku.spec.datastructures.execution.HeaderWithFallbackData;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.executionlayer.ExecutionPayloadWithValue;
 
 public class ExecutionBuilderModule {
 

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionClientHandler.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionClientHandler.java
@@ -22,6 +22,7 @@ import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
 import tech.pegasys.teku.spec.datastructures.execution.PowBlock;
 import tech.pegasys.teku.spec.datastructures.execution.versions.deneb.BlobsBundle;
+import tech.pegasys.teku.spec.executionlayer.ExecutionPayloadWithValue;
 import tech.pegasys.teku.spec.executionlayer.ForkChoiceState;
 import tech.pegasys.teku.spec.executionlayer.ForkChoiceUpdatedResult;
 import tech.pegasys.teku.spec.executionlayer.PayloadBuildingAttributes;

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
@@ -57,6 +57,7 @@ import tech.pegasys.teku.spec.datastructures.execution.HeaderWithFallbackData;
 import tech.pegasys.teku.spec.datastructures.execution.PowBlock;
 import tech.pegasys.teku.spec.datastructures.execution.versions.deneb.BlobsBundle;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.executionlayer.ExecutionPayloadWithValue;
 import tech.pegasys.teku.spec.executionlayer.ForkChoiceState;
 import tech.pegasys.teku.spec.executionlayer.ForkChoiceUpdatedResult;
 import tech.pegasys.teku.spec.executionlayer.PayloadBuildingAttributes;

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/CapellaExecutionClientHandlerTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/CapellaExecutionClientHandlerTest.java
@@ -45,6 +45,7 @@ import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
 import tech.pegasys.teku.spec.datastructures.execution.versions.bellatrix.ExecutionPayloadBellatrix;
 import tech.pegasys.teku.spec.datastructures.execution.versions.capella.ExecutionPayloadCapella;
 import tech.pegasys.teku.spec.executionlayer.ExecutionPayloadStatus;
+import tech.pegasys.teku.spec.executionlayer.ExecutionPayloadWithValue;
 import tech.pegasys.teku.spec.executionlayer.ForkChoiceState;
 import tech.pegasys.teku.spec.executionlayer.PayloadBuildingAttributes;
 import tech.pegasys.teku.spec.executionlayer.PayloadStatus;

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/DenebExecutionClientHandlerTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/DenebExecutionClientHandlerTest.java
@@ -42,6 +42,7 @@ import tech.pegasys.teku.spec.datastructures.execution.versions.capella.Executio
 import tech.pegasys.teku.spec.datastructures.execution.versions.deneb.BlobsBundle;
 import tech.pegasys.teku.spec.datastructures.execution.versions.deneb.ExecutionPayloadDeneb;
 import tech.pegasys.teku.spec.executionlayer.ExecutionPayloadStatus;
+import tech.pegasys.teku.spec.executionlayer.ExecutionPayloadWithValue;
 import tech.pegasys.teku.spec.executionlayer.PayloadStatus;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerBlockProductionManagerImplTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerBlockProductionManagerImplTest.java
@@ -51,6 +51,7 @@ import tech.pegasys.teku.spec.datastructures.execution.FallbackReason;
 import tech.pegasys.teku.spec.datastructures.execution.HeaderWithFallbackData;
 import tech.pegasys.teku.spec.datastructures.execution.versions.deneb.BlobsBundle;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.executionlayer.ExecutionPayloadWithValue;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 class ExecutionLayerBlockProductionManagerImplTest {

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImplTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImplTest.java
@@ -50,6 +50,7 @@ import tech.pegasys.teku.spec.datastructures.execution.FallbackData;
 import tech.pegasys.teku.spec.datastructures.execution.FallbackReason;
 import tech.pegasys.teku.spec.datastructures.execution.HeaderWithFallbackData;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.executionlayer.ExecutionPayloadWithValue;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 class ExecutionLayerManagerImplTest {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionPayloadWithValue.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionPayloadWithValue.java
@@ -11,7 +11,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.ethereum.executionlayer;
+package tech.pegasys.teku.spec.executionlayer;
 
 import com.google.common.base.MoreObjects;
 import java.util.Objects;


### PR DESCRIPTION
## PR Description
- Created `EngineJsonRpcMethod` interface as a generic representation of a method-object that encapsulates a JSON-RPC call.
- Implemented `EngineForkChoiceUpdatedV1` and `EngineForkChoiceUpdatedV2` with their respective unit tests
- Updated both Bellatrix and Capella execution client handlers to use the new method-objects

Note: some of the unit tests regarding FCU on `BellatrixExecutionClientHandlerTest` and `CapellaExecutionClientHandlerTest` could be removed. However, they are a good way to ensure the refactoring isn't breaking any existing logic between execution handlers and engine clients. I decided it was worth keeping them around until the end of the final phase of the refactoring (that will end up with us removing the milestone-based handlers anyway).

## Fixed Issue(s)
related to #6784 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
