### PR TITLE
Avoid allocating a message digest everytime we receive a message

### DIFF
--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/BranchNode.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/BranchNode.java
@@ -16,10 +16,10 @@ package tech.pegasys.teku.infrastructure.ssz.tree;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import java.security.MessageDigest;
 import java.util.function.Function;
 import org.apache.tuweni.bytes.Bytes32;
 import org.jetbrains.annotations.NotNull;
+import tech.pegasys.teku.infrastructure.crypto.Sha256;
 import tech.pegasys.teku.infrastructure.ssz.tree.GIndexUtil.NodeRelation;
 
 /**
@@ -61,12 +61,10 @@ public interface BranchNode extends TreeNode {
   BranchNode rebind(boolean left, TreeNode newNode);
 
   @Override
-  default Bytes32 hashTreeRoot(MessageDigest messageDigest) {
-    final Bytes32 leftRoot = left().hashTreeRoot(messageDigest);
-    final Bytes32 rightRoot = right().hashTreeRoot(messageDigest);
-    leftRoot.update(messageDigest);
-    rightRoot.update(messageDigest);
-    return Bytes32.wrap(messageDigest.digest());
+  default Bytes32 hashTreeRoot(Sha256 sha256) {
+    final Bytes32 leftRoot = left().hashTreeRoot(sha256);
+    final Bytes32 rightRoot = right().hashTreeRoot(sha256);
+    return Bytes32.wrap(sha256.digest(leftRoot, rightRoot));
   }
 
   @NotNull

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/BranchNode.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/BranchNode.java
@@ -61,7 +61,7 @@ public interface BranchNode extends TreeNode {
   BranchNode rebind(boolean left, TreeNode newNode);
 
   @Override
-  default Bytes32 hashTreeRoot(Sha256 sha256) {
+  default Bytes32 hashTreeRoot(final Sha256 sha256) {
     final Bytes32 leftRoot = left().hashTreeRoot(sha256);
     final Bytes32 rightRoot = right().hashTreeRoot(sha256);
     return Bytes32.wrap(sha256.digest(leftRoot, rightRoot));

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/LazyBranchNode.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/LazyBranchNode.java
@@ -102,7 +102,7 @@ public class LazyBranchNode implements BranchNode {
   }
 
   @Override
-  public Bytes32 hashTreeRoot(Sha256 sha256) {
+  public Bytes32 hashTreeRoot(final Sha256 sha256) {
     Bytes32 cachedHash = this.cachedHash;
     if (cachedHash == null) {
       cachedHash = Bytes32.wrap(sha256.digest(leftRoot, rightRoot));
@@ -112,7 +112,7 @@ public class LazyBranchNode implements BranchNode {
   }
 
   @Override
-  public TreeNode updated(TreeUpdates newNodes) {
+  public TreeNode updated(final TreeUpdates newNodes) {
     if (newNodes.isEmpty()) {
       return this;
     } else if (newNodes.isFinal()) {

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/LazyBranchNode.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/LazyBranchNode.java
@@ -14,11 +14,11 @@
 package tech.pegasys.teku.infrastructure.ssz.tree;
 
 import com.google.common.base.Suppliers;
-import java.security.MessageDigest;
 import java.util.function.Supplier;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.crypto.Hash;
+import tech.pegasys.teku.infrastructure.crypto.Sha256;
 
 public class LazyBranchNode implements BranchNode {
   private volatile Bytes32 cachedHash;
@@ -102,12 +102,10 @@ public class LazyBranchNode implements BranchNode {
   }
 
   @Override
-  public Bytes32 hashTreeRoot(MessageDigest messageDigest) {
+  public Bytes32 hashTreeRoot(Sha256 sha256) {
     Bytes32 cachedHash = this.cachedHash;
     if (cachedHash == null) {
-      leftRoot.update(messageDigest);
-      rightRoot.update(messageDigest);
-      cachedHash = Bytes32.wrap(messageDigest.digest());
+      cachedHash = Bytes32.wrap(sha256.digest(leftRoot, rightRoot));
       this.cachedHash = cachedHash;
     }
     return cachedHash;

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/SimpleBranchNode.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/SimpleBranchNode.java
@@ -13,9 +13,9 @@
 
 package tech.pegasys.teku.infrastructure.ssz.tree;
 
-import java.security.MessageDigest;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.crypto.Sha256;
 
 class SimpleBranchNode implements BranchNode, TreeNode {
 
@@ -67,10 +67,10 @@ class SimpleBranchNode implements BranchNode, TreeNode {
   }
 
   @Override
-  public Bytes32 hashTreeRoot(MessageDigest messageDigest) {
+  public Bytes32 hashTreeRoot(Sha256 sha256) {
     Bytes32 cachedHash = this.cachedHash;
     if (cachedHash == null) {
-      cachedHash = BranchNode.super.hashTreeRoot(messageDigest);
+      cachedHash = BranchNode.super.hashTreeRoot(sha256);
       this.cachedHash = cachedHash;
     }
     return cachedHash;

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/SimpleBranchNode.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/SimpleBranchNode.java
@@ -44,7 +44,7 @@ class SimpleBranchNode implements BranchNode, TreeNode {
   }
 
   @Override
-  public TreeNode updated(TreeUpdates newNodes) {
+  public TreeNode updated(final TreeUpdates newNodes) {
     if (newNodes.isEmpty()) {
       return this;
     } else if (newNodes.isFinal()) {
@@ -67,7 +67,7 @@ class SimpleBranchNode implements BranchNode, TreeNode {
   }
 
   @Override
-  public Bytes32 hashTreeRoot(Sha256 sha256) {
+  public Bytes32 hashTreeRoot(final Sha256 sha256) {
     Bytes32 cachedHash = this.cachedHash;
     if (cachedHash == null) {
       cachedHash = BranchNode.super.hashTreeRoot(sha256);

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/SimpleLeafNode.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/SimpleLeafNode.java
@@ -15,11 +15,11 @@ package tech.pegasys.teku.infrastructure.ssz.tree;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import java.security.MessageDigest;
 import java.util.Arrays;
 import java.util.Objects;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.crypto.Sha256;
 
 class SimpleLeafNode implements LeafNode, TreeNode {
 
@@ -58,7 +58,7 @@ class SimpleLeafNode implements LeafNode, TreeNode {
   }
 
   @Override
-  public Bytes32 hashTreeRoot(MessageDigest messageDigest) {
+  public Bytes32 hashTreeRoot(Sha256 sha256) {
     Bytes32 cachedHash = this.cachedHash;
     if (cachedHash != null) {
       return cachedHash;

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/SimpleLeafNode.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/SimpleLeafNode.java
@@ -58,7 +58,7 @@ class SimpleLeafNode implements LeafNode, TreeNode {
   }
 
   @Override
-  public Bytes32 hashTreeRoot(Sha256 sha256) {
+  public Bytes32 hashTreeRoot(final Sha256 sha256) {
     Bytes32 cachedHash = this.cachedHash;
     if (cachedHash != null) {
       return cachedHash;
@@ -67,7 +67,7 @@ class SimpleLeafNode implements LeafNode, TreeNode {
   }
 
   @Override
-  public TreeNode updated(TreeUpdates newNodes) {
+  public TreeNode updated(final TreeUpdates newNodes) {
     if (newNodes.isEmpty()) {
       return this;
     } else {

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/SszNodeTemplate.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/SszNodeTemplate.java
@@ -157,8 +157,7 @@ public class SszNodeTemplate {
     checkArgument(off == leafPos.getLength());
   }
 
-  public Bytes32 calculateHashTreeRoot(
-      final Bytes ssz, final int offset, final Sha256 messageDigest) {
+  public Bytes32 calculateHashTreeRoot(final Bytes ssz, final int offset, final Sha256 sha256) {
     return binaryTraverse(
         SELF_G_INDEX,
         defaultTree,
@@ -172,7 +171,7 @@ public class SszNodeTemplate {
           @Override
           public Bytes32 visitBranch(
               long gIndex, TreeNode node, Bytes32 leftVisitResult, Bytes32 rightVisitResult) {
-            return Bytes32.wrap(messageDigest.digest(leftVisitResult, rightVisitResult));
+            return Bytes32.wrap(sha256.digest(leftVisitResult, rightVisitResult));
           }
         });
   }

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/SszNodeTemplate.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/SszNodeTemplate.java
@@ -23,7 +23,6 @@ import static tech.pegasys.teku.infrastructure.ssz.tree.GIndexUtil.gIdxRightGInd
 
 import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
 import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
-import java.security.MessageDigest;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -31,6 +30,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.bytes.MutableBytes;
+import tech.pegasys.teku.infrastructure.crypto.Sha256;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszSchema;
 
 /**
@@ -158,7 +158,7 @@ public class SszNodeTemplate {
   }
 
   public Bytes32 calculateHashTreeRoot(
-      final Bytes ssz, final int offset, final MessageDigest messageDigest) {
+      final Bytes ssz, final int offset, final Sha256 messageDigest) {
     return binaryTraverse(
         SELF_G_INDEX,
         defaultTree,
@@ -172,9 +172,7 @@ public class SszNodeTemplate {
           @Override
           public Bytes32 visitBranch(
               long gIndex, TreeNode node, Bytes32 leftVisitResult, Bytes32 rightVisitResult) {
-            leftVisitResult.update(messageDigest);
-            rightVisitResult.update(messageDigest);
-            return Bytes32.wrap(messageDigest.digest());
+            return Bytes32.wrap(messageDigest.digest(leftVisitResult, rightVisitResult));
           }
         });
   }

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/SszSuperNode.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/SszSuperNode.java
@@ -78,7 +78,7 @@ public class SszSuperNode implements TreeNode, LeafDataNode {
   }
 
   @Override
-  public Bytes32 hashTreeRoot(Sha256 sha256) {
+  public Bytes32 hashTreeRoot(final Sha256 sha256) {
     Bytes32 cachedHash = this.cachedHash;
     if (cachedHash == null) {
       cachedHash = calcHashTreeRoot(sha256);
@@ -144,7 +144,7 @@ public class SszSuperNode implements TreeNode, LeafDataNode {
   }
 
   @Override
-  public TreeNode updated(TreeUpdates newNodes) {
+  public TreeNode updated(final TreeUpdates newNodes) {
     if (newNodes.isEmpty()) {
       return this;
     }

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/SszSuperNode.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/SszSuperNode.java
@@ -15,14 +15,14 @@ package tech.pegasys.teku.infrastructure.ssz.tree;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import java.security.MessageDigest;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.bytes.MutableBytes;
 import org.jetbrains.annotations.NotNull;
-import tech.pegasys.teku.infrastructure.crypto.MessageDigestFactory;
+import tech.pegasys.teku.infrastructure.crypto.Hash;
+import tech.pegasys.teku.infrastructure.crypto.Sha256;
 import tech.pegasys.teku.infrastructure.ssz.tree.GIndexUtil.NodeRelation;
 import tech.pegasys.teku.infrastructure.ssz.tree.SszNodeTemplate.Location;
 
@@ -70,46 +70,43 @@ public class SszSuperNode implements TreeNode, LeafDataNode {
   public Bytes32 hashTreeRoot() {
     Bytes32 cachedHash = this.cachedHash;
     if (cachedHash == null) {
-      final MessageDigest messageDigest = MessageDigestFactory.createSha256();
-      cachedHash = calcHashTreeRoot(messageDigest);
+      final Sha256 sha256 = Hash.getSha256Instance();
+      cachedHash = calcHashTreeRoot(sha256);
       this.cachedHash = cachedHash;
     }
     return cachedHash;
   }
 
   @Override
-  public Bytes32 hashTreeRoot(MessageDigest messageDigest) {
+  public Bytes32 hashTreeRoot(Sha256 sha256) {
     Bytes32 cachedHash = this.cachedHash;
     if (cachedHash == null) {
-      cachedHash = calcHashTreeRoot(messageDigest);
+      cachedHash = calcHashTreeRoot(sha256);
       this.cachedHash = cachedHash;
     }
     return cachedHash;
   }
 
-  private Bytes32 calcHashTreeRoot(final MessageDigest messageDigest) {
-    return hashTreeRoot(0, 0, messageDigest);
+  private Bytes32 calcHashTreeRoot(final Sha256 sha256) {
+    return hashTreeRoot(0, 0, sha256);
   }
 
-  private Bytes32 hashTreeRoot(
-      final int curDepth, final int offset, final MessageDigest messageDigest) {
+  private Bytes32 hashTreeRoot(final int curDepth, final int offset, final Sha256 sha256) {
     if (curDepth == depth) {
       if (offset < ssz.size()) {
-        return elementTemplate.calculateHashTreeRoot(ssz, offset, messageDigest);
+        return elementTemplate.calculateHashTreeRoot(ssz, offset, sha256);
       } else {
         assert offset <= elementTemplate.getSszLength() * (getMaxElements() - 1);
         return DEFAULT_NODE.hashTreeRoot();
       }
     } else {
-      final Bytes32 leftRoot = hashTreeRoot(curDepth + 1, offset, messageDigest);
+      final Bytes32 leftRoot = hashTreeRoot(curDepth + 1, offset, sha256);
       final Bytes32 rightRoot =
           hashTreeRoot(
               curDepth + 1,
               offset + elementTemplate.getSszLength() * (1 << ((depth - curDepth) - 1)),
-              messageDigest);
-      leftRoot.update(messageDigest);
-      rightRoot.update(messageDigest);
-      return Bytes32.wrap(messageDigest.digest());
+              sha256);
+      return Bytes32.wrap(sha256.digest(leftRoot, rightRoot));
     }
   }
 

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/TreeNode.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/TreeNode.java
@@ -136,7 +136,7 @@ public interface TreeNode {
    * @see #updated(long, TreeNode)
    * @see #updated(long, Function)
    */
