### PR TITLE
Fix `handleError` and `handleSuccess` race condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,3 +24,5 @@ For information on changes in released versions of Teku, see the [releases page]
 - Add support for Chiado (Gnosis testnet): `--network=chiado`
 
 ### Bug Fixes
+
+- Fix a race condition on EL api result handling which may lead to beacon node remain syncing forever

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JClient.java
@@ -48,7 +48,7 @@ public abstract class Web3JClient {
 
   // Default to the provider having a previous failure at startup so we log when it is first
   // available but uses a very old value to make sure we log if the first request fails
-  private long lastError = STARTUP_LAST_ERROR_TIME;
+  private long lastErrorTime = STARTUP_LAST_ERROR_TIME;
   private boolean initialized = false;
 
   protected Web3JClient(
@@ -121,14 +121,14 @@ public abstract class Web3JClient {
 
   protected synchronized void handleSuccess(final boolean isCriticalRequest) {
     if (isCriticalRequest) {
-      if (lastError == STARTUP_LAST_ERROR_TIME) {
+      if (lastErrorTime == STARTUP_LAST_ERROR_TIME) {
         eventLog.executionClientIsOnline();
         executionClientEventsPublisher.onAvailabilityUpdated(true);
-      } else if (lastError != NO_ERROR_TIME) {
+      } else if (lastErrorTime != NO_ERROR_TIME) {
         eventLog.executionClientRecovered();
         executionClientEventsPublisher.onAvailabilityUpdated(true);
       }
-      lastError = NO_ERROR_TIME;
+      lastErrorTime = NO_ERROR_TIME;
     }
   }
 
@@ -156,8 +156,8 @@ public abstract class Web3JClient {
 
   private boolean shouldReportError() {
     final long timeNow = timeProvider.getTimeInMillis().longValue();
-    if (lastError == NO_ERROR_TIME || timeNow - lastError > ERROR_REPEAT_DELAY_MILLIS) {
-      lastError = timeNow;
+    if (lastErrorTime == NO_ERROR_TIME || timeNow - lastErrorTime > ERROR_REPEAT_DELAY_MILLIS) {
+      lastErrorTime = timeNow;
       return true;
     }
     return false;

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JClient.java
@@ -20,7 +20,6 @@ import java.time.Duration;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicLong;
 import org.web3j.protocol.Web3j;
 import org.web3j.protocol.Web3jService;
 import org.web3j.protocol.core.Request;
@@ -49,7 +48,7 @@ public abstract class Web3JClient {
 
   // Default to the provider having a previous failure at startup so we log when it is first
   // available but uses a very old value to make sure we log if the first request fails
-  private final AtomicLong lastError = new AtomicLong(STARTUP_LAST_ERROR_TIME);
+  private long lastError = STARTUP_LAST_ERROR_TIME;
   private boolean initialized = false;
 
   protected Web3JClient(
@@ -112,7 +111,7 @@ public abstract class Web3JClient {
     handleError(true, error, couldBeAuthError);
   }
 
-  protected void handleError(
+  protected synchronized void handleError(
       final boolean isCritical, final Throwable error, final boolean couldBeAuthError) {
     if (isCritical && shouldReportError()) {
       logExecutionClientError(error, couldBeAuthError);
@@ -120,16 +119,16 @@ public abstract class Web3JClient {
     }
   }
 
-  protected void handleSuccess(final boolean isCriticalRequest) {
+  protected synchronized void handleSuccess(final boolean isCriticalRequest) {
     if (isCriticalRequest) {
-      final long lastErrorTime = lastError.getAndUpdate(x -> NO_ERROR_TIME);
-      if (lastErrorTime == STARTUP_LAST_ERROR_TIME) {
+      if (lastError == STARTUP_LAST_ERROR_TIME) {
         eventLog.executionClientIsOnline();
         executionClientEventsPublisher.onAvailabilityUpdated(true);
-      } else if (lastErrorTime != NO_ERROR_TIME) {
+      } else if (lastError != NO_ERROR_TIME) {
         eventLog.executionClientRecovered();
         executionClientEventsPublisher.onAvailabilityUpdated(true);
       }
+      lastError = NO_ERROR_TIME;
     }
   }
 
@@ -157,17 +156,11 @@ public abstract class Web3JClient {
 
   private boolean shouldReportError() {
     final long timeNow = timeProvider.getTimeInMillis().longValue();
-    final long maybeUpdatedTime =
-        lastError.accumulateAndGet(
-            timeNow,
-            (lastErrorTime, givenErrorTimeUpdate) -> {
-              if (lastErrorTime == NO_ERROR_TIME
-                  || givenErrorTimeUpdate - lastErrorTime > ERROR_REPEAT_DELAY_MILLIS) {
-                return givenErrorTimeUpdate;
-              }
-              return lastErrorTime;
-            });
-    return maybeUpdatedTime == timeNow;
+    if (lastError == NO_ERROR_TIME || timeNow - lastError > ERROR_REPEAT_DELAY_MILLIS) {
+      lastError = timeNow;
+      return true;
+    }
+    return false;
   }
 
   private void logExecutionClientError(final Throwable error, final boolean couldBeAuthError) {


### PR DESCRIPTION
Guarantee that handleError and handleSuccess are fully executed atomically, not just lastError tracking.

Not doing that we may end up calling `onAvailabilityUpdated` in a different order with respect to the order we use to update the lastError timestamp tracker

fixes #7159 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
