### PR TITLE
Added method objects for engine_getPayloadV1/V2/V3

### DIFF
--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineGetPayloadV1.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineGetPayloadV1.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright ConsenSys Software Inc., 2023
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionclient.methods;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.units.bigints.UInt256;
+import tech.pegasys.teku.ethereum.executionclient.ExecutionEngineClient;
+import tech.pegasys.teku.ethereum.executionclient.response.ResponseUnwrapper;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSchema;
+import tech.pegasys.teku.spec.executionlayer.ExecutionPayloadWithValue;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsBellatrix;
+
+public class EngineGetPayloadV1 extends AbstractEngineJsonRpcMethod<ExecutionPayloadWithValue> {
+
+  private static final Logger LOG = LogManager.getLogger();
+
+  private final Spec spec;
+
+  public EngineGetPayloadV1(final ExecutionEngineClient executionEngineClient, final Spec spec) {
+    super(executionEngineClient);
+    this.spec = spec;
+  }
+
+  @Override
+  public String getName() {
+    return "engine_getPayload";
+  }
+
+  @Override
+  public int getVersion() {
+    return 1;
+  }
+
+  @Override
+  public SafeFuture<ExecutionPayloadWithValue> execute(final JsonRpcRequestParams params) {
+    final ExecutionPayloadContext executionPayloadContext =
+        params.getRequiredParameter(0, ExecutionPayloadContext.class);
+    final UInt64 slot = params.getRequiredParameter(1, UInt64.class);
+
+    LOG.trace(
+        "calling engineGetPayloadV1(payloadId={}, slot={})",
+        executionPayloadContext.getPayloadId(),
+        slot);
+
+    return executionEngineClient
+        .getPayloadV1(executionPayloadContext.getPayloadId())
+        .thenApply(ResponseUnwrapper::unwrapExecutionClientResponseOrThrow)
+        .thenApply(
+            payload -> {
+              final ExecutionPayloadSchema<?> payloadSchema =
+                  SchemaDefinitionsBellatrix.required(spec.atSlot(slot).getSchemaDefinitions())
+                      .getExecutionPayloadSchema();
+              return new ExecutionPayloadWithValue(
+                  payload.asInternalExecutionPayload(payloadSchema), UInt256.ZERO);
+            })
+        .thenPeek(
+            payloadAndValue ->
+                LOG.trace(
+                    "engineGetPayloadV1(payloadId={}, slot={}) -> {}",
+                    executionPayloadContext.getPayloadId(),
+                    slot,
+                    payloadAndValue));
+  }
+}

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineGetPayloadV2.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineGetPayloadV2.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright ConsenSys Software Inc., 2023
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionclient.methods;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import tech.pegasys.teku.ethereum.executionclient.ExecutionEngineClient;
+import tech.pegasys.teku.ethereum.executionclient.response.ResponseUnwrapper;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSchema;
+import tech.pegasys.teku.spec.executionlayer.ExecutionPayloadWithValue;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsBellatrix;
+
+public class EngineGetPayloadV2 extends AbstractEngineJsonRpcMethod<ExecutionPayloadWithValue> {
+
+  private static final Logger LOG = LogManager.getLogger();
+
+  private final Spec spec;
+
+  public EngineGetPayloadV2(final ExecutionEngineClient executionEngineClient, final Spec spec) {
+    super(executionEngineClient);
+    this.spec = spec;
+  }
+
+  @Override
+  public String getName() {
+    return "engine_getPayload";
+  }
+
+  @Override
+  public int getVersion() {
+    return 2;
+  }
+
+  @Override
+  public SafeFuture<ExecutionPayloadWithValue> execute(final JsonRpcRequestParams params) {
+    final ExecutionPayloadContext executionPayloadContext =
+        params.getRequiredParameter(0, ExecutionPayloadContext.class);
+    final UInt64 slot = params.getRequiredParameter(1, UInt64.class);
+
+    LOG.trace(
+        "calling engineGetPayloadV2(payloadId={}, slot={})",
+        executionPayloadContext.getPayloadId(),
+        slot);
+
+    return executionEngineClient
+        .getPayloadV2(executionPayloadContext.getPayloadId())
+        .thenApply(ResponseUnwrapper::unwrapExecutionClientResponseOrThrow)
+        .thenApply(
+            response -> {
+              final ExecutionPayloadSchema<?> payloadSchema =
+                  SchemaDefinitionsBellatrix.required(spec.atSlot(slot).getSchemaDefinitions())
+                      .getExecutionPayloadSchema();
+              return new ExecutionPayloadWithValue(
+                  response.executionPayload.asInternalExecutionPayload(payloadSchema),
+                  response.blockValue);
+            })
+        .thenPeek(
+            payloadAndValue ->
+                LOG.trace(
+                    "engineGetPayloadV2(payloadId={}, slot={}) -> {}",
+                    executionPayloadContext.getPayloadId(),
+                    slot,
+                    payloadAndValue));
+  }
+}

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineGetPayloadV3.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineGetPayloadV3.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright ConsenSys Software Inc., 2023
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionclient.methods;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import tech.pegasys.teku.ethereum.executionclient.ExecutionEngineClient;
+import tech.pegasys.teku.ethereum.executionclient.response.ResponseUnwrapper;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSchema;
+import tech.pegasys.teku.spec.executionlayer.ExecutionPayloadWithValue;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsBellatrix;
+
+public class EngineGetPayloadV3 extends AbstractEngineJsonRpcMethod<ExecutionPayloadWithValue> {
+
+  private static final Logger LOG = LogManager.getLogger();
+
+  private final Spec spec;
+
+  public EngineGetPayloadV3(final ExecutionEngineClient executionEngineClient, final Spec spec) {
+    super(executionEngineClient);
+    this.spec = spec;
+  }
+
+  @Override
+  public String getName() {
+    return "engine_getPayload";
+  }
+
+  @Override
+  public int getVersion() {
+    return 3;
+  }
+
+  @Override
+  public SafeFuture<ExecutionPayloadWithValue> execute(final JsonRpcRequestParams params) {
+    final ExecutionPayloadContext executionPayloadContext =
+        params.getRequiredParameter(0, ExecutionPayloadContext.class);
+    final UInt64 slot = params.getRequiredParameter(1, UInt64.class);
+
+    LOG.trace(
+        "calling engineGetPayloadV3(payloadId={}, slot={})",
+        executionPayloadContext.getPayloadId(),
+        slot);
+
+    return executionEngineClient
+        .getPayloadV3(executionPayloadContext.getPayloadId())
+        .thenApply(ResponseUnwrapper::unwrapExecutionClientResponseOrThrow)
+        .thenApply(
+            response -> {
+              final ExecutionPayloadSchema<?> payloadSchema =
+                  SchemaDefinitionsBellatrix.required(spec.atSlot(slot).getSchemaDefinitions())
+                      .getExecutionPayloadSchema();
+              return new ExecutionPayloadWithValue(
+                  response.executionPayload.asInternalExecutionPayload(payloadSchema),
+                  response.blockValue);
+            })
+        .thenPeek(
+            payloadAndValue ->
+                LOG.trace(
+                    "engineGetPayloadV3(payloadId={}, slot={}) -> {}",
+                    executionPayloadContext.getPayloadId(),
+                    slot,
+                    payloadAndValue));
+  }
+}

