### PR TITLE
Fix proposer config refresh

### DIFF
--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/proposerconfig/ProposerConfigProviderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/proposerconfig/ProposerConfigProviderTest.java
@@ -94,6 +94,7 @@ public class ProposerConfigProviderTest {
 
     assertThat(futureMaybeConfig).isCompletedWithValue(Optional.of(proposerConfigA));
 
+    timeProvider.advanceTimeBySeconds(LAST_PROPOSER_CONFIG_VALIDITY_PERIOD + 10);
     futureMaybeConfig = proposerConfigProvider.getProposerConfig();
 
     when(proposerConfigLoader.getProposerConfig(sourceUrl))

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/proposerconfig/ProposerConfigProviderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/proposerconfig/ProposerConfigProviderTest.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.validator.client.proposerconfig;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -101,6 +102,7 @@ public class ProposerConfigProviderTest {
         .thenThrow(new RuntimeException("error"));
     asyncRunner.executeQueuedActions();
 
+    verify(proposerConfigLoader, times(2)).getProposerConfig(any());
     assertThat(futureMaybeConfig).isCompletedWithValue(Optional.of(proposerConfigA));
   }
 


### PR DESCRIPTION
Refactor the proposer config reload logic, removing the (odd) case in which the provider could stuck providing always the same config skipping the refresh.

fixed a unit test too

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
