### PR TITLE
Perform readiness check when starting the VC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,4 +16,6 @@ For information on changes in released versions of Teku, see the [releases page]
 
 ### Additions and Improvements
  - Enabled peer scoring by default. Can be disabled explicitly using `--Xp2p-gossip-scoring-enabled=false`
+ - When failovers are configured, a validator client will perform a readiness check on startup to avoid retrieving validator statuses from a node which is not ready
+
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,6 @@ For information on changes in released versions of Teku, see the [releases page]
 
 ### Additions and Improvements
  - Enabled peer scoring by default. Can be disabled explicitly using `--Xp2p-gossip-scoring-enabled=false`
- - When failovers are configured, a validator client will perform a readiness check on startup to avoid retrieving validator statuses from a node which is not ready
+ - When failovers are configured, a validator client will perform a readiness check on startup to avoid retrieving validator statuses from a node which is not ready.
 
 ### Bug Fixes

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/ValidatorLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/ValidatorLogger.java
@@ -85,7 +85,7 @@ public class ValidatorLogger {
     log.warn(
         ColorConsolePrinter.print(
             String.format(
-                "%sThe primary beacon node is NOT ready to accept requests (offline or not in sync). Future requests will use one of the configured failover beacon nodes until the primary one is ready again.",
+                "%sThe primary beacon node is NOT ready to accept requests. Future requests will use one of the configured failover beacon nodes until the primary one is ready again.",
                 PREFIX),
             Color.YELLOW));
   }

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessManager.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessManager.java
@@ -107,12 +107,7 @@ public class BeaconNodeReadinessManager extends Service implements ValidatorTimi
 
   @Override
   public void onAttestationAggregationDue(final UInt64 slot) {
-    performReadinessCheckAgainstAllNodes()
-        .finish(
-            throwable ->
-                LOG.error(
-                    "Error while querying the syncing status of the configured Beacon Nodes",
-                    throwable));
+    performReadinessCheckAgainstAllNodes().ifExceptionGetsHereRaiseABug();
   }
 
   private SafeFuture<Void> performReadinessCheckAgainstAllNodes() {

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApi.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApi.java
@@ -159,14 +159,16 @@ public class RemoteBeaconNodeApi implements BeaconNodeApi {
   public SafeFuture<Void> subscribeToEvents() {
     return beaconChainEventAdapter
         .start()
-        .thenCompose(__ -> beaconNodeReadinessManager.start().toVoid());
+        .thenCompose(__ -> beaconNodeReadinessManager.start())
+        .toVoid();
   }
 
   @Override
   public SafeFuture<Void> unsubscribeFromEvents() {
     return beaconChainEventAdapter
         .stop()
-        .thenCompose(__ -> beaconNodeReadinessManager.stop().toVoid());
+        .thenCompose(__ -> beaconNodeReadinessManager.stop())
+        .toVoid();
   }
 
   @Override

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/sentry/SentryBeaconNodeApi.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/sentry/SentryBeaconNodeApi.java
@@ -242,14 +242,16 @@ public class SentryBeaconNodeApi implements BeaconNodeApi {
   public SafeFuture<Void> subscribeToEvents() {
     return beaconChainEventAdapter
         .start()
-        .thenCompose(__ -> beaconNodeReadinessManager.start().toVoid());
+        .thenCompose(__ -> beaconNodeReadinessManager.start())
+        .toVoid();
   }
 
   @Override
   public SafeFuture<Void> unsubscribeFromEvents() {
     return beaconChainEventAdapter
         .stop()
-        .thenCompose(__ -> beaconNodeReadinessManager.stop().toVoid());
+        .thenCompose(__ -> beaconNodeReadinessManager.stop())
+        .toVoid();
   }
 
   @Override

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/sentry/SentryBeaconNodeApi.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/sentry/SentryBeaconNodeApi.java
@@ -50,12 +50,15 @@ public class SentryBeaconNodeApi implements BeaconNodeApi {
 
   private final BeaconChainEventAdapter beaconChainEventAdapter;
   private final ValidatorApiChannel validatorApiChannel;
+  private final BeaconNodeReadinessManager beaconNodeReadinessManager;
 
   private SentryBeaconNodeApi(
       final BeaconChainEventAdapter beaconChainEventAdapter,
-      final ValidatorApiChannel validatorApiChannel) {
+      final ValidatorApiChannel validatorApiChannel,
+      final BeaconNodeReadinessManager beaconNodeReadinessManager) {
     this.beaconChainEventAdapter = beaconChainEventAdapter;
     this.validatorApiChannel = validatorApiChannel;
+    this.beaconNodeReadinessManager = beaconNodeReadinessManager;
   }
 
   public static BeaconNodeApi create(
@@ -162,7 +165,8 @@ public class SentryBeaconNodeApi implements BeaconNodeApi {
 
     eventChannels.subscribe(BeaconNodeReadinessChannel.class, beaconChainEventAdapter);
 
-    return new SentryBeaconNodeApi(beaconChainEventAdapter, sentryValidatorApi);
+    return new SentryBeaconNodeApi(
+        beaconChainEventAdapter, sentryValidatorApi, beaconNodeReadinessManager);
   }
 
   private static RemoteValidatorApiChannel createPrimaryValidatorApiChannel(
@@ -236,12 +240,16 @@ public class SentryBeaconNodeApi implements BeaconNodeApi {
 
   @Override
   public SafeFuture<Void> subscribeToEvents() {
-    return beaconChainEventAdapter.start();
+    return beaconChainEventAdapter
+        .start()
+        .thenCompose(__ -> beaconNodeReadinessManager.start().toVoid());
   }
 
   @Override
   public SafeFuture<Void> unsubscribeFromEvents() {
-    return beaconChainEventAdapter.stop();
+    return beaconChainEventAdapter
+        .stop()
+        .thenCompose(__ -> beaconNodeReadinessManager.stop().toVoid());
   }
 
   @Override

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessManagerTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessManagerTest.java
@@ -67,7 +67,7 @@ public class BeaconNodeReadinessManagerTest {
     when(failoverBeaconNodeApi.getSyncingStatus())
         .thenReturn(SafeFuture.completedFuture(SYNCING_STATUS));
 
-    beaconNodeReadinessManager.start();
+    beaconNodeReadinessManager.start().join();
 
     assertThat(beaconNodeReadinessManager.isReady(beaconNodeApi)).isFalse();
     assertThat(beaconNodeReadinessManager.isReady(failoverBeaconNodeApi)).isFalse();
@@ -76,7 +76,9 @@ public class BeaconNodeReadinessManagerTest {
     verify(beaconNodeReadinessChannel).onPrimaryNodeNotReady();
     verify(beaconNodeReadinessChannel).onFailoverNodeNotReady(failoverBeaconNodeApi);
 
-    beaconNodeReadinessManager.stop();
+    beaconNodeReadinessManager.stop().join();
+
+    assertThat(beaconNodeReadinessManager.isRunning()).isFalse();
   }
 
   @Test

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessManagerTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessManagerTest.java
@@ -58,6 +58,28 @@ public class BeaconNodeReadinessManagerTest {
           beaconNodeReadinessChannel);
 
   @Test
+  public void performsReadinessCheckOnStartup() {
+    // default to true if never started
+    assertThat(beaconNodeReadinessManager.isReady(beaconNodeApi)).isTrue();
+    assertThat(beaconNodeReadinessManager.isReady(failoverBeaconNodeApi)).isTrue();
+
+    when(beaconNodeApi.getSyncingStatus()).thenReturn(SafeFuture.completedFuture(SYNCING_STATUS));
+    when(failoverBeaconNodeApi.getSyncingStatus())
+        .thenReturn(SafeFuture.completedFuture(SYNCING_STATUS));
+
+    beaconNodeReadinessManager.start();
+
+    assertThat(beaconNodeReadinessManager.isReady(beaconNodeApi)).isFalse();
+    assertThat(beaconNodeReadinessManager.isReady(failoverBeaconNodeApi)).isFalse();
+
+    verify(validatorLogger).primaryBeaconNodeNotReady();
+    verify(beaconNodeReadinessChannel).onPrimaryNodeNotReady();
+    verify(beaconNodeReadinessChannel).onFailoverNodeNotReady(failoverBeaconNodeApi);
+
+    beaconNodeReadinessManager.stop();
+  }
+
+  @Test
   public void retrievesReadinessAndPublishesToAChannel() {
     // default to true if never ran
     assertThat(beaconNodeReadinessManager.isReady(beaconNodeApi)).isTrue();


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Perform readiness check on startup when failovers are configured to avoid calling `eth/v1/beacon/states/head/validators`  (that endpoint does not return 503 when node is still syncing) on a node which is not synced.

Reported by a Discord user: https://discordapp.com/channels/697535391594446898/697539289042649190/1092731844841185360

Avoids behaviour where initial validator statuses are retrieved on a node which is not synced. (`Unable to retrieve status for validator`) This can cause a validator to not attest on the epoch the VC starts:
![image](https://user-images.githubusercontent.com/14827647/229774154-32b70a98-2b98-4cc5-a538-ac7be86910fc.png)
![image](https://user-images.githubusercontent.com/14827647/229792006-56afc545-896a-4e51-9918-14d1c61b41d6.png)


## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
