### PR TITLE
Make maxConcurrentRequests in the blobs fetcher based on MAX_BLOBS_PER_BLOCK

### DIFF
--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/DefaultSyncServiceFactory.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/DefaultSyncServiceFactory.java
@@ -129,7 +129,7 @@ public class DefaultSyncServiceFactory implements SyncServiceFactory {
 
     final FetchRecentBlobSidecarsService fetchRecentBlobSidecarsService =
         FetchRecentBlobSidecarsService.create(
-            asyncRunner, blobSidecarPool, forwardSyncService, fetchTaskFactory);
+            asyncRunner, blobSidecarPool, forwardSyncService, fetchTaskFactory, spec);
 
     final SyncStateTracker syncStateTracker = createSyncStateTracker(forwardSyncService);
 

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/gossip/blobs/FetchRecentBlobSidecarsService.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/gossip/blobs/FetchRecentBlobSidecarsService.java
@@ -60,7 +60,7 @@ public class FetchRecentBlobSidecarsService
       final FetchTaskFactory fetchTaskFactory,
       final Spec spec) {
     final int maxConcurrentRequests =
-        FetchRecentBlocksService.MAX_CONCURRENT_REQUESTS * spec.getMaxBlobsPerBlock().orElse(0);
+        FetchRecentBlocksService.MAX_CONCURRENT_REQUESTS * spec.getMaxBlobsPerBlock().orElse(1);
     return new FetchRecentBlobSidecarsService(
         asyncRunner, blobSidecarPool, forwardSync, fetchTaskFactory, maxConcurrentRequests);
   }

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/gossip/blobs/FetchRecentBlobSidecarsService.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/gossip/blobs/FetchRecentBlobSidecarsService.java
@@ -19,9 +19,11 @@ import tech.pegasys.teku.beacon.sync.fetch.FetchBlobSidecarTask;
 import tech.pegasys.teku.beacon.sync.fetch.FetchTaskFactory;
 import tech.pegasys.teku.beacon.sync.forward.ForwardSync;
 import tech.pegasys.teku.beacon.sync.gossip.AbstractFetchService;
+import tech.pegasys.teku.beacon.sync.gossip.blocks.FetchRecentBlocksService;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.subscribers.Subscribers;
+import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BlobIdentifier;
 import tech.pegasys.teku.statetransition.blobs.BlobSidecarPool;
@@ -31,8 +33,6 @@ public class FetchRecentBlobSidecarsService
     implements RecentBlobSidecarFetcher {
 
   private static final Logger LOG = LogManager.getLogger();
-
-  private static final int MAX_CONCURRENT_REQUESTS = 3;
 
   private final BlobSidecarPool blobSidecarPool;
   private final ForwardSync forwardSync;
@@ -57,9 +57,12 @@ public class FetchRecentBlobSidecarsService
       final AsyncRunner asyncRunner,
       final BlobSidecarPool blobSidecarPool,
       final ForwardSync forwardSync,
-      final FetchTaskFactory fetchTaskFactory) {
+      final FetchTaskFactory fetchTaskFactory,
+      final Spec spec) {
+    final int maxConcurrentRequests =
+        FetchRecentBlocksService.MAX_CONCURRENT_REQUESTS * spec.getMaxBlobsPerBlock().orElse(0);
     return new FetchRecentBlobSidecarsService(
-        asyncRunner, blobSidecarPool, forwardSync, fetchTaskFactory, MAX_CONCURRENT_REQUESTS);
+        asyncRunner, blobSidecarPool, forwardSync, fetchTaskFactory, maxConcurrentRequests);
   }
 
   @Override

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/gossip/blocks/FetchRecentBlocksService.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/gossip/blocks/FetchRecentBlocksService.java
@@ -32,7 +32,7 @@ public class FetchRecentBlocksService
 
   private static final Logger LOG = LogManager.getLogger();
 
-  private static final int MAX_CONCURRENT_REQUESTS = 3;
+  public static final int MAX_CONCURRENT_REQUESTS = 3;
 
   private final ForwardSync forwardSync;
   private final PendingPool<SignedBeaconBlock> pendingBlocksPool;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Value shouldn't be hardcoded to 3 as in the block fetcher, but should be calculated based on MAX_BLOBS_PER_BLOCK

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
