### PR TITLE
performance tracker refactoring

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/performance/DefaultPerformanceTracker.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/performance/DefaultPerformanceTracker.java
@@ -283,8 +283,8 @@ public class DefaultPerformanceTracker implements PerformanceTracker {
         new HashMap<>();
     for (Map.Entry<UInt64, List<Attestation>> entry : attestationsIncludedOnChain.entrySet()) {
       for (Attestation attestation : entry.getValue()) {
-        Bytes32 attestationDataHash = attestation.getData().hashTreeRoot();
-        NavigableMap<UInt64, SszBitlist> slotToBitlists =
+        final Bytes32 attestationDataHash = attestation.getData().hashTreeRoot();
+        final NavigableMap<UInt64, SszBitlist> slotToBitlists =
             slotAndBitlistsByAttestationDataHash.computeIfAbsent(
                 attestationDataHash, __ -> new TreeMap<>());
         slotToBitlists.merge(
@@ -325,7 +325,7 @@ public class DefaultPerformanceTracker implements PerformanceTracker {
 
     // IntSummaryStatistics returns Integer.MIN and MAX when the summarized integer list
     // is empty.
-    int numberOfProducedAttestations = producedAttestations.size();
+    final int numberOfProducedAttestations = producedAttestations.size();
     return producedAttestations.size() > 0
         ? new AttestationPerformance(
             analyzedEpoch,
@@ -350,11 +350,11 @@ public class DefaultPerformanceTracker implements PerformanceTracker {
     final Set<BeaconBlock> blocksInEpoch = new HashSet<>();
     final AtomicReference<UInt64> currSlot = new AtomicReference<>(inclusiveEndEpochEndSlot);
     return SafeFuture.asyncDoWhile(
-            () -> getBlockInEffectAtSlot(blocksInEpoch, epochStartSlot, currSlot))
+            () -> fillBlockInEffectAtSlot(blocksInEpoch, epochStartSlot, currSlot))
         .thenApply(__ -> blocksInEpoch);
   }
 
-  private SafeFuture<Boolean> getBlockInEffectAtSlot(
+  private SafeFuture<Boolean> fillBlockInEffectAtSlot(
       final Set<BeaconBlock> blocksInEpoch,
       final UInt64 epochStartSlot,
       final AtomicReference<UInt64> currSlot) {

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/performance/DefaultPerformanceTracker.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/performance/DefaultPerformanceTracker.java
@@ -77,6 +77,8 @@ public class DefaultPerformanceTracker implements PerformanceTracker {
   private volatile Optional<UInt64> nodeStartEpoch = Optional.empty();
   private final AtomicReference<UInt64> latestAnalyzedEpoch = new AtomicReference<>(UInt64.ZERO);
 
+  private volatile SafeFuture<Void> ongoingReportingTasks = SafeFuture.COMPLETE;
+
   public DefaultPerformanceTracker(
       CombinedChainDataClient combinedChainDataClient,
       StatusLogger statusLogger,
@@ -101,6 +103,12 @@ public class DefaultPerformanceTracker implements PerformanceTracker {
 
   @Override
   public void onSlot(UInt64 slot) {
+    synchronized (this) {
+      if (!ongoingReportingTasks.isDone()) {
+        return;
+      }
+      ongoingReportingTasks = new SafeFuture<>();
+    }
     // Ensure a consistent view as the field is volatile.
     final Optional<UInt64> nodeStartEpoch = this.nodeStartEpoch;
     if (nodeStartEpoch.isEmpty() || combinedChainDataClient.getChainHead().isEmpty()) {
@@ -136,7 +144,8 @@ public class DefaultPerformanceTracker implements PerformanceTracker {
       reportingTasks.add(reportSyncCommitteePerformance(currentEpoch));
     }
 
-    SafeFuture.allOf(reportingTasks.toArray(SafeFuture[]::new)).join();
+    ongoingReportingTasks = SafeFuture.allOf(reportingTasks.toArray(SafeFuture[]::new));
+    ongoingReportingTasks.ifExceptionGetsHereRaiseABug();
   }
 
   private SafeFuture<?> reportBlockPerformance(final UInt64 currentEpoch) {
@@ -240,7 +249,7 @@ public class DefaultPerformanceTracker implements PerformanceTracker {
   }
 
   private SafeFuture<AttestationPerformance> getAttestationPerformanceForEpoch(
-      UInt64 currentEpoch, UInt64 analyzedEpoch) {
+      final UInt64 currentEpoch, final UInt64 analyzedEpoch) {
     checkArgument(
         analyzedEpoch.isLessThanOrEqualTo(currentEpoch.minus(ATTESTATION_INCLUSION_RANGE)),
         "Epoch to analyze attestation performance must be at least 2 epochs less than the current epoch");
@@ -248,122 +257,146 @@ public class DefaultPerformanceTracker implements PerformanceTracker {
     // Attestations can be included in either the epoch they were produced in or in
     // the following epoch. Thus, the most recent epoch for which we can evaluate attestation
     // performance is current epoch - 2.
-    UInt64 analysisRangeEndEpoch = analyzedEpoch.plus(ATTESTATION_INCLUSION_RANGE);
+    final UInt64 analysisRangeEndEpoch = analyzedEpoch.plus(ATTESTATION_INCLUSION_RANGE);
 
     // Get included attestations for the given epochs in a map from slot to attestations
     // included in block.
-    Map<UInt64, List<Attestation>> attestationsIncludedOnChain =
+    final SafeFuture<Map<UInt64, List<Attestation>>> attestationsIncludedOnChainFuture =
         getAttestationsIncludedInEpochs(analyzedEpoch, analysisRangeEndEpoch);
 
     // Get sent attestations in range
-    Set<Attestation> producedAttestations =
+    final Set<Attestation> producedAttestations =
         producedAttestationsByEpoch.getOrDefault(analyzedEpoch, Collections.emptySet());
     return combinedChainDataClient
         .getBestState()
         .orElseThrow()
-        .thenApply(
-            state -> {
-              int correctTargetCount = 0;
-              int correctHeadBlockCount = 0;
-              IntList inclusionDistances = new IntArrayList();
-
-              // Pre-process attestations included on chain to group them by
-              // data hash to inclusion slot to aggregation bitlist
-              Map<Bytes32, NavigableMap<UInt64, SszBitlist>> slotAndBitlistsByAttestationDataHash =
-                  new HashMap<>();
-              for (Map.Entry<UInt64, List<Attestation>> entry :
-                  attestationsIncludedOnChain.entrySet()) {
-                for (Attestation attestation : entry.getValue()) {
-                  Bytes32 attestationDataHash = attestation.getData().hashTreeRoot();
-                  NavigableMap<UInt64, SszBitlist> slotToBitlists =
-                      slotAndBitlistsByAttestationDataHash.computeIfAbsent(
-                          attestationDataHash, __ -> new TreeMap<>());
-                  slotToBitlists.merge(
-                      entry.getKey(), attestation.getAggregationBits(), SszBitlist::nullableOr);
-                }
-              }
-
-              for (Attestation sentAttestation : producedAttestations) {
-                Bytes32 sentAttestationDataHash = sentAttestation.getData().hashTreeRoot();
-                UInt64 sentAttestationSlot = sentAttestation.getData().getSlot();
-                if (!slotAndBitlistsByAttestationDataHash.containsKey(sentAttestationDataHash)) {
-                  continue;
-                }
-                NavigableMap<UInt64, SszBitlist> slotAndBitlists =
-                    slotAndBitlistsByAttestationDataHash.get(sentAttestationDataHash);
-                for (UInt64 slot : slotAndBitlists.keySet()) {
-                  if (slotAndBitlists
-                      .get(slot)
-                      .isSuperSetOf(sentAttestation.getAggregationBits())) {
-                    inclusionDistances.add(slot.minus(sentAttestationSlot).intValue());
-                    break;
-                  }
-                }
-
-                // Check if the attestation had correct target
-                Bytes32 attestationTargetRoot = sentAttestation.getData().getTarget().getRoot();
-                if (attestationTargetRoot.equals(spec.getBlockRoot(state, analyzedEpoch))) {
-                  correctTargetCount++;
-
-                  // Check if the attestation had correct head block root
-                  Bytes32 attestationHeadBlockRoot = sentAttestation.getData().getBeaconBlockRoot();
-                  if (attestationHeadBlockRoot.equals(
-                      spec.getBlockRootAtSlot(state, sentAttestationSlot))) {
-                    correctHeadBlockCount++;
-                  }
-                }
-              }
-
-              IntSummaryStatistics inclusionDistanceStatistics =
-                  inclusionDistances.intStream().summaryStatistics();
-
-              // IntSummaryStatistics returns Integer.MIN and MAX when the summarized integer list
-              // is empty.
-              int numberOfProducedAttestations = producedAttestations.size();
-              return producedAttestations.size() > 0
-                  ? new AttestationPerformance(
-                      analyzedEpoch,
-                      validatorTracker.getNumberOfValidatorsForEpoch(analyzedEpoch),
-                      numberOfProducedAttestations,
-                      (int) inclusionDistanceStatistics.getCount(),
-                      inclusionDistanceStatistics.getMax(),
-                      inclusionDistanceStatistics.getMin(),
-                      inclusionDistanceStatistics.getAverage(),
-                      correctTargetCount,
-                      correctHeadBlockCount)
-                  : AttestationPerformance.empty(
-                      analyzedEpoch, validatorTracker.getNumberOfValidatorsForEpoch(analyzedEpoch));
-            });
+        .thenCombine(
+            attestationsIncludedOnChainFuture,
+            (state, attestationsIncludedOnChain) ->
+                calculateAttestationPerformance(
+                    analyzedEpoch, state, producedAttestations, attestationsIncludedOnChain));
   }
 
-  private Set<BeaconBlock> getBlocksInEpochs(UInt64 startEpochInclusive, UInt64 endEpochExclusive) {
-    UInt64 epochStartSlot = spec.computeStartSlotAtEpoch(startEpochInclusive);
-    UInt64 inclusiveEndEpochEndSlot = spec.computeStartSlotAtEpoch(endEpochExclusive).decrement();
+  private AttestationPerformance calculateAttestationPerformance(
+      final UInt64 analyzedEpoch,
+      final BeaconState state,
+      final Set<Attestation> producedAttestations,
+      final Map<UInt64, List<Attestation>> attestationsIncludedOnChain) {
+    final IntList inclusionDistances = new IntArrayList();
+    int correctTargetCount = 0;
+    int correctHeadBlockCount = 0;
 
-    Set<BeaconBlock> blocksInEpoch = new HashSet<>();
-    UInt64 currSlot = inclusiveEndEpochEndSlot;
-    while (currSlot.isGreaterThanOrEqualTo(epochStartSlot)) {
-      Optional<BeaconBlock> block =
-          combinedChainDataClient
-              .getBlockInEffectAtSlot(currSlot)
-              .join()
-              .map(SignedBeaconBlock::getMessage);
-      block.ifPresent(blocksInEpoch::add);
-
-      if (block.isEmpty() || block.get().getSlot().equals(UInt64.ZERO)) {
-        break;
+    // Pre-process attestations included on chain to group them by
+    // data hash to inclusion slot to aggregation bitlist
+    final Map<Bytes32, NavigableMap<UInt64, SszBitlist>> slotAndBitlistsByAttestationDataHash =
+        new HashMap<>();
+    for (Map.Entry<UInt64, List<Attestation>> entry : attestationsIncludedOnChain.entrySet()) {
+      for (Attestation attestation : entry.getValue()) {
+        Bytes32 attestationDataHash = attestation.getData().hashTreeRoot();
+        NavigableMap<UInt64, SszBitlist> slotToBitlists =
+            slotAndBitlistsByAttestationDataHash.computeIfAbsent(
+                attestationDataHash, __ -> new TreeMap<>());
+        slotToBitlists.merge(
+            entry.getKey(), attestation.getAggregationBits(), SszBitlist::nullableOr);
       }
-      currSlot = block.get().getSlot().decrement();
     }
-    return blocksInEpoch;
+
+    for (Attestation sentAttestation : producedAttestations) {
+      final Bytes32 sentAttestationDataHash = sentAttestation.getData().hashTreeRoot();
+      final UInt64 sentAttestationSlot = sentAttestation.getData().getSlot();
+      if (!slotAndBitlistsByAttestationDataHash.containsKey(sentAttestationDataHash)) {
+        continue;
+      }
+      final NavigableMap<UInt64, SszBitlist> slotAndBitlists =
+          slotAndBitlistsByAttestationDataHash.get(sentAttestationDataHash);
+      for (UInt64 slot : slotAndBitlists.keySet()) {
+        if (slotAndBitlists.get(slot).isSuperSetOf(sentAttestation.getAggregationBits())) {
+          inclusionDistances.add(slot.minus(sentAttestationSlot).intValue());
+          break;
+        }
+      }
+
+      // Check if the attestation had correct target
+      final Bytes32 attestationTargetRoot = sentAttestation.getData().getTarget().getRoot();
+      if (attestationTargetRoot.equals(spec.getBlockRoot(state, analyzedEpoch))) {
+        correctTargetCount++;
+
+        // Check if the attestation had correct head block root
+        final Bytes32 attestationHeadBlockRoot = sentAttestation.getData().getBeaconBlockRoot();
+        if (attestationHeadBlockRoot.equals(spec.getBlockRootAtSlot(state, sentAttestationSlot))) {
+          correctHeadBlockCount++;
+        }
+      }
+    }
+
+    final IntSummaryStatistics inclusionDistanceStatistics =
+        inclusionDistances.intStream().summaryStatistics();
+
+    // IntSummaryStatistics returns Integer.MIN and MAX when the summarized integer list
+    // is empty.
+    int numberOfProducedAttestations = producedAttestations.size();
+    return producedAttestations.size() > 0
+        ? new AttestationPerformance(
+            analyzedEpoch,
+            validatorTracker.getNumberOfValidatorsForEpoch(analyzedEpoch),
+            numberOfProducedAttestations,
+            (int) inclusionDistanceStatistics.getCount(),
+            inclusionDistanceStatistics.getMax(),
+            inclusionDistanceStatistics.getMin(),
+            inclusionDistanceStatistics.getAverage(),
+            correctTargetCount,
+            correctHeadBlockCount)
+        : AttestationPerformance.empty(
+            analyzedEpoch, validatorTracker.getNumberOfValidatorsForEpoch(analyzedEpoch));
   }
 
-  private Map<UInt64, List<Attestation>> getAttestationsIncludedInEpochs(
+  private SafeFuture<Set<BeaconBlock>> getBlocksInEpochs(
       UInt64 startEpochInclusive, UInt64 endEpochExclusive) {
-    return getBlocksInEpochs(startEpochInclusive, endEpochExclusive).stream()
-        .collect(
-            Collectors.toMap(
-                BeaconBlock::getSlot, block -> block.getBody().getAttestations().asList()));
+    final UInt64 epochStartSlot = spec.computeStartSlotAtEpoch(startEpochInclusive);
+    final UInt64 inclusiveEndEpochEndSlot =
+        spec.computeStartSlotAtEpoch(endEpochExclusive).decrement();
+
+    final Set<BeaconBlock> blocksInEpoch = new HashSet<>();
+    final AtomicReference<UInt64> currSlot = new AtomicReference<>(inclusiveEndEpochEndSlot);
+    return SafeFuture.asyncDoWhile(
+            () -> getBlockInEffectAtSlot(blocksInEpoch, epochStartSlot, currSlot))
+        .thenApply(__ -> blocksInEpoch);
+  }
+
+  private SafeFuture<Boolean> getBlockInEffectAtSlot(
+      final Set<BeaconBlock> blocksInEpoch,
+      final UInt64 epochStartSlot,
+      final AtomicReference<UInt64> currSlot) {
+    if (currSlot.get().isGreaterThanOrEqualTo(epochStartSlot)) {
+      return combinedChainDataClient
+          .getBlockInEffectAtSlot(currSlot.get())
+          .thenApply(maybeSignedBlock -> maybeSignedBlock.map(SignedBeaconBlock::getMessage))
+          .thenPeek(
+              maybeBlock ->
+                  maybeBlock.ifPresent(
+                      block -> {
+                        blocksInEpoch.add(block);
+                        currSlot.set(currSlot.get().minusMinZero(1));
+                      }))
+          .thenApply(
+              maybeBlock ->
+                  maybeBlock.map(block -> !block.getSlot().equals(UInt64.ZERO)).orElse(false));
+
+    } else {
+      return SafeFuture.completedFuture(false);
+    }
+  }
+
+  private SafeFuture<Map<UInt64, List<Attestation>>> getAttestationsIncludedInEpochs(
+      UInt64 startEpochInclusive, UInt64 endEpochExclusive) {
+    return getBlocksInEpochs(startEpochInclusive, endEpochExclusive)
+        .thenApply(
+            beaconBlocks ->
+                beaconBlocks.stream()
+                    .collect(
+                        Collectors.toMap(
+                            BeaconBlock::getSlot,
+                            block -> block.getBody().getAttestations().asList())));
   }
 
   @Override

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/performance/DefaultPerformanceTracker.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/performance/DefaultPerformanceTracker.java
@@ -136,7 +136,7 @@ public class DefaultPerformanceTracker implements PerformanceTracker {
       reportingTasks.add(reportSyncCommitteePerformance(currentEpoch));
     }
 
-    SafeFuture.allOf(reportingTasks.toArray(SafeFuture[]::new)).ifExceptionGetsHereRaiseABug();
+    SafeFuture.allOf(reportingTasks.toArray(SafeFuture[]::new)).join();
   }
 
   private SafeFuture<?> reportBlockPerformance(final UInt64 currentEpoch) {

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/performance/DefaultPerformanceTrackerTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/performance/DefaultPerformanceTrackerTest.java
@@ -18,6 +18,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.validator.coordinator.performance.DefaultPerformanceTracker.ATTESTATION_INCLUSION_RANGE;
@@ -360,6 +361,25 @@ public class DefaultPerformanceTrackerTest {
     performanceTracker.onSlot(spec.computeStartSlotAtEpoch(epoch));
     verify(log).performance(performance.toString());
     verify(validatorPerformanceMetrics).updateSyncCommitteePerformance(performance);
+  }
+
+  @Test
+  void shouldNotOverlapExecutions() {
+    final SafeFuture<SyncCommitteePerformance> syncCommitteePerformance = new SafeFuture<>();
+    final UInt64 epoch = UInt64.valueOf(2);
+    when(syncCommitteePerformanceTracker.calculatePerformance(epoch.minus(1)))
+        .thenReturn(syncCommitteePerformance);
+
+    performanceTracker.onSlot(spec.computeStartSlotAtEpoch(epoch));
+    verify(log, never()).performance(anyString());
+    performanceTracker.onSlot(spec.computeStartSlotAtEpoch(epoch));
+    verify(log, never()).performance(anyString());
+
+    final SyncCommitteePerformance performance = new SyncCommitteePerformance(epoch, 10, 9, 8, 7);
+    syncCommitteePerformance.complete(performance);
+
+    verify(log, times(1)).performance(performance.toString());
+    verify(validatorPerformanceMetrics, times(1)).updateSyncCommitteePerformance(performance);
   }
 
   private Attestation createAttestation(

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/performance/DefaultPerformanceTrackerTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/performance/DefaultPerformanceTrackerTest.java
@@ -18,7 +18,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.validator.coordinator.performance.DefaultPerformanceTracker.ATTESTATION_INCLUSION_RANGE;
@@ -361,25 +360,6 @@ public class DefaultPerformanceTrackerTest {
     performanceTracker.onSlot(spec.computeStartSlotAtEpoch(epoch));
     verify(log).performance(performance.toString());
     verify(validatorPerformanceMetrics).updateSyncCommitteePerformance(performance);
-  }
-
-  @Test
-  void shouldNotOverlapExecutions() {
-    final SafeFuture<SyncCommitteePerformance> syncCommitteePerformance = new SafeFuture<>();
-    final UInt64 epoch = UInt64.valueOf(2);
-    when(syncCommitteePerformanceTracker.calculatePerformance(epoch.minus(1)))
-        .thenReturn(syncCommitteePerformance);
-
-    performanceTracker.onSlot(spec.computeStartSlotAtEpoch(epoch));
-    verify(log, never()).performance(anyString());
-    performanceTracker.onSlot(spec.computeStartSlotAtEpoch(epoch));
-    verify(log, never()).performance(anyString());
-
-    final SyncCommitteePerformance performance = new SyncCommitteePerformance(epoch, 10, 9, 8, 7);
-    syncCommitteePerformance.complete(performance);
-
-    verify(log, times(1)).performance(performance.toString());
-    verify(validatorPerformanceMetrics, times(1)).updateSyncCommitteePerformance(performance);
   }
 
   private Attestation createAttestation(


### PR DESCRIPTION
Removed all the `join()` on safe futures to make performance tracker fully async.

I put back the join in onSlot() since it avoid overlapping executions and blocking onSlot() won't block other onSlot() to run

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
