### PR TITLE
Add Besu genesis override option on ATs #7005

### DIFF
--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/CapellaUpgradeAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/CapellaUpgradeAcceptanceTest.java
@@ -15,109 +15,71 @@ package tech.pegasys.teku.test.acceptance;
 
 import com.google.common.io.Resources;
 import java.net.URL;
-import java.util.Map;
 import org.junit.jupiter.api.Test;
-import tech.pegasys.teku.ethereum.execution.types.Eth1Address;
-import tech.pegasys.teku.infrastructure.time.SystemTimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.test.acceptance.dsl.AcceptanceTestBase;
-import tech.pegasys.teku.test.acceptance.dsl.BesuDockerVersion;
 import tech.pegasys.teku.test.acceptance.dsl.BesuNode;
-import tech.pegasys.teku.test.acceptance.dsl.GenesisGenerator.InitialStateData;
 import tech.pegasys.teku.test.acceptance.dsl.TekuNode;
 import tech.pegasys.teku.test.acceptance.dsl.TekuNode.Config;
-import tech.pegasys.teku.test.acceptance.dsl.tools.deposits.ValidatorKeystores;
 
 public class CapellaUpgradeAcceptanceTest extends AcceptanceTestBase {
 
-  private static final String NETWORK_NAME = "swift";
   private static final URL JWT_FILE = Resources.getResource("auth/ee-jwt-secret.hex");
-  public static final Eth1Address WITHDRAWAL_ADDRESS =
-      Eth1Address.fromHexString("0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee");
-
-  private final SystemTimeProvider timeProvider = new SystemTimeProvider();
 
   @Test
   void shouldUpgradeToCapella() throws Exception {
-    final UInt64 timeInSeconds = timeProvider.getTimeInSeconds();
-    final int genesisTime = timeInSeconds.plus(10).intValue();
-
     BesuNode primaryEL =
         createBesuNode(
-            BesuDockerVersion.STABLE,
             c -> {
               c.withMergeSupport(true);
-              c.withGenesisFile("besu/shanghaiGenesis.json");
-              //              c.withP2pEnabled(true);
+              c.withGenesisFile("besu/mergedGenesis.json");
+              c.withP2pEnabled(true);
               c.withJwtTokenAuthorization(JWT_FILE);
-            },
-            Map.of("shanghaiTime", String.valueOf(999)));
+            });
     primaryEL.start();
 
-    //    BesuNode secondaryEL =
-    //        createBesuNode(
-    //            c -> {
-    //              c.withMergeSupport(true);
-    //              c.withGenesisFile("besu/shanghaiGenesis.json");
-    //              c.withP2pEnabled(true);
-    //              c.withJwtTokenAuthorization(JWT_FILE);
-    //            });
-    //    secondaryEL.start();
-    //    secondaryEL.addPeer(primaryEL);
-
-    final ValidatorKeystores validatorKeys =
-        createTekuDepositSender(NETWORK_NAME).generateValidatorKeys(4, WITHDRAWAL_ADDRESS);
-    final InitialStateData initialStateData =
-        createGenesisGenerator()
-            .network(NETWORK_NAME)
-            .withAltairEpoch(UInt64.ZERO)
-            .withBellatrixEpoch(UInt64.ZERO)
-            .withCapellaEpoch(UInt64.ONE)
-            .withTotalTerminalDifficulty(0)
-            .genesisPayloadSource(primaryEL)
-            .validatorKeys(validatorKeys)
-            //            .genesisDelaySeconds(10)
-            .generate();
+    BesuNode secondaryEL =
+        createBesuNode(
+            c -> {
+              c.withMergeSupport(true);
+              c.withGenesisFile("besu/mergedGenesis.json");
+              c.withP2pEnabled(true);
+              c.withJwtTokenAuthorization(JWT_FILE);
+            });
+    secondaryEL.start();
+    secondaryEL.addPeer(primaryEL);
 
     TekuNode primaryNode =
         createTekuNode(
             c -> {
-              c.withRealNetwork();
-              c.withStartupTargetPeerCount(0);
-              c.withGenesisTime(genesisTime);
+              c.withRealNetwork().withStartupTargetPeerCount(0);
               c.withExecutionEngine(primaryEL);
               c.withJwtSecretFile(JWT_FILE);
-              c.withTotalTerminalDifficulty(0);
-              c.withInitialState(initialStateData);
-              c.withValidatorKeystores(validatorKeys);
-              c.withValidatorProposerDefaultFeeRecipient(
-                  "0xFE3B557E8Fb62b89F4916B721be55cEb828dBd73");
               c.withEngineApiMethodNegotiation();
               applyMilestoneConfig(c);
             });
