### PR TITLE
Add capability to pass blob versioned hashes to engine_newPayloadV3

### DIFF
--- a/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JExecutionEngineClientTest.java
+++ b/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JExecutionEngineClientTest.java
@@ -221,7 +221,6 @@ public class Web3JExecutionEngineClientTest {
     mockSuccessfulResponse(bodyResponse);
 
     final ExecutionPayload executionPayload = dataStructureUtil.randomExecutionPayload();
-
     final ExecutionPayloadV3 executionPayloadV3 =
         ExecutionPayloadV3.fromInternalExecutionPayload(executionPayload);
     final List<VersionedHash> blobVersionedHashes = dataStructureUtil.randomVersionedHashes(3);
@@ -246,7 +245,7 @@ public class Web3JExecutionEngineClientTest {
                 .collect(Collectors.toList()));
   }
 
-  private void mockSuccessfulResponse(String responseBody) {
+  private void mockSuccessfulResponse(final String responseBody) {
     mockWebServer.enqueue(
         new MockResponse()
             .setResponseCode(200)
@@ -264,7 +263,7 @@ public class Web3JExecutionEngineClientTest {
     }
   }
 
-  private void verifyJsonRpcMethodCall(Map<String, Object> data, final String method) {
+  private void verifyJsonRpcMethodCall(final Map<String, Object> data, final String method) {
     assertThat(data.get("method")).asInstanceOf(STRING).isEqualTo(method);
     assertThat(data.get("id")).asInstanceOf(INTEGER).isGreaterThanOrEqualTo(0);
     assertThat(data.get("jsonrpc")).asInstanceOf(STRING).isEqualTo("2.0");

--- a/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JExecutionEngineClientTest.java
+++ b/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JExecutionEngineClientTest.java
@@ -237,14 +237,14 @@ public class Web3JExecutionEngineClientTest {
     final Map<String, Object> requestData = takeRequest();
     verifyJsonRpcMethodCall(requestData, "engine_newPayloadV3");
 
-    final Map<String, Object> executionPayloadParameter =
+    final Map<String, Object> executionPayloadV3Parameter =
         (Map<String, Object>) ((List<Object>) requestData.get("params")).get(0);
     // 16 fields in ExecutionPayloadV3
-    assertThat(executionPayloadParameter).hasSize(16);
+    assertThat(executionPayloadV3Parameter).hasSize(16);
     // sanity check
-    assertThat(executionPayloadParameter.get("parentHash"))
+    assertThat(executionPayloadV3Parameter.get("parentHash"))
         .isEqualTo(executionPayloadV3.parentHash.toHexString());
-    assertThat(executionPayloadParameter.get("excessDataGas"))
+    assertThat(executionPayloadV3Parameter.get("excessDataGas"))
         .isEqualTo(executionPayloadV3.excessDataGas.toHexString());
     assertThat(((List<Object>) requestData.get("params")).get(1))
         .asInstanceOf(LIST)

--- a/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JExecutionEngineClientTest.java
+++ b/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JExecutionEngineClientTest.java
@@ -270,7 +270,7 @@ public class Web3JExecutionEngineClientTest {
     assertThat(data.get("jsonrpc")).asInstanceOf(STRING).isEqualTo("2.0");
   }
 
-  private static class JsonRpcResponse {
+  public static class JsonRpcResponse {
 
     private final String jsonrpc = "2.0";
     private final String id = "0";

--- a/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JExecutionEngineClientTest.java
+++ b/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JExecutionEngineClientTest.java
@@ -237,6 +237,15 @@ public class Web3JExecutionEngineClientTest {
     final Map<String, Object> requestData = takeRequest();
     verifyJsonRpcMethodCall(requestData, "engine_newPayloadV3");
 
+    final Map<String, Object> executionPayloadParameter =
+        (Map<String, Object>) ((List<Object>) requestData.get("params")).get(0);
+    // 16 fields in ExecutionPayloadV3
+    assertThat(executionPayloadParameter).hasSize(16);
+    // sanity check
+    assertThat(executionPayloadParameter.get("parentHash"))
+        .isEqualTo(executionPayloadV3.parentHash.toHexString());
+    assertThat(executionPayloadParameter.get("excessDataGas"))
+        .isEqualTo(executionPayloadV3.excessDataGas.toHexString());
     assertThat(((List<Object>) requestData.get("params")).get(1))
         .asInstanceOf(LIST)
         .containsExactlyElementsOf(

--- a/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JExecutionEngineClientTest.java
+++ b/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JExecutionEngineClientTest.java
@@ -15,10 +15,13 @@ package tech.pegasys.teku.ethereum.executionclient.web3j;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.assertj.core.api.InstanceOfAssertFactories.INTEGER;
 import static org.assertj.core.api.InstanceOfAssertFactories.LIST;
 import static org.assertj.core.api.InstanceOfAssertFactories.STRING;
 import static org.mockito.Mockito.mock;
+import static tech.pegasys.teku.spec.SpecMilestone.CAPELLA;
+import static tech.pegasys.teku.spec.SpecMilestone.DENEB;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonFactory;
@@ -33,6 +36,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
@@ -41,9 +45,11 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import tech.pegasys.teku.ethereum.executionclient.events.ExecutionClientEventsChannel;
+import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV3;
 import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceStateV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceUpdatedResult;
 import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV1;
+import tech.pegasys.teku.ethereum.executionclient.schema.PayloadStatusV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.Response;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.bytes.Bytes20;
@@ -54,10 +60,12 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecContext;
 import tech.pegasys.teku.spec.TestSpecInvocationContextProvider.SpecContext;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.executionlayer.PayloadStatus;
+import tech.pegasys.teku.spec.logic.versions.deneb.types.VersionedHash;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
-@TestSpecContext(milestone = SpecMilestone.CAPELLA)
+@TestSpecContext(milestone = {CAPELLA, DENEB})
 public class Web3JExecutionEngineClientTest {
 
   private static final Duration DEFAULT_TIMEOUT = Duration.ofMinutes(1);
@@ -71,6 +79,7 @@ public class Web3JExecutionEngineClientTest {
   ObjectMapper objectMapper;
   DataStructureUtil dataStructureUtil;
   Spec spec;
+  SpecMilestone specMilestone;
 
   Web3JExecutionEngineClient eeClient;
 
@@ -81,6 +90,7 @@ public class Web3JExecutionEngineClientTest {
     objectMapper = new ObjectMapper();
     dataStructureUtil = specContext.getDataStructureUtil();
     spec = specContext.getSpec();
+    specMilestone = specContext.getSpecMilestone();
     mockWebServer.start();
     Web3jClientBuilder web3JClientBuilder = new Web3jClientBuilder();
     Web3JClient web3JClient =
@@ -116,11 +126,7 @@ public class Web3JExecutionEngineClientTest {
             + validationError
             + "\"}}}";
 
-    mockWebServer.enqueue(
-        new MockResponse()
-            .setResponseCode(200)
-            .setBody(bodyResponse)
-            .addHeader("Content-Type", "application/json"));
+    mockSuccessfulResponse(bodyResponse);
 
     final ForkChoiceStateV1 forkChoiceStateV1Request =
         new ForkChoiceStateV1(
@@ -197,6 +203,49 @@ public class Web3JExecutionEngineClientTest {
     assertThat(requestData.get("params")).asInstanceOf(LIST).containsExactly(consensusCapabilities);
   }
 
+  @TestTemplate
+  @SuppressWarnings("unchecked")
+  public void newPayloadV3_shouldBuildRequestAndResponseSuccessfully() {
+    assumeThat(specMilestone).isGreaterThanOrEqualTo(DENEB);
+
+    final Bytes32 latestValidHash = dataStructureUtil.randomBytes32();
+    final PayloadStatus payloadStatusResponse =
+        PayloadStatus.valid(Optional.of(latestValidHash), Optional.empty());
+
+    final String bodyResponse =
+        "{\"jsonrpc\": \"2.0\", \"id\": 0, \"result\":"
+            + "{ \"status\": \"VALID\", \"latestValidHash\": \""
+            + latestValidHash
+            + "\", \"validationError\": null}}";
+
+    mockSuccessfulResponse(bodyResponse);
+
+    final ExecutionPayload executionPayload = dataStructureUtil.randomExecutionPayload();
+
+    final ExecutionPayloadV3 executionPayloadV3 =
+        ExecutionPayloadV3.fromInternalExecutionPayload(executionPayload);
+    final List<VersionedHash> blobVersionedHashes = dataStructureUtil.randomVersionedHashes(3);
+
+    final SafeFuture<Response<PayloadStatusV1>> futureResponse =
+        eeClient.newPayloadV3(executionPayloadV3, blobVersionedHashes);
+
+    assertThat(futureResponse)
+        .succeedsWithin(1, TimeUnit.SECONDS)
+        .matches(
+            response ->
+                response.getPayload().asInternalExecutionPayload().equals(payloadStatusResponse));
+
+    final Map<String, Object> requestData = takeRequest();
+    verifyJsonRpcMethodCall(requestData, "engine_newPayloadV3");
+
+    assertThat(((List<Object>) requestData.get("params")).get(1))
+        .asInstanceOf(LIST)
+        .containsExactlyElementsOf(
+            blobVersionedHashes.stream()
+                .map(VersionedHash::toHexString)
+                .collect(Collectors.toList()));
+  }
+
   private void mockSuccessfulResponse(String responseBody) {
     mockWebServer.enqueue(
         new MockResponse()
@@ -221,7 +270,7 @@ public class Web3JExecutionEngineClientTest {
     assertThat(data.get("jsonrpc")).asInstanceOf(STRING).isEqualTo("2.0");
   }
 
-  public static class JsonRpcResponse {
+  private static class JsonRpcResponse {
 
     private final String jsonrpc = "2.0";
     private final String id = "0";

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ExecutionEngineClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ExecutionEngineClient.java
@@ -28,6 +28,7 @@ import tech.pegasys.teku.ethereum.executionclient.schema.TransitionConfiguration
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.bytes.Bytes8;
 import tech.pegasys.teku.spec.datastructures.execution.PowBlock;
+import tech.pegasys.teku.spec.logic.versions.deneb.types.VersionedHash;
 
 public interface ExecutionEngineClient {
   // eth namespace
@@ -46,7 +47,8 @@ public interface ExecutionEngineClient {
 
   SafeFuture<Response<PayloadStatusV1>> newPayloadV2(ExecutionPayloadV1 executionPayload);
 
-  SafeFuture<Response<PayloadStatusV1>> newPayloadV3(ExecutionPayloadV1 executionPayload);
+  SafeFuture<Response<PayloadStatusV1>> newPayloadV3(
+      ExecutionPayloadV1 executionPayload, List<VersionedHash> blobVersionedHashes);
 
   SafeFuture<Response<ForkChoiceUpdatedResult>> forkChoiceUpdatedV1(
       ForkChoiceStateV1 forkChoiceState, Optional<PayloadAttributesV1> payloadAttributes);

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ThrottlingExecutionEngineClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ThrottlingExecutionEngineClient.java
@@ -31,6 +31,7 @@ import tech.pegasys.teku.infrastructure.async.ThrottlingTaskQueue;
 import tech.pegasys.teku.infrastructure.bytes.Bytes8;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.spec.datastructures.execution.PowBlock;
+import tech.pegasys.teku.spec.logic.versions.deneb.types.VersionedHash;
 
 public class ThrottlingExecutionEngineClient implements ExecutionEngineClient {
   private final ExecutionEngineClient delegate;
@@ -88,8 +89,8 @@ public class ThrottlingExecutionEngineClient implements ExecutionEngineClient {
 
   @Override
   public SafeFuture<Response<PayloadStatusV1>> newPayloadV3(
-      final ExecutionPayloadV1 executionPayload) {
-    return taskQueue.queueTask(() -> delegate.newPayloadV3(executionPayload));
+      final ExecutionPayloadV1 executionPayload, final List<VersionedHash> blobVersionedHashes) {
+    return taskQueue.queueTask(() -> delegate.newPayloadV3(executionPayload, blobVersionedHashes));
   }
 
   @Override

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineNewPayloadV3.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineNewPayloadV3.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.teku.ethereum.executionclient.methods;
 
+import java.util.Collections;
+import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.ethereum.executionclient.ExecutionEngineClient;
@@ -24,6 +26,7 @@ import tech.pegasys.teku.ethereum.executionclient.schema.PayloadStatusV1;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.executionlayer.PayloadStatus;
+import tech.pegasys.teku.spec.logic.versions.deneb.types.VersionedHash;
 
 public class EngineNewPayloadV3 extends AbstractEngineJsonRpcMethod<PayloadStatus> {
 
@@ -47,6 +50,8 @@ public class EngineNewPayloadV3 extends AbstractEngineJsonRpcMethod<PayloadStatu
   public SafeFuture<PayloadStatus> execute(final JsonRpcRequestParams params) {
     final ExecutionPayload executionPayload =
         params.getRequiredParameter(0, ExecutionPayload.class);
+    final List<VersionedHash> blobVersionedHashes =
+        params.getOptionalListParameter(1, VersionedHash.class).orElse(Collections.emptyList());
 
     LOG.trace("Calling {}(executionPayload={})", getVersionedName(), executionPayload);
     final ExecutionPayloadV1 executionPayloadV1;
@@ -58,7 +63,7 @@ public class EngineNewPayloadV3 extends AbstractEngineJsonRpcMethod<PayloadStatu
       executionPayloadV1 = ExecutionPayloadV1.fromInternalExecutionPayload(executionPayload);
     }
     return executionEngineClient
-        .newPayloadV3(executionPayloadV1)
+        .newPayloadV3(executionPayloadV1, blobVersionedHashes)
         .thenApply(ResponseUnwrapper::unwrapExecutionClientResponseOrThrow)
         .thenApply(PayloadStatusV1::asInternalExecutionPayload)
         .thenPeek(

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/methods/JsonRpcRequestParams.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/methods/JsonRpcRequestParams.java
@@ -51,6 +51,11 @@ public class JsonRpcRequestParams {
     return Optional.of((T) param);
   }
 
+  @SuppressWarnings({"unchecked", "unused"})
+  public <T> Optional<List<T>> getOptionalListParameter(final int index, Class<T> __) {
+    return getOptionalParameter(index, (Class<List<T>>) (Object) List.class);
+  }
+
   public static class Builder {
 
     private final List<Object> params = new ArrayList<>();

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/metrics/MetricRecordingExecutionEngineClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/metrics/MetricRecordingExecutionEngineClient.java
@@ -34,6 +34,7 @@ import tech.pegasys.teku.infrastructure.metrics.MetricsCountersByIntervals;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.spec.datastructures.execution.PowBlock;
+import tech.pegasys.teku.spec.logic.versions.deneb.types.VersionedHash;
 
 public class MetricRecordingExecutionEngineClient extends MetricRecordingAbstractClient
     implements ExecutionEngineClient {
@@ -110,8 +111,9 @@ public class MetricRecordingExecutionEngineClient extends MetricRecordingAbstrac
 
   @Override
   public SafeFuture<Response<PayloadStatusV1>> newPayloadV3(
-      final ExecutionPayloadV1 executionPayload) {
-    return countRequest(() -> delegate.newPayloadV3(executionPayload), NEW_PAYLOAD_V3_METHOD);
+      final ExecutionPayloadV1 executionPayload, final List<VersionedHash> blobVersionedHashes) {
+    return countRequest(
+        () -> delegate.newPayloadV3(executionPayload, blobVersionedHashes), NEW_PAYLOAD_V3_METHOD);
   }
 
   @Override

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JExecutionEngineClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JExecutionEngineClient.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
 import org.web3j.protocol.core.DefaultBlockParameterName;
@@ -40,6 +41,7 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.bytes.Bytes8;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.execution.PowBlock;
+import tech.pegasys.teku.spec.logic.versions.deneb.types.VersionedHash;
 
 public class Web3JExecutionEngineClient implements ExecutionEngineClient {
 
@@ -140,11 +142,13 @@ public class Web3JExecutionEngineClient implements ExecutionEngineClient {
 
   @Override
   public SafeFuture<Response<PayloadStatusV1>> newPayloadV3(
-      final ExecutionPayloadV1 executionPayload) {
+      final ExecutionPayloadV1 executionPayload, final List<VersionedHash> blobVersionedHashes) {
+    final List<String> blobVersionedHashesData =
+        blobVersionedHashes.stream().map(VersionedHash::toHexString).collect(Collectors.toList());
     final Request<?, PayloadStatusV1Web3jResponse> web3jRequest =
         new Request<>(
             "engine_newPayloadV3",
-            Collections.singletonList(executionPayload),
+            List.of(executionPayload, blobVersionedHashesData),
             web3JClient.getWeb3jService(),
             PayloadStatusV1Web3jResponse.class);
     return web3JClient.doRequest(web3jRequest, EL_ENGINE_BLOCK_EXECUTION_TIMEOUT);

--- a/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineNewPayloadV3Test.java
+++ b/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineNewPayloadV3Test.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.ethereum.executionclient.methods;
 
+import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -23,6 +24,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -38,6 +40,7 @@ import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.executionlayer.ExecutionPayloadStatus;
 import tech.pegasys.teku.spec.executionlayer.PayloadStatus;
+import tech.pegasys.teku.spec.logic.versions.deneb.types.VersionedHash;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 class EngineNewPayloadV3Test {
@@ -75,7 +78,7 @@ class EngineNewPayloadV3Test {
     final ExecutionPayload executionPayload = dataStructureUtil.randomExecutionPayload();
     final String errorResponseFromClient = "error!";
 
-    when(executionEngineClient.newPayloadV3(any()))
+    when(executionEngineClient.newPayloadV3(any(), any()))
         .thenReturn(dummyFailedResponse(errorResponseFromClient));
 
     final JsonRpcRequestParams params =
@@ -98,7 +101,7 @@ class EngineNewPayloadV3Test {
 
     jsonRpcMethod = new EngineNewPayloadV3(executionEngineClient);
 
-    when(executionEngineClient.newPayloadV3(executionPayloadV1))
+    when(executionEngineClient.newPayloadV3(executionPayloadV1, emptyList()))
         .thenReturn(dummySuccessfulResponse());
 
     final JsonRpcRequestParams params =
@@ -106,7 +109,7 @@ class EngineNewPayloadV3Test {
 
     assertThat(jsonRpcMethod.execute(params)).isCompleted();
 
-    verify(executionEngineClient).newPayloadV3(eq(executionPayloadV1));
+    verify(executionEngineClient).newPayloadV3(eq(executionPayloadV1), eq(emptyList()));
     verifyNoMoreInteractions(executionEngineClient);
   }
 
@@ -122,7 +125,7 @@ class EngineNewPayloadV3Test {
 
     jsonRpcMethod = new EngineNewPayloadV3(executionEngineClient);
 
-    when(executionEngineClient.newPayloadV3(executionPayloadV2))
+    when(executionEngineClient.newPayloadV3(executionPayloadV2, emptyList()))
         .thenReturn(dummySuccessfulResponse());
 
     final JsonRpcRequestParams params =
@@ -130,31 +133,32 @@ class EngineNewPayloadV3Test {
 
     assertThat(jsonRpcMethod.execute(params)).isCompleted();
 
-    verify(executionEngineClient).newPayloadV3(eq(executionPayloadV2));
+    verify(executionEngineClient).newPayloadV3(eq(executionPayloadV2), eq(emptyList()));
     verifyNoMoreInteractions(executionEngineClient);
   }
 
   @Test
-  public void shouldCallNewPayloadV3WithExecutionPayloadV3WhenInDeneb() {
+  public void shouldCallNewPayloadV3WithExecutionPayloadV3AndBlobVersionedHashesWhenInDeneb() {
     final Spec denebSpec = TestSpecFactory.createMinimalDeneb();
     final DataStructureUtil dataStructureUtilDeneb = new DataStructureUtil(denebSpec);
 
     final ExecutionPayload executionPayload = dataStructureUtilDeneb.randomExecutionPayload();
+    final List<VersionedHash> blobVersionedHashes = dataStructureUtilDeneb.randomVersionedHashes(4);
     final ExecutionPayloadV3 executionPayloadV3 =
         ExecutionPayloadV3.fromInternalExecutionPayload(executionPayload);
     assertThat(executionPayloadV3).isExactlyInstanceOf(ExecutionPayloadV3.class);
 
     jsonRpcMethod = new EngineNewPayloadV3(executionEngineClient);
 
-    when(executionEngineClient.newPayloadV3(executionPayloadV3))
+    when(executionEngineClient.newPayloadV3(executionPayloadV3, blobVersionedHashes))
         .thenReturn(dummySuccessfulResponse());
 
     final JsonRpcRequestParams params =
-        new JsonRpcRequestParams.Builder().add(executionPayload).build();
+        new JsonRpcRequestParams.Builder().add(executionPayload).add(blobVersionedHashes).build();
 
     assertThat(jsonRpcMethod.execute(params)).isCompleted();
 
-    verify(executionEngineClient).newPayloadV3(eq(executionPayloadV3));
+    verify(executionEngineClient).newPayloadV3(eq(executionPayloadV3), eq(blobVersionedHashes));
     verifyNoMoreInteractions(executionEngineClient);
   }
 

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionClientHandler.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionClientHandler.java
@@ -17,9 +17,9 @@ import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
 import tech.pegasys.teku.spec.datastructures.execution.GetPayloadResponse;
+import tech.pegasys.teku.spec.datastructures.execution.NewPayloadRequest;
 import tech.pegasys.teku.spec.datastructures.execution.PowBlock;
 import tech.pegasys.teku.spec.executionlayer.ForkChoiceState;
 import tech.pegasys.teku.spec.executionlayer.ForkChoiceUpdatedResult;
@@ -40,7 +40,7 @@ public interface ExecutionClientHandler {
   SafeFuture<GetPayloadResponse> engineGetPayload(
       ExecutionPayloadContext executionPayloadContext, UInt64 slot);
 
-  SafeFuture<PayloadStatus> engineNewPayload(ExecutionPayload executionPayload);
+  SafeFuture<PayloadStatus> engineNewPayload(NewPayloadRequest newPayloadRequest);
 
   SafeFuture<TransitionConfiguration> engineExchangeTransitionConfiguration(
       TransitionConfiguration transitionConfiguration);

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionClientHandlerImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionClientHandlerImpl.java
@@ -19,9 +19,9 @@ import tech.pegasys.teku.ethereum.executionclient.methods.EngineApiMethods;
 import tech.pegasys.teku.ethereum.executionclient.methods.JsonRpcRequestParams;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
 import tech.pegasys.teku.spec.datastructures.execution.GetPayloadResponse;
+import tech.pegasys.teku.spec.datastructures.execution.NewPayloadRequest;
 import tech.pegasys.teku.spec.datastructures.execution.PowBlock;
 import tech.pegasys.teku.spec.executionlayer.ForkChoiceState;
 import tech.pegasys.teku.spec.executionlayer.ForkChoiceUpdatedResult;
@@ -82,9 +82,12 @@ public class ExecutionClientHandlerImpl implements ExecutionClientHandler {
   }
 
   @Override
-  public SafeFuture<PayloadStatus> engineNewPayload(final ExecutionPayload executionPayload) {
+  public SafeFuture<PayloadStatus> engineNewPayload(final NewPayloadRequest newPayloadRequest) {
     final JsonRpcRequestParams params =
-        new JsonRpcRequestParams.Builder().add(executionPayload).build();
+        new JsonRpcRequestParams.Builder()
+            .add(newPayloadRequest.getExecutionPayload())
+            .addOptional(newPayloadRequest.getVersionedHashes())
+            .build();
 
     return methodsResolver
         .getMethod(EngineApiMethods.ENGINE_NEW_PAYLOAD, PayloadStatus.class)

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
@@ -54,6 +54,7 @@ import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadResult;
 import tech.pegasys.teku.spec.datastructures.execution.FallbackReason;
 import tech.pegasys.teku.spec.datastructures.execution.GetPayloadResponse;
 import tech.pegasys.teku.spec.datastructures.execution.HeaderWithFallbackData;
+import tech.pegasys.teku.spec.datastructures.execution.NewPayloadRequest;
 import tech.pegasys.teku.spec.datastructures.execution.PowBlock;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.executionlayer.ForkChoiceState;
@@ -230,9 +231,9 @@ public class ExecutionLayerManagerImpl implements ExecutionLayerManager {
   }
 
   @Override
-  public SafeFuture<PayloadStatus> engineNewPayload(final ExecutionPayload executionPayload) {
-    LOG.trace("calling engineNewPayload(executionPayload={})", executionPayload);
-    return executionClientHandler.engineNewPayload(executionPayload);
+  public SafeFuture<PayloadStatus> engineNewPayload(final NewPayloadRequest newPayloadRequest) {
+    LOG.trace("calling engineNewPayload(newPayloadRequest={})", newPayloadRequest);
+    return executionClientHandler.engineNewPayload(newPayloadRequest);
   }
 
   @Override

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/BellatrixExecutionClientHandlerTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/BellatrixExecutionClientHandlerTest.java
@@ -30,6 +30,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
+import tech.pegasys.teku.spec.datastructures.execution.NewPayloadRequest;
 import tech.pegasys.teku.spec.executionlayer.ExecutionPayloadStatus;
 import tech.pegasys.teku.spec.executionlayer.ForkChoiceState;
 import tech.pegasys.teku.spec.executionlayer.PayloadBuildingAttributes;
@@ -69,6 +70,7 @@ class BellatrixExecutionClientHandlerTest extends ExecutionHandlerClientTest {
   void engineNewPayload_shouldCallNewPayloadV1() {
     final ExecutionClientHandler handler = getHandler();
     final ExecutionPayload payload = dataStructureUtil.randomExecutionPayload();
+    final NewPayloadRequest newPayloadRequest = new NewPayloadRequest(payload);
     final ExecutionPayloadV1 payloadV1 = ExecutionPayloadV1.fromInternalExecutionPayload(payload);
     final SafeFuture<Response<PayloadStatusV1>> dummyResponse =
         SafeFuture.completedFuture(
@@ -76,7 +78,7 @@ class BellatrixExecutionClientHandlerTest extends ExecutionHandlerClientTest {
                 new PayloadStatusV1(
                     ExecutionPayloadStatus.ACCEPTED, dataStructureUtil.randomBytes32(), null)));
     when(executionEngineClient.newPayloadV1(payloadV1)).thenReturn(dummyResponse);
-    handler.engineNewPayload(payload);
+    handler.engineNewPayload(newPayloadRequest);
     verify(executionEngineClient).newPayloadV1(payloadV1);
   }
 

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/CapellaExecutionClientHandlerTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/CapellaExecutionClientHandlerTest.java
@@ -41,6 +41,7 @@ import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
 import tech.pegasys.teku.spec.datastructures.execution.GetPayloadResponse;
+import tech.pegasys.teku.spec.datastructures.execution.NewPayloadRequest;
 import tech.pegasys.teku.spec.datastructures.execution.versions.bellatrix.ExecutionPayloadBellatrix;
 import tech.pegasys.teku.spec.datastructures.execution.versions.capella.ExecutionPayloadCapella;
 import tech.pegasys.teku.spec.executionlayer.ExecutionPayloadStatus;
@@ -121,6 +122,7 @@ public class CapellaExecutionClientHandlerTest extends ExecutionHandlerClientTes
   void engineNewPayload_capellaFork() {
     final ExecutionClientHandler handler = getHandler();
     final ExecutionPayload payload = dataStructureUtil.randomExecutionPayload();
+    final NewPayloadRequest newPayloadRequest = new NewPayloadRequest(payload);
     final ExecutionPayloadV2 payloadV2 = ExecutionPayloadV2.fromInternalExecutionPayload(payload);
     final SafeFuture<Response<PayloadStatusV1>> dummyResponse =
         SafeFuture.completedFuture(
@@ -128,7 +130,7 @@ public class CapellaExecutionClientHandlerTest extends ExecutionHandlerClientTes
                 new PayloadStatusV1(
                     ExecutionPayloadStatus.ACCEPTED, dataStructureUtil.randomBytes32(), null)));
     when(executionEngineClient.newPayloadV2(payloadV2)).thenReturn(dummyResponse);
-    final SafeFuture<PayloadStatus> future = handler.engineNewPayload(payload);
+    final SafeFuture<PayloadStatus> future = handler.engineNewPayload(newPayloadRequest);
     verify(executionEngineClient).newPayloadV2(payloadV2);
     assertThat(future).isCompleted();
   }
@@ -139,13 +141,14 @@ public class CapellaExecutionClientHandlerTest extends ExecutionHandlerClientTes
     final Spec bellatrixSpec = TestSpecFactory.createMinimalBellatrix();
     DataStructureUtil data = new DataStructureUtil(bellatrixSpec);
     final ExecutionPayload payload = data.randomExecutionPayload();
+    final NewPayloadRequest newPayloadRequest = new NewPayloadRequest(payload);
     final ExecutionPayloadV1 payloadV1 = ExecutionPayloadV1.fromInternalExecutionPayload(payload);
     final SafeFuture<Response<PayloadStatusV1>> dummyResponse =
         SafeFuture.completedFuture(
             new Response<>(
                 new PayloadStatusV1(ExecutionPayloadStatus.ACCEPTED, data.randomBytes32(), null)));
     when(executionEngineClient.newPayloadV2(payloadV1)).thenReturn(dummyResponse);
-    final SafeFuture<PayloadStatus> future = handler.engineNewPayload(payload);
+    final SafeFuture<PayloadStatus> future = handler.engineNewPayload(newPayloadRequest);
     verify(executionEngineClient).newPayloadV2(payloadV1);
     verify(executionEngineClient, never()).newPayloadV1(payloadV1);
     assertThat(future).isCompleted();

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/DenebExecutionClientHandlerTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/DenebExecutionClientHandlerTest.java
@@ -13,12 +13,14 @@
 
 package tech.pegasys.teku.ethereum.executionlayer;
 
+import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
 import java.util.concurrent.ExecutionException;
 import org.apache.tuweni.units.bigints.UInt256;
 import org.junit.jupiter.api.BeforeEach;
@@ -37,11 +39,13 @@ import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
 import tech.pegasys.teku.spec.datastructures.execution.GetPayloadResponse;
+import tech.pegasys.teku.spec.datastructures.execution.NewPayloadRequest;
 import tech.pegasys.teku.spec.datastructures.execution.versions.bellatrix.ExecutionPayloadBellatrix;
 import tech.pegasys.teku.spec.datastructures.execution.versions.capella.ExecutionPayloadCapella;
 import tech.pegasys.teku.spec.datastructures.execution.versions.deneb.ExecutionPayloadDeneb;
 import tech.pegasys.teku.spec.executionlayer.ExecutionPayloadStatus;
 import tech.pegasys.teku.spec.executionlayer.PayloadStatus;
+import tech.pegasys.teku.spec.logic.versions.deneb.types.VersionedHash;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class DenebExecutionClientHandlerTest extends ExecutionHandlerClientTest {
@@ -157,14 +161,15 @@ public class DenebExecutionClientHandlerTest extends ExecutionHandlerClientTest 
     final DataStructureUtil data = new DataStructureUtil(denebSpecStartingAtBellatrix);
 
     final ExecutionPayload payload = data.randomExecutionPayload(UInt64.ONE);
+    final NewPayloadRequest newPayloadRequest = new NewPayloadRequest(payload);
     final ExecutionPayloadV1 payloadV1 = ExecutionPayloadV1.fromInternalExecutionPayload(payload);
     final SafeFuture<Response<PayloadStatusV1>> dummyResponse =
         SafeFuture.completedFuture(
             new Response<>(
                 new PayloadStatusV1(ExecutionPayloadStatus.ACCEPTED, data.randomBytes32(), null)));
-    when(executionEngineClient.newPayloadV3(payloadV1)).thenReturn(dummyResponse);
-    final SafeFuture<PayloadStatus> future = handler.engineNewPayload(payload);
-    verify(executionEngineClient).newPayloadV3(payloadV1);
+    when(executionEngineClient.newPayloadV3(payloadV1, emptyList())).thenReturn(dummyResponse);
+    final SafeFuture<PayloadStatus> future = handler.engineNewPayload(newPayloadRequest);
+    verify(executionEngineClient).newPayloadV3(payloadV1, emptyList());
     verify(executionEngineClient, never()).newPayloadV2(payloadV1);
     verify(executionEngineClient, never()).newPayloadV1(payloadV1);
     assertThat(future).isCompleted();
@@ -184,14 +189,15 @@ public class DenebExecutionClientHandlerTest extends ExecutionHandlerClientTest 
     final DataStructureUtil data = new DataStructureUtil(denebSpecStartingAtCapella);
 
     final ExecutionPayload payload = data.randomExecutionPayload(UInt64.ONE);
+    final NewPayloadRequest newPayloadRequest = new NewPayloadRequest(payload);
     final ExecutionPayloadV2 payloadV2 = ExecutionPayloadV2.fromInternalExecutionPayload(payload);
     final SafeFuture<Response<PayloadStatusV1>> dummyResponse =
         SafeFuture.completedFuture(
             new Response<>(
                 new PayloadStatusV1(ExecutionPayloadStatus.ACCEPTED, data.randomBytes32(), null)));
-    when(executionEngineClient.newPayloadV3(payloadV2)).thenReturn(dummyResponse);
-    final SafeFuture<PayloadStatus> future = handler.engineNewPayload(payload);
-    verify(executionEngineClient).newPayloadV3(payloadV2);
+    when(executionEngineClient.newPayloadV3(payloadV2, emptyList())).thenReturn(dummyResponse);
+    final SafeFuture<PayloadStatus> future = handler.engineNewPayload(newPayloadRequest);
+    verify(executionEngineClient).newPayloadV3(payloadV2, emptyList());
     verify(executionEngineClient, never()).newPayloadV2(payloadV2);
     verify(executionEngineClient, never()).newPayloadV1(payloadV2);
     assertThat(future).isCompleted();
@@ -201,15 +207,17 @@ public class DenebExecutionClientHandlerTest extends ExecutionHandlerClientTest 
   void engineNewPayload_denebFork() {
     final ExecutionClientHandler handler = getHandler();
     final ExecutionPayload payload = dataStructureUtil.randomExecutionPayload();
+    final List<VersionedHash> versionedHashes = dataStructureUtil.randomVersionedHashes(3);
+    final NewPayloadRequest newPayloadRequest = new NewPayloadRequest(payload, versionedHashes);
     final ExecutionPayloadV3 payloadV3 = ExecutionPayloadV3.fromInternalExecutionPayload(payload);
     final SafeFuture<Response<PayloadStatusV1>> dummyResponse =
         SafeFuture.completedFuture(
             new Response<>(
                 new PayloadStatusV1(
                     ExecutionPayloadStatus.ACCEPTED, dataStructureUtil.randomBytes32(), null)));
-    when(executionEngineClient.newPayloadV3(payloadV3)).thenReturn(dummyResponse);
-    final SafeFuture<PayloadStatus> future = handler.engineNewPayload(payload);
-    verify(executionEngineClient).newPayloadV3(payloadV3);
+    when(executionEngineClient.newPayloadV3(payloadV3, versionedHashes)).thenReturn(dummyResponse);
+    final SafeFuture<PayloadStatus> future = handler.engineNewPayload(newPayloadRequest);
+    verify(executionEngineClient).newPayloadV3(payloadV3, versionedHashes);
     assertThat(future).isCompleted();
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/NewPayloadRequest.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/NewPayloadRequest.java
@@ -45,8 +45,12 @@ public class NewPayloadRequest {
 
   @Override
   public boolean equals(final Object o) {
-    if (this == o) return true;
-    if (!(o instanceof NewPayloadRequest)) return false;
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof NewPayloadRequest)) {
+      return false;
+    }
     final NewPayloadRequest that = (NewPayloadRequest) o;
     return Objects.equals(executionPayload, that.executionPayload)
         && Objects.equals(versionedHashes, that.versionedHashes);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/NewPayloadRequest.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/NewPayloadRequest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright ConsenSys Software Inc., 2023
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.execution;
+
+import com.google.common.base.MoreObjects;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import tech.pegasys.teku.spec.logic.versions.deneb.types.VersionedHash;
+
+public class NewPayloadRequest {
+
+  private final ExecutionPayload executionPayload;
+  private final Optional<List<VersionedHash>> versionedHashes;
+
+  public NewPayloadRequest(final ExecutionPayload executionPayload) {
+    this.executionPayload = executionPayload;
+    this.versionedHashes = Optional.empty();
+  }
+
+  public NewPayloadRequest(
+      final ExecutionPayload executionPayload, final List<VersionedHash> versionedHashes) {
+    this.executionPayload = executionPayload;
+    this.versionedHashes = Optional.of(versionedHashes);
+  }
+
+  public ExecutionPayload getExecutionPayload() {
+    return executionPayload;
+  }
+
+  public Optional<List<VersionedHash>> getVersionedHashes() {
+    return versionedHashes;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) return true;
+    if (!(o instanceof NewPayloadRequest)) return false;
+    final NewPayloadRequest that = (NewPayloadRequest) o;
+    return Objects.equals(executionPayload, that.executionPayload)
+        && Objects.equals(versionedHashes, that.versionedHashes);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(executionPayload, versionedHashes);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("executionPayload", executionPayload)
+        .add("versionedHashes", versionedHashes)
+        .toString();
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannel.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannel.java
@@ -27,6 +27,7 @@ import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadResult;
 import tech.pegasys.teku.spec.datastructures.execution.GetPayloadResponse;
 import tech.pegasys.teku.spec.datastructures.execution.HeaderWithFallbackData;
+import tech.pegasys.teku.spec.datastructures.execution.NewPayloadRequest;
 import tech.pegasys.teku.spec.datastructures.execution.PowBlock;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 
@@ -60,7 +61,8 @@ public interface ExecutionLayerChannel extends ChannelInterface {
         }
 
         @Override
-        public SafeFuture<PayloadStatus> engineNewPayload(final ExecutionPayload executionPayload) {
+        public SafeFuture<PayloadStatus> engineNewPayload(
+            final NewPayloadRequest newPayloadRequest) {
           return SafeFuture.completedFuture(PayloadStatus.SYNCING);
         }
 
@@ -101,7 +103,7 @@ public interface ExecutionLayerChannel extends ChannelInterface {
       ForkChoiceState forkChoiceState,
       Optional<PayloadBuildingAttributes> payloadBuildingAttributes);
 
-  SafeFuture<PayloadStatus> engineNewPayload(ExecutionPayload executionPayload);
+  SafeFuture<PayloadStatus> engineNewPayload(NewPayloadRequest newPayloadRequest);
 
   SafeFuture<TransitionConfiguration> engineExchangeTransitionConfiguration(
       TransitionConfiguration transitionConfiguration);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
@@ -54,6 +54,7 @@ import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadResult;
 import tech.pegasys.teku.spec.datastructures.execution.GetPayloadResponse;
 import tech.pegasys.teku.spec.datastructures.execution.HeaderWithFallbackData;
+import tech.pegasys.teku.spec.datastructures.execution.NewPayloadRequest;
 import tech.pegasys.teku.spec.datastructures.execution.PowBlock;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.util.BlobsUtil;
@@ -280,7 +281,8 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
   }
 
   @Override
-  public SafeFuture<PayloadStatus> engineNewPayload(final ExecutionPayload executionPayload) {
+  public SafeFuture<PayloadStatus> engineNewPayload(final NewPayloadRequest newPayloadRequest) {
+    final ExecutionPayload executionPayload = newPayloadRequest.getExecutionPayload();
     final PayloadStatus returnedStatus =
         Optional.ofNullable(knownPosBlocks.get(executionPayload.getBlockHash()))
             .orElse(payloadStatus);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/PayloadStatus.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/PayloadStatus.java
@@ -52,6 +52,15 @@ public class PayloadStatus {
         Optional.empty());
   }
 
+  public static PayloadStatus valid(
+      Optional<Bytes32> latestValidHash, Optional<String> validationError) {
+    return new PayloadStatus(
+        Optional.of(ExecutionPayloadStatus.VALID),
+        latestValidHash,
+        validationError,
+        Optional.empty());
+  }
+
   public static PayloadStatus create(
       ExecutionPayloadStatus status,
       Optional<Bytes32> latestValidHash,

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/types/VersionedHash.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/types/VersionedHash.java
@@ -45,6 +45,10 @@ public class VersionedHash {
     return this.version.equals(version);
   }
 
+  public String toHexString() {
+    return Bytes.wrap(version, value).toHexString();
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -182,6 +182,7 @@ import tech.pegasys.teku.spec.executionlayer.PayloadBuildingAttributes;
 import tech.pegasys.teku.spec.logic.common.statetransition.epoch.RewardAndPenalty;
 import tech.pegasys.teku.spec.logic.common.statetransition.epoch.RewardAndPenalty.RewardComponent;
 import tech.pegasys.teku.spec.logic.common.statetransition.epoch.RewardAndPenaltyDeltas;
+import tech.pegasys.teku.spec.logic.versions.deneb.types.VersionedHash;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsAltair;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsBellatrix;
@@ -2058,6 +2059,12 @@ public final class DataStructureUtil {
         Bytes.concatenate(
             Bytes.fromHexString("0x010000000000000000000000"),
             randomEth1Address().getWrappedBytes()));
+  }
+
+  public List<VersionedHash> randomVersionedHashes(final int count) {
+    return IntStream.range(0, count)
+        .mapToObj(__ -> new VersionedHash(randomBytes32()))
+        .collect(toList());
   }
 
   public Blob randomBlob() {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoicePayloadExecutor.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoicePayloadExecutor.java
@@ -21,6 +21,7 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
+import tech.pegasys.teku.spec.datastructures.execution.NewPayloadRequest;
 import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannel;
 import tech.pegasys.teku.spec.executionlayer.PayloadStatus;
 import tech.pegasys.teku.spec.logic.versions.bellatrix.block.OptimisticExecutionPayloadExecutor;
@@ -73,7 +74,8 @@ class ForkChoicePayloadExecutor implements OptimisticExecutionPayloadExecutor {
     result =
         Optional.of(
             executionLayer
-                .engineNewPayload(executionPayload)
+                // TODO: pass versioned_hashes
+                .engineNewPayload(new NewPayloadRequest(executionPayload))
                 .thenCompose(
                     result -> {
                       if (result.hasValidStatus()) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
This PR mostly changes the interfaces and introduces `NewPayloadRequest` as in the spec.

- Add `blobVersionedHashes` as second parameter to `engine_newPayloadV3`

In next PR, will pass the real versioned hashes in `ForkChoicePayloadExecutor`

## Fixed Issue(s)
will help with #7203

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
