### PR TITLE
Set optional missing fields to empty when deserializing

### DIFF
--- a/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/DeserializableFieldDefinition.java
+++ b/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/DeserializableFieldDefinition.java
@@ -15,8 +15,17 @@ package tech.pegasys.teku.infrastructure.json.types;
 
 import com.fasterxml.jackson.core.JsonParser;
 import java.io.IOException;
+import java.util.Optional;
 
 public interface DeserializableFieldDefinition<TObject, TBuilder>
     extends SerializableFieldDefinition<TObject> {
   void readField(TBuilder target, JsonParser parser) throws IOException;
+
+  default Optional<RequiredDeserializableFieldDefinition<TObject, TBuilder, ?>> toRequired() {
+    return Optional.empty();
+  }
+
+  default Optional<OptionalDeserializableFieldDefinition<TObject, TBuilder, ?>> toOptional() {
+    return Optional.empty();
+  }
 }

--- a/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/DeserializableObjectTypeDefinition.java
+++ b/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/DeserializableObjectTypeDefinition.java
@@ -80,8 +80,21 @@ class DeserializableObjectTypeDefinition<TObject, TBuilder>
 
     final List<String> missingRequiredFields =
         deserializableFields.keySet().stream()
+            .filter(key -> !presentFields.contains(key))
             .filter(
-                key -> !presentFields.contains(key) && deserializableFields.get(key).isRequired())
+                key -> {
+                  final DeserializableFieldDefinition<TObject, TBuilder> objectField =
+                      deserializableFields.get(key);
+                  if (objectField.isRequired()) {
+                    return true;
+                  }
+                  // set optional missing fields to Optional.empty()
+                  if (objectField instanceof OptionalDeserializableFieldDefinition) {
+                    ((OptionalDeserializableFieldDefinition<TObject, TBuilder, ?>) objectField)
+                        .setFieldToEmpty(builder);
+                  }
+                  return false;
+                })
             .collect(Collectors.toList());
     if (!missingRequiredFields.isEmpty()) {
       throw new MissingRequiredFieldException(

--- a/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/DeserializableObjectTypeDefinition.java
+++ b/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/DeserializableObjectTypeDefinition.java
@@ -28,7 +28,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.infrastructure.json.exceptions.MissingRequiredFieldException;
@@ -79,10 +79,8 @@ class DeserializableObjectTypeDefinition<TObject, TBuilder>
       }
     }
 
-    final List<String> missingFields =
-        deserializableFields.keySet().stream()
-            .filter(key -> !presentFields.contains(key))
-            .collect(Collectors.toList());
+    final Stream<String> missingFields =
+        deserializableFields.keySet().stream().filter(key -> !presentFields.contains(key));
 
     final List<String> missingRequiredFields = new ArrayList<>();
 

--- a/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/DeserializableObjectTypeDefinition.java
+++ b/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/DeserializableObjectTypeDefinition.java
@@ -92,10 +92,7 @@ class DeserializableObjectTypeDefinition<TObject, TBuilder>
             missingRequiredFields.add(field);
           } else {
             // if missing field is optional, set it to empty
-            if (fieldDefinition instanceof OptionalDeserializableFieldDefinition) {
-              ((OptionalDeserializableFieldDefinition<TObject, TBuilder, ?>) fieldDefinition)
-                  .setFieldToEmpty(builder);
-            }
+            fieldDefinition.toOptional().ifPresent(fd -> fd.setFieldToEmpty(builder));
           }
         });
 

--- a/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/DeserializableObjectTypeDefinition.java
+++ b/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/DeserializableObjectTypeDefinition.java
@@ -93,7 +93,7 @@ class DeserializableObjectTypeDefinition<TObject, TBuilder>
           if (fieldDefinition.isRequired()) {
             missingRequiredFields.add(field);
           } else {
-            // set missing optional fields to empty
+            // if missing field is optional, set it to empty
             if (fieldDefinition instanceof OptionalDeserializableFieldDefinition) {
               ((OptionalDeserializableFieldDefinition<TObject, TBuilder, ?>) fieldDefinition)
                   .setFieldToEmpty(builder);

--- a/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/OptionalDeserializableFieldDefinition.java
+++ b/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/OptionalDeserializableFieldDefinition.java
@@ -42,6 +42,10 @@ public class OptionalDeserializableFieldDefinition<TObject, TBuilder, TField>
     setter.accept(target, value);
   }
 
+  public void setFieldToEmpty(final TBuilder target) {
+    setter.accept(target, Optional.empty());
+  }
+
   @Override
   public boolean equals(final Object o) {
     if (this == o) {

--- a/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/OptionalDeserializableFieldDefinition.java
+++ b/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/OptionalDeserializableFieldDefinition.java
@@ -42,6 +42,11 @@ public class OptionalDeserializableFieldDefinition<TObject, TBuilder, TField>
     setter.accept(target, value);
   }
 
+  @Override
+  public Optional<OptionalDeserializableFieldDefinition<TObject, TBuilder, ?>> toOptional() {
+    return Optional.of(this);
+  }
+
   public void setFieldToEmpty(final TBuilder target) {
     setter.accept(target, Optional.empty());
   }

--- a/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/RequiredDeserializableFieldDefinition.java
+++ b/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/RequiredDeserializableFieldDefinition.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.infrastructure.json.types;
 import com.fasterxml.jackson.core.JsonParser;
 import java.io.IOException;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 
@@ -40,6 +41,11 @@ class RequiredDeserializableFieldDefinition<TObject, TBuilder, TField>
   public void readField(final TBuilder target, final JsonParser parser) throws IOException {
     final TField value = deserializableType.deserialize(parser);
     setter.accept(target, value);
+  }
+
+  @Override
+  public Optional<RequiredDeserializableFieldDefinition<TObject, TBuilder, ?>> toRequired() {
+    return Optional.of(this);
   }
 
   @Override

--- a/infrastructure/json/src/test/java/tech/pegasys/teku/infrastructure/json/types/DeserializableObjectTypeDefinitionTest.java
+++ b/infrastructure/json/src/test/java/tech/pegasys/teku/infrastructure/json/types/DeserializableObjectTypeDefinitionTest.java
@@ -144,7 +144,7 @@ class DeserializableObjectTypeDefinitionTest {
 
   private static class MutableValue {
     private String required;
-    private Optional<String> optional = Optional.empty();
+    private Optional<String> optional;
 
     public String getRequired() {
       return required;
@@ -183,7 +183,7 @@ class DeserializableObjectTypeDefinitionTest {
 
   private static class ImmutableValueBuilder {
     private String required;
-    private Optional<String> optional = Optional.empty();
+    private Optional<String> optional;
 
     public ImmutableValueBuilder required(final String required) {
       this.required = required;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Currently if deserializing using `DeserializableTypeDefinition.object(...)` and there is a missing field in the json which is defined as `withOptionalField()` It won't be set to Optional.empty(). Instead the default would be used which could be null unless explicitly defined. It could lead to misuses of the framework and null optional fields which is not ideal.

`DeserializableObjectTypeDefinitionTest` has test cases, which cover optional fields so removed the initialization to Optional.empty() to test the change.

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
