### PR TITLE
Updated Capella AT to use Engine API method negotiation

### DIFF
--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNode.java
@@ -971,6 +971,11 @@ public class TekuNode extends Node {
       return this;
     }
 
+    public Config withEngineApiMethodNegotiation() {
+      configMap.put("Xexchange-capabilities-enabled", "true");
+      return this;
+    }
+
     public Config withJwtSecretFile(final URL jwtFile) {
       this.maybeJwtFile = Optional.of(jwtFile);
       configMap.put(EE_JWT_SECRET_FILE_KEY, JWT_SECRET_FILE_PATH);

--- a/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineJsonRpcMethodTest.java
+++ b/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineJsonRpcMethodTest.java
@@ -13,19 +13,27 @@
 
 package tech.pegasys.teku.ethereum.executionclient.methods;
 
-import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
-public interface EngineJsonRpcMethod<T> {
+import org.junit.jupiter.api.Test;
 
-  String getName();
+class EngineJsonRpcMethodTest {
 
-  int getVersion();
+  @Test
+  public void shouldNotBeNegotiableWhenVersionIsZero() {
+    EngineJsonRpcMethod<?> method = spy(EngineJsonRpcMethod.class);
+    when(method.getVersion()).thenReturn(0);
 
-  String getVersionedName();
+    assertThat(method.isNegotiable()).isFalse();
+  }
 
-  SafeFuture<T> execute(JsonRpcRequestParams params);
+  @Test
+  public void shouldBeNegotiableWhenVersionIsNotZero() {
+    EngineJsonRpcMethod<?> method = spy(EngineJsonRpcMethod.class);
+    when(method.getVersion()).thenReturn(1);
 
-  default boolean isNegotiable() {
-    return getVersion() != 0;
+    assertThat(method.isNegotiable()).isTrue();
   }
 }

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/NegotiatedExecutionJsonRpcMethodsResolver.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/NegotiatedExecutionJsonRpcMethodsResolver.java
@@ -41,6 +41,7 @@ public class NegotiatedExecutionJsonRpcMethodsResolver implements ExecutionJsonR
   }
 
   @Override
+  @SuppressWarnings("unchecked")
   public <T> EngineJsonRpcMethod<T> getMethod(
       final EngineApiMethods method, final Class<T> resultType) {
     if (!remoteEngineApiCapabilitiesProvider.isAvailable()) {
@@ -49,6 +50,9 @@ public class NegotiatedExecutionJsonRpcMethodsResolver implements ExecutionJsonR
 
     final List<EngineJsonRpcMethod<?>> availableLocalMethodVersions =
         getAvailableMethodVersions(method, localEngineApiCapabilitiesProvider.supportedMethods());
+    if (shouldSkipNegotiation(availableLocalMethodVersions)) {
+      return (EngineJsonRpcMethod<T>) availableLocalMethodVersions.get(0);
+    }
 
     final List<EngineJsonRpcMethod<?>> availableRemoteMethodVersions =
         getAvailableMethodVersions(method, remoteEngineApiCapabilitiesProvider.supportedMethods());
@@ -64,6 +68,12 @@ public class NegotiatedExecutionJsonRpcMethodsResolver implements ExecutionJsonR
     }
 
     return negotiatedMethod;
+  }
+
+  private boolean shouldSkipNegotiation(
+      final List<EngineJsonRpcMethod<?>> availableLocalMethodVersions) {
+    return availableLocalMethodVersions.size() == 1
+        && !availableLocalMethodVersions.get(0).isNegotiable();
   }
 
   private List<EngineJsonRpcMethod<?>> getAvailableMethodVersions(


### PR DESCRIPTION
## PR Description
- Skipping negotiation for Engine API methods without version
- Updated Capella AT to use method negotiation

## Fixed Issue(s)
fixes #6784 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
