### PR TITLE
Improved voluntary-exit command to allow network to be set

### DIFF
--- a/teku/src/integration-test/java/tech/pegasys/teku/cli/subcommand/VoluntaryExitCommandTest.java
+++ b/teku/src/integration-test/java/tech/pegasys/teku/cli/subcommand/VoluntaryExitCommandTest.java
@@ -156,12 +156,40 @@ public class VoluntaryExitCommandTest {
             false,
             List.of("--validator-public-keys", keyManagerPubKey2 + "," + nonExistingKey));
 
-    int parseResult = beaconNodeCommand.parse(args.toArray(new String[0]));
+    final int parseResult = beaconNodeCommand.parse(args.toArray(new String[0]));
 
     assertThat(parseResult).isEqualTo(0);
     assertValidatorsExited(keyManagerPubKey2);
     assertValidatorsNotExited(
         keyManagerPubKey1, validatorPubKey1, validatorPubKey2, nonExistingKey);
+  }
+
+  @Test
+  public void shouldAcceptNetworkOnCommandLine() {
+    // No beacon-api offered by spec, so would need to be loaded from local network option
+    final List<String> args =
+        getCommandArguments(
+            true,
+            false,
+            List.of("--network", "minimal", "--validator-public-keys", validatorPubKey1));
+
+    final int parseResult = beaconNodeCommand.parse(args.toArray(new String[0]));
+
+    assertThat(parseResult).isEqualTo(0);
+    assertThat(stdOut.toString(UTF_8)).contains("Loading local settings for minimal network");
+    assertValidatorsExited(validatorPubKey1);
+  }
+
+  @Test
+  public void shouldFailToRunExitWithoutASpec() {
+    // Network unset, no http service to fetch from
+    final List<String> args =
+        getCommandArguments(true, false, List.of("--validator-public-keys", validatorPubKey1));
+
+    final int parseResult = beaconNodeCommand.parse(args.toArray(new String[0]));
+    assertThat(parseResult).isEqualTo(1);
+
+    assertThat(stdOut.toString(UTF_8)).contains("Loading network settings from");
   }
 
   @Test

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/VoluntaryExitCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/VoluntaryExitCommand.java
@@ -55,6 +55,7 @@ import tech.pegasys.teku.infrastructure.logging.ValidatorLogger;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.service.serviceutils.layout.DataDirLayout;
 import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecFactory;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.operations.VoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.state.Fork;
@@ -122,6 +123,13 @@ public class VoluntaryExitCommand implements Callable<Integer> {
 
   @CommandLine.Mixin(name = "Data")
   private ValidatorClientDataOptions dataOptions;
+
+  @CommandLine.Option(
+      names = {"-n", "--network"},
+      paramLabel = "<NETWORK>",
+      description = "Represents which network to use.",
+      arity = "1")
+  private String network;
 
   @CommandLine.Option(
       names = {"--validator-public-keys"},
@@ -282,7 +290,13 @@ public class VoluntaryExitCommand implements Callable<Integer> {
             .map(RemoteSpecLoader::createApiClient)
             .orElseThrow();
 
-    spec = getSpec(apiClient);
+    if (network == null) {
+      SUB_COMMAND_LOG.display(" - Loading network settings from " + apiClient.getBaseEndpoint());
+      spec = getSpec(apiClient);
+    } else {
+      SUB_COMMAND_LOG.display(" - Loading local settings for " + network + " network");
+      spec = SpecFactory.create(network);
+    }
 
     validateOrDefaultEpoch();
     fork = spec.getForkSchedule().getFork(epoch);


### PR DESCRIPTION
Added test cases to demonstrate loading network parameter from local.

Addresses the network parameter issue in issue, but the spec defaults will be addressed in a separate issue.

fixes #7489

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
