### PR TITLE
Use bouncycastle jdk18on instead of jdk15on

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -102,7 +102,7 @@ dependencyManagement {
 
     dependency 'org.awaitility:awaitility:4.2.0'
 
-    dependency 'org.bouncycastle:bcprov-jdk15on:1.70'
+    dependency 'org.bouncycastle:bcprov-jdk18on:1.76'
 
     dependencySet(group: 'org.junit.jupiter', version: '5.10.0') {
       entry 'junit-jupiter-api'

--- a/infrastructure/bls-keystore/build.gradle
+++ b/infrastructure/bls-keystore/build.gradle
@@ -15,7 +15,7 @@ apply plugin: 'java-library'
 
 dependencies {
   implementation 'com.fasterxml.jackson.core:jackson-databind'
-  implementation 'org.bouncycastle:bcprov-jdk15on'
+  implementation 'org.bouncycastle:bcprov-jdk18on'
   implementation 'com.google.guava:guava'
   implementation 'org.apache.logging.log4j:log4j-api'
   implementation 'org.apache.tuweni:tuweni-bytes'

--- a/infrastructure/bls/build.gradle
+++ b/infrastructure/bls/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-  api 'org.bouncycastle:bcprov-jdk15on'
+  api 'org.bouncycastle:bcprov-jdk18on'
 
   implementation 'org.apache.tuweni:tuweni-bytes'
   implementation 'org.apache.tuweni:tuweni-ssz'

--- a/infrastructure/crypto/build.gradle
+++ b/infrastructure/crypto/build.gradle
@@ -1,8 +1,8 @@
 dependencies {
-  api 'org.bouncycastle:bcprov-jdk15on'
+  api 'org.bouncycastle:bcprov-jdk18on'
   api 'org.apache.tuweni:tuweni-bytes'
 
 
-  jmhImplementation 'org.bouncycastle:bcprov-jdk15on'
+  jmhImplementation 'org.bouncycastle:bcprov-jdk18on'
   jmhImplementation project(':infrastructure:crypto')
 }

--- a/validator/client/build.gradle
+++ b/validator/client/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-  api 'org.bouncycastle:bcprov-jdk15on'
+  api 'org.bouncycastle:bcprov-jdk18on'
   implementation project(':infrastructure:bls')
   implementation project(':infrastructure:crypto')
   implementation project(':infrastructure:exceptions')

--- a/validator/eventadapter/build.gradle
+++ b/validator/eventadapter/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-  api 'org.bouncycastle:bcprov-jdk15on'
+  api 'org.bouncycastle:bcprov-jdk18on'
   implementation project(':ethereum:spec')
   implementation project(':ethereum:statetransition')
   implementation project(':infrastructure:async')


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
It looks like recommendation is to use `jdk18on` 
https://www.bouncycastle.org/latest_releases.html 
https://github.com/bcgit/bc-java/issues/1289

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
