### PR TITLE
Automatically enable Rest API if port is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ For information on changes in released versions of Teku, see the [releases page]
 - The `/eth/v1/beacon/blocks/:block_id` endpoint has been removed in favor of the v2 Altair endpoint `/eth/v2/beacon/blocks/:block_id`.
 - The `/eth/v1/debug/beacon/states/:state_id` endpoint has been removed in favor of the v2 Altair endpoint `/eth/v2/debug/beacon/states/:state_id`
 - The `/eth/v1/validator/liveness/:epoch` endpoint was requiring the wrong body input and now conforms to the beacon-api spec.
+- When `--rest-api-enabled` option is not specified where `--rest-api-port` is, `--rest-api-enabled` will be set as true.
 
 ### Additions and Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ For information on changes in released versions of Teku, see the [releases page]
 - The `/eth/v1/beacon/blocks/:block_id` endpoint has been removed in favor of the v2 Altair endpoint `/eth/v2/beacon/blocks/:block_id`.
 - The `/eth/v1/debug/beacon/states/:state_id` endpoint has been removed in favor of the v2 Altair endpoint `/eth/v2/debug/beacon/states/:state_id`
 - The `/eth/v1/validator/liveness/:epoch` endpoint was requiring the wrong body input and now conforms to the beacon-api spec.
-- When `--rest-api-enabled` option is not specified where `--rest-api-port` is, `--rest-api-enabled` will be set as true.
+- When `--rest-api-enabled` option is not specified and `--rest-api-port` is, `--rest-api-enabled` will now be set as true.
 
 ### Additions and Improvements
 

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/BeaconRestApiOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/BeaconRestApiOptions.java
@@ -31,7 +31,7 @@ public class BeaconRestApiOptions {
       paramLabel = "<INTEGER>",
       description = "Port number of Beacon Rest API",
       arity = "1")
