### PR TITLE
Send client information in User-Agent header when making builder bid request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,6 @@ For information on changes in released versions of Teku, see the [releases page]
  - Enabled deposit tree snapshot bundles for major networks and persists it after finalization to decrease EL pressure and speed up node startup. Use `--deposit-snapshot-enabled=false` to disable.
  - Optimized validator exit processing during state transition, to speed up block import containing multiple validator exits.
  - Locally submitted exits and bls changes will now periodically broadcast if they are not actioned, to address operations being lost in remote pools.
- - Set `User-Agent` header to "teku/v<version>" (e.g. teku/v23.5.0) when making builder bid requests to help relayers identify clients and versions. Use `--builder-set-user-agent-header=false` to disable. 
+ - Set `User-Agent` header to "teku/v<version>" (e.g. teku/v23.4.0) when making builder bid requests to help builders identify clients and versions. Use `--builder-set-user-agent-header=false` to disable. 
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,5 +24,6 @@ For information on changes in released versions of Teku, see the [releases page]
  - Enabled deposit tree snapshot bundles for major networks and persists it after finalization to decrease EL pressure and speed up node startup. Use `--deposit-snapshot-enabled=false` to disable.
  - Optimized validator exit processing during state transition, to speed up block import containing multiple validator exits.
  - Locally submitted exits and bls changes will now periodically broadcast if they are not actioned, to address operations being lost in remote pools.
+ - Set `User-Agent` header to "teku/v<version>" (e.g. teku/v23.5.0) when making builder bid requests to help relayers identify clients and versions. Use `--builder-set-user-agent-header=false` to disable. 
 
 ### Bug Fixes

