### PR TITLE
Disable parallel integration tests for :networking:eth2

### DIFF
--- a/networking/eth2/build.gradle
+++ b/networking/eth2/build.gradle
@@ -1,3 +1,7 @@
+integrationTest {
+  maxParallelForks = 1
+}
+
 dependencies {
   api project(':networking:p2p')
   implementation project(':ethereum:events')


### PR DESCRIPTION
Temporary solution to avoid flaky eth2 networking integration tests (especially for RPC testing)

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
