### PR TITLE
Updated block pruner to use block column rather than index

### DIFF
--- a/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
@@ -42,7 +42,7 @@ import tech.pegasys.teku.storage.api.WeakSubjectivityUpdate;
 
 public interface Database extends AutoCloseable {
 
-  int PRUNE_BATCH_SIZE = 10000;
+  int PRUNE_BATCH_SIZE = 500;
 
   void storeInitialAnchor(AnchorPoint genesis);
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
@@ -628,14 +628,9 @@ public class CombinedKvStoreDao<S extends SchemaCombined>
 
     @Override
     public void pruneFinalizedBlocks(final UInt64 firstSlotToPrune, final UInt64 lastSlotToPrune) {
-      try (final Stream<ColumnEntry<Bytes32, UInt64>> stream =
-          db.stream(schema.getColumnSlotsByFinalizedRoot())) {
-        stream
-            .filter(
-                entry ->
-                    entry.getValue().isGreaterThanOrEqualTo(firstSlotToPrune)
-                        && entry.getValue().isLessThanOrEqualTo(lastSlotToPrune))
-            .forEach(entry -> deleteFinalizedBlock(entry.getValue(), entry.getKey()));
+      try (final Stream<ColumnEntry<UInt64, SignedBeaconBlock>> stream =
+          db.stream(schema.getColumnFinalizedBlocksBySlot(), firstSlotToPrune, lastSlotToPrune)) {
+        stream.forEach(entry -> deleteFinalizedBlock(entry.getKey(), entry.getValue().getRoot()));
       }
     }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
@@ -627,14 +627,6 @@ public class CombinedKvStoreDao<S extends SchemaCombined>
     }
 
     @Override
-    public void pruneFinalizedBlocks(final UInt64 firstSlotToPrune, final UInt64 lastSlotToPrune) {
-      try (final Stream<ColumnEntry<UInt64, SignedBeaconBlock>> stream =
-          db.stream(schema.getColumnFinalizedBlocksBySlot(), firstSlotToPrune, lastSlotToPrune)) {
-        stream.forEach(entry -> deleteFinalizedBlock(entry.getKey(), entry.getValue().getRoot()));
-      }
-    }
-
-    @Override
     public void addNonCanonicalRootAtSlot(final UInt64 slot, final Set<Bytes32> blockRoots) {
       Optional<Set<Bytes32>> maybeRoots = db.get(schema.getColumnNonCanonicalRootsBySlot(), slot);
       final Set<Bytes32> roots = maybeRoots.orElse(new HashSet<>());

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDao.java
@@ -215,8 +215,6 @@ public interface KvStoreCombinedDao extends AutoCloseable {
 
     void deleteNonCanonicalBlockOnly(final Bytes32 blockRoot);
 
-    void pruneFinalizedBlocks(UInt64 firstSlotToPrune, UInt64 lastSlotToPrune);
-
     void addFinalizedState(final Bytes32 blockRoot, final BeaconState state);
 
     void addReconstructedFinalizedState(final Bytes32 blockRoot, final BeaconState state);

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoAdapter.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoAdapter.java
@@ -498,11 +498,6 @@ public class KvStoreCombinedDaoAdapter implements KvStoreCombinedDao, V4Migratab
     }
 
     @Override
-    public void pruneFinalizedBlocks(final UInt64 firstSlotToPrune, final UInt64 lastSlotToPrune) {
-      finalizedUpdater.pruneFinalizedBlocks(firstSlotToPrune, lastSlotToPrune);
-    }
-
-    @Override
     public void addNonCanonicalRootAtSlot(final UInt64 slot, final Set<Bytes32> blockRoots) {
       finalizedUpdater.addNonCanonicalRootAtSlot(slot, blockRoots);
     }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4FinalizedKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4FinalizedKvStoreDao.java
@@ -272,14 +272,9 @@ public class V4FinalizedKvStoreDao {
 
     @Override
     public void pruneFinalizedBlocks(final UInt64 firstSlotToPrune, final UInt64 lastSlotToPrune) {
-      try (final Stream<ColumnEntry<Bytes32, UInt64>> stream =
-          db.stream(schema.getColumnSlotsByFinalizedRoot())) {
-        stream
-            .filter(
-                entry ->
-                    entry.getValue().isGreaterThanOrEqualTo(firstSlotToPrune)
-                        && entry.getValue().isLessThanOrEqualTo(lastSlotToPrune))
-            .forEach(entry -> deleteFinalizedBlock(entry.getValue(), entry.getKey()));
+      try (final Stream<ColumnEntry<UInt64, SignedBeaconBlock>> stream =
+          db.stream(schema.getColumnFinalizedBlocksBySlot(), firstSlotToPrune, lastSlotToPrune)) {
+        stream.forEach(entry -> deleteFinalizedBlock(entry.getKey(), entry.getValue().getRoot()));
       }
     }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4FinalizedKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4FinalizedKvStoreDao.java
@@ -271,14 +271,6 @@ public class V4FinalizedKvStoreDao {
     }
 
     @Override
-    public void pruneFinalizedBlocks(final UInt64 firstSlotToPrune, final UInt64 lastSlotToPrune) {
-      try (final Stream<ColumnEntry<UInt64, SignedBeaconBlock>> stream =
-          db.stream(schema.getColumnFinalizedBlocksBySlot(), firstSlotToPrune, lastSlotToPrune)) {
-        stream.forEach(entry -> deleteFinalizedBlock(entry.getKey(), entry.getValue().getRoot()));
-      }
-    }
-
-    @Override
     public void addNonCanonicalRootAtSlot(final UInt64 slot, final Set<Bytes32> blockRoots) {
       Optional<Set<Bytes32>> maybeRoots = db.get(schema.getColumnNonCanonicalRootsBySlot(), slot);
       final Set<Bytes32> roots = maybeRoots.orElse(new HashSet<>());

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/pruner/BlockPrunerTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/pruner/BlockPrunerTest.java
@@ -101,7 +101,7 @@ class BlockPrunerTest {
         .thenReturn(Optional.of(dataStructureUtil.randomCheckpoint(finalizedEpoch)));
     triggerNextPruning();
     // SlotToKeep = FinalizedEpoch (50) * SlotsPerEpoch(10) - EpochsToKeep(5) * SlotsPerEpoch(10)
-    // = 500 - 50 = 450, last slot to prune = 550 - 1 = 449.
+    // = 500 - 50 = 450, last slot to prune = 450 - 1 = 449.
     final UInt64 lastSlotToPrune = UInt64.valueOf(449);
     verify(database).pruneFinalizedBlocks(lastSlotToPrune);
   }


### PR DESCRIPTION
The index is hash based, meaning to find all the slots we'd need to scan the entire index. The block column requires reading more data, but is ordered by slot, and we can range query to only get the slots we want, so logically it should be simpler.

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
