### PR TITLE
Add MAX_REQUEST_BLOB_SIDECARS to SpecConfigDeneb

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigDeneb.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigDeneb.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.teku.spec.config;
 
+import static tech.pegasys.teku.spec.config.Constants.MAX_REQUEST_BLOCKS_DENEB;
+
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.infrastructure.bytes.Bytes4;
@@ -40,6 +42,10 @@ public interface SpecConfigDeneb extends SpecConfigCapella {
   int getFieldElementsPerBlob();
 
   int getMaxBlobsPerBlock();
+
+  default UInt64 getMaxRequestBlobSidecars() {
+    return MAX_REQUEST_BLOCKS_DENEB.times(getMaxBlobsPerBlock());
+  }
 
   Optional<String> getTrustedSetupPath();
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandler.java
@@ -13,7 +13,6 @@
 
 package tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods;
 
-import static tech.pegasys.teku.spec.config.Constants.MAX_REQUEST_BLOCKS_DENEB;
 import static tech.pegasys.teku.spec.config.Constants.MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -89,8 +88,10 @@ public class BlobSidecarsByRangeMessageHandler
         message.getCount(),
         startSlot);
 
-    final UInt64 maxBlobsPerBlock = getMaxBlobsPerBlock(startSlot);
-    final UInt64 maxRequestBlobSidecars = MAX_REQUEST_BLOCKS_DENEB.times(maxBlobsPerBlock);
+    final SpecConfigDeneb specConfig = SpecConfigDeneb.required(spec.atSlot(startSlot).getConfig());
+
+    final UInt64 maxBlobsPerBlock = UInt64.valueOf(specConfig.getMaxBlobsPerBlock());
+    final UInt64 maxRequestBlobSidecars = specConfig.getMaxRequestBlobSidecars();
 
     if (!peer.wantToMakeRequest()
         || !peer.wantToReceiveBlobSidecars(
@@ -140,13 +141,6 @@ public class BlobSidecarsByRangeMessageHandler
               callback.completeSuccessfully();
             },
             error -> handleProcessingRequestError(error, callback));
