### PR TITLE
fetch available blobs only

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/helpers/MiscHelpersDeneb.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/helpers/MiscHelpersDeneb.java
@@ -35,6 +35,7 @@ import tech.pegasys.teku.kzg.KZGProof;
 import tech.pegasys.teku.kzg.ckzg4844.CKZG4844;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.config.SpecConfigDeneb;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.execution.Transaction;
 import tech.pegasys.teku.spec.datastructures.execution.versions.deneb.Blob;
 import tech.pegasys.teku.spec.datastructures.execution.versions.deneb.BlobsSidecar;
@@ -88,6 +89,14 @@ public class MiscHelpersDeneb extends MiscHelpersBellatrix {
       final BlobsSidecar blobsSidecar) {
     validateBlobsSidecar(slot, beaconBlockRoot, kzgCommitments, blobsSidecar);
     return true;
+  }
+
+  public int getBlobSidecarsCount(final Optional<SignedBeaconBlock> signedBeaconBlock) {
+    return signedBeaconBlock
+        .flatMap(SignedBeaconBlock::getBeaconBlock)
+        .flatMap(beaconBlock -> beaconBlock.getBody().toVersionDeneb())
+        .map(beaconBlockBodyDeneb -> beaconBlockBodyDeneb.getBlobKzgCommitments().size())
+        .orElse(0);
   }
 
   @VisibleForTesting

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandler.java
@@ -310,9 +310,7 @@ public class BlobSidecarsByRangeMessageHandler
       maybeCurrentBlock.ifPresent(
           block -> {
             if (block.getSlot().equals(currentSlot.get())
-                && currentIndex
-                    .get()
-                    .equals(getMaxBlobSidecarIndex())) {
+                && currentIndex.get().equals(getMaxBlobSidecarIndex())) {
               maybeCurrentBlock = Optional.empty();
             }
           });

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandler.java
@@ -269,15 +269,7 @@ public class BlobSidecarsByRangeMessageHandler
                   final MiscHelpersDeneb miscHelpersDeneb =
                       spec.atSlot(currentSlot.get()).miscHelpers().toVersionDeneb().orElseThrow();
                   blobSidecarsCount = miscHelpersDeneb.getBlobSidecarsCount(block);
-                  if (blobSidecarsCount > maxBlobsPerBlock.intValue()) {
-                    return SafeFuture.failedFuture(
-                        new RpcException.ResourceUnavailableException(
-                            String.format(
-                                "Blob Sidecars count %d is greater than max allowed Blob Sidecars per block %d",
-                                blobSidecarsCount, maxBlobsPerBlock.intValue())));
-                  } else {
-                    return retrieveBlobSidecar();
-                  }
+                  return retrieveBlobSidecar();
                 });
       } else {
         return retrieveBlobSidecar();

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandler.java
@@ -144,7 +144,6 @@ public class BlobSidecarsByRangeMessageHandler
               final BlobSidecarsByRangeMessageHandler.RequestState initialState =
                   new BlobSidecarsByRangeMessageHandler.RequestState(
                       callback,
-                      maxBlobsPerBlock,
                       maxRequestBlobSidecars,
                       headBlockRoot,
                       startSlot,
@@ -217,7 +216,6 @@ public class BlobSidecarsByRangeMessageHandler
 
     private final AtomicInteger sentBlobSidecars = new AtomicInteger(0);
     private final ResponseCallback<BlobSidecar> callback;
-    private final UInt64 maxBlobsPerBlock;
     private final UInt64 maxRequestBlobSidecars;
     private final Bytes32 headBlockRoot;
     private final AtomicReference<UInt64> currentSlot;
@@ -230,13 +228,11 @@ public class BlobSidecarsByRangeMessageHandler
 
     RequestState(
         final ResponseCallback<BlobSidecar> callback,
-        final UInt64 maxBlobsPerBlock,
         final UInt64 maxRequestBlobSidecars,
         final Bytes32 headBlockRoot,
         final UInt64 currentSlot,
         final UInt64 maxSlot) {
       this.callback = callback;
-      this.maxBlobsPerBlock = maxBlobsPerBlock;
       this.maxRequestBlobSidecars = maxRequestBlobSidecars;
       this.headBlockRoot = headBlockRoot;
       this.currentSlot = new AtomicReference<>(currentSlot);

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandler.java
@@ -282,7 +282,7 @@ public class BlobSidecarsByRangeMessageHandler
     }
 
     void incrementSlotAndIndex() {
-      if (currentIndex.get().equals(UInt64.valueOf(blobSidecarsCount).minusMinZero(UInt64.ONE))) {
+      if (currentIndex.get().equals(getMaxBlobSidecarIndex())) {
         currentIndex.set(UInt64.ZERO);
         currentSlot.updateAndGet(UInt64::increment);
       } else {
@@ -312,10 +312,14 @@ public class BlobSidecarsByRangeMessageHandler
             if (block.getSlot().equals(currentSlot.get())
                 && currentIndex
                     .get()
-                    .equals(UInt64.valueOf(blobSidecarsCount).minusMinZero(UInt64.ONE))) {
+                    .equals(getMaxBlobSidecarIndex())) {
               maybeCurrentBlock = Optional.empty();
             }
           });
+    }
+
+    private UInt64 getMaxBlobSidecarIndex() {
+      return UInt64.valueOf(blobSidecarsCount).minusMinZero(UInt64.ONE);
     }
   }
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandler.java
@@ -143,11 +143,7 @@ public class BlobSidecarsByRangeMessageHandler
               }
               final BlobSidecarsByRangeMessageHandler.RequestState initialState =
                   new BlobSidecarsByRangeMessageHandler.RequestState(
-                      callback,
-                      maxRequestBlobSidecars,
-                      headBlockRoot,
-                      startSlot,
-                      maxSlot);
+                      callback, maxRequestBlobSidecars, headBlockRoot, startSlot, maxSlot);
               if (initialState.isComplete()) {
                 return SafeFuture.completedFuture(initialState);
               }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandlerTest.java
