### PR TITLE
Finish off builder flow for Deneb

### DIFF
--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/AbstractBlockFactoryTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/AbstractBlockFactoryTest.java
@@ -24,8 +24,10 @@ import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -47,6 +49,8 @@ import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.Be
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregate;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.bellatrix.BeaconBlockBodyBellatrix;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.bellatrix.BlindedBeaconBlockBodyBellatrix;
+import tech.pegasys.teku.spec.datastructures.builder.BlindedBlobsBundle;
+import tech.pegasys.teku.spec.datastructures.builder.BuilderPayload;
 import tech.pegasys.teku.spec.datastructures.execution.BlobsBundle;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
@@ -67,6 +71,7 @@ import tech.pegasys.teku.spec.logic.common.block.AbstractBlockProcessor;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
 import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsBellatrix;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsDeneb;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.OperationPool;
 import tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPool;
@@ -97,8 +102,11 @@ public abstract class AbstractBlockFactoryTest {
   protected final Eth1DataCache eth1DataCache = mock(Eth1DataCache.class);
 
   protected ExecutionPayload executionPayload = null;
-  protected ExecutionPayloadHeader executionPayloadHeader = null;
   protected Optional<BlobsBundle> blobsBundle = Optional.empty();
+
+  protected ExecutionPayloadHeader executionPayloadHeader = null;
+  protected Optional<BlindedBlobsBundle> blindedBlobsBundle = Optional.empty();
+
   protected ExecutionPayloadResult cachedExecutionPayloadResult = null;
 
   @BeforeAll
@@ -220,8 +228,8 @@ public abstract class AbstractBlockFactoryTest {
       assertThat(block.getBody().getOptionalBlobKzgCommitments())
           .hasValueSatisfying(
               blobKzgCommitments ->
-                  assertThat(blobKzgCommitments.stream().map(SszKZGCommitment::getKZGCommitment))
-                      .hasSameElementsAs(blobsBundle.orElseThrow().getCommitments()));
+                  assertThat(blobKzgCommitments)
+                      .hasSameElementsAs(getCommitmentsFromBlobsBundle()));
     } else {
       assertThat(block.getBody().getOptionalBlobKzgCommitments()).isEmpty();
     }
@@ -240,8 +248,12 @@ public abstract class AbstractBlockFactoryTest {
       final SignedBlockContainer blindedBlockContainer, final Spec spec) {
     final BlockFactory blockFactory = createBlockFactory(spec);
 
+    final BuilderPayload builderPayload = getBuilderPayload(spec);
     when(executionLayer.getUnblindedPayload(blindedBlockContainer))
-        .thenReturn(SafeFuture.completedFuture(executionPayload));
+        .thenReturn(SafeFuture.completedFuture(builderPayload));
+    // simulate caching of the unblinded payload
+    when(executionLayer.getCachedUnblindedPayload(blindedBlockContainer.getSlot()))
+        .thenReturn(Optional.ofNullable(builderPayload));
     // used for unblinding the blob sidecars
     setupCachedBlobsBundle(blindedBlockContainer.getSlot());
 
@@ -330,6 +342,13 @@ public abstract class AbstractBlockFactoryTest {
     return blobsBundle;
   }
 
+  protected BlindedBlobsBundle prepareBlindedBlobsBundle(final Spec spec, final int count) {
+    final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+    final BlindedBlobsBundle blindedBlobsBundle = dataStructureUtil.randomBlindedBlobsBundle(count);
+    this.blindedBlobsBundle = Optional.of(blindedBlobsBundle);
+    return blindedBlobsBundle;
+  }
+
   private void setupExecutionLayerBlockAndBlobsProduction() {
     // pre Deneb
     when(executionLayer.initiateBlockProduction(any(), any(), eq(false)))
@@ -381,7 +400,8 @@ public abstract class AbstractBlockFactoryTest {
                       Optional.empty(),
                       Optional.of(
                           SafeFuture.completedFuture(
-                              HeaderWithFallbackData.create(executionPayloadHeader))));
+                              HeaderWithFallbackData.create(
+                                  executionPayloadHeader, blindedBlobsBundle))));
               cachedExecutionPayloadResult = executionPayloadResult;
               return executionPayloadResult;
             });
@@ -400,5 +420,39 @@ public abstract class AbstractBlockFactoryTest {
             Optional.empty());
     when(executionLayer.getCachedPayloadResult(slot))
         .thenReturn(Optional.of(executionPayloadResult));
