### PR TITLE
Add performance calculation metrics

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/performance/DefaultPerformanceTracker.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/performance/DefaultPerformanceTracker.java
@@ -126,6 +126,7 @@ public class DefaultPerformanceTracker implements PerformanceTracker {
       return;
     }
 
+    final long startTime = System.currentTimeMillis();
     final List<SafeFuture<?>> reportingTasks = new ArrayList<>();
     // Output attestation performance information for current epoch - 2 since attestations can be
     // included in both the epoch they were produced in or in the one following.
@@ -144,10 +145,14 @@ public class DefaultPerformanceTracker implements PerformanceTracker {
       reportingTasks.add(reportSyncCommitteePerformance(currentEpoch));
     }
 
-    final long startTime = System.currentTimeMillis();
     SafeFuture.allOf(reportingTasks.toArray(SafeFuture[]::new))
         .handleException(LOG::error)
-        .alwaysRun(() -> timingsSettableGauge.set(System.currentTimeMillis() - startTime))
+        .alwaysRun(
+            () -> {
+              if (reportingTasks.size() > 0) {
+                timingsSettableGauge.set(System.currentTimeMillis() - startTime);
+              }
+            })
         .join();
   }
 

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/performance/DefaultPerformanceTrackerTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/performance/DefaultPerformanceTrackerTest.java
@@ -32,6 +32,7 @@ import tech.pegasys.teku.bls.BLSKeyPair;
 import tech.pegasys.teku.bls.BLSTestUtil;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.logging.StatusLogger;
+import tech.pegasys.teku.infrastructure.metrics.SettableGauge;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
@@ -71,7 +72,8 @@ public class DefaultPerformanceTrackerTest {
           ValidatorPerformanceTrackingMode.ALL,
           validatorTracker,
           syncCommitteePerformanceTracker,
-          spec);
+          spec,
+          mock(SettableGauge.class));
 
   @BeforeEach
   void beforeEach() {

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -61,6 +61,7 @@ import tech.pegasys.teku.infrastructure.collections.LimitedMap;
 import tech.pegasys.teku.infrastructure.events.EventChannels;
 import tech.pegasys.teku.infrastructure.exceptions.InvalidConfigurationException;
 import tech.pegasys.teku.infrastructure.io.PortAvailability;
+import tech.pegasys.teku.infrastructure.metrics.SettableGauge;
 import tech.pegasys.teku.infrastructure.metrics.SettableLabelledGauge;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -522,6 +523,12 @@ public class BeaconChainController extends Service implements BeaconChainControl
     ValidatorPerformanceTrackingMode mode =
         beaconConfig.validatorConfig().getValidatorPerformanceTrackingMode();
     if (mode.isEnabled()) {
+      final SettableGauge performanceTrackerTimings =
+          SettableGauge.create(
+              metricsSystem,
+              BEACON,
+              "performance_tracker_timings",
+              "Tracks how much time (in millis) performance tracker takes to perform calculations");
       performanceTracker =
           new DefaultPerformanceTracker(
               combinedChainDataClient,
@@ -530,7 +537,8 @@ public class BeaconChainController extends Service implements BeaconChainControl
               beaconConfig.validatorConfig().getValidatorPerformanceTrackingMode(),
               activeValidatorTracker,
               new SyncCommitteePerformanceTracker(spec, combinedChainDataClient),
-              spec);
+              spec,
+              performanceTrackerTimings);
       eventChannels.subscribe(SlotEventsChannel.class, performanceTracker);
     } else {
       performanceTracker = new NoOpPerformanceTracker();


### PR DESCRIPTION
We saw several times performance calculation lagging significantly. This PR adds a timing tracking metrics for it.

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
