### PR TITLE
Fixes historical sync

### DIFF
--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/historical/HistoricalBatchFetcher.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/historical/HistoricalBatchFetcher.java
@@ -229,12 +229,7 @@ public class HistoricalBatchFetcher {
           Optional.of(
               requestParams
                   .getStartSlot()
-                  .max(
-                      spec.getGenesisSpec()
-                          .miscHelpers()
-                          .toVersionDeneb()
-                          .orElseThrow()
-                          .computeFirstSlotWithBlobSupport()));
+                  .max(spec.computeFirstSlotWithBlobSupport().orElseThrow()));
       LOG.trace(
           "Request {} blob sidecars from {} to {}",
           requestParams.getCount(),
@@ -380,6 +375,10 @@ public class HistoricalBatchFetcher {
             proposerPublicKeys.add(List.of(proposerPublicKey));
           }
         });
+
+    if (signatures.isEmpty()) {
+      return SafeFuture.COMPLETE;
+    }
 
     return signatureVerificationService
         .verify(proposerPublicKeys, signingRoots, signatures)

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -884,9 +884,8 @@ public class Spec {
     return forkSchedule.getSupportedMilestones().stream()
         .flatMap(milestone -> forMilestone(milestone).getConfig().toVersionDeneb().stream())
         .findFirst()
-        .map(
-            specConfigDeneb ->
-                specConfigDeneb.getDenebForkEpoch().times(specConfigDeneb.getSlotsPerEpoch()));
+        .map(SpecConfigDeneb::getDenebForkEpoch)
+        .map(this::computeStartSlotAtEpoch);
   }
 
   // Private helpers

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -881,9 +881,9 @@ public class Spec {
   }
 
   public Optional<UInt64> computeFirstSlotWithBlobSupport() {
-    return forkSchedule.getSupportedMilestones().stream()
-        .flatMap(milestone -> forMilestone(milestone).getConfig().toVersionDeneb().stream())
-        .findFirst()
+    return forMilestone(forkSchedule.getHighestSupportedMilestone())
+        .getConfig()
+        .toVersionDeneb()
         .map(SpecConfigDeneb::getDenebForkEpoch)
         .map(this::computeStartSlotAtEpoch);
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -100,7 +100,6 @@ import tech.pegasys.teku.spec.logic.common.util.BeaconStateUtil;
 import tech.pegasys.teku.spec.logic.common.util.LightClientUtil;
 import tech.pegasys.teku.spec.logic.common.util.SyncCommitteeUtil;
 import tech.pegasys.teku.spec.logic.versions.bellatrix.block.OptimisticExecutionPayloadExecutor;
-import tech.pegasys.teku.spec.logic.versions.deneb.helpers.MiscHelpersDeneb;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
 
 public class Spec {
@@ -882,16 +881,12 @@ public class Spec {
   }
 
   public Optional<UInt64> computeFirstSlotWithBlobSupport() {
-    return forkSchedule.getActiveMilestones().stream()
-        .map(
-            forkAndSpecMilestone ->
-                forMilestone(forkAndSpecMilestone.getSpecMilestone())
-                    .miscHelpers()
-                    .toVersionDeneb())
-        .filter(Optional::isPresent)
-        .map(Optional::get)
+    return forkSchedule.getSupportedMilestones().stream()
+        .flatMap(milestone -> forMilestone(milestone).getConfig().toVersionDeneb().stream())
         .findFirst()
-        .map(MiscHelpersDeneb::computeFirstSlotWithBlobSupport);
+        .map(
+            specConfigDeneb ->
+                specConfigDeneb.getDenebForkEpoch().times(specConfigDeneb.getSlotsPerEpoch()));
   }
 
   // Private helpers

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -100,6 +100,7 @@ import tech.pegasys.teku.spec.logic.common.util.BeaconStateUtil;
 import tech.pegasys.teku.spec.logic.common.util.LightClientUtil;
 import tech.pegasys.teku.spec.logic.common.util.SyncCommitteeUtil;
 import tech.pegasys.teku.spec.logic.versions.bellatrix.block.OptimisticExecutionPayloadExecutor;
+import tech.pegasys.teku.spec.logic.versions.deneb.helpers.MiscHelpersDeneb;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
 
 public class Spec {
@@ -878,6 +879,19 @@ public class Spec {
 
   public UInt64 computeSubnetForBlobSidecar(final SignedBlobSidecar signedBlobSidecar) {
     return signedBlobSidecar.getBlobSidecar().getIndex().mod(BLOB_SIDECAR_SUBNET_COUNT);
+  }
+
+  public Optional<UInt64> computeFirstSlotWithBlobSupport() {
+    return forkSchedule.getActiveMilestones().stream()
+        .map(
+            forkAndSpecMilestone ->
+                forMilestone(forkAndSpecMilestone.getSpecMilestone())
+                    .miscHelpers()
+                    .toVersionDeneb())
+        .filter(Optional::isPresent)
+        .map(Optional::get)
+        .findFirst()
+        .map(MiscHelpersDeneb::computeFirstSlotWithBlobSupport);
   }
 
   // Private helpers

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/helpers/MiscHelpersDeneb.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/helpers/MiscHelpersDeneb.java
@@ -127,9 +127,4 @@ public class MiscHelpersDeneb extends MiscHelpersBellatrix {
         .map(beaconBlockBodyDeneb -> beaconBlockBodyDeneb.getBlobKzgCommitments().size())
         .orElse(0);
   }
-
-  public UInt64 computeFirstSlotWithBlobSupport() {
-    final UInt64 denebForkEpoch = specConfig.toVersionDeneb().orElseThrow().getDenebForkEpoch();
-    return denebForkEpoch.times(specConfig.getSlotsPerEpoch());
-  }
 }

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/deneb/helpers/MiscHelpersDenebTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/deneb/helpers/MiscHelpersDenebTest.java
@@ -18,11 +18,9 @@ import static tech.pegasys.teku.spec.config.SpecConfigDeneb.VERSIONED_HASH_VERSI
 
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
-import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.kzg.KZGCommitment;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.config.SpecConfigLoader;
 import tech.pegasys.teku.spec.logic.versions.deneb.types.VersionedHash;
 
 class MiscHelpersDenebTest {
@@ -44,31 +42,5 @@ class MiscHelpersDenebTest {
             KZGCommitment.fromHexString(
                 "0x85d1edf1ee88f68260e750abb2c766398ad1125d4e94e1de04034075ccbd2bb79c5689b952ef15374fd03ca2b2475371"));
     assertThat(actual).isEqualTo(VERSIONED_HASH);
-  }
-
-  @Test
-  public void shouldComputeDenebStartSlot() {
-    assertThat(miscHelpersDeneb.computeFirstSlotWithBlobSupport()).isEqualTo(UInt64.valueOf(0));
-    final Spec spec2 =
-        TestSpecFactory.createDeneb(
-            SpecConfigLoader.loadConfig(
-                "minimal",
-                phase0Builder ->
-                    phase0Builder
-                        .altairBuilder(altairBuilder -> altairBuilder.altairForkEpoch(UInt64.ZERO))
-                        .bellatrixBuilder(
-                            bellatrixBuilder -> bellatrixBuilder.bellatrixForkEpoch(UInt64.ZERO))
-                        .capellaBuilder(
-                            capellaBuilder -> capellaBuilder.capellaForkEpoch(UInt64.ZERO))
-                        .denebBuilder(
-                            denebBuilder ->
-                                denebBuilder
-                                    .denebForkEpoch(UInt64.valueOf(2))
-                                    .kzgNoop(true)
-                                    .trustedSetupPath(""))));
-    final MiscHelpersDeneb miscHelpersDeneb2 =
-        new MiscHelpersDeneb(spec2.getGenesisSpecConfig().toVersionDeneb().orElseThrow());
-    assertThat(miscHelpersDeneb2.computeFirstSlotWithBlobSupport())
-        .isEqualTo(UInt64.valueOf(spec2.slotsPerEpoch(UInt64.ZERO)).times(2));
   }
 }


### PR DESCRIPTION
Fix a bug when computing  FirstSlotWithBlobSupport that was keeping genesis spec.
Moved in spec and it will stream active milestones and will keep the first supporting deneb.

Fixed another bug which was an edge case: if the batch we have downloaded contains only the genesis block, we will exclude it from signature verification, ending up with an empty signature verification sets, which fails. So we keep downloading this genesis block forever.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
