### PR TITLE
[Decoupling] Implement `BlockFactoryDeneb` (part 2)

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/AbstractBlockFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/AbstractBlockFactory.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright ConsenSys Software Inc., 2023
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.coordinator;
+
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+
+public abstract class AbstractBlockFactory implements BlockFactory {
+
+  protected final Spec spec;
+  protected final BlockOperationSelectorFactory operationSelector;
+
+  protected AbstractBlockFactory(
+      final Spec spec, final BlockOperationSelectorFactory operationSelector) {
+    this.spec = spec;
+    this.operationSelector = operationSelector;
+  }
+
+  @Override
+  public SafeFuture<SignedBeaconBlock> unblindSignedBeaconBlockIfBlinded(
+      final SignedBeaconBlock blindedSignedBeaconBlock) {
+    if (blindedSignedBeaconBlock.isBlinded()) {
+      return spec.unblindSignedBeaconBlock(
+          blindedSignedBeaconBlock, operationSelector.createUnblinderSelector());
+    }
+    return SafeFuture.completedFuture(blindedSignedBeaconBlock);
+  }
+}

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactory.java
@@ -13,70 +13,24 @@
 
 package tech.pegasys.teku.validator.coordinator;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
-import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockAndState;
+import tech.pegasys.teku.spec.datastructures.blocks.BlockContainer;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 
-public class BlockFactory {
-  private final Spec spec;
-  private final BlockOperationSelectorFactory operationSelector;
+public interface BlockFactory {
 
-  public BlockFactory(final Spec spec, final BlockOperationSelectorFactory operationSelector) {
-    this.spec = spec;
-    this.operationSelector = operationSelector;
-  }
+  SafeFuture<BlockContainer> createUnsignedBlock(
+      BeaconState blockSlotState,
+      UInt64 newSlot,
+      BLSSignature randaoReveal,
+      Optional<Bytes32> optionalGraffiti,
+      boolean blinded);
 
-  public SafeFuture<BeaconBlock> createUnsignedBlock(
-      final BeaconState blockSlotState,
-      final UInt64 newSlot,
-      final BLSSignature randaoReveal,
-      final Optional<Bytes32> optionalGraffiti,
-      final boolean blinded) {
-    checkArgument(
-        blockSlotState.getSlot().equals(newSlot),
-        "Block slot state for slot %s but should be for slot %s",
-        blockSlotState.getSlot(),
-        newSlot);
-
-    // Process empty slots up to the one before the new block slot
-    final UInt64 slotBeforeBlock = newSlot.minus(UInt64.ONE);
-
-    final Bytes32 parentRoot = spec.getBlockRootAtSlot(blockSlotState, slotBeforeBlock);
-
-    return spec.createNewUnsignedBlock(
-            newSlot,
-            spec.getBeaconProposerIndex(blockSlotState, newSlot),
-            blockSlotState,
-            parentRoot,
-            operationSelector.createSelector(
-                parentRoot, blockSlotState, randaoReveal, optionalGraffiti),
-            blinded)
-        .thenApply(BeaconBlockAndState::getBlock);
-  }
-
-  public SafeFuture<SignedBeaconBlock> unblindSignedBeaconBlockIfBlinded(
-      final SignedBeaconBlock blindedSignedBeaconBlock) {
-    if (blindedSignedBeaconBlock.isBlinded()) {
-      return spec.unblindSignedBeaconBlock(
-          blindedSignedBeaconBlock, operationSelector.createUnblinderSelector());
-    }
-    return SafeFuture.completedFuture(blindedSignedBeaconBlock);
-  }
-
-  public SignedBeaconBlock blindSignedBeaconBlockIfUnblinded(
-      final SignedBeaconBlock unblindedSignedBeaconBlock) {
-    if (unblindedSignedBeaconBlock.isBlinded()) {
-      return unblindedSignedBeaconBlock;
-    }
-    return spec.blindSignedBeaconBlock(unblindedSignedBeaconBlock);
-  }
+  SafeFuture<SignedBeaconBlock> unblindSignedBeaconBlockIfBlinded(
+      SignedBeaconBlock blindedSignedBeaconBlock);
 }

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactoryDeneb.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactoryDeneb.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright ConsenSys Software Inc., 2023
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.coordinator;
+
+import java.util.List;
+import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlindedBlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
+import tech.pegasys.teku.spec.datastructures.blocks.BlockContainer;
+import tech.pegasys.teku.spec.datastructures.blocks.versions.deneb.BlindedBlockContents;
+import tech.pegasys.teku.spec.datastructures.blocks.versions.deneb.BlockContents;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsDeneb;
+
+public class BlockFactoryDeneb extends BlockFactoryPhase0 {
+
+  private final SchemaDefinitionsDeneb schemaDefinitionsDeneb;
+
+  public BlockFactoryDeneb(final Spec spec, final BlockOperationSelectorFactory operationSelector) {
+    super(spec, operationSelector);
+    this.schemaDefinitionsDeneb =
+        SchemaDefinitionsDeneb.required(
+            spec.forMilestone(SpecMilestone.DENEB).getSchemaDefinitions());
+  }
+
+  @Override
+  public SafeFuture<BlockContainer> createUnsignedBlock(
+      final BeaconState blockSlotState,
+      final UInt64 newSlot,
+      final BLSSignature randaoReveal,
+      final Optional<Bytes32> optionalGraffiti,
+      final boolean blinded) {
+    return super.createUnsignedBlock(
+            blockSlotState, newSlot, randaoReveal, optionalGraffiti, blinded)
+        .thenApply(BlockContainer::getBlock)
+        .thenCompose(
+            block -> {
+              if (block.isBlinded()) {
+                return operationSelector
+                    .createBlindedBlobSidecarsSelector()
+                    .apply(block)
+                    .thenApply(
+                        blindedBlobSidecars ->
+                            createBlindedBlockContents(block, blindedBlobSidecars));
+              }
+              return operationSelector
+                  .createBlobSidecarsSelector()
+                  .apply(block)
+                  .thenApply(blobSidecars -> createBlockContents(block, blobSidecars));
+            });
+  }
+
+  private BlockContents createBlockContents(
+      final BeaconBlock block, final List<BlobSidecar> blobSidecars) {
+    return schemaDefinitionsDeneb.getBlockContentsSchema().create(block, blobSidecars);
+  }
+
+  private BlindedBlockContents createBlindedBlockContents(
+      final BeaconBlock block, final List<BlindedBlobSidecar> blindedBlobSidecars) {
+    return schemaDefinitionsDeneb
+        .getBlindedBlockContentsSchema()
+        .create(block, blindedBlobSidecars);
+  }
+}

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactoryPhase0.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactoryPhase0.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright ConsenSys Software Inc., 2023
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.coordinator;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockAndState;
+import tech.pegasys.teku.spec.datastructures.blocks.BlockContainer;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+
+public class BlockFactoryPhase0 extends AbstractBlockFactory {
+
+  public BlockFactoryPhase0(
+      final Spec spec, final BlockOperationSelectorFactory operationSelector) {
+    super(spec, operationSelector);
+  }
+
+  @Override
+  public SafeFuture<BlockContainer> createUnsignedBlock(
+      final BeaconState blockSlotState,
+      final UInt64 newSlot,
+      final BLSSignature randaoReveal,
+      final Optional<Bytes32> optionalGraffiti,
+      final boolean blinded) {
+    checkArgument(
+        blockSlotState.getSlot().equals(newSlot),
+        "Block slot state for slot %s but should be for slot %s",
+        blockSlotState.getSlot(),
+        newSlot);
+
+    // Process empty slots up to the one before the new block slot
+    final UInt64 slotBeforeBlock = newSlot.minus(UInt64.ONE);
+
+    final Bytes32 parentRoot = spec.getBlockRootAtSlot(blockSlotState, slotBeforeBlock);
+
+    return spec.createNewUnsignedBlock(
+            newSlot,
+            spec.getBeaconProposerIndex(blockSlotState, newSlot),
+            blockSlotState,
+            parentRoot,
+            operationSelector.createSelector(
+                parentRoot, blockSlotState, randaoReveal, optionalGraffiti),
+            blinded)
+        .thenApply(BeaconBlockAndState::getBlock);
+  }
+}

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
@@ -382,8 +382,12 @@ public class BlockOperationSelectorFactory {
   private SafeFuture<BlobsBundle> getCachedBlobsBundle(final UInt64 slot) {
     return executionLayerBlockProductionManager
         .getCachedPayloadResult(slot)
-        .orElseThrow(() -> new IllegalStateException("payloadResult is required"))
+        .orElseThrow(
+            () ->
+                new IllegalStateException(
+                    "ExecutionPayloadResult is not available for slot " + slot))
         .getBlobsBundleFuture()
-        .orElseThrow(() -> new IllegalStateException("blobs bundle is required"));
+        .orElseThrow(
+            () -> new IllegalStateException("BlobsBundle is not available for slot " + slot));
   }
 }

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
@@ -385,7 +385,7 @@ public class BlockOperationSelectorFactory {
                   final Blob blob = blobsBundle.getBlobs().get(i);
                   final KZGProof kzgProof = blobsBundle.getProofs().get(i);
                   final KZGCommitment kzgCommitment = blobsBundle.getCommitments().get(i);
-                  final BlindedBlobSidecar blobSidecar =
+                  final BlindedBlobSidecar blindedBlobSidecar =
                       blindedBlobSidecarSchema.create(
                           block.getRoot(),
                           UInt64.valueOf(i),
@@ -395,7 +395,7 @@ public class BlockOperationSelectorFactory {
                           blob.hashTreeRoot(),
                           kzgProof.getBytesCompressed(),
                           kzgCommitment.getBytesCompressed());
-                  blindedBlobSidecars.add(blobSidecar);
+                  blindedBlobSidecars.add(blindedBlobSidecar);
                 }
                 return blindedBlobSidecars;
               });

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
@@ -336,10 +336,7 @@ public class BlockOperationSelectorFactory {
   public Function<BeaconBlock, SafeFuture<List<BlobSidecar>>> createBlobSidecarsSelector() {
     return block -> {
       final BlobSidecarSchema blobSidecarSchema =
-          spec.atSlot(block.getSlot())
-              .getSchemaDefinitions()
-              .toVersionDeneb()
-              .orElseThrow()
+          SchemaDefinitionsDeneb.required(spec.atSlot(block.getSlot()).getSchemaDefinitions())
               .getBlobSidecarSchema();
       return getCachedBlobsBundle(block.getSlot())
           .thenApply(
@@ -371,10 +368,7 @@ public class BlockOperationSelectorFactory {
       createBlindedBlobSidecarsSelector() {
     return block -> {
       final BlindedBlobSidecarSchema blindedBlobSidecarSchema =
-          spec.atSlot(block.getSlot())
-              .getSchemaDefinitions()
-              .toVersionDeneb()
-              .orElseThrow()
+          SchemaDefinitionsDeneb.required(spec.atSlot(block.getSlot()).getSchemaDefinitions())
               .getBlindedBlobSidecarSchema();
       return getCachedBlobsBundle(block.getSlot())
           .thenApply(

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
@@ -348,8 +348,8 @@ public class BlockOperationSelectorFactory {
                 final List<BlobSidecar> blobSidecars = new ArrayList<>(numberOfBlobs);
                 for (int i = 0; i < numberOfBlobs; i++) {
                   final Blob blob = blobsBundle.getBlobs().get(i);
-                  final KZGProof kzgProof = blobsBundle.getProofs().get(i);
                   final KZGCommitment kzgCommitment = blobsBundle.getCommitments().get(i);
+                  final KZGProof kzgProof = blobsBundle.getProofs().get(i);
                   final BlobSidecar blobSidecar =
                       blobSidecarSchema.create(
                           block.getRoot(),
@@ -358,8 +358,8 @@ public class BlockOperationSelectorFactory {
                           block.getParentRoot(),
                           block.getProposerIndex(),
                           blob.getBytes(),
-                          kzgProof.getBytesCompressed(),
-                          kzgCommitment.getBytesCompressed());
+                          kzgCommitment.getBytesCompressed(),
+                          kzgProof.getBytesCompressed());
                   blobSidecars.add(blobSidecar);
                 }
                 return blobSidecars;
@@ -393,8 +393,8 @@ public class BlockOperationSelectorFactory {
                           block.getParentRoot(),
                           block.getProposerIndex(),
                           blob.hashTreeRoot(),
-                          kzgProof.getBytesCompressed(),
-                          kzgCommitment.getBytesCompressed());
+                          kzgCommitment.getBytesCompressed(),
+                          kzgProof.getBytesCompressed());
                   blindedBlobSidecars.add(blindedBlobSidecar);
                 }
                 return blindedBlobSidecars;

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/MilestoneBasedBlockFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/MilestoneBasedBlockFactory.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright ConsenSys Software Inc., 2023
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.coordinator;
+
+import com.google.common.base.Suppliers;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.datastructures.blocks.BlockContainer;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+
+public class MilestoneBasedBlockFactory extends AbstractBlockFactory {
+
+  private final Map<SpecMilestone, BlockFactory> registeredFactories = new HashMap<>();
+
+  public MilestoneBasedBlockFactory(
+      final Spec spec, final BlockOperationSelectorFactory operationSelector) {
+    super(spec, operationSelector);
+    final BlockFactoryPhase0 blockFactoryPhase0 = new BlockFactoryPhase0(spec, operationSelector);
+
+    // Not needed for all milestones
+    final Supplier<BlockFactoryDeneb> blockFactoryDenebSupplier =
+        Suppliers.memoize(() -> new BlockFactoryDeneb(spec, operationSelector));
+
+    // Populate forks factories
+    spec.getEnabledMilestones()
+        .forEach(
+            forkAndSpecMilestone -> {
+              final SpecMilestone milestone = forkAndSpecMilestone.getSpecMilestone();
+              if (milestone.isGreaterThanOrEqualTo(SpecMilestone.DENEB)) {
+                registeredFactories.put(milestone, blockFactoryDenebSupplier.get());
+              } else {
+                registeredFactories.put(milestone, blockFactoryPhase0);
+              }
+            });
+  }
+
+  @Override
+  public SafeFuture<BlockContainer> createUnsignedBlock(
+      final BeaconState blockSlotState,
+      final UInt64 newSlot,
+      final BLSSignature randaoReveal,
+      final Optional<Bytes32> optionalGraffiti,
+      final boolean blinded) {
+    final SpecMilestone milestone = spec.atSlot(newSlot).getMilestone();
+    return registeredFactories
+        .get(milestone)
+        .createUnsignedBlock(blockSlotState, newSlot, randaoReveal, optionalGraffiti, blinded);
+  }
+}

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/AbstractBlockFactoryTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/AbstractBlockFactoryTest.java
@@ -1,0 +1,349 @@
+/*
+ * Copyright ConsenSys Software Inc., 2023
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.coordinator;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
+
+import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.bls.BLSSignatureVerifier;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobsBundle;
+import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
+import tech.pegasys.teku.spec.datastructures.blocks.BlockContainer;
+import tech.pegasys.teku.spec.datastructures.blocks.Eth1Data;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.BeaconBlockBodyAltair;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.BeaconBlockBodySchemaAltair;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregate;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.bellatrix.BeaconBlockBodyBellatrix;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.bellatrix.BlindedBeaconBlockBodyBellatrix;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.deneb.BeaconBlockBodyDeneb;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.deneb.BlindedBeaconBlockBodyDeneb;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadResult;
+import tech.pegasys.teku.spec.datastructures.execution.HeaderWithFallbackData;
+import tech.pegasys.teku.spec.datastructures.operations.Attestation;
+import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
+import tech.pegasys.teku.spec.datastructures.operations.Deposit;
+import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
+import tech.pegasys.teku.spec.datastructures.operations.SignedBlsToExecutionChange;
+import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
+import tech.pegasys.teku.spec.datastructures.util.BeaconBlockBodyLists;
+import tech.pegasys.teku.spec.executionlayer.ExecutionLayerBlockProductionManager;
+import tech.pegasys.teku.spec.logic.common.block.AbstractBlockProcessor;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsBellatrix;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.statetransition.OperationPool;
+import tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPool;
+import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceNotifier;
+import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeContributionPool;
+import tech.pegasys.teku.storage.client.RecentChainData;
+import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystemBuilder;
+import tech.pegasys.teku.storage.storageSystem.StorageSystem;
+
+@SuppressWarnings("unchecked")
+public abstract class AbstractBlockFactoryTest {
+
+  private static final Eth1Data ETH1_DATA = new Eth1Data();
+
+  protected final AggregatingAttestationPool attestationsPool =
+      mock(AggregatingAttestationPool.class);
+  protected final OperationPool<AttesterSlashing> attesterSlashingPool = mock(OperationPool.class);
+  protected final OperationPool<ProposerSlashing> proposerSlashingPool = mock(OperationPool.class);
+  protected final OperationPool<SignedVoluntaryExit> voluntaryExitPool = mock(OperationPool.class);
+  protected final OperationPool<SignedBlsToExecutionChange> blsToExecutionChangePool =
+      mock(OperationPool.class);
+  protected final ForkChoiceNotifier forkChoiceNotifier = mock(ForkChoiceNotifier.class);
+  protected final ExecutionLayerBlockProductionManager executionLayer =
+      mock(ExecutionLayerBlockProductionManager.class);
+  protected final SyncCommitteeContributionPool syncCommitteeContributionPool =
+      mock(SyncCommitteeContributionPool.class);
+  protected final DepositProvider depositProvider = mock(DepositProvider.class);
+  protected final Eth1DataCache eth1DataCache = mock(Eth1DataCache.class);
+
+  protected ExecutionPayload executionPayload = null;
+  protected ExecutionPayloadHeader executionPayloadHeader = null;
+  protected BlobsBundle blobsBundle = null;
+  protected ExecutionPayloadResult cachedExecutionPayloadResult = null;
+
+  @BeforeAll
+  public static void initSession() {
+    AbstractBlockProcessor.depositSignatureVerifier = BLSSignatureVerifier.NO_OP;
+  }
+
+  @AfterAll
+  public static void resetSession() {
+    AbstractBlockProcessor.depositSignatureVerifier =
+        AbstractBlockProcessor.DEFAULT_DEPOSIT_SIGNATURE_VERIFIER;
+  }
+
+  abstract BlockFactory createBlockFactory(Spec spec);
+
+  protected SyncAggregate getSyncAggregate(final BeaconBlock block) {
+    return BeaconBlockBodyAltair.required(block.getBody()).getSyncAggregate();
+  }
+
+  protected ExecutionPayload getExecutionPayload(final BeaconBlock block) {
+    return BeaconBlockBodyBellatrix.required(block.getBody()).getExecutionPayload();
+  }
+
+  protected ExecutionPayloadHeader getExecutionPayloadHeader(final BeaconBlock block) {
+    return BlindedBeaconBlockBodyBellatrix.required(block.getBody()).getExecutionPayloadHeader();
+  }
+
+  protected BlockContainer assertBlockCreated(
+      final int blockSlot, final Spec spec, final boolean postMerge, final boolean blinded) {
+    final UInt64 newSlot = UInt64.valueOf(blockSlot);
+    final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+    final BeaconBlockBodyLists blockBodyLists = BeaconBlockBodyLists.ofSpec(spec);
+    final StorageSystem localChain = InMemoryStorageSystemBuilder.buildDefault(spec);
+    final RecentChainData recentChainData = localChain.recentChainData();
+
+    final SszList<Deposit> deposits = blockBodyLists.createDeposits();
+    final SszList<Attestation> attestations = blockBodyLists.createAttestations();
+    final SszList<AttesterSlashing> attesterSlashings = blockBodyLists.createAttesterSlashings();
+    final SszList<ProposerSlashing> proposerSlashings = blockBodyLists.createProposerSlashings();
+    final SszList<SignedVoluntaryExit> voluntaryExits = blockBodyLists.createVoluntaryExits();
+    final SszList<SignedBlsToExecutionChange> blsToExecutionChanges =
+        blockBodyLists.createBlsToExecutionChanges();
+
+    final SpecMilestone milestone = spec.atSlot(newSlot).getMilestone();
+
+    if (milestone.isGreaterThanOrEqualTo(SpecMilestone.BELLATRIX)) {
+      if (postMerge) {
+        localChain
+            .chainUpdater()
+            .initializeGenesisWithPayload(false, dataStructureUtil.randomExecutionPayloadHeader());
+      } else {
+        localChain.chainUpdater().initializeGenesis(false);
+      }
+    } else {
+      checkArgument(
+          !postMerge, "Cannot initialize genesis state post merge in non Bellatrix genesis");
+      localChain.chainUpdater().initializeGenesis(false);
+    }
+
+    final BlockFactory blockFactory = createBlockFactory(spec);
+
+    when(depositProvider.getDeposits(any(), any())).thenReturn(deposits);
+    when(attestationsPool.getAttestationsForBlock(any(), any(), any())).thenReturn(attestations);
+    when(attesterSlashingPool.getItemsForBlock(any(), any(), any())).thenReturn(attesterSlashings);
+    when(proposerSlashingPool.getItemsForBlock(any(), any(), any())).thenReturn(proposerSlashings);
+    when(voluntaryExitPool.getItemsForBlock(any(), any(), any())).thenReturn(voluntaryExits);
+    when(blsToExecutionChangePool.getItemsForBlock(any())).thenReturn(blsToExecutionChanges);
+    when(eth1DataCache.getEth1Vote(any())).thenReturn(ETH1_DATA);
+    when(forkChoiceNotifier.getPayloadId(any(), any()))
+        .thenReturn(
+            SafeFuture.completedFuture(
+                Optional.of(dataStructureUtil.randomPayloadExecutionContext(false))));
+
+    setupExecutionLayerBlockAndBlobsProduction();
+
+    final BLSSignature randaoReveal = dataStructureUtil.randomSignature();
+    final Bytes32 bestBlockRoot = recentChainData.getBestBlockRoot().orElseThrow();
+    final BeaconState blockSlotState =
+        recentChainData
+            .retrieveStateAtSlot(new SlotAndBlockRoot(UInt64.valueOf(blockSlot), bestBlockRoot))
+            .join()
+            .orElseThrow();
+
+    when(syncCommitteeContributionPool.createSyncAggregateForBlock(newSlot, bestBlockRoot))
+        .thenAnswer(invocation -> createEmptySyncAggregate(spec));
+
+    final BlockContainer blockContainer =
+        safeJoin(
+            blockFactory.createUnsignedBlock(
+                blockSlotState, newSlot, randaoReveal, Optional.empty(), blinded));
+
+    final BeaconBlock block = blockContainer.getBlock();
+
+    assertThat(block).isNotNull();
+    assertThat(block.getSlot()).isEqualTo(newSlot);
+    assertThat(block.getBody().getRandaoReveal()).isEqualTo(randaoReveal);
+    assertThat(block.getBody().getEth1Data()).isEqualTo(ETH1_DATA);
+    assertThat(block.getBody().getDeposits()).isEqualTo(deposits);
+    assertThat(block.getBody().getAttestations()).isEqualTo(attestations);
+    assertThat(block.getBody().getAttesterSlashings()).isEqualTo(attesterSlashings);
+    assertThat(block.getBody().getProposerSlashings()).isEqualTo(proposerSlashings);
+    assertThat(block.getBody().getVoluntaryExits()).isEqualTo(voluntaryExits);
+    assertThat(block.getBody().getGraffiti()).isNotNull();
+
+    if (milestone.isGreaterThanOrEqualTo(SpecMilestone.CAPELLA)) {
+      assertThat(block.getBody().getOptionalBlsToExecutionChanges())
+          .isPresent()
+          .hasValue(blsToExecutionChanges);
+    } else {
+      assertThat(block.getBody().getOptionalBlsToExecutionChanges()).isEmpty();
+    }
+
+    if (milestone.isGreaterThanOrEqualTo(SpecMilestone.DENEB)) {
+      if (blinded) {
+        assertThat(BlindedBeaconBlockBodyDeneb.required(block.getBody()).getBlobKzgCommitments())
+            .map(SszKZGCommitment::getKZGCommitment)
+            .hasSameElementsAs(blobsBundle.getCommitments());
+      } else {
+        assertThat(BeaconBlockBodyDeneb.required(block.getBody()).getBlobKzgCommitments())
+            .map(SszKZGCommitment::getKZGCommitment)
+            .hasSameElementsAs(blobsBundle.getCommitments());
+      }
+    }
+
+    return blockContainer;
+  }
+
+  protected SyncAggregate createEmptySyncAggregate(final Spec spec) {
+    return BeaconBlockBodySchemaAltair.required(
+            spec.getGenesisSchemaDefinitions().getBeaconBlockBodySchema())
+        .getSyncAggregateSchema()
+        .createEmpty();
+  }
+
+  protected SignedBeaconBlock assertBlockUnblinded(
+      final SignedBeaconBlock beaconBlock, final Spec spec) {
+    final BlockFactory blockFactory = createBlockFactory(spec);
+
+    when(executionLayer.getUnblindedPayload(beaconBlock))
+        .thenReturn(SafeFuture.completedFuture(executionPayload));
+
+    final SignedBeaconBlock block =
+        blockFactory.unblindSignedBeaconBlockIfBlinded(beaconBlock).join();
+
+    if (!beaconBlock.getMessage().getBody().isBlinded()) {
+      verifyNoInteractions(executionLayer);
+    } else {
+      verify(executionLayer).getUnblindedPayload(beaconBlock);
+    }
+
+    assertThat(block).isNotNull();
+    assertThat(block.hashTreeRoot()).isEqualTo(beaconBlock.hashTreeRoot());
+    assertThat(block.getMessage().getBody().isBlinded()).isFalse();
+    assertThat(block.getMessage().getBody().getOptionalExecutionPayloadHeader())
+        .isEqualTo(Optional.empty());
+
+    return block;
+  }
+
+  protected SignedBeaconBlock assertBlockBlinded(
+      final SignedBeaconBlock beaconBlock, final Spec spec) {
+
+    final SignedBeaconBlock block = blindSignedBeaconBlockIfUnblinded(spec, beaconBlock);
+
+    assertThat(block).isNotNull();
+    assertThat(block.hashTreeRoot()).isEqualTo(beaconBlock.hashTreeRoot());
+    assertThat(block.getMessage().getBody().isBlinded()).isTrue();
+    assertThat(block.getMessage().getBody().getOptionalExecutionPayload())
+        .isEqualTo(Optional.empty());
+
+    return block;
+  }
+
+  protected SignedBeaconBlock blindSignedBeaconBlockIfUnblinded(
+      final Spec spec, final SignedBeaconBlock unblindedSignedBeaconBlock) {
+    if (unblindedSignedBeaconBlock.isBlinded()) {
+      return unblindedSignedBeaconBlock;
+    }
+    return spec.blindSignedBeaconBlock(unblindedSignedBeaconBlock);
+  }
+
+  protected void prepareDefaultPayload(final Spec spec) {
+    executionPayload =
+        SchemaDefinitionsBellatrix.required(spec.getGenesisSpec().getSchemaDefinitions())
+            .getExecutionPayloadSchema()
+            .getDefault();
+
+    executionPayloadHeader =
+        SchemaDefinitionsBellatrix.required(spec.getGenesisSpec().getSchemaDefinitions())
+            .getExecutionPayloadHeaderSchema()
+            .getHeaderOfDefaultPayload();
+  }
+
+  protected BlobsBundle prepareBlobsBundle(final Spec spec) {
+    final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+    final BlobsBundle blobsBundle = dataStructureUtil.randomBlobsBundle();
+    this.blobsBundle = blobsBundle;
+    return blobsBundle;
+  }
+
+  private void setupExecutionLayerBlockAndBlobsProduction() {
+    // pre Deneb
+    when(executionLayer.initiateBlockProduction(any(), any(), eq(false)))
+        .then(
+            args ->
+                new ExecutionPayloadResult(
+                    args.getArgument(0),
+                    Optional.of(SafeFuture.completedFuture(executionPayload)),
+                    Optional.empty(),
+                    Optional.empty()));
+    when(executionLayer.initiateBlockProduction(any(), any(), eq(true)))
+        .then(
+            args ->
+                new ExecutionPayloadResult(
+                    args.getArgument(0),
+                    Optional.empty(),
+                    Optional.of(
+                        SafeFuture.completedFuture(
+                            HeaderWithFallbackData.create(executionPayloadHeader))),
+                    Optional.empty()));
+    // post Deneb
+    when(executionLayer.initiateBlockAndBlobsProduction(any(), any(), eq(false)))
+        .thenAnswer(
+            args -> {
+              final ExecutionPayloadResult executionPayloadResult =
+                  new ExecutionPayloadResult(
+                      args.getArgument(0),
+                      Optional.of(SafeFuture.completedFuture(executionPayload)),
+                      Optional.empty(),
+                      Optional.of(SafeFuture.completedFuture(blobsBundle)));
+              cachedExecutionPayloadResult = executionPayloadResult;
+              return executionPayloadResult;
+            });
+    when(executionLayer.initiateBlockAndBlobsProduction(any(), any(), eq(true)))
+        .thenAnswer(
+            args -> {
+              final ExecutionPayloadResult executionPayloadResult =
+                  new ExecutionPayloadResult(
+                      args.getArgument(0),
+                      Optional.empty(),
+                      Optional.of(
+                          SafeFuture.completedFuture(
+                              HeaderWithFallbackData.create(executionPayloadHeader))),
+                      Optional.of(SafeFuture.completedFuture(blobsBundle)));
+              cachedExecutionPayloadResult = executionPayloadResult;
+              return executionPayloadResult;
+            });
+    // simulate caching of the payload result
+    when(executionLayer.getCachedPayloadResult(any()))
+        .thenAnswer(__ -> Optional.of(cachedExecutionPayloadResult));
+  }
+}

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/AbstractBlockFactoryTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/AbstractBlockFactoryTest.java
@@ -296,7 +296,7 @@ public abstract class AbstractBlockFactoryTest {
     when(executionLayer.initiateBlockProduction(any(), any(), eq(false)))
         .thenAnswer(
             args -> {
-              ExecutionPayloadResult executionPayloadResult =
+              final ExecutionPayloadResult executionPayloadResult =
                   new ExecutionPayloadResult(
                       args.getArgument(0),
                       Optional.of(SafeFuture.completedFuture(executionPayload)),
@@ -308,7 +308,7 @@ public abstract class AbstractBlockFactoryTest {
     when(executionLayer.initiateBlockProduction(any(), any(), eq(true)))
         .thenAnswer(
             args -> {
-              ExecutionPayloadResult executionPayloadResult =
+              final ExecutionPayloadResult executionPayloadResult =
                   new ExecutionPayloadResult(
                       args.getArgument(0),
                       Optional.empty(),

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/AbstractBlockFactoryTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/AbstractBlockFactoryTest.java
@@ -294,23 +294,31 @@ public abstract class AbstractBlockFactoryTest {
   private void setupExecutionLayerBlockAndBlobsProduction() {
     // pre Deneb
     when(executionLayer.initiateBlockProduction(any(), any(), eq(false)))
-        .then(
-            args ->
-                new ExecutionPayloadResult(
-                    args.getArgument(0),
-                    Optional.of(SafeFuture.completedFuture(executionPayload)),
-                    Optional.empty(),
-                    Optional.empty()));
+        .thenAnswer(
+            args -> {
+              ExecutionPayloadResult executionPayloadResult =
+                  new ExecutionPayloadResult(
+                      args.getArgument(0),
+                      Optional.of(SafeFuture.completedFuture(executionPayload)),
+                      Optional.empty(),
+                      Optional.empty());
+              cachedExecutionPayloadResult = executionPayloadResult;
+              return executionPayloadResult;
+            });
     when(executionLayer.initiateBlockProduction(any(), any(), eq(true)))
-        .then(
-            args ->
-                new ExecutionPayloadResult(
-                    args.getArgument(0),
-                    Optional.empty(),
-                    Optional.of(
-                        SafeFuture.completedFuture(
-                            HeaderWithFallbackData.create(executionPayloadHeader))),
-                    Optional.empty()));
+        .thenAnswer(
+            args -> {
+              ExecutionPayloadResult executionPayloadResult =
+                  new ExecutionPayloadResult(
+                      args.getArgument(0),
+                      Optional.empty(),
+                      Optional.of(
+                          SafeFuture.completedFuture(
+                              HeaderWithFallbackData.create(executionPayloadHeader))),
+                      Optional.empty());
+              cachedExecutionPayloadResult = executionPayloadResult;
+              return executionPayloadResult;
+            });
     // post Deneb
     when(executionLayer.initiateBlockAndBlobsProduction(any(), any(), eq(false)))
         .thenAnswer(

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/AbstractBlockFactoryTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/AbstractBlockFactoryTest.java
@@ -45,8 +45,6 @@ import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.Be
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregate;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.bellatrix.BeaconBlockBodyBellatrix;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.bellatrix.BlindedBeaconBlockBodyBellatrix;
-import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.deneb.BeaconBlockBodyDeneb;
-import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.deneb.BlindedBeaconBlockBodyDeneb;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadResult;
@@ -208,15 +206,13 @@ public abstract class AbstractBlockFactoryTest {
     }
 
     if (milestone.isGreaterThanOrEqualTo(SpecMilestone.DENEB)) {
-      if (blinded) {
-        assertThat(BlindedBeaconBlockBodyDeneb.required(block.getBody()).getBlobKzgCommitments())
-            .map(SszKZGCommitment::getKZGCommitment)
-            .hasSameElementsAs(blobsBundle.getCommitments());
-      } else {
-        assertThat(BeaconBlockBodyDeneb.required(block.getBody()).getBlobKzgCommitments())
-            .map(SszKZGCommitment::getKZGCommitment)
-            .hasSameElementsAs(blobsBundle.getCommitments());
-      }
+      assertThat(block.getBody().getOptionalBlobKzgCommitments())
+          .hasValueSatisfying(
+              blobKzgCommitments ->
+                  assertThat(blobKzgCommitments.stream().map(SszKZGCommitment::getKZGCommitment))
+                      .hasSameElementsAs(blobsBundle.getCommitments()));
+    } else {
+      assertThat(block.getBody().getOptionalBlobKzgCommitments()).isEmpty();
     }
 
     return blockContainer;

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/AbstractBlockFactoryTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/AbstractBlockFactoryTest.java
@@ -288,9 +288,9 @@ public abstract class AbstractBlockFactoryTest {
             .getHeaderOfDefaultPayload();
   }
 
-  protected BlobsBundle prepareBlobsBundle(final Spec spec) {
+  protected BlobsBundle prepareBlobsBundle(final Spec spec, final int count) {
     final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
-    final BlobsBundle blobsBundle = dataStructureUtil.randomBlobsBundle();
+    final BlobsBundle blobsBundle = dataStructureUtil.randomBlobsBundle(count);
     this.blobsBundle = blobsBundle;
     return blobsBundle;
   }

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryDenebTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryDenebTest.java
@@ -75,7 +75,7 @@ public class BlockFactoryDenebTest extends AbstractBlockFactoryTest {
   }
 
   @Override
-  BlockFactory createBlockFactory(final Spec spec) {
+  public BlockFactory createBlockFactory(final Spec spec) {
     final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
     final Bytes32 graffiti = dataStructureUtil.randomBytes32();
     return new BlockFactoryDeneb(

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryDenebTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryDenebTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright ConsenSys Software Inc., 2023
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.coordinator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobsBundle;
+import tech.pegasys.teku.spec.datastructures.blocks.BlindedBlockContainer;
+import tech.pegasys.teku.spec.datastructures.blocks.BlockContainer;
+import tech.pegasys.teku.spec.datastructures.blocks.versions.deneb.BlindedBlockContents;
+import tech.pegasys.teku.spec.datastructures.blocks.versions.deneb.BlockContents;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class BlockFactoryDenebTest extends AbstractBlockFactoryTest {
+
+  private final Spec spec = TestSpecFactory.createMinimalDeneb();
+
+  @Test
+  void shouldCreateBlockContentsWhenDenebIsActive() {
+
+    prepareDefaultPayload(spec);
+    final BlobsBundle blobsBundle = prepareBlobsBundle(spec);
+
+    final BlockContainer blockContainer = assertBlockCreated(1, spec, false, false);
+
+    assertThat(blockContainer).isInstanceOf(BlockContents.class);
+    assertThat(blockContainer.getBlobSidecars())
+        .hasValueSatisfying(
+            blobSidecars -> assertThat(blobSidecars).hasSize(blobsBundle.getNumberOfBlobs()));
+  }
+
+  @Test
+  void shouldCreateBlindedBlockContentsWhenDenebIsActiveAndBlindedBlockRequested() {
+
+    prepareDefaultPayload(spec);
+    final BlobsBundle blobsBundle = prepareBlobsBundle(spec);
+
+    final BlockContainer blockContainer = assertBlockCreated(1, spec, false, true);
+
+    assertThat(blockContainer).isInstanceOf(BlindedBlockContents.class);
+    final BlindedBlockContainer blindedBlockContainer = blockContainer.toBlinded().orElseThrow();
+    assertThat(blindedBlockContainer.getBlindedBlobSidecars())
+        .hasValueSatisfying(
+            blindedBlobSidecars ->
+                assertThat(blindedBlobSidecars).hasSize(blobsBundle.getNumberOfBlobs()));
+  }
+
+  @Override
+  BlockFactory createBlockFactory(final Spec spec) {
+    final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+    final Bytes32 graffiti = dataStructureUtil.randomBytes32();
+    return new BlockFactoryDeneb(
+        spec,
+        new BlockOperationSelectorFactory(
+            spec,
+            attestationsPool,
+            attesterSlashingPool,
+            proposerSlashingPool,
+            voluntaryExitPool,
+            blsToExecutionChangePool,
+            syncCommitteeContributionPool,
+            depositProvider,
+            eth1DataCache,
+            graffiti,
+            forkChoiceNotifier,
+            executionLayer));
+  }
+}

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryPhase0Test.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryPhase0Test.java
@@ -13,96 +13,28 @@
 
 package tech.pegasys.teku.validator.coordinator;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.when;
-import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 import static tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregateAssert.assertThatSyncAggregate;
 
-import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import tech.pegasys.teku.bls.BLSSignature;
-import tech.pegasys.teku.bls.BLSSignatureVerifier;
-import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
-import tech.pegasys.teku.spec.datastructures.blocks.Eth1Data;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
-import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
-import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.BeaconBlockBodyAltair;
-import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.BeaconBlockBodySchemaAltair;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregate;
-import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.bellatrix.BeaconBlockBodyBellatrix;
-import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.bellatrix.BlindedBeaconBlockBodyBellatrix;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.capella.BeaconBlockBodyCapella;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
-import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadResult;
-import tech.pegasys.teku.spec.datastructures.execution.HeaderWithFallbackData;
-import tech.pegasys.teku.spec.datastructures.operations.Attestation;
-import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
-import tech.pegasys.teku.spec.datastructures.operations.Deposit;
-import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.SignedBlsToExecutionChange;
-import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
-import tech.pegasys.teku.spec.datastructures.util.BeaconBlockBodyLists;
-import tech.pegasys.teku.spec.executionlayer.ExecutionLayerBlockProductionManager;
-import tech.pegasys.teku.spec.logic.common.block.AbstractBlockProcessor;
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.StateTransitionException;
-import tech.pegasys.teku.spec.schemas.SchemaDefinitionsBellatrix;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
-import tech.pegasys.teku.statetransition.OperationPool;
-import tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPool;
-import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceNotifier;
-import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeContributionPool;
-import tech.pegasys.teku.storage.client.RecentChainData;
-import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystemBuilder;
-import tech.pegasys.teku.storage.storageSystem.StorageSystem;
 
-@SuppressWarnings("unchecked")
-class BlockFactoryPhase0Test {
-  private static final Eth1Data ETH1_DATA = new Eth1Data();
-
-  final AggregatingAttestationPool attestationsPool = mock(AggregatingAttestationPool.class);
-  final OperationPool<AttesterSlashing> attesterSlashingPool = mock(OperationPool.class);
-  final OperationPool<ProposerSlashing> proposerSlashingPool = mock(OperationPool.class);
-  final OperationPool<SignedVoluntaryExit> voluntaryExitPool = mock(OperationPool.class);
-  final OperationPool<SignedBlsToExecutionChange> blsToExecutionChangePool =
-      mock(OperationPool.class);
-  final ForkChoiceNotifier forkChoiceNotifier = mock(ForkChoiceNotifier.class);
-  final ExecutionLayerBlockProductionManager executionLayer =
-      mock(ExecutionLayerBlockProductionManager.class);
-  final SyncCommitteeContributionPool syncCommitteeContributionPool =
-      mock(SyncCommitteeContributionPool.class);
-  final DepositProvider depositProvider = mock(DepositProvider.class);
-  final Eth1DataCache eth1DataCache = mock(Eth1DataCache.class);
-  ExecutionPayload executionPayload = null;
-  ExecutionPayloadHeader executionPayloadHeader = null;
-
-  @BeforeAll
-  public static void initSession() {
-    AbstractBlockProcessor.depositSignatureVerifier = BLSSignatureVerifier.NO_OP;
-  }
-
-  @AfterAll
-  public static void resetSession() {
-    AbstractBlockProcessor.depositSignatureVerifier =
-        AbstractBlockProcessor.DEFAULT_DEPOSIT_SIGNATURE_VERIFIER;
-  }
+class BlockFactoryPhase0Test extends AbstractBlockFactoryTest {
 
   @Test
   public void shouldCreateBlockAfterNormalSlot() {
@@ -122,7 +54,7 @@ class BlockFactoryPhase0Test {
   @Test
   void shouldIncludeSyncAggregateWhenAltairIsActive() {
     final BeaconBlock block =
-        assertBlockCreated(1, TestSpecFactory.createMinimalAltair(), false, false);
+        assertBlockCreated(1, TestSpecFactory.createMinimalAltair(), false, false).getBlock();
     final SyncAggregate result = getSyncAggregate(block);
     assertThatSyncAggregate(result).isNotNull();
     verify(syncCommitteeContributionPool)
@@ -135,7 +67,7 @@ class BlockFactoryPhase0Test {
 
     prepareDefaultPayload(spec);
 
-    final BeaconBlock block = assertBlockCreated(1, spec, false, false);
+    final BeaconBlock block = assertBlockCreated(1, spec, false, false).getBlock();
     final ExecutionPayload result = getExecutionPayload(block);
     assertThat(result).isEqualTo(executionPayload);
   }
@@ -145,7 +77,7 @@ class BlockFactoryPhase0Test {
     final Spec spec = TestSpecFactory.createMinimalCapella();
     prepareDefaultPayload(spec);
 
-    final BeaconBlock block = assertBlockCreated(1, spec, false, false);
+    final BeaconBlock block = assertBlockCreated(1, spec, false, false).getBlock();
     final SszList<SignedBlsToExecutionChange> blsToExecutionChanges =
         BeaconBlockBodyCapella.required(block.getBody()).getBlsToExecutionChanges();
     assertThat(blsToExecutionChanges).isNotNull();
@@ -157,7 +89,7 @@ class BlockFactoryPhase0Test {
 
     prepareDefaultPayload(spec);
 
-    final BeaconBlock block = assertBlockCreated(1, spec, false, true);
+    final BeaconBlock block = assertBlockCreated(1, spec, false, true).getBlock();
     final ExecutionPayloadHeader result = getExecutionPayloadHeader(block);
     assertThat(result).isEqualTo(executionPayloadHeader);
   }
@@ -235,182 +167,8 @@ class BlockFactoryPhase0Test {
     assertBlockUnblinded(originalBlindedSignedBlock, spec);
   }
 
-  private SyncAggregate getSyncAggregate(final BeaconBlock block) {
-    return BeaconBlockBodyAltair.required(block.getBody()).getSyncAggregate();
-  }
-
-  private ExecutionPayload getExecutionPayload(final BeaconBlock block) {
-    return BeaconBlockBodyBellatrix.required(block.getBody()).getExecutionPayload();
-  }
-
-  private ExecutionPayloadHeader getExecutionPayloadHeader(final BeaconBlock block) {
-    return BlindedBeaconBlockBodyBellatrix.required(block.getBody()).getExecutionPayloadHeader();
-  }
-
-  private BeaconBlock assertBlockCreated(
-      final int blockSlot, final Spec spec, final boolean postMerge, final boolean blinded) {
-    final UInt64 newSlot = UInt64.valueOf(blockSlot);
-    final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
-    final BeaconBlockBodyLists blockBodyLists = BeaconBlockBodyLists.ofSpec(spec);
-    final StorageSystem localChain = InMemoryStorageSystemBuilder.buildDefault(spec);
-    final RecentChainData recentChainData = localChain.recentChainData();
-
-    final SszList<Deposit> deposits = blockBodyLists.createDeposits();
-    final SszList<Attestation> attestations = blockBodyLists.createAttestations();
-    final SszList<AttesterSlashing> attesterSlashings = blockBodyLists.createAttesterSlashings();
-    final SszList<ProposerSlashing> proposerSlashings = blockBodyLists.createProposerSlashings();
-    final SszList<SignedVoluntaryExit> voluntaryExits = blockBodyLists.createVoluntaryExits();
-    final SszList<SignedBlsToExecutionChange> blsToExecutionChanges =
-        blockBodyLists.createBlsToExecutionChanges();
-
-    if (spec.getGenesisSpec().getMilestone().isGreaterThanOrEqualTo(SpecMilestone.BELLATRIX)) {
-      if (postMerge) {
-        localChain
-            .chainUpdater()
-            .initializeGenesisWithPayload(false, dataStructureUtil.randomExecutionPayloadHeader());
-      } else {
-        localChain.chainUpdater().initializeGenesis(false);
-      }
-    } else {
-      checkArgument(
-          !postMerge, "Cannot initialize genesis state post merge in non Bellatrix genesis");
-      localChain.chainUpdater().initializeGenesis(false);
-    }
-
-    final Bytes32 graffiti = dataStructureUtil.randomBytes32();
-    final BlockFactory blockFactory =
-        new BlockFactoryPhase0(
-            spec,
-            new BlockOperationSelectorFactory(
-                spec,
-                attestationsPool,
-                attesterSlashingPool,
-                proposerSlashingPool,
-                voluntaryExitPool,
-                blsToExecutionChangePool,
-                syncCommitteeContributionPool,
-                depositProvider,
-                eth1DataCache,
-                graffiti,
-                forkChoiceNotifier,
-                executionLayer));
-
-    when(depositProvider.getDeposits(any(), any())).thenReturn(deposits);
-    when(attestationsPool.getAttestationsForBlock(any(), any(), any())).thenReturn(attestations);
-    when(attesterSlashingPool.getItemsForBlock(any(), any(), any())).thenReturn(attesterSlashings);
-    when(proposerSlashingPool.getItemsForBlock(any(), any(), any())).thenReturn(proposerSlashings);
-    when(voluntaryExitPool.getItemsForBlock(any(), any(), any())).thenReturn(voluntaryExits);
-    when(blsToExecutionChangePool.getItemsForBlock(any())).thenReturn(blsToExecutionChanges);
-    when(eth1DataCache.getEth1Vote(any())).thenReturn(ETH1_DATA);
-    when(forkChoiceNotifier.getPayloadId(any(), any()))
-        .thenReturn(
-            SafeFuture.completedFuture(
-                Optional.of(dataStructureUtil.randomPayloadExecutionContext(false))));
-    when(executionLayer.initiateBlockProduction(any(), any(), eq(false)))
-        .then(
-            args ->
-                new ExecutionPayloadResult(
-                    args.getArgument(0),
-                    Optional.of(SafeFuture.completedFuture(executionPayload)),
-                    Optional.empty(),
-                    Optional.empty()));
-    when(executionLayer.initiateBlockProduction(any(), any(), eq(true)))
-        .then(
-            args ->
-                new ExecutionPayloadResult(
-                    args.getArgument(0),
-                    Optional.empty(),
-                    Optional.of(
-                        SafeFuture.completedFuture(
-                            HeaderWithFallbackData.create(executionPayloadHeader))),
-                    Optional.empty()));
-
-    final BLSSignature randaoReveal = dataStructureUtil.randomSignature();
-    final Bytes32 bestBlockRoot = recentChainData.getBestBlockRoot().orElseThrow();
-    final BeaconState blockSlotState =
-        recentChainData
-            .retrieveStateAtSlot(new SlotAndBlockRoot(UInt64.valueOf(blockSlot), bestBlockRoot))
-            .join()
-            .orElseThrow();
-
-    when(syncCommitteeContributionPool.createSyncAggregateForBlock(newSlot, bestBlockRoot))
-        .thenAnswer(invocation -> createEmptySyncAggregate(spec));
-
-    final BeaconBlock block =
-        safeJoin(
-                blockFactory.createUnsignedBlock(
-                    blockSlotState, newSlot, randaoReveal, Optional.empty(), blinded))
-            .getBlock();
-
-    assertThat(block).isNotNull();
-    assertThat(block.getSlot()).isEqualTo(newSlot);
-    assertThat(block.getBody().getRandaoReveal()).isEqualTo(randaoReveal);
-    assertThat(block.getBody().getEth1Data()).isEqualTo(ETH1_DATA);
-    assertThat(block.getBody().getDeposits()).isEqualTo(deposits);
-    assertThat(block.getBody().getAttestations()).isEqualTo(attestations);
-    assertThat(block.getBody().getAttesterSlashings()).isEqualTo(attesterSlashings);
-    assertThat(block.getBody().getProposerSlashings()).isEqualTo(proposerSlashings);
-    assertThat(block.getBody().getVoluntaryExits()).isEqualTo(voluntaryExits);
-    assertThat(block.getBody().getGraffiti()).isEqualTo(graffiti);
-
-    if (spec.getGenesisSpec().getMilestone().isGreaterThanOrEqualTo(SpecMilestone.CAPELLA)) {
-      assertThat(block.getBody().getOptionalBlsToExecutionChanges())
-          .isPresent()
-          .hasValue(blsToExecutionChanges);
-    } else {
-      assertThat(block.getBody().getOptionalBlsToExecutionChanges()).isEmpty();
-    }
-
-    return block;
-  }
-
-  private SyncAggregate createEmptySyncAggregate(final Spec spec) {
-    return BeaconBlockBodySchemaAltair.required(
-            spec.getGenesisSchemaDefinitions().getBeaconBlockBodySchema())
-        .getSyncAggregateSchema()
-        .createEmpty();
-  }
-
-  private SignedBeaconBlock assertBlockUnblinded(
-      final SignedBeaconBlock beaconBlock, final Spec spec) {
-    final BlockFactory blockFactory = createBlockFactory(spec);
-
-    when(executionLayer.getUnblindedPayload(beaconBlock))
-        .thenReturn(SafeFuture.completedFuture(executionPayload));
-
-    final SignedBeaconBlock block =
-        blockFactory.unblindSignedBeaconBlockIfBlinded(beaconBlock).join();
-
-    if (!beaconBlock.getMessage().getBody().isBlinded()) {
-      verifyNoInteractions(executionLayer);
-    } else {
-      verify(executionLayer).getUnblindedPayload(beaconBlock);
-    }
-
-    assertThat(block).isNotNull();
-    assertThat(block.hashTreeRoot()).isEqualTo(beaconBlock.hashTreeRoot());
-    assertThat(block.getMessage().getBody().isBlinded()).isFalse();
-    assertThat(block.getMessage().getBody().getOptionalExecutionPayloadHeader())
-        .isEqualTo(Optional.empty());
-
-    return block;
-  }
-
-  private SignedBeaconBlock assertBlockBlinded(
-      final SignedBeaconBlock beaconBlock, final Spec spec) {
-
-    final SignedBeaconBlock block = blindSignedBeaconBlockIfUnblinded(spec, beaconBlock);
-
-    assertThat(block).isNotNull();
-    assertThat(block.hashTreeRoot()).isEqualTo(beaconBlock.hashTreeRoot());
-    assertThat(block.getMessage().getBody().isBlinded()).isTrue();
-    assertThat(block.getMessage().getBody().getOptionalExecutionPayload())
-        .isEqualTo(Optional.empty());
-
-    return block;
-  }
-
-  private BlockFactory createBlockFactory(final Spec spec) {
+  @Override
+  public BlockFactory createBlockFactory(final Spec spec) {
     final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
     final Bytes32 graffiti = dataStructureUtil.randomBytes32();
     return new BlockFactoryPhase0(
@@ -428,25 +186,5 @@ class BlockFactoryPhase0Test {
             graffiti,
             forkChoiceNotifier,
             executionLayer));
-  }
-
-  private void prepareDefaultPayload(final Spec spec) {
-    executionPayload =
-        SchemaDefinitionsBellatrix.required(spec.getGenesisSpec().getSchemaDefinitions())
-            .getExecutionPayloadSchema()
-            .getDefault();
-
-    executionPayloadHeader =
-        SchemaDefinitionsBellatrix.required(spec.getGenesisSpec().getSchemaDefinitions())
-            .getExecutionPayloadHeaderSchema()
-            .getHeaderOfDefaultPayload();
-  }
-
-  private SignedBeaconBlock blindSignedBeaconBlockIfUnblinded(
-      final Spec spec, final SignedBeaconBlock unblindedSignedBeaconBlock) {
-    if (unblindedSignedBeaconBlock.isBlinded()) {
-      return unblindedSignedBeaconBlock;
-    }
-    return spec.blindSignedBeaconBlock(unblindedSignedBeaconBlock);
   }
 }

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryTest.java
@@ -448,7 +448,8 @@ class BlockOperationSelectorFactoryTest {
             parentRoot, blockSlotState, dataStructureUtil.randomSignature(), Optional.empty())
         .accept(bodyBuilder);
 
-    assertThat(bodyBuilder.blobKzgCommitments.stream().map(SszKZGCommitment::getKZGCommitment))
+    assertThat(bodyBuilder.blobKzgCommitments)
+        .map(SszKZGCommitment::getKZGCommitment)
         .hasSameElementsAs(blobsBundle.getCommitments());
   }
 

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryTest.java
@@ -36,6 +36,10 @@ import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlindedBlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobsBundle;
+import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.Eth1Data;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
@@ -74,7 +78,7 @@ import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeContribution
 import tech.pegasys.teku.statetransition.validation.OperationValidator;
 
 class BlockOperationSelectorFactoryTest {
-  private final Spec spec = TestSpecFactory.createMinimalCapella();
+  private final Spec spec = TestSpecFactory.createMinimalDeneb();
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
 
   private final Function<UInt64, BeaconBlockBodySchema<?>> beaconBlockSchemaSupplier =
@@ -420,6 +424,102 @@ class BlockOperationSelectorFactoryTest {
     assertThat(blockUnblinder.executionPayload).isCompletedWithValue(randomExecutionPayload);
   }
 
+  @Test
+  void shouldIncludeKzgCommitmentsInBlock() {
+    final BeaconState blockSlotState = dataStructureUtil.randomBeaconState();
+
+    final ExecutionPayloadContext executionPayloadContext =
+        dataStructureUtil.randomPayloadExecutionContext(false);
+    final ExecutionPayload randomExecutionPayload = dataStructureUtil.randomExecutionPayload();
+
+    when(forkChoiceNotifier.getPayloadId(any(), any()))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(executionPayloadContext)));
+
+    final BlobsBundle blobsBundle = dataStructureUtil.randomBlobsBundle();
+
+    prepareBlockAndBlobsProductionWithPayload(
+        randomExecutionPayload, executionPayloadContext, blockSlotState, blobsBundle);
+
+    final CapturingBeaconBlockBodyBuilder bodyBuilder =
+        new CapturingBeaconBlockBodyBuilder(false, true);
+
+    factory
+        .createSelector(
+            parentRoot, blockSlotState, dataStructureUtil.randomSignature(), Optional.empty())
+        .accept(bodyBuilder);
+
+    assertThat(bodyBuilder.blobKzgCommitments.stream().map(SszKZGCommitment::getKZGCommitment))
+        .hasSameElementsAs(blobsBundle.getCommitments());
+  }
+
+  @Test
+  void shouldCreateBlobSidecarsForBlockFromCachedPayloadResult() {
+    final BeaconBlock block = dataStructureUtil.randomBeaconBlock();
+
+    final BlobsBundle blobsBundle = dataStructureUtil.randomBlobsBundle(3);
+
+    prepareCachedPayloadResult(
+        block.getSlot(),
+        dataStructureUtil.randomExecutionPayload(),
+        dataStructureUtil.randomPayloadExecutionContext(false),
+        blobsBundle);
+
+    final List<BlobSidecar> blobSidecars =
+        safeJoin(factory.createBlobSidecarsSelector().apply(block));
+
+    assertThat(blobSidecars)
+        .hasSize(blobsBundle.getNumberOfBlobs())
+        .first()
+        .satisfies(
+            // assert on one of the sidecars
+            blobSidecar -> {
+              assertThat(blobSidecar.getBlockRoot()).isEqualTo(block.getRoot());
+              assertThat(blobSidecar.getBlockParentRoot()).isEqualTo(block.getParentRoot());
+              assertThat(blobSidecar.getIndex()).isEqualTo(UInt64.ZERO);
+              assertThat(blobSidecar.getSlot()).isEqualTo(block.getSlot());
+              assertThat(blobSidecar.getProposerIndex()).isEqualTo(block.getProposerIndex());
+              assertThat(blobSidecar.getBlob()).isEqualTo(blobsBundle.getBlobs().get(0));
+              assertThat(blobSidecar.getKZGCommitment())
+                  .isEqualTo(blobsBundle.getCommitments().get(0));
+              assertThat(blobSidecar.getKZGProof()).isEqualTo(blobsBundle.getProofs().get(0));
+            });
+  }
+
+  @Test
+  void shouldCreateBlindedBlobSidecarsForBlindedBlockFromCachedPayloadResult() {
+    final BeaconBlock block = dataStructureUtil.randomBlindedBeaconBlock();
+
+    final BlobsBundle blobsBundle = dataStructureUtil.randomBlobsBundle(3);
+
+    prepareCachedPayloadResult(
+        block.getSlot(),
+        dataStructureUtil.randomExecutionPayload(),
+        dataStructureUtil.randomPayloadExecutionContext(false),
+        blobsBundle);
+
+    final List<BlindedBlobSidecar> blindedBlobSidecars =
+        safeJoin(factory.createBlindedBlobSidecarsSelector().apply(block));
+
+    assertThat(blindedBlobSidecars)
+        .hasSize(blobsBundle.getNumberOfBlobs())
+        .first()
+        .satisfies(
+            // assert on one of the blinded sidecars
+            blindedBlobSidecar -> {
+              assertThat(blindedBlobSidecar.getBlockRoot()).isEqualTo(block.getRoot());
+              assertThat(blindedBlobSidecar.getBlockParentRoot()).isEqualTo(block.getParentRoot());
+              assertThat(blindedBlobSidecar.getIndex()).isEqualTo(UInt64.ZERO);
+              assertThat(blindedBlobSidecar.getSlot()).isEqualTo(block.getSlot());
+              assertThat(blindedBlobSidecar.getProposerIndex()).isEqualTo(block.getProposerIndex());
+              assertThat(blindedBlobSidecar.getBlobRoot())
+                  .isEqualTo(blobsBundle.getBlobs().get(0).hashTreeRoot());
+              assertThat(blindedBlobSidecar.getKZGCommitment())
+                  .isEqualTo(blobsBundle.getCommitments().get(0));
+              assertThat(blindedBlobSidecar.getKZGProof())
+                  .isEqualTo(blobsBundle.getProofs().get(0));
+            });
+  }
+
   private void prepareBlockProductionWithPayload(
       final ExecutionPayload executionPayload,
       final ExecutionPayloadContext executionPayloadContext,
@@ -448,8 +548,40 @@ class BlockOperationSelectorFactoryTest {
                 Optional.empty()));
   }
 
+  private void prepareBlockAndBlobsProductionWithPayload(
+      final ExecutionPayload executionPayload,
+      final ExecutionPayloadContext executionPayloadContext,
+      final BeaconState blockSlotState,
+      final BlobsBundle blobsBundle) {
+    when(executionLayer.initiateBlockAndBlobsProduction(
+            executionPayloadContext, blockSlotState, false))
+        .thenReturn(
+            new ExecutionPayloadResult(
+                executionPayloadContext,
+                Optional.of(SafeFuture.completedFuture(executionPayload)),
+                Optional.empty(),
+                Optional.of(SafeFuture.completedFuture(blobsBundle))));
+  }
+
+  private void prepareCachedPayloadResult(
+      final UInt64 slot,
+      final ExecutionPayload executionPayload,
+      final ExecutionPayloadContext executionPayloadContext,
+      final BlobsBundle blobsBundle) {
+    when(executionLayer.getCachedPayloadResult(slot))
+        .thenReturn(
+            Optional.of(
+                new ExecutionPayloadResult(
+                    executionPayloadContext,
+                    Optional.of(SafeFuture.completedFuture(executionPayload)),
+                    Optional.empty(),
+                    Optional.of(SafeFuture.completedFuture(blobsBundle)))));
+  }
+
   private static class CapturingBeaconBlockBodyBuilder implements BeaconBlockBodyBuilder {
+
     private final boolean blinded;
+    private final boolean supportsKzgCommitments;
 
     protected BLSSignature randaoReveal;
     protected Bytes32 graffiti;
@@ -460,9 +592,17 @@ class BlockOperationSelectorFactoryTest {
     protected SyncAggregate syncAggregate;
     protected ExecutionPayload executionPayload;
     protected ExecutionPayloadHeader executionPayloadHeader;
+    protected SszList<SszKZGCommitment> blobKzgCommitments;
 
-    public CapturingBeaconBlockBodyBuilder(boolean blinded) {
+    public CapturingBeaconBlockBodyBuilder(final boolean blinded) {
       this.blinded = blinded;
+      this.supportsKzgCommitments = false;
+    }
+
+    public CapturingBeaconBlockBodyBuilder(
+        final boolean blinded, final boolean supportsKzgCommitments) {
+      this.blinded = blinded;
+      this.supportsKzgCommitments = supportsKzgCommitments;
     }
 
     @Override
@@ -525,21 +665,22 @@ class BlockOperationSelectorFactoryTest {
     }
 
     @Override
-    public BeaconBlockBodyBuilder executionPayload(SafeFuture<ExecutionPayload> executionPayload) {
+    public BeaconBlockBodyBuilder executionPayload(
+        final SafeFuture<ExecutionPayload> executionPayload) {
       this.executionPayload = safeJoin(executionPayload);
       return this;
     }
 
     @Override
     public BeaconBlockBodyBuilder executionPayloadHeader(
-        SafeFuture<ExecutionPayloadHeader> executionPayloadHeader) {
+        final SafeFuture<ExecutionPayloadHeader> executionPayloadHeader) {
       this.executionPayloadHeader = safeJoin(executionPayloadHeader);
       return this;
     }
 
     @Override
     public BeaconBlockBodyBuilder blsToExecutionChanges(
-        SszList<SignedBlsToExecutionChange> blsToExecutionChanges) {
+        final SszList<SignedBlsToExecutionChange> blsToExecutionChanges) {
       this.blsToExecutionChanges = blsToExecutionChanges;
       return this;
     }
@@ -561,13 +702,13 @@ class BlockOperationSelectorFactoryTest {
 
     @Override
     public Boolean supportsKzgCommitments() {
-      return false;
+      return supportsKzgCommitments;
     }
 
     @Override
     public BeaconBlockBodyBuilder blobKzgCommitments(
-        SafeFuture<SszList<SszKZGCommitment>> blobKzgCommitments) {
-      // do nothing
+        final SafeFuture<SszList<SszKZGCommitment>> blobKzgCommitments) {
+      this.blobKzgCommitments = safeJoin(blobKzgCommitments);
       return this;
     }
 
@@ -581,13 +722,14 @@ class BlockOperationSelectorFactoryTest {
     protected SafeFuture<ExecutionPayload> executionPayload;
 
     public CapturingBeaconBlockUnblinder(
-        SchemaDefinitions schemaDefinitions, SignedBeaconBlock signedBlindedBeaconBlock) {
+        final SchemaDefinitions schemaDefinitions,
+        final SignedBeaconBlock signedBlindedBeaconBlock) {
       super(schemaDefinitions, signedBlindedBeaconBlock);
     }
 
     @Override
     public void setExecutionPayloadSupplier(
-        Supplier<SafeFuture<ExecutionPayload>> executionPayloadSupplier) {
+        final Supplier<SafeFuture<ExecutionPayload>> executionPayloadSupplier) {
       this.executionPayload = executionPayloadSupplier.get();
     }
 

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerBlockProductionManagerImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerBlockProductionManagerImpl.java
@@ -20,6 +20,8 @@ import tech.pegasys.teku.ethereum.events.SlotEventsChannel;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobsBundle;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlindedBlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
@@ -112,6 +114,12 @@ public class ExecutionLayerBlockProductionManagerImpl
       final SignedBeaconBlock signedBlindedBeaconBlock) {
     return executionLayerChannel.builderGetPayload(
         signedBlindedBeaconBlock, this::getCachedPayloadResult);
+  }
+
+  @Override
+  public SafeFuture<SignedBlobSidecar> getUnblindedBlobSidecar(
+      final SignedBlindedBlobSidecar signedBlindedBlobSidecar) {
+    throw new UnsupportedOperationException("Not yet implemented");
   }
 
   private ExecutionPayloadResult builderGetHeader(

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerBlockProductionManagerImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerBlockProductionManagerImpl.java
@@ -20,8 +20,6 @@ import tech.pegasys.teku.ethereum.events.SlotEventsChannel;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobsBundle;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlindedBlobSidecar;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
@@ -114,12 +112,6 @@ public class ExecutionLayerBlockProductionManagerImpl
       final SignedBeaconBlock signedBlindedBeaconBlock) {
     return executionLayerChannel.builderGetPayload(
         signedBlindedBeaconBlock, this::getCachedPayloadResult);
-  }
-
-  @Override
-  public SafeFuture<SignedBlobSidecar> getUnblindedBlobSidecar(
-      final SignedBlindedBlobSidecar signedBlindedBlobSidecar) {
-    throw new UnsupportedOperationException("Not yet implemented");
   }
 
   private ExecutionPayloadResult builderGetHeader(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/versions/deneb/BlobsBundle.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/versions/deneb/BlobsBundle.java
@@ -47,6 +47,10 @@ public class BlobsBundle {
     return blobs;
   }
 
+  public int getNumberOfBlobs() {
+    return blobs.size();
+  }
+
   public String toBriefString() {
     return MoreObjects.toStringHelper(this)
         .add(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/BlockContainer.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/BlockContainer.java
@@ -45,10 +45,6 @@ public interface BlockContainer extends SszData {
     return toBlinded().isPresent();
   }
 
-  static BlockContainer fromBeaconBlock(final BeaconBlock block) {
-    return block;
-  }
-
   static BlockContainer fromSszData(final SszData sszData) {
     if (sszData instanceof BlockContainer) {
       return (BlockContainer) sszData;

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/BlockContainer.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/BlockContainer.java
@@ -21,7 +21,7 @@ import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.versions.deneb.BlockContents;
 
 /**
- * Interface used to represent both {@link BlockContents} and {@link BeaconBlock} and their blinded
+ * Interface used to represent both {@link BeaconBlock} and {@link BlockContents} and their blinded
  * variants: <a
  * href="https://github.com/ethereum/beacon-APIs/tree/master/types/deneb">beacon-APIs/types/deneb</a>
  */
@@ -43,6 +43,10 @@ public interface BlockContainer extends SszData {
 
   default boolean isBlinded() {
     return toBlinded().isPresent();
+  }
+
+  static BlockContainer fromBeaconBlock(final BeaconBlock block) {
+    return block;
   }
 
   static BlockContainer fromSszData(final SszData sszData) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBlockContainer.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBlockContainer.java
@@ -22,7 +22,7 @@ import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSide
 import tech.pegasys.teku.spec.datastructures.blocks.versions.deneb.SignedBlockContents;
 
 /**
- * Interface used to represent both {@link SignedBlockContents} and {@link SignedBeaconBlock} and
+ * Interface used to represent both {@link SignedBeaconBlock} and {@link SignedBlockContents} and
  * their blinded variants: <a
  * href="https://github.com/ethereum/beacon-APIs/tree/master/types/deneb">beacon-APIs/types/deneb</a>
  */

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/BeaconBlockBody.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/BeaconBlockBody.java
@@ -37,6 +37,7 @@ import tech.pegasys.teku.spec.datastructures.operations.Deposit;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.SignedBlsToExecutionChange;
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
+import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.spec.datastructures.type.SszSignature;
 
 public interface BeaconBlockBody extends SszContainer {
@@ -76,7 +77,13 @@ public interface BeaconBlockBody extends SszContainer {
     return Optional.empty();
   }
 
-  Optional<SszList<SignedBlsToExecutionChange>> getOptionalBlsToExecutionChanges();
+  default Optional<SszList<SignedBlsToExecutionChange>> getOptionalBlsToExecutionChanges() {
+    return Optional.empty();
+  }
+
+  default Optional<SszList<SszKZGCommitment>> getOptionalBlobKzgCommitments() {
+    return Optional.empty();
+  }
 
   default boolean isBlinded() {
     return false;

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/altair/BeaconBlockBodyAltairImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/altair/BeaconBlockBodyAltairImpl.java
@@ -26,7 +26,6 @@ import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.Deposit;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
-import tech.pegasys.teku.spec.datastructures.operations.SignedBlsToExecutionChange;
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.type.SszSignature;
 
@@ -133,11 +132,6 @@ public class BeaconBlockBodyAltairImpl
   @Override
   public SszList<SignedVoluntaryExit> getVoluntaryExits() {
     return getField7();
-  }
-
-  @Override
-  public Optional<SszList<SignedBlsToExecutionChange>> getOptionalBlsToExecutionChanges() {
-    return Optional.empty();
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BeaconBlockBodyBellatrixImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BeaconBlockBodyBellatrixImpl.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.bellatri
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
@@ -31,7 +30,6 @@ import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.Deposit;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
-import tech.pegasys.teku.spec.datastructures.operations.SignedBlsToExecutionChange;
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.type.SszSignature;
 
@@ -141,11 +139,6 @@ class BeaconBlockBodyBellatrixImpl
   @Override
   public SszList<SignedVoluntaryExit> getVoluntaryExits() {
     return getField7();
-  }
-
-  @Override
-  public Optional<SszList<SignedBlsToExecutionChange>> getOptionalBlsToExecutionChanges() {
-    return Optional.empty();
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BlindedBeaconBlockBodyBellatrixImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BlindedBeaconBlockBodyBellatrixImpl.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.bellatri
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
@@ -31,7 +30,6 @@ import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.Deposit;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
-import tech.pegasys.teku.spec.datastructures.operations.SignedBlsToExecutionChange;
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.type.SszSignature;
 
@@ -142,11 +140,6 @@ class BlindedBeaconBlockBodyBellatrixImpl
   @Override
   public SszList<SignedVoluntaryExit> getVoluntaryExits() {
     return getField7();
-  }
-
-  @Override
-  public Optional<SszList<SignedBlsToExecutionChange>> getOptionalBlsToExecutionChanges() {
-    return Optional.empty();
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/capella/BeaconBlockBodyCapella.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/capella/BeaconBlockBodyCapella.java
@@ -32,6 +32,11 @@ public interface BeaconBlockBodyCapella extends BeaconBlockBodyBellatrix {
   SszList<SignedBlsToExecutionChange> getBlsToExecutionChanges();
 
   @Override
+  default Optional<SszList<SignedBlsToExecutionChange>> getOptionalBlsToExecutionChanges() {
+    return Optional.of(getBlsToExecutionChanges());
+  }
+
+  @Override
   BeaconBlockBodySchemaCapella<?> getSchema();
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/capella/BeaconBlockBodyCapellaImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/capella/BeaconBlockBodyCapellaImpl.java
@@ -135,11 +135,6 @@ public class BeaconBlockBodyCapellaImpl
   }
 
   @Override
-  public Optional<SszList<SignedBlsToExecutionChange>> getOptionalBlsToExecutionChanges() {
-    return Optional.of(getBlsToExecutionChanges());
-  }
-
-  @Override
   public SyncAggregate getSyncAggregate() {
     return getField8();
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/capella/BlindedBeaconBlockBodyCapella.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/capella/BlindedBeaconBlockBodyCapella.java
@@ -29,12 +29,17 @@ public interface BlindedBeaconBlockBodyCapella extends BlindedBeaconBlockBodyBel
                         + body.getClass().getSimpleName()));
   }
 
+  SszList<SignedBlsToExecutionChange> getBlsToExecutionChanges();
+
+  @Override
+  default Optional<SszList<SignedBlsToExecutionChange>> getOptionalBlsToExecutionChanges() {
+    return Optional.of(getBlsToExecutionChanges());
+  }
+
   @Override
   default Optional<BlindedBeaconBlockBodyCapella> toBlindedVersionCapella() {
     return Optional.of(this);
   }
-
-  SszList<SignedBlsToExecutionChange> getBlsToExecutionChanges();
 
   @Override
   BlindedBeaconBlockBodySchemaCapella<?> getSchema();

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/capella/BlindedBeaconBlockBodyCapellaImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/capella/BlindedBeaconBlockBodyCapellaImpl.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.capella;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
@@ -144,11 +143,6 @@ class BlindedBeaconBlockBodyCapellaImpl
   @Override
   public SszList<SignedVoluntaryExit> getVoluntaryExits() {
     return getField7();
-  }
-
-  @Override
-  public Optional<SszList<SignedBlsToExecutionChange>> getOptionalBlsToExecutionChanges() {
-    return Optional.of(getBlsToExecutionChanges());
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/deneb/BeaconBlockBodyDeneb.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/deneb/BeaconBlockBodyDeneb.java
@@ -32,6 +32,11 @@ public interface BeaconBlockBodyDeneb extends BeaconBlockBodyCapella {
   SszList<SszKZGCommitment> getBlobKzgCommitments();
 
   @Override
+  default Optional<SszList<SszKZGCommitment>> getOptionalBlobKzgCommitments() {
+    return Optional.of(getBlobKzgCommitments());
+  }
+
+  @Override
   BeaconBlockBodySchemaDeneb<?> getSchema();
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/deneb/BeaconBlockBodyDenebImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/deneb/BeaconBlockBodyDenebImpl.java
@@ -150,11 +150,6 @@ public class BeaconBlockBodyDenebImpl
   }
 
   @Override
-  public Optional<SszList<SignedBlsToExecutionChange>> getOptionalBlsToExecutionChanges() {
-    return Optional.of(getBlsToExecutionChanges());
-  }
-
-  @Override
   public SyncAggregate getSyncAggregate() {
     return getField8();
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/deneb/BlindedBeaconBlockBodyDeneb.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/deneb/BlindedBeaconBlockBodyDeneb.java
@@ -29,12 +29,17 @@ public interface BlindedBeaconBlockBodyDeneb extends BlindedBeaconBlockBodyCapel
                         + body.getClass().getSimpleName()));
   }
 
+  SszList<SszKZGCommitment> getBlobKzgCommitments();
+
+  @Override
+  default Optional<SszList<SszKZGCommitment>> getOptionalBlobKzgCommitments() {
+    return Optional.of(getBlobKzgCommitments());
+  }
+
   @Override
   default Optional<BlindedBeaconBlockBodyDeneb> toBlindedVersionDeneb() {
     return Optional.of(this);
   }
-
-  SszList<SszKZGCommitment> getBlobKzgCommitments();
 
   @Override
   BlindedBeaconBlockBodySchemaDeneb<?> getSchema();

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/deneb/BlindedBeaconBlockBodyDenebImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/deneb/BlindedBeaconBlockBodyDenebImpl.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.deneb;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
@@ -148,11 +147,6 @@ class BlindedBeaconBlockBodyDenebImpl
   @Override
   public SszList<SignedVoluntaryExit> getVoluntaryExits() {
     return getField7();
-  }
-
-  @Override
-  public Optional<SszList<SignedBlsToExecutionChange>> getOptionalBlsToExecutionChanges() {
-    return Optional.of(getBlsToExecutionChanges());
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/phase0/BeaconBlockBodyPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/phase0/BeaconBlockBodyPhase0.java
@@ -27,7 +27,6 @@ import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.Deposit;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
-import tech.pegasys.teku.spec.datastructures.operations.SignedBlsToExecutionChange;
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.type.SszSignature;
 
@@ -123,11 +122,6 @@ public class BeaconBlockBodyPhase0
   @Override
   public SszList<SignedVoluntaryExit> getVoluntaryExits() {
     return getField7();
-  }
-
-  @Override
-  public Optional<SszList<SignedBlsToExecutionChange>> getOptionalBlsToExecutionChanges() {
-    return Optional.empty();
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadResult.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadResult.java
@@ -14,12 +14,9 @@
 package tech.pegasys.teku.spec.datastructures.execution;
 
 import com.google.common.base.MoreObjects;
-import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
-import tech.pegasys.teku.kzg.KZGCommitment;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.Blob;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobsBundle;
 
 public class ExecutionPayloadResult {
@@ -53,14 +50,6 @@ public class ExecutionPayloadResult {
 
   public Optional<SafeFuture<BlobsBundle>> getBlobsBundleFuture() {
     return blobsBundleFuture;
-  }
-
-  public Optional<SafeFuture<List<KZGCommitment>>> getCommitmentsFuture() {
-    return blobsBundleFuture.map(future -> future.thenApply(BlobsBundle::getCommitments));
-  }
-
-  public Optional<SafeFuture<List<Blob>>> getBlobsFuture() {
-    return blobsBundleFuture.map(future -> future.thenApply(BlobsBundle::getBlobs));
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerBlockProductionManager.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerBlockProductionManager.java
@@ -16,6 +16,8 @@ package tech.pegasys.teku.spec.executionlayer;
 import java.util.Optional;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlindedBlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
@@ -53,6 +55,12 @@ public interface ExecutionLayerBlockProductionManager {
             SignedBeaconBlock signedBlindedBeaconBlock) {
           return SafeFuture.completedFuture(null);
         }
+
+        @Override
+        public SafeFuture<SignedBlobSidecar> getUnblindedBlobSidecar(
+            final SignedBlindedBlobSidecar signedBlindedBlobSidecar) {
+          return SafeFuture.completedFuture(null);
+        }
       };
 
   /**
@@ -81,4 +89,7 @@ public interface ExecutionLayerBlockProductionManager {
   Optional<ExecutionPayloadResult> getCachedPayloadResult(UInt64 slot);
 
   SafeFuture<ExecutionPayload> getUnblindedPayload(SignedBeaconBlock signedBlindedBeaconBlock);
+
+  SafeFuture<SignedBlobSidecar> getUnblindedBlobSidecar(
+      SignedBlindedBlobSidecar signedBlindedBlobSidecar);
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerBlockProductionManager.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerBlockProductionManager.java
@@ -16,8 +16,6 @@ package tech.pegasys.teku.spec.executionlayer;
 import java.util.Optional;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlindedBlobSidecar;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
@@ -55,12 +53,6 @@ public interface ExecutionLayerBlockProductionManager {
             SignedBeaconBlock signedBlindedBeaconBlock) {
           return SafeFuture.completedFuture(null);
         }
-
-        @Override
-        public SafeFuture<SignedBlobSidecar> getUnblindedBlobSidecar(
-            final SignedBlindedBlobSidecar signedBlindedBlobSidecar) {
-          return SafeFuture.completedFuture(null);
-        }
       };
 
   /**
@@ -89,7 +81,4 @@ public interface ExecutionLayerBlockProductionManager {
   Optional<ExecutionPayloadResult> getCachedPayloadResult(UInt64 slot);
 
   SafeFuture<ExecutionPayload> getUnblindedPayload(SignedBeaconBlock signedBlindedBeaconBlock);
-
-  SafeFuture<SignedBlobSidecar> getUnblindedBlobSidecar(
-      SignedBlindedBlobSidecar signedBlindedBlobSidecar);
 }

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -2113,13 +2113,20 @@ public final class DataStructureUtil {
   }
 
   public BlobsBundle randomBlobsBundle() {
+    return randomBlobsBundle(Optional.empty());
+  }
+
+  public BlobsBundle randomBlobsBundle(final int count) {
+    return randomBlobsBundle(Optional.of(count));
+  }
+
+  private BlobsBundle randomBlobsBundle(final Optional<Integer> count) {
     final BlobSchema blobSchema =
         SchemaDefinitionsDeneb.required(spec.getGenesisSchemaDefinitions()).getBlobSchema();
-    List<KZGCommitment> commitments =
-        randomSszKzgCommitmentList().stream()
-            .map(SszKZGCommitment::getKZGCommitment)
-            .collect(toList());
-    List<KZGProof> proofs =
+    final List<KZGCommitment> commitments =
+        (count.isPresent() ? randomSszKzgCommitmentList(count.get()) : randomSszKzgCommitmentList())
+            .stream().map(SszKZGCommitment::getKZGCommitment).collect(toList());
+    final List<KZGProof> proofs =
         IntStream.range(0, commitments.size()).mapToObj(__ -> randomKZGProof()).collect(toList());
     return new BlobsBundle(
         commitments,

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -178,6 +178,7 @@ import tech.pegasys.teku.validator.coordinator.DutyMetrics;
 import tech.pegasys.teku.validator.coordinator.Eth1DataCache;
 import tech.pegasys.teku.validator.coordinator.Eth1DataProvider;
 import tech.pegasys.teku.validator.coordinator.Eth1VotingPeriod;
+import tech.pegasys.teku.validator.coordinator.MilestoneBasedBlockFactory;
 import tech.pegasys.teku.validator.coordinator.ValidatorApiHandler;
 import tech.pegasys.teku.validator.coordinator.performance.DefaultPerformanceTracker;
 import tech.pegasys.teku.validator.coordinator.performance.NoOpPerformanceTracker;
@@ -747,22 +748,21 @@ public class BeaconChainController extends Service implements BeaconChainControl
     LOG.debug("BeaconChainController.initValidatorApiHandler()");
     final ExecutionLayerBlockProductionManager executionLayerInitiator =
         ExecutionLayerBlockManagerFactory.create(executionLayer, eventChannels);
-    final BlockFactory blockFactory =
-        new BlockFactory(
+    final BlockOperationSelectorFactory operationSelector =
+        new BlockOperationSelectorFactory(
             spec,
-            new BlockOperationSelectorFactory(
-                spec,
-                attestationPool,
-                attesterSlashingPool,
-                proposerSlashingPool,
-                voluntaryExitPool,
-                blsToExecutionChangePool,
-                syncCommitteeContributionPool,
-                depositProvider,
-                eth1DataCache,
-                VersionProvider.getDefaultGraffiti(),
-                forkChoiceNotifier,
-                executionLayerInitiator));
+            attestationPool,
+            attesterSlashingPool,
+            proposerSlashingPool,
+            voluntaryExitPool,
+            blsToExecutionChangePool,
+            syncCommitteeContributionPool,
+            depositProvider,
+            eth1DataCache,
+            VersionProvider.getDefaultGraffiti(),
+            forkChoiceNotifier,
+            executionLayerInitiator);
+    final BlockFactory blockFactory = new MilestoneBasedBlockFactory(spec, operationSelector);
     SyncCommitteeSubscriptionManager syncCommitteeSubscriptionManager =
         beaconConfig.p2pConfig().isSubscribeAllSubnetsEnabled()
             ? new AllSyncCommitteeSubscriptions(p2pNetwork, spec)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Next part of https://github.com/ConsenSys/teku/pull/7129

- Introduce `BlockFactoryDeneb` which creates `BlockContents` or `BlindedBlockContents` instead of `BeaconBlock`.
- `BlockFactoryDeneb` is only used when slot is Deneb one
- Made `getOptionalBlsToExecutionChanges` in `BeaconBlockBody` to act in a similar way to other optional fields.

**Next parts:**

- Unblinding of `BlockContainer` in `AbstractBlockPublisher` (in order to publish and import blobs)
- Signing of blob sidecars in `BlockProductionDuty`
- Implement remote calls (VC -> BN)

## Fixed Issue(s)
when next parts are done, it will fix couple of tasks in https://github.com/ConsenSys/teku/issues/6822

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
