### PR TITLE
Introduces `ForkChoiceUpdatedV3` for Deneb

### DIFF
--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ExecutionEngineClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ExecutionEngineClient.java
@@ -25,6 +25,7 @@ import tech.pegasys.teku.ethereum.executionclient.schema.GetPayloadV2Response;
 import tech.pegasys.teku.ethereum.executionclient.schema.GetPayloadV3Response;
 import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV2;
+import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV3;
 import tech.pegasys.teku.ethereum.executionclient.schema.PayloadStatusV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.Response;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -57,6 +58,9 @@ public interface ExecutionEngineClient {
 
   SafeFuture<Response<ForkChoiceUpdatedResult>> forkChoiceUpdatedV2(
       ForkChoiceStateV1 forkChoiceState, Optional<PayloadAttributesV2> payloadAttributes);
+
+  SafeFuture<Response<ForkChoiceUpdatedResult>> forkChoiceUpdatedV3(
+      ForkChoiceStateV1 forkChoiceState, Optional<PayloadAttributesV3> payloadAttributes);
 
   SafeFuture<Response<List<String>>> exchangeCapabilities(List<String> capabilities);
 }

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ThrottlingExecutionEngineClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ThrottlingExecutionEngineClient.java
@@ -26,6 +26,7 @@ import tech.pegasys.teku.ethereum.executionclient.schema.GetPayloadV2Response;
 import tech.pegasys.teku.ethereum.executionclient.schema.GetPayloadV3Response;
 import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV2;
+import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV3;
 import tech.pegasys.teku.ethereum.executionclient.schema.PayloadStatusV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.Response;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -109,6 +110,14 @@ public class ThrottlingExecutionEngineClient implements ExecutionEngineClient {
       final Optional<PayloadAttributesV2> payloadAttributes) {
     return taskQueue.queueTask(
         () -> delegate.forkChoiceUpdatedV2(forkChoiceState, payloadAttributes));
+  }
+
+  @Override
+  public SafeFuture<Response<ForkChoiceUpdatedResult>> forkChoiceUpdatedV3(
+      final ForkChoiceStateV1 forkChoiceState,
+      final Optional<PayloadAttributesV3> payloadAttributes) {
+    return taskQueue.queueTask(
+        () -> delegate.forkChoiceUpdatedV3(forkChoiceState, payloadAttributes));
   }
 
   @Override

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineForkChoiceUpdatedV3.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineForkChoiceUpdatedV3.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright ConsenSys Software Inc., 2023
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionclient.methods;
+
+import java.util.Optional;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import tech.pegasys.teku.ethereum.executionclient.ExecutionEngineClient;
+import tech.pegasys.teku.ethereum.executionclient.response.ResponseUnwrapper;
+import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceStateV1;
+import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceUpdatedResult;
+import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV3;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.spec.executionlayer.ForkChoiceState;
+import tech.pegasys.teku.spec.executionlayer.PayloadBuildingAttributes;
+
+public class EngineForkChoiceUpdatedV3
+    extends AbstractEngineJsonRpcMethod<
+        tech.pegasys.teku.spec.executionlayer.ForkChoiceUpdatedResult> {
+
+  private static final Logger LOG = LogManager.getLogger();
+
+  public EngineForkChoiceUpdatedV3(final ExecutionEngineClient executionEngineClient) {
+    super(executionEngineClient);
+  }
+
+  @Override
+  public String getName() {
+    return EngineApiMethod.ENGINE_FORK_CHOICE_UPDATED.getName();
+  }
+
+  @Override
+  public int getVersion() {
+    return 3;
+  }
+
+  @Override
+  public SafeFuture<tech.pegasys.teku.spec.executionlayer.ForkChoiceUpdatedResult> execute(
+      final JsonRpcRequestParams params) {
+    final ForkChoiceState forkChoiceState = params.getRequiredParameter(0, ForkChoiceState.class);
+    final Optional<PayloadBuildingAttributes> payloadBuildingAttributes =
+        params.getOptionalParameter(1, PayloadBuildingAttributes.class);
+
+    LOG.trace(
+        "Calling {}(forkChoiceState={}, payloadAttributes={})",
+        getVersionedName(),
+        forkChoiceState,
+        payloadBuildingAttributes);
+
+    final Optional<PayloadAttributesV3> maybePayloadAttributes =
+        payloadBuildingAttributes.flatMap(
+            attributes ->
+                PayloadAttributesV3.fromInternalPayloadBuildingAttributesV3(
+                    payloadBuildingAttributes));
+
+    return executionEngineClient
+        .forkChoiceUpdatedV3(
+            ForkChoiceStateV1.fromInternalForkChoiceState(forkChoiceState), maybePayloadAttributes)
+        .thenApply(ResponseUnwrapper::unwrapExecutionClientResponseOrThrow)
+        .thenApply(ForkChoiceUpdatedResult::asInternalExecutionPayload)
+        .thenPeek(
+            forkChoiceUpdatedResult ->
+                LOG.trace(
+                    "Response {}(forkChoiceState={}, payloadAttributes={}) -> {}",
+                    getVersionedName(),
+                    forkChoiceState,
+                    payloadBuildingAttributes,
+                    forkChoiceUpdatedResult));
+  }
+}

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/metrics/MetricRecordingExecutionEngineClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/metrics/MetricRecordingExecutionEngineClient.java
@@ -28,6 +28,7 @@ import tech.pegasys.teku.ethereum.executionclient.schema.GetPayloadV2Response;
 import tech.pegasys.teku.ethereum.executionclient.schema.GetPayloadV3Response;
 import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV2;
