### PR TITLE
Fix leveldb open iterators metrics counter

### DIFF
--- a/storage/src/main/java/tech/pegasys/teku/storage/server/leveldb/LevelDbInstance.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/leveldb/LevelDbInstance.java
@@ -343,7 +343,6 @@ public class LevelDbInstance implements KvStoreAccessor {
 
   private synchronized <T> T withIterator(final Function<DBIterator, T> action) {
     assertOpen();
-    openedIteratorsCounter.inc();
     final DBIterator iterator = createIterator();
     try {
       return action.apply(iterator);
@@ -375,6 +374,7 @@ public class LevelDbInstance implements KvStoreAccessor {
   private DBIterator createIterator() {
     final DBIterator iterator = db.iterator(new ReadOptions().fillCache(false));
     openIterators.add(iterator);
+    openedIteratorsCounter.inc();
     return iterator;
   }
 


### PR DESCRIPTION
counter increment in the wrong place, not capturing the iterators opened outside the `withIterator` method

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
