### PR TITLE
Ignoring trivy alert for snakeyaml 1.33

### DIFF
--- a/gradle/trivyignore.txt
+++ b/gradle/trivyignore.txt
@@ -1,0 +1,2 @@
+# Only applicable when parsing yaml from untrusted sources
+CVE-2022-1471


### PR DESCRIPTION
## PR Description

CVE-2022-1471 is applicable only when parsing yaml from untrusted sources

## Fixed Issue(s)
fixes #6977

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
