### PR TITLE
Added option for adding non-critical methods on Web3JClient

### DIFF
--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/DefaultExecutionWeb3jClientProvider.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/DefaultExecutionWeb3jClientProvider.java
@@ -58,6 +58,8 @@ public class DefaultExecutionWeb3jClientProvider implements ExecutionWeb3jClient
             .jwtConfigOpt(jwtConfig)
             .timeProvider(timeProvider)
             .executionClientEventsPublisher(executionClientEventsPublisher)
+            .nonCriticalMethods(
+                "engine_exchangeCapabilities", "engine_exchangeTransitionConfigurationV1")
             .build();
     this.alreadyBuilt = true;
   }

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JClient.java
@@ -17,6 +17,8 @@ import static tech.pegasys.teku.infrastructure.exceptions.ExceptionUtil.getMessa
 
 import java.io.IOException;
 import java.time.Duration;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
 import org.web3j.protocol.Web3j;
@@ -40,6 +42,7 @@ public abstract class Web3JClient {
   private final ExecutionClientEventsChannel executionClientEventsPublisher;
   private Web3jService web3jService;
   private Web3j eth1Web3j;
+  private final Collection<String> nonCriticalMethods = new HashSet<>();
 
   // Default to the provider having a previous failure at startup so we log when it is first
   // available but uses a very old value to make sure we log if the first request fails
@@ -49,10 +52,12 @@ public abstract class Web3JClient {
   protected Web3JClient(
       final EventLogger eventLog,
       final TimeProvider timeProvider,
-      final ExecutionClientEventsChannel executionClientEventsPublisher) {
+      final ExecutionClientEventsChannel executionClientEventsPublisher,
+      final Collection<String> nonCriticalMethods) {
     this.eventLog = eventLog;
     this.timeProvider = timeProvider;
     this.executionClientEventsPublisher = executionClientEventsPublisher;
+    this.nonCriticalMethods.addAll(nonCriticalMethods);
   }
 
   protected synchronized void initWeb3jService(final Web3jService web3jService) {
@@ -77,39 +82,50 @@ public abstract class Web3JClient {
             (response, exception) -> {
               if (exception != null) {
                 final boolean couldBeAuthError = isAuthenticationException(exception);
-                handleError(exception, couldBeAuthError);
+                handleError(isCriticalRequest(web3jRequest), exception, couldBeAuthError);
                 return Response.withErrorMessage(getMessageOrSimpleName(exception));
               } else if (response.hasError()) {
                 final String errorMessage =
                     response.getError().getCode() + ": " + response.getError().getMessage();
-                handleError(new IOException(errorMessage));
+                handleError(isCriticalRequest(web3jRequest), new IOException(errorMessage), false);
                 return Response.withErrorMessage(errorMessage);
               } else {
-                handleSuccess();
+                handleSuccess(isCriticalRequest(web3jRequest));
                 return new Response<>(response.getResult());
               }
             });
   }
 
+  private boolean isCriticalRequest(Request<?, ?> request) {
+    return !nonCriticalMethods.contains(request.getMethod());
+  }
+
   protected void handleError(final Throwable error) {
-    handleError(error, false);
+    handleError(true, error, false);
   }
 
   protected void handleError(final Throwable error, final boolean couldBeAuthError) {
-    if (shouldReportError()) {
+    handleError(true, error, couldBeAuthError);
+  }
+
+  protected void handleError(
+      final boolean isCritical, final Throwable error, final boolean couldBeAuthError) {
+    if (isCritical && shouldReportError()) {
       logExecutionClientError(error, couldBeAuthError);
       executionClientEventsPublisher.onAvailabilityUpdated(false);
     }
   }
 
-  protected void handleSuccess() {
-    final long lastErrorTime = lastError.getAndUpdate(x -> NO_ERROR_TIME);
-    if (lastErrorTime == STARTUP_LAST_ERROR_TIME) {
-      eventLog.executionClientIsOnline();
-      executionClientEventsPublisher.onAvailabilityUpdated(true);
-    } else if (lastErrorTime != NO_ERROR_TIME) {
-      eventLog.executionClientRecovered();
-      executionClientEventsPublisher.onAvailabilityUpdated(true);
+  protected void handleSuccess(final boolean isCriticalRequest) {
+    if (isCriticalRequest) {
+      final long lastErrorTime = lastError.getAndUpdate(x -> NO_ERROR_TIME);
+      if (lastErrorTime == STARTUP_LAST_ERROR_TIME) {
+        eventLog.executionClientIsOnline();
+        executionClientEventsPublisher.onAvailabilityUpdated(true);
+      } else if (lastErrorTime != NO_ERROR_TIME) {
+        eventLog.executionClientRecovered();
+        executionClientEventsPublisher.onAvailabilityUpdated(true);
+      }
     }
   }
 

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3jClientBuilder.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3jClientBuilder.java
@@ -20,6 +20,8 @@ import static tech.pegasys.teku.infrastructure.logging.EventLogger.EVENT_LOG;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.Duration;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.Optional;
 import tech.pegasys.teku.ethereum.executionclient.auth.JwtConfig;
 import tech.pegasys.teku.ethereum.executionclient.events.ExecutionClientEventsChannel;
@@ -31,8 +33,8 @@ public class Web3jClientBuilder {
   private URI endpoint;
   private Optional<JwtConfig> jwtConfigOpt = Optional.empty();
   private Duration timeout;
-
   private ExecutionClientEventsChannel executionClientEventsPublisher;
+  private Collection<String> nonCriticalMethods = new HashSet<>();
 
   public Web3jClientBuilder endpoint(String endpoint) {
     this.endpoint = parseEndpoint(endpoint);
@@ -86,14 +88,25 @@ public class Web3jClientBuilder {
             timeProvider,
             timeout,
             jwtConfigOpt,
-            executionClientEventsPublisher);
+            executionClientEventsPublisher,
+            nonCriticalMethods);
       case "ws":
       case "wss":
         return new Web3jWebsocketClient(
-            EVENT_LOG, endpoint, timeProvider, jwtConfigOpt, executionClientEventsPublisher);
+            EVENT_LOG,
+            endpoint,
+            timeProvider,
+            jwtConfigOpt,
+            executionClientEventsPublisher,
+            nonCriticalMethods);
       case "file":
         return new Web3jIpcClient(
-            EVENT_LOG, endpoint, timeProvider, jwtConfigOpt, executionClientEventsPublisher);
+            EVENT_LOG,
+            endpoint,
+            timeProvider,
+            jwtConfigOpt,
+            executionClientEventsPublisher,
+            nonCriticalMethods);
       default:
         throw new InvalidConfigurationException(prepareInvalidSchemeMessage(endpoint));
     }

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3jClientBuilder.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3jClientBuilder.java
@@ -20,6 +20,7 @@ import static tech.pegasys.teku.infrastructure.logging.EventLogger.EVENT_LOG;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Optional;
@@ -34,7 +35,7 @@ public class Web3jClientBuilder {
   private Optional<JwtConfig> jwtConfigOpt = Optional.empty();
   private Duration timeout;
   private ExecutionClientEventsChannel executionClientEventsPublisher;
-  private Collection<String> nonCriticalMethods = new HashSet<>();
+  private final Collection<String> nonCriticalMethods = new HashSet<>();
 
   public Web3jClientBuilder endpoint(String endpoint) {
     this.endpoint = parseEndpoint(endpoint);
@@ -70,6 +71,11 @@ public class Web3jClientBuilder {
   public Web3jClientBuilder executionClientEventsPublisher(
       final ExecutionClientEventsChannel executionClientEventsPublisher) {
     this.executionClientEventsPublisher = executionClientEventsPublisher;
+    return this;
+  }
+
+  public Web3jClientBuilder nonCriticalMethods(String... methods) {
+    nonCriticalMethods.addAll(Arrays.asList(methods));
     return this;
   }
 

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3jHttpClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3jHttpClient.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.ethereum.executionclient.web3j;
 
 import java.net.URI;
 import java.time.Duration;
+import java.util.Collection;
 import java.util.Optional;
 import okhttp3.OkHttpClient;
 import org.apache.logging.log4j.LogManager;
@@ -36,8 +37,9 @@ class Web3jHttpClient extends Web3JClient {
       final TimeProvider timeProvider,
       final Duration timeout,
       final Optional<JwtConfig> jwtConfig,
-      final ExecutionClientEventsChannel executionClientEventsPublisher) {
-    super(eventLog, timeProvider, executionClientEventsPublisher);
+      final ExecutionClientEventsChannel executionClientEventsPublisher,
+      final Collection<String> nonCriticalMethods) {
+    super(eventLog, timeProvider, executionClientEventsPublisher, nonCriticalMethods);
     final OkHttpClient okHttpClient =
         OkHttpClientCreator.create(timeout, LOG, jwtConfig, timeProvider);
     final Web3jService httpService = new HttpService(endpoint.toString(), okHttpClient);

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3jIpcClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3jIpcClient.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.ethereum.executionclient.web3j;
 
 import java.net.URI;
 import java.nio.file.Path;
+import java.util.Collection;
 import java.util.Optional;
 import org.apache.commons.lang3.SystemUtils;
 import org.apache.logging.log4j.LogManager;
@@ -36,8 +37,9 @@ class Web3jIpcClient extends Web3JClient {
       final URI endpoint,
       final TimeProvider timeProvider,
       final Optional<JwtConfig> jwtConfig,
-      final ExecutionClientEventsChannel executionClientEventsPublisher) {
-    super(eventLog, timeProvider, executionClientEventsPublisher);
+      final ExecutionClientEventsChannel executionClientEventsPublisher,
+      final Collection<String> nonCriticalMethods) {
+    super(eventLog, timeProvider, executionClientEventsPublisher, nonCriticalMethods);
     if (jwtConfig.isPresent()) {
       LOG.warn("JWT configuration is ignored with IPC endpoint URI");
     }

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3jWebsocketClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3jWebsocketClient.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.ethereum.executionclient.web3j;
 import java.net.ConnectException;
 import java.net.URI;
 import java.time.Duration;
+import java.util.Collection;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.web3j.protocol.core.Request;
@@ -39,8 +40,9 @@ class Web3jWebsocketClient extends Web3JClient {
       final URI endpoint,
       final TimeProvider timeProvider,
       final Optional<JwtConfig> jwtConfig,
-      final ExecutionClientEventsChannel executionClientEventsPublisher) {
-    super(eventLog, timeProvider, executionClientEventsPublisher);
+      final ExecutionClientEventsChannel executionClientEventsPublisher,
+      final Collection<String> nonCriticalMethods) {
+    super(eventLog, timeProvider, executionClientEventsPublisher, nonCriticalMethods);
     this.webSocketClient = new WebSocketClient(endpoint);
     final WebSocketService webSocketService = new WebSocketService(webSocketClient, false);
     initWeb3jService(webSocketService);

--- a/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JClientTest.java
+++ b/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JClientTest.java
@@ -52,13 +52,13 @@ public class Web3JClientTest {
 
   private static final URI ENDPOINT = URI.create("");
   private static final Duration DEFAULT_TIMEOUT = Duration.ofMinutes(1);
+  private static final Collection<String> NON_CRITICAL_METHODS = Set.of("method_notCritical");
 
   private final EventLogger eventLog = mock(EventLogger.class);
 
   private final ExecutionClientEventsChannel executionClientEventsPublisher =
       mock(ExecutionClientEventsChannel.class);
 
-  private static final Collection<String> nonCriticalMethods = Set.of("method_notCritical");
 
   @SuppressWarnings("unused")
   static Stream<Arguments> getClientInstances() {
@@ -74,7 +74,7 @@ public class Web3JClientTest {
                           eventLog,
                           timeProvider,
                           executionClientEventsPublisher,
-                          nonCriticalMethods) {};
+                          NON_CRITICAL_METHODS) {};
                   web3jClient.initWeb3jService(web3jService);
                   return web3jClient;
                 }),
@@ -89,7 +89,7 @@ public class Web3JClientTest {
                           DEFAULT_TIMEOUT,
                           Optional.empty(),
                           executionClientEventsPublisher,
-                          nonCriticalMethods) {};
+                          NON_CRITICAL_METHODS) {};
                   client.initWeb3jService(web3jService);
                   return client;
                 }),
@@ -103,7 +103,7 @@ public class Web3JClientTest {
                           timeProvider,
                           Optional.empty(),
                           executionClientEventsPublisher,
-                          nonCriticalMethods);
+                          NON_CRITICAL_METHODS);
                   client.initWeb3jService(webSocketService);
                   return client;
                 }),
@@ -117,7 +117,7 @@ public class Web3JClientTest {
                           timeProvider,
                           Optional.empty(),
                           executionClientEventsPublisher,
-                          nonCriticalMethods);
+                          NON_CRITICAL_METHODS);
                   client.initWeb3jService(web3jService);
                   return client;
                 }))
