### PR TITLE
Added constant values for SSZUint64 and UInt64

### DIFF
--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/primitive/SszUInt64.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/primitive/SszUInt64.java
@@ -28,7 +28,7 @@ public class SszUInt64 extends AbstractSszPrimitive<UInt64, SszUInt64> {
     if (val.isZero()) {
       return ZERO;
     }
-    if (val.isThirtyTwoGwei()) {
+    if (val.isThirtyTwoEth()) {
       return THIRTY_TWO_ETH;
     }
     if (val.isMaxValue()) {

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/primitive/SszUInt64.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/primitive/SszUInt64.java
@@ -20,7 +20,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 public class SszUInt64 extends AbstractSszPrimitive<UInt64, SszUInt64> {
 
   public static final SszUInt64 ZERO = SszUInt64.valueOf(UInt64.ZERO);
-  public static final SszUInt64 THIRTY_TWO_GWEI = SszUInt64.valueOf(UInt64.THIRTY_TWO_GWEI);
+  public static final SszUInt64 THIRTY_TWO_ETH = SszUInt64.valueOf(UInt64.THIRTY_TWO_ETH);
 
   public static final SszUInt64 MAX_VALUE = SszUInt64.valueOf(UInt64.MAX_VALUE);
 
@@ -29,7 +29,7 @@ public class SszUInt64 extends AbstractSszPrimitive<UInt64, SszUInt64> {
       return ZERO;
     }
     if (val.isThirtyTwoGwei()) {
-      return THIRTY_TWO_GWEI;
+      return THIRTY_TWO_ETH;
     }
     if (val.isMaxValue()) {
       return MAX_VALUE;

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/primitive/SszUInt64.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/primitive/SszUInt64.java
@@ -20,14 +20,17 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 public class SszUInt64 extends AbstractSszPrimitive<UInt64, SszUInt64> {
 
   public static final SszUInt64 ZERO = SszUInt64.valueOf(UInt64.ZERO);
-  public static final SszUInt64 MAX_EFFECTIVE_BALANCE =
-      SszUInt64.valueOf(UInt64.MAX_EFFECTIVE_BALANCE);
+  public static final SszUInt64 THIRTY_TWO_GWEI = SszUInt64.valueOf(UInt64.THIRTY_TWO_GWEI);
+
+  public static final SszUInt64 MAX_VALUE = SszUInt64.valueOf(UInt64.MAX_VALUE);
 
   public static SszUInt64 of(UInt64 val) {
     if (val.isZero()) {
       return ZERO;
-    } else if (val.isMaxEffectiveBalance()) {
-      return MAX_EFFECTIVE_BALANCE;
+    } else if (val.isThirtyTwoGwei()) {
+      return THIRTY_TWO_GWEI;
+    } else if (val.isMaxValue()) {
+      return MAX_VALUE;
     }
     return new SszUInt64(val);
   }

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/primitive/SszUInt64.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/primitive/SszUInt64.java
@@ -19,9 +19,20 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 public class SszUInt64 extends AbstractSszPrimitive<UInt64, SszUInt64> {
 
-  public static final SszUInt64 ZERO = SszUInt64.of(UInt64.ZERO);
+  public static final SszUInt64 ZERO = SszUInt64.valueOf(UInt64.ZERO);
+  public static final SszUInt64 MAX_EFFECTIVE_BALANCE =
+      SszUInt64.valueOf(UInt64.MAX_EFFECTIVE_BALANCE);
 
   public static SszUInt64 of(UInt64 val) {
+    if (val.isZero()) {
+      return ZERO;
+    } else if (val.isMaxEffectiveBalance()) {
+      return MAX_EFFECTIVE_BALANCE;
+    }
+    return new SszUInt64(val);
+  }
+
+  private static SszUInt64 valueOf(final UInt64 val) {
     return new SszUInt64(val);
   }
 

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/primitive/SszUInt64.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/primitive/SszUInt64.java
@@ -27,9 +27,11 @@ public class SszUInt64 extends AbstractSszPrimitive<UInt64, SszUInt64> {
   public static SszUInt64 of(UInt64 val) {
     if (val.isZero()) {
       return ZERO;
-    } else if (val.isThirtyTwoGwei()) {
+    }
+    if (val.isThirtyTwoGwei()) {
       return THIRTY_TWO_GWEI;
-    } else if (val.isMaxValue()) {
+    }
+    if (val.isMaxValue()) {
       return MAX_VALUE;
     }
     return new SszUInt64(val);

--- a/infrastructure/unsigned/src/main/java/tech/pegasys/teku/infrastructure/unsigned/UInt64.java
+++ b/infrastructure/unsigned/src/main/java/tech/pegasys/teku/infrastructure/unsigned/UInt64.java
@@ -27,7 +27,7 @@ public final class UInt64 implements Comparable<UInt64> {
   private static final long LOW_MASK = 0x00000000ffffffffL;
 
   public static final UInt64 ZERO = new UInt64(0);
-  public static final UInt64 THIRTY_TWO_GWEI = new UInt64(32_000_000_000L);
+  public static final UInt64 THIRTY_TWO_ETH = new UInt64(32_000_000_000L);
   public static final UInt64 ONE = new UInt64(1);
   public static final UInt64 MAX_VALUE = new UInt64(-1L);
 
@@ -87,7 +87,7 @@ public final class UInt64 implements Comparable<UInt64> {
       return ZERO;
     }
     if (value == 32_000_000_000L) {
-      return THIRTY_TWO_GWEI;
+      return THIRTY_TWO_ETH;
     }
     if (value == -1L) {
       return MAX_VALUE;

--- a/infrastructure/unsigned/src/main/java/tech/pegasys/teku/infrastructure/unsigned/UInt64.java
+++ b/infrastructure/unsigned/src/main/java/tech/pegasys/teku/infrastructure/unsigned/UInt64.java
@@ -27,7 +27,7 @@ public final class UInt64 implements Comparable<UInt64> {
   private static final long LOW_MASK = 0x00000000ffffffffL;
 
   public static final UInt64 ZERO = new UInt64(0);
-  public static final UInt64 MAX_EFFECTIVE_BALANCE = new UInt64(32_000_000_000L);
+  public static final UInt64 THIRTY_TWO_GWEI = new UInt64(32_000_000_000L);
   public static final UInt64 ONE = new UInt64(1);
   public static final UInt64 MAX_VALUE = new UInt64(-1L);
 
@@ -86,7 +86,9 @@ public final class UInt64 implements Comparable<UInt64> {
     if (value == 0L) {
       return ZERO;
     } else if (value == 32_000_000_000L) {
-      return MAX_EFFECTIVE_BALANCE;
+      return THIRTY_TWO_GWEI;
+    } else if (value == -1L) {
+      return MAX_VALUE;
     } else {
       return new UInt64(value);
     }
@@ -377,8 +379,12 @@ public final class UInt64 implements Comparable<UInt64> {
    *
    * @return true if the value is 32_000_000_000L
    */
-  public boolean isMaxEffectiveBalance() {
+  public boolean isThirtyTwoGwei() {
     return value == 32_000_000_000L;
+  }
+
+  public boolean isMaxValue() {
+    return value == -1L;
   }
 
   /**

--- a/infrastructure/unsigned/src/main/java/tech/pegasys/teku/infrastructure/unsigned/UInt64.java
+++ b/infrastructure/unsigned/src/main/java/tech/pegasys/teku/infrastructure/unsigned/UInt64.java
@@ -380,7 +380,7 @@ public final class UInt64 implements Comparable<UInt64> {
    *
    * @return true if the value is 32_000_000_000L
    */
-  public boolean isThirtyTwoGwei() {
+  public boolean isThirtyTwoEth() {
     return value == 32_000_000_000L;
   }
 

--- a/infrastructure/unsigned/src/main/java/tech/pegasys/teku/infrastructure/unsigned/UInt64.java
+++ b/infrastructure/unsigned/src/main/java/tech/pegasys/teku/infrastructure/unsigned/UInt64.java
@@ -85,13 +85,14 @@ public final class UInt64 implements Comparable<UInt64> {
   public static UInt64 fromLongBits(final long value) {
     if (value == 0L) {
       return ZERO;
-    } else if (value == 32_000_000_000L) {
-      return THIRTY_TWO_GWEI;
-    } else if (value == -1L) {
-      return MAX_VALUE;
-    } else {
-      return new UInt64(value);
     }
+    if (value == 32_000_000_000L) {
+      return THIRTY_TWO_GWEI;
+    }
+    if (value == -1L) {
+      return MAX_VALUE;
+    }
+    return new UInt64(value);
   }
 
   /**

--- a/infrastructure/unsigned/src/main/java/tech/pegasys/teku/infrastructure/unsigned/UInt64.java
+++ b/infrastructure/unsigned/src/main/java/tech/pegasys/teku/infrastructure/unsigned/UInt64.java
@@ -27,6 +27,7 @@ public final class UInt64 implements Comparable<UInt64> {
   private static final long LOW_MASK = 0x00000000ffffffffL;
 
   public static final UInt64 ZERO = new UInt64(0);
+  public static final UInt64 MAX_EFFECTIVE_BALANCE = new UInt64(32_000_000_000L);
   public static final UInt64 ONE = new UInt64(1);
   public static final UInt64 MAX_VALUE = new UInt64(-1L);
 
@@ -82,7 +83,13 @@ public final class UInt64 implements Comparable<UInt64> {
    * @return the created UInt64.
    */
   public static UInt64 fromLongBits(final long value) {
-    return value == 0 ? ZERO : new UInt64(value);
+    if (value == 0L) {
+      return ZERO;
+    } else if (value == 32_000_000_000L) {
+      return MAX_EFFECTIVE_BALANCE;
+    } else {
+      return new UInt64(value);
+    }
   }
 
   /**
@@ -363,6 +370,15 @@ public final class UInt64 implements Comparable<UInt64> {
    */
   public boolean isZero() {
     return value == 0;
+  }
+
+  /**
+   * Returns true if the value is 32_000_000_000L
+   *
+   * @return true if the value is 32_000_000_000L
+   */
+  public boolean isMaxEffectiveBalance() {
+    return value == 32_000_000_000L;
   }
 
   /**

--- a/infrastructure/unsigned/src/test/java/tech/pegasys/teku/infrastructure/unsigned/UInt64Test.java
+++ b/infrastructure/unsigned/src/test/java/tech/pegasys/teku/infrastructure/unsigned/UInt64Test.java
@@ -290,7 +290,7 @@ class UInt64Test {
   @Test
   void constants_shouldHaveExpectedValues() {
     assertThat(UInt64.ZERO).isEqualTo(UInt64.valueOf(0));
-    assertThat(UInt64.MAX_EFFECTIVE_BALANCE).isEqualTo(UInt64.valueOf(32_000_000_000L));
+    assertThat(UInt64.THIRTY_TWO_GWEI).isEqualTo(UInt64.valueOf(32_000_000_000L));
     assertThat(UInt64.ONE).isEqualTo(UInt64.valueOf(1));
     assertThat(UInt64.MAX_VALUE).isEqualTo(UInt64.fromLongBits(-1));
   }

--- a/infrastructure/unsigned/src/test/java/tech/pegasys/teku/infrastructure/unsigned/UInt64Test.java
+++ b/infrastructure/unsigned/src/test/java/tech/pegasys/teku/infrastructure/unsigned/UInt64Test.java
@@ -290,7 +290,7 @@ class UInt64Test {
   @Test
   void constants_shouldHaveExpectedValues() {
     assertThat(UInt64.ZERO).isEqualTo(UInt64.valueOf(0));
-    assertThat(UInt64.THIRTY_TWO_GWEI).isEqualTo(UInt64.valueOf(32_000_000_000L));
+    assertThat(UInt64.THIRTY_TWO_ETH).isEqualTo(UInt64.valueOf(32_000_000_000L));
     assertThat(UInt64.ONE).isEqualTo(UInt64.valueOf(1));
     assertThat(UInt64.MAX_VALUE).isEqualTo(UInt64.fromLongBits(-1));
   }

--- a/infrastructure/unsigned/src/test/java/tech/pegasys/teku/infrastructure/unsigned/UInt64Test.java
+++ b/infrastructure/unsigned/src/test/java/tech/pegasys/teku/infrastructure/unsigned/UInt64Test.java
@@ -290,6 +290,7 @@ class UInt64Test {
   @Test
   void constants_shouldHaveExpectedValues() {
     assertThat(UInt64.ZERO).isEqualTo(UInt64.valueOf(0));
+    assertThat(UInt64.MAX_EFFECTIVE_BALANCE).isEqualTo(UInt64.valueOf(32_000_000_000L));
     assertThat(UInt64.ONE).isEqualTo(UInt64.valueOf(1));
     assertThat(UInt64.MAX_VALUE).isEqualTo(UInt64.fromLongBits(-1));
   }


### PR DESCRIPTION
We've got a heavy amount of duplication with 32GWEI, and zero was already fairly well handled in UInt64, but added similar logic in SSZUInt64.

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
