### PR TITLE
Fix "Get state RANDAO" summary

### DIFF
--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_beacon_states_{state_id}_randao.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_beacon_states_{state_id}_randao.json
@@ -2,7 +2,7 @@
   "get" : {
     "tags" : [ "Beacon" ],
     "operationId" : "getStateRandao",
-    "summary" : "Get chain genesis details",
+    "summary" : "Get state RANDAO",
     "description" : "Fetch the RANDAO mix for the requested epoch from the state identified by `state_id`.\n\nIf an epoch is not specified then the RANDAO mix for the state's current epoch will be returned.\n\nBy adjusting the `state_id` parameter you can query for any historic value of the RANDAO mix. Ordinarily states from the same epoch will mutate the RANDAO mix for that epoch as blocks are applied.",
     "parameters" : [ {
       "name" : "state_id",

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateRandao.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateRandao.java
@@ -69,7 +69,7 @@ public class GetStateRandao extends RestApiEndpoint {
             .build();
     return EndpointMetadata.get(ROUTE)
         .operationId("getStateRandao")
-        .summary("Get chain genesis details")
+        .summary("Get state RANDAO")
         .description(
             "Fetch the RANDAO mix for the requested epoch from the state identified by `state_id`.\n\n"
                 + "If an epoch is not specified then the RANDAO mix for the state's current epoch will be returned.\n\n"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

Fix the "Get state RANDAO" summary, which is mistakenly labeled as "Get chain genesis details" in the API doc: https://consensys.github.io/teku/#tag/Beacon/operation/getStateRandao

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

fixes https://github.com/ConsenSys/doc.teku/issues/434

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
