### PR TITLE
Improve calculation of total bytes of blobs

### DIFF
--- a/infrastructure/kzg/src/main/java/tech/pegasys/teku/kzg/ckzg4844/CKZG4844.java
+++ b/infrastructure/kzg/src/main/java/tech/pegasys/teku/kzg/ckzg4844/CKZG4844.java
@@ -140,7 +140,7 @@ public final class CKZG4844 implements KZG {
               blobs.size(), kzgCommitments.size(), kzgProofs.size()));
     }
     try {
-      final byte[] blobsBytes = CKZG4844Utils.flattenBytes(blobs);
+      final byte[] blobsBytes = CKZG4844Utils.flattenBlobs(blobs);
       final byte[] commitmentsBytes = CKZG4844Utils.flattenCommitments(kzgCommitments);
       final byte[] proofBytes = CKZG4844Utils.flattenProofs(kzgProofs);
       return CKZG4844JNI.verifyBlobKzgProofBatch(

--- a/infrastructure/kzg/src/main/java/tech/pegasys/teku/kzg/ckzg4844/CKZG4844Utils.java
+++ b/infrastructure/kzg/src/main/java/tech/pegasys/teku/kzg/ckzg4844/CKZG4844Utils.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.kzg.ckzg4844;
 
+import ethereum.ckzg4844.CKZG4844JNI;
 import java.io.BufferedReader;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -38,6 +39,10 @@ public class CKZG4844Utils {
   public static byte[] flattenBytes(final List<? extends Bytes> bytes) {
     return flattenBytes(
         bytes.stream(), bytes.stream().map(Bytes::size).reduce(Integer::sum).orElse(0));
+  }
+
+  public static byte[] flattenBlobs(final List<Bytes> blobs) {
+    return flattenBytes(blobs.stream(), CKZG4844JNI.getBytesPerBlob() * blobs.size());
   }
 
   public static byte[] flattenCommitments(final List<KZGCommitment> commitments) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Don't stream over blob bytes unnecessarily to get total size, when size of blobs is known.

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
