### PR TITLE
Revert "Remove image signing from uploadDocker task (#7077)"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -570,7 +570,7 @@ task uploadDocker {
         exec {
           workingDir dockerBuildDir
           executable "sh"
-          args "-c", "docker push ${t} "
+          args "-c", "docker trust sign ${t} && docker push ${t} "
         }
       }
     }


### PR DESCRIPTION
## PR Description
It looks like docker signing service is working again. We can restore image signing.

## Fixed Issue(s)
N/A

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