-  private int restApiPort = BeaconRestApiConfig.DEFAULT_REST_API_PORT;
+  private Integer restApiPort;
 
   @Option(
       names = {"--rest-api-docs-enabled"},
@@ -130,6 +130,12 @@ public class BeaconRestApiOptions {
   private int validatorThreads = BeaconRestApiConfig.DEFAULT_SUBSCRIBE_THREADS_COUNT;
 
   public void configure(final TekuConfiguration.Builder builder) {
+    if (restApiPort == null) {
+      restApiPort = BeaconRestApiConfig.DEFAULT_REST_API_PORT;
+    } else {
+      restApiEnabled = true;
+    }
+
     builder.restApi(
         restApiBuilder ->
             restApiBuilder

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/BeaconRestApiOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/BeaconRestApiOptions.java
@@ -49,7 +49,7 @@ public class BeaconRestApiOptions {
       description = "Enables Beacon Rest API",
       fallbackValue = "true",
       arity = "0..1")
-  private boolean restApiEnabled = false;
+  private Boolean restApiEnabled;
 
   @Option(
       names = {"--rest-api-interface"},
@@ -130,10 +130,14 @@ public class BeaconRestApiOptions {
   private int validatorThreads = BeaconRestApiConfig.DEFAULT_SUBSCRIBE_THREADS_COUNT;
 
   public void configure(final TekuConfiguration.Builder builder) {
-    if (restApiPort == null) {
+    // Set defaults
+    if (restApiEnabled == null && restApiPort == null) {
+      restApiEnabled = false;
       restApiPort = BeaconRestApiConfig.DEFAULT_REST_API_PORT;
-    } else {
+    } else if (restApiEnabled == null) {
       restApiEnabled = true;
+    } else if (restApiPort == null) {
+      restApiPort = BeaconRestApiConfig.DEFAULT_REST_API_PORT;
     }
 
     builder.restApi(

--- a/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
@@ -471,10 +471,7 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
         .storageConfiguration(
             b -> b.eth1DepositContract(networkConfig.getEth1DepositContractAddress()))
         .metrics(b -> b.metricsCategories(DEFAULT_METRICS_CATEGORIES))
-        .restApi(
-            b ->
-                b.eth1DepositContractAddress(networkConfig.getEth1DepositContractAddress())
-                    .restApiEnabled(false))
+        .restApi(b -> b.eth1DepositContractAddress(networkConfig.getEth1DepositContractAddress()))
         .p2p(p -> p.peerRateLimit(500).peerRequestLimit(50))
         .discovery(
             d ->
@@ -543,7 +540,7 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
             b ->
                 b.restApiPort(5051)
                     .restApiDocsEnabled(false)
-                    .restApiEnabled(true)
+                    .restApiEnabled(false)
                     .restApiLightClientEnabled(false)
                     .restApiInterface("127.0.0.1")
                     .restApiHostAllowlist(List.of("127.0.0.1", "localhost"))

--- a/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
@@ -540,7 +540,7 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
             b ->
                 b.restApiPort(5051)
                     .restApiDocsEnabled(false)
-                    .restApiEnabled(false)
+                    .restApiEnabled(true)
                     .restApiLightClientEnabled(false)
                     .restApiInterface("127.0.0.1")
                     .restApiHostAllowlist(List.of("127.0.0.1", "localhost"))

--- a/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
@@ -471,7 +471,10 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
         .storageConfiguration(
             b -> b.eth1DepositContract(networkConfig.getEth1DepositContractAddress()))
         .metrics(b -> b.metricsCategories(DEFAULT_METRICS_CATEGORIES))
-        .restApi(b -> b.eth1DepositContractAddress(networkConfig.getEth1DepositContractAddress()))
+        .restApi(
+            b ->
+                b.eth1DepositContractAddress(networkConfig.getEth1DepositContractAddress())
+                    .restApiEnabled(false))
         .p2p(p -> p.peerRateLimit(500).peerRequestLimit(50))
         .discovery(
             d ->

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/ReflectionBasedBeaconRestApiOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/ReflectionBasedBeaconRestApiOptionsTest.java
@@ -66,6 +66,66 @@ public class ReflectionBasedBeaconRestApiOptionsTest extends AbstractBeaconNodeC
   }
 
   @Test
+  public void restApiEnabledAndPortNotSpecified_shouldProvideDefaults() {
+    TekuConfiguration tekuConfiguration = getTekuConfigurationFromArguments();
+    final BeaconRestApiConfig config = getConfig(tekuConfiguration);
+    assertThat(config.isRestApiEnabled()).isFalse();
+    assertThat(config.getRestApiPort()).isEqualTo(5051);
+    assertThat(
+            createConfigBuilder().restApi(b -> b.restApiEnabled(false).restApiPort(5051)).build())
+        .usingRecursiveComparison()
+        .isEqualTo(tekuConfiguration);
+  }
+
+  @Test
+  public void restApiEnabledNullAndPortSpecified_shouldEnable() {
+    TekuConfiguration tekuConfiguration = getTekuConfigurationFromArguments("--rest-api-port=5051");
+    final BeaconRestApiConfig config = getConfig(tekuConfiguration);
+    assertThat(config.isRestApiEnabled()).isTrue();
+    assertThat(config.getRestApiPort()).isEqualTo(5051);
+    assertThat(createConfigBuilder().restApi(b -> b.restApiEnabled(true).restApiPort(5051)).build())
+        .usingRecursiveComparison()
+        .isEqualTo(tekuConfiguration);
+  }
+
+  @Test
+  public void restApiEnabledAndPortNotSpecified_shouldProvideDefault() {
+    TekuConfiguration tekuConfiguration =
+        getTekuConfigurationFromArguments("--rest-api-enabled=true");
+    final BeaconRestApiConfig config = getConfig(tekuConfiguration);
+    assertThat(config.isRestApiEnabled()).isTrue();
+    assertThat(config.getRestApiPort()).isEqualTo(5051);
+    assertThat(createConfigBuilder().restApi(b -> b.restApiEnabled(true).restApiPort(5051)).build())
+        .usingRecursiveComparison()
+        .isEqualTo(tekuConfiguration);
+  }
+
+  @Test
+  public void restApiEnabledAndPortSpecified_shouldHaveSpecifiedValues() {
+    TekuConfiguration tekuConfiguration =
+        getTekuConfigurationFromArguments("--rest-api-enabled=true", "--rest-api-port=5051");
+    final BeaconRestApiConfig config = getConfig(tekuConfiguration);
+    assertThat(config.isRestApiEnabled()).isTrue();
+    assertThat(config.getRestApiPort()).isEqualTo(5051);
+    assertThat(createConfigBuilder().restApi(b -> b.restApiEnabled(true).restApiPort(5051)).build())
+        .usingRecursiveComparison()
+        .isEqualTo(tekuConfiguration);
+  }
+
+  @Test
+  public void restApiNotEnabledAndPortSpecified_shouldNotOverrideEnabledDefinition() {
+    TekuConfiguration tekuConfiguration =
+        getTekuConfigurationFromArguments("--rest-api-enabled=false", "--rest-api-port=5051");
+    final BeaconRestApiConfig config = getConfig(tekuConfiguration);
+    assertThat(config.isRestApiEnabled()).isFalse();
+    assertThat(config.getRestApiPort()).isEqualTo(5051);
+    assertThat(
+            createConfigBuilder().restApi(b -> b.restApiEnabled(false).restApiPort(5051)).build())
+        .usingRecursiveComparison()
+        .isEqualTo(tekuConfiguration);
+  }
+
+  @Test
   public void restApiLightClientEnabled_shouldNotRequireAValue() {
     TekuConfiguration tekuConfiguration =
         getTekuConfigurationFromArguments("--Xrest-api-light-client-enabled");

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/ReflectionBasedBeaconRestApiOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/ReflectionBasedBeaconRestApiOptionsTest.java
@@ -79,11 +79,11 @@ public class ReflectionBasedBeaconRestApiOptionsTest extends AbstractBeaconNodeC
 
   @Test
   public void restApiEnabledNullAndPortSpecified_shouldEnable() {
-    TekuConfiguration tekuConfiguration = getTekuConfigurationFromArguments("--rest-api-port=5051");
+    TekuConfiguration tekuConfiguration = getTekuConfigurationFromArguments("--rest-api-port=5058");
     final BeaconRestApiConfig config = getConfig(tekuConfiguration);
     assertThat(config.isRestApiEnabled()).isTrue();
-    assertThat(config.getRestApiPort()).isEqualTo(5051);
-    assertThat(createConfigBuilder().restApi(b -> b.restApiEnabled(true).restApiPort(5051)).build())
+    assertThat(config.getRestApiPort()).isEqualTo(5058);
+    assertThat(createConfigBuilder().restApi(b -> b.restApiEnabled(true).restApiPort(5058)).build())
         .usingRecursiveComparison()
         .isEqualTo(tekuConfiguration);
   }
@@ -103,11 +103,11 @@ public class ReflectionBasedBeaconRestApiOptionsTest extends AbstractBeaconNodeC
   @Test
   public void restApiEnabledAndPortSpecified_shouldHaveSpecifiedValues() {
     TekuConfiguration tekuConfiguration =
-        getTekuConfigurationFromArguments("--rest-api-enabled=true", "--rest-api-port=5051");
+        getTekuConfigurationFromArguments("--rest-api-enabled=true", "--rest-api-port=5058");
     final BeaconRestApiConfig config = getConfig(tekuConfiguration);
     assertThat(config.isRestApiEnabled()).isTrue();
-    assertThat(config.getRestApiPort()).isEqualTo(5051);
-    assertThat(createConfigBuilder().restApi(b -> b.restApiEnabled(true).restApiPort(5051)).build())
+    assertThat(config.getRestApiPort()).isEqualTo(5058);
+    assertThat(createConfigBuilder().restApi(b -> b.restApiEnabled(true).restApiPort(5058)).build())
         .usingRecursiveComparison()
         .isEqualTo(tekuConfiguration);
   }
@@ -115,12 +115,12 @@ public class ReflectionBasedBeaconRestApiOptionsTest extends AbstractBeaconNodeC
   @Test
   public void restApiNotEnabledAndPortSpecified_shouldNotOverrideEnabledDefinition() {
     TekuConfiguration tekuConfiguration =
-        getTekuConfigurationFromArguments("--rest-api-enabled=false", "--rest-api-port=5051");
+        getTekuConfigurationFromArguments("--rest-api-enabled=false", "--rest-api-port=5058");
     final BeaconRestApiConfig config = getConfig(tekuConfiguration);
     assertThat(config.isRestApiEnabled()).isFalse();
-    assertThat(config.getRestApiPort()).isEqualTo(5051);
+    assertThat(config.getRestApiPort()).isEqualTo(5058);
     assertThat(
-            createConfigBuilder().restApi(b -> b.restApiEnabled(false).restApiPort(5051)).build())
+            createConfigBuilder().restApi(b -> b.restApiEnabled(false).restApiPort(5058)).build())
         .usingRecursiveComparison()
         .isEqualTo(tekuConfiguration);
   }


### PR DESCRIPTION
fixes #6961 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