--- a/ethereum/executionclient/build.gradle
+++ b/ethereum/executionclient/build.gradle
@@ -6,6 +6,7 @@ dependencies {
   implementation project(':infrastructure:logging')
   implementation project(':infrastructure:async')
   implementation project(':infrastructure:events')
+  implementation project(':infrastructure:version')
   implementation project(':ethereum:execution-types')
   implementation project(':ethereum:spec')
   implementation project(':ethereum:json-types')

--- a/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/rest/OkHttpRestClientTest.java
+++ b/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/rest/OkHttpRestClientTest.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.net.SocketException;
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import okhttp3.OkHttpClient;
@@ -40,6 +41,7 @@ import tech.pegasys.teku.infrastructure.json.types.SerializableTypeDefinition;
 
 class OkHttpRestClientTest {
 
+  private static final Map<String, String> TEST_HEADERS = Map.of("foo", "bar");
   private static final String TEST_PATH = "v1/test";
   private static final Bytes32 TEST_BLOCK_HASH =
       Bytes32.fromHexString("0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2");
@@ -84,7 +86,7 @@ class OkHttpRestClientTest {
             .addHeader("Content-Type", "application/json"));
 
     final SafeFuture<Response<TestObject>> responseFuture =
-        underTest.getAsync(TEST_PATH, responseTypeDefinition);
+        underTest.getAsync(TEST_PATH, TEST_HEADERS, responseTypeDefinition);
 
     assertThat(responseFuture)
         .succeedsWithin(Duration.ofSeconds(1))
@@ -99,6 +101,7 @@ class OkHttpRestClientTest {
 
     assertThat(request.getPath()).isEqualTo("/" + TEST_PATH);
     assertThat(request.getMethod()).isEqualTo("GET");
+    assertThat(request.getHeader("foo")).isEqualTo("bar");
   }
 
   @Test
@@ -127,7 +130,7 @@ class OkHttpRestClientTest {
     mockWebServer.enqueue(new MockResponse().setResponseCode(400).setBody(errorBody));
 
     final SafeFuture<Response<TestObject>> responseFuture =
-        underTest.getAsync(TEST_PATH, responseTypeDefinition);
+        underTest.getAsync(TEST_PATH, TEST_HEADERS, responseTypeDefinition);
 
     assertThat(responseFuture)
         .succeedsWithin(Duration.ofSeconds(1))
@@ -141,7 +144,7 @@ class OkHttpRestClientTest {
     mockWebServer.enqueue(new MockResponse().setResponseCode(500));
 
     final SafeFuture<Response<TestObject>> secondResponseFuture =
-        underTest.getAsync(TEST_PATH, responseTypeDefinition);
+        underTest.getAsync(TEST_PATH, TEST_HEADERS, responseTypeDefinition);
 
     assertThat(secondResponseFuture)
         .succeedsWithin(Duration.ofSeconds(1))
@@ -160,6 +163,7 @@ class OkHttpRestClientTest {
         (req) -> {
           assertThat(req.getPath()).isEqualTo("/" + TEST_PATH);
           assertThat(req.getMethod()).isEqualTo("GET");
+          assertThat(request.getHeader("foo")).isEqualTo("bar");
         };
 
     assertThat(List.of(request, secondRequest)).allSatisfy(requestsAssertions);

--- a/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/rest/RestBuilderClientTest.java
+++ b/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/rest/RestBuilderClientTest.java
@@ -82,7 +82,7 @@ class RestBuilderClientTest {
 
   private static final Pattern TEKU_USER_AGENT_REGEX = Pattern.compile("teku/v.*");
 
-  private static final Consumer<RecordedRequest> USER_AGENT_HEADER_ASSERTIONS =
+  private static final Consumer<RecordedRequest> USER_AGENT_HEADER_ASSERTION =
       recordedRequest ->
           assertThat(recordedRequest.getHeader("User-Agent")).matches(TEKU_USER_AGENT_REGEX);
 
@@ -278,7 +278,7 @@ class RestBuilderClientTest {
             });
 
     verifyGetRequest(
-        "/eth/v1/builder/header/1/" + PARENT_HASH + "/" + PUB_KEY, USER_AGENT_HEADER_ASSERTIONS);
+        "/eth/v1/builder/header/1/" + PARENT_HASH + "/" + PUB_KEY, USER_AGENT_HEADER_ASSERTION);
   }
 
   @TestTemplate
@@ -294,7 +294,8 @@ class RestBuilderClientTest {
               assertThat(response.getPayload()).isEmpty();
             });
 
-    verifyGetRequest("/eth/v1/builder/header/1/" + PARENT_HASH + "/" + PUB_KEY);
+    verifyGetRequest(
+        "/eth/v1/builder/header/1/" + PARENT_HASH + "/" + PUB_KEY, USER_AGENT_HEADER_ASSERTION);
   }
 
   @TestTemplate
@@ -313,7 +314,7 @@ class RestBuilderClientTest {
             });
 
     verifyGetRequest(
-        "/eth/v1/builder/header/1/" + PARENT_HASH + "/" + PUB_KEY, USER_AGENT_HEADER_ASSERTIONS);
+        "/eth/v1/builder/header/1/" + PARENT_HASH + "/" + PUB_KEY, USER_AGENT_HEADER_ASSERTION);
 
     mockWebServer.enqueue(
         new MockResponse().setResponseCode(500).setBody(INTERNAL_SERVER_ERROR_MESSAGE));
@@ -327,7 +328,7 @@ class RestBuilderClientTest {
             });
 
     verifyGetRequest(
-        "/eth/v1/builder/header/1/" + PARENT_HASH + "/" + PUB_KEY, USER_AGENT_HEADER_ASSERTIONS);
+        "/eth/v1/builder/header/1/" + PARENT_HASH + "/" + PUB_KEY, USER_AGENT_HEADER_ASSERTION);
   }
 
   @TestTemplate
@@ -349,7 +350,7 @@ class RestBuilderClientTest {
         .withMessageContaining("required fields: (withdrawals_root) were not set");
 
     verifyGetRequest(
-        "/eth/v1/builder/header/1/" + PARENT_HASH + "/" + PUB_KEY, USER_AGENT_HEADER_ASSERTIONS);
+        "/eth/v1/builder/header/1/" + PARENT_HASH + "/" + PUB_KEY, USER_AGENT_HEADER_ASSERTION);
   }
 
   @TestTemplate
