### PR TITLE
Remove unused dependencies

### DIFF
--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -23,7 +23,6 @@ dependencies {
   testFixturesImplementation project(':infrastructure:crypto')
   testFixturesImplementation project(':infrastructure:time')
   testFixturesImplementation project(':infrastructure:bls-keystore')
-  testFixturesImplementation 'com.google.code.gson:gson'
   testFixturesImplementation 'com.squareup.okhttp3:okhttp'
   testFixturesImplementation 'io.libp2p:jvm-libp2p-minimal'
   testFixturesImplementation 'org.apache.commons:commons-lang3'

--- a/beacon/pow/build.gradle
+++ b/beacon/pow/build.gradle
@@ -16,8 +16,7 @@ dependencies {
   implementation project(':storage:api')
 
   api 'org.web3j:core'
-  
-  implementation 'com.google.code.gson:gson'
+
   implementation 'org.apache.tuweni:tuweni-units'
 
   testImplementation testFixtures(project(':infrastructure:async'))

--- a/data/provider/build.gradle
+++ b/data/provider/build.gradle
@@ -15,7 +15,6 @@ dependencies {
     implementation project(':beacon:sync')
     implementation project(':validator:api')
 
-    implementation 'com.google.code.gson:gson'
     implementation 'org.apache.tuweni:tuweni-units'
 
     testImplementation testFixtures(project(':ethereum:spec'))

--- a/ethereum/spec/build.gradle
+++ b/ethereum/spec/build.gradle
@@ -29,7 +29,6 @@ dependencies {
     implementation project(':infrastructure:time')
 
     testFixturesApi 'com.google.guava:guava'
-    testFixturesApi 'com.google.guava:guava'
     testFixturesApi 'org.apache.tuweni:tuweni-bytes'
     testFixturesApi project(':ethereum:pow:api')
     testFixturesApi project(':infrastructure:ssz')

--- a/ethereum/spec/build.gradle
+++ b/ethereum/spec/build.gradle
@@ -9,7 +9,6 @@ dependencies {
 
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
-    implementation 'com.google.code.gson:gson'
     implementation 'org.apache.tuweni:tuweni-bytes'
     implementation 'org.apache.tuweni:tuweni-ssz'
     implementation 'org.apache.tuweni:tuweni-ssz'

--- a/ethereum/statetransition/build.gradle
+++ b/ethereum/statetransition/build.gradle
@@ -24,7 +24,6 @@ dependencies {
   implementation project(':storage')
   implementation project(':storage:api')
 
-  implementation 'com.google.code.gson:gson'
   implementation 'org.apache.tuweni:tuweni-units'
 
   testImplementation testFixtures(project(':ethereum:spec'))

--- a/gradle/license-report-config/allowed-licenses.json
+++ b/gradle/license-report-config/allowed-licenses.json
@@ -100,10 +100,6 @@
       "moduleLicense": "MIT License"
     },
     {
-      "moduleName": "com.google.code.gson:gson",
-      "moduleLicense": "Apache License, Version 2.0"
-    },
-    {
       "moduleName": "io.libp2p:jvm-libp2p-minimal",
       "moduleLicense": "Apache License, Version 2.0",
       "moduleLicenseUrl": "https://github.com/libp2p/jvm-libp2p/blob/develop/LICENSE-APACHE"

--- a/gradle/license-report-config/allowed-licenses.json
+++ b/gradle/license-report-config/allowed-licenses.json
@@ -100,6 +100,10 @@
       "moduleLicense": "MIT License"
     },
     {
+      "moduleName": "com.google.code.gson:gson",
+      "moduleLicense": "Apache License, Version 2.0"
+    },
+    {
       "moduleName": "io.libp2p:jvm-libp2p-minimal",
       "moduleLicense": "Apache License, Version 2.0",
       "moduleLicenseUrl": "https://github.com/libp2p/jvm-libp2p/blob/develop/LICENSE-APACHE"

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -25,8 +25,6 @@ dependencyManagement {
       entry 'mockwebserver'
     }
 
-    dependency 'commons-cli:commons-cli:1.4'
-
     dependency 'info.picocli:picocli:4.7.4'
 
     dependencySet(group: 'io.javalin', version: '5.6.0') {

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -21,8 +21,10 @@ dependencyManagement {
 
     dependency 'com.launchdarkly:okhttp-eventsource:4.1.1'
 
-    dependency 'com.squareup.okhttp3:okhttp:4.11.0'
-    dependency 'com.squareup.okhttp3:mockwebserver:4.11.0'
+    dependencySet(group: 'com.squareup.okhttp3', version: '4.11.0') {
+      entry 'okhttp'
+      entry 'mockwebserver'
+    }
 
     dependency 'commons-cli:commons-cli:1.4'
 
@@ -105,8 +107,6 @@ dependencyManagement {
     dependency 'org.awaitility:awaitility:4.2.0'
 
     dependency 'org.bouncycastle:bcprov-jdk15on:1.70'
-
-    dependency 'org.java-websocket:Java-WebSocket:1.5.3'
 
     dependencySet(group: 'org.junit.jupiter', version: '5.9.3') {
       entry 'junit-jupiter-api'

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -5,9 +5,6 @@ dependencyManagement {
     dependency 'com.fasterxml.jackson.dataformat:jackson-dataformat-toml:2.15.2'
     dependency 'com.fasterxml.jackson.module:jackson-module-kotlin:2.15.2'
 
-
-    dependency 'com.google.auto.service:auto-service:1.0-rc7'
-
     dependencySet(group: 'com.google.errorprone', version: '2.20.0') {
       entry 'error_prone_annotation'
       entry 'error_prone_check_api'
@@ -18,8 +15,8 @@ dependencyManagement {
     dependency 'tech.pegasys.tools.epchecks:errorprone-checks:1.1.1'
 
     dependency 'com.google.guava:guava:32.1.1-jre'
+    dependency 'com.google.code.gson:gson:2.10.1'
 
-    dependency 'com.googlecode.json-simple:json-simple:1.1.1'
     dependency 'org.jsoup:jsoup:1.16.1'
 
     dependency 'com.launchdarkly:okhttp-eventsource:4.1.1'
@@ -35,8 +32,6 @@ dependencyManagement {
       entry 'javalin'
       entry 'javalin-rendering'
     }
-    dependency 'io.protostuff:protostuff-core:1.6.2'
-    dependency 'io.protostuff:protostuff-runtime:1.6.2'
 
     dependency 'io.libp2p:jvm-libp2p-minimal:0.10.0-RELEASE'
     dependency 'tech.pegasys:jblst:0.3.10'
@@ -45,8 +40,6 @@ dependencyManagement {
     dependency 'org.hdrhistogram:HdrHistogram:2.1.12'
 
     dependency 'org.jetbrains.kotlin:kotlin-stdlib:1.9.0'
-
-    dependency 'io.pkts:pkts-core:3.0.3'
 
     dependency 'org.mock-server:mockserver-junit-jupiter:5.15.0'
 
@@ -113,7 +106,7 @@ dependencyManagement {
 
     dependency 'org.bouncycastle:bcprov-jdk15on:1.70'
 
-    dependency 'org.java-websocket:Java-WebSocket:1.5.2'
+    dependency 'org.java-websocket:Java-WebSocket:1.5.3'
 
     dependencySet(group: 'org.junit.jupiter', version: '5.9.3') {
       entry 'junit-jupiter-api'

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -15,7 +15,6 @@ dependencyManagement {
     dependency 'tech.pegasys.tools.epchecks:errorprone-checks:1.1.1'
 
     dependency 'com.google.guava:guava:32.1.1-jre'
-    dependency 'com.google.code.gson:gson:2.10.1'
 
     dependency 'org.jsoup:jsoup:1.16.1'
 

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -167,8 +167,8 @@ dependencyManagement {
     }
 
     dependencySet(group: 'org.jupnp', version: '2.7.1') {
-      entry "org.jupnp.support"
       entry "org.jupnp"
+      entry "org.jupnp.support"
     }
 
     dependencySet(group: 'io.jsonwebtoken', version: '0.11.5') {

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -18,7 +18,6 @@ dependencyManagement {
     dependency 'tech.pegasys.tools.epchecks:errorprone-checks:1.1.1'
 
     dependency 'com.google.guava:guava:32.1.1-jre'
-    dependency 'com.google.code.gson:gson:2.10.1'
 
     dependency 'com.googlecode.json-simple:json-simple:1.1.1'
     dependency 'org.jsoup:jsoup:1.16.1'

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -166,8 +166,10 @@ dependencyManagement {
       exclude 'org.apache.tuweni:units'
     }
 
-    dependency 'org.jupnp:org.jupnp.support:2.7.1'
-    dependency 'org.jupnp:org.jupnp:2.7.1'
+    dependencySet(group: 'org.jupnp', version: '2.7.1') {
+      entry "org.jupnp.support"
+      entry "org.jupnp"
+    }
 
     dependencySet(group: 'io.jsonwebtoken', version: '0.11.5') {
       entry 'jjwt-api'

--- a/infrastructure/bls/build.gradle
+++ b/infrastructure/bls/build.gradle
@@ -8,9 +8,5 @@ dependencies {
   implementation project(':infrastructure:crypto')
   implementation project(':infrastructure:logging')
 
-  testImplementation('com.googlecode.json-simple:json-simple') {
-      exclude group: 'junit', module: 'junit'
-  }
-
   testFixturesImplementation 'org.apache.tuweni:tuweni-bytes'
 }

--- a/services/executionlayer/build.gradle
+++ b/services/executionlayer/build.gradle
@@ -14,7 +14,6 @@ dependencies {
   implementation project(':infrastructure:serviceutils')
   implementation project(':validator:client')
 
-  implementation 'com.google.code.gson:gson'
   implementation 'org.apache.tuweni:tuweni-units'
 
   testImplementation testFixtures(project(':ethereum:spec'))

--- a/services/powchain/build.gradle
+++ b/services/powchain/build.gradle
@@ -18,7 +18,6 @@ dependencies {
   implementation project(':infrastructure:serviceutils')
   implementation project(':validator:client')
 
-  implementation 'com.google.code.gson:gson'
   implementation 'org.apache.tuweni:tuweni-units'
 
   testImplementation project(':ethereum:pow:merkletree')

--- a/teku/build.gradle
+++ b/teku/build.gradle
@@ -44,7 +44,6 @@ dependencies {
   api 'com.google.guava:guava'
 
   implementation 'commons-io:commons-io'
-  implementation 'com.google.code.gson:gson'
   implementation 'com.squareup.okhttp3:okhttp'
   implementation 'info.picocli:picocli'
   implementation 'io.libp2p:jvm-libp2p-minimal'


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

- Removed `protostuff` (introduced in https://github.com/Consensys/teku/pull/267 but all of this code has been deleted)
- Removed `auto-service` (very old usage of `@AutoService` annotation in https://github.com/Consensys/teku/commit/a93184eb5b6545e3736f025a5b67e3315c5d5862 . It has been deleted)
- Removed `json-simple` (There was ReferenceTests class in bls module using this library which has been deleted https://github.com/Consensys/teku/blob/3a7029a7dce64d3824bd8afa0b57149ffc82a0c4/bls/src/test/java/tech/pegasys/teku/bls/hashToG2/ReferenceTests.java)
- Remove `pkts` (It was brought in https://github.com/Consensys/teku/commit/a93184eb5b6545e3736f025a5b67e3315c5d5862. It was part of Pantheon project skeleton and pkts was used for discovery, but not used/needed in Teku https://github.com/Consensys/pantheon/blob/090b4e7094c0f9e937e7034cfa5adcf880f3a16f/ethereum/p2p/src/test/java/net/consensys/pantheon/ethereum/p2p/discovery/PeerDiscoveryPacketPcapSedesTest.java#L21)
- Remove `gson` dependency. Jackson is used all over Teku.
- Remove `commons-cli` since picocli is used
- Removed Java-WebSocket from versions.gradle. It is transitive dependency of `org.web3j.core` and is updated there and because it is not used in the code is not captured by `dependencyUpdates` gradle command
- Some small nits/cleanups

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
