### PR TITLE
Remove no longer applicable engine version enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ For information on changes in released versions of Teku, see the [releases page]
 
 ### Breaking Changes
 
-- The Development option `--Xprogressive-balances-mode` has been removed and will no longer be recognised as a command line option.
+- The Development options `--Xprogressive-balances-mode` and `--Xee-version` have been removed and will no longer be recognised as command line options.
 - Network configs updated following Consensus Specs changes. If you run custom network, you will need to add [lines with network parameters](https://github.com/ConsenSys/teku/blob/475986c523b606c6936d7b4207c1da920ad82ea0/ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/configs/mainnet.yaml#L98-L125) to your custom config. If you are using a remote validator `auto` network feature, you will need to update both Beacon Node and Validator Client.  
 
 ### Additions and Improvements

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
@@ -13,7 +13,6 @@
 
 package tech.pegasys.teku.ethereum.executionlayer;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static tech.pegasys.teku.spec.config.Constants.MAXIMUM_CONCURRENT_EB_REQUESTS;
 import static tech.pegasys.teku.spec.config.Constants.MAXIMUM_CONCURRENT_EE_REQUESTS;
 
@@ -38,7 +37,6 @@ import tech.pegasys.teku.ethereum.executionclient.rest.RestClient;
 import tech.pegasys.teku.ethereum.executionclient.web3j.Web3JClient;
 import tech.pegasys.teku.ethereum.executionclient.web3j.Web3JExecutionEngineClient;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
-import tech.pegasys.teku.infrastructure.exceptions.InvalidConfigurationException;
 import tech.pegasys.teku.infrastructure.logging.EventLogger;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
@@ -118,15 +116,9 @@ public class ExecutionLayerManagerImpl implements ExecutionLayerManager {
   }
 
   public static ExecutionEngineClient createEngineClient(
-      final Version version,
       final Web3JClient web3JClient,
       final TimeProvider timeProvider,
       final MetricsSystem metricsSystem) {
-    checkNotNull(version);
-    LOG.info("Execution Engine version: {}", version);
-    if (version != Version.KILNV2) {
-      throw new InvalidConfigurationException("Unsupported execution engine version: " + version);
-    }
     final ExecutionEngineClient engineClient = new Web3JExecutionEngineClient(web3JClient);
     final ExecutionEngineClient metricEngineClient =
         new MetricRecordingExecutionEngineClient(engineClient, timeProvider, metricsSystem);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannel.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannel.java
@@ -136,10 +136,4 @@ public interface ExecutionLayerChannel extends ChannelInterface {
    */
   SafeFuture<HeaderWithFallbackData> builderGetHeader(
       ExecutionPayloadContext executionPayloadContext, BeaconState state);
-
-  enum Version {
-    KILNV2;
-
-    public static final Version DEFAULT_VERSION = KILNV2;
-  }
 }

--- a/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerConfiguration.java
+++ b/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerConfiguration.java
@@ -25,7 +25,6 @@ import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.infrastructure.exceptions.InvalidConfigurationException;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannel.Version;
 
 public class ExecutionLayerConfiguration {
   private static final Logger LOG = LogManager.getLogger();
@@ -43,7 +42,6 @@ public class ExecutionLayerConfiguration {
 
   private final Spec spec;
   private final Optional<String> engineEndpoint;
-  private final Version engineVersion;
   private final Optional<String> engineJwtSecretFile;
   private final Optional<String> builderEndpoint;
   private final boolean isBuilderCircuitBreakerEnabled;
@@ -57,7 +55,6 @@ public class ExecutionLayerConfiguration {
   private ExecutionLayerConfiguration(
       final Spec spec,
       final Optional<String> engineEndpoint,
-      final Version engineVersion,
       final Optional<String> engineJwtSecretFile,
       final Optional<String> builderEndpoint,
       final boolean isBuilderCircuitBreakerEnabled,
@@ -69,7 +66,6 @@ public class ExecutionLayerConfiguration {
       final boolean exchangeCapabilitiesEnabled) {
     this.spec = spec;
     this.engineEndpoint = engineEndpoint;
-    this.engineVersion = engineVersion;
     this.engineJwtSecretFile = engineJwtSecretFile;
     this.builderEndpoint = builderEndpoint;
     this.isBuilderCircuitBreakerEnabled = isBuilderCircuitBreakerEnabled;
@@ -103,10 +99,6 @@ public class ExecutionLayerConfiguration {
 
   public Optional<String> getEngineJwtSecretFile() {
     return engineJwtSecretFile;
-  }
-
-  public Version getEngineVersion() {
-    return engineVersion;
   }
 
   public Optional<String> getBuilderEndpoint() {
@@ -144,7 +136,6 @@ public class ExecutionLayerConfiguration {
   public static class Builder {
     private Spec spec;
     private Optional<String> engineEndpoint = Optional.empty();
-    private Version engineVersion = Version.DEFAULT_VERSION;
     private Optional<String> engineJwtSecretFile = Optional.empty();
     private Optional<String> builderEndpoint = Optional.empty();
     private boolean isBuilderCircuitBreakerEnabled = DEFAULT_BUILDER_CIRCUIT_BREAKER_ENABLED;
@@ -182,7 +173,6 @@ public class ExecutionLayerConfiguration {
       return new ExecutionLayerConfiguration(
           spec,
           engineEndpoint,
-          engineVersion,
           engineJwtSecretFile,
           builderEndpoint,
           isBuilderCircuitBreakerEnabled,
@@ -196,11 +186,6 @@ public class ExecutionLayerConfiguration {
 
     public Builder engineEndpoint(final String engineEndpoint) {
       this.engineEndpoint = Optional.ofNullable(engineEndpoint);
-      return this;
-    }
-
-    public Builder engineVersion(final Version version) {
-      this.engineVersion = version;
       return this;
     }
 

--- a/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerService.java
+++ b/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerService.java
@@ -180,10 +180,7 @@ public class ExecutionLayerService extends Service {
 
     final ExecutionEngineClient executionEngineClient =
         ExecutionLayerManagerImpl.createEngineClient(
-            config.getEngineVersion(),
-            engineWeb3jClientProvider.getWeb3JClient(),
-            timeProvider,
-            metricsSystem);
+            engineWeb3jClientProvider.getWeb3JClient(), timeProvider, metricsSystem);
 
     final EngineApiCapabilitiesProvider localEngineApiCapabilitiesProvider =
         new LocalEngineApiCapabilitiesProvider(config.getSpec(), executionEngineClient);

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ExecutionLayerOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ExecutionLayerOptions.java
@@ -26,7 +26,6 @@ import static tech.pegasys.teku.services.executionlayer.ExecutionLayerConfigurat
 import picocli.CommandLine.Help.Visibility;
 import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Option;
-import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannel.Version;
 
 public class ExecutionLayerOptions {
 
@@ -38,14 +37,6 @@ public class ExecutionLayerOptions {
       description = "URL for Execution Engine node.",
       arity = "1")
   private String executionEngineEndpoint = null;
-
-  @Option(
-      names = {"--Xee-version"},
-      paramLabel = "<EXECUTION_ENGINE_VERSION>",
-      description = "Execution Engine API version. " + "Valid values: ${COMPLETION-CANDIDATES}",
-      arity = "1",
-      hidden = true)
-  private Version executionEngineVersion = Version.DEFAULT_VERSION;
 
   @Option(
       names = {"--ee-jwt-secret-file"},
@@ -139,7 +130,6 @@ public class ExecutionLayerOptions {
     builder.executionLayer(
         b ->
             b.engineEndpoint(executionEngineEndpoint)
-                .engineVersion(executionEngineVersion)
                 .engineJwtSecretFile(engineJwtSecretFile)
                 .builderEndpoint(builderEndpoint)
                 .isBuilderCircuitBreakerEnabled(builderCircuitBreakerEnabled)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Just removing ExecutionLayerChannel.Version enum since it is always KILNV2 and it can also be confusing to others looking at the code. Also removed the `-Xee-version` option.
## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