@@ -375,7 +376,7 @@ class RestBuilderClientTest {
             "java.lang.IllegalArgumentException: Wrong response version: expected CAPELLA, received BELLATRIX");
 
     verifyGetRequest(
-        "/eth/v1/builder/header/1/" + PARENT_HASH + "/" + PUB_KEY, USER_AGENT_HEADER_ASSERTIONS);
+        "/eth/v1/builder/header/1/" + PARENT_HASH + "/" + PUB_KEY, USER_AGENT_HEADER_ASSERTION);
   }
 
   @TestTemplate

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/OkHttpRestClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/OkHttpRestClient.java
@@ -101,7 +101,7 @@ public class OkHttpRestClient implements RestClient {
 
   private Request createGetRequest(final String apiPath, final Map<String, String> headers) {
     final HttpUrl httpUrl = createHttpUrl(apiPath);
-    final Builder requestBuilder = new Builder().url(httpUrl);
+    final Request.Builder requestBuilder = new Builder().url(httpUrl);
     headers.forEach(requestBuilder::header);
     return requestBuilder.build();
   }

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/OkHttpRestClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/OkHttpRestClient.java
@@ -24,7 +24,6 @@ import okhttp3.HttpUrl;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
-import okhttp3.Request.Builder;
 import okhttp3.RequestBody;
 import okhttp3.ResponseBody;
 import okio.BufferedSink;
@@ -101,7 +100,7 @@ public class OkHttpRestClient implements RestClient {
 
   private Request createGetRequest(final String apiPath, final Map<String, String> headers) {
     final HttpUrl httpUrl = createHttpUrl(apiPath);
-    final Request.Builder requestBuilder = new Builder().url(httpUrl);
+    final Request.Builder requestBuilder = new Request.Builder().url(httpUrl);
     headers.forEach(requestBuilder::header);
     return requestBuilder.build();
   }
@@ -125,7 +124,7 @@ public class OkHttpRestClient implements RestClient {
 
   private Request createPostRequest(final String apiPath, final RequestBody requestBody) {
     final HttpUrl httpUrl = createHttpUrl(apiPath);
-    return new Builder().url(httpUrl).post(requestBody).build();
+    return new Request.Builder().url(httpUrl).post(requestBody).build();
   }
 
   private HttpUrl createHttpUrl(final String apiPath) {

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/RestClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/RestClient.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.teku.ethereum.executionclient.rest;
 
+import java.util.Collections;
+import java.util.Map;
 import tech.pegasys.teku.ethereum.executionclient.schema.Response;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
@@ -20,10 +22,14 @@ import tech.pegasys.teku.infrastructure.json.types.SerializableTypeDefinition;
 
 public interface RestClient {
 
+  Map<String, String> NO_HEADERS = Collections.emptyMap();
+
   SafeFuture<Response<Void>> getAsync(final String apiPath);
 
   <T> SafeFuture<Response<T>> getAsync(
-      final String apiPath, final DeserializableTypeDefinition<T> responseTypeDefinition);
+      final String apiPath,
+      final Map<String, String> headers,
+      final DeserializableTypeDefinition<T> responseTypeDefinition);
 
   <S> SafeFuture<Response<Void>> postAsync(
       final String apiPath,

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
@@ -133,12 +133,14 @@ public class ExecutionLayerManagerImpl implements ExecutionLayerManager {
   }
 
   public static BuilderClient createBuilderClient(
-      final RestClient builderRestClient,
+      final RestClient restClient,
       final Spec spec,
       final TimeProvider timeProvider,
-      final MetricsSystem metricsSystem) {
+      final MetricsSystem metricsSystem,
+      final boolean setUserAgentHeader) {
 
-    final RestBuilderClient restBuilderClient = new RestBuilderClient(builderRestClient, spec);
+    final RestBuilderClient restBuilderClient =
+        new RestBuilderClient(restClient, spec, setUserAgentHeader);
     final MetricRecordingBuilderClient metricRecordingBuilderClient =
         new MetricRecordingBuilderClient(restBuilderClient, timeProvider, metricsSystem);
     return new ThrottlingBuilderClient(

--- a/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerConfiguration.java
+++ b/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerConfiguration.java
@@ -36,6 +36,7 @@ public class ExecutionLayerConfiguration {
   public static final int DEFAULT_BUILDER_CIRCUIT_BREAKER_ALLOWED_CONSECUTIVE_FAULTS = 3;
   public static final int BUILDER_CIRCUIT_BREAKER_WINDOW_HARD_CAP = 64;
   public static final int DEFAULT_BUILDER_BID_COMPARE_FACTOR = 100;
+  public static final boolean DEFAULT_BUILDER_SET_USER_AGENT_HEADER = true;
   public static final String BUILDER_ALWAYS_KEYWORD = "BUILDER_ALWAYS";
 
   public static final boolean DEFAULT_EXCHANGE_CAPABILITIES_ENABLED = true;
@@ -50,6 +51,7 @@ public class ExecutionLayerConfiguration {
   private final int builderCircuitBreakerAllowedFaults;
   private final int builderCircuitBreakerAllowedConsecutiveFaults;
   private final Optional<Integer> builderBidCompareFactor;
+  private final boolean builderSetUserAgentHeader;
   private final boolean exchangeCapabilitiesEnabled;
 
   private ExecutionLayerConfiguration(
@@ -63,6 +65,7 @@ public class ExecutionLayerConfiguration {
       final int builderCircuitBreakerAllowedFaults,
       final int builderCircuitBreakerAllowedConsecutiveFaults,
       final Optional<Integer> builderBidCompareFactor,
+      final boolean builderSetUserAgentHeader,
       final boolean exchangeCapabilitiesEnabled) {
     this.spec = spec;
     this.engineEndpoint = engineEndpoint;
@@ -75,6 +78,7 @@ public class ExecutionLayerConfiguration {
     this.builderCircuitBreakerAllowedConsecutiveFaults =
         builderCircuitBreakerAllowedConsecutiveFaults;
     this.builderBidCompareFactor = builderBidCompareFactor;
+    this.builderSetUserAgentHeader = builderSetUserAgentHeader;
     this.exchangeCapabilitiesEnabled = exchangeCapabilitiesEnabled;
   }
 
@@ -133,6 +137,10 @@ public class ExecutionLayerConfiguration {
     return builderBidCompareFactor;
   }
 
+  public boolean getBuilderSetUserAgentHeader() {
+    return builderSetUserAgentHeader;
+  }
+
   public static class Builder {
     private Spec spec;
     private Optional<String> engineEndpoint = Optional.empty();
@@ -145,6 +153,7 @@ public class ExecutionLayerConfiguration {
     private int builderCircuitBreakerAllowedConsecutiveFaults =
         DEFAULT_BUILDER_CIRCUIT_BREAKER_ALLOWED_CONSECUTIVE_FAULTS;
     private String builderBidCompareFactor = Integer.toString(DEFAULT_BUILDER_BID_COMPARE_FACTOR);
+    private boolean builderSetUserAgentHeader = DEFAULT_BUILDER_SET_USER_AGENT_HEADER;
     private boolean exchangeCapabilitiesEnabled = DEFAULT_EXCHANGE_CAPABILITIES_ENABLED;
 
     private Builder() {}
@@ -181,6 +190,7 @@ public class ExecutionLayerConfiguration {
           builderCircuitBreakerAllowedFaults,
           builderCircuitBreakerAllowedConsecutiveFaults,
           builderBidCompareFactor,
+          builderSetUserAgentHeader,
           exchangeCapabilitiesEnabled);
     }
 
@@ -234,6 +244,11 @@ public class ExecutionLayerConfiguration {
 
     public Builder builderBidCompareFactor(final String builderBidCompareFactor) {
       this.builderBidCompareFactor = builderBidCompareFactor;
+      return this;
+    }
+
+    public Builder builderSetUserAgentHeader(final boolean builderSetUserAgentHeader) {
+      this.builderSetUserAgentHeader = builderSetUserAgentHeader;
       return this;
     }
 

--- a/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerService.java
+++ b/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerService.java
@@ -220,7 +220,8 @@ public class ExecutionLayerService extends Service {
                     restClientProvider.getRestClient(),
                     config.getSpec(),
                     timeProvider,
-                    metricsSystem));
+                    metricsSystem,
+                    config.getBuilderSetUserAgentHeader()));
 
     final BlobsBundleValidator blobsBundleValidator =
         config.getSpec().isMilestoneSupported(SpecMilestone.DENEB)

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ExecutionLayerOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ExecutionLayerOptions.java
@@ -20,6 +20,7 @@ import static tech.pegasys.teku.services.executionlayer.ExecutionLayerConfigurat
 import static tech.pegasys.teku.services.executionlayer.ExecutionLayerConfiguration.DEFAULT_BUILDER_CIRCUIT_BREAKER_ALLOWED_FAULTS;
 import static tech.pegasys.teku.services.executionlayer.ExecutionLayerConfiguration.DEFAULT_BUILDER_CIRCUIT_BREAKER_ENABLED;
 import static tech.pegasys.teku.services.executionlayer.ExecutionLayerConfiguration.DEFAULT_BUILDER_CIRCUIT_BREAKER_WINDOW;
+import static tech.pegasys.teku.services.executionlayer.ExecutionLayerConfiguration.DEFAULT_BUILDER_SET_USER_AGENT_HEADER;
 import static tech.pegasys.teku.services.executionlayer.ExecutionLayerConfiguration.DEFAULT_EXCHANGE_CAPABILITIES_ENABLED;
 
 import picocli.CommandLine.Help.Visibility;
@@ -114,6 +115,17 @@ public class ExecutionLayerOptions {
   private String builderBidCompareFactor = Integer.toString(DEFAULT_BUILDER_BID_COMPARE_FACTOR);
 
   @Option(
+      names = {"--builder-set-user-agent-header"},
+      paramLabel = "<BOOLEAN>",
+      description =
+          "Set User-Agent header when making a builder bid request to the builder to help builders identify clients and versions",
+      arity = "1",
+      showDefaultValue = Visibility.ALWAYS,
+      fallbackValue = "true",
+      hidden = true)
+  private boolean builderSetUserAgentHeader = DEFAULT_BUILDER_SET_USER_AGENT_HEADER;
+
+  @Option(
       hidden = true,
       names = {"--exchange-capabilities-enabled", "--Xexchange-capabilities-enabled"},
       paramLabel = "<BOOLEAN>",
@@ -136,6 +148,7 @@ public class ExecutionLayerOptions {
                 .builderCircuitBreakerAllowedConsecutiveFaults(
                     builderCircuitBreakerAllowedConsecutiveFaults)
                 .builderBidCompareFactor(builderBidCompareFactor)
+                .builderSetUserAgentHeader(builderSetUserAgentHeader)
                 .exchangeCapabilitiesEnabled(exchangeCapabilitiesEnabled));
     depositOptions.configure(builder);
   }

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ExecutionLayerOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ExecutionLayerOptions.java
@@ -118,7 +118,7 @@ public class ExecutionLayerOptions {
       names = {"--builder-set-user-agent-header"},
       paramLabel = "<BOOLEAN>",
       description =
-          "Set User-Agent header when making a builder bid request to the builder to help builders identify clients and versions",
+          "Set User-Agent header to teku/v<version> (e.g. teku/v23.4.0) when making a builder bid request to help builders identify clients and versions",
       arity = "1",
       showDefaultValue = Visibility.ALWAYS,
       fallbackValue = "true",


### PR DESCRIPTION
## PR Description

- Set User-Agent header to `VersionProvider.CLIENT_IDENTITY/VersionProvider.IMPLEMENTATION_VERSION` for builder bid requests
- By default okhttp seems to be sending User-Agent in the format `okhttp/4.10.0`. Wondering if we should remove this using an interceptor?

## Fixed Issue(s)
fixes #7030 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
