### PR TITLE
Fix duplicate code of PUBKEY_TYPE in BeaconRestApiTypes and ValidatorTypes

### DIFF
--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/Pubkey.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/Pubkey.json
@@ -1,6 +1,6 @@
 {
   "type" : "string",
-  "title" : "PubKey",
+  "title" : "Pubkey",
   "pattern" : "^0x[a-fA-F0-9]{96}$",
   "description" : "The validator's BLS public key, uniquely identifying them. _48-bytes, hex encoded with 0x prefix, case insensitive._",
   "example" : "0x93247f2209abcacf57b75a51dafae777f9dd38bc7053d1af526f220a7489a6d3a2753e5f3e8b1cfe39b56f43611df74a"

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/RegisteredValidatorsType.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/RegisteredValidatorsType.json
@@ -10,7 +10,7 @@
       "format" : "uint64"
     },
     "pubkey" : {
-      "$ref" : "#/components/schemas/PubKey"
+      "$ref" : "#/components/schemas/Pubkey"
     },
     "fee_recipient" : {
       "type" : "string",

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApiTypes.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApiTypes.java
@@ -56,9 +56,7 @@ import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.STRING_TYPE;
 
 import java.util.function.Function;
 import org.apache.tuweni.bytes.Bytes32;
-import org.apache.tuweni.bytes.Bytes48;
 import tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.GetStateValidators.StatusParameter;
-import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.http.RestApiConstants;
 import tech.pegasys.teku.infrastructure.json.types.CoreTypes;
@@ -78,18 +76,6 @@ public class BeaconRestApiTypes {
           .example("active_ongoing")
           .description("ValidatorStatus string")
           .format("string")
-          .build();
-
-  public static final DeserializableTypeDefinition<BLSPublicKey> PUBKEY_TYPE =
-      DeserializableTypeDefinition.string(BLSPublicKey.class)
-          .name("PubKey")
-          .formatter(BLSPublicKey::toString)
-          .parser(value -> BLSPublicKey.fromBytesCompressedValidate(Bytes48.fromHexString(value)))
-          .pattern("^0x[a-fA-F0-9]{96}$")
-          .example(
-              "0x93247f2209abcacf57b75a51dafae777f9dd38bc7053d1af526f220a7489a6d3a2753e5f3e8b1cfe39b56f43611df74a")
-          .description(
-              "The validator's BLS public key, uniquely identifying them. _48-bytes, hex encoded with 0x prefix, case insensitive._")
           .build();
 
   public static final ParameterMetadata<String> PARAMETER_STATE_ID =

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/schema/ProposersData.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/schema/ProposersData.java
@@ -14,7 +14,7 @@
 package tech.pegasys.teku.beaconrestapi.schema;
 
 import static tech.pegasys.teku.ethereum.json.types.EthereumTypes.ETH1ADDRESS_TYPE;
-import static tech.pegasys.teku.ethereum.json.types.EthereumTypes.VALIDATED_PUBLIC_KEY_TYPE;
+import static tech.pegasys.teku.ethereum.json.types.SharedApiTypes.PUBLIC_KEY_API_TYPE;
 import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.UINT64_TYPE;
 import static tech.pegasys.teku.infrastructure.json.types.SerializableTypeDefinition.listOf;
 
@@ -62,7 +62,7 @@ public class ProposersData {
             .withField("proposer_index", UINT64_TYPE, Map.Entry::getKey)
             .withField(
                 "pubkey",
-                VALIDATED_PUBLIC_KEY_TYPE,
+                PUBLIC_KEY_API_TYPE,
                 entry ->
                     entry.getValue().getSignedValidatorRegistration().getMessage().getPublicKey())
             .withField(

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/schema/ProposersData.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/schema/ProposersData.java
@@ -13,8 +13,8 @@
 
 package tech.pegasys.teku.beaconrestapi.schema;
 
-import static tech.pegasys.teku.beaconrestapi.BeaconRestApiTypes.PUBKEY_TYPE;
 import static tech.pegasys.teku.ethereum.json.types.EthereumTypes.ETH1ADDRESS_TYPE;
+import static tech.pegasys.teku.ethereum.json.types.EthereumTypes.VALIDATED_PUBLIC_KEY_TYPE;
 import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.UINT64_TYPE;
 import static tech.pegasys.teku.infrastructure.json.types.SerializableTypeDefinition.listOf;
 
@@ -62,7 +62,7 @@ public class ProposersData {
             .withField("proposer_index", UINT64_TYPE, Map.Entry::getKey)
             .withField(
                 "pubkey",
-                PUBKEY_TYPE,
+                VALIDATED_PUBLIC_KEY_TYPE,
                 entry ->
                     entry.getValue().getSignedValidatorRegistration().getMessage().getPublicKey())
             .withField(

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/schema/ProposersData.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/schema/ProposersData.java
@@ -14,7 +14,7 @@
 package tech.pegasys.teku.beaconrestapi.schema;
 
 import static tech.pegasys.teku.ethereum.json.types.EthereumTypes.ETH1ADDRESS_TYPE;
-import static tech.pegasys.teku.ethereum.json.types.SharedApiTypes.PUBLIC_KEY_API_TYPE;
+import static tech.pegasys.teku.ethereum.json.types.SharedApiTypes.PUBKEY_API_TYPE;
 import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.UINT64_TYPE;
 import static tech.pegasys.teku.infrastructure.json.types.SerializableTypeDefinition.listOf;
 
@@ -62,7 +62,7 @@ public class ProposersData {
             .withField("proposer_index", UINT64_TYPE, Map.Entry::getKey)
             .withField(
                 "pubkey",
-                PUBLIC_KEY_API_TYPE,
+                PUBKEY_API_TYPE,
                 entry ->
                     entry.getValue().getSignedValidatorRegistration().getMessage().getPublicKey())
             .withField(

--- a/ethereum/json-types/src/main/java/tech/pegasys/teku/ethereum/json/types/EthereumTypes.java
+++ b/ethereum/json-types/src/main/java/tech/pegasys/teku/ethereum/json/types/EthereumTypes.java
@@ -18,7 +18,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import org.apache.tuweni.bytes.Bytes;
-import org.apache.tuweni.bytes.Bytes48;
 import org.jetbrains.annotations.NotNull;
 import tech.pegasys.teku.api.schema.Version;
 import tech.pegasys.teku.bls.BLSPublicKey;
@@ -60,20 +59,6 @@ public class EthereumTypes {
       DeserializableTypeDefinition.string(BLSPublicKey.class)
           .formatter(BLSPublicKey::toString)
           .parser(BLSPublicKey::fromHexString)
-          .example(
-              "0x93247f2209abcacf57b75a51dafae777f9dd38bc7053d1a"
-                  + "f526f220a7489a6d3a2753e5f3e8b1cfe39b56f43611df74a")
-          .description(
-              "`BLSPublicKey Hex` The validator's BLS public key, uniquely identifying them. "
-                  + "48-bytes, hex encoded with 0x prefix, case insensitive.")
-          .format("string")
-          .build();
-
-  public static final StringValueTypeDefinition<BLSPublicKey> VALIDATED_PUBLIC_KEY_TYPE =
-      DeserializableTypeDefinition.string(BLSPublicKey.class)
-          .formatter(BLSPublicKey::toString)
-          .parser(value -> BLSPublicKey.fromBytesCompressedValidate(Bytes48.fromHexString(value)))
-          .pattern("^0x[a-fA-F0-9]{96}$")
           .example(
               "0x93247f2209abcacf57b75a51dafae777f9dd38bc7053d1a"
                   + "f526f220a7489a6d3a2753e5f3e8b1cfe39b56f43611df74a")

--- a/ethereum/json-types/src/main/java/tech/pegasys/teku/ethereum/json/types/EthereumTypes.java
+++ b/ethereum/json-types/src/main/java/tech/pegasys/teku/ethereum/json/types/EthereumTypes.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes48;
 import org.jetbrains.annotations.NotNull;
 import tech.pegasys.teku.api.schema.Version;
 import tech.pegasys.teku.bls.BLSPublicKey;
@@ -59,6 +60,20 @@ public class EthereumTypes {
       DeserializableTypeDefinition.string(BLSPublicKey.class)
           .formatter(BLSPublicKey::toString)
           .parser(BLSPublicKey::fromHexString)
+          .example(
+              "0x93247f2209abcacf57b75a51dafae777f9dd38bc7053d1a"
+                  + "f526f220a7489a6d3a2753e5f3e8b1cfe39b56f43611df74a")
+          .description(
+              "`BLSPublicKey Hex` The validator's BLS public key, uniquely identifying them. "
+                  + "48-bytes, hex encoded with 0x prefix, case insensitive.")
+          .format("string")
+          .build();
+
+  public static final StringValueTypeDefinition<BLSPublicKey> VALIDATED_PUBLIC_KEY_TYPE =
+      DeserializableTypeDefinition.string(BLSPublicKey.class)
+          .formatter(BLSPublicKey::toString)
+          .parser(value -> BLSPublicKey.fromBytesCompressedValidate(Bytes48.fromHexString(value)))
+          .pattern("^0x[a-fA-F0-9]{96}$")
           .example(
               "0x93247f2209abcacf57b75a51dafae777f9dd38bc7053d1a"
                   + "f526f220a7489a6d3a2753e5f3e8b1cfe39b56f43611df74a")

--- a/ethereum/json-types/src/main/java/tech/pegasys/teku/ethereum/json/types/SharedApiTypes.java
+++ b/ethereum/json-types/src/main/java/tech/pegasys/teku/ethereum/json/types/SharedApiTypes.java
@@ -19,10 +19,13 @@ import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.UINT64_TYPE;
 
 import java.util.Optional;
 import java.util.function.Function;
+import org.apache.tuweni.bytes.Bytes48;
+import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.ethereum.json.types.wrappers.GetGenesisApiData;
 import tech.pegasys.teku.ethereum.json.types.wrappers.GetGenesisApiData.GetGenesisApiDataBuilder;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableObjectTypeDefinitionBuilder;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
+import tech.pegasys.teku.infrastructure.json.types.StringValueTypeDefinition;
 import tech.pegasys.teku.infrastructure.ssz.SszData;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszSchema;
 
@@ -51,6 +54,18 @@ public class SharedApiTypes {
                   GetGenesisApiData::getGenesisForkVersion,
                   GetGenesisApiDataBuilder::genesisForkVersion)
               .build());
+
+  public static final StringValueTypeDefinition<BLSPublicKey> PUBLIC_KEY_API_TYPE =
+      DeserializableTypeDefinition.string(BLSPublicKey.class)
+          .name("Pubkey")
+          .formatter(BLSPublicKey::toString)
+          .parser(value -> BLSPublicKey.fromBytesCompressedValidate(Bytes48.fromHexString(value)))
+          .pattern("^0x[a-fA-F0-9]{96}$")
+          .example(
+              "0x93247f2209abcacf57b75a51dafae777f9dd38bc7053d1af526f220a7489a6d3a2753e5f3e8b1cfe39b56f43611df74a")
+          .description(
+              "The validator's BLS public key, uniquely identifying them. _48-bytes, hex encoded with 0x prefix, case insensitive._")
+          .build();
 
   public static <T extends SszData, S extends SszSchema<T>>
       DeserializableTypeDefinition<T> withDataWrapper(final S schema) {

--- a/ethereum/json-types/src/main/java/tech/pegasys/teku/ethereum/json/types/SharedApiTypes.java
+++ b/ethereum/json-types/src/main/java/tech/pegasys/teku/ethereum/json/types/SharedApiTypes.java
@@ -55,7 +55,7 @@ public class SharedApiTypes {
                   GetGenesisApiDataBuilder::genesisForkVersion)
               .build());
 
-  public static final StringValueTypeDefinition<BLSPublicKey> PUBLIC_KEY_API_TYPE =
+  public static final StringValueTypeDefinition<BLSPublicKey> PUBKEY_API_TYPE =
       DeserializableTypeDefinition.string(BLSPublicKey.class)
           .name("Pubkey")
           .formatter(BLSPublicKey::toString)

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/ValidatorTypes.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/ValidatorTypes.java
@@ -13,7 +13,7 @@
 
 package tech.pegasys.teku.validator.client.restapi;
 
-import static tech.pegasys.teku.ethereum.json.types.SharedApiTypes.PUBLIC_KEY_API_TYPE;
+import static tech.pegasys.teku.ethereum.json.types.SharedApiTypes.PUBKEY_API_TYPE;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.PUBKEY;
 import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.BOOLEAN_TYPE;
 import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.STRING_TYPE;
@@ -83,7 +83,7 @@ public class ValidatorTypes {
 
   public static final SerializableTypeDefinition<Validator> ACTIVE_VALIDATOR =
       SerializableTypeDefinition.object(Validator.class)
-          .withField("validating_pubkey", PUBLIC_KEY_API_TYPE, Validator::getPublicKey)
+          .withField("validating_pubkey", PUBKEY_API_TYPE, Validator::getPublicKey)
           .withOptionalField(
               "derivation_path",
               CoreTypes.string("The derivation path (if present in the imported keystore)."),
@@ -121,7 +121,7 @@ public class ValidatorTypes {
           .initializer(ExternalValidator::new)
           .withField(
               "pubkey",
-              PUBLIC_KEY_API_TYPE,
+              PUBKEY_API_TYPE,
               ExternalValidator::getPublicKey,
               ExternalValidator::setPublicKey)
           .withOptionalField("url", URL_TYPE, ExternalValidator::getUrl, ExternalValidator::setUrl)
@@ -134,7 +134,7 @@ public class ValidatorTypes {
               .initializer(ExternalValidator::new)
               .withField(
                   "pubkey",
-                  PUBLIC_KEY_API_TYPE,
+                  PUBKEY_API_TYPE,
                   ExternalValidator::getPublicKey,
                   ExternalValidator::setPublicKey)
               .withOptionalField(
@@ -160,7 +160,7 @@ public class ValidatorTypes {
               .initializer(ExternalValidator::new)
               .withField(
                   "pubkey",
-                  PUBLIC_KEY_API_TYPE,
+                  PUBKEY_API_TYPE,
                   ExternalValidator::getPublicKey,
                   ExternalValidator::setPublicKey)
               .withOptionalField(
@@ -198,7 +198,7 @@ public class ValidatorTypes {
           .initializer(DeleteKeysRequest::new)
           .withField(
               "pubkeys",
-              DeserializableTypeDefinition.listOf(PUBLIC_KEY_API_TYPE),
+              DeserializableTypeDefinition.listOf(PUBKEY_API_TYPE),
               DeleteKeysRequest::getPublicKeys,
               DeleteKeysRequest::setPublicKeys)
           .build();

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/ValidatorTypes.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/ValidatorTypes.java
@@ -13,7 +13,7 @@
 
 package tech.pegasys.teku.validator.client.restapi;
 
-import static tech.pegasys.teku.ethereum.json.types.EthereumTypes.VALIDATED_PUBLIC_KEY_TYPE;
+import static tech.pegasys.teku.ethereum.json.types.SharedApiTypes.PUBLIC_KEY_API_TYPE;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.PUBKEY;
 import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.BOOLEAN_TYPE;
 import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.STRING_TYPE;
@@ -83,7 +83,7 @@ public class ValidatorTypes {
 
   public static final SerializableTypeDefinition<Validator> ACTIVE_VALIDATOR =
       SerializableTypeDefinition.object(Validator.class)
-          .withField("validating_pubkey", VALIDATED_PUBLIC_KEY_TYPE, Validator::getPublicKey)
+          .withField("validating_pubkey", PUBLIC_KEY_API_TYPE, Validator::getPublicKey)
           .withOptionalField(
               "derivation_path",
               CoreTypes.string("The derivation path (if present in the imported keystore)."),
@@ -121,7 +121,7 @@ public class ValidatorTypes {
           .initializer(ExternalValidator::new)
           .withField(
               "pubkey",
-              VALIDATED_PUBLIC_KEY_TYPE,
+              PUBLIC_KEY_API_TYPE,
               ExternalValidator::getPublicKey,
               ExternalValidator::setPublicKey)
           .withOptionalField("url", URL_TYPE, ExternalValidator::getUrl, ExternalValidator::setUrl)
@@ -134,7 +134,7 @@ public class ValidatorTypes {
               .initializer(ExternalValidator::new)
               .withField(
                   "pubkey",
-                  VALIDATED_PUBLIC_KEY_TYPE,
+                  PUBLIC_KEY_API_TYPE,
                   ExternalValidator::getPublicKey,
                   ExternalValidator::setPublicKey)
               .withOptionalField(
@@ -160,7 +160,7 @@ public class ValidatorTypes {
               .initializer(ExternalValidator::new)
               .withField(
                   "pubkey",
-                  VALIDATED_PUBLIC_KEY_TYPE,
+                  PUBLIC_KEY_API_TYPE,
                   ExternalValidator::getPublicKey,
                   ExternalValidator::setPublicKey)
               .withOptionalField(
@@ -198,7 +198,7 @@ public class ValidatorTypes {
           .initializer(DeleteKeysRequest::new)
           .withField(
               "pubkeys",
-              DeserializableTypeDefinition.listOf(VALIDATED_PUBLIC_KEY_TYPE),
+              DeserializableTypeDefinition.listOf(PUBLIC_KEY_API_TYPE),
               DeleteKeysRequest::getPublicKeys,
               DeleteKeysRequest::setPublicKeys)
           .build();

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/ValidatorTypes.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/ValidatorTypes.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.validator.client.restapi;
 
+import static tech.pegasys.teku.ethereum.json.types.EthereumTypes.VALIDATED_PUBLIC_KEY_TYPE;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.PUBKEY;
 import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.BOOLEAN_TYPE;
 import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.STRING_TYPE;
@@ -79,21 +80,10 @@ public class ValidatorTypes {
               PostKeysRequest::getSlashingProtection,
               PostKeysRequest::setSlashingProtection)
           .build();
-  public static final DeserializableTypeDefinition<BLSPublicKey> PUBKEY_TYPE =
-      DeserializableTypeDefinition.string(BLSPublicKey.class)
-          .name("PubKey")
-          .formatter(BLSPublicKey::toString)
-          .parser(value -> BLSPublicKey.fromBytesCompressedValidate(Bytes48.fromHexString(value)))
-          .pattern("^0x[a-fA-F0-9]{96}$")
-          .example(
-              "0x93247f2209abcacf57b75a51dafae777f9dd38bc7053d1af526f220a7489a6d3a2753e5f3e8b1cfe39b56f43611df74a")
-          .description(
-              "The validator's BLS public key, uniquely identifying them. _48-bytes, hex encoded with 0x prefix, case insensitive._")
-          .build();
 
   public static final SerializableTypeDefinition<Validator> ACTIVE_VALIDATOR =
       SerializableTypeDefinition.object(Validator.class)
-          .withField("validating_pubkey", PUBKEY_TYPE, Validator::getPublicKey)
+          .withField("validating_pubkey", VALIDATED_PUBLIC_KEY_TYPE, Validator::getPublicKey)
           .withOptionalField(
               "derivation_path",
               CoreTypes.string("The derivation path (if present in the imported keystore)."),
@@ -131,7 +121,7 @@ public class ValidatorTypes {
           .initializer(ExternalValidator::new)
           .withField(
               "pubkey",
-              PUBKEY_TYPE,
+              VALIDATED_PUBLIC_KEY_TYPE,
               ExternalValidator::getPublicKey,
               ExternalValidator::setPublicKey)
           .withOptionalField("url", URL_TYPE, ExternalValidator::getUrl, ExternalValidator::setUrl)
@@ -144,7 +134,7 @@ public class ValidatorTypes {
               .initializer(ExternalValidator::new)
               .withField(
                   "pubkey",
-                  PUBKEY_TYPE,
+                  VALIDATED_PUBLIC_KEY_TYPE,
                   ExternalValidator::getPublicKey,
                   ExternalValidator::setPublicKey)
               .withOptionalField(
@@ -170,7 +160,7 @@ public class ValidatorTypes {
               .initializer(ExternalValidator::new)
               .withField(
                   "pubkey",
-                  PUBKEY_TYPE,
+                  VALIDATED_PUBLIC_KEY_TYPE,
                   ExternalValidator::getPublicKey,
                   ExternalValidator::setPublicKey)
               .withOptionalField(
@@ -208,7 +198,7 @@ public class ValidatorTypes {
           .initializer(DeleteKeysRequest::new)
           .withField(
               "pubkeys",
-              DeserializableTypeDefinition.listOf(PUBKEY_TYPE),
+              DeserializableTypeDefinition.listOf(VALIDATED_PUBLIC_KEY_TYPE),
               DeleteKeysRequest::getPublicKeys,
               DeleteKeysRequest::setPublicKeys)
           .build();

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/apis/GetFeeRecipient.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/apis/GetFeeRecipient.java
@@ -25,7 +25,7 @@ import java.util.Optional;
 import java.util.function.Function;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.ethereum.execution.types.Eth1Address;
-import tech.pegasys.teku.ethereum.json.types.EthereumTypes;
+import tech.pegasys.teku.ethereum.json.types.SharedApiTypes;
 import tech.pegasys.teku.infrastructure.json.types.SerializableTypeDefinition;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.EndpointMetadata;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiEndpoint;
@@ -41,9 +41,7 @@ public class GetFeeRecipient extends RestApiEndpoint {
           .name("GetFeeRecipientData")
           .withField("ethaddress", ETH1ADDRESS_TYPE, GetFeeRecipientResponse::getEthAddress)
           .withOptionalField(
-              PUBKEY,
-              EthereumTypes.VALIDATED_PUBLIC_KEY_TYPE,
-              GetFeeRecipientResponse::getPublicKey)
+              PUBKEY, SharedApiTypes.PUBLIC_KEY_API_TYPE, GetFeeRecipientResponse::getPublicKey)
           .build();
 
   private static final SerializableTypeDefinition<GetFeeRecipientResponse> RESPONSE_TYPE =

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/apis/GetFeeRecipient.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/apis/GetFeeRecipient.java
@@ -25,12 +25,12 @@ import java.util.Optional;
 import java.util.function.Function;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.ethereum.execution.types.Eth1Address;
+import tech.pegasys.teku.ethereum.json.types.EthereumTypes;
 import tech.pegasys.teku.infrastructure.json.types.SerializableTypeDefinition;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.EndpointMetadata;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiEndpoint;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiRequest;
 import tech.pegasys.teku.validator.client.ProposerConfigManager;
-import tech.pegasys.teku.validator.client.restapi.ValidatorTypes;
 
 public class GetFeeRecipient extends RestApiEndpoint {
   public static final String ROUTE = "/eth/v1/validator/{pubkey}/feerecipient";
@@ -41,7 +41,9 @@ public class GetFeeRecipient extends RestApiEndpoint {
           .name("GetFeeRecipientData")
           .withField("ethaddress", ETH1ADDRESS_TYPE, GetFeeRecipientResponse::getEthAddress)
           .withOptionalField(
-              PUBKEY, ValidatorTypes.PUBKEY_TYPE, GetFeeRecipientResponse::getPublicKey)
+              PUBKEY,
+              EthereumTypes.VALIDATED_PUBLIC_KEY_TYPE,
+              GetFeeRecipientResponse::getPublicKey)
           .build();
 
   private static final SerializableTypeDefinition<GetFeeRecipientResponse> RESPONSE_TYPE =

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/apis/GetFeeRecipient.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/apis/GetFeeRecipient.java
@@ -41,7 +41,7 @@ public class GetFeeRecipient extends RestApiEndpoint {
           .name("GetFeeRecipientData")
           .withField("ethaddress", ETH1ADDRESS_TYPE, GetFeeRecipientResponse::getEthAddress)
           .withOptionalField(
-              PUBKEY, SharedApiTypes.PUBLIC_KEY_API_TYPE, GetFeeRecipientResponse::getPublicKey)
+              PUBKEY, SharedApiTypes.PUBKEY_API_TYPE, GetFeeRecipientResponse::getPublicKey)
           .build();
 
   private static final SerializableTypeDefinition<GetFeeRecipientResponse> RESPONSE_TYPE =

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/apis/GetGasLimit.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/apis/GetGasLimit.java
@@ -44,9 +44,7 @@ public class GetGasLimit extends RestApiEndpoint {
           .withField(
               "gas_limit", CoreTypes.UINT64_TYPE, GetGasLimit.GetGasLimitResponse::getGasLimit)
           .withField(
-              PUBKEY,
-              SharedApiTypes.PUBLIC_KEY_API_TYPE,
-              GetGasLimit.GetGasLimitResponse::getPublicKey)
+              PUBKEY, SharedApiTypes.PUBKEY_API_TYPE, GetGasLimit.GetGasLimitResponse::getPublicKey)
           .build();
 
   private static final SerializableTypeDefinition<GetGasLimit.GetGasLimitResponse> RESPONSE_TYPE =

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/apis/GetGasLimit.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/apis/GetGasLimit.java
@@ -24,7 +24,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 import tech.pegasys.teku.bls.BLSPublicKey;
-import tech.pegasys.teku.ethereum.json.types.EthereumTypes;
+import tech.pegasys.teku.ethereum.json.types.SharedApiTypes;
 import tech.pegasys.teku.infrastructure.json.types.CoreTypes;
 import tech.pegasys.teku.infrastructure.json.types.SerializableTypeDefinition;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.EndpointMetadata;
@@ -45,7 +45,7 @@ public class GetGasLimit extends RestApiEndpoint {
               "gas_limit", CoreTypes.UINT64_TYPE, GetGasLimit.GetGasLimitResponse::getGasLimit)
           .withField(
               PUBKEY,
-              EthereumTypes.VALIDATED_PUBLIC_KEY_TYPE,
+              SharedApiTypes.PUBLIC_KEY_API_TYPE,
               GetGasLimit.GetGasLimitResponse::getPublicKey)
           .build();
 

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/apis/GetGasLimit.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/apis/GetGasLimit.java
@@ -24,6 +24,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.ethereum.json.types.EthereumTypes;
 import tech.pegasys.teku.infrastructure.json.types.CoreTypes;
 import tech.pegasys.teku.infrastructure.json.types.SerializableTypeDefinition;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.EndpointMetadata;
@@ -31,7 +32,6 @@ import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiEndpoint;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiRequest;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.validator.client.ProposerConfigManager;
-import tech.pegasys.teku.validator.client.restapi.ValidatorTypes;
 
 public class GetGasLimit extends RestApiEndpoint {
 
@@ -44,7 +44,9 @@ public class GetGasLimit extends RestApiEndpoint {
           .withField(
               "gas_limit", CoreTypes.UINT64_TYPE, GetGasLimit.GetGasLimitResponse::getGasLimit)
           .withField(
-              PUBKEY, ValidatorTypes.PUBKEY_TYPE, GetGasLimit.GetGasLimitResponse::getPublicKey)
+              PUBKEY,
+              EthereumTypes.VALIDATED_PUBLIC_KEY_TYPE,
+              GetGasLimit.GetGasLimitResponse::getPublicKey)
           .build();
 
   private static final SerializableTypeDefinition<GetGasLimit.GetGasLimitResponse> RESPONSE_TYPE =

--- a/validator/client/src/test/resources/tech/pegasys/teku/validator/client/restapi/schema/DeleteKeysRequest.json
+++ b/validator/client/src/test/resources/tech/pegasys/teku/validator/client/restapi/schema/DeleteKeysRequest.json
@@ -6,7 +6,7 @@
     "pubkeys" : {
       "type" : "array",
       "items" : {
-        "$ref" : "#/components/schemas/PubKey"
+        "$ref" : "#/components/schemas/Pubkey"
       }
     }
   }

--- a/validator/client/src/test/resources/tech/pegasys/teku/validator/client/restapi/schema/GetFeeRecipientData.json
+++ b/validator/client/src/test/resources/tech/pegasys/teku/validator/client/restapi/schema/GetFeeRecipientData.json
@@ -10,7 +10,7 @@
       "format" : "byte"
     },
     "pubkey" : {
-      "$ref" : "#/components/schemas/PubKey"
+      "$ref" : "#/components/schemas/Pubkey"
     }
   }
 }

--- a/validator/client/src/test/resources/tech/pegasys/teku/validator/client/restapi/schema/GetGasLimitData.json
+++ b/validator/client/src/test/resources/tech/pegasys/teku/validator/client/restapi/schema/GetGasLimitData.json
@@ -10,7 +10,7 @@
       "format" : "uint64"
     },
     "pubkey" : {
-      "$ref" : "#/components/schemas/PubKey"
+      "$ref" : "#/components/schemas/Pubkey"
     }
   }
 }

--- a/validator/client/src/test/resources/tech/pegasys/teku/validator/client/restapi/schema/ImportRemoteSignerDefinition.json
+++ b/validator/client/src/test/resources/tech/pegasys/teku/validator/client/restapi/schema/ImportRemoteSignerDefinition.json
@@ -4,7 +4,7 @@
   "required" : [ "pubkey" ],
   "properties" : {
     "pubkey" : {
-      "$ref" : "#/components/schemas/PubKey"
+      "$ref" : "#/components/schemas/Pubkey"
     },
     "url" : {
       "$ref" : "#/components/schemas/Signer"

--- a/validator/client/src/test/resources/tech/pegasys/teku/validator/client/restapi/schema/ListKeysResponse.json
+++ b/validator/client/src/test/resources/tech/pegasys/teku/validator/client/restapi/schema/ListKeysResponse.json
@@ -10,7 +10,7 @@
         "required" : [ "validating_pubkey", "readonly" ],
         "properties" : {
           "validating_pubkey" : {
-            "$ref" : "#/components/schemas/PubKey"
+            "$ref" : "#/components/schemas/Pubkey"
           },
           "derivation_path" : {
             "type" : "string",

--- a/validator/client/src/test/resources/tech/pegasys/teku/validator/client/restapi/schema/Pubkey.json
+++ b/validator/client/src/test/resources/tech/pegasys/teku/validator/client/restapi/schema/Pubkey.json
@@ -1,5 +1,5 @@
 {
-  "title": "PubKey",
+  "title": "Pubkey",
   "type": "string",
   "pattern": "^0x[a-fA-F0-9]{96}$",
   "description": "The validator's BLS public key, uniquely identifying them. _48-bytes, hex encoded with 0x prefix, case insensitive._",

--- a/validator/client/src/test/resources/tech/pegasys/teku/validator/client/restapi/schema/SignerDefinition.json
+++ b/validator/client/src/test/resources/tech/pegasys/teku/validator/client/restapi/schema/SignerDefinition.json
@@ -4,7 +4,7 @@
   "required" : [ "pubkey", "readonly" ],
   "properties" : {
     "pubkey" : {
-      "$ref" : "#/components/schemas/PubKey"
+      "$ref" : "#/components/schemas/Pubkey"
     },
     "url" : {
       "$ref" : "#/components/schemas/Signer"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

- Created a new `PUBKEY_API_TYPE` in SharedApiType
- Removed `PUBKEY_TYPE` from BeaconRestApiTypes and ValidatorTypes and replaced all usages with `PUBKEY_API_TYPE`
- A bit of a nit but renamed PubKey to Pubkey to match how it is in the spec https://github.com/ethereum/keymanager-APIs/blob/master/apis/gas_limit.yaml

## Fixed Issue(s)
fixes #5792 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
