### PR TITLE
Rename `check_validators_doppelganger` method label for consistency

### DIFF
--- a/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/BeaconNodeRequestLabels.java
+++ b/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/BeaconNodeRequestLabels.java
@@ -38,5 +38,5 @@ public class BeaconNodeRequestLabels {
   public static final String SEND_CONTRIBUTIONS_AND_PROOFS_METHOD = "send_contributions_and_proofs";
   public static final String PREPARE_BEACON_PROPOSERS_METHOD = "prepare_beacon_proposers";
   public static final String REGISTER_VALIDATORS_METHOD = "register_validators";
-  public static final String CHECK_VALIDATORS_DOPPELGANGER_METHOD = "check_validators_doppelganger";
+  public static final String GET_VALIDATORS_LIVENESS = "get_validators_liveness";
 }

--- a/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
+++ b/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
@@ -234,7 +234,7 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
       List<UInt64> validatorIndices, UInt64 epoch) {
     return countOptionalDataRequest(
         delegate.getValidatorsLiveness(validatorIndices, epoch),
-        BeaconNodeRequestLabels.CHECK_VALIDATORS_DOPPELGANGER_METHOD);
+        BeaconNodeRequestLabels.GET_VALIDATORS_LIVENESS);
   }
 
   private <T> SafeFuture<T> countDataRequest(

--- a/validator/beaconnode/src/test/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannelTest.java
+++ b/validator/beaconnode/src/test/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannelTest.java
@@ -213,9 +213,9 @@ class MetricRecordingValidatorApiChannelTest {
             BeaconNodeRequestLabels.CREATE_SYNC_COMMITTEE_CONTRIBUTION_METHOD,
             dataStructureUtil.randomSyncCommitteeContribution(slot)),
         requestDataTest(
-            "checkValidatorsDoppelganger",
+            "getValidatorsLiveness",
             channel -> channel.getValidatorsLiveness(validatorIndices, epoch),
-            BeaconNodeRequestLabels.CHECK_VALIDATORS_DOPPELGANGER_METHOD,
+            BeaconNodeRequestLabels.GET_VALIDATORS_LIVENESS,
             new ArrayList<>()));
   }
 

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandler.java
@@ -288,7 +288,7 @@ public class FailoverValidatorApiHandler implements ValidatorApiChannel {
       final List<UInt64> validatorIndices, final UInt64 epoch) {
     return tryRequestUntilSuccess(
         apiChannel -> apiChannel.getValidatorsLiveness(validatorIndices, epoch),
-        BeaconNodeRequestLabels.CHECK_VALIDATORS_DOPPELGANGER_METHOD);
+        BeaconNodeRequestLabels.GET_VALIDATORS_LIVENESS);
   }
 
   private <T> SafeFuture<T> relayRequest(

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandlerTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandlerTest.java
@@ -693,9 +693,9 @@ class FailoverValidatorApiHandlerTest {
             BeaconNodeRequestLabels.CREATE_SYNC_COMMITTEE_CONTRIBUTION_METHOD,
             Optional.of(mock(SyncCommitteeContribution.class))),
         getArguments(
-            "checkValidatorsDoppelganger",
+            "getValidatorsLiveness",
             apiChannel -> apiChannel.getValidatorsLiveness(List.of(UInt64.ZERO), epoch),
-            BeaconNodeRequestLabels.CHECK_VALIDATORS_DOPPELGANGER_METHOD,
+            BeaconNodeRequestLabels.GET_VALIDATORS_LIVENESS,
             Optional.of(List.of(validatorLivenessAtEpoch))));
   }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Just rename `check_validators_doppelganger` to `get_validators_liveness` to be consistent and rename constant as well.

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
