### PR TITLE
Update db op alert log to make it visible

### DIFF
--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/DbLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/DbLogger.java
@@ -28,12 +28,13 @@ public class DbLogger {
   @SuppressWarnings("PrivateStaticFinalLoggers")
   private final Logger logger;
 
-  public DbLogger(String name) {
+  public DbLogger(final String name) {
     this.logger = LogManager.getLogger(name);
   }
 
-  public void onDbOpAlertThreshold(String opName, long startTimeMillis, long endTimeMillis) {
-    long duration = endTimeMillis - startTimeMillis;
+  public void onDbOpAlertThreshold(
+      final String opName, final long startTimeMillis, final long endTimeMillis) {
+    final long duration = endTimeMillis - startTimeMillis;
     if (dbOpAlertThresholdMillis > 0 && duration >= dbOpAlertThresholdMillis) {
       logger.warn(
           print(

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/DbLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/DbLogger.java
@@ -32,13 +32,13 @@ public class DbLogger {
     this.logger = LogManager.getLogger(name);
   }
 
-  public void onDbOpAlertThreshold(String opName, long startTimeNanos, long endTimeNanos) {
-    long duration = endTimeNanos - startTimeNanos;
+  public void onDbOpAlertThreshold(String opName, long startTimeMillis, long endTimeMillis) {
+    long duration = endTimeMillis - startTimeMillis;
     if (dbOpAlertThresholdMillis > 0 && duration >= dbOpAlertThresholdMillis) {
       logger.warn(
           print(
               String.format(
-                  "DB operation %s took too long: %d milliseconds. The alert threshold is set to: %d milliseconds",
+                  "DB operation %s took too long: %d ms. The alert threshold is set to: %d ms",
                   opName, duration, dbOpAlertThresholdMillis),
               Color.YELLOW));
     }

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/DbLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/DbLogger.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.infrastructure.logging;
 
 import static tech.pegasys.teku.infrastructure.logging.ColorConsolePrinter.print;
 
-import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.infrastructure.logging.ColorConsolePrinter.Color;
@@ -34,12 +33,12 @@ public class DbLogger {
   }
 
   public void onDbOpAlertThreshold(String opName, long startTimeNanos, long endTimeNanos) {
-    long duration = TimeUnit.NANOSECONDS.toMillis(endTimeNanos - startTimeNanos);
+    long duration = endTimeNanos - startTimeNanos;
     if (dbOpAlertThresholdMillis > 0 && duration >= dbOpAlertThresholdMillis) {
       logger.warn(
           print(
               String.format(
-                  "DB operation: \"%s\" took too long: %d milliseconds. The alert threshold is set to: %d milliseconds",
+                  "DB operation %s took too long: %d milliseconds. The alert threshold is set to: %d milliseconds",
                   opName, duration, dbOpAlertThresholdMillis),
               Color.YELLOW));
     }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
@@ -979,7 +979,7 @@ public class KvStoreDatabase implements Database {
     }
 
     LOG.trace("Applying hot updates");
-    long startTime = System.nanoTime();
+    long startTime = System.currentTimeMillis();
     try (final HotUpdater updater = hotUpdater()) {
       // Store new hot data
       update.getGenesisTime().ifPresent(updater::setGenesisTime);
@@ -1011,8 +1011,8 @@ public class KvStoreDatabase implements Database {
       updater.commit();
     }
 
-    long endTime = System.nanoTime();
-    DB_LOGGER.onDbOpAlertThreshold("Block Import", startTime, endTime);
+    long endTime = System.currentTimeMillis();
+    DB_LOGGER.onDbOpAlertThreshold("KvStoreDatabase::doUpdate", startTime, endTime);
     LOG.trace("Update complete");
     return new UpdateResult(finalizedOptimisticExecutionPayload);
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/leveldb/LevelDbTransaction.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/leveldb/LevelDbTransaction.java
@@ -93,10 +93,10 @@ public class LevelDbTransaction implements KvStoreTransaction {
     applyUpdate(
         () -> {
           try {
-            long startTime = System.nanoTime();
+            long startTime = System.currentTimeMillis();
             db.write(writeBatch);
-            long endTime = System.nanoTime();
-            DB_LOGGER.onDbOpAlertThreshold("Transaction Commit", startTime, endTime);
+            long endTime = System.currentTimeMillis();
+            DB_LOGGER.onDbOpAlertThreshold("LevelDbTransaction::commit", startTime, endTime);
           } finally {
             close();
           }


### PR DESCRIPTION
this should fix db alert log visibility in grafana\loki (bonus: calculate in millis instead of nano)

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
