### PR TITLE
Raised error if a rest api fails to start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,4 @@ For information on changes in released versions of Teku, see the [releases page]
 - Add `/teku/v1/beacon/blob_sidecars/{slot}` Teku API which returns all blob sidecars (canonical and non-canonical) at a specific slot
 
 ### Bug Fixes
+- When the rest-api's fail to start up they can now potentially 'fail fast' rather than silently ignoring the issue.

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/RestApi.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/RestApi.java
@@ -65,6 +65,18 @@ public class RestApi extends Service {
                 "TCP Port %d is already in use. "
                     + "You may need to stop another process or change the HTTP port for this process.",
                 app.port()));
+      } else if (e instanceof IllegalStateException
+          || Throwables.getRootCause(e) instanceof IllegalStateException) {
+        // IllegalStateException is a sign that something needed has failed to be initialised.
+        // throwing it here will terminate the process effectively.
+        LOG.error("Failed to start Rest API", e);
+        throw e;
+      } else if (app.jettyServer() == null || !app.jettyServer().started) {
+        // failing to create the jetty server or start the jetty server is fatal.
+        throw new IllegalStateException("Rest API failed to start", e);
+      } else {
+        // there may be non fatal exceptions, lets at least see an error.
+        LOG.error("Error encountered starting rest api", e);
       }
     }
     return SafeFuture.COMPLETE;

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/RestApi.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/RestApi.java
@@ -76,7 +76,7 @@ public class RestApi extends Service {
         throw new IllegalStateException("Rest API failed to start", e);
       } else {
         // there may be non fatal exceptions, lets at least see an error.
-        LOG.error("Error encountered starting rest api", e);
+        LOG.error("Error encountered starting Rest API", e);
       }
     }
     return SafeFuture.COMPLETE;

--- a/infrastructure/restapi/src/test/java/tech/pegasys/teku/infrastructure/restapi/RestApiTest.java
+++ b/infrastructure/restapi/src/test/java/tech/pegasys/teku/infrastructure/restapi/RestApiTest.java
@@ -19,9 +19,16 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.javalin.Javalin;
+import java.io.IOException;
 import java.net.BindException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
 import tech.pegasys.teku.infrastructure.exceptions.InvalidConfigurationException;
 
 class RestApiTest {
@@ -33,6 +40,22 @@ class RestApiTest {
   void start_shouldThrowInvalidConfigurationExceptionWhenPortInUse() {
     when(app.start()).thenThrow(new RuntimeException("Oh no", new BindException("Port in use")));
     assertThatThrownBy(restApi::start).isInstanceOf(InvalidConfigurationException.class);
+    assertThat(restApi.getRestApiDocs()).isEmpty();
+  }
+
+  @Test
+  @DisabledOnOs(OS.WINDOWS)
+  void start_shouldThrowInvalidConfigurationExceptionWhenPortInUse(@TempDir final Path tempDir)
+      throws IOException {
+
+    final Path managerDir = tempDir.resolve("manager");
+    Files.createDirectory(
+        managerDir,
+        PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("--x--x---")));
+
+    final RestApi restApi =
+        new RestApi(app, Optional.empty(), Optional.of(managerDir.resolve("pass")));
+    assertThatThrownBy(restApi::start).isInstanceOf(IllegalStateException.class);
     assertThat(restApi.getRestApiDocs()).isEmpty();
   }
 }

--- a/infrastructure/restapi/src/test/java/tech/pegasys/teku/infrastructure/restapi/RestApiTest.java
+++ b/infrastructure/restapi/src/test/java/tech/pegasys/teku/infrastructure/restapi/RestApiTest.java
@@ -45,8 +45,7 @@ class RestApiTest {
 
   @Test
   @DisabledOnOs(OS.WINDOWS)
-  void start_shouldFailFastWhenTokenNotWritable(@TempDir final Path tempDir)
-      throws IOException {
+  void start_shouldFailFastWhenTokenNotWritable(@TempDir final Path tempDir) throws IOException {
 
     final Path managerDir = tempDir.resolve("manager");
     Files.createDirectory(

--- a/infrastructure/restapi/src/test/java/tech/pegasys/teku/infrastructure/restapi/RestApiTest.java
+++ b/infrastructure/restapi/src/test/java/tech/pegasys/teku/infrastructure/restapi/RestApiTest.java
@@ -45,7 +45,7 @@ class RestApiTest {
 
   @Test
   @DisabledOnOs(OS.WINDOWS)
-  void start_shouldThrowInvalidConfigurationExceptionWhenPortInUse(@TempDir final Path tempDir)
+  void start_shouldFailFastWhenTokenNotWritable(@TempDir final Path tempDir)
       throws IOException {
 
     final Path managerDir = tempDir.resolve("manager");


### PR DESCRIPTION
This will allow us to fail fast rather than potentially silently swallow errors.

at least partially addresses #7502 which saw no 'listening on' for validator api.

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
