### PR TITLE
Dependency updates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,9 +24,9 @@ plugins {
   id 'com.github.ben-manes.versions' version '0.46.0'
   id 'com.github.jk1.dependency-license-report' version '2.1'
   id 'io.spring.dependency-management' version '1.1.0'
-  id 'net.ltgt.errorprone' version '3.0.1' apply false
+  id 'net.ltgt.errorprone' version '3.1.0' apply false
   id 'de.undercouch.download' version '5.4.0'
-  id 'org.ajoberstar.grgit' version '5.0.0'
+  id 'org.ajoberstar.grgit' version '5.2.0'
 }
 
 rootProject.version = calculatePublishVersion()

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -1,9 +1,9 @@
 dependencyManagement {
   dependencies {
-    dependency 'com.fasterxml.jackson.core:jackson-databind:2.14.2'
-    dependency 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.14.2'
-    dependency 'com.fasterxml.jackson.dataformat:jackson-dataformat-toml:2.14.2'
-    dependency 'com.fasterxml.jackson.module:jackson-module-kotlin:2.14.2'
+    dependency 'com.fasterxml.jackson.core:jackson-databind:2.15.0'
+    dependency 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.15.0'
+    dependency 'com.fasterxml.jackson.dataformat:jackson-dataformat-toml:2.15.0'
+    dependency 'com.fasterxml.jackson.module:jackson-module-kotlin:2.15.0'
 
 
     dependency 'com.google.auto.service:auto-service:1.0-rc7'
@@ -21,7 +21,7 @@ dependencyManagement {
     dependency 'com.google.code.gson:gson:2.10.1'
 
     dependency 'com.googlecode.json-simple:json-simple:1.1.1'
-    dependency 'org.jsoup:jsoup:1.15.4'
+    dependency 'org.jsoup:jsoup:1.16.1'
 
     dependency 'com.launchdarkly:okhttp-eventsource:4.1.0'
 
@@ -30,7 +30,7 @@ dependencyManagement {
 
     dependency 'commons-cli:commons-cli:1.4'
 
-    dependency 'info.picocli:picocli:4.7.2'
+    dependency 'info.picocli:picocli:4.7.3'
 
     dependencySet(group: 'io.javalin', version: '5.4.2') {
       entry 'javalin'
@@ -45,7 +45,7 @@ dependencyManagement {
 
     dependency 'org.hdrhistogram:HdrHistogram:2.1.12'
 
-    dependency 'org.jetbrains.kotlin:kotlin-stdlib:1.8.20'
+    dependency 'org.jetbrains.kotlin:kotlin-stdlib:1.8.21'
 
     dependency 'io.pkts:pkts-core:3.0.3'
 
@@ -113,13 +113,13 @@ dependencyManagement {
 
     dependency 'org.java-websocket:Java-WebSocket:1.5.2'
 
-    dependencySet(group: 'org.junit.jupiter', version: '5.9.2') {
+    dependencySet(group: 'org.junit.jupiter', version: '5.9.3') {
       entry 'junit-jupiter-api'
       entry 'junit-jupiter-engine'
       entry 'junit-jupiter-params'
     }
 
-    dependencySet(group: 'org.mockito', version: '5.3.0') {
+    dependencySet(group: 'org.mockito', version: '5.3.1') {
       entry 'mockito-core'
       entry 'mockito-junit-jupiter'
     }
@@ -171,7 +171,7 @@ dependencyManagement {
       exclude 'org.apache.tuweni:units'
     }
 
-    dependency 'tech.pegasys.signers.internal:bls-keystore:2.2.9'
+    dependency 'tech.pegasys.signers.internal:bls-keystore:2.2.10'
 
     dependency 'org.jupnp:org.jupnp.support:2.7.0'
     dependency 'org.jupnp:org.jupnp:2.7.0'


### PR DESCRIPTION
## PR Description

```
- com.fasterxml.jackson.core:jackson-databind [2.14.2 -> 2.15.0] ✅
     https://github.com/FasterXML/jackson
 - com.fasterxml.jackson.dataformat:jackson-dataformat-toml [2.14.2 -> 2.15.0] ✅
     https://github.com/FasterXML/jackson-dataformats-text
 - com.fasterxml.jackson.dataformat:jackson-dataformat-yaml [2.14.2 -> 2.15.0] ✅
     https://github.com/FasterXML/jackson-dataformats-text
 - com.fasterxml.jackson.module:jackson-module-kotlin [2.14.2 -> 2.15.0] ✅
     https://github.com/FasterXML/jackson-module-kotlin
 - com.squareup.okhttp3:mockwebserver [4.10.0 -> 5.0.0-alpha.11] ❌
     https://square.github.io/okhttp/
 - com.squareup.okhttp3:okhttp [4.10.0 -> 5.0.0-alpha.11] ❌
     https://square.github.io/okhttp/
 - info.picocli:picocli [4.7.2 -> 4.7.3] ✅
     https://picocli.info
 - io.prometheus:simpleclient [0.9.0 -> 0.16.0] ❌
     http://github.com/prometheus/client_java
 - net.ltgt.errorprone:net.ltgt.errorprone.gradle.plugin [3.0.1 -> 3.1.0] ✅
 - org.ajoberstar.grgit:org.ajoberstar.grgit.gradle.plugin [5.0.0 -> 5.2.0] ✅
     https://github.com/ajoberstar/grgit
 - org.hyperledger.besu:besu-datatypes [22.10.4 -> 23.4.0] ❌
     http://github.com/hyperledger/besu
 - org.hyperledger.besu:evm [22.10.4 -> 23.4.0] ❌
     http://github.com/hyperledger/besu
 - org.hyperledger.besu:plugin-api [22.10.4 -> 23.4.0] ❌
     http://github.com/hyperledger/besu
 - org.hyperledger.besu.internal:config [22.10.4 -> 23.4.0] ❌
     http://github.com/hyperledger/besu
 - org.hyperledger.besu.internal:core [22.10.4 -> 23.4.0] ❌
     http://github.com/hyperledger/besu
 - org.hyperledger.besu.internal:metrics-core [22.10.4 -> 23.4.0] ❌
     http://github.com/hyperledger/besu
 - org.jetbrains.kotlin:kotlin-stdlib [1.8.20 -> 1.8.21] ✅
     https://kotlinlang.org/
 - org.jsoup:jsoup [1.15.4 -> 1.16.1] ✅
     https://jsoup.org/
 - org.junit.jupiter:junit-jupiter-api [5.9.2 -> 5.9.3] ✅
     https://junit.org/junit5/
 - org.junit.jupiter:junit-jupiter-engine [5.9.2 -> 5.9.3] ✅
     https://junit.org/junit5/
 - org.junit.jupiter:junit-jupiter-params [5.9.2 -> 5.9.3] ✅
     https://junit.org/junit5/
 - org.mockito:mockito-core [5.3.0 -> 5.3.1] ✅
     https://github.com/mockito/mockito
 - org.quartz-scheduler:quartz [2.3.2 -> 2.5.0-rc1] ❌
     https://www.quartz-scheduler.org/
 - org.rocksdb:rocksdbjni [7.7.3 -> 8.1.1.1] ❌
     https://rocksdb.org
 - org.web3j:core [4.9.8 -> 5.0.0] ❌
     https://web3j.io
 - tech.pegasys.signers.internal:bls-keystore [2.2.9 -> 2.2.10] ✅
     http://github.com/ConsenSys/signers

Gradle release-candidate updates:
 - Gradle: [8.1 -> 8.1.1] ❌\
```

## Fixed Issue(s)
N/A

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
