### PR TITLE
Unhide `--p2p-discovery-site-local-addresses-enabled`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ For information on changes in released versions of Teku, see the [releases page]
 - Send validator registrations to the Beacon node when the Validator client has reconnected to the event stream
 - Added optional query parameters `require_prepared_proposers` and `require_validator_registrations` to the `teku/v1/admin/readiness` endpoint
 - Added experimental feature `--Xdeposit-snapshot-enabled` to use bundled deposit contract tree snapshot and persist it after finalization to decrease EL pressure and speed up node startup
-- Added `--p2p-discovery-site-local-addresses-enabled` option to allow discovery connections to local network addresses 
+- Added `--p2p-discovery-site-local-addresses-enabled` option to allow discovery connections to local (RFC1918) addresses.
 
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - The `/eth/v1/beacon/blocks/:block_id` endpoint has been deprecated in favor of the v2 Altair endpoint `/eth/v2/beacon/blocks/:block_id`
 - The `/eth/v1/validator/blocks/:slot` endpoint has been deprecated in favor of the v2 Altair endpoint `/eth/v2/validator/blocks/:slot`
 - The `/eth/v1/debug/beacon/heads` endpoint has been deprecated in favor of the v2 Bellatrix endpoint `/eth/v2/debug/beacon/heads`
+- The `--p2p-discovery-site-local-addresses-enabled` option will be set to `false` by default. If you use the client's discovery inside the local network, update its launch command to toggle the option.  
 
 ## Current Releases
 For information on changes in released versions of Teku, see the [releases page](https://github.com/ConsenSys/teku/releases).
@@ -19,5 +20,7 @@ For information on changes in released versions of Teku, see the [releases page]
 - Send validator registrations to the Beacon node when the Validator client has reconnected to the event stream
 - Added optional query parameters `require_prepared_proposers` and `require_validator_registrations` to the `teku/v1/admin/readiness` endpoint
 - Added experimental feature `--Xdeposit-snapshot-enabled` to use bundled deposit contract tree snapshot and persist it after finalization to decrease EL pressure and speed up node startup
+- Added `--p2p-discovery-site-local-addresses-enabled` option to allow discovery connections to local network addresses 
+
 
 ### Bug Fixes

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/DiscoveryConfig.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/DiscoveryConfig.java
@@ -27,7 +27,7 @@ public class DiscoveryConfig {
   public static final boolean DEFAULT_P2P_DISCOVERY_ENABLED = true;
   public static final int DEFAULT_P2P_PEERS_LOWER_BOUND = 64;
   public static final int DEFAULT_P2P_PEERS_UPPER_BOUND = 100;
-  public static final boolean DEFAULT_SITE_LOCAL_ADDRESSES_ENABLED = true;
+  public static final boolean DEFAULT_SITE_LOCAL_ADDRESSES_ENABLED = false;
 
   private final boolean isDiscoveryEnabled;
   private final int listenUdpPort;

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/DiscoveryConfig.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/DiscoveryConfig.java
@@ -27,7 +27,7 @@ public class DiscoveryConfig {
   public static final boolean DEFAULT_P2P_DISCOVERY_ENABLED = true;
   public static final int DEFAULT_P2P_PEERS_LOWER_BOUND = 64;
   public static final int DEFAULT_P2P_PEERS_UPPER_BOUND = 100;
-  public static final boolean DEFAULT_SITE_LOCAL_ADDRESSES_ENABLED = false;
+  public static final boolean DEFAULT_SITE_LOCAL_ADDRESSES_ENABLED = true;
 
   private final boolean isDiscoveryEnabled;
   private final int listenUdpPort;

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
@@ -240,7 +240,7 @@ public class P2POptions {
       P2PConfig.DEFAULT_BATCH_VERIFY_STRICT_THREAD_LIMIT_ENABLED;
 
   @Option(
-      names = {"--Xp2p-discovery-site-local-addresses-enabled"},
+      names = {"--p2p-discovery-site-local-addresses-enabled"},
       paramLabel = "<BOOLEAN>",
       showDefaultValue = Visibility.ALWAYS,
       description =

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
@@ -244,7 +244,7 @@ public class P2POptions {
       paramLabel = "<BOOLEAN>",
       showDefaultValue = Visibility.ALWAYS,
       description =
-          "Whether discover accepts messages and peer records with site local (RFC1918) addresses",
+          "Whether discovery accepts messages and peer records with site local (RFC1918) addresses",
       arity = "0..1",
       hidden = true,
       fallbackValue = "true")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
It's follow-up for the #6242 
How do I see it:
- this one PR: we unhide the feature but left it toggled off to give some time to update it
- before the next release we toggle it to the `false` by default and add appropriate CHANGELOG entry 

```
Syntax: --p2p-discovery-site-local-addresses-enabled[=<BOOLEAN>]
Example: --p2p-discovery-site-local-addresses-enabled=true
Environment variable: P2P_DISCOVERY_SITE_LOCAL_ADDRESSES_ENABLED=true
Configuration file: p2p-discovery-site-local-addresses-enabled: true
```

Whether discovery accepts messages and peer records with site local (RFC1918) addresses. Default is `false`.

Normal Teku operation should not send traffic to local networks (RFC1918) addresses.
```
   The Internet Assigned Numbers Authority (IANA) has reserved the
   following three blocks of the IP address space for private internets:

 	10.0.0.0    	-   10.255.255.255  (10/8 prefix)
 	172.16.0.0  	-   172.31.255.255  (172.16/12 prefix)
 	192.168.0.0 	-   192.168.255.255 (192.168/16 prefix)
```	 
For some reasons operators may need to enable discovery of local addresses, for example when you run multiple consensus layer nodes in one local network, these nodes are not discovered in public Internet and are advertised with local IPs. Such configurations are usual for test or private networks. When running in such configuration this flag should be toggled (set to true).



## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
