### PR TITLE
Updated jackson libraries to switch to using dataformats-text

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -1,8 +1,7 @@
 dependencyManagement {
   dependencies {
     dependency 'com.fasterxml.jackson.core:jackson-databind:2.14.2'
-    dependency 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.14.2'
-    dependency 'com.fasterxml.jackson.dataformat:jackson-dataformat-toml:2.14.2'
+    dependency 'com.fasterxml.jackson.dataformat:jackson-dataformats-text:2.14.2'
     dependency 'com.fasterxml.jackson.module:jackson-module-kotlin:2.14.2'
 
 


### PR DESCRIPTION
dataformats-yaml had some issues, and I also noticed that dataformats-text supports toml.

This should replace both libs with the current version.

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
