### PR TITLE
Sign voluntary exits using the Capella fork domain post Deneb

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -490,6 +490,13 @@ public class Spec {
         .getDomain(domainType, epoch, fork, genesisValidatorsRoot);
   }
 
+  public Bytes32 getVoluntaryExitDomain(
+      final UInt64 epoch, final Fork fork, final Bytes32 genesisValidatorsRoot) {
+    return atEpoch(epoch)
+        .beaconStateAccessors()
+        .getVoluntaryExitDomain(epoch, fork, genesisValidatorsRoot);
+  }
+
   public Bytes32 getRandaoMix(final BeaconState state, final UInt64 epoch) {
     return atState(state).beaconStateAccessors().getRandaoMix(state, epoch);
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java
@@ -31,7 +31,6 @@ import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.constants.Domain;
-import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
 import tech.pegasys.teku.spec.datastructures.state.Validator;
@@ -320,11 +319,7 @@ public abstract class BeaconStateAccessors {
   }
 
   public Bytes32 getVoluntaryExitDomain(
-      final SignedVoluntaryExit signedVoluntaryExit, final BeaconState state) {
-    return getDomain(
-        Domain.VOLUNTARY_EXIT,
-        signedVoluntaryExit.getMessage().getEpoch(),
-        state.getFork(),
-        state.getGenesisValidatorsRoot());
+      final UInt64 epoch, final Fork fork, final Bytes32 genesisValidatorsRoot) {
+    return getDomain(Domain.VOLUNTARY_EXIT, epoch, fork, genesisValidatorsRoot);
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/operations/OperationSignatureVerifier.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/operations/OperationSignatureVerifier.java
@@ -106,7 +106,9 @@ public class OperationSignatureVerifier {
       return false;
     }
 
-    final Bytes32 domain = beaconStateAccessors.getVoluntaryExitDomain(signedExit, state);
+    final Bytes32 domain =
+        beaconStateAccessors.getVoluntaryExitDomain(
+            exit.getEpoch(), state.getFork(), state.getGenesisValidatorsRoot());
 
     final Bytes signingRoot = miscHelpers.computeSigningRoot(exit, domain);
     return signatureVerifier.verify(maybePublicKey.get(), signingRoot, signedExit.getSignature());

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/helpers/BeaconStateAccessorsDeneb.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/helpers/BeaconStateAccessorsDeneb.java
@@ -18,8 +18,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.config.SpecConfigCapella;
 import tech.pegasys.teku.spec.config.SpecConfigDeneb;
 import tech.pegasys.teku.spec.constants.Domain;
-import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.logic.common.helpers.Predicates;
 import tech.pegasys.teku.spec.logic.versions.altair.helpers.BeaconStateAccessorsAltair;
 
@@ -32,13 +31,17 @@ public class BeaconStateAccessorsDeneb extends BeaconStateAccessorsAltair {
     super(config, predicates, miscHelpers);
   }
 
+  /**
+   * <a href="https://eips.ethereum.org/EIPS/eip-7044">EIP-7044: Perpetually Valid Signed Voluntary
+   * Exits</a>
+   */
   @Override
   public Bytes32 getVoluntaryExitDomain(
-      final SignedVoluntaryExit signedVoluntaryExit, final BeaconState state) {
+      final UInt64 epoch, final Fork fork, final Bytes32 genesisValidatorsRoot) {
     return miscHelpers.computeDomain(
         Domain.VOLUNTARY_EXIT,
         SpecConfigCapella.required(config).getCapellaForkVersion(),
-        state.getGenesisValidatorsRoot());
+        genesisValidatorsRoot);
   }
 
   /**

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/signatures/SigningRootUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/signatures/SigningRootUtil.java
@@ -124,11 +124,8 @@ public class SigningRootUtil {
       final VoluntaryExit voluntaryExit, final ForkInfo forkInfo) {
     final SpecVersion specVersion = spec.atEpoch(voluntaryExit.getEpoch());
     final Bytes32 domain =
-        spec.getDomain(
-            Domain.VOLUNTARY_EXIT,
-            voluntaryExit.getEpoch(),
-            forkInfo.getFork(),
-            forkInfo.getGenesisValidatorsRoot());
+        spec.getVoluntaryExitDomain(
+            voluntaryExit.getEpoch(), forkInfo.getFork(), forkInfo.getGenesisValidatorsRoot());
     return specVersion.miscHelpers().computeSigningRoot(voluntaryExit, domain);
   }
 

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/signatures/LocalSignerTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/signatures/LocalSignerTest.java
@@ -39,9 +39,9 @@ import tech.pegasys.teku.spec.util.DataStructureUtil;
 // failures in this test. If there are no changes to signing code, just update the expected result.
 class LocalSignerTest {
   private final Spec spec = TestSpecFactory.createMinimalPhase0();
+  private final Spec denebSpec = TestSpecFactory.createMinimalDeneb();
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
-  private final DataStructureUtil dataStructureUtilDeneb =
-      new DataStructureUtil(TestSpecFactory.createMinimalDeneb());
+  private final DataStructureUtil dataStructureUtilDeneb = new DataStructureUtil(denebSpec);
 
   private final ForkInfo fork = dataStructureUtil.randomForkInfo();
 
@@ -216,6 +216,26 @@ class LocalSignerTest {
             Bytes.fromBase64String(
                 "qumUYTSgi8hmsS3/a1oDLGSIfOQ4+PgByZpDprnvlQKaDTXnlzGQloQ/W0kAeMa8EhXvGvF0OiGkQxEEznpVsFNhZ01H+3S2StWqq7S0mbRcbJhT6fEcyrOMqRer36q8"));
 
+    final SafeFuture<BLSSignature> result = signer.signVoluntaryExit(voluntaryExit, fork);
+    asyncRunner.executeQueuedActions();
+
+    assertThat(result)
+        .withFailMessage(
+            "expected: %s\nbut was: %s",
+            expectedSignature.toBytesCompressed().toBase64String(),
+            result.getImmediately().toBytesCompressed().toBase64String())
+        .isCompletedWithValue(expectedSignature);
+  }
+
+  @Test
+  public void shouldSignVoluntaryExitWithCapellaForkDomainAfterDeneb() {
+    final VoluntaryExit voluntaryExit = dataStructureUtilDeneb.randomVoluntaryExit();
+    final BLSSignature expectedSignature =
+        BLSSignature.fromBytesCompressed(
+            Bytes.fromBase64String(
+                "j08XcEXfa3g/D/F8lYUmkFS2ZXcnfW82Y0lGA5jnnWmBB/1ypPtsEEwvAO3DpXNnCRSCxVUhJFqUa1krAuxTgZZofyvakpLM/EA5Nqe0Rq8Epk7uPfX5fPiEg/1vJFn9"));
+
+    final LocalSigner signer = new LocalSigner(denebSpec, KEYPAIR, asyncRunner);
     final SafeFuture<BLSSignature> result = signer.signVoluntaryExit(voluntaryExit, fork);
     asyncRunner.executeQueuedActions();
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Related to https://github.com/ethereum/consensus-specs/pull/3288

We were not using the capella fork domain for signing exits which occur post Deneb fork.

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
