### PR TITLE
Use thread local on locally created sha256 

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
@@ -14,8 +14,7 @@
 package tech.pegasys.teku.spec.logic.common.helpers;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static tech.pegasys.teku.infrastructure.crypto.Hash.sha256;
-import static tech.pegasys.teku.infrastructure.crypto.Hash.sha256Unwrapped;
+import static tech.pegasys.teku.infrastructure.crypto.Hash.getSha256Instance;
 import static tech.pegasys.teku.spec.logic.common.helpers.MathHelpers.bytesToUInt64;
 import static tech.pegasys.teku.spec.logic.common.helpers.MathHelpers.uint64ToBytes;
 import static tech.pegasys.teku.spec.logic.common.helpers.MathHelpers.uintTo4Bytes;
@@ -27,6 +26,7 @@ import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.bytes.Bytes4;
+import tech.pegasys.teku.infrastructure.crypto.Sha256;
 import tech.pegasys.teku.infrastructure.ssz.Merkleizable;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszByteVector;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
@@ -57,6 +57,8 @@ public class MiscHelpers {
   public int computeShuffledIndex(int index, int indexCount, Bytes32 seed) {
     checkArgument(index < indexCount, "CommitteeUtil.computeShuffledIndex1");
 
+    final Sha256 sha256 = getSha256Instance();
+
     int indexRet = index;
     final int shuffleRoundCount = specConfig.getShuffleRoundCount();
 
@@ -65,12 +67,15 @@ public class MiscHelpers {
       Bytes roundAsByte = Bytes.of((byte) round);
 
       // This needs to be unsigned modulo.
-      int pivot = bytesToUInt64(sha256(seed, roundAsByte).slice(0, 8)).mod(indexCount).intValue();
+      int pivot =
+          bytesToUInt64(sha256.wrappedDigest(seed, roundAsByte).slice(0, 8))
+              .mod(indexCount)
+              .intValue();
       int flip = Math.floorMod(pivot + indexCount - indexRet, indexCount);
       int position = Math.max(indexRet, flip);
 
       Bytes positionDiv256 = uintTo4Bytes(Math.floorDiv(position, 256L));
-      byte[] hashBytes = sha256Unwrapped(seed, roundAsByte, positionDiv256);
+      byte[] hashBytes = sha256.digest(seed, roundAsByte, positionDiv256);
 
       int bitIndex = position & 0xff;
       int theByte = hashBytes[bitIndex / 8];
@@ -83,15 +88,19 @@ public class MiscHelpers {
     return indexRet;
   }
 
-  public int computeProposerIndex(BeaconState state, IntList indices, Bytes32 seed) {
+  public int computeProposerIndex(
+      final BeaconState state, final IntList indices, final Bytes32 seed) {
     checkArgument(!indices.isEmpty(), "compute_proposer_index indices must not be empty");
+
+    final Sha256 sha256 = getSha256Instance();
+
     int i = 0;
     final int total = indices.size();
     byte[] hash = null;
     while (true) {
       int candidateIndex = indices.getInt(computeShuffledIndex(i % total, total, seed));
       if (i % 32 == 0) {
-        hash = sha256Unwrapped(seed, uint64ToBytes(Math.floorDiv(i, 32L)));
+        hash = sha256.digest(seed, uint64ToBytes(Math.floorDiv(i, 32L)));
       }
       int randomByte = UnsignedBytes.toInt(hash[i % 32]);
       UInt64 effectiveBalance = state.getValidators().get(candidateIndex).getEffectiveBalance();
@@ -172,12 +181,14 @@ public class MiscHelpers {
       return;
     }
 
+    final Sha256 sha256 = getSha256Instance();
+
     for (int round = specConfig.getShuffleRoundCount() - 1; round >= 0; round--) {
 
       final Bytes roundAsByte = Bytes.of((byte) round);
 
       // This needs to be unsigned modulo.
-      final Bytes hash = sha256(seed, roundAsByte);
+      final Bytes hash = sha256.wrappedDigest(seed, roundAsByte);
       int pivot = bytesToUInt64(hash.slice(0, 8)).mod(listSize).intValue();
 
       byte[] hashBytes = EMPTY_HASH;
@@ -189,13 +200,13 @@ public class MiscHelpers {
           flip = pivot - i;
           bitIndex = i & 0xff;
           if (bitIndex == 0 || i == mirror1) {
-            hashBytes = sha256Unwrapped(seed, roundAsByte, uintTo4Bytes(i / 256));
+            hashBytes = sha256.digest(seed, roundAsByte, uintTo4Bytes(i / 256));
           }
         } else {
           flip = pivot + listSize - i;
           bitIndex = flip & 0xff;
           if (bitIndex == 0xff || i == pivot + 1) {
-            hashBytes = sha256Unwrapped(seed, roundAsByte, uintTo4Bytes(flip / 256));
+            hashBytes = sha256.digest(seed, roundAsByte, uintTo4Bytes(flip / 256));
           }
         }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/Predicates.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/Predicates.java
@@ -13,10 +13,11 @@
 
 package tech.pegasys.teku.spec.logic.common.helpers;
 
-import static tech.pegasys.teku.infrastructure.crypto.Hash.sha256;
+import static tech.pegasys.teku.infrastructure.crypto.Hash.getSha256Instance;
 import static tech.pegasys.teku.spec.constants.WithdrawalPrefixes.ETH1_ADDRESS_WITHDRAWAL_BYTE;
 
 import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.crypto.Sha256;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszBytes32Vector;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.config.SpecConfig;
@@ -48,13 +49,18 @@ public class Predicates {
   }
 
   public boolean isValidMerkleBranch(
-      Bytes32 leaf, SszBytes32Vector branch, int depth, int index, Bytes32 root) {
+      final Bytes32 leaf,
+      final SszBytes32Vector branch,
+      final int depth,
+      int index,
+      final Bytes32 root) {
+    final Sha256 sha256 = getSha256Instance();
     Bytes32 value = leaf;
     for (int i = 0; i < depth; i++) {
       if ((index & 1) == 1) {
-        value = sha256(branch.getElement(i), value);
+        value = sha256.wrappedDigest(branch.getElement(i), value);
       } else {
-        value = sha256(value, branch.getElement(i));
+        value = sha256.wrappedDigest(value, branch.getElement(i));
       }
       index >>>= 1;
     }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/helpers/BeaconStateAccessorsAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/helpers/BeaconStateAccessorsAltair.java
@@ -14,7 +14,7 @@
 package tech.pegasys.teku.spec.logic.versions.altair.helpers;
 
 import static java.util.stream.Collectors.toList;
-import static tech.pegasys.teku.infrastructure.crypto.Hash.sha256Unwrapped;
+import static tech.pegasys.teku.infrastructure.crypto.Hash.getSha256Instance;
 import static tech.pegasys.teku.spec.logic.common.helpers.MathHelpers.integerSquareRoot;
 import static tech.pegasys.teku.spec.logic.common.helpers.MathHelpers.uint64ToBytes;
 
@@ -23,6 +23,7 @@ import it.unimi.dsi.fastutil.ints.IntList;
 import java.util.List;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.infrastructure.crypto.Sha256;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.ByteUtil;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -107,12 +108,14 @@ public class BeaconStateAccessorsAltair extends BeaconStateAccessors {
     final UInt64 maxEffectiveBalance = config.getMaxEffectiveBalance();
     final int syncCommitteeSize = altairConfig.getSyncCommitteeSize();
 
+    final Sha256 sha256 = getSha256Instance();
+
     while (syncCommitteeIndices.size() < syncCommitteeSize) {
       final int shuffledIndex =
           miscHelpers.computeShuffledIndex(i % activeValidatorCount, activeValidatorCount, seed);
       final int candidateIndex = activeValidatorIndices.getInt(shuffledIndex);
       final int randomByte =
-          ByteUtil.toUnsignedInt(sha256Unwrapped(seed, uint64ToBytes(i / 32))[i % 32]);
+          ByteUtil.toUnsignedInt(sha256.digest(seed, uint64ToBytes(i / 32))[i % 32]);
       final UInt64 effectiveBalance = validators.get(candidateIndex).getEffectiveBalance();
       if (effectiveBalance
           .times(MAX_RANDOM_BYTE)

--- a/infrastructure/crypto/src/main/java/tech/pegasys/teku/infrastructure/crypto/Hash.java
+++ b/infrastructure/crypto/src/main/java/tech/pegasys/teku/infrastructure/crypto/Hash.java
@@ -44,13 +44,6 @@ public class Hash {
     return Bytes32.wrap(digest.digest());
   }
 
-  public static byte[] sha256Unwrapped(final Bytes a, final Bytes b) {
-    final MessageDigest digest = SHA256_MESSAGE_DIGEST_THREAD_LOCAL.get();
-    a.update(digest);
-    b.update(digest);
-    return digest.digest();
-  }
-
   public static Bytes32 sha256(final Bytes a, final Bytes b, final Bytes c) {
     final MessageDigest digest = SHA256_MESSAGE_DIGEST_THREAD_LOCAL.get();
     a.update(digest);
@@ -59,17 +52,19 @@ public class Hash {
     return Bytes32.wrap(digest.digest());
   }
 
-  public static byte[] sha256Unwrapped(final Bytes a, final Bytes b, final Bytes c) {
-    final MessageDigest digest = SHA256_MESSAGE_DIGEST_THREAD_LOCAL.get();
-    a.update(digest);
-    b.update(digest);
-    c.update(digest);
-    return digest.digest();
-  }
-
   public static Bytes32 keccak256(final Bytes input) {
     final MessageDigest digest = KECCAK_256_MESSAGE_DIGEST_THREAD_LOCAL.get();
     input.update(digest);
     return Bytes32.wrap(digest.digest());
+  }
+
+  /**
+   * used when we need to do several hashing in loops, so we can query the thread local once and do
+   * hashings
+   *
+   * @return Sha256
+   */
+  public static Sha256 getSha256Instance() {
+    return new Sha256(SHA256_MESSAGE_DIGEST_THREAD_LOCAL.get());
   }
 }

--- a/infrastructure/crypto/src/main/java/tech/pegasys/teku/infrastructure/crypto/Sha256.java
+++ b/infrastructure/crypto/src/main/java/tech/pegasys/teku/infrastructure/crypto/Sha256.java
@@ -24,8 +24,8 @@ import org.apache.tuweni.bytes.Bytes32;
 public class Sha256 {
   private final MessageDigest messageDigest;
 
-  public Sha256() {
-    this.messageDigest = MessageDigestFactory.createSha256();
+  Sha256(final MessageDigest messageDigest) {
+    this.messageDigest = messageDigest;
   }
 
   public byte[] digest(final Bytes a, final Bytes b) {


### PR DESCRIPTION
Just a tiny one to follow up with #7149 to reduce TL lookups when hashing in loops. We can still get the digest from the TL but wrap it into the sha256 class we can safely do hashings with.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
