### PR TITLE
Blobs pool improvements

### DIFF
--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/historical/HistoricalBatchFetcher.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/historical/HistoricalBatchFetcher.java
@@ -405,7 +405,7 @@ public class HistoricalBatchFetcher {
             block.getSlotAndBlockRoot(), Collections.emptyList());
     LOG.trace("Validating {} blob sidecars for block {}", blobSidecars.size(), block.getRoot());
     final BlobSidecarsAndValidationResult validationResult =
-        blobSidecarManager.createAvailabilityChecker(block).validateImmediately(blobSidecars);
+        blobSidecarManager.createAvailabilityCheckerAndValidateImmediately(block, blobSidecars);
 
     if (validationResult.isFailure()) {
       final String causeMessage =

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/historical/HistoricalBatchFetcherTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/historical/HistoricalBatchFetcherTest.java
@@ -49,7 +49,6 @@ import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.generator.ChainBuilder;
 import tech.pegasys.teku.spec.logic.common.util.AsyncBLSSignatureVerifier;
 import tech.pegasys.teku.spec.logic.versions.deneb.blobs.BlobSidecarsAndValidationResult;
-import tech.pegasys.teku.spec.logic.versions.deneb.blobs.BlobSidecarsAvailabilityChecker;
 import tech.pegasys.teku.statetransition.blobs.BlobSidecarManager;
 import tech.pegasys.teku.storage.api.StorageQueryChannel;
 import tech.pegasys.teku.storage.api.StorageUpdateChannel;
@@ -67,8 +66,6 @@ public class HistoricalBatchFetcherTest {
   private ChainBuilder forkBuilder;
 
   private final BlobSidecarManager blobSidecarManager = mock(BlobSidecarManager.class);
-  private final BlobSidecarsAvailabilityChecker blobSidecarsAvailabilityChecker =
-      mock(BlobSidecarsAvailabilityChecker.class);
   private final StorageUpdateChannel storageUpdateChannel = mock(StorageUpdateChannel.class);
 
   @SuppressWarnings("unchecked")

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/historical/HistoricalBatchFetcherTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/historical/HistoricalBatchFetcherTest.java
@@ -151,10 +151,8 @@ public class HistoricalBatchFetcherTest {
 
     when(signatureVerifier.verify(any(), any(), anyList()))
         .thenReturn(SafeFuture.completedFuture(true));
-    when(blobSidecarManager.createAvailabilityChecker(any()))
-        .thenReturn(blobSidecarsAvailabilityChecker);
-    when(blobSidecarsAvailabilityChecker.validateImmediately(anyList()))
-        .thenAnswer(i -> BlobSidecarsAndValidationResult.validResult(i.getArgument(0)));
+    when(blobSidecarManager.createAvailabilityCheckerAndValidateImmediately(any(), anyList()))
+        .thenAnswer(i -> BlobSidecarsAndValidationResult.validResult(i.getArgument(1)));
   }
 
   @Test
@@ -213,11 +211,11 @@ public class HistoricalBatchFetcherTest {
   @Test
   public void run_failsOnBlobSidecarsValidationFailure() {
     when(blobSidecarManager.isAvailabilityRequiredAtSlot(any())).thenReturn(true);
-    when(blobSidecarsAvailabilityChecker.validateImmediately(anyList()))
+    when(blobSidecarManager.createAvailabilityCheckerAndValidateImmediately(any(), anyList()))
         .thenAnswer(
             i ->
                 BlobSidecarsAndValidationResult.invalidResult(
-                    i.getArgument(0), new IllegalStateException("oopsy")));
+                    i.getArgument(1), new IllegalStateException("oopsy")));
 
     assertThat(peer.getOutstandingRequests()).isEqualTo(0);
     final SafeFuture<BeaconBlockSummary> future = fetcher.run();

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blobs/BlobSidecarManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blobs/BlobSidecarManager.java
@@ -13,11 +13,13 @@
 
 package tech.pegasys.teku.statetransition.blobs;
 
+import java.util.List;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.logic.versions.deneb.blobs.BlobSidecarsAndValidationResult;
 import tech.pegasys.teku.spec.logic.versions.deneb.blobs.BlobSidecarsAvailabilityChecker;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
 
@@ -48,6 +50,12 @@ public interface BlobSidecarManager {
             final SignedBeaconBlock block) {
           return BlobSidecarsAvailabilityChecker.NOOP;
         }
+
+        @Override
+        public BlobSidecarsAndValidationResult createAvailabilityCheckerAndValidateImmediately(
+            final SignedBeaconBlock block, final List<BlobSidecar> blobSidecars) {
+          return BlobSidecarsAndValidationResult.NOT_REQUIRED;
+        }
       };
 
   SafeFuture<InternalValidationResult> validateAndPrepareForBlockImport(
@@ -60,6 +68,9 @@ public interface BlobSidecarManager {
   boolean isAvailabilityRequiredAtSlot(UInt64 slot);
 
   BlobSidecarsAvailabilityChecker createAvailabilityChecker(SignedBeaconBlock block);
+
+  BlobSidecarsAndValidationResult createAvailabilityCheckerAndValidateImmediately(
+      SignedBeaconBlock block, List<BlobSidecar> blobSidecars);
 
   interface ReceivedBlobSidecarListener {
     void onBlobSidecarReceived(BlobSidecar blobSidecar);

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blobs/BlobSidecarManagerImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blobs/BlobSidecarManagerImpl.java
@@ -139,6 +139,7 @@ public class BlobSidecarManagerImpl implements BlobSidecarManager, SlotEventsCha
         spec, asyncRunner, recentChainData, blockBlobSidecarsTracker);
   }
 
+  @Override
   public BlobSidecarsAndValidationResult createAvailabilityCheckerAndValidateImmediately(
       final SignedBeaconBlock block, final List<BlobSidecar> blobSidecars) {
     // Block is pre-Deneb, blobs are not supported yet

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blobs/BlobSidecarManagerImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blobs/BlobSidecarManagerImpl.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.statetransition.blobs;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
@@ -25,6 +26,7 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.logic.versions.deneb.blobs.BlobSidecarsAndValidationResult;
 import tech.pegasys.teku.spec.logic.versions.deneb.blobs.BlobSidecarsAvailabilityChecker;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceBlobSidecarsAvailabilityChecker;
 import tech.pegasys.teku.statetransition.util.FutureItems;
@@ -135,6 +137,24 @@ public class BlobSidecarManagerImpl implements BlobSidecarManager, SlotEventsCha
 
     return new ForkChoiceBlobSidecarsAvailabilityChecker(
         spec, asyncRunner, recentChainData, blockBlobSidecarsTracker);
+  }
+
+  public BlobSidecarsAndValidationResult createAvailabilityCheckerAndValidateImmediately(
+      final SignedBeaconBlock block, final List<BlobSidecar> blobSidecars) {
+    // Block is pre-Deneb, blobs are not supported yet
+    if (block.getMessage().getBody().toVersionDeneb().isEmpty()) {
+      return BlobSidecarsAndValidationResult.NOT_REQUIRED;
+    }
+
+    // we don't care to set maxBlobsPerBlock since it isn't used with this immediate validation flow
+    final BlockBlobSidecarsTracker blockBlobSidecarsTracker =
+        new BlockBlobSidecarsTracker(block.getSlotAndBlockRoot(), UInt64.ZERO);
+
+    blockBlobSidecarsTracker.setBlock(block);
+
+    return new ForkChoiceBlobSidecarsAvailabilityChecker(
+            spec, asyncRunner, recentChainData, blockBlobSidecarsTracker)
+        .validateImmediately(blobSidecars);
   }
 
   @Override

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/BlobSidecarPoolImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/BlobSidecarPoolImpl.java
@@ -133,6 +133,9 @@ public class BlobSidecarPoolImpl extends AbstractIgnoringFutureHistoricalSlot
 
   @Override
   public synchronized void onNewBlobSidecar(final BlobSidecar blobSidecar) {
+    if (recentChainData.containsBlock(blobSidecar.getBlockRoot())) {
+      return;
+    }
     if (shouldIgnoreItemAtSlot(blobSidecar.getSlot())) {
       return;
     }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/BlobSidecarPoolImplTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/BlobSidecarPoolImplTest.java
@@ -158,6 +158,30 @@ public class BlobSidecarPoolImplTest {
   }
 
   @Test
+  public void onNewBlobSidecar_shouldIgnoreBlobsForAlreadyImportedBlocks() {
+    final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(currentSlot);
+    final BlobSidecar blobSidecar =
+        dataStructureUtil
+            .createRandomBlobSidecarBuilder()
+            .slot(currentSlot)
+            .blockRoot(block.getRoot())
+            .build();
+
+    when(recentChainData.containsBlock(blobSidecar.getBlockRoot())).thenReturn(true);
+
+    blobSidecarPool.onNewBlobSidecar(blobSidecar);
+
+    assertThat(blobSidecarPool.containsBlock(block.getRoot())).isFalse();
+    assertThat(requiredBlockRootEvents).isEmpty();
+    assertThat(requiredBlockRootDroppedEvents).isEmpty();
+    assertThat(requiredBlobSidecarEvents).isEmpty();
+    assertThat(requiredBlobSidecarDroppedEvents).isEmpty();
+
+    assertBlobSidecarsCount(0);
+    assertBlobSidecarsTrackersCount(0);
+  }
+
+  @Test
   public void onNewBlobSidecarOnNewBlock_addTrackerWithBothBlockAndBlobSidecar() {
     final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(currentSlot);
     final BlobSidecar blobSidecar =
@@ -279,7 +303,7 @@ public class BlobSidecarPoolImplTest {
   }
 
   @Test
-  public void onBlobSidecarsFromSync_shouldNotTriggerFetch() {
+  public void onCompletedBlockAndBlobSidecars_shouldNotTriggerFetch() {
 
     final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(currentSlot);
 


### PR DESCRIPTION
1. This PR improves historical sync which now creates a `BlockBlobSidecarsTracker` that doesn't go in the BlobsPool anymore. Since there is no actual import, that Tracker would have been forgotten there filling up the pool.
Now there is a specialized flow that creates a tracker on the fly just to be used with the on availability checker.

2. When we forward sync, gossip is started when we are close to the head while we are still importing blobs and blocks via syncing. Added a filter on the pool to avoid tracking blobs related to already imported blocks.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
