### PR TITLE
BlobSidecarsByRange send only canonical blobs

### DIFF
--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/historical/ReconstructHistoricalStatesServiceTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/historical/ReconstructHistoricalStatesServiceTest.java
@@ -174,7 +174,7 @@ public class ReconstructHistoricalStatesServiceTest {
 
   @Test
   void shouldHandleStartWithPartialStorage(@TempDir final Path tempDir) throws IOException {
-    chainBuilder.finalizeCurrentChain();
+    chainBuilder.finalizeCurrentChain(Optional.empty());
     final StorageSystem storageSystem = InMemoryStorageSystemBuilder.buildDefault(spec);
     final ChainUpdater updater = storageSystem.chainUpdater();
     updater.initializeGenesis(chainBuilder.getGenesis().getState());

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/util/SlotAndBlockRootAndBlobIndex.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/util/SlotAndBlockRootAndBlobIndex.java
@@ -19,6 +19,7 @@ import java.util.Objects;
 import org.apache.tuweni.bytes.Bytes32;
 import org.jetbrains.annotations.NotNull;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 
 /** Key for storing blobs in DB */
 public class SlotAndBlockRootAndBlobIndex implements Comparable<SlotAndBlockRootAndBlobIndex> {
@@ -44,6 +45,10 @@ public class SlotAndBlockRootAndBlobIndex implements Comparable<SlotAndBlockRoot
 
   public UInt64 getBlobIndex() {
     return blobIndex;
+  }
+
+  public SlotAndBlockRoot getSlotAndBlockRoot() {
+    return new SlotAndBlockRoot(slot, blockRoot);
   }
 
   @Override

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandler.java
@@ -146,7 +146,7 @@ public class BlobSidecarsByRangeMessageHandler
                     combinedChainDataClient.getAncestorRoots(startSlot, UInt64.ONE, hotSlotsCount);
 
                 // refresh finalized slot to avoid race condition that can occur if we finalize just
-                // after getting hot canonical roots
+                // before getting hot canonical roots
                 finalizedSlot = combinedChainDataClient.getFinalizedBlockSlot().orElse(UInt64.ZERO);
               } else {
                 canonicalHotRoots = ImmutableSortedMap.of();

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandler.java
@@ -18,12 +18,16 @@ import static tech.pegasys.teku.spec.config.Constants.MIN_EPOCHS_FOR_BLOB_SIDECA
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableSortedMap;
 import java.nio.channels.ClosedChannelException;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Optional;
+import java.util.SortedMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.plugin.services.metrics.Counter;
 import org.hyperledger.besu.plugin.services.metrics.LabelledMetric;
@@ -34,6 +38,7 @@ import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.teku.networking.eth2.rpc.core.PeerRequiredLocalMessageHandler;
 import tech.pegasys.teku.networking.eth2.rpc.core.ResponseCallback;
 import tech.pegasys.teku.networking.eth2.rpc.core.RpcException;
+import tech.pegasys.teku.networking.eth2.rpc.core.RpcException.ResourceUnavailableException;
 import tech.pegasys.teku.networking.p2p.rpc.StreamClosedException;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.config.SpecConfigDeneb;
@@ -127,12 +132,31 @@ public class BlobSidecarsByRangeMessageHandler
               if (checkRequestInMinEpochsRange(requestEpoch)
                   && !checkBlobSidecarsAreAvailable(earliestAvailableSlot, endSlot)) {
                 return SafeFuture.failedFuture(
-                    new RpcException.ResourceUnavailableException(
-                        "Requested blob sidecars are not available."));
+                    new ResourceUnavailableException("Requested blob sidecars are not available."));
               }
-              final BlobSidecarsByRangeMessageHandler.RequestState initialState =
-                  new BlobSidecarsByRangeMessageHandler.RequestState(
-                      callback, maxRequestBlobSidecars, startSlot, endSlot);
+
+              final UInt64 finalizedSlot =
+                  combinedChainDataClient.getFinalizedBlockSlot().orElse(UInt64.ZERO);
+
+              final SortedMap<UInt64, Bytes32> canonicalHotRoots;
+              if (endSlot.isGreaterThan(finalizedSlot)) {
+                final UInt64 count = endSlot.minus(finalizedSlot);
+                final UInt64 hotBlocksStartSlot = finalizedSlot.plus(1);
+
+                canonicalHotRoots =
+                    combinedChainDataClient.getAncestorRoots(hotBlocksStartSlot, UInt64.ONE, count);
+              } else {
+                canonicalHotRoots = ImmutableSortedMap.of();
+              }
+
+              final RequestState initialState =
+                  new RequestState(
+                      callback,
+                      maxRequestBlobSidecars,
+                      startSlot,
+                      endSlot,
+                      canonicalHotRoots,
+                      finalizedSlot);
               if (initialState.isComplete()) {
                 return SafeFuture.completedFuture(initialState);
               }
@@ -203,6 +227,8 @@ public class BlobSidecarsByRangeMessageHandler
     private final UInt64 maxRequestBlobSidecars;
     private final UInt64 startSlot;
     private final UInt64 endSlot;
+    private final UInt64 finalizedSlot;
+    private final Map<UInt64, Bytes32> canonicalHotRoots;
 
     private Optional<Iterator<SlotAndBlockRootAndBlobIndex>> blobSidecarKeysIterator =
         Optional.empty();
@@ -211,11 +237,15 @@ public class BlobSidecarsByRangeMessageHandler
         final ResponseCallback<BlobSidecar> callback,
         final UInt64 maxRequestBlobSidecars,
         final UInt64 startSlot,
-        final UInt64 endSlot) {
+        final UInt64 endSlot,
+        final Map<UInt64, Bytes32> canonicalHotRoots,
+        final UInt64 finalizedSlot) {
       this.callback = callback;
       this.maxRequestBlobSidecars = maxRequestBlobSidecars;
       this.startSlot = startSlot;
       this.endSlot = endSlot;
+      this.finalizedSlot = finalizedSlot;
+      this.canonicalHotRoots = canonicalHotRoots;
     }
 
     SafeFuture<Void> sendBlobSidecar(final BlobSidecar blobSidecar) {
@@ -237,34 +267,30 @@ public class BlobSidecarsByRangeMessageHandler
     }
 
     private SafeFuture<Optional<BlobSidecar>> getNextBlobSidecar(
-        final Iterator<SlotAndBlockRootAndBlobIndex> iterator) {
-      if (iterator.hasNext()) {
-        final SlotAndBlockRootAndBlobIndex slotAndBlockRootAndBlobIndex = iterator.next();
+        final Iterator<SlotAndBlockRootAndBlobIndex> blobSidecarKeysIterator) {
+      if (blobSidecarKeysIterator.hasNext()) {
+        final SlotAndBlockRootAndBlobIndex slotAndBlockRootAndBlobIndex =
+            blobSidecarKeysIterator.next();
 
-        if (isSlotAndBlockRootAndBlobIndexFinalized(slotAndBlockRootAndBlobIndex)) {
+        if (finalizedSlot.isGreaterThanOrEqualTo(slotAndBlockRootAndBlobIndex.getSlot())) {
           return combinedChainDataClient.getBlobSidecarByKey(slotAndBlockRootAndBlobIndex);
         }
 
         // not finalized, let's check if it is on canonical chain
-        if (combinedChainDataClient.isAncestorOfCanonicalHead(
-            slotAndBlockRootAndBlobIndex.getSlotAndBlockRoot())) {
+        if (isCanonical(slotAndBlockRootAndBlobIndex)) {
           return combinedChainDataClient.getBlobSidecarByKey(slotAndBlockRootAndBlobIndex);
         }
 
         // non-canonical, try next one
-        return getNextBlobSidecar(iterator);
+        return getNextBlobSidecar(blobSidecarKeysIterator);
       }
 
       return SafeFuture.completedFuture(Optional.empty());
     }
 
-    private boolean isSlotAndBlockRootAndBlobIndexFinalized(
-        final SlotAndBlockRootAndBlobIndex slotAndBlockRootAndBlobIndex) {
-      return combinedChainDataClient
-          .getFinalizedBlockSlot()
-          .map(
-              finalizedSlot ->
-                  finalizedSlot.isGreaterThanOrEqualTo(slotAndBlockRootAndBlobIndex.getSlot()))
+    private boolean isCanonical(final SlotAndBlockRootAndBlobIndex slotAndBlockRootAndBlobIndex) {
+      return Optional.ofNullable(canonicalHotRoots.get(slotAndBlockRootAndBlobIndex.getSlot()))
+          .map(blockRoot -> blockRoot.equals(slotAndBlockRootAndBlobIndex.getBlockRoot()))
           .orElse(false);
     }
 

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandlerTest.java
@@ -109,6 +109,7 @@ public class BlobSidecarsByRangeMessageHandlerTest {
         .thenReturn(SafeFuture.completedFuture(Optional.of(ZERO)));
     when(combinedChainDataClient.getCurrentEpoch()).thenReturn(denebForkEpoch.increment());
     when(combinedChainDataClient.getBestBlockRoot()).thenReturn(Optional.of(headBlockRoot));
+    when(combinedChainDataClient.isAncestorOfCanonicalHead(any())).thenReturn(true);
     when(listener.respond(any())).thenReturn(SafeFuture.COMPLETE);
   }
 

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandlerTest.java
@@ -267,8 +267,7 @@ public class BlobSidecarsByRangeMessageHandlerTest {
             .collect(Collectors.toUnmodifiableList());
 
     // let return only canonical slot and block root as canonical
-    when(combinedChainDataClient.getAncestorRoots(
-            eq(latestFinalizedSlot.increment()), eq(ONE), any()))
+    when(combinedChainDataClient.getAncestorRoots(eq(startSlot), eq(ONE), any()))
         .thenReturn(
             ImmutableSortedMap.of(
                 canonicalSlotAndBlockRoot.getSlot(), canonicalSlotAndBlockRoot.getBlockRoot()));

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
@@ -460,6 +460,21 @@ public class CombinedChainDataClient {
     return recentChainData.getAncestorRootsOnHeadChain(startSlot, step, count);
   }
 
+  public boolean isAncestorOfCanonicalHead(final SlotAndBlockRoot slotAndBlockRoot) {
+    final Optional<ChainHead> chainHead = recentChainData.getChainHead();
+    final Optional<ReadOnlyForkChoiceStrategy> forkChoiceStrategy =
+        recentChainData.getForkChoiceStrategy();
+    if (chainHead.isEmpty() || forkChoiceStrategy.isEmpty()) {
+      return false;
+    }
+
+    return forkChoiceStrategy
+        .get()
+        .getAncestor(slotAndBlockRoot.getBlockRoot(), slotAndBlockRoot.getSlot())
+        .map(blockRootAtSlot -> blockRootAtSlot.equals(slotAndBlockRoot.getBlockRoot()))
+        .orElse(false);
+  }
+
   /** @return The earliest available block's slot */
   public SafeFuture<Optional<UInt64>> getEarliestAvailableBlockSlot() {
     return earliestAvailableBlockSlot.get();
@@ -522,8 +537,16 @@ public class CombinedChainDataClient {
     if (recentChainData.isPreGenesis()) {
       return false;
     }
-    final UInt64 finalizedSlot = recentChainData.getStore().getLatestFinalizedBlockSlot();
+    final UInt64 finalizedSlot = getStore().getLatestFinalizedBlockSlot();
     return slot.compareTo(finalizedSlot) >= 0;
+  }
+
+  public Optional<UInt64> getFinalizedBlockSlot() {
+    if (recentChainData.isPreGenesis()) {
+      return Optional.empty();
+    }
+
+    return Optional.of(getStore().getLatestFinalizedBlockSlot());
   }
 
   public Optional<SignedBeaconBlock> getFinalizedBlock() {
@@ -546,8 +569,7 @@ public class CombinedChainDataClient {
   }
 
   public Optional<Checkpoint> getJustifiedCheckpoint() {
-    return Optional.ofNullable(recentChainData.getStore())
-        .map(ReadOnlyStore::getJustifiedCheckpoint);
+    return Optional.ofNullable(getStore()).map(ReadOnlyStore::getJustifiedCheckpoint);
   }
 
   public Optional<GenesisData> getGenesisData() {

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
@@ -470,7 +470,7 @@ public class CombinedChainDataClient {
 
     return forkChoiceStrategy
         .get()
-        .getAncestor(slotAndBlockRoot.getBlockRoot(), slotAndBlockRoot.getSlot())
+        .getAncestor(chainHead.get().getRoot(), slotAndBlockRoot.getSlot())
         .map(blockRootAtSlot -> blockRootAtSlot.equals(slotAndBlockRoot.getBlockRoot()))
         .orElse(false);
   }

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/client/ChainUpdater.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/client/ChainUpdater.java
@@ -148,7 +148,7 @@ public class ChainUpdater {
   }
 
   public SignedBlockAndState finalizeCurrentChain() {
-    final List<SignedBlockAndState> newBlocks = chainBuilder.finalizeCurrentChain();
+    final List<SignedBlockAndState> newBlocks = chainBuilder.finalizeCurrentChain(Optional.empty());
     newBlocks.forEach(this::saveBlock);
     final SignedBlockAndState newHead = newBlocks.get(newBlocks.size() - 1);
     updateBestBlock(newHead);
@@ -156,7 +156,7 @@ public class ChainUpdater {
   }
 
   public SignedBlockAndState finalizeCurrentChainOptimistically() {
-    final List<SignedBlockAndState> newBlocks = chainBuilder.finalizeCurrentChain();
+    final List<SignedBlockAndState> newBlocks = chainBuilder.finalizeCurrentChain(Optional.empty());
     newBlocks.forEach(this::saveOptimisticBlock);
     final SignedBlockAndState newHead = newBlocks.get(newBlocks.size() - 1);
     updateBestBlock(newHead);


### PR DESCRIPTION
This PR makes sure that BlobSidecarsByRange RPC responds only with blobsidecars belonging to canonical chain.

It is implemented with the following logic:

- Splits the range in two logical sub ranges of slots: finalized and non finalized.
  - For the finalized subrange, It assumes the storage is already pruned from non canonical blobs, so we keep them as they are.
  - For non-finalized subrange, it obtains the canonical  `Map<Slot,BlockRoot>` from combinedChainDataClient, and it filters out blobs that do not refer to any of those SlotAndBlockRoot.

fixes #7246 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
