### PR TITLE
Improve checkpoint sync error logging when url is without path

### DIFF
--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/WeakSubjectivityInitializer.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/WeakSubjectivityInitializer.java
@@ -19,7 +19,6 @@ import static tech.pegasys.teku.networks.Eth2NetworkConfiguration.INITIAL_STATE_
 import java.io.IOException;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.function.Function;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -44,9 +43,6 @@ public class WeakSubjectivityInitializer {
 
   private static final Logger LOG = LogManager.getLogger();
 
-  private static final Function<String, String> FAILED_TO_LOAD_STATE_ERROR_MESSAGE_GENERATOR =
-      resource -> String.format("Failed to load initial state from %s", resource);
-
   public Optional<AnchorPoint> loadInitialAnchorPoint(
       final Spec spec, final Optional<String> initialStateResource) {
     return initialStateResource.map(
@@ -64,19 +60,19 @@ public class WeakSubjectivityInitializer {
                   UrlSanitizer.sanitizePotentialUrl(stateResourceWithPath);
               LOG.info(
                   String.format(
-                      "%s. Will try to load initial state from %s instead.",
-                      FAILED_TO_LOAD_STATE_ERROR_MESSAGE_GENERATOR.apply(sanitizedResource),
-                      sanitizedResourceWithPath));
+                      "Failed to load initial state from %s. Will try to load initial state from %s instead.",
+                      sanitizedResource, sanitizedResourceWithPath));
               try {
                 return getAnchorPoint(spec, stateResourceWithPath, sanitizedResourceWithPath);
-              } catch (final IOException | SszDeserializeException ex1) {
+              } catch (final IOException | SszDeserializeException exWithPath) {
                 throw new InvalidConfigurationException(
-                    FAILED_TO_LOAD_STATE_ERROR_MESSAGE_GENERATOR.apply(sanitizedResourceWithPath),
-                    ex);
+                    String.format(
+                        "Failed to load initial state from %s", sanitizedResourceWithPath),
+                    exWithPath);
               }
             } else {
               throw new InvalidConfigurationException(
-                  FAILED_TO_LOAD_STATE_ERROR_MESSAGE_GENERATOR.apply(sanitizedResource), ex);
+                  String.format("Failed to load initial state from %s", sanitizedResource), ex);
             }
           }
         });


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Small nit. When loading initial state from an url without the fully specified path, e.g. https://beaconstate.ethstaker.cc, before it was logging the whole error. It would be nicer to just have a log message to avoid spamming the logs. If second try fails, It will fail again and error will be displayed to user anyways.

