### PR TITLE
newPayloadV3 send null `versionedHashes` pre-deneb

### DIFF
--- a/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JExecutionEngineClientTest.java
+++ b/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JExecutionEngineClientTest.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.ethereum.executionclient.web3j;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
-import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.assertj.core.api.InstanceOfAssertFactories.INTEGER;
 import static org.assertj.core.api.InstanceOfAssertFactories.LIST;
 import static org.assertj.core.api.InstanceOfAssertFactories.STRING;
@@ -207,8 +206,7 @@ public class Web3JExecutionEngineClientTest {
   @TestTemplate
   @SuppressWarnings("unchecked")
   public void newPayloadV3_shouldBuildRequestAndResponseSuccessfully() {
-    assumeThat(specMilestone).isGreaterThanOrEqualTo(DENEB);
-
+    final boolean isDeneb = spec.isMilestoneSupported(DENEB);
     final Bytes32 latestValidHash = dataStructureUtil.randomBytes32();
     final PayloadStatus payloadStatusResponse =
         PayloadStatus.valid(Optional.of(latestValidHash), Optional.empty());
@@ -224,10 +222,12 @@ public class Web3JExecutionEngineClientTest {
     final ExecutionPayload executionPayload = dataStructureUtil.randomExecutionPayload();
     final ExecutionPayloadV3 executionPayloadV3 =
         ExecutionPayloadV3.fromInternalExecutionPayload(executionPayload);
-    final List<VersionedHash> blobVersionedHashes = dataStructureUtil.randomVersionedHashes(3);
+
+    final Optional<List<VersionedHash>> blobVersionedHashes =
+        isDeneb ? Optional.of(dataStructureUtil.randomVersionedHashes(3)) : Optional.empty();
 
     final SafeFuture<Response<PayloadStatusV1>> futureResponse =
-        eeClient.newPayloadV3(executionPayloadV3, Optional.of(blobVersionedHashes));
+        eeClient.newPayloadV3(executionPayloadV3, blobVersionedHashes);
 
     assertThat(futureResponse)
         .succeedsWithin(1, TimeUnit.SECONDS)
@@ -245,19 +245,26 @@ public class Web3JExecutionEngineClientTest {
     // sanity check
     assertThat(executionPayloadV3Parameter.get("parentHash"))
         .isEqualTo(executionPayloadV3.parentHash.toHexString());
-    assertThat(executionPayloadV3Parameter.get("dataGasUsed"))
-        .isEqualTo(
-            Bytes.ofUnsignedLong(executionPayloadV3.dataGasUsed.longValue()).toQuantityHexString());
-    assertThat(executionPayloadV3Parameter.get("excessDataGas"))
-        .isEqualTo(
-            Bytes.ofUnsignedLong(executionPayloadV3.excessDataGas.longValue())
-                .toQuantityHexString());
-    assertThat(((List<Object>) requestData.get("params")).get(1))
-        .asInstanceOf(LIST)
-        .containsExactlyElementsOf(
-            blobVersionedHashes.stream()
-                .map(VersionedHash::toHexString)
-                .collect(Collectors.toList()));
+
+    if (isDeneb) {
+      assertThat(executionPayloadV3Parameter.get("dataGasUsed"))
+          .isEqualTo(
+              Bytes.ofUnsignedLong(executionPayloadV3.dataGasUsed.longValue())
+                  .toQuantityHexString());
+      assertThat(executionPayloadV3Parameter.get("excessDataGas"))
+          .isEqualTo(
+              Bytes.ofUnsignedLong(executionPayloadV3.excessDataGas.longValue())
+                  .toQuantityHexString());
+      assertThat(((List<Object>) requestData.get("params")).get(1))
+          .asInstanceOf(LIST)
+          .containsExactlyElementsOf(
+              blobVersionedHashes.get().stream()
+                  .map(VersionedHash::toHexString)
+                  .collect(Collectors.toList()));
+    } else {
+      // pre-deneb param must be null
+      assertThat(((List<Object>) requestData.get("params")).get(1)).isNull();
+    }
   }
 
   private void mockSuccessfulResponse(final String responseBody) {

--- a/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JExecutionEngineClientTest.java
+++ b/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JExecutionEngineClientTest.java
@@ -262,7 +262,7 @@ public class Web3JExecutionEngineClientTest {
                   .map(VersionedHash::toHexString)
                   .collect(Collectors.toList()));
     } else {
-      // pre-deneb param must be null
+      // pre-deneb versionedHashes param must be null
       assertThat(((List<Object>) requestData.get("params")).get(1)).isNull();
     }
   }

--- a/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JExecutionEngineClientTest.java
+++ b/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JExecutionEngineClientTest.java
@@ -227,7 +227,7 @@ public class Web3JExecutionEngineClientTest {
     final List<VersionedHash> blobVersionedHashes = dataStructureUtil.randomVersionedHashes(3);
 
     final SafeFuture<Response<PayloadStatusV1>> futureResponse =
-        eeClient.newPayloadV3(executionPayloadV3, blobVersionedHashes);
+        eeClient.newPayloadV3(executionPayloadV3, Optional.of(blobVersionedHashes));
 
     assertThat(futureResponse)
         .succeedsWithin(1, TimeUnit.SECONDS)

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ExecutionEngineClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ExecutionEngineClient.java
@@ -48,7 +48,7 @@ public interface ExecutionEngineClient {
   SafeFuture<Response<PayloadStatusV1>> newPayloadV2(ExecutionPayloadV1 executionPayload);
 
   SafeFuture<Response<PayloadStatusV1>> newPayloadV3(
-      ExecutionPayloadV1 executionPayload, List<VersionedHash> blobVersionedHashes);
+      ExecutionPayloadV1 executionPayload, Optional<List<VersionedHash>> blobVersionedHashes);
 
   SafeFuture<Response<ForkChoiceUpdatedResult>> forkChoiceUpdatedV1(
       ForkChoiceStateV1 forkChoiceState, Optional<PayloadAttributesV1> payloadAttributes);

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ThrottlingExecutionEngineClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ThrottlingExecutionEngineClient.java
@@ -89,7 +89,8 @@ public class ThrottlingExecutionEngineClient implements ExecutionEngineClient {
 
   @Override
   public SafeFuture<Response<PayloadStatusV1>> newPayloadV3(
-      final ExecutionPayloadV1 executionPayload, final List<VersionedHash> blobVersionedHashes) {
+      final ExecutionPayloadV1 executionPayload,
+      final Optional<List<VersionedHash>> blobVersionedHashes) {
     return taskQueue.queueTask(() -> delegate.newPayloadV3(executionPayload, blobVersionedHashes));
   }
 

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineNewPayloadV3.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineNewPayloadV3.java
@@ -13,8 +13,8 @@
 
 package tech.pegasys.teku.ethereum.executionclient.methods;
 
-import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.ethereum.executionclient.ExecutionEngineClient;
@@ -50,8 +50,8 @@ public class EngineNewPayloadV3 extends AbstractEngineJsonRpcMethod<PayloadStatu
   public SafeFuture<PayloadStatus> execute(final JsonRpcRequestParams params) {
     final ExecutionPayload executionPayload =
         params.getRequiredParameter(0, ExecutionPayload.class);
-    final List<VersionedHash> blobVersionedHashes =
-        params.getOptionalListParameter(1, VersionedHash.class).orElse(Collections.emptyList());
+    final Optional<List<VersionedHash>> blobVersionedHashes =
+        params.getOptionalListParameter(1, VersionedHash.class);
 
     LOG.trace("Calling {}(executionPayload={})", getVersionedName(), executionPayload);
     final ExecutionPayloadV1 executionPayloadV1;

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/metrics/MetricRecordingExecutionEngineClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/metrics/MetricRecordingExecutionEngineClient.java
@@ -111,7 +111,8 @@ public class MetricRecordingExecutionEngineClient extends MetricRecordingAbstrac
 
   @Override
   public SafeFuture<Response<PayloadStatusV1>> newPayloadV3(
-      final ExecutionPayloadV1 executionPayload, final List<VersionedHash> blobVersionedHashes) {
+      final ExecutionPayloadV1 executionPayload,
+      final Optional<List<VersionedHash>> blobVersionedHashes) {
     return countRequest(
         () -> delegate.newPayloadV3(executionPayload, blobVersionedHashes), NEW_PAYLOAD_V3_METHOD);
   }

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JExecutionEngineClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JExecutionEngineClient.java
@@ -142,13 +142,15 @@ public class Web3JExecutionEngineClient implements ExecutionEngineClient {
 
   @Override
   public SafeFuture<Response<PayloadStatusV1>> newPayloadV3(
-      final ExecutionPayloadV1 executionPayload, final List<VersionedHash> blobVersionedHashes) {
-    final List<String> blobVersionedHashesData =
-        blobVersionedHashes.stream().map(VersionedHash::toHexString).collect(Collectors.toList());
+      final ExecutionPayloadV1 executionPayload,
+      final Optional<List<VersionedHash>> blobVersionedHashes) {
+    final Optional<List<String>> blobVersionedHashesData =
+        blobVersionedHashes.map(
+            hashes -> hashes.stream().map(VersionedHash::toHexString).collect(Collectors.toList()));
     final Request<?, PayloadStatusV1Web3jResponse> web3jRequest =
         new Request<>(
             "engine_newPayloadV3",
-            List.of(executionPayload, blobVersionedHashesData),
+            list(executionPayload, blobVersionedHashesData.orElse(null)),
             web3JClient.getWeb3jService(),
             PayloadStatusV1Web3jResponse.class);
     return web3JClient.doRequest(web3jRequest, EL_ENGINE_BLOCK_EXECUTION_TIMEOUT);

--- a/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineNewPayloadV3Test.java
+++ b/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineNewPayloadV3Test.java
@@ -13,7 +13,6 @@
 
 package tech.pegasys.teku.ethereum.executionclient.methods;
 
-import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -25,6 +24,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -101,7 +101,7 @@ class EngineNewPayloadV3Test {
 
     jsonRpcMethod = new EngineNewPayloadV3(executionEngineClient);
 
-    when(executionEngineClient.newPayloadV3(executionPayloadV1, emptyList()))
+    when(executionEngineClient.newPayloadV3(executionPayloadV1, Optional.empty()))
         .thenReturn(dummySuccessfulResponse());
 
     final JsonRpcRequestParams params =
@@ -109,7 +109,7 @@ class EngineNewPayloadV3Test {
 
     assertThat(jsonRpcMethod.execute(params)).isCompleted();
 
-    verify(executionEngineClient).newPayloadV3(eq(executionPayloadV1), eq(emptyList()));
+    verify(executionEngineClient).newPayloadV3(eq(executionPayloadV1), eq(Optional.empty()));
     verifyNoMoreInteractions(executionEngineClient);
   }
 
@@ -125,7 +125,7 @@ class EngineNewPayloadV3Test {
 
     jsonRpcMethod = new EngineNewPayloadV3(executionEngineClient);
 
-    when(executionEngineClient.newPayloadV3(executionPayloadV2, emptyList()))
+    when(executionEngineClient.newPayloadV3(executionPayloadV2, Optional.empty()))
         .thenReturn(dummySuccessfulResponse());
 
     final JsonRpcRequestParams params =
@@ -133,7 +133,7 @@ class EngineNewPayloadV3Test {
 
     assertThat(jsonRpcMethod.execute(params)).isCompleted();
 
-    verify(executionEngineClient).newPayloadV3(eq(executionPayloadV2), eq(emptyList()));
+    verify(executionEngineClient).newPayloadV3(eq(executionPayloadV2), eq(Optional.empty()));
     verifyNoMoreInteractions(executionEngineClient);
   }
 
@@ -150,7 +150,7 @@ class EngineNewPayloadV3Test {
 
     jsonRpcMethod = new EngineNewPayloadV3(executionEngineClient);
 
-    when(executionEngineClient.newPayloadV3(executionPayloadV3, blobVersionedHashes))
+    when(executionEngineClient.newPayloadV3(executionPayloadV3, Optional.of(blobVersionedHashes)))
         .thenReturn(dummySuccessfulResponse());
 
     final JsonRpcRequestParams params =
@@ -158,7 +158,8 @@ class EngineNewPayloadV3Test {
 
     assertThat(jsonRpcMethod.execute(params)).isCompleted();
 
-    verify(executionEngineClient).newPayloadV3(eq(executionPayloadV3), eq(blobVersionedHashes));
+    verify(executionEngineClient)
+        .newPayloadV3(eq(executionPayloadV3), eq(Optional.of(blobVersionedHashes)));
     verifyNoMoreInteractions(executionEngineClient);
   }
 

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionClientHandlerImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionClientHandlerImpl.java
@@ -83,15 +83,14 @@ public class ExecutionClientHandlerImpl implements ExecutionClientHandler {
 
   @Override
   public SafeFuture<PayloadStatus> engineNewPayload(final NewPayloadRequest newPayloadRequest) {
-    final JsonRpcRequestParams params =
-        new JsonRpcRequestParams.Builder()
-            .add(newPayloadRequest.getExecutionPayload())
-            .addOptional(newPayloadRequest.getVersionedHashes())
-            .build();
+    JsonRpcRequestParams.Builder paramsBuilder =
+        new JsonRpcRequestParams.Builder().add(newPayloadRequest.getExecutionPayload());
+
+    newPayloadRequest.getVersionedHashes().ifPresent(paramsBuilder::add);
 
     return methodsResolver
         .getMethod(EngineApiMethods.ENGINE_NEW_PAYLOAD, PayloadStatus.class)
-        .execute(params);
+        .execute(paramsBuilder.build());
   }
 
   @Override

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/DenebExecutionClientHandlerTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/DenebExecutionClientHandlerTest.java
@@ -13,7 +13,6 @@
 
 package tech.pegasys.teku.ethereum.executionlayer;
 
-import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
@@ -21,6 +20,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import org.apache.tuweni.units.bigints.UInt256;
 import org.junit.jupiter.api.BeforeEach;
@@ -167,9 +167,9 @@ public class DenebExecutionClientHandlerTest extends ExecutionHandlerClientTest 
         SafeFuture.completedFuture(
             new Response<>(
                 new PayloadStatusV1(ExecutionPayloadStatus.ACCEPTED, data.randomBytes32(), null)));
-    when(executionEngineClient.newPayloadV3(payloadV1, emptyList())).thenReturn(dummyResponse);
+    when(executionEngineClient.newPayloadV3(payloadV1, Optional.empty())).thenReturn(dummyResponse);
     final SafeFuture<PayloadStatus> future = handler.engineNewPayload(newPayloadRequest);
-    verify(executionEngineClient).newPayloadV3(payloadV1, emptyList());
+    verify(executionEngineClient).newPayloadV3(payloadV1, Optional.empty());
     verify(executionEngineClient, never()).newPayloadV2(payloadV1);
     verify(executionEngineClient, never()).newPayloadV1(payloadV1);
     assertThat(future).isCompleted();
@@ -195,9 +195,9 @@ public class DenebExecutionClientHandlerTest extends ExecutionHandlerClientTest 
         SafeFuture.completedFuture(
             new Response<>(
                 new PayloadStatusV1(ExecutionPayloadStatus.ACCEPTED, data.randomBytes32(), null)));
-    when(executionEngineClient.newPayloadV3(payloadV2, emptyList())).thenReturn(dummyResponse);
+    when(executionEngineClient.newPayloadV3(payloadV2, Optional.empty())).thenReturn(dummyResponse);
     final SafeFuture<PayloadStatus> future = handler.engineNewPayload(newPayloadRequest);
-    verify(executionEngineClient).newPayloadV3(payloadV2, emptyList());
+    verify(executionEngineClient).newPayloadV3(payloadV2, Optional.empty());
     verify(executionEngineClient, never()).newPayloadV2(payloadV2);
     verify(executionEngineClient, never()).newPayloadV1(payloadV2);
     assertThat(future).isCompleted();
@@ -207,8 +207,10 @@ public class DenebExecutionClientHandlerTest extends ExecutionHandlerClientTest 
   void engineNewPayload_denebFork() {
     final ExecutionClientHandler handler = getHandler();
     final ExecutionPayload payload = dataStructureUtil.randomExecutionPayload();
-    final List<VersionedHash> versionedHashes = dataStructureUtil.randomVersionedHashes(3);
-    final NewPayloadRequest newPayloadRequest = new NewPayloadRequest(payload, versionedHashes);
+    final Optional<List<VersionedHash>> versionedHashes =
+        Optional.of(dataStructureUtil.randomVersionedHashes(3));
+    final NewPayloadRequest newPayloadRequest =
+        new NewPayloadRequest(payload, versionedHashes.get());
     final ExecutionPayloadV3 payloadV3 = ExecutionPayloadV3.fromInternalExecutionPayload(payload);
     final SafeFuture<Response<PayloadStatusV1>> dummyResponse =
         SafeFuture.completedFuture(


### PR DESCRIPTION
in `engine_newPayloadV3`, let's send `null` instead of `[]` as second parameter (`versionedHashes`) when V3 is used before Deneb activates.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
