### PR TITLE
Add parentBeaconBlockRoot to EngineNewPayloadV3

### DIFF
--- a/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JExecutionEngineClientTest.java
+++ b/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JExecutionEngineClientTest.java
@@ -225,9 +225,10 @@ public class Web3JExecutionEngineClientTest {
         ExecutionPayloadV3.fromInternalExecutionPayload(executionPayload);
 
     final List<VersionedHash> blobVersionedHashes = dataStructureUtil.randomVersionedHashes(3);
+    final Bytes32 parentBeaconBlockRoot = dataStructureUtil.randomBytes32();
 
     final SafeFuture<Response<PayloadStatusV1>> futureResponse =
-        eeClient.newPayloadV3(executionPayloadV3, blobVersionedHashes);
+        eeClient.newPayloadV3(executionPayloadV3, blobVersionedHashes, parentBeaconBlockRoot);
 
     assertThat(futureResponse)
         .succeedsWithin(1, TimeUnit.SECONDS)
@@ -259,6 +260,9 @@ public class Web3JExecutionEngineClientTest {
             blobVersionedHashes.stream()
                 .map(VersionedHash::toHexString)
                 .collect(Collectors.toList()));
+    assertThat(((List<Object>) requestData.get("params")).get(2))
+        .asString()
+        .isEqualTo(parentBeaconBlockRoot.toHexString());
   }
 
   private void mockSuccessfulResponse(final String responseBody) {

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ExecutionEngineClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ExecutionEngineClient.java
@@ -50,7 +50,9 @@ public interface ExecutionEngineClient {
   SafeFuture<Response<PayloadStatusV1>> newPayloadV2(ExecutionPayloadV2 executionPayload);
 
   SafeFuture<Response<PayloadStatusV1>> newPayloadV3(
-      ExecutionPayloadV3 executionPayload, List<VersionedHash> blobVersionedHashes);
+      ExecutionPayloadV3 executionPayload,
+      List<VersionedHash> blobVersionedHashes,
+      Bytes32 parentBeaconBlockRoot);
 
   SafeFuture<Response<ForkChoiceUpdatedResult>> forkChoiceUpdatedV1(
       ForkChoiceStateV1 forkChoiceState, Optional<PayloadAttributesV1> payloadAttributes);

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ThrottlingExecutionEngineClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ThrottlingExecutionEngineClient.java
@@ -91,8 +91,11 @@ public class ThrottlingExecutionEngineClient implements ExecutionEngineClient {
 
   @Override
   public SafeFuture<Response<PayloadStatusV1>> newPayloadV3(
-      final ExecutionPayloadV3 executionPayload, final List<VersionedHash> blobVersionedHashes) {
-    return taskQueue.queueTask(() -> delegate.newPayloadV3(executionPayload, blobVersionedHashes));
+      final ExecutionPayloadV3 executionPayload,
+      final List<VersionedHash> blobVersionedHashes,
+      final Bytes32 parentBeaconBlockRoot) {
+    return taskQueue.queueTask(
+        () -> delegate.newPayloadV3(executionPayload, blobVersionedHashes, parentBeaconBlockRoot));
   }
 
   @Override

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineNewPayloadV3.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineNewPayloadV3.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.ethereum.executionclient.methods;
 import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.ethereum.executionclient.ExecutionEngineClient;
 import tech.pegasys.teku.ethereum.executionclient.response.ResponseUnwrapper;
 import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV3;
@@ -49,17 +50,19 @@ public class EngineNewPayloadV3 extends AbstractEngineJsonRpcMethod<PayloadStatu
         params.getRequiredParameter(0, ExecutionPayload.class);
     final List<VersionedHash> blobVersionedHashes =
         params.getRequiredListParameter(1, VersionedHash.class);
+    final Bytes32 parentBeaconBlockRoot = params.getRequiredParameter(2, Bytes32.class);
 
     LOG.trace(
-        "Calling {}(executionPayload={}, blobVersionedHashes={})",
+        "Calling {}(executionPayload={}, blobVersionedHashes={}, parentBeaconBlockRoot={})",
         getVersionedName(),
         executionPayload,
-        blobVersionedHashes);
+        blobVersionedHashes,
+        parentBeaconBlockRoot);
 
     final ExecutionPayloadV3 executionPayloadV3 =
         ExecutionPayloadV3.fromInternalExecutionPayload(executionPayload);
     return executionEngineClient
-        .newPayloadV3(executionPayloadV3, blobVersionedHashes)
+        .newPayloadV3(executionPayloadV3, blobVersionedHashes, parentBeaconBlockRoot)
         .thenApply(ResponseUnwrapper::unwrapExecutionClientResponseOrThrow)
         .thenApply(PayloadStatusV1::asInternalExecutionPayload)
         .thenPeek(

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/metrics/MetricRecordingExecutionEngineClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/metrics/MetricRecordingExecutionEngineClient.java
@@ -113,9 +113,12 @@ public class MetricRecordingExecutionEngineClient extends MetricRecordingAbstrac
 
   @Override
   public SafeFuture<Response<PayloadStatusV1>> newPayloadV3(
-      final ExecutionPayloadV3 executionPayload, final List<VersionedHash> blobVersionedHashes) {
+      final ExecutionPayloadV3 executionPayload,
+      final List<VersionedHash> blobVersionedHashes,
+      final Bytes32 parentBeaconBlockRoot) {
     return countRequest(
-        () -> delegate.newPayloadV3(executionPayload, blobVersionedHashes), NEW_PAYLOAD_V3_METHOD);
+        () -> delegate.newPayloadV3(executionPayload, blobVersionedHashes, parentBeaconBlockRoot),
+        NEW_PAYLOAD_V3_METHOD);
   }
 
   @Override

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JExecutionEngineClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JExecutionEngineClient.java
@@ -143,13 +143,16 @@ public class Web3JExecutionEngineClient implements ExecutionEngineClient {
 
   @Override
   public SafeFuture<Response<PayloadStatusV1>> newPayloadV3(
-      final ExecutionPayloadV3 executionPayload, final List<VersionedHash> blobVersionedHashes) {
+      final ExecutionPayloadV3 executionPayload,
+      final List<VersionedHash> blobVersionedHashes,
+      final Bytes32 parentBeaconBlockRoot) {
     final List<String> expectedBlobVersionedHashes =
         blobVersionedHashes.stream().map(VersionedHash::toHexString).collect(Collectors.toList());
     final Request<?, PayloadStatusV1Web3jResponse> web3jRequest =
         new Request<>(
             "engine_newPayloadV3",
-            list(executionPayload, expectedBlobVersionedHashes),
+            list(
+                executionPayload, expectedBlobVersionedHashes, parentBeaconBlockRoot.toHexString()),
             web3JClient.getWeb3jService(),
             PayloadStatusV1Web3jResponse.class);
     return web3JClient.doRequest(web3jRequest, EL_ENGINE_BLOCK_EXECUTION_TIMEOUT);

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionClientHandlerImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionClientHandlerImpl.java
@@ -101,7 +101,8 @@ public class ExecutionClientHandlerImpl implements ExecutionClientHandler {
     final JsonRpcRequestParams.Builder paramsBuilder =
         new JsonRpcRequestParams.Builder()
             .add(executionPayload)
-            .addOptional(newPayloadRequest.getVersionedHashes());
+            .addOptional(newPayloadRequest.getVersionedHashes())
+            .addOptional(newPayloadRequest.getParentBeaconBlockRoot());
 
     return engineMethodsResolver
         .getMethod(

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/DenebExecutionClientHandlerTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/DenebExecutionClientHandlerTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.when;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
+import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -79,17 +80,20 @@ public class DenebExecutionClientHandlerTest extends ExecutionHandlerClientTest 
   void engineNewPayload_shouldCallNewPayloadV3() {
     final ExecutionClientHandler handler = getHandler();
     final ExecutionPayload payload = dataStructureUtil.randomExecutionPayload();
+    final Bytes32 parentBeaconBlockRoot = dataStructureUtil.randomBytes32();
     final List<VersionedHash> versionedHashes = dataStructureUtil.randomVersionedHashes(3);
-    final NewPayloadRequest newPayloadRequest = new NewPayloadRequest(payload, versionedHashes);
+    final NewPayloadRequest newPayloadRequest =
+        new NewPayloadRequest(payload, versionedHashes, parentBeaconBlockRoot);
     final ExecutionPayloadV3 payloadV3 = ExecutionPayloadV3.fromInternalExecutionPayload(payload);
     final SafeFuture<Response<PayloadStatusV1>> dummyResponse =
         SafeFuture.completedFuture(
             new Response<>(
                 new PayloadStatusV1(
                     ExecutionPayloadStatus.ACCEPTED, dataStructureUtil.randomBytes32(), null)));
-    when(executionEngineClient.newPayloadV3(payloadV3, versionedHashes)).thenReturn(dummyResponse);
+    when(executionEngineClient.newPayloadV3(payloadV3, versionedHashes, parentBeaconBlockRoot))
+        .thenReturn(dummyResponse);
     final SafeFuture<PayloadStatus> future = handler.engineNewPayload(newPayloadRequest);
-    verify(executionEngineClient).newPayloadV3(payloadV3, versionedHashes);
+    verify(executionEngineClient).newPayloadV3(payloadV3, versionedHashes, parentBeaconBlockRoot);
     assertThat(future).isCompleted();
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/NewPayloadRequest.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/NewPayloadRequest.java
@@ -17,22 +17,28 @@ import com.google.common.base.MoreObjects;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.spec.logic.versions.deneb.types.VersionedHash;
 
 public class NewPayloadRequest {
 
   private final ExecutionPayload executionPayload;
   private final Optional<List<VersionedHash>> versionedHashes;
+  private final Optional<Bytes32> parentBeaconBlockRoot;
 
   public NewPayloadRequest(final ExecutionPayload executionPayload) {
     this.executionPayload = executionPayload;
     this.versionedHashes = Optional.empty();
+    this.parentBeaconBlockRoot = Optional.empty();
   }
 
   public NewPayloadRequest(
-      final ExecutionPayload executionPayload, final List<VersionedHash> versionedHashes) {
+      final ExecutionPayload executionPayload,
+      final List<VersionedHash> versionedHashes,
+      final Bytes32 parentBeaconBlockRoot) {
     this.executionPayload = executionPayload;
     this.versionedHashes = Optional.of(versionedHashes);
+    this.parentBeaconBlockRoot = Optional.of(parentBeaconBlockRoot);
   }
 
   public ExecutionPayload getExecutionPayload() {
@@ -41,6 +47,10 @@ public class NewPayloadRequest {
 
   public Optional<List<VersionedHash>> getVersionedHashes() {
     return versionedHashes;
+  }
+
+  public Optional<Bytes32> getParentBeaconBlockRoot() {
+    return parentBeaconBlockRoot;
   }
 
   @Override
@@ -53,12 +63,13 @@ public class NewPayloadRequest {
     }
     final NewPayloadRequest that = (NewPayloadRequest) o;
     return Objects.equals(executionPayload, that.executionPayload)
-        && Objects.equals(versionedHashes, that.versionedHashes);
+        && Objects.equals(versionedHashes, that.versionedHashes)
+        && Objects.equals(parentBeaconBlockRoot, that.parentBeaconBlockRoot);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(executionPayload, versionedHashes);
+    return Objects.hash(executionPayload, versionedHashes, parentBeaconBlockRoot);
   }
 
   @Override
@@ -66,6 +77,7 @@ public class NewPayloadRequest {
     return MoreObjects.toStringHelper(this)
         .add("executionPayload", executionPayload)
         .add("versionedHashes", versionedHashes)
+        .add("parentBeaconBlockRoot", parentBeaconBlockRoot)
         .toString();
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
@@ -287,9 +287,10 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
         Optional.ofNullable(knownPosBlocks.get(executionPayload.getBlockHash()))
             .orElse(payloadStatus);
     LOG.info(
-        "newPayload: executionPayload blockHash: {}  versionedHashes: {} -> {}",
+        "newPayload: executionPayload blockHash: {}  versionedHashes: {} parentBeaconBlockRoot: {} -> {}",
         executionPayload.getBlockHash(),
         newPayloadRequest.getVersionedHashes(),
+        newPayloadRequest.getParentBeaconBlockRoot(),
         returnedStatus);
     return SafeFuture.completedFuture(returnedStatus);
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/BlockProcessor.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/BlockProcessor.java
@@ -150,7 +150,7 @@ public interface BlockProcessor {
       Optional<? extends OptimisticExecutionPayloadExecutor> payloadExecutor)
       throws BlockProcessingException;
 
-  NewPayloadRequest computeNewPayloadRequest(BeaconBlockBody beaconBlockBody)
+  NewPayloadRequest computeNewPayloadRequest(BeaconState state, BeaconBlockBody beaconBlockBody)
       throws BlockProcessingException;
 
   void validateExecutionPayloadHeader(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/block/BlockProcessorAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/block/BlockProcessorAltair.java
@@ -321,7 +321,8 @@ public class BlockProcessorAltair extends AbstractBlockProcessor {
   }
 
   @Override
-  public NewPayloadRequest computeNewPayloadRequest(final BeaconBlockBody beaconBlockBody)
+  public NewPayloadRequest computeNewPayloadRequest(
+      final BeaconState state, final BeaconBlockBody beaconBlockBody)
       throws BlockProcessingException {
     throw new UnsupportedOperationException("No NewPayloadRequest in Altair");
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/bellatrix/block/BlockProcessorBellatrix.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/bellatrix/block/BlockProcessorBellatrix.java
@@ -160,7 +160,8 @@ public class BlockProcessorBellatrix extends BlockProcessorAltair {
     validateExecutionPayloadHeader(state, executionPayloadHeader);
 
     if (payloadExecutor.isPresent()) {
-      final NewPayloadRequest payloadToExecute = computeNewPayloadRequest(beaconBlockBody);
+      final NewPayloadRequest payloadToExecute =
+          computeNewPayloadRequest(genericState, beaconBlockBody);
       final boolean optimisticallyAccept =
           payloadExecutor
               .get()
@@ -200,7 +201,8 @@ public class BlockProcessorBellatrix extends BlockProcessorAltair {
   }
 
   @Override
-  public NewPayloadRequest computeNewPayloadRequest(final BeaconBlockBody beaconBlockBody)
+  public NewPayloadRequest computeNewPayloadRequest(
+      final BeaconState state, final BeaconBlockBody beaconBlockBody)
       throws BlockProcessingException {
     final ExecutionPayload executionPayload = extractExecutionPayload(beaconBlockBody);
     return new NewPayloadRequest(executionPayload);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/block/BlockProcessorDeneb.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/block/BlockProcessorDeneb.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.spec.logic.versions.deneb.block;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.spec.config.SpecConfigDeneb;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
@@ -86,7 +87,8 @@ public class BlockProcessorDeneb extends BlockProcessorCapella {
   }
 
   @Override
-  public NewPayloadRequest computeNewPayloadRequest(final BeaconBlockBody beaconBlockBody)
+  public NewPayloadRequest computeNewPayloadRequest(
+      final BeaconState state, final BeaconBlockBody beaconBlockBody)
       throws BlockProcessingException {
     final ExecutionPayload executionPayload = extractExecutionPayload(beaconBlockBody);
     final SszList<SszKZGCommitment> blobKzgCommitments = extractBlobKzgCommitments(beaconBlockBody);
@@ -95,7 +97,8 @@ public class BlockProcessorDeneb extends BlockProcessorCapella {
             .map(SszKZGCommitment::getKZGCommitment)
             .map(miscHelpers::kzgCommitmentToVersionedHash)
             .collect(Collectors.toList());
-    return new NewPayloadRequest(executionPayload, versionedHashes);
+    final Bytes32 parentBeaconBlockRoot = state.getLatestBlockHeader().getParentRoot();
+    return new NewPayloadRequest(executionPayload, versionedHashes, parentBeaconBlockRoot);
   }
 
   public SszList<SszKZGCommitment> extractBlobKzgCommitments(final BeaconBlockBody beaconBlockBody)

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/block/BlockProcessorPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/block/BlockProcessorPhase0.java
@@ -130,7 +130,8 @@ public final class BlockProcessorPhase0 extends AbstractBlockProcessor {
   }
 
   @Override
-  public NewPayloadRequest computeNewPayloadRequest(final BeaconBlockBody beaconBlockBody)
+  public NewPayloadRequest computeNewPayloadRequest(
+      final BeaconState state, final BeaconBlockBody beaconBlockBody)
       throws BlockProcessingException {
     throw new UnsupportedOperationException("No NewPayloadRequest in phase0");
   }

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/bellatrix/block/BlockProcessorBellatrixTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/bellatrix/block/BlockProcessorBellatrixTest.java
@@ -38,7 +38,7 @@ public class BlockProcessorBellatrixTest extends BlockProcessorAltairTest {
 
   @Test
   void shouldRejectAltairBlock() {
-    BeaconState preState = createBeaconState();
+    final BeaconState preState = createBeaconState();
     final SignedBeaconBlock block =
         dataStructureUtil.randomSignedBeaconBlock(preState.getSlot().increment());
     assertThatThrownBy(
@@ -48,10 +48,11 @@ public class BlockProcessorBellatrixTest extends BlockProcessorAltairTest {
 
   @Test
   public void shouldCreateNewPayloadRequest() throws BlockProcessingException {
+    final BeaconState preState = createBeaconState();
     final BeaconBlockBody blockBody = dataStructureUtil.randomBeaconBlockBody();
 
     final NewPayloadRequest newPayloadRequest =
-        spec.getBlockProcessor(UInt64.ONE).computeNewPayloadRequest(blockBody);
+        spec.getBlockProcessor(UInt64.ONE).computeNewPayloadRequest(preState, blockBody);
 
     assertThat(newPayloadRequest.getExecutionPayload())
         .isEqualTo(blockBody.getOptionalExecutionPayload().orElseThrow());

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/deneb/block/BlockProcessorDenebTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/deneb/block/BlockProcessorDenebTest.java
@@ -92,5 +92,8 @@ public class BlockProcessorDenebTest extends BlockProcessorCapellaTest {
                 assertThat(versionedHash.getVersion())
                     .isEqualTo(SpecConfigDeneb.VERSIONED_HASH_VERSION_KZG))
         .hasSameElementsAs(expectedVersionedHashes);
+    assertThat(newPayloadRequest.getParentBeaconBlockRoot()).isPresent();
+    assertThat(newPayloadRequest.getParentBeaconBlockRoot().get())
+        .isEqualTo(preState.getLatestBlockHeader().getParentRoot());
   }
 }

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/deneb/block/BlockProcessorDenebTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/deneb/block/BlockProcessorDenebTest.java
@@ -70,6 +70,7 @@ public class BlockProcessorDenebTest extends BlockProcessorCapellaTest {
   @Test
   @Override
   public void shouldCreateNewPayloadRequest() throws BlockProcessingException {
+    final BeaconState preState = createBeaconState();
     final BeaconBlockBody blockBody = dataStructureUtil.randomBeaconBlockBodyWithCommitments(3);
     final MiscHelpers miscHelpers = spec.atSlot(UInt64.ONE).miscHelpers();
     final List<VersionedHash> expectedVersionedHashes =
@@ -79,7 +80,7 @@ public class BlockProcessorDenebTest extends BlockProcessorCapellaTest {
             .collect(Collectors.toList());
 
     final NewPayloadRequest newPayloadRequest =
-        spec.getBlockProcessor(UInt64.ONE).computeNewPayloadRequest(blockBody);
+        spec.getBlockProcessor(UInt64.ONE).computeNewPayloadRequest(preState, blockBody);
 
     assertThat(newPayloadRequest.getExecutionPayload())
         .isEqualTo(blockBody.getOptionalExecutionPayload().orElseThrow());


### PR DESCRIPTION
updates the engine API and `computeNewPayloadRequest` in blockProcessor to pass the value.

fixes #7263

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