--- a/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineGetPayloadV1Test.java
+++ b/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineGetPayloadV1Test.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright ConsenSys Software Inc., 2023
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionclient.methods;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.ethereum.executionclient.ExecutionEngineClient;
+import tech.pegasys.teku.ethereum.executionclient.response.InvalidRemoteResponseException;
+import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV1;
+import tech.pegasys.teku.ethereum.executionclient.schema.Response;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+class EngineGetPayloadV1Test {
+
+  private final Spec spec = TestSpecFactory.createMinimalBellatrix();
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+  private final ExecutionEngineClient executionEngineClient = mock(ExecutionEngineClient.class);
+  private EngineGetPayloadV1 jsonRpcMethod;
+
+  @BeforeEach
+  public void setUp() {
+    jsonRpcMethod = new EngineGetPayloadV1(executionEngineClient, spec);
+  }
+
+  @Test
+  public void shouldReturnExpectedNameAndVersion() {
+    assertThat(jsonRpcMethod.getName()).isEqualTo("engine_getPayload");
+    assertThat(jsonRpcMethod.getVersion()).isEqualTo(1);
+    assertThat(jsonRpcMethod.getVersionedName()).isEqualTo("engine_getPayloadV1");
+  }
+
+  @Test
+  public void executionPayloadContextParamIsRequired() {
+    final JsonRpcRequestParams params = new JsonRpcRequestParams.Builder().build();
+
+    assertThatThrownBy(() -> jsonRpcMethod.execute(params))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Missing required parameter at index 0");
+
+    verifyNoInteractions(executionEngineClient);
+  }
+
+  @Test
+  public void slotParamIsRequired() {
+    final ExecutionPayloadContext executionPayloadContext =
+        dataStructureUtil.randomPayloadExecutionContext(false);
+
+    final JsonRpcRequestParams params =
+        new JsonRpcRequestParams.Builder().add(executionPayloadContext).build();
+
+    assertThatThrownBy(() -> jsonRpcMethod.execute(params))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Missing required parameter at index 1");
+
+    verifyNoInteractions(executionEngineClient);
+  }
+
+  @Test
+  public void shouldReturnFailedExecutionWhenEngineClientRequestFails() {
+    final ExecutionPayloadContext executionPayloadContext =
+        dataStructureUtil.randomPayloadExecutionContext(false);
+    final String errorResponseFromClient = "error!";
+
+    when(executionEngineClient.getPayloadV1(any()))
+        .thenReturn(dummyFailedResponse(errorResponseFromClient));
+
+    final JsonRpcRequestParams params =
+        new JsonRpcRequestParams.Builder().add(executionPayloadContext).add(UInt64.ZERO).build();
+
+    assertThat(jsonRpcMethod.execute(params))
+        .failsWithin(1, TimeUnit.SECONDS)
+        .withThrowableOfType(ExecutionException.class)
+        .withRootCauseInstanceOf(InvalidRemoteResponseException.class)
+        .withMessageContaining(
+            "Invalid remote response from the execution client: %s", errorResponseFromClient);
+  }
+
+  @Test
+  public void shouldCallExecutionEngineClientGetPayloadV1() {
+    final ExecutionPayloadContext executionPayloadContext =
+        dataStructureUtil.randomPayloadExecutionContext(false);
+
+    when(executionEngineClient.getPayloadV1(eq(executionPayloadContext.getPayloadId())))
+        .thenReturn(dummySuccessfulResponse());
+
+    final JsonRpcRequestParams params =
+        new JsonRpcRequestParams.Builder().add(executionPayloadContext).add(UInt64.ZERO).build();
+
+    assertThat(jsonRpcMethod.execute(params)).isCompleted();
+
+    verify(executionEngineClient).getPayloadV1(eq(executionPayloadContext.getPayloadId()));
+    verifyNoMoreInteractions(executionEngineClient);
+  }
+
+  private SafeFuture<Response<ExecutionPayloadV1>> dummySuccessfulResponse() {
+    return SafeFuture.completedFuture(
+        new Response<>(
+            ExecutionPayloadV1.fromInternalExecutionPayload(
+                dataStructureUtil.randomExecutionPayload())));
+  }
+
+  private SafeFuture<Response<ExecutionPayloadV1>> dummyFailedResponse(final String errorMsg) {
+    return SafeFuture.completedFuture(Response.withErrorMessage(errorMsg));
+  }
+}

