### PR TITLE
Improve retrieval of blobs in GetBlobSidecars

### DIFF
--- a/data/provider/src/test/java/tech/pegasys/teku/api/blobselector/BlobSidecarSelectorFactoryTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/blobselector/BlobSidecarSelectorFactoryTest.java
@@ -137,7 +137,7 @@ public class BlobSidecarSelectorFactoryTest {
   }
 
   @Test
-  public void slotSelector_shouldGetBlobSidecarsByRetrievingBlock()
+  public void slotSelector_shouldGetBlobSidecarsByRetrievingBlockWhenSlotNotFinalized()
       throws ExecutionException, InterruptedException {
     when(client.isFinalized(block.getSlot())).thenReturn(false);
     when(client.getBlockAtSlotExact(block.getSlot()))

--- a/data/provider/src/test/java/tech/pegasys/teku/api/stateselector/StateSelectorFactoryTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/stateselector/StateSelectorFactoryTest.java
@@ -163,7 +163,7 @@ public class StateSelectorFactoryTest {
   }
 
   @Test
-  public void createSelectorForStateId_shouldNotThrowBadRequestOnJustifiedKeyword() {
+  public void createSelectorForStateId_shouldCreateSelectorOnJustifiedKeyword() {
     final StateSelector selector = factory.createSelectorForStateId("justified");
     assertThat(selector).isNotNull();
   }

--- a/storage/api/src/main/java/tech/pegasys/teku/storage/api/StorageQueryChannel.java
+++ b/storage/api/src/main/java/tech/pegasys/teku/storage/api/StorageQueryChannel.java
@@ -43,13 +43,13 @@ public interface StorageQueryChannel extends ChannelInterface {
   /** @return The earliest available finalized block */
   SafeFuture<Optional<SignedBeaconBlock>> getEarliestAvailableBlock();
 
-  SafeFuture<Optional<SignedBeaconBlock>> getFinalizedBlockAtSlot(final UInt64 slot);
+  SafeFuture<Optional<SignedBeaconBlock>> getFinalizedBlockAtSlot(UInt64 slot);
 
-  SafeFuture<Optional<SignedBeaconBlock>> getLatestFinalizedBlockAtSlot(final UInt64 slot);
+  SafeFuture<Optional<SignedBeaconBlock>> getLatestFinalizedBlockAtSlot(UInt64 slot);
 
-  SafeFuture<Optional<SignedBeaconBlock>> getBlockByBlockRoot(final Bytes32 blockRoot);
+  SafeFuture<Optional<SignedBeaconBlock>> getBlockByBlockRoot(Bytes32 blockRoot);
 
-  SafeFuture<Optional<SignedBlockAndState>> getHotBlockAndStateByBlockRoot(final Bytes32 blockRoot);
+  SafeFuture<Optional<SignedBlockAndState>> getHotBlockAndStateByBlockRoot(Bytes32 blockRoot);
 
   SafeFuture<Optional<StateAndBlockSummary>> getHotStateAndBlockSummaryByBlockRoot(
       final Bytes32 blockRoot);
@@ -61,22 +61,24 @@ public interface StorageQueryChannel extends ChannelInterface {
    * @param blockRoots The roots of blocks to look up
    * @return A map from root too block of any found blocks
    */
-  SafeFuture<Map<Bytes32, SignedBeaconBlock>> getHotBlocksByRoot(final Set<Bytes32> blockRoots);
+  SafeFuture<Map<Bytes32, SignedBeaconBlock>> getHotBlocksByRoot(Set<Bytes32> blockRoots);
 
   SafeFuture<List<BlobSidecar>> getBlobSidecarsBySlotAndBlockRoot(
-      final SlotAndBlockRoot slotAndBlockRoot);
+      SlotAndBlockRoot slotAndBlockRoot);
 
-  SafeFuture<Optional<SlotAndBlockRoot>> getSlotAndBlockRootByStateRoot(final Bytes32 stateRoot);
+  SafeFuture<Optional<SlotAndBlockRoot>> getSlotAndBlockRootByStateRoot(Bytes32 stateRoot);
 
-  SafeFuture<Optional<BeaconState>> getLatestFinalizedStateAtSlot(final UInt64 slot);
+  SafeFuture<Optional<BeaconState>> getLatestFinalizedStateAtSlot(UInt64 slot);
 
-  SafeFuture<Optional<BeaconState>> getLatestAvailableFinalizedState(final UInt64 slot);
+  SafeFuture<Optional<BeaconState>> getLatestAvailableFinalizedState(UInt64 slot);
 
-  SafeFuture<Optional<BeaconState>> getFinalizedStateByBlockRoot(final Bytes32 blockRoot);
+  SafeFuture<Optional<UInt64>> getFinalizedSlotByBlockRoot(Bytes32 blockRoot);
 
-  SafeFuture<Optional<UInt64>> getFinalizedSlotByStateRoot(final Bytes32 stateRoot);
+  SafeFuture<Optional<BeaconState>> getFinalizedStateByBlockRoot(Bytes32 blockRoot);
 
-  SafeFuture<List<SignedBeaconBlock>> getNonCanonicalBlocksBySlot(final UInt64 slot);
+  SafeFuture<Optional<UInt64>> getFinalizedSlotByStateRoot(Bytes32 stateRoot);
+
+  SafeFuture<List<SignedBeaconBlock>> getNonCanonicalBlocksBySlot(UInt64 slot);
 
   SafeFuture<Optional<Checkpoint>> getAnchor();
 
@@ -86,6 +88,8 @@ public interface StorageQueryChannel extends ChannelInterface {
   SafeFuture<Optional<UInt64>> getEarliestAvailableBlobSidecarSlot();
 
   SafeFuture<Optional<BlobSidecar>> getBlobSidecar(SlotAndBlockRootAndBlobIndex key);
+
+  SafeFuture<List<SlotAndBlockRootAndBlobIndex>> getBlobSidecarKeys(UInt64 slot);
 
   SafeFuture<List<SlotAndBlockRootAndBlobIndex>> getBlobSidecarKeys(
       UInt64 startSlot, UInt64 endSlot, UInt64 limit);

--- a/storage/api/src/main/java/tech/pegasys/teku/storage/api/StorageQueryChannel.java
+++ b/storage/api/src/main/java/tech/pegasys/teku/storage/api/StorageQueryChannel.java
@@ -89,6 +89,7 @@ public interface StorageQueryChannel extends ChannelInterface {
 
   SafeFuture<Optional<BlobSidecar>> getBlobSidecar(SlotAndBlockRootAndBlobIndex key);
 
+  /** This method could return non-canonical blob sidecar keys if the slot is not finalized */
   SafeFuture<List<SlotAndBlockRootAndBlobIndex>> getBlobSidecarKeys(UInt64 slot);
 
   SafeFuture<List<SlotAndBlockRootAndBlobIndex>> getBlobSidecarKeys(

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
@@ -182,6 +182,9 @@ public class CombinedChainDataClient {
 
   private Stream<SlotAndBlockRootAndBlobIndex> filterBlobSidecarKeys(
       final List<SlotAndBlockRootAndBlobIndex> keys, final List<UInt64> indices) {
+    if (indices.isEmpty()) {
+      return keys.stream();
+    }
     return keys.stream().filter(key -> indices.contains(key.getBlobIndex()));
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
@@ -164,6 +164,10 @@ public class CombinedChainDataClient {
                     .orElseGet(() -> SafeFuture.completedFuture(Optional.empty())));
   }
 
+  /**
+   * Retrieves blob sidecars for the given slot. If the slot is not finalized, it could return
+   * non-canonical blob sidecars.
+   */
   public SafeFuture<List<BlobSidecar>> getBlobSidecars(
       final UInt64 slot, final List<UInt64> indices) {
     return historicalChainData

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
@@ -165,32 +165,31 @@ public class CombinedChainDataClient {
   }
 
   public SafeFuture<List<BlobSidecar>> getBlobSidecars(
+      final UInt64 slot, final List<UInt64> indices) {
+    return historicalChainData
+        .getBlobSidecarKeys(slot)
+        .thenApply(keys -> filterBlobSidecarKeys(keys, indices))
+        .thenCompose(this::getBlobSidecars);
+  }
+
+  public SafeFuture<List<BlobSidecar>> getBlobSidecars(
       final SlotAndBlockRoot slotAndBlockRoot, final List<UInt64> indices) {
-    final SafeFuture<List<SlotAndBlockRootAndBlobIndex>> blobSidecarKeys =
-        getBlobSidecarKeys(slotAndBlockRoot);
-    final SafeFuture<List<SlotAndBlockRootAndBlobIndex>> filteredKeysFuture =
-        blobSidecarKeys.thenApply(
-            blobKeys ->
-                blobKeys.stream()
-                    .filter(
-                        blobKey -> {
-                          if (indices.isEmpty()) {
-                            return true;
-                          } else {
-                            return indices.contains(blobKey.getBlobIndex());
-                          }
-                        })
-                    .collect(toList()));
-    return filteredKeysFuture
-        .thenCompose(
-            keys -> {
-              final Stream<SafeFuture<Optional<BlobSidecar>>> maybeBlobSidecarsFutures =
-                  keys.stream().map(this::getBlobSidecarByKey);
-              return SafeFuture.collectAll(maybeBlobSidecarsFutures);
-            })
+    return historicalChainData
+        .getBlobSidecarKeys(slotAndBlockRoot)
+        .thenApply(keys -> filterBlobSidecarKeys(keys, indices))
+        .thenCompose(this::getBlobSidecars);
+  }
+
+  private Stream<SlotAndBlockRootAndBlobIndex> filterBlobSidecarKeys(
+      final List<SlotAndBlockRootAndBlobIndex> keys, final List<UInt64> indices) {
+    return keys.stream().filter(key -> indices.contains(key.getBlobIndex()));
+  }
+
+  private SafeFuture<List<BlobSidecar>> getBlobSidecars(
+      final Stream<SlotAndBlockRootAndBlobIndex> keys) {
+    return SafeFuture.collectAll(keys.map(this::getBlobSidecarByKey))
         .thenApply(
-            maybeBlobSidecars ->
-                maybeBlobSidecars.stream().flatMap(Optional::stream).collect(toList()));
+            blobSidecars -> blobSidecars.stream().flatMap(Optional::stream).collect(toList()));
   }
 
   public SafeFuture<Optional<BeaconState>> getStateAtSlotExact(final UInt64 slot) {
@@ -362,6 +361,10 @@ public class CombinedChainDataClient {
             maybeSlot -> maybeSlot.map(this::getStateAtSlotExact).orElse(STATE_NOT_AVAILABLE));
   }
 
+  public SafeFuture<Optional<UInt64>> getFinalizedSlotByBlockRoot(final Bytes32 blockRoot) {
+    return historicalChainData.getFinalizedSlotByBlockRoot(blockRoot);
+  }
+
   private SafeFuture<Optional<BeaconState>> getStateFromSlotAndBlock(
       final SlotAndBlockRoot slotAndBlockRoot) {
     final UpdatableStore store = getStore();
@@ -491,21 +494,6 @@ public class CombinedChainDataClient {
     return recentChainData.getAncestorRootsOnHeadChain(startSlot, step, count);
   }
 
-  public boolean isAncestorOfCanonicalHead(final SlotAndBlockRoot slotAndBlockRoot) {
-    final Optional<ChainHead> chainHead = recentChainData.getChainHead();
-    final Optional<ReadOnlyForkChoiceStrategy> forkChoiceStrategy =
-        recentChainData.getForkChoiceStrategy();
-    if (chainHead.isEmpty() || forkChoiceStrategy.isEmpty()) {
-      return false;
-    }
-
-    return forkChoiceStrategy
-        .get()
-        .getAncestor(chainHead.get().getRoot(), slotAndBlockRoot.getSlot())
-        .map(blockRootAtSlot -> blockRootAtSlot.equals(slotAndBlockRoot.getBlockRoot()))
-        .orElse(false);
-  }
-
   /** @return The earliest available block's slot */
   public SafeFuture<Optional<UInt64>> getEarliestAvailableBlockSlot() {
     return earliestAvailableBlockSlot.get();
@@ -556,11 +544,6 @@ public class CombinedChainDataClient {
   public SafeFuture<List<SlotAndBlockRootAndBlobIndex>> getBlobSidecarKeys(
       final UInt64 startSlot, final UInt64 endSlot, final UInt64 limit) {
     return historicalChainData.getBlobSidecarKeys(startSlot, endSlot, limit);
-  }
-
-  public SafeFuture<List<SlotAndBlockRootAndBlobIndex>> getBlobSidecarKeys(
-      final SlotAndBlockRoot slotAndBlockRoot) {
-    return historicalChainData.getBlobSidecarKeys(slotAndBlockRoot);
   }
 
   private boolean isRecentData(final UInt64 slot) {

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/CombinedStorageChannelSplitter.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/CombinedStorageChannelSplitter.java
@@ -184,6 +184,11 @@ public class CombinedStorageChannelSplitter implements CombinedStorageChannel {
   }
 
   @Override
+  public SafeFuture<Optional<UInt64>> getFinalizedSlotByBlockRoot(final Bytes32 blockRoot) {
+    return asyncRunner.runAsync(() -> queryDelegate.getFinalizedSlotByBlockRoot(blockRoot));
+  }
+
+  @Override
   public SafeFuture<Optional<BeaconState>> getFinalizedStateByBlockRoot(final Bytes32 blockRoot) {
     return asyncRunner.runAsync(() -> queryDelegate.getFinalizedStateByBlockRoot(blockRoot));
   }
@@ -216,6 +221,11 @@ public class CombinedStorageChannelSplitter implements CombinedStorageChannel {
   @Override
   public SafeFuture<Optional<BlobSidecar>> getBlobSidecar(final SlotAndBlockRootAndBlobIndex key) {
     return asyncRunner.runAsync(() -> queryDelegate.getBlobSidecar(key));
+  }
+
+  @Override
+  public SafeFuture<List<SlotAndBlockRootAndBlobIndex>> getBlobSidecarKeys(final UInt64 slot) {
+    return asyncRunner.runAsync(() -> queryDelegate.getBlobSidecarKeys(slot));
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
@@ -84,6 +84,11 @@ public interface Database extends AutoCloseable {
   Stream<SlotAndBlockRootAndBlobIndex> streamBlobSidecarKeys(UInt64 startSlot, UInt64 endSlot);
 
   @MustBeClosed
+  default Stream<SlotAndBlockRootAndBlobIndex> streamBlobSidecarKeys(UInt64 slot) {
+    return streamBlobSidecarKeys(slot, slot);
+  }
+
+  @MustBeClosed
   Stream<BlobSidecar> streamBlobSidecars(SlotAndBlockRoot slotAndBlockRoot);
 
   List<SlotAndBlockRootAndBlobIndex> getBlobSidecarKeys(SlotAndBlockRoot slotAndBlockRoot);

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageQueryChannel.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageQueryChannel.java
@@ -104,6 +104,11 @@ public class StubStorageQueryChannel implements StorageQueryChannel {
   }
 
   @Override
+  public SafeFuture<Optional<UInt64>> getFinalizedSlotByBlockRoot(final Bytes32 blockRoot) {
+    return SafeFuture.completedFuture(Optional.empty());
+  }
+
+  @Override
   public SafeFuture<Optional<BeaconState>> getFinalizedStateByBlockRoot(Bytes32 blockRoot) {
     return SafeFuture.completedFuture(Optional.empty());
   }
@@ -136,6 +141,11 @@ public class StubStorageQueryChannel implements StorageQueryChannel {
   @Override
   public SafeFuture<Optional<BlobSidecar>> getBlobSidecar(final SlotAndBlockRootAndBlobIndex key) {
     return SafeFuture.completedFuture(Optional.empty());
+  }
+
+  @Override
+  public SafeFuture<List<SlotAndBlockRootAndBlobIndex>> getBlobSidecarKeys(final UInt64 slot) {
+    return SafeFuture.completedFuture(List.of());
   }
 
   @Override


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

- `blockRootSelector` tries to get finalized slot from the root if it is not present, it falls back to getting a block by the root.
- `slotSelector` checks if the slot is finalized, if it is, then it gets all blob sidecars for it (assumes that DB does not contain any additional blob sidecars for finalized slots). If slot is not finalized, it falls back to getting a block at a given slot. 
- Refactor of the `getBlobSidecars` method in `CombinedChainDataClient`

## Fixed Issue(s)
fixes #7290 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
