### PR TITLE
Reduce default allowed faults to 5 for builder circuit breaker

### DIFF
--- a/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerConfiguration.java
+++ b/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerConfiguration.java
@@ -28,7 +28,7 @@ import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannel.Version;
 public class ExecutionLayerConfiguration {
   public static final boolean DEFAULT_BUILDER_CIRCUIT_BREAKER_ENABLED = true;
   public static final int DEFAULT_BUILDER_CIRCUIT_BREAKER_WINDOW = 32;
-  public static final int DEFAULT_BUILDER_CIRCUIT_BREAKER_ALLOWED_FAULTS = 8;
+  public static final int DEFAULT_BUILDER_CIRCUIT_BREAKER_ALLOWED_FAULTS = 5;
   public static final int DEFAULT_BUILDER_CIRCUIT_BREAKER_ALLOWED_CONSECUTIVE_FAULTS = 3;
 
   public static final int BUILDER_CIRCUIT_BREAKER_WINDOW_HARD_CAP = 64;


### PR DESCRIPTION
As per some discussion, let's reduce the default default allowed faults to 5 for builder circuit breaker.

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