+import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV3;
 import tech.pegasys.teku.ethereum.executionclient.schema.PayloadStatusV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.Response;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -53,6 +54,9 @@ public class MetricRecordingExecutionEngineClient extends MetricRecordingAbstrac
   public static final String FORKCHOICE_UPDATED_V2_METHOD = "forkchoice_updatedV2";
   public static final String FORKCHOICE_UPDATED_WITH_ATTRIBUTES_V2_METHOD =
       "forkchoice_updated_with_attributesV2";
+  public static final String FORKCHOICE_UPDATED_V3_METHOD = "forkchoice_updatedV3";
+  public static final String FORKCHOICE_UPDATED_WITH_ATTRIBUTES_V3_METHOD =
+      "forkchoice_updated_with_attributesV3";
   public static final String GET_PAYLOAD_V3_METHOD = "get_payloadV3";
   public static final String NEW_PAYLOAD_V3_METHOD = "new_payloadV3";
 
@@ -138,6 +142,17 @@ public class MetricRecordingExecutionEngineClient extends MetricRecordingAbstrac
         payloadAttributes.isPresent()
             ? FORKCHOICE_UPDATED_WITH_ATTRIBUTES_V2_METHOD
             : FORKCHOICE_UPDATED_V2_METHOD);
+  }
+
+  @Override
+  public SafeFuture<Response<ForkChoiceUpdatedResult>> forkChoiceUpdatedV3(
+      final ForkChoiceStateV1 forkChoiceState,
+      final Optional<PayloadAttributesV3> payloadAttributes) {
+    return countRequest(
+        () -> delegate.forkChoiceUpdatedV3(forkChoiceState, payloadAttributes),
+        payloadAttributes.isPresent()
+            ? FORKCHOICE_UPDATED_WITH_ATTRIBUTES_V3_METHOD
+            : FORKCHOICE_UPDATED_V3_METHOD);
   }
 
   @Override

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/PayloadAttributesV3.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/PayloadAttributesV3.java
@@ -14,51 +14,36 @@
 package tech.pegasys.teku.ethereum.executionclient.schema;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.bytes.Bytes20;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.datastructures.execution.versions.capella.Withdrawal;
 import tech.pegasys.teku.spec.executionlayer.PayloadBuildingAttributes;
 
