### PR TITLE
Multipeer forward sync for decoupled blobs

### DIFF
--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/DefaultSyncServiceFactory.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/DefaultSyncServiceFactory.java
@@ -64,6 +64,7 @@ public class DefaultSyncServiceFactory implements SyncServiceFactory {
   private final StorageUpdateChannel storageUpdateChannel;
   private final Eth2P2PNetwork p2pNetwork;
   private final BlockImporter blockImporter;
+  private final BlobsSidecarManager blobsSidecarManager;
   private final PendingPool<SignedBeaconBlock> pendingBlocks;
   private final int getStartupTargetPeerCount;
   private final AsyncBLSSignatureVerifier signatureVerifier;
@@ -82,6 +83,7 @@ public class DefaultSyncServiceFactory implements SyncServiceFactory {
       final StorageUpdateChannel storageUpdateChannel,
       final Eth2P2PNetwork p2pNetwork,
       final BlockImporter blockImporter,
+      final BlobsSidecarManager blobsSidecarManager,
       final PendingPool<SignedBeaconBlock> pendingBlocks,
       final int getStartupTargetPeerCount,
       final SignatureVerificationService signatureVerifier,
@@ -98,6 +100,7 @@ public class DefaultSyncServiceFactory implements SyncServiceFactory {
     this.storageUpdateChannel = storageUpdateChannel;
     this.p2pNetwork = p2pNetwork;
     this.blockImporter = blockImporter;
+    this.blobsSidecarManager = blobsSidecarManager;
     this.pendingBlocks = pendingBlocks;
     this.getStartupTargetPeerCount = getStartupTargetPeerCount;
     this.signatureVerifier = signatureVerifier;
@@ -168,6 +171,7 @@ public class DefaultSyncServiceFactory implements SyncServiceFactory {
               pendingBlocks,
               p2pNetwork,
               blockImporter,
+              blobsSidecarManager,
               spec);
     } else {
       LOG.info("Using single peer sync");
@@ -178,8 +182,7 @@ public class DefaultSyncServiceFactory implements SyncServiceFactory {
               p2pNetwork,
               recentChainData,
               blockImporter,
-              // TODO: change to the real value when renamed and initialized
-              BlobsSidecarManager.NOOP,
+              blobsSidecarManager,
               spec);
     }
     return forwardSync;

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/BatchImporter.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/BatchImporter.java
@@ -108,9 +108,12 @@ public class BatchImporter {
     if (!blobSidecars.containsKey(blockRoot)) {
       return importBlock(block, source);
     }
-    LOG.debug("Importing {} blob sidecars for block with root {}", blobSidecars, blockRoot);
-    return importBlobSidecars(blobSidecars.get(blockRoot))
-        .thenCompose(__ -> importBlock(block, source));
+    final List<BlobSidecar> blobSidecarsForBlock = blobSidecars.get(blockRoot);
+    LOG.debug(
+        "Importing {} blob sidecars for block with root {}",
+        blobSidecarsForBlock.size(),
+        blockRoot);
+    return importBlobSidecars(blobSidecarsForBlock).thenCompose(__ -> importBlock(block, source));
   }
 
   private SafeFuture<Void> importBlobSidecars(final List<BlobSidecar> blobSidecars) {

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/BatchImporter.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/BatchImporter.java
@@ -17,31 +17,40 @@ import static com.google.common.base.Preconditions.checkState;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.beacon.sync.forward.multipeer.batches.Batch;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.networking.eth2.peers.SyncSource;
 import tech.pegasys.teku.networking.p2p.peer.DisconnectReason;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.execution.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
+import tech.pegasys.teku.statetransition.blobs.BlobsSidecarManager;
 import tech.pegasys.teku.statetransition.block.BlockImporter;
 
 public class BatchImporter {
   private static final Logger LOG = LogManager.getLogger();
 
   private final BlockImporter blockImporter;
+  private final BlobsSidecarManager blobsSidecarManager;
   private final AsyncRunner asyncRunner;
 
-  public BatchImporter(final BlockImporter blockImporter, final AsyncRunner asyncRunner) {
+  public BatchImporter(
+      final BlockImporter blockImporter,
+      final BlobsSidecarManager blobsSidecarManager,
+      final AsyncRunner asyncRunner) {
     this.blockImporter = blockImporter;
+    this.blobsSidecarManager = blobsSidecarManager;
     this.asyncRunner = asyncRunner;
   }
 
   /**
-   * Import the blocks in the specified batch.
+   * Import the blocks and blob sidecars (if any) in the specified batch.
    *
    * <p>Guaranteed to return immediately and perform the import on worker threads.
    *
@@ -51,6 +60,8 @@ public class BatchImporter {
   public SafeFuture<BatchImportResult> importBatch(final Batch batch) {
     // Copy the data from batch as we're going to use them from off the event thread.
     final List<SignedBeaconBlock> blocks = new ArrayList<>(batch.getBlocks());
+    final Map<Bytes32, List<BlobSidecar>> blobSidecars = Map.copyOf(batch.getBlobSidecars());
+
     final Optional<SyncSource> source = batch.getSource();
 
     checkState(!blocks.isEmpty(), "Batch has no blocks to import");
@@ -58,14 +69,15 @@ public class BatchImporter {
         () -> {
           final SignedBeaconBlock firstBlock = blocks.get(0);
           SafeFuture<BlockImportResult> importResult =
-              importBlock(firstBlock, source.orElseThrow());
+              importBlobSidecarsAndBlock(firstBlock, blobSidecars, source.orElseThrow());
           for (int i = 1; i < blocks.size(); i++) {
             final SignedBeaconBlock block = blocks.get(i);
             importResult =
                 importResult.thenCompose(
                     previousResult -> {
                       if (previousResult.isSuccessful()) {
-                        return importBlock(block, source.orElseThrow());
+                        return importBlobSidecarsAndBlock(
+                            block, blobSidecars, source.orElseThrow());
                       } else {
                         return SafeFuture.completedFuture(previousResult);
                       }
@@ -86,6 +98,24 @@ public class BatchImporter {
                 return BatchImportResult.IMPORT_FAILED;
               });
         });
+  }
+
+  private SafeFuture<BlockImportResult> importBlobSidecarsAndBlock(
+      final SignedBeaconBlock block,
+      final Map<Bytes32, List<BlobSidecar>> blobSidecars,
+      final SyncSource source) {
+    final Bytes32 blockRoot = block.getRoot();
+    if (!blobSidecars.containsKey(blockRoot)) {
+      return importBlock(block, source);
+    }
+    LOG.debug("Importing {} blob sidecars for block with root {}", blobSidecars, blockRoot);
+    return importBlobSidecars(blobSidecars.get(blockRoot))
+        .thenCompose(__ -> importBlock(block, source));
+  }
+
+  private SafeFuture<Void> importBlobSidecars(final List<BlobSidecar> blobSidecars) {
+    return SafeFuture.allOfFailFast(
+        blobSidecars.stream().map(blobsSidecarManager::importBlobSidecar));
   }
 
   private SafeFuture<BlockImportResult> importBlock(

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/MultipeerSyncService.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/MultipeerSyncService.java
@@ -38,6 +38,7 @@ import tech.pegasys.teku.networking.p2p.network.P2PNetwork;
 import tech.pegasys.teku.service.serviceutils.Service;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.statetransition.blobs.BlobsSidecarManager;
 import tech.pegasys.teku.statetransition.block.BlockImporter;
 import tech.pegasys.teku.statetransition.util.PendingPool;
 import tech.pegasys.teku.storage.client.RecentChainData;
@@ -71,6 +72,7 @@ public class MultipeerSyncService extends Service implements ForwardSyncService 
       final PendingPool<SignedBeaconBlock> pendingBlocks,
       final P2PNetwork<Eth2Peer> p2pNetwork,
       final BlockImporter blockImporter,
+      final BlobsSidecarManager blobsSidecarManager,
       final Spec spec) {
     final EventThread eventThread = new AsyncRunnerEventThread("sync", asyncRunnerFactory);
     final SettableLabelledGauge targetChainCountGauge =
@@ -88,8 +90,9 @@ public class MultipeerSyncService extends Service implements ForwardSyncService 
             eventThread,
             asyncRunner,
             recentChainData,
-            new BatchImporter(blockImporter, asyncRunner),
-            new BatchFactory(eventThread, new PeerScoringConflictResolutionStrategy()),
+            new BatchImporter(blockImporter, blobsSidecarManager, asyncRunner),
+            new BatchFactory(
+                eventThread, blobsSidecarManager, new PeerScoringConflictResolutionStrategy()),
             FORWARD_SYNC_BATCH_SIZE,
             MultipeerCommonAncestorFinder.create(recentChainData, eventThread, spec),
             timeProvider);

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/Batch.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/Batch.java
@@ -14,11 +14,14 @@
 package tech.pegasys.teku.beacon.sync.forward.multipeer.batches;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.beacon.sync.forward.multipeer.chains.TargetChain;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.peers.SyncSource;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.execution.versions.deneb.BlobSidecar;
 
 /** A section of a particular target chain that can be downloaded in parallel. */
 public interface Batch {
@@ -33,6 +36,8 @@ public interface Batch {
   Optional<SignedBeaconBlock> getLastBlock();
 
   List<SignedBeaconBlock> getBlocks();
+
+  Map<Bytes32, List<BlobSidecar>> getBlobSidecars();
 
   Optional<SyncSource> getSource();
 

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/Batch.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/Batch.java
@@ -37,7 +37,7 @@ public interface Batch {
 
   List<SignedBeaconBlock> getBlocks();
 
-  Map<Bytes32, List<BlobSidecar>> getBlobSidecars();
+  Map<Bytes32, List<BlobSidecar>> getBlobSidecarsByBlockRoot();
 
   Optional<SyncSource> getSource();
 

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/BatchFactory.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/BatchFactory.java
@@ -16,15 +16,20 @@ package tech.pegasys.teku.beacon.sync.forward.multipeer.batches;
 import tech.pegasys.teku.beacon.sync.forward.multipeer.chains.TargetChain;
 import tech.pegasys.teku.infrastructure.async.eventthread.EventThread;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.statetransition.blobs.BlobsSidecarManager;
 
 public class BatchFactory {
 
   private final EventThread eventThread;
+  private final BlobsSidecarManager blobsSidecarManager;
   private final ConflictResolutionStrategy conflictResolutionStrategy;
 
   public BatchFactory(
-      final EventThread eventThread, final ConflictResolutionStrategy conflictResolutionStrategy) {
+      final EventThread eventThread,
+      final BlobsSidecarManager blobsSidecarManager,
+      final ConflictResolutionStrategy conflictResolutionStrategy) {
     this.eventThread = eventThread;
+    this.blobsSidecarManager = blobsSidecarManager;
     this.conflictResolutionStrategy = conflictResolutionStrategy;
   }
 
@@ -34,6 +39,12 @@ public class BatchFactory {
     return new EventThreadOnlyBatch(
         eventThread,
         new SyncSourceBatch(
-            eventThread, syncSourceProvider, conflictResolutionStrategy, chain, start, count));
+            eventThread,
+            blobsSidecarManager,
+            syncSourceProvider,
+            conflictResolutionStrategy,
+            chain,
+            start,
+            count));
   }
 }

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/ConflictResolutionStrategy.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/ConflictResolutionStrategy.java
@@ -41,6 +41,17 @@ public interface ConflictResolutionStrategy {
   void reportInvalidBatch(Batch batch, SyncSource source);
 
   /**
+   * Report that a batch is inconsistent so that any reputation changes can be applied. An
+   * inconsistent batch is still valid, so penalisation shouldn't be very harsh. For example, a peer
+   * could send blocks for a certain range, but then provide more blob sidecars than expected for
+   * the same range.
+   *
+   * @param batch the inconsistent batch
+   * @param source the source that provided the batch data
+   */
+  void reportInconsistentBatch(Batch batch, SyncSource source);
+
+  /**
    * Report that a batch was confirmed as part of the target chain. This is called before the blocks
    * are actually imported and only indicates that the first and last block matches the
    *

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/EventThreadOnlyBatch.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/EventThreadOnlyBatch.java
@@ -15,12 +15,15 @@ package tech.pegasys.teku.beacon.sync.forward.multipeer.batches;
 
 import com.google.common.base.MoreObjects;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.beacon.sync.forward.multipeer.chains.TargetChain;
 import tech.pegasys.teku.infrastructure.async.eventthread.EventThread;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.peers.SyncSource;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.execution.versions.deneb.BlobSidecar;
 
 public class EventThreadOnlyBatch implements Batch {
   private final EventThread eventThread;
@@ -65,6 +68,12 @@ public class EventThreadOnlyBatch implements Batch {
   public List<SignedBeaconBlock> getBlocks() {
     eventThread.checkOnEventThread();
     return delegate.getBlocks();
+  }
+
+  @Override
+  public Map<Bytes32, List<BlobSidecar>> getBlobSidecars() {
+    eventThread.checkOnEventThread();
+    return delegate.getBlobSidecars();
   }
 
   @Override

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/EventThreadOnlyBatch.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/EventThreadOnlyBatch.java
@@ -71,9 +71,9 @@ public class EventThreadOnlyBatch implements Batch {
   }
 
   @Override
-  public Map<Bytes32, List<BlobSidecar>> getBlobSidecars() {
+  public Map<Bytes32, List<BlobSidecar>> getBlobSidecarsByBlockRoot() {
     eventThread.checkOnEventThread();
-    return delegate.getBlobSidecars();
+    return delegate.getBlobSidecarsByBlockRoot();
   }
 
   @Override

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/PeerScoringConflictResolutionStrategy.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/PeerScoringConflictResolutionStrategy.java
@@ -43,6 +43,12 @@ public class PeerScoringConflictResolutionStrategy implements ConflictResolution
   }
 
   @Override
+  public void reportInconsistentBatch(final Batch batch, final SyncSource source) {
+    LOG.debug("Penalising peer {} for providing inconsistent batch data {}", source, batch);
+    source.adjustReputation(SMALL_PENALTY);
+  }
+
+  @Override
   public void reportConfirmedBatch(final Batch batch, final SyncSource source) {
     source.adjustReputation(SMALL_REWARD);
   }

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/SyncSourceBatch.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/SyncSourceBatch.java
@@ -409,7 +409,8 @@ public class SyncSourceBatch implements Batch {
         Sets.difference(newBlobSidecarsByBlockRoot.keySet(), blockRootsWithKzgCommitments);
     if (!unexpectedBlobSidecarsRoots.isEmpty()) {
       LOG.debug(
-          "Unexpected blob sidecars with roots {} were received", unexpectedBlobSidecarsRoots);
+          "Marking batch invalid because unexpected blob sidecars with roots {} were received",
+          unexpectedBlobSidecarsRoots);
       return false;
     }
 

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/SyncSourceBatch.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/SyncSourceBatch.java
@@ -409,6 +409,7 @@ public class SyncSourceBatch implements Batch {
         }
       }
     }
+
     final SetView<Bytes32> unexpectedBlobSidecarsRoots =
         Sets.difference(newBlobSidecarsByBlockRoot.keySet(), blockRootsWithKzgCommitments);
     if (!unexpectedBlobSidecarsRoots.isEmpty()) {
@@ -417,6 +418,8 @@ public class SyncSourceBatch implements Batch {
           syncSource,
           unexpectedBlobSidecarsRoots);
       syncSource.adjustReputation(ReputationAdjustment.SMALL_PENALTY);
+      // clearing the unexpected blob sidecars from the batch
+      unexpectedBlobSidecarsRoots.immutableCopy().forEach(newBlobSidecarsByBlockRoot::remove);
     }
 
     return true;

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/SyncSourceBatch.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/SyncSourceBatch.java
@@ -410,16 +410,16 @@ public class SyncSourceBatch implements Batch {
       }
     }
 
-    final SetView<Bytes32> unexpectedBlobSidecarsRoots =
+    final SetView<Bytes32> unexpectedBlobSidecarsBlockRoots =
         Sets.difference(newBlobSidecarsByBlockRoot.keySet(), blockRootsWithKzgCommitments);
-    if (!unexpectedBlobSidecarsRoots.isEmpty()) {
+    if (!unexpectedBlobSidecarsBlockRoots.isEmpty()) {
       LOG.debug(
           "Applying minor penalty to peer {} because unexpected blob sidecars with roots {} were received",
           syncSource,
-          unexpectedBlobSidecarsRoots);
+          unexpectedBlobSidecarsBlockRoots);
       syncSource.adjustReputation(ReputationAdjustment.SMALL_PENALTY);
       // clearing the unexpected blob sidecars from the batch
-      unexpectedBlobSidecarsRoots.immutableCopy().forEach(newBlobSidecarsByBlockRoot::remove);
+      unexpectedBlobSidecarsBlockRoots.immutableCopy().forEach(newBlobSidecarsByBlockRoot::remove);
     }
 
     return true;

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/SyncSourceBatch.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/SyncSourceBatch.java
@@ -117,7 +117,7 @@ public class SyncSourceBatch implements Batch {
   }
 
   @Override
-  public Map<Bytes32, List<BlobSidecar>> getBlobSidecars() {
+  public Map<Bytes32, List<BlobSidecar>> getBlobSidecarsByBlockRoot() {
     return blobSidecarsByBlockRoot;
   }
 

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/SyncSourceBatch.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/SyncSourceBatch.java
@@ -19,14 +19,18 @@ import static com.google.common.base.Preconditions.checkState;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Throwables;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.beacon.sync.forward.multipeer.chains.TargetChain;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.eventthread.EventThread;
 import tech.pegasys.teku.infrastructure.logging.LogFormatter;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.peers.SyncSource;
 import tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.BlocksByRangeResponseInvalidResponseException;
@@ -34,11 +38,15 @@ import tech.pegasys.teku.networking.p2p.peer.PeerDisconnectedException;
 import tech.pegasys.teku.networking.p2p.rpc.RpcResponseListener;
 import tech.pegasys.teku.spec.datastructures.blocks.MinimalBeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.deneb.BeaconBlockBodyDeneb;
+import tech.pegasys.teku.spec.datastructures.execution.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.statetransition.blobs.BlobsSidecarManager;
 
 public class SyncSourceBatch implements Batch {
   private static final Logger LOG = LogManager.getLogger();
 
   private final EventThread eventThread;
+  private final BlobsSidecarManager blobsSidecarManager;
   private final SyncSourceSelector syncSourceProvider;
   private final ConflictResolutionStrategy conflictResolutionStrategy;
   private final TargetChain targetChain;
@@ -53,9 +61,11 @@ public class SyncSourceBatch implements Batch {
   private boolean awaitingBlocks = false;
 
   private final List<SignedBeaconBlock> blocks = new ArrayList<>();
+  private final Map<Bytes32, List<BlobSidecar>> blobSidecarsByBlockRoot = new HashMap<>();
 
   SyncSourceBatch(
       final EventThread eventThread,
+      final BlobsSidecarManager blobsSidecarManager,
       final SyncSourceSelector syncSourceProvider,
       final ConflictResolutionStrategy conflictResolutionStrategy,
       final TargetChain targetChain,
@@ -64,6 +74,7 @@ public class SyncSourceBatch implements Batch {
     checkArgument(
         count.isGreaterThanOrEqualTo(UInt64.ONE), "Must include at least one slot in a batch");
     this.eventThread = eventThread;
+    this.blobsSidecarManager = blobsSidecarManager;
     this.syncSourceProvider = syncSourceProvider;
     this.conflictResolutionStrategy = conflictResolutionStrategy;
     this.targetChain = targetChain;
@@ -99,6 +110,11 @@ public class SyncSourceBatch implements Batch {
   @Override
   public List<SignedBeaconBlock> getBlocks() {
     return blocks;
+  }
+
+  @Override
+  public Map<Bytes32, List<BlobSidecar>> getBlobSidecars() {
+    return blobSidecarsByBlockRoot;
   }
 
   @Override
@@ -187,6 +203,7 @@ public class SyncSourceBatch implements Batch {
     final UInt64 startSlot =
         getLastBlock().map(SignedBeaconBlock::getSlot).map(UInt64::increment).orElse(firstSlot);
     final UInt64 remainingSlots = count.minus(startSlot.minus(firstSlot));
+    final UInt64 endSlot = startSlot.plus(remainingSlots).minus(UInt64.ONE);
 
     checkState(
         remainingSlots.isGreaterThan(UInt64.ZERO),
@@ -201,15 +218,38 @@ public class SyncSourceBatch implements Batch {
     awaitingBlocks = true;
     final SyncSource syncSource = currentSyncSource.orElseThrow();
 
+    final SafeFuture<Void> blobSidecarsRequest;
+    final Optional<BlobSidecarRequestHandler> maybeBlobSidecarRequestHandler;
+
+    if (blobsSidecarManager.isAvailabilityRequiredAtSlot(endSlot)) {
+      LOG.debug(
+          "Requesting blob sidecars for {} slots starting at {} from peer {}",
+          remainingSlots,
+          startSlot,
+          syncSource);
+      final BlobSidecarRequestHandler blobSidecarRequestHandler = new BlobSidecarRequestHandler();
+      maybeBlobSidecarRequestHandler = Optional.of(blobSidecarRequestHandler);
+      blobSidecarsRequest =
+          syncSource.requestBlobSidecarsByRange(
+              startSlot, remainingSlots, blobSidecarRequestHandler);
+    } else {
+      maybeBlobSidecarRequestHandler = Optional.empty();
+      blobSidecarsRequest = SafeFuture.COMPLETE;
+    }
+
     LOG.debug(
         "Requesting blocks for {} slots starting at {} from peer {}",
         remainingSlots,
         startSlot,
         syncSource);
 
-    syncSource
-        .requestBlocksByRange(startSlot, remainingSlots, blockRequestHandler)
-        .thenRunAsync(() -> onRequestComplete(blockRequestHandler), eventThread)
+    final SafeFuture<Void> blocksRequest =
+        syncSource.requestBlocksByRange(startSlot, remainingSlots, blockRequestHandler);
+
+    SafeFuture.allOfFailFast(blocksRequest, blobSidecarsRequest)
+        .thenRunAsync(
+            () -> onRequestComplete(blockRequestHandler, maybeBlobSidecarRequestHandler),
+            eventThread)
         .handleAsync(
             (__, error) -> {
               if (error != null) {
@@ -251,24 +291,33 @@ public class SyncSourceBatch implements Batch {
     firstBlockConfirmed = false;
     lastBlockConfirmed = false;
     blocks.clear();
+    blobSidecarsByBlockRoot.clear();
   }
 
-  private void onRequestComplete(final BlockRequestHandler blockRequestHandler) {
+  private void onRequestComplete(
+      final BlockRequestHandler blockRequestHandler,
+      final Optional<BlobSidecarRequestHandler> maybeBlobSidecarRequestHandler) {
     eventThread.checkOnEventThread();
     final List<SignedBeaconBlock> newBlocks = blockRequestHandler.complete();
 
     awaitingBlocks = false;
-    if (!blocks.isEmpty() && !newBlocks.isEmpty()) {
-      final SignedBeaconBlock previousBlock = blocks.get(blocks.size() - 1);
-      final SignedBeaconBlock firstNewBlock = newBlocks.get(0);
-      if (!firstNewBlock.getParentRoot().equals(previousBlock.getRoot())) {
-        LOG.debug(
-            "Marking batch invalid because new blocks do not form a chain with previous blocks");
+
+    if (!validateNewBlocks(newBlocks)) {
+      markAsInvalid();
+      return;
+    }
+    blocks.addAll(newBlocks);
+
+    if (maybeBlobSidecarRequestHandler.isPresent()) {
+      final Map<Bytes32, List<BlobSidecar>> newBlobSidecarsByBlockRoot =
+          maybeBlobSidecarRequestHandler.get().complete();
+      if (!validateNewBlobSidecars(newBlocks, newBlobSidecarsByBlockRoot)) {
         markAsInvalid();
         return;
       }
+      blobSidecarsByBlockRoot.putAll(newBlobSidecarsByBlockRoot);
     }
-    blocks.addAll(newBlocks);
+
     if (newBlocks.isEmpty()
         || newBlocks.get(newBlocks.size() - 1).getSlot().equals(getLastSlot())) {
       complete = true;
@@ -299,6 +348,58 @@ public class SyncSourceBatch implements Batch {
         .toString();
   }
 
+  private boolean validateNewBlocks(final List<SignedBeaconBlock> newBlocks) {
+    if (blocks.isEmpty() || newBlocks.isEmpty()) {
+      return true;
+    }
+    final SignedBeaconBlock previousBlock = blocks.get(blocks.size() - 1);
+    final SignedBeaconBlock firstNewBlock = newBlocks.get(0);
+    if (!firstNewBlock.getParentRoot().equals(previousBlock.getRoot())) {
+      LOG.debug(
+          "Marking batch invalid because new blocks do not form a chain with previous blocks");
+      return false;
+    }
+    return true;
+  }
+
+  private boolean validateNewBlobSidecars(
+      final List<SignedBeaconBlock> newBlocks,
+      final Map<Bytes32, List<BlobSidecar>> newBlobSidecarsByBlockRoot) {
+    for (final SignedBeaconBlock block : newBlocks) {
+      final Bytes32 blockRoot = block.getRoot();
+      final List<BlobSidecar> blobSidecars =
+          newBlobSidecarsByBlockRoot.getOrDefault(blockRoot, List.of());
+      final int numberOfKzgCommitments =
+          block
+              .getMessage()
+              .getBody()
+              .toVersionDeneb()
+              .map(BeaconBlockBodyDeneb::getBlobKzgCommitments)
+              .map(SszList::size)
+              .orElse(0);
+      if (blobSidecars.size() != numberOfKzgCommitments) {
+        LOG.debug(
+            "Marking batch invalid because {} blob sidecars were received, but the number of KZG commitments in a block ({}) were {}",
+            blobSidecars.size(),
+            blockRoot,
+            numberOfKzgCommitments);
+        return false;
+      }
+      final UInt64 blockSlot = block.getSlot();
+      for (final BlobSidecar blobSidecar : blobSidecars) {
+        if (!blobSidecar.getSlot().equals(blockSlot)) {
+          LOG.debug(
+              "Marking batch invalid because blob sidecar for root {} was received with slot {} which is different than the block slot {}",
+              blockRoot,
+              blobSidecar.getSlot(),
+              blockSlot);
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
   private String formatBlockAndParent(final SignedBeaconBlock block1) {
     return block1.toLogString()
         + " (parent: "
@@ -317,6 +418,23 @@ public class SyncSourceBatch implements Batch {
 
     public List<SignedBeaconBlock> complete() {
       return blocks;
+    }
+  }
+
+  private static class BlobSidecarRequestHandler implements RpcResponseListener<BlobSidecar> {
+    private final Map<Bytes32, List<BlobSidecar>> blobSidecarsByBlockRoot = new HashMap<>();
+
+    @Override
+    public SafeFuture<?> onResponse(final BlobSidecar blobSidecar) {
+      final List<BlobSidecar> blobSidecars =
+          blobSidecarsByBlockRoot.computeIfAbsent(
+              blobSidecar.getBlockRoot(), __ -> new ArrayList<>());
+      blobSidecars.add(blobSidecar);
+      return SafeFuture.COMPLETE;
+    }
+
+    public Map<Bytes32, List<BlobSidecar>> complete() {
+      return blobSidecarsByBlockRoot;
     }
   }
 }

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/singlepeer/PeerSync.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/singlepeer/PeerSync.java
@@ -170,7 +170,7 @@ public class PeerSync {
 
               final SafeFuture<Void> blobSidecarsRequest;
 
-              if (requestContext.blobSidecarsRequired) {
+              if (blobsSidecarManager.isAvailabilityRequiredAtSlot(requestContext.endSlot)) {
                 LOG.debug(
                     "Request {} blob sidecars starting at {} from peer {}",
                     requestContext.count,
@@ -320,25 +320,18 @@ public class PeerSync {
     final UInt64 diff = status.getHeadSlot().minusMinZero(startSlot).plus(UInt64.ONE);
     final UInt64 count = diff.min(FORWARD_SYNC_BATCH_SIZE); // limit the request count
     final UInt64 endSlot = startSlot.plus(count).decrement();
-    final boolean blobSidecarsRequired = blobsSidecarManager.isAvailabilityRequiredAtSlot(endSlot);
-    return new RequestContext(startSlot, count, endSlot, blobSidecarsRequired);
+    return new RequestContext(startSlot, count, endSlot);
   }
 
   private static class RequestContext {
     private final UInt64 startSlot;
     private final UInt64 count;
     private final UInt64 endSlot;
-    private final boolean blobSidecarsRequired;
 
-    private RequestContext(
-        final UInt64 startSlot,
-        final UInt64 count,
-        final UInt64 endSlot,
-        final boolean blobSidecarsRequired) {
+    private RequestContext(final UInt64 startSlot, final UInt64 count, final UInt64 endSlot) {
       this.startSlot = startSlot;
       this.count = count;
       this.endSlot = endSlot;
-      this.blobSidecarsRequired = blobSidecarsRequired;
     }
   }
 

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/BatchImporterTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/BatchImporterTest.java
@@ -25,6 +25,7 @@ import static tech.pegasys.teku.infrastructure.async.FutureUtil.ignoreFuture;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -38,21 +39,25 @@ import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.statetransition.blobs.BlobsSidecarManager;
 import tech.pegasys.teku.statetransition.block.BlockImporter;
 
 class BatchImporterTest {
   private final DataStructureUtil dataStructureUtil =
       new DataStructureUtil(TestSpecFactory.createMinimalCapella());
   private final BlockImporter blockImporter = mock(BlockImporter.class);
+  private final BlobsSidecarManager blobsSidecarManager = mock(BlobsSidecarManager.class);
   private final StubAsyncRunner asyncRunner = new StubAsyncRunner();
   private final Batch batch = mock(Batch.class);
   final SyncSource syncSource = mock(SyncSource.class);
 
-  private final BatchImporter importer = new BatchImporter(blockImporter, asyncRunner);
+  private final BatchImporter importer =
+      new BatchImporter(blockImporter, blobsSidecarManager, asyncRunner);
 
   @BeforeEach
   public void setup() {
     when(batch.getSource()).thenReturn(Optional.of(syncSource));
+    when(batch.getBlobSidecars()).thenReturn(Map.of());
   }
 
   @Test
@@ -77,6 +82,7 @@ class BatchImporterTest {
     // We should have copied the blocks to avoid accessing the Batch data from
     // other threads
     verify(batch).getBlocks();
+    verify(batch).getBlobSidecars();
     verify(batch).getSource();
 
     asyncRunner.executeQueuedActions();

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/BatchImporterTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/BatchImporterTest.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.beacon.sync.forward.multipeer.BatchImporter.BatchImportResult;
@@ -35,16 +36,18 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
 import tech.pegasys.teku.networking.eth2.peers.SyncSource;
 import tech.pegasys.teku.networking.p2p.peer.DisconnectReason;
+import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.execution.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.blobs.BlobsSidecarManager;
 import tech.pegasys.teku.statetransition.block.BlockImporter;
 
 class BatchImporterTest {
-  private final DataStructureUtil dataStructureUtil =
-      new DataStructureUtil(TestSpecFactory.createMinimalCapella());
+  private final Spec spec = TestSpecFactory.createMinimalDeneb();
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
   private final BlockImporter blockImporter = mock(BlockImporter.class);
   private final BlobsSidecarManager blobsSidecarManager = mock(BlobsSidecarManager.class);
   private final StubAsyncRunner asyncRunner = new StubAsyncRunner();
@@ -58,6 +61,7 @@ class BatchImporterTest {
   public void setup() {
     when(batch.getSource()).thenReturn(Optional.of(syncSource));
     when(batch.getBlobSidecars()).thenReturn(Map.of());
+    when(blobsSidecarManager.importBlobSidecar(any())).thenReturn(SafeFuture.COMPLETE);
   }
 
   @Test
@@ -78,8 +82,9 @@ class BatchImporterTest {
 
     // Should not be started on the calling thread
     verifyNoInteractions(blockImporter);
+    verifyNoInteractions(blobsSidecarManager);
 
-    // We should have copied the blocks to avoid accessing the Batch data from
+    // We should have copied the blocks and blob sidecars to avoid accessing the Batch data from
     // other threads
     verify(batch).getBlocks();
     verify(batch).getBlobSidecars();
@@ -92,6 +97,52 @@ class BatchImporterTest {
     blockImportedSuccessfully(block2, importResult2);
     assertThat(result).isNotDone();
     blockImportedSuccessfully(block3, importResult3);
+    assertThat(result).isCompletedWithValue(BatchImportResult.IMPORTED_ALL_BLOCKS);
+
+    // And check we didn't touch the batch from a different thread
+    verifyNoMoreInteractions(batch);
+  }
+
+  @Test
+  void shouldImportBlobSidecarsAndBlocksInOrder() {
+    final SignedBeaconBlock block1 = dataStructureUtil.randomSignedBeaconBlock(1);
+    final SignedBeaconBlock block2 = dataStructureUtil.randomSignedBeaconBlock(2);
+
+    final List<BlobSidecar> blobSidecars1 = dataStructureUtil.randomBlobSidecarsForBlock(block1);
+    final List<BlobSidecar> blobSidecars2 = dataStructureUtil.randomBlobSidecarsForBlock(block2);
+
+    final SafeFuture<BlockImportResult> importResult1 = new SafeFuture<>();
+    final SafeFuture<BlockImportResult> importResult2 = new SafeFuture<>();
+
+    final List<SignedBeaconBlock> blocks = new ArrayList<>(List.of(block1, block2));
+    final Map<Bytes32, List<BlobSidecar>> blobSidecars =
+        Map.of(block1.getRoot(), blobSidecars1, block2.getRoot(), blobSidecars2);
+
+    when(batch.getBlocks()).thenReturn(blocks);
+    when(batch.getBlobSidecars()).thenReturn(blobSidecars);
+
+    when(blockImporter.importBlock(block1)).thenReturn(importResult1);
+    when(blockImporter.importBlock(block2)).thenReturn(importResult2);
+
+    final SafeFuture<BatchImportResult> result = importer.importBatch(batch);
+
+    // Should not be started on the calling thread
+    verifyNoInteractions(blockImporter);
+    verifyNoInteractions(blobsSidecarManager);
+
+    // We should have copied the blocks and blob sidecars  to avoid accessing the Batch data from
+    // other threads
+    verify(batch).getBlocks();
+    verify(batch).getBlobSidecars();
+    verify(batch).getSource();
+
+    asyncRunner.executeQueuedActions();
+
+    blobSidecarsImportedSuccessfully(blobSidecars1);
+    blockImportedSuccessfully(block1, importResult1);
+    assertThat(result).isNotDone();
+    blobSidecarsImportedSuccessfully(blobSidecars2);
+    blockImportedSuccessfully(block2, importResult2);
     assertThat(result).isCompletedWithValue(BatchImportResult.IMPORTED_ALL_BLOCKS);
 
     // And check we didn't touch the batch from a different thread
@@ -198,11 +249,16 @@ class BatchImporterTest {
     verifyNoMoreInteractions(blockImporter);
   }
 
+  private void blobSidecarsImportedSuccessfully(final List<BlobSidecar> blobSidecars) {
+    blobSidecars.forEach(
+        blobSidecar -> ignoreFuture(verify(blobsSidecarManager).importBlobSidecar(blobSidecar)));
+    verifyNoMoreInteractions(blobsSidecarManager);
+  }
+
   private void blockImportedSuccessfully(
-      final SignedBeaconBlock block, final SafeFuture<BlockImportResult> importResult1) {
+      final SignedBeaconBlock block, final SafeFuture<BlockImportResult> importResult) {
     ignoreFuture(verify(blockImporter).importBlock(block));
     verifyNoMoreInteractions(blockImporter);
-
-    importResult1.complete(BlockImportResult.successful(block));
+    importResult.complete(BlockImportResult.successful(block));
   }
 }

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/BatchImporterTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/BatchImporterTest.java
@@ -60,7 +60,7 @@ class BatchImporterTest {
   @BeforeEach
   public void setup() {
     when(batch.getSource()).thenReturn(Optional.of(syncSource));
-    when(batch.getBlobSidecars()).thenReturn(Map.of());
+    when(batch.getBlobSidecarsByBlockRoot()).thenReturn(Map.of());
     when(blobsSidecarManager.importBlobSidecar(any())).thenReturn(SafeFuture.COMPLETE);
   }
 
@@ -87,7 +87,7 @@ class BatchImporterTest {
     // We should have copied the blocks and blob sidecars to avoid accessing the Batch data from
     // other threads
     verify(batch).getBlocks();
-    verify(batch).getBlobSidecars();
+    verify(batch).getBlobSidecarsByBlockRoot();
     verify(batch).getSource();
 
     asyncRunner.executeQueuedActions();
@@ -119,7 +119,7 @@ class BatchImporterTest {
         Map.of(block1.getRoot(), blobSidecars1, block2.getRoot(), blobSidecars2);
 
     when(batch.getBlocks()).thenReturn(blocks);
-    when(batch.getBlobSidecars()).thenReturn(blobSidecars);
+    when(batch.getBlobSidecarsByBlockRoot()).thenReturn(blobSidecars);
 
     when(blockImporter.importBlock(block1)).thenReturn(importResult1);
     when(blockImporter.importBlock(block2)).thenReturn(importResult2);
@@ -133,7 +133,7 @@ class BatchImporterTest {
     // We should have copied the blocks and blob sidecars  to avoid accessing the Batch data from
     // other threads
     verify(batch).getBlocks();
-    verify(batch).getBlobSidecars();
+    verify(batch).getBlobSidecarsByBlockRoot();
     verify(batch).getSource();
 
     asyncRunner.executeQueuedActions();

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/SyncSourceBatchTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/SyncSourceBatchTest.java
@@ -229,30 +229,6 @@ public class SyncSourceBatchTest {
   }
 
   @Test
-  void shouldReportAsInvalidWhenUnexpectedBlobSidecarsRootsWereReceived() {
-    when(blobsSidecarManager.isAvailabilityRequiredAtSlot(any())).thenReturn(true);
-
-    final Batch batch = createBatch(10, 10);
-
-    batch.requestMoreBlocks(() -> {});
-
-    final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(19);
-
-    final List<BlobSidecar> blobSidecars =
-        new ArrayList<>(dataStructureUtil.randomBlobSidecarsForBlock(block));
-    // receiving more unexpected sidecars
-    blobSidecars.addAll(
-        dataStructureUtil.randomBlobSidecarsForBlock(
-            dataStructureUtil.randomSignedBeaconBlock(18)));
-
-    receiveBlocks(batch, block);
-    receiveBlobSidecars(batch, blobSidecars);
-
-    // batch should be reported as invalid
-    verify(conflictResolutionStrategy).reportInvalidBatch(batch, getSyncSource(batch));
-  }
-
-  @Test
   void shouldReportAsInvalidWhenUnexpectedNumberOfBlobSidecarsWereReceived() {
     when(blobsSidecarManager.isAvailabilityRequiredAtSlot(any())).thenReturn(true);
 
@@ -298,6 +274,30 @@ public class SyncSourceBatchTest {
                         .index(UInt64.valueOf(index))
                         .build())
             .collect(toList());
+
+    receiveBlocks(batch, block);
+    receiveBlobSidecars(batch, blobSidecars);
+
+    // batch should be reported as invalid
+    verify(conflictResolutionStrategy).reportInvalidBatch(batch, getSyncSource(batch));
+  }
+
+  @Test
+  void shouldReportAsInvalidWhenUnexpectedBlobSidecarsWithRootsWereReceived() {
+    when(blobsSidecarManager.isAvailabilityRequiredAtSlot(any())).thenReturn(true);
+
+    final Batch batch = createBatch(10, 10);
+
+    batch.requestMoreBlocks(() -> {});
+
+    final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(19);
+
+    final List<BlobSidecar> blobSidecars =
+        new ArrayList<>(dataStructureUtil.randomBlobSidecarsForBlock(block));
+    // receiving sidecars with unknown roots
+    blobSidecars.addAll(
+        dataStructureUtil.randomBlobSidecarsForBlock(
+            dataStructureUtil.randomSignedBeaconBlock(18)));
 
     receiveBlocks(batch, block);
     receiveBlobSidecars(batch, blobSidecars);

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/SyncSourceBatchTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/SyncSourceBatchTest.java
@@ -295,15 +295,15 @@ public class SyncSourceBatchTest {
 
     final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(19);
 
-    final List<BlobSidecar> blobSidecars =
-        new ArrayList<>(dataStructureUtil.randomBlobSidecarsForBlock(block));
+    final List<BlobSidecar> blobSidecars = dataStructureUtil.randomBlobSidecarsForBlock(block);
+    final List<BlobSidecar> unexpectedBlobSidecars = new ArrayList<>(blobSidecars);
     // receiving sidecars with unknown roots
-    blobSidecars.addAll(
+    unexpectedBlobSidecars.addAll(
         dataStructureUtil.randomBlobSidecarsForBlock(
             dataStructureUtil.randomSignedBeaconBlock(18)));
 
     receiveBlocks(batch, block);
-    receiveBlobSidecars(batch, blobSidecars);
+    receiveBlobSidecars(batch, unexpectedBlobSidecars);
 
     assertThat(batch.isComplete()).isTrue();
     assertThat(batch.getBlocks()).containsExactly(block);

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/SyncSourceBatchTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/SyncSourceBatchTest.java
@@ -159,7 +159,9 @@ public class SyncSourceBatchTest {
 
     assertThat(batch.isComplete()).isTrue();
     assertThat(batch.getBlocks()).containsExactly(block);
-    assertThat(batch.getBlobSidecars()).hasSize(1).containsEntry(block.getRoot(), blobSidecars);
+    assertThat(batch.getBlobSidecarsByBlockRoot())
+        .hasSize(1)
+        .containsEntry(block.getRoot(), blobSidecars);
   }
 
   @Test

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/SyncSourceBatchTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/SyncSourceBatchTest.java
@@ -13,13 +13,16 @@
 
 package tech.pegasys.teku.beacon.sync.forward.multipeer.batches;
 
+import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.beacon.sync.forward.multipeer.batches.BatchAssert.assertThatBatch;
 import static tech.pegasys.teku.beacon.sync.forward.multipeer.chains.TargetChainTestUtil.chainWith;
 
@@ -28,7 +31,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.IntStream;
 import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.beacon.sync.forward.multipeer.chains.TargetChain;
 import tech.pegasys.teku.infrastructure.async.eventthread.InlineEventThread;
@@ -41,18 +46,27 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.deneb.BeaconBlockBodyDeneb;
+import tech.pegasys.teku.spec.datastructures.execution.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.statetransition.blobs.BlobsSidecarManager;
 
 public class SyncSourceBatchTest {
 
-  private final Spec spec = TestSpecFactory.createMinimalCapella();
+  private final Spec spec = TestSpecFactory.createMinimalDeneb();
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
   private final TargetChain targetChain =
       chainWith(new SlotAndBlockRoot(UInt64.valueOf(1000), Bytes32.ZERO));
   private final InlineEventThread eventThread = new InlineEventThread();
+  private final BlobsSidecarManager blobsSidecarManager = mock(BlobsSidecarManager.class);
   private final ConflictResolutionStrategy conflictResolutionStrategy =
       mock(ConflictResolutionStrategy.class);
   private final Map<Batch, List<StubSyncSource>> syncSources = new HashMap<>();
+
+  @BeforeEach
+  public void setUp() {
+    when(blobsSidecarManager.isAvailabilityRequiredAtSlot(any())).thenReturn(false);
+  }
 
   @Test
   void requestMoreBlocks_shouldRequestFromStartOnFirstRequest() {
@@ -118,6 +132,34 @@ public class SyncSourceBatchTest {
     final StubSyncSource secondSyncSource = getSyncSource(batch);
     assertThat(secondSyncSource).isNotSameAs(firstSyncSource);
     secondSyncSource.assertRequestedBlocks(70, 50);
+  }
+
+  @Test
+  void requestMoreBlocks_shouldRequestBlobSidecarsWhenRequired() {
+    when(blobsSidecarManager.isAvailabilityRequiredAtSlot(any())).thenReturn(true);
+
+    final Runnable callback = mock(Runnable.class);
+    final Batch batch = createBatch(70, 50);
+
+    batch.requestMoreBlocks(callback);
+    verifyNoInteractions(callback);
+
+    // only receiving last block (70 + 50 - 1)
+    final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(119);
+    final List<BlobSidecar> blobSidecars = dataStructureUtil.randomBlobSidecarsForBlock(block);
+
+    receiveBlocks(batch, block);
+    receiveBlobSidecars(batch, blobSidecars);
+
+    getSyncSource(batch).assertRequestedBlocks(70, 50);
+    getSyncSource(batch).assertRequestedBlobSidecars(70, 50);
+
+    verify(callback).run();
+    verifyNoMoreInteractions(callback);
+
+    assertThat(batch.isComplete()).isTrue();
+    assertThat(batch.getBlocks()).containsExactly(block);
+    assertThat(batch.getBlobSidecars()).hasSize(1).containsEntry(block.getRoot(), blobSidecars);
   }
 
   @Test
@@ -187,11 +229,66 @@ public class SyncSourceBatchTest {
   }
 
   @Test
+  void shouldReportAsInvalidWhenUnexpectedNumberOfBlobSidecarsWereReceived() {
+    when(blobsSidecarManager.isAvailabilityRequiredAtSlot(any())).thenReturn(true);
+
+    final Batch batch = createBatch(10, 10);
+
+    batch.requestMoreBlocks(() -> {});
+
+    final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(19);
+
+    final List<BlobSidecar> blobSidecars =
+        new ArrayList<>(dataStructureUtil.randomBlobSidecarsForBlock(block));
+    // receiving more sidecars than expected
+    blobSidecars.add(
+        dataStructureUtil.createRandomBlobSidecarBuilder().blockRoot(block.getRoot()).build());
+
+    receiveBlocks(batch, block);
+    receiveBlobSidecars(batch, blobSidecars);
+
+    // batch should be reported as invalid
+    verify(conflictResolutionStrategy).reportInvalidBatch(batch, getSyncSource(batch));
+  }
+
+  @Test
+  void shouldReportAsInvalidWhenBlobSidecarsWithUnexpectedSlotsWereReceived() {
+    when(blobsSidecarManager.isAvailabilityRequiredAtSlot(any())).thenReturn(true);
+
+    final Batch batch = createBatch(10, 10);
+
+    batch.requestMoreBlocks(() -> {});
+
+    final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(19);
+
+    final int numberOfKzgCommitments =
+        BeaconBlockBodyDeneb.required(block.getMessage().getBody()).getBlobKzgCommitments().size();
+    // receiving sidecars with different slot than the block
+    final List<BlobSidecar> blobSidecars =
+        IntStream.range(0, numberOfKzgCommitments)
+            .mapToObj(
+                index ->
+                    dataStructureUtil
+                        .createRandomBlobSidecarBuilder()
+                        .blockRoot(block.getRoot())
+                        .index(UInt64.valueOf(index))
+                        .build())
+            .collect(toList());
+
+    receiveBlocks(batch, block);
+    receiveBlobSidecars(batch, blobSidecars);
+
+    // batch should be reported as invalid
+    verify(conflictResolutionStrategy).reportInvalidBatch(batch, getSyncSource(batch));
+  }
+
+  @Test
   void shouldSkipMakingRequestWhenNoTargetPeerIsAvailable() {
     final SyncSourceSelector emptySourceSelector = Optional::empty;
     final SyncSourceBatch batch =
         new SyncSourceBatch(
             eventThread,
+            blobsSidecarManager,
             emptySourceSelector,
             conflictResolutionStrategy,
             targetChain,
@@ -220,6 +317,7 @@ public class SyncSourceBatchTest {
     final SyncSourceBatch batch =
         new SyncSourceBatch(
             eventThread,
+            blobsSidecarManager,
             syncSourceProvider,
             conflictResolutionStrategy,
             targetChain,
@@ -231,6 +329,10 @@ public class SyncSourceBatchTest {
 
   protected void receiveBlocks(final Batch batch, final SignedBeaconBlock... blocks) {
     getSyncSource(batch).receiveBlocks(blocks);
+  }
+
+  protected void receiveBlobSidecars(final Batch batch, final List<BlobSidecar> blobSidecars) {
+    getSyncSource(batch).receiveBlobSidecars(blobSidecars.toArray(new BlobSidecar[] {}));
   }
 
   protected void requestError(final Batch batch, final Throwable error) {

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/SyncSourceBatchTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/SyncSourceBatchTest.java
@@ -42,7 +42,6 @@ import tech.pegasys.teku.networking.eth2.peers.StubSyncSource;
 import tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.BlocksByRangeResponseInvalidResponseException;
 import tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.BlocksByRangeResponseInvalidResponseException.InvalidResponseType;
 import tech.pegasys.teku.networking.p2p.peer.PeerDisconnectedException;
-import tech.pegasys.teku.networking.p2p.reputation.ReputationAdjustment;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
@@ -286,7 +285,7 @@ public class SyncSourceBatchTest {
   }
 
   @Test
-  void shouldApplyMinorPenaltyToPeerWhenUnexpectedBlobSidecarsWithRootsWereReceived() {
+  void shouldMarkBatchAsInconsistentWhenUnexpectedBlobSidecarsWithRootsWereReceived() {
     when(blobsSidecarManager.isAvailabilityRequiredAtSlot(any())).thenReturn(true);
 
     final Batch batch = createBatch(10, 10);
@@ -312,8 +311,7 @@ public class SyncSourceBatchTest {
         .containsEntry(block.getRoot(), blobSidecars);
 
     // reputation of the peer should have been adjusted
-    assertThat(getSyncSource(batch).getReceivedReputationAdjustments())
-        .containsExactly(ReputationAdjustment.SMALL_PENALTY);
+    verify(conflictResolutionStrategy).reportInconsistentBatch(batch, getSyncSource(batch));
   }
 
   @Test

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/SyncSourceBatchTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/SyncSourceBatchTest.java
@@ -229,6 +229,30 @@ public class SyncSourceBatchTest {
   }
 
   @Test
+  void shouldReportAsInvalidWhenUnexpectedBlobSidecarsRootsWereReceived() {
+    when(blobsSidecarManager.isAvailabilityRequiredAtSlot(any())).thenReturn(true);
+
+    final Batch batch = createBatch(10, 10);
+
+    batch.requestMoreBlocks(() -> {});
+
+    final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(19);
+
+    final List<BlobSidecar> blobSidecars =
+        new ArrayList<>(dataStructureUtil.randomBlobSidecarsForBlock(block));
+    // receiving more unexpected sidecars
+    blobSidecars.addAll(
+        dataStructureUtil.randomBlobSidecarsForBlock(
+            dataStructureUtil.randomSignedBeaconBlock(18)));
+
+    receiveBlocks(batch, block);
+    receiveBlobSidecars(batch, blobSidecars);
+
+    // batch should be reported as invalid
+    verify(conflictResolutionStrategy).reportInvalidBatch(batch, getSyncSource(batch));
+  }
+
+  @Test
   void shouldReportAsInvalidWhenUnexpectedNumberOfBlobSidecarsWereReceived() {
     when(blobsSidecarManager.isAvailabilityRequiredAtSlot(any())).thenReturn(true);
 

--- a/beacon/sync/src/testFixtures/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/StubBatchFactory.java
+++ b/beacon/sync/src/testFixtures/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/StubBatchFactory.java
@@ -150,6 +150,9 @@ public class StubBatchFactory extends BatchFactory implements Iterable<Batch> {
     }
 
     @Override
+    public void reportInconsistentBatch(final Batch batch, final SyncSource source) {}
+
+    @Override
     public void reportConfirmedBatch(final Batch batch, final SyncSource source) {}
 
     @Override

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -1974,21 +1974,8 @@ public final class DataStructureUtil {
     return randomBlob().getBytes();
   }
 
-  public BlobsSidecar randomBlobsSidecarForBlock(final SignedBeaconBlock block) {
-    return randomBlobsSidecar(
-        block.getRoot(),
-        block.getSlot(),
-        BeaconBlockBodyDeneb.required(block.getBeaconBlock().orElseThrow().getBody())
-            .getBlobKzgCommitments()
-            .size());
-  }
-
   public BlobsSidecar randomBlobsSidecar() {
     return randomBlobsSidecar(randomBytes32(), randomUInt64());
-  }
-
-  public BlobsSidecar randomBlobsSidecar(final UInt64 slot) {
-    return randomBlobsSidecar(randomBytes32(), slot);
   }
 
   public BlobsSidecar randomBlobsSidecar(final Bytes32 blockRoot, final UInt64 slot) {
@@ -1998,6 +1985,22 @@ public final class DataStructureUtil {
 
     return randomBlobsSidecar(
         blockRoot, slot, randomInt((int) blobsSidecarSchema.getBlobsSchema().getMaxLength()));
+  }
+
+  public List<BlobSidecar> randomBlobSidecarsForBlock(final SignedBeaconBlock block) {
+    final int numberOfKzgCommitments =
+        BeaconBlockBodyDeneb.required(block.getBeaconBlock().orElseThrow().getBody())
+            .getBlobKzgCommitments()
+            .size();
+    return IntStream.range(0, numberOfKzgCommitments)
+        .mapToObj(
+            index ->
+                createRandomBlobSidecarBuilder()
+                    .slot(block.getSlot())
+                    .blockRoot(block.getRoot())
+                    .index(UInt64.valueOf(index))
+                    .build())
+        .collect(toList());
   }
 
   public BlobSidecar randomBlobSidecar() {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/DefaultEth2Peer.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/DefaultEth2Peer.java
@@ -191,7 +191,7 @@ class DefaultEth2Peer extends DelegatingPeer implements Eth2Peer {
     final Optional<StatusMessage> statusMessage = statusMessageFactory.createStatusMessage();
     if (statusMessage.isEmpty()) {
       final Exception error =
-          new IllegalStateException("Unable to generate local status message.  Node is not ready.");
+          new IllegalStateException("Unable to generate local status message. Node is not ready.");
       return SafeFuture.failedFuture(error);
     }
     LOG.trace("Sending status message {} to {}", statusMessage.get(), getAddress());

--- a/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/peers/StubSyncSource.java
+++ b/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/peers/StubSyncSource.java
@@ -34,6 +34,8 @@ public class StubSyncSource implements SyncSource {
   private final List<Request> blocksRequests = new ArrayList<>();
   private final List<Request> blobSidecarsRequests = new ArrayList<>();
 
+  private final List<ReputationAdjustment> reputationAdjustments = new ArrayList<>();
+
   private Optional<SafeFuture<Void>> currentBlockRequest = Optional.empty();
   private Optional<RpcResponseListener<SignedBeaconBlock>> currentBlockListener = Optional.empty();
 
@@ -96,8 +98,14 @@ public class StubSyncSource implements SyncSource {
         .contains(new Request(UInt64.valueOf(startSlot), UInt64.valueOf(count)));
   }
 
+  public List<ReputationAdjustment> getReceivedReputationAdjustments() {
+    return reputationAdjustments;
+  }
+
   @Override
-  public void adjustReputation(final ReputationAdjustment adjustment) {}
+  public void adjustReputation(final ReputationAdjustment adjustment) {
+    reputationAdjustments.add(adjustment);
+  }
 
   private static final class Request {
     private final UInt64 start;

--- a/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/peers/StubSyncSource.java
+++ b/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/peers/StubSyncSource.java
@@ -34,8 +34,6 @@ public class StubSyncSource implements SyncSource {
   private final List<Request> blocksRequests = new ArrayList<>();
   private final List<Request> blobSidecarsRequests = new ArrayList<>();
 
-  private final List<ReputationAdjustment> reputationAdjustments = new ArrayList<>();
-
   private Optional<SafeFuture<Void>> currentBlockRequest = Optional.empty();
   private Optional<RpcResponseListener<SignedBeaconBlock>> currentBlockListener = Optional.empty();
 
@@ -98,14 +96,8 @@ public class StubSyncSource implements SyncSource {
         .contains(new Request(UInt64.valueOf(startSlot), UInt64.valueOf(count)));
   }
 
-  public List<ReputationAdjustment> getReceivedReputationAdjustments() {
-    return reputationAdjustments;
-  }
-
   @Override
-  public void adjustReputation(final ReputationAdjustment adjustment) {
-    reputationAdjustments.add(adjustment);
-  }
+  public void adjustReputation(final ReputationAdjustment adjustment) {}
 
   private static final class Request {
     private final UInt64 start;

--- a/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/peers/StubSyncSource.java
+++ b/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/peers/StubSyncSource.java
@@ -91,6 +91,11 @@ public class StubSyncSource implements SyncSource {
         .contains(new Request(UInt64.valueOf(startSlot), UInt64.valueOf(count)));
   }
 
+  public void assertRequestedBlobSidecars(final long startSlot, final long count) {
+    assertThat(blobSidecarsRequests)
+        .contains(new Request(UInt64.valueOf(startSlot), UInt64.valueOf(count)));
+  }
+
   @Override
   public void adjustReputation(final ReputationAdjustment adjustment) {}
 

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -1024,6 +1024,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
         storageUpdateChannel,
         p2pNetwork,
         blockImporter,
+        blobsSidecarManager,
         pendingBlocks,
         beaconConfig.eth2NetworkConfig().getStartupTargetPeerCount(),
         signatureVerificationService,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

- Main changes are in `SyncSourceBatch` and `BatchImporter`.
- Essentially when creating the batch, simultaneously block and blob sidecars are downloaded and then stored together. Then for every block, its blob sidecars are imported and after that the block is imported.

## Fixed Issue(s)
fixes #6948 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
