### PR TITLE
Fix BlobSidecarsByRange rpc method edge cases

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandler.java
@@ -143,7 +143,7 @@ public class BlobSidecarsByRangeMessageHandler
 
               final SortedMap<UInt64, Bytes32> canonicalHotRoots;
               if (endSlot.isGreaterThan(finalizedSlot)) {
-                final UInt64 hotSlotsCount = endSlot.minus(startSlot).increment();
+                final UInt64 hotSlotsCount = endSlot.increment().minusMinZero(startSlot);
 
                 canonicalHotRoots =
                     combinedChainDataClient.getAncestorRoots(startSlot, UInt64.ONE, hotSlotsCount);
@@ -263,8 +263,8 @@ public class BlobSidecarsByRangeMessageHandler
         return combinedChainDataClient
             .getBlobSidecarKeys(startSlot, endSlot, maxRequestBlobSidecars)
             .thenCompose(
-                list -> {
-                  blobSidecarKeysIterator = Optional.of(list.iterator());
+                keys -> {
+                  blobSidecarKeysIterator = Optional.of(keys.iterator());
                   return getNextBlobSidecar(blobSidecarKeysIterator.get());
                 });
       } else {

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerTest.java
@@ -187,11 +187,12 @@ class Eth2PeerTest {
     // Deneb starts from epoch 1, so request start slot should be 8 and the count should be 6
     assertThat(request.getStartSlot()).isEqualTo(UInt64.valueOf(8));
     assertThat(request.getCount()).isEqualTo(UInt64.valueOf(6));
+    assertThat(request.getMaximumResponseChunks()).isEqualTo(36); // 6 * MAX_BLOBS_PER_BLOCK (6)
   }
 
   @Test
   @SuppressWarnings({"unchecked", "FutureReturnValueIgnored"})
-  public void shouldSetCountToZeroWhenSlotEqualsToDenebTransitionSlot() {
+  public void shouldSetCountToZeroWhenRequestIsPreDeneb() {
 
     final Eth2RpcMethod<BlobSidecarsByRangeRequestMessage, BlobSidecar> blobSidecarsByRangeMethod =
         mock(Eth2RpcMethod.class);

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandlerTest.java
@@ -64,6 +64,9 @@ import tech.pegasys.teku.storage.store.UpdatableStore;
 
 public class BlobSidecarsByRangeMessageHandlerTest {
 
+  private static final RequestApproval ZERO_OBJECTS_REQUEST_APPROVAL =
+      new RequestApproval.RequestApprovalBuilder().timeSeconds(ZERO).objectsCount(0).build();
+
   private static final RpcEncoding RPC_ENCODING =
       RpcEncoding.createSszSnappyEncoding(
           TestSpecFactory.createDefault().getNetworkingConfig().getMaxChunkSize());
@@ -345,15 +348,39 @@ public class BlobSidecarsByRangeMessageHandlerTest {
     final BlobSidecarsByRangeRequestMessage request =
         new BlobSidecarsByRangeRequestMessage(startSlot, ZERO, maxBlobsPerBlock);
 
-    final Optional<RequestApproval> zeroObjectRequests =
-        Optional.of(
-            new RequestApproval.RequestApprovalBuilder().timeSeconds(ZERO).objectsCount(0).build());
-
-    when(peer.approveBlobSidecarsRequest(listener, 0)).thenReturn(zeroObjectRequests);
+    when(peer.approveBlobSidecarsRequest(listener, 0))
+        .thenReturn(Optional.of(ZERO_OBJECTS_REQUEST_APPROVAL));
 
     handler.onIncomingMessage(protocolId, peer, request, listener);
 
-    // Requesting 5 * maxBlobsPerBlock blob sidecars
+    verify(peer, times(1)).approveBlobSidecarsRequest(any(), eq(Long.valueOf(0)));
+    // no adjustment
+    verify(peer, never()).adjustBlobSidecarsRequest(any(), anyLong());
+
+    final ArgumentCaptor<BlobSidecar> argumentCaptor = ArgumentCaptor.forClass(BlobSidecar.class);
+
+    verify(listener, never()).respond(argumentCaptor.capture());
+
+    final List<BlobSidecar> actualSent = argumentCaptor.getAllValues();
+
+    verify(listener).completeSuccessfully();
+
+    AssertionsForInterfaceTypes.assertThat(actualSent).isEmpty();
+  }
+
+  @Test
+  public void shouldIgnoreRequestWhenCountIsZeroAndHotSlotRequested() {
+    // not finalized
+    final UInt64 hotStartSlot = startSlot.plus(7);
+
+    final BlobSidecarsByRangeRequestMessage request =
+        new BlobSidecarsByRangeRequestMessage(hotStartSlot, ZERO, maxBlobsPerBlock);
+
+    when(peer.approveBlobSidecarsRequest(listener, 0))
+        .thenReturn(Optional.of(ZERO_OBJECTS_REQUEST_APPROVAL));
+
+    handler.onIncomingMessage(protocolId, peer, request, listener);
+
     verify(peer, times(1)).approveBlobSidecarsRequest(any(), eq(Long.valueOf(0)));
     // no adjustment
     verify(peer, never()).adjustBlobSidecarsRequest(any(), anyLong());


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Edge cases captured by @jtraglia on Discord https://discord.com/channels/697535391594446898/1050616638497640548/1133165930575315027

- There is mixed usage of retrieving maxBlobsPerBlock either by slot or getting it directly from spec around the code. Given currently, there is no difference and it is cleaner to get it from the spec directly and avoids the pre deneb 0 count edge case.
- Fixed an arithmetic exception possibility + unit test

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