-public class PayloadAttributesV2 extends PayloadAttributesV1 {
+public class PayloadAttributesV3 extends PayloadAttributesV2 {
 
-  public final List<WithdrawalV1> withdrawals;
+  public final Bytes32 parentBeaconBlockRoot;
 
-  public PayloadAttributesV2(
+  public PayloadAttributesV3(
       @JsonProperty("timestamp") UInt64 timestamp,
       @JsonProperty("prevRandao") Bytes32 prevRandao,
       @JsonProperty("suggestedFeeRecipient") Bytes20 suggestedFeeRecipient,
-      @JsonProperty("withdrawals") final List<WithdrawalV1> withdrawals) {
-    super(timestamp, prevRandao, suggestedFeeRecipient);
-    this.withdrawals = withdrawals;
+      @JsonProperty("withdrawals") final List<WithdrawalV1> withdrawals,
+      @JsonProperty("parentBeaconBlockRoot") final Bytes32 parentBeaconBlockRoot) {
+    super(timestamp, prevRandao, suggestedFeeRecipient, withdrawals);
+    this.parentBeaconBlockRoot = parentBeaconBlockRoot;
   }
 
-  public static Optional<PayloadAttributesV2> fromInternalPayloadBuildingAttributesV2(
+  public static Optional<PayloadAttributesV3> fromInternalPayloadBuildingAttributesV3(
       Optional<PayloadBuildingAttributes> payloadBuildingAttributes) {
     return payloadBuildingAttributes.map(
         (payloadAttributes) ->
-            new PayloadAttributesV2(
+            new PayloadAttributesV3(
                 payloadAttributes.getTimestamp(),
                 payloadAttributes.getPrevRandao(),
                 payloadAttributes.getFeeRecipient(),
-                PayloadAttributesV2.getWithdrawals(payloadAttributes.getWithdrawals())));
-  }
-
-  public static List<WithdrawalV1> getWithdrawals(
-      final Optional<List<Withdrawal>> maybeWithdrawals) {
-    if (maybeWithdrawals.isEmpty()) {
-      return null;
-    }
-
-    final List<WithdrawalV1> withdrawals = new ArrayList<>();
-
-    for (final Withdrawal w : maybeWithdrawals.get()) {
-      withdrawals.add(
-          new WithdrawalV1(w.getIndex(), w.getValidatorIndex(), w.getAddress(), w.getAmount()));
-    }
-    return withdrawals;
+                getWithdrawals(payloadAttributes.getWithdrawals()),
+                payloadAttributes.getParentBeaconBlockRoot()));
   }
 }

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JExecutionEngineClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JExecutionEngineClient.java
@@ -37,6 +37,7 @@ import tech.pegasys.teku.ethereum.executionclient.schema.GetPayloadV2Response;
 import tech.pegasys.teku.ethereum.executionclient.schema.GetPayloadV3Response;
 import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV2;
+import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV3;
 import tech.pegasys.teku.ethereum.executionclient.schema.PayloadStatusV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.Response;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -174,6 +175,19 @@ public class Web3JExecutionEngineClient implements ExecutionEngineClient {
     Request<?, ForkChoiceUpdatedResultWeb3jResponse> web3jRequest =
         new Request<>(
             "engine_forkchoiceUpdatedV2",
+            list(forkChoiceState, payloadAttributes.orElse(null)),
+            web3JClient.getWeb3jService(),
+            ForkChoiceUpdatedResultWeb3jResponse.class);
+    return web3JClient.doRequest(web3jRequest, EL_ENGINE_BLOCK_EXECUTION_TIMEOUT);
+  }
+
+  @Override
+  public SafeFuture<Response<ForkChoiceUpdatedResult>> forkChoiceUpdatedV3(
+      final ForkChoiceStateV1 forkChoiceState,
+      final Optional<PayloadAttributesV3> payloadAttributes) {
+    Request<?, ForkChoiceUpdatedResultWeb3jResponse> web3jRequest =
+        new Request<>(
+            "engine_forkchoiceUpdatedV3",
             list(forkChoiceState, payloadAttributes.orElse(null)),
             web3JClient.getWeb3jService(),
             ForkChoiceUpdatedResultWeb3jResponse.class);

--- a/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineForkChoiceUpdatedV3Test.java
+++ b/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineForkChoiceUpdatedV3Test.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright ConsenSys Software Inc., 2023
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionclient.methods;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.ethereum.executionclient.ExecutionEngineClient;
+import tech.pegasys.teku.ethereum.executionclient.response.InvalidRemoteResponseException;
+import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceStateV1;
+import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceUpdatedResult;
+import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV3;
+import tech.pegasys.teku.ethereum.executionclient.schema.PayloadStatusV1;
+import tech.pegasys.teku.ethereum.executionclient.schema.Response;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.executionlayer.ExecutionPayloadStatus;
+import tech.pegasys.teku.spec.executionlayer.ForkChoiceState;
+import tech.pegasys.teku.spec.executionlayer.PayloadBuildingAttributes;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+class EngineForkChoiceUpdatedV3Test {
+
+  private final Spec spec = TestSpecFactory.createMinimalDeneb();
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+  private final ExecutionEngineClient executionEngineClient = mock(ExecutionEngineClient.class);
+  private EngineForkChoiceUpdatedV3 jsonRpcMethod;
+
+  @BeforeEach
+  public void setUp() {
+    jsonRpcMethod = new EngineForkChoiceUpdatedV3(executionEngineClient);
+  }
+
+  @Test
+  public void shouldReturnExpectedNameAndVersion() {
+    assertThat(jsonRpcMethod.getName()).isEqualTo("engine_forkchoiceUpdated");
+    assertThat(jsonRpcMethod.getVersion()).isEqualTo(3);
+    assertThat(jsonRpcMethod.getVersionedName()).isEqualTo("engine_forkchoiceUpdatedV3");
+  }
+
+  @Test
+  public void forkChoiceStateParamIsRequired() {
+    final JsonRpcRequestParams params = new JsonRpcRequestParams.Builder().build();
+
+    assertThatThrownBy(() -> jsonRpcMethod.execute(params))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Missing required parameter at index 0");
+
+    verifyNoInteractions(executionEngineClient);
+  }
+
+  @Test
+  public void payloadBuildingAttributesParamIsOptional() {
+    final ForkChoiceState forkChoiceState = dataStructureUtil.randomForkChoiceState(false);
+
+    when(executionEngineClient.forkChoiceUpdatedV3(any(), eq(Optional.empty())))
+        .thenReturn(dummySuccessfulResponse());
+
+    final JsonRpcRequestParams params =
+        new JsonRpcRequestParams.Builder().add(forkChoiceState).build();
+
+    assertThat(jsonRpcMethod.execute(params)).isCompleted();
+
+    verify(executionEngineClient).forkChoiceUpdatedV3(any(), eq(Optional.empty()));
+  }
+
+  @Test
+  public void shouldReturnFailedFutureWithMessageWhenEngineClientRequestFails() {
+    final ForkChoiceState forkChoiceState = dataStructureUtil.randomForkChoiceState(false);
+    final String errorResponseFromClient = "error!";
+
+    when(executionEngineClient.forkChoiceUpdatedV3(any(), any()))
+        .thenReturn(dummyFailedResponse(errorResponseFromClient));
+
+    final JsonRpcRequestParams params =
+        new JsonRpcRequestParams.Builder().add(forkChoiceState).build();
+
+    assertThat(jsonRpcMethod.execute(params))
+        .failsWithin(1, TimeUnit.SECONDS)
+        .withThrowableOfType(ExecutionException.class)
+        .withRootCauseInstanceOf(InvalidRemoteResponseException.class)
+        .withMessageContaining(
+            "Invalid remote response from the execution client: %s", errorResponseFromClient);
+  }
+
+  @Test
+  public void shouldCallForkChoiceUpdateV3WithPayloadAttributesV3WhenInCapella() {
+    final ForkChoiceState forkChoiceState = dataStructureUtil.randomForkChoiceState(false);
+    final PayloadBuildingAttributes payloadBuildingAttributes =
+        dataStructureUtil.randomPayloadBuildingAttributes(false);
+    final ForkChoiceStateV1 forkChoiceStateV1 =
+        ForkChoiceStateV1.fromInternalForkChoiceState(forkChoiceState);
+    final Optional<PayloadAttributesV3> payloadAttributesV3 =
+        PayloadAttributesV3.fromInternalPayloadBuildingAttributesV3(
+            Optional.of(payloadBuildingAttributes));
+
+    jsonRpcMethod = new EngineForkChoiceUpdatedV3(executionEngineClient);
+
+    when(executionEngineClient.forkChoiceUpdatedV3(forkChoiceStateV1, payloadAttributesV3))
+        .thenReturn(dummySuccessfulResponse());
+
+    final JsonRpcRequestParams params =
+        new JsonRpcRequestParams.Builder()
+            .add(forkChoiceState)
+            .add(payloadBuildingAttributes)
+            .build();
+
+    assertThat(jsonRpcMethod.execute(params)).isCompleted();
+
+    verify(executionEngineClient).forkChoiceUpdatedV3(forkChoiceStateV1, payloadAttributesV3);
+  }
+
+  private SafeFuture<Response<ForkChoiceUpdatedResult>> dummySuccessfulResponse() {
+    return SafeFuture.completedFuture(
+        new Response<>(
+            new ForkChoiceUpdatedResult(
+                new PayloadStatusV1(
+                    ExecutionPayloadStatus.ACCEPTED, dataStructureUtil.randomBytes32(), ""),
+                dataStructureUtil.randomBytes8())));
+  }
+
+  private SafeFuture<Response<ForkChoiceUpdatedResult>> dummyFailedResponse(
+      final String errorMessage) {
+    return SafeFuture.completedFuture(Response.withErrorMessage(errorMessage));
+  }
+}

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/MilestoneBasedEngineJsonRpcMethodsResolver.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/MilestoneBasedEngineJsonRpcMethodsResolver.java
@@ -25,6 +25,7 @@ import tech.pegasys.teku.ethereum.executionclient.ExecutionEngineClient;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineApiMethod;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineForkChoiceUpdatedV1;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineForkChoiceUpdatedV2;
+import tech.pegasys.teku.ethereum.executionclient.methods.EngineForkChoiceUpdatedV3;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineGetPayloadV1;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineGetPayloadV2;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineGetPayloadV3;
@@ -96,7 +97,7 @@ public class MilestoneBasedEngineJsonRpcMethodsResolver implements EngineJsonRpc
 
     methods.put(ENGINE_NEW_PAYLOAD, new EngineNewPayloadV3(executionEngineClient));
     methods.put(ENGINE_GET_PAYLOAD, new EngineGetPayloadV3(executionEngineClient, spec));
-    methods.put(ENGINE_FORK_CHOICE_UPDATED, new EngineForkChoiceUpdatedV2(executionEngineClient));
+    methods.put(ENGINE_FORK_CHOICE_UPDATED, new EngineForkChoiceUpdatedV3(executionEngineClient));
 
     return methods;
   }

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/BellatrixExecutionClientHandlerTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/BellatrixExecutionClientHandlerTest.java
@@ -96,6 +96,7 @@ class BellatrixExecutionClientHandlerTest extends ExecutionHandlerClientTest {
             dataStructureUtil.randomEth1Address(),
             Optional.empty(),
             Optional.empty(),
+            dataStructureUtil.randomBytes32(),
             dataStructureUtil.randomUInt64());
     final Optional<PayloadAttributesV1> payloadAttributes =
         PayloadAttributesV1.fromInternalPayloadBuildingAttributes(Optional.of(attributes));

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/CapellaExecutionClientHandlerTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/CapellaExecutionClientHandlerTest.java
@@ -128,6 +128,7 @@ public class CapellaExecutionClientHandlerTest extends ExecutionHandlerClientTes
             dataStructureUtil.randomEth1Address(),
             Optional.empty(),
             Optional.of(List.of()),
+            dataStructureUtil.randomBytes32(),
             // building block for Capella
             capellaStartSlot.plus(1));
     final Optional<PayloadAttributesV2> payloadAttributes =

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/DenebExecutionClientHandlerTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/DenebExecutionClientHandlerTest.java
@@ -28,7 +28,7 @@ import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV3;
 import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceStateV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceUpdatedResult;
 import tech.pegasys.teku.ethereum.executionclient.schema.GetPayloadV3Response;
-import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV2;
+import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV3;
 import tech.pegasys.teku.ethereum.executionclient.schema.PayloadStatusV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.Response;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -108,8 +108,8 @@ public class DenebExecutionClientHandlerTest extends ExecutionHandlerClientTest 
             Optional.of(List.of()),
             dataStructureUtil.randomBytes32(),
             dataStructureUtil.randomUInt64());
