### PR TITLE
Improvements when using VC with failovers

### DIFF
--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/ValidatorLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/ValidatorLogger.java
@@ -81,25 +81,20 @@ public class ValidatorLogger {
             Color.YELLOW));
   }
 
-  public void primaryBeaconNodeNotReady(final boolean failoversConfigured) {
+  public void primaryBeaconNodeNotReady() {
     log.warn(
         ColorConsolePrinter.print(
             String.format(
-                "%sThe%s beacon node is not ready to accept requests (offline or not in sync). %s",
-                PREFIX,
-                failoversConfigured ? " primary" : "",
-                failoversConfigured
-                    ? "Future requests will use one of the configured failover beacon nodes until the primary one is ready again."
-                    : "Future requests to it are likely to fail."),
+                "%sThe primary beacon node is NOT ready to accept requests (offline or not in sync). Future requests will use one of the configured failover beacon nodes until the primary one is ready again.",
+                PREFIX),
             Color.YELLOW));
   }
 
-  public void primaryBeaconNodeIsBackAndReady(final boolean failoversConfigured) {
+  public void primaryBeaconNodeIsBackAndReady() {
     log.info(
         ColorConsolePrinter.print(
             String.format(
-                "%sThe%s beacon node is back in sync and ready to accept requests now",
-                PREFIX, failoversConfigured ? " primary" : ""),
+                "%sThe primary beacon node is back and ready to accept requests now", PREFIX),
             Color.GREEN));
   }
 

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/required/SyncingStatus.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/required/SyncingStatus.java
@@ -60,11 +60,11 @@ public class SyncingStatus {
   }
 
   public boolean isReady() {
-    if (elOffline.isPresent() && elOffline.get()) {
+    if (elOffline.orElse(false)) {
       return false;
     }
     if (isSyncing) {
-      return isOptimistic.isPresent() && isOptimistic.get();
+      return isOptimistic.orElse(false);
     }
     return true;
   }

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessChannel.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessChannel.java
@@ -16,8 +16,8 @@ package tech.pegasys.teku.validator.remote;
 import tech.pegasys.teku.infrastructure.events.VoidReturningChannelInterface;
 
 /**
- * Readiness is determined by {@link BeaconNodeReadinessManager }. The callbacks are only triggered
- * if failovers are configured.
+ * Readiness is determined by the {@link BeaconNodeReadinessManager}. The callbacks are only
+ * triggered if failovers are configured.
  */
 public interface BeaconNodeReadinessChannel extends VoidReturningChannelInterface {
 

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessChannel.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessChannel.java
@@ -15,7 +15,10 @@ package tech.pegasys.teku.validator.remote;
 
 import tech.pegasys.teku.infrastructure.events.VoidReturningChannelInterface;
 
-/** Readiness is determined by {@link BeaconNodeReadinessManager } */
+/**
+ * Readiness is determined by {@link BeaconNodeReadinessManager }. The callbacks are only triggered
+ * if failovers are configured.
+ */
 public interface BeaconNodeReadinessChannel extends VoidReturningChannelInterface {
 
   void onPrimaryNodeNotReady();

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessChannel.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessChannel.java
@@ -15,11 +15,12 @@ package tech.pegasys.teku.validator.remote;
 
 import tech.pegasys.teku.infrastructure.events.VoidReturningChannelInterface;
 
-public interface RemoteBeaconNodeSyncingChannel extends VoidReturningChannelInterface {
+/** Readiness is determined by {@link BeaconNodeReadinessManager } */
+public interface BeaconNodeReadinessChannel extends VoidReturningChannelInterface {
 
-  void onPrimaryNodeNotInSync();
+  void onPrimaryNodeNotReady();
 
-  void onFailoverNodeNotInSync(RemoteValidatorApiChannel failoverNotInSync);
+  void onFailoverNodeNotReady(RemoteValidatorApiChannel failoverNotReady);
 
-  void onPrimaryNodeBackInSync();
+  void onPrimaryNodeBackReady();
 }

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessManager.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessManager.java
@@ -41,17 +41,17 @@ public class BeaconNodeReadinessManager implements ValidatorTimingChannel {
   private final RemoteValidatorApiChannel primaryBeaconNodeApi;
   private final List<RemoteValidatorApiChannel> failoverBeaconNodeApis;
   private final ValidatorLogger validatorLogger;
-  private final RemoteBeaconNodeSyncingChannel remoteBeaconNodeSyncingChannel;
+  private final BeaconNodeReadinessChannel beaconNodeReadinessChannel;
 
   public BeaconNodeReadinessManager(
       final RemoteValidatorApiChannel primaryBeaconNodeApi,
       final List<RemoteValidatorApiChannel> failoverBeaconNodeApis,
       final ValidatorLogger validatorLogger,
-      final RemoteBeaconNodeSyncingChannel remoteBeaconNodeSyncingChannel) {
+      final BeaconNodeReadinessChannel beaconNodeReadinessChannel) {
     this.primaryBeaconNodeApi = primaryBeaconNodeApi;
     this.failoverBeaconNodeApis = failoverBeaconNodeApis;
     this.validatorLogger = validatorLogger;
-    this.remoteBeaconNodeSyncingChannel = remoteBeaconNodeSyncingChannel;
+    this.beaconNodeReadinessChannel = beaconNodeReadinessChannel;
   }
 
   public boolean isReady(final RemoteValidatorApiChannel beaconNodeApi) {
@@ -88,6 +88,10 @@ public class BeaconNodeReadinessManager implements ValidatorTimingChannel {
 
   @Override
   public void onAttestationAggregationDue(final UInt64 slot) {
+    // no readiness check needed when no failovers are configured
+    if (failoverBeaconNodeApis.isEmpty()) {
+      return;
+    }
     final SafeFuture<Void> primaryReadinessCheck = performPrimaryReadinessCheck();
     final Stream<SafeFuture<?>> failoverReadinessChecks =
         failoverBeaconNodeApis.stream().map(this::performFailoverReadinessCheck);
@@ -115,21 +119,20 @@ public class BeaconNodeReadinessManager implements ValidatorTimingChannel {
         .thenApply(
             syncingStatus -> {
               if (syncingStatus.isReady()) {
-                LOG.debug("{} is in sync and ready to accept requests", beaconNodeApiEndpoint);
+                LOG.debug(
+                    "{} is ready to accept requests: {}", beaconNodeApiEndpoint, syncingStatus);
                 return true;
               }
               LOG.debug(
-                  "{} is not ready to accept requests because it is not in sync",
-                  beaconNodeApiEndpoint);
+                  "{} is NOT ready to accept requests: {}", beaconNodeApiEndpoint, syncingStatus);
               return false;
             })
         .exceptionally(
             throwable -> {
               LOG.debug(
                   String.format(
-                      "%s is not ready to accept requests because the syncing status request failed",
-                      beaconNodeApiEndpoint),
-                  throwable);
+                      "%s is NOT ready to accept requests because the syncing status request failed: %s",
+                      beaconNodeApiEndpoint, throwable.getMessage()));
               return false;
             })
         .thenAccept(
@@ -148,8 +151,8 @@ public class BeaconNodeReadinessManager implements ValidatorTimingChannel {
       return;
     }
     if (latestPrimaryNodeReadiness.compareAndSet(false, true)) {
-      validatorLogger.primaryBeaconNodeIsBackAndReady(failoversConfigured());
-      remoteBeaconNodeSyncingChannel.onPrimaryNodeBackInSync();
+      validatorLogger.primaryBeaconNodeIsBackAndReady();
+      beaconNodeReadinessChannel.onPrimaryNodeBackReady();
     }
   }
 
@@ -157,15 +160,11 @@ public class BeaconNodeReadinessManager implements ValidatorTimingChannel {
       final RemoteValidatorApiChannel beaconNodeApi, final boolean isPrimaryNode) {
     if (isPrimaryNode) {
       if (latestPrimaryNodeReadiness.compareAndSet(true, false)) {
-        validatorLogger.primaryBeaconNodeNotReady(failoversConfigured());
+        validatorLogger.primaryBeaconNodeNotReady();
       }
-      remoteBeaconNodeSyncingChannel.onPrimaryNodeNotInSync();
+      beaconNodeReadinessChannel.onPrimaryNodeNotReady();
     } else {
-      remoteBeaconNodeSyncingChannel.onFailoverNodeNotInSync(beaconNodeApi);
+      beaconNodeReadinessChannel.onFailoverNodeNotReady(beaconNodeApi);
     }
-  }
-
-  private boolean failoversConfigured() {
-    return !failoverBeaconNodeApis.isEmpty();
   }
 }

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessManager.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessManager.java
@@ -141,7 +141,7 @@ public class BeaconNodeReadinessManager implements ValidatorTimingChannel {
               LOG.debug(
                   String.format(
                       "%s is NOT ready to accept requests because the syncing status request failed: %s",
-                      beaconNodeApiEndpoint, throwable.getMessage()));
+                      beaconNodeApiEndpoint, throwable));
               return false;
             })
         .thenAccept(

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandler.java
@@ -30,7 +30,6 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.plugin.services.metrics.Counter;
 import org.hyperledger.besu.plugin.services.metrics.LabelledMetric;
-import tech.pegasys.teku.api.exceptions.RemoteServiceNotAvailableException;
 import tech.pegasys.teku.api.migrated.ValidatorLivenessAtEpoch;
 import tech.pegasys.teku.api.response.v1.beacon.ValidatorStatus;
 import tech.pegasys.teku.bls.BLSPublicKey;
@@ -299,9 +298,9 @@ public class FailoverValidatorApiHandler implements ValidatorApiChannel {
   /**
    * Relays the given request to the primary Beacon Node along with all failover Beacon Node
    * endpoints if relayRequestToFailovers flag is true. If there are failovers configured, the
-   * request to the primary Beacon Node will fail immediately if the {@link
-   * BeaconNodeReadinessManager} marked it as not ready.The returned {@link SafeFuture} will
-   * complete with the response from the primary Beacon Node or in case in failure, it will complete
+   * request to the primary Beacon Node will be skipped if the {@link BeaconNodeReadinessManager}
+   * marked it as NOT ready.The returned {@link SafeFuture} will complete with the response from the
+   * primary Beacon Node or in case in failure or if the primary node is NOT ready, it will complete
    * with the first successful response from a failover node. The returned {@link SafeFuture} will
    * only complete exceptionally when the request to the primary Beacon Node and all the requests to
    * the failover nodes fail. In this case, the returned {@link SafeFuture} will complete
@@ -312,38 +311,53 @@ public class FailoverValidatorApiHandler implements ValidatorApiChannel {
       final String method,
       final boolean relayRequestToFailovers) {
     if (failoverDelegates.isEmpty() || !relayRequestToFailovers) {
-      return runPrimaryRequestWithNoFailovers(request, method);
+      return runPrimaryRequest(request, method);
     }
-    final SafeFuture<T> primaryResponse = runPrimaryRequestWithConfiguredFailovers(request, method);
     final Map<RemoteValidatorApiChannel, Throwable> capturedExceptions = new ConcurrentHashMap<>();
-    final List<SafeFuture<T>> failoversResponses =
+    final List<SafeFuture<T>> failoverResponses =
         failoverDelegates.stream()
             .map(
                 failover ->
-                    runFailoverRequest(failover, request, method)
+                    runRequest(failover, request, method)
                         .catchAndRethrow(throwable -> capturedExceptions.put(failover, throwable)))
             .collect(Collectors.toList());
-    return primaryResponse.exceptionallyCompose(
-        primaryThrowable -> {
-          capturedExceptions.put(primaryDelegate, primaryThrowable);
-          LOG.debug(
-              "Remote request ({}) which is sent to all configured Beacon Node endpoints failed on the primary Beacon Node {}. Will try to use a response from a failover.",
-              method,
-              primaryDelegate.getEndpoint());
-          return SafeFuture.firstSuccess(failoversResponses)
-              .exceptionallyCompose(
-                  __ -> {
-                    final FailoverRequestException failoverRequestException =
-                        new FailoverRequestException(method, capturedExceptions);
-                    return SafeFuture.failedFuture(failoverRequestException);
-                  });
-        });
+    if (!beaconNodeReadinessManager.isReady(primaryDelegate)) {
+      LOG.debug(
+          "Remote request ({}) will NOT be sent to the primary Beacon Node {} because it is NOT ready. Will try to use a response from a failover.",
+          method,
+          primaryDelegate.getEndpoint());
+      return getFirstSuccessfulResponseFromFailovers(failoverResponses, method, capturedExceptions);
+    }
+    return runPrimaryRequest(request, method)
+        .exceptionallyCompose(
+            primaryThrowable -> {
+              capturedExceptions.put(primaryDelegate, primaryThrowable);
+              LOG.debug(
+                  "Remote request ({}) which is sent to all configured Beacon Node endpoints failed on the primary Beacon Node {}. Will try to use a response from a failover.",
+                  method,
+                  primaryDelegate.getEndpoint());
+              return getFirstSuccessfulResponseFromFailovers(
+                  failoverResponses, method, capturedExceptions);
+            });
+  }
+
+  private <T> SafeFuture<T> getFirstSuccessfulResponseFromFailovers(
+      final List<SafeFuture<T>> failoverResponses,
+      final String method,
+      final Map<RemoteValidatorApiChannel, Throwable> capturedExceptions) {
+    return SafeFuture.firstSuccess(failoverResponses)
+        .exceptionallyCompose(
+            __ -> {
+              final FailoverRequestException failoverRequestException =
+                  new FailoverRequestException(method, capturedExceptions);
+              return SafeFuture.failedFuture(failoverRequestException);
+            });
   }
 
   /**
    * Tries the given request first with the primary Beacon Node. If there are failovers configured,
-   * the request to the primary Beacon Node will fail immediately if the {@link
-   * BeaconNodeReadinessManager} marked it as not ready. If the request to the primary Beacon Node
+   * the request to the primary Beacon Node will be skipped if the {@link
+   * BeaconNodeReadinessManager} marked it as NOT ready. If the request to the primary Beacon Node
    * fails, the request will be retried against each failover Beacon Node in order of readiness
    * determined by the {@link BeaconNodeReadinessManager} until there is a successful response. In
    * case all the requests fail, the returned {@link SafeFuture} will complete exceptionally with a
@@ -352,88 +366,91 @@ public class FailoverValidatorApiHandler implements ValidatorApiChannel {
   private <T> SafeFuture<T> tryRequestUntilSuccess(
       final ValidatorApiChannelRequest<T> request, final String method) {
     if (failoverDelegates.isEmpty()) {
-      return runPrimaryRequestWithNoFailovers(request, method);
+      return runPrimaryRequest(request, method);
     }
-    return runPrimaryRequestWithConfiguredFailovers(request, method)
+    if (!beaconNodeReadinessManager.isReady(primaryDelegate)) {
+      LOG.debug(
+          "Remote request ({}) will NOT be sent to the primary Beacon Node {} because it is NOT ready. Will try sending the request to one of the configured failovers.",
+          method,
+          primaryDelegate.getEndpoint());
+      return makeRequestToFailoversUntilSuccess(request, method, new HashMap<>());
+    }
+    return runPrimaryRequest(request, method)
         .exceptionallyCompose(
             throwable -> {
+              LOG.debug(
+                  "Remote request ({}) to the primary Beacon Node {} failed. Will try sending the request to one of the configured failovers.",
+                  method,
+                  primaryDelegate.getEndpoint());
               final Map<RemoteValidatorApiChannel, Throwable> capturedExceptions = new HashMap<>();
               capturedExceptions.put(primaryDelegate, throwable);
-              final Iterator<RemoteValidatorApiChannel> failoverDelegates =
-                  beaconNodeReadinessManager.getFailoversInOrderOfReadiness();
-              return makeFailoverRequestUntilSuccess(
-                  failoverDelegates.next(), failoverDelegates, request, method, capturedExceptions);
+              return makeRequestToFailoversUntilSuccess(request, method, capturedExceptions);
             });
   }
 
-  private <T> SafeFuture<T> makeFailoverRequestUntilSuccess(
+  private <T> SafeFuture<T> makeRequestToFailoversUntilSuccess(
+      final ValidatorApiChannelRequest<T> request,
+      final String method,
+      final Map<RemoteValidatorApiChannel, Throwable> capturedExceptions) {
+    final Iterator<RemoteValidatorApiChannel> failoverDelegates =
+        beaconNodeReadinessManager.getFailoversInOrderOfReadiness();
+    return makeRequestToFailoversUntilSuccess(
+        failoverDelegates.next(), failoverDelegates, request, method, capturedExceptions);
+  }
+
+  private <T> SafeFuture<T> makeRequestToFailoversUntilSuccess(
       final RemoteValidatorApiChannel currentFailoverDelegate,
       final Iterator<RemoteValidatorApiChannel> failoverDelegates,
       final ValidatorApiChannelRequest<T> request,
       final String method,
       final Map<RemoteValidatorApiChannel, Throwable> capturedExceptions) {
-    final SafeFuture<T> response = runFailoverRequest(currentFailoverDelegate, request, method);
-    return response.exceptionallyCompose(
-        throwable -> {
-          capturedExceptions.put(currentFailoverDelegate, throwable);
-          if (!failoverDelegates.hasNext()) {
-            final FailoverRequestException failoverRequestException =
-                new FailoverRequestException(method, capturedExceptions);
-            return SafeFuture.failedFuture(failoverRequestException);
-          }
-          final RemoteValidatorApiChannel nextFailoverDelegate = failoverDelegates.next();
-          LOG.debug(
-              "Remote request ({}) to a failover Beacon Node {} failed. Will try sending request to another failover {}",
-              method,
-              currentFailoverDelegate.getEndpoint(),
-              nextFailoverDelegate.getEndpoint());
-          return makeFailoverRequestUntilSuccess(
-              nextFailoverDelegate, failoverDelegates, request, method, capturedExceptions);
-        });
+    final SafeFuture<T> response = runRequest(currentFailoverDelegate, request, method);
+    return response
+        .exceptionallyCompose(
+            throwable -> {
+              capturedExceptions.put(currentFailoverDelegate, throwable);
+              if (!failoverDelegates.hasNext()) {
+                final FailoverRequestException failoverRequestException =
+                    new FailoverRequestException(method, capturedExceptions);
+                return SafeFuture.failedFuture(failoverRequestException);
+              }
+              final RemoteValidatorApiChannel nextFailoverDelegate = failoverDelegates.next();
+              LOG.debug(
+                  "Remote request ({}) to a failover Beacon Node {} failed. Will try sending the request to another failover {}",
+                  method,
+                  currentFailoverDelegate.getEndpoint(),
+                  nextFailoverDelegate.getEndpoint());
+              return makeRequestToFailoversUntilSuccess(
+                  nextFailoverDelegate, failoverDelegates, request, method, capturedExceptions);
+            })
+        .thenPeek(
+            __ ->
+                LOG.debug(
+                    "Remote request ({}) succeeded using a failover Beacon Node {}",
+                    method,
+                    currentFailoverDelegate.getEndpoint()));
   }
 
-  private <T> SafeFuture<T> runPrimaryRequestWithNoFailovers(
+  private <T> SafeFuture<T> runPrimaryRequest(
       final ValidatorApiChannelRequest<T> request, final String method) {
-    return runRequest(primaryDelegate, request, false, method);
-  }
-
-  private <T> SafeFuture<T> runPrimaryRequestWithConfiguredFailovers(
-      final ValidatorApiChannelRequest<T> request, final String method) {
-    return runRequest(primaryDelegate, request, true, method);
-  }
-
-  private <T> SafeFuture<T> runFailoverRequest(
-      final RemoteValidatorApiChannel failoverDelegate,
-      final ValidatorApiChannelRequest<T> request,
-      final String method) {
-    return runRequest(failoverDelegate, request, false, method);
+    return runRequest(primaryDelegate, request, method);
   }
 
   private <T> SafeFuture<T> runRequest(
       final RemoteValidatorApiChannel delegate,
       final ValidatorApiChannelRequest<T> request,
-      final boolean failIfNotReady,
       final String method) {
-    final SafeFuture<T> futureResponse;
-    if (!failIfNotReady || beaconNodeReadinessManager.isReady(delegate)) {
-      futureResponse = request.run(delegate);
-    } else {
-      final RemoteServiceNotAvailableException exception =
-          new RemoteServiceNotAvailableException(
-              String.format(
-                  "Beacon node %s was marked as not ready to accept requests",
-                  delegate.getEndpoint()));
-      futureResponse = SafeFuture.failedFuture(exception);
-    }
-    return futureResponse.handleComposed(
-        (response, throwable) -> {
-          if (throwable != null) {
-            recordFailedRequest(delegate, method);
-            return SafeFuture.failedFuture(throwable);
-          }
-          recordSuccessfulRequest(delegate, method);
-          return SafeFuture.completedFuture(response);
-        });
+    return request
+        .run(delegate)
+        .handleComposed(
+            (response, throwable) -> {
+              if (throwable != null) {
+                recordFailedRequest(delegate, method);
+                return SafeFuture.failedFuture(throwable);
+              }
+              recordSuccessfulRequest(delegate, method);
+              return SafeFuture.completedFuture(response);
+            });
   }
 
   private void recordSuccessfulRequest(

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandler.java
@@ -351,7 +351,12 @@ public class FailoverValidatorApiHandler implements ValidatorApiChannel {
               final FailoverRequestException failoverRequestException =
                   new FailoverRequestException(method, capturedExceptions);
               return SafeFuture.failedFuture(failoverRequestException);
-            });
+            })
+        .thenPeek(
+            __ ->
+                LOG.debug(
+                    "Received a successful response from a failover for remote request ({})",
+                    method));
   }
 
   /**

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandler.java
@@ -450,6 +450,9 @@ public class FailoverValidatorApiHandler implements ValidatorApiChannel {
         .handleComposed(
             (response, throwable) -> {
               if (throwable != null) {
+                LOG.trace(
+                    String.format("Request (%s) to %s failed", method, delegate.getEndpoint()),
+                    throwable);
                 recordFailedRequest(delegate, method);
                 return SafeFuture.failedFuture(throwable);
               }

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApi.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApi.java
@@ -103,8 +103,8 @@ public class RemoteBeaconNodeApi implements BeaconNodeApi {
       LOG.info("Will use {} as failover Beacon Node endpoints", failoverEndpoints);
     }
 
-    final RemoteBeaconNodeSyncingChannel remoteBeaconNodeSyncingChannel =
-        eventChannels.getPublisher(RemoteBeaconNodeSyncingChannel.class);
+    final BeaconNodeReadinessChannel beaconNodeReadinessChannel =
+        eventChannels.getPublisher(BeaconNodeReadinessChannel.class);
 
     final ValidatorTimingChannel validatorTimingChannel =
         eventChannels.getPublisher(ValidatorTimingChannel.class);
@@ -114,7 +114,7 @@ public class RemoteBeaconNodeApi implements BeaconNodeApi {
             primaryValidatorApi,
             failoverValidatorApis,
             ValidatorLogger.VALIDATOR_LOGGER,
-            remoteBeaconNodeSyncingChannel);
+            beaconNodeReadinessChannel);
 
     eventChannels.subscribe(ValidatorTimingChannel.class, beaconNodeReadinessManager);
 
@@ -146,7 +146,7 @@ public class RemoteBeaconNodeApi implements BeaconNodeApi {
             metricsSystem,
             validatorConfig.generateEarlyAttestations());
 
-    eventChannels.subscribe(RemoteBeaconNodeSyncingChannel.class, beaconChainEventAdapter);
+    eventChannels.subscribe(BeaconNodeReadinessChannel.class, beaconChainEventAdapter);
 
     return new RemoteBeaconNodeApi(beaconChainEventAdapter, validatorApi);
   }

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/sentry/SentryBeaconNodeApi.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/sentry/SentryBeaconNodeApi.java
@@ -36,10 +36,10 @@ import tech.pegasys.teku.validator.beaconnode.BeaconNodeApi;
 import tech.pegasys.teku.validator.beaconnode.GenesisDataProvider;
 import tech.pegasys.teku.validator.beaconnode.TimeBasedEventAdapter;
 import tech.pegasys.teku.validator.beaconnode.metrics.MetricRecordingValidatorApiChannel;
+import tech.pegasys.teku.validator.remote.BeaconNodeReadinessChannel;
 import tech.pegasys.teku.validator.remote.BeaconNodeReadinessManager;
 import tech.pegasys.teku.validator.remote.FailoverValidatorApiHandler;
 import tech.pegasys.teku.validator.remote.RemoteBeaconNodeEndpoints;
-import tech.pegasys.teku.validator.remote.RemoteBeaconNodeSyncingChannel;
 import tech.pegasys.teku.validator.remote.RemoteValidatorApiChannel;
 import tech.pegasys.teku.validator.remote.RemoteValidatorApiHandler;
 import tech.pegasys.teku.validator.remote.eventsource.EventSourceBeaconChainEventAdapter;
@@ -84,8 +84,8 @@ public class SentryBeaconNodeApi implements BeaconNodeApi {
     final EventChannels eventChannels = serviceConfig.getEventChannels();
     final MetricsSystem metricsSystem = serviceConfig.getMetricsSystem();
 
-    final RemoteBeaconNodeSyncingChannel remoteBeaconNodeSyncingChannel =
-        eventChannels.getPublisher(RemoteBeaconNodeSyncingChannel.class);
+    final BeaconNodeReadinessChannel beaconNodeReadinessChannel =
+        eventChannels.getPublisher(BeaconNodeReadinessChannel.class);
 
     final ValidatorTimingChannel validatorTimingChannel =
         eventChannels.getPublisher(ValidatorTimingChannel.class);
@@ -95,7 +95,7 @@ public class SentryBeaconNodeApi implements BeaconNodeApi {
             dutiesProviderPrimaryValidatorApiChannel,
             dutiesProviderFailoverValidatorApiChannel,
             ValidatorLogger.VALIDATOR_LOGGER,
-            remoteBeaconNodeSyncingChannel);
+            beaconNodeReadinessChannel);
 
     eventChannels.subscribe(ValidatorTimingChannel.class, beaconNodeReadinessManager);
 
@@ -160,7 +160,7 @@ public class SentryBeaconNodeApi implements BeaconNodeApi {
             serviceConfig.getMetricsSystem(),
             validatorConfig.generateEarlyAttestations());
 
-    eventChannels.subscribe(RemoteBeaconNodeSyncingChannel.class, beaconChainEventAdapter);
+    eventChannels.subscribe(BeaconNodeReadinessChannel.class, beaconChainEventAdapter);
 
     return new SentryBeaconNodeApi(beaconChainEventAdapter, sentryValidatorApi);
   }

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessManagerTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessManagerTest.java
@@ -47,15 +47,15 @@ public class BeaconNodeReadinessManagerTest {
 
   private final ValidatorLogger validatorLogger = mock(ValidatorLogger.class);
 
-  private final RemoteBeaconNodeSyncingChannel remoteBeaconNodeSyncingChannel =
-      mock(RemoteBeaconNodeSyncingChannel.class);
+  private final BeaconNodeReadinessChannel beaconNodeReadinessChannel =
+      mock(BeaconNodeReadinessChannel.class);
 
   private final BeaconNodeReadinessManager beaconNodeReadinessManager =
       new BeaconNodeReadinessManager(
           beaconNodeApi,
           List.of(failoverBeaconNodeApi),
           validatorLogger,
-          remoteBeaconNodeSyncingChannel);
+          beaconNodeReadinessChannel);
 
   @Test
   public void retrievesReadinessAndPublishesToAChannel() {
@@ -63,7 +63,7 @@ public class BeaconNodeReadinessManagerTest {
     assertThat(beaconNodeReadinessManager.isReady(beaconNodeApi)).isTrue();
     assertThat(beaconNodeReadinessManager.isReady(failoverBeaconNodeApi)).isTrue();
 
-    verifyNoInteractions(validatorLogger, remoteBeaconNodeSyncingChannel);
+    verifyNoInteractions(validatorLogger, beaconNodeReadinessChannel);
 
     when(beaconNodeApi.getSyncingStatus()).thenReturn(SafeFuture.completedFuture(SYNCED_STATUS));
     when(failoverBeaconNodeApi.getSyncingStatus())
@@ -75,7 +75,7 @@ public class BeaconNodeReadinessManagerTest {
     assertThat(beaconNodeReadinessManager.isReady(failoverBeaconNodeApi)).isFalse();
 
     verifyNoInteractions(validatorLogger);
-    verify(remoteBeaconNodeSyncingChannel).onFailoverNodeNotInSync(failoverBeaconNodeApi);
+    verify(beaconNodeReadinessChannel).onFailoverNodeNotReady(failoverBeaconNodeApi);
 
     when(beaconNodeApi.getSyncingStatus())
         .thenReturn(SafeFuture.failedFuture(new IllegalStateException("oopsy")));
@@ -87,8 +87,8 @@ public class BeaconNodeReadinessManagerTest {
     assertThat(beaconNodeReadinessManager.isReady(beaconNodeApi)).isFalse();
     assertThat(beaconNodeReadinessManager.isReady(failoverBeaconNodeApi)).isTrue();
 
-    verify(validatorLogger).primaryBeaconNodeNotReady(true);
-    verify(remoteBeaconNodeSyncingChannel).onPrimaryNodeNotInSync();
+    verify(validatorLogger).primaryBeaconNodeNotReady();
+    verify(beaconNodeReadinessChannel).onPrimaryNodeNotReady();
 
     // primary node recovers
     when(beaconNodeApi.getSyncingStatus()).thenReturn(SafeFuture.completedFuture(SYNCED_STATUS));
@@ -97,8 +97,8 @@ public class BeaconNodeReadinessManagerTest {
 
     assertThat(beaconNodeReadinessManager.isReady(beaconNodeApi)).isTrue();
 
-    verify(validatorLogger).primaryBeaconNodeIsBackAndReady(true);
-    verify(remoteBeaconNodeSyncingChannel).onPrimaryNodeBackInSync();
+    verify(validatorLogger).primaryBeaconNodeIsBackAndReady();
+    verify(beaconNodeReadinessChannel).onPrimaryNodeBackReady();
   }
 
   @Test
@@ -107,7 +107,7 @@ public class BeaconNodeReadinessManagerTest {
     assertThat(beaconNodeReadinessManager.isReady(beaconNodeApi)).isTrue();
     assertThat(beaconNodeReadinessManager.isReady(failoverBeaconNodeApi)).isTrue();
 
-    verifyNoInteractions(validatorLogger, remoteBeaconNodeSyncingChannel);
+    verifyNoInteractions(validatorLogger, beaconNodeReadinessChannel);
 
     when(beaconNodeApi.getSyncingStatus())
         .thenReturn(SafeFuture.completedFuture(EL_OFFLINE_STATUS));
@@ -119,8 +119,8 @@ public class BeaconNodeReadinessManagerTest {
     assertThat(beaconNodeReadinessManager.isReady(beaconNodeApi)).isFalse();
     assertThat(beaconNodeReadinessManager.isReady(failoverBeaconNodeApi)).isTrue();
 
-    verify(validatorLogger).primaryBeaconNodeNotReady(true);
-    verify(remoteBeaconNodeSyncingChannel).onPrimaryNodeNotInSync();
+    verify(validatorLogger).primaryBeaconNodeNotReady();
+    verify(beaconNodeReadinessChannel).onPrimaryNodeNotReady();
   }
 
   @Test
@@ -132,7 +132,7 @@ public class BeaconNodeReadinessManagerTest {
             beaconNodeApi,
             List.of(failoverBeaconNodeApi, anotherFailover, yetAnotherFailover),
             validatorLogger,
-            remoteBeaconNodeSyncingChannel);
+            beaconNodeReadinessChannel);
 
     when(beaconNodeApi.getSyncingStatus()).thenReturn(SafeFuture.completedFuture(SYNCED_STATUS));
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

- Rename `RemoteBeaconNodeSyncingChannel` to `BeaconNodeReadinessChannel`
- Don't perform readiness check when no failovers are configured. (it is not needed)
- Immediately going to failover if BN is not ready. (It was doing that before as well but it was using exceptions which was triggering logging and it could be confusing). I think it is more readable now.
- Improve logging a little bit.
- Add timeout for the syncing status call


## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