+
     primaryNode.start();
     primaryNode.waitForMilestone(SpecMilestone.CAPELLA);
 
-    //    UInt64 genesisTime = primaryNode.getGenesisTime();
+    UInt64 genesisTime = primaryNode.getGenesisTime();
 
-    //    TekuNode lateJoiningNode =
-    //        createTekuNode(
-    //            c -> {
-    //              c.withGenesisTime(genesisTime.intValue());
-    //              c.withRealNetwork();
-    //              c.withPeers(primaryNode);
-    //              c.withInteropValidators(0, 0);
-    //              c.withExecutionEngine(primaryEL);
-    //              c.withJwtSecretFile(JWT_FILE);
-    //              c.withEngineApiMethodNegotiation();
-    //              c.withTotalTerminalDifficulty(0);
-    //              c.withInitialState(initialStateData);
-    //              applyMilestoneConfig(c);
-    //            });
+    TekuNode lateJoiningNode =
+        createTekuNode(
+            c -> {
+              c.withGenesisTime(genesisTime.intValue());
+              c.withRealNetwork();
+              c.withPeers(primaryNode);
+              c.withInteropValidators(0, 0);
+              c.withExecutionEngine(primaryEL);
+              c.withJwtSecretFile(JWT_FILE);
+              c.withEngineApiMethodNegotiation();
+              applyMilestoneConfig(c);
+            });
 
-    //    lateJoiningNode.start();
-    //    lateJoiningNode.waitUntilInSyncWith(primaryNode);
+    lateJoiningNode.start();
+    lateJoiningNode.waitUntilInSyncWith(primaryNode);
 
     primaryNode.waitForNewBlock();
   }

--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/CapellaUpgradeAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/CapellaUpgradeAcceptanceTest.java
@@ -15,71 +15,109 @@ package tech.pegasys.teku.test.acceptance;
 
 import com.google.common.io.Resources;
 import java.net.URL;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.ethereum.execution.types.Eth1Address;
+import tech.pegasys.teku.infrastructure.time.SystemTimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.test.acceptance.dsl.AcceptanceTestBase;
+import tech.pegasys.teku.test.acceptance.dsl.BesuDockerVersion;
 import tech.pegasys.teku.test.acceptance.dsl.BesuNode;
+import tech.pegasys.teku.test.acceptance.dsl.GenesisGenerator.InitialStateData;
 import tech.pegasys.teku.test.acceptance.dsl.TekuNode;
 import tech.pegasys.teku.test.acceptance.dsl.TekuNode.Config;
+import tech.pegasys.teku.test.acceptance.dsl.tools.deposits.ValidatorKeystores;
 
 public class CapellaUpgradeAcceptanceTest extends AcceptanceTestBase {
 
+  private static final String NETWORK_NAME = "swift";
   private static final URL JWT_FILE = Resources.getResource("auth/ee-jwt-secret.hex");
+  public static final Eth1Address WITHDRAWAL_ADDRESS =
+      Eth1Address.fromHexString("0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee");
+
+  private final SystemTimeProvider timeProvider = new SystemTimeProvider();
 
   @Test
   void shouldUpgradeToCapella() throws Exception {
+    final UInt64 timeInSeconds = timeProvider.getTimeInSeconds();
+    final int genesisTime = timeInSeconds.plus(10).intValue();
+
     BesuNode primaryEL =
         createBesuNode(
+            BesuDockerVersion.STABLE,
             c -> {
               c.withMergeSupport(true);
-              c.withGenesisFile("besu/mergedGenesis.json");
-              c.withP2pEnabled(true);
+              c.withGenesisFile("besu/shanghaiGenesis.json");
+              //              c.withP2pEnabled(true);
               c.withJwtTokenAuthorization(JWT_FILE);
-            });
+            },
+            Map.of("shanghaiTime", String.valueOf(999)));
     primaryEL.start();
 
