### PR TITLE
Block builder should fail when schema is null

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BeaconBlockBodyBuilderBellatrix.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BeaconBlockBodyBuilderBellatrix.java
@@ -71,9 +71,11 @@ public class BeaconBlockBodyBuilderBellatrix extends BeaconBlockBodyBuilderAltai
   @Override
   protected void validateSchema() {
     if (isBlinded()) {
-      checkState(blindedSchema != null, "blindedSchema must be set");
+      checkState(
+          blindedSchema != null && schema == null, "blindedSchema must be set with no schema");
     } else {
-      checkState(schema != null, "schema must be set");
+      checkState(
+          schema != null && blindedSchema == null, "schema must be set with no blindedSchema");
     }
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BeaconBlockBodyBuilderBellatrix.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BeaconBlockBodyBuilderBellatrix.java
@@ -70,7 +70,11 @@ public class BeaconBlockBodyBuilderBellatrix extends BeaconBlockBodyBuilderAltai
 
   @Override
   protected void validateSchema() {
-    checkState(schema != null || blindedSchema != null, "schema or blindedSchema must be set");
+    if (isBlinded()) {
+      checkState(blindedSchema != null, "blindedSchema must be set");
+    } else {
+      checkState(schema != null, "schema must be set");
+    }
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/capella/BeaconBlockBodyBuilderCapella.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/capella/BeaconBlockBodyBuilderCapella.java
@@ -65,7 +65,11 @@ public class BeaconBlockBodyBuilderCapella extends BeaconBlockBodyBuilderBellatr
 
   @Override
   protected void validateSchema() {
-    checkState(schema != null || blindedSchema != null, "schema or blindedSchema must be set");
+    if (isBlinded()) {
+      checkState(blindedSchema != null, "blindedSchema must be set");
+    } else {
+      checkState(schema != null, "schema must be set");
+    }
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/capella/BeaconBlockBodyBuilderCapella.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/capella/BeaconBlockBodyBuilderCapella.java
@@ -66,9 +66,11 @@ public class BeaconBlockBodyBuilderCapella extends BeaconBlockBodyBuilderBellatr
   @Override
   protected void validateSchema() {
     if (isBlinded()) {
-      checkState(blindedSchema != null, "blindedSchema must be set");
+      checkState(
+          blindedSchema != null && schema == null, "blindedSchema must be set with no schema");
     } else {
-      checkState(schema != null, "schema must be set");
+      checkState(
+          schema != null && blindedSchema == null, "schema must be set with no blindedSchema");
     }
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/deneb/BeaconBlockBodyBuilderDeneb.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/deneb/BeaconBlockBodyBuilderDeneb.java
@@ -62,7 +62,11 @@ public class BeaconBlockBodyBuilderDeneb extends BeaconBlockBodyBuilderCapella {
 
   @Override
   protected void validateSchema() {
-    checkState(schema != null || blindedSchema != null, "schema or blindedSchema must be set");
+    if (isBlinded()) {
+      checkState(blindedSchema != null, "blindedSchema must be set");
+    } else {
+      checkState(schema != null, "schema must be set");
+    }
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/deneb/BeaconBlockBodyBuilderDeneb.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/deneb/BeaconBlockBodyBuilderDeneb.java
@@ -63,9 +63,11 @@ public class BeaconBlockBodyBuilderDeneb extends BeaconBlockBodyBuilderCapella {
   @Override
   protected void validateSchema() {
     if (isBlinded()) {
-      checkState(blindedSchema != null, "blindedSchema must be set");
+      checkState(
+          blindedSchema != null && schema == null, "blindedSchema must be set with no schema");
     } else {
-      checkState(schema != null, "schema must be set");
+      checkState(
+          schema != null && blindedSchema == null, "schema must be set with no blindedSchema");
     }
   }
 

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BeaconBlockBodyBellatrixTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BeaconBlockBodyBellatrixTest.java
@@ -57,6 +57,7 @@ class BeaconBlockBodyBellatrixTest extends AbstractBeaconBlockBodyTest<BeaconBlo
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   void builderShouldFailWhenOverridingBlindedSchemaWithANullSchema() {
     BeaconBlockBodyBuilderBellatrix beaconBlockBodyBuilderBellatrix =
         new BeaconBlockBodyBuilderBellatrix();
@@ -80,6 +81,7 @@ class BeaconBlockBodyBellatrixTest extends AbstractBeaconBlockBodyTest<BeaconBlo
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   void builderShouldFailWhenOverridingSchemaWithANullBlindedSchema() {
     BeaconBlockBodyBuilderBellatrix beaconBlockBodyBuilderBellatrix =
         new BeaconBlockBodyBuilderBellatrix();

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BeaconBlockBodyBellatrixTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BeaconBlockBodyBellatrixTest.java
@@ -77,7 +77,7 @@ class BeaconBlockBodyBellatrixTest extends AbstractBeaconBlockBodyTest<BeaconBlo
                     .deposits(mock(SszList.class))
                     .voluntaryExits(mock(SszList.class))
                     .build());
-    assertEquals(exception.getMessage(), "schema must be set");
+    assertEquals(exception.getMessage(), "schema must be set with no blindedSchema");
   }
 
   @Test
@@ -101,7 +101,7 @@ class BeaconBlockBodyBellatrixTest extends AbstractBeaconBlockBodyTest<BeaconBlo
                     .deposits(mock(SszList.class))
                     .voluntaryExits(mock(SszList.class))
                     .build());
-    assertEquals(exception.getMessage(), "blindedSchema must be set");
+    assertEquals(exception.getMessage(), "blindedSchema must be set with no schema");
   }
 
   @Override

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BeaconBlockBodyBellatrixTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BeaconBlockBodyBellatrixTest.java
@@ -13,14 +13,21 @@
 
 package tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.bellatrix;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 
 import java.util.function.Consumer;
+import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.datastructures.blocks.Eth1Data;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodyBuilder;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.common.AbstractBeaconBlockBodyTest;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregate;
@@ -47,6 +54,52 @@ class BeaconBlockBodyBellatrixTest extends AbstractBeaconBlockBodyTest<BeaconBlo
     BeaconBlockBodyBellatrix testBeaconBlockBody = safeJoin(createBlockBody());
 
     assertNotEquals(defaultBlockBody, testBeaconBlockBody);
+  }
+
+  @Test
+  void builderShouldFailWhenOverridingBlindedSchemaWithANullSchema() {
+    BeaconBlockBodyBuilderBellatrix beaconBlockBodyBuilderBellatrix =
+        new BeaconBlockBodyBuilderBellatrix();
+    Exception exception =
+        assertThrows(
+            IllegalStateException.class,
+            () ->
+                beaconBlockBodyBuilderBellatrix
+                    .blindedSchema(mock(BlindedBeaconBlockBodySchemaBellatrixImpl.class))
+                    .schema((BeaconBlockBodySchemaBellatrixImpl) null)
+                    .randaoReveal(mock(BLSSignature.class))
+                    .eth1Data(mock(Eth1Data.class))
+                    .graffiti(mock(Bytes32.class))
+                    .attestations(mock(SszList.class))
+                    .proposerSlashings(mock(SszList.class))
+                    .attesterSlashings(mock(SszList.class))
+                    .deposits(mock(SszList.class))
+                    .voluntaryExits(mock(SszList.class))
+                    .build());
+    assertEquals(exception.getMessage(), "schema must be set");
+  }
+
+  @Test
+  void builderShouldFailWhenOverridingSchemaWithANullBlindedSchema() {
+    BeaconBlockBodyBuilderBellatrix beaconBlockBodyBuilderBellatrix =
+        new BeaconBlockBodyBuilderBellatrix();
+    Exception exception =
+        assertThrows(
+            IllegalStateException.class,
+            () ->
+                beaconBlockBodyBuilderBellatrix
+                    .schema(mock(BeaconBlockBodySchemaBellatrixImpl.class))
+                    .blindedSchema(null)
+                    .randaoReveal(mock(BLSSignature.class))
+                    .eth1Data(mock(Eth1Data.class))
+                    .graffiti(mock(Bytes32.class))
+                    .attestations(mock(SszList.class))
+                    .proposerSlashings(mock(SszList.class))
+                    .attesterSlashings(mock(SszList.class))
+                    .deposits(mock(SszList.class))
+                    .voluntaryExits(mock(SszList.class))
+                    .build());
+    assertEquals(exception.getMessage(), "blindedSchema must be set");
   }
 
   @Override

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/capella/BeaconBlockBodyCapellaTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/capella/BeaconBlockBodyCapellaTest.java
@@ -61,6 +61,7 @@ class BeaconBlockBodyCapellaTest extends AbstractBeaconBlockBodyTest<BeaconBlock
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   void builderShouldFailWhenOverridingBlindedSchemaWithANullSchema() {
     BeaconBlockBodyBuilderCapella beaconBlockBodyBuilderCapella =
         new BeaconBlockBodyBuilderCapella();
@@ -84,6 +85,7 @@ class BeaconBlockBodyCapellaTest extends AbstractBeaconBlockBodyTest<BeaconBlock
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   void builderShouldFailWhenOverridingSchemaWithANullBlindedSchema() {
     BeaconBlockBodyBuilderCapella beaconBlockBodyBuilderCapella =
         new BeaconBlockBodyBuilderCapella();

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/capella/BeaconBlockBodyCapellaTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/capella/BeaconBlockBodyCapellaTest.java
@@ -81,7 +81,7 @@ class BeaconBlockBodyCapellaTest extends AbstractBeaconBlockBodyTest<BeaconBlock
                     .deposits(mock(SszList.class))
                     .voluntaryExits(mock(SszList.class))
                     .build());
-    assertEquals(exception.getMessage(), "schema must be set");
+    assertEquals(exception.getMessage(), "schema must be set with no blindedSchema");
   }
 
   @Test
@@ -105,7 +105,7 @@ class BeaconBlockBodyCapellaTest extends AbstractBeaconBlockBodyTest<BeaconBlock
                     .deposits(mock(SszList.class))
                     .voluntaryExits(mock(SszList.class))
                     .build());
-    assertEquals(exception.getMessage(), "blindedSchema must be set");
+    assertEquals(exception.getMessage(), "blindedSchema must be set with no schema");
   }
 
   @Override

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/capella/BeaconBlockBodyCapellaTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/capella/BeaconBlockBodyCapellaTest.java
@@ -13,15 +13,21 @@
 
 package tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.capella;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 
 import java.util.function.Consumer;
+import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.datastructures.blocks.Eth1Data;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodyBuilder;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.common.AbstractBeaconBlockBodyTest;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.BeaconBlockBodyAltair;
@@ -52,6 +58,52 @@ class BeaconBlockBodyCapellaTest extends AbstractBeaconBlockBodyTest<BeaconBlock
     BeaconBlockBodyAltair testBeaconBlockBody = safeJoin(createBlockBody());
 
     assertNotEquals(defaultBlockBody, testBeaconBlockBody);
+  }
+
+  @Test
+  void builderShouldFailWhenOverridingBlindedSchemaWithANullSchema() {
+    BeaconBlockBodyBuilderCapella beaconBlockBodyBuilderCapella =
+        new BeaconBlockBodyBuilderCapella();
+    Exception exception =
+        assertThrows(
+            IllegalStateException.class,
+            () ->
+                beaconBlockBodyBuilderCapella
+                    .blindedSchema(mock(BlindedBeaconBlockBodySchemaCapellaImpl.class))
+                    .schema((BeaconBlockBodySchemaCapellaImpl) null)
+                    .randaoReveal(mock(BLSSignature.class))
+                    .eth1Data(mock(Eth1Data.class))
+                    .graffiti(mock(Bytes32.class))
+                    .attestations(mock(SszList.class))
+                    .proposerSlashings(mock(SszList.class))
+                    .attesterSlashings(mock(SszList.class))
+                    .deposits(mock(SszList.class))
+                    .voluntaryExits(mock(SszList.class))
+                    .build());
+    assertEquals(exception.getMessage(), "schema must be set");
+  }
+
+  @Test
+  void builderShouldFailWhenOverridingSchemaWithANullBlindedSchema() {
+    BeaconBlockBodyBuilderCapella beaconBlockBodyBuilderCapella =
+        new BeaconBlockBodyBuilderCapella();
+    Exception exception =
+        assertThrows(
+            IllegalStateException.class,
+            () ->
+                beaconBlockBodyBuilderCapella
+                    .schema(mock(BeaconBlockBodySchemaCapellaImpl.class))
+                    .blindedSchema((BlindedBeaconBlockBodySchemaCapellaImpl) null)
+                    .randaoReveal(mock(BLSSignature.class))
+                    .eth1Data(mock(Eth1Data.class))
+                    .graffiti(mock(Bytes32.class))
+                    .attestations(mock(SszList.class))
+                    .proposerSlashings(mock(SszList.class))
+                    .attesterSlashings(mock(SszList.class))
+                    .deposits(mock(SszList.class))
+                    .voluntaryExits(mock(SszList.class))
+                    .build());
+    assertEquals(exception.getMessage(), "blindedSchema must be set");
   }
 
   @Override

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/deneb/BeaconBlockBodyDenebTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/deneb/BeaconBlockBodyDenebTest.java
@@ -64,6 +64,7 @@ class BeaconBlockBodyDenebTest extends AbstractBeaconBlockBodyTest<BeaconBlockBo
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   void builderShouldFailWhenOverridingBlindedSchemaWithANullSchema() {
     BeaconBlockBodyBuilderDeneb beaconBlockBodyBuilderDeneb = new BeaconBlockBodyBuilderDeneb();
     Exception exception =
@@ -86,6 +87,7 @@ class BeaconBlockBodyDenebTest extends AbstractBeaconBlockBodyTest<BeaconBlockBo
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   void builderShouldFailWhenOverridingSchemaWithANullBlindedSchema() {
     BeaconBlockBodyBuilderDeneb beaconBlockBodyBuilderDeneb = new BeaconBlockBodyBuilderDeneb();
     Exception exception =

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/deneb/BeaconBlockBodyDenebTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/deneb/BeaconBlockBodyDenebTest.java
@@ -13,15 +13,21 @@
 
 package tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.deneb;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 
 import java.util.function.Consumer;
+import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.datastructures.blocks.Eth1Data;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodyBuilder;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.common.AbstractBeaconBlockBodyTest;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.BeaconBlockBodyAltair;
@@ -55,6 +61,50 @@ class BeaconBlockBodyDenebTest extends AbstractBeaconBlockBodyTest<BeaconBlockBo
     BeaconBlockBodyAltair testBeaconBlockBody = safeJoin(createBlockBody());
 
     assertNotEquals(defaultBlockBody, testBeaconBlockBody);
+  }
+
+  @Test
+  void builderShouldFailWhenOverridingBlindedSchemaWithANullSchema() {
+    BeaconBlockBodyBuilderDeneb beaconBlockBodyBuilderDeneb = new BeaconBlockBodyBuilderDeneb();
+    Exception exception =
+        assertThrows(
+            IllegalStateException.class,
+            () ->
+                beaconBlockBodyBuilderDeneb
+                    .blindedSchema(mock(BlindedBeaconBlockBodySchemaDenebImpl.class))
+                    .schema((BeaconBlockBodySchemaDenebImpl) null)
+                    .randaoReveal(mock(BLSSignature.class))
+                    .eth1Data(mock(Eth1Data.class))
+                    .graffiti(mock(Bytes32.class))
+                    .attestations(mock(SszList.class))
+                    .proposerSlashings(mock(SszList.class))
+                    .attesterSlashings(mock(SszList.class))
+                    .deposits(mock(SszList.class))
+                    .voluntaryExits(mock(SszList.class))
+                    .build());
+    assertEquals(exception.getMessage(), "schema must be set");
+  }
+
+  @Test
+  void builderShouldFailWhenOverridingSchemaWithANullBlindedSchema() {
+    BeaconBlockBodyBuilderDeneb beaconBlockBodyBuilderDeneb = new BeaconBlockBodyBuilderDeneb();
+    Exception exception =
+        assertThrows(
+            IllegalStateException.class,
+            () ->
+                beaconBlockBodyBuilderDeneb
+                    .schema(mock(BeaconBlockBodySchemaDenebImpl.class))
+                    .blindedSchema((BlindedBeaconBlockBodySchemaDenebImpl) null)
+                    .randaoReveal(mock(BLSSignature.class))
+                    .eth1Data(mock(Eth1Data.class))
+                    .graffiti(mock(Bytes32.class))
+                    .attestations(mock(SszList.class))
+                    .proposerSlashings(mock(SszList.class))
+                    .attesterSlashings(mock(SszList.class))
+                    .deposits(mock(SszList.class))
+                    .voluntaryExits(mock(SszList.class))
+                    .build());
+    assertEquals(exception.getMessage(), "blindedSchema must be set");
   }
 
   @Override

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/deneb/BeaconBlockBodyDenebTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/deneb/BeaconBlockBodyDenebTest.java
@@ -83,7 +83,7 @@ class BeaconBlockBodyDenebTest extends AbstractBeaconBlockBodyTest<BeaconBlockBo
                     .deposits(mock(SszList.class))
                     .voluntaryExits(mock(SszList.class))
                     .build());
-    assertEquals(exception.getMessage(), "schema must be set");
+    assertEquals(exception.getMessage(), "schema must be set with no blindedSchema");
   }
 
   @Test
@@ -106,7 +106,7 @@ class BeaconBlockBodyDenebTest extends AbstractBeaconBlockBodyTest<BeaconBlockBo
                     .deposits(mock(SszList.class))
                     .voluntaryExits(mock(SszList.class))
                     .build());
-    assertEquals(exception.getMessage(), "blindedSchema must be set");
+    assertEquals(exception.getMessage(), "blindedSchema must be set with no schema");
   }
 
   @Override


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Checks if the schema or blinded schema is not null according to the block builder `blinded` property.
An issue was reported on [discord](https://discord.com/channels/697535391594446898/1050616638497640548/1142112922168995900) by @jtraglia:
With the previous implementation, `builder.blindedSchema(validSchema).schema(null).build()` would pass

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
