### PR TITLE
Improved error reporting for localSignerTest

### DIFF
--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/signatures/LocalSignerTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/signatures/LocalSignerTest.java
@@ -61,7 +61,12 @@ class LocalSignerTest {
     final SafeFuture<BLSSignature> result = signer.signBlock(block, fork);
     asyncRunner.executeQueuedActions();
 
-    assertThat(result).isCompletedWithValue(expectedSignature);
+    assertThat(result)
+        .withFailMessage(
+            "expected: %s\nbut was: %s",
+            expectedSignature.toBytesCompressed().toBase64String(),
+            result.getImmediately().toBytesCompressed().toBase64String())
+        .isCompletedWithValue(expectedSignature);
   }
 
   @Test
@@ -75,7 +80,12 @@ class LocalSignerTest {
     final SafeFuture<BLSSignature> result = signer.signBlock(block, fork);
     asyncRunner.executeQueuedActions();
 
-    assertThat(result).isCompletedWithValue(expectedSignature);
+    assertThat(result)
+        .withFailMessage(
+            "expected: %s\nbut was: %s",
+            expectedSignature.toBytesCompressed().toBase64String(),
+            result.getImmediately().toBytesCompressed().toBase64String())
+        .isCompletedWithValue(expectedSignature);
   }
 
   @Test
@@ -96,7 +106,12 @@ class LocalSignerTest {
     final SafeFuture<BLSSignature> result = signer.signBlobSidecar(blobSidecar, fork);
     asyncRunner.executeQueuedActions();
 
-    assertThat(result).isCompletedWithValue(expectedSignature);
+    assertThat(result)
+        .withFailMessage(
+            "expected: %s\nbut was: %s",
+            expectedSignature.toBytesCompressed().toBase64String(),
+            result.getImmediately().toBytesCompressed().toBase64String())
+        .isCompletedWithValue(expectedSignature);
   }
 
   @Test
@@ -117,7 +132,12 @@ class LocalSignerTest {
     final SafeFuture<BLSSignature> result = signer.signBlindedBlobSidecar(blindedBlobSidecar, fork);
     asyncRunner.executeQueuedActions();
 
-    assertThat(result).isCompletedWithValue(expectedSignature);
+    assertThat(result)
+        .withFailMessage(
+            "expected: %s\nbut was: %s",
+            expectedSignature.toBytesCompressed().toBase64String(),
+            result.getImmediately().toBytesCompressed().toBase64String())
+        .isCompletedWithValue(expectedSignature);
   }
 
   @Test
@@ -129,7 +149,12 @@ class LocalSignerTest {
     final SafeFuture<BLSSignature> reveal = signer.createRandaoReveal(UInt64.valueOf(7), fork);
     asyncRunner.executeQueuedActions();
 
-    assertThat(reveal).isCompletedWithValue(expectedSignature);
+    assertThat(reveal)
+        .withFailMessage(
+            "expected: %s\nbut was: %s",
+            expectedSignature.toBytesCompressed().toBase64String(),
+            reveal.getImmediately().toBytesCompressed().toBase64String())
+        .isCompletedWithValue(expectedSignature);
   }
 
   @Test
@@ -143,7 +168,12 @@ class LocalSignerTest {
     final SafeFuture<BLSSignature> result = signer.signAttestationData(attestationData, fork);
     asyncRunner.executeQueuedActions();
 
-    assertThat(result).isCompletedWithValue(expectedSignature);
+    assertThat(result)
+        .withFailMessage(
+            "expected: %s\nbut was: %s",
+            expectedSignature.toBytesCompressed().toBase64String(),
+            result.getImmediately().toBytesCompressed().toBase64String())
+        .isCompletedWithValue(expectedSignature);
   }
 
   @Test
@@ -156,7 +186,12 @@ class LocalSignerTest {
     final SafeFuture<BLSSignature> result = signer.signAggregationSlot(UInt64.valueOf(7), fork);
     asyncRunner.executeQueuedActions();
 
-    assertThat(result).isCompletedWithValue(expectedSignature);
+    assertThat(result)
+        .withFailMessage(
+            "expected: %s\nbut was: %s",
+            expectedSignature.toBytesCompressed().toBase64String(),
+            result.getImmediately().toBytesCompressed().toBase64String())
+        .isCompletedWithValue(expectedSignature);
   }
 
   @Test
@@ -184,7 +219,12 @@ class LocalSignerTest {
     final SafeFuture<BLSSignature> result = signer.signVoluntaryExit(voluntaryExit, fork);
     asyncRunner.executeQueuedActions();
 
-    assertThat(result).isCompletedWithValue(expectedSignature);
+    assertThat(result)
+        .withFailMessage(
+            "expected: %s\nbut was: %s",
+            expectedSignature.toBytesCompressed().toBase64String(),
+            result.getImmediately().toBytesCompressed().toBase64String())
+        .isCompletedWithValue(expectedSignature);
   }
 
   @Test
@@ -199,6 +239,11 @@ class LocalSignerTest {
     final SafeFuture<BLSSignature> result = signer.signValidatorRegistration(validatorRegistration);
     asyncRunner.executeQueuedActions();
 
-    assertThat(result).isCompletedWithValue(expectedSignature);
+    assertThat(result)
+        .withFailMessage(
+            "expected: %s\nbut was: %s",
+            expectedSignature.toBytesCompressed().toBase64String(),
+            result.getImmediately().toBytesCompressed().toBase64String())
+        .isCompletedWithValue(expectedSignature);
   }
 }


### PR DESCRIPTION
Previously it was difficult to update because base64 was being used as input but hex used as comparison.

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
