### PR TITLE
Use `engine_exchangeCapabilities` to log warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,4 +14,6 @@ For information on changes in released versions of Teku, see the [releases page]
 
 ### Additions and Improvements
 
+Introduce `--exchange-capabilities-monitoring-enabled` parameter. If enabled, EL will be queried periodically for the Engine API methods it supports. If incompatibility is detected, there will be a warning in the logs. The default is `true`.
+
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,6 @@ For information on changes in released versions of Teku, see the [releases page]
 
 ### Additions and Improvements
 
-Introduce `--exchange-capabilities-monitoring-enabled` parameter. If enabled, EL will be queried periodically for the Engine API methods it supports. If incompatibility is detected, there will be a warning in the logs. The default is `true`.
+Introduce `--exchange-capabilities-monitoring-enabled` parameter. If enabled, EL will be queried periodically for the Engine API methods it supports. If incompatibility is detected, there will be a warning raised in the logs. The default is `true`.
 
 ### Bug Fixes

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineJsonRpcMethod.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineJsonRpcMethod.java
@@ -23,6 +23,11 @@ public interface EngineJsonRpcMethod<T> {
 
   SafeFuture<T> execute(JsonRpcRequestParams params);
 
+  /** Override this method, when an Engine API method has been deprecated * */
+  default boolean isDeprecated() {
+    return false;
+  }
+
   default String getVersionedName() {
     return getVersion() == 0 ? getName() : getName() + "V" + getVersion();
   }

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineJsonRpcMethod.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/methods/EngineJsonRpcMethod.java
@@ -23,7 +23,7 @@ public interface EngineJsonRpcMethod<T> {
 
   SafeFuture<T> execute(JsonRpcRequestParams params);
 
-  /** Override this method, when an Engine API method has been deprecated * */
+  /** Override this method, when an Engine API method has been deprecated */
   default boolean isDeprecated() {
     return false;
   }

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/EngineCapabilitiesMonitor.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/EngineCapabilitiesMonitor.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright ConsenSys Software Inc., 2023
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionlayer;
+
+import com.google.common.base.Suppliers;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import tech.pegasys.teku.ethereum.events.SlotEventsChannel;
+import tech.pegasys.teku.ethereum.executionclient.ExecutionEngineClient;
+import tech.pegasys.teku.ethereum.executionclient.response.ResponseUnwrapper;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.logging.EventLogger;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+
+public class EngineCapabilitiesMonitor implements SlotEventsChannel {
+
+  private static final Logger LOG = LogManager.getLogger();
+
+  private static final int EPOCHS_PER_MONITORING = 10;
+  private static final UInt64 SLOT_IN_THE_EPOCH_TO_RUN_MONITORING = UInt64.valueOf(3);
+
+  private final AtomicReference<UInt64> lastRunEpoch = new AtomicReference<>();
+
+  private final Spec spec;
+  private final EventLogger eventLogger;
+  private final Supplier<List<String>> capabilitiesSupplier;
+  private final ExecutionEngineClient executionEngineClient;
+
+  public EngineCapabilitiesMonitor(
+      final Spec spec,
+      final EventLogger eventLogger,
+      final EngineJsonRpcMethodsResolver engineMethodsResolver,
+      final ExecutionEngineClient executionEngineClient) {
+    this.spec = spec;
+    this.eventLogger = eventLogger;
+    this.capabilitiesSupplier = Suppliers.memoize(engineMethodsResolver::getCapabilities);
+    this.executionEngineClient = executionEngineClient;
+  }
+
+  @Override
+  public void onSlot(final UInt64 slot) {
+    final UInt64 currentEpoch = spec.computeEpochAtSlot(slot);
+    if (epochIsApplicable(currentEpoch) && slotIsApplicable(slot)) {
+      monitor()
+          .handleException(ex -> LOG.error("Exception exchanging Engine API capabilities", ex))
+          .always(() -> lastRunEpoch.set(currentEpoch));
+    }
+  }
+
+  private boolean epochIsApplicable(final UInt64 epoch) {
+    return lastRunEpoch.get() == null
+        || epoch.minusMinZero(lastRunEpoch.get()).isGreaterThanOrEqualTo(EPOCHS_PER_MONITORING);
+  }
+
+  private boolean slotIsApplicable(final UInt64 slot) {
+    return slot.mod(spec.getSlotsPerEpoch(slot))
+        .equals(SLOT_IN_THE_EPOCH_TO_RUN_MONITORING.minusMinZero(1));
+  }
+
+  private SafeFuture<Void> monitor() {
+    final List<String> capabilities = capabilitiesSupplier.get();
+    return executionEngineClient
+        .exchangeCapabilities(capabilities)
+        .thenApply(ResponseUnwrapper::unwrapExecutionClientResponseOrThrow)
+        .thenAccept(
+            engineCapabilities -> {
+              LOG.debug("Engine API capabilities: " + engineCapabilities);
+              final List<String> missingEngineCapabilities =
+                  capabilities.stream()
+                      .filter(capability -> !engineCapabilities.contains(capability))
+                      .collect(Collectors.toList());
+              if (!missingEngineCapabilities.isEmpty()) {
+                eventLogger.missingEngineApiCapabilities(missingEngineCapabilities);
+              }
+            });
+  }
+}

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/EngineCapabilitiesMonitor.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/EngineCapabilitiesMonitor.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.ethereum.executionlayer;
 
 import com.google.common.base.Suppliers;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
@@ -49,7 +50,8 @@ public class EngineCapabilitiesMonitor implements SlotEventsChannel {
       final ExecutionEngineClient executionEngineClient) {
     this.spec = spec;
     this.eventLogger = eventLogger;
-    this.capabilitiesSupplier = Suppliers.memoize(engineMethodsResolver::getCapabilities);
+    this.capabilitiesSupplier =
+        Suppliers.memoize(() -> new ArrayList<>(engineMethodsResolver.getCapabilities()));
     this.executionEngineClient = executionEngineClient;
   }
 

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/EngineCapabilitiesMonitor.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/EngineCapabilitiesMonitor.java
@@ -33,7 +33,7 @@ public class EngineCapabilitiesMonitor implements SlotEventsChannel {
   private static final Logger LOG = LogManager.getLogger();
 
   private static final int EPOCHS_PER_MONITORING = 10;
-  private static final UInt64 SLOT_IN_THE_EPOCH_TO_RUN_MONITORING = UInt64.valueOf(3);
+  static final UInt64 SLOT_IN_THE_EPOCH_TO_RUN_MONITORING = UInt64.valueOf(3);
 
   private final AtomicReference<UInt64> lastRunEpoch = new AtomicReference<>();
 

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/EngineJsonRpcMethodsResolver.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/EngineJsonRpcMethodsResolver.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.ethereum.executionlayer;
 
+import java.util.List;
 import java.util.function.Supplier;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineApiMethod;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineJsonRpcMethod;
@@ -22,4 +23,6 @@ public interface EngineJsonRpcMethodsResolver {
 
   <T> EngineJsonRpcMethod<T> getMethod(
       EngineApiMethod method, Supplier<SpecMilestone> milestoneSupplier, Class<T> resultType);
+
+  List<String> getCapabilities();
 }

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/EngineJsonRpcMethodsResolver.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/EngineJsonRpcMethodsResolver.java
@@ -13,7 +13,7 @@
 
 package tech.pegasys.teku.ethereum.executionlayer;
 
-import java.util.List;
+import java.util.Set;
 import java.util.function.Supplier;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineApiMethod;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineJsonRpcMethod;
@@ -29,5 +29,5 @@ public interface EngineJsonRpcMethodsResolver {
    * href="https://github.com/ethereum/execution-apis/blob/main/src/engine/common.md#engine_exchangecapabilities">engine_exchangeCapabilities</a>
    * request
    */
-  List<String> getCapabilities();
+  Set<String> getCapabilities();
 }

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/EngineJsonRpcMethodsResolver.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/EngineJsonRpcMethodsResolver.java
@@ -24,5 +24,10 @@ public interface EngineJsonRpcMethodsResolver {
   <T> EngineJsonRpcMethod<T> getMethod(
       EngineApiMethod method, Supplier<SpecMilestone> milestoneSupplier, Class<T> resultType);
 
+  /**
+   * Get CL capabilities required for the <a
+   * href="https://github.com/ethereum/execution-apis/blob/main/src/engine/common.md#engine_exchangecapabilities">engine_exchangeCapabilities</a>
+   * request
+   */
   List<String> getCapabilities();
 }

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/MilestoneBasedEngineJsonRpcMethodsResolver.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/MilestoneBasedEngineJsonRpcMethodsResolver.java
@@ -18,6 +18,7 @@ import static tech.pegasys.teku.ethereum.executionclient.methods.EngineApiMethod
 import static tech.pegasys.teku.ethereum.executionclient.methods.EngineApiMethod.ENGINE_NEW_PAYLOAD;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -75,7 +76,7 @@ public class MilestoneBasedEngineJsonRpcMethodsResolver implements EngineJsonRpc
   }
 
   private Map<EngineApiMethod, EngineJsonRpcMethod<?>> bellatrixSupportedMethods() {
-    final Map<EngineApiMethod, EngineJsonRpcMethod<?>> methods = new TreeMap<>();
+    final Map<EngineApiMethod, EngineJsonRpcMethod<?>> methods = new HashMap<>();
 
     methods.put(ENGINE_NEW_PAYLOAD, new EngineNewPayloadV1(executionEngineClient));
     methods.put(ENGINE_GET_PAYLOAD, new EngineGetPayloadV1(executionEngineClient, spec));
@@ -85,7 +86,7 @@ public class MilestoneBasedEngineJsonRpcMethodsResolver implements EngineJsonRpc
   }
 
   private Map<EngineApiMethod, EngineJsonRpcMethod<?>> capellaSupportedMethods() {
-    final Map<EngineApiMethod, EngineJsonRpcMethod<?>> methods = new TreeMap<>();
+    final Map<EngineApiMethod, EngineJsonRpcMethod<?>> methods = new HashMap<>();
 
     methods.put(ENGINE_NEW_PAYLOAD, new EngineNewPayloadV2(executionEngineClient));
     methods.put(ENGINE_GET_PAYLOAD, new EngineGetPayloadV2(executionEngineClient, spec));
@@ -95,7 +96,7 @@ public class MilestoneBasedEngineJsonRpcMethodsResolver implements EngineJsonRpc
   }
 
   private Map<EngineApiMethod, EngineJsonRpcMethod<?>> denebSupportedMethods() {
-    final Map<EngineApiMethod, EngineJsonRpcMethod<?>> methods = new TreeMap<>();
+    final Map<EngineApiMethod, EngineJsonRpcMethod<?>> methods = new HashMap<>();
 
     methods.put(ENGINE_NEW_PAYLOAD, new EngineNewPayloadV3(executionEngineClient));
     methods.put(ENGINE_GET_PAYLOAD, new EngineGetPayloadV3(executionEngineClient, spec));

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/MilestoneBasedEngineJsonRpcMethodsResolver.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/MilestoneBasedEngineJsonRpcMethodsResolver.java
@@ -19,8 +19,8 @@ import static tech.pegasys.teku.ethereum.executionclient.methods.EngineApiMethod
 
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -124,11 +124,11 @@ public class MilestoneBasedEngineJsonRpcMethodsResolver implements EngineJsonRpc
   }
 
   @Override
-  public List<String> getCapabilities() {
+  public Set<String> getCapabilities() {
     return methodsByMilestone.values().stream()
         .flatMap(methods -> methods.values().stream())
         .filter(method -> !method.isDeprecated())
         .map(EngineJsonRpcMethod::getVersionedName)
-        .collect(Collectors.toList());
+        .collect(Collectors.toSet());
   }
 }

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/MilestoneBasedEngineJsonRpcMethodsResolver.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/MilestoneBasedEngineJsonRpcMethodsResolver.java
@@ -18,7 +18,6 @@ import static tech.pegasys.teku.ethereum.executionclient.methods.EngineApiMethod
 import static tech.pegasys.teku.ethereum.executionclient.methods.EngineApiMethod.ENGINE_NEW_PAYLOAD;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -76,7 +75,7 @@ public class MilestoneBasedEngineJsonRpcMethodsResolver implements EngineJsonRpc
   }
 
   private Map<EngineApiMethod, EngineJsonRpcMethod<?>> bellatrixSupportedMethods() {
-    final Map<EngineApiMethod, EngineJsonRpcMethod<?>> methods = new HashMap<>();
+    final Map<EngineApiMethod, EngineJsonRpcMethod<?>> methods = new TreeMap<>();
 
     methods.put(ENGINE_NEW_PAYLOAD, new EngineNewPayloadV1(executionEngineClient));
     methods.put(ENGINE_GET_PAYLOAD, new EngineGetPayloadV1(executionEngineClient, spec));
@@ -86,7 +85,7 @@ public class MilestoneBasedEngineJsonRpcMethodsResolver implements EngineJsonRpc
   }
 
   private Map<EngineApiMethod, EngineJsonRpcMethod<?>> capellaSupportedMethods() {
-    final Map<EngineApiMethod, EngineJsonRpcMethod<?>> methods = new HashMap<>();
+    final Map<EngineApiMethod, EngineJsonRpcMethod<?>> methods = new TreeMap<>();
 
     methods.put(ENGINE_NEW_PAYLOAD, new EngineNewPayloadV2(executionEngineClient));
     methods.put(ENGINE_GET_PAYLOAD, new EngineGetPayloadV2(executionEngineClient, spec));
@@ -96,7 +95,7 @@ public class MilestoneBasedEngineJsonRpcMethodsResolver implements EngineJsonRpc
   }
 
   private Map<EngineApiMethod, EngineJsonRpcMethod<?>> denebSupportedMethods() {
-    final Map<EngineApiMethod, EngineJsonRpcMethod<?>> methods = new HashMap<>();
+    final Map<EngineApiMethod, EngineJsonRpcMethod<?>> methods = new TreeMap<>();
 
     methods.put(ENGINE_NEW_PAYLOAD, new EngineNewPayloadV3(executionEngineClient));
     methods.put(ENGINE_GET_PAYLOAD, new EngineGetPayloadV3(executionEngineClient, spec));
@@ -126,7 +125,9 @@ public class MilestoneBasedEngineJsonRpcMethodsResolver implements EngineJsonRpc
   @Override
   public List<String> getCapabilities() {
     return methodsByMilestone.values().stream()
-        .flatMap(methods -> methods.values().stream().map(EngineJsonRpcMethod::getVersionedName))
+        .flatMap(methods -> methods.values().stream())
+        .filter(method -> !method.isDeprecated())
+        .map(EngineJsonRpcMethod::getVersionedName)
         .collect(Collectors.toList());
   }
 }

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/MilestoneBasedEngineJsonRpcMethodsResolver.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/MilestoneBasedEngineJsonRpcMethodsResolver.java
@@ -19,8 +19,11 @@ import static tech.pegasys.teku.ethereum.executionclient.methods.EngineApiMethod
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import tech.pegasys.teku.ethereum.executionclient.ExecutionEngineClient;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineApiMethod;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineForkChoiceUpdatedV1;
@@ -40,7 +43,7 @@ import tech.pegasys.teku.spec.datastructures.util.ForkAndSpecMilestone;
 public class MilestoneBasedEngineJsonRpcMethodsResolver implements EngineJsonRpcMethodsResolver {
 
   private final Map<SpecMilestone, Map<EngineApiMethod, EngineJsonRpcMethod<?>>>
-      methodsByMilestone = new HashMap<>();
+      methodsByMilestone = new LinkedHashMap<>();
 
   private final Spec spec;
   private final ExecutionEngineClient executionEngineClient;
@@ -118,5 +121,12 @@ public class MilestoneBasedEngineJsonRpcMethodsResolver implements EngineJsonRpc
           "Can't find method with name " + method.getName() + " for milestone " + milestone);
     }
     return foundMethod;