**Before**
```
2023-08-16 14:36:02.265 INFO  - Loading initial state from https://beaconstate.ethstaker.cc
2023-08-16 14:36:02.708 ERROR - Failed to load initial state from https://beaconstate.ethstaker.cc : 
tech.pegasys.teku.infrastructure.ssz.sos.SszDeserializeException: Invalid SSZ: trying to read more bytes than available
at tech.pegasys.teku.infrastructure.ssz.sos.SimpleSszReader.checkIfAvailable(SimpleSszReader.java:50) ~[classes/:?]
at tech.pegasys.teku.infrastructure.ssz.sos.SimpleSszReader.slice(SimpleSszReader.java:34) ~[classes/:?]
at tech.pegasys.teku.infrastructure.ssz.schema.impl.AbstractSszContainerSchema.sszDeserializeTree(AbstractSszContainerSchema.java:289) ~[classes/:?]
at tech.pegasys.teku.infrastructure.ssz.schema.SszSchema.sszDeserialize(SszSchema.java:80) ~[classes/:?]
at tech.pegasys.teku.infrastructure.ssz.schema.SszSchema.sszDeserialize(SszSchema.java:84) ~[classes/:?]
at tech.pegasys.teku.spec.Spec.deserializeBeaconState(Spec.java:317) ~[classes/:?]
at tech.pegasys.teku.spec.datastructures.util.ChainDataLoader.loadState(ChainDataLoader.java:24) ~[classes/:?]
at tech.pegasys.teku.services.beaconchain.WeakSubjectivityInitializer.getAnchorPoint(WeakSubjectivityInitializer.java:88) ~[classes/:?]
at tech.pegasys.teku.services.beaconchain.WeakSubjectivityInitializer.lambda$loadInitialAnchorPoint$0(WeakSubjectivityInitializer.java:52) ~[classes/:?]
at java.util.Optional.map(Optional.java:260) ~[?:?]
at tech.pegasys.teku.services.beaconchain.WeakSubjectivityInitializer.loadInitialAnchorPoint(WeakSubjectivityInitializer.java:48) ~[classes/:?]
at tech.pegasys.teku.services.beaconchain.BeaconChainController.setupInitialState(BeaconChainController.java:1200) ~[classes/:?]
at tech.pegasys.teku.services.beaconchain.BeaconChainController.lambda$initialize$11(BeaconChainController.java:393) ~[classes/:?]
at java.util.concurrent.CompletableFuture$UniCompose.tryFire(CompletableFuture.java:1150) ~[?:?]
at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:510) ~[?:?]
at java.util.concurrent.CompletableFuture.complete(CompletableFuture.java:2147) ~[?:?]
at tech.pegasys.teku.infrastructure.async.SafeFuture.lambda$propagateResult$3(SafeFuture.java:148) ~[classes/:?]
at java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:863) ~[?:?]
at java.util.concurrent.CompletableFuture.uniWhenCompleteStage(CompletableFuture.java:887) ~[?:?]
at java.util.concurrent.CompletableFuture.whenComplete(CompletableFuture.java:2325) ~[?:?]
at tech.pegasys.teku.infrastructure.async.SafeFuture.whenComplete(SafeFuture.java:626) ~[classes/:?]
at tech.pegasys.teku.infrastructure.async.SafeFuture.whenComplete(SafeFuture.java:33) ~[classes/:?]
at tech.pegasys.teku.infrastructure.async.SafeFuture.propagateResult(SafeFuture.java:143) ~[classes/:?]
at tech.pegasys.teku.infrastructure.async.SafeFuture.lambda$exceptionallyCompose$34(SafeFuture.java:426) ~[classes/:?]
at java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:863) ~[?:?]
at java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:841) ~[?:?]
at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:510) ~[?:?]
at java.util.concurrent.CompletableFuture.complete(CompletableFuture.java:2147) ~[?:?]
at tech.pegasys.teku.infrastructure.async.SafeFuture.lambda$propagateResult$3(SafeFuture.java:148) ~[classes/:?]
at java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:863) ~[?:?]
at java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:841) ~[?:?]
at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:510) ~[?:?]
at java.util.concurrent.CompletableFuture.complete(CompletableFuture.java:2147) ~[?:?]
at tech.pegasys.teku.infrastructure.async.SafeFuture.lambda$propagateToAsync$20(SafeFuture.java:326) ~[classes/:?]
at tech.pegasys.teku.infrastructure.async.SafeFuture.of(SafeFuture.java:82) ~[classes/:?]
at tech.pegasys.teku.infrastructure.async.AsyncRunner.lambda$runAsync$2(AsyncRunner.java:47) ~[classes/:?]
at tech.pegasys.teku.infrastructure.async.SafeFuture.of(SafeFuture.java:74) ~[classes/:?]
at tech.pegasys.teku.infrastructure.async.ScheduledExecutorAsyncRunner.lambda$createRunnableForAction$1(ScheduledExecutorAsyncRunner.java:124) ~[classes/:?]
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) [?:?]
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) [?:?]
at java.lang.Thread.run(Thread.java:833) [?:?]
2023-08-16 14:36:02.723 INFO  - Trying to load initial state from https://beaconstate.ethstaker.cc/eth/v2/debug/beacon/states/finalized instead
2023-08-16 14:36:02.723 INFO  - Loading initial state from https://beaconstate.ethstaker.cc/eth/v2/debug/beacon/states/finalized
2023-08-16 14:36:36.959 INFO  - Loaded initial state at epoch 222311.....
```

**After**
```
2023-08-16 14:56:44.976 INFO  - Loading initial state from https://beaconstate.ethstaker.cc
2023-08-16 14:56:45.396 INFO  - Failed to load initial state from https://beaconstate.ethstaker.cc. Will try to load initial state from https://beaconstate.ethstaker.cc/eth/v2/debug/beacon/states/finalized instead.
2023-08-16 14:56:45.397 INFO  - Loading initial state from https://beaconstate.ethstaker.cc/eth/v2/debug/beacon/states/finalized
2023-08-16 14:57:08.055 INFO  - Loaded initial state at epoch 222316.....
```

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
