### PR TITLE
Process attestations when the state from their target block state is available in cache

### DIFF
--- a/ethereum/dataproviders/src/main/java/tech/pegasys/teku/dataproviders/generators/CachingTaskQueue.java
+++ b/ethereum/dataproviders/src/main/java/tech/pegasys/teku/dataproviders/generators/CachingTaskQueue.java
@@ -218,6 +218,10 @@ public class CachingTaskQueue<K, V> {
     cache.keySet().removeIf(removalCondition);
   }
 
+  public void clear() {
+    cache.clear();
+  }
+
   public interface CacheableTask<K, V> {
     /**
      * The key that uniquely identifies this task. Two tasks with equal keys should also have

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AttestationStateSelector.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AttestationStateSelector.java
@@ -88,6 +88,15 @@ public class AttestationStateSelector {
       return completedFuture(Optional.empty());
     }
 
+    // Check if the attestations head block state is already available in cache and usable
+    if (targetBlockSlot.get().isGreaterThanOrEqualTo(earliestSlot)) {
+      final Optional<BeaconState> maybeState =
+          recentChainData.getStore().getBlockStateIfAvailable(targetBlockRoot);
+      if (maybeState.isPresent()) {
+        return SafeFuture.completedFuture(maybeState);
+      }
+    }
+
     if (isJustificationTooOld(targetBlockRoot, targetBlockSlot.get())) {
       // we already justified a more recent slot on all compatible heads
       LOG.debug(

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
@@ -299,6 +299,13 @@ class Store implements UpdatableStore {
   }
 
   @Override
+  public void clearCaches() {
+    states.clear();
+    checkpointStates.clear();
+    blocks.clear();
+  }
+
+  @Override
   public StoreTransaction startTransaction(final StorageUpdateChannel storageUpdateChannel) {
     return startTransaction(storageUpdateChannel, StoreUpdateHandler.NOOP);
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/UpdatableStore.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/UpdatableStore.java
@@ -37,6 +37,9 @@ public interface UpdatableStore extends ReadOnlyStore {
   @Override
   ForkChoiceStrategy getForkChoiceStrategy();
 
+  /** Clears in-memory caches. This is not something you'll want to do in production codee... */
+  void clearCaches();
+
   interface StoreTransaction extends MutableStore {
     SafeFuture<Void> commit();
 


### PR DESCRIPTION
## PR Description
When selecting a state to use to process attestation gossip, check if the attestations `beaconBlockRoot` state is already available in the cache before deciding if it's worth regenerating a state. This allows us to process significantly more attestations without requiring additional state generations - particularly if attestations are received for blocks we just imported on a long fork.

Also potentially reduces the number of generations we'd do during periods of non-finality by better leveraging what we have in cache.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