+  }
+
+  private List<SszKZGCommitment> getCommitmentsFromBlobsBundle() {
+    return blobsBundle
+        .map(
+            blobsBundle ->
+                blobsBundle.getCommitments().stream()
+                    .map(SszKZGCommitment::new)
+                    .collect(Collectors.toList()))
+        .or(
+            () ->
+                blindedBlobsBundle.map(
+                    blindedBlobsBundle -> blindedBlobsBundle.getCommitments().asList()))
+        .orElseThrow(
+            () ->
+                new IllegalStateException(
+                    "Neither BlobsBundle or BlindedBlobsBundle were prepared"));
+  }
+
+  private BuilderPayload getBuilderPayload(final Spec spec) {
+    // pre Deneb
+    if (blobsBundle.isEmpty()) {
+      return executionPayload;
+    }
+    // post Deneb
+    final SchemaDefinitionsDeneb schemaDefinitionsDeneb =
+        SchemaDefinitionsDeneb.required(spec.getGenesisSchemaDefinitions());
+    final tech.pegasys.teku.spec.datastructures.builder.BlobsBundle builderBlobsBundle =
+        schemaDefinitionsDeneb
+            .getBlobsBundleSchema()
+            .createFromExecutionBlobsBundle(blobsBundle.orElseThrow());
+    return schemaDefinitionsDeneb
+        .getExecutionPayloadAndBlobsBundleSchema()
+        .create(executionPayload, builderBlobsBundle);
   }
 }

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryDenebTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryDenebTest.java
@@ -133,7 +133,7 @@ public class BlockFactoryDenebTest extends AbstractBlockFactoryTest {
         assertBlockUnblinded(blindedBlockContents, spec);
 
     // make sure getCachedUnblindedPayload is second in order of method calling
-    InOrder inOrder = Mockito.inOrder(executionLayer);
+    final InOrder inOrder = Mockito.inOrder(executionLayer);
     inOrder.verify(executionLayer).getUnblindedPayload(blindedBlockContents);
     inOrder.verify(executionLayer).getCachedUnblindedPayload(blindedBlockContents.getSlot());
 

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionBuilderModule.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionBuilderModule.java
@@ -35,6 +35,8 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlindedBlockContainer;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
+import tech.pegasys.teku.spec.datastructures.builder.BlindedBlobsBundle;
+import tech.pegasys.teku.spec.datastructures.builder.BlobsBundle;
 import tech.pegasys.teku.spec.datastructures.builder.BuilderBid;
 import tech.pegasys.teku.spec.datastructures.builder.BuilderPayload;
 import tech.pegasys.teku.spec.datastructures.builder.SignedBuilderBid;
@@ -48,6 +50,8 @@ import tech.pegasys.teku.spec.datastructures.execution.FallbackReason;
 import tech.pegasys.teku.spec.datastructures.execution.GetPayloadResponse;
 import tech.pegasys.teku.spec.datastructures.execution.HeaderWithFallbackData;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsDeneb;
 
 public class ExecutionBuilderModule {
 
@@ -108,14 +112,13 @@ public class ExecutionBuilderModule {
 
     if (fallbackReason != null) {
       return Optional.of(
-          getResultFromLocalExecutionPayload(
+          getResultFromLocalGetPayloadResponse(
               localGetPayloadResponse, state.getSlot(), fallbackReason));
     }
 
     return Optional.empty();
   }
 
-  // TODO: Implement for Deneb
   public SafeFuture<HeaderWithFallbackData> builderGetHeader(
       final ExecutionPayloadContext executionPayloadContext, final BeaconState state) {
 
@@ -161,7 +164,7 @@ public class ExecutionBuilderModule {
             safeLocalGetPayloadResponse,
             (signedBuilderBidMaybe, maybeLocalGetPayloadResponse) -> {
               if (signedBuilderBidMaybe.isEmpty()) {
-                return getResultFromLocalExecutionPayload(
+                return getResultFromLocalGetPayloadResponse(
                     localGetPayloadResponse, slot, FallbackReason.BUILDER_HEADER_NOT_AVAILABLE);
               } else {
                 final SignedBuilderBid signedBuilderBid = signedBuilderBidMaybe.get();
@@ -176,7 +179,7 @@ public class ExecutionBuilderModule {
 
                 if (isLocalPayloadValueWinning(builderBidValue, localBlockValue)) {
                   logLocalPayloadWin(builderBidValue, localBlockValue);
-                  return getResultFromLocalExecutionPayload(
+                  return getResultFromLocalGetPayloadResponse(
                       localGetPayloadResponse, slot, FallbackReason.LOCAL_BLOCK_VALUE_WON);
                 }
 
@@ -194,7 +197,7 @@ public class ExecutionBuilderModule {
               LOG.error(
                   "Unable to obtain a valid bid from builder. Falling back to local execution engine.",
                   error);
-              return getResultFromLocalExecutionPayload(
+              return getResultFromLocalGetPayloadResponse(
                   localGetPayloadResponse, slot, FallbackReason.BUILDER_ERROR);
             });
   }
@@ -216,7 +219,10 @@ public class ExecutionBuilderModule {
     final ExecutionPayloadHeader executionPayloadHeader =
         builderBidValidator.validateAndGetPayloadHeader(
             spec, signedBuilderBid, validatorRegistration, state, localExecutionPayload);
-    return SafeFuture.completedFuture(HeaderWithFallbackData.create(executionPayloadHeader));
+    final Optional<BlindedBlobsBundle> blindedBlobsBundle =
+        signedBuilderBid.getMessage().getOptionalBlindedBlobsBundle();
+    return SafeFuture.completedFuture(
+        HeaderWithFallbackData.create(executionPayloadHeader, blindedBlobsBundle));
   }
 
   public SafeFuture<Void> builderRegisterValidators(
@@ -274,7 +280,8 @@ public class ExecutionBuilderModule {
     final SafeFuture<HeaderWithFallbackData> headerWithFallbackDataFuture =
         maybeProcessedSlot.get();
 
-    return getPayloadFromFallbackData(signedBlindedBlockContainer, headerWithFallbackDataFuture);
+    return getPayloadFromBuilderOrFallbackData(
+        signedBlindedBlockContainer, headerWithFallbackDataFuture);
   }
 
   private boolean isTransitionNotFinalized(final ExecutionPayloadContext executionPayloadContext) {
@@ -297,22 +304,35 @@ public class ExecutionBuilderModule {
     }
   }
 
-  private SafeFuture<HeaderWithFallbackData> getResultFromLocalExecutionPayload(
+  private SafeFuture<HeaderWithFallbackData> getResultFromLocalGetPayloadResponse(
       final SafeFuture<GetPayloadResponse> localGetPayloadResponse,
       final UInt64 slot,
       final FallbackReason reason) {
     return localGetPayloadResponse.thenApply(
         getPayloadResponse -> {
-          ExecutionPayloadHeader executionPayloadHeader =
-              spec.atSlot(slot)
-                  .getSchemaDefinitions()
+          final SchemaDefinitions schemaDefinitions = spec.atSlot(slot).getSchemaDefinitions();
+          final ExecutionPayload executionPayload = getPayloadResponse.getExecutionPayload();
+          final ExecutionPayloadHeader executionPayloadHeader =
+              schemaDefinitions
                   .toVersionBellatrix()
                   .orElseThrow()
                   .getExecutionPayloadHeaderSchema()
-                  .createFromExecutionPayload(getPayloadResponse.getExecutionPayload());
+                  .createFromExecutionPayload(executionPayload);
+          final Optional<BlindedBlobsBundle> blindedBlobsBundle =
+              getPayloadResponse
+                  .getBlobsBundle()
+                  .map(
+                      executionBlobsBundle -> {
+                        final SchemaDefinitionsDeneb schemaDefinitionsDeneb =
+                            SchemaDefinitionsDeneb.required(schemaDefinitions);
+                        return schemaDefinitionsDeneb
+                            .getBlindedBlobsBundleSchema()
+                            .createFromExecutionBlobsBundle(executionBlobsBundle);
+                      });
+          final FallbackData fallbackData =
+              new FallbackData(executionPayload, getPayloadResponse.getBlobsBundle(), reason);
           return HeaderWithFallbackData.create(
-              executionPayloadHeader,
-              new FallbackData(getPayloadResponse.getExecutionPayload(), reason));
+              executionPayloadHeader, blindedBlobsBundle, fallbackData);
         });
   }
 
@@ -332,6 +352,9 @@ public class ExecutionBuilderModule {
             builderPayload -> {
               final ExecutionPayload executionPayload = builderPayload.getExecutionPayload();
               logReceivedBuilderExecutionPayload(executionPayload);
+              builderPayload
+                  .getOptionalBlobsBundle()
+                  .ifPresent(this::logReceivedBuilderBlobsBundle);
               executionLayerManager.recordExecutionPayloadFallbackSource(
                   Source.BUILDER, FallbackReason.NONE);
               LOG.trace(
@@ -341,12 +364,12 @@ public class ExecutionBuilderModule {
             });
   }
 
-  // TODO: Implement for Deneb
-  private SafeFuture<BuilderPayload> getPayloadFromFallbackData(
+  private SafeFuture<BuilderPayload> getPayloadFromBuilderOrFallbackData(
       final SignedBlindedBlockContainer signedBlindedBlockContainer,
       final SafeFuture<HeaderWithFallbackData> headerWithFallbackDataFuture) {
     // note: we don't do any particular consistency check here.
     // the header/payload compatibility check is done by SignedBeaconBlockUnblinder
+    // the blobs bundle compatibility is done by SignedBlobSidecarsUnblinder
     return headerWithFallbackDataFuture.thenCompose(
         headerWithFallbackData -> {
           if (headerWithFallbackData.getFallbackDataOptional().isEmpty()) {
@@ -354,10 +377,29 @@ public class ExecutionBuilderModule {
           } else {
             final FallbackData fallbackData =
                 headerWithFallbackData.getFallbackDataOptional().get();
-            logFallbackToLocalExecutionPayload(fallbackData);
+            logFallbackToLocalExecutionPayloadAndBlobsBundle(fallbackData);
             executionLayerManager.recordExecutionPayloadFallbackSource(
                 Source.BUILDER_LOCAL_EL_FALLBACK, fallbackData.getReason());
-            return SafeFuture.completedFuture(fallbackData.getExecutionPayload());
+            final BuilderPayload builderPayload =
+                fallbackData
+                    .getBlobsBundle()
+                    .map(
+                        executionBlobsBundle -> {
+                          final SchemaDefinitionsDeneb schemaDefinitions =
+                              SchemaDefinitionsDeneb.required(
+                                  spec.atSlot(signedBlindedBlockContainer.getSlot())
+                                      .getSchemaDefinitions());
+                          final BlobsBundle blobsBundle =
+                              schemaDefinitions
+                                  .getBlobsBundleSchema()
+                                  .createFromExecutionBlobsBundle(executionBlobsBundle);
+                          return (BuilderPayload)
+                              schemaDefinitions
+                                  .getExecutionPayloadAndBlobsBundleSchema()
+                                  .create(fallbackData.getExecutionPayload(), blobsBundle);
+                        })
+                    .orElseGet(fallbackData::getExecutionPayload);
+            return SafeFuture.completedFuture(builderPayload);
           }
         });
   }
@@ -391,31 +433,56 @@ public class ExecutionBuilderModule {
     eventLogger.builderIsNotAvailable(errorMessage);
   }
 
-  private void logFallbackToLocalExecutionPayload(final FallbackData fallbackData) {
-    LOG.log(
-        fallbackData.getReason() == FallbackReason.NOT_NEEDED ? Level.DEBUG : Level.INFO,
-        "Falling back to locally produced execution payload (Block Number {}, Block Hash = {}, Fallback Reason = {})",
-        fallbackData.getExecutionPayload().getBlockNumber(),
-        fallbackData.getExecutionPayload().getBlockHash(),
-        fallbackData.getReason());
+  private void logFallbackToLocalExecutionPayloadAndBlobsBundle(final FallbackData fallbackData) {
+    final Level logLevel =
+        fallbackData.getReason() == FallbackReason.NOT_NEEDED ? Level.DEBUG : Level.INFO;
+    final ExecutionPayload executionPayload = fallbackData.getExecutionPayload();
+    fallbackData
+        .getBlobsBundle()
+        .ifPresentOrElse(
+            blobsBundle ->
+                LOG.log(
+                    logLevel,
+                    "Falling back to locally produced execution payload and blobs bundle (Block Number {}, Block Hash = {}, Blobs = {}, Fallback Reason = {})",
+                    executionPayload.getBlockNumber(),
+                    executionPayload.getBlockHash(),
+                    blobsBundle.getNumberOfBlobs(),
+                    fallbackData.getReason()),
+            () ->
+                LOG.log(
+                    logLevel,
+                    "Falling back to locally produced execution payload (Block Number {}, Block Hash = {}, Fallback Reason = {})",
+                    executionPayload.getBlockNumber(),
+                    executionPayload.getBlockHash(),
+                    fallbackData.getReason()));
   }
 
   private void logReceivedBuilderExecutionPayload(final ExecutionPayload executionPayload) {
     LOG.info(
-        "Received execution payload from Builder (Block Number {}, Block Hash = {})",
+        "Received execution payload from Builder (Block Number = {}, Block Hash = {})",
         executionPayload.getBlockNumber(),
         executionPayload.getBlockHash());
   }
 
+  private void logReceivedBuilderBlobsBundle(final BlobsBundle blobsBundle) {
+    LOG.info("Received blobs bundle from Builder (Blobs = {})", blobsBundle.getNumberOfBlobs());
+  }
+
   private void logReceivedBuilderBid(final BuilderBid builderBid) {
     final ExecutionPayloadHeader payloadHeader = builderBid.getHeader();
+    final String blobsLog =
+        builderBid
+            .getOptionalBlindedBlobsBundle()
+            .map(blindedBlobsBundle -> ", Blobs = " + blindedBlobsBundle.getNumberOfBlobs())
+            .orElse("");
     LOG.info(
-        "Received Builder Bid (Block Number = {}, Block Hash = {}, MEV Reward (ETH) = {}, Gas Limit = {}, Gas Used = {})",
+        "Received Builder Bid (Block Number = {}, Block Hash = {}, MEV Reward (ETH) = {}, Gas Limit = {}, Gas Used = {}{})",
         payloadHeader.getBlockNumber(),
         payloadHeader.getBlockHash(),
         weiToEth(builderBid.getValue()),
         payloadHeader.getGasLimit(),
-        payloadHeader.getGasUsed());
+        payloadHeader.getGasUsed(),
+        blobsLog);
   }
 
   private void logLocalPayloadWin(final UInt256 builderBidValue, final UInt256 localPayloadValue) {

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionBuilderModule.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionBuilderModule.java
@@ -465,7 +465,8 @@ public class ExecutionBuilderModule {
   }
 
   private void logReceivedBuilderBlobsBundle(final BlobsBundle blobsBundle) {
-    LOG.info("Received blobs bundle from Builder (Blobs = {})", blobsBundle.getNumberOfBlobs());
+    LOG.info(
+        "Received blobs bundle from Builder (Blobs count = {})", blobsBundle.getNumberOfBlobs());
   }
 
   private void logReceivedBuilderBid(final BuilderBid builderBid) {
@@ -473,7 +474,7 @@ public class ExecutionBuilderModule {
     final String blobsLog =
         builderBid
             .getOptionalBlindedBlobsBundle()
-            .map(blindedBlobsBundle -> ", Blobs = " + blindedBlobsBundle.getNumberOfBlobs())
+            .map(blindedBlobsBundle -> ", Blobs count = " + blindedBlobsBundle.getNumberOfBlobs())
             .orElse("");
     LOG.info(
         "Received Builder Bid (Block Number = {}, Block Hash = {}, MEV Reward (ETH) = {}, Gas Limit = {}, Gas Used = {}{})",

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerBlockProductionManagerImplTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerBlockProductionManagerImplTest.java
@@ -40,7 +40,12 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBlindedBlockContainer;
+import tech.pegasys.teku.spec.datastructures.blocks.versions.deneb.SignedBlindedBlockContents;
+import tech.pegasys.teku.spec.datastructures.builder.BlindedBlobsBundle;
+import tech.pegasys.teku.spec.datastructures.builder.BuilderBid;
 import tech.pegasys.teku.spec.datastructures.builder.BuilderPayload;
+import tech.pegasys.teku.spec.datastructures.builder.ExecutionPayloadAndBlobsBundle;
 import tech.pegasys.teku.spec.datastructures.builder.SignedBuilderBid;
 import tech.pegasys.teku.spec.datastructures.execution.BlobsBundle;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
@@ -52,6 +57,7 @@ import tech.pegasys.teku.spec.datastructures.execution.FallbackReason;
 import tech.pegasys.teku.spec.datastructures.execution.GetPayloadResponse;
 import tech.pegasys.teku.spec.datastructures.execution.HeaderWithFallbackData;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsDeneb;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 class ExecutionLayerBlockProductionManagerImplTest {
@@ -60,7 +66,7 @@ class ExecutionLayerBlockProductionManagerImplTest {
 
   private final BuilderClient builderClient = Mockito.mock(BuilderClient.class);
 
-  private Spec spec = TestSpecFactory.createMinimalDeneb();
+  private Spec spec = TestSpecFactory.createMinimalCapella();
 
   private DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
 
@@ -110,20 +116,21 @@ class ExecutionLayerBlockProductionManagerImplTest {
     final HeaderWithFallbackData expectedResult =
         HeaderWithFallbackData.create(
             header, new FallbackData(payload, FallbackReason.BUILDER_NOT_AVAILABLE));
-    SafeFuture<HeaderWithFallbackData> headerWithFallbackDataFuture =
+    final SafeFuture<HeaderWithFallbackData> headerWithFallbackDataFuture =
         executionPayloadResult.getHeaderWithFallbackDataFuture().orElseThrow();
     assertThat(headerWithFallbackDataFuture.get()).isEqualTo(expectedResult);
-    verifyFallbackToLocalEL(slot, executionPayloadContext, expectedResult);
+    final BuilderPayload localPayload =
+        verifyFallbackToLocalEL(slot, executionPayloadContext, expectedResult);
 
     assertThat(blockProductionManager.getCachedPayloadResult(slot))
         .contains(executionPayloadResult);
     // wrong slot
     assertThat(blockProductionManager.getCachedPayloadResult(slot.plus(1))).isEmpty();
 
-    SafeFuture<BuilderPayload> unblindedPayload =
+    final SafeFuture<BuilderPayload> unblindedPayload =
         blockProductionManager.getUnblindedPayload(
             dataStructureUtil.randomSignedBlindedBeaconBlock(slot));
-    assertThat(unblindedPayload.get()).isEqualTo(payload);
+    assertThat(unblindedPayload.get()).isEqualTo(localPayload);
 
     // wrong slot, we will hit builder client by this call
     final SignedBeaconBlock signedBlindedBeaconBlock =
@@ -142,9 +149,9 @@ class ExecutionLayerBlockProductionManagerImplTest {
     final BeaconState state = dataStructureUtil.randomBeaconState(slot);
 
     // we expect result from the builder
-    final ExecutionPayloadHeader header =
-        prepareBuilderGetHeaderResponse(executionPayloadContext, false);
+    final BuilderBid builderBid = prepareBuilderGetHeaderResponse(executionPayloadContext, false);
     prepareEngineGetPayloadResponse(executionPayloadContext, UInt256.ZERO, slot);
+    final ExecutionPayloadHeader header = builderBid.getHeader();
     final HeaderWithFallbackData expectedResult = HeaderWithFallbackData.create(header);
 
     final ExecutionPayloadResult executionPayloadResult =
@@ -153,7 +160,7 @@ class ExecutionLayerBlockProductionManagerImplTest {
         .isEqualTo(executionPayloadContext);
     assertThat(executionPayloadResult.getExecutionPayloadFuture()).isEmpty();
     assertThat(executionPayloadResult.getBlobsBundleFuture()).isEmpty();
-    SafeFuture<HeaderWithFallbackData> headerWithFallbackDataFuture =
+    final SafeFuture<HeaderWithFallbackData> headerWithFallbackDataFuture =
         executionPayloadResult.getHeaderWithFallbackDataFuture().orElseThrow();
     assertThat(headerWithFallbackDataFuture.get()).isEqualTo(expectedResult);
 
@@ -219,16 +226,20 @@ class ExecutionLayerBlockProductionManagerImplTest {
     final UInt64 slot = executionPayloadContext.getForkChoiceState().getHeadBlockSlot();
     final BeaconState state = dataStructureUtil.randomBeaconState(slot);
 
-    final ExecutionPayload payload =
-        prepareEngineGetPayloadResponse(executionPayloadContext, UInt256.ZERO, slot);
+    final GetPayloadResponse getPayloadResponse =
+        prepareEngineGetPayloadResponseWithBlobs(executionPayloadContext, UInt256.ZERO, slot);
+
+    final ExecutionPayload payload = getPayloadResponse.getExecutionPayload();
+    final BlobsBundle blobsBundle = getPayloadResponse.getBlobsBundle().orElseThrow();
+
+    final SchemaDefinitionsDeneb schemaDefinitions =
+        SchemaDefinitionsDeneb.required(spec.getGenesisSchemaDefinitions());
 
     final ExecutionPayloadHeader header =
-        spec.getGenesisSpec()
-            .getSchemaDefinitions()
-            .toVersionDeneb()
-            .orElseThrow()
-            .getExecutionPayloadHeaderSchema()
-            .createFromExecutionPayload(payload);
+        schemaDefinitions.getExecutionPayloadHeaderSchema().createFromExecutionPayload(payload);
+
+    final BlindedBlobsBundle blindedBlobsBundle =
+        schemaDefinitions.getBlindedBlobsBundleSchema().createFromExecutionBlobsBundle(blobsBundle);
 
     final ExecutionPayloadResult executionPayloadResult =
         blockProductionManager.initiateBlockAndBlobsProduction(
@@ -241,19 +252,23 @@ class ExecutionLayerBlockProductionManagerImplTest {
     // we expect local engine header as result
     final HeaderWithFallbackData expectedResult =
         HeaderWithFallbackData.create(
-            header, new FallbackData(payload, FallbackReason.BUILDER_NOT_AVAILABLE));
-    SafeFuture<HeaderWithFallbackData> headerWithFallbackDataFuture =
+            header,
+            Optional.of(blindedBlobsBundle),
+            new FallbackData(
+                payload, Optional.of(blobsBundle), FallbackReason.BUILDER_NOT_AVAILABLE));
+    final SafeFuture<HeaderWithFallbackData> headerWithFallbackDataFuture =
         executionPayloadResult.getHeaderWithFallbackDataFuture().orElseThrow();
     assertThat(headerWithFallbackDataFuture.get()).isEqualTo(expectedResult);
-    verifyFallbackToLocalEL(slot, executionPayloadContext, expectedResult);
+    final BuilderPayload localPayload =
+        verifyFallbackToLocalEL(slot, executionPayloadContext, expectedResult);
 
     assertThat(blockProductionManager.getCachedPayloadResult(slot))
         .contains(executionPayloadResult);
 
-    SafeFuture<BuilderPayload> unblindedPayload =
+    final SafeFuture<BuilderPayload> unblindedPayload =
         blockProductionManager.getUnblindedPayload(
-            dataStructureUtil.randomSignedBlindedBeaconBlock(slot));
-    assertThat(unblindedPayload.get()).isEqualTo(payload);
+            dataStructureUtil.randomSignedBlindedBlockContents(slot));
+    assertThat(unblindedPayload.get()).isEqualTo(localPayload);
 
     verifyNoMoreInteractions(builderClient);
     verifyNoMoreInteractions(executionClientHandler);
@@ -270,10 +285,13 @@ class ExecutionLayerBlockProductionManagerImplTest {
     final BeaconState state = dataStructureUtil.randomBeaconState(slot);
 
     // we expect result from the builder
-    final ExecutionPayloadHeader header =
-        prepareBuilderGetHeaderResponse(executionPayloadContext, false);
-    prepareEngineGetPayloadResponse(executionPayloadContext, UInt256.ZERO, slot);
-    final HeaderWithFallbackData expectedResult = HeaderWithFallbackData.create(header);
+    final BuilderBid builderBid = prepareBuilderGetHeaderResponse(executionPayloadContext, false);
+    prepareEngineGetPayloadResponseWithBlobs(executionPayloadContext, UInt256.ZERO, slot);
+
+    final HeaderWithFallbackData expectedResult =
+        HeaderWithFallbackData.create(
+            builderBid.getHeader(),
+            Optional.of(builderBid.getOptionalBlindedBlobsBundle().orElseThrow()));
 
     final ExecutionPayloadResult executionPayloadResult =
         blockProductionManager.initiateBlockAndBlobsProduction(
@@ -283,7 +301,7 @@ class ExecutionLayerBlockProductionManagerImplTest {
     assertThat(executionPayloadResult.getExecutionPayloadFuture()).isEmpty();
     assertThat(executionPayloadResult.getBlobsBundleFuture()).isEmpty();
 
-    SafeFuture<HeaderWithFallbackData> headerWithFallbackDataFuture =
+    final SafeFuture<HeaderWithFallbackData> headerWithFallbackDataFuture =
         executionPayloadResult.getHeaderWithFallbackDataFuture().orElseThrow();
     assertThat(headerWithFallbackDataFuture.get()).isEqualTo(expectedResult);
 
@@ -291,17 +309,18 @@ class ExecutionLayerBlockProductionManagerImplTest {
     verifyBuilderCalled(slot, executionPayloadContext);
     verifyEngineCalled(executionPayloadContext, slot);
 
-    final SignedBeaconBlock signedBlindedBeaconBlock =
-        dataStructureUtil.randomSignedBlindedBeaconBlock(slot);
+    final SignedBlindedBlockContents signedBlindedBlockContents =
+        dataStructureUtil.randomSignedBlindedBlockContents(slot);
 
-    final ExecutionPayload payload = prepareBuilderGetPayloadResponse(signedBlindedBeaconBlock);
+    final ExecutionPayloadAndBlobsBundle payloadAndBlobsBundle =
+        prepareBuilderGetPayloadResponseWithBlobs(signedBlindedBlockContents);
 
     // we expect result from the builder
-    assertThat(blockProductionManager.getUnblindedPayload(signedBlindedBeaconBlock))
-        .isCompletedWithValue(payload);
+    assertThat(blockProductionManager.getUnblindedPayload(signedBlindedBlockContents))
+        .isCompletedWithValue(payloadAndBlobsBundle);
 
     // we expect both builder and local engine have been called
-    verify(builderClient).getPayload(signedBlindedBeaconBlock);
+    verify(builderClient).getPayload(signedBlindedBlockContents);
     verifyNoMoreInteractions(executionClientHandler);
     verifySourceCounter(Source.BUILDER, FallbackReason.NONE);
   }
@@ -337,10 +356,11 @@ class ExecutionLayerBlockProductionManagerImplTest {
         .contains(executionPayloadResult);
 
     // we will hit builder client by this call
-    final SignedBeaconBlock signedBlindedBeaconBlock =
-        dataStructureUtil.randomSignedBlindedBeaconBlock(slot);
-    assertThatThrownBy(() -> blockProductionManager.getUnblindedPayload(signedBlindedBeaconBlock));
-    verify(builderClient).getPayload(signedBlindedBeaconBlock);
+    final SignedBlindedBlockContents signedBlindedBlockContents =
+        dataStructureUtil.randomSignedBlindedBlockContents(slot);
+    assertThatThrownBy(
+        () -> blockProductionManager.getUnblindedPayload(signedBlindedBlockContents));
+    verify(builderClient).getPayload(signedBlindedBlockContents);
   }
 
   private void setupDeneb() {
@@ -351,7 +371,7 @@ class ExecutionLayerBlockProductionManagerImplTest {
         new ExecutionLayerBlockProductionManagerImpl(executionLayerManager);
   }
 
-  private ExecutionPayloadHeader prepareBuilderGetHeaderResponse(
+  private BuilderBid prepareBuilderGetHeaderResponse(
       final ExecutionPayloadContext executionPayloadContext, final boolean prepareEmptyResponse) {
     final UInt64 slot = executionPayloadContext.getForkChoiceState().getHeadBlockSlot();
 
@@ -373,17 +393,16 @@ class ExecutionLayerBlockProductionManagerImplTest {
                 .orElseThrow(),
             executionPayloadContext.getParentHash());
 
-    return signedBuilderBid.getMessage().getHeader();
+    return signedBuilderBid.getMessage();
   }
 
-  private void verifyFallbackToLocalEL(
+  private BuilderPayload verifyFallbackToLocalEL(
       final UInt64 slot,
       final ExecutionPayloadContext executionPayloadContext,
       final HeaderWithFallbackData headerWithFallbackData) {
     final FallbackData fallbackData =
         headerWithFallbackData.getFallbackDataOptional().orElseThrow();
     final FallbackReason fallbackReason = fallbackData.getReason();
-    final ExecutionPayload executionPayload = fallbackData.getExecutionPayload();
     if (fallbackReason == FallbackReason.BUILDER_HEADER_NOT_AVAILABLE
         || fallbackReason == FallbackReason.BUILDER_ERROR
         || fallbackReason == FallbackReason.LOCAL_BLOCK_VALUE_WON) {
@@ -398,6 +417,24 @@ class ExecutionLayerBlockProductionManagerImplTest {
     final SignedBeaconBlock signedBlindedBeaconBlock =
         dataStructureUtil.randomSignedBlindedBeaconBlock(slot);
 
+    final BuilderPayload builderPayload =
+        spec.atSlot(slot)
+            .getSchemaDefinitions()
+            .toVersionDeneb()
+            .map(
+                schemaDefinitionsDeneb -> {
+                  final tech.pegasys.teku.spec.datastructures.builder.BlobsBundle blobsBundle =
+                      schemaDefinitionsDeneb
+                          .getBlobsBundleSchema()
+                          .createFromExecutionBlobsBundle(
+                              fallbackData.getBlobsBundle().orElseThrow());
+                  return (BuilderPayload)
+                      schemaDefinitionsDeneb
+                          .getExecutionPayloadAndBlobsBundleSchema()
+                          .create(fallbackData.getExecutionPayload(), blobsBundle);
+                })
+            .orElseGet(fallbackData::getExecutionPayload);
+
     // we expect result from the cached payload
     assertThat(
             executionLayerManager.builderGetPayload(
@@ -409,24 +446,32 @@ class ExecutionLayerBlockProductionManagerImplTest {
                             Optional.empty(),
                             Optional.empty(),
                             Optional.of(SafeFuture.completedFuture(headerWithFallbackData))))))
-        .isCompletedWithValue(executionPayload);
+        .isCompletedWithValue(builderPayload);
 
     // we expect no additional calls
     verifyNoMoreInteractions(builderClient);
     verifyNoMoreInteractions(executionClientHandler);
 
     verifySourceCounter(Source.BUILDER_LOCAL_EL_FALLBACK, fallbackReason);
+
+    return builderPayload;
   }
 
   private ExecutionPayload prepareBuilderGetPayloadResponse(
-      final SignedBeaconBlock signedBlindedBeaconBlock) {
-
+      final SignedBlindedBlockContainer signedBlindedBlockContainer) {
     final ExecutionPayload payload = dataStructureUtil.randomExecutionPayload();
-
-    when(builderClient.getPayload(signedBlindedBeaconBlock))
+    when(builderClient.getPayload(signedBlindedBlockContainer))
         .thenReturn(SafeFuture.completedFuture(new Response<>(payload)));
-
     return payload;
+  }
+
+  private ExecutionPayloadAndBlobsBundle prepareBuilderGetPayloadResponseWithBlobs(
+      final SignedBlindedBlockContainer signedBlindedBlockContainer) {
+    final ExecutionPayloadAndBlobsBundle payloadAndBlobsBundle =
+        dataStructureUtil.randomExecutionPayloadAndBlobsBundle();
+    when(builderClient.getPayload(signedBlindedBlockContainer))
+        .thenReturn(SafeFuture.completedFuture(new Response<>(payloadAndBlobsBundle)));
+    return payloadAndBlobsBundle;
   }
 
   private ExecutionPayload prepareEngineGetPayloadResponse(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/builder/BlindedBlobsBundleSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/builder/BlindedBlobsBundleSchema.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.datastructures.builder;
 
+import java.util.stream.Collectors;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema3;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszBytes32;
@@ -20,6 +21,7 @@ import tech.pegasys.teku.infrastructure.ssz.schema.SszListSchema;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.spec.config.SpecConfigDeneb;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.Blob;
 import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitmentSchema;
 import tech.pegasys.teku.spec.datastructures.type.SszKZGProof;
@@ -63,5 +65,27 @@ public class BlindedBlobsBundleSchema
   @Override
   public BlindedBlobsBundle createFromBackingNode(final TreeNode node) {
     return new BlindedBlobsBundle(this, node);
+  }
+
+  public BlindedBlobsBundle createFromExecutionBlobsBundle(
+      final tech.pegasys.teku.spec.datastructures.execution.BlobsBundle blobsBundle) {
+    return new BlindedBlobsBundle(
+        this,
+        getCommitmentsSchema()
+            .createFromElements(
+                blobsBundle.getCommitments().stream()
+                    .map(SszKZGCommitment::new)
+                    .collect(Collectors.toList())),
+        getProofsSchema()
+            .createFromElements(
+                blobsBundle.getProofs().stream()
+                    .map(SszKZGProof::new)
+                    .collect(Collectors.toList())),
+        getBlobRootsSchema()
+            .createFromElements(
+                blobsBundle.getBlobs().stream()
+                    .map(Blob::hashTreeRoot)
+                    .map(SszBytes32::of)
+                    .collect(Collectors.toList())));
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/builder/BlobsBundleSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/builder/BlobsBundleSchema.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.datastructures.builder;
 
+import java.util.stream.Collectors;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema3;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszListSchema;
@@ -61,5 +62,22 @@ public class BlobsBundleSchema
   @Override
   public BlobsBundle createFromBackingNode(final TreeNode node) {
     return new BlobsBundle(this, node);
+  }
+
+  public BlobsBundle createFromExecutionBlobsBundle(
+      final tech.pegasys.teku.spec.datastructures.execution.BlobsBundle blobsBundle) {
+    return new BlobsBundle(
+        this,
+        getCommitmentsSchema()
+            .createFromElements(
+                blobsBundle.getCommitments().stream()
+                    .map(SszKZGCommitment::new)
+                    .collect(Collectors.toList())),
+        getProofsSchema()
+            .createFromElements(
+                blobsBundle.getProofs().stream()
+                    .map(SszKZGProof::new)
+                    .collect(Collectors.toList())),
+        getBlobsSchema().createFromElements(blobsBundle.getBlobs()));
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/builder/ExecutionPayloadAndBlobsBundleSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/builder/ExecutionPayloadAndBlobsBundleSchema.java
@@ -37,4 +37,9 @@ public class ExecutionPayloadAndBlobsBundleSchema
   public ExecutionPayloadAndBlobsBundle createFromBackingNode(final TreeNode node) {
     return new ExecutionPayloadAndBlobsBundle(this, node);
   }
+
+  public ExecutionPayloadAndBlobsBundle create(
+      final ExecutionPayload executionPayload, final BlobsBundle blobsBundle) {
+    return new ExecutionPayloadAndBlobsBundle(this, executionPayload, blobsBundle);
+  }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/FallbackData.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/FallbackData.java
@@ -29,6 +29,15 @@ public class FallbackData {
     this.reason = reason;
   }
 
+  public FallbackData(
+      final ExecutionPayload executionPayload,
+      final Optional<BlobsBundle> blobsBundle,
+      final FallbackReason reason) {
+    this.executionPayload = executionPayload;
+    this.blobsBundle = blobsBundle;
+    this.reason = reason;
+  }
+
   public ExecutionPayload getExecutionPayload() {
     return executionPayload;
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/HeaderWithFallbackData.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/HeaderWithFallbackData.java
@@ -54,6 +54,14 @@ public class HeaderWithFallbackData {
 
   public static HeaderWithFallbackData create(
       final ExecutionPayloadHeader executionPayloadHeader,
+      final Optional<BlindedBlobsBundle> blindedBlobsBundle,
+      final FallbackData fallbackData) {
+    return new HeaderWithFallbackData(
+        executionPayloadHeader, blindedBlobsBundle, Optional.of(fallbackData));
+  }
+
+  public static HeaderWithFallbackData create(
+      final ExecutionPayloadHeader executionPayloadHeader,
       final Optional<BlindedBlobsBundle> blindedBlobsBundle) {
     return new HeaderWithFallbackData(executionPayloadHeader, blindedBlobsBundle, Optional.empty());
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
@@ -427,7 +427,7 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
                               .orElseThrow()
                               .size()
                           == blobsBundle.getNumberOfBlobs(),
-                      "provided signed blinded block contains different number of kzg commitments than the expected %d",
+                      "provided signed blinded block contains different number of kzg commitments than the expected %s",
                       blobsBundle.getNumberOfBlobs());
                   return (BuilderPayload)
                       SchemaDefinitionsDeneb.required(schemaDefinitions)

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
@@ -348,9 +348,7 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
                   executionPayload.getBlockHash());
               lastBuilderPayloadToBeUnblinded = Optional.of(executionPayload);
               final ExecutionPayloadHeader payloadHeader =
-                  schemaDefinitions
-                      .toVersionBellatrix()
-                      .orElseThrow()
+                  SchemaDefinitionsBellatrix.required(schemaDefinitions)
                       .getExecutionPayloadHeaderSchema()
                       .createFromExecutionPayload(executionPayload);
               final Optional<BlindedBlobsBundle> blindedBlobsBundle =

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -2191,18 +2191,20 @@ public final class DataStructureUtil {
         randomSszList(schema.getBlobsSchema(), this::randomBlob, numberOfBlobs));
   }
 
-  public BlindedBlobsBundle randomBlindedBlobsBundle() {
+  public BlindedBlobsBundle randomBlindedBlobsBundle(final int count) {
     final UInt64 slot = randomSlot();
     final SchemaDefinitionsDeneb schemaDefinitions = getDenebSchemaDefinitions(slot);
     final BlindedBlobsBundleSchema schema = schemaDefinitions.getBlindedBlobsBundleSchema();
 
-    final int numberOfBlobs = randomNumberOfBlobsPerBlock();
-
     return new BlindedBlobsBundle(
         schema,
-        randomSszList(schema.getCommitmentsSchema(), this::randomSszKZGCommitment, numberOfBlobs),
-        randomSszList(schema.getProofsSchema(), this::randomSszKZGProof, numberOfBlobs),
-        randomSszList(schema.getBlobRootsSchema(), numberOfBlobs, this::randomSszBytes32));
+        randomSszList(schema.getCommitmentsSchema(), this::randomSszKZGCommitment, count),
+        randomSszList(schema.getProofsSchema(), this::randomSszKZGProof, count),
+        randomSszList(schema.getBlobRootsSchema(), count, this::randomSszBytes32));
+  }
+
+  public BlindedBlobsBundle randomBlindedBlobsBundle() {
+    return randomBlindedBlobsBundle(randomNumberOfBlobsPerBlock());
   }
 
   public BlobsBundle randomBlobsBundle() {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandler.java
@@ -129,7 +129,7 @@ public class BlobSidecarsByRangeMessageHandler
         .thenCompose(
             earliestAvailableSlot -> {
               final UInt64 requestEpoch = spec.computeEpochAtSlot(startSlot);
-              if (checkRequestInMinEpochsRange(requestEpoch)
+              if (checkRequestInBlobServeRange(requestEpoch)
                   && !checkBlobSidecarsAreAvailable(earliestAvailableSlot, endSlot)) {
                 return SafeFuture.failedFuture(
                     new ResourceUnavailableException("Requested blob sidecars are not available."));
@@ -181,7 +181,7 @@ public class BlobSidecarsByRangeMessageHandler
         .orElse(false);
   }
 
-  private boolean checkRequestInMinEpochsRange(final UInt64 requestEpoch) {
+  private boolean checkRequestInBlobServeRange(final UInt64 requestEpoch) {
     final UInt64 currentEpoch = combinedChainDataClient.getCurrentEpoch();
     final UInt64 minEpochForBlobSidecars =
         denebForkEpoch.max(currentEpoch.minusMinZero(MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS));


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

- Resolved TODOs in `ExecutionBuilderModule` (basically implement getHeader and getPayload for both local, local fallback and builder + some logging)
- Enabled disabled tests + fixed current tests for deneb building
- Fixed a bug when setting the kzg commitments for blinded flow (tests are useful 🛩️  )
- Modified `ExecutionLayerChannelStub` for Deneb
- Fixed a bug where blob sidecars when unblinded simulatenously with block which caused the cached builder payload value not being available

## Fixed Issue(s)
fixes #7170 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
