### PR TITLE
Use shouldOverrideBuilder flag from engine_getPayloadV3 response

### DIFF
--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineGetPayloadV3.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineGetPayloadV3.java
@@ -76,7 +76,11 @@ public class EngineGetPayloadV3 extends AbstractEngineJsonRpcMethod<GetPayloadRe
               final ExecutionPayload executionPayload =
                   response.executionPayload.asInternalExecutionPayload(payloadSchema);
               final BlobsBundle blobsBundle = getBlobsBundle(response, schemaDefinitions);
-              return new GetPayloadResponse(executionPayload, response.blockValue, blobsBundle);
+              return new GetPayloadResponse(
+                  executionPayload,
+                  response.blockValue,
+                  blobsBundle,
+                  response.shouldOverrideBuilder);
             })
         .thenPeek(
             getPayloadResponse ->

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/GetPayloadV3Response.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/GetPayloadV3Response.java
@@ -29,12 +29,16 @@ public class GetPayloadV3Response {
 
   public final BlobsBundleV1 blobsBundle;
 
+  public final boolean shouldOverrideBuilder;
+
   public GetPayloadV3Response(
       @JsonProperty("executionPayload") final ExecutionPayloadV3 executionPayload,
       @JsonProperty("blockValue") final UInt256 blockValue,
-      @JsonProperty("blobsBundle") final BlobsBundleV1 blobsBundle) {
+      @JsonProperty("blobsBundle") final BlobsBundleV1 blobsBundle,
+      @JsonProperty("shouldOverrideBuilder") final boolean shouldOverrideBuilder) {
     this.executionPayload = executionPayload;
     this.blockValue = blockValue;
     this.blobsBundle = blobsBundle;
+    this.shouldOverrideBuilder = shouldOverrideBuilder;
   }
 }

--- a/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineGetPayloadV3Test.java
+++ b/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineGetPayloadV3Test.java
@@ -128,7 +128,7 @@ class EngineGetPayloadV3Test {
     jsonRpcMethod = new EngineGetPayloadV3(executionEngineClient, spec);
 
     final GetPayloadResponse expectedGetPayloadResponse =
-        new GetPayloadResponse(executionPayloadDeneb, blockValue, blobsBundle);
+        new GetPayloadResponse(executionPayloadDeneb, blockValue, blobsBundle, false);
     assertThat(jsonRpcMethod.execute(params)).isCompletedWithValue(expectedGetPayloadResponse);
 
     verify(executionEngineClient).getPayloadV3(eq(executionPayloadContext.getPayloadId()));
@@ -144,7 +144,8 @@ class EngineGetPayloadV3Test {
             new GetPayloadV3Response(
                 ExecutionPayloadV3.fromInternalExecutionPayload(executionPayload),
                 blockValue,
-                BlobsBundleV1.fromInternalBlobsBundle(blobsBundle))));
+                BlobsBundleV1.fromInternalBlobsBundle(blobsBundle),
+                false)));
   }
 
   private SafeFuture<Response<GetPayloadV3Response>> dummyFailedResponse(

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
@@ -82,7 +82,8 @@ public class ExecutionLayerManagerImpl implements ExecutionLayerManager {
       final BuilderBidValidator builderBidValidator,
       final BuilderCircuitBreaker builderCircuitBreaker,
       final BlobsBundleValidator blobsBundleValidator,
-      final Optional<Integer> builderBidCompareFactor) {
+      final Optional<Integer> builderBidCompareFactor,
+      final boolean useShouldOverrideBuilderFlag) {
     final LabelledMetric<Counter> executionPayloadSourceCounter =
         metricsSystem.createLabelledCounter(
             TekuMetricCategory.BEACON,
@@ -111,7 +112,8 @@ public class ExecutionLayerManagerImpl implements ExecutionLayerManager {
         builderCircuitBreaker,
         executionPayloadSourceCounter,
         blobsBundleValidator,
-        builderBidCompareFactor);
+        builderBidCompareFactor,
+        useShouldOverrideBuilderFlag);
   }
 
   public static ExecutionEngineClient createEngineClient(
@@ -149,7 +151,8 @@ public class ExecutionLayerManagerImpl implements ExecutionLayerManager {
       final BuilderCircuitBreaker builderCircuitBreaker,
       final LabelledMetric<Counter> executionPayloadSourceCounter,
       final BlobsBundleValidator blobsBundleValidator,
-      final Optional<Integer> builderBidCompareFactor) {
+      final Optional<Integer> builderBidCompareFactor,
+      final boolean useShouldOverrideBuilderFlag) {
     this.executionClientHandler = executionClientHandler;
     this.spec = spec;
     this.blobsBundleValidator = blobsBundleValidator;
@@ -162,7 +165,8 @@ public class ExecutionLayerManagerImpl implements ExecutionLayerManager {
             builderCircuitBreaker,
             builderClient,
             eventLogger,
-            builderBidCompareFactor);
+            builderBidCompareFactor,
+            useShouldOverrideBuilderFlag);
   }
 
   @Override

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/DenebExecutionClientHandlerTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/DenebExecutionClientHandlerTest.java
@@ -66,7 +66,8 @@ public class DenebExecutionClientHandlerTest extends ExecutionHandlerClientTest 
                     ExecutionPayloadV3.fromInternalExecutionPayload(
                         dataStructureUtil.randomExecutionPayload()),
                     UInt256.MAX_VALUE,
-                    BlobsBundleV1.fromInternalBlobsBundle(dataStructureUtil.randomBlobsBundle()))));
+                    BlobsBundleV1.fromInternalBlobsBundle(dataStructureUtil.randomBlobsBundle()),
+                    true)));
     when(executionEngineClient.getPayloadV3(context.getPayloadId())).thenReturn(dummyResponse);
 
     final UInt64 slot = dataStructureUtil.randomUInt64(1_000_000);
