### PR TITLE
Fix ReconstructHistoricalStatesService not starting when initial anchor slot is 0

### DIFF
--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/historical/ReconstructHistoricalStatesService.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/historical/ReconstructHistoricalStatesService.java
@@ -114,7 +114,7 @@ public class ReconstructHistoricalStatesService extends Service {
               final UInt64 anchorSlot = checkpoint.get().getEpochStartSlot(spec);
 
               chainDataClient
-                  .getLatestAvailableFinalizedState(anchorSlot.decrement())
+                  .getLatestAvailableFinalizedState(anchorSlot.minusMinZero(1))
                   .thenComposeChecked(
                       latestState -> {
                         if (latestState.isPresent()) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

- This fixes an uint64 underflow issue when initial anchor slot is 0 (no --initial-state or genesis state specified) and `reconstruct-historic-states` is set to true. Technically in that case after this change, the ReconstructHistoricalStatesService does nothing and just completes with log message `ReconstructHistoricalStatesService reconstruction complete` but it is better than throwing an error.

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