-    final Optional<PayloadAttributesV2> payloadAttributes =
-        PayloadAttributesV2.fromInternalPayloadBuildingAttributesV2(Optional.of(attributes));
+    final Optional<PayloadAttributesV3> payloadAttributes =
+        PayloadAttributesV3.fromInternalPayloadBuildingAttributesV3(Optional.of(attributes));
     final SafeFuture<Response<ForkChoiceUpdatedResult>> dummyResponse =
         SafeFuture.completedFuture(
             new Response<>(
@@ -117,11 +117,11 @@ public class DenebExecutionClientHandlerTest extends ExecutionHandlerClientTest 
                     new PayloadStatusV1(
                         ExecutionPayloadStatus.ACCEPTED, dataStructureUtil.randomBytes32(), ""),
                     dataStructureUtil.randomBytes8())));
-    when(executionEngineClient.forkChoiceUpdatedV2(forkChoiceStateV1, payloadAttributes))
+    when(executionEngineClient.forkChoiceUpdatedV3(forkChoiceStateV1, payloadAttributes))
         .thenReturn(dummyResponse);
     final SafeFuture<tech.pegasys.teku.spec.executionlayer.ForkChoiceUpdatedResult> future =
         handler.engineForkChoiceUpdated(forkChoiceState, Optional.of(attributes));
-    verify(executionEngineClient).forkChoiceUpdatedV2(forkChoiceStateV1, payloadAttributes);
+    verify(executionEngineClient).forkChoiceUpdatedV3(forkChoiceStateV1, payloadAttributes);
     assertThat(future).isCompleted();
   }
 

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/DenebExecutionClientHandlerTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/DenebExecutionClientHandlerTest.java
@@ -106,6 +106,7 @@ public class DenebExecutionClientHandlerTest extends ExecutionHandlerClientTest 
             dataStructureUtil.randomEth1Address(),
             Optional.empty(),
             Optional.of(List.of()),
+            dataStructureUtil.randomBytes32(),
             dataStructureUtil.randomUInt64());
     final Optional<PayloadAttributesV2> payloadAttributes =
         PayloadAttributesV2.fromInternalPayloadBuildingAttributesV2(Optional.of(attributes));

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/DenebExecutionClientHandlerTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/DenebExecutionClientHandlerTest.java
@@ -94,7 +94,7 @@ public class DenebExecutionClientHandlerTest extends ExecutionHandlerClientTest 
   }
 
   @Test