--- a/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineGetPayloadV2Test.java
+++ b/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineGetPayloadV2Test.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright ConsenSys Software Inc., 2023
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionclient.methods;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.ethereum.executionclient.ExecutionEngineClient;
+import tech.pegasys.teku.ethereum.executionclient.response.InvalidRemoteResponseException;
+import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV2;
+import tech.pegasys.teku.ethereum.executionclient.schema.GetPayloadV2Response;
+import tech.pegasys.teku.ethereum.executionclient.schema.Response;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+class EngineGetPayloadV2Test {
+
+  private final Spec spec = TestSpecFactory.createMinimalBellatrix();
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+  private final ExecutionEngineClient executionEngineClient = mock(ExecutionEngineClient.class);
+  private EngineGetPayloadV2 jsonRpcMethod;
+
+  @BeforeEach
+  public void setUp() {
+    jsonRpcMethod = new EngineGetPayloadV2(executionEngineClient, spec);
+  }
+
+  @Test
+  public void shouldReturnExpectedNameAndVersion() {
+    assertThat(jsonRpcMethod.getName()).isEqualTo("engine_getPayload");
+    assertThat(jsonRpcMethod.getVersion()).isEqualTo(2);
+    assertThat(jsonRpcMethod.getVersionedName()).isEqualTo("engine_getPayloadV2");
+  }
+
+  @Test
+  public void executionPayloadContextParamIsRequired() {
+    final JsonRpcRequestParams params = new JsonRpcRequestParams.Builder().build();
+
+    assertThatThrownBy(() -> jsonRpcMethod.execute(params))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Missing required parameter at index 0");
+
+    verifyNoInteractions(executionEngineClient);
+  }
+
+  @Test
+  public void slotParamIsRequired() {
+    final ExecutionPayloadContext executionPayloadContext =
+        dataStructureUtil.randomPayloadExecutionContext(false);
+
+    final JsonRpcRequestParams params =
+        new JsonRpcRequestParams.Builder().add(executionPayloadContext).build();
+
+    assertThatThrownBy(() -> jsonRpcMethod.execute(params))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Missing required parameter at index 1");
+
+    verifyNoInteractions(executionEngineClient);
+  }
+
+  @Test
+  public void shouldReturnFailedExecutionWhenEngineClientRequestFails() {
+    final ExecutionPayloadContext executionPayloadContext =
+        dataStructureUtil.randomPayloadExecutionContext(false);
+    final String errorResponseFromClient = "error!";
+
+    when(executionEngineClient.getPayloadV2(any()))
+        .thenReturn(dummyFailedResponse(errorResponseFromClient));
+
+    final JsonRpcRequestParams params =
+        new JsonRpcRequestParams.Builder().add(executionPayloadContext).add(UInt64.ZERO).build();
+
+    assertThat(jsonRpcMethod.execute(params))
+        .failsWithin(1, TimeUnit.SECONDS)
+        .withThrowableOfType(ExecutionException.class)
+        .withRootCauseInstanceOf(InvalidRemoteResponseException.class)
+        .withMessageContaining(
+            "Invalid remote response from the execution client: %s", errorResponseFromClient);
+  }
+
+  @Test
+  public void shouldCallGetPayloadV2AndParseResponseSuccessfullyWhenInBellatrix() {
+    final Spec bellatrixSpec = TestSpecFactory.createMinimalBellatrix();
+    final DataStructureUtil dataStructureUtilBellatrix = new DataStructureUtil(bellatrixSpec);
+
+    final ExecutionPayloadContext executionPayloadContext =
+        dataStructureUtilBellatrix.randomPayloadExecutionContext(false);
+
+    when(executionEngineClient.getPayloadV2(eq(executionPayloadContext.getPayloadId())))
+        .thenReturn(dummySuccessfulResponse());
+
+    final JsonRpcRequestParams params =
+        new JsonRpcRequestParams.Builder().add(executionPayloadContext).add(UInt64.ZERO).build();
+
+    jsonRpcMethod = new EngineGetPayloadV2(executionEngineClient, bellatrixSpec);
+
+    assertThat(jsonRpcMethod.execute(params)).isCompleted();
+
+    verify(executionEngineClient).getPayloadV2(eq(executionPayloadContext.getPayloadId()));
+    verifyNoMoreInteractions(executionEngineClient);
+  }
+
+  @Test
+  public void shouldCallGetPayloadV2AndParseResponseSuccessfullyWhenInCapella() {
+    final Spec capellaSpec = TestSpecFactory.createMinimalCapella();
+    final DataStructureUtil dataStructureUtilCapella = new DataStructureUtil(capellaSpec);
+
+    final ExecutionPayloadContext executionPayloadContext =
+        dataStructureUtilCapella.randomPayloadExecutionContext(false);
+
+    when(executionEngineClient.getPayloadV2(eq(executionPayloadContext.getPayloadId())))
+        .thenReturn(dummySuccessfulResponse());
+
+    final JsonRpcRequestParams params =
+        new JsonRpcRequestParams.Builder().add(executionPayloadContext).add(UInt64.ZERO).build();
+
+    jsonRpcMethod = new EngineGetPayloadV2(executionEngineClient, capellaSpec);
+
+    assertThat(jsonRpcMethod.execute(params)).isCompleted();
+
+    verify(executionEngineClient).getPayloadV2(eq(executionPayloadContext.getPayloadId()));
+    verifyNoMoreInteractions(executionEngineClient);
+  }
+
+  private SafeFuture<Response<GetPayloadV2Response>> dummySuccessfulResponse() {
+    return SafeFuture.completedFuture(
+        new Response<>(
+            new GetPayloadV2Response(
+                ExecutionPayloadV2.fromInternalExecutionPayload(
+                    dataStructureUtil.randomExecutionPayload()),
+                dataStructureUtil.randomUInt256())));
+  }
+
+  private SafeFuture<Response<GetPayloadV2Response>> dummyFailedResponse(
+      final String errorMessage) {
+    return SafeFuture.completedFuture(Response.withErrorMessage(errorMessage));
+  }
+}

