### PR TITLE
rate limit based on the served objects instead of the requested objects count

### DIFF
--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/chains/ThrottlingSyncSource.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/chains/ThrottlingSyncSource.java
@@ -56,7 +56,7 @@ public class ThrottlingSyncSource implements SyncSource {
       final UInt64 startSlot,
       final UInt64 count,
       final RpcResponseListener<SignedBeaconBlock> listener) {
-    if (blocksRateTracker.popObjectRequests(count.longValue()).getRight() > 0) {
+    if (blocksRateTracker.popObjectRequests(count.longValue()).isPresent()) {
       LOG.debug("Sending request for {} blocks", count);
       return delegate.requestBlocksByRange(startSlot, count, listener);
     } else {
@@ -68,7 +68,7 @@ public class ThrottlingSyncSource implements SyncSource {
   @Override
   public SafeFuture<Void> requestBlobSidecarsByRange(
       final UInt64 startSlot, final UInt64 count, final RpcResponseListener<BlobSidecar> listener) {
-    if (blobSidecarsRateTracker.popObjectRequests(count.longValue()).getRight() > 0) {
+    if (blobSidecarsRateTracker.popObjectRequests(count.longValue()).isPresent()) {
       LOG.debug("Sending request for {} blob sidecars", count);
       return delegate.requestBlobSidecarsByRange(startSlot, count, listener);
     } else {

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/chains/ThrottlingSyncSource.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/chains/ThrottlingSyncSource.java
@@ -56,7 +56,7 @@ public class ThrottlingSyncSource implements SyncSource {
       final UInt64 startSlot,
       final UInt64 count,
       final RpcResponseListener<SignedBeaconBlock> listener) {
-    if (blocksRateTracker.popObjectRequests(count.longValue()) > 0) {
+    if (blocksRateTracker.popObjectRequests(count.longValue()).getRight() > 0) {
       LOG.debug("Sending request for {} blocks", count);
       return delegate.requestBlocksByRange(startSlot, count, listener);
     } else {
@@ -68,7 +68,7 @@ public class ThrottlingSyncSource implements SyncSource {
   @Override
   public SafeFuture<Void> requestBlobSidecarsByRange(
       final UInt64 startSlot, final UInt64 count, final RpcResponseListener<BlobSidecar> listener) {
-    if (blobSidecarsRateTracker.popObjectRequests(count.longValue()) > 0) {
+    if (blobSidecarsRateTracker.popObjectRequests(count.longValue()).getRight() > 0) {
       LOG.debug("Sending request for {} blob sidecars", count);
       return delegate.requestBlobSidecarsByRange(startSlot, count, listener);
     } else {

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/chains/ThrottlingSyncSource.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/chains/ThrottlingSyncSource.java
@@ -56,7 +56,7 @@ public class ThrottlingSyncSource implements SyncSource {
       final UInt64 startSlot,
       final UInt64 count,
       final RpcResponseListener<SignedBeaconBlock> listener) {
-    if (blocksRateTracker.popObjectRequests(count.longValue()).isPresent()) {
+    if (blocksRateTracker.approveObjectsRequest(count.longValue()).isPresent()) {
       LOG.debug("Sending request for {} blocks", count);
       return delegate.requestBlocksByRange(startSlot, count, listener);
     } else {
@@ -68,7 +68,7 @@ public class ThrottlingSyncSource implements SyncSource {
   @Override
   public SafeFuture<Void> requestBlobSidecarsByRange(
       final UInt64 startSlot, final UInt64 count, final RpcResponseListener<BlobSidecar> listener) {
-    if (blobSidecarsRateTracker.popObjectRequests(count.longValue()).isPresent()) {
+    if (blobSidecarsRateTracker.approveObjectsRequest(count.longValue()).isPresent()) {
       LOG.debug("Sending request for {} blob sidecars", count);
       return delegate.requestBlobSidecarsByRange(startSlot, count, listener);
     } else {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/DefaultEth2Peer.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/DefaultEth2Peer.java
@@ -353,6 +353,11 @@ class DefaultEth2Peer extends DelegatingPeer implements Eth2Peer {
   }
 
   @Override
+  public void cancelBlockRequests(final long initialBlockCount, final UInt64 time) {
+    adjustObjectRequests(blockRequestTracker, initialBlockCount, time);
+  }
+
+  @Override
   public Pair<UInt64, Boolean> popBlobSidecarRequests(
       final ResponseCallback<BlobSidecar> callback, long blobSidecarsCount) {
     return popObjectRequests(
@@ -364,6 +369,11 @@ class DefaultEth2Peer extends DelegatingPeer implements Eth2Peer {
       final long returnedBlobSidecarsCount, final long initialBlobSidecarCount, final UInt64 time) {
     adjustObjectRequests(
         blobSidecarsRequestTracker, returnedBlobSidecarsCount, initialBlobSidecarCount, time);
+  }
+
+  @Override
+  public void cancelBlobSidecarRequests(final long initialBlobSidecarCount, final UInt64 time) {
+    adjustObjectRequests(blobSidecarsRequestTracker, initialBlobSidecarCount, time);
   }
 
   @Override
@@ -405,6 +415,11 @@ class DefaultEth2Peer extends DelegatingPeer implements Eth2Peer {
       final long initialObjectCount,
       final UInt64 time) {
     requestTracker.adjustRequestObjects(returnedObjectCount, initialObjectCount, time);
+  }
+
+  private void adjustObjectRequests(
+      final RateTracker requestTracker, final long initialObjectCount, final UInt64 time) {
+    requestTracker.adjustRequestObjects(0, initialObjectCount, time);
   }
 
   private <T> Pair<UInt64, Boolean> popObjectRequests(

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/DefaultEth2Peer.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/DefaultEth2Peer.java
@@ -410,7 +410,7 @@ class DefaultEth2Peer extends DelegatingPeer implements Eth2Peer {
       final RateTracker requestTracker,
       final long objectCount,
       final ResponseCallback<T> callback) {
-    Optional<RequestApproval> objectsRequest = requestTracker.popObjectRequests(objectCount);
+    final Optional<RequestApproval> objectsRequest = requestTracker.popObjectRequests(objectCount);
     if (objectsRequest.isEmpty()) {
       LOG.debug("Peer {} disconnected due to {} rate limits", getId(), requestType);
       callback.completeWithErrorResponse(

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/DefaultEth2Peer.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/DefaultEth2Peer.java
@@ -347,8 +347,9 @@ class DefaultEth2Peer extends DelegatingPeer implements Eth2Peer {
   }
 
   @Override
-  public void adjustBlockRequests(final long blocksCount, final UInt64 time) {
-    adjustObjectRequests(blockRequestTracker, blocksCount, time);
+  public void adjustBlockRequests(
+      final long returnedBlocksCount, final long initialBlockCount, final UInt64 time) {
+    adjustObjectRequests(blockRequestTracker, returnedBlocksCount, initialBlockCount, time);
   }
 
   @Override
@@ -359,8 +360,10 @@ class DefaultEth2Peer extends DelegatingPeer implements Eth2Peer {
   }
 
   @Override
-  public void adjustBlobSidecarRequests(final long blobSidecarsCount, final UInt64 time) {
-    adjustObjectRequests(blobSidecarsRequestTracker, blobSidecarsCount, time);
+  public void adjustBlobSidecarRequests(
+      final long returnedBlobSidecarsCount, final long initialBlobSidecarCount, final UInt64 time) {
+    adjustObjectRequests(
+        blobSidecarsRequestTracker, returnedBlobSidecarsCount, initialBlobSidecarCount, time);
   }
 
   @Override
@@ -397,8 +400,11 @@ class DefaultEth2Peer extends DelegatingPeer implements Eth2Peer {
   }
 
   private void adjustObjectRequests(
-      final RateTracker requestTracker, final long objectCount, final UInt64 time) {
-    requestTracker.adjustRequestObjects(objectCount, time);
+      final RateTracker requestTracker,
+      final long returnedObjectCount,
+      final long initialObjectCount,
+      final UInt64 time) {
+    requestTracker.adjustRequestObjects(returnedObjectCount, initialObjectCount, time);
   }
 
   private <T> Pair<UInt64, Boolean> popObjectRequests(

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/DefaultEth2Peer.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/DefaultEth2Peer.java
@@ -340,19 +340,19 @@ class DefaultEth2Peer extends DelegatingPeer implements Eth2Peer {
   }
 
   @Override
-  public Optional<RateTracker.ObjectsRequestResponse> popBlockRequests(
+  public Optional<RequestApproval> popBlockRequests(
       final ResponseCallback<SignedBeaconBlock> callback, long blocksCount) {
     return popObjectRequests("blocks", blockRequestTracker, blocksCount, callback);
   }
 
   @Override
   public void adjustBlockRequests(
-      final RateTracker.ObjectsRequestResponse blocksRequest, final long returnedBlocksCount) {
+      final RequestApproval blocksRequest, final long returnedBlocksCount) {
     adjustObjectRequests(blockRequestTracker, blocksRequest, returnedBlocksCount);
   }
 
   @Override
-  public Optional<RateTracker.ObjectsRequestResponse> popBlobSidecarRequests(
+  public Optional<RequestApproval> popBlobSidecarRequests(
       final ResponseCallback<BlobSidecar> callback, long blobSidecarsCount) {
     return popObjectRequests(
         "blob sidecars", blobSidecarsRequestTracker, blobSidecarsCount, callback);
@@ -360,8 +360,7 @@ class DefaultEth2Peer extends DelegatingPeer implements Eth2Peer {
 
   @Override
   public void adjustBlobSidecarRequests(
-      final RateTracker.ObjectsRequestResponse blobSidecarsRequest,
-      final long returnedBlobSidecarsCount) {
+      final RequestApproval blobSidecarsRequest, final long returnedBlobSidecarsCount) {
     adjustObjectRequests(
         blobSidecarsRequestTracker, blobSidecarsRequest, returnedBlobSidecarsCount);
   }
@@ -401,18 +400,17 @@ class DefaultEth2Peer extends DelegatingPeer implements Eth2Peer {
 
   private void adjustObjectRequests(
       final RateTracker requestTracker,
-      final RateTracker.ObjectsRequestResponse objectsRequestResponse,
+      final RequestApproval requestApproval,
       final long returnedObjectsCount) {
-    requestTracker.adjustObjectRequests(objectsRequestResponse, returnedObjectsCount);
+    requestTracker.adjustObjectRequests(requestApproval, returnedObjectsCount);
   }
 
-  private <T> Optional<RateTracker.ObjectsRequestResponse> popObjectRequests(
+  private <T> Optional<RequestApproval> popObjectRequests(
       final String requestType,
       final RateTracker requestTracker,
       final long objectCount,
       final ResponseCallback<T> callback) {
-    Optional<RateTracker.ObjectsRequestResponse> objectsRequest =
-        requestTracker.popObjectRequests(objectCount);
+    Optional<RequestApproval> objectsRequest = requestTracker.popObjectRequests(objectCount);
     if (objectsRequest.isEmpty()) {
       LOG.debug("Peer {} disconnected due to {} rate limits", getId(), requestType);
       callback.completeWithErrorResponse(

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2Peer.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2Peer.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.networking.eth2.peers;
 
 import java.util.List;
 import java.util.Optional;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.ssz.SszData;
@@ -101,13 +102,15 @@ public interface Eth2Peer extends Peer, SyncSource {
   <I extends RpcRequest, O extends SszData> SafeFuture<O> requestSingleItem(
       final Eth2RpcMethod<I, O> method, final I request);
 
-  void popBlockRequests(long blocksCount);
+  Pair<UInt64, Boolean> popBlockRequests(
+      ResponseCallback<SignedBeaconBlock> callback, long blocksCount);
 
-  boolean wantToRequestBlocks(ResponseCallback<SignedBeaconBlock> callback, long blocksCount);
+  void adjustBlockRequests(long blocksCount, UInt64 time);
 
-  void popBlobSidecarRequests(long blobSidecarsCount);
+  Pair<UInt64, Boolean> popBlobSidecarRequests(
+      ResponseCallback<BlobSidecar> callback, long blobSidecarsCount);
 
-  boolean wantToRequestBlobSidecars(ResponseCallback<BlobSidecar> callback, long blobSidecarsCount);
+  void adjustBlobSidecarRequests(long blobSidecarsCount, UInt64 time);
 
   boolean popRequest();
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2Peer.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2Peer.java
@@ -105,12 +105,13 @@ public interface Eth2Peer extends Peer, SyncSource {
   Pair<UInt64, Boolean> popBlockRequests(
       ResponseCallback<SignedBeaconBlock> callback, long blocksCount);
 
-  void adjustBlockRequests(long blocksCount, UInt64 time);
+  void adjustBlockRequests(long returnedBlocksCount, long initialBlockCount, UInt64 time);
 
   Pair<UInt64, Boolean> popBlobSidecarRequests(
       ResponseCallback<BlobSidecar> callback, long blobSidecarsCount);
 
-  void adjustBlobSidecarRequests(long blobSidecarsCount, UInt64 time);
+  void adjustBlobSidecarRequests(
+      long returnedBlobSidecarCount, long initialBlobSidecarCount, UInt64 time);
 
   boolean popRequest();
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2Peer.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2Peer.java
@@ -107,11 +107,15 @@ public interface Eth2Peer extends Peer, SyncSource {
 
   void adjustBlockRequests(long returnedBlocksCount, long initialBlockCount, UInt64 time);
 
+  void cancelBlockRequests(long initialBlockCount, UInt64 time);
+
   Pair<UInt64, Boolean> popBlobSidecarRequests(
       ResponseCallback<BlobSidecar> callback, long blobSidecarsCount);
 
   void adjustBlobSidecarRequests(
       long returnedBlobSidecarCount, long initialBlobSidecarCount, UInt64 time);
+
+  void cancelBlobSidecarRequests(long initialBlobSidecarCount, UInt64 time);
 
   boolean popRequest();
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2Peer.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2Peer.java
@@ -101,9 +101,13 @@ public interface Eth2Peer extends Peer, SyncSource {
   <I extends RpcRequest, O extends SszData> SafeFuture<O> requestSingleItem(
       final Eth2RpcMethod<I, O> method, final I request);
 
-  boolean popBlockRequests(ResponseCallback<SignedBeaconBlock> callback, long blocksCount);
+  void popBlockRequests(long blocksCount);
 
-  boolean popBlobSidecarRequests(ResponseCallback<BlobSidecar> callback, long blobSidecarsCount);
+  boolean wantToRequestBlocks(ResponseCallback<SignedBeaconBlock> callback, long blocksCount);
+
+  void popBlobSidecarRequests(long blobSidecarsCount);
+
+  boolean wantToRequestBlobSidecars(ResponseCallback<BlobSidecar> callback, long blobSidecarsCount);
 
   boolean popRequest();
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2Peer.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2Peer.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.networking.eth2.peers;
 
 import java.util.List;
 import java.util.Optional;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.ssz.SszData;
@@ -102,20 +101,17 @@ public interface Eth2Peer extends Peer, SyncSource {
   <I extends RpcRequest, O extends SszData> SafeFuture<O> requestSingleItem(
       final Eth2RpcMethod<I, O> method, final I request);
 
-  Pair<UInt64, Boolean> popBlockRequests(
+  Optional<RateTracker.ObjectsRequestResponse> popBlockRequests(
       ResponseCallback<SignedBeaconBlock> callback, long blocksCount);
 
-  void adjustBlockRequests(long returnedBlocksCount, long initialBlockCount, UInt64 time);
+  void adjustBlockRequests(
+      RateTracker.ObjectsRequestResponse blocksRequest, long returnedBlocksCount);
 
-  void cancelBlockRequests(long initialBlockCount, UInt64 time);
-
-  Pair<UInt64, Boolean> popBlobSidecarRequests(
+  Optional<RateTracker.ObjectsRequestResponse> popBlobSidecarRequests(
       ResponseCallback<BlobSidecar> callback, long blobSidecarsCount);
 
   void adjustBlobSidecarRequests(
-      long returnedBlobSidecarCount, long initialBlobSidecarCount, UInt64 time);
-
-  void cancelBlobSidecarRequests(long initialBlobSidecarCount, UInt64 time);
+      RateTracker.ObjectsRequestResponse blobSidecarsRequest, long returnedBlobSidecarsCount);
 
   boolean popRequest();
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2Peer.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2Peer.java
@@ -101,18 +101,18 @@ public interface Eth2Peer extends Peer, SyncSource {
   <I extends RpcRequest, O extends SszData> SafeFuture<O> requestSingleItem(
       final Eth2RpcMethod<I, O> method, final I request);
 
-  Optional<RequestApproval> popBlockRequests(
+  Optional<RequestApproval> approveBlocksRequest(
       ResponseCallback<SignedBeaconBlock> callback, long blocksCount);
 
-  void adjustBlockRequests(RequestApproval blocksRequest, long returnedBlocksCount);
+  void adjustBlocksRequest(RequestApproval blocksRequest, long returnedBlocksCount);
 
-  Optional<RequestApproval> popBlobSidecarRequests(
+  Optional<RequestApproval> approveBlobSidecarsRequest(
       ResponseCallback<BlobSidecar> callback, long blobSidecarsCount);
 
-  void adjustBlobSidecarRequests(
+  void adjustBlobSidecarsRequest(
       RequestApproval blobSidecarsRequest, long returnedBlobSidecarsCount);
 
-  boolean popRequest();
+  boolean approveRequest();
 
   SafeFuture<UInt64> sendPing();
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2Peer.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2Peer.java
@@ -101,17 +101,16 @@ public interface Eth2Peer extends Peer, SyncSource {
   <I extends RpcRequest, O extends SszData> SafeFuture<O> requestSingleItem(
       final Eth2RpcMethod<I, O> method, final I request);
 
-  Optional<RateTracker.ObjectsRequestResponse> popBlockRequests(
+  Optional<RequestApproval> popBlockRequests(
       ResponseCallback<SignedBeaconBlock> callback, long blocksCount);
 
-  void adjustBlockRequests(
-      RateTracker.ObjectsRequestResponse blocksRequest, long returnedBlocksCount);
+  void adjustBlockRequests(RequestApproval blocksRequest, long returnedBlocksCount);
 
-  Optional<RateTracker.ObjectsRequestResponse> popBlobSidecarRequests(
+  Optional<RequestApproval> popBlobSidecarRequests(
       ResponseCallback<BlobSidecar> callback, long blobSidecarsCount);
 
   void adjustBlobSidecarRequests(
-      RateTracker.ObjectsRequestResponse blobSidecarsRequest, long returnedBlobSidecarsCount);
+      RequestApproval blobSidecarsRequest, long returnedBlobSidecarsCount);
 
   boolean popRequest();
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/ObjectRequestsKey.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/ObjectRequestsKey.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright ConsenSys Software Inc., 2023
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.networking.eth2.peers;
+
+import java.util.Comparator;
+import java.util.Objects;
+import org.jetbrains.annotations.NotNull;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+public class ObjectRequestsKey implements Comparable<ObjectRequestsKey> {
+  private final UInt64 timeSeconds;
+  private final int requestId;
+
+  public ObjectRequestsKey(final UInt64 timeSeconds, final int requestId) {
+    this.timeSeconds = timeSeconds;
+    this.requestId = requestId;
+  }
+
+  public UInt64 getTimeSeconds() {
+    return timeSeconds;
+  }
+
+  public int getRequestId() {
+    return requestId;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(timeSeconds, requestId);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ObjectRequestsKey that = (ObjectRequestsKey) o;
+    return Objects.equals(this.timeSeconds, that.timeSeconds) && this.requestId == that.requestId;
+  }
+
+  @Override
+  public int compareTo(@NotNull ObjectRequestsKey other) {
+    return Comparator.comparing(ObjectRequestsKey::getTimeSeconds)
+        .thenComparingInt(ObjectRequestsKey::getRequestId)
+        .compare(this, other);
+  }
+}

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/RateTracker.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/RateTracker.java
@@ -21,7 +21,7 @@ import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 public class RateTracker {
-  private final NavigableMap<ObjectRequestsKey, Long> requestCount;
+  private final NavigableMap<RequestsKey, Long> requestCount;
   private final int peerRateLimit;
   private final UInt64 timeoutSeconds;
   private long objectsWithinWindow = 0L;
@@ -59,7 +59,7 @@ public class RateTracker {
 
   private void resetRequestId(UInt64 currentTime) {
     if (requestCount.keySet().stream()
-        .noneMatch(objectRequestsKey -> objectRequestsKey.getTimeSeconds().equals(currentTime))) {
+        .noneMatch(requestsKey -> requestsKey.getTimeSeconds().equals(currentTime))) {
       this.newRequestId.set(0);
     }
   }
@@ -79,8 +79,8 @@ public class RateTracker {
     if (currentTime.isLessThan(timeoutSeconds)) {
       return;
     }
-    final NavigableMap<ObjectRequestsKey, Long> headMap =
-        requestCount.headMap(new ObjectRequestsKey(currentTime.minus(timeoutSeconds), 0), false);
+    final NavigableMap<RequestsKey, Long> headMap =
+        requestCount.headMap(new RequestsKey(currentTime.minus(timeoutSeconds), 0), false);
     headMap.values().forEach(value -> objectsWithinWindow -= value);
     headMap.clear();
   }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/RateTracker.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/RateTracker.java
@@ -100,6 +100,19 @@ public class RateTracker {
     }
 
     @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      ObjectRequestsEntryKey that = (ObjectRequestsEntryKey) o;
+      return Objects.equals(this.timeSeconds, that.timeSeconds)
+          && Objects.equals(this.requestId, that.requestId);
+    }
+
+    @Override
     public int compareTo(@NotNull ObjectRequestsEntryKey other) {
       return timeSeconds.compareTo(other.timeSeconds);
     }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/RateTracker.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/RateTracker.java
@@ -46,7 +46,6 @@ public class RateTracker {
       return Optional.empty();
     }
     objectsWithinWindow += objectCount;
-    resetRequestId(currentTime);
     final RequestApproval requestApproval =
         new RequestApproval.RequestApprovalBuilder()
             .requestId(newRequestId.getAndIncrement())
@@ -55,13 +54,6 @@ public class RateTracker {
             .build();
     requestCount.put(requestApproval.getRequestKey(), objectCount);
     return Optional.of(requestApproval);
-  }
-
-  private void resetRequestId(UInt64 currentTime) {
-    if (requestCount.keySet().stream()
-        .noneMatch(requestsKey -> requestsKey.getTimeSeconds().equals(currentTime))) {
-      this.newRequestId.set(0);
-    }
   }
 
   public synchronized void adjustObjectRequests(

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/RateTracker.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/RateTracker.java
@@ -48,13 +48,16 @@ public class RateTracker {
     return Pair.of(currentTime, objectCount);
   }
 
-  public synchronized void adjustRequestObjects(final long objectsCount, final UInt64 time) {
+  public synchronized void adjustRequestObjects(
+      final long returnedObjectCount, final long initialObjectCount, final UInt64 time) {
+    pruneRequests(timeProvider.getTimeInSeconds());
     if (requestCount.containsKey(time)) {
-      requestCount.put(time, objectsCount);
+      requestCount.put(time, returnedObjectCount);
+      requestsWithinWindow = requestsWithinWindow - initialObjectCount + returnedObjectCount;
     }
   }
 
-  void pruneRequests(UInt64 time) {
+  void pruneRequests(final UInt64 time) {
     if (time.isLessThan(timeoutSeconds)) {
       return;
     }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/RateTracker.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/RateTracker.java
@@ -56,7 +56,7 @@ public class RateTracker {
             .timeSeconds(currentTime)
             .objectCount(objectCount)
             .build();
-    requestCount.put(new ObjectRequestsEntryKey(requestApproval), objectCount);
+    requestCount.put(requestApproval.getRequestKey(), objectCount);
     return Optional.of(requestApproval);
   }
 
@@ -72,11 +72,9 @@ public class RateTracker {
   public synchronized void adjustObjectRequests(
       final RequestApproval requestApproval, final long returnedObjectsCount) {
     pruneRequests();
-    final ObjectRequestsEntryKey objectRequestsEntryKey =
-        new ObjectRequestsEntryKey(requestApproval);
-    if (requestCount.containsKey(objectRequestsEntryKey)) {
-      final long initialObjectsCount = requestCount.get(objectRequestsEntryKey);
-      requestCount.put(objectRequestsEntryKey, returnedObjectsCount);
+    if (requestCount.containsKey(requestApproval.getRequestKey())) {
+      final long initialObjectsCount = requestCount.get(requestApproval.getRequestKey());
+      requestCount.put(requestApproval.getRequestKey(), returnedObjectsCount);
       objectsWithinWindow = objectsWithinWindow - initialObjectsCount + returnedObjectsCount;
     }
   }
@@ -100,11 +98,6 @@ public class RateTracker {
     public ObjectRequestsEntryKey(final UInt64 timeSeconds, final int requestId) {
       this.timeSeconds = timeSeconds;
       this.requestId = requestId;
-    }
-
-    public ObjectRequestsEntryKey(final RequestApproval requestApproval) {
-      this.timeSeconds = requestApproval.getTimeSeconds();
-      this.requestId = requestApproval.getRequestId();
     }
 
     public UInt64 getTimeSeconds() {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/RateTracker.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/RateTracker.java
@@ -48,6 +48,11 @@ public class RateTracker {
     return objectCount;
   }
 
+  public synchronized long wantToRequestObjects(final long objectsCount) {
+    final long remainingCapacity = peerRateLimit - requestsWithinWindow;
+    return remainingCapacity <= 0L ? 0L : objectsCount;
+  }
+
   void pruneRequests() {
     final UInt64 currentTime = timeProvider.getTimeInSeconds();
     if (currentTime.isLessThan(timeoutSeconds)) {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/RateTracker.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/RateTracker.java
@@ -122,14 +122,13 @@ public class RateTracker {
         return false;
       }
       ObjectRequestsEntryKey that = (ObjectRequestsEntryKey) o;
-      return Objects.equals(this.timeSeconds, that.timeSeconds)
-          && Objects.equals(this.requestId, that.requestId);
+      return Objects.equals(this.timeSeconds, that.timeSeconds) && this.requestId == that.requestId;
     }
 
     @Override
     public int compareTo(@NotNull ObjectRequestsEntryKey other) {
       return Comparator.comparing(ObjectRequestsEntryKey::getTimeSeconds)
-          .thenComparing(ObjectRequestsEntryKey::getRequestId)
+          .thenComparingInt(ObjectRequestsEntryKey::getRequestId)
           .compare(this, other);
     }
   }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/RequestApproval.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/RequestApproval.java
@@ -17,15 +17,15 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 public class RequestApproval {
 
-  private ObjectRequestsKey requestKey;
+  private RequestsKey requestKey;
   private final long objectsCount;
 
-  private RequestApproval(ObjectRequestsKey requestKey, long objectsCount) {
+  private RequestApproval(RequestsKey requestKey, long objectsCount) {
     this.requestKey = requestKey;
     this.objectsCount = objectsCount;
   }
 
-  public ObjectRequestsKey getRequestKey() {
+  public RequestsKey getRequestKey() {
     return requestKey;
   }
 
@@ -55,7 +55,7 @@ public class RequestApproval {
 
     public RequestApproval build() {
       return new RequestApproval(
-          new ObjectRequestsKey(this.timeSeconds, this.requestId), this.objectsCount);
+          new RequestsKey(this.timeSeconds, this.requestId), this.objectsCount);
     }
   }
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/RequestApproval.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/RequestApproval.java
@@ -13,22 +13,21 @@
 
 package tech.pegasys.teku.networking.eth2.peers;
 
-import java.util.UUID;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 public class RequestApproval {
 
-  private final UUID requestId;
+  private final int requestId;
   private final UInt64 timeSeconds;
   private final long objectsCount;
 
-  private RequestApproval(UUID requestId, UInt64 timeSeconds, long objectsCount) {
+  private RequestApproval(int requestId, UInt64 timeSeconds, long objectsCount) {
     this.requestId = requestId;
     this.timeSeconds = timeSeconds;
     this.objectsCount = objectsCount;
   }
 
-  public UUID getRequestId() {
+  public int getRequestId() {
     return requestId;
   }
 
@@ -41,16 +40,27 @@ public class RequestApproval {
   }
 
   public static final class RequestApprovalBuilder {
+    private int requestId;
     private UInt64 timeSeconds;
-    private final long objectsCount;
+    private long objectsCount;
 
-    public RequestApprovalBuilder(final UInt64 timeSeconds, final long objectsCount) {
+    public RequestApprovalBuilder requestId(final int requestId) {
+      this.requestId = requestId;
+      return this;
+    }
+
+    public RequestApprovalBuilder timeSeconds(final UInt64 timeSeconds) {
       this.timeSeconds = timeSeconds;
+      return this;
+    }
+
+    public RequestApprovalBuilder objectCount(final long objectsCount) {
       this.objectsCount = objectsCount;
+      return this;
     }
 
     public RequestApproval build() {
-      return new RequestApproval(UUID.randomUUID(), this.timeSeconds, this.objectsCount);
+      return new RequestApproval(this.requestId, this.timeSeconds, this.objectsCount);
     }
   }
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/RequestApproval.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/RequestApproval.java
@@ -17,22 +17,16 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 public class RequestApproval {
 
-  private final int requestId;
-  private final UInt64 timeSeconds;
+  private RateTracker.ObjectRequestsEntryKey requestKey;
   private final long objectsCount;
 
-  private RequestApproval(int requestId, UInt64 timeSeconds, long objectsCount) {
-    this.requestId = requestId;
-    this.timeSeconds = timeSeconds;
+  private RequestApproval(RateTracker.ObjectRequestsEntryKey requestKey, long objectsCount) {
+    this.requestKey = requestKey;
     this.objectsCount = objectsCount;
   }
 
-  public int getRequestId() {
-    return requestId;
-  }
-
-  public UInt64 getTimeSeconds() {
-    return timeSeconds;
+  public RateTracker.ObjectRequestsEntryKey getRequestKey() {
+    return requestKey;
   }
 
   public long getObjectsCount() {
@@ -60,7 +54,9 @@ public class RequestApproval {
     }
 
     public RequestApproval build() {
-      return new RequestApproval(this.requestId, this.timeSeconds, this.objectsCount);
+      return new RequestApproval(
+          new RateTracker.ObjectRequestsEntryKey(this.timeSeconds, this.requestId),
+          this.objectsCount);
     }
   }
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/RequestApproval.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/RequestApproval.java
@@ -13,11 +13,12 @@
 
 package tech.pegasys.teku.networking.eth2.peers;
 
+import java.util.Objects;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 public class RequestApproval {
 
-  private RequestsKey requestKey;
+  private final RequestsKey requestKey;
   private final long objectsCount;
 
   private RequestApproval(RequestsKey requestKey, long objectsCount) {
@@ -31,6 +32,23 @@ public class RequestApproval {
 
   public long getObjectsCount() {
     return objectsCount;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final RequestApproval that = (RequestApproval) o;
+    return objectsCount == that.objectsCount && Objects.equals(requestKey, that.requestKey);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(requestKey, objectsCount);
   }
 
   public static final class RequestApprovalBuilder {
@@ -48,7 +66,7 @@ public class RequestApproval {
       return this;
     }
 
-    public RequestApprovalBuilder objectCount(final long objectsCount) {
+    public RequestApprovalBuilder objectsCount(final long objectsCount) {
       this.objectsCount = objectsCount;
       return this;
     }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/RequestApproval.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/RequestApproval.java
@@ -17,15 +17,15 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 public class RequestApproval {
 
-  private RateTracker.ObjectRequestsEntryKey requestKey;
+  private ObjectRequestsKey requestKey;
   private final long objectsCount;
 
-  private RequestApproval(RateTracker.ObjectRequestsEntryKey requestKey, long objectsCount) {
+  private RequestApproval(ObjectRequestsKey requestKey, long objectsCount) {
     this.requestKey = requestKey;
     this.objectsCount = objectsCount;
   }
 
-  public RateTracker.ObjectRequestsEntryKey getRequestKey() {
+  public ObjectRequestsKey getRequestKey() {
     return requestKey;
   }
 
@@ -55,8 +55,7 @@ public class RequestApproval {
 
     public RequestApproval build() {
       return new RequestApproval(
-          new RateTracker.ObjectRequestsEntryKey(this.timeSeconds, this.requestId),
-          this.objectsCount);
+          new ObjectRequestsKey(this.timeSeconds, this.requestId), this.objectsCount);
     }
   }
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/RequestApproval.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/RequestApproval.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright ConsenSys Software Inc., 2023
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.networking.eth2.peers;
+
+import java.util.UUID;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+public class RequestApproval {
+
+  private final UUID requestId;
+  private final UInt64 timeSeconds;
+  private final long objectsCount;
+
+  private RequestApproval(UUID requestId, UInt64 timeSeconds, long objectsCount) {
+    this.requestId = requestId;
+    this.timeSeconds = timeSeconds;
+    this.objectsCount = objectsCount;
+  }
+
+  public UUID getRequestId() {
+    return requestId;
+  }
+
+  public UInt64 getTimeSeconds() {
+    return timeSeconds;
+  }
+
+  public long getObjectsCount() {
+    return objectsCount;
+  }
+
+  public static final class RequestApprovalBuilder {
+    private UInt64 timeSeconds;
+    private final long objectsCount;
+
+    public RequestApprovalBuilder(final UInt64 timeSeconds, final long objectsCount) {
+      this.timeSeconds = timeSeconds;
+      this.objectsCount = objectsCount;
+    }
+
+    public RequestApproval build() {
+      return new RequestApproval(UUID.randomUUID(), this.timeSeconds, this.objectsCount);
+    }
+  }
+}

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/RequestsKey.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/RequestsKey.java
@@ -41,14 +41,14 @@ public class RequestsKey implements Comparable<RequestsKey> {
   }
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(final Object o) {
     if (this == o) {
       return true;
     }
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    RequestsKey that = (RequestsKey) o;
+    final RequestsKey that = (RequestsKey) o;
     return Objects.equals(this.timeSeconds, that.timeSeconds) && this.requestId == that.requestId;
   }
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/RequestsKey.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/RequestsKey.java
@@ -18,11 +18,11 @@ import java.util.Objects;
 import org.jetbrains.annotations.NotNull;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
-public class ObjectRequestsKey implements Comparable<ObjectRequestsKey> {
+public class RequestsKey implements Comparable<RequestsKey> {
   private final UInt64 timeSeconds;
   private final int requestId;
 
-  public ObjectRequestsKey(final UInt64 timeSeconds, final int requestId) {
+  public RequestsKey(final UInt64 timeSeconds, final int requestId) {
     this.timeSeconds = timeSeconds;
     this.requestId = requestId;
   }
@@ -48,14 +48,14 @@ public class ObjectRequestsKey implements Comparable<ObjectRequestsKey> {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    ObjectRequestsKey that = (ObjectRequestsKey) o;
+    RequestsKey that = (RequestsKey) o;
     return Objects.equals(this.timeSeconds, that.timeSeconds) && this.requestId == that.requestId;
   }
 
   @Override
-  public int compareTo(@NotNull ObjectRequestsKey other) {
-    return Comparator.comparing(ObjectRequestsKey::getTimeSeconds)
-        .thenComparingInt(ObjectRequestsKey::getRequestId)
+  public int compareTo(@NotNull RequestsKey other) {
+    return Comparator.comparing(RequestsKey::getTimeSeconds)
+        .thenComparingInt(RequestsKey::getRequestId)
         .compare(this, other);
   }
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandler.java
@@ -136,7 +136,9 @@ public class BeaconBlocksByRangeMessageHandler
         .finish(
             requestState -> {
               peer.adjustBlockRequests(
-                  requestState.sentBlocks.get(), rateLimiterResponse.getLeft());
+                  requestState.sentBlocks.get(),
+                  message.getCount().longValue(),
+                  rateLimiterResponse.getLeft());
               totalBlocksRequestedCounter.inc(requestState.sentBlocks.get());
               callback.completeSuccessfully();
             },

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandler.java
@@ -131,7 +131,7 @@ public class BeaconBlocksByRangeMessageHandler
     }
 
     requestCounter.labels("ok").inc();
-
+    totalBlocksRequestedCounter.inc(message.getCount().longValue());
     sendMatchingBlocks(message, callback)
         .finish(
             requestState -> {
@@ -139,7 +139,6 @@ public class BeaconBlocksByRangeMessageHandler
                 peer.adjustBlockRequests(
                     blockRequestsApproval.get(), requestState.sentBlocks.get());
               }
-              totalBlocksRequestedCounter.inc(requestState.sentBlocks.get());
               callback.completeSuccessfully();
             },
             error -> {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandler.java
@@ -34,7 +34,7 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
-import tech.pegasys.teku.networking.eth2.peers.RateTracker;
+import tech.pegasys.teku.networking.eth2.peers.RequestApproval;
 import tech.pegasys.teku.networking.eth2.rpc.beaconchain.BeaconChainMethodIds;
 import tech.pegasys.teku.networking.eth2.rpc.core.PeerRequiredLocalMessageHandler;
 import tech.pegasys.teku.networking.eth2.rpc.core.ResponseCallback;
@@ -122,7 +122,7 @@ public class BeaconBlocksByRangeMessageHandler
         message.getStartSlot(),
         message.getStep());
 
-    final Optional<RateTracker.ObjectsRequestResponse> blockRequests =
+    final Optional<RequestApproval> blockRequests =
         peer.popBlockRequests(callback, message.getCount().longValue());
 
     if (!peer.popRequest() || blockRequests.isEmpty()) {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRootMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRootMessageHandler.java
@@ -30,7 +30,7 @@ import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszBytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
-import tech.pegasys.teku.networking.eth2.peers.RateTracker;
+import tech.pegasys.teku.networking.eth2.peers.RequestApproval;
 import tech.pegasys.teku.networking.eth2.rpc.beaconchain.BeaconChainMethodIds;
 import tech.pegasys.teku.networking.eth2.rpc.core.PeerRequiredLocalMessageHandler;
 import tech.pegasys.teku.networking.eth2.rpc.core.ResponseCallback;
@@ -92,7 +92,7 @@ public class BeaconBlocksByRootMessageHandler
 
       SafeFuture<Void> future = SafeFuture.COMPLETE;
 
-      final Optional<RateTracker.ObjectsRequestResponse> blockRequests =
+      final Optional<RequestApproval> blockRequests =
           peer.popBlockRequests(callback, message.size());
 
       if (!peer.popRequest() || blockRequests.isEmpty()) {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRootMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRootMessageHandler.java
@@ -92,10 +92,10 @@ public class BeaconBlocksByRootMessageHandler
 
       SafeFuture<Void> future = SafeFuture.COMPLETE;
 
-      final Optional<RequestApproval> blockRequestsApproval =
+      final Optional<RequestApproval> approveBlocksRequest =
           peer.popBlockRequests(callback, message.size());
 
-      if (!peer.popRequest() || blockRequestsApproval.isEmpty()) {
+      if (!peer.popRequest() || approveBlocksRequest.isEmpty()) {
         requestCounter.labels("rate_limited").inc();
         return;
       }
@@ -130,13 +130,12 @@ public class BeaconBlocksByRootMessageHandler
       future.finish(
           () -> {
             if (sentBlocks.get() != message.size()) {
-              peer.adjustBlockRequests(blockRequestsApproval.get(), sentBlocks.get());
+              peer.adjustBlockRequests(approveBlocksRequest.get(), sentBlocks.get());
             }
-            totalBlocksRequestedCounter.inc(sentBlocks.get());
             callback.completeSuccessfully();
           },
           err -> {
-            peer.adjustBlockRequests(blockRequestsApproval.get(), 0);
+            peer.adjustBlockRequests(approveBlocksRequest.get(), 0);
             handleError(callback, err);
           });
     } else {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRootMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRootMessageHandler.java
@@ -101,7 +101,7 @@ public class BeaconBlocksByRootMessageHandler
       }
 
       requestCounter.labels("ok").inc();
-
+      totalBlocksRequestedCounter.inc(message.size());
       final AtomicInteger sentBlocks = new AtomicInteger(0);
 
       for (SszBytes32 blockRoot : message) {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRootMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRootMessageHandler.java
@@ -129,12 +129,17 @@ public class BeaconBlocksByRootMessageHandler
       }
       future.finish(
           () -> {
-            peer.adjustBlockRequests(
-                sentBlocks.get(), message.size(), rateLimiterResponse.getLeft());
+            if (sentBlocks.get() != message.size()) {
+              peer.adjustBlockRequests(
+                  sentBlocks.get(), message.size(), rateLimiterResponse.getLeft());
+            }
             totalBlocksRequestedCounter.inc(sentBlocks.get());
             callback.completeSuccessfully();
           },
-          err -> handleError(callback, err));
+          err -> {
+            peer.cancelBlockRequests(message.size(), rateLimiterResponse.getLeft());
+            handleError(callback, err);
+          });
     } else {
       requestCounter.labels("ok").inc();
       callback.completeSuccessfully();

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRootMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRootMessageHandler.java
@@ -92,10 +92,10 @@ public class BeaconBlocksByRootMessageHandler
 
       SafeFuture<Void> future = SafeFuture.COMPLETE;
 
-      final Optional<RequestApproval> approveBlocksRequest =
-          peer.popBlockRequests(callback, message.size());
+      final Optional<RequestApproval> blocksRequestApproval =
+          peer.approveBlocksRequest(callback, message.size());
 
-      if (!peer.popRequest() || approveBlocksRequest.isEmpty()) {
+      if (!peer.approveRequest() || blocksRequestApproval.isEmpty()) {
         requestCounter.labels("rate_limited").inc();
         return;
       }
@@ -130,12 +130,12 @@ public class BeaconBlocksByRootMessageHandler
       future.finish(
           () -> {
             if (sentBlocks.get() != message.size()) {
-              peer.adjustBlockRequests(approveBlocksRequest.get(), sentBlocks.get());
+              peer.adjustBlocksRequest(blocksRequestApproval.get(), sentBlocks.get());
             }
             callback.completeSuccessfully();
           },
           err -> {
-            peer.adjustBlockRequests(approveBlocksRequest.get(), 0);
+            peer.adjustBlocksRequest(blocksRequestApproval.get(), 0);
             handleError(callback, err);
           });
     } else {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRootMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRootMessageHandler.java
@@ -120,11 +120,10 @@ public class BeaconBlocksByRootMessageHandler
                               }
                               return block
                                   .map(
-                                      signedBeaconBlock -> {
-                                        callback.respond(signedBeaconBlock);
-                                        sentBlocks.incrementAndGet();
-                                        return SafeFuture.COMPLETE;
-                                      })
+                                      signedBeaconBlock ->
+                                          callback
+                                              .respond(signedBeaconBlock)
+                                              .thenRun(sentBlocks::incrementAndGet))
                                   .orElse(SafeFuture.COMPLETE);
                             }));
       }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRootMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRootMessageHandler.java
@@ -129,7 +129,8 @@ public class BeaconBlocksByRootMessageHandler
       }
       future.finish(
           () -> {
-            peer.adjustBlockRequests(sentBlocks.get(), rateLimiterResponse.getLeft());
+            peer.adjustBlockRequests(
+                sentBlocks.get(), message.size(), rateLimiterResponse.getLeft());
             totalBlocksRequestedCounter.inc(sentBlocks.get());
             callback.completeSuccessfully();
           },

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRootMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRootMessageHandler.java
@@ -92,10 +92,10 @@ public class BeaconBlocksByRootMessageHandler
 
       SafeFuture<Void> future = SafeFuture.COMPLETE;
 
-      final Optional<RequestApproval> blockRequests =
+      final Optional<RequestApproval> blockRequestsApproval =
           peer.popBlockRequests(callback, message.size());
 
-      if (!peer.popRequest() || blockRequests.isEmpty()) {
+      if (!peer.popRequest() || blockRequestsApproval.isEmpty()) {
         requestCounter.labels("rate_limited").inc();
         return;
       }
@@ -130,13 +130,13 @@ public class BeaconBlocksByRootMessageHandler
       future.finish(
           () -> {
             if (sentBlocks.get() != message.size()) {
-              peer.adjustBlockRequests(blockRequests.get(), sentBlocks.get());
+              peer.adjustBlockRequests(blockRequestsApproval.get(), sentBlocks.get());
             }
             totalBlocksRequestedCounter.inc(sentBlocks.get());
             callback.completeSuccessfully();
           },
           err -> {
-            peer.adjustBlockRequests(blockRequests.get(), 0);
+            peer.adjustBlockRequests(blockRequestsApproval.get(), 0);
             handleError(callback, err);
           });
     } else {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandler.java
@@ -34,7 +34,7 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
-import tech.pegasys.teku.networking.eth2.peers.RateTracker;
+import tech.pegasys.teku.networking.eth2.peers.RequestApproval;
 import tech.pegasys.teku.networking.eth2.rpc.core.PeerRequiredLocalMessageHandler;
 import tech.pegasys.teku.networking.eth2.rpc.core.ResponseCallback;
 import tech.pegasys.teku.networking.eth2.rpc.core.RpcException;
@@ -118,7 +118,7 @@ public class BlobSidecarsByRangeMessageHandler
       return;
     }
 
-    final Optional<RateTracker.ObjectsRequestResponse> blobSidecarRequests =
+    final Optional<RequestApproval> blobSidecarRequests =
         peer.popBlobSidecarRequests(callback, requestedCount.longValue());
 
     if (!peer.popRequest() || blobSidecarRequests.isEmpty()) {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandler.java
@@ -172,7 +172,8 @@ public class BlobSidecarsByRangeMessageHandler
         .finish(
             requestState -> {
               final int sentBlobSidecars = requestState.sentBlobSidecars.get();
-              peer.adjustBlobSidecarRequests(sentBlobSidecars, rateLimiterResponse.getLeft());
+              peer.adjustBlobSidecarRequests(
+                  sentBlobSidecars, requestedCount.longValue(), rateLimiterResponse.getLeft());
               totalBlobSidecarsRequestedCounter.inc(sentBlobSidecars);
               LOG.trace("Sent {} blob sidecars to peer {}.", sentBlobSidecars, peer.getId());
               callback.completeSuccessfully();

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandler.java
@@ -118,10 +118,10 @@ public class BlobSidecarsByRangeMessageHandler
       return;
     }
 
-    final Optional<RequestApproval> blobSidecarRequestsApproval =
+    final Optional<RequestApproval> approveBlobSidecarsRequest =
         peer.popBlobSidecarRequests(callback, requestedCount.longValue());
 
-    if (!peer.popRequest() || blobSidecarRequestsApproval.isEmpty()) {
+    if (!peer.popRequest() || approveBlobSidecarsRequest.isEmpty()) {
       requestCounter.labels("rate_limited").inc();
       return;
     }
@@ -174,13 +174,13 @@ public class BlobSidecarsByRangeMessageHandler
             requestState -> {
               final int sentBlobSidecars = requestState.sentBlobSidecars.get();
               if (sentBlobSidecars != requestedCount.longValue()) {
-                peer.adjustBlobSidecarRequests(blobSidecarRequestsApproval.get(), sentBlobSidecars);
+                peer.adjustBlobSidecarRequests(approveBlobSidecarsRequest.get(), sentBlobSidecars);
               }
               LOG.trace("Sent {} blob sidecars to peer {}.", sentBlobSidecars, peer.getId());
               callback.completeSuccessfully();
             },
             error -> {
-              peer.adjustBlobSidecarRequests(blobSidecarRequestsApproval.get(), 0);
+              peer.adjustBlobSidecarRequests(approveBlobSidecarsRequest.get(), 0);
               handleProcessingRequestError(error, callback);
             });
   }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandler.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.SortedMap;
 import java.util.concurrent.atomic.AtomicInteger;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
@@ -35,6 +34,7 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
+import tech.pegasys.teku.networking.eth2.peers.RateTracker;
 import tech.pegasys.teku.networking.eth2.rpc.core.PeerRequiredLocalMessageHandler;
 import tech.pegasys.teku.networking.eth2.rpc.core.ResponseCallback;
 import tech.pegasys.teku.networking.eth2.rpc.core.RpcException;
@@ -118,10 +118,10 @@ public class BlobSidecarsByRangeMessageHandler
       return;
     }
 
-    final Pair<UInt64, Boolean> rateLimiterResponse =
+    final Optional<RateTracker.ObjectsRequestResponse> blobSidecarRequests =
         peer.popBlobSidecarRequests(callback, requestedCount.longValue());
 
-    if (!peer.popRequest() || !rateLimiterResponse.getRight()) {
+    if (!peer.popRequest() || blobSidecarRequests.isEmpty()) {
       requestCounter.labels("rate_limited").inc();
       return;
     }
@@ -173,16 +173,14 @@ public class BlobSidecarsByRangeMessageHandler
             requestState -> {
               final int sentBlobSidecars = requestState.sentBlobSidecars.get();
               if (sentBlobSidecars != requestedCount.longValue()) {
-                peer.adjustBlobSidecarRequests(
-                    sentBlobSidecars, requestedCount.longValue(), rateLimiterResponse.getLeft());
+                peer.adjustBlobSidecarRequests(blobSidecarRequests.get(), sentBlobSidecars);
               }
               totalBlobSidecarsRequestedCounter.inc(sentBlobSidecars);
               LOG.trace("Sent {} blob sidecars to peer {}.", sentBlobSidecars, peer.getId());
               callback.completeSuccessfully();
             },
             error -> {
-              peer.cancelBlobSidecarRequests(
-                  requestedCount.longValue(), rateLimiterResponse.getLeft());
+              peer.adjustBlobSidecarRequests(blobSidecarRequests.get(), 0);
               handleProcessingRequestError(error, callback);
             });
   }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandler.java
@@ -118,10 +118,10 @@ public class BlobSidecarsByRangeMessageHandler
       return;
     }
 
-    final Optional<RequestApproval> blobSidecarRequests =
+    final Optional<RequestApproval> blobSidecarRequestsApproval =
         peer.popBlobSidecarRequests(callback, requestedCount.longValue());
 
-    if (!peer.popRequest() || blobSidecarRequests.isEmpty()) {
+    if (!peer.popRequest() || blobSidecarRequestsApproval.isEmpty()) {
       requestCounter.labels("rate_limited").inc();
       return;
     }
@@ -173,14 +173,14 @@ public class BlobSidecarsByRangeMessageHandler
             requestState -> {
               final int sentBlobSidecars = requestState.sentBlobSidecars.get();
               if (sentBlobSidecars != requestedCount.longValue()) {
-                peer.adjustBlobSidecarRequests(blobSidecarRequests.get(), sentBlobSidecars);
+                peer.adjustBlobSidecarRequests(blobSidecarRequestsApproval.get(), sentBlobSidecars);
               }
               totalBlobSidecarsRequestedCounter.inc(sentBlobSidecars);
               LOG.trace("Sent {} blob sidecars to peer {}.", sentBlobSidecars, peer.getId());
               callback.completeSuccessfully();
             },
             error -> {
-              peer.adjustBlobSidecarRequests(blobSidecarRequests.get(), 0);
+              peer.adjustBlobSidecarRequests(blobSidecarRequestsApproval.get(), 0);
               handleProcessingRequestError(error, callback);
             });
   }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandler.java
@@ -118,10 +118,10 @@ public class BlobSidecarsByRangeMessageHandler
       return;
     }
 
-    final Optional<RequestApproval> approveBlobSidecarsRequest =
-        peer.popBlobSidecarRequests(callback, requestedCount.longValue());
+    final Optional<RequestApproval> blobSidecarsRequestApproval =
+        peer.approveBlobSidecarsRequest(callback, requestedCount.longValue());
 
-    if (!peer.popRequest() || approveBlobSidecarsRequest.isEmpty()) {
+    if (!peer.approveRequest() || blobSidecarsRequestApproval.isEmpty()) {
       requestCounter.labels("rate_limited").inc();
       return;
     }
@@ -174,13 +174,13 @@ public class BlobSidecarsByRangeMessageHandler
             requestState -> {
               final int sentBlobSidecars = requestState.sentBlobSidecars.get();
               if (sentBlobSidecars != requestedCount.longValue()) {
-                peer.adjustBlobSidecarRequests(approveBlobSidecarsRequest.get(), sentBlobSidecars);
+                peer.adjustBlobSidecarsRequest(blobSidecarsRequestApproval.get(), sentBlobSidecars);
               }
               LOG.trace("Sent {} blob sidecars to peer {}.", sentBlobSidecars, peer.getId());
               callback.completeSuccessfully();
             },
             error -> {
-              peer.adjustBlobSidecarRequests(approveBlobSidecarsRequest.get(), 0);
+              peer.adjustBlobSidecarsRequest(blobSidecarsRequestApproval.get(), 0);
               handleProcessingRequestError(error, callback);
             });
   }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandler.java
@@ -127,6 +127,7 @@ public class BlobSidecarsByRangeMessageHandler
     }
 
     requestCounter.labels("ok").inc();
+    totalBlobSidecarsRequestedCounter.inc(message.getCount().longValue());
 
     combinedChainDataClient
         .getEarliestAvailableBlobSidecarSlot()
@@ -175,7 +176,6 @@ public class BlobSidecarsByRangeMessageHandler
               if (sentBlobSidecars != requestedCount.longValue()) {
                 peer.adjustBlobSidecarRequests(blobSidecarRequestsApproval.get(), sentBlobSidecars);
               }
-              totalBlobSidecarsRequestedCounter.inc(sentBlobSidecars);
               LOG.trace("Sent {} blob sidecars to peer {}.", sentBlobSidecars, peer.getId());
               callback.completeSuccessfully();
             },

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandler.java
@@ -149,7 +149,8 @@ public class BlobSidecarsByRootMessageHandler
 
     future.finish(
         () -> {
-          peer.adjustBlobSidecarRequests(sentBlobSidecars.get(), rateLimiterResponse.getLeft());
+          peer.adjustBlobSidecarRequests(
+              sentBlobSidecars.get(), message.size(), rateLimiterResponse.getLeft());
           totalBlobSidecarsRequestedCounter.inc(sentBlobSidecars.get());
           callback.completeSuccessfully();
         },

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandler.java
@@ -112,10 +112,10 @@ public class BlobSidecarsByRootMessageHandler
         message.size(),
         message);
 
-    final Optional<RequestApproval> approveBlobSidecarsRequest =
-        peer.popBlobSidecarRequests(callback, message.size());
+    final Optional<RequestApproval> blobSidecarsRequestApproval =
+        peer.approveBlobSidecarsRequest(callback, message.size());
 
-    if (!peer.popRequest() || approveBlobSidecarsRequest.isEmpty()) {
+    if (!peer.approveRequest() || blobSidecarsRequestApproval.isEmpty()) {
       requestCounter.labels("rate_limited").inc();
       return;
     }
@@ -149,13 +149,13 @@ public class BlobSidecarsByRootMessageHandler
     future.finish(
         () -> {
           if (sentBlobSidecars.get() != message.size()) {
-            peer.adjustBlobSidecarRequests(
-                approveBlobSidecarsRequest.get(), sentBlobSidecars.get());
+            peer.adjustBlobSidecarsRequest(
+                blobSidecarsRequestApproval.get(), sentBlobSidecars.get());
           }
           callback.completeSuccessfully();
         },
         err -> {
-          peer.adjustBlobSidecarRequests(approveBlobSidecarsRequest.get(), 0);
+          peer.adjustBlobSidecarsRequest(blobSidecarsRequestApproval.get(), 0);
           handleError(callback, err);
         });
   }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandler.java
@@ -112,10 +112,10 @@ public class BlobSidecarsByRootMessageHandler
         message.size(),
         message);
 
-    final Optional<RequestApproval> blobSidecarRequestsApproval =
+    final Optional<RequestApproval> approveBlobSidecarsRequest =
         peer.popBlobSidecarRequests(callback, message.size());
 
-    if (!peer.popRequest() || blobSidecarRequestsApproval.isEmpty()) {
+    if (!peer.popRequest() || approveBlobSidecarsRequest.isEmpty()) {
       requestCounter.labels("rate_limited").inc();
       return;
     }
@@ -150,12 +150,12 @@ public class BlobSidecarsByRootMessageHandler
         () -> {
           if (sentBlobSidecars.get() != message.size()) {
             peer.adjustBlobSidecarRequests(
-                blobSidecarRequestsApproval.get(), sentBlobSidecars.get());
+                approveBlobSidecarsRequest.get(), sentBlobSidecars.get());
           }
           callback.completeSuccessfully();
         },
         err -> {
-          peer.adjustBlobSidecarRequests(blobSidecarRequestsApproval.get(), 0);
+          peer.adjustBlobSidecarRequests(approveBlobSidecarsRequest.get(), 0);
           handleError(callback, err);
         });
   }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandler.java
@@ -140,11 +140,10 @@ public class BlobSidecarsByRootMessageHandler
                   maybeSidecar ->
                       maybeSidecar
                           .map(
-                              blobSidecar -> {
-                                callback.respond(blobSidecar);
-                                sentBlobSidecars.incrementAndGet();
-                                return SafeFuture.COMPLETE;
-                              })
+                              blobSidecar ->
+                                  callback
+                                      .respond(blobSidecar)
+                                      .thenRun(sentBlobSidecars::incrementAndGet))
                           .orElse(SafeFuture.COMPLETE));
     }
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandler.java
@@ -28,7 +28,7 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
-import tech.pegasys.teku.networking.eth2.peers.RateTracker;
+import tech.pegasys.teku.networking.eth2.peers.RequestApproval;
 import tech.pegasys.teku.networking.eth2.rpc.core.PeerRequiredLocalMessageHandler;
 import tech.pegasys.teku.networking.eth2.rpc.core.ResponseCallback;
 import tech.pegasys.teku.networking.eth2.rpc.core.RpcException;
@@ -112,7 +112,7 @@ public class BlobSidecarsByRootMessageHandler
         message.size(),
         message);
 
-    final Optional<RateTracker.ObjectsRequestResponse> blobSidecarRequests =
+    final Optional<RequestApproval> blobSidecarRequests =
         peer.popBlobSidecarRequests(callback, message.size());
 
     if (!peer.popRequest() || blobSidecarRequests.isEmpty()) {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandler.java
@@ -121,6 +121,7 @@ public class BlobSidecarsByRootMessageHandler
     }
 
     requestCounter.labels("ok").inc();
+    totalBlobSidecarsRequestedCounter.inc(message.size());
 
     SafeFuture<Void> future = SafeFuture.COMPLETE;
     final AtomicInteger sentBlobSidecars = new AtomicInteger(0);
@@ -151,7 +152,6 @@ public class BlobSidecarsByRootMessageHandler
             peer.adjustBlobSidecarRequests(
                 blobSidecarRequestsApproval.get(), sentBlobSidecars.get());
           }
-          totalBlobSidecarsRequestedCounter.inc(sentBlobSidecars.get());
           callback.completeSuccessfully();
         },
         err -> {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/MetadataMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/MetadataMessageHandler.java
@@ -39,7 +39,7 @@ public class MetadataMessageHandler
       Eth2Peer peer,
       EmptyMessage message,
       ResponseCallback<MetadataMessage> callback) {
-    if (!peer.popRequest()) {
+    if (!peer.approveRequest()) {
       return;
     }
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/PingMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/PingMessageHandler.java
@@ -35,7 +35,7 @@ public class PingMessageHandler extends PeerRequiredLocalMessageHandler<PingMess
       final PingMessage message,
       final ResponseCallback<PingMessage> callback) {
     LOG.trace("Peer {} sent ping.", peer.getId());
-    if (!peer.popRequest()) {
+    if (!peer.approveRequest()) {
       return;
     }
     peer.updateMetadataSeqNumber(message.getSeqNumber());

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/StatusMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/StatusMessageHandler.java
@@ -46,7 +46,7 @@ public class StatusMessageHandler
       final StatusMessage message,
       final ResponseCallback<StatusMessage> callback) {
     LOG.trace("Peer {} sent status {}", peer.getId(), message);
-    if (!peer.popRequest()) {
+    if (!peer.approveRequest()) {
       return;
     }
     final PeerStatus status = PeerStatus.fromStatusMessage(message);

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/RateTrackerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/RateTrackerTest.java
@@ -28,7 +28,7 @@ public class RateTrackerTest {
     final RateTracker tracker = new RateTracker(1, 1, timeProvider);
     final long objectCount = 1;
     final Optional<RequestApproval> objectRequests = tracker.popObjectRequests(objectCount);
-    assertRequestsAllowed(objectRequests, objectCount, timeProvider);
+    assertRequestsAllowed(objectRequests, objectCount, 0, timeProvider);
   }
 
   @Test
@@ -36,7 +36,7 @@ public class RateTrackerTest {
     final RateTracker tracker = new RateTracker(1, 15000, timeProvider);
     final long objectCount = 1;
     final Optional<RequestApproval> objectRequests = tracker.popObjectRequests(objectCount);
-    assertRequestsAllowed(objectRequests, objectCount, timeProvider);
+    assertRequestsAllowed(objectRequests, objectCount, 0, timeProvider);
   }
 
   @Test
@@ -45,12 +45,12 @@ public class RateTrackerTest {
     long objectCount = 1;
 
     Optional<RequestApproval> objectRequests = tracker.popObjectRequests(objectCount);
-    assertRequestsAllowed(objectRequests, objectCount, timeProvider);
+    assertRequestsAllowed(objectRequests, objectCount, 0, timeProvider);
 
     timeProvider.advanceTimeBySeconds(2L);
 
     objectRequests = tracker.popObjectRequests(objectCount);
-    assertRequestsAllowed(objectRequests, objectCount, timeProvider);
+    assertRequestsAllowed(objectRequests, objectCount, 0, timeProvider);
   }
 
   @Test
@@ -58,7 +58,7 @@ public class RateTrackerTest {
     final RateTracker tracker = new RateTracker(1, 1, timeProvider);
     final long objectCount = 1;
     Optional<RequestApproval> objectRequests = tracker.popObjectRequests(objectCount);
-    assertRequestsAllowed(objectRequests, objectCount, timeProvider);
+    assertRequestsAllowed(objectRequests, objectCount, 0, timeProvider);
 
     objectRequests = tracker.popObjectRequests(objectCount);
     assertThat(objectRequests).isEmpty();
@@ -69,7 +69,7 @@ public class RateTrackerTest {
     final RateTracker tracker = new RateTracker(10, 1, timeProvider);
     long objectCount = 10;
     Optional<RequestApproval> objectRequests = tracker.popObjectRequests(objectCount);
-    assertRequestsAllowed(objectRequests, objectCount, timeProvider);
+    assertRequestsAllowed(objectRequests, objectCount, 0, timeProvider);
 
     objectRequests = tracker.popObjectRequests(objectCount);
     assertThat(objectRequests).isEmpty();
@@ -78,7 +78,7 @@ public class RateTrackerTest {
 
     objectCount = 1;
     objectRequests = tracker.popObjectRequests(objectCount);
-    assertRequestsAllowed(objectRequests, objectCount, timeProvider);
+    assertRequestsAllowed(objectRequests, objectCount, 0, timeProvider);
   }
 
   @Test
@@ -87,14 +87,14 @@ public class RateTrackerTest {
 
     long objectCount = 9;
     Optional<RequestApproval> objectRequests = tracker.popObjectRequests(objectCount);
-    assertRequestsAllowed(objectRequests, objectCount, timeProvider);
+    assertRequestsAllowed(objectRequests, objectCount, 0, timeProvider);
     // time:1000 count:9
 
     timeProvider.advanceTimeBySeconds(1L);
 
     objectCount = 5;
     objectRequests = tracker.popObjectRequests(objectCount);
-    assertRequestsAllowed(objectRequests, objectCount, timeProvider);
+    assertRequestsAllowed(objectRequests, objectCount, 0, timeProvider);
     // time:1001 count:14
 
     timeProvider.advanceTimeBySeconds(1L);
@@ -108,7 +108,7 @@ public class RateTrackerTest {
 
     objectCount = 5;
     objectRequests = tracker.popObjectRequests(objectCount);
-    assertRequestsAllowed(objectRequests, objectCount, timeProvider);
+    assertRequestsAllowed(objectRequests, objectCount, 0, timeProvider);
     // time:1003 count:10 - reject
 
     objectRequests = tracker.popObjectRequests(objectCount);
@@ -118,13 +118,13 @@ public class RateTrackerTest {
     // time:1006 count:0
     objectCount = 9;
     objectRequests = tracker.popObjectRequests(objectCount);
-    assertRequestsAllowed(objectRequests, objectCount, timeProvider);
+    assertRequestsAllowed(objectRequests, objectCount, 0, timeProvider);
 
     timeProvider.advanceTimeBySeconds(1L);
     // time:1007 count:9
     objectCount = 5;
     objectRequests = tracker.popObjectRequests(objectCount);
-    assertRequestsAllowed(objectRequests, objectCount, timeProvider);
+    assertRequestsAllowed(objectRequests, objectCount, 0, timeProvider);
     // time:1007 count:14 - reject
 
     objectCount = 1;
@@ -135,11 +135,11 @@ public class RateTrackerTest {
     // time:1009 count:5
     objectCount = 4;
     objectRequests = tracker.popObjectRequests(objectCount);
-    assertRequestsAllowed(objectRequests, objectCount, timeProvider);
+    assertRequestsAllowed(objectRequests, objectCount, 0, timeProvider);
     // time:1009 count:9
     objectCount = 1;
     objectRequests = tracker.popObjectRequests(objectCount);
-    assertRequestsAllowed(objectRequests, objectCount, timeProvider);
+    assertRequestsAllowed(objectRequests, objectCount, 1, timeProvider);
     // time:1009 count:10 - reject
     objectCount = 1;
     objectRequests = tracker.popObjectRequests(objectCount);
@@ -152,7 +152,7 @@ public class RateTrackerTest {
 
     // time: 1000, tracker count: 0, limit: 10, remaining: 10
     Optional<RequestApproval> objectRequests = tracker.popObjectRequests(10);
-    assertRequestsAllowed(objectRequests, 10, timeProvider);
+    assertRequestsAllowed(objectRequests, 10, 0, timeProvider);
 
     // time: 1000, tracker count: 10, limit: 10, remaining: 0
     Optional<RequestApproval> anotherObjectRequests = tracker.popObjectRequests(5);
@@ -161,12 +161,12 @@ public class RateTrackerTest {
     tracker.adjustObjectRequests(objectRequests.get(), 3);
     // time: 1000, tracker count: 3, limit: 10, remaining: 7
     objectRequests = tracker.popObjectRequests(7);
-    assertRequestsAllowed(objectRequests, 7, timeProvider);
+    assertRequestsAllowed(objectRequests, 7, 1, timeProvider);
     // time: 1000, tracker count: 10, limit: 10, remaining: 0
     tracker.adjustObjectRequests(objectRequests.get(), 5);
     // time: 1000, tracker count: 8, limit: 10, remaining: 2
     objectRequests = tracker.popObjectRequests(3);
-    assertRequestsAllowed(objectRequests, 3, timeProvider);
+    assertRequestsAllowed(objectRequests, 3, 2, timeProvider);
     // respond as long as the remaining capacity is > 0
     // time: 1000, tracker count: 11, limit: 10, remaining: 0
     tracker.adjustObjectRequests(objectRequests.get(), 3);
@@ -176,10 +176,13 @@ public class RateTrackerTest {
   }
 
   private void assertRequestsAllowed(
-      Optional<RequestApproval> objectRequests, long objectCount, StubTimeProvider timeProvider) {
-    assertThat(objectRequests).isPresent();
-    assertThat(objectRequests.get().getObjectsCount()).isEqualTo(objectCount);
-    assertThat(objectRequests.get().getRequestKey().getTimeSeconds())
-        .isEqualTo(timeProvider.getTimeInSeconds());
+      final Optional<RequestApproval> requestApproval,
+      final long objectCount,
+      final int requestId,
+      final StubTimeProvider timeProvider) {
+    assertThat(requestApproval).isPresent();
+    assertThat(requestApproval.get().getObjectsCount()).isEqualTo(objectCount);
+    assertThat(requestApproval.get().getRequestKey())
+        .isEqualTo(new ObjectRequestsKey(timeProvider.getTimeInSeconds(), requestId));
   }
 }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/RateTrackerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/RateTrackerTest.java
@@ -183,6 +183,6 @@ public class RateTrackerTest {
     assertThat(requestApproval).isPresent();
     assertThat(requestApproval.get().getObjectsCount()).isEqualTo(objectCount);
     assertThat(requestApproval.get().getRequestKey())
-        .isEqualTo(new ObjectRequestsKey(timeProvider.getTimeInSeconds(), requestId));
+        .isEqualTo(new RequestsKey(timeProvider.getTimeInSeconds(), requestId));
   }
 }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/RateTrackerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/RateTrackerTest.java
@@ -27,8 +27,7 @@ public class RateTrackerTest {
   public void shouldAllowAddingItemsWithinLimit() {
     final RateTracker tracker = new RateTracker(1, 1, timeProvider);
     final long objectCount = 1;
-    final Optional<RateTracker.ObjectsRequestResponse> objectRequests =
-        tracker.popObjectRequests(objectCount);
+    final Optional<RequestApproval> objectRequests = tracker.popObjectRequests(objectCount);
     assertRequestsAllowed(objectRequests, objectCount, timeProvider);
   }
 
@@ -36,8 +35,7 @@ public class RateTrackerTest {
   public void shouldNotUnderflowWhenTimeWindowGreaterThanCurrentTime() {
     final RateTracker tracker = new RateTracker(1, 15000, timeProvider);
     final long objectCount = 1;
-    final Optional<RateTracker.ObjectsRequestResponse> objectRequests =
-        tracker.popObjectRequests(objectCount);
+    final Optional<RequestApproval> objectRequests = tracker.popObjectRequests(objectCount);
     assertRequestsAllowed(objectRequests, objectCount, timeProvider);
   }
 
@@ -46,8 +44,7 @@ public class RateTrackerTest {
     final RateTracker tracker = new RateTracker(1, 1, timeProvider);
     long objectCount = 1;
 
-    Optional<RateTracker.ObjectsRequestResponse> objectRequests =
-        tracker.popObjectRequests(objectCount);
+    Optional<RequestApproval> objectRequests = tracker.popObjectRequests(objectCount);
     assertRequestsAllowed(objectRequests, objectCount, timeProvider);
 
     timeProvider.advanceTimeBySeconds(2L);
@@ -60,8 +57,7 @@ public class RateTrackerTest {
   public void shouldReturnFalseIfCacheFull() {
     final RateTracker tracker = new RateTracker(1, 1, timeProvider);
     final long objectCount = 1;
-    Optional<RateTracker.ObjectsRequestResponse> objectRequests =
-        tracker.popObjectRequests(objectCount);
+    Optional<RequestApproval> objectRequests = tracker.popObjectRequests(objectCount);
     assertRequestsAllowed(objectRequests, objectCount, timeProvider);
 
     objectRequests = tracker.popObjectRequests(objectCount);
@@ -72,8 +68,7 @@ public class RateTrackerTest {
   public void shouldAddMultipleValuesToCache() throws InterruptedException {
     final RateTracker tracker = new RateTracker(10, 1, timeProvider);
     long objectCount = 10;
-    Optional<RateTracker.ObjectsRequestResponse> objectRequests =
-        tracker.popObjectRequests(objectCount);
+    Optional<RequestApproval> objectRequests = tracker.popObjectRequests(objectCount);
     assertRequestsAllowed(objectRequests, objectCount, timeProvider);
 
     objectRequests = tracker.popObjectRequests(objectCount);
@@ -91,8 +86,7 @@ public class RateTrackerTest {
     final RateTracker tracker = new RateTracker(10, 2, timeProvider);
 
     long objectCount = 9;
-    Optional<RateTracker.ObjectsRequestResponse> objectRequests =
-        tracker.popObjectRequests(objectCount);
+    Optional<RequestApproval> objectRequests = tracker.popObjectRequests(objectCount);
     assertRequestsAllowed(objectRequests, objectCount, timeProvider);
     // time:1000 count:9
 
@@ -157,12 +151,11 @@ public class RateTrackerTest {
     final RateTracker tracker = new RateTracker(10, 2, timeProvider);
 
     // time: 1000, tracker count: 0, limit: 10, remaining: 10
-    Optional<RateTracker.ObjectsRequestResponse> objectRequests = tracker.popObjectRequests(10);
+    Optional<RequestApproval> objectRequests = tracker.popObjectRequests(10);
     assertRequestsAllowed(objectRequests, 10, timeProvider);
 
     // time: 1000, tracker count: 10, limit: 10, remaining: 0
-    Optional<RateTracker.ObjectsRequestResponse> anotherObjectRequests =
-        tracker.popObjectRequests(5);
+    Optional<RequestApproval> anotherObjectRequests = tracker.popObjectRequests(5);
     assertThat(anotherObjectRequests).isEmpty();
 
     tracker.adjustObjectRequests(objectRequests.get(), 3);
@@ -183,9 +176,7 @@ public class RateTrackerTest {
   }
 
   private void assertRequestsAllowed(
-      Optional<RateTracker.ObjectsRequestResponse> objectRequests,
-      long objectCount,
-      StubTimeProvider timeProvider) {
+      Optional<RequestApproval> objectRequests, long objectCount, StubTimeProvider timeProvider) {
     assertThat(objectRequests).isPresent();
     assertThat(objectRequests.get().getObjectsCount()).isEqualTo(objectCount);
     assertThat(objectRequests.get().getTimeSeconds()).isEqualTo(timeProvider.getTimeInSeconds());

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/RateTrackerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/RateTrackerTest.java
@@ -34,123 +34,123 @@ public class RateTrackerTest {
   @Test
   public void shouldAllowAddingItemsWithinLimit() {
     final RateTracker tracker = new RateTracker(1, 1, timeProvider);
-    final long objectCount = 1;
-    final Optional<RequestApproval> objectRequests = tracker.popObjectRequests(objectCount);
-    assertRequestsAllowed(objectRequests, objectCount, timeProvider);
+    final long objectsCount = 1;
+    final Optional<RequestApproval> objectRequests = tracker.approveObjectsRequest(objectsCount);
+    assertRequestsAllowed(objectRequests, objectsCount, timeProvider);
   }
 
   @Test
   public void shouldNotUnderflowWhenTimeWindowGreaterThanCurrentTime() {
     final RateTracker tracker = new RateTracker(1, 15000, timeProvider);
-    final long objectCount = 1;
-    final Optional<RequestApproval> objectRequests = tracker.popObjectRequests(objectCount);
-    assertRequestsAllowed(objectRequests, objectCount, timeProvider);
+    final long objectsCount = 1;
+    final Optional<RequestApproval> objectRequests = tracker.approveObjectsRequest(objectsCount);
+    assertRequestsAllowed(objectRequests, objectsCount, timeProvider);
   }
 
   @Test
   public void shouldAllowAddingItemsAfterTimeoutPasses() {
     final RateTracker tracker = new RateTracker(1, 1, timeProvider);
-    long objectCount = 1;
+    long objectsCount = 1;
 
-    Optional<RequestApproval> objectRequests = tracker.popObjectRequests(objectCount);
-    assertRequestsAllowed(objectRequests, objectCount, timeProvider);
+    Optional<RequestApproval> objectRequests = tracker.approveObjectsRequest(objectsCount);
+    assertRequestsAllowed(objectRequests, objectsCount, timeProvider);
 
     timeProvider.advanceTimeBySeconds(2L);
 
-    objectRequests = tracker.popObjectRequests(objectCount);
-    assertRequestsAllowed(objectRequests, objectCount, timeProvider);
+    objectRequests = tracker.approveObjectsRequest(objectsCount);
+    assertRequestsAllowed(objectRequests, objectsCount, timeProvider);
   }
 
   @Test
   public void shouldReturnFalseIfCacheFull() {
     final RateTracker tracker = new RateTracker(1, 1, timeProvider);
-    final long objectCount = 1;
-    Optional<RequestApproval> objectRequests = tracker.popObjectRequests(objectCount);
-    assertRequestsAllowed(objectRequests, objectCount, timeProvider);
+    final long objectsCount = 1;
+    Optional<RequestApproval> objectRequests = tracker.approveObjectsRequest(objectsCount);
+    assertRequestsAllowed(objectRequests, objectsCount, timeProvider);
 
-    objectRequests = tracker.popObjectRequests(objectCount);
+    objectRequests = tracker.approveObjectsRequest(objectsCount);
     assertThat(objectRequests).isEmpty();
   }
 
   @Test
   public void shouldAddMultipleValuesToCache() throws InterruptedException {
     final RateTracker tracker = new RateTracker(10, 1, timeProvider);
-    long objectCount = 10;
-    Optional<RequestApproval> objectRequests = tracker.popObjectRequests(objectCount);
-    assertRequestsAllowed(objectRequests, objectCount, timeProvider);
+    long objectsCount = 10;
+    Optional<RequestApproval> objectRequests = tracker.approveObjectsRequest(objectsCount);
+    assertRequestsAllowed(objectRequests, objectsCount, timeProvider);
 
-    objectRequests = tracker.popObjectRequests(objectCount);
+    objectRequests = tracker.approveObjectsRequest(objectsCount);
     assertThat(objectRequests).isEmpty();
 
     timeProvider.advanceTimeBySeconds(2L);
 
-    objectCount = 1;
-    objectRequests = tracker.popObjectRequests(objectCount);
-    assertRequestsAllowed(objectRequests, objectCount, timeProvider);
+    objectsCount = 1;
+    objectRequests = tracker.approveObjectsRequest(objectsCount);
+    assertRequestsAllowed(objectRequests, objectsCount, timeProvider);
   }
 
   @Test
   public void shouldMaintainCounterOverTime() {
     final RateTracker tracker = new RateTracker(10, 2, timeProvider);
 
-    long objectCount = 9;
-    Optional<RequestApproval> objectRequests = tracker.popObjectRequests(objectCount);
-    assertRequestsAllowed(objectRequests, objectCount, timeProvider);
+    long objectsCount = 9;
+    Optional<RequestApproval> objectRequests = tracker.approveObjectsRequest(objectsCount);
+    assertRequestsAllowed(objectRequests, objectsCount, timeProvider);
     // time:1000 count:9
 
     timeProvider.advanceTimeBySeconds(1L);
 
-    objectCount = 5;
-    objectRequests = tracker.popObjectRequests(objectCount);
-    assertRequestsAllowed(objectRequests, objectCount, timeProvider);
+    objectsCount = 5;
+    objectRequests = tracker.approveObjectsRequest(objectsCount);
+    assertRequestsAllowed(objectRequests, objectsCount, timeProvider);
     // time:1001 count:14
 
     timeProvider.advanceTimeBySeconds(1L);
     // time:1002 count:14 - reject.
-    objectCount = 5;
-    objectRequests = tracker.popObjectRequests(objectCount);
+    objectsCount = 5;
+    objectRequests = tracker.approveObjectsRequest(objectsCount);
     assertThat(objectRequests).isEmpty();
 
     timeProvider.advanceTimeBySeconds(1L);
     // time:1003 count:5
 
-    objectCount = 5;
-    objectRequests = tracker.popObjectRequests(objectCount);
-    assertRequestsAllowed(objectRequests, objectCount, timeProvider);
+    objectsCount = 5;
+    objectRequests = tracker.approveObjectsRequest(objectsCount);
+    assertRequestsAllowed(objectRequests, objectsCount, timeProvider);
     // time:1003 count:10 - reject
 
-    objectRequests = tracker.popObjectRequests(objectCount);
+    objectRequests = tracker.approveObjectsRequest(objectsCount);
     assertThat(objectRequests).isEmpty();
 
     timeProvider.advanceTimeBySeconds(3L);
     // time:1006 count:0
-    objectCount = 9;
-    objectRequests = tracker.popObjectRequests(objectCount);
-    assertRequestsAllowed(objectRequests, objectCount, timeProvider);
+    objectsCount = 9;
+    objectRequests = tracker.approveObjectsRequest(objectsCount);
+    assertRequestsAllowed(objectRequests, objectsCount, timeProvider);
 
     timeProvider.advanceTimeBySeconds(1L);
     // time:1007 count:9
-    objectCount = 5;
-    objectRequests = tracker.popObjectRequests(objectCount);
-    assertRequestsAllowed(objectRequests, objectCount, timeProvider);
+    objectsCount = 5;
+    objectRequests = tracker.approveObjectsRequest(objectsCount);
+    assertRequestsAllowed(objectRequests, objectsCount, timeProvider);
     // time:1007 count:14 - reject
 
-    objectCount = 1;
-    objectRequests = tracker.popObjectRequests(objectCount);
+    objectsCount = 1;
+    objectRequests = tracker.approveObjectsRequest(objectsCount);
     assertThat(objectRequests).isEmpty();
 
     timeProvider.advanceTimeBySeconds(2L);
     // time:1009 count:5
-    objectCount = 4;
-    objectRequests = tracker.popObjectRequests(objectCount);
-    assertRequestsAllowed(objectRequests, objectCount, timeProvider);
+    objectsCount = 4;
+    objectRequests = tracker.approveObjectsRequest(objectsCount);
+    assertRequestsAllowed(objectRequests, objectsCount, timeProvider);
     // time:1009 count:9
-    objectCount = 1;
-    objectRequests = tracker.popObjectRequests(objectCount);
-    assertRequestsAllowed(objectRequests, objectCount, timeProvider);
+    objectsCount = 1;
+    objectRequests = tracker.approveObjectsRequest(objectsCount);
+    assertRequestsAllowed(objectRequests, objectsCount, timeProvider);
     // time:1009 count:10 - reject
-    objectCount = 1;
-    objectRequests = tracker.popObjectRequests(objectCount);
+    objectsCount = 1;
+    objectRequests = tracker.approveObjectsRequest(objectsCount);
     assertThat(objectRequests).isEmpty();
   }
 
@@ -159,36 +159,36 @@ public class RateTrackerTest {
     final RateTracker tracker = new RateTracker(10, 2, timeProvider);
 
     // time: 1000, tracker count: 0, limit: 10, remaining: 10
-    Optional<RequestApproval> objectRequests = tracker.popObjectRequests(10);
+    Optional<RequestApproval> objectRequests = tracker.approveObjectsRequest(10);
     assertRequestsAllowed(objectRequests, 10, timeProvider);
 
     // time: 1000, tracker count: 10, limit: 10, remaining: 0
-    Optional<RequestApproval> anotherObjectRequests = tracker.popObjectRequests(5);
+    Optional<RequestApproval> anotherObjectRequests = tracker.approveObjectsRequest(5);
     assertThat(anotherObjectRequests).isEmpty();
 
-    tracker.adjustObjectRequests(objectRequests.get(), 3);
+    tracker.adjustObjectsRequest(objectRequests.get(), 3);
     // time: 1000, tracker count: 3, limit: 10, remaining: 7
-    objectRequests = tracker.popObjectRequests(7);
+    objectRequests = tracker.approveObjectsRequest(7);
     assertRequestsAllowed(objectRequests, 7, timeProvider);
     // time: 1000, tracker count: 10, limit: 10, remaining: 0
-    tracker.adjustObjectRequests(objectRequests.get(), 5);
+    tracker.adjustObjectsRequest(objectRequests.get(), 5);
     // time: 1000, tracker count: 8, limit: 10, remaining: 2
-    objectRequests = tracker.popObjectRequests(3);
+    objectRequests = tracker.approveObjectsRequest(3);
     assertRequestsAllowed(objectRequests, 3, timeProvider);
     // respond as long as the remaining capacity is > 0
     // time: 1000, tracker count: 11, limit: 10, remaining: 0
-    tracker.adjustObjectRequests(objectRequests.get(), 3);
+    tracker.adjustObjectsRequest(objectRequests.get(), 3);
     // time: 1000, tracker count: 11, limit: 10, remaining: 0
-    objectRequests = tracker.popObjectRequests(2);
+    objectRequests = tracker.approveObjectsRequest(2);
     assertThat(objectRequests).isEmpty();
   }
 
   private void assertRequestsAllowed(
       final Optional<RequestApproval> requestApproval,
-      final long objectCount,
+      final long objectsCount,
       final StubTimeProvider timeProvider) {
     assertThat(requestApproval).isPresent();
-    assertThat(requestApproval.get().getObjectsCount()).isEqualTo(objectCount);
+    assertThat(requestApproval.get().getObjectsCount()).isEqualTo(objectsCount);
     assertThat(requestApproval.get().getRequestKey())
         .isEqualTo(new RequestsKey(timeProvider.getTimeInSeconds(), requestId.getAndIncrement()));
   }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/RateTrackerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/RateTrackerTest.java
@@ -15,10 +15,9 @@ package tech.pegasys.teku.networking.eth2.peers;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.apache.commons.lang3.tuple.Pair;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
-import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 public class RateTrackerTest {
 
@@ -28,16 +27,18 @@ public class RateTrackerTest {
   public void shouldAllowAddingItemsWithinLimit() {
     final RateTracker tracker = new RateTracker(1, 1, timeProvider);
     final long objectCount = 1;
-    final Pair<UInt64, Long> trackerResponse = tracker.popObjectRequests(objectCount);
-    assertThat(trackerResponse).isEqualTo(Pair.of(timeProvider.getTimeInSeconds(), objectCount));
+    final Optional<RateTracker.ObjectsRequestResponse> objectRequests =
+        tracker.popObjectRequests(objectCount);
+    assertRequestsAllowed(objectRequests, objectCount, timeProvider);
   }
 
   @Test
   public void shouldNotUnderflowWhenTimeWindowGreaterThanCurrentTime() {
     final RateTracker tracker = new RateTracker(1, 15000, timeProvider);
     final long objectCount = 1;
-    final Pair<UInt64, Long> trackerResponse = tracker.popObjectRequests(objectCount);
-    assertThat(trackerResponse).isEqualTo(Pair.of(timeProvider.getTimeInSeconds(), objectCount));
+    final Optional<RateTracker.ObjectsRequestResponse> objectRequests =
+        tracker.popObjectRequests(objectCount);
+    assertRequestsAllowed(objectRequests, objectCount, timeProvider);
   }
 
   @Test
@@ -45,41 +46,44 @@ public class RateTrackerTest {
     final RateTracker tracker = new RateTracker(1, 1, timeProvider);
     long objectCount = 1;
 
-    Pair<UInt64, Long> trackerResponse = tracker.popObjectRequests(objectCount);
-    assertThat(trackerResponse).isEqualTo(Pair.of(timeProvider.getTimeInSeconds(), objectCount));
+    Optional<RateTracker.ObjectsRequestResponse> objectRequests =
+        tracker.popObjectRequests(objectCount);
+    assertRequestsAllowed(objectRequests, objectCount, timeProvider);
 
     timeProvider.advanceTimeBySeconds(2L);
 
-    trackerResponse = tracker.popObjectRequests(objectCount);
-    assertThat(trackerResponse).isEqualTo(Pair.of(timeProvider.getTimeInSeconds(), objectCount));
+    objectRequests = tracker.popObjectRequests(objectCount);
+    assertRequestsAllowed(objectRequests, objectCount, timeProvider);
   }
 
   @Test
   public void shouldReturnFalseIfCacheFull() {
     final RateTracker tracker = new RateTracker(1, 1, timeProvider);
     final long objectCount = 1;
-    Pair<UInt64, Long> trackerResponse = tracker.popObjectRequests(objectCount);
-    assertThat(trackerResponse).isEqualTo(Pair.of(timeProvider.getTimeInSeconds(), objectCount));
+    Optional<RateTracker.ObjectsRequestResponse> objectRequests =
+        tracker.popObjectRequests(objectCount);
+    assertRequestsAllowed(objectRequests, objectCount, timeProvider);
 
-    trackerResponse = tracker.popObjectRequests(objectCount);
-    assertThat(trackerResponse).isEqualTo(Pair.of(timeProvider.getTimeInSeconds(), 0L));
+    objectRequests = tracker.popObjectRequests(objectCount);
+    assertThat(objectRequests).isEmpty();
   }
 
   @Test
   public void shouldAddMultipleValuesToCache() throws InterruptedException {
     final RateTracker tracker = new RateTracker(10, 1, timeProvider);
     long objectCount = 10;
-    Pair<UInt64, Long> trackerResponse = tracker.popObjectRequests(objectCount);
-    assertThat(trackerResponse).isEqualTo(Pair.of(timeProvider.getTimeInSeconds(), objectCount));
+    Optional<RateTracker.ObjectsRequestResponse> objectRequests =
+        tracker.popObjectRequests(objectCount);
+    assertRequestsAllowed(objectRequests, objectCount, timeProvider);
 
-    trackerResponse = tracker.popObjectRequests(objectCount);
-    assertThat(trackerResponse).isEqualTo(Pair.of(timeProvider.getTimeInSeconds(), 0L));
+    objectRequests = tracker.popObjectRequests(objectCount);
+    assertThat(objectRequests).isEmpty();
 
     timeProvider.advanceTimeBySeconds(2L);
 
     objectCount = 1;
-    trackerResponse = tracker.popObjectRequests(objectCount);
-    assertThat(trackerResponse).isEqualTo(Pair.of(timeProvider.getTimeInSeconds(), objectCount));
+    objectRequests = tracker.popObjectRequests(objectCount);
+    assertRequestsAllowed(objectRequests, objectCount, timeProvider);
   }
 
   @Test
@@ -87,64 +91,65 @@ public class RateTrackerTest {
     final RateTracker tracker = new RateTracker(10, 2, timeProvider);
 
     long objectCount = 9;
-    Pair<UInt64, Long> trackerResponse = tracker.popObjectRequests(objectCount);
-    assertThat(trackerResponse).isEqualTo(Pair.of(timeProvider.getTimeInSeconds(), objectCount));
+    Optional<RateTracker.ObjectsRequestResponse> objectRequests =
+        tracker.popObjectRequests(objectCount);
+    assertRequestsAllowed(objectRequests, objectCount, timeProvider);
     // time:1000 count:9
 
     timeProvider.advanceTimeBySeconds(1L);
 
     objectCount = 5;
-    trackerResponse = tracker.popObjectRequests(objectCount);
-    assertThat(trackerResponse).isEqualTo(Pair.of(timeProvider.getTimeInSeconds(), objectCount));
+    objectRequests = tracker.popObjectRequests(objectCount);
+    assertRequestsAllowed(objectRequests, objectCount, timeProvider);
     // time:1001 count:14
 
     timeProvider.advanceTimeBySeconds(1L);
     // time:1002 count:14 - reject.
     objectCount = 5;
-    trackerResponse = tracker.popObjectRequests(objectCount);
-    assertThat(trackerResponse).isEqualTo(Pair.of(timeProvider.getTimeInSeconds(), 0L));
+    objectRequests = tracker.popObjectRequests(objectCount);
+    assertThat(objectRequests).isEmpty();
 
     timeProvider.advanceTimeBySeconds(1L);
     // time:1003 count:5
 
     objectCount = 5;
-    trackerResponse = tracker.popObjectRequests(objectCount);
-    assertThat(trackerResponse).isEqualTo(Pair.of(timeProvider.getTimeInSeconds(), objectCount));
+    objectRequests = tracker.popObjectRequests(objectCount);
+    assertRequestsAllowed(objectRequests, objectCount, timeProvider);
     // time:1003 count:10 - reject
 
-    trackerResponse = tracker.popObjectRequests(objectCount);
-    assertThat(trackerResponse).isEqualTo(Pair.of(timeProvider.getTimeInSeconds(), 0L));
+    objectRequests = tracker.popObjectRequests(objectCount);
+    assertThat(objectRequests).isEmpty();
 
     timeProvider.advanceTimeBySeconds(3L);
     // time:1006 count:0
     objectCount = 9;
-    trackerResponse = tracker.popObjectRequests(objectCount);
-    assertThat(trackerResponse).isEqualTo(Pair.of(timeProvider.getTimeInSeconds(), objectCount));
+    objectRequests = tracker.popObjectRequests(objectCount);
+    assertRequestsAllowed(objectRequests, objectCount, timeProvider);
 
     timeProvider.advanceTimeBySeconds(1L);
     // time:1007 count:9
     objectCount = 5;
-    trackerResponse = tracker.popObjectRequests(objectCount);
-    assertThat(trackerResponse).isEqualTo(Pair.of(timeProvider.getTimeInSeconds(), objectCount));
+    objectRequests = tracker.popObjectRequests(objectCount);
+    assertRequestsAllowed(objectRequests, objectCount, timeProvider);
     // time:1007 count:14 - reject
 
     objectCount = 1;
-    trackerResponse = tracker.popObjectRequests(objectCount);
-    assertThat(trackerResponse).isEqualTo(Pair.of(timeProvider.getTimeInSeconds(), 0L));
+    objectRequests = tracker.popObjectRequests(objectCount);
+    assertThat(objectRequests).isEmpty();
 
     timeProvider.advanceTimeBySeconds(2L);
     // time:1009 count:5
     objectCount = 4;
-    trackerResponse = tracker.popObjectRequests(objectCount);
-    assertThat(trackerResponse).isEqualTo(Pair.of(timeProvider.getTimeInSeconds(), objectCount));
+    objectRequests = tracker.popObjectRequests(objectCount);
+    assertRequestsAllowed(objectRequests, objectCount, timeProvider);
     // time:1009 count:9
     objectCount = 1;
-    trackerResponse = tracker.popObjectRequests(objectCount);
-    assertThat(trackerResponse).isEqualTo(Pair.of(timeProvider.getTimeInSeconds(), objectCount));
+    objectRequests = tracker.popObjectRequests(objectCount);
+    assertRequestsAllowed(objectRequests, objectCount, timeProvider);
     // time:1009 count:10 - reject
     objectCount = 1;
-    trackerResponse = tracker.popObjectRequests(objectCount);
-    assertThat(trackerResponse).isEqualTo(Pair.of(timeProvider.getTimeInSeconds(), 0L));
+    objectRequests = tracker.popObjectRequests(objectCount);
+    assertThat(objectRequests).isEmpty();
   }
 
   @Test
@@ -152,27 +157,37 @@ public class RateTrackerTest {
     final RateTracker tracker = new RateTracker(10, 2, timeProvider);
 
     // time: 1000, tracker count: 0, limit: 10, remaining: 10
-    Pair<UInt64, Long> trackerResponse = tracker.popObjectRequests(10);
-    assertThat(trackerResponse).isEqualTo(Pair.of(timeProvider.getTimeInSeconds(), 10L));
+    Optional<RateTracker.ObjectsRequestResponse> objectRequests = tracker.popObjectRequests(10);
+    assertRequestsAllowed(objectRequests, 10, timeProvider);
 
     // time: 1000, tracker count: 10, limit: 10, remaining: 0
-    trackerResponse = tracker.popObjectRequests(5);
-    assertThat(trackerResponse).isEqualTo(Pair.of(timeProvider.getTimeInSeconds(), 0L));
+    Optional<RateTracker.ObjectsRequestResponse> anotherObjectRequests =
+        tracker.popObjectRequests(5);
+    assertThat(anotherObjectRequests).isEmpty();
 
-    tracker.adjustRequestObjects(3, 10, timeProvider.getTimeInSeconds());
+    tracker.adjustObjectRequests(objectRequests.get(), 3);
     // time: 1000, tracker count: 3, limit: 10, remaining: 7
-    trackerResponse = tracker.popObjectRequests(7);
-    assertThat(trackerResponse).isEqualTo(Pair.of(timeProvider.getTimeInSeconds(), 7L));
+    objectRequests = tracker.popObjectRequests(7);
+    assertRequestsAllowed(objectRequests, 7, timeProvider);
     // time: 1000, tracker count: 10, limit: 10, remaining: 0
-    tracker.adjustRequestObjects(5, 7, timeProvider.getTimeInSeconds());
+    tracker.adjustObjectRequests(objectRequests.get(), 5);
     // time: 1000, tracker count: 8, limit: 10, remaining: 2
-    trackerResponse = tracker.popObjectRequests(3);
-    assertThat(trackerResponse).isEqualTo(Pair.of(timeProvider.getTimeInSeconds(), 3L));
+    objectRequests = tracker.popObjectRequests(3);
+    assertRequestsAllowed(objectRequests, 3, timeProvider);
     // respond as long as the remaining capacity is > 0
     // time: 1000, tracker count: 11, limit: 10, remaining: 0
-    tracker.adjustRequestObjects(3, 3, timeProvider.getTimeInSeconds());
+    tracker.adjustObjectRequests(objectRequests.get(), 3);
     // time: 1000, tracker count: 11, limit: 10, remaining: 0
-    trackerResponse = tracker.popObjectRequests(2);
-    assertThat(trackerResponse).isEqualTo(Pair.of(timeProvider.getTimeInSeconds(), 0L));
+    objectRequests = tracker.popObjectRequests(2);
+    assertThat(objectRequests).isEmpty();
+  }
+
+  private void assertRequestsAllowed(
+      Optional<RateTracker.ObjectsRequestResponse> objectRequests,
+      long objectCount,
+      StubTimeProvider timeProvider) {
+    assertThat(objectRequests).isPresent();
+    assertThat(objectRequests.get().getObjectsCount()).isEqualTo(objectCount);
+    assertThat(objectRequests.get().getTimeSeconds()).isEqualTo(timeProvider.getTimeInSeconds());
   }
 }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/RateTrackerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/RateTrackerTest.java
@@ -147,4 +147,25 @@ public class RateTrackerTest {
     trackerResponse = tracker.popObjectRequests(objectCount);
     assertThat(trackerResponse).isEqualTo(Pair.of(timeProvider.getTimeInSeconds(), zero));
   }
+
+  @Test
+  public void shouldAdjustObjectsCount() {
+    final RateTracker tracker = new RateTracker(10, 2, timeProvider);
+
+    Pair<UInt64, Long> trackerResponse = tracker.popObjectRequests(10);
+    assertThat(trackerResponse).isEqualTo(Pair.of(timeProvider.getTimeInSeconds(), 10L));
+
+    trackerResponse = tracker.popObjectRequests(5);
+    assertThat(trackerResponse).isEqualTo(Pair.of(timeProvider.getTimeInSeconds(), zero));
+
+    tracker.adjustRequestObjects(3, 10, timeProvider.getTimeInSeconds());
+
+    trackerResponse = tracker.popObjectRequests(7);
+    assertThat(trackerResponse).isEqualTo(Pair.of(timeProvider.getTimeInSeconds(), 7L));
+
+    tracker.adjustRequestObjects(5, 7, timeProvider.getTimeInSeconds());
+
+    trackerResponse = tracker.popObjectRequests(3);
+    assertThat(trackerResponse).isEqualTo(Pair.of(timeProvider.getTimeInSeconds(), 3L));
+  }
 }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/RateTrackerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/RateTrackerTest.java
@@ -179,6 +179,7 @@ public class RateTrackerTest {
       Optional<RequestApproval> objectRequests, long objectCount, StubTimeProvider timeProvider) {
     assertThat(objectRequests).isPresent();
     assertThat(objectRequests.get().getObjectsCount()).isEqualTo(objectCount);
-    assertThat(objectRequests.get().getTimeSeconds()).isEqualTo(timeProvider.getTimeInSeconds());
+    assertThat(objectRequests.get().getRequestKey().getTimeSeconds())
+        .isEqualTo(timeProvider.getTimeInSeconds());
   }
 }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandlerTest.java
@@ -94,7 +94,8 @@ class BeaconBlocksByRangeMessageHandlerTest {
   private final BeaconBlocksByRangeMessageHandler handler =
       new BeaconBlocksByRangeMessageHandler(spec, metricsSystem, combinedChainDataClient);
   private final Optional<RequestApproval> allowedObjectRequests =
-      Optional.of(new RequestApproval.RequestApprovalBuilder(ZERO, 100).build());
+      Optional.of(
+          new RequestApproval.RequestApprovalBuilder().objectCount(100).timeSeconds(ZERO).build());
 
   @BeforeEach
   public void setup() {

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandlerTest.java
@@ -44,7 +44,7 @@ import org.mockito.Mockito;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
-import tech.pegasys.teku.networking.eth2.peers.RateTracker;
+import tech.pegasys.teku.networking.eth2.peers.RequestApproval;
 import tech.pegasys.teku.networking.eth2.rpc.beaconchain.BeaconChainMethodIds;
 import tech.pegasys.teku.networking.eth2.rpc.core.ResponseCallback;
 import tech.pegasys.teku.networking.eth2.rpc.core.RpcException;
@@ -93,8 +93,8 @@ class BeaconBlocksByRangeMessageHandlerTest {
   private final String protocolId = BeaconChainMethodIds.getBlocksByRangeMethodId(2, RPC_ENCODING);
   private final BeaconBlocksByRangeMessageHandler handler =
       new BeaconBlocksByRangeMessageHandler(spec, metricsSystem, combinedChainDataClient);
-  private final Optional<RateTracker.ObjectsRequestResponse> allowedObjectRequests =
-      Optional.of(new RateTracker.ObjectsRequestResponse.ObjectsRequestBuilder(100).build());
+  private final Optional<RequestApproval> allowedObjectRequests =
+      Optional.of(new RequestApproval.RequestApprovalBuilder(ZERO, 100).build());
 
   @BeforeEach
   public void setup() {

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandlerTest.java
@@ -94,7 +94,7 @@ class BeaconBlocksByRangeMessageHandlerTest {
   @BeforeEach
   public void setup() {
     when(peer.popRequest()).thenReturn(true);
-    when(peer.popBlockRequests(any(), anyLong())).thenReturn(true);
+    when(peer.wantToRequestBlocks(any(), anyLong())).thenReturn(true);
     when(combinedChainDataClient.getEarliestAvailableBlockSlot())
         .thenReturn(completedFuture(Optional.of(ZERO)));
   }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandlerTest.java
@@ -93,14 +93,14 @@ class BeaconBlocksByRangeMessageHandlerTest {
   private final String protocolId = BeaconChainMethodIds.getBlocksByRangeMethodId(2, RPC_ENCODING);
   private final BeaconBlocksByRangeMessageHandler handler =
       new BeaconBlocksByRangeMessageHandler(spec, metricsSystem, combinedChainDataClient);
-  private final Optional<RequestApproval> allowedObjectRequests =
+  private final Optional<RequestApproval> allowedObjectsRequest =
       Optional.of(
-          new RequestApproval.RequestApprovalBuilder().objectCount(100).timeSeconds(ZERO).build());
+          new RequestApproval.RequestApprovalBuilder().objectsCount(100).timeSeconds(ZERO).build());
 
   @BeforeEach
   public void setup() {
-    when(peer.popRequest()).thenReturn(true);
-    when(peer.popBlockRequests(any(), anyLong())).thenReturn(allowedObjectRequests);
+    when(peer.approveRequest()).thenReturn(true);
+    when(peer.approveBlocksRequest(any(), anyLong())).thenReturn(allowedObjectsRequest);
     when(combinedChainDataClient.getEarliestAvailableBlockSlot())
         .thenReturn(completedFuture(Optional.of(ZERO)));
     when(listener.respond(any())).thenReturn(SafeFuture.COMPLETE);
@@ -249,10 +249,10 @@ class BeaconBlocksByRangeMessageHandlerTest {
     requestBlocks(startBlock, count, skip);
 
     // Requesting 5 blocks
-    verify(peer, times(1)).popBlockRequests(any(), eq(Long.valueOf(count)));
+    verify(peer, times(1)).approveBlocksRequest(any(), eq(Long.valueOf(count)));
     // Sending 0 blocks (First block is missing, return error)
     verify(peer, times(1))
-        .adjustBlockRequests(eq(allowedObjectRequests.get()), eq(Long.valueOf(0)));
+        .adjustBlocksRequest(eq(allowedObjectsRequest.get()), eq(Long.valueOf(0)));
 
     final RpcException expectedError =
         new RpcException.ResourceUnavailableException(
@@ -275,10 +275,10 @@ class BeaconBlocksByRangeMessageHandlerTest {
     requestBlocks(startBlock, count, skip);
 
     // Requesting 5 blocks
-    verify(peer, times(1)).popBlockRequests(any(), eq(Long.valueOf(count)));
+    verify(peer, times(1)).approveBlocksRequest(any(), eq(Long.valueOf(count)));
     // Sending 0 blocks (First block is missing, return error)
     verify(peer, times(1))
-        .adjustBlockRequests(eq(allowedObjectRequests.get()), eq(Long.valueOf(0)));
+        .adjustBlocksRequest(eq(allowedObjectsRequest.get()), eq(Long.valueOf(0)));
 
     final RpcException expectedError =
         new RpcException.ResourceUnavailableException(
@@ -298,9 +298,9 @@ class BeaconBlocksByRangeMessageHandlerTest {
     requestBlocks(startBlock, count, skip);
 
     // Requesting 5 blocks
-    verify(peer, times(1)).popBlockRequests(any(), eq(Long.valueOf(count)));
+    verify(peer, times(1)).approveBlocksRequest(any(), eq(Long.valueOf(count)));
     // Sending 5 blocks as initially requested: No rate limiter adjustment
-    verify(peer, never()).adjustBlockRequests(any(), anyLong());
+    verify(peer, never()).adjustBlocksRequest(any(), anyLong());
 
     verifyBlocksReturned(3, 4, 5, 6, 7);
   }
@@ -316,9 +316,9 @@ class BeaconBlocksByRangeMessageHandlerTest {
     requestBlocks(startBlock, count, skip);
 
     // Requesting 1 block
-    verify(peer, times(1)).popBlockRequests(any(), eq(Long.valueOf(count)));
+    verify(peer, times(1)).approveBlocksRequest(any(), eq(Long.valueOf(count)));
     // Sending 1 block as initially requested: No rate limiter adjustment
-    verify(peer, never()).adjustBlockRequests(any(), anyLong());
+    verify(peer, never()).adjustBlocksRequest(any(), anyLong());
 
     verifyBlocksReturned(3);
   }
@@ -336,10 +336,10 @@ class BeaconBlocksByRangeMessageHandlerTest {
     requestBlocks(startBlock, count, skip);
 
     // Requesting 5 blocks
-    verify(peer, times(1)).popBlockRequests(any(), eq(Long.valueOf(count)));
+    verify(peer, times(1)).approveBlocksRequest(any(), eq(Long.valueOf(count)));
     // Sending 1 block
     verify(peer, times(1))
-        .adjustBlockRequests(eq(allowedObjectRequests.get()), eq(Long.valueOf(1)));
+        .adjustBlocksRequest(eq(allowedObjectsRequest.get()), eq(Long.valueOf(1)));
 
     verifyBlocksReturned(2);
   }
@@ -356,10 +356,10 @@ class BeaconBlocksByRangeMessageHandlerTest {
     requestBlocks(startBlock, count, skip);
 
     // Requesting 5 blocks
-    verify(peer, times(1)).popBlockRequests(any(), eq(Long.valueOf(count)));
+    verify(peer, times(1)).approveBlocksRequest(any(), eq(Long.valueOf(count)));
     // Sending 4 blocks only
     verify(peer, times(1))
-        .adjustBlockRequests(eq(allowedObjectRequests.get()), eq(Long.valueOf(4)));
+        .adjustBlocksRequest(eq(allowedObjectsRequest.get()), eq(Long.valueOf(4)));
     // Slot 4 is empty so we only return 4 blocks
     verifyBlocksReturned(2, 3, 5, 6);
   }
@@ -376,10 +376,10 @@ class BeaconBlocksByRangeMessageHandlerTest {
     requestBlocks(startBlock, count, skip);
 
     // Requesting 4 blocks
-    verify(peer, times(1)).popBlockRequests(any(), eq(Long.valueOf(count)));
+    verify(peer, times(1)).approveBlocksRequest(any(), eq(Long.valueOf(count)));
     // Sending 1 block
     verify(peer, times(1))
-        .adjustBlockRequests(eq(allowedObjectRequests.get()), eq(Long.valueOf(1)));
+        .adjustBlocksRequest(eq(allowedObjectsRequest.get()), eq(Long.valueOf(1)));
 
     verifyBlocksReturned(4);
   }
@@ -401,10 +401,10 @@ class BeaconBlocksByRangeMessageHandlerTest {
         listener);
 
     // Requesting 50 blocks
-    verify(peer, times(1)).popBlockRequests(any(), eq(Long.valueOf(count)));
+    verify(peer, times(1)).approveBlocksRequest(any(), eq(Long.valueOf(count)));
     // Sending 0 blocks
     verify(peer, times(1))
-        .adjustBlockRequests(eq(allowedObjectRequests.get()), eq(Long.valueOf(0)));
+        .adjustBlocksRequest(eq(allowedObjectsRequest.get()), eq(Long.valueOf(0)));
 
     verifyNoBlocksReturned();
     // The first block is after the best block available, so we shouldn't request anything
@@ -422,9 +422,9 @@ class BeaconBlocksByRangeMessageHandlerTest {
     requestBlocks(startBlock, count, skip);
 
     // Requesting 5 blocks
-    verify(peer, times(1)).popBlockRequests(any(), eq(Long.valueOf(count)));
+    verify(peer, times(1)).approveBlocksRequest(any(), eq(Long.valueOf(count)));
     // Sending 5 blocks as initially requested: No rate limiter adjustment
-    verify(peer, never()).adjustBlockRequests(any(), anyLong());
+    verify(peer, never()).adjustBlocksRequest(any(), anyLong());
 
     verifyBlocksReturned(1, 2, 3, 4, 5);
     verify(combinedChainDataClient, never()).getAncestorRoots(any(), any(), any());
@@ -442,9 +442,9 @@ class BeaconBlocksByRangeMessageHandlerTest {
     requestBlocks(startBlock, count, skip);
 
     // Requesting 5 blocks
-    verify(peer, times(1)).popBlockRequests(any(), eq(Long.valueOf(count)));
+    verify(peer, times(1)).approveBlocksRequest(any(), eq(Long.valueOf(count)));
     // Sending 5 blocks as initially requested: No rate limiter adjustment
-    verify(peer, never()).adjustBlockRequests(any(), anyLong());
+    verify(peer, never()).adjustBlocksRequest(any(), anyLong());
 
     verifyBlocksReturned(1, 2, 3, 4, 5);
   }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRangeMessageHandlerTest.java
@@ -32,6 +32,7 @@ import java.util.Optional;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
@@ -94,9 +95,10 @@ class BeaconBlocksByRangeMessageHandlerTest {
   @BeforeEach
   public void setup() {
     when(peer.popRequest()).thenReturn(true);
-    when(peer.wantToRequestBlocks(any(), anyLong())).thenReturn(true);
+    when(peer.popBlockRequests(any(), anyLong())).thenReturn(Pair.of(ZERO, true));
     when(combinedChainDataClient.getEarliestAvailableBlockSlot())
         .thenReturn(completedFuture(Optional.of(ZERO)));
+    when(listener.respond(any())).thenReturn(SafeFuture.COMPLETE);
   }
 
   @Test

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRootMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRootMessageHandlerTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 import static tech.pegasys.teku.networking.eth2.rpc.core.RpcResponseStatus.INVALID_REQUEST_CODE;
 
 import java.util.List;
@@ -77,7 +78,8 @@ public class BeaconBlocksByRootMessageHandlerTest {
   final ResponseCallback<SignedBeaconBlock> callback = mock(ResponseCallback.class);
 
   private final Optional<RequestApproval> allowedObjectRequests =
-      Optional.of(new RequestApproval.RequestApprovalBuilder(UInt64.ZERO, 100).build());
+      Optional.of(
+          new RequestApproval.RequestApprovalBuilder().objectCount(100).timeSeconds(ZERO).build());
 
   @BeforeEach
   public void setup() {

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRootMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRootMessageHandlerTest.java
@@ -21,11 +21,13 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 import static tech.pegasys.teku.networking.eth2.rpc.core.RpcResponseStatus.INVALID_REQUEST_CODE;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -76,7 +78,7 @@ public class BeaconBlocksByRootMessageHandlerTest {
   public void setup() {
     chainUpdater.initializeGenesis();
     when(peer.popRequest()).thenReturn(true);
-    when(peer.wantToRequestBlocks(any(), anyLong())).thenReturn(true);
+    when(peer.popBlockRequests(any(), anyLong())).thenReturn(Pair.of(ZERO, true));
     when(recentChainData.getStore()).thenReturn(store);
     // Forward block requests from the mock to the actual store
     when(store.retrieveSignedBlock(any()))

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRootMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRootMessageHandlerTest.java
@@ -76,7 +76,7 @@ public class BeaconBlocksByRootMessageHandlerTest {
   public void setup() {
     chainUpdater.initializeGenesis();
     when(peer.popRequest()).thenReturn(true);
-    when(peer.popBlockRequests(any(), anyLong())).thenReturn(true);
+    when(peer.wantToRequestBlocks(any(), anyLong())).thenReturn(true);
     when(recentChainData.getStore()).thenReturn(store);
     // Forward block requests from the mock to the actual store
     when(store.retrieveSignedBlock(any()))

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRootMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRootMessageHandlerTest.java
@@ -34,7 +34,7 @@ import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
-import tech.pegasys.teku.networking.eth2.peers.RateTracker;
+import tech.pegasys.teku.networking.eth2.peers.RequestApproval;
 import tech.pegasys.teku.networking.eth2.rpc.beaconchain.BeaconChainMethodIds;
 import tech.pegasys.teku.networking.eth2.rpc.core.ResponseCallback;
 import tech.pegasys.teku.networking.eth2.rpc.core.RpcException;
@@ -76,8 +76,8 @@ public class BeaconBlocksByRootMessageHandlerTest {
   @SuppressWarnings("unchecked")
   final ResponseCallback<SignedBeaconBlock> callback = mock(ResponseCallback.class);
 
-  private final Optional<RateTracker.ObjectsRequestResponse> allowedObjectRequests =
-      Optional.of(new RateTracker.ObjectsRequestResponse.ObjectsRequestBuilder(100).build());
+  private final Optional<RequestApproval> allowedObjectRequests =
+      Optional.of(new RequestApproval.RequestApprovalBuilder(UInt64.ZERO, 100).build());
 
   @BeforeEach
   public void setup() {

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRootMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BeaconBlocksByRootMessageHandlerTest.java
@@ -31,6 +31,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.teku.networking.eth2.rpc.beaconchain.BeaconChainMethodIds;
@@ -84,6 +85,7 @@ public class BeaconBlocksByRootMessageHandlerTest {
     when(store.retrieveSignedBlock(any()))
         .thenAnswer(
             i -> storageSystem.recentChainData().getStore().retrieveSignedBlock(i.getArgument(0)));
+    when(callback.respond(any())).thenReturn(SafeFuture.COMPLETE);
   }
 
   @Test

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandlerTest.java
@@ -102,7 +102,8 @@ public class BlobSidecarsByRangeMessageHandlerTest {
       new BlobSidecarsByRangeMessageHandler(
           spec, denebForkEpoch, metricsSystem, combinedChainDataClient);
   private final Optional<RequestApproval> allowedObjectRequests =
-      Optional.of(new RequestApproval.RequestApprovalBuilder(ZERO, 100).build());
+      Optional.of(
+          new RequestApproval.RequestApprovalBuilder().objectCount(100).timeSeconds(ZERO).build());
 
   @BeforeEach
   public void setUp() {
@@ -335,7 +336,8 @@ public class BlobSidecarsByRangeMessageHandlerTest {
         new BlobSidecarsByRangeRequestMessage(startSlot, ZERO, maxBlobsPerBlock);
 
     final Optional<RequestApproval> zeroObjectRequests =
-        Optional.of(new RequestApproval.RequestApprovalBuilder(ZERO, 0).build());
+        Optional.of(
+            new RequestApproval.RequestApprovalBuilder().timeSeconds(ZERO).objectCount(0).build());
 
     when(peer.popBlobSidecarRequests(listener, 0)).thenReturn(zeroObjectRequests);
 

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandlerTest.java
@@ -104,7 +104,7 @@ public class BlobSidecarsByRangeMessageHandlerTest {
   @BeforeEach
   public void setUp() {
     when(peer.popRequest()).thenReturn(true);
-    when(peer.popBlobSidecarRequests(eq(listener), anyLong())).thenReturn(true);
+    when(peer.wantToRequestBlobSidecars(eq(listener), anyLong())).thenReturn(true);
     when(combinedChainDataClient.getEarliestAvailableBlobSidecarSlot())
         .thenReturn(SafeFuture.completedFuture(Optional.of(ZERO)));
     when(combinedChainDataClient.getCurrentEpoch()).thenReturn(denebForkEpoch.increment());
@@ -154,7 +154,7 @@ public class BlobSidecarsByRangeMessageHandlerTest {
   @Test
   public void shouldNotSendBlobSidecarsIfPeerIsRateLimited() {
 
-    when(peer.popBlobSidecarRequests(listener, count.times(maxBlobsPerBlock).longValue()))
+    when(peer.wantToRequestBlobSidecars(listener, count.times(maxBlobsPerBlock).longValue()))
         .thenReturn(false);
 
     final BlobSidecarsByRangeRequestMessage request =
@@ -292,7 +292,7 @@ public class BlobSidecarsByRangeMessageHandlerTest {
     final BlobSidecarsByRangeRequestMessage request =
         new BlobSidecarsByRangeRequestMessage(startSlot, ZERO, maxBlobsPerBlock);
 
-    when(peer.popBlobSidecarRequests(listener, 0)).thenReturn(true);
+    when(peer.wantToRequestBlobSidecars(listener, 0)).thenReturn(true);
 
     handler.onIncomingMessage(protocolId, peer, request, listener);
 

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandlerTest.java
@@ -43,7 +43,7 @@ import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
-import tech.pegasys.teku.networking.eth2.peers.RateTracker;
+import tech.pegasys.teku.networking.eth2.peers.RequestApproval;
 import tech.pegasys.teku.networking.eth2.rpc.beaconchain.BeaconChainMethodIds;
 import tech.pegasys.teku.networking.eth2.rpc.core.ResponseCallback;
 import tech.pegasys.teku.networking.eth2.rpc.core.RpcException;
@@ -101,8 +101,8 @@ public class BlobSidecarsByRangeMessageHandlerTest {
   private final BlobSidecarsByRangeMessageHandler handler =
       new BlobSidecarsByRangeMessageHandler(
           spec, denebForkEpoch, metricsSystem, combinedChainDataClient);
-  private final Optional<RateTracker.ObjectsRequestResponse> allowedObjectRequests =
-      Optional.of(new RateTracker.ObjectsRequestResponse.ObjectsRequestBuilder(100).build());
+  private final Optional<RequestApproval> allowedObjectRequests =
+      Optional.of(new RequestApproval.RequestApprovalBuilder(ZERO, 100).build());
 
   @BeforeEach
   public void setUp() {
@@ -334,8 +334,8 @@ public class BlobSidecarsByRangeMessageHandlerTest {
     final BlobSidecarsByRangeRequestMessage request =
         new BlobSidecarsByRangeRequestMessage(startSlot, ZERO, maxBlobsPerBlock);
 
-    final Optional<RateTracker.ObjectsRequestResponse> zeroObjectRequests =
-        Optional.of(new RateTracker.ObjectsRequestResponse.ObjectsRequestBuilder(0).build());
+    final Optional<RequestApproval> zeroObjectRequests =
+        Optional.of(new RequestApproval.RequestApprovalBuilder(ZERO, 0).build());
 
     when(peer.popBlobSidecarRequests(listener, 0)).thenReturn(zeroObjectRequests);
 

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandlerTest.java
@@ -33,6 +33,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.tuweni.bytes.Bytes32;
 import org.assertj.core.api.AssertionsForInterfaceTypes;
 import org.junit.jupiter.api.BeforeEach;
@@ -104,7 +105,7 @@ public class BlobSidecarsByRangeMessageHandlerTest {
   @BeforeEach
   public void setUp() {
     when(peer.popRequest()).thenReturn(true);
-    when(peer.wantToRequestBlobSidecars(eq(listener), anyLong())).thenReturn(true);
+    when(peer.popBlobSidecarRequests(eq(listener), anyLong())).thenReturn(Pair.of(ZERO, true));
     when(combinedChainDataClient.getEarliestAvailableBlobSidecarSlot())
         .thenReturn(SafeFuture.completedFuture(Optional.of(ZERO)));
     when(combinedChainDataClient.getCurrentEpoch()).thenReturn(denebForkEpoch.increment());
@@ -154,8 +155,8 @@ public class BlobSidecarsByRangeMessageHandlerTest {
   @Test
   public void shouldNotSendBlobSidecarsIfPeerIsRateLimited() {
 
-    when(peer.wantToRequestBlobSidecars(listener, count.times(maxBlobsPerBlock).longValue()))
-        .thenReturn(false);
+    when(peer.popBlobSidecarRequests(listener, count.times(maxBlobsPerBlock).longValue()))
+        .thenReturn(Pair.of(ZERO, false));
 
     final BlobSidecarsByRangeRequestMessage request =
         new BlobSidecarsByRangeRequestMessage(startSlot, count, maxBlobsPerBlock);
@@ -292,7 +293,7 @@ public class BlobSidecarsByRangeMessageHandlerTest {
     final BlobSidecarsByRangeRequestMessage request =
         new BlobSidecarsByRangeRequestMessage(startSlot, ZERO, maxBlobsPerBlock);
 
-    when(peer.wantToRequestBlobSidecars(listener, 0)).thenReturn(true);
+    when(peer.popBlobSidecarRequests(listener, 0)).thenReturn(Pair.of(ZERO, true));
 
     handler.onIncomingMessage(protocolId, peer, request, listener);
 

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandlerTest.java
@@ -38,7 +38,7 @@ import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
-import tech.pegasys.teku.networking.eth2.peers.RateTracker;
+import tech.pegasys.teku.networking.eth2.peers.RequestApproval;
 import tech.pegasys.teku.networking.eth2.rpc.beaconchain.BeaconChainMethodIds;
 import tech.pegasys.teku.networking.eth2.rpc.core.ResponseCallback;
 import tech.pegasys.teku.networking.eth2.rpc.core.RpcException;
@@ -94,8 +94,8 @@ public class BlobSidecarsByRootMessageHandlerTest {
       new BlobSidecarsByRootMessageHandler(
           spec, metricsSystem, denebForkEpoch, combinedChainDataClient);
 
-  private final Optional<RateTracker.ObjectsRequestResponse> allowedObjectRequests =
-      Optional.of(new RateTracker.ObjectsRequestResponse.ObjectsRequestBuilder(100).build());
+  private final Optional<RequestApproval> allowedObjectRequests =
+      Optional.of(new RequestApproval.RequestApprovalBuilder(UInt64.ZERO, 100).build());
 
   @BeforeEach
   public void setup() {

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandlerTest.java
@@ -96,7 +96,7 @@ public class BlobSidecarsByRootMessageHandlerTest {
   @BeforeEach
   public void setup() {
     when(peer.popRequest()).thenReturn(true);
-    when(peer.popBlobSidecarRequests(eq(callback), anyLong())).thenReturn(true);
+    when(peer.wantToRequestBlobSidecars(eq(callback), anyLong())).thenReturn(true);
     when(combinedChainDataClient.getBlockByBlockRoot(any()))
         .thenReturn(
             SafeFuture.completedFuture(
@@ -148,7 +148,7 @@ public class BlobSidecarsByRootMessageHandlerTest {
   @Test
   public void shouldNotSendBlobSidecarsIfPeerIsRateLimited() {
 
-    when(peer.popBlobSidecarRequests(callback, 5)).thenReturn(false);
+    when(peer.wantToRequestBlobSidecars(callback, 5)).thenReturn(false);
 
     final BlobSidecarsByRootRequestMessage request =
         new BlobSidecarsByRootRequestMessage(

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandlerTest.java
@@ -23,12 +23,14 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 import static tech.pegasys.teku.networking.eth2.rpc.core.RpcResponseStatus.INVALID_REQUEST_CODE;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -96,7 +98,7 @@ public class BlobSidecarsByRootMessageHandlerTest {
   @BeforeEach
   public void setup() {
     when(peer.popRequest()).thenReturn(true);
-    when(peer.wantToRequestBlobSidecars(eq(callback), anyLong())).thenReturn(true);
+    when(peer.popBlobSidecarRequests(eq(callback), anyLong())).thenReturn(Pair.of(ZERO, true));
     when(combinedChainDataClient.getBlockByBlockRoot(any()))
         .thenReturn(
             SafeFuture.completedFuture(
@@ -148,7 +150,7 @@ public class BlobSidecarsByRootMessageHandlerTest {
   @Test
   public void shouldNotSendBlobSidecarsIfPeerIsRateLimited() {
 
-    when(peer.wantToRequestBlobSidecars(callback, 5)).thenReturn(false);
+    when(peer.popBlobSidecarRequests(callback, 5)).thenReturn(Pair.of(ZERO, false));
 
     final BlobSidecarsByRootRequestMessage request =
         new BlobSidecarsByRootRequestMessage(

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandlerTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 import static tech.pegasys.teku.networking.eth2.rpc.core.RpcResponseStatus.INVALID_REQUEST_CODE;
 
 import java.util.List;
@@ -95,7 +96,8 @@ public class BlobSidecarsByRootMessageHandlerTest {
           spec, metricsSystem, denebForkEpoch, combinedChainDataClient);
 
   private final Optional<RequestApproval> allowedObjectRequests =
-      Optional.of(new RequestApproval.RequestApprovalBuilder(UInt64.ZERO, 100).build());
+      Optional.of(
+          new RequestApproval.RequestApprovalBuilder().objectCount(100).timeSeconds(ZERO).build());
 
   @BeforeEach
   public void setup() {

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/StatusMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/StatusMessageHandlerTest.java
@@ -68,7 +68,7 @@ class StatusMessageHandlerTest {
   @BeforeEach
   public void setUp() {
     when(statusMessageFactory.createStatusMessage()).thenReturn(Optional.of(LOCAL_STATUS));
-    when(peer.popRequest()).thenReturn(true);
+    when(peer.approveRequest()).thenReturn(true);
   }
 
   @Test

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/Eth2IncomingRequestHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/core/Eth2IncomingRequestHandlerTest.java
@@ -56,7 +56,7 @@ public class Eth2IncomingRequestHandlerTest
     lenient()
         .when(combinedChainDataClient.getBlockAtSlotExact(any(), any()))
         .thenAnswer(i -> getBlockAtSlot(i.getArgument(0)));
-    when(peer.popRequest()).thenReturn(true);
+    when(peer.approveRequest()).thenReturn(true);
   }
 
   @Override

--- a/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/peers/RespondingEth2Peer.java
+++ b/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/peers/RespondingEth2Peer.java
@@ -14,7 +14,6 @@
 package tech.pegasys.teku.networking.eth2.peers;
 
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
-import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -25,7 +24,6 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.bytes.Bytes4;
@@ -303,32 +301,25 @@ public class RespondingEth2Peer implements Eth2Peer {
   }
 
   @Override
-  public Pair<UInt64, Boolean> popBlockRequests(
+  public Optional<RateTracker.ObjectsRequestResponse> popBlockRequests(
       final ResponseCallback<SignedBeaconBlock> callback, final long blocksCount) {
-    return Pair.of(ZERO, true);
+    return Optional.of(new RateTracker.ObjectsRequestResponse.ObjectsRequestBuilder(0).build());
   }
 
   @Override
   public void adjustBlockRequests(
-      final long returnedBlockCount, final long initialBlockCount, UInt64 time) {}
+      final RateTracker.ObjectsRequestResponse blockRequests, final long returnedBlocksCount) {}
 
   @Override
-  public void cancelBlockRequests(final long initialBlockCount, UInt64 time) {}
-
-  @Override
-  public Pair<UInt64, Boolean> popBlobSidecarRequests(
+  public Optional<RateTracker.ObjectsRequestResponse> popBlobSidecarRequests(
       final ResponseCallback<BlobSidecar> callback, final long blobSidecarsCount) {
-    return Pair.of(ZERO, true);
+    return Optional.of(new RateTracker.ObjectsRequestResponse.ObjectsRequestBuilder(0).build());
   }
 
   @Override
   public void adjustBlobSidecarRequests(
-      final long returnedBlobSidecarsCount,
-      final long initialBlobSidecarCount,
-      final UInt64 time) {}
-
-  @Override
-  public void cancelBlobSidecarRequests(final long initialBlobSidecarCount, final UInt64 time) {}
+      final RateTracker.ObjectsRequestResponse blobSidecarRequests,
+      final long returnedBlobSidecarsCount) {}
 
   @Override
   public boolean popRequest() {

--- a/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/peers/RespondingEth2Peer.java
+++ b/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/peers/RespondingEth2Peer.java
@@ -302,33 +302,33 @@ public class RespondingEth2Peer implements Eth2Peer {
   }
 
   @Override
-  public Optional<RequestApproval> popBlockRequests(
+  public Optional<RequestApproval> approveBlocksRequest(
       final ResponseCallback<SignedBeaconBlock> callback, final long blocksCount) {
     return Optional.of(
         new RequestApproval.RequestApprovalBuilder()
             .requestId(0)
             .timeSeconds(ZERO)
-            .objectCount(0)
+            .objectsCount(0)
             .build());
   }
 
   @Override
-  public void adjustBlockRequests(
+  public void adjustBlocksRequest(
       final RequestApproval blockRequests, final long returnedBlocksCount) {}
 
   @Override
-  public Optional<RequestApproval> popBlobSidecarRequests(
+  public Optional<RequestApproval> approveBlobSidecarsRequest(
       final ResponseCallback<BlobSidecar> callback, final long blobSidecarsCount) {
     return Optional.of(
-        new RequestApproval.RequestApprovalBuilder().timeSeconds(ZERO).objectCount(0).build());
+        new RequestApproval.RequestApprovalBuilder().timeSeconds(ZERO).objectsCount(0).build());
   }
 
   @Override
-  public void adjustBlobSidecarRequests(
+  public void adjustBlobSidecarsRequest(
       final RequestApproval blobSidecarRequests, final long returnedBlobSidecarsCount) {}
 
   @Override
-  public boolean popRequest() {
+  public boolean approveRequest() {
     return true;
   }
 

--- a/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/peers/RespondingEth2Peer.java
+++ b/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/peers/RespondingEth2Peer.java
@@ -304,7 +304,12 @@ public class RespondingEth2Peer implements Eth2Peer {
   @Override
   public Optional<RequestApproval> popBlockRequests(
       final ResponseCallback<SignedBeaconBlock> callback, final long blocksCount) {
-    return Optional.of(new RequestApproval.RequestApprovalBuilder(ZERO, 0).build());
+    return Optional.of(
+        new RequestApproval.RequestApprovalBuilder()
+            .requestId(0)
+            .timeSeconds(ZERO)
+            .objectCount(0)
+            .build());
   }
 
   @Override
@@ -314,7 +319,8 @@ public class RespondingEth2Peer implements Eth2Peer {
   @Override
   public Optional<RequestApproval> popBlobSidecarRequests(
       final ResponseCallback<BlobSidecar> callback, final long blobSidecarsCount) {
-    return Optional.of(new RequestApproval.RequestApprovalBuilder(ZERO, 0).build());
+    return Optional.of(
+        new RequestApproval.RequestApprovalBuilder().timeSeconds(ZERO).objectCount(0).build());
   }
 
   @Override

--- a/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/peers/RespondingEth2Peer.java
+++ b/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/peers/RespondingEth2Peer.java
@@ -304,21 +304,25 @@ public class RespondingEth2Peer implements Eth2Peer {
 
   @Override
   public Pair<UInt64, Boolean> popBlockRequests(
-      ResponseCallback<SignedBeaconBlock> callback, long blocksCount) {
+      final ResponseCallback<SignedBeaconBlock> callback, final long blocksCount) {
     return Pair.of(ZERO, true);
   }
 
   @Override
-  public void adjustBlockRequests(long blobSidecarsCount, final UInt64 time) {}
+  public void adjustBlockRequests(
+      final long returnedBlockCount, final long initialBlockCount, UInt64 time) {}
 
   @Override
   public Pair<UInt64, Boolean> popBlobSidecarRequests(
-      ResponseCallback<BlobSidecar> callback, long blobSidecarsCount) {
+      final ResponseCallback<BlobSidecar> callback, final long blobSidecarsCount) {
     return Pair.of(ZERO, true);
   }
 
   @Override
-  public void adjustBlobSidecarRequests(long blobSidecarsCount, final UInt64 time) {}
+  public void adjustBlobSidecarRequests(
+      final long returnedBlobSidecarsCount,
+      final long initialBlobSidecarCount,
+      final UInt64 time) {}
 
   @Override
   public boolean popRequest() {

--- a/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/peers/RespondingEth2Peer.java
+++ b/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/peers/RespondingEth2Peer.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.networking.eth2.peers;
 
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
+import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -301,25 +302,24 @@ public class RespondingEth2Peer implements Eth2Peer {
   }
 
   @Override
-  public Optional<RateTracker.ObjectsRequestResponse> popBlockRequests(
+  public Optional<RequestApproval> popBlockRequests(
       final ResponseCallback<SignedBeaconBlock> callback, final long blocksCount) {
-    return Optional.of(new RateTracker.ObjectsRequestResponse.ObjectsRequestBuilder(0).build());
+    return Optional.of(new RequestApproval.RequestApprovalBuilder(ZERO, 0).build());
   }
 
   @Override
   public void adjustBlockRequests(
-      final RateTracker.ObjectsRequestResponse blockRequests, final long returnedBlocksCount) {}
+      final RequestApproval blockRequests, final long returnedBlocksCount) {}
 
   @Override
-  public Optional<RateTracker.ObjectsRequestResponse> popBlobSidecarRequests(
+  public Optional<RequestApproval> popBlobSidecarRequests(
       final ResponseCallback<BlobSidecar> callback, final long blobSidecarsCount) {
-    return Optional.of(new RateTracker.ObjectsRequestResponse.ObjectsRequestBuilder(0).build());
+    return Optional.of(new RequestApproval.RequestApprovalBuilder(ZERO, 0).build());
   }
 
   @Override
   public void adjustBlobSidecarRequests(
-      final RateTracker.ObjectsRequestResponse blobSidecarRequests,
-      final long returnedBlobSidecarsCount) {}
+      final RequestApproval blobSidecarRequests, final long returnedBlobSidecarsCount) {}
 
   @Override
   public boolean popRequest() {

--- a/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/peers/RespondingEth2Peer.java
+++ b/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/peers/RespondingEth2Peer.java
@@ -313,6 +313,9 @@ public class RespondingEth2Peer implements Eth2Peer {
       final long returnedBlockCount, final long initialBlockCount, UInt64 time) {}
 
   @Override
+  public void cancelBlockRequests(final long initialBlockCount, UInt64 time) {}
+
+  @Override
   public Pair<UInt64, Boolean> popBlobSidecarRequests(
       final ResponseCallback<BlobSidecar> callback, final long blobSidecarsCount) {
     return Pair.of(ZERO, true);
@@ -323,6 +326,9 @@ public class RespondingEth2Peer implements Eth2Peer {
       final long returnedBlobSidecarsCount,
       final long initialBlobSidecarCount,
       final UInt64 time) {}
+
+  @Override
+  public void cancelBlobSidecarRequests(final long initialBlobSidecarCount, final UInt64 time) {}
 
   @Override
   public boolean popRequest() {

--- a/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/peers/RespondingEth2Peer.java
+++ b/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/peers/RespondingEth2Peer.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.networking.eth2.peers;
 
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
+import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -24,6 +25,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.bytes.Bytes4;
@@ -301,22 +303,22 @@ public class RespondingEth2Peer implements Eth2Peer {
   }
 
   @Override
-  public boolean wantToRequestBlocks(
+  public Pair<UInt64, Boolean> popBlockRequests(
       ResponseCallback<SignedBeaconBlock> callback, long blocksCount) {
-    return true;
+    return Pair.of(ZERO, true);
   }
 
   @Override
-  public void popBlockRequests(final long blocksCount) {}
+  public void adjustBlockRequests(long blobSidecarsCount, final UInt64 time) {}
 
   @Override
-  public boolean wantToRequestBlobSidecars(
+  public Pair<UInt64, Boolean> popBlobSidecarRequests(
       ResponseCallback<BlobSidecar> callback, long blobSidecarsCount) {
-    return true;
+    return Pair.of(ZERO, true);
   }
 
   @Override
-  public void popBlobSidecarRequests(long blobSidecarsCount) {}
+  public void adjustBlobSidecarRequests(long blobSidecarsCount, final UInt64 time) {}
 
   @Override
   public boolean popRequest() {

--- a/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/peers/RespondingEth2Peer.java
+++ b/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/peers/RespondingEth2Peer.java
@@ -301,16 +301,22 @@ public class RespondingEth2Peer implements Eth2Peer {
   }
 
   @Override
-  public boolean popBlockRequests(
-      final ResponseCallback<SignedBeaconBlock> callback, final long blocksCount) {
+  public boolean wantToRequestBlocks(
+      ResponseCallback<SignedBeaconBlock> callback, long blocksCount) {
     return true;
   }
 
   @Override
-  public boolean popBlobSidecarRequests(
-      final ResponseCallback<BlobSidecar> callback, final long blobSidecarsCount) {
+  public void popBlockRequests(final long blocksCount) {}
+
+  @Override
+  public boolean wantToRequestBlobSidecars(
+      ResponseCallback<BlobSidecar> callback, long blobSidecarsCount) {
     return true;
   }
+
+  @Override
+  public void popBlobSidecarRequests(long blobSidecarsCount) {}
 
   @Override
   public boolean popRequest() {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

Update objects requests rate limiting based on the served objects count instead of the requested objects count:
`BeaconBlockByRange`, `BeaconBlockByRoot`, `BlobSidecarsByRange` and `BlobSidecarsByRoot` are all rate limited based on the requested objects count (The rate limiter is triggered when the request is received). In most case the real served objects count is lower (For blocks request, some blocks could not be returned and BlobSidecars we estimate the requested objects count by assuming that every block will contains `MAX_BLOB_SIDECARS_BY_BLOCK` Blob Sidecars which is not always/rarely the case).
The proposed solution is to add an object count adjustment to the rate limiter:
- `popBlockRequests` and `popBlobSidecarsRequests` will update the rate limiter with the max estimated objects counts.
- `adjustBlockRequests` and `adjustBlobSidecarsRequests` will adjust the initially estimated objects count and replace it with the served objects count (only if the adjustment happens during the same rate limiting time window).
- `cancelBlockRequests` and `cancelBlobSidecarRequests` will reset the initially estimated objects if the request is cancelled for some reason (mainly errors when serving the requests)

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
#6788 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
