### PR TITLE
Enable gzip encoding for REST API responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ For information on changes in released versions of Teku, see the [releases page]
 - Update attestation subnet subscriptions strategy according to [the spec changes](https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/p2p-interface.md#attestation-subnet-subscription). All nodes (including non-validating ones) will subscribe to 2 subnets regardless of the number of validators.
 - Added `/eth/v1/validator/{pubkey}/voluntary_exit` Validator API endpoint
 - Add support for Holesky test network `--network=holesky`
+- Add support for gzip encoding in REST API
 
 ### Bug Fixes
 - Fixed a bug in network configuration loader which was ignoring MIN_EPOCHS_FOR_BLOCK_REQUESTS parameter. 

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/RestApiBuilder.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/RestApiBuilder.java
@@ -131,6 +131,11 @@ public class RestApiBuilder {
             config -> {
               config.http.defaultContentType = "application/json";
               config.showJavalinBanner = false;
+              config.compression.gzipOnly();
+              // Work around a bug in Javalin where it decides whether to compress on each call to
+              // write which could result in a mix of compressed and uncompressed content
+              // and means it doesn't evaluate the length of the response correctly.
+              config.pvt.compressionStrategy.setMinSizeForCompression(0);
               configureCors(config);
               swaggerBuilder.configureUI(config);
               config.jetty.server(this::createJettyServer);

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/JavalinRestApiRequest.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/endpoints/JavalinRestApiRequest.java
@@ -24,9 +24,7 @@ import io.javalin.http.Header;
 import io.javalin.http.sse.SseClient;
 import io.javalin.http.sse.SseHandler;
 import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.io.OutputStream;
-import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -98,11 +96,7 @@ public class JavalinRestApiRequest implements RestApiRequest {
   }
 
   private OutputStream getResponseOutputStream() {
-    try {
-      return context.res().getOutputStream();
-    } catch (IOException e) {
-      throw new UncheckedIOException(e);
-    }
+    return context.outputStream();
   }
 
   private void respond(


### PR DESCRIPTION
## PR Description
Enable gzip encoding for REST API responses
Use gzip encoding when available when downloading initial-state


## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