+  }
+
+  @Override
+  public List<String> getCapabilities() {
+    return methodsByMilestone.values().stream()
+        .flatMap(methods -> methods.values().stream().map(EngineJsonRpcMethod::getVersionedName))
+        .collect(Collectors.toList());
   }
 }

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/MilestoneBasedEngineJsonRpcMethodsResolver.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/MilestoneBasedEngineJsonRpcMethodsResolver.java
@@ -19,9 +19,9 @@ import static tech.pegasys.teku.ethereum.executionclient.methods.EngineApiMethod
 
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import tech.pegasys.teku.ethereum.executionclient.ExecutionEngineClient;
@@ -43,7 +43,7 @@ import tech.pegasys.teku.spec.datastructures.util.ForkAndSpecMilestone;
 public class MilestoneBasedEngineJsonRpcMethodsResolver implements EngineJsonRpcMethodsResolver {
 
   private final Map<SpecMilestone, Map<EngineApiMethod, EngineJsonRpcMethod<?>>>
-      methodsByMilestone = new LinkedHashMap<>();
+      methodsByMilestone = new TreeMap<>();
 
   private final Spec spec;
   private final ExecutionEngineClient executionEngineClient;

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/EngineCapabilitiesMonitorTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/EngineCapabilitiesMonitorTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright ConsenSys Software Inc., 2023
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionlayer;
+
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import tech.pegasys.teku.ethereum.executionclient.ExecutionEngineClient;
+import tech.pegasys.teku.ethereum.executionclient.schema.Response;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.logging.EventLogger;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+
+public class EngineCapabilitiesMonitorTest {
+
+  private final Spec spec = TestSpecFactory.createDefault();
+  private final EventLogger eventLogger = mock(EventLogger.class);
+  private final EngineJsonRpcMethodsResolver engineMethodsResolver =
+      mock(EngineJsonRpcMethodsResolver.class);
+  private final ExecutionEngineClient executionEngineClient = mock(ExecutionEngineClient.class);
+
+  private final List<String> capabilities = List.of("method1", "method2");
+
+  private EngineCapabilitiesMonitor engineCapabilitiesMonitor;
+
+  @BeforeEach
+  public void setUp() {
+    when(engineMethodsResolver.getCapabilities()).thenReturn(capabilities);
+    mockEngineCapabilitiesResponse(capabilities);
+    engineCapabilitiesMonitor =
+        new EngineCapabilitiesMonitor(
+            spec, eventLogger, engineMethodsResolver, executionEngineClient);
+  }
+
+  @Test
+  public void logsWarningIfEngineDoesNotSupportCapabilities() {
+    // engine only supports one of the methods
+    mockEngineCapabilitiesResponse(List.of("method1"));
+
+    // 3rd slot in epoch
+    engineCapabilitiesMonitor.onSlot(UInt64.valueOf(2));
+
+    verify(eventLogger).missingEngineApiCapabilities(List.of("method2"));
+  }
+
+  @Test
+  public void doesNotLogWarningIfEngineSupportsAllRequiredCapabilities() {
+    // 3rd slot in epoch
+    engineCapabilitiesMonitor.onSlot(UInt64.valueOf(2));
+
+    verifyNoInteractions(eventLogger);
+  }
+
+  @Test
+  public void doesNotRunMonitoringIfNotAtRequiredEpoch() {
+    // one run at epoch 0
+    engineCapabilitiesMonitor.onSlot(UInt64.valueOf(2));
+    verify(executionEngineClient, times(1)).exchangeCapabilities(anyList());
+
+    clearInvocations(executionEngineClient);
+
+    // should not run next epoch
+    engineCapabilitiesMonitor.onSlot(computeApplicableSlotForEpoch(UInt64.ONE));
+    verify(executionEngineClient, never()).exchangeCapabilities(anyList());
+
+    // should not run at epoch 9
+    engineCapabilitiesMonitor.onSlot(computeApplicableSlotForEpoch(UInt64.valueOf(9)));
+    verify(executionEngineClient, never()).exchangeCapabilities(anyList());
+
+    // should run again at epoch 10
+    engineCapabilitiesMonitor.onSlot(computeApplicableSlotForEpoch(UInt64.valueOf(10)));
+    verify(executionEngineClient, times(1)).exchangeCapabilities(anyList());
+
+    clearInvocations(executionEngineClient);
+
+    // should not run at epoch 12
+    engineCapabilitiesMonitor.onSlot(computeApplicableSlotForEpoch(UInt64.valueOf(12)));
+    verify(executionEngineClient, never()).exchangeCapabilities(anyList());
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {1, 3, 8, 9, 11, 12})
+  public void doesNotRunMonitoringIfNotAtRequiredSlot(final int slot) {
+    engineCapabilitiesMonitor.onSlot(UInt64.valueOf(slot));
+    verifyNoInteractions(executionEngineClient);
+  }
+
+  private void mockEngineCapabilitiesResponse(final List<String> engineCapabilities) {
+    when(executionEngineClient.exchangeCapabilities(capabilities))
+        .thenReturn(SafeFuture.completedFuture(new Response<>(engineCapabilities)));
+  }
+
+  private UInt64 computeApplicableSlotForEpoch(final UInt64 epoch) {
+    return spec.computeStartSlotAtEpoch(epoch).plus(2);
+  }
+}

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/EngineCapabilitiesMonitorTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/EngineCapabilitiesMonitorTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.ethereum.executionlayer.EngineCapabilitiesMonitor.SLOT_IN_THE_EPOCH_TO_RUN_MONITORING;
 
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -115,6 +116,7 @@ public class EngineCapabilitiesMonitorTest {
   }
 
   private UInt64 computeApplicableSlotForEpoch(final UInt64 epoch) {
-    return spec.computeStartSlotAtEpoch(epoch).plus(2);
+    return spec.computeStartSlotAtEpoch(epoch)
+        .plus(SLOT_IN_THE_EPOCH_TO_RUN_MONITORING.minusMinZero(1));
   }
 }

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/EngineCapabilitiesMonitorTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/EngineCapabilitiesMonitorTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.ethereum.executionlayer.EngineCapabilitiesMonitor.SLOT_IN_THE_EPOCH_TO_RUN_MONITORING;
 
