### PR TITLE
Increase max attestation inclusion slot (beacon chain changes)

### DIFF
--- a/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/ReferenceTestFinder.java
+++ b/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/ReferenceTestFinder.java
@@ -29,7 +29,8 @@ public class ReferenceTestFinder {
   private static final Path TEST_PATH_FROM_MODULE =
       Path.of("src", "referenceTest", "resources", "consensus-spec-tests", "tests");
   private static final List<String> SUPPORTED_FORKS =
-      List.of(TestFork.PHASE0, TestFork.ALTAIR, TestFork.BELLATRIX, TestFork.CAPELLA);
+      List.of(
+          TestFork.PHASE0, TestFork.ALTAIR, TestFork.BELLATRIX, TestFork.CAPELLA, TestFork.DENEB);
 
   @MustBeClosed
   public static Stream<TestDefinition> findReferenceTests() throws IOException {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -214,7 +214,7 @@ public class Spec {
   public Optional<NetworkingSpecConfigDeneb> getNetworkingConfigDeneb() {
     return Optional.ofNullable(forMilestone(DENEB))
         .map(SpecVersion::getConfig)
-        .map(specConfig -> (SpecConfigDeneb) specConfig.getNetworkingConfig());
+        .map(specConfig -> (NetworkingSpecConfigDeneb) specConfig.getNetworkingConfig());
   }
 
   public SchemaDefinitions getGenesisSchemaDefinitions() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/operations/OperationSignatureVerifier.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/operations/OperationSignatureVerifier.java
@@ -95,7 +95,9 @@ public class OperationSignatureVerifier {
   }
 
   public boolean verifyVoluntaryExitSignature(
-      BeaconState state, SignedVoluntaryExit signedExit, BLSSignatureVerifier signatureVerifier) {
+      final BeaconState state,
+      final SignedVoluntaryExit signedExit,
+      final BLSSignatureVerifier signatureVerifier) {
     final VoluntaryExit exit = signedExit.getMessage();
 
     final Optional<BLSPublicKey> maybePublicKey =

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/operations/validation/AttestationDataValidator.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/operations/validation/AttestationDataValidator.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright ConsenSys Software Inc., 2023
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.logic.common.operations.validation;
+
+import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
+
+public interface AttestationDataValidator
+    extends OperationStateTransitionValidator<AttestationData> {
+
+  enum AttestationInvalidReason implements OperationInvalidReason {
+    COMMITTEE_INDEX_TOO_HIGH("CommitteeIndex too high"),
+    NOT_FROM_CURRENT_OR_PREVIOUS_EPOCH("Attestation not from current or previous epoch"),
+    SLOT_NOT_IN_EPOCH("Attestation slot not in specified epoch"),
+    SUBMITTED_TOO_QUICKLY("Attestation submitted too quickly"),
+    SUBMITTED_TOO_LATE("Attestation submitted too late"),
+    INCORRECT_CURRENT_JUSTIFIED_CHECKPOINT(
+        "Attestation source does not match current justified checkpoint"),
+    INCORRECT_PREVIOUS_JUSTIFIED_CHECKPOINT(
+        "Attestation source does not match previous justified checkpoint");
+
+    private final String description;
+
+    AttestationInvalidReason(final String description) {
+      this.description = description;
+    }
+
+    @Override
+    public String describe() {
+      return description;
+    }
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/SpecLogicAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/SpecLogicAltair.java
@@ -19,6 +19,7 @@ import tech.pegasys.teku.spec.logic.common.AbstractSpecLogic;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateMutators;
 import tech.pegasys.teku.spec.logic.common.helpers.Predicates;
 import tech.pegasys.teku.spec.logic.common.operations.OperationSignatureVerifier;
+import tech.pegasys.teku.spec.logic.common.operations.validation.AttestationDataValidator;
 import tech.pegasys.teku.spec.logic.common.operations.validation.OperationValidator;
 import tech.pegasys.teku.spec.logic.common.util.AttestationUtil;
 import tech.pegasys.teku.spec.logic.common.util.BeaconStateUtil;
@@ -36,6 +37,7 @@ import tech.pegasys.teku.spec.logic.versions.altair.statetransition.epoch.EpochP
 import tech.pegasys.teku.spec.logic.versions.altair.statetransition.epoch.ValidatorStatusFactoryAltair;
 import tech.pegasys.teku.spec.logic.versions.altair.util.AttestationUtilAltair;
 import tech.pegasys.teku.spec.logic.versions.bellatrix.helpers.BellatrixTransitionHelpers;
+import tech.pegasys.teku.spec.logic.versions.phase0.operations.validation.AttestationDataValidatorPhase0;
 import tech.pegasys.teku.spec.logic.versions.phase0.operations.validation.OperationValidatorPhase0;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsAltair;
 
@@ -106,9 +108,11 @@ public class SpecLogicAltair extends AbstractSpecLogic {
         new AttestationUtilAltair(config, schemaDefinitions, beaconStateAccessors, miscHelpers);
     // specific operation validator from spec so that things can hapepn like rejecting bls to
     // execution change
+    final AttestationDataValidator attestationDataValidator =
+        new AttestationDataValidatorPhase0(config, miscHelpers, beaconStateAccessors);
     final OperationValidator operationValidator =
         new OperationValidatorPhase0(
-            config, predicates, miscHelpers, beaconStateAccessors, attestationUtil);
+            config, predicates, beaconStateAccessors, attestationDataValidator, attestationUtil);
     final ValidatorStatusFactoryAltair validatorStatusFactory =
         new ValidatorStatusFactoryAltair(
             config,

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/helpers/BeaconStateAccessorsAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/helpers/BeaconStateAccessorsAltair.java
@@ -196,7 +196,7 @@ public class BeaconStateAccessorsAltair extends BeaconStateAccessors {
         && inclusionDelay.isLessThanOrEqualTo(config.getSquareRootSlotsPerEpoch())) {
       participationFlagIndices.add(ParticipationFlags.TIMELY_SOURCE_FLAG_INDEX);
     }
-    if (isMatchingTarget && inclusionDelay.isLessThanOrEqualTo(config.getSlotsPerEpoch())) {
+    if (shouldSetTargetTimelinessFlag(isMatchingTarget, inclusionDelay)) {
       participationFlagIndices.add(ParticipationFlags.TIMELY_TARGET_FLAG_INDEX);
     }
     if (isMatchingHead
@@ -204,6 +204,11 @@ public class BeaconStateAccessorsAltair extends BeaconStateAccessors {
       participationFlagIndices.add(ParticipationFlags.TIMELY_HEAD_FLAG_INDEX);
     }
     return participationFlagIndices;
+  }
+
+  protected boolean shouldSetTargetTimelinessFlag(
+      final boolean isMatchingTarget, final UInt64 inclusionDelay) {
+    return isMatchingTarget && inclusionDelay.isLessThanOrEqualTo(config.getSlotsPerEpoch());
   }
 
   public static BeaconStateAccessorsAltair required(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/bellatrix/SpecLogicBellatrix.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/bellatrix/SpecLogicBellatrix.java
@@ -18,6 +18,7 @@ import tech.pegasys.teku.spec.config.SpecConfigBellatrix;
 import tech.pegasys.teku.spec.logic.common.AbstractSpecLogic;
 import tech.pegasys.teku.spec.logic.common.helpers.Predicates;
 import tech.pegasys.teku.spec.logic.common.operations.OperationSignatureVerifier;
+import tech.pegasys.teku.spec.logic.common.operations.validation.AttestationDataValidator;
 import tech.pegasys.teku.spec.logic.common.operations.validation.OperationValidator;
 import tech.pegasys.teku.spec.logic.common.util.AttestationUtil;
 import tech.pegasys.teku.spec.logic.common.util.BeaconStateUtil;
@@ -37,6 +38,7 @@ import tech.pegasys.teku.spec.logic.versions.bellatrix.helpers.BellatrixTransiti
 import tech.pegasys.teku.spec.logic.versions.bellatrix.helpers.MiscHelpersBellatrix;
 import tech.pegasys.teku.spec.logic.versions.bellatrix.statetransition.epoch.EpochProcessorBellatrix;
 import tech.pegasys.teku.spec.logic.versions.bellatrix.util.BlindBlockUtilBellatrix;
+import tech.pegasys.teku.spec.logic.versions.phase0.operations.validation.AttestationDataValidatorPhase0;
 import tech.pegasys.teku.spec.logic.versions.phase0.operations.validation.OperationValidatorPhase0;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsBellatrix;
 
@@ -110,9 +112,11 @@ public class SpecLogicBellatrix extends AbstractSpecLogic {
             config, schemaDefinitions, predicates, miscHelpers, beaconStateAccessors);
     final AttestationUtil attestationUtil =
         new AttestationUtilAltair(config, schemaDefinitions, beaconStateAccessors, miscHelpers);
+    final AttestationDataValidator attestationDataValidator =
+        new AttestationDataValidatorPhase0(config, miscHelpers, beaconStateAccessors);
     final OperationValidator operationValidator =
         new OperationValidatorPhase0(
-            config, predicates, miscHelpers, beaconStateAccessors, attestationUtil);
+            config, predicates, beaconStateAccessors, attestationDataValidator, attestationUtil);
     final ValidatorStatusFactoryAltair validatorStatusFactory =
         new ValidatorStatusFactoryAltair(
             config,

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/SpecLogicCapella.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/SpecLogicCapella.java
@@ -18,6 +18,7 @@ import tech.pegasys.teku.spec.config.SpecConfigCapella;
 import tech.pegasys.teku.spec.logic.common.AbstractSpecLogic;
 import tech.pegasys.teku.spec.logic.common.helpers.Predicates;
 import tech.pegasys.teku.spec.logic.common.operations.OperationSignatureVerifier;
+import tech.pegasys.teku.spec.logic.common.operations.validation.AttestationDataValidator;
 import tech.pegasys.teku.spec.logic.common.operations.validation.OperationValidator;
 import tech.pegasys.teku.spec.logic.common.util.AttestationUtil;
 import tech.pegasys.teku.spec.logic.common.util.BeaconStateUtil;
@@ -39,6 +40,7 @@ import tech.pegasys.teku.spec.logic.versions.capella.forktransition.CapellaState
 import tech.pegasys.teku.spec.logic.versions.capella.helpers.MiscHelpersCapella;
 import tech.pegasys.teku.spec.logic.versions.capella.operations.validation.OperationValidatorCapella;
 import tech.pegasys.teku.spec.logic.versions.capella.statetransition.epoch.EpochProcessorCapella;
+import tech.pegasys.teku.spec.logic.versions.phase0.operations.validation.AttestationDataValidatorPhase0;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsCapella;
 
 public class SpecLogicCapella extends AbstractSpecLogic {
@@ -110,9 +112,11 @@ public class SpecLogicCapella extends AbstractSpecLogic {
             config, schemaDefinitions, predicates, miscHelpers, beaconStateAccessors);
     final AttestationUtil attestationUtil =
         new AttestationUtilAltair(config, schemaDefinitions, beaconStateAccessors, miscHelpers);
+    final AttestationDataValidator attestationDataValidator =
+        new AttestationDataValidatorPhase0(config, miscHelpers, beaconStateAccessors);
     final OperationValidator operationValidator =
         new OperationValidatorCapella(
-            config, predicates, miscHelpers, beaconStateAccessors, attestationUtil);
+            config, predicates, beaconStateAccessors, attestationDataValidator, attestationUtil);
     final ValidatorStatusFactoryAltair validatorStatusFactory =
         new ValidatorStatusFactoryAltair(
             config,

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/operations/validation/OperationValidatorCapella.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/operations/validation/OperationValidatorCapella.java
@@ -19,8 +19,8 @@ import tech.pegasys.teku.spec.datastructures.operations.BlsToExecutionChange;
 import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
-import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
 import tech.pegasys.teku.spec.logic.common.helpers.Predicates;
+import tech.pegasys.teku.spec.logic.common.operations.validation.AttestationDataValidator;
 import tech.pegasys.teku.spec.logic.common.operations.validation.OperationInvalidReason;
 import tech.pegasys.teku.spec.logic.common.util.AttestationUtil;
 import tech.pegasys.teku.spec.logic.versions.phase0.operations.validation.OperationValidatorPhase0;
@@ -33,10 +33,10 @@ public class OperationValidatorCapella extends OperationValidatorPhase0 {
   public OperationValidatorCapella(
       final SpecConfig specConfig,
       final Predicates predicates,
-      final MiscHelpers miscHelpers,
       final BeaconStateAccessors beaconStateAccessors,
+      final AttestationDataValidator attestationDataValidator,
       final AttestationUtil attestationUtil) {
-    super(specConfig, predicates, miscHelpers, beaconStateAccessors, attestationUtil);
+    super(specConfig, predicates, beaconStateAccessors, attestationDataValidator, attestationUtil);
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/SpecLogicDeneb.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/SpecLogicDeneb.java
@@ -18,6 +18,7 @@ import tech.pegasys.teku.spec.config.SpecConfigDeneb;
 import tech.pegasys.teku.spec.logic.common.AbstractSpecLogic;
 import tech.pegasys.teku.spec.logic.common.helpers.Predicates;
 import tech.pegasys.teku.spec.logic.common.operations.OperationSignatureVerifier;
+import tech.pegasys.teku.spec.logic.common.operations.validation.AttestationDataValidator;
 import tech.pegasys.teku.spec.logic.common.operations.validation.OperationValidator;
 import tech.pegasys.teku.spec.logic.common.util.AttestationUtil;
 import tech.pegasys.teku.spec.logic.common.util.BeaconStateUtil;
@@ -39,6 +40,7 @@ import tech.pegasys.teku.spec.logic.versions.deneb.block.BlockProcessorDeneb;
 import tech.pegasys.teku.spec.logic.versions.deneb.forktransition.DenebStateUpgrade;
 import tech.pegasys.teku.spec.logic.versions.deneb.helpers.BeaconStateAccessorsDeneb;
 import tech.pegasys.teku.spec.logic.versions.deneb.helpers.MiscHelpersDeneb;
+import tech.pegasys.teku.spec.logic.versions.deneb.operations.validation.AttestationDataValidatorDeneb;
 import tech.pegasys.teku.spec.logic.versions.deneb.util.BlindBlockUtilDeneb;
 import tech.pegasys.teku.spec.logic.versions.deneb.util.ForkChoiceUtilDeneb;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsDeneb;
@@ -109,9 +111,11 @@ public class SpecLogicDeneb extends AbstractSpecLogic {
             config, schemaDefinitions, predicates, miscHelpers, beaconStateAccessors);
     final AttestationUtil attestationUtil =
         new AttestationUtilAltair(config, schemaDefinitions, beaconStateAccessors, miscHelpers);
+    final AttestationDataValidator attestationDataValidator =
+        new AttestationDataValidatorDeneb(config, miscHelpers, beaconStateAccessors);
     final OperationValidator operationValidator =
         new OperationValidatorCapella(
-            config, predicates, miscHelpers, beaconStateAccessors, attestationUtil);
+            config, predicates, beaconStateAccessors, attestationDataValidator, attestationUtil);
     final ValidatorStatusFactoryAltair validatorStatusFactory =
         new ValidatorStatusFactoryAltair(
             config,

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/helpers/BeaconStateAccessorsDeneb.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/helpers/BeaconStateAccessorsDeneb.java
@@ -14,20 +14,33 @@
 package tech.pegasys.teku.spec.logic.versions.deneb.helpers;
 
 import org.apache.tuweni.bytes.Bytes32;
-import tech.pegasys.teku.spec.config.SpecConfigAltair;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.config.SpecConfigCapella;
+import tech.pegasys.teku.spec.config.SpecConfigDeneb;
 import tech.pegasys.teku.spec.constants.Domain;
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.logic.common.helpers.Predicates;
 import tech.pegasys.teku.spec.logic.versions.altair.helpers.BeaconStateAccessorsAltair;
-import tech.pegasys.teku.spec.logic.versions.altair.helpers.MiscHelpersAltair;
 
 public class BeaconStateAccessorsDeneb extends BeaconStateAccessorsAltair {
 
   public BeaconStateAccessorsDeneb(
-      SpecConfigAltair config, Predicates predicates, MiscHelpersAltair miscHelpers) {
+      final SpecConfigDeneb config,
+      final Predicates predicates,
+      final MiscHelpersDeneb miscHelpers) {
     super(config, predicates, miscHelpers);
+  }
+
+  /**
+   * <a
+   * href="https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/beacon-chain.md#modified-get_attestation_participation_flag_indices">Modified
+   * get_attestation_participation_flag_indices</a>
+   */
+  @Override
+  protected boolean shouldSetTargetTimelinessFlag(
+      final boolean isMatchingTarget, final UInt64 inclusionDelay) {
+    return isMatchingTarget;
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/helpers/BeaconStateAccessorsDeneb.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/helpers/BeaconStateAccessorsDeneb.java
@@ -32,6 +32,15 @@ public class BeaconStateAccessorsDeneb extends BeaconStateAccessorsAltair {
     super(config, predicates, miscHelpers);
   }
 
+  @Override
+  public Bytes32 getVoluntaryExitDomain(
+      final SignedVoluntaryExit signedVoluntaryExit, final BeaconState state) {
+    return miscHelpers.computeDomain(
+        Domain.VOLUNTARY_EXIT,
+        SpecConfigCapella.required(config).getCapellaForkVersion(),
+        state.getGenesisValidatorsRoot());
+  }
+
   /**
    * <a
    * href="https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/beacon-chain.md#modified-get_attestation_participation_flag_indices">Modified
@@ -41,14 +50,5 @@ public class BeaconStateAccessorsDeneb extends BeaconStateAccessorsAltair {
   protected boolean shouldSetTargetTimelinessFlag(
       final boolean isMatchingTarget, final UInt64 inclusionDelay) {
     return isMatchingTarget;
-  }
-
-  @Override
-  public Bytes32 getVoluntaryExitDomain(
-      final SignedVoluntaryExit signedVoluntaryExit, final BeaconState state) {
-    return miscHelpers.computeDomain(
-        Domain.VOLUNTARY_EXIT,
-        SpecConfigCapella.required(config).getCapellaForkVersion(),
-        state.getGenesisValidatorsRoot());
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/operations/validation/AttestationDataValidatorDeneb.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/operations/validation/AttestationDataValidatorDeneb.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright ConsenSys Software Inc., 2023
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.logic.versions.deneb.operations.validation;
+
+import java.util.Optional;
+import tech.pegasys.teku.spec.config.SpecConfig;
+import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
+import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
+import tech.pegasys.teku.spec.logic.common.operations.validation.OperationInvalidReason;
+import tech.pegasys.teku.spec.logic.versions.phase0.operations.validation.AttestationDataValidatorPhase0;
+
+public class AttestationDataValidatorDeneb extends AttestationDataValidatorPhase0 {
+
+  public AttestationDataValidatorDeneb(
+      final SpecConfig specConfig,
+      final MiscHelpers miscHelpers,
+      final BeaconStateAccessors beaconStateAccessors) {
+    super(specConfig, miscHelpers, beaconStateAccessors);
+  }
+
+  /**
+   * <a
+   * href="https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/beacon-chain.md#modified-process_attestation">Modified
+   * process_attestation</a>
+   */
+  @Override
+  protected Optional<OperationInvalidReason> isSubmittedTooLate(
+      final BeaconState state, final AttestationData data) {
+    return Optional.empty();
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/SpecLogicPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/SpecLogicPhase0.java
@@ -21,6 +21,7 @@ import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateMutators;
 import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
 import tech.pegasys.teku.spec.logic.common.helpers.Predicates;
 import tech.pegasys.teku.spec.logic.common.operations.OperationSignatureVerifier;
+import tech.pegasys.teku.spec.logic.common.operations.validation.AttestationDataValidator;
 import tech.pegasys.teku.spec.logic.common.operations.validation.OperationValidator;
 import tech.pegasys.teku.spec.logic.common.util.AttestationUtil;
 import tech.pegasys.teku.spec.logic.common.util.BeaconStateUtil;
@@ -32,6 +33,7 @@ import tech.pegasys.teku.spec.logic.common.util.ValidatorsUtil;
 import tech.pegasys.teku.spec.logic.versions.bellatrix.helpers.BellatrixTransitionHelpers;
 import tech.pegasys.teku.spec.logic.versions.phase0.block.BlockProcessorPhase0;
 import tech.pegasys.teku.spec.logic.versions.phase0.helpers.BeaconStateAccessorsPhase0;
+import tech.pegasys.teku.spec.logic.versions.phase0.operations.validation.AttestationDataValidatorPhase0;
 import tech.pegasys.teku.spec.logic.versions.phase0.operations.validation.OperationValidatorPhase0;
 import tech.pegasys.teku.spec.logic.versions.phase0.statetransition.epoch.EpochProcessorPhase0;
 import tech.pegasys.teku.spec.logic.versions.phase0.statetransition.epoch.ValidatorStatusFactoryPhase0;
@@ -96,9 +98,11 @@ public class SpecLogicPhase0 extends AbstractSpecLogic {
             config, schemaDefinitions, predicates, miscHelpers, beaconStateAccessors);
     final AttestationUtil attestationUtil =
         new AttestationUtilPhase0(config, schemaDefinitions, beaconStateAccessors, miscHelpers);
+    final AttestationDataValidator attestationDataValidator =
+        new AttestationDataValidatorPhase0(config, miscHelpers, beaconStateAccessors);
     final OperationValidator operationValidator =
         new OperationValidatorPhase0(
-            config, predicates, miscHelpers, beaconStateAccessors, attestationUtil);
+            config, predicates, beaconStateAccessors, attestationDataValidator, attestationUtil);
     final ValidatorStatusFactoryPhase0 validatorStatusFactory =
         new ValidatorStatusFactoryPhase0(
             config, beaconStateUtil, attestationUtil, beaconStateAccessors, predicates);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/operations/validation/OperationValidatorPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/operations/validation/OperationValidatorPhase0.java
@@ -23,8 +23,8 @@ import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
-import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
 import tech.pegasys.teku.spec.logic.common.helpers.Predicates;
+import tech.pegasys.teku.spec.logic.common.operations.validation.AttestationDataValidator;
 import tech.pegasys.teku.spec.logic.common.operations.validation.OperationInvalidReason;
 import tech.pegasys.teku.spec.logic.common.operations.validation.OperationValidator;
 import tech.pegasys.teku.spec.logic.common.util.AttestationUtil;
@@ -40,11 +40,10 @@ public class OperationValidatorPhase0 implements OperationValidator {
   public OperationValidatorPhase0(
       final SpecConfig specConfig,
       final Predicates predicates,
-      final MiscHelpers miscHelpers,
       final BeaconStateAccessors beaconStateAccessors,
+      final AttestationDataValidator attestationDataValidator,
       final AttestationUtil attestationUtil) {
-    this.attestationDataValidator =
-        new AttestationDataValidator(specConfig, miscHelpers, beaconStateAccessors);
+    this.attestationDataValidator = attestationDataValidator;
     this.attesterSlashingValidator =
         new AttesterSlashingValidator(predicates, beaconStateAccessors, attestationUtil);
     this.proposerSlashingValidator =

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/phase0/operations/validation/OperationValidatorPhase0Test.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/phase0/operations/validation/OperationValidatorPhase0Test.java
@@ -23,8 +23,8 @@ import tech.pegasys.teku.spec.datastructures.operations.BlsToExecutionChange;
 import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
-import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
 import tech.pegasys.teku.spec.logic.common.helpers.Predicates;
+import tech.pegasys.teku.spec.logic.common.operations.validation.AttestationDataValidator;
 import tech.pegasys.teku.spec.logic.common.operations.validation.OperationInvalidReason;
 import tech.pegasys.teku.spec.logic.common.operations.validation.OperationValidator;
 import tech.pegasys.teku.spec.logic.common.util.AttestationUtil;
@@ -35,12 +35,16 @@ public class OperationValidatorPhase0Test {
   void shouldRejectBlsOperationsPhase0() {
     final SpecConfig specConfig = mock(SpecConfig.class);
     final Predicates predicates = mock(Predicates.class);
-    final MiscHelpers miscHelpers = mock(MiscHelpers.class);
     final BeaconStateAccessors beaconStateAccessors = mock(BeaconStateAccessors.class);
+    final AttestationDataValidator attestationDataValidator = mock(AttestationDataValidator.class);
     final AttestationUtil attestationUtil = mock(AttestationUtil.class);
     final OperationValidator operationValidator =
         new OperationValidatorPhase0(
-            specConfig, predicates, miscHelpers, beaconStateAccessors, attestationUtil);
+            specConfig,
+            predicates,
+            beaconStateAccessors,
+            attestationDataValidator,
+            attestationUtil);
 
     assertThat(
             operationValidator.validateBlsToExecutionChange(
@@ -48,8 +52,8 @@ public class OperationValidatorPhase0Test {
         .containsInstanceOf(OperationInvalidReason.class);
     verifyNoInteractions(specConfig);
     verifyNoInteractions(predicates);
-    verifyNoInteractions(miscHelpers);
     verifyNoInteractions(beaconStateAccessors);
+    verifyNoInteractions(attestationDataValidator);
     verifyNoInteractions(attestationUtil);
   }
 }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPoolTest.java
@@ -40,8 +40,8 @@ import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation.AttestationSchema;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.logic.common.operations.validation.AttestationDataValidator.AttestationInvalidReason;
 import tech.pegasys.teku.spec.logic.common.statetransition.attestation.AttestationWorthinessChecker;
-import tech.pegasys.teku.spec.logic.versions.phase0.operations.validation.AttestationDataValidator.AttestationInvalidReason;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 class AggregatingAttestationPoolTest {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/GossipTopics.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/GossipTopics.java
@@ -18,6 +18,7 @@ import java.util.Set;
 import tech.pegasys.teku.infrastructure.bytes.Bytes4;
 import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
 import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.config.NetworkingSpecConfigDeneb;
 import tech.pegasys.teku.spec.constants.NetworkConstants;
 
 /**
@@ -73,11 +74,14 @@ public class GossipTopics {
     for (int i = 0; i < NetworkConstants.SYNC_COMMITTEE_SUBNET_COUNT; i++) {
       topics.add(getSyncCommitteeSubnetTopic(forkDigest, i, gossipEncoding));
     }
-    if (spec.getNetworkingConfigDeneb().isPresent()) {
-      for (int i = 0; i < spec.getNetworkingConfigDeneb().get().getBlobSidecarSubnetCount(); i++) {
-        topics.add(getBlobSidecarSubnetTopic(forkDigest, i, gossipEncoding));
-      }
-    }
+    spec.getNetworkingConfigDeneb()
+        .map(NetworkingSpecConfigDeneb::getBlobSidecarSubnetCount)
+        .ifPresent(
+            blobSidecarSubnetCount -> {
+              for (int i = 0; i < blobSidecarSubnetCount; i++) {
+                topics.add(getBlobSidecarSubnetTopic(forkDigest, i, gossipEncoding));
+              }
+            });
     for (GossipTopicName topicName : GossipTopicName.values()) {
       topics.add(GossipTopics.getTopic(forkDigest, topicName, gossipEncoding));
     }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/GossipTopics.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/GossipTopics.java
@@ -18,7 +18,6 @@ import java.util.Set;
 import tech.pegasys.teku.infrastructure.bytes.Bytes4;
 import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.config.NetworkingSpecConfigDeneb;
 import tech.pegasys.teku.spec.constants.NetworkConstants;
 
 /**
@@ -74,14 +73,11 @@ public class GossipTopics {
     for (int i = 0; i < NetworkConstants.SYNC_COMMITTEE_SUBNET_COUNT; i++) {
       topics.add(getSyncCommitteeSubnetTopic(forkDigest, i, gossipEncoding));
     }
-    spec.getNetworkingConfigDeneb()
-        .map(NetworkingSpecConfigDeneb::getBlobSidecarSubnetCount)
-        .ifPresent(
-            blobSidecarSubnetCount -> {
-              for (int i = 0; i < blobSidecarSubnetCount; i++) {
-                topics.add(getBlobSidecarSubnetTopic(forkDigest, i, gossipEncoding));
-              }
-            });
+    if (spec.getNetworkingConfigDeneb().isPresent()) {
+      for (int i = 0; i < spec.getNetworkingConfigDeneb().get().getBlobSidecarSubnetCount(); i++) {
+        topics.add(getBlobSidecarSubnetTopic(forkDigest, i, gossipEncoding));
+      }
+    }
     for (GossipTopicName topicName : GossipTopicName.values()) {
       topics.add(GossipTopics.getTopic(forkDigest, topicName, gossipEncoding));
     }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

- Made AttestationDataValidator an interface and fork specific. Created isSubmittedTooLate in Phase0 version and overwrote it in Deneb.
- Created shouldSetTargetTimelinessFlag in BeaconStateAccessorsAltair and overwrote it in the Deneb version.
- Reenable ref tests

[beacon-chain.md changes](https://github.com/ethereum/consensus-specs/pull/3360/files#diff-9f15a67423aa26dc6425173446b92922db983cecb326b8e7beff60934cfe27ce)

## Fixed Issue(s)
one part of #7299 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
