### PR TITLE
Update ATs to use Besu 23.1.1

### DIFF
--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/RemoteValidatorCompatibilityAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/RemoteValidatorCompatibilityAcceptanceTest.java
@@ -15,7 +15,7 @@ package tech.pegasys.teku.test.acceptance;
 
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.test.acceptance.dsl.AcceptanceTestBase;
-import tech.pegasys.teku.test.acceptance.dsl.DockerVersion;
+import tech.pegasys.teku.test.acceptance.dsl.TekuDockerVersion;
 import tech.pegasys.teku.test.acceptance.dsl.TekuNode;
 import tech.pegasys.teku.test.acceptance.dsl.TekuValidatorNode;
 
@@ -27,21 +27,21 @@ public class RemoteValidatorCompatibilityAcceptanceTest extends AcceptanceTestBa
 
   @Test
   void shouldRunUpdatedValidatorAgainstOldBeaconNode() throws Exception {
-    verifyCompatibility(DockerVersion.V22_8_1, DockerVersion.LOCAL_BUILD);
+    verifyCompatibility(TekuDockerVersion.V22_8_1, TekuDockerVersion.LOCAL_BUILD);
   }
 
   @Test
   void shouldRunUpdatedValidatorAgainstLastReleaseBeaconNode() throws Exception {
-    verifyCompatibility(DockerVersion.LAST_RELEASE, DockerVersion.LOCAL_BUILD);
+    verifyCompatibility(TekuDockerVersion.LAST_RELEASE, TekuDockerVersion.LOCAL_BUILD);
   }
 
   @Test
   void shouldRunLastReleaseValidatorAgainstUpdatedBeaconNode() throws Exception {
-    verifyCompatibility(DockerVersion.LOCAL_BUILD, DockerVersion.LAST_RELEASE);
+    verifyCompatibility(TekuDockerVersion.LOCAL_BUILD, TekuDockerVersion.LAST_RELEASE);
   }
 
   private void verifyCompatibility(
-      final DockerVersion beaconNodeVersion, final DockerVersion validatorNodeVersion)
+      final TekuDockerVersion beaconNodeVersion, final TekuDockerVersion validatorNodeVersion)
       throws Exception {
     createBeaconNode(beaconNodeVersion);
     createValidatorClient(validatorNodeVersion);
@@ -54,7 +54,7 @@ public class RemoteValidatorCompatibilityAcceptanceTest extends AcceptanceTestBa
     validatorClient.waitForLogMessageContaining("Published aggregate");
   }
 
