### PR TITLE
Added a feature to remove keys on reload

### DIFF
--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
@@ -168,6 +168,10 @@ public class StatusLogger {
     log.info("Loading {} validator keys...", validatorCount);
   }
 
+  public void removingValidators(final int removedValidatorCount) {
+    log.info("Removing {} validator keys no longer in config...", removedValidatorCount);
+  }
+
   public void atLoadedValidatorNumber(
       final int loadedValidatorCount, final int totalValidatorCount) {
     log.info("Loaded validator key {} of {}.", loadedValidatorCount, totalValidatorCount);

--- a/interop-keys/remove_keys.sh
+++ b/interop-keys/remove_keys.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ # Copyright 2021 Copyright Consensys Software Inc., 2022
+ #
+ # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ # the License. You may obtain a copy of the License at
+ #
+ # http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ # specific language governing permissions and limitations under the License.
+
+for COMMAND in "jq" "curl" "echo" "cat"
+do
+  command -v $COMMAND 2>/dev/null || { echo >&2 "I require $COMMAND but it's not installed.  Aborting."; exit 1; }
+done
+
+TEMP=`mktemp -d`
+
+function cleanup() {
+    rm -rf "${TEMP}"
+}
+trap cleanup EXIT
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+SIGNER_URL=${1:-http://localhost:19000}
+if [ ! -z "${2:-}" ]
+then
+  AUTHORIZATION_HEADER="-HAuthorization: Bearer $2"
+  echo $AUTHORIZATION_HEADER
+fi
+echo "Signer url: $SIGNER_URL"
+echo "Initialising payload.json..."
+echo "{ \"keystores\": [" > "${TEMP}/payload.json"
+
+echo "  - > writing keystores..."
+
+for FILE in `ls ${DIR}/keys/*.json`
+do
+  if [ ! -z "${D:-}" ]
+  then
+    echo "," >> "${TEMP}/payload.json"
+  else
+    D=1
+  fi
+  cat $FILE|jq -c |jq -Rs . >> "${TEMP}/payload.json"
+done
+
+echo "],
+\"passwords\": [" >> "${TEMP}/payload.json"
+echo "  - > writing passwords..."
+
+for FILE in `ls ${DIR}/passwords/*.txt`
+do
+  if [ ! -z "${P:-}" ]
+  then
+    echo "," >> "${TEMP}/payload.json"
+  else
+    P=1
+  fi
+  cat $FILE|jq -Rs .>> "${TEMP}/payload.json"
+done
+
+echo "]
+}" >> "${TEMP}/payload.json"
+
+echo "Sending payload.json to ${SIGNER_URL}/eth/v1/keystores..."
+
+curl --fail -q -X POST ${SIGNER_URL}/eth/v1/keystores \
+     "${AUTHORIZATION_HEADER:-}" \
+     -H "Content-Type: application/json" \
+     -d "@${TEMP}/payload.json" \
+     -o "${TEMP}/result.json"
+
+ echo "Wrote result to ${TEMP}/result.json."

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorKeysOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorKeysOptions.java
@@ -104,6 +104,17 @@ public class ValidatorKeysOptions {
   private int validatorExternalSignerConcurrentRequestLimit =
       ValidatorConfig.DEFAULT_VALIDATOR_EXTERNAL_SIGNER_CONCURRENT_REQUEST_LIMIT;
 
+  @CommandLine.Option(
+      names = {"--Xvalidators-remove-on-reload-enabled"},
+      paramLabel = "<BOOLEAN>",
+      description = "Remove validators on reload (HUP) if they are no longer present.",
+      hidden = true,
+      showDefaultValue = CommandLine.Help.Visibility.ALWAYS,
+      fallbackValue = "true",
+      arity = "0..1")
+  private boolean removeValidatorsOnReloadEnabled =
+      ValidatorConfig.DEFAULT_IS_REMOVE_VALIDATORS_ON_RELOAD;
+
   public void configure(TekuConfiguration.Builder builder) {
     builder.validator(
         config ->
@@ -118,6 +129,7 @@ public class ValidatorKeysOptions {
                 .validatorExternalSignerKeystorePasswordFile(
                     convertToPath(validatorExternalSignerKeystorePasswordFile))
                 .validatorExternalSignerTruststore(convertToPath(validatorExternalSignerTruststore))
+                .removeValidatorsOnReloadEnabled(removeValidatorsOnReloadEnabled)
                 .validatorExternalSignerTruststorePasswordFile(
                     convertToPath(validatorExternalSignerTruststorePasswordFile)));
   }

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
@@ -58,6 +58,8 @@ public class ValidatorConfig {
   public static final int DEFAULT_VALIDATOR_REGISTRATION_SENDING_BATCH_SIZE = 100;
   public static final UInt64 DEFAULT_BUILDER_REGISTRATION_GAS_LIMIT = UInt64.valueOf(30_000_000);
 
+  public static final boolean DEFAULT_IS_REMOVE_VALIDATORS_ON_RELOAD = false;
+
   public static final int DEFAULT_EXECUTOR_THREADS = 5;
 
   private final List<String> validatorKeys;
@@ -92,6 +94,7 @@ public class ValidatorConfig {
   private final Optional<String> sentryNodeConfigurationFile;
 
   private final int executorThreads;
+  private final boolean removeValidatorsOnReloadEnabled;
 
   private ValidatorConfig(
       final List<String> validatorKeys,
@@ -124,7 +127,8 @@ public class ValidatorConfig {
       final Optional<BLSPublicKey> builderRegistrationPublicKeyOverride,
       final int executorMaxQueueSize,
       final int executorThreads,
-      final Optional<String> sentryNodeConfigurationFile) {
+      final Optional<String> sentryNodeConfigurationFile,
+      final boolean removeValidatorsOnReloadEnabled) {
     this.validatorKeys = validatorKeys;
     this.validatorExternalSignerPublicKeySources = validatorExternalSignerPublicKeySources;
     this.validatorExternalSignerUrl = validatorExternalSignerUrl;
@@ -159,6 +163,7 @@ public class ValidatorConfig {
     this.executorMaxQueueSize = executorMaxQueueSize;
     this.executorThreads = executorThreads;
     this.sentryNodeConfigurationFile = sentryNodeConfigurationFile;
+    this.removeValidatorsOnReloadEnabled = removeValidatorsOnReloadEnabled;
   }
 
   public static Builder builder() {
@@ -191,6 +196,10 @@ public class ValidatorConfig {
 
   public int getValidatorExternalSignerConcurrentRequestLimit() {
     return validatorExternalSignerConcurrentRequestLimit;
+  }
+
+  public boolean isRemoveValidatorsOnReloadEnabled() {
+    return removeValidatorsOnReloadEnabled;
   }
 
   public Pair<Path, Path> getValidatorExternalSignerKeystorePasswordFilePair() {
@@ -340,6 +349,8 @@ public class ValidatorConfig {
 
     private int executorThreads = DEFAULT_EXECUTOR_THREADS;
 
+    private boolean removeValidatorsOnReloadEnabled = DEFAULT_IS_REMOVE_VALIDATORS_ON_RELOAD;
+
     private Builder() {}
 
     public Builder validatorKeys(List<String> validatorKeys) {
@@ -398,6 +409,11 @@ public class ValidatorConfig {
         final Path validatorExternalSignerKeystorePasswordFile) {
       this.validatorExternalSignerKeystorePasswordFile =
           validatorExternalSignerKeystorePasswordFile;
+      return this;
+    }
+
+    public Builder removeValidatorsOnReloadEnabled(final boolean removeValidatorsOnReloadEnabled) {
+      this.removeValidatorsOnReloadEnabled = removeValidatorsOnReloadEnabled;
       return this;
     }
 
@@ -582,7 +598,8 @@ public class ValidatorConfig {
           builderRegistrationPublicKeyOverride,
           executorMaxQueueSize,
           executorThreads,
-          sentryNodeConfigurationFile);
+          sentryNodeConfigurationFile,
+          removeValidatorsOnReloadEnabled);
     }
 
     private void validateExternalSignerUrlAndPublicKeys() {

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/ValidatorLoaderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/ValidatorLoaderTest.java
@@ -403,7 +403,8 @@ class ValidatorLoaderTest {
             Optional.of(validatorSource),
             null,
             Optional.of(dataDirLayout),
-            slashingProtectionLogger);
+            slashingProtectionLogger,
+            true);
 
     when(validatorSource.deleteValidator(publicKey)).thenReturn(DeleteKeyResult.success());
     loader.deleteLocalMutableValidator(publicKey);
@@ -558,7 +559,7 @@ class ValidatorLoaderTest {
   }
 
   @Test
-  void shouldNotRemoveExternalValidatorsOnReload() {
+  void shouldRemoveExternalValidatorsOnReload() {
     final PublicKeyLoader publicKeyLoader = mock(PublicKeyLoader.class);
     final List<BLSPublicKey> initialKeys = List.of(PUBLIC_KEY1);
     final String publicKeysUrl = "http://example.com";
@@ -569,6 +570,7 @@ class ValidatorLoaderTest {
             .validatorExternalSignerUrl(SIGNER_URL)
             .validatorExternalSignerPublicKeySources(Collections.singletonList(publicKeysUrl))
             .validatorExternalSignerSlashingProtectionEnabled(true)
+            .removeValidatorsOnReloadEnabled(true)
             .build();
     final ValidatorLoader validatorLoader =
         ValidatorLoader.create(
@@ -591,7 +593,7 @@ class ValidatorLoaderTest {
     when(publicKeyLoader.getPublicKeys(List.of(publicKeysUrl))).thenReturn(reconfiguredKeys);
 
     validatorLoader.loadValidators();
-    assertThat(validators.getPublicKeys()).containsExactlyInAnyOrder(PUBLIC_KEY1, PUBLIC_KEY2);
+    assertThat(validators.getPublicKeys()).containsExactlyInAnyOrder(PUBLIC_KEY2);
   }
 
   @Test


### PR DESCRIPTION
Behind a feature toggle. Removes keys in the same way that the keymanager does, to ensure that the signer can't be referenced once the key has been removed.

Previously the HUP signal was purely additive, so you couldn't actually remove keys without a restart.

Made a script that allows removal of keys, so that i can add, reload, remove, reload with that interop folder.

Offers a solution to #7503

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
