### PR TITLE
Added epoch state cache configuration

### DIFF
--- a/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
@@ -505,7 +505,7 @@ class Store implements UpdatableStore {
   }
 
   @Override
-  public SafeFuture<Optional<SignedBlockAndState>> retrieveBlockAndState(Bytes32 blockRoot) {
+  public SafeFuture<Optional<SignedBlockAndState>> retrieveBlockAndState(final Bytes32 blockRoot) {
     return getAndCacheBlockAndState(blockRoot);
   }
 
@@ -516,7 +516,7 @@ class Store implements UpdatableStore {
   }
 
   @Override
-  public SafeFuture<Optional<BeaconState>> retrieveBlockState(Bytes32 blockRoot) {
+  public SafeFuture<Optional<BeaconState>> retrieveBlockState(final Bytes32 blockRoot) {
     return getAndCacheBlockAndState(blockRoot)
         .thenApply(
             maybeStateAndBlockSummary ->
@@ -524,13 +524,14 @@ class Store implements UpdatableStore {
   }
 
   @Override
-  public SafeFuture<Optional<BeaconState>> retrieveCheckpointState(Checkpoint checkpoint) {
+  public SafeFuture<Optional<BeaconState>> retrieveCheckpointState(final Checkpoint checkpoint) {
     return checkpointStates.perform(
         new StateAtSlotTask(spec, checkpoint.toSlotAndBlockRoot(spec), this::retrieveBlockState));
   }
 
   @Override
-  public SafeFuture<Optional<BeaconState>> retrieveStateAtSlot(SlotAndBlockRoot slotAndBlockRoot) {
+  public SafeFuture<Optional<BeaconState>> retrieveStateAtSlot(
+      final SlotAndBlockRoot slotAndBlockRoot) {
     return checkpointStates.perform(
         new StateAtSlotTask(spec, slotAndBlockRoot, this::retrieveBlockState));
   }
@@ -561,7 +562,7 @@ class Store implements UpdatableStore {
 
   @Override
   public SafeFuture<Optional<BeaconState>> retrieveCheckpointState(
-      Checkpoint checkpoint, final BeaconState latestStateAtEpoch) {
+      final Checkpoint checkpoint, final BeaconState latestStateAtEpoch) {
     return checkpointStates.perform(
         new StateAtSlotTask(
             spec,
@@ -589,7 +590,7 @@ class Store implements UpdatableStore {
     }
   }
 
-  VoteTracker getVote(UInt64 validatorIndex) {
+  VoteTracker getVote(final UInt64 validatorIndex) {
     readVotesLock.lock();
     try {
       if (validatorIndex.intValue() >= votes.length) {
@@ -847,13 +848,13 @@ class Store implements UpdatableStore {
         });
   }
 
-  void updateFinalizedAnchor(AnchorPoint latestFinalized) {
+  void updateFinalizedAnchor(final AnchorPoint latestFinalized) {
     pruneOldFinalizedStateFromEpochCache(this.finalizedAnchor);
     finalizedAnchor = latestFinalized;
     cacheFinalizedAnchorPoint(latestFinalized);
   }
 
-  private void cacheFinalizedAnchorPoint(AnchorPoint latestFinalized) {
+  private void cacheFinalizedAnchorPoint(final AnchorPoint latestFinalized) {
     maybeEpochStates.ifPresent(
         epochStates -> {
           final BeaconState state = latestFinalized.getState();
@@ -878,7 +879,7 @@ class Store implements UpdatableStore {
         });
   }
 
-  void updateJustifiedCheckpoint(Checkpoint checkpoint) {
+  void updateJustifiedCheckpoint(final Checkpoint checkpoint) {
     this.justifiedCheckpoint = checkpoint;
     maybeEpochStates.ifPresent(
         epochStates -> {
@@ -891,7 +892,7 @@ class Store implements UpdatableStore {
         });
   }
 
-  void updateBestJustifiedCheckpoint(Checkpoint checkpoint) {
+  void updateBestJustifiedCheckpoint(final Checkpoint checkpoint) {
     this.bestJustifiedCheckpoint = checkpoint;
   }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
@@ -311,7 +311,7 @@ class Store implements UpdatableStore {
                 SettableGauge.create(
                     metricsSystem,
                     TekuMetricCategory.STORAGE,
-                    "memory_epoch_states_count",
+                    "memory_epoch_states_cache_size",
                     "Number of Epoch aligned states held in the in-memory store"));
       }
       states.startMetrics();

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
@@ -664,12 +664,13 @@ class Store implements UpdatableStore {
 
       final Map<Bytes32, StateAndBlockSummary> epochStates = maybeEpochStates.get();
       if (!slot.mod(spec.getSlotsPerEpoch(slot)).isZero()) {
+        // pre-epoch transition state
+        // This will be referenced during epoch transition if the first slot of the epoch is empty
         final Optional<StateAndBlockSummary> maybeParent =
             states.getIfAvailable(summary.getParentRoot());
         maybeParent.ifPresent(
             stateAndBlockSummary -> epochStates.put(summary.getParentRoot(), stateAndBlockSummary));
       }
-      // pre-epoch transition state
       // post epoch transition state
       epochStates.put(summary.getRoot(), summary);
       epochStatesCountGauge.ifPresent(counter -> counter.set(maybeEpochStates.get().size()));

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
@@ -19,6 +19,7 @@ import static tech.pegasys.teku.dataproviders.lookup.BlockProvider.fromDynamicMa
 import static tech.pegasys.teku.dataproviders.lookup.BlockProvider.fromMap;
 import static tech.pegasys.teku.infrastructure.time.TimeUtilities.secondsToMillis;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -26,6 +27,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
@@ -45,11 +47,13 @@ import tech.pegasys.teku.dataproviders.lookup.StateAndBlockSummaryProvider;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.collections.LimitedMap;
+import tech.pegasys.teku.infrastructure.collections.LimitedSet;
 import tech.pegasys.teku.infrastructure.metrics.SettableGauge;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
@@ -82,6 +86,10 @@ class Store implements UpdatableStore {
 
   private final MetricsSystem metricsSystem;
   private Optional<SettableGauge> blockCountGauge = Optional.empty();
+
+  private Optional<SettableGauge> epochStatesCountGauge = Optional.empty();
+
+  private final Optional<Set<StateAndBlockSummary>> maybeEpochStates;
 
   private final Spec spec;
   private final StateAndBlockSummaryProvider stateProvider;
@@ -123,7 +131,8 @@ class Store implements UpdatableStore {
       final ForkChoiceStrategy forkChoiceStrategy,
       final Map<UInt64, VoteTracker> votes,
       final Map<Bytes32, SignedBeaconBlock> blocks,
-      final CachingTaskQueue<SlotAndBlockRoot, BeaconState> checkpointStates) {
+      final CachingTaskQueue<SlotAndBlockRoot, BeaconState> checkpointStates,
+      final Optional<Set<StateAndBlockSummary>> maybeEpochStates) {
     checkArgument(
         time.isGreaterThanOrEqualTo(genesisTime),
         "Time must be greater than or equal to genesisTime");
@@ -155,6 +164,7 @@ class Store implements UpdatableStore {
 
     // Track latest finalized block
     this.finalizedAnchor = finalizedAnchor;
+    this.maybeEpochStates = maybeEpochStates;
     states.cache(finalizedAnchor.getRoot(), finalizedAnchor);
     this.finalizedOptimisticTransitionPayload = finalizedOptimisticTransitionPayload;
 
@@ -204,6 +214,12 @@ class Store implements UpdatableStore {
     final CachingTaskQueue<Bytes32, StateAndBlockSummary> stateTaskQueue =
         CachingTaskQueue.create(
             asyncRunner, metricsSystem, "memory_states", config.getStateCacheSize());
+
+    final Optional<Set<StateAndBlockSummary>> maybeEpochStates =
+        config.getEpochStateCacheSize() > 0
+            ? Optional.of(LimitedSet.createSynchronizedIterable(config.getEpochStateCacheSize()))
+            : Optional.empty();
+
     final UInt64 currentEpoch = spec.computeEpochAtSlot(spec.getCurrentSlot(time, genesisTime));
     final ForkChoiceStrategy forkChoiceStrategy =
         ForkChoiceStrategy.initialize(
@@ -235,7 +251,8 @@ class Store implements UpdatableStore {
         forkChoiceStrategy,
         votes,
         blocks,
-        checkpointStateTaskQueue);
+        checkpointStateTaskQueue,
+        maybeEpochStates);
   }
 
   private static ProtoArray buildProtoArray(
@@ -290,6 +307,16 @@ class Store implements UpdatableStore {
                   TekuMetricCategory.STORAGE,
                   "memory_block_count",
                   "Number of beacon blocks held in the in-memory store"));
+
+      if (maybeEpochStates.isPresent()) {
+        epochStatesCountGauge =
+            Optional.of(
+                SettableGauge.create(
+                    metricsSystem,
+                    TekuMetricCategory.STORAGE,
+                    "memory_epoch_states_count",
+                    "Number of Epoch aligned states held in the in-memory store"));
+      }
       states.startMetrics();
       checkpointStates.startMetrics();
     } finally {
@@ -575,7 +602,11 @@ class Store implements UpdatableStore {
 
   private SafeFuture<Optional<BeaconState>> getAndCacheBlockState(final Bytes32 blockRoot) {
     return getOrRegenerateBlockAndState(blockRoot)
-        .thenApply(res -> res.map(StateAndBlockSummary::getState));
+        .thenApply(
+            res -> {
+              cacheIfEpochState(res);
+              return res.map(StateAndBlockSummary::getState);
+            });
   }
 
   private SafeFuture<Optional<SignedBlockAndState>> getAndCacheBlockAndState(
@@ -609,12 +640,41 @@ class Store implements UpdatableStore {
     if (cachedResult.isPresent()) {
       return SafeFuture.completedFuture(cachedResult);
     }
+
+    // is it an epoch boundary?
+    if (maybeEpochStates.isPresent()) {
+      final Optional<StateAndBlockSummary> maybeEpochState =
+          maybeEpochStates.get().stream()
+              .filter(
+                  stateAndBlockSummary ->
+                      stateAndBlockSummary.getBlockSummary().getRoot().equals(blockRoot))
+              .findFirst();
+      if (maybeEpochState.isPresent()) {
+        return SafeFuture.completedFuture(maybeEpochState);
+      }
+    }
     return createStateGenerationTask(blockRoot)
         .thenCompose(
             maybeTask ->
                 maybeTask.isPresent()
-                    ? states.perform(maybeTask.get())
+                    ? states.perform(maybeTask.get()).thenPeek(this::cacheIfEpochState)
                     : EmptyStoreResults.EMPTY_STATE_AND_BLOCK_SUMMARY_FUTURE);
+  }
+
+  private void cacheIfEpochState(Optional<StateAndBlockSummary> maybeStateAndBlockSummary) {
+    if (maybeStateAndBlockSummary.isPresent() && maybeEpochStates.isPresent()) {
+      final UInt64 slot = maybeStateAndBlockSummary.get().getSlot();
+      final int slotsPerEpoch =
+          spec.atSlot(maybeStateAndBlockSummary.get().getSlot()).getConfig().getSlotsPerEpoch();
+      if (slot.mod(slotsPerEpoch).isZero()) {
+        BeaconBlockSummary summary = maybeStateAndBlockSummary.get().getBlockSummary();
+
+        if (maybeEpochStates.get().add(maybeStateAndBlockSummary.get())) {
+          LOG.trace("epochCache ADD {}({})", summary.getRoot(), summary.getSlot());
+        }
+        epochStatesCountGauge.ifPresent(counter -> counter.set(maybeEpochStates.get().size()));
+      }
+    }
   }
 
   private SafeFuture<Optional<StateGenerationTask>> createStateGenerationTask(
@@ -746,5 +806,25 @@ class Store implements UpdatableStore {
     } finally {
       writeLock.unlock();
     }
+  }
+
+  @VisibleForTesting
+  Optional<Set<StateAndBlockSummary>> getEpochStates() {
+    return maybeEpochStates;
+  }
+
+  void removeStateAndBlock(final Bytes32 root) {
+    blocks.remove(root);
+    states.remove(root);
+  }
+
+  void cleanupEpochStates() {
+    final UInt64 finalizedSlot = finalizedAnchor.getSlot();
+    maybeEpochStates.ifPresent(
+        stateAndBlockSummaries -> {
+          stateAndBlockSummaries.removeIf(
+              summary -> summary.getState().getSlot().isLessThan(finalizedSlot));
+          epochStatesCountGauge.ifPresent(counter -> counter.set(stateAndBlockSummaries.size()));
+        });
   }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
@@ -838,8 +838,7 @@ class Store implements UpdatableStore {
     states.remove(root);
     maybeEpochStates.ifPresent(
         epochStates -> {
-          if (!finalizedAnchor.getRoot().equals(root)
-              && !finalizedAnchor.getParentRoot().equals(root)) {
+          if (!finalizedAnchor.getRoot().equals(root)) {
             final StateAndBlockSummary stateAndBlockSummary = epochStates.remove(root);
             if (stateAndBlockSummary != null) {
               LOG.trace("epochCache REM {}", stateAndBlockSummary::getSlot);

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreConfig.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreConfig.java
@@ -22,6 +22,8 @@ public class StoreConfig {
   public static final int MAX_CACHE_SIZE = 10_000;
 
   public static final int DEFAULT_STATE_CACHE_SIZE = 32 * 5;
+
+  public static final int DEFAULT_EPOCH_STATE_CACHE_SIZE = 0;
   public static final int DEFAULT_BLOCK_CACHE_SIZE = 32;
   public static final int DEFAULT_CHECKPOINT_STATE_CACHE_SIZE = 20;
   public static final int DEFAULT_HOT_STATE_PERSISTENCE_FREQUENCY_IN_EPOCHS = 2;
@@ -29,6 +31,8 @@ public class StoreConfig {
   public static final int DEFAULT_EARLIEST_AVAILABLE_BLOCK_SLOT_QUERY_FREQUENCY = 0;
 
   private final int stateCacheSize;
+
+  private final int epochStateCacheSize;
   private final int blockCacheSize;
   private final int checkpointStateCacheSize;
   private final int hotStatePersistenceFrequencyInEpochs;
@@ -39,12 +43,14 @@ public class StoreConfig {
       final int blockCacheSize,
       final int checkpointStateCacheSize,
       final int hotStatePersistenceFrequencyInEpochs,
-      int earliestAvailableBlockSlotFrequency) {
+      final int earliestAvailableBlockSlotFrequency,
+      final int epochStateCacheSize) {
     this.stateCacheSize = stateCacheSize;
     this.blockCacheSize = blockCacheSize;
     this.checkpointStateCacheSize = checkpointStateCacheSize;
     this.hotStatePersistenceFrequencyInEpochs = hotStatePersistenceFrequencyInEpochs;
     this.earliestAvailableBlockSlotFrequency = earliestAvailableBlockSlotFrequency;
+    this.epochStateCacheSize = epochStateCacheSize;
   }
 
   public static Builder builder() {
@@ -57,6 +63,10 @@ public class StoreConfig {
 
   public int getStateCacheSize() {
     return stateCacheSize;
+  }
+
+  public int getEpochStateCacheSize() {
+    return epochStateCacheSize;
   }
 
   public int getBlockCacheSize() {
@@ -85,6 +95,7 @@ public class StoreConfig {
     }
     final StoreConfig that = (StoreConfig) o;
     return stateCacheSize == that.stateCacheSize
+        && epochStateCacheSize == that.epochStateCacheSize
         && blockCacheSize == that.blockCacheSize
         && checkpointStateCacheSize == that.checkpointStateCacheSize
         && hotStatePersistenceFrequencyInEpochs == that.hotStatePersistenceFrequencyInEpochs;
@@ -94,6 +105,7 @@ public class StoreConfig {
   public int hashCode() {
     return Objects.hash(
         stateCacheSize,
+        epochStateCacheSize,
         blockCacheSize,
         checkpointStateCacheSize,
         hotStatePersistenceFrequencyInEpochs);
@@ -101,6 +113,8 @@ public class StoreConfig {
 
   public static class Builder {
     private int stateCacheSize = DEFAULT_STATE_CACHE_SIZE;
+
+    private int epochStateCacheSize = DEFAULT_EPOCH_STATE_CACHE_SIZE;
     private int blockCacheSize = DEFAULT_BLOCK_CACHE_SIZE;
     private int checkpointStateCacheSize = DEFAULT_CHECKPOINT_STATE_CACHE_SIZE;
     private int hotStatePersistenceFrequencyInEpochs =
@@ -115,12 +129,19 @@ public class StoreConfig {
           blockCacheSize,
           checkpointStateCacheSize,
           hotStatePersistenceFrequencyInEpochs,
-          earliestAvailableBlockSlotFrequency);
+          earliestAvailableBlockSlotFrequency,
+          epochStateCacheSize);
     }
 
     public Builder stateCacheSize(final int stateCacheSize) {
       validateCacheSize(stateCacheSize);
       this.stateCacheSize = stateCacheSize;
+      return this;
+    }
+
+    public Builder epochStateCacheSize(final int epochStateCacheSize) {
+      validateCacheSize(stateCacheSize);
+      this.epochStateCacheSize = epochStateCacheSize;
       return this;
     }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransactionUpdates.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransactionUpdates.java
@@ -121,14 +121,9 @@ class StoreTransactionUpdates {
         finalizedData -> store.finalizedAnchor = finalizedData.getLatestFinalized());
 
     // Prune blocks and states
-    prunedHotBlockRoots
-        .keySet()
-        .forEach(
-            (root) -> {
-              store.blocks.remove(root);
-              store.states.remove(root);
-            });
+    prunedHotBlockRoots.keySet().forEach(store::removeStateAndBlock);
 
+    store.cleanupEpochStates();
     store.checkpointStates.removeIf(
         slotAndBlockRoot -> prunedHotBlockRoots.containsKey(slotAndBlockRoot.getBlockRoot()));
 

--- a/storage/src/test/java/tech/pegasys/teku/storage/store/AbstractStoreTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/store/AbstractStoreTest.java
@@ -59,6 +59,7 @@ public abstract class AbstractStoreTest {
             .checkpointStateCacheSize(cacheSize)
             .blockCacheSize(cacheSize)
             .stateCacheSize(cacheSize)
+            .epochStateCacheSize(cacheSize)
             .build();
 
     final UpdatableStore store = createGenesisStore(pruningOptions);

--- a/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTest.java
@@ -128,7 +128,7 @@ class StoreTest extends AbstractStoreTest {
         .containsExactlyInAnyOrder(24, 8);
   }
 
-  private SlotAndBlockRoot stateAndBlockAtSlot(int i, ChainBuilder chainBuilder) {
+  private SlotAndBlockRoot stateAndBlockAtSlot(final int i, final ChainBuilder chainBuilder) {
     return new SlotAndBlockRoot(UInt64.valueOf(i), chainBuilder.getBlockAtSlot(i).getRoot());
   }
 

--- a/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTest.java
@@ -121,7 +121,7 @@ class StoreTest extends AbstractStoreTest {
     assertThat(store.retrieveStateAtSlot(stateAndBlockAtSlot(24, chainBuilder))).isCompleted();
     assertThat(store.retrieveStateAtSlot(stateAndBlockAtSlot(8, chainBuilder))).isCompleted();
     assertThat(
-            s.getEpochStates().orElseThrow().stream()
+            s.getEpochStates().orElseThrow().values().stream()
                 .map(StateAndBlockSummary::getSlot)
                 .map(UInt64::intValue)
                 .collect(Collectors.toList()))

--- a/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTest.java
@@ -34,17 +34,19 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
+import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
+import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
 import tech.pegasys.teku.spec.datastructures.forkchoice.InvalidCheckpointException;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.CheckpointState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.generator.ChainBuilder;
 import tech.pegasys.teku.storage.api.StubStorageUpdateChannel;
 import tech.pegasys.teku.storage.api.StubStorageUpdateChannelWithDelays;
 import tech.pegasys.teku.storage.store.UpdatableStore.StoreTransaction;
 
 class StoreTest extends AbstractStoreTest {
-
   @Test
   public void create_timeLessThanGenesisTime() {
     final UInt64 genesisTime = UInt64.valueOf(100);
@@ -87,6 +89,47 @@ class StoreTest extends AbstractStoreTest {
               .describedAs("block %s", expectedBlock.getSlot())
               .isCompletedWithValue(Optional.of(expectedBlock));
         });
+  }
+
+  @Test
+  public void epochStatesCacheMostRecentlyAddedStates() {
+    final int cacheSize = 2;
+    final StoreConfig pruningOptions =
+        StoreConfig.builder()
+            .checkpointStateCacheSize(cacheSize)
+            .blockCacheSize(cacheSize)
+            .stateCacheSize(cacheSize)
+            .epochStateCacheSize(cacheSize)
+            .build();
+
+    final UpdatableStore store = createGenesisStore(pruningOptions);
+
+    chainBuilder.generateBlocksUpToSlot(25);
+    // Add blocks
+    final StoreTransaction tx = store.startTransaction(new StubStorageUpdateChannel());
+    chainBuilder
+        .streamBlocksAndStates(0, 25)
+        .forEach(
+            blockAndState -> {
+              tx.putBlockAndState(
+                  blockAndState, spec.calculateBlockCheckpoints(blockAndState.getState()));
+            });
+    tx.commit().join();
+
+    final Store s = (Store) store;
+    assertThat(store.retrieveStateAtSlot(stateAndBlockAtSlot(16, chainBuilder))).isCompleted();
+    assertThat(store.retrieveStateAtSlot(stateAndBlockAtSlot(24, chainBuilder))).isCompleted();
+    assertThat(store.retrieveStateAtSlot(stateAndBlockAtSlot(8, chainBuilder))).isCompleted();
+    assertThat(
+            s.getEpochStates().orElseThrow().stream()
+                .map(StateAndBlockSummary::getSlot)
+                .map(UInt64::intValue)
+                .collect(Collectors.toList()))
+        .containsExactlyInAnyOrder(24, 8);
+  }
+
+  private SlotAndBlockRoot stateAndBlockAtSlot(int i, ChainBuilder chainBuilder) {
+    return new SlotAndBlockRoot(UInt64.valueOf(i), chainBuilder.getBlockAtSlot(i).getRoot());
   }
 
   @Test

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/StoreOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/StoreOptions.java
@@ -42,9 +42,17 @@ public class StoreOptions {
       hidden = true,
       names = {"--Xstore-state-cache-size"},
       paramLabel = "<INTEGER>",
-      description = "Number of state to cache in memory",
+      description = "Number of states to cache in memory",
       arity = "1")
   private int stateCacheSize = StoreConfig.DEFAULT_STATE_CACHE_SIZE;
+
+  @Option(
+      hidden = true,
+      names = {"--Xstore-epoch-state-cache-size"},
+      paramLabel = "<INTEGER>",
+      description = "Number of epoch aligned states to cache in memory",
+      arity = "1")
+  private int epochStateCacheSize = StoreConfig.DEFAULT_EPOCH_STATE_CACHE_SIZE;
 
   @Option(
       hidden = true,
@@ -70,6 +78,7 @@ public class StoreOptions {
             b.hotStatePersistenceFrequencyInEpochs(hotStatePersistenceFrequencyInEpochs)
                 .blockCacheSize(blockCacheSize)
                 .stateCacheSize(stateCacheSize)
+                .epochStateCacheSize(epochStateCacheSize)
                 .earliestAvailableBlockSlotFrequency(earliestAvailableBlockSlotQueryFrequency)
                 .checkpointStateCacheSize(checkpointStateCacheSize));
   }


### PR DESCRIPTION
Now that attestations aren't being validated against states so often, we need a cache closer aligned to what we're doing when we need to regenerate - basically we want to avoid regeneration of state if at all possible.

One epoch transition the finalized and sometimes justified state get read, and were causing regenerations, so adding a cache to handle storing those, but leaving it size 0 by default for now.

The idea would be to have the current state cache reduced significantly in size, potentially to about half an epoch or so, and have an epoch cache with a maximum size over 2, and could probably be below 10 by default.

This would mean the vast majority of the time, no state regeneration is required, and our states in memory can drop to a much lower number than currently stored in memory (32 * 5 max by default currently).

Tested in minimal network, needs to be deployed to a more complex setup to see if it behaves well in a real environment.
