### PR TITLE
Send validator registrations on reconnections to the event stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,5 +17,6 @@ For information on changes in released versions of Teku, see the [releases page]
 ### Breaking Changes
 
 ### Additions and Improvements
+- Send validator registrations to the Beacon node when the Validator client has reconnected to the event stream
 
 ### Bug Fixes

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorRegistratorTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorRegistratorTest.java
@@ -306,9 +306,36 @@ class ValidatorRegistratorTest {
   }
 
   @TestTemplate
+  void doesNotRegisterValidatorsOnPossibleMissedEvents_ifNotReady() {
+    when(proposerConfigPropertiesProvider.isReadyToProvideProperties()).thenReturn(false);
+
+    validatorRegistrator.onPossibleMissedEvents();
+
+    verifyNoInteractions(ownedValidators, validatorRegistrationBatchSender, signer);
+  }
+
+  @TestTemplate
+  void registerValidatorsOnPossibleMissedEvents() {
+    setActiveValidators(validator1, validator2, validator3);
+
+    validatorRegistrator.onPossibleMissedEvents();
+
+    final List<SignedValidatorRegistration> registrationCall = captureRegistrationCall();
+
+    verifyRegistrations(registrationCall, List.of(validator1, validator2, validator3));
+  }
+
+  @TestTemplate
   void doesNotRegisterNewlyAddedValidators_ifNotReady() {
     when(proposerConfigPropertiesProvider.isReadyToProvideProperties()).thenReturn(false);
 
+    validatorRegistrator.onValidatorsAdded();
+
+    verifyNoInteractions(ownedValidators, validatorRegistrationBatchSender, signer);
+  }
+
+  @TestTemplate
+  void doesNotRegisterNewlyAddedValidators_ifFirstCallHasNotBeenDone() {
     validatorRegistrator.onValidatorsAdded();
 
     verifyNoInteractions(ownedValidators, validatorRegistrationBatchSender, signer);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Send validator registrations on `onPossibleMissedEvents()`

## Fixed Issue(s)
changes for #6918 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
