### PR TITLE
Initial logic for calculating total attestation rewards for epoch

### DIFF
--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/JsonTypeDefinitionBeaconRestApi.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/JsonTypeDefinitionBeaconRestApi.java
@@ -262,7 +262,7 @@ public class JsonTypeDefinitionBeaconRestApi implements BeaconRestApi {
             // Rewards Handlers
             .endpoint(new GetSyncCommitteeRewards(dataProvider))
             .endpoint(new GetBlockRewards(dataProvider))
-            .endpoint(new GetAttestationRewards())
+            .endpoint(new GetAttestationRewards(dataProvider.getChainDataProvider()))
             // Validator Handlers
             .endpoint(new PostAttesterDuties(dataProvider))
             .endpoint(new GetProposerDuties(dataProvider))

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/rewards/GetAttestationRewards.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/rewards/GetAttestationRewards.java
@@ -114,7 +114,7 @@ public class GetAttestationRewards extends RestApiEndpoint {
 
     request.respondAsync(
         chainDataProvider
-            .calculateEpochAttestationRewards(epoch, validatorsPubKeys)
+            .calculateAttestationRewardsAtEpoch(epoch, validatorsPubKeys)
             .thenApply(
                 result ->
                     result

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/rewards/GetAttestationRewards.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/rewards/GetAttestationRewards.java
@@ -26,20 +26,25 @@ import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.STRING_TYPE;
 import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.UINT64_TYPE;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import org.apache.commons.lang3.NotImplementedException;
+import java.util.List;
+import tech.pegasys.teku.api.ChainDataProvider;
 import tech.pegasys.teku.api.migrated.AttestationRewardsData;
 import tech.pegasys.teku.api.migrated.GetAttestationRewardsResponse;
 import tech.pegasys.teku.api.migrated.IdealAttestationReward;
 import tech.pegasys.teku.api.migrated.TotalAttestationReward;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 import tech.pegasys.teku.infrastructure.json.types.SerializableTypeDefinition;
+import tech.pegasys.teku.infrastructure.restapi.endpoints.AsyncApiResponse;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.EndpointMetadata;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiEndpoint;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiRequest;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 public class GetAttestationRewards extends RestApiEndpoint {
 
   public static final String ROUTE = "/eth/v1/beacon/rewards/attestations/{epoch}";
+
+  private final ChainDataProvider chainDataProvider;
 
   private static final SerializableTypeDefinition<IdealAttestationReward> IDEAL_REWARDS_TYPE =
       SerializableTypeDefinition.object(IdealAttestationReward.class)
@@ -82,13 +87,14 @@ public class GetAttestationRewards extends RestApiEndpoint {
           .withField("data", DATA_TYPE, GetAttestationRewardsResponse::getAttestationRewardsData)
           .build();
 
-  public GetAttestationRewards() {
+  public GetAttestationRewards(final ChainDataProvider chainDataProvider) {
     super(
         EndpointMetadata.post(ROUTE)
             .operationId("getAttestationsRewards")
             .summary("Get Attestations Rewards")
             .description(
-                "Retrieve attestation reward info for validators specified by array of public keys or validator index. If no array is provided, return reward info for every validator.")
+                "Retrieve attestation reward info for validators specified by array of public keys or validator index"
+                    + ". If no array is provided, return reward info for every validator.")
             .tags(TAG_BEACON, TAG_REWARDS, TAG_EXPERIMENTAL)
             .pathParam(EPOCH_PARAMETER)
             .requestBodyType(DeserializableTypeDefinition.listOf(STRING_TYPE))
@@ -97,10 +103,23 @@ public class GetAttestationRewards extends RestApiEndpoint {
             .withNotFoundResponse()
             .withInternalErrorResponse()
             .build());
+
+    this.chainDataProvider = chainDataProvider;
   }
 
   @Override
   public void handleRequest(RestApiRequest request) throws JsonProcessingException {
-    throw new NotImplementedException();
+    final UInt64 epoch = request.getPathParameter(EPOCH_PARAMETER);
+    final List<String> validatorsPubKeys = request.getRequestBody();
+
+    request.respondAsync(
+        chainDataProvider
+            .calculateEpochAttestationRewards(epoch, validatorsPubKeys)
+            .thenApply(
+                result ->
+                    result
+                        .map(data -> new GetAttestationRewardsResponse(false, true, data))
+                        .map(AsyncApiResponse::respondOk)
+                        .orElse(AsyncApiResponse.respondNotFound())));
   }
 }

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/rewards/GetAttestationRewardsTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/rewards/GetAttestationRewardsTest.java
@@ -55,7 +55,7 @@ class GetAttestationRewardsTest extends AbstractMigratedBeaconHandlerTest {
 
   @BeforeEach
   void setup() {
-    setHandler(new GetAttestationRewards());
+    setHandler(new GetAttestationRewards(chainDataProvider));
   }
 
   @Test

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
@@ -593,21 +593,16 @@ public class ChainDataProvider {
           "Can't calculate attestation rewards for for epoch " + epoch + " pre Altair");
     }
 
-    final SafeFuture<Optional<StateAndMetaData>> stateFuture =
-        defaultStateSelectorFactory.forSlot(slot).getState();
-
-    return stateFuture.thenCompose(
-        maybeState -> {
-          if (maybeState.isEmpty()) {
-            return SafeFuture.completedFuture(Optional.empty());
-          }
-
-          final EpochAttestationRewardsCalculator epochAttestationRewardsCalculator =
-              new EpochAttestationRewardsCalculator(
-                  spec.atSlot(slot), maybeState.get().getData(), validatorsPubKeys);
-          return SafeFuture.completedFuture(
-              Optional.of(epochAttestationRewardsCalculator.calculate()));
-        });
+    return defaultStateSelectorFactory
+        .forSlot(slot)
+        .getState()
+        .thenApply(
+            maybeState ->
+                maybeState.map(
+                    stateAndMetaData ->
+                        new EpochAttestationRewardsCalculator(
+                                spec.atSlot(slot), maybeState.get().getData(), validatorsPubKeys)
+                            .calculate()));
   }
 
   private UInt64 findSlotAtEndOfNextEpoch(final UInt64 epoch) {

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
@@ -587,6 +587,12 @@ public class ChainDataProvider {
   public SafeFuture<Optional<AttestationRewardsData>> calculateEpochAttestationRewards(
       final UInt64 epoch, final List<String> validatorsPubKeys) {
     final UInt64 slot = findSlotAtEndOfNextEpoch(epoch);
+
+    if (!spec.atEpoch(epoch).getMilestone().isGreaterThanOrEqualTo(SpecMilestone.ALTAIR)) {
+      throw new BadRequestException(
+          "Can't calculate attestation rewards for for epoch " + epoch + " pre Altair");
+    }
+
     final SafeFuture<Optional<StateAndMetaData>> stateFuture =
         defaultStateSelectorFactory.forSlot(slot).getState();
 

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
@@ -37,6 +37,7 @@ import org.apache.tuweni.bytes.Bytes48;
 import tech.pegasys.teku.api.blockselector.BlockSelectorFactory;
 import tech.pegasys.teku.api.exceptions.BadRequestException;
 import tech.pegasys.teku.api.exceptions.ServiceUnavailableException;
+import tech.pegasys.teku.api.migrated.AttestationRewardsData;
 import tech.pegasys.teku.api.migrated.BlockHeadersResponse;
 import tech.pegasys.teku.api.migrated.BlockRewardData;
 import tech.pegasys.teku.api.migrated.StateSyncCommitteesData;
@@ -45,6 +46,7 @@ import tech.pegasys.teku.api.migrated.StateValidatorData;
 import tech.pegasys.teku.api.migrated.SyncCommitteeRewardData;
 import tech.pegasys.teku.api.response.v1.beacon.GenesisData;
 import tech.pegasys.teku.api.response.v1.beacon.ValidatorStatus;
+import tech.pegasys.teku.api.rewards.EpochAttestationRewardsCalculator;
 import tech.pegasys.teku.api.schema.BeaconState;
 import tech.pegasys.teku.api.schema.Fork;
 import tech.pegasys.teku.api.stateselector.StateSelectorFactory;
@@ -580,6 +582,37 @@ public class ChainDataProvider {
                               state ->
                                   rewardCalculator.getBlockRewardData(blockAndMetaData, state)));
             });
+  }
+
+  public SafeFuture<Optional<AttestationRewardsData>> calculateEpochAttestationRewards(
+      final UInt64 epoch, final List<String> validatorsPubKeys) {
+    final UInt64 slot = findSlotAtEndOfNextEpoch(epoch);
+    final SafeFuture<Optional<StateAndMetaData>> stateFuture =
+        defaultStateSelectorFactory.forSlot(slot).getState();
+
+    return stateFuture.thenCompose(
+        maybeState -> {
+          if (maybeState.isEmpty()) {
+            return SafeFuture.completedFuture(Optional.empty());
+          }
+
+          final EpochAttestationRewardsCalculator epochAttestationRewardsCalculator =
+              new EpochAttestationRewardsCalculator(
+                  spec.atSlot(slot), maybeState.get().getData(), validatorsPubKeys);
+          return SafeFuture.completedFuture(
+              Optional.of(epochAttestationRewardsCalculator.calculate()));
+        });
+  }
+
+  private UInt64 findSlotAtEndOfNextEpoch(final UInt64 epoch) {
+    /*
+     We need to fetch the state corresponding to the slot at the end of the next epoch because attestations can
+     be included up to the end of the next epoch of the slot they are attesting to.
+
+     Example: if user is requests rewards for epoch 10, we find the slot at the start of epoch 12 and
+     subtract 1 to get the end slot of epoch 11.
+    */
+    return spec.computeStartSlotAtEpoch(epoch.plus(2)).minus(1);
   }
 
   public SpecMilestone getMilestoneAtSlot(final UInt64 slot) {

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
@@ -584,7 +584,7 @@ public class ChainDataProvider {
             });
   }
 
-  public SafeFuture<Optional<AttestationRewardsData>> calculateEpochAttestationRewards(
+  public SafeFuture<Optional<AttestationRewardsData>> calculateAttestationRewardsAtEpoch(
       final UInt64 epoch, final List<String> validatorsPubKeys) {
     final UInt64 slot = findSlotAtEndOfNextEpoch(epoch);
 

--- a/data/provider/src/main/java/tech/pegasys/teku/api/rewards/EpochAttestationRewardsCalculator.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/rewards/EpochAttestationRewardsCalculator.java
@@ -13,86 +13,22 @@
 
 package tech.pegasys.teku.api.rewards;
 
-import static java.util.stream.Collectors.toList;
-
 import java.util.List;
-import java.util.stream.IntStream;
-import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.api.migrated.AttestationRewardsData;
-import tech.pegasys.teku.api.migrated.IdealAttestationReward;
-import tech.pegasys.teku.api.migrated.TotalAttestationReward;
-import tech.pegasys.teku.infrastructure.ssz.SszList;
-import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.SpecVersion;
-import tech.pegasys.teku.spec.constants.EthConstants;
-import tech.pegasys.teku.spec.datastructures.state.Validator;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
-import tech.pegasys.teku.spec.logic.common.statetransition.epoch.EpochProcessor;
-import tech.pegasys.teku.spec.logic.common.statetransition.epoch.RewardAndPenaltyDeltas;
-import tech.pegasys.teku.spec.logic.common.statetransition.epoch.status.ValidatorStatuses;
 
 public class EpochAttestationRewardsCalculator {
-
-  private static final Logger LOG = LogManager.getLogger();
-
-  private final BeaconState state;
-  private final EpochProcessor epochProcessor;
-  private final ValidatorStatuses validatorStatuses;
-  private final List<Integer> validatorIndexes;
 
   public EpochAttestationRewardsCalculator(
       final SpecVersion specVersion,
       final BeaconState state,
       final List<String> validatorPublicKeys) {
-    this.state = state;
-    this.epochProcessor = specVersion.getEpochProcessor();
-    this.validatorStatuses = specVersion.getValidatorStatusFactory().createValidatorStatuses(state);
-    this.validatorIndexes = getValidatorIndexes(state, validatorPublicKeys);
+    //TODO implement EpochAttestationRewardsCalculator business logic
   }
 
-  private List<Integer> getValidatorIndexes(
-      final BeaconState state, final List<String> validatorPublicKeys) {
-    final SszList<Validator> allValidators = state.getValidators();
-    return IntStream.range(0, allValidators.size())
-        .filter(
-            i ->
-                validatorPublicKeys.isEmpty()
-                    || validatorPublicKeys.contains(
-                        allValidators.get(i).getPublicKey().toHexString()))
-        .filter(i -> validatorStatuses.getStatuses().get(i).isEligibleValidator())
-        .boxed()
-        .collect(toList());
-  }
 
   public AttestationRewardsData calculate() {
-    try {
-      final List<TotalAttestationReward> totalAttestationRewards = totalAttestationRewards();
-      final List<IdealAttestationReward> idealAttestationRewards = idealAttestationRewards();
-      return new AttestationRewardsData(idealAttestationRewards, totalAttestationRewards);
-    } catch (RuntimeException ex) {
-      LOG.error("Error calculating detailed rewards and penalties", ex);
-      throw ex;
-    }
-  }
-
-  private List<TotalAttestationReward> totalAttestationRewards() {
-    final RewardAndPenaltyDeltas totalRewardAndPenaltyDeltas =
-        epochProcessor.getDetailedRewardAndPenaltyDeltas(state, validatorStatuses);
-
-    return validatorIndexes.stream()
-        .map(i -> new ImmutablePair<>(i, totalRewardAndPenaltyDeltas.getDelta(i)))
-        .map(p -> new TotalAttestationReward(p.left, p.right))
-        .collect(toList());
-  }
-
-  public List<IdealAttestationReward> idealAttestationRewards() {
-    // TODO-lucas not implemented yet
-    return IntStream.rangeClosed(0, 32)
-        .boxed()
-        .map(UInt64::valueOf)
-        .map(i -> new IdealAttestationReward(EthConstants.ETH_TO_GWEI.times(i), 0L, 0L, 0L))
-        .collect(toList());
+    return new AttestationRewardsData(List.of(), List.of());
   }
 }

--- a/data/provider/src/main/java/tech/pegasys/teku/api/rewards/EpochAttestationRewardsCalculator.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/rewards/EpochAttestationRewardsCalculator.java
@@ -13,18 +13,52 @@
 
 package tech.pegasys.teku.api.rewards;
 
-import java.util.List;
-import tech.pegasys.teku.api.migrated.AttestationRewardsData;
-import tech.pegasys.teku.spec.SpecVersion;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import static java.util.stream.Collectors.toList;
 
+import java.util.List;
+import java.util.stream.IntStream;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import tech.pegasys.teku.api.migrated.AttestationRewardsData;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
+import tech.pegasys.teku.spec.SpecVersion;
+import tech.pegasys.teku.spec.datastructures.state.Validator;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.logic.common.statetransition.epoch.EpochProcessor;
+import tech.pegasys.teku.spec.logic.common.statetransition.epoch.status.ValidatorStatuses;
+
+@SuppressWarnings("unused")
 public class EpochAttestationRewardsCalculator {
+
+  private static final Logger LOG = LogManager.getLogger();
+
+  private final BeaconState state;
+  private final EpochProcessor epochProcessor;
+  private final ValidatorStatuses validatorStatuses;
+  private final List<Integer> validatorIndexes;
 
   public EpochAttestationRewardsCalculator(
       final SpecVersion specVersion,
       final BeaconState state,
       final List<String> validatorPublicKeys) {
-    // TODO implement EpochAttestationRewardsCalculator business logic
+    this.state = state;
+    this.epochProcessor = specVersion.getEpochProcessor();
+    this.validatorStatuses = specVersion.getValidatorStatusFactory().createValidatorStatuses(state);
+    this.validatorIndexes = getValidatorIndexes(state, validatorPublicKeys);
+  }
+
+  private List<Integer> getValidatorIndexes(
+      final BeaconState state, final List<String> validatorPublicKeys) {
+    final SszList<Validator> allValidators = state.getValidators();
+    return IntStream.range(0, allValidators.size())
+        .filter(
+            i ->
+                validatorPublicKeys.isEmpty()
+                    || validatorPublicKeys.contains(
+                        allValidators.get(i).getPublicKey().toHexString()))
+        .filter(i -> validatorStatuses.getStatuses().get(i).isEligibleValidator())
+        .boxed()
+        .collect(toList());
   }
 
   public AttestationRewardsData calculate() {

--- a/data/provider/src/main/java/tech/pegasys/teku/api/rewards/EpochAttestationRewardsCalculator.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/rewards/EpochAttestationRewardsCalculator.java
@@ -55,13 +55,13 @@ public class EpochAttestationRewardsCalculator {
   private List<Integer> getValidatorIndexes(
       final BeaconState state, final List<String> validatorPublicKeys) {
     final SszList<Validator> allValidators = state.getValidators();
-
     return IntStream.range(0, allValidators.size())
         .filter(
             i ->
                 validatorPublicKeys.isEmpty()
                     || validatorPublicKeys.contains(
                         allValidators.get(i).getPublicKey().toHexString()))
+        .filter(i -> validatorStatuses.getStatuses().get(i).isEligibleValidator())
         .boxed()
         .collect(toList());
   }

--- a/data/provider/src/main/java/tech/pegasys/teku/api/rewards/EpochAttestationRewardsCalculator.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/rewards/EpochAttestationRewardsCalculator.java
@@ -24,9 +24,8 @@ public class EpochAttestationRewardsCalculator {
       final SpecVersion specVersion,
       final BeaconState state,
       final List<String> validatorPublicKeys) {
-    //TODO implement EpochAttestationRewardsCalculator business logic
+    // TODO implement EpochAttestationRewardsCalculator business logic
   }
-
 
   public AttestationRewardsData calculate() {
     return new AttestationRewardsData(List.of(), List.of());

--- a/data/provider/src/main/java/tech/pegasys/teku/api/rewards/EpochAttestationRewardsCalculator.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/rewards/EpochAttestationRewardsCalculator.java
@@ -55,10 +55,13 @@ public class EpochAttestationRewardsCalculator {
   private List<Integer> getValidatorIndexes(
       final BeaconState state, final List<String> validatorPublicKeys) {
     final SszList<Validator> allValidators = state.getValidators();
-    // Find all indexes of validators to include in result
+
     return IntStream.range(0, allValidators.size())
         .filter(
-            i -> validatorPublicKeys.contains(allValidators.get(i).getPublicKey().toHexString()))
+            i ->
+                validatorPublicKeys.isEmpty()
+                    || validatorPublicKeys.contains(
+                        allValidators.get(i).getPublicKey().toHexString()))
         .boxed()
         .collect(toList());
   }

--- a/data/provider/src/main/java/tech/pegasys/teku/api/rewards/EpochAttestationRewardsCalculator.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/rewards/EpochAttestationRewardsCalculator.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright ConsenSys Software Inc., 2023
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.api.rewards;
+
+import static java.util.stream.Collectors.toList;
+
+import java.util.List;
+import java.util.stream.IntStream;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import tech.pegasys.teku.api.migrated.AttestationRewardsData;
+import tech.pegasys.teku.api.migrated.IdealAttestationReward;
+import tech.pegasys.teku.api.migrated.TotalAttestationReward;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.SpecVersion;
+import tech.pegasys.teku.spec.constants.EthConstants;
+import tech.pegasys.teku.spec.datastructures.state.Validator;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.logic.common.statetransition.epoch.EpochProcessor;
+import tech.pegasys.teku.spec.logic.common.statetransition.epoch.RewardAndPenaltyDeltas;
+import tech.pegasys.teku.spec.logic.common.statetransition.epoch.status.ValidatorStatuses;
+
+public class EpochAttestationRewardsCalculator {
+
+  private static final Logger LOG = LogManager.getLogger();
+
+  private final BeaconState state;
+  private final EpochProcessor epochProcessor;
+  private final ValidatorStatuses validatorStatuses;
+  private final List<Integer> validatorIndexes;
+
+  public EpochAttestationRewardsCalculator(
+      final SpecVersion specVersion,
+      final BeaconState state,
+      final List<String> validatorPublicKeys) {
+    this.state = state;
+    this.epochProcessor = specVersion.getEpochProcessor();
+    this.validatorStatuses = specVersion.getValidatorStatusFactory().createValidatorStatuses(state);
+    this.validatorIndexes = getValidatorIndexes(state, validatorPublicKeys);
+  }
+
+  private List<Integer> getValidatorIndexes(
+      final BeaconState state, final List<String> validatorPublicKeys) {
+    final SszList<Validator> allValidators = state.getValidators();
+    // Find all indexes of validators to include in result
+    return IntStream.range(0, allValidators.size())
+        .filter(
+            i -> validatorPublicKeys.contains(allValidators.get(i).getPublicKey().toHexString()))
+        .boxed()
+        .collect(toList());
+  }
+
+  public AttestationRewardsData calculate() {
+    try {
+      final List<TotalAttestationReward> totalAttestationRewards = totalAttestationRewards();
+      final List<IdealAttestationReward> idealAttestationRewards = idealAttestationRewards();
+      return new AttestationRewardsData(idealAttestationRewards, totalAttestationRewards);
+    } catch (RuntimeException ex) {
+      LOG.error("Error calculating detailed rewards and penalties", ex);
+      throw ex;
+    }
+  }
+
+  private List<TotalAttestationReward> totalAttestationRewards() {
+    final RewardAndPenaltyDeltas totalRewardAndPenaltyDeltas =
+        epochProcessor.getDetailedRewardAndPenaltyDeltas(state, validatorStatuses);
+
+    return validatorIndexes.stream()
+        .map(i -> new ImmutablePair<>(i, totalRewardAndPenaltyDeltas.getDelta(i)))
+        .map(p -> new TotalAttestationReward(p.left, p.right))
+        .collect(toList());
+  }
+
+  public List<IdealAttestationReward> idealAttestationRewards() {
+    // TODO-lucas not implemented yet
+    return IntStream.rangeClosed(0, 32)
+        .boxed()
+        .map(UInt64::valueOf)
+        .map(i -> new IdealAttestationReward(EthConstants.ETH_TO_GWEI.times(i), 0L, 0L, 0L))
+        .collect(toList());
+  }
+}

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/migrated/TotalAttestationReward.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/migrated/TotalAttestationReward.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.api.migrated;
 
+import java.security.InvalidParameterException;
 import java.util.Objects;
 import java.util.Optional;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -40,11 +41,13 @@ public class TotalAttestationReward {
   public TotalAttestationReward(long validatorIndex, final RewardAndPenalty rewardAndPenalty) {
     this.validatorIndex = validatorIndex;
 
-    if (!rewardAndPenalty.getClass().isAssignableFrom(DetailedRewardAndPenalty.class)) {
-      throw new IllegalStateException("Can't cast RewardAndPenalty to DetailedRewardAndPenalty");
-    }
     final DetailedRewardAndPenalty detailedRewardAndPenalty =
-        (DetailedRewardAndPenalty) rewardAndPenalty;
+        rewardAndPenalty
+            .asDetailed()
+            .orElseThrow(
+                () ->
+                    new InvalidParameterException(
+                        "TotalAttestationRewards requires a DetailedRewardAndPenalty instance"));
 
     this.head =
         detailedRewardAndPenalty.getReward(RewardComponent.HEAD).longValue()

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/migrated/TotalAttestationReward.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/migrated/TotalAttestationReward.java
@@ -16,6 +16,9 @@ package tech.pegasys.teku.api.migrated;
 import java.util.Objects;
 import java.util.Optional;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.logic.common.statetransition.epoch.DetailedRewardAndPenalty;
+import tech.pegasys.teku.spec.logic.common.statetransition.epoch.RewardAndPenalty;
+import tech.pegasys.teku.spec.logic.common.statetransition.epoch.RewardAndPenalty.RewardComponent;
 
 public class TotalAttestationReward {
 
@@ -32,6 +35,27 @@ public class TotalAttestationReward {
     this.target = target;
     this.source = source;
     this.inclusionDelay = inclusionDelay;
+  }
+
+  public TotalAttestationReward(long validatorIndex, final RewardAndPenalty rewardAndPenalty) {
+    this.validatorIndex = validatorIndex;
+
+    if (!rewardAndPenalty.getClass().isAssignableFrom(DetailedRewardAndPenalty.class)) {
+      throw new IllegalStateException("Can't cast RewardAndPenalty to DetailedRewardAndPenalty");
+    }
+    final DetailedRewardAndPenalty detailedRewardAndPenalty =
+        (DetailedRewardAndPenalty) rewardAndPenalty;
+
+    this.head =
+        detailedRewardAndPenalty.getReward(RewardComponent.HEAD).longValue()
+            - detailedRewardAndPenalty.getPenalty(RewardComponent.HEAD).longValue();
+    this.target =
+        detailedRewardAndPenalty.getReward(RewardComponent.TARGET).longValue()
+            - detailedRewardAndPenalty.getPenalty(RewardComponent.TARGET).longValue();
+    this.source =
+        detailedRewardAndPenalty.getReward(RewardComponent.SOURCE).longValue()
+            - detailedRewardAndPenalty.getPenalty(RewardComponent.SOURCE).longValue();
+    this.inclusionDelay = Optional.empty();
   }
 
   public long getValidatorIndex() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/EpochProcessor.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/EpochProcessor.java
@@ -26,6 +26,12 @@ public interface EpochProcessor {
   RewardAndPenaltyDeltas getRewardAndPenaltyDeltas(
       BeaconState state, ValidatorStatuses validatorStatuses);
 
+  default RewardAndPenaltyDeltas getDetailedRewardAndPenaltyDeltas(
+      BeaconState state, ValidatorStatuses validatorStatuses) {
+    // TODO-lucas not implemented
+    return null;
+  }
+
   BeaconState processEpoch(BeaconState preState) throws EpochProcessingException;
 
   default void initProgressiveTotalBalancesIfRequired(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/EpochProcessor.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/EpochProcessor.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.spec.logic.common.statetransition.epoch;
 
 import java.util.List;
+import java.util.function.Function;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
@@ -23,14 +24,45 @@ import tech.pegasys.teku.spec.logic.common.statetransition.epoch.status.Validato
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.EpochProcessingException;
 
 public interface EpochProcessor {
-  RewardAndPenaltyDeltas getRewardAndPenaltyDeltas(
-      BeaconState state, ValidatorStatuses validatorStatuses);
 
-  default RewardAndPenaltyDeltas getDetailedRewardAndPenaltyDeltas(
+  /**
+   * Calculates the penalties and rewards at a specific state for a set of validators. The result of
+   * the calculation will contain exclusively objects of type {@link AggregatedRewardAndPenalty}.
+   *
+   * @param state the beacon state that will be used
+   * @param validatorStatuses a list of validator status
+   * @return a {@link RewardAndPenaltyDeltas} object with the result of rewards and penalties
+   *     calculation for each eligible validator.
+   * @see tech.pegasys.teku.spec.logic.common.statetransition.epoch.status.ValidatorStatusFactory
+   * @see ValidatorStatus#isEligibleValidator()
+   * @see tech.pegasys.teku.spec.logic.common.statetransition.epoch.RewardsAndPenaltiesCalculator
+   */
+  default RewardAndPenaltyDeltas getRewardAndPenaltyDeltas(
       BeaconState state, ValidatorStatuses validatorStatuses) {
-    // TODO-lucas not implemented
-    return null;
+    return getRewardAndPenaltyDeltas(
+        state, validatorStatuses, RewardsAndPenaltiesCalculator::getDeltas);
   }
+
+  /**
+   * Calculates the penalties and rewards at a specific state for a set of validators. The result of
+   * the calculation will contain exclusively objects of type {@link AggregatedRewardAndPenalty} or
+   * {@link DetailedRewardAndPenalty} depending on the function chosen in the
+   * <i>calculatorFunction</i> parameter.
+   *
+   * @param state the beacon state that will be used
+   * @param validatorStatuses a list of validator status
+   * @param calculatorFunction a mapper function defining what method from the {@link
+   *     RewardsAndPenaltiesCalculator} should be used when collecting results.
+   * @return a {@link RewardAndPenaltyDeltas} object with the result of rewards and penalties
+   *     calculation for each eligible validator.
+   * @see tech.pegasys.teku.spec.logic.common.statetransition.epoch.status.ValidatorStatusFactory
+   * @see ValidatorStatus#isEligibleValidator()
+   * @see tech.pegasys.teku.spec.logic.common.statetransition.epoch.RewardsAndPenaltiesCalculator
+   */
+  RewardAndPenaltyDeltas getRewardAndPenaltyDeltas(
+      BeaconState state,
+      ValidatorStatuses validatorStatuses,
+      Function<RewardsAndPenaltiesCalculator, RewardAndPenaltyDeltas> calculatorFunction);
 
   BeaconState processEpoch(BeaconState preState) throws EpochProcessingException;
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/RewardAndPenalty.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/RewardAndPenalty.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.logic.common.statetransition.epoch;
 
+import java.util.Optional;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 public interface RewardAndPenalty {
@@ -32,4 +33,12 @@ public interface RewardAndPenalty {
   UInt64 getReward();
 
   UInt64 getPenalty();
+
+  default Optional<DetailedRewardAndPenalty> asDetailed() {
+    if (this.getClass().isAssignableFrom(DetailedRewardAndPenalty.class)) {
+      return Optional.of((DetailedRewardAndPenalty) this);
+    } else {
+      return Optional.empty();
+    }
+  }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/RewardsAndPenaltiesCalculator.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/RewardsAndPenaltiesCalculator.java
@@ -46,10 +46,7 @@ public abstract class RewardsAndPenaltiesCalculator {
 
   public abstract RewardAndPenaltyDeltas getDeltas() throws IllegalArgumentException;
 
-  public RewardAndPenaltyDeltas getDetailedDeltas() throws IllegalArgumentException {
-    // TODO-lucas not implemented
-    return null;
-  }
+  public abstract RewardAndPenaltyDeltas getDetailedDeltas() throws IllegalArgumentException;
 
   protected UInt64 getFinalityDelay() {
     return finalityDelay;

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/RewardsAndPenaltiesCalculator.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/RewardsAndPenaltiesCalculator.java
@@ -46,6 +46,11 @@ public abstract class RewardsAndPenaltiesCalculator {
 
   public abstract RewardAndPenaltyDeltas getDeltas() throws IllegalArgumentException;
 
+  public RewardAndPenaltyDeltas getDetailedDeltas() throws IllegalArgumentException {
+    // TODO-lucas not implemented
+    return null;
+  }
+
   protected UInt64 getFinalityDelay() {
     return finalityDelay;
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/statetransition/epoch/EpochProcessorAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/statetransition/epoch/EpochProcessorAltair.java
@@ -88,6 +88,21 @@ public class EpochProcessorAltair extends AbstractEpochProcessor {
     return calculator.getDeltas();
   }
 
+  @Override
+  public RewardAndPenaltyDeltas getDetailedRewardAndPenaltyDeltas(
+      final BeaconState genericState, final ValidatorStatuses validatorStatuses) {
+    final BeaconStateAltair state = BeaconStateAltair.required(genericState);
+    final RewardsAndPenaltiesCalculatorAltair calculator =
+        new RewardsAndPenaltiesCalculatorAltair(
+            specConfigAltair,
+            state,
+            validatorStatuses,
+            miscHelpersAltair,
+            beaconStateAccessorsAltair);
+
+    return calculator.getDetailedDeltas();
+  }
+
   /**
    * Corresponds to process_participation_flag_updates in beacon-chain spec
    *

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/statetransition/epoch/EpochProcessorAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/statetransition/epoch/EpochProcessorAltair.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.spec.logic.versions.altair.statetransition.epoch;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Function;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.ssz.SszMutableList;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszMutableUInt64List;
@@ -31,6 +32,7 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.altair.M
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateMutators;
 import tech.pegasys.teku.spec.logic.common.statetransition.epoch.AbstractEpochProcessor;
 import tech.pegasys.teku.spec.logic.common.statetransition.epoch.RewardAndPenaltyDeltas;
+import tech.pegasys.teku.spec.logic.common.statetransition.epoch.RewardsAndPenaltiesCalculator;
 import tech.pegasys.teku.spec.logic.common.statetransition.epoch.status.ProgressiveTotalBalancesAltair;
 import tech.pegasys.teku.spec.logic.common.statetransition.epoch.status.TotalBalances;
 import tech.pegasys.teku.spec.logic.common.statetransition.epoch.status.ValidatorStatus;
@@ -88,9 +90,11 @@ public class EpochProcessorAltair extends AbstractEpochProcessor {
     return calculator.getDeltas();
   }
 
-  @Override
-  public RewardAndPenaltyDeltas getDetailedRewardAndPenaltyDeltas(
-      final BeaconState genericState, final ValidatorStatuses validatorStatuses) {
+  public RewardAndPenaltyDeltas getRewardAndPenaltyDeltas(
+      final BeaconState genericState,
+      final ValidatorStatuses validatorStatuses,
+      final Function<RewardsAndPenaltiesCalculator, RewardAndPenaltyDeltas> calculatorFunction) {
+
     final BeaconStateAltair state = BeaconStateAltair.required(genericState);
     final RewardsAndPenaltiesCalculatorAltair calculator =
         new RewardsAndPenaltiesCalculatorAltair(
@@ -100,7 +104,7 @@ public class EpochProcessorAltair extends AbstractEpochProcessor {
             miscHelpersAltair,
             beaconStateAccessorsAltair);
 
-    return calculator.getDetailedDeltas();
+    return calculatorFunction.apply(calculator);
   }
 
   /**

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/statetransition/epoch/EpochProcessorAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/statetransition/epoch/EpochProcessorAltair.java
@@ -90,6 +90,7 @@ public class EpochProcessorAltair extends AbstractEpochProcessor {
     return calculator.getDeltas();
   }
 
+  @Override
   public RewardAndPenaltyDeltas getRewardAndPenaltyDeltas(
       final BeaconState genericState,
       final ValidatorStatuses validatorStatuses,

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/statetransition/epoch/RewardsAndPenaltiesCalculatorAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/statetransition/epoch/RewardsAndPenaltiesCalculatorAltair.java
@@ -67,6 +67,18 @@ public class RewardsAndPenaltiesCalculatorAltair extends RewardsAndPenaltiesCalc
     return deltas;
   }
 
+  public RewardAndPenaltyDeltas getDetailedDeltas() throws IllegalArgumentException {
+    final RewardAndPenaltyDeltas deltas =
+        RewardAndPenaltyDeltas.detailed(validatorStatuses.getValidatorCount());
+
+    for (int flagIndex = 0; flagIndex < PARTICIPATION_FLAG_WEIGHTS.size(); flagIndex++) {
+      processFlagIndexDeltas(deltas, flagIndex);
+    }
+    processInactivityPenaltyDeltas(deltas);
+
+    return deltas;
+  }
+
   /**
    * Corresponds to altair beacon chain accessor get_flag_index_deltas
    *

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/statetransition/epoch/RewardsAndPenaltiesCalculatorAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/statetransition/epoch/RewardsAndPenaltiesCalculatorAltair.java
@@ -67,6 +67,7 @@ public class RewardsAndPenaltiesCalculatorAltair extends RewardsAndPenaltiesCalc
     return deltas;
   }
 
+  @Override
   public RewardAndPenaltyDeltas getDetailedDeltas() throws IllegalArgumentException {
     final RewardAndPenaltyDeltas deltas =
         RewardAndPenaltyDeltas.detailed(validatorStatuses.getValidatorCount());

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/statetransition/epoch/EpochProcessorPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/statetransition/epoch/EpochProcessorPhase0.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.logic.versions.phase0.statetransition.epoch;
 
+import java.util.function.Function;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
@@ -22,6 +23,7 @@ import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateMutators;
 import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
 import tech.pegasys.teku.spec.logic.common.statetransition.epoch.AbstractEpochProcessor;
 import tech.pegasys.teku.spec.logic.common.statetransition.epoch.RewardAndPenaltyDeltas;
+import tech.pegasys.teku.spec.logic.common.statetransition.epoch.RewardsAndPenaltiesCalculator;
 import tech.pegasys.teku.spec.logic.common.statetransition.epoch.status.ValidatorStatusFactory;
 import tech.pegasys.teku.spec.logic.common.statetransition.epoch.status.ValidatorStatuses;
 import tech.pegasys.teku.spec.logic.common.util.BeaconStateUtil;
@@ -52,12 +54,14 @@ public class EpochProcessorPhase0 extends AbstractEpochProcessor {
 
   @Override
   public RewardAndPenaltyDeltas getRewardAndPenaltyDeltas(
-      BeaconState state, ValidatorStatuses validatorStatuses) {
+      final BeaconState state,
+      final ValidatorStatuses validatorStatuses,
+      final Function<RewardsAndPenaltiesCalculator, RewardAndPenaltyDeltas> calculatorFunction) {
     final RewardsAndPenaltiesCalculatorPhase0 calculator =
         new RewardsAndPenaltiesCalculatorPhase0(
             specConfig, state, validatorStatuses, miscHelpers, beaconStateAccessors);
 
-    return calculator.getDeltas();
+    return calculatorFunction.apply(calculator);
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/statetransition/epoch/RewardsAndPenaltiesCalculatorPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/statetransition/epoch/RewardsAndPenaltiesCalculatorPhase0.java
@@ -40,12 +40,7 @@ public class RewardsAndPenaltiesCalculatorPhase0 extends RewardsAndPenaltiesCalc
     super(specConfig, miscHelpers, beaconStateAccessors, state, validatorStatuses);
   }
 
-  /**
-   * Return attestation reward/penalty deltas for each validator
-   *
-   * @return
-   * @throws IllegalArgumentException
-   */
+  /** Return attestation reward/penalty deltas for each validator */
   @Override
   public RewardAndPenaltyDeltas getDeltas() throws IllegalArgumentException {
     return getDeltas(this::applyAllDeltas);
@@ -72,6 +67,12 @@ public class RewardsAndPenaltiesCalculatorPhase0 extends RewardsAndPenaltiesCalc
       step.apply(deltas, totalBalances, finalityDelay, validator, baseReward, delta);
     }
     return deltas;
+  }
+
+  @Override
+  public RewardAndPenaltyDeltas getDetailedDeltas() throws IllegalArgumentException {
+    throw new UnsupportedOperationException(
+        "Can't calculate detailed RewardAndPenaltyDeltas pre-Altair");
   }
 
   private void applyAllDeltas(
@@ -236,6 +237,7 @@ public class RewardsAndPenaltiesCalculatorPhase0 extends RewardsAndPenaltiesCalc
   }
 
   public interface Step {
+
     void apply(
         final RewardAndPenaltyDeltas deltas,
         final TotalBalances totalBalances,


### PR DESCRIPTION
## PR Description
- Implemented stub `EpochAttestationRewardsCalculator` with the business logic for calculating attestation rewards for an epoch (real implementation will come in a future PR, including tests).
- Refactored `EpochProcessor` with a new method `getRewardAndPenaltyDeltas` accepting a function as a parameter to choose between calculating the aggregated or detailed RewardsAndPenalties. Kept a default implementation of the method that uses the current aggregated view (no impact on existing code).

## Fixed Issue(s)
related to #6703 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
