### PR TITLE
Implement clarification of MAX_REQUEST_BLOB_SIDECARS

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/Constants.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/Constants.java
@@ -28,11 +28,10 @@ public class Constants {
   public static final UInt64 ATTESTATION_PROPAGATION_SLOT_RANGE = UInt64.valueOf(32);
   public static final int MAXIMUM_GOSSIP_CLOCK_DISPARITY = 500; // in ms
 
-  // Deneb Blobs
+  // Deneb
   public static final UInt64 MAX_REQUEST_BLOBS_SIDECARS = UInt64.valueOf(128);
   public static final UInt64 MAX_REQUEST_BLOCKS_DENEB = UInt64.valueOf(128);
-  public static final UInt64 MAX_REQUEST_BLOB_SIDECARS = UInt64.valueOf(128);
-
+  // ~18 days
   public static final int MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUESTS = 4096;
   public static final int MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS = 4096;
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/networking/libp2p/rpc/BlobSidecarsByRangeRequestMessage.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/networking/libp2p/rpc/BlobSidecarsByRangeRequestMessage.java
@@ -40,8 +40,8 @@ public class BlobSidecarsByRangeRequestMessage
     }
   }
 
-  public static final BlobSidecarsByRangeRequestMessage.BlobSidecarsByRangeRequestMessageSchema
-      SSZ_SCHEMA = new BlobSidecarsByRangeRequestMessage.BlobSidecarsByRangeRequestMessageSchema();
+  public static final BlobSidecarsByRangeRequestMessageSchema SSZ_SCHEMA =
+      new BlobSidecarsByRangeRequestMessageSchema();
 
   private BlobSidecarsByRangeRequestMessage(
       final BlobSidecarsByRangeRequestMessage.BlobSidecarsByRangeRequestMessageSchema type,

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/networking/libp2p/rpc/BlobSidecarsByRootRequestMessage.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/networking/libp2p/rpc/BlobSidecarsByRootRequestMessage.java
@@ -13,7 +13,7 @@
 
 package tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc;
 
-import static tech.pegasys.teku.spec.config.Constants.MAX_REQUEST_BLOB_SIDECARS;
+import static tech.pegasys.teku.spec.config.Constants.MAX_REQUEST_BLOCKS_DENEB;
 
 import java.util.List;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
@@ -25,9 +25,9 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 public class BlobSidecarsByRootRequestMessage extends SszListImpl<BlobIdentifier>
     implements SszList<BlobIdentifier>, RpcRequest {
 
-  // size validation according to the spec (MAX_REQUEST_BLOB_SIDECARS * MAX_BLOBS_PER_BLOCK) is done
+  // size validation according to the spec (MAX_REQUEST_BLOCKS_DENEB * MAX_BLOBS_PER_BLOCK) is done
   // in the RPC handler
-  public static final UInt64 MAX_LENGTH = MAX_REQUEST_BLOB_SIDECARS.times(128);
+  public static final UInt64 MAX_LENGTH = MAX_REQUEST_BLOCKS_DENEB.times(128);
 
   public static class BlobSidecarsByRootRequestMessageSchema
       extends AbstractSszListSchema<BlobIdentifier, BlobSidecarsByRootRequestMessage> {

--- a/infrastructure/kzg/src/main/java/tech/pegasys/teku/kzg/KZG.java
+++ b/infrastructure/kzg/src/main/java/tech/pegasys/teku/kzg/KZG.java
@@ -28,7 +28,7 @@ public interface KZG {
         public void loadTrustedSetup(final String trustedSetup) throws KZGException {}
 
         @Override
-        public void loadTrustedSetup(TrustedSetup trustedSetup) throws KZGException {}
+        public void loadTrustedSetup(final TrustedSetup trustedSetup) throws KZGException {}
 
         @Override
         public void freeTrustedSetup() throws KZGException {}

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/BeaconChainMethods.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/BeaconChainMethods.java
@@ -127,7 +127,7 @@ public class BeaconChainMethods {
         new ArrayList<>(
             List.of(status, goodBye, beaconBlocksByRoot, beaconBlocksByRange, getMetadata, ping));
     blobSidecarsByRoot.ifPresent(allMethods::add);
-    beaconBlockAndBlobsSidecarByRoot().ifPresent(allMethods::add);
+    beaconBlockAndBlobsSidecarByRoot.ifPresent(allMethods::add);
     blobsSidecarsByRange.ifPresent(allMethods::add);
     blobSidecarsByRange.ifPresent(allMethods::add);
   }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/BeaconChainMethods.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/BeaconChainMethods.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.networking.eth2.rpc.beaconchain;
 
 import static tech.pegasys.teku.spec.config.Constants.MAX_BLOCK_BY_RANGE_REQUEST_SIZE;
 import static tech.pegasys.teku.spec.config.Constants.MAX_REQUEST_BLOBS_SIDECARS;
-import static tech.pegasys.teku.spec.config.Constants.MAX_REQUEST_BLOCKS_DENEB;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -49,7 +48,6 @@ import tech.pegasys.teku.networking.eth2.rpc.core.methods.VersionedEth2RpcMethod
 import tech.pegasys.teku.networking.p2p.rpc.RpcMethod;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.config.SpecConfigDeneb;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.deneb.SignedBeaconBlockAndBlobsSidecar;
 import tech.pegasys.teku.spec.datastructures.execution.versions.deneb.BlobSidecar;
@@ -431,18 +429,9 @@ public class BeaconChainMethods {
     final RpcContextCodec<Bytes4, BlobSidecar> forkDigestContextCodec =
         RpcContextCodec.forkDigest(spec, recentChainData, ForkDigestPayloadContext.BLOB_SIDECAR);
 
-    final int maxBlobsPerBlock =
-        SpecConfigDeneb.required(spec.forMilestone(SpecMilestone.DENEB).getConfig())
-            .getMaxBlobsPerBlock();
-
     final BlobSidecarsByRangeMessageHandler blobSidecarsByRangeHandler =
         new BlobSidecarsByRangeMessageHandler(
-            spec,
-            getDenebForkEpoch(spec),
-            metricsSystem,
-            combinedChainDataClient,
-            MAX_REQUEST_BLOCKS_DENEB.times(maxBlobsPerBlock),
-            UInt64.valueOf(maxBlobsPerBlock));
+            spec, getDenebForkEpoch(spec), metricsSystem, combinedChainDataClient);
 
     return Optional.of(
         new SingleProtocolEth2RpcMethod<>(

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/BeaconChainMethods.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/BeaconChainMethods.java
@@ -15,7 +15,7 @@ package tech.pegasys.teku.networking.eth2.rpc.beaconchain;
 
 import static tech.pegasys.teku.spec.config.Constants.MAX_BLOCK_BY_RANGE_REQUEST_SIZE;
 import static tech.pegasys.teku.spec.config.Constants.MAX_REQUEST_BLOBS_SIDECARS;
-import static tech.pegasys.teku.spec.config.Constants.MAX_REQUEST_BLOB_SIDECARS;
+import static tech.pegasys.teku.spec.config.Constants.MAX_REQUEST_BLOCKS_DENEB;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -441,7 +441,7 @@ public class BeaconChainMethods {
             getDenebForkEpoch(spec),
             metricsSystem,
             combinedChainDataClient,
-            MAX_REQUEST_BLOB_SIDECARS.times(maxBlobsPerBlock),
+            MAX_REQUEST_BLOCKS_DENEB.times(maxBlobsPerBlock),
             UInt64.valueOf(maxBlobsPerBlock));
 
     return Optional.of(

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandler.java
@@ -14,7 +14,7 @@
 package tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods;
 
 import static tech.pegasys.teku.networking.eth2.rpc.core.RpcResponseStatus.INVALID_REQUEST_CODE;
-import static tech.pegasys.teku.spec.config.Constants.MAX_REQUEST_BLOB_SIDECARS;
+import static tech.pegasys.teku.spec.config.Constants.MAX_REQUEST_BLOCKS_DENEB;
 import static tech.pegasys.teku.spec.config.Constants.MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUESTS;
 
 import com.google.common.base.Throwables;
@@ -84,15 +84,16 @@ public class BlobSidecarsByRootMessageHandler
   @Override
   public Optional<RpcException> validateRequest(
       final String protocolId, final BlobSidecarsByRootRequestMessage request) {
-    final int maxRequestSize = calculateMaxRequestSize();
-    if (request.size() > maxRequestSize) {
+    // MAX_REQUEST_BLOCKS_DENEB * MAX_BLOBS_PER_BLOCK
+    final int maxRequestBlobSidecars = calculateMaxRequestBlobSidecars();
+    if (request.size() > maxRequestBlobSidecars) {
       requestCounter.labels("count_too_big").inc();
       return Optional.of(
           new RpcException(
               INVALID_REQUEST_CODE,
               String.format(
                   "Only a maximum of %d blob sidecars can be requested per request",
-                  maxRequestSize)));
+                  maxRequestBlobSidecars)));
     }
     return Optional.empty();
   }
@@ -143,12 +144,11 @@ public class BlobSidecarsByRootMessageHandler
     future.finish(callback::completeSuccessfully, err -> handleError(callback, err));
   }
 
-  // MAX_REQUEST_BLOB_SIDECARS * MAX_BLOBS_PER_BLOCK
-  private int calculateMaxRequestSize() {
+  private int calculateMaxRequestBlobSidecars() {
     final UInt64 currentEpoch = combinedChainDataClient.getCurrentEpoch();
     final int maxBlobsPerBlock =
         SpecConfigDeneb.required(spec.atEpoch(currentEpoch).getConfig()).getMaxBlobsPerBlock();
-    return MAX_REQUEST_BLOB_SIDECARS.times(maxBlobsPerBlock).intValue();
+    return MAX_REQUEST_BLOCKS_DENEB.times(maxBlobsPerBlock).intValue();
   }
 
   private UInt64 getFinalizedEpoch() {

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandlerTest.java
@@ -26,7 +26,7 @@ import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.networking.eth2.rpc.core.RpcResponseStatus.INVALID_REQUEST_CODE;
 import static tech.pegasys.teku.networking.eth2.rpc.core.RpcResponseStatus.RESOURCE_UNAVAILABLE;
 import static tech.pegasys.teku.spec.config.Constants.MAX_CHUNK_SIZE_BELLATRIX;
-import static tech.pegasys.teku.spec.config.Constants.MAX_REQUEST_BLOB_SIDECARS;
+import static tech.pegasys.teku.spec.config.Constants.MAX_REQUEST_BLOCKS_DENEB;
 import static tech.pegasys.teku.spec.config.Constants.SYNC_BLOB_SIDECARS_SIZE;
 
 import java.util.List;
@@ -119,7 +119,7 @@ public class BlobSidecarsByRootMessageHandlerTest {
   @Test
   public void validateRequest_shouldNotAllowRequestLargerThanMaximumAllowed() {
     final int maxRequestSize =
-        MAX_REQUEST_BLOB_SIDECARS
+        MAX_REQUEST_BLOCKS_DENEB
             .times(
                 SpecConfigDeneb.required(spec.atEpoch(denebForkEpoch).getConfig())
                     .getMaxBlobsPerBlock())
@@ -285,7 +285,7 @@ public class BlobSidecarsByRootMessageHandlerTest {
           final int maxBlobsPerBlock =
               SpecConfigDeneb.required(spec.forMilestone(milestone).getConfig())
                   .getMaxBlobsPerBlock();
-          final UInt64 maxRequestSize = MAX_REQUEST_BLOB_SIDECARS.times(maxBlobsPerBlock);
+          final UInt64 maxRequestSize = MAX_REQUEST_BLOCKS_DENEB.times(maxBlobsPerBlock);
           assertThat(SYNC_BLOB_SIDECARS_SIZE.isLessThanOrEqualTo(maxRequestSize)).isTrue();
         });
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

- Implement https://github.com/ethereum/consensus-specs/pull/3269
- Add dynamic MAX_BLOBS_PER_BLOCK retrieval dependent on the startSlot in the `BlobSidecarsByRangeMessageHandler`

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
