### PR TITLE
Allowed voluntary exits to be generated for external validators.

### DIFF
--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/LocalValidatorKeysAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/LocalValidatorKeysAcceptanceTest.java
@@ -86,7 +86,7 @@ public class LocalValidatorKeysAcceptanceTest extends AcceptanceTestBase {
         validatorKeystores.getPublicKeys().get(1), UInt64.valueOf(30000000));
 
     // generate voluntary exit
-    api.postVoluntaryExit(validatorKeystores.getPublicKeys().get(1), 1);
+    api.generateVoluntaryExitAndCheckValidatorIndex(validatorKeystores.getPublicKeys().get(1), 1);
 
     api.assertValidatorFeeRecipient(validatorKeystores.getPublicKeys().get(1), defaultFeeRecipient);
 

--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/RemoteValidatorKeysAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/RemoteValidatorKeysAcceptanceTest.java
@@ -77,6 +77,10 @@ public class RemoteValidatorKeysAcceptanceTest extends AcceptanceTestBase {
 
     validatorClient.waitForLogMessageContaining("Published block");
 
+    // generate voluntary exit
+    validatorNodeApi.generateVoluntaryExitAndCheckValidatorIndex(
+        validatorKeystores.getPublicKeys().get(1), 1);
+
     // remove a validator
     final BLSPublicKey removedPubKey = validatorKeystores.getPublicKeys().get(0);
     validatorNodeApi.removeRemoteValidatorAndCheckStatus(removedPubKey, "deleted");

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/tools/ValidatorKeysApi.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/tools/ValidatorKeysApi.java
@@ -69,8 +69,8 @@ public class ValidatorKeysApi {
     tempDir.toFile().delete();
   }
 
-  public void postVoluntaryExit(final BLSPublicKey publicKey, final int validatorIndex)
-      throws IOException {
+  public void generateVoluntaryExitAndCheckValidatorIndex(
+      final BLSPublicKey publicKey, final int validatorIndex) throws IOException {
     final UInt64 epoch = UInt64.ONE;
     final String value = getPostVoluntaryExitString(publicKey, Optional.of(epoch));
     final JsonNode result = jsonProvider.getObjectMapper().readTree(value).get("data");
@@ -88,7 +88,7 @@ public class ValidatorKeysApi {
     }
 
     final String result = httpClient.post(validatorUri.get(), url, "", authHeaders());
-    LOG.debug("POST Keys: " + result);
+    LOG.debug("POST VoluntaryExit: " + result);
     return result;
   }
 

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ActiveKeyManager.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ActiveKeyManager.java
@@ -77,6 +77,11 @@ public class ActiveKeyManager implements KeyManager {
         .collect(Collectors.toList());
   }
 
+  @Override
+  public Optional<Validator> getActiveValidatorByPublicKey(BLSPublicKey publicKey) {
+    return validatorLoader.getOwnedValidators().getValidator(publicKey);
+  }
+
   /**
    * Delete a collection of validators
    *

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/KeyManager.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/KeyManager.java
@@ -30,6 +30,8 @@ public interface KeyManager {
 
   List<ExternalValidator> getActiveRemoteValidatorKeys();
 
+  Optional<Validator> getActiveValidatorByPublicKey(final BLSPublicKey publicKey);
+
   DeleteKeysResponse deleteValidators(
       final List<BLSPublicKey> validators, final Path slashingProtectionPath);
 

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/NoOpKeyManager.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/NoOpKeyManager.java
@@ -39,6 +39,11 @@ public class NoOpKeyManager implements KeyManager {
   }
 
   @Override
+  public Optional<Validator> getActiveValidatorByPublicKey(BLSPublicKey publicKey) {
+    return Optional.empty();
+  }
+
+  @Override
   public DeleteKeysResponse deleteValidators(
       final List<BLSPublicKey> validators, final Path slashingProtectionPath) {
     return new DeleteKeysResponse(Collections.emptyList(), "");

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/VoluntaryExitDataProviderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/VoluntaryExitDataProviderTest.java
@@ -163,7 +163,7 @@ class VoluntaryExitDataProviderTest {
 
   @Test
   void createExitForValidator_notFound() {
-    when(keyManager.getActiveValidatorKeys()).thenReturn(List.of());
+    when(keyManager.getActiveValidatorByPublicKey(any())).thenReturn(Optional.empty());
     final ForkInfo forkInfo = dataStructureUtil.randomForkInfo();
     assertThat(
             provider.getExitForValidator(


### PR DESCRIPTION
Enhanced the remote validator acceptance test to generate a signed exit to ensure it continues to function.

Fixes #7431

## PR Description

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
