### PR TITLE
Set mainnet trusted setup as default for unknown networks

### DIFF
--- a/ethereum/networks/src/main/java/tech/pegasys/teku/networks/Eth2NetworkConfiguration.java
+++ b/ethereum/networks/src/main/java/tech/pegasys/teku/networks/Eth2NetworkConfiguration.java
@@ -461,8 +461,13 @@ public class Eth2NetworkConfiguration {
 
     public Builder applyNetworkDefaults(final String networkName) {
       Eth2Network.fromStringLenient(networkName)
-          .ifPresentOrElse(this::applyNetworkDefaults, () -> reset().constants(networkName));
+          .ifPresentOrElse(
+              this::applyNetworkDefaults, () -> resetAndApplyBasicDefaults(networkName));
       return this;
+    }
+
+    private Builder resetAndApplyBasicDefaults(final String networkName) {
+      return reset().trustedSetupFromClasspath("mainnet-trusted-setup.txt").constants(networkName);
     }
 
     public Builder applyNetworkDefaults(final Eth2Network network) {
@@ -488,7 +493,7 @@ public class Eth2NetworkConfiguration {
         case LESS_SWIFT:
           return applyLessSwiftNetworkDefaults();
         default:
-          return reset().constants(network.configName());
+          return resetAndApplyBasicDefaults(network.configName());
       }
     }
 

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/Eth2NetworkOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/Eth2NetworkOptionsTest.java
@@ -71,6 +71,26 @@ class Eth2NetworkOptionsTest extends AbstractBeaconNodeCommandTest {
   }
 
   @Test
+  void shouldUseTrustedSetupIfSpecified() {
+    final TekuConfiguration config =
+        getTekuConfigurationFromArguments("--Xtrusted-setup", "/test.txt");
+    final Optional<String> trustedSetup = config.eth2NetworkConfiguration().getTrustedSetup();
+    assertThat(trustedSetup).isEqualTo(Optional.of("/test.txt"));
+    assertThat(createConfigBuilder().eth2NetworkConfig(b -> b.trustedSetup("/test.txt")).build())
+        .usingRecursiveComparison()
+        .isEqualTo(config);
+  }
+
+  @Test
+  void shouldUseDefaultTrustedSetupIfUnspecified() {
+    final TekuConfiguration config = getTekuConfigurationFromArguments();
+    final Optional<String> trustedSetup = config.eth2NetworkConfiguration().getTrustedSetup();
+    assertThat(trustedSetup)
+        .matches(ts -> ts.map(path -> path.endsWith("mainnet-trusted-setup.txt")).orElse(false));
+    assertThat(createConfigBuilder().build()).usingRecursiveComparison().isEqualTo(config);
+  }
+
+  @Test
   void shouldUseBellatrixForkEpochIfSpecified() {
     final TekuConfiguration config =
         getTekuConfigurationFromArguments(


### PR DESCRIPTION
For convenience we can always set mainnet trusted setup as default

This fixes my initial problem which is `genesis` command is not working when creating a Deneb genesis, because it is not able to get trustedSetup from parameter but then network config requires it.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
