### PR TITLE
Change maximum number of block requests for Deneb

### DIFF
--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/chains/SyncSourceFactory.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/chains/SyncSourceFactory.java
@@ -38,12 +38,7 @@ public class SyncSourceFactory {
   public SyncSource getOrCreateSyncSource(final Eth2Peer peer, final Spec spec) {
     // Limit request rate to just a little under what we'd accept
     final int maxBlocksPerMinute = MAX_BLOCKS_PER_MINUTE - SYNC_BATCH_SIZE.intValue() - 1;
-
-    final int maxBlobsPerBlock = spec.getMaxBlobsPerBlock().orElse(0);
-
-    final int maxBlobSidecarsPerMinute =
-        (MAX_BLOCKS_PER_MINUTE * maxBlobsPerBlock)
-            - (SYNC_BATCH_SIZE.times(maxBlobsPerBlock).intValue() - 1);
+    final int maxBlobSidecarsPerMinute = maxBlocksPerMinute * spec.getMaxBlobsPerBlock().orElse(0);
 
     return syncSourcesByPeer.computeIfAbsent(
         peer,

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/SpecMilestone.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/SpecMilestone.java
@@ -45,7 +45,7 @@ public enum SpecMilestone {
    * @param milestone The milestone being inspected
    * @return An ordered list of all milestones preceding the supplied milestone
    */
-  public static List<SpecMilestone> getAllPriorMilestones(SpecMilestone milestone) {
+  public static List<SpecMilestone> getAllPriorMilestones(final SpecMilestone milestone) {
     final List<SpecMilestone> allMilestones = Arrays.asList(SpecMilestone.values());
     final int milestoneIndex = allMilestones.indexOf(milestone);
     return allMilestones.subList(0, milestoneIndex);
@@ -55,7 +55,7 @@ public enum SpecMilestone {
    * @param milestone The milestone being inspected
    * @return An ordered list of the supplied milestone and all milestones succeeding it
    */
-  public static List<SpecMilestone> getAllMilestonesFrom(SpecMilestone milestone) {
+  public static List<SpecMilestone> getAllMilestonesFrom(final SpecMilestone milestone) {
     final List<SpecMilestone> allMilestones = Arrays.asList(SpecMilestone.values());
     final int milestoneIndex = allMilestones.indexOf(milestone);
     return allMilestones.subList(milestoneIndex, SpecMilestone.values().length);
@@ -65,7 +65,7 @@ public enum SpecMilestone {
    * @param milestone The milestone being inspected
    * @return An ordered list of all milestones up to and included the specified milestone
    */
-  static List<SpecMilestone> getMilestonesUpTo(SpecMilestone milestone) {
+  static List<SpecMilestone> getMilestonesUpTo(final SpecMilestone milestone) {
     final List<SpecMilestone> allMilestones = Arrays.asList(SpecMilestone.values());
     final int milestoneIndex = allMilestones.indexOf(milestone);
     return allMilestones.subList(0, milestoneIndex + 1);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/SpecMilestone.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/SpecMilestone.java
@@ -53,12 +53,12 @@ public enum SpecMilestone {
 
   /**
    * @param milestone The milestone being inspected
-   * @return An ordered list of all milestones succeeding the supplied milestone
+   * @return An ordered list of the supplied milestone and all milestones succeeding it
    */
-  public static List<SpecMilestone> getAllFutureMilestones(SpecMilestone milestone) {
+  public static List<SpecMilestone> getAllMilestonesFrom(SpecMilestone milestone) {
     final List<SpecMilestone> allMilestones = Arrays.asList(SpecMilestone.values());
     final int milestoneIndex = allMilestones.indexOf(milestone);
-    return allMilestones.subList(milestoneIndex + 1, SpecMilestone.values().length);
+    return allMilestones.subList(milestoneIndex, SpecMilestone.values().length);
   }
 
   /**

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/Constants.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/Constants.java
@@ -21,7 +21,7 @@ public class Constants {
   // Networking
   public static final int GOSSIP_MAX_SIZE = 1048576; // bytes
   public static final int GOSSIP_MAX_SIZE_BELLATRIX = 10485760; // bytes
-  public static final int MAX_REQUEST_BLOCKS = 1024;
+  public static final UInt64 MAX_REQUEST_BLOCKS = UInt64.valueOf(1024);
   public static final int MAX_CHUNK_SIZE = 1048576; // bytes
   public static final int MAX_CHUNK_SIZE_BELLATRIX = 10485760; // bytes
   public static final int ATTESTATION_SUBNET_COUNT = 64;
@@ -68,7 +68,6 @@ public class Constants {
   // Teku Sync
   public static final UInt64 MAX_BLOCK_BY_RANGE_REQUEST_SIZE = UInt64.valueOf(200);
   public static final UInt64 SYNC_BATCH_SIZE = UInt64.valueOf(50);
-  public static final UInt64 SYNC_BLOB_SIDECARS_SIZE = UInt64.valueOf(50);
   public static final int MAX_BLOCKS_PER_MINUTE = 500;
 
   // Teku Validator Client Specific

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/networking/libp2p/rpc/BeaconBlocksByRootRequestMessage.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/networking/libp2p/rpc/BeaconBlocksByRootRequestMessage.java
@@ -30,7 +30,7 @@ public class BeaconBlocksByRootRequestMessage extends SszListImpl<SszBytes32>
     implements SszList<SszBytes32>, RpcRequest {
 
   // size validation according to the spec is done in the RPC handler
-  public static final UInt64 MAX_LENGTH = MAX_REQUEST_BLOCKS.times(2);
+  public static final UInt64 MAX_LENGTH = MAX_REQUEST_BLOCKS;
 
   public static class BeaconBlocksByRootRequestMessageSchema
       extends AbstractSszListSchema<SszBytes32, BeaconBlocksByRootRequestMessage> {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/networking/libp2p/rpc/BeaconBlocksByRootRequestMessage.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/networking/libp2p/rpc/BeaconBlocksByRootRequestMessage.java
@@ -24,15 +24,19 @@ import tech.pegasys.teku.infrastructure.ssz.primitive.SszBytes32;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
 import tech.pegasys.teku.infrastructure.ssz.schema.impl.AbstractSszListSchema;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 public class BeaconBlocksByRootRequestMessage extends SszListImpl<SszBytes32>
     implements SszList<SszBytes32>, RpcRequest {
+
+  // size validation according to the spec is done in the RPC handler
+  public static final UInt64 MAX_LENGTH = MAX_REQUEST_BLOCKS.times(2);
 
   public static class BeaconBlocksByRootRequestMessageSchema
       extends AbstractSszListSchema<SszBytes32, BeaconBlocksByRootRequestMessage> {
 
     private BeaconBlocksByRootRequestMessageSchema() {
-      super(SszPrimitiveSchemas.BYTES32_SCHEMA, MAX_REQUEST_BLOCKS);
+      super(SszPrimitiveSchemas.BYTES32_SCHEMA, MAX_LENGTH.longValue());
     }
 
     @Override

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/networking/libp2p/rpc/BeaconBlocksByRootRequestMessageTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/networking/libp2p/rpc/BeaconBlocksByRootRequestMessageTest.java
@@ -13,7 +13,10 @@
 
 package tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static tech.pegasys.teku.infrastructure.ssz.SszDataAssert.assertThatSszData;
+import static tech.pegasys.teku.spec.config.Constants.MAX_REQUEST_BLOCKS;
+import static tech.pegasys.teku.spec.config.Constants.MAX_REQUEST_BLOCKS_DENEB;
 
 import java.util.List;
 import org.apache.tuweni.bytes.Bytes;
@@ -35,5 +38,12 @@ class BeaconBlocksByRootRequestMessageTest {
     final BeaconBlocksByRootRequestMessage result =
         BeaconBlocksByRootRequestMessage.SSZ_SCHEMA.sszDeserialize(data);
     assertThatSszData(result).isEqualByAllMeansTo(request);
+  }
+
+  @Test
+  public void verifyMaxLengthOfContainerIsGreaterOrEqualToMaxRequestBlocks() {
+    assertThat(BeaconBlocksByRootRequestMessage.SSZ_SCHEMA.getMaxLength())
+        .isGreaterThanOrEqualTo(MAX_REQUEST_BLOCKS.longValue())
+        .isGreaterThanOrEqualTo(MAX_REQUEST_BLOCKS_DENEB.longValue());
   }
 }

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/networking/libp2p/rpc/BlobSidecarsByRootRequestMessageTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/networking/libp2p/rpc/BlobSidecarsByRootRequestMessageTest.java
@@ -50,7 +50,7 @@ class BlobSidecarsByRootRequestMessageTest {
   @Test
   public void verifyMaxLengthOfContainerIsGreaterOrEqualToMaxRequestBlobSidecars() {
     final List<SpecMilestone> shardingMilestones =
-        SpecMilestone.getAllFutureMilestones(SpecMilestone.CAPELLA);
+        SpecMilestone.getAllMilestonesFrom(SpecMilestone.DENEB);
 
     shardingMilestones.forEach(
         milestone -> {

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/networking/libp2p/rpc/BlobSidecarsByRootRequestMessageTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/networking/libp2p/rpc/BlobSidecarsByRootRequestMessageTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright ConsenSys Software Inc., 2023
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.infrastructure.ssz.SszDataAssert.assertThatSszData;
+
+import java.util.List;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.config.SpecConfigDeneb;
+
+class BlobSidecarsByRootRequestMessageTest {
+
+  @Test
+  public void shouldRoundTripViaSsz() {
+    final BlobSidecarsByRootRequestMessage request =
+        new BlobSidecarsByRootRequestMessage(
+            List.of(
+                new BlobIdentifier(
+                    Bytes32.fromHexString(
+                        "0x1111111111111111111111111111111111111111111111111111111111111111"),
+                    UInt64.ZERO),
+                new BlobIdentifier(
+                    Bytes32.fromHexString(
+                        "0x2222222222222222222222222222222222222222222222222222222222222222"),
+                    UInt64.ONE)));
+    final Bytes data = request.sszSerialize();
+    final BlobSidecarsByRootRequestMessage result =
+        BlobSidecarsByRootRequestMessage.SSZ_SCHEMA.sszDeserialize(data);
+    assertThatSszData(result).isEqualByAllMeansTo(request);
+  }
+
+  @Test
+  public void verifyMaxLengthOfContainerIsGreaterOrEqualToMaxRequestBlobSidecars() {
+    final List<SpecMilestone> shardingMilestones =
+        SpecMilestone.getAllFutureMilestones(SpecMilestone.CAPELLA);
+
+    shardingMilestones.forEach(
+        milestone -> {
+          final Spec spec = TestSpecFactory.createMainnet(milestone);
+          final UInt64 maxRequestBlobSidecars =
+              SpecConfigDeneb.required(spec.forMilestone(milestone).getConfig())
+                  .getMaxRequestBlobSidecars();
+          assertThat(BeaconBlocksByRootRequestMessage.SSZ_SCHEMA.getMaxLength())
+              .isGreaterThanOrEqualTo(maxRequestBlobSidecars.longValue());
+        });
+  }
+}

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/DefaultEth2Peer.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/DefaultEth2Peer.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.networking.eth2.peers;
 
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 import static tech.pegasys.teku.networking.eth2.rpc.core.RpcResponseStatus.INVALID_REQUEST_CODE;
-import static tech.pegasys.teku.spec.config.Constants.MAX_REQUEST_BLOCKS;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Suppliers;
@@ -210,13 +209,7 @@ class DefaultEth2Peer extends DelegatingPeer implements Eth2Peer {
 
   @Override
   public SafeFuture<Void> requestBlocksByRoot(
-      final List<Bytes32> blockRoots, final RpcResponseListener<SignedBeaconBlock> listener)
-      throws RpcException {
-    if (blockRoots.size() > MAX_REQUEST_BLOCKS) {
-      throw new RpcException(
-          INVALID_REQUEST_CODE,
-          "Only a maximum of " + MAX_REQUEST_BLOCKS + " blocks can be requested per request");
-    }
+      final List<Bytes32> blockRoots, final RpcResponseListener<SignedBeaconBlock> listener) {
     final Eth2RpcMethod<BeaconBlocksByRootRequestMessage, SignedBeaconBlock> blockByRoot =
         rpcMethods.beaconBlocksByRoot();
     return requestStream(blockByRoot, new BeaconBlocksByRootRequestMessage(blockRoots), listener);

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/BeaconChainMethods.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/BeaconChainMethods.java
@@ -13,8 +13,6 @@
 
 package tech.pegasys.teku.networking.eth2.rpc.beaconchain;
 
-import static tech.pegasys.teku.spec.config.Constants.MAX_BLOCK_BY_RANGE_REQUEST_SIZE;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -234,8 +232,7 @@ public class BeaconChainMethods {
           final PeerLookup peerLookup,
           final RpcEncoding rpcEncoding) {
     final BeaconBlocksByRangeMessageHandler beaconBlocksByRangeHandler =
-        new BeaconBlocksByRangeMessageHandler(
-            spec, metricsSystem, combinedChainDataClient, MAX_BLOCK_BY_RANGE_REQUEST_SIZE);
+        new BeaconBlocksByRangeMessageHandler(spec, metricsSystem, combinedChainDataClient);
 
     final BeaconBlocksByRangeRequestMessageSchema requestType =
         BeaconBlocksByRangeRequestMessage.SSZ_SCHEMA;

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandler.java
@@ -90,7 +90,7 @@ public class BeaconBlocksByRangeMessageHandler
           new InvalidRpcMethodVersion("Must request altair blocks using v2 protocol"));
     }
 
-    if (request.getStep().compareTo(ONE) < 0) {
+    if (request.getStep().isLessThan(ONE)) {
       requestCounter.labels("invalid_step").inc();
       return Optional.of(new RpcException(INVALID_REQUEST_CODE, "Step must be greater than zero"));
     }
@@ -121,8 +121,7 @@ public class BeaconBlocksByRangeMessageHandler
         message.getStartSlot(),
         message.getStep());
 
-    if (!peer.wantToMakeRequest()
-        || !peer.wantToReceiveBlocks(callback, message.getCount().longValue())) {
+    if (!peer.popRequest() || !peer.popBlockRequests(callback, message.getCount().longValue())) {
       requestCounter.labels("rate_limited").inc();
       return;
     }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandler.java
@@ -18,6 +18,7 @@ import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 import static tech.pegasys.teku.networking.eth2.rpc.core.RpcResponseStatus.INVALID_REQUEST_CODE;
 import static tech.pegasys.teku.spec.config.Constants.MAX_REQUEST_BLOCKS;
+import static tech.pegasys.teku.spec.config.Constants.MAX_REQUEST_BLOCKS_DENEB;
 
 import com.google.common.base.Throwables;
 import java.nio.channels.ClosedChannelException;
@@ -53,18 +54,15 @@ public class BeaconBlocksByRangeMessageHandler
 
   private final Spec spec;
   private final CombinedChainDataClient combinedChainDataClient;
-  private final UInt64 maxRequestSize;
   private final LabelledMetric<Counter> requestCounter;
   private final Counter totalBlocksRequestedCounter;
 
   public BeaconBlocksByRangeMessageHandler(
       final Spec spec,
       final MetricsSystem metricsSystem,
-      final CombinedChainDataClient combinedChainDataClient,
-      final UInt64 maxRequestSize) {
+      final CombinedChainDataClient combinedChainDataClient) {
     this.spec = spec;
     this.combinedChainDataClient = combinedChainDataClient;
-    this.maxRequestSize = maxRequestSize;
     requestCounter =
         metricsSystem.createLabelledCounter(
             TekuMetricCategory.NETWORK,
@@ -92,6 +90,21 @@ public class BeaconBlocksByRangeMessageHandler
           new InvalidRpcMethodVersion("Must request altair blocks using v2 protocol"));
     }
 
+    if (request.getStep().compareTo(ONE) < 0) {
+      requestCounter.labels("invalid_step").inc();
+      return Optional.of(new RpcException(INVALID_REQUEST_CODE, "Step must be greater than zero"));
+    }
+
+    final UInt64 maxRequestBlocks = getMaxRequestBlocks(latestMilestoneRequested);
+
+    if (request.getCount().isGreaterThan(maxRequestBlocks)) {
+      requestCounter.labels("count_too_big").inc();
+      return Optional.of(
+          new RpcException(
+              INVALID_REQUEST_CODE,
+              "Only a maximum of " + maxRequestBlocks + " blocks can be requested per request"));
+    }
+
     return Optional.empty();
   }
 
@@ -107,22 +120,9 @@ public class BeaconBlocksByRangeMessageHandler
         message.getCount(),
         message.getStartSlot(),
         message.getStep());
-    if (message.getStep().compareTo(ONE) < 0) {
-      requestCounter.labels("invalid_step").inc();
-      callback.completeWithErrorResponse(
-          new RpcException(INVALID_REQUEST_CODE, "Step must be greater than zero"));
-      return;
-    }
-    if (message.getCount().compareTo(UInt64.valueOf(MAX_REQUEST_BLOCKS)) > 0) {
-      requestCounter.labels("count_too_big").inc();
-      callback.completeWithErrorResponse(
-          new RpcException(
-              INVALID_REQUEST_CODE,
-              "Only a maximum of " + MAX_REQUEST_BLOCKS + " blocks can be requested per request"));
-      return;
-    }
-    if (!peer.popRequest()
-        || !peer.popBlockRequests(callback, maxRequestSize.min(message.getCount()).longValue())) {
+
+    if (!peer.wantToMakeRequest()
+        || !peer.wantToReceiveBlocks(callback, message.getCount().longValue())) {
       requestCounter.labels("rate_limited").inc();
       return;
     }
@@ -149,23 +149,30 @@ public class BeaconBlocksByRangeMessageHandler
             });
   }
 
+  private UInt64 getMaxRequestBlocks(final SpecMilestone milestone) {
+    return milestone.isGreaterThanOrEqualTo(SpecMilestone.DENEB)
+        ? MAX_REQUEST_BLOCKS_DENEB
+        : MAX_REQUEST_BLOCKS;
+  }
+
   private SafeFuture<?> sendMatchingBlocks(
       final BeaconBlocksByRangeRequestMessage message,
       final ResponseCallback<SignedBeaconBlock> callback) {
-    final UInt64 count = maxRequestSize.min(message.getCount());
-    final UInt64 endSlot = message.getStartSlot().plus(message.getStep().times(count)).minus(ONE);
+    final UInt64 startSlot = message.getStartSlot();
+    final UInt64 count = message.getCount();
+    final UInt64 step = message.getStep();
+    final UInt64 endSlot = startSlot.plus(step.times(count)).minus(ONE);
 
     return combinedChainDataClient
         .getEarliestAvailableBlockSlot()
         .thenCompose(
             earliestSlot -> {
-              if (earliestSlot.map(s -> s.isGreaterThan(message.getStartSlot())).orElse(true)) {
+              if (earliestSlot.map(s -> s.isGreaterThan(startSlot)).orElse(true)) {
                 // We're missing the first block so return an error
                 return SafeFuture.failedFuture(
                     new RpcException.ResourceUnavailableException(
                         "Requested historical blocks are currently unavailable"));
               }
-
               final UInt64 headBlockSlot =
                   combinedChainDataClient
                       .getChainHead()
@@ -176,9 +183,7 @@ public class BeaconBlocksByRangeMessageHandler
                 // All blocks are finalized so skip scanning the protoarray
                 hotRoots = new TreeMap<>();
               } else {
-                hotRoots =
-                    combinedChainDataClient.getAncestorRoots(
-                        message.getStartSlot(), message.getStep(), count);
+                hotRoots = combinedChainDataClient.getAncestorRoots(startSlot, step, count);
               }
               // Don't send anything past the last slot found in protoarray to ensure blocks are
               // consistent
@@ -187,13 +192,7 @@ public class BeaconBlocksByRangeMessageHandler
               // so we don't need to worry about inconsistent blocks
               final UInt64 headSlot = hotRoots.isEmpty() ? headBlockSlot : hotRoots.lastKey();
               return sendNextBlock(
-                      new RequestState(
-                          message.getStartSlot(),
-                          message.getStep(),
-                          count,
-                          headSlot,
-                          hotRoots,
-                          callback))
+                      new RequestState(startSlot, step, count, headSlot, hotRoots, callback))
                   .toVoid();
             });
   }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandler.java
@@ -114,8 +114,7 @@ public class BlobSidecarsByRangeMessageHandler
     }
 
     if (!peer.popRequest()
-        || !peer.popBlobSidecarRequests(
-            callback, maxRequestBlobSidecars.min(message.getCount()).longValue())) {
+        || !peer.popBlobSidecarRequests(callback, message.getCount().longValue())) {
       requestCounter.labels("rate_limited").inc();
       return;
     }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandler.java
@@ -113,8 +113,7 @@ public class BlobSidecarsByRangeMessageHandler
       return;
     }
 
-    if (!peer.popRequest()
-        || !peer.popBlobSidecarRequests(callback, message.getCount().longValue())) {
+    if (!peer.popRequest() || !peer.popBlobSidecarRequests(callback, requestedCount.longValue())) {
       requestCounter.labels("rate_limited").inc();
       return;
     }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandler.java
@@ -14,7 +14,7 @@
 package tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods;
 
 import static tech.pegasys.teku.networking.eth2.rpc.core.RpcResponseStatus.INVALID_REQUEST_CODE;
-import static tech.pegasys.teku.spec.config.Constants.MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUESTS;
+import static tech.pegasys.teku.spec.config.Constants.MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS;
 
 import com.google.common.base.Throwables;
 import java.nio.channels.ClosedChannelException;
@@ -190,7 +190,7 @@ public class BlobSidecarsByRootMessageHandler
   private UInt64 computeMinimumRequestEpoch(final UInt64 finalizedEpoch) {
     final UInt64 currentEpoch = combinedChainDataClient.getCurrentEpoch();
     return finalizedEpoch
-        .max(currentEpoch.minusMinZero(MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUESTS))
+        .max(currentEpoch.minusMinZero(MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS))
         .max(denebForkEpoch);
   }
 

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerTest.java
@@ -21,6 +21,9 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.spec.config.Constants.MAX_REQUEST_BLOCKS;
+import static tech.pegasys.teku.spec.config.Constants.MAX_REQUEST_BLOCKS_DENEB;
+import static tech.pegasys.teku.spec.config.Constants.SYNC_BATCH_SIZE;
 
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -207,6 +210,13 @@ class Eth2PeerTest {
     peer.requestBlobSidecarsByRange(UInt64.ONE, UInt64.valueOf(7), __ -> SafeFuture.COMPLETE);
 
     verify(delegate, never()).sendRequest(any(), any(), any());
+  }
+
+  @Test
+  public void verifySyncBatchSizeIsNotLargerThanMaxRequestBlocks() {
+    assertThat(SYNC_BATCH_SIZE.longValue())
+        .isLessThanOrEqualTo(MAX_REQUEST_BLOCKS.longValue())
+        .isLessThanOrEqualTo(MAX_REQUEST_BLOCKS_DENEB.longValue());
   }
 
   private PeerStatus randomPeerStatus() {

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandlerTest.java
@@ -27,6 +27,7 @@ import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 import static tech.pegasys.teku.networking.eth2.rpc.core.RpcResponseStatus.INVALID_REQUEST_CODE;
 import static tech.pegasys.teku.spec.config.Constants.MAX_CHUNK_SIZE;
 import static tech.pegasys.teku.spec.config.Constants.MAX_REQUEST_BLOCKS;
+import static tech.pegasys.teku.spec.config.Constants.MAX_REQUEST_BLOCKS_DENEB;
 
 import java.util.List;
 import java.util.NavigableMap;
@@ -66,7 +67,6 @@ class BeaconBlocksByRangeMessageHandlerTest {
 
   private final Spec spec = TestSpecFactory.createMinimalPhase0();
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
-  private final UInt64 maxRequestSize = UInt64.valueOf(8);
   private final List<StateAndBlockSummary> blocksWStates =
       IntStream.rangeClosed(0, 10)
           .mapToObj(dataStructureUtil::randomSignedBlockAndState)
@@ -88,8 +88,7 @@ class BeaconBlocksByRangeMessageHandlerTest {
   private final MetricsSystem metricsSystem = new NoOpMetricsSystem();
   private final String protocolId = BeaconChainMethodIds.getBlocksByRangeMethodId(2, RPC_ENCODING);
   private final BeaconBlocksByRangeMessageHandler handler =
-      new BeaconBlocksByRangeMessageHandler(
-          spec, metricsSystem, combinedChainDataClient, maxRequestSize);
+      new BeaconBlocksByRangeMessageHandler(spec, metricsSystem, combinedChainDataClient);
 
   @BeforeEach
   public void setup() {
@@ -112,8 +111,7 @@ class BeaconBlocksByRangeMessageHandlerTest {
   public void validateRequest_altairSpec_v2RequestForPhase0Block() {
     final Spec spec = TestSpecFactory.createMinimalWithAltairForkEpoch(UInt64.valueOf(4));
     final BeaconBlocksByRangeMessageHandler handler =
-        new BeaconBlocksByRangeMessageHandler(
-            spec, metricsSystem, combinedChainDataClient, maxRequestSize);
+        new BeaconBlocksByRangeMessageHandler(spec, metricsSystem, combinedChainDataClient);
 
     final Optional<RpcException> result =
         handler.validateRequest(
@@ -126,8 +124,7 @@ class BeaconBlocksByRangeMessageHandlerTest {
   public void validateRequest_altairSpec_v2RequestForAltairBlock() {
     final Spec spec = TestSpecFactory.createMinimalWithAltairForkEpoch(UInt64.valueOf(4));
     final BeaconBlocksByRangeMessageHandler handler =
-        new BeaconBlocksByRangeMessageHandler(
-            spec, metricsSystem, combinedChainDataClient, maxRequestSize);
+        new BeaconBlocksByRangeMessageHandler(spec, metricsSystem, combinedChainDataClient);
 
     final Optional<RpcException> result =
         handler.validateRequest(
@@ -140,8 +137,7 @@ class BeaconBlocksByRangeMessageHandlerTest {
   public void validateRequest_altairSpec_v2RequestForRangeOfBlocksAcrossForkBoundary() {
     final Spec spec = TestSpecFactory.createMinimalWithAltairForkEpoch(UInt64.valueOf(4));
     final BeaconBlocksByRangeMessageHandler handler =
-        new BeaconBlocksByRangeMessageHandler(
-            spec, metricsSystem, combinedChainDataClient, maxRequestSize);
+        new BeaconBlocksByRangeMessageHandler(spec, metricsSystem, combinedChainDataClient);
 
     final Optional<RpcException> result =
         handler.validateRequest(
@@ -149,6 +145,63 @@ class BeaconBlocksByRangeMessageHandlerTest {
             new BeaconBlocksByRangeRequestMessage(UInt64.valueOf(30), UInt64.valueOf(10), ONE));
 
     assertThat(result).isEmpty();
+  }
+
+  @Test
+  public void validateRequest_shouldRejectRequestWhenStepIsZero() {
+    final int startBlock = 15;
+    final int skip = 0;
+
+    final Optional<RpcException> result =
+        handler.validateRequest(
+            protocolId,
+            new BeaconBlocksByRangeRequestMessage(
+                UInt64.valueOf(startBlock), MAX_REQUEST_BLOCKS, UInt64.valueOf(skip)));
+
+    assertThat(result)
+        .hasValue(new RpcException(INVALID_REQUEST_CODE, "Step must be greater than zero"));
+  }
+
+  @Test
+  public void validateRequest_shouldRejectRequestWhenCountIsTooBig() {
+    final int startBlock = 15;
+    final int skip = 1;
+
+    final Optional<RpcException> result =
+        handler.validateRequest(
+            protocolId,
+            new BeaconBlocksByRangeRequestMessage(
+                UInt64.valueOf(startBlock), MAX_REQUEST_BLOCKS.increment(), UInt64.valueOf(skip)));
+
+    assertThat(result)
+        .hasValue(
+            new RpcException(
+                INVALID_REQUEST_CODE,
+                "Only a maximum of 1024 blocks can be requested per request"));
+  }
+
+  @Test
+  public void validateRequest_shouldRejectRequestWhenCountIsTooBigForDeneb() {
+    final int startBlock = 15;
+    final int skip = 1;
+
+    final Spec spec = TestSpecFactory.createMinimalWithDenebForkEpoch(ONE);
+
+    final BeaconBlocksByRangeMessageHandler handler =
+        new BeaconBlocksByRangeMessageHandler(spec, metricsSystem, combinedChainDataClient);
+
+    final Optional<RpcException> result =
+        handler.validateRequest(
+            protocolId,
+            new BeaconBlocksByRangeRequestMessage(
+                UInt64.valueOf(startBlock),
+                MAX_REQUEST_BLOCKS_DENEB.increment(),
+                UInt64.valueOf(skip)));
+
+    assertThat(result)
+        .hasValue(
+            new RpcException(
+                INVALID_REQUEST_CODE, "Only a maximum of 128 blocks can be requested per request"));
   }
 
   @Test
@@ -279,64 +332,23 @@ class BeaconBlocksByRangeMessageHandlerTest {
 
   @Test
   public void shouldStopAtBestSlot() {
+    final int count = 50;
     final int startBlock = 15;
-    final UInt64 count = UInt64.valueOf(MAX_REQUEST_BLOCKS);
     final int skip = 5;
 
     withCanonicalHeadBlock(blocksWStates.get(5));
-    withAncestorRoots(startBlock, maxRequestSize.intValue(), skip, hotBlocks());
+    withAncestorRoots(startBlock, count, skip, hotBlocks());
 
     handler.onIncomingMessage(
         protocolId,
         peer,
         new BeaconBlocksByRangeRequestMessage(
-            UInt64.valueOf(startBlock), count, UInt64.valueOf(skip)),
+            UInt64.valueOf(startBlock), UInt64.valueOf(count), UInt64.valueOf(skip)),
         listener);
 
     verifyNoBlocksReturned();
-    // The first block is after the best block available so we shouldn't request anything
+    // The first block is after the best block available, so we shouldn't request anything
     verify(combinedChainDataClient, never()).getBlockAtSlotExact(any(), any());
-  }
-
-  @Test
-  public void shouldRejectRequestWhenStepIsZero() {
-    final int startBlock = 15;
-    final UInt64 count = UInt64.valueOf(MAX_REQUEST_BLOCKS);
-    final int skip = 0;
-
-    withCanonicalHeadBlock(blocksWStates.get(5));
-
-    handler.onIncomingMessage(
-        protocolId,
-        peer,
-        new BeaconBlocksByRangeRequestMessage(
-            UInt64.valueOf(startBlock), count, UInt64.valueOf(skip)),
-        listener);
-
-    verify(listener)
-        .completeWithErrorResponse(
-            new RpcException(INVALID_REQUEST_CODE, "Step must be greater than zero"));
-    verifyNoMoreInteractions(listener);
-    verifyNoMoreInteractions(combinedChainDataClient);
-  }
-
-  @Test
-  void shouldLimitNumberOfBlocksReturned() {
-    final int startBlock = 1;
-    final UInt64 count = maxRequestSize.plus(ONE);
-    final int skip = 1;
-
-    withCanonicalHeadBlock(blocksWStates.get(10));
-    withAncestorRoots(startBlock, maxRequestSize.intValue(), skip, hotBlocks(1, 2, 3, 6, 7, 8, 9));
-
-    handler.onIncomingMessage(
-        protocolId,
-        peer,
-        new BeaconBlocksByRangeRequestMessage(
-            UInt64.valueOf(startBlock), count, UInt64.valueOf(skip)),
-        listener);
-
-    verifyBlocksReturned(1, 2, 3, 6, 7, 8);
   }
 
   @Test

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRootMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRootMessageHandlerTest.java
@@ -23,7 +23,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.networking.eth2.rpc.core.RpcResponseStatus.INVALID_REQUEST_CODE;
 import static tech.pegasys.teku.spec.config.Constants.MAX_CHUNK_SIZE;
-import static tech.pegasys.teku.spec.config.Constants.MAX_REQUEST_BLOCKS;
 import static tech.pegasys.teku.spec.config.Constants.MAX_REQUEST_BLOCKS_DENEB;
 
 import java.util.List;
@@ -87,26 +86,9 @@ public class BeaconBlocksByRootMessageHandlerTest {
 
   @Test
   public void onIncomingMessage_shouldRejectRequestWhenCountIsTooBig() {
-    when(recentChainData.getCurrentEpoch()).thenReturn(Optional.of(altairForkEpoch));
-
-    final List<Bytes32> roots =
-        UInt64.range(UInt64.ZERO, MAX_REQUEST_BLOCKS.increment())
-            .map(__ -> Bytes32.ZERO)
-            .collect(Collectors.toList());
-
-    handler.onIncomingMessage(
-        V2_PROTOCOL_ID, peer, new BeaconBlocksByRootRequestMessage(roots), callback);
-
-    verify(callback)
-        .completeWithErrorResponse(
-            new RpcException(
-                INVALID_REQUEST_CODE,
-                "Only a maximum of 1024 blocks can be requested per request"));
-  }
-
-  @Test
-  public void onIncomingMessage_shouldRejectRequestWhenCountIsTooBigForDeneb() {
     final UInt64 denebForkEpoch = UInt64.valueOf(4);
+    // Testing for Deneb since can't initialize BeaconBlocksByRootMessageHandler with size more
+    // than MAX_REQUEST_BLOCKS
     final Spec spec = TestSpecFactory.createMinimalWithDenebForkEpoch(denebForkEpoch);
 
     when(recentChainData.getCurrentEpoch()).thenReturn(Optional.of(denebForkEpoch));

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRootMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRootMessageHandlerTest.java
@@ -28,11 +28,9 @@ import static tech.pegasys.teku.spec.config.Constants.MAX_REQUEST_BLOCKS_DENEB;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.provider.Arguments;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.teku.networking.eth2.rpc.beaconchain.BeaconChainMethodIds;
@@ -179,10 +177,6 @@ public class BeaconBlocksByRootMessageHandlerTest {
             V2_PROTOCOL_ID, chainUpdater.advanceChain(altairForkSlot.plus(1)).getBlock());
 
     assertThat(result).isEmpty();
-  }
-
-  public static Stream<Arguments> protocolIdParams() {
-    return Stream.of(Arguments.of(V2_PROTOCOL_ID));
   }
 
   private BeaconBlocksByRootRequestMessage createRequest(final List<SignedBeaconBlock> forBlocks) {

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandlerTest.java
@@ -97,7 +97,8 @@ public class BlobSidecarsByRangeMessageHandlerTest {
   @BeforeEach
   public void setUp() {
     when(peer.popRequest()).thenReturn(true);
-    when(peer.popBlobSidecarRequests(listener, count.times(maxBlobsPerBlock).longValue())).thenReturn(true);
+    when(peer.popBlobSidecarRequests(listener, count.times(maxBlobsPerBlock).longValue()))
+        .thenReturn(true);
     when(combinedChainDataClient.getEarliestAvailableBlobSidecarEpoch())
         .thenReturn(SafeFuture.completedFuture(Optional.of(ZERO)));
     when(combinedChainDataClient.getCurrentEpoch()).thenReturn(denebForkEpoch.increment());

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandlerTest.java
@@ -26,7 +26,6 @@ import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.networking.eth2.rpc.core.RpcResponseStatus.INVALID_REQUEST_CODE;
 import static tech.pegasys.teku.networking.eth2.rpc.core.RpcResponseStatus.RESOURCE_UNAVAILABLE;
 import static tech.pegasys.teku.spec.config.Constants.MAX_CHUNK_SIZE_BELLATRIX;
-import static tech.pegasys.teku.spec.config.Constants.SYNC_BLOB_SIDECARS_SIZE;
 
 import java.util.List;
 import java.util.Optional;
@@ -45,7 +44,6 @@ import tech.pegasys.teku.networking.eth2.rpc.core.ResponseCallback;
 import tech.pegasys.teku.networking.eth2.rpc.core.RpcException;
 import tech.pegasys.teku.networking.eth2.rpc.core.encodings.RpcEncoding;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.config.SpecConfigDeneb;
 import tech.pegasys.teku.spec.datastructures.execution.versions.deneb.BlobSidecar;
@@ -117,8 +115,7 @@ public class BlobSidecarsByRootMessageHandlerTest {
 
   @Test
   public void validateRequest_shouldNotAllowRequestLargerThanMaximumAllowed() {
-    final int maxRequestBlobSidecars =
-        getMaxRequestBlobSidecars(spec, SpecMilestone.DENEB).intValue();
+    final int maxRequestBlobSidecars = getMaxRequestBlobSidecars();
     final BlobSidecarsByRootRequestMessage request =
         new BlobSidecarsByRootRequestMessage(
             dataStructureUtil.randomBlobIdentifiers(maxRequestBlobSidecars + 1));
@@ -268,22 +265,9 @@ public class BlobSidecarsByRootMessageHandlerTest {
     verify(callback).completeSuccessfully();
   }
 
-  @Test
-  public void
-      verifySyncBlobSidecarsSizeIsNotLargerThanMaxRequestBlobSidecarsForShardingMilestones() {
-    final List<SpecMilestone> shardingMilestones =
-        SpecMilestone.getAllFutureMilestones(SpecMilestone.CAPELLA);
-
-    shardingMilestones.forEach(
-        milestone -> {
-          final Spec spec = TestSpecFactory.createMainnet(milestone);
-          final UInt64 maxRequestBlobSidecars = getMaxRequestBlobSidecars(spec, milestone);
-          assertThat(SYNC_BLOB_SIDECARS_SIZE.isLessThanOrEqualTo(maxRequestBlobSidecars)).isTrue();
-        });
-  }
-
-  private UInt64 getMaxRequestBlobSidecars(final Spec spec, final SpecMilestone milestone) {
-    return SpecConfigDeneb.required(spec.forMilestone(milestone).getConfig())
-        .getMaxRequestBlobSidecars();
+  private int getMaxRequestBlobSidecars() {
+    return SpecConfigDeneb.required(spec.atEpoch(denebForkEpoch).getConfig())
+        .getMaxRequestBlobSidecars()
+        .intValue();
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
This PR does few things:

- Make MAX_REQUEST_BLOCKS dynamic for pre-Deneb and post-Deneb (MAX_REQUEST_BLOCKS_DENEB)
- Added a size request check in `blocksByRoot`
- Changed implementation of `blobSidecarsByRange` requested objects check
- Removed SYNC_BLOB_SIDECARS_SIZE because we should use same batch size of  SYNC_BATCH_SIZE
- Removed usages of MAX_BLOCK_BY_RANGE_REQUEST_SIZE when initializing the BlockByRangeHandler


## Fixed Issue(s)
fixes #6870 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
