### PR TITLE
Remove hidden option `--Xbeacon-liveness-tracking-enabled`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,6 @@
 - The `/eth/v1/beacon/blocks/:block_id` endpoint has been deprecated in favor of the v2 Altair endpoint `/eth/v2/beacon/blocks/:block_id`
 - The `/eth/v1/validator/blocks/:slot` endpoint has been deprecated in favor of the v2 Altair endpoint `/eth/v2/validator/blocks/:slot`
 - The `/eth/v1/debug/beacon/heads` endpoint has been deprecated in favor of the v2 Bellatrix endpoint `/eth/v2/debug/beacon/heads`
-- The commandline option `--network` of the `validator-client` subcommand has been undeprecated and can be used to select a network for standalone validator clients. When set to `auto`, it automatically
-  fetches network configuration information from the configured beacon node endpoint.
-- `--Xbeacon-liveness-tracking-enabled` option will be removed. The `--beacon-liveness-tracking-enabled` option should be used instead (disabled by default)
 
 ## Current Releases
 For information on changes in released versions of Teku, see the [releases page](https://github.com/ConsenSys/teku/releases).
@@ -15,8 +12,11 @@ For information on changes in released versions of Teku, see the [releases page]
 ## Unreleased Changes
 
 ### Breaking Changes
+- `--Xbeacon-liveness-tracking-enabled` has been removed in favour of `--beacon-liveness-tracking-enabled`
 
 ### Additions and Improvements
+- The commandline option `--network` of the `validator-client` subcommand has been **un**deprecated for values other than `auto`.
 - Send validator registrations to the Beacon node when the Validator client has reconnected to the event stream
+- Added optional query parameters `require_prepared_proposers` and `require_validator_registrations` to the `teku/v1/admin/readiness` endpoint
 
 ### Bug Fixes

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/BeaconRestApiOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/BeaconRestApiOptions.java
@@ -113,7 +113,7 @@ public class BeaconRestApiOptions {
   }
 
   @Option(
-      names = {"--beacon-liveness-tracking-enabled", "--Xbeacon-liveness-tracking-enabled"},
+      names = {"--beacon-liveness-tracking-enabled"},
       paramLabel = "<BOOLEAN>",
       showDefaultValue = Visibility.ALWAYS,
       description = "Track validator liveness and enable requests to the liveness rest api.",

--- a/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
@@ -149,9 +149,6 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
     beaconNodeCommand.parse(args);
     String str = getCommandLineOutput();
 
-    // --Xbeacon-liveness-tracking-enabled is kept temporarily for backward compatibility
-    str = str.replace("--Xbeacon-liveness-tracking-enabled", "");
-
     assertThat(str).doesNotContain("--X");
   }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Remove hidden option `--Xbeacon-liveness-tracking-enabled`

Modified CHANGELOG by:
- Added breaking change for the removed hidden option
- Added the new parameters for the readiness endpoint
- Added the undepreciation of the `--network` values for the `validator-client` command

Raised a PR on docs side to remove a no longer needed note
https://github.com/ConsenSys/doc.teku/pull/437

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