-  void engineForkChoiceUpdated_shouldCallEngineForkChoiceUpdatedV2() {
+  void engineForkChoiceUpdated_shouldCallEngineForkChoiceUpdatedV3() {
     final ExecutionClientHandler handler = getHandler();
     final ForkChoiceState forkChoiceState = dataStructureUtil.randomForkChoiceState(false);
     final ForkChoiceStateV1 forkChoiceStateV1 =

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/MilestoneBasedEngineJsonRpcMethodsResolverTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/MilestoneBasedEngineJsonRpcMethodsResolverTest.java
@@ -31,6 +31,7 @@ import tech.pegasys.teku.ethereum.executionclient.ExecutionEngineClient;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineApiMethod;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineForkChoiceUpdatedV1;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineForkChoiceUpdatedV2;
+import tech.pegasys.teku.ethereum.executionclient.methods.EngineForkChoiceUpdatedV3;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineGetPayloadV1;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineGetPayloadV2;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineGetPayloadV3;
@@ -142,6 +143,6 @@ class MilestoneBasedEngineJsonRpcMethodsResolverTest {
     return Stream.of(
         arguments(ENGINE_NEW_PAYLOAD, EngineNewPayloadV3.class),
         arguments(ENGINE_GET_PAYLOAD, EngineGetPayloadV3.class),
-        arguments(ENGINE_FORK_CHOICE_UPDATED, EngineForkChoiceUpdatedV2.class));
+        arguments(ENGINE_FORK_CHOICE_UPDATED, EngineForkChoiceUpdatedV3.class));
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
@@ -183,7 +183,7 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
       checkBellatrixActivation();
     }
 
-    return SafeFuture.completedFuture(
+    final ForkChoiceUpdatedResult forkChoiceUpdatedResult =
         new ForkChoiceUpdatedResult(
             PayloadStatus.VALID,
             payloadBuildingAttributes.map(
@@ -195,7 +195,15 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
                       new HeadAndAttributes(
                           forkChoiceState.getHeadExecutionBlockHash(), payloadAttributes1));
                   return payloadId;
-                })));
+                }));
+
+    LOG.info(
+        "forkChoiceUpdated: forkChoiceState: {} payloadBuildingAttributes: {} -> forkChoiceUpdatedResult: {}",
+        forkChoiceState,
+        payloadBuildingAttributes,
+        forkChoiceUpdatedResult);
+
+    return SafeFuture.completedFuture(forkChoiceUpdatedResult);
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/PayloadBuildingAttributes.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/PayloadBuildingAttributes.java
@@ -29,8 +29,8 @@ public class PayloadBuildingAttributes {
   private final Bytes32 prevRandao;
   private final Eth1Address feeRecipient;
   private final Optional<SignedValidatorRegistration> validatorRegistration;
-
   private final Optional<List<Withdrawal>> maybeWithdrawals;
+  private final Bytes32 parentBeaconBlockRoot;
 
   private final UInt64 blockSlot;
 
@@ -40,12 +40,14 @@ public class PayloadBuildingAttributes {
       final Eth1Address feeRecipient,
       final Optional<SignedValidatorRegistration> validatorRegistration,
       final Optional<List<Withdrawal>> maybeWithdrawals,
+      final Bytes32 parentBeaconBlockRoot,
       final UInt64 blockSlot) {
     this.timestamp = timestamp;
     this.prevRandao = prevRandao;
     this.feeRecipient = feeRecipient;
     this.validatorRegistration = validatorRegistration;
     this.maybeWithdrawals = maybeWithdrawals;
+    this.parentBeaconBlockRoot = parentBeaconBlockRoot;
     this.blockSlot = blockSlot;
   }
 
@@ -63,6 +65,10 @@ public class PayloadBuildingAttributes {
 
   public UInt64 getBlockSlot() {
     return blockSlot;
+  }
+
+  public Bytes32 getParentBeaconBlockRoot() {
+    return parentBeaconBlockRoot;
   }
 
   public Optional<SignedValidatorRegistration> getValidatorRegistration() {
@@ -91,12 +97,19 @@ public class PayloadBuildingAttributes {
         && Objects.equals(prevRandao, that.prevRandao)
         && Objects.equals(feeRecipient, that.feeRecipient)
         && Objects.equals(validatorRegistration, that.validatorRegistration)
-        && Objects.equals(maybeWithdrawals, that.maybeWithdrawals);
+        && Objects.equals(maybeWithdrawals, that.maybeWithdrawals)
+        && Objects.equals(parentBeaconBlockRoot, that.parentBeaconBlockRoot);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(timestamp, prevRandao, feeRecipient, validatorRegistration);
+    return Objects.hash(
+        timestamp,
+        prevRandao,
+        feeRecipient,
+        validatorRegistration,
+        maybeWithdrawals,
+        parentBeaconBlockRoot);
   }
 
   @Override
@@ -107,6 +120,7 @@ public class PayloadBuildingAttributes {
         .add("feeRecipient", feeRecipient)
         .add("validatorRegistration", validatorRegistration)
         .add("withdrawals", maybeWithdrawals)
+        .add("parentBeaconBlockRoot", parentBeaconBlockRoot)
         .toString();
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/PayloadBuildingAttributes.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/PayloadBuildingAttributes.java
@@ -98,6 +98,7 @@ public class PayloadBuildingAttributes {
         && Objects.equals(feeRecipient, that.feeRecipient)
         && Objects.equals(validatorRegistration, that.validatorRegistration)
         && Objects.equals(maybeWithdrawals, that.maybeWithdrawals)
+        && Objects.equals(blockSlot, that.blockSlot)
         && Objects.equals(parentBeaconBlockRoot, that.parentBeaconBlockRoot);
   }
 
@@ -109,6 +110,7 @@ public class PayloadBuildingAttributes {
         feeRecipient,
         validatorRegistration,
         maybeWithdrawals,
+        blockSlot,
         parentBeaconBlockRoot);
   }
 
@@ -120,6 +122,7 @@ public class PayloadBuildingAttributes {
         .add("feeRecipient", feeRecipient)
         .add("validatorRegistration", validatorRegistration)
         .add("withdrawals", maybeWithdrawals)
+        .add("blockSlot", blockSlot)
         .add("parentBeaconBlockRoot", parentBeaconBlockRoot)
         .toString();
   }

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -1722,6 +1722,7 @@ public final class DataStructureUtil {
             ? Optional.of(randomSignedValidatorRegistration())
             : Optional.empty(),
         randomWithdrawalList(),
+        randomBytes32(),
         randomUInt64());
   }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ProposersDataManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ProposersDataManager.java
@@ -196,15 +196,13 @@ public class ProposersDataManager implements SlotEventsChannel {
       return SafeFuture.completedFuture(Optional.empty());
     }
     final UInt64 epoch = spec.computeEpochAtSlot(blockSlot);
+    final Bytes32 currentHeadBlockRoot =
+        forkChoiceUpdateData.getForkChoiceState().getHeadBlockRoot();
     return getStateInEpoch(epoch)
         .thenApplyAsync(
             maybeState ->
                 calculatePayloadBuildingAttributes(
-                    forkChoiceUpdateData.getForkChoiceState().getHeadBlockRoot(),
-                    blockSlot,
-                    epoch,
-                    maybeState,
-                    mandatory),
+                    currentHeadBlockRoot, blockSlot, epoch, maybeState, mandatory),
             eventThread);
   }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ProposersDataManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ProposersDataManager.java