-  }
-
-  @VisibleForTesting
-  UInt64 getMaxBlobsPerBlock(final UInt64 slot) {
-    final int maxBlobsPerBlock =
-        SpecConfigDeneb.required(spec.atSlot(slot).getConfig()).getMaxBlobsPerBlock();
-    return UInt64.valueOf(maxBlobsPerBlock);
   }
 
   private boolean checkBlobSidecarsAreAvailable(

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandler.java
@@ -14,7 +14,6 @@
 package tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods;
 
 import static tech.pegasys.teku.networking.eth2.rpc.core.RpcResponseStatus.INVALID_REQUEST_CODE;
-import static tech.pegasys.teku.spec.config.Constants.MAX_REQUEST_BLOCKS_DENEB;
 import static tech.pegasys.teku.spec.config.Constants.MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUESTS;
 
 import com.google.common.base.Throwables;
@@ -84,15 +83,14 @@ public class BlobSidecarsByRootMessageHandler
   @Override
   public Optional<RpcException> validateRequest(
       final String protocolId, final BlobSidecarsByRootRequestMessage request) {
-    // MAX_REQUEST_BLOCKS_DENEB * MAX_BLOBS_PER_BLOCK
-    final int maxRequestBlobSidecars = calculateMaxRequestBlobSidecars();
-    if (request.size() > maxRequestBlobSidecars) {
+    final UInt64 maxRequestBlobSidecars = getMaxRequestBlobSidecars();
+    if (maxRequestBlobSidecars.isLessThan(request.size())) {
       requestCounter.labels("count_too_big").inc();
       return Optional.of(
           new RpcException(
               INVALID_REQUEST_CODE,
               String.format(
-                  "Only a maximum of %d blob sidecars can be requested per request",
+                  "Only a maximum of %s blob sidecars can be requested per request",
                   maxRequestBlobSidecars)));
     }
     return Optional.empty();
@@ -144,11 +142,10 @@ public class BlobSidecarsByRootMessageHandler
     future.finish(callback::completeSuccessfully, err -> handleError(callback, err));
   }
 
-  private int calculateMaxRequestBlobSidecars() {
+  private UInt64 getMaxRequestBlobSidecars() {
     final UInt64 currentEpoch = combinedChainDataClient.getCurrentEpoch();
-    final int maxBlobsPerBlock =
-        SpecConfigDeneb.required(spec.atEpoch(currentEpoch).getConfig()).getMaxBlobsPerBlock();
-    return MAX_REQUEST_BLOCKS_DENEB.times(maxBlobsPerBlock).intValue();
+    return SpecConfigDeneb.required(spec.atEpoch(currentEpoch).getConfig())
+        .getMaxRequestBlobSidecars();
   }
 
   private UInt64 getFinalizedEpoch() {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandler.java
@@ -84,7 +84,7 @@ public class BlobSidecarsByRootMessageHandler
   public Optional<RpcException> validateRequest(
       final String protocolId, final BlobSidecarsByRootRequestMessage request) {
     final UInt64 maxRequestBlobSidecars = getMaxRequestBlobSidecars();
-    if (maxRequestBlobSidecars.isLessThan(request.size())) {
+    if (request.size() > maxRequestBlobSidecars.intValue()) {
       requestCounter.labels("count_too_big").inc();
       return Optional.of(
           new RpcException(

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandlerTest.java
@@ -25,7 +25,6 @@ import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 import static tech.pegasys.teku.spec.config.Constants.MAX_CHUNK_SIZE;
-import static tech.pegasys.teku.spec.config.Constants.MAX_REQUEST_BLOCKS_DENEB;
 
 import java.util.List;
 import java.util.Optional;
@@ -46,6 +45,7 @@ import tech.pegasys.teku.networking.eth2.rpc.core.RpcException;
 import tech.pegasys.teku.networking.eth2.rpc.core.encodings.RpcEncoding;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.config.SpecConfigDeneb;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.execution.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BlobSidecarsByRangeRequestMessage;
@@ -62,6 +62,9 @@ public class BlobSidecarsByRangeMessageHandlerTest {
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
 
   private final UInt64 denebForkEpoch = UInt64.valueOf(1);
+
+  private final SpecConfigDeneb specConfig =
+      SpecConfigDeneb.required(spec.atEpoch(denebForkEpoch).getConfig());
 
   private final int slotsPerEpoch = spec.getSlotsPerEpoch(ZERO);
 
@@ -88,7 +91,7 @@ public class BlobSidecarsByRangeMessageHandlerTest {
       new BlobSidecarsByRangeMessageHandler(
           spec, denebForkEpoch, metricsSystem, combinedChainDataClient);
 
-  private final UInt64 maxBlobsPerBlock = handler.getMaxBlobsPerBlock(startSlot);
+  private final UInt64 maxBlobsPerBlock = UInt64.valueOf(specConfig.getMaxBlobsPerBlock());
 
   @BeforeEach
   public void setUp() {
@@ -227,7 +230,7 @@ public class BlobSidecarsByRangeMessageHandlerTest {
         .new RequestState(
             listener,
             maxBlobsPerBlock,
-            MAX_REQUEST_BLOCKS_DENEB.times(maxBlobsPerBlock),
+            specConfig.getMaxRequestBlobSidecars(),
             headBlockRoot,
             currentSlot,
             count);

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandlerTest.java
@@ -26,7 +26,6 @@ import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.networking.eth2.rpc.core.RpcResponseStatus.INVALID_REQUEST_CODE;
 import static tech.pegasys.teku.networking.eth2.rpc.core.RpcResponseStatus.RESOURCE_UNAVAILABLE;
 import static tech.pegasys.teku.spec.config.Constants.MAX_CHUNK_SIZE_BELLATRIX;
-import static tech.pegasys.teku.spec.config.Constants.MAX_REQUEST_BLOCKS_DENEB;
 import static tech.pegasys.teku.spec.config.Constants.SYNC_BLOB_SIDECARS_SIZE;
 
 import java.util.List;
@@ -119,7 +118,7 @@ public class BlobSidecarsByRootMessageHandlerTest {
   @Test
   public void validateRequest_shouldNotAllowRequestLargerThanMaximumAllowed() {
     final int maxRequestBlobSidecars =
-        calculateMaxRequestBlobSidecars(spec, SpecMilestone.DENEB).intValue();
+        getMaxRequestBlobSidecars(spec, SpecMilestone.DENEB).intValue();
     final BlobSidecarsByRootRequestMessage request =
         new BlobSidecarsByRootRequestMessage(
             dataStructureUtil.randomBlobIdentifiers(maxRequestBlobSidecars + 1));
@@ -278,13 +277,13 @@ public class BlobSidecarsByRootMessageHandlerTest {
     shardingMilestones.forEach(
         milestone -> {
           final Spec spec = TestSpecFactory.createMainnet(milestone);
-          final UInt64 maxRequestBlobSidecars = calculateMaxRequestBlobSidecars(spec, milestone);
+          final UInt64 maxRequestBlobSidecars = getMaxRequestBlobSidecars(spec, milestone);
           assertThat(SYNC_BLOB_SIDECARS_SIZE.isLessThanOrEqualTo(maxRequestBlobSidecars)).isTrue();
         });
   }
 
-  private UInt64 calculateMaxRequestBlobSidecars(final Spec spec, final SpecMilestone milestone) {
-    return MAX_REQUEST_BLOCKS_DENEB.times(
-        SpecConfigDeneb.required(spec.forMilestone(milestone).getConfig()).getMaxBlobsPerBlock());
+  private UInt64 getMaxRequestBlobSidecars(final Spec spec, final SpecMilestone milestone) {
+    return SpecConfigDeneb.required(spec.forMilestone(milestone).getConfig())
+        .getMaxRequestBlobSidecars();
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
I think this way is cleaner. Also follows a pattern used in SpecConfig (`getMinEpochsForBlocksRequests`). It allows to be overriden in the future for next milestone without having to change the logic in other places.

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
