### PR TITLE
Avoid exception in stable subnet subscriber when discovery is disabled

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/AllSubnetsSubscriber.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/AllSubnetsSubscriber.java
@@ -17,18 +17,14 @@ import static java.util.stream.Collectors.toSet;
 
 import java.util.Set;
 import java.util.stream.IntStream;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.config.NetworkingSpecConfig;
 import tech.pegasys.teku.spec.datastructures.validator.SubnetSubscription;
 
 public class AllSubnetsSubscriber implements StableSubnetSubscriber {
-  private static final Logger LOG = LogManager.getLogger();
 
   public static StableSubnetSubscriber create(
       final AttestationTopicSubscriber subscriber, final NetworkingSpecConfig networkingConfig) {
-    LOG.info("Subscribing to all attestation subnets");
     final Set<SubnetSubscription> subscriptions =
         IntStream.range(0, networkingConfig.getAttestationSubnetCount())
             .mapToObj(subnetId -> new SubnetSubscription(subnetId, UInt64.MAX_VALUE))

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/NodeBasedStableSubnetSubscriber.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/NodeBasedStableSubnetSubscriber.java
@@ -19,7 +19,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NavigableSet;
-import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
@@ -37,12 +36,12 @@ public class NodeBasedStableSubnetSubscriber implements StableSubnetSubscriber {
   private final NavigableSet<SubnetSubscription> subnetSubscriptions = new TreeSet<>();
   private final Spec spec;
   private final int subnetsPerNode;
-  private final Optional<UInt256> discoveryNodeId;
+  private final UInt256 discoveryNodeId;
 
   public NodeBasedStableSubnetSubscriber(
       final AttestationTopicSubscriber persistentSubnetSubscriber,
       final Spec spec,
-      final Optional<UInt256> discoveryNodeId) {
+      final UInt256 discoveryNodeId) {
     this.persistentSubnetSubscriber = persistentSubnetSubscriber;
     this.spec = spec;
     this.subnetsPerNode = spec.getNetworkingConfig().getSubnetsPerNode();
@@ -81,14 +80,10 @@ public class NodeBasedStableSubnetSubscriber implements StableSubnetSubscriber {
       return emptySet();
     }
 
-    final UInt256 nodeId =
-        discoveryNodeId.orElseThrow(
-            () -> new IllegalArgumentException("Unable to get discovery node id"));
-
     final List<UInt64> nodeSubscribedSubnets =
         spec.atSlot(currentSlot)
             .miscHelpers()
-            .computeSubscribedSubnets(nodeId, spec.computeEpochAtSlot(currentSlot));
+            .computeSubscribedSubnets(discoveryNodeId, spec.computeEpochAtSlot(currentSlot));
 
     LOG.trace(
         "Computed persistent subnets {}",
@@ -104,7 +99,7 @@ public class NodeBasedStableSubnetSubscriber implements StableSubnetSubscriber {
               nodeSubscribedSubnetsIterator.next().intValue(),
               spec.atSlot(currentSlot)
                   .miscHelpers()
-                  .calculateNodeSubnetUnsubscriptionSlot(nodeId, currentSlot));
+                  .calculateNodeSubnetUnsubscriptionSlot(discoveryNodeId, currentSlot));
       newSubnetSubscriptions.add(newSubnetSubscription);
     }
     return newSubnetSubscriptions;

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/StableSubnetSubscriber.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/StableSubnetSubscriber.java
@@ -17,6 +17,11 @@ import tech.pegasys.teku.ethereum.events.SlotEventsChannel;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 public interface StableSubnetSubscriber extends SlotEventsChannel {
+  StableSubnetSubscriber NOOP =
+      new StableSubnetSubscriber() {
+        @Override
+        public void onSlot(UInt64 slot) {}
+      };
 
   @Override
   default void onSlot(final UInt64 slot) {}

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/subnets/NodeBasedStableSubnetSubscriberTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/subnets/NodeBasedStableSubnetSubscriberTest.java
@@ -23,7 +23,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
@@ -123,9 +122,7 @@ public class NodeBasedStableSubnetSubscriberTest {
 
     final NodeBasedStableSubnetSubscriber subscriber =
         new NodeBasedStableSubnetSubscriber(
-            attestationTopicSubscriberMock,
-            specMock,
-            Optional.of(dataStructureUtil.randomUInt256()));
+            attestationTopicSubscriberMock, specMock, dataStructureUtil.randomUInt256());
 
     final ArgumentCaptor<Set<SubnetSubscription>> subscriptionCaptor =
         ArgumentCaptor.forClass(Set.class);
@@ -154,6 +151,6 @@ public class NodeBasedStableSubnetSubscriberTest {
   @NotNull
   private NodeBasedStableSubnetSubscriber createSubscriber() {
     return new NodeBasedStableSubnetSubscriber(
-        attestationTopicSubscriber, spec, Optional.of(dataStructureUtil.randomUInt256()));
+        attestationTopicSubscriber, spec, dataStructureUtil.randomUInt256());
   }
 }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/subnets/StableSubnetSubscriberTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/subnets/StableSubnetSubscriberTest.java
@@ -22,7 +22,6 @@ import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import it.unimi.dsi.fastutil.ints.IntSet;
-import java.util.Optional;
 import java.util.Set;
 import org.apache.tuweni.units.bigints.UInt256;
 import org.junit.jupiter.api.Test;
@@ -42,7 +41,7 @@ public class StableSubnetSubscriberTest {
   private final DataStructureUtil dataStructureUtil =
       new DataStructureUtil(TestSpecFactory.createDefault());
 
-  private final Optional<UInt256> nodeId = Optional.of(dataStructureUtil.randomUInt256());
+  private final UInt256 nodeId = dataStructureUtil.randomUInt256();
 
   @Test
   void shouldSubscribeToSubnetsPerNodeAtStart() {
@@ -58,7 +57,7 @@ public class StableSubnetSubscriberTest {
     final UInt64 unsubscriptionSlot =
         spec.getGenesisSpec()
             .miscHelpers()
-            .calculateNodeSubnetUnsubscriptionSlot(nodeId.get(), currentSlot);
+            .calculateNodeSubnetUnsubscriptionSlot(nodeId, currentSlot);
     subnetSubscriptions
         .getValue()
         .forEach(


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
In some occasions we have discovery disabled, for example in acceptance tests. Let's move to `NOOP`  pattern with stable subnet subscription to avoid exceptions on every slot.
## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