-  private void createValidatorClient(final DockerVersion version) {
+  private void createValidatorClient(final TekuDockerVersion version) {
     validatorClient =
         createValidatorNode(
             version,
@@ -65,7 +65,7 @@ public class RemoteValidatorCompatibilityAcceptanceTest extends AcceptanceTestBa
                     .withBeaconNode(beaconNode));
   }
 
-  private void createBeaconNode(final DockerVersion version) {
+  private void createBeaconNode(final TekuDockerVersion version) {
     beaconNode =
         createTekuNode(
             version,

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/AcceptanceTestBase.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/AcceptanceTestBase.java
@@ -51,11 +51,11 @@ public class AcceptanceTestBase {
   }
 
   protected TekuNode createTekuNode(final Consumer<TekuNode.Config> configOptions) {
-    return createTekuNode(DockerVersion.LOCAL_BUILD, configOptions);
+    return createTekuNode(TekuDockerVersion.LOCAL_BUILD, configOptions);
   }
 
   protected TekuNode createTekuNode(
-      final DockerVersion version, final Consumer<TekuNode.Config> configOptions) {
+      final TekuDockerVersion version, final Consumer<TekuNode.Config> configOptions) {
     try {
       return addNode(TekuNode.create(network, version, configOptions));
     } catch (IOException | TimeoutException e) {
@@ -74,11 +74,11 @@ public class AcceptanceTestBase {
 
   protected TekuValidatorNode createValidatorNode(
       final Consumer<TekuValidatorNode.Config> configOptions) {
-    return createValidatorNode(DockerVersion.LOCAL_BUILD, configOptions);
+    return createValidatorNode(TekuDockerVersion.LOCAL_BUILD, configOptions);
   }
 
   protected TekuValidatorNode createValidatorNode(
-      final DockerVersion version, final Consumer<TekuValidatorNode.Config> configOptions) {
+      final TekuDockerVersion version, final Consumer<TekuValidatorNode.Config> configOptions) {
     return addNode(TekuValidatorNode.create(network, version, configOptions));
   }
 

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/BesuDockerVersion.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/BesuDockerVersion.java
@@ -14,7 +14,7 @@
 package tech.pegasys.teku.test.acceptance.dsl;
 
 public enum BesuDockerVersion {
-  STABLE("22.7.0");
+  STABLE("23.1.1");
 
   private final String version;
 

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/BesuNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/BesuNode.java
@@ -202,6 +202,7 @@ public class BesuNode extends Node {
       configMap.put("host-allowlist", new String[] {"*"});
       configMap.put("discovery-enabled", false);
       configMap.put("genesis-file", "/genesis.json");
+      configMap.put("tx-pool-limit-by-account-percentage", "1");
     }
 
     public BesuNode.Config withMiningEnabled(final boolean enabled) {

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/Node.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/Node.java
@@ -77,7 +77,7 @@ public abstract class Node {
   protected Node(
       final Network network,
       final String dockerImageName,
-      final DockerVersion dockerImageVersion,
+      final TekuDockerVersion dockerImageVersion,
       final Logger log) {
     this(network, dockerImageName + ":" + dockerImageVersion.getVersion(), log);
   }
@@ -88,7 +88,7 @@ public abstract class Node {
     this.container =
         new NodeContainer(dockerImage)
             .withImagePullPolicy(
-                dockerImage.endsWith(DockerVersion.LOCAL_BUILD.getVersion())
+                dockerImage.endsWith(TekuDockerVersion.LOCAL_BUILD.getVersion())
                     ? PullPolicy.defaultPolicy()
                     : PullPolicy.ageBased(Duration.ofMinutes(5)))
             .withNetwork(network)

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuDepositSender.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuDepositSender.java
@@ -39,7 +39,7 @@ public class TekuDepositSender extends Node {
   private final ValidatorKeyGenerator validatorKeyGenerator = new ValidatorKeyGenerator();
 
   public TekuDepositSender(final Network network, final Spec spec) {
-    super(network, TekuNode.TEKU_DOCKER_IMAGE_NAME, DockerVersion.LOCAL_BUILD, LOG);
+    super(network, TekuNode.TEKU_DOCKER_IMAGE_NAME, TekuDockerVersion.LOCAL_BUILD, LOG);
     this.spec = spec;
   }
 

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuDockerVersion.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuDockerVersion.java
@@ -13,14 +13,14 @@
 
 package tech.pegasys.teku.test.acceptance.dsl;
 
-public enum DockerVersion {
+public enum TekuDockerVersion {
   LOCAL_BUILD("develop"),
   LAST_RELEASE("latest"),
   V22_8_1("22.8.1");
 
   private final String version;
 
-  DockerVersion(final String version) {
+  TekuDockerVersion(final String version) {
     this.version = version;
   }
 

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNode.java
@@ -114,7 +114,7 @@ public class TekuNode extends Node {
   private boolean started = false;
   private Set<File> configFiles;
 
-  private TekuNode(final Network network, final DockerVersion version, final Config config) {
+  private TekuNode(final Network network, final TekuDockerVersion version, final Config config) {
     super(network, TEKU_DOCKER_IMAGE_NAME, version, LOG);
     this.config = config;
 
@@ -133,7 +133,7 @@ public class TekuNode extends Node {
   }
 
   public static TekuNode create(
-      final Network network, final DockerVersion version, final Consumer<Config> configOptions)
+      final Network network, final TekuDockerVersion version, final Consumer<Config> configOptions)
       throws TimeoutException, IOException {
 
     final Config config = new Config();

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuValidatorNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuValidatorNode.java
@@ -58,7 +58,9 @@ public class TekuValidatorNode extends Node {
           new TrustingSimpleHttpsClient(), this::getValidatorApiUrl, this::getApiPassword);
 
   private TekuValidatorNode(
-      final Network network, final TekuDockerVersion version, final TekuValidatorNode.Config config) {
+      final Network network,
+      final TekuDockerVersion version,
+      final TekuValidatorNode.Config config) {
     super(network, TEKU_DOCKER_IMAGE_NAME, version, LOG);
     this.config = config;
     if (config.configMap.containsKey("validator-api-enabled")) {

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuValidatorNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuValidatorNode.java
@@ -58,7 +58,7 @@ public class TekuValidatorNode extends Node {
           new TrustingSimpleHttpsClient(), this::getValidatorApiUrl, this::getApiPassword);
 
   private TekuValidatorNode(
-      final Network network, final DockerVersion version, final TekuValidatorNode.Config config) {
+      final Network network, final TekuDockerVersion version, final TekuValidatorNode.Config config) {
     super(network, TEKU_DOCKER_IMAGE_NAME, version, LOG);
     this.config = config;
     if (config.configMap.containsKey("validator-api-enabled")) {
@@ -73,7 +73,7 @@ public class TekuValidatorNode extends Node {
 
   public static TekuValidatorNode create(
       final Network network,
-      final DockerVersion version,
+      final TekuDockerVersion version,
       Consumer<TekuValidatorNode.Config> configOptions) {
 
     final TekuValidatorNode.Config config = new TekuValidatorNode.Config();

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuVoluntaryExit.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuVoluntaryExit.java
@@ -34,7 +34,7 @@ public class TekuVoluntaryExit extends Node {
   private Set<File> configFiles;
 
   private TekuVoluntaryExit(final Network network, final TekuVoluntaryExit.Config config) {
-    super(network, TEKU_DOCKER_IMAGE_NAME, DockerVersion.LOCAL_BUILD, LOG);
+    super(network, TEKU_DOCKER_IMAGE_NAME, TekuDockerVersion.LOCAL_BUILD, LOG);
     this.config = config;
 
     container

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/tools/TekuCLI.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/tools/TekuCLI.java
@@ -20,14 +20,14 @@ import org.apache.logging.log4j.Logger;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.output.OutputFrame.OutputType;
 import org.testcontainers.containers.output.WaitingConsumer;
-import tech.pegasys.teku.test.acceptance.dsl.DockerVersion;
+import tech.pegasys.teku.test.acceptance.dsl.TekuDockerVersion;
 import tech.pegasys.teku.test.acceptance.dsl.TekuNode;
 
 class TekuCLI extends GenericContainer<TekuCLI> {
   private static final Logger LOG = LogManager.getLogger();
 
   public TekuCLI() {
-    super(TekuNode.TEKU_DOCKER_IMAGE_NAME + ":" + DockerVersion.LOCAL_BUILD.getVersion());
+    super(TekuNode.TEKU_DOCKER_IMAGE_NAME + ":" + TekuDockerVersion.LOCAL_BUILD.getVersion());
     this.withLogConsumer(frame -> LOG.info(frame.getUtf8String().trim()));
   }
 


### PR DESCRIPTION
## PR Description
- Renaming DockerVersion to TekuDockerVersion
- Upgrading Besu version on ATs to 23.1.1 (latest)
  - Required a small adjustment on the tx pool config to work

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
