### PR TITLE
Add pruning metrics

### DIFF
--- a/services/chainstorage/build.gradle
+++ b/services/chainstorage/build.gradle
@@ -5,6 +5,7 @@ dependencies {
   implementation project(':infrastructure:async')
   implementation project(':infrastructure:exceptions')
   implementation project(':infrastructure:logging')
+  implementation project(':infrastructure:metrics')
   implementation project(':infrastructure:serviceutils')
   implementation project(':storage')
   implementation project(':storage:api')

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/pruner/BlobSidecarPruner.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/pruner/BlobSidecarPruner.java
@@ -24,6 +24,7 @@ import org.hyperledger.besu.plugin.services.metrics.LabelledGauge;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.Cancellable;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.metrics.SettableLabelledGauge;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -44,6 +45,9 @@ public class BlobSidecarPruner extends Service {
   private final int pruneLimit;
   private final TimeProvider timeProvider;
   private final boolean blobSidecarsStorageCountersEnabled;
+  private final String pruningMetricsType;
+  private final SettableLabelledGauge pruningTimingsLabelledGauge;
+  private final SettableLabelledGauge pruningActiveLabelledGauge;
 
   private Optional<Cancellable> scheduledPruner = Optional.empty();
   private Optional<UInt64> genesisTime = Optional.empty();
@@ -59,7 +63,10 @@ public class BlobSidecarPruner extends Service {
       final TimeProvider timeProvider,
       final Duration pruneInterval,
       final int pruneLimit,
-      final boolean blobSidecarsStorageCountersEnabled) {
+      final boolean blobSidecarsStorageCountersEnabled,
+      final String pruningMetricsType,
+      final SettableLabelledGauge pruningTimingsLabelledGauge,
+      final SettableLabelledGauge pruningActiveLabelledGauge) {
     this.spec = spec;
     this.database = database;
     this.asyncRunner = asyncRunner;
@@ -67,6 +74,9 @@ public class BlobSidecarPruner extends Service {
     this.pruneLimit = pruneLimit;
     this.timeProvider = timeProvider;
     this.blobSidecarsStorageCountersEnabled = blobSidecarsStorageCountersEnabled;
+    this.pruningMetricsType = pruningMetricsType;
+    this.pruningTimingsLabelledGauge = pruningTimingsLabelledGauge;
+    this.pruningActiveLabelledGauge = pruningActiveLabelledGauge;
 
     if (blobSidecarsStorageCountersEnabled) {
       LabelledGauge labelledGauge =
@@ -100,7 +110,13 @@ public class BlobSidecarPruner extends Service {
   }
 
   private void pruneBlobs() {
+    pruningActiveLabelledGauge.set(1, pruningMetricsType);
+    final long start = System.currentTimeMillis();
+
     pruneBlobsPriorToAvailabilityWindow();
+
+    pruningTimingsLabelledGauge.set(System.currentTimeMillis() - start, pruningMetricsType);
+    pruningActiveLabelledGauge.set(0, pruningMetricsType);
 
     if (blobSidecarsStorageCountersEnabled) {
       blobColumnSize.set(database.getBlobSidecarColumnCount());
@@ -127,12 +143,8 @@ public class BlobSidecarPruner extends Service {
     }
     LOG.debug("Pruning blobs up to slot {}, limit {}", latestPrunableSlot, pruneLimit);
     try {
-      final long start = System.currentTimeMillis();
       final boolean limitReached = database.pruneOldestBlobSidecars(latestPrunableSlot, pruneLimit);
-      LOG.debug(
-          "Blobs pruning finished in {} ms. Limit reached: {}",
-          () -> System.currentTimeMillis() - start,
-          () -> limitReached);
+      LOG.debug("Blobs pruning finished. Limit reached: {}", () -> limitReached);
     } catch (ShuttingDownException | RejectedExecutionException ex) {
       LOG.debug("Shutting down", ex);
     }

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/pruner/BlobSidecarPrunerTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/pruner/BlobSidecarPrunerTest.java
@@ -28,6 +28,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
+import tech.pegasys.teku.infrastructure.metrics.SettableLabelledGauge;
 import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -63,7 +64,10 @@ public class BlobSidecarPrunerTest {
           timeProvider,
           PRUNE_INTERVAL,
           PRUNE_LIMIT,
-          false);
+          false,
+          "test",
+          mock(SettableLabelledGauge.class),
+          mock(SettableLabelledGauge.class));
 
   @BeforeEach
   void setUp() {
@@ -147,7 +151,10 @@ public class BlobSidecarPrunerTest {
             timeProvider,
             PRUNE_INTERVAL,
             PRUNE_LIMIT,
-            false);
+            false,
+            "test",
+            mock(SettableLabelledGauge.class),
+            mock(SettableLabelledGauge.class));
     when(databaseOverride.getGenesisTime()).thenReturn(Optional.of(genesisTime));
     assertThat(blobsPrunerOverride.start()).isCompleted();
 
@@ -198,7 +205,10 @@ public class BlobSidecarPrunerTest {
             timeProvider,
             PRUNE_INTERVAL,
             PRUNE_LIMIT,
-            false);
+            false,
+            "test",
+            mock(SettableLabelledGauge.class),
+            mock(SettableLabelledGauge.class));
     when(databaseOverride.getGenesisTime()).thenReturn(Optional.of(genesisTime));
     assertThat(blobsPrunerOverride.start()).isCompleted();
 

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/pruner/BlockPrunerTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/pruner/BlockPrunerTest.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
+import tech.pegasys.teku.infrastructure.metrics.SettableLabelledGauge;
 import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
@@ -51,7 +52,15 @@ class BlockPrunerTest {
   private final StubAsyncRunner asyncRunner = new StubAsyncRunner(timeProvider);
   private final Database database = mock(Database.class);
 
-  private final BlockPruner pruner = new BlockPruner(spec, database, asyncRunner, PRUNE_INTERVAL);
+  private final BlockPruner pruner =
+      new BlockPruner(
+          spec,
+          database,
+          asyncRunner,
+          PRUNE_INTERVAL,
+          "test",
+          mock(SettableLabelledGauge.class),
+          mock(SettableLabelledGauge.class));
 
   @BeforeEach
   void setUp() {


### PR DESCRIPTION
To early detect possible IO issues, added 2 metrics to track when pruning is active and how long was the last session.

For both blocks and blob sidecars.

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
