### PR TITLE
Using Trivy v0.37.3 on builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -235,7 +235,7 @@ jobs:
           name: Install trivy
           command: |
             apk add --update-cache --upgrade curl bash
-            curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin
+            curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.37.3
       - run:
           name: Scan with trivy
           shell: /bin/sh


### PR DESCRIPTION
## PR Description
It looks like newer version of Trivy have introduced an issue to the build (https://github.com/aquasecurity/trivy/issues/3760).

While we wait for an answer to it, I have updated our job to use Trivy v0.37.3 (last version that was working).

I'll create another issue to follow up on this. We should be able to use the latest version of Trivy (or we need to ensure we regularly check if we can upgrade).

## Fixed Issue(s)
fixes #6899 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
