### PR TITLE
Added test cases for RewardsCalculator

### DIFF
--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/BeaconBlockBuilder.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/BeaconBlockBuilder.java
@@ -14,11 +14,16 @@
 package tech.pegasys.teku.spec.util;
 
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.spec.SpecVersion;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodySchema;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregate;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
+import tech.pegasys.teku.spec.datastructures.operations.Attestation;
+import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
+import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
+import tech.pegasys.teku.spec.datastructures.operations.SignedBlsToExecutionChange;
 
 public class BeaconBlockBuilder {
 
@@ -27,6 +32,12 @@ public class BeaconBlockBuilder {
 
   private SyncAggregate syncAggregate;
   private ExecutionPayload executionPayload;
+
+  private SszList<ProposerSlashing> proposerSlashings;
+  private SszList<SignedBlsToExecutionChange> blsToExecutionChanges;
+  private SszList<AttesterSlashing> attesterSlashings;
+
+  private SszList<Attestation> attestations;
 
   public BeaconBlockBuilder(final SpecVersion spec, final DataStructureUtil dataStructureUtil) {
     this.spec = spec;
@@ -44,6 +55,27 @@ public class BeaconBlockBuilder {
     return this;
   }
 
+  public BeaconBlockBuilder blsToExecutionChanges(
+      SszList<SignedBlsToExecutionChange> blsToExecutionChanges) {
+    this.blsToExecutionChanges = blsToExecutionChanges;
+    return this;
+  }
+
+  public BeaconBlockBuilder proposerSlashings(SszList<ProposerSlashing> proposerSlashings) {
+    this.proposerSlashings = proposerSlashings;
+    return this;
+  }
+
+  public BeaconBlockBuilder attesterSlashings(SszList<AttesterSlashing> attesterSlashings) {
+    this.attesterSlashings = attesterSlashings;
+    return this;
+  }
+
+  public BeaconBlockBuilder attestations(SszList<Attestation> attestations) {
+    this.attestations = attestations;
+    return this;
+  }
+
   public SafeFuture<BeaconBlock> build() {
     final BeaconBlockBodySchema<?> bodySchema =
         spec.getSchemaDefinitions().getBeaconBlockBodySchema();
@@ -58,6 +90,22 @@ public class BeaconBlockBuilder {
               .map(definitions -> definitions.getExecutionPayloadSchema().getDefault())
               .orElse(null);
     }
+    if (blsToExecutionChanges == null) {
+      blsToExecutionChanges =
+          bodySchema
+              .toVersionCapella()
+              .map(schema -> schema.getBlsToExecutionChangesSchema().getDefault())
+              .orElse(null);
+    }
+    if (proposerSlashings == null) {
+      proposerSlashings = bodySchema.getProposerSlashingsSchema().getDefault();
+    }
+    if (attesterSlashings == null) {
+      attesterSlashings = bodySchema.getAttesterSlashingsSchema().getDefault();
+    }
+    if (attestations == null) {
+      attestations = bodySchema.getAttestationsSchema().getDefault();
+    }
     return bodySchema
         .createBlockBody(
             builder -> {
@@ -65,9 +113,9 @@ public class BeaconBlockBuilder {
                   .randaoReveal(dataStructureUtil.randomSignature())
                   .eth1Data(dataStructureUtil.randomEth1Data())
                   .graffiti(dataStructureUtil.randomBytes32())
-                  .attestations(bodySchema.getAttestationsSchema().getDefault())
-                  .proposerSlashings(bodySchema.getProposerSlashingsSchema().getDefault())
-                  .attesterSlashings(bodySchema.getAttesterSlashingsSchema().getDefault())
+                  .attestations(attestations)
+                  .proposerSlashings(proposerSlashings)
+                  .attesterSlashings(attesterSlashings)
                   .deposits(bodySchema.getDepositsSchema().getDefault())
                   .voluntaryExits(bodySchema.getVoluntaryExitsSchema().getDefault());
               if (builder.supportsSyncAggregate()) {
@@ -75,6 +123,9 @@ public class BeaconBlockBuilder {
               }
               if (builder.supportsExecutionPayload()) {
                 builder.executionPayload(SafeFuture.completedFuture(executionPayload));
+              }
+              if (builder.supportsBlsToExecutionChanges()) {
+                builder.blsToExecutionChanges(blsToExecutionChanges);
               }
             })
         .thenApply(

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -1410,6 +1410,14 @@ public final class DataStructureUtil {
         randomSignedBeaconBlockHeader(slot, proposerIndex));
   }
 
+  public ProposerSlashing randomProposerSlashing(int validatorLimit) {
+    return randomProposerSlashing(randomUInt64(), randomUInt64(validatorLimit));
+  }
+
+  public AttesterSlashing randomAttesterSlashing(int validatorLimit) {
+    return randomAttesterSlashing(randomUInt64(validatorLimit));
+  }
+
   public IndexedAttestation randomIndexedAttestation() {
     return randomIndexedAttestation(randomUInt64(), randomUInt64(), randomUInt64());
   }
@@ -2071,6 +2079,29 @@ public final class DataStructureUtil {
                     .index(UInt64.valueOf(index))
                     .buildSigned())
         .collect(toList());
+  }
+
+  public SszList<ProposerSlashing> randomProposerSlashings(
+      final int count, final int validatorIndexLimit) {
+    return randomSszList(
+        spec.getGenesisSchemaDefinitions().getBeaconBlockBodySchema().getProposerSlashingsSchema(),
+        () -> randomProposerSlashing(validatorIndexLimit),
+        count);
+  }
+
+  public SszList<AttesterSlashing> randomAttesterSlashings(
+      final int count, final int validatorIndexLimit) {
+    return randomSszList(
+        spec.getGenesisSchemaDefinitions().getBeaconBlockBodySchema().getAttesterSlashingsSchema(),
+        () -> randomAttesterSlashing(validatorIndexLimit),
+        count);
+  }
+
+  public SszList<Attestation> randomAttestations(final int count, final UInt64 slot) {
+    return randomSszList(
+        spec.getGenesisSchemaDefinitions().getBeaconBlockBodySchema().getAttestationsSchema(),
+        () -> randomAttestation(slot),
+        count);
   }
 
   public BlobSidecar randomBlobSidecar() {


### PR DESCRIPTION
Can now build blocks with the test BeaconBlockBuilder with random data that might be needed for testing things like attester slashings and sync aggregates, which improves the tests we can write for unit testing.

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
