### PR TITLE
Allow overriding of deposit contract deploy block

### DIFF
--- a/teku/src/main/java/tech/pegasys/teku/cli/options/Eth2NetworkOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/Eth2NetworkOptions.java
@@ -174,6 +174,14 @@ public class Eth2NetworkOptions {
   private boolean forkChoiceUpdateHeadOnBlockImportEnabled =
       Eth2NetworkConfiguration.DEFAULT_FORK_CHOICE_UPDATE_HEAD_ON_BLOCK_IMPORT_ENABLED;
 
+  @Option(
+      names = {"--Xeth1-deposit-contract-deploy-block-override"},
+      hidden = true,
+      paramLabel = "<NUMBER>",
+      description = "Override deposit contract block number.",
+      arity = "1")
+  private Long eth1DepositContractDeployBlockOverride;
+
   public Eth2NetworkConfiguration getNetworkConfiguration() {
     return createEth2NetworkConfig();
   }
@@ -231,6 +239,9 @@ public class Eth2NetworkOptions {
     }
     if (trustedSetup != null) {
       builder.trustedSetup(trustedSetup);
+    }
+    if (eth1DepositContractDeployBlockOverride != null) {
+      builder.eth1DepositContractDeployBlock(eth1DepositContractDeployBlockOverride);
     }
     builder
         .safeSlotsToImportOptimistically(safeSlotsToImportOptimistically)

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/Eth2P2PNetworkOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/Eth2P2PNetworkOptionsTest.java
@@ -25,6 +25,7 @@ import tech.pegasys.teku.cli.AbstractBeaconNodeCommandTest;
 import tech.pegasys.teku.cli.OSUtils;
 import tech.pegasys.teku.config.TekuConfiguration;
 import tech.pegasys.teku.ethereum.execution.types.Eth1Address;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.P2PConfig;
 import tech.pegasys.teku.networks.Eth2NetworkConfiguration;
 import tech.pegasys.teku.spec.networks.Eth2Network;
@@ -105,6 +106,30 @@ public class Eth2P2PNetworkOptionsTest extends AbstractBeaconNodeCommandTest {
                     b -> {
                       b.applyNetworkDefaults(Eth2Network.MAINNET);
                       b.eth1DepositContractAddress("0xFE3B557E8Fb62b89F4916B721be55cEb828dBd73");
+                    })
+                .build())
+        .usingRecursiveComparison()
+        .isEqualTo(tekuConfiguration);
+  }
+
+  @Test
+  public void overrideDepositContractDeployBlock() {
+    beaconNodeCommand.parse(
+        new String[] {
+          "--network", "mainnet", "--Xeth1-deposit-contract-deploy-block-override", "345"
+        });
+
+    final TekuConfiguration tekuConfiguration = getResultingTekuConfiguration();
+    final Eth2NetworkConfiguration configuration = tekuConfiguration.eth2NetworkConfiguration();
+    final Optional<UInt64> configuredDepositContractDeployBlock =
+        configuration.getEth1DepositContractDeployBlock();
+    assertThat(configuredDepositContractDeployBlock).isEqualTo(Optional.of(UInt64.valueOf(345L)));
+    assertThat(
+            createConfigBuilder()
+                .eth2NetworkConfig(
+                    b -> {
+                      b.applyNetworkDefaults(Eth2Network.MAINNET);
+                      b.eth1DepositContractDeployBlock(345L);
                     })
                 .build())
         .usingRecursiveComparison()


### PR DESCRIPTION
makes @parithosh happy by allowing deposit contract deploy block to be overridable via `--Xeth1-deposit-contract-deploy-block-override`


## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
