### PR TITLE
Avoid db iteration when it's not needed

### DIFF
--- a/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
@@ -731,13 +731,9 @@ public class ChainDataProvider {
   }
 
   public SafeFuture<Optional<Bytes32>> getFinalizedBlockRoot(final UInt64 slot) {
-    final SafeFuture<Optional<SignedBeaconBlock>> futureFinalizedBlock =
-        combinedChainDataClient.getFinalizedBlockInEffectAtSlot(slot);
-    return futureFinalizedBlock.thenApply(
-        maybeFinalizedBlock ->
-            maybeFinalizedBlock
-                .filter(block -> block.getSlot().equals(slot))
-                .map(SignedBeaconBlock::getRoot));
+    return combinedChainDataClient
+        .getFinalizedBlockAtSlotExact(slot)
+        .thenApply(maybeFinalizedBlock -> maybeFinalizedBlock.map(SignedBeaconBlock::getRoot));
   }
 
   public SpecMilestone getMilestoneAtHead() {

--- a/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/AbstractRpcMethodIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/AbstractRpcMethodIntegrationTest.java
@@ -256,7 +256,7 @@ public abstract class AbstractRpcMethodIntegrationTest {
             slot ->
                 peerStorage
                     .recentChainData()
-                    .getBlockRootBySlot(slot)
+                    .getBlockRootInEffectBySlot(slot)
                     .map(root -> new SlotAndBlockRoot(slot, root)))
         .flatMap(Optional::stream)
         .map(this::safeRetrieveBlobSidecars)

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
@@ -93,9 +93,10 @@ public class CombinedChainDataClient {
     }
 
     // Try to pull root from recent data
-    final Optional<Bytes32> recentRoot = recentChainData.getBlockRootBySlot(slot);
+    final Optional<Bytes32> recentRoot = recentChainData.getBlockRootInEffectBySlot(slot);
     if (recentRoot.isPresent()) {
-      return getBlockByBlockRoot(recentRoot.get());
+      return getBlockByBlockRoot(recentRoot.get())
+          .thenApply(maybeBlock -> maybeBlock.filter(block -> block.getSlot().equals(slot)));
     }
 
     return historicalChainData.getFinalizedBlockAtSlot(slot);
@@ -116,9 +117,11 @@ public class CombinedChainDataClient {
     }
 
     // Try to pull root from recent data
-    final Optional<Bytes32> recentRoot = recentChainData.getBlockRootBySlot(slot, headBlockRoot);
+    final Optional<Bytes32> recentRoot =
+        recentChainData.getBlockRootInEffectBySlot(slot, headBlockRoot);
     if (recentRoot.isPresent()) {
-      return getBlockByBlockRoot(recentRoot.get());
+      return getBlockByBlockRoot(recentRoot.get())
+          .thenApply(maybeBlock -> maybeBlock.filter(block -> block.getSlot().equals(slot)));
     }
 
     return historicalChainData.getFinalizedBlockAtSlot(slot);
@@ -130,7 +133,7 @@ public class CombinedChainDataClient {
     }
 
     // Try to pull root from recent data
-    final Optional<Bytes32> recentRoot = recentChainData.getBlockRootBySlot(slot);
+    final Optional<Bytes32> recentRoot = recentChainData.getBlockRootInEffectBySlot(slot);
     if (recentRoot.isPresent()) {
       return getBlockByBlockRoot(recentRoot.get());
     }
@@ -199,7 +202,7 @@ public class CombinedChainDataClient {
   }
 
   public SafeFuture<Optional<BeaconState>> getStateAtSlotExact(final UInt64 slot) {
-    final Optional<Bytes32> recentBlockRoot = recentChainData.getBlockRootBySlot(slot);
+    final Optional<Bytes32> recentBlockRoot = recentChainData.getBlockRootInEffectBySlot(slot);
     if (recentBlockRoot.isPresent()) {
       return getStore()
           .retrieveStateAtSlot(new SlotAndBlockRoot(slot, recentBlockRoot.get()))
@@ -215,7 +218,8 @@ public class CombinedChainDataClient {
 
   public SafeFuture<Optional<BeaconState>> getStateAtSlotExact(
       final UInt64 slot, final Bytes32 chainHead) {
-    final Optional<Bytes32> recentBlockRoot = recentChainData.getBlockRootBySlot(slot, chainHead);
+    final Optional<Bytes32> recentBlockRoot =
+        recentChainData.getBlockRootInEffectBySlot(slot, chainHead);
     if (recentBlockRoot.isPresent()) {
       return getStore()
           .retrieveStateAtSlot(new SlotAndBlockRoot(slot, recentBlockRoot.get()))

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
@@ -386,7 +386,7 @@ public abstract class RecentChainData implements StoreUpdateHandler {
     // latest block (when false). If this is a different fork to the previous chain the root at
     // originalChainTipSlot will be different from originalHeadRoot. If it's an extension of the
     // same chain it will match.
-    return getBlockRootBySlot(originalChainTipSlot)
+    return getBlockRootInEffectBySlot(originalChainTipSlot)
         .map(rootAtOldBestSlot -> !rootAtOldBestSlot.equals(originalHeadRoot))
         .orElse(true);
   }
@@ -525,7 +525,7 @@ public abstract class RecentChainData implements StoreUpdateHandler {
   }
 
   public SafeFuture<Optional<BeaconState>> retrieveStateInEffectAtSlot(final UInt64 slot) {
-    Optional<Bytes32> rootAtSlot = getBlockRootBySlot(slot);
+    Optional<Bytes32> rootAtSlot = getBlockRootInEffectBySlot(slot);
     if (rootAtSlot.isEmpty()) {
       return EmptyStoreResults.EMPTY_STATE_FUTURE;
     }
@@ -547,11 +547,12 @@ public abstract class RecentChainData implements StoreUpdateHandler {
     return store.retrieveEarliestBlobSidecarSlot();
   }
 
-  public Optional<Bytes32> getBlockRootBySlot(final UInt64 slot) {
-    return chainHead.flatMap(head -> getBlockRootBySlot(slot, head.getRoot()));
+  public Optional<Bytes32> getBlockRootInEffectBySlot(final UInt64 slot) {
+    return chainHead.flatMap(head -> getBlockRootInEffectBySlot(slot, head.getRoot()));
   }
 
-  public Optional<Bytes32> getBlockRootBySlot(final UInt64 slot, final Bytes32 headBlockRoot) {
+  public Optional<Bytes32> getBlockRootInEffectBySlot(
+      final UInt64 slot, final Bytes32 headBlockRoot) {
     return getForkChoiceStrategy()
         .flatMap(strategy -> spec.getAncestor(strategy, headBlockRoot, slot));
   }

--- a/storage/src/test/java/tech/pegasys/teku/storage/client/RecentChainDataTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/client/RecentChainDataTest.java
@@ -617,7 +617,7 @@ class RecentChainDataTest {
     finalizeBlock(recentChainData, finalizedEpoch, finalizedBlock);
     advanceBestBlock(recentChainData);
 
-    assertThat(recentChainData.getBlockRootBySlot(targetSlot)).isEmpty();
+    assertThat(recentChainData.getBlockRootInEffectBySlot(targetSlot)).isEmpty();
   }
 
   @Test
@@ -635,7 +635,8 @@ class RecentChainDataTest {
     finalizeBlock(recentChainData, finalizedEpoch, finalizedBlock);
     advanceBestBlock(recentChainData);
 
-    assertThat(recentChainData.getBlockRootBySlot(targetSlot)).contains(historicalBlock.getRoot());
+    assertThat(recentChainData.getBlockRootInEffectBySlot(targetSlot))
+        .contains(historicalBlock.getRoot());
   }
 
   @Test
@@ -643,7 +644,7 @@ class RecentChainDataTest {
     initPostGenesis();
     final SignedBlockAndState bestBlock = advanceBestBlock(recentChainData);
 
-    assertThat(recentChainData.getBlockRootBySlot(bestBlock.getSlot()))
+    assertThat(recentChainData.getBlockRootInEffectBySlot(bestBlock.getSlot()))
         .contains(bestBlock.getRoot());
   }
 
@@ -653,7 +654,7 @@ class RecentChainDataTest {
     final SignedBlockAndState targetBlock = advanceBestBlock(recentChainData);
     advanceBestBlock(recentChainData);
 
-    assertThat(recentChainData.getBlockRootBySlot(targetBlock.getSlot()))
+    assertThat(recentChainData.getBlockRootInEffectBySlot(targetBlock.getSlot()))
         .contains(targetBlock.getRoot());
   }
 
@@ -663,7 +664,8 @@ class RecentChainDataTest {
     final SignedBlockAndState bestBlock = advanceBestBlock(recentChainData);
 
     final UInt64 targetSlot = bestBlock.getSlot().plus(ONE);
-    assertThat(recentChainData.getBlockRootBySlot(targetSlot)).contains(bestBlock.getRoot());
+    assertThat(recentChainData.getBlockRootInEffectBySlot(targetSlot))
+        .contains(bestBlock.getRoot());
   }
 
   @Test
@@ -707,14 +709,14 @@ class RecentChainDataTest {
     // Check slots that should be unavailable
     for (int i = 0; i < finalizedBlockSlot.intValue(); i++) {
       final UInt64 targetSlot = UInt64.valueOf(i);
-      assertThat(recentChainData.getBlockRootBySlot(targetSlot)).isEmpty();
+      assertThat(recentChainData.getBlockRootInEffectBySlot(targetSlot)).isEmpty();
     }
     // Check slots that should be available
     for (int i = finalizedBlockSlot.intValue(); i <= bestBlock.getSlot().intValue(); i++) {
       final UInt64 targetSlot = UInt64.valueOf(i);
       final SignedBlockAndState expectedResult =
           chainBuilder.getLatestBlockAndStateAtSlot(targetSlot);
-      final Optional<Bytes32> result = recentChainData.getBlockRootBySlot(targetSlot);
+      final Optional<Bytes32> result = recentChainData.getBlockRootInEffectBySlot(targetSlot);
       assertThat(result)
           .withFailMessage(
               "Expected root at slot %s to be %s (%s) but was %s",
@@ -729,7 +731,8 @@ class RecentChainDataTest {
     final SignedBlockAndState targetBlock = advanceBestBlock(recentChainData);
     final SignedBlockAndState bestBlock = advanceBestBlock(recentChainData);
 
-    assertThat(recentChainData.getBlockRootBySlot(bestBlock.getSlot(), targetBlock.getRoot()))
+    assertThat(
+            recentChainData.getBlockRootInEffectBySlot(bestBlock.getSlot(), targetBlock.getRoot()))
         .contains(targetBlock.getRoot());
   }
 
@@ -739,7 +742,7 @@ class RecentChainDataTest {
     final Bytes32 headRoot = dataStructureUtil.randomBytes32();
     final SignedBlockAndState bestBlock = advanceBestBlock(recentChainData);
 
-    assertThat(recentChainData.getBlockRootBySlot(bestBlock.getSlot(), headRoot)).isEmpty();
+    assertThat(recentChainData.getBlockRootInEffectBySlot(bestBlock.getSlot(), headRoot)).isEmpty();
   }
 
   @Test
@@ -769,7 +772,7 @@ class RecentChainDataTest {
         assertThat(expectedBlock)
             .isNotEqualTo(chainBuilder.getLatestBlockAndStateAtSlot(targetSlot));
       }
-      assertThat(recentChainData.getBlockRootBySlot(targetSlot, headRoot))
+      assertThat(recentChainData.getBlockRootInEffectBySlot(targetSlot, headRoot))
           .contains(expectedBlock.getRoot());
     }
   }

--- a/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategyTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategyTest.java
@@ -506,7 +506,7 @@ public class ForkChoiceStrategyTest extends AbstractBlockMetadataStoreTest {
             .getSlot();
 
     final Bytes32 rootToBeInvalidated =
-        recentChainData.getBlockRootBySlot(justifiedSlot.increment()).orElseThrow();
+        recentChainData.getBlockRootInEffectBySlot(justifiedSlot.increment()).orElseThrow();
 
     protoArray.onExecutionPayloadResult(
         rootToBeInvalidated,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
In all fixed cases we were looking for latest block in effect and later filtering it by slot, so actually looking for exact slot block, but acquiring db iterator while it's not really needed in these cases. Optimizing a bit. Not sure on the proper checks in the beginning, actually both tries to lookup from store, but if the block is finalized it's not needed.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
