### PR TITLE
Openapi node update fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ executors:
 
   node_executor:
     docker:
-      - image: circleci/node:14-buster
+      - image: circleci/node:16-bullseye
         auth:
           <<: *docker-auth
 

--- a/.openapidoc/publish.js
+++ b/.openapidoc/publish.js
@@ -50,7 +50,9 @@ async function main() {
  * @param {string} dirPath
  */
 function prepareDistDir(dirPath) {
-  fs.rmdirSync(dirPath, {recursive: true});
+  if (fs.existsSync(dirPath)) {
+    fs.rmdirSync(dirPath, {recursive: true});
+  }
   fs.mkdirSync(dirPath, {recursive: true});
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
My guess is obsolete rimraf behavior is changed with node 16 and it doesn't fall silently anymore on this with node 16 (like it did in 14), so this check should fix it

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