@@ -74,6 +75,9 @@ public class DenebExecutionClientHandlerTest extends ExecutionHandlerClientTest 
     verify(executionEngineClient).getPayloadV3(context.getPayloadId());
     assertThat(future).isCompleted();
     assertThat(future.get().getExecutionPayload()).isInstanceOf(ExecutionPayloadDeneb.class);
+    assertThat(future.get().getBlockValue()).isEqualTo(UInt256.MAX_VALUE);
+    assertThat(future.get().getBlobsBundle()).isPresent();
+    assertThat(future.get().getShouldOverrideBuilder()).isTrue();
   }
 
   @Test

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerBlockProductionManagerImplTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerBlockProductionManagerImplTest.java
@@ -491,7 +491,7 @@ class ExecutionLayerBlockProductionManagerImplTest {
     final ExecutionPayload payload = dataStructureUtil.randomExecutionPayload();
     final BlobsBundle blobsBundle = dataStructureUtil.randomBlobsBundle();
     final GetPayloadResponse getPayloadResponse =
-        new GetPayloadResponse(payload, blockValue, blobsBundle);
+        new GetPayloadResponse(payload, blockValue, blobsBundle, false);
     when(executionClientHandler.engineGetPayload(executionPayloadContext, slot))
         .thenReturn(SafeFuture.completedFuture(getPayloadResponse));
     return getPayloadResponse;
@@ -511,7 +511,8 @@ class ExecutionLayerBlockProductionManagerImplTest {
             : BuilderBidValidator.NOOP,
         builderCircuitBreaker,
         BlobsBundleValidator.NOOP,
-        Optional.of(100));
+        Optional.of(100),
+        true);
   }
 
   private void updateBuilderStatus(SafeFuture<Response<Void>> builderClientResponse, UInt64 slot) {

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImplTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImplTest.java
@@ -41,8 +41,12 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
+import tech.pegasys.teku.spec.datastructures.builder.BlindedBlobsBundle;
 import tech.pegasys.teku.spec.datastructures.builder.BuilderBid;
+import tech.pegasys.teku.spec.datastructures.builder.BuilderPayload;
 import tech.pegasys.teku.spec.datastructures.builder.SignedBuilderBid;
+import tech.pegasys.teku.spec.datastructures.execution.BlobsBundle;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
@@ -52,6 +56,7 @@ import tech.pegasys.teku.spec.datastructures.execution.FallbackReason;
 import tech.pegasys.teku.spec.datastructures.execution.GetPayloadResponse;
 import tech.pegasys.teku.spec.datastructures.execution.HeaderWithFallbackData;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsDeneb;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 class ExecutionLayerManagerImplTest {
@@ -60,7 +65,7 @@ class ExecutionLayerManagerImplTest {
 
   private final BuilderClient builderClient = Mockito.mock(BuilderClient.class);
 
-  private Spec spec = TestSpecFactory.createMinimalBellatrix();
+  private Spec spec = TestSpecFactory.createMinimalDeneb();
 
   private DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
 
@@ -437,6 +442,51 @@ class ExecutionLayerManagerImplTest {
 
   @Test
   public void
+      builderGetHeaderGetPayload_shouldReturnHeaderAndPayloadViaEngineIfShouldOverrideBuilderIsSetToTrue() {
+    setBuilderOnline();
+
+    final ExecutionPayloadContext executionPayloadContext =
+        dataStructureUtil.randomPayloadExecutionContext(false, true);
+    final UInt64 slot = executionPayloadContext.getForkChoiceState().getHeadBlockSlot();
+    final BeaconState state = dataStructureUtil.randomBeaconState(slot);
+
+    prepareBuilderGetHeaderResponse(executionPayloadContext, false);
+
+    final GetPayloadResponse getPayloadResponse =
+        prepareEngineGetPayloadResponse(executionPayloadContext, UInt256.ZERO, true, slot);
+
+    // we expect result from the local engine
+    final ExecutionPayloadHeader expectedHeader =
+        spec.atSlot(slot)
+            .getSchemaDefinitions()
+            .toVersionBellatrix()
+            .orElseThrow()
+            .getExecutionPayloadHeaderSchema()
+            .createFromExecutionPayload(getPayloadResponse.getExecutionPayload());
+    final BlindedBlobsBundle expectedBlindedBlobsBundle =
+        spec.atSlot(slot)
+            .getSchemaDefinitions()
+            .toVersionDeneb()
+            .orElseThrow()
+            .getBlindedBlobsBundleSchema()
+            .createFromExecutionBlobsBundle(getPayloadResponse.getBlobsBundle().orElseThrow());
+
+    // we expect local engine header as result
+    final HeaderWithFallbackData expectedResult =
+        HeaderWithFallbackData.create(
+            expectedHeader,
+            Optional.of(expectedBlindedBlobsBundle),
+            new FallbackData(
+                getPayloadResponse.getExecutionPayload(),
+                getPayloadResponse.getBlobsBundle(),
+                FallbackReason.SHOULD_OVERRIDE_BUILDER_FLAG_IS_TRUE));
+    assertThat(executionLayerManager.builderGetHeader(executionPayloadContext, state))
+        .isCompletedWithValue(expectedResult);
+    verifyFallbackToLocalEL(slot, executionPayloadContext, expectedResult);
+  }
+
+  @Test
+  public void
       builderGetHeaderGetPayload_shouldReturnHeaderAndPayloadViaEngineOnBidValidationFailure() {
     executionLayerManager = createExecutionLayerChannelImpl(true, true);
     setBuilderOnline();
@@ -739,9 +789,9 @@ class ExecutionLayerManagerImplTest {
     final FallbackData fallbackData =
         headerWithFallbackData.getFallbackDataOptional().orElseThrow();
     final FallbackReason fallbackReason = fallbackData.getReason();
-    final ExecutionPayload executionPayload = fallbackData.getExecutionPayload();
     if (fallbackReason == FallbackReason.BUILDER_HEADER_NOT_AVAILABLE
         || fallbackReason == FallbackReason.BUILDER_ERROR
+        || fallbackReason == FallbackReason.SHOULD_OVERRIDE_BUILDER_FLAG_IS_TRUE
         || fallbackReason == FallbackReason.LOCAL_BLOCK_VALUE_WON) {
       // we expect both builder and local engine have been called
       verifyBuilderCalled(slot, executionPayloadContext);
@@ -751,13 +801,33 @@ class ExecutionLayerManagerImplTest {
     }
     verifyEngineCalled(executionPayloadContext, slot);
 
-    final SignedBeaconBlock signedBlindedBeaconBlock =
-        dataStructureUtil.randomSignedBlindedBeaconBlock(slot);
+    final BuilderPayload builderPayload =
+        fallbackData
+            .getBlobsBundle()
+            .map(
+                executionBlobsBundle -> {
+                  final SchemaDefinitionsDeneb schemaDefinitions =
+                      SchemaDefinitionsDeneb.required(spec.atSlot(slot).getSchemaDefinitions());
+                  final tech.pegasys.teku.spec.datastructures.builder.BlobsBundle blobsBundle =
+                      schemaDefinitions
+                          .getBlobsBundleSchema()
+                          .createFromExecutionBlobsBundle(executionBlobsBundle);
+                  return (BuilderPayload)
+                      schemaDefinitions
+                          .getExecutionPayloadAndBlobsBundleSchema()
+                          .create(fallbackData.getExecutionPayload(), blobsBundle);
+                })
+            .orElse(fallbackData.getExecutionPayload());
+
+    final SignedBlockContainer signedBlindedBlockContainer =
+        fallbackData.getBlobsBundle().isPresent()
+            ? dataStructureUtil.randomSignedBlindedBlockContents(slot)
+            : dataStructureUtil.randomSignedBlindedBeaconBlock(slot);
 
     // we expect result from the cached payload
     assertThat(
             executionLayerManager.builderGetPayload(
-                signedBlindedBeaconBlock,
+                signedBlindedBlockContainer,
                 (aSlot) ->
                     Optional.of(
                         new ExecutionPayloadResult(
@@ -765,7 +835,7 @@ class ExecutionLayerManagerImplTest {
                             Optional.empty(),
                             Optional.empty(),
                             Optional.of(SafeFuture.completedFuture(headerWithFallbackData))))))
-        .isCompletedWithValue(executionPayload);
+        .isCompletedWithValue(builderPayload);
 
     // we expect no additional calls
     verifyNoMoreInteractions(builderClient);
@@ -810,6 +880,20 @@ class ExecutionLayerManagerImplTest {
     return getPayloadResponse;
   }
 
+  private GetPayloadResponse prepareEngineGetPayloadResponse(
+      final ExecutionPayloadContext executionPayloadContext,
+      final UInt256 blockValue,
+      final boolean shouldOverrideBuilder,
+      final UInt64 slot) {
+    final ExecutionPayload payload = dataStructureUtil.randomExecutionPayload();
+    final BlobsBundle blobsBundle = dataStructureUtil.randomBlobsBundle(3);
+    final GetPayloadResponse getPayloadResponse =
+        new GetPayloadResponse(payload, blockValue, blobsBundle, shouldOverrideBuilder);
+    when(executionClientHandler.engineGetPayload(executionPayloadContext, slot))
+        .thenReturn(SafeFuture.completedFuture(getPayloadResponse));
+    return getPayloadResponse;
+  }
+
   private ExecutionLayerManagerImpl createExecutionLayerChannelImpl(
       final boolean builderEnabled, final boolean builderValidatorEnabled) {
     return createExecutionLayerChannelImpl(
@@ -832,7 +916,8 @@ class ExecutionLayerManagerImplTest {
             : BuilderBidValidator.NOOP,
         builderCircuitBreaker,
         BlobsBundleValidator.NOOP,
-        builderBidCompareFactor);
+        builderBidCompareFactor,
+        true);
   }
 
   private void updateBuilderStatus(final SafeFuture<Response<Void>> builderClientResponse) {

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImplTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImplTest.java
@@ -443,6 +443,7 @@ class ExecutionLayerManagerImplTest {
   @Test
   public void
       builderGetHeaderGetPayload_shouldReturnHeaderAndPayloadViaEngineIfShouldOverrideBuilderIsSetToTrue() {
+    // the shouldOverrideBuilder flag is available only from Deneb
     setupDeneb();
     setBuilderOnline();
 

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImplTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImplTest.java
@@ -65,7 +65,7 @@ class ExecutionLayerManagerImplTest {
 
   private final BuilderClient builderClient = Mockito.mock(BuilderClient.class);
 
-  private Spec spec = TestSpecFactory.createMinimalDeneb();
+  private Spec spec = TestSpecFactory.createMinimalCapella();
 
   private DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
 
@@ -443,6 +443,7 @@ class ExecutionLayerManagerImplTest {
   @Test
   public void
       builderGetHeaderGetPayload_shouldReturnHeaderAndPayloadViaEngineIfShouldOverrideBuilderIsSetToTrue() {
+    setupDeneb();
     setBuilderOnline();
 
     final ExecutionPayloadContext executionPayloadContext =
@@ -755,6 +756,12 @@ class ExecutionLayerManagerImplTest {
     // we expect both builder and local engine have been called
     verify(builderClient).getPayload(signedBlindedBeaconBlock);
     verifyNoMoreInteractions(executionClientHandler);
+  }
+
+  private void setupDeneb() {
+    spec = TestSpecFactory.createMinimalDeneb();
+    dataStructureUtil = new DataStructureUtil(spec);
+    setup();
   }
 
   private BuilderBid prepareBuilderGetHeaderResponse(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/FallbackReason.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/FallbackReason.java
@@ -23,6 +23,7 @@ public enum FallbackReason {
   BUILDER_NOT_CONFIGURED("builder_not_configured"),
   BUILDER_HEADER_NOT_AVAILABLE("builder_header_not_available"),
   LOCAL_BLOCK_VALUE_WON("local_block_value_won"),
+  SHOULD_OVERRIDE_BUILDER_FLAG_IS_TRUE("should_override_builder_flag_is_true"),
   BUILDER_ERROR("builder_error"),
   NONE("");
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/GetPayloadResponse.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/GetPayloadResponse.java
@@ -23,26 +23,31 @@ public class GetPayloadResponse {
   private final ExecutionPayload executionPayload;
   private final UInt256 blockValue;
   private final Optional<BlobsBundle> blobsBundle;
+  private final boolean shouldOverrideBuilder;
 
   public GetPayloadResponse(final ExecutionPayload executionPayload) {
     this.executionPayload = executionPayload;
     this.blockValue = UInt256.ZERO;
     this.blobsBundle = Optional.empty();
+    this.shouldOverrideBuilder = false;
   }
 
   public GetPayloadResponse(final ExecutionPayload executionPayload, final UInt256 blockValue) {
     this.executionPayload = executionPayload;
     this.blockValue = blockValue;
     this.blobsBundle = Optional.empty();
+    this.shouldOverrideBuilder = false;
   }
 
   public GetPayloadResponse(
       final ExecutionPayload executionPayload,
       final UInt256 blockValue,
-      final BlobsBundle blobsBundle) {
+      final BlobsBundle blobsBundle,
+      final boolean shouldOverrideBuilder) {
     this.executionPayload = executionPayload;
     this.blockValue = blockValue;
     this.blobsBundle = Optional.of(blobsBundle);
+    this.shouldOverrideBuilder = shouldOverrideBuilder;
   }
 
   public ExecutionPayload getExecutionPayload() {
@@ -57,6 +62,10 @@ public class GetPayloadResponse {
     return blobsBundle;
   }
 
+  public boolean getShouldOverrideBuilder() {
+    return shouldOverrideBuilder;
+  }
+
   @Override
   public boolean equals(final Object o) {
     if (this == o) {
@@ -66,14 +75,15 @@ public class GetPayloadResponse {
       return false;
     }
     final GetPayloadResponse that = (GetPayloadResponse) o;
-    return Objects.equals(executionPayload, that.executionPayload)
+    return shouldOverrideBuilder == that.shouldOverrideBuilder
+        && Objects.equals(executionPayload, that.executionPayload)
         && Objects.equals(blockValue, that.blockValue)
         && Objects.equals(blobsBundle, that.blobsBundle);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(executionPayload, blockValue, blobsBundle);
+    return Objects.hash(executionPayload, blockValue, blobsBundle, shouldOverrideBuilder);
   }
 
   @Override
@@ -82,6 +92,7 @@ public class GetPayloadResponse {
         .add("executionPayload", executionPayload)
         .add("blockValue", blockValue)
         .add("blobsBundle", blobsBundle)
+        .add("shouldOverrideBuilder", shouldOverrideBuilder)
         .toString();
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
@@ -281,7 +281,7 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
             .map(
                 blobsBundle -> {
                   LOG.info("getPayload: blobsBundle: {}", blobsBundle.toBriefString());
-                  return new GetPayloadResponse(executionPayload, UInt256.ZERO, blobsBundle);
+                  return new GetPayloadResponse(executionPayload, UInt256.ZERO, blobsBundle, false);
                 })
             .orElse(new GetPayloadResponse(executionPayload));
 

--- a/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerConfiguration.java
+++ b/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerConfiguration.java
@@ -36,6 +36,7 @@ public class ExecutionLayerConfiguration {
   public static final int BUILDER_CIRCUIT_BREAKER_WINDOW_HARD_CAP = 64;
   public static final int DEFAULT_BUILDER_BID_COMPARE_FACTOR = 100;
   public static final boolean DEFAULT_BUILDER_SET_USER_AGENT_HEADER = true;
+  public static final boolean DEFAULT_USE_SHOULD_OVERRIDE_BUILDER_FLAG = true;
   public static final String BUILDER_ALWAYS_KEYWORD = "BUILDER_ALWAYS";
 
   private final Spec spec;
@@ -48,6 +49,7 @@ public class ExecutionLayerConfiguration {
   private final int builderCircuitBreakerAllowedConsecutiveFaults;
   private final Optional<Integer> builderBidCompareFactor;
   private final boolean builderSetUserAgentHeader;
+  private final boolean useShouldOverrideBuilderFlag;
 
   private ExecutionLayerConfiguration(
       final Spec spec,
@@ -59,7 +61,8 @@ public class ExecutionLayerConfiguration {
       final int builderCircuitBreakerAllowedFaults,
       final int builderCircuitBreakerAllowedConsecutiveFaults,
       final Optional<Integer> builderBidCompareFactor,
-      final boolean builderSetUserAgentHeader) {
+      final boolean builderSetUserAgentHeader,
+      final boolean useShouldOverrideBuilderFlag) {
     this.spec = spec;
     this.engineEndpoint = engineEndpoint;
     this.engineJwtSecretFile = engineJwtSecretFile;
@@ -71,6 +74,7 @@ public class ExecutionLayerConfiguration {
         builderCircuitBreakerAllowedConsecutiveFaults;
     this.builderBidCompareFactor = builderBidCompareFactor;
     this.builderSetUserAgentHeader = builderSetUserAgentHeader;
+    this.useShouldOverrideBuilderFlag = useShouldOverrideBuilderFlag;
   }
 
   public static Builder builder() {
@@ -124,6 +128,10 @@ public class ExecutionLayerConfiguration {
     return builderSetUserAgentHeader;
   }
 
+  public boolean getUseShouldOverrideBuilderFlag() {
+    return useShouldOverrideBuilderFlag;
+  }
+
   public static class Builder {
     private Spec spec;
     private Optional<String> engineEndpoint = Optional.empty();
@@ -136,6 +144,7 @@ public class ExecutionLayerConfiguration {
         DEFAULT_BUILDER_CIRCUIT_BREAKER_ALLOWED_CONSECUTIVE_FAULTS;
     private String builderBidCompareFactor = Integer.toString(DEFAULT_BUILDER_BID_COMPARE_FACTOR);
     private boolean builderSetUserAgentHeader = DEFAULT_BUILDER_SET_USER_AGENT_HEADER;
+    private boolean useShouldOverrideBuilderFlag = DEFAULT_USE_SHOULD_OVERRIDE_BUILDER_FLAG;
 
     private Builder() {}
 
@@ -170,7 +179,8 @@ public class ExecutionLayerConfiguration {
           builderCircuitBreakerAllowedFaults,
           builderCircuitBreakerAllowedConsecutiveFaults,
           builderBidCompareFactor,
-          builderSetUserAgentHeader);
+          builderSetUserAgentHeader,
+          useShouldOverrideBuilderFlag);
     }
 
     public Builder engineEndpoint(final String engineEndpoint) {
@@ -223,6 +233,11 @@ public class ExecutionLayerConfiguration {
 
     public Builder builderSetUserAgentHeader(final boolean builderSetUserAgentHeader) {
       this.builderSetUserAgentHeader = builderSetUserAgentHeader;
+      return this;
+    }
+
+    public Builder useShouldOverrideBuilderFlag(final boolean useShouldOverrideBuilderFlag) {
+      this.useShouldOverrideBuilderFlag = useShouldOverrideBuilderFlag;
       return this;
     }
 

--- a/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerService.java
+++ b/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerService.java
@@ -204,7 +204,8 @@ public class ExecutionLayerService extends Service {
         new BuilderBidValidatorImpl(EVENT_LOG),
         builderCircuitBreaker,
         blobsBundleValidator,
-        config.getBuilderBidCompareFactor());
+        config.getBuilderBidCompareFactor(),
+        config.getUseShouldOverrideBuilderFlag());
   }
 
   ExecutionLayerService(

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ExecutionLayerOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ExecutionLayerOptions.java
@@ -21,6 +21,7 @@ import static tech.pegasys.teku.services.executionlayer.ExecutionLayerConfigurat
 import static tech.pegasys.teku.services.executionlayer.ExecutionLayerConfiguration.DEFAULT_BUILDER_CIRCUIT_BREAKER_ENABLED;
 import static tech.pegasys.teku.services.executionlayer.ExecutionLayerConfiguration.DEFAULT_BUILDER_CIRCUIT_BREAKER_WINDOW;
 import static tech.pegasys.teku.services.executionlayer.ExecutionLayerConfiguration.DEFAULT_BUILDER_SET_USER_AGENT_HEADER;
+import static tech.pegasys.teku.services.executionlayer.ExecutionLayerConfiguration.DEFAULT_USE_SHOULD_OVERRIDE_BUILDER_FLAG;
 
 import picocli.CommandLine.Help.Visibility;
 import picocli.CommandLine.Mixin;
@@ -115,6 +116,17 @@ public class ExecutionLayerOptions {
       hidden = true)
   private boolean builderSetUserAgentHeader = DEFAULT_BUILDER_SET_USER_AGENT_HEADER;
 
+  @Option(
+      names = {"--Xuse-should-override-builder-flag"},
+      paramLabel = "<BOOLEAN>",
+      description =
+          "Whether or not to use the shouldOverrideBuilder flag provided by the Engine API.",
+      arity = "1",
+      showDefaultValue = Visibility.ALWAYS,
+      fallbackValue = "true",
+      hidden = true)
+  private boolean useShouldOverrideBuilderFlag = DEFAULT_USE_SHOULD_OVERRIDE_BUILDER_FLAG;
+
   public void configure(final Builder builder) {
     builder.executionLayer(
         b ->
@@ -127,7 +139,8 @@ public class ExecutionLayerOptions {
                 .builderCircuitBreakerAllowedConsecutiveFaults(
                     builderCircuitBreakerAllowedConsecutiveFaults)
                 .builderBidCompareFactor(builderBidCompareFactor)
-                .builderSetUserAgentHeader(builderSetUserAgentHeader));
+                .builderSetUserAgentHeader(builderSetUserAgentHeader)
+                .useShouldOverrideBuilderFlag(useShouldOverrideBuilderFlag));
     depositOptions.configure(builder);
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Implement changes as per https://github.com/ethereum/execution-apis/pull/425 . Basically if flag is true coming from local EL, then local payload is used, else builder.

Also introduces `--Xuse-should-override-builder-flag` which could turn on/off this behaviour. Default is true.

Marking as draft as spec is not finalized/merged.

## Fixed Issue(s)
fixes #7020 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
