### PR TITLE
fix PubKeyLoader from externalSigner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,4 +14,6 @@ For information on changes in released versions of Teku, see the [releases page]
 
 ### Additions and Improvements
 
+- `--validators-external-signer-public-keys` parameter now accepts `external-signer` value. It will enable public key retrieval from external signer standard API, making sure that configured keystore and trustStore will be used, if any.
+
 ### Bug Fixes

--- a/validator/api/build.gradle
+++ b/validator/api/build.gradle
@@ -10,6 +10,7 @@ dependencies {
   implementation project(':data:serializer')
 
   testImplementation testFixtures(project(':infrastructure:bls'))
+  testImplementation testFixtures(project(':infrastructure:logging'))
   testImplementation testFixtures(project(':ethereum:spec'))
 }
 

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
@@ -603,7 +603,7 @@ public class ValidatorConfig {
                 final URL url = new URL(source);
                 if (hostAndPortMatching(url, validatorExternalSignerUrl)) {
                   LOG.warn(
-                      "'--validators-external-signer-public-keys' contains an URL matching the external-signer-url host and port. Use 'external-signer' instead if you want to use all public keys exposed by the external-signer");
+                      "'--validators-external-signer-public-keys' contains an URL matching the external-signer-url host and port. Use 'external-signer' instead if you want to use all public keys exposed by the external signer");
                 }
               } catch (MalformedURLException e) {
                 throw new InvalidConfigurationException(

--- a/validator/api/src/test/java/tech/pegasys/teku/validator/api/ValidatorConfigTest.java
+++ b/validator/api/src/test/java/tech/pegasys/teku/validator/api/ValidatorConfigTest.java
@@ -81,7 +81,7 @@ class ValidatorConfigTest {
       Assertions.assertThatCode(builder::build).doesNotThrowAnyException();
 
       logCaptor.assertWarnLog(
-          "'--validators-external-signer-public-keys' contains an URL matching the external-signer-url host and port. Use 'external-signer' instead if you want to use all public keys exposed by the external-signer");
+          "'--validators-external-signer-public-keys' contains an URL matching the external-signer-url host and port. Use 'external-signer' instead if you want to use all public keys exposed by the external signer");
     }
   }
 

