### PR TITLE
Restructure `BlockContainer`

### DIFF
--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetNewBlindedBlock.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetNewBlindedBlock.java
@@ -119,8 +119,7 @@ public class GetNewBlindedBlock extends RestApiEndpoint {
         return spec.getForkSchedule().getSpecMilestoneAtSlot(((BeaconBlock) sszData).getSlot());
       } else if (sszData instanceof BlindedBlockContents) {
         return spec.getForkSchedule()
-            .getSpecMilestoneAtSlot(
-                ((BlindedBlockContents) sszData).getBlindedBeaconBlock().getSlot());
+            .getSpecMilestoneAtSlot(((BlindedBlockContents) sszData).getBlock().getSlot());
       } else {
         throw new UnsupportedOperationException(
             String.format(
@@ -181,15 +180,14 @@ public class GetNewBlindedBlock extends RestApiEndpoint {
                         .map(SchemaDefinitionsDeneb::getBlindedBlockContentsSchema),
                 (blindedBlockContents, milestone) ->
                     schemaDefinitionCache
-                        .milestoneAtSlot(blindedBlockContents.getBlindedBeaconBlock().getSlot())
+                        .milestoneAtSlot(blindedBlockContents.getBlock().getSlot())
                         .equals(milestone)),
             Function.identity())
         .withField(
             "version",
             MILESTONE_TYPE,
             blindedBlockContents ->
-                schemaDefinitionCache.milestoneAtSlot(
-                    blindedBlockContents.getBlindedBeaconBlock().getSlot()))
+                schemaDefinitionCache.milestoneAtSlot(blindedBlockContents.getBlock().getSlot()))
         .build();
   }
 }

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v2/validator/GetNewBlock.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v2/validator/GetNewBlock.java
@@ -159,14 +159,14 @@ public class GetNewBlock extends RestApiEndpoint {
                         .map(SchemaDefinitionsDeneb::getBlockContentsSchema),
                 (blockContents, milestone) ->
                     schemaDefinitionCache
-                        .milestoneAtSlot(blockContents.getBeaconBlock().getSlot())
+                        .milestoneAtSlot(blockContents.getBlock().getSlot())
                         .equals(milestone)),
             Function.identity())
         .withField(
             "version",
             MILESTONE_TYPE,
             blockContents ->
-                schemaDefinitionCache.milestoneAtSlot(blockContents.getBeaconBlock().getSlot()))
+                schemaDefinitionCache.milestoneAtSlot(blockContents.getBlock().getSlot()))
         .build();
   }
 
