### PR TITLE
Avoid blob array data copy

### DIFF
--- a/infrastructure/kzg/src/main/java/tech/pegasys/teku/kzg/KZGCommitment.java
+++ b/infrastructure/kzg/src/main/java/tech/pegasys/teku/kzg/KZGCommitment.java
@@ -74,8 +74,8 @@ public final class KZGCommitment {
     return bytesCompressed;
   }
 
-  public byte[] toArray() {
-    return bytesCompressed.toArray();
+  public byte[] toArrayUnsafe() {
+    return bytesCompressed.toArrayUnsafe();
   }
 
   public String toAbbreviatedString() {

--- a/infrastructure/kzg/src/main/java/tech/pegasys/teku/kzg/ckzg4844/CKZG4844.java
+++ b/infrastructure/kzg/src/main/java/tech/pegasys/teku/kzg/ckzg4844/CKZG4844.java
@@ -166,7 +166,7 @@ public final class CKZG4844 implements KZG {
       throws KZGException {
     try {
       final byte[] proof =
-          CKZG4844JNI.computeBlobKzgProof(blob.toArrayUnsafe(), kzgCommitment.toArray());
+          CKZG4844JNI.computeBlobKzgProof(blob.toArrayUnsafe(), kzgCommitment.toArrayUnsafe());
       return KZGProof.fromArray(proof);
     } catch (final Exception ex) {
       throw new KZGException(

--- a/infrastructure/kzg/src/main/java/tech/pegasys/teku/kzg/ckzg4844/CKZG4844.java
+++ b/infrastructure/kzg/src/main/java/tech/pegasys/teku/kzg/ckzg4844/CKZG4844.java
@@ -154,7 +154,7 @@ public final class CKZG4844 implements KZG {
   @Override
   public KZGCommitment blobToKzgCommitment(final Bytes blob) throws KZGException {
     try {
-      final byte[] commitmentBytes = CKZG4844JNI.blobToKzgCommitment(blob.toArray());
+      final byte[] commitmentBytes = CKZG4844JNI.blobToKzgCommitment(blob.toArrayUnsafe());
       return KZGCommitment.fromArray(commitmentBytes);
     } catch (final Exception ex) {
       throw new KZGException("Failed to produce KZG commitment from blob", ex);
@@ -165,7 +165,8 @@ public final class CKZG4844 implements KZG {
   public KZGProof computeBlobKzgProof(final Bytes blob, final KZGCommitment kzgCommitment)
       throws KZGException {
     try {
-      final byte[] proof = CKZG4844JNI.computeBlobKzgProof(blob.toArray(), kzgCommitment.toArray());
+      final byte[] proof =
+          CKZG4844JNI.computeBlobKzgProof(blob.toArrayUnsafe(), kzgCommitment.toArray());
       return KZGProof.fromArray(proof);
     } catch (final Exception ex) {
       throw new KZGException(


### PR DESCRIPTION
`toArrayUnsafe` avoids blobs array to be copied into a new array. We trust kzg lib.

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