+import java.util.HashSet;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -48,7 +49,7 @@ public class EngineCapabilitiesMonitorTest {
 
   @BeforeEach
   public void setUp() {
-    when(engineMethodsResolver.getCapabilities()).thenReturn(capabilities);
+    when(engineMethodsResolver.getCapabilities()).thenReturn(new HashSet<>(capabilities));
     mockEngineCapabilitiesResponse(capabilities);
     engineCapabilitiesMonitor =
         new EngineCapabilitiesMonitor(

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionHandlerClientTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionHandlerClientTest.java
@@ -13,10 +13,11 @@
 
 package tech.pegasys.teku.ethereum.executionlayer;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.ethereum.executionclient.ExecutionEngineClient;
@@ -34,14 +35,15 @@ public abstract class ExecutionHandlerClientTest {
   @SuppressWarnings("FutureReturnValueIgnored")
   @Test
   void eth1GetPowBlock_shouldCallExecutionClient() {
-    ExecutionClientHandler handler = getHandler();
+    final ExecutionClientHandler handler = getHandler();
     final Bytes32 blockHash = Bytes32.random();
     final PowBlock block = createPowBlock(blockHash);
 
     when(executionEngineClient.getPowBlock(blockHash))
         .thenReturn(SafeFuture.completedFuture(block));
-    handler.eth1GetPowBlock(blockHash);
-    verify(executionEngineClient).getPowBlock(blockHash);
+
+    final SafeFuture<Optional<PowBlock>> result = handler.eth1GetPowBlock(blockHash);
+    assertThat(result).isCompletedWithValue(Optional.of(block));
   }
 
   private PowBlock createPowBlock(final Bytes32 blockHash) {
@@ -55,12 +57,13 @@ public abstract class ExecutionHandlerClientTest {
   @SuppressWarnings("FutureReturnValueIgnored")
   @Test
   void eth1GetPowChainHead_shouldCallExecutionClient() {
-    ExecutionClientHandler handler = getHandler();
+    final ExecutionClientHandler handler = getHandler();
     final PowBlock block = createPowBlock(Bytes32.random());
 
     when(executionEngineClient.getPowChainHead()).thenReturn(SafeFuture.completedFuture(block));
-    handler.eth1GetPowChainHead();
-    verify(executionEngineClient).getPowChainHead();
+
+    final SafeFuture<PowBlock> result = handler.eth1GetPowChainHead();
+    assertThat(result).isCompletedWithValue(block);
   }
 
   final ExecutionClientHandler getHandler() {

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/MilestoneBasedEngineJsonRpcMethodsResolverTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/MilestoneBasedEngineJsonRpcMethodsResolverTest.java
@@ -166,7 +166,7 @@ class MilestoneBasedEngineJsonRpcMethodsResolverTest {
     final List<String> capabilities = engineMethodsResolver.getCapabilities();
 
     assertThat(capabilities)
-        .containsExactly(
+        .containsExactlyInAnyOrder(
             "engine_newPayloadV1",
             "engine_getPayloadV1",
             "engine_forkchoiceUpdatedV1",

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/MilestoneBasedEngineJsonRpcMethodsResolverTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/MilestoneBasedEngineJsonRpcMethodsResolverTest.java
@@ -157,22 +157,25 @@ class MilestoneBasedEngineJsonRpcMethodsResolverTest {
 
   @Test
   void getsCapabilities() {
-    final Spec denebSpec = TestSpecFactory.createMinimalWithDenebForkEpoch(UInt64.ONE);
+    final Spec spec =
+        TestSpecFactory.createMinimalWithCapellaAndDenebForkEpoch(UInt64.ONE, UInt64.valueOf(2));
 
     final MilestoneBasedEngineJsonRpcMethodsResolver engineMethodsResolver =
-        new MilestoneBasedEngineJsonRpcMethodsResolver(denebSpec, executionEngineClient);
+        new MilestoneBasedEngineJsonRpcMethodsResolver(spec, executionEngineClient);
 
     final List<String> capabilities = engineMethodsResolver.getCapabilities();
 
-    // when in Capella, but Deneb is scheduled, Bellatrix methods will not be considered supported
     assertThat(capabilities)
         .containsExactly(
-            "engine_forkchoiceUpdatedV2",
-            "engine_getPayloadV2",
+            "engine_newPayloadV1",
+            "engine_getPayloadV1",
+            "engine_forkchoiceUpdatedV1",
             "engine_newPayloadV2",
-            "engine_forkchoiceUpdatedV3",
+            "engine_getPayloadV2",
+            "engine_forkchoiceUpdatedV2",
+            "engine_newPayloadV3",
             "engine_getPayloadV3",
-            "engine_newPayloadV3");
+            "engine_forkchoiceUpdatedV3");
   }
 
   private static Stream<Arguments> denebMethods() {

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/MilestoneBasedEngineJsonRpcMethodsResolverTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/MilestoneBasedEngineJsonRpcMethodsResolverTest.java
@@ -21,6 +21,7 @@ import static tech.pegasys.teku.ethereum.executionclient.methods.EngineApiMethod
 import static tech.pegasys.teku.ethereum.executionclient.methods.EngineApiMethod.ENGINE_GET_PAYLOAD;
 import static tech.pegasys.teku.ethereum.executionclient.methods.EngineApiMethod.ENGINE_NEW_PAYLOAD;
 
+import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -39,6 +40,7 @@ import tech.pegasys.teku.ethereum.executionclient.methods.EngineJsonRpcMethod;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineNewPayloadV1;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineNewPayloadV2;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineNewPayloadV3;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecFactory;
@@ -151,6 +153,26 @@ class MilestoneBasedEngineJsonRpcMethodsResolverTest {
         engineMethodsResolver.getMethod(method, () -> SpecMilestone.DENEB, Object.class);
 
     assertThat(providedMethod).isExactlyInstanceOf(expectedMethodClass);
+  }
+
+  @Test
+  void getsCapabilities() {
+    final Spec denebSpec = TestSpecFactory.createMinimalWithDenebForkEpoch(UInt64.ONE);
+
+    final MilestoneBasedEngineJsonRpcMethodsResolver engineMethodsResolver =
+        new MilestoneBasedEngineJsonRpcMethodsResolver(denebSpec, executionEngineClient);
+
+    final List<String> capabilities = engineMethodsResolver.getCapabilities();
+
+    // when in Capella, but Deneb is scheduled, Bellatrix methods will not be considered supported
+    assertThat(capabilities)
+        .containsExactly(
+            "engine_forkchoiceUpdatedV2",
+            "engine_getPayloadV2",
+            "engine_newPayloadV2",
+            "engine_forkchoiceUpdatedV3",
+            "engine_getPayloadV3",
+            "engine_newPayloadV3");
   }
 
   private static Stream<Arguments> denebMethods() {

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/MilestoneBasedEngineJsonRpcMethodsResolverTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/MilestoneBasedEngineJsonRpcMethodsResolverTest.java
@@ -21,7 +21,7 @@ import static tech.pegasys.teku.ethereum.executionclient.methods.EngineApiMethod
 import static tech.pegasys.teku.ethereum.executionclient.methods.EngineApiMethod.ENGINE_GET_PAYLOAD;
 import static tech.pegasys.teku.ethereum.executionclient.methods.EngineApiMethod.ENGINE_NEW_PAYLOAD;
 
-import java.util.List;
+import java.util.Set;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -163,7 +163,7 @@ class MilestoneBasedEngineJsonRpcMethodsResolverTest {
     final MilestoneBasedEngineJsonRpcMethodsResolver engineMethodsResolver =
         new MilestoneBasedEngineJsonRpcMethodsResolver(spec, executionEngineClient);
 
-    final List<String> capabilities = engineMethodsResolver.getCapabilities();
+    final Set<String> capabilities = engineMethodsResolver.getCapabilities();
 
     assertThat(capabilities)
         .containsExactlyInAnyOrder(

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java
@@ -162,7 +162,7 @@ public class EventLogger {
         String.format(
             "Execution Client does not support required Engine API methods: %s. Make sure it is upgraded to a compatible version.",
             missingCapabilities),
-        Color.RED);
+        Color.YELLOW);
   }
 
   public void builderIsNotAvailable(final String errorMessage) {

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java
@@ -20,6 +20,7 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.util.List;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.LogManager;
@@ -154,6 +155,14 @@ public class EventLogger {
 
   public void executionClientRecovered() {
     info("Execution Client is responding to requests again after a previous failure", Color.GREEN);
+  }
+
+  public void missingEngineApiCapabilities(final List<String> missingCapabilities) {
+    warn(
+        String.format(
+            "Execution Client does not support required Engine API methods: %s. Make sure it is upgraded to a compatible version.",
+            missingCapabilities),
+        Color.YELLOW);
   }
 
   public void builderIsNotAvailable(final String errorMessage) {

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java
@@ -162,7 +162,7 @@ public class EventLogger {
         String.format(
             "Execution Client does not support required Engine API methods: %s. Make sure it is upgraded to a compatible version.",
             missingCapabilities),
-        Color.YELLOW);
+        Color.RED);
   }
 
   public void builderIsNotAvailable(final String errorMessage) {

--- a/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerConfiguration.java
+++ b/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerConfiguration.java
@@ -36,6 +36,7 @@ public class ExecutionLayerConfiguration {
   public static final int DEFAULT_BUILDER_BID_COMPARE_FACTOR = 100;
   public static final boolean DEFAULT_BUILDER_SET_USER_AGENT_HEADER = true;
   public static final boolean DEFAULT_USE_SHOULD_OVERRIDE_BUILDER_FLAG = true;
+  public static final boolean DEFAULT_EXCHANGE_CAPABILITIES_MONITORING_ENABLED = true;
   public static final String BUILDER_ALWAYS_KEYWORD = "BUILDER_ALWAYS";
 
   private final Spec spec;
@@ -49,6 +50,7 @@ public class ExecutionLayerConfiguration {
   private final Optional<Integer> builderBidCompareFactor;
   private final boolean builderSetUserAgentHeader;
   private final boolean useShouldOverrideBuilderFlag;
+  private final boolean exchangeCapabilitiesMonitoringEnabled;
 
   private ExecutionLayerConfiguration(
       final Spec spec,
@@ -61,7 +63,8 @@ public class ExecutionLayerConfiguration {
       final int builderCircuitBreakerAllowedConsecutiveFaults,
       final Optional<Integer> builderBidCompareFactor,
       final boolean builderSetUserAgentHeader,
-      final boolean useShouldOverrideBuilderFlag) {
+      final boolean useShouldOverrideBuilderFlag,
+      final boolean exchangeCapabilitiesMonitoringEnabled) {
     this.spec = spec;
     this.engineEndpoint = engineEndpoint;
     this.engineJwtSecretFile = engineJwtSecretFile;
@@ -74,6 +77,7 @@ public class ExecutionLayerConfiguration {
     this.builderBidCompareFactor = builderBidCompareFactor;
     this.builderSetUserAgentHeader = builderSetUserAgentHeader;
     this.useShouldOverrideBuilderFlag = useShouldOverrideBuilderFlag;
+    this.exchangeCapabilitiesMonitoringEnabled = exchangeCapabilitiesMonitoringEnabled;
   }
 
   public static Builder builder() {
@@ -131,6 +135,10 @@ public class ExecutionLayerConfiguration {
     return useShouldOverrideBuilderFlag;
   }
 
+  public boolean isExchangeCapabilitiesMonitoringEnabled() {
+    return exchangeCapabilitiesMonitoringEnabled;
+  }
+
   public static class Builder {
     private Spec spec;
     private Optional<String> engineEndpoint = Optional.empty();
@@ -144,6 +152,8 @@ public class ExecutionLayerConfiguration {
     private String builderBidCompareFactor = Integer.toString(DEFAULT_BUILDER_BID_COMPARE_FACTOR);
     private boolean builderSetUserAgentHeader = DEFAULT_BUILDER_SET_USER_AGENT_HEADER;
     private boolean useShouldOverrideBuilderFlag = DEFAULT_USE_SHOULD_OVERRIDE_BUILDER_FLAG;
+    private boolean exchangeCapabilitiesMonitoringEnabled =
+        DEFAULT_EXCHANGE_CAPABILITIES_MONITORING_ENABLED;
 
     private Builder() {}
 
@@ -179,7 +189,8 @@ public class ExecutionLayerConfiguration {
           builderCircuitBreakerAllowedConsecutiveFaults,
           builderBidCompareFactor,
           builderSetUserAgentHeader,
-          useShouldOverrideBuilderFlag);
+          useShouldOverrideBuilderFlag,
+          exchangeCapabilitiesMonitoringEnabled);
     }
 
     public Builder engineEndpoint(final String engineEndpoint) {
@@ -237,6 +248,12 @@ public class ExecutionLayerConfiguration {
 
     public Builder useShouldOverrideBuilderFlag(final boolean useShouldOverrideBuilderFlag) {
       this.useShouldOverrideBuilderFlag = useShouldOverrideBuilderFlag;
+      return this;
+    }
+
+    public Builder exchangeCapabilitiesMonitoringEnabled(
+        final boolean exchangeCapabilitiesMonitoringEnabled) {
+      this.exchangeCapabilitiesMonitoringEnabled = exchangeCapabilitiesMonitoringEnabled;
       return this;
     }
 

--- a/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerService.java
+++ b/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerService.java
@@ -180,11 +180,14 @@ public class ExecutionLayerService extends Service {
         new ExecutionClientHandlerImpl(
             config.getSpec(), executionEngineClient, engineMethodsResolver);
 
-    final EngineCapabilitiesMonitor engineCapabilitiesMonitor =
-        new EngineCapabilitiesMonitor(
-            config.getSpec(), EVENT_LOG, engineMethodsResolver, executionEngineClient);
-
-    serviceConfig.getEventChannels().subscribe(SlotEventsChannel.class, engineCapabilitiesMonitor);
+    if (config.isExchangeCapabilitiesMonitoringEnabled()) {
+      final EngineCapabilitiesMonitor engineCapabilitiesMonitor =
+          new EngineCapabilitiesMonitor(
+              config.getSpec(), EVENT_LOG, engineMethodsResolver, executionEngineClient);
+      serviceConfig
+          .getEventChannels()
+          .subscribe(SlotEventsChannel.class, engineCapabilitiesMonitor);
+    }
 
     final Optional<BuilderClient> builderClient =
         builderRestClientProvider.map(

--- a/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerService.java
+++ b/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerService.java
@@ -36,6 +36,7 @@ import tech.pegasys.teku.ethereum.executionlayer.BlobsBundleValidatorImpl;
 import tech.pegasys.teku.ethereum.executionlayer.BuilderBidValidatorImpl;
 import tech.pegasys.teku.ethereum.executionlayer.BuilderCircuitBreaker;
 import tech.pegasys.teku.ethereum.executionlayer.BuilderCircuitBreakerImpl;
+import tech.pegasys.teku.ethereum.executionlayer.EngineCapabilitiesMonitor;
 import tech.pegasys.teku.ethereum.executionlayer.ExecutionClientHandler;
 import tech.pegasys.teku.ethereum.executionlayer.ExecutionClientHandlerImpl;
 import tech.pegasys.teku.ethereum.executionlayer.ExecutionLayerManager;
@@ -178,6 +179,12 @@ public class ExecutionLayerService extends Service {
     final ExecutionClientHandler executionClientHandler =
         new ExecutionClientHandlerImpl(
             config.getSpec(), executionEngineClient, engineMethodsResolver);
+
+    final EngineCapabilitiesMonitor engineCapabilitiesMonitor =
+        new EngineCapabilitiesMonitor(
+            config.getSpec(), EVENT_LOG, engineMethodsResolver, executionEngineClient);
+
+    serviceConfig.getEventChannels().subscribe(SlotEventsChannel.class, engineCapabilitiesMonitor);
 
     final Optional<BuilderClient> builderClient =
         builderRestClientProvider.map(

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ExecutionLayerOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ExecutionLayerOptions.java
@@ -59,7 +59,7 @@ public class ExecutionLayerOptions {
       names = {"--Xbuilder-circuit-breaker-enabled"},
       paramLabel = "<BOOLEAN>",
       description = "Enables Circuit Breaker logic for builder usage.",
-      arity = "1",
+      arity = "0..1",
       showDefaultValue = Visibility.ALWAYS,
       fallbackValue = "true",
       hidden = true)
@@ -111,10 +111,9 @@ public class ExecutionLayerOptions {
       paramLabel = "<BOOLEAN>",
       description =
           "Set User-Agent header to teku/v<version> (e.g. teku/v23.4.0) when making a builder bid request to help builders identify clients and versions",
-      arity = "1",
+      arity = "0..1",
       showDefaultValue = Visibility.ALWAYS,
-      fallbackValue = "true",
-      hidden = true)
+      fallbackValue = "true")
   private boolean builderSetUserAgentHeader = DEFAULT_BUILDER_SET_USER_AGENT_HEADER;
 
   @Option(
@@ -122,7 +121,7 @@ public class ExecutionLayerOptions {
       paramLabel = "<BOOLEAN>",
       description =
           "Whether or not to use the shouldOverrideBuilder flag provided by the Engine API.",
-      arity = "1",
+      arity = "0..1",
       showDefaultValue = Visibility.ALWAYS,
       fallbackValue = "true",
       hidden = true)
@@ -133,10 +132,9 @@ public class ExecutionLayerOptions {
       paramLabel = "<BOOLEAN>",
       description =
           "Enables querying EL periodically for the Engine API methods it supports. If incompatibility is detected, there will be a warning raised in the logs.",
-      arity = "1",
+      arity = "0..1",
       showDefaultValue = Visibility.ALWAYS,
-      fallbackValue = "true",
-      hidden = true)
+      fallbackValue = "true")
   private boolean exchangeCapabilitiesMonitoringEnabled =
       DEFAULT_EXCHANGE_CAPABILITIES_MONITORING_ENABLED;
 

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ExecutionLayerOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ExecutionLayerOptions.java
@@ -21,6 +21,7 @@ import static tech.pegasys.teku.services.executionlayer.ExecutionLayerConfigurat
 import static tech.pegasys.teku.services.executionlayer.ExecutionLayerConfiguration.DEFAULT_BUILDER_CIRCUIT_BREAKER_ENABLED;
 import static tech.pegasys.teku.services.executionlayer.ExecutionLayerConfiguration.DEFAULT_BUILDER_CIRCUIT_BREAKER_WINDOW;
 import static tech.pegasys.teku.services.executionlayer.ExecutionLayerConfiguration.DEFAULT_BUILDER_SET_USER_AGENT_HEADER;
+import static tech.pegasys.teku.services.executionlayer.ExecutionLayerConfiguration.DEFAULT_EXCHANGE_CAPABILITIES_MONITORING_ENABLED;
 import static tech.pegasys.teku.services.executionlayer.ExecutionLayerConfiguration.DEFAULT_USE_SHOULD_OVERRIDE_BUILDER_FLAG;
 
 import picocli.CommandLine.Help.Visibility;
@@ -127,6 +128,18 @@ public class ExecutionLayerOptions {
       hidden = true)
   private boolean useShouldOverrideBuilderFlag = DEFAULT_USE_SHOULD_OVERRIDE_BUILDER_FLAG;
 
+  @Option(
+      names = {"--exchange-capabilities-monitoring-enabled"},
+      paramLabel = "<BOOLEAN>",
+      description =
+          "Enable calling the Engine API exchangeCapabilities method periodically and logging a warning in case of incompatibilities.",
+      arity = "1",
+      showDefaultValue = Visibility.ALWAYS,
+      fallbackValue = "true",
+      hidden = true)
+  private boolean exchangeCapabilitiesMonitoringEnabled =
+      DEFAULT_EXCHANGE_CAPABILITIES_MONITORING_ENABLED;
+
   public void configure(final Builder builder) {
     builder.executionLayer(
         b ->
@@ -140,7 +153,8 @@ public class ExecutionLayerOptions {
                     builderCircuitBreakerAllowedConsecutiveFaults)
                 .builderBidCompareFactor(builderBidCompareFactor)
                 .builderSetUserAgentHeader(builderSetUserAgentHeader)
-                .useShouldOverrideBuilderFlag(useShouldOverrideBuilderFlag));
+                .useShouldOverrideBuilderFlag(useShouldOverrideBuilderFlag)
+                .exchangeCapabilitiesMonitoringEnabled(exchangeCapabilitiesMonitoringEnabled));
     depositOptions.configure(builder);
   }
 }

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ExecutionLayerOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ExecutionLayerOptions.java
@@ -132,7 +132,7 @@ public class ExecutionLayerOptions {
       names = {"--exchange-capabilities-monitoring-enabled"},
       paramLabel = "<BOOLEAN>",
       description =
-          "Enable calling the Engine API exchangeCapabilities method periodically and logging a warning in case of incompatibilities.",
+          "Enables querying EL periodically for the Engine API methods it supports. If incompatibility is detected, there will be a warning raised in the logs.",
       arity = "1",
       showDefaultValue = Visibility.ALWAYS,
       fallbackValue = "true",

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
@@ -155,7 +155,7 @@ public class P2POptions {
       description = "Enables multipeer sync",
       fallbackValue = "true",
       hidden = true,
-      arity = "1")
+      arity = "0..1")
   private boolean multiPeerSyncEnabled = SyncConfig.DEFAULT_MULTI_PEER_SYNC_ENABLED;
 
   @Option(

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
@@ -68,7 +68,7 @@ public class ValidatorOptions {
       showDefaultValue = Visibility.ALWAYS,
       fallbackValue = "true",
       description = "Enable locking validator keystore files",
-      arity = "1")
+      arity = "0..1")
   private boolean validatorKeystoreLockingEnabled =
       ValidatorConfig.DEFAULT_VALIDATOR_KEYSTORE_LOCKING_ENABLED;
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

- Enhanced EngineJsonRpcMethodsResolver to return capabilities for all milestones. If a method has been deprecated (added default method in interface) or deleted of course from the code, It will not be returned.
- Create EngineCapabilitiesMonitor which does an exchange capabilities check every 10 epochs (could be too much) against EL.
- It checks engine capabilites against the local capabilities. If some are not supported by EL, a warning will be logged.
- Introduce new parameter `--exchange-capabilities-monitoring-enabled`


## Fixed Issue(s)
fixes #7327 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
