### PR TITLE
Ensure DA pending blocks are not re-fetched

### DIFF
--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/gossip/blocks/FetchRecentBlocksService.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/gossip/blocks/FetchRecentBlocksService.java
@@ -96,6 +96,10 @@ public class FetchRecentBlocksService
       // We've already got this block
       return;
     }
+    if (blobSidecarPool.containsBlock(blockRoot)) {
+      // We already have this block, waiting for blobs
+      return;
+    }
     final FetchBlockTask task = createTask(blockRoot);
     if (allTasks.putIfAbsent(blockRoot, task) != null) {
       // We're already tracking this task

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/gossip/blocks/FetchRecentBlocksServiceTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/gossip/blocks/FetchRecentBlocksServiceTest.java
@@ -78,6 +78,8 @@ public class FetchRecentBlocksServiceTest {
             fetchTaskFactory,
             maxConcurrentRequests);
 
+    // blobs pool doesn't contain blocks by default
+    when(blobSidecarPool.containsBlock(any())).thenReturn(false);
     lenient().when(fetchTaskFactory.createFetchBlockTask(any())).thenAnswer(this::createMockTask);
     recentBlockFetcher.subscribeBlockFetched(importedBlocks::add);
   }
@@ -235,6 +237,15 @@ public class FetchRecentBlocksServiceTest {
     when(forwardSync.isSyncActive()).thenReturn(true);
 
     recentBlockFetcher.requestRecentBlock(dataStructureUtil.randomBytes32());
+    assertTaskCounts(0, 0, 0);
+  }
+
+  @Test
+  void shouldNotFetchIfBlockIsWaitingForBlobs() {
+    Bytes32 blockRoot = dataStructureUtil.randomBytes32();
+    when(blobSidecarPool.containsBlock(blockRoot)).thenReturn(true);
+
+    recentBlockFetcher.requestRecentBlock(blockRoot);
     assertTaskCounts(0, 0, 0);
   }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blobs/BlobSidecarPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blobs/BlobSidecarPool.java
@@ -50,6 +50,11 @@ public interface BlobSidecarPool extends SlotEventsChannel {
         }
 
         @Override