@@ -227,7 +227,7 @@ public class Web3JClientTest {
   void shouldNotUpdateAvailabilityWhenNonCriticalMethodSucceeds(final ClientFactory clientFactory)
       throws Exception {
     final Web3JClient client = clientFactory.create(eventLog, executionClientEventsPublisher);
-    final String nonCriticalMethod = nonCriticalMethods.stream().findFirst().orElseThrow();
+    final String nonCriticalMethod = NON_CRITICAL_METHODS.stream().findFirst().orElseThrow();
     final Request<Void, VoidResponse> request =
         new Request<>(
             nonCriticalMethod, new ArrayList<>(), client.getWeb3jService(), VoidResponse.class);
@@ -244,7 +244,7 @@ public class Web3JClientTest {
   void shouldNotUpdateAvailabilityWhenNonCriticalMethodFailsWithException(
       final ClientFactory clientFactory) throws Exception {
     final Web3JClient client = clientFactory.create(eventLog, executionClientEventsPublisher);
-    final String nonCriticalMethod = nonCriticalMethods.stream().findFirst().orElseThrow();
+    final String nonCriticalMethod = NON_CRITICAL_METHODS.stream().findFirst().orElseThrow();
     final Request<Void, VoidResponse> request =
         new Request<>(
             nonCriticalMethod, new ArrayList<>(), client.getWeb3jService(), VoidResponse.class);
@@ -261,7 +261,7 @@ public class Web3JClientTest {
   void shouldNotUpdateAvailabilityWhenNonCriticalMethodFailsWithErrorResponse(
       final ClientFactory clientFactory) throws Exception {
     final Web3JClient client = clientFactory.create(eventLog, executionClientEventsPublisher);
-    final String nonCriticalMethod = nonCriticalMethods.stream().findFirst().orElseThrow();
+    final String nonCriticalMethod = NON_CRITICAL_METHODS.stream().findFirst().orElseThrow();
     final Request<Void, VoidResponse> request =
         new Request<>(
             nonCriticalMethod, new ArrayList<>(), client.getWeb3jService(), VoidResponse.class);

--- a/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JClientTest.java
+++ b/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JClientTest.java
@@ -59,7 +59,6 @@ public class Web3JClientTest {
   private final ExecutionClientEventsChannel executionClientEventsPublisher =
       mock(ExecutionClientEventsChannel.class);
 
-
   @SuppressWarnings("unused")
   static Stream<Arguments> getClientInstances() {
     final TimeProvider timeProvider = StubTimeProvider.withTimeInSeconds(1000);

--- a/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3jWebsocketClientTest.java
+++ b/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3jWebsocketClientTest.java
@@ -29,6 +29,7 @@ import java.net.URI;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -55,7 +56,12 @@ public class Web3jWebsocketClientTest {
   public void setup() {
     this.web3jWebsocketClient =
         new Web3jWebsocketClient(
-            EVENT_LOG, endpoint, timeProvider, Optional.empty(), executionClientEventsPublisher);
+            EVENT_LOG,
+            endpoint,
+            timeProvider,
+            Optional.empty(),
+            executionClientEventsPublisher,
+            Set.of());
     web3jWebsocketClient.initWeb3jService(webSocketService);
   }
 

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/NegotiatedExecutionJsonRpcMethodsResolver.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/NegotiatedExecutionJsonRpcMethodsResolver.java
@@ -45,6 +45,8 @@ public class NegotiatedExecutionJsonRpcMethodsResolver implements ExecutionJsonR
   public <T> EngineJsonRpcMethod<T> getMethod(
       final EngineApiMethods method, final Class<T> resultType) {
     if (!remoteEngineApiCapabilitiesProvider.isAvailable()) {
+      LOG.debug("Remote EngineApiCapabilitiesProvider not available. Using local fallback option.");
+
       return fallbackResolver.getMethod(method, resultType);
     }
 


### PR DESCRIPTION
## PR Description

Added option for adding non-critical methods on Web3JClient.
Non-critical methods won't trigger availability updates.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
