### PR TITLE
Added a debug-tool for checking validator keys

### DIFF
--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugToolsCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugToolsCommand.java
@@ -52,7 +52,7 @@ import tech.pegasys.teku.validator.client.restapi.ValidatorRestApiConfig;
 @Command(
     name = "debug-tools",
     description = "Utilities for debugging issues",
-    subcommands = {DebugDbCommand.class, PrettyPrintCommand.class},
+    subcommands = {DebugDbCommand.class, PrettyPrintCommand.class, ValidatorKeysCheckCommand.class},
     showDefaultValues = true,
     abbreviateSynopsis = true,
     mixinStandardHelpOptions = true,

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/ValidatorKeysCheckCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/ValidatorKeysCheckCommand.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright Consensys Software Inc., 2023
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.cli.subcommand.debug;
+
+import com.google.common.base.Throwables;
+import java.io.FileNotFoundException;
+import java.io.UncheckedIOException;
+import java.nio.file.AccessDeniedException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.Callable;
+import org.apache.commons.lang3.tuple.Pair;
+import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
+import org.hyperledger.besu.plugin.services.MetricsSystem;
+import picocli.CommandLine;
+import tech.pegasys.teku.bls.keystore.KeyStoreValidationException;
+import tech.pegasys.teku.cli.converter.PicoCliVersionProvider;
+import tech.pegasys.teku.cli.options.ValidatorKeysOptions;
+import tech.pegasys.teku.config.TekuConfiguration;
+import tech.pegasys.teku.infrastructure.async.AsyncRunner;
+import tech.pegasys.teku.infrastructure.async.AsyncRunnerFactory;
+import tech.pegasys.teku.infrastructure.async.MetricTrackingExecutorFactory;
+import tech.pegasys.teku.infrastructure.exceptions.InvalidConfigurationException;
+import tech.pegasys.teku.infrastructure.logging.SubCommandLogger;
+import tech.pegasys.teku.spec.SpecFactory;
+import tech.pegasys.teku.validator.client.loader.LocalValidatorVerifier;
+import tech.pegasys.teku.validator.client.loader.ValidatorSource;
+
+@CommandLine.Command(
+    name = "key-check",
+    aliases = {"kc"},
+    description = "Check attributes of a validator key, and where it is running from.",
+    showDefaultValues = true,
+    abbreviateSynopsis = true,
+    mixinStandardHelpOptions = true,
+    versionProvider = PicoCliVersionProvider.class,
+    synopsisHeading = "%n",
+    descriptionHeading = "%nDescription:%n%n",
+    optionListHeading = "%nOptions:%n",
+    footerHeading = "%n",
+    footer = "Teku is licensed under the Apache License 2.0")
+public class ValidatorKeysCheckCommand implements Callable<Integer> {
+  public static final SubCommandLogger SUB_COMMAND_LOG = new SubCommandLogger();
+
+  @CommandLine.Mixin(name = "Validator Keys")
+  private ValidatorKeysOptions validatorKeysOptions;
+
+  @CommandLine.Option(
+      names = {"--verbose-output-enabled", "-v", "-verbose"},
+      paramLabel = "<BOOLEAN>",
+      showDefaultValue = CommandLine.Help.Visibility.ALWAYS,
+      fallbackValue = "true",
+      description = "Verbose output should be displayed.",
+      arity = "0..1")
+  private boolean isVerboseOutputEnabled = false;
+
+  private final MetricsSystem metricsSystem = new NoOpMetricsSystem();
+
+  private AsyncRunner asyncRunner;
+
+  private LocalValidatorVerifier verifier;
+
+  private List<Pair<Path, Path>> filePairs;
+
+  @Override
+  public Integer call() {
+    TekuConfiguration config = tekuConfiguration();
+
+    final AsyncRunnerFactory asyncRunnerFactory =
+        AsyncRunnerFactory.createDefault(new MetricTrackingExecutorFactory(metricsSystem));
+    asyncRunner = asyncRunnerFactory.create("keychecker", 2);
+    verifier =
+        new LocalValidatorVerifier(
+            SpecFactory.create("mainnet"),
+            config.validatorClient().getValidatorConfig().getValidatorKeys(),
+            asyncRunner);
+
+    if (!filesLocatorCanParseEntries()) {
+      return 1;
+    }
+
+    if (!keysCanBeLoadedAndLocked()) {
+      return 1;
+    }
+
+    SUB_COMMAND_LOG.display("Successfully completed checking keystore files.");
+    return 0;
+  }
+
+  private boolean keysCanBeLoadedAndLocked() {
+    int failedKeys = 0;
+    int successfulKeys = 0;
+    for (Pair<Path, Path> keystorePasswordPathPair : filePairs) {
+      try {
+        if (isVerboseOutputEnabled) {
+          SUB_COMMAND_LOG.display(
+              String.format(" -> Creating provider from %s", keystorePasswordPathPair.getKey()));
+        }
+        ValidatorSource.ValidatorProvider provider =
+            verifier.createValidatorProvider(keystorePasswordPathPair);
+        if (canCreateSignerFromValidatorProvider(provider)) {
+          successfulKeys++;
+        } else {
+          failedKeys++;
+        }
+      } catch (final KeyStoreValidationException e) {
+        if (Throwables.getRootCause(e) instanceof FileNotFoundException) {
+          SUB_COMMAND_LOG.error(
+              String.format(
+                  "Unable to load keystore: %s\nCheck that the files have been correctly specified, and permissions are correct",
+                  e.getMessage()));
+          failedKeys++;
+        }
+      } catch (InvalidConfigurationException e) {
+        if (Throwables.getRootCause(e) instanceof AccessDeniedException) {
+          SUB_COMMAND_LOG.error(
+              String.format(
+                  "Unable to load keystore: %s\nCheck file permissions on the key and password.",
+                  e.getMessage()));
+        }
+        failedKeys++;
+      }
+    }
+
+    if (failedKeys == 0) {
+      SUB_COMMAND_LOG.display(String.format("Loaded %d keys successfully", successfulKeys));
+    } else if (successfulKeys == 0) {
+      SUB_COMMAND_LOG.error(String.format("Failed to load %d keys", failedKeys));
+    } else {
+      SUB_COMMAND_LOG.error(
+          String.format(
+              "Failed to load %d keys, but %d were loaded successfully.",
+              failedKeys, successfulKeys));
+    }
+    return failedKeys == 0;
+  }
+
+  private boolean filesLocatorCanParseEntries() {
+    try {
+      filePairs = verifier.parse();
+    } catch (InvalidConfigurationException ex) {
+      SUB_COMMAND_LOG.error(
+          String.format("Failed to load available validators: %s", ex.getMessage()));
+      return false;
+    }
+    return true;
+  }
+
+  private boolean canCreateSignerFromValidatorProvider(
+      ValidatorSource.ValidatorProvider validatorProvider) {
+    try {
+      if (isVerboseOutputEnabled) {
+        SUB_COMMAND_LOG.display(
+            String.format("  + Creating signer for %s", validatorProvider.getPublicKey()));
+      }
+      validatorProvider.createSigner();
+    } catch (InvalidConfigurationException ex) {
+      SUB_COMMAND_LOG.error(
+          String.format(
+              "Failed to load signer %s: %s", validatorProvider.getPublicKey(), ex.getMessage()));
+      return false;
+    } catch (UncheckedIOException ex) {
+      SUB_COMMAND_LOG.error(
+          String.format(
+              "Failed to load signer %s: %s\nCheck the folder permissions for write access.",
+              validatorProvider.getPublicKey(), ex.getMessage()));
+      return false;
+    }
+    return true;
+  }
+
+  private TekuConfiguration tekuConfiguration() {
+
+    final TekuConfiguration.Builder builder =
+        TekuConfiguration.builder().metrics(b -> b.metricsEnabled(false));
+
+    validatorKeysOptions.configure(builder);
+
+    // we don't use the data path, but keep configuration happy.
+    builder.data(config -> config.dataBasePath(Path.of(".")));
+    builder.validator(config -> config.validatorKeystoreLockingEnabled(false));
+    return builder.build();
+  }
+}

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/ValidatorKeysCheckCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/ValidatorKeysCheckCommand.java
@@ -57,7 +57,7 @@ public class ValidatorKeysCheckCommand implements Callable<Integer> {
   private ValidatorKeysOptions validatorKeysOptions;
 
   @CommandLine.Option(
-      names = {"--verbose-output-enabled", "-v", "-verbose"},
+      names = {"--verbose-output-enabled", "--v", "--verbose"},
       paramLabel = "<BOOLEAN>",
       showDefaultValue = CommandLine.Help.Visibility.ALWAYS,
       fallbackValue = "true",

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/ValidatorKeysCheckCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/ValidatorKeysCheckCommand.java
@@ -75,7 +75,7 @@ public class ValidatorKeysCheckCommand implements Callable<Integer> {
 
   @Override
   public Integer call() {
-    TekuConfiguration config = tekuConfiguration();
+    final TekuConfiguration config = tekuConfiguration();
 
     final AsyncRunnerFactory asyncRunnerFactory =
         AsyncRunnerFactory.createDefault(new MetricTrackingExecutorFactory(metricsSystem));
@@ -101,13 +101,13 @@ public class ValidatorKeysCheckCommand implements Callable<Integer> {
   private boolean keysCanBeLoadedAndLocked() {
     int failedKeys = 0;
     int successfulKeys = 0;
-    for (Pair<Path, Path> keystorePasswordPathPair : filePairs) {
+    for (final Pair<Path, Path> keystorePasswordPathPair : filePairs) {
       try {
         if (isVerboseOutputEnabled) {
           SUB_COMMAND_LOG.display(
               String.format(" -> Creating provider from %s", keystorePasswordPathPair.getKey()));
         }
-        ValidatorSource.ValidatorProvider provider =
+        final ValidatorSource.ValidatorProvider provider =
             verifier.createValidatorProvider(keystorePasswordPathPair);
         if (canCreateSignerFromValidatorProvider(provider)) {
           successfulKeys++;
@@ -122,7 +122,7 @@ public class ValidatorKeysCheckCommand implements Callable<Integer> {
                   e.getMessage()));
           failedKeys++;
         }
-      } catch (InvalidConfigurationException e) {
+      } catch (final InvalidConfigurationException e) {
         if (Throwables.getRootCause(e) instanceof AccessDeniedException) {
           SUB_COMMAND_LOG.error(
               String.format(
@@ -149,7 +149,7 @@ public class ValidatorKeysCheckCommand implements Callable<Integer> {
   private boolean filesLocatorCanParseEntries() {
     try {
       filePairs = verifier.parse();
-    } catch (InvalidConfigurationException ex) {
+    } catch (final InvalidConfigurationException ex) {
       SUB_COMMAND_LOG.error(
           String.format("Failed to load available validators: %s", ex.getMessage()));
       return false;
@@ -158,7 +158,7 @@ public class ValidatorKeysCheckCommand implements Callable<Integer> {
   }
 
   private boolean canCreateSignerFromValidatorProvider(
-      ValidatorSource.ValidatorProvider validatorProvider) {
+      final ValidatorSource.ValidatorProvider validatorProvider) {
     try {
       if (isVerboseOutputEnabled) {
         SUB_COMMAND_LOG.display(
@@ -170,7 +170,7 @@ public class ValidatorKeysCheckCommand implements Callable<Integer> {
           String.format(
               "Failed to load signer %s: %s", validatorProvider.getPublicKey(), ex.getMessage()));
       return false;
-    } catch (UncheckedIOException ex) {
+    } catch (final UncheckedIOException ex) {
       SUB_COMMAND_LOG.error(
           String.format(
               "Failed to load signer %s: %s\nCheck the folder permissions for write access.",

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/LocalValidatorSource.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/LocalValidatorSource.java
@@ -155,8 +155,7 @@ public class LocalValidatorSource extends AbstractValidatorSource implements Val
         .resolve(fileName + ".txt");
   }
 
-  private ValidatorProvider createValidatorProvider(
-      final Pair<Path, Path> keystorePasswordFilePair) {
+  ValidatorProvider createValidatorProvider(final Pair<Path, Path> keystorePasswordFilePair) {
     final Path keystorePath = keystorePasswordFilePair.getLeft();
     final Path passwordPath = keystorePasswordFilePair.getRight();
     try {

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/LocalValidatorVerifier.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/LocalValidatorVerifier.java
@@ -27,7 +27,7 @@ public class LocalValidatorVerifier {
   private final LocalValidatorSource validatorSource;
 
   public LocalValidatorVerifier(
-      final Spec spec, List<String> keystoreFiles, AsyncRunner asyncRunner) {
+      final Spec spec, final List<String> keystoreFiles, final AsyncRunner asyncRunner) {
     keyStoreFilesLocator = new KeyStoreFilesLocator(keystoreFiles, File.pathSeparator);
 
     validatorSource =
@@ -46,7 +46,7 @@ public class LocalValidatorVerifier {
   }
 
   public ValidatorSource.ValidatorProvider createValidatorProvider(
-      Pair<Path, Path> keystorePasswordPathPair) {
+      final Pair<Path, Path> keystorePasswordPathPair) {
     return validatorSource.createValidatorProvider(keystorePasswordPathPair);
   }
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/LocalValidatorVerifier.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/LocalValidatorVerifier.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Consensys Software Inc., 2023
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.client.loader;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+import org.apache.commons.lang3.tuple.Pair;
+import tech.pegasys.teku.infrastructure.async.AsyncRunner;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.validator.api.KeyStoreFilesLocator;
+
+public class LocalValidatorVerifier {
+  private final KeyStoreFilesLocator keyStoreFilesLocator;
+  private final LocalValidatorSource validatorSource;
+
+  public LocalValidatorVerifier(
+      final Spec spec, List<String> keystoreFiles, AsyncRunner asyncRunner) {
+    keyStoreFilesLocator = new KeyStoreFilesLocator(keystoreFiles, File.pathSeparator);
+
+    validatorSource =
+        new LocalValidatorSource(
+            spec,
+            true,
+            new KeystoreLocker(),
+            keyStoreFilesLocator,
+            asyncRunner,
+            true,
+            Optional.empty());
+  }
+
+  public List<Pair<Path, Path>> parse() {
+    return keyStoreFilesLocator.parse();
+  }
+
+  public ValidatorSource.ValidatorProvider createValidatorProvider(
+      Pair<Path, Path> keystorePasswordPathPair) {
+    return validatorSource.createValidatorProvider(keystorePasswordPathPair);
+  }
+}

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/LocalValidatorVerifierTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/LocalValidatorVerifierTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright Consensys Software Inc., 2023
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.client.loader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static tech.pegasys.teku.infrastructure.async.SyncAsyncRunner.SYNC_RUNNER;
+
+import java.io.File;
+import java.nio.file.AccessDeniedException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import tech.pegasys.teku.bls.keystore.KeyStoreValidationException;
+import tech.pegasys.teku.infrastructure.exceptions.InvalidConfigurationException;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.signatures.Signer;
+
+class LocalValidatorVerifierTest {
+  private final Spec spec = TestSpecFactory.createDefault();
+
+  @Test
+  void shouldLoadSignerSuccessfully(@TempDir final Path tempDir) throws Exception {
+    ValidatorLoaderTest.writeKeystore(tempDir);
+    final String key = tempDir.resolve("key.json").toString();
+    final String pass = tempDir.resolve("key.txt").toString();
+    final LocalValidatorVerifier verifier =
+        new LocalValidatorVerifier(spec, List.of(key + File.pathSeparator + pass), SYNC_RUNNER);
+    final List<Pair<Path, Path>> keys = verifier.parse();
+    assertThat(keys.size()).isEqualTo(1);
+    final ValidatorSource.ValidatorProvider provider =
+        verifier.createValidatorProvider(keys.get(0));
+    final Signer signer = provider.createSigner();
+    assertThat(signer).isNotNull();
+  }
+
+  @Test
+  void shouldThrowExceptionWhenPasswordFileNotFound(@TempDir final Path tempDir) throws Exception {
+    ValidatorLoaderTest.writeKeystore(tempDir);
+    final String key = tempDir.resolve("key.json").toString();
+    final String pass = tempDir.resolve("notfound").toString();
+    final LocalValidatorVerifier verifier =
+        new LocalValidatorVerifier(spec, List.of(key + File.pathSeparator + pass), SYNC_RUNNER);
+    assertThatThrownBy(verifier::parse)
+        .isInstanceOf(InvalidConfigurationException.class)
+        .hasMessageContaining("Could not find the password file");
+  }
+
+  @Test
+  void shouldThrowExceptionWhenKeystoreFileNotFound(@TempDir final Path tempDir) throws Exception {
+    ValidatorLoaderTest.writeKeystore(tempDir);
+    final String key = tempDir.resolve("keynotfound.json").toString();
+    final String pass = tempDir.resolve("pass.txt").toString();
+    final LocalValidatorVerifier verifier =
+        new LocalValidatorVerifier(spec, List.of(key + File.pathSeparator + pass), SYNC_RUNNER);
+    assertThatThrownBy(verifier::parse)
+        .isInstanceOf(InvalidConfigurationException.class)
+        .hasMessageContaining("Could not find the key file");
+  }
+
+  @Test
+  void shouldThrowExceptionWhenCannotReadPasswordFile(@TempDir final Path tempDir)
+      throws Exception {
+    ValidatorLoaderTest.writeKeystore(tempDir);
+    Files.setPosixFilePermissions(tempDir.resolve("key.txt"), Set.of());
+    final String key = tempDir.resolve("key.json").toString();
+    final String pass = tempDir.resolve("key.txt").toString();
+    final LocalValidatorVerifier verifier =
+        new LocalValidatorVerifier(spec, List.of(key + File.pathSeparator + pass), SYNC_RUNNER);
+    final List<Pair<Path, Path>> keys = verifier.parse();
+    assertThat(keys.size()).isEqualTo(1);
+    assertThatThrownBy(() -> verifier.createValidatorProvider(keys.get(0)))
+        .hasCauseInstanceOf(AccessDeniedException.class);
+  }
+
+  @Test
+  void shouldThrowExceptionWhenCannotReadKeyFile(@TempDir final Path tempDir) throws Exception {
+    ValidatorLoaderTest.writeKeystore(tempDir);
+    final String key = tempDir.resolve("key.json").toString();
+    final String pass = tempDir.resolve("key.txt").toString();
+    Files.setPosixFilePermissions(tempDir.resolve("key.json"), Set.of());
+    final LocalValidatorVerifier verifier =
+        new LocalValidatorVerifier(spec, List.of(key + File.pathSeparator + pass), SYNC_RUNNER);
+    final List<Pair<Path, Path>> keys = verifier.parse();
+    assertThat(keys.size()).isEqualTo(1);
+    assertThatThrownBy(() -> verifier.createValidatorProvider(keys.get(0)))
+        .hasCauseInstanceOf(KeyStoreValidationException.class);
+  }
+}

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/LocalValidatorVerifierTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/LocalValidatorVerifierTest.java
@@ -25,6 +25,8 @@ import java.util.List;
 import java.util.Set;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 import tech.pegasys.teku.bls.keystore.KeyStoreValidationException;
 import tech.pegasys.teku.infrastructure.exceptions.InvalidConfigurationException;
@@ -75,6 +77,7 @@ class LocalValidatorVerifierTest {
   }
 
   @Test
+  @DisabledOnOs(OS.WINDOWS) // can't set posix permissions on windows
   void shouldThrowExceptionWhenCannotReadPasswordFile(@TempDir final Path tempDir)
       throws Exception {
     ValidatorLoaderTest.writeKeystore(tempDir);
@@ -90,6 +93,7 @@ class LocalValidatorVerifierTest {
   }
 
   @Test
+  @DisabledOnOs(OS.WINDOWS) // can't set posix permissions on windows
   void shouldThrowExceptionWhenCannotReadKeyFile(@TempDir final Path tempDir) throws Exception {
     ValidatorLoaderTest.writeKeystore(tempDir);
     final String key = tempDir.resolve("key.json").toString();

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/ValidatorLoaderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/ValidatorLoaderTest.java
@@ -738,7 +738,7 @@ class ValidatorLoaderTest {
     assertThat(validators.hasNoValidators()).isTrue();
   }
 
-  private void writeKeystore(final Path tempDir) throws Exception {
+  static void writeKeystore(final Path tempDir) throws Exception {
     final URL resource = Resources.getResource("pbkdf2TestVector.json");
     Files.copy(Path.of(resource.toURI()), tempDir.resolve("key.json"));
     Files.writeString(tempDir.resolve("key.txt"), "testpassword");


### PR DESCRIPTION
To use it most effectively you should really run as the user that runs teku, something like
```
sudo -u teku teku debug-tools kc --validator-keys /keys:/passwords
```

The validator-keys option parses in the same way that the main teku validator-keys locator does, so should accept files or paths and handle them consistently with teku itself.

There's a verbose mode which may mostly help developers, as it lists the keys and signers as created.

Fixes #7440

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