-  default TreeNode updated(TreeUpdates newNodes) {
+  default TreeNode updated(final TreeUpdates newNodes) {
     TreeNode ret = this;
     for (int i = 0; i < newNodes.size(); i++) {
       ret = ret.updated(newNodes.getRelativeGIndex(i), newNodes.getNode(i));

--- a/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/TreeNode.java
+++ b/infrastructure/ssz/src/main/java/tech/pegasys/teku/infrastructure/ssz/tree/TreeNode.java
@@ -15,12 +15,12 @@ package tech.pegasys.teku.infrastructure.ssz.tree;
 
 import static java.util.Collections.singletonList;
 
-import java.security.MessageDigest;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import org.apache.tuweni.bytes.Bytes32;
 import org.jetbrains.annotations.NotNull;
-import tech.pegasys.teku.infrastructure.crypto.MessageDigestFactory;
+import tech.pegasys.teku.infrastructure.crypto.Hash;
+import tech.pegasys.teku.infrastructure.crypto.Sha256;
 
 /**
  * Basic interface for Backing Tree node Backing Binary Tree concept for SSZ structures is described
@@ -36,11 +36,11 @@ public interface TreeNode {
    * `hash_tree_root` of a {@link LeafNode} is the node {@link Bytes32} content
    */
   default Bytes32 hashTreeRoot() {
-    final MessageDigest digest = MessageDigestFactory.createSha256();
-    return hashTreeRoot(digest);
+    final Sha256 sha256 = Hash.getSha256Instance();
+    return hashTreeRoot(sha256);
   }
 
-  Bytes32 hashTreeRoot(MessageDigest messageDigest);
+  Bytes32 hashTreeRoot(Sha256 sha256);
 
   /**
    * Gets this node descendant by its 'generalized index'


### PR DESCRIPTION
This PR removes the allocation of the messageDigest when we start the ssz hashing, by reusing the allocated one in the thread local.

An evident benefit is less memory allocation when we receive attestations, that needs to be hashed to check if it is already in the `PendingPool`.


This is a 6 min run on mainnet:
<img width="1714" alt="image" src="https://github.com/Consensys/teku/assets/15999009/03d4966d-fb42-448b-aac7-4a79e84ed558">

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
