### PR TITLE
De/serialize `BlockContainer` when making BN requests from VC

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/BeaconBlockSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/BeaconBlockSchema.java
@@ -28,7 +28,8 @@ import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodySch
 
 public class BeaconBlockSchema
     extends ContainerSchema5<
-        BeaconBlock, SszUInt64, SszUInt64, SszBytes32, SszBytes32, BeaconBlockBody> {
+        BeaconBlock, SszUInt64, SszUInt64, SszBytes32, SszBytes32, BeaconBlockBody>
+    implements BlockContainerSchema<BeaconBlock> {
 
   public BeaconBlockSchema(
       final BeaconBlockBodySchema<?> blockBodySchema, final String containerName) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/BlockContainer.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/BlockContainer.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.spec.datastructures.blocks;
 
 import java.util.List;
 import java.util.Optional;
+import tech.pegasys.teku.infrastructure.ssz.SszContainer;
 import tech.pegasys.teku.infrastructure.ssz.SszData;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
@@ -25,7 +26,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.versions.deneb.BlockContents
  * variants: <a
  * href="https://github.com/ethereum/beacon-APIs/tree/master/types/deneb">beacon-APIs/types/deneb</a>
  */
-public interface BlockContainer extends SszData {
+public interface BlockContainer extends SszData, SszContainer {
 
   BeaconBlock getBlock();
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/BlockContainerSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/BlockContainerSchema.java
@@ -14,7 +14,12 @@
 package tech.pegasys.teku.spec.datastructures.blocks;
 
 import tech.pegasys.teku.infrastructure.ssz.schema.SszContainerSchema;
+import tech.pegasys.teku.spec.datastructures.blocks.versions.deneb.BlockContentsSchema;
 
+/**
+ * Interface used to represent both {@link BeaconBlockSchema} and {@link BlockContentsSchema} and
+ * their blinded variants
+ */
 public interface BlockContainerSchema<T extends BlockContainer> extends SszContainerSchema<T> {
 
   @SuppressWarnings("unchecked")

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/BlockContainerSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/BlockContainerSchema.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright ConsenSys Software Inc., 2023
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.blocks;
+
+import tech.pegasys.teku.infrastructure.ssz.schema.SszContainerSchema;
+
+public interface BlockContainerSchema<T extends BlockContainer> extends SszContainerSchema<T> {
+
+  @SuppressWarnings("unchecked")
+  default BlockContainerSchema<BlockContainer> castTypeToBlockContainer() {
+    return (BlockContainerSchema<BlockContainer>) this;
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBeaconBlockSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBeaconBlockSchema.java
@@ -22,7 +22,8 @@ import tech.pegasys.teku.spec.datastructures.type.SszSignature;
 import tech.pegasys.teku.spec.datastructures.type.SszSignatureSchema;
 
 public class SignedBeaconBlockSchema
-    extends ContainerSchema2<SignedBeaconBlock, BeaconBlock, SszSignature> {
+    extends ContainerSchema2<SignedBeaconBlock, BeaconBlock, SszSignature>
+    implements SignedBlockContainerSchema<SignedBeaconBlock> {
 
   public SignedBeaconBlockSchema(
       final BeaconBlockSchema beaconBlockSchema, final String containerName) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBlockContainer.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBlockContainer.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
 import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.ssz.SszContainer;
 import tech.pegasys.teku.infrastructure.ssz.SszData;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecar;
@@ -27,7 +28,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.versions.deneb.SignedBlockCo
  * their blinded variants: <a
  * href="https://github.com/ethereum/beacon-APIs/tree/master/types/deneb">beacon-APIs/types/deneb</a>
  */
-public interface SignedBlockContainer extends SszData {
+public interface SignedBlockContainer extends SszData, SszContainer {
 
   Predicate<SignedBlockContainer> IS_SIGNED_BEACON_BLOCK =
       blockContainer -> blockContainer instanceof SignedBeaconBlock;

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBlockContainerSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBlockContainerSchema.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright ConsenSys Software Inc., 2023
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.blocks;
+
+import tech.pegasys.teku.infrastructure.ssz.schema.SszContainerSchema;
+
+public interface SignedBlockContainerSchema<T extends SignedBlockContainer>
+    extends SszContainerSchema<T> {
+
+  @SuppressWarnings("unchecked")
+  default SignedBlockContainerSchema<SignedBlockContainer> castTypeToSignedBlockContainer() {
+    return (SignedBlockContainerSchema<SignedBlockContainer>) this;
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBlockContainerSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBlockContainerSchema.java
@@ -14,7 +14,12 @@
 package tech.pegasys.teku.spec.datastructures.blocks;
 
 import tech.pegasys.teku.infrastructure.ssz.schema.SszContainerSchema;
+import tech.pegasys.teku.spec.datastructures.blocks.versions.deneb.SignedBlockContentsSchema;
 
+/**
+ * Interface used to represent both {@link SignedBeaconBlockSchema} and {@link
+ * SignedBlockContentsSchema} and their blinded variants
+ */
 public interface SignedBlockContainerSchema<T extends SignedBlockContainer>
     extends SszContainerSchema<T> {
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/versions/deneb/BlindedBlockContentsSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/versions/deneb/BlindedBlockContentsSchema.java
@@ -24,9 +24,11 @@ import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlindedBlobSid
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlindedBlobSidecarSchema;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSchema;
+import tech.pegasys.teku.spec.datastructures.blocks.BlockContainerSchema;
 
 public class BlindedBlockContentsSchema
-    extends ContainerSchema2<BlindedBlockContents, BeaconBlock, SszList<BlindedBlobSidecar>> {
+    extends ContainerSchema2<BlindedBlockContents, BeaconBlock, SszList<BlindedBlobSidecar>>
+    implements BlockContainerSchema<BlindedBlockContents> {
 
   static final SszFieldName FIELD_BLINDED_BLOB_SIDECARS = () -> "blinded_blob_sidecars";
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/versions/deneb/BlockContentsSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/versions/deneb/BlockContentsSchema.java
@@ -24,9 +24,11 @@ import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarSchema;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSchema;
+import tech.pegasys.teku.spec.datastructures.blocks.BlockContainerSchema;
 
 public class BlockContentsSchema
-    extends ContainerSchema2<BlockContents, BeaconBlock, SszList<BlobSidecar>> {
+    extends ContainerSchema2<BlockContents, BeaconBlock, SszList<BlobSidecar>>
+    implements BlockContainerSchema<BlockContents> {
 
   static final SszFieldName FIELD_BLOB_SIDECARS = () -> "blob_sidecars";
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/versions/deneb/SignedBlindedBlockContentsSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/versions/deneb/SignedBlindedBlockContentsSchema.java
@@ -24,10 +24,12 @@ import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlindedB
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlindedBlobSidecarSchema;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlockSchema;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainerSchema;
 
 public class SignedBlindedBlockContentsSchema
     extends ContainerSchema2<
-        SignedBlindedBlockContents, SignedBeaconBlock, SszList<SignedBlindedBlobSidecar>> {
+        SignedBlindedBlockContents, SignedBeaconBlock, SszList<SignedBlindedBlobSidecar>>
+    implements SignedBlockContainerSchema<SignedBlindedBlockContents> {
 
   static final SszFieldName FIELD_BLOB_SIDECARS = () -> "signed_blinded_blob_sidecars";
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/versions/deneb/SignedBlockContentsSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/versions/deneb/SignedBlockContentsSchema.java
@@ -24,9 +24,11 @@ import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSide
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecarSchema;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlockSchema;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainerSchema;
 
 public class SignedBlockContentsSchema
-    extends ContainerSchema2<SignedBlockContents, SignedBeaconBlock, SszList<SignedBlobSidecar>> {
+    extends ContainerSchema2<SignedBlockContents, SignedBeaconBlock, SszList<SignedBlobSidecar>>
+    implements SignedBlockContainerSchema<SignedBlockContents> {
 
   static final SszFieldName FIELD_SIGNED_BLOB_SIDECARS = () -> "signed_blob_sidecars";
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitions.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitions.java
@@ -21,7 +21,11 @@ import java.util.Optional;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszBitvector;
 import tech.pegasys.teku.infrastructure.ssz.schema.collections.SszBitvectorSchema;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSchema;
+import tech.pegasys.teku.spec.datastructures.blocks.BlockContainer;
+import tech.pegasys.teku.spec.datastructures.blocks.BlockContainerSchema;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlockSchema;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainerSchema;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodySchema;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.metadata.MetadataMessageSchema;
 import tech.pegasys.teku.spec.datastructures.operations.AggregateAndProof.AggregateAndProofSchema;
@@ -47,6 +51,14 @@ public interface SchemaDefinitions {
   BeaconBlockBodySchema<?> getBlindedBeaconBlockBodySchema();
 
   SignedBeaconBlockSchema getSignedBlindedBeaconBlockSchema();
+
+  BlockContainerSchema<BlockContainer> getBlockContainerSchema();
+
+  BlockContainerSchema<BlockContainer> getBlindedBlockContainerSchema();
+
+  SignedBlockContainerSchema<SignedBlockContainer> getSignedBlockContainerSchema();
+
+  SignedBlockContainerSchema<SignedBlockContainer> getSignedBlindedBlockContainerSchema();
 
   MetadataMessageSchema<?> getMetadataMessageSchema();
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsAltair.java
@@ -17,7 +17,11 @@ import com.google.common.base.Preconditions;
 import java.util.Optional;
 import tech.pegasys.teku.spec.config.SpecConfigAltair;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSchema;
+import tech.pegasys.teku.spec.datastructures.blocks.BlockContainer;
+import tech.pegasys.teku.spec.datastructures.blocks.BlockContainerSchema;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlockSchema;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainerSchema;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodySchema;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.BeaconBlockBodySchemaAltair;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.BeaconBlockBodySchemaAltairImpl;
@@ -114,6 +118,26 @@ public class SchemaDefinitionsAltair extends AbstractSchemaDefinitions {
   @Override
   public SignedBeaconBlockSchema getSignedBlindedBeaconBlockSchema() {
     return getSignedBeaconBlockSchema();
+  }
+
+  @Override
+  public BlockContainerSchema<BlockContainer> getBlockContainerSchema() {
+    return getBeaconBlockSchema().castTypeToBlockContainer();
+  }
+
+  @Override
+  public BlockContainerSchema<BlockContainer> getBlindedBlockContainerSchema() {
+    return getBeaconBlockSchema().castTypeToBlockContainer();
+  }
+
+  @Override
+  public SignedBlockContainerSchema<SignedBlockContainer> getSignedBlockContainerSchema() {
+    return getSignedBeaconBlockSchema().castTypeToSignedBlockContainer();
+  }
+
+  @Override
+  public SignedBlockContainerSchema<SignedBlockContainer> getSignedBlindedBlockContainerSchema() {
+    return getSignedBlindedBeaconBlockSchema().castTypeToSignedBlockContainer();
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsBellatrix.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsBellatrix.java
@@ -22,6 +22,8 @@ import tech.pegasys.teku.spec.datastructures.blocks.BlockContainer;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockContainerSchema;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlockSchema;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainerSchema;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodySchema;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.bellatrix.BeaconBlockBodySchemaBellatrix;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.bellatrix.BeaconBlockBodySchemaBellatrixImpl;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.bellatrix.BlindedBeaconBlockBodySchemaBellatrix;

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsBellatrix.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsBellatrix.java
@@ -18,8 +18,10 @@ import static com.google.common.base.Preconditions.checkArgument;
 import java.util.Optional;
 import tech.pegasys.teku.spec.config.SpecConfigBellatrix;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSchema;
+import tech.pegasys.teku.spec.datastructures.blocks.BlockContainer;
+import tech.pegasys.teku.spec.datastructures.blocks.BlockContainerSchema;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlockSchema;
-import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodySchema;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.bellatrix.BeaconBlockBodySchemaBellatrix;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.bellatrix.BeaconBlockBodySchemaBellatrixImpl;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.bellatrix.BlindedBeaconBlockBodySchemaBellatrix;
@@ -116,6 +118,26 @@ public class SchemaDefinitionsBellatrix extends SchemaDefinitionsAltair {
   @Override
   public SignedBeaconBlockSchema getSignedBlindedBeaconBlockSchema() {
     return signedBlindedBeaconBlockSchema;
+  }
+
+  @Override
+  public BlockContainerSchema<BlockContainer> getBlockContainerSchema() {
+    return getBeaconBlockSchema().castTypeToBlockContainer();
+  }
+
+  @Override
+  public BlockContainerSchema<BlockContainer> getBlindedBlockContainerSchema() {
+    return getBlindedBeaconBlockSchema().castTypeToBlockContainer();
+  }
+
+  @Override
+  public SignedBlockContainerSchema<SignedBlockContainer> getSignedBlockContainerSchema() {
+    return getSignedBeaconBlockSchema().castTypeToSignedBlockContainer();
+  }
+
+  @Override
+  public SignedBlockContainerSchema<SignedBlockContainer> getSignedBlindedBlockContainerSchema() {
+    return getSignedBlindedBeaconBlockSchema().castTypeToSignedBlockContainer();
   }
 
   public ExecutionPayloadSchema<?> getExecutionPayloadSchema() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsCapella.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsCapella.java
@@ -18,8 +18,10 @@ import static com.google.common.base.Preconditions.checkArgument;
 import java.util.Optional;
 import tech.pegasys.teku.spec.config.SpecConfigCapella;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSchema;
+import tech.pegasys.teku.spec.datastructures.blocks.BlockContainer;
+import tech.pegasys.teku.spec.datastructures.blocks.BlockContainerSchema;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlockSchema;
-import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodySchema;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.capella.BeaconBlockBodySchemaCapella;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.capella.BeaconBlockBodySchemaCapellaImpl;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.capella.BlindedBeaconBlockBodySchemaCapella;
@@ -143,6 +145,26 @@ public class SchemaDefinitionsCapella extends SchemaDefinitionsBellatrix {
   @Override
   public SignedBeaconBlockSchema getSignedBlindedBeaconBlockSchema() {
     return signedBlindedBeaconBlockSchema;
+  }
+
+  @Override
+  public BlockContainerSchema<BlockContainer> getBlockContainerSchema() {
+    return getBeaconBlockSchema().castTypeToBlockContainer();
+  }
+
+  @Override
+  public BlockContainerSchema<BlockContainer> getBlindedBlockContainerSchema() {
+    return getBlindedBeaconBlockSchema().castTypeToBlockContainer();
+  }
+
+  @Override
+  public SignedBlockContainerSchema<SignedBlockContainer> getSignedBlockContainerSchema() {
+    return getSignedBeaconBlockSchema().castTypeToSignedBlockContainer();
+  }
+
+  @Override
+  public SignedBlockContainerSchema<SignedBlockContainer> getSignedBlindedBlockContainerSchema() {
+    return getSignedBlindedBeaconBlockSchema().castTypeToSignedBlockContainer();
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsCapella.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsCapella.java
@@ -22,6 +22,8 @@ import tech.pegasys.teku.spec.datastructures.blocks.BlockContainer;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockContainerSchema;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlockSchema;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainerSchema;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodySchema;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.capella.BeaconBlockBodySchemaCapella;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.capella.BeaconBlockBodySchemaCapellaImpl;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.capella.BlindedBeaconBlockBodySchemaCapella;

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsDeneb.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsDeneb.java
@@ -23,8 +23,10 @@ import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarSch
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlindedBlobSidecarSchema;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecarSchema;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSchema;
+import tech.pegasys.teku.spec.datastructures.blocks.BlockContainer;
+import tech.pegasys.teku.spec.datastructures.blocks.BlockContainerSchema;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlockSchema;
-import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodySchema;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.deneb.BeaconBlockBodySchemaDeneb;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.deneb.BeaconBlockBodySchemaDenebImpl;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.deneb.BlindedBeaconBlockBodySchemaDeneb;
@@ -168,6 +170,26 @@ public class SchemaDefinitionsDeneb extends SchemaDefinitionsCapella {
   @Override
   public SignedBeaconBlockSchema getSignedBlindedBeaconBlockSchema() {
     return signedBlindedBeaconBlockSchema;
+  }
+
+  @Override
+  public BlockContainerSchema<BlockContainer> getBlockContainerSchema() {
+    return getBlockContentsSchema().castTypeToBlockContainer();
+  }
+
+  @Override
+  public BlockContainerSchema<BlockContainer> getBlindedBlockContainerSchema() {
+    return getBlindedBlockContentsSchema().castTypeToBlockContainer();
+  }
+
+  @Override
+  public SignedBlockContainerSchema<SignedBlockContainer> getSignedBlockContainerSchema() {
+    return getSignedBlockContentsSchema().castTypeToSignedBlockContainer();
+  }
+
+  @Override
+  public SignedBlockContainerSchema<SignedBlockContainer> getSignedBlindedBlockContainerSchema() {
+    return getSignedBlindedBlockContentsSchema().castTypeToSignedBlockContainer();
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsDeneb.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsDeneb.java
@@ -27,6 +27,8 @@ import tech.pegasys.teku.spec.datastructures.blocks.BlockContainer;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockContainerSchema;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlockSchema;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainerSchema;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodySchema;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.deneb.BeaconBlockBodySchemaDeneb;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.deneb.BeaconBlockBodySchemaDenebImpl;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.deneb.BlindedBeaconBlockBodySchemaDeneb;

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsPhase0.java
@@ -16,7 +16,11 @@ package tech.pegasys.teku.spec.schemas;
 import java.util.Optional;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSchema;
+import tech.pegasys.teku.spec.datastructures.blocks.BlockContainer;
+import tech.pegasys.teku.spec.datastructures.blocks.BlockContainerSchema;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlockSchema;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainerSchema;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodySchema;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.phase0.BeaconBlockBodySchemaPhase0;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.metadata.versions.phase0.MetadataMessageSchemaPhase0;
@@ -75,6 +79,26 @@ public class SchemaDefinitionsPhase0 extends AbstractSchemaDefinitions {
   @Override
   public SignedBeaconBlockSchema getSignedBlindedBeaconBlockSchema() {
     return getSignedBeaconBlockSchema();
+  }
+
+  @Override
+  public BlockContainerSchema<BlockContainer> getBlockContainerSchema() {
+    return getBeaconBlockSchema().castTypeToBlockContainer();
+  }
+
+  @Override
+  public BlockContainerSchema<BlockContainer> getBlindedBlockContainerSchema() {
+    return getBeaconBlockSchema().castTypeToBlockContainer();
+  }
+
+  @Override
+  public SignedBlockContainerSchema<SignedBlockContainer> getSignedBlockContainerSchema() {
+    return getSignedBeaconBlockSchema().castTypeToSignedBlockContainer();
+  }
+
+  @Override
+  public SignedBlockContainerSchema<SignedBlockContainer> getSignedBlindedBlockContainerSchema() {
+    return getSignedBlindedBeaconBlockSchema().castTypeToSignedBlockContainer();
   }
 
   @Override

--- a/validator/remote/src/integration-test/java/tech/pegasys/teku/validator/remote/typedef/AbstractTypeDefRequestTestBase.java
+++ b/validator/remote/src/integration-test/java/tech/pegasys/teku/validator/remote/typedef/AbstractTypeDefRequestTestBase.java
@@ -30,6 +30,7 @@ import tech.pegasys.teku.provider.JsonProvider;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecInvocationContextProvider.SpecContext;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class AbstractTypeDefRequestTestBase {
@@ -40,6 +41,7 @@ public class AbstractTypeDefRequestTestBase {
   protected static final JsonProvider JSON_PROVIDER = new JsonProvider();
 
   protected DataStructureUtil dataStructureUtil;
+  protected SchemaDefinitions schemaDefinitions;
   protected Spec spec;
   protected SpecMilestone specMilestone;
 
@@ -47,9 +49,10 @@ public class AbstractTypeDefRequestTestBase {
   protected final OkHttpClient okHttpClient = new OkHttpClient.Builder().build();
 
   @BeforeEach
-  public void beforeEach(SpecContext specContext) throws Exception {
+  public void beforeEach(final SpecContext specContext) throws Exception {
     mockWebServer.start();
     dataStructureUtil = specContext.getDataStructureUtil();
+    schemaDefinitions = specContext.getSchemaDefinitions();
     spec = specContext.getSpec();
     specMilestone = specContext.getSpecMilestone();
   }

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
@@ -266,7 +266,6 @@ public class RemoteValidatorApiHandler implements RemoteValidatorApiChannel {
                 .orElse(emptyList()));
   }
 
-  // TODO: create BlockContents for Deneb in typeDefClient
   @Override
   public SafeFuture<Optional<BlockContainer>> createUnsignedBlock(
       final UInt64 slot,
@@ -277,11 +276,10 @@ public class RemoteValidatorApiHandler implements RemoteValidatorApiChannel {
         () -> typeDefClient.createUnsignedBlock(slot, randaoReveal, graffiti, blinded));
   }
 
-  // TODO: pass SignedBlockContainer to typeDefClient
   @Override
   public SafeFuture<SendSignedBlockResult> sendSignedBlock(
       final SignedBlockContainer blockContainer) {
-    return sendRequest(() -> typeDefClient.sendSignedBlock(blockContainer.getSignedBlock()));
+    return sendRequest(() -> typeDefClient.sendSignedBlock(blockContainer));
   }
 
   @Override

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/OkHttpValidatorTypeDefClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/OkHttpValidatorTypeDefClient.java
@@ -24,7 +24,7 @@ import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockContainer;
-import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
 import tech.pegasys.teku.spec.datastructures.builder.SignedValidatorRegistration;
 import tech.pegasys.teku.spec.datastructures.genesis.GenesisData;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
@@ -64,7 +64,7 @@ public class OkHttpValidatorTypeDefClient {
     this.getSyncingStatusRequest = new GetSyncingStatusRequest(okHttpClient, baseEndpoint);
     this.getGenesisRequest = new GetGenesisRequest(okHttpClient, baseEndpoint);
     this.sendSignedBlockRequest =
-        new SendSignedBlockRequest(baseEndpoint, okHttpClient, preferSszBlockEncoding);
+        new SendSignedBlockRequest(spec, baseEndpoint, okHttpClient, preferSszBlockEncoding);
     this.registerValidatorsRequest =
         new RegisterValidatorsRequest(baseEndpoint, okHttpClient, false);
     this.createAttestationDataRequest =
@@ -83,8 +83,8 @@ public class OkHttpValidatorTypeDefClient {
                 new GenesisData(response.getGenesisTime(), response.getGenesisValidatorsRoot()));
   }
 
-  public SendSignedBlockResult sendSignedBlock(final SignedBeaconBlock beaconBlock) {
-    return sendSignedBlockRequest.sendSignedBlock(beaconBlock);
+  public SendSignedBlockResult sendSignedBlock(final SignedBlockContainer blockContainer) {
+    return sendSignedBlockRequest.sendSignedBlock(blockContainer);
   }
 
   public Optional<BlockContainer> createUnsignedBlock(

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/handlers/SendSignedBlockRequest.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/handlers/SendSignedBlockRequest.java
@@ -24,7 +24,10 @@ import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
-import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
 import tech.pegasys.teku.validator.api.SendSignedBlockResult;
 import tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod;
 import tech.pegasys.teku.validator.remote.typedef.ResponseHandler;
@@ -35,56 +38,70 @@ public class SendSignedBlockRequest extends AbstractTypeDefRequest {
       new ResponseHandler<>()
           .withHandler(SC_UNSUPPORTED_MEDIA_TYPE, this::handleUnsupportedSszRequest);
 
+  private final Spec spec;
   private final AtomicBoolean preferSszBlockEncoding;
 
   public SendSignedBlockRequest(
+      final Spec spec,
       final HttpUrl baseEndpoint,
       final OkHttpClient okHttpClient,
       final boolean preferSszBlockEncoding) {
     super(baseEndpoint, okHttpClient);
+    this.spec = spec;
     this.preferSszBlockEncoding = new AtomicBoolean(preferSszBlockEncoding);
   }
 
-  public SendSignedBlockResult sendSignedBlock(final SignedBeaconBlock signedBeaconBlock) {
-    final ValidatorApiMethod apiMethod =
-        signedBeaconBlock.getMessage().getBody().isBlinded()
-            ? SEND_SIGNED_BLINDED_BLOCK
-            : SEND_SIGNED_BLOCK;
+  public SendSignedBlockResult sendSignedBlock(final SignedBlockContainer signedBlockContainer) {
+    final boolean blinded = signedBlockContainer.isBlinded();
+
+    final ValidatorApiMethod apiMethod = blinded ? SEND_SIGNED_BLINDED_BLOCK : SEND_SIGNED_BLOCK;
+
+    final SchemaDefinitions schemaDefinitions =
+        spec.atSlot(signedBlockContainer.getSlot()).getSchemaDefinitions();
+
+    final DeserializableTypeDefinition<SignedBlockContainer> typeDefinition =
+        blinded
+            ? schemaDefinitions.getSignedBlindedBlockContainerSchema().getJsonTypeDefinition()
+            : schemaDefinitions.getSignedBlockContainerSchema().getJsonTypeDefinition();
 
     return preferSszBlockEncoding.get()
-        ? sendSignedBlockAsSszOrFallback(signedBeaconBlock, apiMethod)
-        : sendSignedBlockAsJson(apiMethod, signedBeaconBlock);
+        ? sendSignedBlockAsSszOrFallback(apiMethod, signedBlockContainer, typeDefinition)
+        : sendSignedBlockAsJson(apiMethod, signedBlockContainer, typeDefinition);
   }
 
   private SendSignedBlockResult sendSignedBlockAsSszOrFallback(
-      final SignedBeaconBlock signedBeaconBlock, final ValidatorApiMethod apiMethod) {
-    final SendSignedBlockResult result = sendSignedBlockAsSsz(apiMethod, signedBeaconBlock);
+      final ValidatorApiMethod apiMethod,
+      final SignedBlockContainer signedBlockContainer,
+      final DeserializableTypeDefinition<SignedBlockContainer> typeDefinition) {
+    final SendSignedBlockResult result = sendSignedBlockAsSsz(apiMethod, signedBlockContainer);
     if (!result.isPublished() && !preferSszBlockEncoding.get()) {
-      return sendSignedBlockAsJson(apiMethod, signedBeaconBlock);
+      return sendSignedBlockAsJson(apiMethod, signedBlockContainer, typeDefinition);
     }
     return result;
   }
 
   private SendSignedBlockResult sendSignedBlockAsSsz(
-      final ValidatorApiMethod apiMethod, final SignedBeaconBlock signedBeaconBlock) {
+      final ValidatorApiMethod apiMethod, final SignedBlockContainer signedBlockContainer) {
     return postOctetStream(
             apiMethod,
             Collections.emptyMap(),
-            signedBeaconBlock.sszSerialize().toArray(),
+            signedBlockContainer.sszSerialize().toArray(),
             sszResponseHandler)
-        .map(__ -> SendSignedBlockResult.success(signedBeaconBlock.getRoot()))
+        .map(__ -> SendSignedBlockResult.success(signedBlockContainer.getRoot()))
         .orElseGet(() -> SendSignedBlockResult.notImported("UNKNOWN"));
   }
 
   private SendSignedBlockResult sendSignedBlockAsJson(
-      final ValidatorApiMethod apiMethod, final SignedBeaconBlock signedBeaconBlock) {
+      final ValidatorApiMethod apiMethod,
+      final SignedBlockContainer signedBlockContainer,
+      final DeserializableTypeDefinition<SignedBlockContainer> typeDefinition) {
     return postJson(
             apiMethod,
             Collections.emptyMap(),
-            signedBeaconBlock,
-            signedBeaconBlock.getSchema().getJsonTypeDefinition(),
+            signedBlockContainer,
+            typeDefinition,
             new ResponseHandler<>())
-        .map(__ -> SendSignedBlockResult.success(signedBeaconBlock.getRoot()))
+        .map(__ -> SendSignedBlockResult.success(signedBlockContainer.getRoot()))
         .orElseGet(() -> SendSignedBlockResult.notImported("UNKNOWN"));
   }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Essentially make VC serialize/deserialze based on either BeaconBlock or BlockContents (from Deneb) and their signed counterparts.

Introduced `BlockContainerSchema` and `SignedBlockContainerSchema` and added following methods to `SchemaDefinitions` and implemented for all forks:
```java
  BlockContainerSchema<BlockContainer> getBlockContainerSchema();
  BlockContainerSchema<BlockContainer> getBlindedBlockContainerSchema();
  SignedBlockContainerSchema<SignedBlockContainer> getSignedBlockContainerSchema();
  SignedBlockContainerSchema<SignedBlockContainer> getSignedBlindedBlockContainerSchema();
```

Changed `CreateBlockRequest` and `SendSignedBlockRequest` to use these schemas for retrieving the relevant DeserializableTypeDefinition.

## Fixed Issue(s)
will fix one of the tasks in #6822 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
