### PR TITLE
Add BlobSidecar getters in CombinedChainDataClient

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -327,8 +327,7 @@ public class Spec {
     return atSlot(slot)
         .getSchemaDefinitions()
         .toVersionDeneb()
-        .orElseThrow(
-            () -> new RuntimeException("Deneb milestone is required to load execution payload"))
+        .orElseThrow(() -> new RuntimeException("Deneb milestone is required to load blob sidecar"))
         .getBlobSidecarSchema()
         .sszDeserialize(serializedBlobSidecar);
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -323,6 +323,16 @@ public class Spec {
         .sszDeserialize(serializedPayload);
   }
 
+  public BlobSidecar deserializeBlobSidecar(final Bytes serializedBlobSidecar, final UInt64 slot) {
+    return atSlot(slot)
+        .getSchemaDefinitions()
+        .toVersionDeneb()
+        .orElseThrow(
+            () -> new RuntimeException("Deneb milestone is required to load execution payload"))
+        .getBlobSidecarSchema()
+        .sszDeserialize(serializedBlobSidecar);
+  }
+
   public BlobsSidecar deserializeBlobsSidecar(
       final Bytes serializedBlobsSidecar, final UInt64 slot) {
     return atSlot(slot)

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/util/SlotAndBlockRootAndBlobIndex.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/util/SlotAndBlockRootAndBlobIndex.java
@@ -45,6 +45,10 @@ public class SlotAndBlockRootAndBlobIndex implements Comparable<SlotAndBlockRoot
     return blobIndex;
   }
 
+  public boolean hasNoBlobs() {
+    return blobIndex.equals(UInt64.MAX_VALUE);
+  }
+
   @Override
   public boolean equals(final Object o) {
     if (this == o) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/util/SlotAndBlockRootAndBlobIndex.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/util/SlotAndBlockRootAndBlobIndex.java
@@ -33,7 +33,8 @@ public class SlotAndBlockRootAndBlobIndex implements Comparable<SlotAndBlockRoot
     this.blobIndex = blobIndex;
   }
 
-  public static SlotAndBlockRootAndBlobIndex createWithNoBlobs(final UInt64 slot, final Bytes32 blockRoot) {
+  public static SlotAndBlockRootAndBlobIndex createWithNoBlobs(
+      final UInt64 slot, final Bytes32 blockRoot) {
     return new SlotAndBlockRootAndBlobIndex(slot, blockRoot, UInt64.MAX_VALUE);
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/util/SlotAndBlockRootAndBlobIndex.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/util/SlotAndBlockRootAndBlobIndex.java
@@ -22,6 +22,8 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 /** Key for storing blobs in DB */
 public class SlotAndBlockRootAndBlobIndex implements Comparable<SlotAndBlockRootAndBlobIndex> {
+  public static final UInt64 NO_BLOBS_INDEX = UInt64.MAX_VALUE;
+
   private final UInt64 slot;
   private final Bytes32 blockRoot;
   private final UInt64 blobIndex;
@@ -33,9 +35,9 @@ public class SlotAndBlockRootAndBlobIndex implements Comparable<SlotAndBlockRoot
     this.blobIndex = blobIndex;
   }
 
-  public static SlotAndBlockRootAndBlobIndex createWithNoBlobs(
+  public static SlotAndBlockRootAndBlobIndex createNoBlobsKey(
       final UInt64 slot, final Bytes32 blockRoot) {
-    return new SlotAndBlockRootAndBlobIndex(slot, blockRoot, UInt64.MAX_VALUE);
+    return new SlotAndBlockRootAndBlobIndex(slot, blockRoot, NO_BLOBS_INDEX);
   }
 
   public UInt64 getSlot() {
@@ -50,8 +52,8 @@ public class SlotAndBlockRootAndBlobIndex implements Comparable<SlotAndBlockRoot
     return blobIndex;
   }
 
-  public boolean hasNoBlobs() {
-    return blobIndex.equals(UInt64.MAX_VALUE);
+  public boolean isNoBlobsKey() {
+    return blobIndex.equals(NO_BLOBS_INDEX);
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/util/SlotAndBlockRootAndBlobIndex.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/util/SlotAndBlockRootAndBlobIndex.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.util;
+
+import com.google.common.base.MoreObjects;
+import java.util.Comparator;
+import java.util.Objects;
+import org.apache.tuweni.bytes.Bytes32;
+import org.jetbrains.annotations.NotNull;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+/** Key for storing blobs in DB */
+public class SlotAndBlockRootAndBlobIndex implements Comparable<SlotAndBlockRootAndBlobIndex> {
+  private final UInt64 slot;
+  private final Bytes32 blockRoot;
+  private final UInt64 blobIndex;
+
+  public SlotAndBlockRootAndBlobIndex(
+      final UInt64 slot, final Bytes32 blockRoot, final UInt64 blobIndex) {
+    this.slot = slot;
+    this.blockRoot = blockRoot;
+    this.blobIndex = blobIndex;
+  }
+
+  public UInt64 getSlot() {
+    return slot;
+  }
+
+  public Bytes32 getBlockRoot() {
+    return blockRoot;
+  }
+
+  public UInt64 getBlobIndex() {
+    return blobIndex;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final SlotAndBlockRootAndBlobIndex that = (SlotAndBlockRootAndBlobIndex) o;
+    return Objects.equals(slot, that.slot)
+        && Objects.equals(blockRoot, that.blockRoot)
+        && Objects.equals(blobIndex, that.blobIndex);
+  }
+
+  @Override
+  public int compareTo(@NotNull SlotAndBlockRootAndBlobIndex o) {
+    return Comparator.comparing(SlotAndBlockRootAndBlobIndex::getSlot)
+        .thenComparing(SlotAndBlockRootAndBlobIndex::getBlockRoot)
+        .thenComparing(SlotAndBlockRootAndBlobIndex::getBlobIndex)
+        .compare(this, o);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(slot, blockRoot, blobIndex);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("slot", slot)
+        .add("blockRoot", blockRoot)
+        .add("blobIndex", blobIndex)
+        .toString();
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/util/SlotAndBlockRootAndBlobIndex.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/util/SlotAndBlockRootAndBlobIndex.java
@@ -33,6 +33,10 @@ public class SlotAndBlockRootAndBlobIndex implements Comparable<SlotAndBlockRoot
     this.blobIndex = blobIndex;
   }
 
+  public static SlotAndBlockRootAndBlobIndex createWithNoBlobs(final UInt64 slot, final Bytes32 blockRoot) {
+    return new SlotAndBlockRootAndBlobIndex(slot, blockRoot, UInt64.MAX_VALUE);
+  }
+
   public UInt64 getSlot() {
     return slot;
   }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandler.java
@@ -19,16 +19,14 @@ import static tech.pegasys.teku.spec.config.Constants.MIN_EPOCHS_FOR_BLOB_SIDECA
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;
 import java.nio.channels.ClosedChannelException;
+import java.util.Iterator;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.plugin.services.metrics.Counter;
 import org.hyperledger.besu.plugin.services.metrics.LabelledMetric;
-import org.jetbrains.annotations.NotNull;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -39,10 +37,9 @@ import tech.pegasys.teku.networking.eth2.rpc.core.RpcException;
 import tech.pegasys.teku.networking.p2p.rpc.StreamClosedException;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.config.SpecConfigDeneb;
-import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.execution.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BlobSidecarsByRangeRequestMessage;
-import tech.pegasys.teku.spec.logic.versions.deneb.helpers.MiscHelpersDeneb;
+import tech.pegasys.teku.spec.datastructures.util.SlotAndBlockRootAndBlobIndex;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 
 /**
@@ -89,7 +86,7 @@ public class BlobSidecarsByRangeMessageHandler
       final BlobSidecarsByRangeRequestMessage message,
       final ResponseCallback<BlobSidecar> callback) {
     final UInt64 startSlot = message.getStartSlot();
-    final UInt64 maxSlot = message.getMaxSlot();
+    final UInt64 endSlot = message.getMaxSlot();
 
     LOG.trace(
         "Peer {} requested {} slots of blob sidecars starting at slot {}.",
@@ -97,7 +94,7 @@ public class BlobSidecarsByRangeMessageHandler
         message.getCount(),
         startSlot);
 
-    final SpecConfigDeneb specConfig = SpecConfigDeneb.required(spec.atSlot(maxSlot).getConfig());
+    final SpecConfigDeneb specConfig = SpecConfigDeneb.required(spec.atSlot(endSlot).getConfig());
     final UInt64 maxBlobsPerBlock = UInt64.valueOf(specConfig.getMaxBlobsPerBlock());
     final UInt64 maxRequestBlobSidecars = specConfig.getMaxRequestBlobSidecars();
 
@@ -122,14 +119,6 @@ public class BlobSidecarsByRangeMessageHandler
     requestCounter.labels("ok").inc();
     totalBlobSidecarsRequestedCounter.inc(requestedCount.longValue());
 
-    final Bytes32 headBlockRoot =
-        combinedChainDataClient
-            .getBestBlockRoot()
-            .orElseThrow(
-                () ->
-                    new IllegalStateException(
-                        "Can't retrieve the block root chosen by fork choice."));
-
     combinedChainDataClient
         .getEarliestAvailableBlobSidecarEpoch()
         .thenCompose(
@@ -143,7 +132,7 @@ public class BlobSidecarsByRangeMessageHandler
               }
               final BlobSidecarsByRangeMessageHandler.RequestState initialState =
                   new BlobSidecarsByRangeMessageHandler.RequestState(
-                      callback, maxRequestBlobSidecars, headBlockRoot, startSlot, maxSlot);
+                      callback, maxRequestBlobSidecars, startSlot, endSlot);
               if (initialState.isComplete()) {
                 return SafeFuture.completedFuture(initialState);
               }
@@ -181,7 +170,6 @@ public class BlobSidecarsByRangeMessageHandler
                 maybeBlobSidecar.map(requestState::sendBlobSidecar).orElse(SafeFuture.COMPLETE))
         .thenCompose(
             __ -> {
-              requestState.incrementSlotAndIndex();
               if (requestState.isComplete()) {
                 return SafeFuture.completedFuture(requestState);
               } else {
@@ -213,37 +201,20 @@ public class BlobSidecarsByRangeMessageHandler
     private final AtomicInteger sentBlobSidecars = new AtomicInteger(0);
     private final ResponseCallback<BlobSidecar> callback;
     private final UInt64 maxRequestBlobSidecars;
-    private final Bytes32 headBlockRoot;
-    private final AtomicReference<UInt64> currentSlot;
-    private final AtomicReference<UInt64> currentIndex;
-    private final UInt64 maxSlot;
+    private final UInt64 startSlot;
+    private final UInt64 endSlot;
 
-    private Optional<SignedBeaconBlock> maybeCurrentBlock = Optional.empty();
-
-    private int blobSidecarsCount = 0;
+    private Optional<Iterator<SlotAndBlockRootAndBlobIndex>> iterator = Optional.empty();
 
     RequestState(
         final ResponseCallback<BlobSidecar> callback,
         final UInt64 maxRequestBlobSidecars,
-        final Bytes32 headBlockRoot,
-        final UInt64 currentSlot,
-        final UInt64 maxSlot) {
+        final UInt64 startSlot,
+        final UInt64 endSlot) {
       this.callback = callback;
       this.maxRequestBlobSidecars = maxRequestBlobSidecars;
-      this.headBlockRoot = headBlockRoot;
-      this.currentSlot = new AtomicReference<>(currentSlot);
-      this.currentIndex = new AtomicReference<>(UInt64.ZERO);
-      this.maxSlot = maxSlot;
-    }
-
-    @VisibleForTesting
-    UInt64 getCurrentSlot() {
-      return currentSlot.get();
-    }
-
-    @VisibleForTesting
-    UInt64 getCurrentIndex() {
-      return currentIndex.get();
+      this.startSlot = startSlot;
+      this.endSlot = endSlot;
     }
 
     SafeFuture<Void> sendBlobSidecar(final BlobSidecar blobSidecar) {
@@ -251,65 +222,31 @@ public class BlobSidecarsByRangeMessageHandler
     }
 
     SafeFuture<Optional<BlobSidecar>> loadNextBlobSidecar() {
-      // currentBlock is used to avoid querying the combinedChainDataClient for the same slot again
-      if (maybeCurrentBlock.isEmpty()) {
+      if (iterator.isEmpty()) {
         return combinedChainDataClient
-            .getBlockAtSlotExact(currentSlot.get(), headBlockRoot)
+            .getBlobSidecarKeys(startSlot, endSlot, maxRequestBlobSidecars)
             .thenCompose(
-                block -> {
-                  maybeCurrentBlock = block;
-                  final MiscHelpersDeneb miscHelpersDeneb =
-                      spec.atSlot(currentSlot.get()).miscHelpers().toVersionDeneb().orElseThrow();
-                  blobSidecarsCount = miscHelpersDeneb.getBlobSidecarsCount(block);
-                  return retrieveBlobSidecar();
+                list -> {
+                  iterator = Optional.of(list.iterator());
+                  return getNextElement(iterator.get());
                 });
       } else {
-        return retrieveBlobSidecar();
+        return getNextElement(iterator.get());
+      }
+    }
+
+    private SafeFuture<Optional<BlobSidecar>> getNextElement(
+        final Iterator<SlotAndBlockRootAndBlobIndex> iterator) {
+      if (iterator.hasNext()) {
+        return combinedChainDataClient.getBlobSidecarByKey(iterator.next());
+      } else {
+        return SafeFuture.completedFuture(Optional.empty());
       }
     }
 
     boolean isComplete() {
-      return currentSlot.get().isGreaterThan(maxSlot)
-          || UInt64.valueOf(sentBlobSidecars.get()).isGreaterThanOrEqualTo(maxRequestBlobSidecars);
-    }
-
-    void incrementSlotAndIndex() {
-      if (currentIndex.get().equals(getMaxBlobSidecarIndex())) {
-        currentIndex.set(UInt64.ZERO);
-        currentSlot.updateAndGet(UInt64::increment);
-      } else {
-        currentIndex.updateAndGet(UInt64::increment);
-      }
-    }
-
-    @NotNull
-    private SafeFuture<Optional<BlobSidecar>> retrieveBlobSidecar() {
-      SafeFuture<Optional<BlobSidecar>> blobSidecar =
-          maybeCurrentBlock
-              .map(SignedBeaconBlock::getRoot)
-              .map(
-                  blockRoot ->
-                      combinedChainDataClient.getBlobSidecarByBlockRootAndIndex(
-                          blockRoot, currentIndex.get()))
-              .orElse(SafeFuture.completedFuture(Optional.empty()));
-
-      refreshCurrentBlock();
-
-      return blobSidecar;
-    }
-
-    private void refreshCurrentBlock() {
-      maybeCurrentBlock.ifPresent(
-          block -> {
-            if (block.getSlot().equals(currentSlot.get())
-                && currentIndex.get().equals(getMaxBlobSidecarIndex())) {
-              maybeCurrentBlock = Optional.empty();
-            }
-          });
-    }
-
-    private UInt64 getMaxBlobSidecarIndex() {
-      return UInt64.valueOf(blobSidecarsCount).minusMinZero(UInt64.ONE);
+      return endSlot.isLessThan(startSlot)
+          || iterator.map(iterator -> !iterator.hasNext()).orElse(false);
     }
   }
 }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandlerTest.java
@@ -23,12 +23,13 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
-import static tech.pegasys.teku.infrastructure.async.FutureUtil.ignoreFuture;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 import static tech.pegasys.teku.networking.eth2.rpc.core.RpcResponseStatus.INVALID_REQUEST_CODE;
 import static tech.pegasys.teku.spec.config.Constants.MAX_CHUNK_SIZE;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -40,7 +41,6 @@ import org.mockito.ArgumentCaptor;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
-import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.teku.networking.eth2.rpc.beaconchain.BeaconChainMethodIds;
@@ -51,13 +51,10 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.config.SpecConfigDeneb;
-import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
-import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
-import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.deneb.BeaconBlockBodyDeneb;
 import tech.pegasys.teku.spec.datastructures.execution.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BlobSidecarsByRangeRequestMessage;
-import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
+import tech.pegasys.teku.spec.datastructures.util.SlotAndBlockRootAndBlobIndex;
 import tech.pegasys.teku.spec.logic.versions.deneb.helpers.MiscHelpersDeneb;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
@@ -191,18 +188,14 @@ public class BlobSidecarsByRangeMessageHandlerTest {
 
   @Test
   public void shouldCompleteSuccessfullyIfRequestNotWithinRange() {
-    SignedBeaconBlock signedBeaconBlock = dataStructureUtil.randomSignedBeaconBlock();
-    int blobSidecarsCount = miscHelpers.getBlobSidecarsCount(Optional.of(signedBeaconBlock));
-    when(combinedChainDataClient.getBlockAtSlotExact(any(), eq(headBlockRoot)))
-        .thenReturn(SafeFuture.completedFuture(Optional.of(signedBeaconBlock)));
-
+    when(combinedChainDataClient.getBlobSidecarKeys(any(), any(), any()))
+        .thenReturn(SafeFuture.completedFuture(Collections.emptyList()));
     final BlobSidecarsByRangeRequestMessage request =
         new BlobSidecarsByRangeRequestMessage(ZERO, count);
 
     handler.onIncomingMessage(protocolId, peer, request, listener);
 
-    verify(combinedChainDataClient, times(count.times(blobSidecarsCount).intValue()))
-        .getBlobSidecarByBlockRootAndIndex(any(), any());
+    verify(combinedChainDataClient, never()).getBlobSidecarByKey(any());
 
     verify(listener, never()).respond(any());
 
@@ -215,16 +208,13 @@ public class BlobSidecarsByRangeMessageHandlerTest {
     final BlobSidecarsByRangeRequestMessage request =
         new BlobSidecarsByRangeRequestMessage(startSlot, count);
 
-    final List<BlobSidecar> expectedSent =
-        setUpBlobSidecarsData(startSlot, request.getMaxSlot(), headBlockRoot);
+    final List<BlobSidecar> expectedSent = setUpBlobSidecarsData(startSlot, request.getMaxSlot());
 
     handler.onIncomingMessage(protocolId, peer, request, listener);
 
     final ArgumentCaptor<BlobSidecar> argumentCaptor = ArgumentCaptor.forClass(BlobSidecar.class);
 
     verify(listener, times(expectedSent.size())).respond(argumentCaptor.capture());
-
-    verify(combinedChainDataClient, times(count.intValue())).getBlockAtSlotExact(any(), any());
 
     final List<BlobSidecar> actualSent = argumentCaptor.getAllValues();
 
@@ -254,82 +244,46 @@ public class BlobSidecarsByRangeMessageHandlerTest {
     AssertionsForInterfaceTypes.assertThat(actualSent).isEmpty();
   }
 
-  @Test
-  public void shouldIterateThroughIndicesAndSlots() {
-
-    UInt64 currentSlot = ZERO;
-    UInt64 count = UInt64.valueOf(5);
-    BlobSidecarsByRangeMessageHandler.RequestState request =
-        handler
-        .new RequestState(
-            listener, specConfig.getMaxRequestBlobSidecars(), headBlockRoot, currentSlot, count);
-
-    for (int slot = currentSlot.intValue(); slot <= count.intValue(); slot++) {
-
-      SszList<SszKZGCommitment> randomCommitments = dataStructureUtil.randomSszKzgCommitmentList();
-      mockSignedBeaconBlock(slot, randomCommitments);
-
-      for (int index = 0; index < randomCommitments.size(); index++) {
-        assertThat(request.isComplete()).isFalse();
-        assertThat(request.getCurrentSlot()).isEqualTo(UInt64.valueOf(slot));
-        assertThat(request.getCurrentIndex()).isEqualTo(UInt64.valueOf(index));
-        ignoreFuture(request.loadNextBlobSidecar());
-        request.incrementSlotAndIndex();
-      }
-    }
-
-    assertThat(request.isComplete()).isTrue();
+  private List<BlobSidecar> setUpBlobSidecarsData(final UInt64 startSlot, final UInt64 maxSlot) {
+    final List<SlotAndBlockRootAndBlobIndex> keys = setupKeyList(startSlot, maxSlot);
+    when(combinedChainDataClient.getBlobSidecarKeys(eq(startSlot), eq(maxSlot), any()))
+        .thenAnswer(
+            args ->
+                SafeFuture.completedFuture(
+                    keys.subList(
+                        0, Math.min(keys.size(), ((UInt64) args.getArgument(2)).intValue()))));
+    return keys.stream().map(this::setUpBlobSidecarDataForKey).collect(Collectors.toList());
   }
 
-  private List<BlobSidecar> setUpBlobSidecarsData(
-      final UInt64 startSlot, final UInt64 maxSlot, final Bytes32 headBlockRoot) {
-    return UInt64.rangeClosed(startSlot, maxSlot)
-        .flatMap(
+  private List<SlotAndBlockRootAndBlobIndex> setupKeyList(
+      final UInt64 startSlot, final UInt64 maxSlot) {
+    final List<SlotAndBlockRootAndBlobIndex> keys = new ArrayList<>();
+    UInt64.rangeClosed(startSlot, maxSlot)
+        .forEach(
             slot -> {
               final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(slot);
-              when(combinedChainDataClient.getBlockAtSlotExact(slot, headBlockRoot))
-                  .thenReturn(SafeFuture.completedFuture(Optional.of(block)));
-              return setUpBlobSidecarsDataForSlot(slot, block).stream();
-            })
-        .collect(Collectors.toList());
+              UInt64.range(
+                      ZERO,
+                      dataStructureUtil.randomUInt64(
+                          miscHelpers.getBlobSidecarsCount(Optional.of(block))))
+                  .forEach(
+                      index ->
+                          keys.add(new SlotAndBlockRootAndBlobIndex(slot, block.getRoot(), index)));
+            });
+    return keys;
   }
 
-  private List<BlobSidecar> setUpBlobSidecarsDataForSlot(
-      final UInt64 slot, final SignedBeaconBlock signedBeaconBlock) {
-    return UInt64.range(
-            ZERO, UInt64.valueOf(miscHelpers.getBlobSidecarsCount(Optional.of(signedBeaconBlock))))
-        .map(
-            index -> {
-              final BlobSidecar blobSidecar =
-                  dataStructureUtil
-                      .createRandomBlobSidecarBuilder()
-                      .blockRoot(signedBeaconBlock.getRoot())
-                      .slot(slot)
-                      .index(index)
-                      .blockParentRoot(signedBeaconBlock.getParentRoot())
-                      .build();
-              when(combinedChainDataClient.getBlobSidecarByBlockRootAndIndex(
-                      signedBeaconBlock.getRoot(), index))
-                  .thenReturn(SafeFuture.completedFuture(Optional.of(blobSidecar)));
-              return blobSidecar;
-            })
-        .collect(Collectors.toList());
-  }
-
-  private void mockSignedBeaconBlock(
-      final int slot, final SszList<SszKZGCommitment> randomCommitments) {
-    SignedBeaconBlock signedBeaconBlock = mock(SignedBeaconBlock.class);
-    when(signedBeaconBlock.getSlot()).thenReturn(UInt64.valueOf(slot));
-    BeaconBlockBody beaconBlockBody = mock(BeaconBlockBody.class);
-    BeaconBlockBodyDeneb beaconBlockBodyDeneb = mock(BeaconBlockBodyDeneb.class);
-    when(beaconBlockBodyDeneb.getBlobKzgCommitments()).thenReturn(randomCommitments);
-    Optional<BeaconBlockBodyDeneb> maybeBeaconBlockBodyDeneb = Optional.of(beaconBlockBodyDeneb);
-    when(beaconBlockBody.toVersionDeneb()).thenReturn(maybeBeaconBlockBodyDeneb);
-    BeaconBlock beaconBlock = mock(BeaconBlock.class);
-    when(beaconBlock.getBody()).thenReturn(beaconBlockBody);
-    Optional<BeaconBlock> maybeBeaconBlock = Optional.of(beaconBlock);
-    when(signedBeaconBlock.getBeaconBlock()).thenReturn(maybeBeaconBlock);
-    when(combinedChainDataClient.getBlockAtSlotExact(eq(UInt64.valueOf(slot)), any()))
-        .thenReturn(SafeFuture.completedFuture(Optional.of(signedBeaconBlock)));
+  private BlobSidecar setUpBlobSidecarDataForKey(final SlotAndBlockRootAndBlobIndex key) {
+    final BlobSidecar blobSidecar =
+        dataStructureUtil
+            .createRandomBlobSidecarBuilder()
+            .blockRoot(key.getBlockRoot())
+            .slot(key.getSlot())
+            .index(key.getBlobIndex())
+            .blockParentRoot(dataStructureUtil.randomBytes32())
+            .build();
+    when(combinedChainDataClient.getBlobSidecarByKey(key))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(blobSidecar)));
+    return blobSidecar;
   }
 }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandlerTest.java
@@ -187,7 +187,7 @@ public class BlobSidecarsByRangeMessageHandlerTest {
   }
 
   @Test
-  public void shouldCompleteSuccessfullyIfRequestNotWithinRange() {
+  public void shouldCompleteSuccessfullyIfNoBlobSidecarsInRange() {
     when(combinedChainDataClient.getBlobSidecarKeys(any(), any(), any()))
         .thenReturn(SafeFuture.completedFuture(Collections.emptyList()));
     final BlobSidecarsByRangeRequestMessage request =

--- a/storage/api/src/main/java/tech/pegasys/teku/storage/api/StorageQueryChannel.java
+++ b/storage/api/src/main/java/tech/pegasys/teku/storage/api/StorageQueryChannel.java
@@ -26,9 +26,11 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
+import tech.pegasys.teku.spec.datastructures.execution.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.execution.versions.deneb.BlobsSidecar;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.datastructures.util.SlotAndBlockRootAndBlobIndex;
 
 public interface StorageQueryChannel extends ChannelInterface {
 
@@ -78,8 +80,13 @@ public interface StorageQueryChannel extends ChannelInterface {
 
   SafeFuture<Optional<DepositTreeSnapshot>> getFinalizedDepositSnapshot();
 
-  /** @return The earliest available finalized blobs sidecar's slot */
-  SafeFuture<Optional<UInt64>> getEarliestAvailableBlobsSidecarSlot();
+  /** @return The earliest available finalized blob sidecar's slot */
+  SafeFuture<Optional<UInt64>> getEarliestAvailableBlobSidecarSlot();
 
-  SafeFuture<Optional<BlobsSidecar>> getBlobsSidecar(final SlotAndBlockRoot slotAndBlockRoot);
+  SafeFuture<Optional<BlobSidecar>> getBlobSidecar(SlotAndBlockRootAndBlobIndex key);
+
+  SafeFuture<List<SlotAndBlockRootAndBlobIndex>> getBlobSidecarKeys(
+      UInt64 startSlot, UInt64 endSlot, UInt64 limit);
+
+  SafeFuture<Optional<BlobsSidecar>> getBlobsSidecar(SlotAndBlockRoot slotAndBlockRoot);
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.storage.client;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Verify.verifyNotNull;
 import static tech.pegasys.teku.infrastructure.async.SafeFuture.completedFuture;
+import static tech.pegasys.teku.spec.datastructures.util.SlotAndBlockRootAndBlobIndex.NO_BLOBS_INDEX;
 
 import com.google.common.annotations.VisibleForTesting;
 import it.unimi.dsi.fastutil.ints.IntList;
@@ -485,27 +486,26 @@ public class CombinedChainDataClient {
 
   public SafeFuture<Optional<BlobSidecar>> getBlobSidecarByBlockRootAndIndex(
       final Bytes32 blockRoot, final UInt64 index) {
-    if (index.equals(UInt64.MAX_VALUE)) {
+    if (index.equals(NO_BLOBS_INDEX)) {
       return SafeFuture.completedFuture(Optional.empty());
     }
     final Optional<UInt64> hotSlotForBlockRoot = recentChainData.getSlotForBlockRoot(blockRoot);
     if (hotSlotForBlockRoot.isPresent()) {
       return getBlobSidecarByKey(
           new SlotAndBlockRootAndBlobIndex(hotSlotForBlockRoot.get(), blockRoot, index));
-    } else {
-      return historicalChainData
-          .getBlockByBlockRoot(blockRoot)
-          .thenCompose(
-              blockOptional -> {
-                if (blockOptional.isPresent()) {
-                  return getBlobSidecarByKey(
-                      new SlotAndBlockRootAndBlobIndex(
-                          blockOptional.get().getSlot(), blockRoot, index));
-                } else {
-                  return SafeFuture.completedFuture(Optional.empty());
-                }
-              });
     }
+    return historicalChainData
+        .getBlockByBlockRoot(blockRoot)
+        .thenCompose(
+            blockOptional -> {
+              if (blockOptional.isPresent()) {
+                return getBlobSidecarByKey(
+                    new SlotAndBlockRootAndBlobIndex(
+                        blockOptional.get().getSlot(), blockRoot, index));
+              } else {
+                return SafeFuture.completedFuture(Optional.empty());
+              }
+            });
   }
 
   public SafeFuture<Optional<BlobSidecar>> getBlobSidecarByKey(

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/ChainStorage.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/ChainStorage.java
@@ -291,7 +291,7 @@ public class ChainStorage
               database.streamBlobSidecarKeys(startSlot, endSlot)) {
             result =
                 blobSidecars
-                    .filter(key -> !key.hasNoBlobs())
+                    .filter(key -> !key.isNoBlobsKey())
                     .limit(limit.longValue())
                     .collect(Collectors.toList());
           }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/ChainStorage.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/ChainStorage.java
@@ -18,6 +18,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.ethereum.pow.api.DepositTreeSnapshot;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -30,11 +32,13 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
+import tech.pegasys.teku.spec.datastructures.execution.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.execution.versions.deneb.BlobsSidecar;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.datastructures.util.SlotAndBlockRootAndBlobIndex;
 import tech.pegasys.teku.storage.api.ChainStorageFacade;
 import tech.pegasys.teku.storage.api.OnDiskStoreData;
 import tech.pegasys.teku.storage.api.StorageQueryChannel;
@@ -268,8 +272,27 @@ public class ChainStorage
   }
 
   @Override
-  public SafeFuture<Optional<UInt64>> getEarliestAvailableBlobsSidecarSlot() {
-    return SafeFuture.of(database::getEarliestBlobsSidecarSlot);
+  public SafeFuture<Optional<UInt64>> getEarliestAvailableBlobSidecarSlot() {
+    return SafeFuture.of(database::getEarliestBlobSidecarSlot);
+  }
+
+  @Override
+  public SafeFuture<Optional<BlobSidecar>> getBlobSidecar(final SlotAndBlockRootAndBlobIndex key) {
+    return SafeFuture.of(() -> database.getBlobSidecar(key));
+  }
+
+  @Override
+  public SafeFuture<List<SlotAndBlockRootAndBlobIndex>> getBlobSidecarKeys(
+      final UInt64 startSlot, final UInt64 endSlot, final UInt64 limit) {
+    return SafeFuture.of(
+        () -> {
+          final List<SlotAndBlockRootAndBlobIndex> result;
+          try (final Stream<SlotAndBlockRootAndBlobIndex> blobSidecars =
+              database.streamBlobSidecarKeys(startSlot, endSlot)) {
+            result = blobSidecars.limit(limit.longValue()).collect(Collectors.toList());
+          }
+          return result;
+        });
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/ChainStorage.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/ChainStorage.java
@@ -289,7 +289,11 @@ public class ChainStorage
           final List<SlotAndBlockRootAndBlobIndex> result;
           try (final Stream<SlotAndBlockRootAndBlobIndex> blobSidecars =
               database.streamBlobSidecarKeys(startSlot, endSlot)) {
-            result = blobSidecars.limit(limit.longValue()).collect(Collectors.toList());
+            result =
+                blobSidecars
+                    .filter(key -> !key.hasNoBlobs())
+                    .limit(limit.longValue())
+                    .collect(Collectors.toList());
           }
           return result;
         });

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/CombinedStorageChannelSplitter.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/CombinedStorageChannelSplitter.java
@@ -27,10 +27,12 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
+import tech.pegasys.teku.spec.datastructures.execution.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.execution.versions.deneb.BlobsSidecar;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.datastructures.util.SlotAndBlockRootAndBlobIndex;
 import tech.pegasys.teku.storage.api.CombinedStorageChannel;
 import tech.pegasys.teku.storage.api.OnDiskStoreData;
 import tech.pegasys.teku.storage.api.StorageQueryChannel;
@@ -209,8 +211,19 @@ public class CombinedStorageChannelSplitter implements CombinedStorageChannel {
   }
 
   @Override
-  public SafeFuture<Optional<UInt64>> getEarliestAvailableBlobsSidecarSlot() {
-    return asyncRunner.runAsync(queryDelegate::getEarliestAvailableBlobsSidecarSlot);
+  public SafeFuture<Optional<UInt64>> getEarliestAvailableBlobSidecarSlot() {
+    return asyncRunner.runAsync(queryDelegate::getEarliestAvailableBlobSidecarSlot);
+  }
+
+  @Override
+  public SafeFuture<Optional<BlobSidecar>> getBlobSidecar(final SlotAndBlockRootAndBlobIndex key) {
+    return asyncRunner.runAsync(() -> queryDelegate.getBlobSidecar(key));
+  }
+
+  @Override
+  public SafeFuture<List<SlotAndBlockRootAndBlobIndex>> getBlobSidecarKeys(
+      UInt64 startSlot, UInt64 endSlot, UInt64 limit) {
+    return asyncRunner.runAsync(() -> queryDelegate.getBlobSidecarKeys(startSlot, endSlot, limit));
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
@@ -29,11 +29,13 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
+import tech.pegasys.teku.spec.datastructures.execution.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.execution.versions.deneb.BlobsSidecar;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.datastructures.util.SlotAndBlockRootAndBlobIndex;
 import tech.pegasys.teku.storage.api.OnDiskStoreData;
 import tech.pegasys.teku.storage.api.StorageUpdate;
 import tech.pegasys.teku.storage.api.UpdateResult;
@@ -62,6 +64,8 @@ public interface Database extends AutoCloseable {
 
   void confirmBlobsSidecar(SlotAndBlockRoot slotAndBlockRoot);
 
+  Optional<BlobSidecar> getBlobSidecar(SlotAndBlockRootAndBlobIndex key);
+
   Optional<BlobsSidecar> getBlobsSidecar(SlotAndBlockRoot slotAndBlockRoot);
 
   void removeBlobsSidecar(SlotAndBlockRoot slotAndBlockRoot);
@@ -89,6 +93,9 @@ public interface Database extends AutoCloseable {
   boolean pruneOldestUnconfirmedBlobsSidecars(UInt64 lastSlotToPrune, int pruneLimit);
 
   @MustBeClosed
+  Stream<SlotAndBlockRootAndBlobIndex> streamBlobSidecarKeys(UInt64 startSlot, UInt64 endSlot);
+
+  @MustBeClosed
   Stream<BlobsSidecar> streamBlobsSidecars(UInt64 startSlot, UInt64 endSlot);
 
   @MustBeClosed
@@ -100,6 +107,8 @@ public interface Database extends AutoCloseable {
 
   @MustBeClosed
   Stream<SlotAndBlockRoot> streamUnconfirmedBlobsSidecars(UInt64 startSlot, UInt64 endSlot);
+
+  Optional<UInt64> getEarliestBlobSidecarSlot();
 
   Optional<UInt64> getEarliestBlobsSidecarSlot();
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
@@ -56,12 +56,14 @@ import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.SlotAndExecutionPayloadSummary;
+import tech.pegasys.teku.spec.datastructures.execution.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.execution.versions.deneb.BlobsSidecar;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.spec.datastructures.hashtree.HashTree;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.datastructures.util.SlotAndBlockRootAndBlobIndex;
 import tech.pegasys.teku.storage.api.OnDiskStoreData;
 import tech.pegasys.teku.storage.api.StorageUpdate;
 import tech.pegasys.teku.storage.api.StoredBlockMetadata;
@@ -764,6 +766,12 @@ public class KvStoreDatabase implements Database {
   }
 
   @Override
+  public Optional<BlobSidecar> getBlobSidecar(final SlotAndBlockRootAndBlobIndex key) {
+    final Optional<Bytes> maybePayload = dao.getBlobSidecar(key);
+    return maybePayload.map(payload -> spec.deserializeBlobSidecar(payload, key.getSlot()));
+  }
+
+  @Override
   public Optional<BlobsSidecar> getBlobsSidecar(final SlotAndBlockRoot slotAndBlockRoot) {
     final Optional<Bytes> maybePayload = dao.getBlobsSidecar(slotAndBlockRoot);
     return maybePayload.map(
@@ -822,6 +830,13 @@ public class KvStoreDatabase implements Database {
 
   @MustBeClosed
   @Override
+  public Stream<SlotAndBlockRootAndBlobIndex> streamBlobSidecarKeys(
+      final UInt64 startSlot, final UInt64 endSlot) {
+    return dao.streamBlobSidecarKeys(startSlot, endSlot);
+  }
+
+  @MustBeClosed
+  @Override
   public Stream<BlobsSidecar> streamBlobsSidecars(final UInt64 startSlot, final UInt64 endSlot) {
     return dao.streamBlobsSidecar(startSlot, endSlot)
         .map(
@@ -850,6 +865,11 @@ public class KvStoreDatabase implements Database {
   public Stream<SlotAndBlockRoot> streamUnconfirmedBlobsSidecars(
       final UInt64 startSlot, final UInt64 endSlot) {
     return dao.streamUnconfirmedBlobsSidecar(startSlot, endSlot);
+  }
+
+  @Override
+  public Optional<UInt64> getEarliestBlobSidecarSlot() {
+    return dao.getEarliestBlobSidecarSlot();
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDao.java
@@ -35,6 +35,7 @@ import tech.pegasys.teku.spec.datastructures.execution.versions.deneb.BlobsSidec
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.datastructures.util.SlotAndBlockRootAndBlobIndex;
 
 public interface KvStoreCombinedDao extends AutoCloseable {
 
@@ -127,7 +128,12 @@ public interface KvStoreCombinedDao extends AutoCloseable {
 
   Optional<UInt64> getOptimisticTransitionBlockSlot();
 
+  Optional<Bytes> getBlobSidecar(SlotAndBlockRootAndBlobIndex key);
+
   Optional<Bytes> getBlobsSidecar(SlotAndBlockRoot slotAndBlockRoot);
+
+  @MustBeClosed
+  Stream<SlotAndBlockRootAndBlobIndex> streamBlobSidecarKeys(UInt64 startSlot, UInt64 endSlot);
 
   @MustBeClosed
   Stream<Entry<SlotAndBlockRoot, Bytes>> streamBlobsSidecar(UInt64 startSlot, UInt64 endSlot);
@@ -137,6 +143,8 @@ public interface KvStoreCombinedDao extends AutoCloseable {
 
   @MustBeClosed
   Stream<SlotAndBlockRoot> streamUnconfirmedBlobsSidecar(UInt64 startSlot, UInt64 endSlot);
+
+  Optional<UInt64> getEarliestBlobSidecarSlot();
 
   Optional<UInt64> getEarliestBlobsSidecarSlot();
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoAdapter.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoAdapter.java
@@ -36,6 +36,7 @@ import tech.pegasys.teku.spec.datastructures.execution.versions.deneb.BlobsSidec
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.datastructures.util.SlotAndBlockRootAndBlobIndex;
 import tech.pegasys.teku.storage.server.kvstore.ColumnEntry;
 import tech.pegasys.teku.storage.server.kvstore.dataaccess.V4FinalizedKvStoreDao.V4FinalizedUpdater;
 import tech.pegasys.teku.storage.server.kvstore.dataaccess.V4HotKvStoreDao.V4HotUpdater;
@@ -233,8 +234,20 @@ public class KvStoreCombinedDaoAdapter implements KvStoreCombinedDao, V4Migratab
   }
 
   @Override
+  public Optional<Bytes> getBlobSidecar(final SlotAndBlockRootAndBlobIndex key) {
+    return finalizedDao.getBlobSidecar(key);
+  }
+
+  @Override
   public Optional<Bytes> getBlobsSidecar(final SlotAndBlockRoot slotAndBlockRoot) {
     return finalizedDao.getBlobsSidecar(slotAndBlockRoot);
+  }
+
+  @Override
+  @MustBeClosed
+  public Stream<SlotAndBlockRootAndBlobIndex> streamBlobSidecarKeys(
+      final UInt64 startSlot, final UInt64 endSlot) {
+    return finalizedDao.streamBlobSidecarKeys(startSlot, endSlot);
   }
 
   @Override
@@ -256,6 +269,11 @@ public class KvStoreCombinedDaoAdapter implements KvStoreCombinedDao, V4Migratab
   public Stream<SlotAndBlockRoot> streamUnconfirmedBlobsSidecar(
       final UInt64 startSlot, final UInt64 endSlot) {
     return finalizedDao.streamUnconfirmedBlobsSidecar(startSlot, endSlot);
+  }
+
+  @Override
+  public Optional<UInt64> getEarliestBlobSidecarSlot() {
+    return finalizedDao.getEarliestBlobSidecarSlot();
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/SchemaCombined.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/SchemaCombined.java
@@ -28,6 +28,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.datastructures.util.SlotAndBlockRootAndBlobIndex;
 
 public interface SchemaCombined extends Schema {
   // Columns
@@ -55,6 +56,8 @@ public interface SchemaCombined extends Schema {
   KvStoreColumn<Bytes32, SignedBeaconBlock> getColumnNonCanonicalBlocksByRoot();
 
   KvStoreColumn<UInt64, Set<Bytes32>> getColumnNonCanonicalRootsBySlot();
+
+  KvStoreColumn<SlotAndBlockRootAndBlobIndex, Bytes> getColumnBlobSidecarBySlotRootBlobIndex();
 
   KvStoreColumn<SlotAndBlockRoot, Bytes> getColumnBlobsSidecarBySlotAndBlockRoot();
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/SchemaFinalizedSnapshotStateAdapter.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/SchemaFinalizedSnapshotStateAdapter.java
@@ -23,6 +23,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.datastructures.util.SlotAndBlockRootAndBlobIndex;
 
 public class SchemaFinalizedSnapshotStateAdapter implements SchemaFinalizedSnapshotState {
 
@@ -37,6 +38,11 @@ public class SchemaFinalizedSnapshotStateAdapter implements SchemaFinalizedSnaps
   @Override
   public KvStoreColumn<UInt64, BeaconState> getColumnFinalizedStatesBySlot() {
     return snapshotDelegate.getColumnFinalizedStatesBySlot();
+  }
+
+  public KvStoreColumn<SlotAndBlockRootAndBlobIndex, Bytes>
+      getColumnBlobSidecarBySlotRootBlobIndex() {
+    return delegate.getColumnBlobSidecarBySlotRootBlobIndex();
   }
 
   public KvStoreColumn<SlotAndBlockRoot, Bytes> getColumnBlobsSidecarBySlotAndBlockRoot() {

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/V6SchemaCombinedSnapshot.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/V6SchemaCombinedSnapshot.java
@@ -17,6 +17,7 @@ import static tech.pegasys.teku.storage.server.kvstore.schema.KvStoreColumn.asCo
 import static tech.pegasys.teku.storage.server.kvstore.serialization.KvStoreSerializer.BLOCK_ROOTS_SERIALIZER;
 import static tech.pegasys.teku.storage.server.kvstore.serialization.KvStoreSerializer.BYTES32_SERIALIZER;
 import static tech.pegasys.teku.storage.server.kvstore.serialization.KvStoreSerializer.BYTES_SERIALIZER;
+import static tech.pegasys.teku.storage.server.kvstore.serialization.KvStoreSerializer.SLOT_AND_BLOCK_ROOT_AND_BLOB_INDEX_KEY_SERIALIZER;
 import static tech.pegasys.teku.storage.server.kvstore.serialization.KvStoreSerializer.SLOT_AND_BLOCK_ROOT_KEY_SERIALIZER;
 import static tech.pegasys.teku.storage.server.kvstore.serialization.KvStoreSerializer.UINT64_SERIALIZER;
 import static tech.pegasys.teku.storage.server.kvstore.serialization.KvStoreSerializer.VOID_SERIALIZER;
@@ -33,6 +34,7 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.datastructures.util.SlotAndBlockRootAndBlobIndex;
 import tech.pegasys.teku.storage.server.kvstore.serialization.KvStoreSerializer;
 
 public class V6SchemaCombinedSnapshot extends V6SchemaCombined
@@ -45,6 +47,7 @@ public class V6SchemaCombinedSnapshot extends V6SchemaCombined
   private final KvStoreColumn<UInt64, Set<Bytes32>> nonCanonicalBlockRootsBySlot;
   private final KvStoreColumn<UInt64, BeaconState> finalizedStatesBySlot;
 
+  private final KvStoreColumn<SlotAndBlockRootAndBlobIndex, Bytes> blobSidecarBySlotRootBlobIndex;
   private final KvStoreColumn<SlotAndBlockRoot, Bytes> blobsSidecarBySlotAndBlockRoot;
   private final KvStoreColumn<SlotAndBlockRoot, Void> unconfirmedBlobsSidecarBySlotAndBlockRoot;
   private final List<Bytes> deletedColumnIds;
@@ -77,6 +80,11 @@ public class V6SchemaCombinedSnapshot extends V6SchemaCombined
     unconfirmedBlobsSidecarBySlotAndBlockRoot =
         KvStoreColumn.create(
             finalizedOffset + 11, SLOT_AND_BLOCK_ROOT_KEY_SERIALIZER, VOID_SERIALIZER);
+    blobSidecarBySlotRootBlobIndex =
+        KvStoreColumn.create(
+            finalizedOffset + 12,
+            SLOT_AND_BLOCK_ROOT_AND_BLOB_INDEX_KEY_SERIALIZER,
+            BYTES_SERIALIZER);
 
     deletedColumnIds =
         List.of(
@@ -121,6 +129,12 @@ public class V6SchemaCombinedSnapshot extends V6SchemaCombined
   @Override
   public KvStoreColumn<UInt64, Set<Bytes32>> getColumnNonCanonicalRootsBySlot() {
     return nonCanonicalBlockRootsBySlot;
+  }
+
+  @Override
+  public KvStoreColumn<SlotAndBlockRootAndBlobIndex, Bytes>
+      getColumnBlobSidecarBySlotRootBlobIndex() {
+    return blobSidecarBySlotRootBlobIndex;
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/V6SchemaCombinedTreeState.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/V6SchemaCombinedTreeState.java
@@ -18,6 +18,7 @@ import static tech.pegasys.teku.storage.server.kvstore.serialization.KvStoreSeri
 import static tech.pegasys.teku.storage.server.kvstore.serialization.KvStoreSerializer.BYTES32_SERIALIZER;
 import static tech.pegasys.teku.storage.server.kvstore.serialization.KvStoreSerializer.BYTES_SERIALIZER;
 import static tech.pegasys.teku.storage.server.kvstore.serialization.KvStoreSerializer.COMPRESSED_BRANCH_INFO_KV_STORE_SERIALIZER;
+import static tech.pegasys.teku.storage.server.kvstore.serialization.KvStoreSerializer.SLOT_AND_BLOCK_ROOT_AND_BLOB_INDEX_KEY_SERIALIZER;
 import static tech.pegasys.teku.storage.server.kvstore.serialization.KvStoreSerializer.SLOT_AND_BLOCK_ROOT_KEY_SERIALIZER;
 import static tech.pegasys.teku.storage.server.kvstore.serialization.KvStoreSerializer.UINT64_SERIALIZER;
 import static tech.pegasys.teku.storage.server.kvstore.serialization.KvStoreSerializer.VOID_SERIALIZER;
@@ -34,6 +35,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
+import tech.pegasys.teku.spec.datastructures.util.SlotAndBlockRootAndBlobIndex;
 import tech.pegasys.teku.storage.server.kvstore.serialization.KvStoreSerializer;
 
 public class V6SchemaCombinedTreeState extends V6SchemaCombined implements SchemaCombinedTreeState {
@@ -47,6 +49,7 @@ public class V6SchemaCombinedTreeState extends V6SchemaCombined implements Schem
   private final KvStoreColumn<Bytes32, Bytes> finalizedStateTreeLeavesByRoot;
   private final KvStoreColumn<Bytes32, CompressedBranchInfo> finalizedStateTreeBranchesByRoot;
 
+  private final KvStoreColumn<SlotAndBlockRootAndBlobIndex, Bytes> blobSidecarBySlotRootBlobIndex;
   private final KvStoreColumn<SlotAndBlockRoot, Bytes> blobsSidecarBySlotAndBlockRoot;
   private final KvStoreColumn<SlotAndBlockRoot, Void> unconfirmedBlobsSidecarBySlotAndBlockRoot;
   private final List<Bytes> deletedColumnIds;
@@ -78,13 +81,17 @@ public class V6SchemaCombinedTreeState extends V6SchemaCombined implements Schem
             V6_FINALIZED_OFFSET + 8,
             BYTES32_SERIALIZER,
             KvStoreSerializer.createSignedBlockSerializer(spec));
-
     blobsSidecarBySlotAndBlockRoot =
         KvStoreColumn.create(
             finalizedOffset + 12, SLOT_AND_BLOCK_ROOT_KEY_SERIALIZER, BYTES_SERIALIZER);
     unconfirmedBlobsSidecarBySlotAndBlockRoot =
         KvStoreColumn.create(
             finalizedOffset + 13, SLOT_AND_BLOCK_ROOT_KEY_SERIALIZER, VOID_SERIALIZER);
+    blobSidecarBySlotRootBlobIndex =
+        KvStoreColumn.create(
+            finalizedOffset + 14,
+            SLOT_AND_BLOCK_ROOT_AND_BLOB_INDEX_KEY_SERIALIZER,
+            BYTES_SERIALIZER);
     deletedColumnIds =
         List.of(
             asColumnId(finalizedOffset + 9),
@@ -130,6 +137,12 @@ public class V6SchemaCombinedTreeState extends V6SchemaCombined implements Schem
   @Override
   public KvStoreColumn<UInt64, Set<Bytes32>> getColumnNonCanonicalRootsBySlot() {
     return nonCanonicalBlockRootsBySlot;
+  }
+
+  @Override
+  public KvStoreColumn<SlotAndBlockRootAndBlobIndex, Bytes>
+      getColumnBlobSidecarBySlotRootBlobIndex() {
+    return blobSidecarBySlotRootBlobIndex;
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/serialization/KvStoreSerializer.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/serialization/KvStoreSerializer.java
@@ -28,6 +28,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.datastructures.util.SlotAndBlockRootAndBlobIndex;
 
 public interface KvStoreSerializer<T> {
   KvStoreSerializer<UInt64> UINT64_SERIALIZER = new UInt64Serializer();
@@ -52,6 +53,9 @@ public interface KvStoreSerializer<T> {
   KvStoreSerializer<Void> VOID_SERIALIZER = new VoidSerializer();
   KvStoreSerializer<SlotAndBlockRoot> SLOT_AND_BLOCK_ROOT_KEY_SERIALIZER =
       new SlotAndBlockRootKeySerializer();
+  KvStoreSerializer<SlotAndBlockRootAndBlobIndex>
+      SLOT_AND_BLOCK_ROOT_AND_BLOB_INDEX_KEY_SERIALIZER =
+          new SlotAndBlockRootAndBlobIndexKeySerializer();
 
   static KvStoreSerializer<BeaconState> createStateSerializer(final Spec spec) {
     return new BeaconStateSerializer(spec);

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/serialization/SlotAndBlockRootAndBlobIndexKeySerializer.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/serialization/SlotAndBlockRootAndBlobIndexKeySerializer.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.server.kvstore.serialization;
+
+import com.google.common.primitives.Longs;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.util.SlotAndBlockRootAndBlobIndex;
+
+/**
+ * This serializer is intended to be used as a Key so that it preserve slot ordering when we stream
+ * data. This is useful for values that are always looked up by root, slot and blobIndex, giving us
+ * the ability to quickly lookup most recent\oldest values by slot as well as perform pruning based
+ * on slot
+ */
+class SlotAndBlockRootAndBlobIndexKeySerializer
+    implements KvStoreSerializer<SlotAndBlockRootAndBlobIndex> {
+  static final int UINT64_SIZE = 64 / Byte.SIZE;
+  static final int BLOB_INDEX_OFFSET = Bytes32.SIZE + UINT64_SIZE;
+
+  @Override
+  public SlotAndBlockRootAndBlobIndex deserialize(final byte[] data) {
+    final UInt64 slot =
+        UInt64.fromLongBits(
+            Longs.fromBytes(
+                data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7]));
+    final Bytes rootBytes = Bytes.wrap(data, UINT64_SIZE, Bytes32.SIZE);
+    final Bytes blobIndexBytes = Bytes.wrap(data, BLOB_INDEX_OFFSET, UINT64_SIZE);
+    final UInt64 blobIndex =
+        UInt64.fromLongBits(
+            Longs.fromBytes(
+                blobIndexBytes.get(0),
+                blobIndexBytes.get(1),
+                blobIndexBytes.get(2),
+                blobIndexBytes.get(3),
+                blobIndexBytes.get(4),
+                blobIndexBytes.get(5),
+                blobIndexBytes.get(6),
+                blobIndexBytes.get(7)));
+    return new SlotAndBlockRootAndBlobIndex(slot, Bytes32.wrap(rootBytes), blobIndex);
+  }
+
+  @Override
+  public byte[] serialize(final SlotAndBlockRootAndBlobIndex value) {
+    return Bytes.concatenate(
+            Bytes.wrap(Longs.toByteArray(value.getSlot().longValue())),
+            value.getBlockRoot(),
+            Bytes.wrap(Longs.toByteArray(value.getBlobIndex().longValue())))
+        .toArrayUnsafe();
+  }
+}

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
@@ -33,11 +33,13 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
+import tech.pegasys.teku.spec.datastructures.execution.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.execution.versions.deneb.BlobsSidecar;
 import tech.pegasys.teku.spec.datastructures.forkchoice.VoteTracker;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.datastructures.util.SlotAndBlockRootAndBlobIndex;
 import tech.pegasys.teku.storage.api.OnDiskStoreData;
 import tech.pegasys.teku.storage.api.StorageUpdate;
 import tech.pegasys.teku.storage.api.UpdateResult;
@@ -274,12 +276,23 @@ public class NoOpDatabase implements Database {
   public void confirmBlobsSidecar(final SlotAndBlockRoot slotAndBlockRoot) {}
 
   @Override
+  public Optional<BlobSidecar> getBlobSidecar(final SlotAndBlockRootAndBlobIndex key) {
+    return Optional.empty();
+  }
+
+  @Override
   public Optional<BlobsSidecar> getBlobsSidecar(final SlotAndBlockRoot slotAndBlockRoot) {
     return Optional.empty();
   }
 
   @Override
   public void removeBlobsSidecar(final SlotAndBlockRoot slotAndBlockRoot) {}
+
+  @Override
+  public Stream<SlotAndBlockRootAndBlobIndex> streamBlobSidecarKeys(
+      final UInt64 startSlot, final UInt64 endSlot) {
+    return Stream.empty();
+  }
 
   @Override
   public Stream<BlobsSidecar> streamBlobsSidecars(final UInt64 startSlot, final UInt64 endSlot) {
@@ -295,6 +308,11 @@ public class NoOpDatabase implements Database {
   @Override
   public Stream<SlotAndBlockRoot> streamBlobsSidecarKeys(UInt64 startSlot, UInt64 endSlot) {
     return Stream.empty();
+  }
+
+  @Override
+  public Optional<UInt64> getEarliestBlobSidecarSlot() {
+    return Optional.empty();
   }
 
   @Override

--- a/storage/src/test/java/tech/pegasys/teku/storage/client/CombinedChainDataClientTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/client/CombinedChainDataClientTest.java
@@ -31,12 +31,12 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
-import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
-import tech.pegasys.teku.spec.datastructures.execution.versions.deneb.BlobsSidecar;
+import tech.pegasys.teku.spec.datastructures.execution.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.metadata.BlockAndMetaData;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.CommitteeAssignment;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.datastructures.util.SlotAndBlockRootAndBlobIndex;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.storage.api.StorageQueryChannel;
 import tech.pegasys.teku.storage.protoarray.ForkChoiceStrategy;
@@ -59,7 +59,7 @@ class CombinedChainDataClientTest {
   final List<SignedBeaconBlock> nonCanonicalBlocks = new ArrayList<>();
   final SignedBeaconBlock firstBlock = dataStructureUtil.randomSignedBeaconBlock(1);
   final SignedBeaconBlock secondBlock = dataStructureUtil.randomSignedBeaconBlock(1);
-  final BlobsSidecar sidecar = dataStructureUtil.randomBlobsSidecar();
+  final BlobSidecar sidecar = dataStructureUtil.randomBlobSidecar();
 
   @BeforeEach
   void setUp() {
@@ -135,25 +135,94 @@ class CombinedChainDataClientTest {
   }
 
   @Test
-  void getsEarliestAvailableBlobsSidecarEpoch() {
-    when(historicalChainData.getEarliestAvailableBlobsSidecarSlot())
+  void getsEarliestAvailableBlobSidecarEpoch() {
+    when(historicalChainData.getEarliestAvailableBlobSidecarSlot())
         .thenReturn(SafeFuture.completedFuture(Optional.of(UInt64.ONE)));
 
     final Optional<UInt64> result =
-        SafeFutureAssert.safeJoin(client.getEarliestAvailableBlobsSidecarEpoch());
+        SafeFutureAssert.safeJoin(client.getEarliestAvailableBlobSidecarEpoch());
 
     assertThat(result).hasValue(UInt64.ZERO);
   }
 
   @Test
-  void getsBlobsSidecarBySlotAndBlockRoot() {
+  void getsBlobSidecarBySlotAndBlockRootAndBlobIndex() {
+    final SlotAndBlockRootAndBlobIndex correctKey =
+        new SlotAndBlockRootAndBlobIndex(
+            sidecar.getSlot(), sidecar.getBlockRoot(), sidecar.getIndex());
     final Bytes32 blockRoot = dataStructureUtil.randomBytes32();
-    when(historicalChainData.getBlobsSidecar(new SlotAndBlockRoot(UInt64.ONE, blockRoot)))
-        .thenReturn(SafeFuture.completedFuture(Optional.of(sidecar)));
+    final SlotAndBlockRootAndBlobIndex incorrectKey =
+        new SlotAndBlockRootAndBlobIndex(sidecar.getSlot(), blockRoot, sidecar.getIndex());
+    setupGetBlobSidecar(correctKey, sidecar);
 
-    final Optional<BlobsSidecar> result =
-        SafeFutureAssert.safeJoin(client.getBlobsSidecarBySlotAndBlockRoot(UInt64.ONE, blockRoot));
+    final Optional<BlobSidecar> correctResult =
+        SafeFutureAssert.safeJoin(client.getBlobSidecarByKey(correctKey));
+    assertThat(correctResult).hasValue(sidecar);
 
+    final Optional<BlobSidecar> incorrectResult =
+        SafeFutureAssert.safeJoin(client.getBlobSidecarByKey(incorrectKey));
+    assertThat(incorrectResult).isEmpty();
+  }
+
+  @Test
+  void getsBlobSidecarBySlotAndBlobIndex() {
+    final SlotAndBlockRootAndBlobIndex key =
+        new SlotAndBlockRootAndBlobIndex(
+            sidecar.getSlot(), sidecar.getBlockRoot(), sidecar.getIndex());
+    setupGetBlobSidecar(key, sidecar);
+    setupGetSlotForBlockRoot(sidecar.getBlockRoot(), sidecar.getSlot());
+
+    final Optional<BlobSidecar> result =
+        SafeFutureAssert.safeJoin(
+            client.getBlobSidecarByBlockRootAndIndex(sidecar.getBlockRoot(), sidecar.getIndex()));
     assertThat(result).hasValue(sidecar);
+
+    final Bytes32 blockRoot = setupGetBlockByBlockRoot(sidecar.getSlot().plus(1));
+    final Optional<BlobSidecar> incorrectResult =
+        SafeFutureAssert.safeJoin(
+            client.getBlobSidecarByBlockRootAndIndex(blockRoot, sidecar.getIndex()));
+    assertThat(incorrectResult).isEmpty();
+  }
+
+  private void setupGetBlobSidecar(
+      final SlotAndBlockRootAndBlobIndex key, final BlobSidecar result) {
+    when(historicalChainData.getBlobSidecar(any()))
+        .thenAnswer(
+            args -> {
+              final SlotAndBlockRootAndBlobIndex argKey = args.getArgument(0);
+              if (argKey.equals(key)) {
+                return SafeFuture.completedFuture(Optional.of(result));
+              } else {
+                return SafeFuture.completedFuture(Optional.empty());
+              }
+            });
+  }
+
+  private void setupGetSlotForBlockRoot(final Bytes32 blockRoot, final UInt64 slot) {
+    when(recentChainData.getSlotForBlockRoot(any()))
+        .thenAnswer(
+            args -> {
+              final Bytes32 argRoot = args.getArgument(0);
+              if (argRoot.equals(blockRoot)) {
+                return Optional.of(slot);
+              } else {
+                return Optional.empty();
+              }
+            });
+  }
+
+  private Bytes32 setupGetBlockByBlockRoot(final UInt64 slot) {
+    final SignedBeaconBlock signedBeaconBlock = dataStructureUtil.randomSignedBeaconBlock(slot);
+    when(historicalChainData.getBlockByBlockRoot(any()))
+        .thenAnswer(
+            args -> {
+              final Bytes32 argRoot = args.getArgument(0);
+              if (argRoot.equals(signedBeaconBlock.getRoot())) {
+                return SafeFuture.completedFuture(Optional.of(signedBeaconBlock));
+              } else {
+                return SafeFuture.completedFuture(Optional.empty());
+              }
+            });
+    return signedBeaconBlock.getRoot();
   }
 }

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/kvstore/serialization/SlotAndBlockRootAndBlobIndexKeySerializerTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/kvstore/serialization/SlotAndBlockRootAndBlobIndexKeySerializerTest.java
@@ -38,4 +38,14 @@ public class SlotAndBlockRootAndBlobIndexKeySerializerTest {
     final SlotAndBlockRootAndBlobIndex deserialized = serializer.deserialize(data);
     assertThat(deserialized).isEqualTo(expected);
   }
+
+  @Test
+  public void hasNoBlobsRoundTrip() {
+    final SlotAndBlockRootAndBlobIndex expected =
+        new SlotAndBlockRootAndBlobIndex(EXPECTED_SLOT, EXPECTED_ROOT, UInt64.MAX_VALUE);
+    assertThat(expected.hasNoBlobs()).isTrue();
+    final byte[] data = serializer.serialize(expected);
+    final SlotAndBlockRootAndBlobIndex deserialized = serializer.deserialize(data);
+    assertThat(deserialized).isEqualTo(expected);
+  }
 }

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/kvstore/serialization/SlotAndBlockRootAndBlobIndexKeySerializerTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/kvstore/serialization/SlotAndBlockRootAndBlobIndexKeySerializerTest.java
@@ -42,8 +42,8 @@ public class SlotAndBlockRootAndBlobIndexKeySerializerTest {
   @Test
   public void hasNoBlobsRoundTrip() {
     final SlotAndBlockRootAndBlobIndex expected =
-        new SlotAndBlockRootAndBlobIndex(EXPECTED_SLOT, EXPECTED_ROOT, UInt64.MAX_VALUE);
-    assertThat(expected.hasNoBlobs()).isTrue();
+        SlotAndBlockRootAndBlobIndex.createNoBlobsKey(EXPECTED_SLOT, EXPECTED_ROOT);
+    assertThat(expected.isNoBlobsKey()).isTrue();
     final byte[] data = serializer.serialize(expected);
     final SlotAndBlockRootAndBlobIndex deserialized = serializer.deserialize(data);
     assertThat(deserialized).isEqualTo(expected);

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/kvstore/serialization/SlotAndBlockRootAndBlobIndexKeySerializerTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/kvstore/serialization/SlotAndBlockRootAndBlobIndexKeySerializerTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright ConsenSys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.server.kvstore.serialization;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.util.SlotAndBlockRootAndBlobIndex;
+
+public class SlotAndBlockRootAndBlobIndexKeySerializerTest {
+
+  private static final UInt64 EXPECTED_SLOT = UInt64.valueOf(1234589);
+  private static final Bytes32 EXPECTED_ROOT =
+      Bytes32.fromHexString("0x235bc3400c2839fd856a524871200bd5e362db615fc4565e1870ed9a2a936464");
+  private static final UInt64 EXPECTED_INDEX = UInt64.valueOf(2);
+
+  private final SlotAndBlockRootAndBlobIndexKeySerializer serializer =
+      new SlotAndBlockRootAndBlobIndexKeySerializer();
+
+  @Test
+  public void roundTrip() {
+    final SlotAndBlockRootAndBlobIndex expected =
+        new SlotAndBlockRootAndBlobIndex(EXPECTED_SLOT, EXPECTED_ROOT, EXPECTED_INDEX);
+    final byte[] data = serializer.serialize(expected);
+    final SlotAndBlockRootAndBlobIndex deserialized = serializer.deserialize(data);
+    assertThat(deserialized).isEqualTo(expected);
+  }
+}

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageQueryChannel.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageQueryChannel.java
@@ -27,9 +27,11 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
+import tech.pegasys.teku.spec.datastructures.execution.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.execution.versions.deneb.BlobsSidecar;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.datastructures.util.SlotAndBlockRootAndBlobIndex;
 
 public class StubStorageQueryChannel implements StorageQueryChannel {
 
@@ -128,8 +130,19 @@ public class StubStorageQueryChannel implements StorageQueryChannel {
   }
 
   @Override
-  public SafeFuture<Optional<UInt64>> getEarliestAvailableBlobsSidecarSlot() {
+  public SafeFuture<Optional<UInt64>> getEarliestAvailableBlobSidecarSlot() {
     return SafeFuture.completedFuture(Optional.empty());
+  }
+
+  @Override
+  public SafeFuture<Optional<BlobSidecar>> getBlobSidecar(final SlotAndBlockRootAndBlobIndex key) {
+    return SafeFuture.completedFuture(Optional.empty());
+  }
+
+  @Override
+  public SafeFuture<List<SlotAndBlockRootAndBlobIndex>> getBlobSidecarKeys(
+      final UInt64 startSlot, final UInt64 endSlot, final UInt64 limit) {
+    return SafeFuture.completedFuture(List.of());
   }
 
   @Override


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
There were 3 possible approaches to implement storage for BlobSidecars:
Using  `Slot+BlockRoot+BlobIndex` key, `BlockRoot+BlobIndex` key or `Slot+BlobIndex` key. Currently we have these type of queries:
 - A. By Slot range RPC, Slot query
 - B. By BlockIdentifiers RPC, BlockRoot + BlobIndex query 
 - C. Earliest available epoch query
 - D. By Slot for pruning, similar to `A`

`A` could be used both for recent missed slots and historical sync. `B` is used only for recent slots but we assume it could be changed in the future, because it's very useful to fill several small gaps in one query. `C` is used once per query along with `A`. `D` is happen once in epoch. We could get following breakdown of operation complexity by chosen key type:
  1. `Slot+BlockRoot+BlobIndex` key
  	A+D. For each slot query slot -> Block to get root and indexes
  	B. For each blobsidecar search for a block to get slot
  	C. First element
  2. `BlockRoot+BlobIndex` key
  	A+D. For each slot query slot -> Block to get root and indexes
  	B. No additional queries
  	C. Extra query for a block or we need to use DB variable with some in memory cache for it
  3. `Slot+BlobIndex` key
  	A. No additional queries
  	B. For each blobSidecar search for a block to get slot
  	C+D. First element

For current usage we assume getting a slot for `B` will be very fast as it's memory operation (for recent slots). Plus for `A` and `D` we could use slot order streaming. It makes `1` and `3` preferrable with not much difference between `1` and `3` when using DB streaming. For clarity we choose `Slot+BlockRoot+BlobIndex` key.

We cannot use DB stream in `BlobSidecarsByRangeMessageHandler` because of the application design and strict requirements for stream closing. Also we couldn't pass streams through async interfaces. There are 2 possible approaches to get this around:
  1. Stream keys and collect it before closing. Key weight should be about 16 (object header) + 24 (UInt64) + 48 (Bytes32) + 24 (UInt64) + 8 bytes list reference = 120 bytes per `SlotAndBlockRootAndBlobIndex`. So maximum 61440 bytes for 128 blocks with 4 blobSidecars in each. 16 peers with maximum possible queries will consume under 1Mb memory for it which sounds acceptable for me
  2. Something tricky like `getNextKeyAfter(V value)` will void opportunity of stream by calling for a lot times plus follows to the weird code.

So I've chosen the 1st

Confirmed/unconfirmed logic, `BlobSidecar` persistence and pruning is not covered by this PR.
Also I'm not sure on the placement of `SlotAndBlockRootAndBlobIndex`.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Fixes #6821 
## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