-    BesuNode secondaryEL =
-        createBesuNode(
-            c -> {
-              c.withMergeSupport(true);
-              c.withGenesisFile("besu/mergedGenesis.json");
-              c.withP2pEnabled(true);
-              c.withJwtTokenAuthorization(JWT_FILE);
-            });
-    secondaryEL.start();
-    secondaryEL.addPeer(primaryEL);
+    //    BesuNode secondaryEL =
+    //        createBesuNode(
+    //            c -> {
+    //              c.withMergeSupport(true);
+    //              c.withGenesisFile("besu/shanghaiGenesis.json");
+    //              c.withP2pEnabled(true);
+    //              c.withJwtTokenAuthorization(JWT_FILE);
+    //            });
+    //    secondaryEL.start();
+    //    secondaryEL.addPeer(primaryEL);
+
+    final ValidatorKeystores validatorKeys =
+        createTekuDepositSender(NETWORK_NAME).generateValidatorKeys(4, WITHDRAWAL_ADDRESS);
+    final InitialStateData initialStateData =
+        createGenesisGenerator()
+            .network(NETWORK_NAME)
+            .withAltairEpoch(UInt64.ZERO)
+            .withBellatrixEpoch(UInt64.ZERO)
+            .withCapellaEpoch(UInt64.ONE)
+            .withTotalTerminalDifficulty(0)
+            .genesisPayloadSource(primaryEL)
+            .validatorKeys(validatorKeys)
+            //            .genesisDelaySeconds(10)
+            .generate();
 
     TekuNode primaryNode =
         createTekuNode(
             c -> {
-              c.withRealNetwork().withStartupTargetPeerCount(0);
+              c.withRealNetwork();
+              c.withStartupTargetPeerCount(0);
+              c.withGenesisTime(genesisTime);
               c.withExecutionEngine(primaryEL);
               c.withJwtSecretFile(JWT_FILE);
+              c.withTotalTerminalDifficulty(0);
+              c.withInitialState(initialStateData);
+              c.withValidatorKeystores(validatorKeys);
+              c.withValidatorProposerDefaultFeeRecipient(
+                  "0xFE3B557E8Fb62b89F4916B721be55cEb828dBd73");
               c.withEngineApiMethodNegotiation();
               applyMilestoneConfig(c);
             });
-
     primaryNode.start();
     primaryNode.waitForMilestone(SpecMilestone.CAPELLA);
 
-    UInt64 genesisTime = primaryNode.getGenesisTime();
+    //    UInt64 genesisTime = primaryNode.getGenesisTime();
 
-    TekuNode lateJoiningNode =
-        createTekuNode(
-            c -> {
-              c.withGenesisTime(genesisTime.intValue());
-              c.withRealNetwork();
-              c.withPeers(primaryNode);
-              c.withInteropValidators(0, 0);
-              c.withExecutionEngine(primaryEL);
-              c.withJwtSecretFile(JWT_FILE);
-              c.withEngineApiMethodNegotiation();
-              applyMilestoneConfig(c);
-            });
+    //    TekuNode lateJoiningNode =
+    //        createTekuNode(
+    //            c -> {
+    //              c.withGenesisTime(genesisTime.intValue());
+    //              c.withRealNetwork();
+    //              c.withPeers(primaryNode);
+    //              c.withInteropValidators(0, 0);
+    //              c.withExecutionEngine(primaryEL);
+    //              c.withJwtSecretFile(JWT_FILE);
+    //              c.withEngineApiMethodNegotiation();
+    //              c.withTotalTerminalDifficulty(0);
+    //              c.withInitialState(initialStateData);
+    //              applyMilestoneConfig(c);
+    //            });
 