--- a/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineGetPayloadV3Test.java
+++ b/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineGetPayloadV3Test.java
@@ -30,8 +30,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.ethereum.executionclient.ExecutionEngineClient;
 import tech.pegasys.teku.ethereum.executionclient.response.InvalidRemoteResponseException;
-import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV2;
-import tech.pegasys.teku.ethereum.executionclient.schema.GetPayloadV2Response;
+import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV3;
+import tech.pegasys.teku.ethereum.executionclient.schema.GetPayloadV3Response;
 import tech.pegasys.teku.ethereum.executionclient.schema.Response;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -41,26 +41,27 @@ import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
 import tech.pegasys.teku.spec.datastructures.execution.versions.bellatrix.ExecutionPayloadBellatrix;
 import tech.pegasys.teku.spec.datastructures.execution.versions.capella.ExecutionPayloadCapella;
+import tech.pegasys.teku.spec.datastructures.execution.versions.deneb.ExecutionPayloadDeneb;
 import tech.pegasys.teku.spec.executionlayer.ExecutionPayloadWithValue;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
-class EngineGetPayloadV2Test {
+class EngineGetPayloadV3Test {
 
-  private final Spec spec = TestSpecFactory.createMinimalCapella();
+  private final Spec spec = TestSpecFactory.createMinimalDeneb();
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
   private final ExecutionEngineClient executionEngineClient = mock(ExecutionEngineClient.class);
-  private EngineGetPayloadV2 jsonRpcMethod;
+  private EngineGetPayloadV3 jsonRpcMethod;
 
   @BeforeEach
   public void setUp() {
-    jsonRpcMethod = new EngineGetPayloadV2(executionEngineClient, spec);
+    jsonRpcMethod = new EngineGetPayloadV3(executionEngineClient, spec);
   }
 
   @Test
   public void shouldReturnExpectedNameAndVersion() {
     assertThat(jsonRpcMethod.getName()).isEqualTo("engine_getPayload");
-    assertThat(jsonRpcMethod.getVersion()).isEqualTo(2);
-    assertThat(jsonRpcMethod.getVersionedName()).isEqualTo("engine_getPayloadV2");
+    assertThat(jsonRpcMethod.getVersion()).isEqualTo(3);
+    assertThat(jsonRpcMethod.getVersionedName()).isEqualTo("engine_getPayloadV3");
   }
 
   @Test
@@ -95,7 +96,7 @@ class EngineGetPayloadV2Test {
         dataStructureUtil.randomPayloadExecutionContext(false);
     final String errorResponseFromClient = "error!";
 
-    when(executionEngineClient.getPayloadV2(any()))
+    when(executionEngineClient.getPayloadV3(any()))
         .thenReturn(dummyFailedResponse(errorResponseFromClient));
 
     final JsonRpcRequestParams params =
@@ -110,7 +111,7 @@ class EngineGetPayloadV2Test {
   }
 
   @Test
-  public void shouldCallGetPayloadV2AndParseResponseSuccessfullyWhenInBellatrix() {
+  public void shouldCallGetPayloadV3AndParseResponseSuccessfullyWhenInBellatrix() {
     final Spec bellatrixSpec = TestSpecFactory.createMinimalBellatrix();
     final DataStructureUtil dataStructureUtilBellatrix = new DataStructureUtil(bellatrixSpec);
 
@@ -121,24 +122,24 @@ class EngineGetPayloadV2Test {
         dataStructureUtilBellatrix.randomExecutionPayload();
     assertThat(executionPayloadBellatrix).isInstanceOf(ExecutionPayloadBellatrix.class);
 
-    when(executionEngineClient.getPayloadV2(eq(executionPayloadContext.getPayloadId())))
+    when(executionEngineClient.getPayloadV3(eq(executionPayloadContext.getPayloadId())))
         .thenReturn(dummySuccessfulResponse(executionPayloadBellatrix, blockValue));
 
     final JsonRpcRequestParams params =
         new JsonRpcRequestParams.Builder().add(executionPayloadContext).add(UInt64.ZERO).build();
 
-    jsonRpcMethod = new EngineGetPayloadV2(executionEngineClient, bellatrixSpec);
+    jsonRpcMethod = new EngineGetPayloadV3(executionEngineClient, bellatrixSpec);
 
     final ExecutionPayloadWithValue expectedPayloadWithValue =
         new ExecutionPayloadWithValue(executionPayloadBellatrix, blockValue);
     assertThat(jsonRpcMethod.execute(params)).isCompletedWithValue(expectedPayloadWithValue);
 
-    verify(executionEngineClient).getPayloadV2(eq(executionPayloadContext.getPayloadId()));
+    verify(executionEngineClient).getPayloadV3(eq(executionPayloadContext.getPayloadId()));
     verifyNoMoreInteractions(executionEngineClient);
   }
 
   @Test
-  public void shouldCallGetPayloadV2AndParseResponseSuccessfullyWhenInCapella() {
+  public void shouldCallGetPayloadV3AndParseResponseSuccessfullyWhenInCapella() {
     final Spec capellaSpec = TestSpecFactory.createMinimalCapella();
     final DataStructureUtil dataStructureUtilCapella = new DataStructureUtil(capellaSpec);
 
@@ -149,31 +150,59 @@ class EngineGetPayloadV2Test {
         dataStructureUtilCapella.randomExecutionPayload();
     assertThat(executionPayloadCapella).isInstanceOf(ExecutionPayloadCapella.class);
 
-    when(executionEngineClient.getPayloadV2(eq(executionPayloadContext.getPayloadId())))
+    when(executionEngineClient.getPayloadV3(eq(executionPayloadContext.getPayloadId())))
         .thenReturn(dummySuccessfulResponse(executionPayloadCapella, blockValue));
 
     final JsonRpcRequestParams params =
         new JsonRpcRequestParams.Builder().add(executionPayloadContext).add(UInt64.ZERO).build();
 
-    jsonRpcMethod = new EngineGetPayloadV2(executionEngineClient, capellaSpec);
+    jsonRpcMethod = new EngineGetPayloadV3(executionEngineClient, capellaSpec);
 
     final ExecutionPayloadWithValue expectedPayloadWithValue =
         new ExecutionPayloadWithValue(executionPayloadCapella, blockValue);
     assertThat(jsonRpcMethod.execute(params)).isCompletedWithValue(expectedPayloadWithValue);
 
-    verify(executionEngineClient).getPayloadV2(eq(executionPayloadContext.getPayloadId()));
+    verify(executionEngineClient).getPayloadV3(eq(executionPayloadContext.getPayloadId()));
     verifyNoMoreInteractions(executionEngineClient);
   }
 
-  private SafeFuture<Response<GetPayloadV2Response>> dummySuccessfulResponse(
+  @Test
+  public void shouldCallGetPayloadV3AndParseResponseSuccessfullyWhenInDeneb() {
+    final Spec denebSpec = TestSpecFactory.createMinimalDeneb();
+    final DataStructureUtil dataStructureUtilDeneb = new DataStructureUtil(denebSpec);
+
+    final ExecutionPayloadContext executionPayloadContext =
+        dataStructureUtilDeneb.randomPayloadExecutionContext(false);
+    final UInt256 blockValue = UInt256.MAX_VALUE;
+    final ExecutionPayload executionPayloadCapella =
+        dataStructureUtilDeneb.randomExecutionPayload();
+    assertThat(executionPayloadCapella).isInstanceOf(ExecutionPayloadDeneb.class);
+
+    when(executionEngineClient.getPayloadV3(eq(executionPayloadContext.getPayloadId())))
+        .thenReturn(dummySuccessfulResponse(executionPayloadCapella, blockValue));
+
+    final JsonRpcRequestParams params =
+        new JsonRpcRequestParams.Builder().add(executionPayloadContext).add(UInt64.ZERO).build();
+
+    jsonRpcMethod = new EngineGetPayloadV3(executionEngineClient, denebSpec);
+
+    final ExecutionPayloadWithValue expectedPayloadWithValue =
+        new ExecutionPayloadWithValue(executionPayloadCapella, blockValue);
+    assertThat(jsonRpcMethod.execute(params)).isCompletedWithValue(expectedPayloadWithValue);
+
+    verify(executionEngineClient).getPayloadV3(eq(executionPayloadContext.getPayloadId()));
+    verifyNoMoreInteractions(executionEngineClient);
+  }
+
+  private SafeFuture<Response<GetPayloadV3Response>> dummySuccessfulResponse(
       final ExecutionPayload executionPayload, final UInt256 blockValue) {
     return SafeFuture.completedFuture(
         new Response<>(
-            new GetPayloadV2Response(
-                ExecutionPayloadV2.fromInternalExecutionPayload(executionPayload), blockValue)));
+            new GetPayloadV3Response(
+                ExecutionPayloadV3.fromInternalExecutionPayload(executionPayload), blockValue)));
   }
 
-  private SafeFuture<Response<GetPayloadV2Response>> dummyFailedResponse(
+  private SafeFuture<Response<GetPayloadV3Response>> dummyFailedResponse(
       final String errorMessage) {
     return SafeFuture.completedFuture(Response.withErrorMessage(errorMessage));
   }

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/BellatrixExecutionClientHandler.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/BellatrixExecutionClientHandler.java
@@ -69,7 +69,6 @@ class BellatrixExecutionClientHandler implements ExecutionClientHandler {
   public SafeFuture<ForkChoiceUpdatedResult> engineForkChoiceUpdated(
       final ForkChoiceState forkChoiceState,
       final Optional<PayloadBuildingAttributes> payloadBuildingAttributes) {
-
     final JsonRpcRequestParams params =
         new JsonRpcRequestParams.Builder()
             .add(forkChoiceState)
@@ -83,7 +82,8 @@ class BellatrixExecutionClientHandler implements ExecutionClientHandler {
   public SafeFuture<ExecutionPayloadWithValue> engineGetPayload(
       final ExecutionPayloadContext executionPayloadContext, final UInt64 slot) {
     final JsonRpcRequestParams params =
-        new JsonRpcRequestParams.Builder().add(executionPayloadContext).add(UInt64.ZERO).build();
+        new JsonRpcRequestParams.Builder().add(executionPayloadContext).add(slot).build();
+
     return new EngineGetPayloadV1(executionEngineClient, spec).execute(params);
   }
 
@@ -91,6 +91,7 @@ class BellatrixExecutionClientHandler implements ExecutionClientHandler {
   public SafeFuture<PayloadStatus> engineNewPayload(final ExecutionPayload executionPayload) {
     final JsonRpcRequestParams params =
         new JsonRpcRequestParams.Builder().add(executionPayload).build();
+
     return new EngineNewPayloadV1(executionEngineClient).execute(params);
   }
 

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/CapellaExecutionClientHandler.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/CapellaExecutionClientHandler.java
@@ -14,29 +14,24 @@
 package tech.pegasys.teku.ethereum.executionlayer;
 
 import java.util.Optional;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.ethereum.executionclient.ExecutionEngineClient;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineForkChoiceUpdatedV2;
+import tech.pegasys.teku.ethereum.executionclient.methods.EngineGetPayloadV2;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineNewPayloadV2;
 import tech.pegasys.teku.ethereum.executionclient.methods.JsonRpcRequestParams;
-import tech.pegasys.teku.ethereum.executionclient.response.ResponseUnwrapper;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
-import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSchema;
 import tech.pegasys.teku.spec.executionlayer.ExecutionPayloadWithValue;
 import tech.pegasys.teku.spec.executionlayer.ForkChoiceState;
 import tech.pegasys.teku.spec.executionlayer.ForkChoiceUpdatedResult;
 import tech.pegasys.teku.spec.executionlayer.PayloadBuildingAttributes;
 import tech.pegasys.teku.spec.executionlayer.PayloadStatus;
-import tech.pegasys.teku.spec.schemas.SchemaDefinitionsBellatrix;
 
 public class CapellaExecutionClientHandler extends BellatrixExecutionClientHandler
     implements ExecutionClientHandler {
-  private static final Logger LOG = LogManager.getLogger();
 
   public CapellaExecutionClientHandler(
       final Spec spec, final ExecutionEngineClient executionEngineClient) {
@@ -46,29 +41,10 @@ public class CapellaExecutionClientHandler extends BellatrixExecutionClientHandl
   @Override
   public SafeFuture<ExecutionPayloadWithValue> engineGetPayload(
       final ExecutionPayloadContext executionPayloadContext, final UInt64 slot) {
-    LOG.trace(
-        "calling engineGetPayloadV2(payloadId={}, slot={})",
-        executionPayloadContext.getPayloadId(),
-        slot);
-    return executionEngineClient
-        .getPayloadV2(executionPayloadContext.getPayloadId())
-        .thenApply(ResponseUnwrapper::unwrapExecutionClientResponseOrThrow)
-        .thenApply(
-            response -> {
-              final ExecutionPayloadSchema<?> payloadSchema =
-                  SchemaDefinitionsBellatrix.required(spec.atSlot(slot).getSchemaDefinitions())
-                      .getExecutionPayloadSchema();
-              return new ExecutionPayloadWithValue(
-                  response.executionPayload.asInternalExecutionPayload(payloadSchema),
-                  response.blockValue);
-            })
-        .thenPeek(
-            payloadAndValue ->
-                LOG.trace(
-                    "engineGetPayloadV2(payloadId={}, slot={}) -> {}",
-                    executionPayloadContext.getPayloadId(),
-                    slot,
-                    payloadAndValue));
+    final JsonRpcRequestParams params =
+        new JsonRpcRequestParams.Builder().add(executionPayloadContext).add(slot).build();
+
+    return new EngineGetPayloadV2(executionEngineClient, spec).execute(params);
   }
 
   @Override


### PR DESCRIPTION
## PR Description
- Implemented `EngineGetPayloadV1`, `EngineGetPayloadV2` and `EngineGetPayloadV3`
- Updated both Bellatrix, Capella and Deneb execution client handlers to use the new method-objects

## Fixed Issue(s)
related to #6784 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
