### PR TITLE
BlobSidecar pool immediate fetch for non-current-slot  + prepare for data unavailable retry

### DIFF
--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/BatchImporter.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/BatchImporter.java
@@ -116,7 +116,7 @@ public class BatchImporter {
         blockRoot);
     // Add blob sidecars to the pool in order for them to be available when the block is being
     // imported
-    blobSidecarPool.onBlobSidecarsFromSync(block, blobSidecars);
+    blobSidecarPool.onCompletedBlockAndBlobSidecars(block, blobSidecars);
     return importBlock(block, source);
   }
 

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/singlepeer/PeerSync.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/singlepeer/PeerSync.java
@@ -62,7 +62,7 @@ public class PeerSync {
           FailureReason.FAILED_WEAK_SUBJECTIVITY_CHECKS,
           FailureReason.FAILED_STATE_TRANSITION,
           FailureReason.UNKNOWN_PARENT,
-          FailureReason.FAILED_BLOBS_AVAILABILITY_CHECK);
+          FailureReason.FAILED_DATA_AVAILABILITY_CHECK_INVALID);
 
   private static final Logger LOG = LogManager.getLogger();
   static final int MAX_THROTTLED_REQUESTS = 10;
@@ -340,7 +340,7 @@ public class PeerSync {
     // Add blob sidecars to the pool in order for them to be available when the block is being
     // imported
     maybeBlobSidecars.ifPresent(
-        blobSidecars -> blobSidecarPool.onBlobSidecarsFromSync(block, blobSidecars));
+        blobSidecars -> blobSidecarPool.onCompletedBlockAndBlobSidecars(block, blobSidecars));
 
     return blockImporter
         .importBlock(block)

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/BatchImporterTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/BatchImporterTest.java
@@ -250,7 +250,7 @@ class BatchImporterTest {
 
   private void blobSidecarsImportedSuccessfully(
       final SignedBeaconBlock block, final List<BlobSidecar> blobSidecars) {
-    verify(blobSidecarPool).onBlobSidecarsFromSync(block, blobSidecars);
+    verify(blobSidecarPool).onCompletedBlockAndBlobSidecars(block, blobSidecars);
     verifyNoMoreInteractions(blobSidecarPool);
   }
 

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/singlepeer/PeerSyncTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/singlepeer/PeerSyncTest.java
@@ -553,7 +553,8 @@ public class PeerSyncTest extends AbstractSyncTest {
       if (!blobSidecarsBySlot.containsKey(slot)) {
         Assertions.fail("Blob sidecars for slot %s is missing", slot);
       }
-      verify(blobSidecarPool).onBlobSidecarsFromSync(any(), eq(blobSidecarsBySlot.get(slot)));
+      verify(blobSidecarPool)
+          .onCompletedBlockAndBlobSidecars(any(), eq(blobSidecarsBySlot.get(slot)));
     }
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/results/BlockImportResult.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/results/BlockImportResult.java
@@ -34,8 +34,14 @@ public interface BlockImportResult {
   BlockImportResult FAILED_DESCENDANT_OF_INVALID_BLOCK =
       new FailedBlockImportResult(FailureReason.DESCENDANT_OF_INVALID_BLOCK, Optional.empty());
 
-  static BlockImportResult failedBlobsAvailabilityCheck(final Optional<Throwable> cause) {
-    return new FailedBlockImportResult(FailureReason.FAILED_BLOBS_AVAILABILITY_CHECK, cause);
+  static BlockImportResult failedDataAvailabilityCheckInvalid(final Optional<Throwable> cause) {
+    return new FailedBlockImportResult(FailureReason.FAILED_DATA_AVAILABILITY_CHECK_INVALID, cause);
+  }
+
+  static BlockImportResult failedDataAvailabilityCheckNotAvailable(
+      final Optional<Throwable> cause) {
+    return new FailedBlockImportResult(
+        FailureReason.FAILED_DATA_AVAILABILITY_CHECK_NOT_AVAILABLE, cause);
   }
 
   static BlockImportResult failedExecutionPayloadExecution(final Throwable cause) {
@@ -74,7 +80,8 @@ public interface BlockImportResult {
     FAILED_EXECUTION_PAYLOAD_EXECUTION,
     FAILED_EXECUTION_PAYLOAD_EXECUTION_SYNCING,
     DESCENDANT_OF_INVALID_BLOCK,
-    FAILED_BLOBS_AVAILABILITY_CHECK,
+    FAILED_DATA_AVAILABILITY_CHECK_INVALID,
+    FAILED_DATA_AVAILABILITY_CHECK_NOT_AVAILABLE,
     INTERNAL_ERROR // A catch-all category for unexpected errors (bugs)
   }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blobs/BlobSidecarPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blobs/BlobSidecarPool.java
@@ -37,7 +37,7 @@ public interface BlobSidecarPool extends SlotEventsChannel {
         public void onNewBlock(final SignedBeaconBlock block) {}
 
         @Override
-        public void onBlobSidecarsFromSync(
+        public void onCompletedBlockAndBlobSidecars(
             final SignedBeaconBlock block, final List<BlobSidecar> blobSidecars) {}
 
         @Override
@@ -80,7 +80,7 @@ public interface BlobSidecarPool extends SlotEventsChannel {
 
   void onNewBlock(SignedBeaconBlock block);
 
-  void onBlobSidecarsFromSync(SignedBeaconBlock block, List<BlobSidecar> blobSidecars);
+  void onCompletedBlockAndBlobSidecars(SignedBeaconBlock block, List<BlobSidecar> blobSidecars);
 
   void removeAllForBlock(Bytes32 blockRoot);
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -378,14 +378,24 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
           payloadResult.getFailureCause().orElseThrow());
     }
 
-    if (blobSidecarsAndValidationResult.isFailure()) {
-      LOG.error(
-          "blobsSidecar validation result: {}", blobSidecarsAndValidationResult.toLogString());
-      return BlockImportResult.failedBlobsAvailabilityCheck(
-          blobSidecarsAndValidationResult.getCause());
-    } else {
-      LOG.debug(
-          "blobsSidecar validation result: {}", blobSidecarsAndValidationResult.toLogString());
+    switch (blobSidecarsAndValidationResult.getValidationResult()) {
+      case VALID:
+      case NOT_REQUIRED:
+        LOG.debug(
+            "blobsSidecar validation result: {}", blobSidecarsAndValidationResult::toLogString);
+
+        break;
+      case NOT_AVAILABLE:
+        LOG.warn(
+            "blobsSidecar validation result: {}", blobSidecarsAndValidationResult::toLogString);
+        return BlockImportResult.failedDataAvailabilityCheckNotAvailable(
+            blobSidecarsAndValidationResult.getCause());
+
+      case INVALID:
+        LOG.error(
+            "blobsSidecar validation result: {}", blobSidecarsAndValidationResult::toLogString);
+        return BlockImportResult.failedDataAvailabilityCheckInvalid(
+            blobSidecarsAndValidationResult.getCause());
     }
 
     final ForkChoiceStrategy forkChoiceStrategy = getForkChoiceStrategy();

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/BlobSidecarPoolImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/BlobSidecarPoolImpl.java
@@ -175,7 +175,7 @@ public class BlobSidecarPoolImpl extends AbstractIgnoringFutureHistoricalSlot
   }
 
   @Override
-  public synchronized void onBlobSidecarsFromSync(
+  public synchronized void onCompletedBlockAndBlobSidecars(
       final SignedBeaconBlock block, final List<BlobSidecar> blobSidecars) {
     final SlotAndBlockRoot slotAndBlockRoot = block.getSlotAndBlockRoot();
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
@@ -196,7 +196,7 @@ class ForkChoiceTest {
     //
     // .thenReturn(SafeFuture.completedFuture(BlobsSidecarAndValidationResult.NOT_AVAILABLE));
 
-    importBlockWithError(blockAndState, FailureReason.FAILED_BLOBS_AVAILABILITY_CHECK);
+    importBlockWithError(blockAndState, FailureReason.FAILED_DATA_AVAILABILITY_CHECK_INVALID);
 
     //    verify(blobSidecarManager).createAvailabilityChecker(blockAndState.getBlock());
     //    verify(blobSidecarAvailabilityChecker).initiateDataAvailabilityCheck();

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/BlobSidecarPoolImplTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/BlobSidecarPoolImplTest.java
@@ -777,7 +777,6 @@ public class BlobSidecarPoolImplTest {
 
     final Duration fetchDelay = blobSidecarPool.calculateFetchDelay(slotAndBlockRoot);
 
-    // we can only wait 200ms less than target
     assertThat(fetchDelay).isEqualTo(Duration.ZERO);
   }
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/BlobSidecarPoolImplTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/BlobSidecarPoolImplTest.java
@@ -249,14 +249,14 @@ public class BlobSidecarPoolImplTest {
   }
 
   @Test
-  public void onBlobSidecarsFromSync_shouldCreateTrackerIgnoringHistoricalTolerance() {
+  public void onCompletedBlockAndBlobSidecars_shouldCreateTrackerIgnoringHistoricalTolerance() {
     final UInt64 slot = currentSlot.minus(historicalTolerance).minus(UInt64.ONE);
 
     final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(slot);
 
     final List<BlobSidecar> blobSidecars = dataStructureUtil.randomBlobSidecarsForBlock(block);
 
-    blobSidecarPool.onBlobSidecarsFromSync(block, blobSidecars);
+    blobSidecarPool.onCompletedBlockAndBlobSidecars(block, blobSidecars);
 
     assertThat(asyncRunner.hasDelayedActions()).isFalse();
 
@@ -285,7 +285,7 @@ public class BlobSidecarPoolImplTest {
 
     final List<BlobSidecar> blobSidecars = List.of();
 
-    blobSidecarPool.onBlobSidecarsFromSync(block, blobSidecars);
+    blobSidecarPool.onCompletedBlockAndBlobSidecars(block, blobSidecars);
 
     assertThat(asyncRunner.hasDelayedActions()).isFalse();
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/BlobSidecarPoolImplTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/BlobSidecarPoolImplTest.java
@@ -565,24 +565,24 @@ public class BlobSidecarPoolImplTest {
   }
 
   @Test
-  public void shouldNotFetchContentWhenBlockIsNotForCurrentSlot() {
+  public void shouldFetchContentWhenBlockIsNotForCurrentSlot() {
     final UInt64 slot = currentSlot.minus(UInt64.ONE);
     final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(slot);
 
     blobSidecarPool.onNewBlock(block);
 
-    assertThat(asyncRunner.hasDelayedActions()).isFalse();
+    assertThat(asyncRunner.hasDelayedActions()).isTrue();
   }
 
   @Test
-  public void shouldNotFetchContentWhenBlobSidecarIsNotForCurrentSlot() {
+  public void shouldFetchContentWhenBlobSidecarIsNotForCurrentSlot() {
     final UInt64 slot = currentSlot.minus(UInt64.ONE);
     final BlobSidecar blobSidecar =
         dataStructureUtil.createRandomBlobSidecarBuilder().slot(slot).build();
 
     blobSidecarPool.onNewBlobSidecar(blobSidecar);
 
-    assertThat(asyncRunner.hasDelayedActions()).isFalse();
+    assertThat(asyncRunner.hasDelayedActions()).isTrue();
   }
 
   @Test
@@ -698,11 +698,10 @@ public class BlobSidecarPoolImplTest {
     // blocks arrives at slot start
     timeProvider.advanceTimeBySeconds(startSlotInSeconds.longValue());
 
-    final Optional<Duration> fetchDelay = blobSidecarPool.calculateFetchDelay(slotAndBlockRoot);
+    final Duration fetchDelay = blobSidecarPool.calculateFetchDelay(slotAndBlockRoot);
 
     // we can wait the full target
-    assertThat(fetchDelay)
-        .isEqualTo(Optional.of(Duration.ofMillis(TARGET_WAIT_MILLIS.longValue())));
+    assertThat(fetchDelay).isEqualTo(Duration.ofMillis(TARGET_WAIT_MILLIS.longValue()));
   }
 
   @Test
@@ -718,10 +717,10 @@ public class BlobSidecarPoolImplTest {
     // blocks arrives 200ms before attestation due
     timeProvider.advanceTimeByMillis(startSlotInMillis.plus(3_800).longValue());
 
-    final Optional<Duration> fetchDelay = blobSidecarPool.calculateFetchDelay(slotAndBlockRoot);
+    final Duration fetchDelay = blobSidecarPool.calculateFetchDelay(slotAndBlockRoot);
 
     // we can wait the full target
-    assertThat(fetchDelay).isEqualTo(Optional.of(Duration.ofMillis(MIN_WAIT_MILLIS.longValue())));
+    assertThat(fetchDelay).isEqualTo(Duration.ofMillis(MIN_WAIT_MILLIS.longValue()));
   }
 
   @Test
@@ -736,11 +735,10 @@ public class BlobSidecarPoolImplTest {
     // blocks arrives 1s after attestation due
     timeProvider.advanceTimeBySeconds(startSlotInSeconds.plus(5).longValue());
 
-    final Optional<Duration> fetchDelay = blobSidecarPool.calculateFetchDelay(slotAndBlockRoot);
+    final Duration fetchDelay = blobSidecarPool.calculateFetchDelay(slotAndBlockRoot);
 
     // we can wait the full target
-    assertThat(fetchDelay)
-        .isEqualTo(Optional.of(Duration.ofMillis(TARGET_WAIT_MILLIS.longValue())));
+    assertThat(fetchDelay).isEqualTo(Duration.ofMillis(TARGET_WAIT_MILLIS.longValue()));
   }
 
   @Test
@@ -764,25 +762,23 @@ public class BlobSidecarPoolImplTest {
 
     timeProvider.advanceTimeByMillis(blockArrivalTimeMillis.longValue());
 
-    final Optional<Duration> fetchDelay = blobSidecarPool.calculateFetchDelay(slotAndBlockRoot);
+    final Duration fetchDelay = blobSidecarPool.calculateFetchDelay(slotAndBlockRoot);
 
     // we can only wait 200ms less than target
     assertThat(fetchDelay)
         .isEqualTo(
-            Optional.of(
-                Duration.ofMillis(
-                    TARGET_WAIT_MILLIS.minus(millisecondsIntoAttDueLimit).longValue())));
+            Duration.ofMillis(TARGET_WAIT_MILLIS.minus(millisecondsIntoAttDueLimit).longValue()));
   }
 
   @Test
-  void calculateFetchDelay_shouldReturnEmptyIfSlotIsOld() {
+  void calculateFetchDelay_shouldReturnZeroIfSlotIsOld() {
     final SlotAndBlockRoot slotAndBlockRoot =
         new SlotAndBlockRoot(currentSlot.minus(1), dataStructureUtil.randomBytes32());
 
-    final Optional<Duration> fetchDelay = blobSidecarPool.calculateFetchDelay(slotAndBlockRoot);
+    final Duration fetchDelay = blobSidecarPool.calculateFetchDelay(slotAndBlockRoot);
 
     // we can only wait 200ms less than target
-    assertThat(fetchDelay).isEqualTo(Optional.empty());
+    assertThat(fetchDelay).isEqualTo(Duration.ZERO);
   }
 
   @Test


### PR DESCRIPTION
- Renames pool's `onBlobSidecarsFromSync` method to `onCompletedBlockAndBlobSidecars`, moving away from flow-based name to a feature-based one
- Splits `FAILED_DATA_AVAILABILITY_CHECK` block import failure in two reasons:
  - `FAILED_DATA_AVAILABILITY_CHECK_INVALID`: data was there but validation failed
  - `FAILED_DATA_AVAILABILITY_CHECK_NOT_AVAILABLE`: data wasn't available
- Modifies the BlobSidecar pool to try to fetch immediately when tracked data (block\blobs) are for a past slot  

The "not available" one will be used to trigger a retry (on a dedicated PR)

related to #7112

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