@@ -199,11 +199,17 @@ public class ProposersDataManager implements SlotEventsChannel {
     return getStateInEpoch(epoch)
         .thenApplyAsync(
             maybeState ->
-                calculatePayloadBuildingAttributes(blockSlot, epoch, maybeState, mandatory),
+                calculatePayloadBuildingAttributes(
+                    forkChoiceUpdateData.getForkChoiceState().getHeadBlockRoot(),
+                    blockSlot,
+                    epoch,
+                    maybeState,
+                    mandatory),
             eventThread);
   }
 
   private Optional<PayloadBuildingAttributes> calculatePayloadBuildingAttributes(
+      final Bytes32 currentHeadBlockRoot,
       final UInt64 blockSlot,
       final UInt64 epoch,
       final Optional<BeaconState> maybeState,
@@ -233,6 +239,7 @@ public class ProposersDataManager implements SlotEventsChannel {
             getFeeRecipient(proposerInfo, blockSlot),
             validatorRegistration,
             spec.getExpectedWithdrawals(state),
+            currentHeadBlockRoot,
             blockSlot));
   }
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
@@ -208,7 +208,7 @@ class ForkChoiceNotifierTest {
     final BeaconState headState = getHeadState();
     final UInt64 blockSlot = headState.getSlot().plus(1);
     final PayloadBuildingAttributes payloadBuildingAttributes =
-        withProposerForSlot(headState, blockSlot);
+        withProposerForSlot(forkChoiceState, headState, blockSlot);
 
     notifyForkChoiceUpdated(forkChoiceState);
     verify(executionLayerChannel)
@@ -222,7 +222,7 @@ class ForkChoiceNotifierTest {
     final BeaconState headState = getHeadState();
     final UInt64 blockSlot = headState.getSlot().plus(1);
     final PayloadBuildingAttributes payloadBuildingAttributes =
-        withProposerForSlot(headState, blockSlot);
+        withProposerForSlot(forkChoiceState, headState, blockSlot);
 
     storageSystem.chainUpdater().setCurrentSlot(blockSlot);
 
@@ -268,7 +268,7 @@ class ForkChoiceNotifierTest {
 
     // proposer index 1 and 0 will propose slot 2 and 3
     final List<PayloadBuildingAttributes> payloadBuildingAttributes =
-        withProposerForTwoSlots(headState, blockSlot, blockSlot.plus(1));
+        withProposerForTwoSlots(forkChoiceState, headState, blockSlot, blockSlot.plus(1));
 
     // current slot is 1
 
@@ -320,7 +320,7 @@ class ForkChoiceNotifierTest {
 
     // proposer index 1 and 0 will propose slot 2 and 3
     final List<PayloadBuildingAttributes> payloadBuildingAttributes =
-        withProposerForTwoSlots(headState, blockSlot, blockSlot.plus(1));
+        withProposerForTwoSlots(forkChoiceState, headState, blockSlot, blockSlot.plus(1));
 
     // current slot is 1
 
@@ -351,11 +351,11 @@ class ForkChoiceNotifierTest {
     UInt64 blockSlot = headState.getSlot().plus(1); // slot 2
 
     final List<PayloadBuildingAttributes> payloadBuildingAttributesArr =
-        withProposerForTwoSlots(headState, blockSlot, blockSlot.plus(1));
+        withProposerForTwoSlots(forkChoiceState, headState, blockSlot, blockSlot.plus(1));
 
     // proposer index 1 and 0 will propose slot 2 and 3
     final PayloadBuildingAttributes payloadBuildingAttributes =
-        withProposerForSlot(headState, blockSlot);
+        withProposerForSlot(forkChoiceState, headState, blockSlot);
 
     // current slot is 1
 
@@ -372,14 +372,15 @@ class ForkChoiceNotifierTest {
     blockSlot = headState.getSlot().plus(1);
 
     // new attributes for new state block production at slot 3
+    final ForkChoiceState forkChoiceStateSlot3 = getCurrentForkChoiceState();
     final PayloadBuildingAttributes payloadBuildingAttributesSlot3 =
         withProposerForSlot(
+            forkChoiceStateSlot3,
             headState,
             blockSlot,
             false,
             Optional.of(payloadBuildingAttributesArr.get(1).getFeeRecipient()),
             Optional.empty());
-    final ForkChoiceState forkChoiceStateSlot3 = getCurrentForkChoiceState();
 
     // store real payload attributes and return an incomplete future
     AtomicReference<SafeFuture<Optional<PayloadBuildingAttributes>>> actualResponseA =
@@ -441,15 +442,15 @@ class ForkChoiceNotifierTest {
     final BeaconState headState = getHeadState();
     final UInt64 blockSlot1 = headState.getSlot().plus(1); // slot 2
     final UInt64 blockSlot2 = headState.getSlot().plus(2); // slot 3
+    final ForkChoiceState forkChoiceState = getCurrentForkChoiceState();
     final List<PayloadBuildingAttributes> payloadBuildingAttributes =
-        withProposerForTwoSlots(headState, blockSlot1, blockSlot2);
+        withProposerForTwoSlots(forkChoiceState, headState, blockSlot1, blockSlot2);
     // context:
     //  current slot is 1
     //  proposer index 1 proposes on slot 2
     //  proposer index 0 proposes on slot 3
 
     // slot is 1 and is not empty -> sending forkChoiceUpdated
-    final ForkChoiceState forkChoiceState = getCurrentForkChoiceState();
     notifyForkChoiceUpdated(forkChoiceState);
     // We are proposing block on slot 2
     verify(executionLayerChannel)
@@ -529,7 +530,7 @@ class ForkChoiceNotifierTest {
     verify(executionLayerChannel).engineForkChoiceUpdated(forkChoiceState, Optional.empty());
 
     final PayloadBuildingAttributes payloadBuildingAttributes =
-        withProposerForSlot(headState, blockSlot);
+        withProposerForSlot(forkChoiceState, headState, blockSlot);
     verify(executionLayerChannel)
         .engineForkChoiceUpdated(forkChoiceState, Optional.of(payloadBuildingAttributes));
   }
@@ -542,7 +543,7 @@ class ForkChoiceNotifierTest {
     final Bytes32 blockRoot = recentChainData.getBestBlockRoot().orElseThrow();
     final UInt64 blockSlot = headState.getSlot().plus(1);
     final PayloadBuildingAttributes payloadBuildingAttributes =
-        withProposerForSlot(headState, blockSlot);
+        withProposerForSlot(forkChoiceState, headState, blockSlot);
 
     final SafeFuture<ForkChoiceUpdatedResult> responseFuture = new SafeFuture<>();
     when(executionLayerChannel.engineForkChoiceUpdated(
@@ -572,6 +573,7 @@ class ForkChoiceNotifierTest {
     final UInt64 blockSlot = headState.getSlot().plus(1);
     final PayloadBuildingAttributes payloadBuildingAttributes =
         withProposerForSlot(
+            forkChoiceState,
             headState,
             blockSlot,
             true,
@@ -609,7 +611,7 @@ class ForkChoiceNotifierTest {
     final Bytes32 wrongBlockRoot = dataStructureUtil.randomBytes32();
 
     final PayloadBuildingAttributes payloadBuildingAttributes =
-        withProposerForSlot(headState, blockSlot);
+        withProposerForSlot(forkChoiceState, headState, blockSlot);
 
     final SafeFuture<ForkChoiceUpdatedResult> responseFuture = new SafeFuture<>();
     when(executionLayerChannel.engineForkChoiceUpdated(
@@ -651,7 +653,7 @@ class ForkChoiceNotifierTest {
             Bytes32.ZERO, UInt64.ZERO, terminalBlockHash, Bytes32.ZERO, Bytes32.ZERO, false);
 
     final PayloadBuildingAttributes payloadBuildingAttributes =
-        withProposerForSlot(headState, blockSlot);
+        withProposerForSlot(forkChoiceState, headState, blockSlot);
 
     notifier.onTerminalBlockReached(terminalBlockHash);
 
@@ -671,7 +673,7 @@ class ForkChoiceNotifierTest {
     final BeaconState headState = getHeadState();
     final UInt64 blockSlot = headState.getSlot().plus(3); // proposing slot 5
     final PayloadBuildingAttributes payloadBuildingAttributes =
-        withProposerForSlot(headState, blockSlot);
+        withProposerForSlot(getCurrentForkChoiceState(), headState, blockSlot);
 
     final Bytes32 blockRoot = recentChainData.getBestBlockRoot().orElseThrow();
 
@@ -712,7 +714,7 @@ class ForkChoiceNotifierTest {
     final UInt64 blockSlot = headState.getSlot().plus(2); // proposing slot 3
     final Bytes32 blockRoot = recentChainData.getBestBlockRoot().orElseThrow();
     final PayloadBuildingAttributes payloadBuildingAttributes =
-        withProposerForSlot(headState, blockSlot);
+        withProposerForSlot(finalizedForkChoiceState, headState, blockSlot);
 
     validateGetPayloadIdOnTheFlyRetrieval(
         blockSlot,
@@ -741,7 +743,8 @@ class ForkChoiceNotifierTest {
     final UInt64 blockSlot = headState.getSlot().plus(2); // proposing slot 3
     final Bytes32 blockRoot = recentChainData.getBestBlockRoot().orElseThrow();
     final PayloadBuildingAttributes payloadBuildingAttributes =
-        withProposerForSlotButDoNotPrepare(headState, blockSlot, defaultFeeRecipient);
+        withProposerForSlotButDoNotPrepare(
+            finalizedForkChoiceState, headState, blockSlot, defaultFeeRecipient);
 
     validateGetPayloadIdOnTheFlyRetrieval(
         blockSlot,
@@ -771,7 +774,8 @@ class ForkChoiceNotifierTest {
     final UInt64 blockSlot = headState.getSlot().plus(2); // proposing slot 3
     final Bytes32 blockRoot = recentChainData.getBestBlockRoot().orElseThrow();
     final PayloadBuildingAttributes payloadBuildingAttributes =
-        withProposerForSlotButDoNotPrepare(headState, blockSlot, Optional.empty());
+        withProposerForSlotButDoNotPrepare(
+            getCurrentForkChoiceState(), headState, blockSlot, Optional.empty());
 
     validateGetPayloadIdOnTheFlyRetrieval(
         blockSlot, blockRoot, finalizedForkChoiceState, payloadId, payloadBuildingAttributes, true);
@@ -786,7 +790,7 @@ class ForkChoiceNotifierTest {
 
     final ForkChoiceState forkChoiceState = getCurrentForkChoiceState();
     final PayloadBuildingAttributes payloadBuildingAttributes =
-        withProposerForSlot(headState, blockSlot);
+        withProposerForSlot(forkChoiceState, headState, blockSlot);
     when(executionLayerChannel.engineForkChoiceUpdated(
             forkChoiceState, Optional.of(payloadBuildingAttributes)))
         .thenReturn(responseFuture);
@@ -808,7 +812,7 @@ class ForkChoiceNotifierTest {
 
     final ForkChoiceState forkChoiceState = getCurrentForkChoiceState();
     final PayloadBuildingAttributes payloadBuildingAttributes =
-        withProposerForSlot(headState, blockSlot);
+        withProposerForSlot(forkChoiceState, headState, blockSlot);
     when(executionLayerChannel.engineForkChoiceUpdated(
             forkChoiceState, Optional.of(payloadBuildingAttributes)))
         .thenReturn(responseFuture);
@@ -875,22 +879,26 @@ class ForkChoiceNotifierTest {
             .retrieveStateAtSlot(new SlotAndBlockRoot(blockSlot, bestBlockRoot))
             .join()
             .orElseThrow();
-    return withProposerForSlot(state, blockSlot);
+    return withProposerForSlot(getCurrentForkChoiceState(), state, blockSlot);
   }
 
   private PayloadBuildingAttributes withProposerForSlotButDoNotPrepare(
+      final ForkChoiceState forkChoiceState,
       final BeaconState headState,
       final UInt64 blockSlot,
       final Optional<Eth1Address> overrideFeeRecipient) {
-    return withProposerForSlot(headState, blockSlot, false, overrideFeeRecipient, Optional.empty());
+    return withProposerForSlot(
+        forkChoiceState, headState, blockSlot, false, overrideFeeRecipient, Optional.empty());
   }
 
   private PayloadBuildingAttributes withProposerForSlot(
-      final BeaconState headState, final UInt64 blockSlot) {
-    return withProposerForSlot(headState, blockSlot, true, Optional.empty(), Optional.empty());
+      final ForkChoiceState forkChoiceState, final BeaconState headState, final UInt64 blockSlot) {
+    return withProposerForSlot(
+        forkChoiceState, headState, blockSlot, true, Optional.empty(), Optional.empty());
   }
 
   private PayloadBuildingAttributes withProposerForSlot(
+      final ForkChoiceState forkChoiceState,
       final BeaconState headState,
       final UInt64 blockSlot,
       final boolean doPrepare,
@@ -899,7 +907,7 @@ class ForkChoiceNotifierTest {
     final int block2Proposer = spec.getBeaconProposerIndex(headState, blockSlot);
     final PayloadBuildingAttributes payloadBuildingAttributes =
         getExpectedPayloadBuildingAttributes(
-            headState, blockSlot, overrideFeeRecipient, validatorRegistration);
+            forkChoiceState, headState, blockSlot, overrideFeeRecipient, validatorRegistration);
     if (doPrepare) {
       proposersDataManager.updatePreparedProposers(
           List.of(
@@ -918,15 +926,18 @@ class ForkChoiceNotifierTest {
   }
 
   private List<PayloadBuildingAttributes> withProposerForTwoSlots(
-      final BeaconState headState, final UInt64 blockSlot1, UInt64 blockSlot2) {
+      final ForkChoiceState forkChoiceState,
+      final BeaconState headState,
+      final UInt64 blockSlot1,
+      final UInt64 blockSlot2) {
     final int block2Proposer1 = spec.getBeaconProposerIndex(headState, blockSlot1);
     final int block2Proposer2 = spec.getBeaconProposerIndex(headState, blockSlot2);
     final PayloadBuildingAttributes payloadBuildingAttributes1 =
         getExpectedPayloadBuildingAttributes(
-            headState, blockSlot1, Optional.empty(), Optional.empty());
+            forkChoiceState, headState, blockSlot1, Optional.empty(), Optional.empty());
     final PayloadBuildingAttributes payloadBuildingAttributes2 =
         getExpectedPayloadBuildingAttributes(
-            headState, blockSlot2, Optional.empty(), Optional.empty());
+            forkChoiceState, headState, blockSlot2, Optional.empty(), Optional.empty());
 
     if (block2Proposer1 == block2Proposer2) {
       throw new UnsupportedOperationException(
@@ -943,6 +954,7 @@ class ForkChoiceNotifierTest {
   }
 
   private PayloadBuildingAttributes getExpectedPayloadBuildingAttributes(
+      final ForkChoiceState forkChoiceState,
       final BeaconState headState,
       final UInt64 blockSlot,
       final Optional<Eth1Address> overrideFeeRecipient,
@@ -957,6 +969,7 @@ class ForkChoiceNotifierTest {
         feeRecipient,
         validatorRegistration,
         dataStructureUtil.randomWithdrawalList(),
+        forkChoiceState.getHeadBlockRoot(),
         blockSlot);
   }
 


### PR DESCRIPTION
- Adds `PayloadAttributesV3` with parent beacon block root
- Adds `ForkChoiceUpdatedV3` and plugs it in the Deneb flow
- Updates `forkChoiceNotifier` to provide the parent block root to our internal `PayloadBuildingAttributes`
- Updates tests

related to #7263

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