-    lateJoiningNode.start();
-    lateJoiningNode.waitUntilInSyncWith(primaryNode);
+    //    lateJoiningNode.start();
+    //    lateJoiningNode.waitUntilInSyncWith(primaryNode);
 
     primaryNode.waitForNewBlock();
   }

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/AcceptanceTestBase.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/AcceptanceTestBase.java
@@ -16,7 +16,9 @@ package tech.pegasys.teku.test.acceptance.dsl;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 import org.apache.logging.log4j.LogManager;
@@ -102,7 +104,14 @@ public class AcceptanceTestBase {
 
   protected BesuNode createBesuNode(
       final BesuDockerVersion version, final Consumer<BesuNode.Config> configOptions) {
-    return addNode(BesuNode.create(network, version, configOptions));
+    return addNode(BesuNode.create(network, version, configOptions, Collections.emptyMap()));
+  }
+
+  protected BesuNode createBesuNode(
+      final BesuDockerVersion version,
+      final Consumer<BesuNode.Config> configOptions,
+      final Map<String, String> genesisOverrides) {
+    return addNode(BesuNode.create(network, version, configOptions, genesisOverrides));
   }
 
   protected GenesisGenerator createGenesisGenerator() {

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/BesuNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/BesuNode.java
@@ -23,14 +23,11 @@ import java.io.UncheckedIOException;
 import java.net.URI;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.testcontainers.containers.Network;
@@ -42,7 +39,6 @@ import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
 import tech.pegasys.teku.spec.datastructures.interop.MergedGenesisTestBuilder;
 
 public class BesuNode extends Node {
-
   private static final Logger LOG = LogManager.getLogger();
   private static final int JSON_RPC_PORT = 8545;
   private static final int ENGINE_JSON_RPC_PORT = 8550;
@@ -53,45 +49,25 @@ public class BesuNode extends Node {
 
   private final Config config;
 
-  private BesuNode(
-      final Network network,
-      final BesuDockerVersion version,
-      final Config config,
-      final Map<String, String> genesisOverrides) {
+  public BesuNode(final Network network, final BesuDockerVersion version, final Config config) {
     super(network, BESU_DOCKER_IMAGE_NAME + ":" + version.getVersion(), LOG);
     this.config = config;
 
     container
         .withExposedPorts(JSON_RPC_PORT, ENGINE_JSON_RPC_PORT, P2P_PORT)
-        .waitingFor(new HttpWaitStrategy().forPort(JSON_RPC_PORT).forPath("/liveness"));
-
-    final List<String> startCommands = new ArrayList<>();
-    startCommands.add("--config-file");
-    startCommands.add(BESU_CONFIG_FILE_PATH);
-
-    if (!genesisOverrides.isEmpty()) {
-      final String overrides =
-          genesisOverrides.entrySet().stream()
-              .map((e) -> e.getKey() + "=" + e.getValue())
-              .collect(Collectors.joining(","));
-
-      startCommands.add("--override-genesis-config");
-      startCommands.add(overrides);
-    }
-
-    container.withCommand(startCommands.toArray(String[]::new));
+        .waitingFor(new HttpWaitStrategy().forPort(JSON_RPC_PORT).forPath("/liveness"))
+        .withCommand("--config-file", BESU_CONFIG_FILE_PATH);
   }
 
   public static BesuNode create(
       final Network network,
       final BesuDockerVersion version,
-      final Consumer<Config> configOptions,
-      final Map<String, String> genesisOverrides) {
+      final Consumer<Config> configOptions) {
 
     final Config config = new Config();
     configOptions.accept(config);
 
-    return new BesuNode(network, version, config, genesisOverrides);
+    return new BesuNode(network, version, config);
   }
 
   public void start() throws Exception {
@@ -191,7 +167,6 @@ public class BesuNode extends Node {
 
   @SuppressWarnings("unused")
   private static class Request {
-
     public final String jsonrpc = "2.0";
     public final String method;
     public final String[] params;
@@ -206,17 +181,14 @@ public class BesuNode extends Node {
   }
 
   private static class Response<T> {
-
     public T result;
   }
 
   private static class NodeInfoResponse {
-
     public String id;
   }
 
   public static class Config {
-
     private static final String[] MERGE_RPC_MODULES = new String[] {"ETH,NET,WEB3,ENGINE,ADMIN"};
     private final Map<String, Object> configMap = new HashMap<>();
     private Optional<URL> maybeJwtFile = Optional.empty();


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

We need this override in order to choose a proper shanghaiTime in our Capella ATs.

Using override with this undocumented Besu option: https://github.com/hyperledger/besu/blob/main/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java#L1257-L1265

## Fixed Issue(s)
fixes #7005 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
