### PR TITLE
Migrate sync constants to sync options + bug fix

### DIFF
--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/DefaultSyncServiceFactory.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/DefaultSyncServiceFactory.java
@@ -163,7 +163,8 @@ public class DefaultSyncServiceFactory implements SyncServiceFactory {
         syncStateProvider,
         syncConfig.isReconstructHistoricStatesEnabled(),
         genesisStateResource,
-        syncConfig.fetchAllHistoricBlocks());
+        syncConfig.fetchAllHistoricBlocks(),
+        syncConfig.getHistoricalSyncBatchSize());
   }
 
   protected SyncStateTracker createSyncStateTracker(final ForwardSync forwardSync) {
@@ -187,6 +188,9 @@ public class DefaultSyncServiceFactory implements SyncServiceFactory {
               blockImporter,
               blobSidecarManager,
               blobSidecarPool,
+              syncConfig.getForwardSyncBatchSize(),
+              syncConfig.getForwardSyncMaxPendingBatches(),
+              syncConfig.getForwardSyncMaxBlocksPerMinute(),
               spec);
     } else {
       LOG.info("Using single peer sync");
@@ -199,6 +203,7 @@ public class DefaultSyncServiceFactory implements SyncServiceFactory {
               blockImporter,
               blobSidecarManager,
               blobSidecarPool,
+              syncConfig.getForwardSyncBatchSize(),
               spec);
     }
     return forwardSync;

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/SyncConfig.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/SyncConfig.java
@@ -20,21 +20,37 @@ public class SyncConfig {
   public static final boolean DEFAULT_MULTI_PEER_SYNC_ENABLED = true;
   public static final boolean DEFAULT_RECONSTRUCT_HISTORIC_STATES_ENABLED = false;
   public static final boolean DEFAULT_FETCH_ALL_HISTORIC_BLOCKS = true;
+  public static final int DEFAULT_FORWARD_SYNC_BATCH_SIZE = 50;
+  public static final int DEFAULT_HISTORICAL_SYNC_BATCH_SIZE = 50;
+  public static final int DEFAULT_FORWARD_SYNC_MAX_PENDING_BATCHES = 5;
+  public static final int DEFAULT_FORWARD_SYNC_MAX_BLOCKS_PER_MINUTE = 500;
 
   private final boolean isEnabled;
   private final boolean isMultiPeerSyncEnabled;
   private final boolean reconstructHistoricStatesEnabled;
   private final boolean fetchAllHistoricBlocks;
+  private final int historicalSyncBatchSize;
+  private final int forwardSyncBatchSize;
+  private final int forwardSyncMaxPendingBatches;
+  private final int forwardSyncMaxBlocksPerMinute;
 
   private SyncConfig(
       final boolean isEnabled,
       final boolean isMultiPeerSyncEnabled,
       final boolean reconstructHistoricStatesEnabled,
-      final boolean fetchAllHistoricBlocks) {
+      final boolean fetchAllHistoricBlocks,
+      final int historicalSyncBatchSize,
+      final int forwardSyncBatchSize,
+      final int forwardSyncMaxPendingBatches,
+      final int forwardSyncMaxBlocksPerMinute) {
     this.isEnabled = isEnabled;
     this.isMultiPeerSyncEnabled = isMultiPeerSyncEnabled;
     this.reconstructHistoricStatesEnabled = reconstructHistoricStatesEnabled;
     this.fetchAllHistoricBlocks = fetchAllHistoricBlocks;
+    this.historicalSyncBatchSize = historicalSyncBatchSize;
+    this.forwardSyncBatchSize = forwardSyncBatchSize;
+    this.forwardSyncMaxPendingBatches = forwardSyncMaxPendingBatches;
+    this.forwardSyncMaxBlocksPerMinute = forwardSyncMaxBlocksPerMinute;
   }
 
   public static Builder builder() {
@@ -57,11 +73,31 @@ public class SyncConfig {
     return fetchAllHistoricBlocks;
   }
 
+  public int getHistoricalSyncBatchSize() {
+    return historicalSyncBatchSize;
+  }
+
+  public int getForwardSyncBatchSize() {
+    return forwardSyncBatchSize;
+  }
+
+  public int getForwardSyncMaxPendingBatches() {
+    return forwardSyncMaxPendingBatches;
+  }
+
+  public int getForwardSyncMaxBlocksPerMinute() {
+    return forwardSyncMaxBlocksPerMinute;
+  }
+
   public static class Builder {
     private Boolean isEnabled;
     private Boolean isMultiPeerSyncEnabled = DEFAULT_MULTI_PEER_SYNC_ENABLED;
     private Boolean reconstructHistoricStatesEnabled = DEFAULT_RECONSTRUCT_HISTORIC_STATES_ENABLED;
     private boolean fetchAllHistoricBlocks = DEFAULT_FETCH_ALL_HISTORIC_BLOCKS;
+    private Integer historicalSyncBatchSize = DEFAULT_HISTORICAL_SYNC_BATCH_SIZE;
+    private Integer forwardSyncBatchSize = DEFAULT_FORWARD_SYNC_BATCH_SIZE;
+    private Integer forwardSyncMaxPendingBatches = DEFAULT_FORWARD_SYNC_MAX_PENDING_BATCHES;
+    private Integer forwardSyncMaxBlocksPerMinute = DEFAULT_FORWARD_SYNC_MAX_BLOCKS_PER_MINUTE;
 
     private Builder() {}
 
@@ -71,7 +107,11 @@ public class SyncConfig {
           isEnabled,
           isMultiPeerSyncEnabled,
           reconstructHistoricStatesEnabled,
-          fetchAllHistoricBlocks);
+          fetchAllHistoricBlocks,
+          historicalSyncBatchSize,
+          forwardSyncBatchSize,
+          forwardSyncMaxPendingBatches,
+          forwardSyncMaxBlocksPerMinute);
     }
 
     private void initMissingDefaults() {
@@ -96,6 +136,30 @@ public class SyncConfig {
     public Builder isMultiPeerSyncEnabled(final Boolean multiPeerSyncEnabled) {
       checkNotNull(multiPeerSyncEnabled);
       isMultiPeerSyncEnabled = multiPeerSyncEnabled;
+      return this;
+    }
+
+    public Builder historicalSyncBatchSize(final Integer historicalSyncBatchSize) {
+      checkNotNull(historicalSyncBatchSize);
+      this.historicalSyncBatchSize = historicalSyncBatchSize;
+      return this;
+    }
+
+    public Builder forwardSyncBatchSize(final Integer forwardSyncBatchSize) {
+      checkNotNull(forwardSyncBatchSize);
+      this.forwardSyncBatchSize = forwardSyncBatchSize;
+      return this;
+    }
+
+    public Builder forwardSyncMaxPendingBatches(final Integer forwardSyncMaxPendingBatches) {
+      checkNotNull(forwardSyncMaxPendingBatches);
+      this.forwardSyncMaxPendingBatches = forwardSyncMaxPendingBatches;
+      return this;
+    }
+
+    public Builder forwardSyncMaxBlocksPerMinute(final Integer forwardSyncMaxBlocksPerMinute) {
+      checkNotNull(forwardSyncMaxBlocksPerMinute);
+      this.forwardSyncMaxBlocksPerMinute = forwardSyncMaxBlocksPerMinute;
       return this;
     }
 

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/BatchSync.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/BatchSync.java
@@ -42,7 +42,6 @@ import tech.pegasys.teku.storage.client.RecentChainData;
 /** Manages the sync process to reach a finalized chain. */
 public class BatchSync implements Sync {
   private static final Logger LOG = LogManager.getLogger();
-  private static final int MAX_PENDING_BATCHES = 5;
   private static final Duration PAUSE_ON_SERVICE_OFFLINE = Duration.ofSeconds(5);
 
   private final EventThread eventThread;
@@ -98,13 +97,14 @@ public class BatchSync implements Sync {
       final RecentChainData recentChainData,
       final BatchImporter batchImporter,
       final BatchFactory batchFactory,
-      final UInt64 batchSize,
+      final int batchSize,
+      final int maxPendingBatches,
       final MultipeerCommonAncestorFinder commonAncestorFinder,
       final TimeProvider timeProvider) {
     final BatchChain activeBatches = new BatchChain();
     final BatchDataRequester batchDataRequester =
         new BatchDataRequester(
-            eventThread, activeBatches, batchFactory, batchSize, MAX_PENDING_BATCHES);
+            eventThread, activeBatches, batchFactory, UInt64.valueOf(batchSize), maxPendingBatches);
     return new BatchSync(
         eventThread,
         asyncRunner,

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/MultipeerSyncService.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/MultipeerSyncService.java
@@ -75,7 +75,7 @@ public class MultipeerSyncService extends Service implements ForwardSyncService 
       final BlobSidecarPool blobSidecarPool,
       final int batchSize,
       final int maxPendingBatches,
-      final int maxBlockPerMinute,
+      final int maxBlocksPerMinute,
       final Spec spec) {
     final EventThread eventThread = new AsyncRunnerEventThread("sync", asyncRunnerFactory);
     final SettableLabelledGauge targetChainCountGauge =
@@ -117,7 +117,7 @@ public class MultipeerSyncService extends Service implements ForwardSyncService 
             recentChainData.getSpec(),
             eventThread,
             p2pNetwork,
-            new SyncSourceFactory(asyncRunner, timeProvider, maxBlockPerMinute, batchSize),
+            new SyncSourceFactory(asyncRunner, timeProvider, maxBlocksPerMinute, batchSize),
             finalizedTargetChains,
             nonfinalizedTargetChains);
     peerChainTracker.subscribeToTargetChainUpdates(syncController::onTargetChainsUpdated);

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/chains/SyncSourceFactory.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/chains/SyncSourceFactory.java
@@ -26,23 +26,23 @@ public class SyncSourceFactory {
   private final AsyncRunner asyncRunner;
   private final TimeProvider timeProvider;
   private final Map<Eth2Peer, SyncSource> syncSourcesByPeer = new HashMap<>();
-  private final int maxBlockPerMinute;
+  private final int maxBlocksPerMinute;
   private final int batchSize;
 
   public SyncSourceFactory(
       final AsyncRunner asyncRunner,
       final TimeProvider timeProvider,
-      final int maxBlockPerMinute,
+      final int maxBlocksPerMinute,
       final int batchSize) {
     this.asyncRunner = asyncRunner;
     this.timeProvider = timeProvider;
-    this.maxBlockPerMinute = maxBlockPerMinute;
+    this.maxBlocksPerMinute = maxBlocksPerMinute;
     this.batchSize = batchSize;
   }
 
   public SyncSource getOrCreateSyncSource(final Eth2Peer peer, final Spec spec) {
     // Limit request rate to just a little under what we'd accept
-    final int maxBlocksPerMinute = maxBlockPerMinute - batchSize - 1;
+    final int maxBlocksPerMinute = this.maxBlocksPerMinute - batchSize - 1;
     final int maxBlobSidecarsPerMinute = maxBlocksPerMinute * spec.getMaxBlobsPerBlock().orElse(1);
 
     return syncSourcesByPeer.computeIfAbsent(

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/chains/SyncSourceFactory.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/chains/SyncSourceFactory.java
@@ -13,9 +13,6 @@
 
 package tech.pegasys.teku.beacon.sync.forward.multipeer.chains;
 
-import static tech.pegasys.teku.spec.config.Constants.FORWARD_SYNC_BATCH_SIZE;
-import static tech.pegasys.teku.spec.config.Constants.MAX_BLOCKS_PER_MINUTE;
-
 import java.util.HashMap;
 import java.util.Map;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
@@ -29,15 +26,23 @@ public class SyncSourceFactory {
   private final AsyncRunner asyncRunner;
   private final TimeProvider timeProvider;
   private final Map<Eth2Peer, SyncSource> syncSourcesByPeer = new HashMap<>();
+  private final int maxBlockPerMinute;
+  private final int batchSize;
 
-  public SyncSourceFactory(final AsyncRunner asyncRunner, final TimeProvider timeProvider) {
+  public SyncSourceFactory(
+      final AsyncRunner asyncRunner,
+      final TimeProvider timeProvider,
+      final int maxBlockPerMinute,
+      final int batchSize) {
     this.asyncRunner = asyncRunner;
     this.timeProvider = timeProvider;
+    this.maxBlockPerMinute = maxBlockPerMinute;
+    this.batchSize = batchSize;
   }
 
   public SyncSource getOrCreateSyncSource(final Eth2Peer peer, final Spec spec) {
     // Limit request rate to just a little under what we'd accept
-    final int maxBlocksPerMinute = MAX_BLOCKS_PER_MINUTE - FORWARD_SYNC_BATCH_SIZE.intValue() - 1;
+    final int maxBlocksPerMinute = maxBlockPerMinute - batchSize - 1;
     final int maxBlobSidecarsPerMinute = maxBlocksPerMinute * spec.getMaxBlobsPerBlock().orElse(1);
 
     return syncSourcesByPeer.computeIfAbsent(

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/singlepeer/SinglePeerSyncServiceFactory.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/singlepeer/SinglePeerSyncServiceFactory.java
@@ -33,6 +33,7 @@ public class SinglePeerSyncServiceFactory {
       final BlockImporter blockImporter,
       final BlobSidecarManager blobSidecarManager,
       final BlobSidecarPool blobSidecarPool,
+      final int batchSize,
       final Spec spec) {
     final SyncManager syncManager =
         SyncManager.create(
@@ -43,6 +44,7 @@ public class SinglePeerSyncServiceFactory {
             blobSidecarManager,
             blobSidecarPool,
             metricsSystem,
+            batchSize,
             spec);
     return new SinglePeerSyncService(syncManager, recentChainData);
   }

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/singlepeer/SyncManager.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/singlepeer/SyncManager.java
@@ -92,6 +92,7 @@ public class SyncManager extends Service {
       final BlobSidecarManager blobSidecarManager,
       final BlobSidecarPool blobSidecarPool,
       final MetricsSystem metricsSystem,
+      final int batchSize,
       final Spec spec) {
     final PeerSync peerSync =
         new PeerSync(
@@ -100,6 +101,7 @@ public class SyncManager extends Service {
             blockImporter,
             blobSidecarManager,
             blobSidecarPool,
+            batchSize,
             metricsSystem);
     return new SyncManager(asyncRunner, network, recentChainData, peerSync, spec);
   }

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/historical/HistoricalBlockSyncService.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/historical/HistoricalBlockSyncService.java
@@ -14,7 +14,6 @@
 package tech.pegasys.teku.beacon.sync.historical;
 
 import static tech.pegasys.teku.infrastructure.logging.StatusLogger.STATUS_LOG;
-import static tech.pegasys.teku.spec.config.Constants.HISTORICAL_SYNC_BATCH_SIZE;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.cache.CacheBuilder;
@@ -134,7 +133,8 @@ public class HistoricalBlockSyncService extends Service {
       final SyncStateProvider syncStateProvider,
       final boolean reconstructHistoricStatesEnabled,
       final Optional<String> genesisStateResource,
-      final boolean fetchAllHistoricBlocks) {
+      final boolean fetchAllHistoricBlocks,
+      final int batchSize) {
     final Optional<ReconstructHistoricalStatesService> reconstructHistoricalStatesService =
         reconstructHistoricStatesEnabled
             ? Optional.of(
@@ -157,7 +157,7 @@ public class HistoricalBlockSyncService extends Service {
         chainData,
         syncStateProvider,
         signatureVerifier,
-        HISTORICAL_SYNC_BATCH_SIZE,
+        UInt64.valueOf(batchSize),
         reconstructHistoricalStatesService,
         fetchAllHistoricBlocks);
   }

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/BatchSyncTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/BatchSyncTest.java
@@ -87,7 +87,8 @@ class BatchSyncTest {
           recentChainData,
           batchImporter,
           batches,
-          BATCH_SIZE,
+          BATCH_SIZE.intValue(),
+          5,
           commonAncestor,
           timeProvider);
 

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/singlepeer/PeerSyncTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/singlepeer/PeerSyncTest.java
@@ -36,6 +36,7 @@ import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.stubbing.OngoingStubbing;
+import tech.pegasys.teku.beacon.sync.SyncConfig;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.bytes.Bytes4;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -51,7 +52,8 @@ import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.StateTrans
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
 
 public class PeerSyncTest extends AbstractSyncTest {
-  private static final UInt64 FORWARD_SYNC_BATCH_SIZE = UInt64.valueOf(50);
+  private static final UInt64 FORWARD_SYNC_BATCH_SIZE =
+      UInt64.valueOf(SyncConfig.DEFAULT_FORWARD_SYNC_BATCH_SIZE);
 
   private static final Bytes32 PEER_HEAD_BLOCK_ROOT = Bytes32.fromHexString("0x1234");
   private static final UInt64 PEER_HEAD_SLOT = UInt64.valueOf(30);

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/singlepeer/PeerSyncTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/singlepeer/PeerSyncTest.java
@@ -23,7 +23,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.beacon.sync.forward.singlepeer.PeerSync.MAX_THROTTLED_REQUESTS;
-import static tech.pegasys.teku.spec.config.Constants.FORWARD_SYNC_BATCH_SIZE;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -52,6 +51,7 @@ import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.StateTrans
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
 
 public class PeerSyncTest extends AbstractSyncTest {
+  private static final UInt64 FORWARD_SYNC_BATCH_SIZE = UInt64.valueOf(50);
 
   private static final Bytes32 PEER_HEAD_BLOCK_ROOT = Bytes32.fromHexString("0x1234");
   private static final UInt64 PEER_HEAD_SLOT = UInt64.valueOf(30);
@@ -96,6 +96,7 @@ public class PeerSyncTest extends AbstractSyncTest {
             blockImporter,
             blobSidecarManager,
             blobSidecarPool,
+            FORWARD_SYNC_BATCH_SIZE.intValue(),
             new NoOpMetricsSystem());
   }
 

--- a/beacon/sync/src/testFixtures/java/tech/pegasys/teku/beacon/sync/SyncingNodeManager.java
+++ b/beacon/sync/src/testFixtures/java/tech/pegasys/teku/beacon/sync/SyncingNodeManager.java
@@ -186,6 +186,7 @@ public class SyncingNodeManager {
             BlobSidecarManager.NOOP,
             BlobSidecarPool.NOOP,
             new NoOpMetricsSystem(),
+            SyncConfig.DEFAULT_FORWARD_SYNC_BATCH_SIZE,
             spec);
 
     final ForwardSyncService syncService = new SinglePeerSyncService(syncManager, recentChainData);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/Constants.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/Constants.java
@@ -60,11 +60,6 @@ public class Constants {
   public static final int STORAGE_QUERY_CHANNEL_PARALLELISM = 10; // # threads
   public static final int PROTOARRAY_FORKCHOICE_PRUNE_THRESHOLD = 256;
 
-  // Teku Sync
-  public static final UInt64 HISTORICAL_SYNC_BATCH_SIZE = UInt64.valueOf(50);
-  public static final UInt64 FORWARD_SYNC_BATCH_SIZE = UInt64.valueOf(50);
-  public static final int MAX_BLOCKS_PER_MINUTE = 500;
-
   // Teku Validator Client Specific
   public static final Duration GENESIS_DATA_RETRY_DELAY = Duration.ofSeconds(10);
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerFactory.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerFactory.java
@@ -67,7 +67,8 @@ public class Eth2PeerFactory {
         metadataMessagesFactory,
         PeerChainValidator.create(spec, metricsSystem, chainDataClient, requiredCheckpoint),
         new RateTracker(peerRateLimit, TIME_OUT, timeProvider),
-        new RateTracker(peerRateLimit, TIME_OUT, timeProvider),
+        new RateTracker(
+            peerRateLimit * spec.getMaxBlobsPerBlock().orElse(1), TIME_OUT, timeProvider),
         new RateTracker(peerRequestLimit, TIME_OUT, timeProvider));
   }
 }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerTest.java
@@ -21,10 +21,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
-import static tech.pegasys.teku.spec.config.Constants.FORWARD_SYNC_BATCH_SIZE;
-import static tech.pegasys.teku.spec.config.Constants.HISTORICAL_SYNC_BATCH_SIZE;
-import static tech.pegasys.teku.spec.config.Constants.MAX_REQUEST_BLOCKS;
-import static tech.pegasys.teku.spec.config.Constants.MAX_REQUEST_BLOCKS_DENEB;
 
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -211,16 +207,6 @@ class Eth2PeerTest {
     peer.requestBlobSidecarsByRange(UInt64.ONE, UInt64.valueOf(7), __ -> SafeFuture.COMPLETE);
 
     verify(delegate, never()).sendRequest(any(), any(), any());
-  }
-
-  @Test
-  public void verifyForwardAndHistoricalSyncBatchSizeIsNotLargerThanMaxRequestBlocks() {
-    assertThat(FORWARD_SYNC_BATCH_SIZE.longValue())
-        .isLessThanOrEqualTo(MAX_REQUEST_BLOCKS.longValue())
-        .isLessThanOrEqualTo(MAX_REQUEST_BLOCKS_DENEB.longValue());
-    assertThat(HISTORICAL_SYNC_BATCH_SIZE.longValue())
-        .isLessThanOrEqualTo(MAX_REQUEST_BLOCKS.longValue())
-        .isLessThanOrEqualTo(MAX_REQUEST_BLOCKS_DENEB.longValue());
   }
 
   private PeerStatus randomPeerStatus() {

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/BeaconNodeDataOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/BeaconNodeDataOptions.java
@@ -121,7 +121,7 @@ public class BeaconNodeDataOptions extends ValidatorClientDataOptions {
       names = {"--Xdata-storage-blobs-pruning-limit"},
       hidden = true,
       paramLabel = "<INTEGER>",
-      description = "Maximum number of blob sidecars that can be pruned in in each pruning session",
+      description = "Maximum number of blob sidecars that can be pruned in each pruning session",
       fallbackValue = "true",
       showDefaultValue = Visibility.ALWAYS,
       arity = "0..1")

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
@@ -163,7 +163,7 @@ public class P2POptions {
       paramLabel = "<NUMBER>",
       showDefaultValue = Visibility.ALWAYS,
       description =
-          "Number of objects being requested in a single batch to a single peer, while forward syncing",
+          "Number of objects being requested in a single batch to a single peer, while syncing historical data",
       hidden = true,
       arity = "1")
   private Integer historicalSyncBatchSize = SyncConfig.DEFAULT_HISTORICAL_SYNC_BATCH_SIZE;
@@ -182,7 +182,8 @@ public class P2POptions {
       names = {"--Xp2p-sync-max-pending-batches"},
       paramLabel = "<NUMBER>",
       showDefaultValue = Visibility.ALWAYS,
-      description = "Maximum number of concurrent batches being requested to peers",
+      description =
+          "Maximum number of concurrent batches being requested to peers, while forward syncing",
       hidden = true,
       arity = "1")
   private Integer forwardSyncMaxPendingBatches =
@@ -193,7 +194,7 @@ public class P2POptions {
       paramLabel = "<NUMBER>",
       showDefaultValue = Visibility.ALWAYS,
       description =
-          "Number of objects being requested per minute to a single peer while, forward syncing",
+          "Number of objects being requested per minute to a single peer, while forward syncing",
       hidden = true,
       arity = "1")
   private Integer forwardSyncRateLimit = SyncConfig.DEFAULT_FORWARD_SYNC_MAX_BLOCKS_PER_MINUTE;

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
@@ -159,6 +159,46 @@ public class P2POptions {
   private boolean multiPeerSyncEnabled = SyncConfig.DEFAULT_MULTI_PEER_SYNC_ENABLED;
 
   @Option(
+      names = {"--Xp2p-historical-sync-batch-size"},
+      paramLabel = "<NUMBER>",
+      showDefaultValue = Visibility.ALWAYS,
+      description =
+          "Number of objects being requested in a single batch to a single peer, while forward syncing",
+      hidden = true,
+      arity = "1")
+  private Integer historicalSyncBatchSize = SyncConfig.DEFAULT_HISTORICAL_SYNC_BATCH_SIZE;
+
+  @Option(
+      names = {"--Xp2p-sync-batch-size"},
+      paramLabel = "<NUMBER>",
+      showDefaultValue = Visibility.ALWAYS,
+      description =
+          "Number of objects being requested in a single batch to a single peer, while forward syncing",
+      hidden = true,
+      arity = "1")
+  private Integer forwardSyncBatchSize = SyncConfig.DEFAULT_FORWARD_SYNC_BATCH_SIZE;
+
+  @Option(
+      names = {"--Xp2p-sync-max-pending-batches"},
+      paramLabel = "<NUMBER>",
+      showDefaultValue = Visibility.ALWAYS,
+      description = "Maximum number of concurrent batches being requested to peers",
+      hidden = true,
+      arity = "1")
+  private Integer forwardSyncMaxPendingBatches =
+      SyncConfig.DEFAULT_FORWARD_SYNC_MAX_PENDING_BATCHES;
+
+  @Option(
+      names = {"--Xp2p-sync-rate-limit"},
+      paramLabel = "<NUMBER>",
+      showDefaultValue = Visibility.ALWAYS,
+      description =
+          "Number of objects being requested per minute to a single peer while, forward syncing",
+      hidden = true,
+      arity = "1")
+  private Integer forwardSyncRateLimit = SyncConfig.DEFAULT_FORWARD_SYNC_MAX_BLOCKS_PER_MINUTE;
+
+  @Option(
       names = {"--p2p-subscribe-all-subnets-enabled"},
       paramLabel = "<BOOLEAN>",
       showDefaultValue = Visibility.ALWAYS,
@@ -326,7 +366,13 @@ public class P2POptions {
                   .listenPort(p2pPort)
                   .advertisedIp(Optional.ofNullable(p2pAdvertisedIp));
             })
-        .sync(s -> s.isMultiPeerSyncEnabled(multiPeerSyncEnabled));
+        .sync(
+            s ->
+                s.isMultiPeerSyncEnabled(multiPeerSyncEnabled)
+                    .historicalSyncBatchSize(historicalSyncBatchSize)
+                    .forwardSyncMaxBlocksPerMinute(forwardSyncRateLimit)
+                    .forwardSyncBatchSize(forwardSyncBatchSize)
+                    .forwardSyncMaxPendingBatches(forwardSyncMaxPendingBatches));
     natOptions.configure(builder);
   }
 }

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
@@ -163,7 +163,8 @@ public class P2POptions {
       paramLabel = "<NUMBER>",
       showDefaultValue = Visibility.ALWAYS,
       description =
-          "Number of objects being requested in a single batch to a single peer, while syncing historical data",
+          "Number of blocks/blobs being requested in a single batch to a single peer, while syncing historical data.\n"
+              + "NOTE: the actual size for blobs batches will be `maxBlobsPerBlock` times the value of this parameter.",
       hidden = true,
       arity = "1")
   private Integer historicalSyncBatchSize = SyncConfig.DEFAULT_HISTORICAL_SYNC_BATCH_SIZE;
@@ -173,7 +174,8 @@ public class P2POptions {
       paramLabel = "<NUMBER>",
       showDefaultValue = Visibility.ALWAYS,
       description =
-          "Number of objects being requested in a single batch to a single peer, while forward syncing",
+          "Number of blocks/blobs being requested in a single batch to a single peer, while syncing.\n"
+              + "NOTE: the actual size for blobs batches will be `maxBlobsPerBlock` times the value of this parameter.",
       hidden = true,
       arity = "1")
   private Integer forwardSyncBatchSize = SyncConfig.DEFAULT_FORWARD_SYNC_BATCH_SIZE;
@@ -182,8 +184,7 @@ public class P2POptions {
       names = {"--Xp2p-sync-max-pending-batches"},
       paramLabel = "<NUMBER>",
       showDefaultValue = Visibility.ALWAYS,
-      description =
-          "Maximum number of concurrent batches being requested to peers, while forward syncing",
+      description = "Maximum number of concurrent batches being requested to peers, while syncing.",
       hidden = true,
       arity = "1")
   private Integer forwardSyncMaxPendingBatches =
@@ -193,8 +194,7 @@ public class P2POptions {
       names = {"--Xp2p-sync-rate-limit"},
       paramLabel = "<NUMBER>",
       showDefaultValue = Visibility.ALWAYS,
-      description =
-          "Number of objects being requested per minute to a single peer, while forward syncing",
+      description = "Number of objects being requested per minute to a single peer, while syncing.",
       hidden = true,
       arity = "1")
   private Integer forwardSyncRateLimit = SyncConfig.DEFAULT_FORWARD_SYNC_MAX_BLOCKS_PER_MINUTE;

--- a/teku/src/main/java/tech/pegasys/teku/config/TekuConfiguration.java
+++ b/teku/src/main/java/tech/pegasys/teku/config/TekuConfiguration.java
@@ -13,6 +13,9 @@
 
 package tech.pegasys.teku.config;
 
+import static tech.pegasys.teku.spec.config.Constants.MAX_REQUEST_BLOCKS;
+import static tech.pegasys.teku.spec.config.Constants.MAX_REQUEST_BLOCKS_DENEB;
+
 import java.util.Optional;
 import java.util.function.Consumer;
 import tech.pegasys.teku.beacon.sync.SyncConfig;
@@ -221,14 +224,26 @@ public class TekuConfiguration {
           b -> b.bootnodesDefault(eth2NetworkConfiguration.getDiscoveryBootnodes()));
       restApiBuilder.eth1DepositContractAddressDefault(depositContractAddress);
 
-      DataConfig dataConfig = dataConfigBuilder.build();
-      ValidatorConfig validatorConfig = validatorConfigBuilder.build();
+      final DataConfig dataConfig = dataConfigBuilder.build();
+      final ValidatorConfig validatorConfig = validatorConfigBuilder.build();
 
-      P2PConfig p2PConfig = p2pConfigBuilder.build();
+      final P2PConfig p2PConfig = p2pConfigBuilder.build();
       syncConfigBuilder.isSyncEnabledDefault(p2PConfig.getNetworkConfig().isEnabled());
 
-      StorageConfiguration storageConfiguration = storageConfigurationBuilder.build();
-      SyncConfig syncConfig = syncConfigBuilder.build();
+      final StorageConfiguration storageConfiguration = storageConfigurationBuilder.build();
+      final SyncConfig syncConfig = syncConfigBuilder.build();
+
+      final long maxAllowedBatchSize = MAX_REQUEST_BLOCKS.min(MAX_REQUEST_BLOCKS_DENEB).longValue();
+
+      if (syncConfig.getForwardSyncBatchSize() > maxAllowedBatchSize) {
+        throw new InvalidConfigurationException(
+            "Forward sync batch size cannot be greater than " + maxAllowedBatchSize);
+      }
+
+      if (syncConfig.getHistoricalSyncBatchSize() > maxAllowedBatchSize) {
+        throw new InvalidConfigurationException(
+            "Historical sync batch size cannot be greater than " + maxAllowedBatchSize);
+      }
 
       // Check for invalid config settings
       if (syncConfig.isReconstructHistoricStatesEnabled()

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/P2POptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/P2POptionsTest.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.beacon.sync.SyncConfig;
 import tech.pegasys.teku.cli.AbstractBeaconNodeCommandTest;
 import tech.pegasys.teku.config.TekuConfiguration;
 import tech.pegasys.teku.infrastructure.exceptions.InvalidConfigurationException;
@@ -36,6 +37,8 @@ public class P2POptionsTest extends AbstractBeaconNodeCommandTest {
 
     final P2PConfig p2pConfig = tekuConfig.p2p();
     assertThat(p2pConfig.getTargetSubnetSubscriberCount()).isEqualTo(5);
+    assertThat(p2pConfig.getPeerRateLimit()).isEqualTo(100);
+    assertThat(p2pConfig.getPeerRequestLimit()).isEqualTo(101);
 
     final DiscoveryConfig discoConfig = tekuConfig.discovery();
     assertThat(discoConfig.isDiscoveryEnabled()).isTrue();
@@ -52,6 +55,12 @@ public class P2POptionsTest extends AbstractBeaconNodeCommandTest {
     assertThat(networkConfig.getPrivateKeySource()).containsInstanceOf(FilePrivateKeySource.class);
     assertThat(((FilePrivateKeySource) networkConfig.getPrivateKeySource().get()).getFileName())
         .isEqualTo("/the/file");
+
+    final SyncConfig syncConfig = tekuConfig.sync();
+    assertThat(syncConfig.getHistoricalSyncBatchSize()).isEqualTo(102);
+    assertThat(syncConfig.getForwardSyncBatchSize()).isEqualTo(103);
+    assertThat(syncConfig.getForwardSyncMaxPendingBatches()).isEqualTo(8);
+    assertThat(syncConfig.getForwardSyncMaxBlocksPerMinute()).isEqualTo(80);
   }
 
   @Test
@@ -299,5 +308,60 @@ public class P2POptionsTest extends AbstractBeaconNodeCommandTest {
         getTekuConfigurationFromArguments("--Xbls-to-execution-changes-subnet-enabled", "false");
     final P2PConfig config = tekuConfiguration.p2p();
     assertThat(config.isBlsToExecutionChangesSubnetEnabled()).isFalse();
+  }
+
+  @Test
+  public void historicalSyncBatchSize_shouldBeSettable() {
+    TekuConfiguration tekuConfiguration =
+        getTekuConfigurationFromArguments("--Xp2p-historical-sync-batch-size", "10");
+    assertThat(tekuConfiguration.sync().getHistoricalSyncBatchSize()).isEqualTo(10);
+    assertThat(createConfigBuilder().sync(s -> s.historicalSyncBatchSize(10)).build())
+        .usingRecursiveComparison()
+        .isEqualTo(tekuConfiguration);
+  }
+
+  @Test
+  public void forwardSyncBatchSize_shouldBeSettable() {
+    TekuConfiguration tekuConfiguration =
+        getTekuConfigurationFromArguments("--Xp2p-sync-batch-size", "10");
+    assertThat(tekuConfiguration.sync().getForwardSyncBatchSize()).isEqualTo(10);
+    assertThat(createConfigBuilder().sync(s -> s.forwardSyncBatchSize(10)).build())
+        .usingRecursiveComparison()
+        .isEqualTo(tekuConfiguration);
+  }
+
+  @Test
+  public void forwardSyncMaxPendingBatches_shouldBeSettable() {
+    TekuConfiguration tekuConfiguration =
+        getTekuConfigurationFromArguments("--Xp2p-sync-max-pending-batches", "10");
+    assertThat(tekuConfiguration.sync().getForwardSyncMaxPendingBatches()).isEqualTo(10);
+    assertThat(createConfigBuilder().sync(s -> s.forwardSyncMaxPendingBatches(10)).build())
+        .usingRecursiveComparison()
+        .isEqualTo(tekuConfiguration);
+  }
+
+  @Test
+  public void forwardSyncRateLimit_shouldBeSettable() {
+    TekuConfiguration tekuConfiguration =
+        getTekuConfigurationFromArguments("--Xp2p-sync-rate-limit", "10");
+    assertThat(tekuConfiguration.sync().getForwardSyncMaxBlocksPerMinute()).isEqualTo(10);
+    assertThat(createConfigBuilder().sync(s -> s.forwardSyncMaxBlocksPerMinute(10)).build())
+        .usingRecursiveComparison()
+        .isEqualTo(tekuConfiguration);
+  }
+
+  @Test
+  public void forwardSyncBatchSize_greaterThanMessageSizeShouldThrowException() {
+    assertThatThrownBy(() -> createConfigBuilder().sync(s -> s.forwardSyncBatchSize(3000)).build())
+        .isInstanceOf(InvalidConfigurationException.class)
+        .hasMessage("Forward sync batch size cannot be greater than 128");
+  }
+
+  @Test
+  public void historicalSyncBatchSize_greaterThanMessageSizeShouldThrowException() {
+    assertThatThrownBy(
+            () -> createConfigBuilder().sync(s -> s.historicalSyncBatchSize(3000)).build())
+        .isInstanceOf(InvalidConfigurationException.class)
+        .hasMessage("Historical sync batch size cannot be greater than 128");
   }
 }

--- a/teku/src/test/resources/P2POptions_config.yaml
+++ b/teku/src/test/resources/P2POptions_config.yaml
@@ -11,3 +11,9 @@ p2p-peer-lower-bound: 70
 p2p-peer-upper-bound: 85
 Xp2p-target-subnet-subscriber-count: 5
 Xp2p-minimum-randomly-selected-peer-count: 1
+Xpeer-rate-limit: 100
+Xpeer-request-limit: 101
+Xp2p-historical-sync-batch-size: 102
+Xp2p-sync-batch-size: 103
+Xp2p-sync-max-pending-batches: 8
+Xp2p-sync-rate-limit: 80


### PR DESCRIPTION
Fix a bug in `RateTracker` initialization for RPC requests relative to BlobSidecars: we were not multiplying the accepted rate by `maxBlobsPerBlock`.

This pr also migrates some sync related constants to actual config params. This can help testing deneb sync with different configurations.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