@@ -102,12 +102,10 @@ public class BlobSidecarsByRangeMessageHandlerTest {
       new BlobSidecarsByRangeMessageHandler(
           spec, denebForkEpoch, metricsSystem, combinedChainDataClient);
 
-  private final UInt64 maxBlobsPerBlock = UInt64.valueOf(specConfig.getMaxBlobsPerBlock());
-
   @BeforeEach
   public void setUp() {
     when(peer.popRequest()).thenReturn(true);
-    when(peer.popBlobSidecarRequests(listener, count.times(maxBlobsPerBlock).longValue()))
+    when(peer.popBlobSidecarRequests(listener, count.longValue()))
         .thenReturn(true);
     when(combinedChainDataClient.getEarliestAvailableBlobSidecarEpoch())
         .thenReturn(SafeFuture.completedFuture(Optional.of(ZERO)));
@@ -264,12 +262,7 @@ public class BlobSidecarsByRangeMessageHandlerTest {
     BlobSidecarsByRangeMessageHandler.RequestState request =
         handler
         .new RequestState(
-            listener,
-            maxBlobsPerBlock,
-            specConfig.getMaxRequestBlobSidecars(),
-            headBlockRoot,
-            currentSlot,
-            count);
+            listener, specConfig.getMaxRequestBlobSidecars(), headBlockRoot, currentSlot, count);
 
     for (int slot = currentSlot.intValue(); slot <= count.intValue(); slot++) {
 

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandlerTest.java
@@ -106,8 +106,7 @@ public class BlobSidecarsByRangeMessageHandlerTest {
   @BeforeEach
   public void setUp() {
     when(peer.popRequest()).thenReturn(true);
-    when(peer.popBlobSidecarRequests(eq(listener), anyLong()))
-        .thenReturn(true);
+    when(peer.popBlobSidecarRequests(eq(listener), anyLong())).thenReturn(true);
     when(combinedChainDataClient.getEarliestAvailableBlobSidecarEpoch())
         .thenReturn(SafeFuture.completedFuture(Optional.of(ZERO)));
     when(combinedChainDataClient.getCurrentEpoch()).thenReturn(denebForkEpoch.increment());

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandlerTest.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -105,7 +106,7 @@ public class BlobSidecarsByRangeMessageHandlerTest {
   @BeforeEach
   public void setUp() {
     when(peer.popRequest()).thenReturn(true);
-    when(peer.popBlobSidecarRequests(listener, count.longValue()))
+    when(peer.popBlobSidecarRequests(eq(listener), anyLong()))
         .thenReturn(true);
     when(combinedChainDataClient.getEarliestAvailableBlobSidecarEpoch())
         .thenReturn(SafeFuture.completedFuture(Optional.of(ZERO)));

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandlerTest.java
@@ -336,8 +336,7 @@ public class BlobSidecarsByRangeMessageHandlerTest {
     when(beaconBlock.getBody()).thenReturn(beaconBlockBody);
     Optional<BeaconBlock> maybeBeaconBlock = Optional.of(beaconBlock);
     when(signedBeaconBlock.getBeaconBlock()).thenReturn(maybeBeaconBlock);
-    Optional<SignedBeaconBlock> maybeSignedBeaconBlock = Optional.of(signedBeaconBlock);
     when(combinedChainDataClient.getBlockAtSlotExact(eq(UInt64.valueOf(slot)), any()))
-        .thenReturn(SafeFuture.completedFuture(maybeSignedBeaconBlock));
+        .thenReturn(SafeFuture.completedFuture(Optional.of(signedBeaconBlock)));
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Refactor the BlobSidecarsByRange RPC method to iterate through the available Blob Sidecars only (based on the block's kzg commitments count)

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
#6881 and #6880 

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