+        public boolean containsBlock(Bytes32 blockRoot) {
+          return false;
+        }
+
+        @Override
         public BlockBlobSidecarsTracker getOrCreateBlockBlobSidecarsTracker(
             SignedBeaconBlock block) {
           throw new UnsupportedOperationException();
@@ -92,6 +97,8 @@ public interface BlobSidecarPool extends SlotEventsChannel {
   void removeAllForBlock(Bytes32 blockRoot);
 
   boolean containsBlobSidecar(BlobIdentifier blobIdentifier);
+
+  boolean containsBlock(Bytes32 blockRoot);
 
   Set<BlobIdentifier> getAllRequiredBlobSidecars();
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/BlobSidecarPoolImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/BlobSidecarPoolImpl.java
@@ -241,8 +241,9 @@ public class BlobSidecarPoolImpl extends AbstractIgnoringFutureHistoricalSlot
         .orElse(false);
   }
 
-  public synchronized boolean containsBlock(final SignedBeaconBlock block) {
-    return Optional.ofNullable(blockBlobSidecarsTrackers.get(block.getRoot()))
+  @Override
+  public synchronized boolean containsBlock(final Bytes32 blockRoot) {
+    return Optional.ofNullable(blockBlobSidecarsTrackers.get(blockRoot))
         .map(tracker -> tracker.getBlockBody().isPresent())
         .orElse(false);
   }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/BlobSidecarPoolImplTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/BlobSidecarPoolImplTest.java
@@ -111,7 +111,7 @@ public class BlobSidecarPoolImplTest {
         dataStructureUtil.randomSignedBeaconBlock(currentSlot.longValue());
     blobSidecarPool.onNewBlock(block);
 
-    assertThat(blobSidecarPool.containsBlock(block)).isTrue();
+    assertThat(blobSidecarPool.containsBlock(block.getRoot())).isTrue();
     assertThat(requiredBlockRootEvents).isEmpty();
     assertThat(requiredBlockRootDroppedEvents).isEmpty();
     assertThat(requiredBlobSidecarEvents).isEmpty();
@@ -147,7 +147,7 @@ public class BlobSidecarPoolImplTest {
         dataStructureUtil.randomSignedBeaconBlock(currentSlot.longValue());
     blobSidecarPool.onNewBlock(block);
 
-    assertThat(blobSidecarPool.containsBlock(block)).isFalse();
+    assertThat(blobSidecarPool.containsBlock(block.getRoot())).isFalse();
     assertThat(requiredBlockRootEvents).isEmpty();
     assertThat(requiredBlockRootDroppedEvents).isEmpty();
     assertThat(requiredBlobSidecarEvents).isEmpty();
@@ -172,7 +172,7 @@ public class BlobSidecarPoolImplTest {
 
     assertThat(blobSidecarPool.containsBlobSidecar(blobIdentifierFromBlobSidecar(blobSidecar)))
         .isTrue();
-    assertThat(blobSidecarPool.containsBlock(block)).isTrue();
+    assertThat(blobSidecarPool.containsBlock(block.getRoot())).isTrue();
     assertThat(requiredBlockRootEvents).isEmpty();
     assertThat(requiredBlockRootDroppedEvents).isEmpty();
     assertThat(requiredBlobSidecarEvents).isEmpty();
@@ -237,8 +237,8 @@ public class BlobSidecarPoolImplTest {
     blobSidecarPool.onNewBlock(blockAtPreviousSlot);
     blobSidecarPool.onNewBlock(block);
 
-    assertThat(blobSidecarPool.containsBlock(blockAtPreviousSlot)).isTrue();
-    assertThat(blobSidecarPool.containsBlock(block)).isTrue();
+    assertThat(blobSidecarPool.containsBlock(blockAtPreviousSlot.getRoot())).isTrue();
+    assertThat(blobSidecarPool.containsBlock(block.getRoot())).isTrue();
     assertThat(requiredBlockRootEvents).isEmpty();
     assertThat(requiredBlockRootDroppedEvents).isEmpty();
     assertThat(requiredBlobSidecarEvents).isEmpty();
@@ -332,7 +332,7 @@ public class BlobSidecarPoolImplTest {
 
     blobSidecarPool.onNewBlock(block);
 
-    assertThat(blobSidecarPool.containsBlock(block)).isFalse();
+    assertThat(blobSidecarPool.containsBlock(block.getRoot())).isFalse();
     assertThat(requiredBlockRootEvents).isEmpty();
     assertThat(requiredBlockRootDroppedEvents).isEmpty();
     assertThat(requiredBlobSidecarEvents).isEmpty();
@@ -369,7 +369,7 @@ public class BlobSidecarPoolImplTest {
       blobSidecarPool.onNewBlock(block);
 
       final int expectedSize = Math.min(maxItems, i + 1);
-      assertThat(blobSidecarPool.containsBlock(block)).isTrue();
+      assertThat(blobSidecarPool.containsBlock(block.getRoot())).isTrue();
       assertThat(blobSidecarPool.getTotalBlobSidecarsTrackers()).isEqualTo(expectedSize);
       assertBlobSidecarsTrackersCount(expectedSize);
     }
@@ -404,7 +404,7 @@ public class BlobSidecarPoolImplTest {
     // Check that all blocks are in the collection
     assertBlobSidecarsTrackersCount(finalizedBlocks.size() + nonFinalBlocks.size());
     for (SignedBeaconBlock block : allBlocks) {
-      assertThat(blobSidecarPool.containsBlock(block)).isTrue();
+      assertThat(blobSidecarPool.containsBlock(block.getRoot())).isTrue();
     }
 
     // Update finalized checkpoint and prune
@@ -414,7 +414,7 @@ public class BlobSidecarPoolImplTest {
     // Check that all final blocks have been pruned
     assertBlobSidecarsTrackersCount(nonFinalBlocks.size());
     for (SignedBeaconBlock block : nonFinalBlocks) {
-      assertThat(blobSidecarPool.containsBlock(block)).isTrue();
+      assertThat(blobSidecarPool.containsBlock(block.getRoot())).isTrue();
     }
   }
 


### PR DESCRIPTION
When we have blocks pending in `DataUnavailableBlockPool`, we don't want that blocks or attestations depending on it, being added to corresponding pendingPools, triggering the recentBlockFetcher, cause the node to redownload and attempt a block import.

builds on top of #7132

diff commit: 218ab4d25fa8220985f74a8d2b04ecce38e93311

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