--- a/validator/client/src/integration-test/java/tech/pegasys/teku/validator/client/signer/ExternalSignerAltairIntegrationTest.java
+++ b/validator/client/src/integration-test/java/tech/pegasys/teku/validator/client/signer/ExternalSignerAltairIntegrationTest.java
@@ -22,10 +22,12 @@ import static tech.pegasys.teku.validator.client.signer.ExternalSignerTestUtil.v
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.net.http.HttpClient;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.AfterEach;
@@ -98,13 +100,13 @@ public class ExternalSignerAltairIntegrationTest {
             .validatorExternalSignerUrl(new URL("http://127.0.0.1:" + client.getLocalPort()))
             .validatorExternalSignerTimeout(TIMEOUT)
             .build();
-    final HttpClientExternalSignerFactory httpClientExternalSignerFactory =
-        new HttpClientExternalSignerFactory(config);
+    final Supplier<HttpClient> externalSignerHttpClientFactory =
+        HttpClientExternalSignerFactory.create(config);
 
     externalSigner =
         new ExternalSigner(
             spec,
-            httpClientExternalSignerFactory.get(),
+            externalSignerHttpClientFactory.get(),
             config.getValidatorExternalSignerUrl(),
             KEYPAIR.getPublicKey(),
             TIMEOUT,

--- a/validator/client/src/integration-test/java/tech/pegasys/teku/validator/client/signer/ExternalSignerBellatrixBlockSigningIntegrationTest.java
+++ b/validator/client/src/integration-test/java/tech/pegasys/teku/validator/client/signer/ExternalSignerBellatrixBlockSigningIntegrationTest.java
@@ -22,9 +22,11 @@ import static tech.pegasys.teku.validator.client.signer.ExternalSignerTestUtil.v
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.net.http.HttpClient;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -73,13 +75,13 @@ public class ExternalSignerBellatrixBlockSigningIntegrationTest {
             .validatorExternalSignerUrl(new URL("http://127.0.0.1:" + client.getLocalPort()))
             .validatorExternalSignerTimeout(TIMEOUT)
             .build();
-    final HttpClientExternalSignerFactory httpClientExternalSignerFactory =
-        new HttpClientExternalSignerFactory(config);
+    final Supplier<HttpClient> externalSignerHttpClientFactory =
+        HttpClientExternalSignerFactory.create(config);
 
     externalSigner =
         new ExternalSigner(
             spec,
-            httpClientExternalSignerFactory.get(),
+            externalSignerHttpClientFactory.get(),
             config.getValidatorExternalSignerUrl(),
             KEYPAIR.getPublicKey(),
             TIMEOUT,

--- a/validator/client/src/integration-test/java/tech/pegasys/teku/validator/client/signer/ExternalSignerIntegrationTest.java
+++ b/validator/client/src/integration-test/java/tech/pegasys/teku/validator/client/signer/ExternalSignerIntegrationTest.java
@@ -28,9 +28,11 @@ import static tech.pegasys.teku.validator.client.signer.ExternalSignerTestUtil.v
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.net.http.HttpClient;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -85,13 +87,13 @@ public class ExternalSignerIntegrationTest {
             .validatorExternalSignerUrl(new URL("http://127.0.0.1:" + client.getLocalPort()))
             .validatorExternalSignerTimeout(TIMEOUT)
             .build();
-    final HttpClientExternalSignerFactory httpClientExternalSignerFactory =
-        new HttpClientExternalSignerFactory(config);
+    final Supplier<HttpClient> externalSignerHttpClientFactory =
+        HttpClientExternalSignerFactory.create(config);
 
     externalSigner =
         new ExternalSigner(
             spec,
-            httpClientExternalSignerFactory.get(),
+            externalSignerHttpClientFactory.get(),
             config.getValidatorExternalSignerUrl(),
             KEYPAIR.getPublicKey(),
             TIMEOUT,

--- a/validator/client/src/integration-test/java/tech/pegasys/teku/validator/client/signer/ExternalSignerUpcheckTLSIntegrationTest.java
+++ b/validator/client/src/integration-test/java/tech/pegasys/teku/validator/client/signer/ExternalSignerUpcheckTLSIntegrationTest.java
@@ -20,9 +20,11 @@ import com.google.common.io.Resources;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.net.http.HttpClient;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.List;
+import java.util.function.Supplier;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -90,11 +92,11 @@ public class ExternalSignerUpcheckTLSIntegrationTest {
             .validatorExternalSignerTruststorePasswordFile(PASSWORD_FILE)
             .build();
 
-    final HttpClientExternalSignerFactory httpClientExternalSignerFactory =
-        new HttpClientExternalSignerFactory(config);
+    final Supplier<HttpClient> externalSignerHttpClientFactory =
+        HttpClientExternalSignerFactory.create(config);
 
     return new ExternalSignerUpcheck(
-        httpClientExternalSignerFactory.get(),
+        externalSignerHttpClientFactory.get(),
         config.getValidatorExternalSignerUrl(),
         config.getValidatorExternalSignerTimeout());
   }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/HttpClientExternalSignerFactory.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/HttpClientExternalSignerFactory.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.validator.client.loader;
 
+import com.google.common.base.Suppliers;
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -37,7 +38,11 @@ import tech.pegasys.teku.validator.api.ValidatorConfig;
 public class HttpClientExternalSignerFactory implements Supplier<HttpClient> {
   private final ValidatorConfig validatorConfig;
 
-  public HttpClientExternalSignerFactory(final ValidatorConfig validatorConfig) {
+  public static Supplier<HttpClient> create(final ValidatorConfig validatorConfig) {
+    return Suppliers.memoize(new HttpClientExternalSignerFactory(validatorConfig)::get);
+  }
+
+  private HttpClientExternalSignerFactory(final ValidatorConfig validatorConfig) {
     this.validatorConfig = validatorConfig;
   }
 

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/PublicKeyLoader.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/PublicKeyLoader.java
@@ -14,27 +14,57 @@
 package tech.pegasys.teku.validator.client.loader;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.infrastructure.exceptions.InvalidConfigurationException;
+import tech.pegasys.teku.infrastructure.http.HttpStatusCodes;
 
 public class PublicKeyLoader {
-  final ObjectMapper objectMapper;
+  public static final String EXTERNAL_SIGNER_PUBKEYS_ENDPOINT = "/api/v1/eth2/publicKeys";
+  public static final String EXTERNAL_SIGNER_SOURCE_ID = "external-signer";
 
-  public PublicKeyLoader() {
-    this(new ObjectMapper());
+  final ObjectMapper objectMapper;
+  final Supplier<HttpClient> externalSignerHttpClientFactory;
+  final URL externalSignerUrl;
+
+  @VisibleForTesting
+  PublicKeyLoader() {
+    this(
+        new ObjectMapper(),
+        () -> {
+          throw new UnsupportedOperationException();
+        },
+        null);
   }
 
-  public PublicKeyLoader(final ObjectMapper objectMapper) {
+  public PublicKeyLoader(
+      final Supplier<HttpClient> externalSignerHttpClientFactory, final URL externalSignerUrl) {
+    this(new ObjectMapper(), externalSignerHttpClientFactory, externalSignerUrl);
+  }
+
+  public PublicKeyLoader(
+      final ObjectMapper objectMapper,
+      final Supplier<HttpClient> externalSignerHttpClientFactory,
+      final URL externalSignerUrl) {
     this.objectMapper = objectMapper;
+    this.externalSignerHttpClientFactory = externalSignerHttpClientFactory;
+    this.externalSignerUrl = externalSignerUrl;
   }
 
   public List<BLSPublicKey> getPublicKeys(final List<String> sources) {
@@ -46,10 +76,16 @@ public class PublicKeyLoader {
       final Set<BLSPublicKey> blsPublicKeySet =
           sources.stream()
               .flatMap(
-                  key ->
-                      key.contains(":")
-                          ? readKeysFromUrl(key)
-                          : Stream.of(BLSPublicKey.fromSSZBytes(Bytes.fromHexString(key))))
+                  key -> {
+                    if (key.equalsIgnoreCase(EXTERNAL_SIGNER_SOURCE_ID)) {
+                      return readKeysFromExternalSigner();
+                    }
+                    if (key.contains(":")) {
+                      return readKeysFromUrl(key);
+                    }
+
+                    return Stream.of(BLSPublicKey.fromSSZBytes(Bytes.fromHexString(key)));
+                  })
               .collect(Collectors.toSet());
 
       return List.copyOf(blsPublicKeySet);
@@ -65,6 +101,30 @@ public class PublicKeyLoader {
       return Arrays.stream(keys).map(key -> BLSPublicKey.fromSSZBytes(Bytes.fromHexString(key)));
     } catch (IOException ex) {
       throw new InvalidConfigurationException("Failed to load public keys from URL " + url, ex);
+    }
+  }
+
+  private Stream<BLSPublicKey> readKeysFromExternalSigner() {
+    try {
+      final URI uri = externalSignerUrl.toURI().resolve(EXTERNAL_SIGNER_PUBKEYS_ENDPOINT);
+      final HttpRequest request = HttpRequest.newBuilder().uri(uri).GET().build();
+      final HttpResponse<String> response =
+          externalSignerHttpClientFactory.get().send(request, BodyHandlers.ofString());
+      if (response.statusCode() != HttpStatusCodes.SC_OK) {
+        throw new ExternalSignerException(
+            "Public Keys endpoint returned " + response.statusCode() + " status code");
+      }
+      final String[] keys = objectMapper.readValue(response.body(), String[].class);
+      return Arrays.stream(keys).map(key -> BLSPublicKey.fromSSZBytes(Bytes.fromHexString(key)));
+    } catch (URISyntaxException | IOException | ExternalSignerException | InterruptedException ex) {
+      throw new InvalidConfigurationException(
+          "Failed to load public keys from external signer.", ex);
+    }
+  }
+
+  static class ExternalSignerException extends Exception {
+    ExternalSignerException(final String message) {
+      super(message);
     }
   }
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/PublicKeyLoader.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/PublicKeyLoader.java
@@ -30,8 +30,6 @@ import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.infrastructure.exceptions.InvalidConfigurationException;
@@ -40,7 +38,6 @@ import tech.pegasys.teku.infrastructure.http.HttpStatusCodes;
 public class PublicKeyLoader {
   public static final String EXTERNAL_SIGNER_PUBKEYS_ENDPOINT = "/api/v1/eth2/publicKeys";
   public static final String EXTERNAL_SIGNER_SOURCE_ID = "external-signer";
-  private static final Logger LOG = LogManager.getLogger();
 
   final ObjectMapper objectMapper;
   final Supplier<HttpClient> externalSignerHttpClientFactory;

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/PublicKeyLoader.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/PublicKeyLoader.java
@@ -95,14 +95,12 @@ public class PublicKeyLoader {
     }
   }
 
-  private Stream<BLSPublicKey> readKeysFromUrl(final String urlString) {
+  private Stream<BLSPublicKey> readKeysFromUrl(final String url) {
     try {
-      final URL url = new URL(urlString);
-      final String[] keys = objectMapper.readValue(url, String[].class);
+      final String[] keys = objectMapper.readValue(new URL(url), String[].class);
       return Arrays.stream(keys).map(key -> BLSPublicKey.fromSSZBytes(Bytes.fromHexString(key)));
     } catch (IOException ex) {
-      throw new InvalidConfigurationException(
-          "Failed to load public keys from URL " + urlString, ex);
+      throw new InvalidConfigurationException("Failed to load public keys from URL " + url, ex);
     }
   }
 

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/PublicKeyLoader.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/PublicKeyLoader.java
@@ -30,6 +30,8 @@ import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.infrastructure.exceptions.InvalidConfigurationException;
@@ -38,6 +40,7 @@ import tech.pegasys.teku.infrastructure.http.HttpStatusCodes;
 public class PublicKeyLoader {
   public static final String EXTERNAL_SIGNER_PUBKEYS_ENDPOINT = "/api/v1/eth2/publicKeys";
   public static final String EXTERNAL_SIGNER_SOURCE_ID = "external-signer";
+  private static final Logger LOG = LogManager.getLogger();
 
   final ObjectMapper objectMapper;
   final Supplier<HttpClient> externalSignerHttpClientFactory;
@@ -95,12 +98,14 @@ public class PublicKeyLoader {
     }
   }
 
-  private Stream<BLSPublicKey> readKeysFromUrl(final String url) {
+  private Stream<BLSPublicKey> readKeysFromUrl(final String urlString) {
     try {
-      final String[] keys = objectMapper.readValue(new URL(url), String[].class);
+      final URL url = new URL(urlString);
+      final String[] keys = objectMapper.readValue(url, String[].class);
       return Arrays.stream(keys).map(key -> BLSPublicKey.fromSSZBytes(Bytes.fromHexString(key)));
     } catch (IOException ex) {
-      throw new InvalidConfigurationException("Failed to load public keys from URL " + url, ex);
+      throw new InvalidConfigurationException(
+          "Failed to load public keys from URL " + urlString, ex);
     }
   }
 

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/ValidatorLoader.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/ValidatorLoader.java
@@ -14,7 +14,6 @@
 package tech.pegasys.teku.validator.client.loader;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Suppliers;
 import java.net.URL;
 import java.net.http.HttpClient;
 import java.util.HashMap;
@@ -69,31 +68,6 @@ public class ValidatorLoader {
     this.graffitiProvider = graffitiProvider;
     this.maybeDataDirLayout = maybeDataDirLayout;
     this.slashingProtectionLogger = slashingProtectionLogger;
-  }
-
-  public static ValidatorLoader create(
-      final Spec spec,
-      final ValidatorConfig config,
-      final InteropConfig interopConfig,
-      final SlashingProtector slashingProtector,
-      final SlashingProtectionLogger slashingProtectorLogger,
-      final PublicKeyLoader publicKeyLoader,
-      final AsyncRunner asyncRunner,
-      final MetricsSystem metricsSystem,
-      final Optional<DataDirLayout> maybeMutableDir) {
-    final Supplier<HttpClient> externalSignerHttpClientFactory =
-        Suppliers.memoize(new HttpClientExternalSignerFactory(config)::get);
-    return create(
-        spec,
-        config,
-        interopConfig,
-        externalSignerHttpClientFactory,
-        slashingProtector,
-        slashingProtectorLogger,
-        publicKeyLoader,
-        asyncRunner,
-        metricsSystem,
-        maybeMutableDir);
   }
 
   // synchronized to ensure that only one load is active at a time
@@ -239,8 +213,7 @@ public class ValidatorLoader {
     return ownedValidators;
   }
 
-  @VisibleForTesting
-  static ValidatorLoader create(
+  public static ValidatorLoader create(
       final Spec spec,
       final ValidatorConfig config,
       final InteropConfig interopConfig,


### PR DESCRIPTION
 `--validators-external-signer-public-keys` accepts `external-signer` value. external signer HttpClient (which includes TLS configuration) will be used when querying the standard `/api/v1/eth2/publicKeys` endpoint against the same url specified via `--validators-external-signer-url`.
 
 I decided to go this way to avoid possible breaking changes to people using https URLs relaying on default JVM trusted store. The benefit is also that, since it is a standard API, user doesn't need to specify the full URL.

fixes #7301 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