@@ -177,7 +177,7 @@ public class GetNewBlock extends RestApiEndpoint {
         return spec.getForkSchedule().getSpecMilestoneAtSlot(((BeaconBlock) sszData).getSlot());
       } else if (sszData instanceof BlockContents) {
         return spec.getForkSchedule()
-            .getSpecMilestoneAtSlot(((BlockContents) sszData).getBeaconBlock().getSlot());
+            .getSpecMilestoneAtSlot(((BlockContents) sszData).getBlock().getSlot());
       } else {
         throw new UnsupportedOperationException(
             String.format(

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/DeserializeBlocksTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/DeserializeBlocksTest.java
@@ -90,7 +90,6 @@ public class DeserializeBlocksTest {
 
     assertThat(result).isInstanceOf(SignedBeaconBlock.class);
 
-    assertThat(result.getBlock()).isEqualTo(randomSignedBeaconBlock.getMessage());
     assertThat(result.getSignedBlock()).isEqualTo(randomSignedBeaconBlock);
     assertThat(result.getSignedBlobSidecars()).isEmpty();
   }
@@ -112,9 +111,8 @@ public class DeserializeBlocksTest {
     assertThat(result).isInstanceOf(SignedBlockContents.class);
 
     assertThat(result.getSignedBlock()).isEqualTo(randomSignedBlockContents.getSignedBlock());
-    assertThat(result.getSignedBlobSidecars()).isPresent();
-    assertThat(result.getSignedBlobSidecars().get())
-        .hasSize(spec.getMaxBlobsPerBlock().orElseThrow());
+    assertThat(result.getSignedBlobSidecars())
+        .isEqualTo(randomSignedBlockContents.getSignedBlobSidecars());
   }
 
   @Test
@@ -158,9 +156,8 @@ public class DeserializeBlocksTest {
 
     assertThat(result.getSignedBlock())
         .isEqualTo(randomSignedBlindedBlockContents.getSignedBlock());
-    assertThat(result.getSignedBlindedBlobSidecars()).isPresent();
-    assertThat(result.getSignedBlindedBlobSidecars().get())
-        .hasSize(spec.getMaxBlobsPerBlock().orElseThrow());
+    assertThat(result.getSignedBlindedBlobSidecars())
+        .isEqualTo(randomSignedBlindedBlockContents.getSignedBlindedBlobSidecars());
   }
 
   private static class BlockContainerBuilder {}

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/DeserializeBlocksTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/DeserializeBlocksTest.java
@@ -39,13 +39,13 @@ public class DeserializeBlocksTest {
           DeserializableOneOfTypeDefinition.object(
                   SignedBlockContainer.class, BlockContainerBuilder.class)
               .withType(
-                  SignedBeaconBlock.isSignedBeaconBlockInstance,
+                  SignedBlockContainer.IS_SIGNED_BEACON_BLOCK,
                   s -> !s.contains("blob_sidecars"),
                   spec.getGenesisSchemaDefinitions()
                       .getSignedBeaconBlockSchema()
                       .getJsonTypeDefinition())
               .withType(
-                  SignedBlockContents.isSignedBlockContentsInstance,
+                  SignedBlockContainer.IS_SIGNED_BLOCK_CONTENTS,
                   s -> s.contains("blob_sidecars"),
                   SchemaDefinitionsDeneb.required(
                           spec.forMilestone(SpecMilestone.DENEB).getSchemaDefinitions())
@@ -59,13 +59,13 @@ public class DeserializeBlocksTest {
           DeserializableOneOfTypeDefinition.object(
                   SignedBlindedBlockContainer.class, BlockContainerBuilder.class)
               .withType(
-                  SignedBeaconBlock.isSignedBlindedBeaconBlockInstance,
+                  SignedBlindedBlockContainer.IS_SIGNED_BLINDED_BEACON_BLOCK,
                   s -> !s.contains("blob_sidecars"),
                   spec.getGenesisSchemaDefinitions()
                       .getSignedBeaconBlockSchema()
                       .getJsonTypeDefinition())
               .withType(
-                  SignedBlindedBlockContents.isSignedBlindedBlockContentsInstance,
+                  SignedBlindedBlockContainer.IS_SIGNED_BLINDED_BLOCK_CONTENTS,
                   s -> s.contains("blob_sidecars"),
                   SchemaDefinitionsDeneb.required(
                           spec.forMilestone(SpecMilestone.DENEB).getSchemaDefinitions())
@@ -90,7 +90,7 @@ public class DeserializeBlocksTest {
 
     assertThat(result).isInstanceOf(SignedBeaconBlock.class);
 
-    assertThat(result.getSignedBeaconBlock()).isPresent();
+    assertThat(result.getBlock()).isNotNull();
     assertThat(result.getSignedBlobSidecars()).isEmpty();
   }
 
@@ -110,7 +110,7 @@ public class DeserializeBlocksTest {
             DESERIALIZABLE_ONE_OF_SIGNED_BEACON_BLOCK_OR_SIGNED_BLOCK_CONTENTS);
     assertThat(result).isInstanceOf(SignedBlockContents.class);
 
-    assertThat(result.getSignedBeaconBlock()).isPresent();
+    assertThat(result.getSignedBlock()).isEqualTo(randomSignedBlockContents.getSignedBlock());
     assertThat(result.getSignedBlobSidecars()).isPresent();
     assertThat(result.getSignedBlobSidecars().get())
         .hasSize(spec.getMaxBlobsPerBlock().orElseThrow());
@@ -133,7 +133,7 @@ public class DeserializeBlocksTest {
 
     assertThat(result).isInstanceOf(SignedBeaconBlock.class);
 
-    assertThat(result.getSignedBeaconBlock()).isPresent();
+    assertThat(result.getSignedBlock()).isEqualTo(randomBlindedBeaconBlock);
     assertThat(result.getSignedBlindedBlobSidecars()).isEmpty();
   }
 
@@ -155,7 +155,8 @@ public class DeserializeBlocksTest {
 
     assertThat(result).isInstanceOf(SignedBlindedBlockContents.class);
 
-    assertThat(result.getSignedBeaconBlock()).isPresent();
+    assertThat(result.getSignedBlock())
+        .isEqualTo(randomSignedBlindedBlockContents.getSignedBlock());
     assertThat(result.getSignedBlindedBlobSidecars()).isPresent();
     assertThat(result.getSignedBlindedBlobSidecars().get())
         .hasSize(spec.getMaxBlobsPerBlock().orElseThrow());

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/DeserializeBlocksTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/DeserializeBlocksTest.java
@@ -90,7 +90,8 @@ public class DeserializeBlocksTest {
 
     assertThat(result).isInstanceOf(SignedBeaconBlock.class);
 
-    assertThat(result.getBlock()).isNotNull();
+    assertThat(result.getBlock()).isEqualTo(randomSignedBeaconBlock.getMessage());
+    assertThat(result.getSignedBlock()).isEqualTo(randomSignedBeaconBlock);
     assertThat(result.getSignedBlobSidecars()).isEmpty();
   }
 

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/DeserializeBlocksTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/DeserializeBlocksTest.java
@@ -33,8 +33,11 @@ import tech.pegasys.teku.spec.util.DataStructureUtil;
 public class DeserializeBlocksTest {
 
   static Spec spec = TestSpecFactory.createMinimalDeneb();
-  DataStructureUtil denebData = new DataStructureUtil(spec);
-  public static final DeserializableOneOfTypeDefinition<SignedBlockContainer, BlockContainerBuilder>
+
+  private final DataStructureUtil denebData = new DataStructureUtil(spec);
+
+  private static final DeserializableOneOfTypeDefinition<
+          SignedBlockContainer, BlockContainerBuilder>
       DESERIALIZABLE_ONE_OF_SIGNED_BEACON_BLOCK_OR_SIGNED_BLOCK_CONTENTS =
           DeserializableOneOfTypeDefinition.object(
                   SignedBlockContainer.class, BlockContainerBuilder.class)
@@ -76,9 +79,9 @@ public class DeserializeBlocksTest {
   @Test
   void shouldDeserializeSignedBeaconBlock() throws JsonProcessingException {
 
-    SignedBeaconBlock randomSignedBeaconBlock = denebData.randomSignedBeaconBlock();
+    final SignedBeaconBlock randomSignedBeaconBlock = denebData.randomSignedBeaconBlock();
 
-    String serializedSignedBeaconBlock =
+    final String serializedSignedBeaconBlock =
         JsonUtil.serialize(
             randomSignedBeaconBlock,
             DESERIALIZABLE_ONE_OF_SIGNED_BEACON_BLOCK_OR_SIGNED_BLOCK_CONTENTS);
@@ -97,9 +100,9 @@ public class DeserializeBlocksTest {
   @Test
   void shouldDeserializeSignedBlockContents() throws JsonProcessingException {
 
-    SignedBlockContents randomSignedBlockContents = denebData.randomSignedBlockContents();
+    final SignedBlockContents randomSignedBlockContents = denebData.randomSignedBlockContents();
 
-    String serializedSignedBlockContents =
+    final String serializedSignedBlockContents =
         JsonUtil.serialize(
             randomSignedBlockContents,
             DESERIALIZABLE_ONE_OF_SIGNED_BEACON_BLOCK_OR_SIGNED_BLOCK_CONTENTS);
@@ -118,9 +121,9 @@ public class DeserializeBlocksTest {
   @Test
   void shouldDeserializeSignedBlindedBeaconBlock() throws JsonProcessingException {
 
-    SignedBeaconBlock randomBlindedBeaconBlock = denebData.randomSignedBeaconBlock();
+    final SignedBeaconBlock randomBlindedBeaconBlock = denebData.randomSignedBeaconBlock();
 
-    String serializedSignedBeaconBlock =
+    final String serializedSignedBeaconBlock =
         JsonUtil.serialize(
             randomBlindedBeaconBlock,
             DESERIALIZABLE_ONE_OF_SIGNED_BLINDED_BEACON_BLOCK_OR_SIGNED_BLINDED_BLOCK_CONTENTS);
@@ -139,10 +142,10 @@ public class DeserializeBlocksTest {
   @Test
   void shouldDeserializeBlindedBlockContents() throws JsonProcessingException {
 
-    SignedBlindedBlockContents randomSignedBlindedBlockContents =
+    final SignedBlindedBlockContents randomSignedBlindedBlockContents =
         denebData.randomSignedBlindedBlockContents();
 
-    String serializedSignedBlindedBlockContents =
+    final String serializedSignedBlindedBlockContents =
         JsonUtil.serialize(
             randomSignedBlindedBlockContents,
             DESERIALIZABLE_ONE_OF_SIGNED_BLINDED_BEACON_BLOCK_OR_SIGNED_BLINDED_BLOCK_CONTENTS);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/BeaconBlock.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/BeaconBlock.java
@@ -27,7 +27,7 @@ import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
 
 public class BeaconBlock
     extends Container5<BeaconBlock, SszUInt64, SszUInt64, SszBytes32, SszBytes32, BeaconBlockBody>
-    implements BeaconBlockSummary, BlockContainer {
+    implements BeaconBlockSummary, BlockContainer, BlindedBlockContainer {
 
   BeaconBlock(final BeaconBlockSchema type, TreeNode backingNode) {
     super(type, backingNode);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/BeaconBlock.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/BeaconBlock.java
@@ -114,7 +114,7 @@ public class BeaconBlock
   }
 
   @Override
-  public Optional<SignedBeaconBlock> getSignedBeaconBlock() {
-    return Optional.empty();
+  public BeaconBlock getBlock() {
+    return this;
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/BlindedBlockContainer.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/BlindedBlockContainer.java
@@ -14,9 +14,12 @@
 package tech.pegasys.teku.spec.datastructures.blocks;
 
 import java.util.List;
+import java.util.Optional;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlindedBlobSidecar;
 
 public interface BlindedBlockContainer extends BlockContainer {
 
-  List<BlindedBlobSidecar> getBlindedBlobSidecars();
+  default Optional<List<BlindedBlobSidecar>> getBlindedBlobSidecars() {
+    return Optional.empty();
+  }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/BlindedBlockContainer.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/BlindedBlockContainer.java
@@ -14,19 +14,9 @@
 package tech.pegasys.teku.spec.datastructures.blocks;
 
 import java.util.List;
-import java.util.Optional;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
-import tech.pegasys.teku.spec.datastructures.blocks.versions.deneb.BlockContents;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlindedBlobSidecar;
 
-/**
- * Interface used to represent both {@link BlockContents} and {@link BeaconBlock} and all their
- * variants
- */
-public interface BlockContainer {
+public interface BlindedBlockContainer extends BlockContainer {
 
-  BeaconBlock getBlock();
-
-  default Optional<List<BlobSidecar>> getBlobSidecars() {
-    return Optional.empty();
-  }
+  List<BlindedBlobSidecar> getBlindedBlobSidecars();
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/BlockContainer.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/BlockContainer.java
@@ -20,7 +20,8 @@ import tech.pegasys.teku.spec.datastructures.blocks.versions.deneb.BlockContents
 
 /**
  * Interface used to represent both {@link BlockContents} and {@link BeaconBlock} and all their
- * variants
+ * variants: <a
+ * href="https://github.com/ethereum/beacon-APIs/tree/master/types/deneb">beacon-APIs/types/deneb</a>
  */
 public interface BlockContainer {
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBeaconBlock.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBeaconBlock.java
@@ -19,7 +19,6 @@ import it.unimi.dsi.fastutil.longs.LongList;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.function.Predicate;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.ssz.containers.Container2;
@@ -187,9 +186,13 @@ public class SignedBeaconBlock extends Container2<SignedBeaconBlock, BeaconBlock
     return getMessage().hashTreeRoot();
   }
 
-  public static Predicate<SignedBlockContainer> isSignedBeaconBlockInstance =
-      signedBeaconBlock -> signedBeaconBlock instanceof SignedBeaconBlock;
+  @Override
+  public BeaconBlock getBlock() {
+    return getMessage();
+  }
 
-  public static Predicate<SignedBlindedBlockContainer> isSignedBlindedBeaconBlockInstance =
-      signedBlindedBeaconBlock -> signedBlindedBeaconBlock instanceof SignedBeaconBlock;
+  @Override
+  public SignedBeaconBlock getSignedBlock() {
+    return this;
+  }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBeaconBlock.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBeaconBlock.java
@@ -187,11 +187,6 @@ public class SignedBeaconBlock extends Container2<SignedBeaconBlock, BeaconBlock
   }
 
   @Override
-  public BeaconBlock getBlock() {
-    return getMessage();
-  }
-
-  @Override
   public SignedBeaconBlock getSignedBlock() {
     return this;
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBlindedBlockContainer.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBlindedBlockContainer.java
@@ -15,9 +15,17 @@ package tech.pegasys.teku.spec.datastructures.blocks;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Predicate;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlindedBlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blocks.versions.deneb.SignedBlindedBlockContents;
 
-public interface SignedBlindedBlockContainer extends BlockContainer {
+public interface SignedBlindedBlockContainer extends SignedBlockContainer {
+
+  Predicate<SignedBlindedBlockContainer> IS_SIGNED_BLINDED_BEACON_BLOCK =
+      blockContainer -> blockContainer instanceof SignedBeaconBlock;
+
+  Predicate<SignedBlindedBlockContainer> IS_SIGNED_BLINDED_BLOCK_CONTENTS =
+      blockContainer -> blockContainer instanceof SignedBlindedBlockContents;
 
   default Optional<List<SignedBlindedBlobSidecar>> getSignedBlindedBlobSidecars() {
     return Optional.empty();

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBlockContainer.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBlockContainer.java
@@ -29,6 +29,11 @@ public interface SignedBlockContainer extends BlockContainer {
   Predicate<SignedBlockContainer> IS_SIGNED_BEACON_BLOCK =
       blockContainer -> blockContainer instanceof SignedBeaconBlock;
 
+  @Override
+  default BeaconBlock getBlock() {
+    return getSignedBlock().getMessage();
+  }
+
   SignedBeaconBlock getSignedBlock();
 
   default Optional<List<SignedBlobSidecar>> getSignedBlobSidecars() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBlockContainer.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBlockContainer.java
@@ -16,6 +16,8 @@ package tech.pegasys.teku.spec.datastructures.blocks;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.versions.deneb.SignedBlockContents;
 
@@ -31,5 +33,15 @@ public interface SignedBlockContainer extends BlockContainer {
 
   default Optional<List<SignedBlobSidecar>> getSignedBlobSidecars() {
     return Optional.empty();
+  }
+
+  @Override
+  default Optional<List<BlobSidecar>> getBlobSidecars() {
+    return getSignedBlobSidecars()
+        .map(
+            signedBlobSidecars ->
+                signedBlobSidecars.stream()
+                    .map(SignedBlobSidecar::getBlobSidecar)
+                    .collect(Collectors.toList()));
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBlockContainer.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBlockContainer.java
@@ -15,9 +15,19 @@ package tech.pegasys.teku.spec.datastructures.blocks;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Predicate;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blocks.versions.deneb.SignedBlockContents;
 
 public interface SignedBlockContainer extends BlockContainer {
+
+  Predicate<SignedBlockContainer> IS_SIGNED_BLOCK_CONTENTS =
+      blockContainer -> blockContainer instanceof SignedBlockContents;
+
+  Predicate<SignedBlockContainer> IS_SIGNED_BEACON_BLOCK =
+      blockContainer -> blockContainer instanceof SignedBeaconBlock;
+
+  SignedBeaconBlock getSignedBlock();
 
   default Optional<List<SignedBlobSidecar>> getSignedBlobSidecars() {
     return Optional.empty();

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/versions/deneb/BlindedBlockContents.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/versions/deneb/BlindedBlockContents.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.spec.datastructures.blocks.versions.deneb;
 
 import java.util.List;
+import java.util.Optional;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.ssz.containers.Container2;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
@@ -50,7 +51,7 @@ public class BlindedBlockContents
   }
 
   @Override
-  public List<BlindedBlobSidecar> getBlindedBlobSidecars() {
-    return getField1().asList();
+  public Optional<List<BlindedBlobSidecar>> getBlindedBlobSidecars() {
+    return Optional.of(getField1().asList());
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/versions/deneb/BlindedBlockContents.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/versions/deneb/BlindedBlockContents.java
@@ -40,14 +40,9 @@ public class BlindedBlockContents
         schema.getBlindedBlobSidecarsSchema().createFromElements(blindedBlobSidecars));
   }
 
-  // We only need a Blinded BeaconBlock
-  public BeaconBlock getBlindedBeaconBlock() {
-    return getField0();
-  }
-
   @Override
   public BeaconBlock getBlock() {
-    return getBlindedBeaconBlock();
+    return getField0();
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/versions/deneb/BlindedBlockContents.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/versions/deneb/BlindedBlockContents.java
@@ -19,11 +19,11 @@ import tech.pegasys.teku.infrastructure.ssz.containers.Container2;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlindedBlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
-import tech.pegasys.teku.spec.datastructures.blocks.BlockContainer;
+import tech.pegasys.teku.spec.datastructures.blocks.BlindedBlockContainer;
 
 public class BlindedBlockContents
     extends Container2<BlindedBlockContents, BeaconBlock, SszList<BlindedBlobSidecar>>
-    implements BlockContainer {
+    implements BlindedBlockContainer {
 
   BlindedBlockContents(final BlindedBlockContentsSchema type, final TreeNode backingNode) {
     super(type, backingNode);
@@ -44,6 +44,12 @@ public class BlindedBlockContents
     return getField0();
   }
 
+  @Override
+  public BeaconBlock getBlock() {
+    return getBlindedBeaconBlock();
+  }
+
+  @Override
   public List<BlindedBlobSidecar> getBlindedBlobSidecars() {
     return getField1().asList();
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/versions/deneb/BlockContents.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/versions/deneb/BlockContents.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.spec.datastructures.blocks.versions.deneb;
 
 import java.util.List;
+import java.util.Optional;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.ssz.containers.Container2;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
@@ -35,11 +36,13 @@ public class BlockContents extends Container2<BlockContents, BeaconBlock, SszLis
     super(schema, beaconBlock, schema.getBlobSidecarsSchema().createFromElements(blobSidecars));
   }
 
-  public BeaconBlock getBeaconBlock() {
+  @Override
+  public BeaconBlock getBlock() {
     return getField0();
   }
 
-  public List<BlobSidecar> getBlobSidecars() {
-    return getField1().asList();
+  @Override
+  public Optional<List<BlobSidecar>> getBlobSidecars() {
+    return Optional.of(getField1().asList());
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/versions/deneb/SignedBlindedBlockContents.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/versions/deneb/SignedBlindedBlockContents.java
@@ -15,11 +15,11 @@ package tech.pegasys.teku.spec.datastructures.blocks.versions.deneb;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.function.Predicate;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.ssz.containers.Container2;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlindedBlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlindedBlockContainer;
 
@@ -44,16 +44,17 @@ public class SignedBlindedBlockContents
   }
 
   @Override
-  public Optional<SignedBeaconBlock> getSignedBeaconBlock() {
-    return Optional.of(getField0());
+  public BeaconBlock getBlock() {
+    return getField0().getBlock();
+  }
+
+  @Override
+  public SignedBeaconBlock getSignedBlock() {
+    return getField0();
   }
 
   @Override
   public Optional<List<SignedBlindedBlobSidecar>> getSignedBlindedBlobSidecars() {
     return Optional.of(getField1().asList());
   }
-
-  public static Predicate<SignedBlindedBlockContainer> isSignedBlindedBlockContentsInstance =
-      signedBlindedBlockContents ->
-          signedBlindedBlockContents instanceof SignedBlindedBlockContents;
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/versions/deneb/SignedBlindedBlockContents.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/versions/deneb/SignedBlindedBlockContents.java
@@ -19,7 +19,6 @@ import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.ssz.containers.Container2;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlindedBlobSidecar;
-import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlindedBlockContainer;
 
@@ -41,11 +40,6 @@ public class SignedBlindedBlockContents
         schema,
         signedBeaconBlock,
         schema.getSignedBlindedBlobSidecarsSchema().createFromElements(signedBlindedBlobSidecars));
-  }
-
-  @Override
-  public BeaconBlock getBlock() {
-    return getField0().getBlock();
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/versions/deneb/SignedBlockContents.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/versions/deneb/SignedBlockContents.java
@@ -19,7 +19,6 @@ import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.ssz.containers.Container2;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecar;
-import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
 
@@ -39,11 +38,6 @@ public class SignedBlockContents
         schema,
         signedBeaconBlock,
         schema.getSignedBlobSidecarsSchema().createFromElements(signedBlobSidecars));
-  }
-
-  @Override
-  public BeaconBlock getBlock() {
-    return getSignedBlock().getBlock();
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/versions/deneb/SignedBlockContents.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/versions/deneb/SignedBlockContents.java
@@ -15,11 +15,11 @@ package tech.pegasys.teku.spec.datastructures.blocks.versions.deneb;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.function.Predicate;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.ssz.containers.Container2;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
 
@@ -42,15 +42,17 @@ public class SignedBlockContents
   }
 
   @Override
-  public Optional<SignedBeaconBlock> getSignedBeaconBlock() {
-    return Optional.of(getField0());
+  public BeaconBlock getBlock() {
+    return getSignedBlock().getBlock();
+  }
+
+  @Override
+  public SignedBeaconBlock getSignedBlock() {
+    return getField0();
   }
 
   @Override
   public Optional<List<SignedBlobSidecar>> getSignedBlobSidecars() {
     return Optional.of(getField1().asList());
   }
-
-  public static Predicate<SignedBlockContainer> isSignedBlockContentsInstance =
-      signedBlockContent -> signedBlockContent instanceof SignedBlockContents;
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Decided to restructure `BlockContainer` a little bit to make it easier to use and more aligned with spec. 

- Changed `getBeaconBlock()` to `getBlock()` and `getSignedBeaconBlock()` to `getSignedBlock()` which allows to remove the optionals. It also aligns more with field names in the beacon api spec.
- Moved some of the `instanceof` predicates into their respective  interfaces. 

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
