### PR TITLE
[Java API] Make StatusMessageFactory configurable in Eth2P2PNetworkBuilder

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkBuilder.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkBuilder.java
@@ -565,7 +565,8 @@ public class Eth2P2PNetworkBuilder {
     return this;
   }
 
-  public Eth2P2PNetworkBuilder statusMessageFactory(final StatusMessageFactory statusMessageFactory) {
+  public Eth2P2PNetworkBuilder statusMessageFactory(
+      final StatusMessageFactory statusMessageFactory) {
     checkNotNull(statusMessageFactory);
     this.statusMessageFactory = statusMessageFactory;
     return this;

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkBuilder.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkBuilder.java
@@ -564,4 +564,10 @@ public class Eth2P2PNetworkBuilder {
     this.spec = spec;
     return this;
   }
+
+  public Eth2P2PNetworkBuilder statusMessageFactory(final StatusMessageFactory statusMessageFactory) {
+    checkNotNull(statusMessageFactory);
+    this.statusMessageFactory = statusMessageFactory;
+    return this;
+  }
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkBuilder.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkBuilder.java
@@ -48,6 +48,7 @@ import tech.pegasys.teku.networking.eth2.gossip.topics.OperationProcessor;
 import tech.pegasys.teku.networking.eth2.gossip.topics.ProcessedAttestationSubscriptionProvider;
 import tech.pegasys.teku.networking.eth2.peers.Eth2PeerManager;
 import tech.pegasys.teku.networking.eth2.peers.Eth2PeerSelectionStrategy;
+import tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.StatusMessageFactory;
 import tech.pegasys.teku.networking.eth2.rpc.core.encodings.RpcEncoding;
 import tech.pegasys.teku.networking.p2p.connection.TargetPeerRange;
 import tech.pegasys.teku.networking.p2p.discovery.DiscoveryConfig;
@@ -119,6 +120,7 @@ public class Eth2P2PNetworkBuilder {
       gossipedSignedContributionAndProofProcessor;
   protected OperationProcessor<ValidateableSyncCommitteeMessage>
       gossipedSyncCommitteeMessageProcessor;
+  protected StatusMessageFactory statusMessageFactory;
 
   protected Eth2P2PNetworkBuilder() {}
 
@@ -137,6 +139,9 @@ public class Eth2P2PNetworkBuilder {
             spec.isMilestoneSupported(SpecMilestone.BELLATRIX)
                 ? MAX_CHUNK_SIZE_BELLATRIX
                 : MAX_CHUNK_SIZE);
+    if (statusMessageFactory == null) {
+      statusMessageFactory = new StatusMessageFactory(combinedChainDataClient.getRecentChainData());
+    }
     final Eth2PeerManager eth2PeerManager =
         Eth2PeerManager.create(
             asyncRunner,
@@ -145,6 +150,7 @@ public class Eth2P2PNetworkBuilder {
             attestationSubnetService,
             syncCommitteeSubnetService,
             rpcEncoding,
+            statusMessageFactory,
             requiredCheckpoint,
             eth2RpcPingInterval,
             eth2RpcOutstandingPingThreshold,

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerManager.java
@@ -106,6 +106,7 @@ public class Eth2PeerManager implements PeerLookup, PeerHandler {
       final SubnetSubscriptionService attestationSubnetService,
       final SubnetSubscriptionService syncCommitteeSubnetService,
       final RpcEncoding rpcEncoding,
+      final StatusMessageFactory statusMessageFactory,
       final Optional<Checkpoint> requiredCheckpoint,
       final Duration eth2RpcPingInterval,
       final int eth2RpcOutstandingPingThreshold,
@@ -115,8 +116,6 @@ public class Eth2PeerManager implements PeerLookup, PeerHandler {
       final int peerRequestLimit,
       final Spec spec) {
 
-    final StatusMessageFactory statusMessageFactory =
-        new StatusMessageFactory(combinedChainDataClient.getRecentChainData());
     final MetadataMessagesFactory metadataMessagesFactory = new MetadataMessagesFactory();
     attestationSubnetService.subscribeToUpdates(
         metadataMessagesFactory::updateAttestationSubnetIds);

--- a/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkFactory.java
+++ b/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkFactory.java
@@ -61,6 +61,7 @@ import tech.pegasys.teku.networking.eth2.gossip.topics.ProcessedAttestationSubsc
 import tech.pegasys.teku.networking.eth2.gossip.topics.VerifiedBlockAttestationsSubscriptionProvider;
 import tech.pegasys.teku.networking.eth2.peers.Eth2PeerManager;
 import tech.pegasys.teku.networking.eth2.peers.Eth2PeerSelectionStrategy;
+import tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.StatusMessageFactory;
 import tech.pegasys.teku.networking.eth2.rpc.core.encodings.RpcEncoding;
 import tech.pegasys.teku.networking.p2p.connection.TargetPeerRange;
 import tech.pegasys.teku.networking.p2p.discovery.DiscoveryConfig;
@@ -204,6 +205,7 @@ public class Eth2P2PNetworkFactory {
                 attestationSubnetService,
                 syncCommitteeSubnetService,
                 rpcEncoding,
+                new StatusMessageFactory(recentChainData),
                 requiredCheckpoint,
                 eth2RpcPingInterval,
                 eth2RpcOutstandingPingThreshold,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

At the moment there no easy ways to replace `StatusMessageFactory` in the `Eth2PeerManager`.
PR adds a new configurable `StatusMessageFactory` option to the `Eth2P2PNetworkBuilder` which is then passed to `Eth2PeerManager` constructor

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
