### PR TITLE
Use `safeJoin` in all UT

### DIFF
--- a/beacon/pow/src/main/java/tech/pegasys/teku/beacon/pow/DepositFetcher.java
+++ b/beacon/pow/src/main/java/tech/pegasys/teku/beacon/pow/DepositFetcher.java
@@ -21,6 +21,7 @@ import static tech.pegasys.teku.infrastructure.logging.StatusLogger.STATUS_LOG;
 
 import com.google.common.base.Throwables;
 import java.math.BigInteger;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -28,6 +29,7 @@ import java.util.NavigableMap;
 import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
@@ -207,7 +209,7 @@ public class DepositFetcher {
     return neededBlockHashes.stream()
         .map(BlockNumberAndHash::getHash)
         .map(eth1Provider::getGuaranteedEth1Block)
-        .collect(toList());
+        .collect(Collectors.toCollection(ArrayList::new)); // mutable List is required
   }
 
   private NavigableMap<BlockNumberAndHash, List<DepositEventEventResponse>>

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/singlepeer/PeerSyncTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/singlepeer/PeerSyncTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.beacon.sync.forward.singlepeer.PeerSync.MAX_THROTTLED_REQUESTS;
+import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -174,7 +175,7 @@ public class PeerSyncTest extends AbstractSyncTest {
     }
 
     assertThat(syncFuture).isCompleted();
-    final PeerSyncResult result = syncFuture.join();
+    final PeerSyncResult result = safeJoin(syncFuture);
     if (shouldDisconnect) {
       verify(peer).disconnectCleanly(DisconnectReason.REMOTE_FAULT);
       assertThat(result).isEqualByComparingTo(PeerSyncResult.BAD_BLOCK);
@@ -215,7 +216,7 @@ public class PeerSyncTest extends AbstractSyncTest {
     verify(peer, never()).disconnectCleanly(any());
     verifyNoInteractions(blockImporter);
     assertThat(syncFuture).isCompleted();
-    PeerSyncResult result = syncFuture.join();
+    PeerSyncResult result = safeJoin(syncFuture);
     assertThat(result).isEqualByComparingTo(PeerSyncResult.CANCELLED);
 
     // check startingSlot

--- a/beacon/validator/src/integrationTest/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerIntegrationTest.java
+++ b/beacon/validator/src/integrationTest/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerIntegrationTest.java
@@ -18,6 +18,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThatSafeFuture;
+import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 
 import java.util.Optional;
@@ -146,7 +147,7 @@ public class ValidatorApiHandlerIntegrationTest {
     final SafeFuture<Optional<AttestationData>> result =
         handler.createAttestationData(targetSlot, committeeIndex);
     assertThatSafeFuture(result).isCompletedWithNonEmptyOptional();
-    final AttestationData attestation = result.join().orElseThrow();
+    final AttestationData attestation = safeJoin(result).orElseThrow();
     assertThat(attestation.getBeaconBlockRoot()).isEqualTo(latestBlock.getRoot());
     assertThat(attestation.getSource()).isEqualTo(genesisCheckpoint);
     assertThat(attestation.getTarget()).isEqualTo(expectedTarget);
@@ -176,7 +177,7 @@ public class ValidatorApiHandlerIntegrationTest {
     final SafeFuture<Optional<AttestationData>> result =
         handler.createAttestationData(targetSlot, committeeIndex);
     assertThatSafeFuture(result).isCompletedWithNonEmptyOptional();
-    final AttestationData attestation = result.join().orElseThrow();
+    final AttestationData attestation = safeJoin(result).orElseThrow();
     assertThat(attestation.getBeaconBlockRoot()).isEqualTo(latestBlock.getRoot());
     assertThat(attestation.getSource()).isEqualTo(genesisCheckpoint);
     assertThat(attestation.getTarget()).isEqualTo(expectedTarget);

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.async.SafeFuture.completedFuture;
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThatSafeFuture;
+import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 import static tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult.FailureReason.DOES_NOT_DESCEND_FROM_LATEST_FINALIZED;
@@ -563,7 +564,7 @@ class ValidatorApiHandlerTest {
         validatorApiHandler.createAttestationData(slot, committeeIndex);
 
     assertThat(result).isCompleted();
-    final Optional<AttestationData> maybeAttestation = result.join();
+    final Optional<AttestationData> maybeAttestation = safeJoin(result);
     assertThat(maybeAttestation).isPresent();
     final AttestationData attestationData = maybeAttestation.orElseThrow();
     assertThat(attestationData)
@@ -620,7 +621,7 @@ class ValidatorApiHandlerTest {
         validatorApiHandler.createAttestationData(slot, committeeIndex);
 
     assertThat(result).isCompleted();
-    final Optional<AttestationData> maybeAttestation = result.join();
+    final Optional<AttestationData> maybeAttestation = safeJoin(result);
     assertThat(maybeAttestation).isPresent();
     final AttestationData attestationData = maybeAttestation.orElseThrow();
     assertThat(attestationData)
@@ -890,7 +891,7 @@ class ValidatorApiHandlerTest {
     when(blockImportChannel.importBlock(block))
         .thenReturn(SafeFuture.completedFuture(BlockImportResult.successful(block)));
     final SafeFuture<SendSignedBlockResult> result = validatorApiHandler.sendSignedBlock(block);
-    result.join();
+    safeJoin(result);
 
     verifyNoInteractions(blobSidecarPool);
     verifyNoInteractions(blobSidecarGossipChannel);
@@ -1188,7 +1189,7 @@ class ValidatorApiHandlerTest {
 
   private <T> Optional<T> assertCompletedSuccessfully(final SafeFuture<Optional<T>> result) {
     assertThat(result).isCompleted();
-    return result.join();
+    return safeJoin(result);
   }
 
   private BeaconState createStateWithActiveValidators() {

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/performance/SyncCommitteePerformanceTrackerTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/performance/SyncCommitteePerformanceTrackerTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 
 import it.unimi.dsi.fastutil.ints.IntSet;
 import java.util.List;
@@ -147,7 +148,7 @@ class SyncCommitteePerformanceTrackerTest {
   private SyncCommitteePerformance calculatePerformance(final UInt64 epoch) {
     final SafeFuture<SyncCommitteePerformance> result = tracker.calculatePerformance(epoch);
     assertThat(result).isCompleted();
-    return result.join();
+    return safeJoin(result);
   }
 
   private void withSyncAggregate(final int slot, final Integer... includedCommitteeIndices) {

--- a/data/provider/src/test/java/tech/pegasys/teku/api/ValidatorDataProviderTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/ValidatorDataProviderTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.async.SafeFuture.completedFuture;
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThatSafeFuture;
+import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 import static tech.pegasys.teku.infrastructure.ssz.SszDataAssert.assertThatSszData;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
@@ -279,7 +280,7 @@ public class ValidatorDataProviderTest {
     final SafeFuture<Optional<AttestationData>> result =
         provider.createAttestationDataAtSlot(ONE, 0);
     assertThat(result).isCompleted();
-    AttestationData data = result.join().orElseThrow();
+    AttestationData data = safeJoin(result).orElseThrow();
     assertThat(data.getIndex()).isEqualTo(internalData.getIndex());
     assertThat(data.getSlot()).isEqualTo(internalData.getSlot());
     assertThat(data.getBeaconBlockRoot()).isEqualTo(internalData.getBeaconBlockRoot());
@@ -381,7 +382,7 @@ public class ValidatorDataProviderTest {
     final SafeFuture<Optional<AttesterDuties>> future =
         provider.getAttesterDuties(UInt64.ONE, IntList.of());
     assertThat(future).isCompleted();
-    Optional<AttesterDuties> maybeData = future.join();
+    Optional<AttesterDuties> maybeData = safeJoin(future);
     assertThat(maybeData.isPresent()).isTrue();
     assertThat(maybeData.get().getDuties()).isEmpty();
   }
@@ -400,7 +401,7 @@ public class ValidatorDataProviderTest {
     final SafeFuture<Optional<AttesterDuties>> future =
         provider.getAttesterDuties(ONE, IntList.of(1, 11));
     assertThat(future).isCompleted();
-    final Optional<AttesterDuties> maybeList = future.join();
+    final Optional<AttesterDuties> maybeList = safeJoin(future);
     final AttesterDuties list = maybeList.orElseThrow();
     assertThat(list.getDuties()).containsExactlyInAnyOrder(v1, v2);
   }

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
@@ -302,7 +302,7 @@ public class ForkChoiceTestExecutor implements TestExecutor {
     final SafeFuture<BlockImportResult> result =
         forkChoice.onBlock(block, Optional.empty(), executionLayer);
     assertThat(result).isCompleted();
-    final BlockImportResult importResult = result.join();
+    final BlockImportResult importResult = safeJoin(result);
     assertThat(importResult)
         .describedAs("Incorrect block import result for block %s", block)
         .has(new Condition<>(r -> r.isSuccessful() == valid, "isSuccessful matching " + valid));

--- a/ethereum/dataproviders/src/test/java/tech/pegasys/teku/dataproviders/generators/StateRegenerationBaseSelectorTest.java
+++ b/ethereum/dataproviders/src/test/java/tech/pegasys/teku/dataproviders/generators/StateRegenerationBaseSelectorTest.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThatSafeFuture;
+import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 
 import java.util.Optional;
 import java.util.function.Supplier;
@@ -208,8 +209,8 @@ class StateRegenerationBaseSelectorTest {
   private void assertSelectedBase(final SignedBlockAndState fromStore) {
     final SafeFuture<Optional<StateAndBlockSummary>> actual = getBestBase();
     assertThat(actual).isCompleted();
-    assertThat(actual.join()).isPresent();
-    assertThat(actual.join().get().getRoot()).isEqualTo(fromStore.getRoot());
+    assertThat(safeJoin(actual)).isPresent();
+    assertThat(safeJoin(actual).get().getRoot()).isEqualTo(fromStore.getRoot());
   }
 
   private SignedBlockAndState withClosestAvailableFromStoreAtSlot(final long slot) {

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/ChainBuilder.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/ChainBuilder.java
@@ -38,7 +38,6 @@ import tech.pegasys.teku.bls.BLSKeyPair;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
-import tech.pegasys.teku.infrastructure.async.SafeFutureAssert;
 import tech.pegasys.teku.infrastructure.async.SyncAsyncRunner;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/ChainBuilder.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/ChainBuilder.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.spec.generator;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.util.Preconditions.checkState;
+import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -593,7 +594,7 @@ public class ChainBuilder {
       final SszList<Attestation> attestations,
       final SszList<AttesterSlashing> attesterSlashings)
       throws EpochProcessingException, SlotProcessingException {
-    return SafeFutureAssert.safeJoin(
+    return safeJoin(
         blockProposalTestUtil.createBlock(
             signer,
             slot,
@@ -644,7 +645,7 @@ public class ChainBuilder {
     }
 
     final SignedBlockAndState nextBlockAndState =
-        SafeFutureAssert.safeJoin(
+        safeJoin(
             blockProposalTestUtil.createBlock(
                 signer,
                 slot,
@@ -718,7 +719,7 @@ public class ChainBuilder {
     }
 
     final SignedBlockAndState nextBlockAndState =
-        SafeFutureAssert.safeJoin(
+        safeJoin(
             blockProposalTestUtil.createBlockWithBlobs(
                 signer,
                 slot,
@@ -871,7 +872,7 @@ public class ChainBuilder {
       final int validatorId, final Function<Signer, SafeFuture<BLSSignature>> signFunction) {
     final SafeFuture<BLSSignature> result = signFunction.apply(getSigner(validatorId));
     assertThat(result).isCompleted();
-    return result.join();
+    return safeJoin(result);
   }
 
   public Signer getSigner(final int validatorId) {

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockImporterTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockImporterTest.java
@@ -607,12 +607,12 @@ public class BlockImporterTest {
 
     SafeFuture<CheckpointState> result = blockImporter.getLatestCheckpointState();
     assertThat(result).isCompleted();
-    assertThat(result.join().getRoot()).isEqualTo(genesis.getRoot());
+    assertThat(safeJoin(result).getRoot()).isEqualTo(genesis.getRoot());
 
     // Second call should be the same
     result = blockImporter.getLatestCheckpointState();
     assertThat(result).isCompleted();
-    assertThat(result.join().getRoot()).isEqualTo(genesis.getRoot());
+    assertThat(safeJoin(result).getRoot()).isEqualTo(genesis.getRoot());
   }
 
   @Test
@@ -641,7 +641,7 @@ public class BlockImporterTest {
     // Pull genesis checkpoint
     SafeFuture<CheckpointState> result = blockImporter.getLatestCheckpointState();
     assertThat(result).isCompleted();
-    assertThat(result.join().getRoot()).isEqualTo(genesis.getRoot());
+    assertThat(safeJoin(result).getRoot()).isEqualTo(genesis.getRoot());
 
     // Update latest finalized
     final UInt64 newFinalizedEpoch = UInt64.valueOf(2);
@@ -652,8 +652,8 @@ public class BlockImporterTest {
     // Second call should pull new finalized checkpoint
     result = blockImporter.getLatestCheckpointState();
     assertThat(result).isCompleted();
-    assertThat(result.join().getEpoch()).isEqualTo(newFinalizedEpoch);
-    assertThat(result.join().getRoot()).isEqualTo(newFinalizedBlock.getRoot());
+    assertThat(safeJoin(result).getEpoch()).isEqualTo(newFinalizedEpoch);
+    assertThat(safeJoin(result).getRoot()).isEqualTo(newFinalizedBlock.getRoot());
   }
 
   @SuppressWarnings("unchecked")
@@ -749,6 +749,6 @@ public class BlockImporterTest {
     assertThat(finalizedCheckpoint).isCompleted();
     UInt64 currentSlot = recentChainData.getCurrentSlot().orElseThrow();
     verify(weakSubjectivityValidator)
-        .validateLatestFinalizedCheckpoint(finalizedCheckpoint.join(), currentSlot);
+        .validateLatestFinalizedCheckpoint(safeJoin(finalizedCheckpoint), currentSlot);
   }
 }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThatSafeFuture;
+import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 import static tech.pegasys.teku.spec.schemas.ApiSchemas.SIGNED_VALIDATOR_REGISTRATIONS_SCHEMA;
 import static tech.pegasys.teku.statetransition.forkchoice.ForkChoiceUpdateData.RESEND_AFTER_MILLIS;
 
@@ -917,7 +918,7 @@ class ForkChoiceNotifierTest {
     }
     validatorRegistration.ifPresent(
         signedValidatorRegistration ->
-            SafeFutureAssert.safeJoin(
+            safeJoin(
                 proposersDataManager.updateValidatorRegistrations(
                     SIGNED_VALIDATOR_REGISTRATIONS_SCHEMA.createFromElements(
                         List.of(signedValidatorRegistration)),
@@ -1007,6 +1008,6 @@ class ForkChoiceNotifierTest {
   private BeaconState getHeadState() {
     final SafeFuture<BeaconState> stateFuture = recentChainData.getBestState().orElseThrow();
     assertThat(stateFuture).isCompleted();
-    return stateFuture.join();
+    return safeJoin(stateFuture);
   }
 }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
@@ -41,7 +41,6 @@ import org.mockito.invocation.InvocationOnMock;
 import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.ethereum.execution.types.Eth1Address;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
-import tech.pegasys.teku.infrastructure.async.SafeFutureAssert;
 import tech.pegasys.teku.infrastructure.async.eventthread.InlineEventThread;
 import tech.pegasys.teku.infrastructure.bytes.Bytes8;
 import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
@@ -54,7 +54,6 @@ import tech.pegasys.teku.bls.BLSKeyPair;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
-import tech.pegasys.teku.infrastructure.async.SafeFutureAssert;
 import tech.pegasys.teku.infrastructure.async.eventthread.InlineEventThread;
 import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 import static tech.pegasys.teku.networks.Eth2NetworkConfiguration.DEFAULT_FORK_CHOICE_UPDATE_HEAD_ON_BLOCK_IMPORT_ENABLED;
@@ -337,7 +338,7 @@ class ForkChoiceTest {
       UInt64 timeIntoSlotMillis =
           recentChainData.getStore().getTimeMillis().plus(advanceTimeSlotMillis);
       transaction.setTimeMillis(timeIntoSlotMillis);
-      SafeFutureAssert.safeJoin(transaction.commit());
+      safeJoin(transaction.commit());
     }
 
     importBlock(expectedChainHead);
@@ -1166,7 +1167,7 @@ class ForkChoiceTest {
   private void assertBlockImportedSuccessfully(
       final SafeFuture<BlockImportResult> importResult, final boolean optimistically) {
     assertThat(importResult).isCompleted();
-    final BlockImportResult result = importResult.join();
+    final BlockImportResult result = safeJoin(importResult);
     assertThat(result.isSuccessful()).describedAs(result.toString()).isTrue();
     assertThat(result.isImportedOptimistically())
         .describedAs(result.toString())
@@ -1190,7 +1191,7 @@ class ForkChoiceTest {
   private void assertBlockImportFailure(
       final SafeFuture<BlockImportResult> importResult, FailureReason failureReason) {
     assertThat(importResult).isCompleted();
-    final BlockImportResult result = importResult.join();
+    final BlockImportResult result = safeJoin(importResult);
     assertThat(result.getFailureReason()).isEqualTo(failureReason);
   }
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/MergeTransitionBlockValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/MergeTransitionBlockValidatorTest.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.statetransition.forkchoice;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThatSafeFuture;
+import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
@@ -168,7 +169,7 @@ class MergeTransitionBlockValidatorTest {
     assertThat(executionLayer.getRequestedPowBlocks())
         .contains(getExecutionPayload(transitionBlock).getParentHash());
     assertThat(result).isCompleted();
-    final PayloadValidationResult validationResult = result.join();
+    final PayloadValidationResult validationResult = safeJoin(result);
     assertThat(validationResult.getInvalidTransitionBlockRoot())
         .contains(transitionBlock.getRoot());
     assertThat(validationResult.getStatus()).matches(PayloadStatus::hasInvalidStatus);

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/ProposerSlashingValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/ProposerSlashingValidatorTest.java
@@ -18,6 +18,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 import static tech.pegasys.teku.statetransition.validation.ValidationResultCode.ACCEPT;
 import static tech.pegasys.teku.statetransition.validation.ValidationResultCode.IGNORE;
 import static tech.pegasys.teku.statetransition.validation.ValidationResultCode.REJECT;
@@ -134,6 +135,6 @@ public class ProposerSlashingValidatorTest {
   private BeaconState getBestState() {
     final SafeFuture<BeaconState> stateFuture = recentChainData.getBestState().orElseThrow();
     assertThat(stateFuture).isCompleted();
-    return stateFuture.join();
+    return safeJoin(stateFuture);
   }
 }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/VoluntaryExitValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/VoluntaryExitValidatorTest.java
@@ -18,6 +18,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 import static tech.pegasys.teku.statetransition.validation.ValidationResultCode.ACCEPT;
 import static tech.pegasys.teku.statetransition.validation.ValidationResultCode.IGNORE;
 import static tech.pegasys.teku.statetransition.validation.ValidationResultCode.REJECT;
@@ -135,6 +136,6 @@ public class VoluntaryExitValidatorTest {
   private BeaconState getBestState() {
     final SafeFuture<BeaconState> stateFuture = recentChainData.getBestState().orElseThrow();
     assertThat(stateFuture).isCompleted();
-    return stateFuture.join();
+    return safeJoin(stateFuture);
   }
 }

--- a/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/GetMetadataIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/GetMetadataIntegrationTest.java
@@ -138,7 +138,7 @@ public class GetMetadataIntegrationTest extends AbstractRpcMethodIntegrationTest
     waitFor(() -> assertThat(res).isDone());
 
     assertThat(res).isCompleted();
-    final MetadataMessage metadata = res.join();
+    final MetadataMessage metadata = safeJoin(res);
     assertThat(metadata).isInstanceOf(expectedType);
     assertThat(metadata.getSeqNumber()).isEqualTo(UInt64.ZERO);
   }

--- a/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/GetMetadataIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/GetMetadataIntegrationTest.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.networking.eth2;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 import static tech.pegasys.teku.infrastructure.async.Waiter.waitFor;
 
 import java.util.List;

--- a/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/VoluntaryExitGossipIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/VoluntaryExitGossipIntegrationTest.java
@@ -93,7 +93,7 @@ public class VoluntaryExitGossipIntegrationTest {
     final SafeFuture<Optional<BeaconState>> stateFuture =
         node1.storageClient().getStore().retrieveBlockState(block.getRoot());
     assertThat(stateFuture).isCompleted();
-    final BeaconState state = stateFuture.join().orElseThrow();
+    final BeaconState state = safeJoin(stateFuture).orElseThrow();
     final VoluntaryExitGenerator exitGenerator =
         new VoluntaryExitGenerator(spec, node1.chainUtil().getValidatorKeys());
     final SignedVoluntaryExit voluntaryExit = exitGenerator.valid(state, 0);

--- a/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/VoluntaryExitGossipIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/VoluntaryExitGossipIntegrationTest.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.networking.eth2;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 import static tech.pegasys.teku.infrastructure.async.Waiter.waitFor;
 
 import java.util.HashSet;

--- a/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/connection/ConnectionManagerTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/connection/ConnectionManagerTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -220,7 +221,7 @@ class ConnectionManagerTest {
     SafeFuture<?> startFuture = manager.start();
     search1.complete(emptyList());
     asyncRunner.executeDueActionsRepeatedly();
-    startFuture.join();
+    safeJoin(startFuture);
 
     verify(discoveryService, times(1)).searchForPeers();
 
@@ -242,7 +243,7 @@ class ConnectionManagerTest {
     SafeFuture<?> startFuture = manager.start();
     search1.completeExceptionally(new RuntimeException("Nope"));
     asyncRunner.executeDueActionsRepeatedly();
-    startFuture.join();
+    safeJoin(startFuture);
 
     verify(discoveryService, times(1)).searchForPeers();
 
@@ -268,8 +269,8 @@ class ConnectionManagerTest {
 
     SafeFuture<?> stopFuture = manager.stop();
 
-    startFuture.join();
-    stopFuture.join();
+    safeJoin(startFuture);
+    safeJoin(stopFuture);
 
     advanceTimeByWarmupSearchInterval();
     verify(discoveryService, times(1)).searchForPeers(); // Shouldn't search again
@@ -287,7 +288,7 @@ class ConnectionManagerTest {
 
     SafeFuture<?> startFuture = manager.start();
     search1.complete(emptyList());
-    startFuture.join();
+    safeJoin(startFuture);
     // First search is empty, second is successful, so we need to capture 2 searches
     asyncRunner.executeDueActionsRepeatedly();
     advanceTimeByWarmupSearchInterval();
@@ -310,7 +311,7 @@ class ConnectionManagerTest {
     SafeFuture<?> startFuture = manager.start();
     search1.complete(List.of(DISCOVERY_PEER1));
     asyncRunner.executeDueActionsRepeatedly();
-    startFuture.join();
+    safeJoin(startFuture);
     verify(discoveryService).searchForPeers();
     verify(network).connect(PEER1);
 
@@ -413,7 +414,7 @@ class ConnectionManagerTest {
     final ConnectionManager manager = createManager();
     SafeFuture<?> startFuture = manager.start();
     asyncRunner.executeDueActionsRepeatedly();
-    startFuture.join();
+    safeJoin(startFuture);
     // Start search
     verify(discoveryService, times(1)).searchForPeers();
 

--- a/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/WeakSubjectivityInitializerTest.java
+++ b/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/WeakSubjectivityInitializerTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -62,7 +63,7 @@ public class WeakSubjectivityInitializerTest {
     assertThat(result).isCompleted();
     verify(queryChannel).getWeakSubjectivityState();
     verify(updateChannel, never()).onWeakSubjectivityUpdate(any());
-    assertThat(result.join()).usingRecursiveComparison().isEqualTo(defaultConfig);
+    assertThat(safeJoin(result)).usingRecursiveComparison().isEqualTo(defaultConfig);
   }
 
   @Test
@@ -87,7 +88,7 @@ public class WeakSubjectivityInitializerTest {
     verify(updateChannel)
         .onWeakSubjectivityUpdate(
             WeakSubjectivityUpdate.setWeakSubjectivityCheckpoint(cliCheckpoint));
-    assertThat(result.join()).usingRecursiveComparison().isEqualTo(cliConfig);
+    assertThat(safeJoin(result)).usingRecursiveComparison().isEqualTo(cliConfig);
   }
 
   @Test
@@ -107,7 +108,7 @@ public class WeakSubjectivityInitializerTest {
     assertThat(result).isCompleted();
     verify(queryChannel).getWeakSubjectivityState();
     verify(updateChannel, never()).onWeakSubjectivityUpdate(any());
-    assertThat(result.join())
+    assertThat(safeJoin(result))
         .usingRecursiveComparison()
         .isEqualTo(WeakSubjectivityConfig.builder(storedState).specProvider(spec).build());
   }
@@ -139,7 +140,7 @@ public class WeakSubjectivityInitializerTest {
     verify(updateChannel)
         .onWeakSubjectivityUpdate(
             WeakSubjectivityUpdate.setWeakSubjectivityCheckpoint(cliCheckpoint));
-    assertThat(result.join()).usingRecursiveComparison().isEqualTo(cliConfig);
+    assertThat(safeJoin(result)).usingRecursiveComparison().isEqualTo(cliConfig);
   }
 
   @Test
@@ -164,7 +165,7 @@ public class WeakSubjectivityInitializerTest {
     assertThat(result).isCompleted();
     verify(queryChannel).getWeakSubjectivityState();
     verify(updateChannel, never()).onWeakSubjectivityUpdate(any());
-    assertThat(result.join()).usingRecursiveComparison().isEqualTo(cliConfig);
+    assertThat(safeJoin(result)).usingRecursiveComparison().isEqualTo(cliConfig);
   }
 
   @Test

--- a/storage/src/integration-test/java/tech/pegasys/teku/storage/server/kvstore/DatabaseTest.java
+++ b/storage/src/integration-test/java/tech/pegasys/teku/storage/server/kvstore/DatabaseTest.java
@@ -2371,7 +2371,7 @@ public class DatabaseTest {
               .map(
                   f -> {
                     assertThat(f).isCompleted();
-                    return f.join();
+                    return safeJoin(f);
                   })
               .flatMap(Optional::stream)
               .collect(toList());
@@ -2394,7 +2394,7 @@ public class DatabaseTest {
             .map(
                 f -> {
                   assertThat(f).isCompleted();
-                  return f.join();
+                  return safeJoin(f);
                 })
             .flatMap(Optional::stream)
             .collect(toList());

--- a/storage/src/integration-test/java/tech/pegasys/teku/storage/server/kvstore/DatabaseTest.java
+++ b/storage/src/integration-test/java/tech/pegasys/teku/storage/server/kvstore/DatabaseTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThatSafeFuture;
+import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 import static tech.pegasys.teku.spec.config.SpecConfig.GENESIS_SLOT;

--- a/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTest.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.storage.store;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThatSafeFuture;
+import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 import static tech.pegasys.teku.infrastructure.async.SyncAsyncRunner.SYNC_RUNNER;
 import static tech.pegasys.teku.infrastructure.time.TimeUtilities.millisToSeconds;
 
@@ -202,7 +203,7 @@ class StoreTest extends AbstractStoreTest {
 
     final SafeFuture<Optional<BeaconState>> result = store.retrieveCheckpointState(checkpoint);
     assertThatSafeFuture(result).isCompletedWithNonEmptyOptional();
-    final BeaconState checkpointState = result.join().orElseThrow();
+    final BeaconState checkpointState = safeJoin(result).orElseThrow();
     assertThat(checkpointState.getSlot()).isEqualTo(checkpoint.getEpochStartSlot(spec));
     assertThat(checkpointState.getLatestBlockHeader().hashTreeRoot())
         .isEqualTo(checkpoint.getRoot());
@@ -230,7 +231,7 @@ class StoreTest extends AbstractStoreTest {
     final SafeFuture<Optional<BeaconState>> resultFuture =
         store.retrieveCheckpointState(checkpoint, baseState);
     assertThatSafeFuture(resultFuture).isCompletedWithNonEmptyOptional();
-    final BeaconState result = resultFuture.join().orElseThrow();
+    final BeaconState result = safeJoin(resultFuture).orElseThrow();
     assertThat(result.getSlot()).isGreaterThan(baseState.getSlot());
     assertThat(result.getSlot()).isEqualTo(checkpoint.getEpochStartSlot(spec));
     assertThat(result.getLatestBlockHeader().hashTreeRoot()).isEqualTo(checkpoint.getRoot());
@@ -266,10 +267,10 @@ class StoreTest extends AbstractStoreTest {
 
     final SafeFuture<CheckpointState> result = store.retrieveFinalizedCheckpointAndState();
     assertThat(result).isCompleted();
-    assertThat(result.join().getCheckpoint()).isEqualTo(finalizedCheckpoint);
-    assertThat(result.join().getRoot()).isEqualTo(finalizedBlockAndState.getRoot());
-    assertThat(result.join().getState()).isNotEqualTo(finalizedBlockAndState.getState());
-    assertThat(result.join().getState().getSlot())
+    assertThat(safeJoin(result).getCheckpoint()).isEqualTo(finalizedCheckpoint);
+    assertThat(safeJoin(result).getRoot()).isEqualTo(finalizedBlockAndState.getRoot());
+    assertThat(safeJoin(result).getState()).isNotEqualTo(finalizedBlockAndState.getState());
+    assertThat(safeJoin(result).getState().getSlot())
         .isEqualTo(finalizedBlockAndState.getSlot().plus(1));
   }
 
@@ -398,7 +399,7 @@ class StoreTest extends AbstractStoreTest {
     final SafeFuture<CheckpointState> finalizedCheckpointState =
         store.retrieveFinalizedCheckpointAndState();
     assertThat(finalizedCheckpointState).isCompleted();
-    assertThat(finalizedCheckpointState.join().getCheckpoint()).isEqualTo(checkpoint1);
+    assertThat(safeJoin(finalizedCheckpointState).getCheckpoint()).isEqualTo(checkpoint1);
     // Check time
     assertThat(store.getTimeMillis()).isEqualTo(expectedTimeMillis);
     assertThat(store.getTimeSeconds()).isEqualTo(millisToSeconds(expectedTimeMillis));

--- a/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTransactionTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTransactionTest.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.storage.store;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 import static tech.pegasys.teku.spec.config.SpecConfig.GENESIS_SLOT;
 
@@ -279,10 +280,10 @@ public class StoreTransactionTest extends AbstractStoreTest {
 
     final SafeFuture<CheckpointState> result = tx.retrieveFinalizedCheckpointAndState();
     assertThat(result).isCompleted();
-    assertThat(result.join().getCheckpoint()).isEqualTo(finalizedCheckpoint);
-    assertThat(result.join().getRoot()).isEqualTo(finalizedBlockAndState.getRoot());
-    assertThat(result.join().getState()).isNotEqualTo(finalizedBlockAndState.getState());
-    assertThat(result.join().getState().getSlot())
+    assertThat(safeJoin(result).getCheckpoint()).isEqualTo(finalizedCheckpoint);
+    assertThat(safeJoin(result).getRoot()).isEqualTo(finalizedBlockAndState.getRoot());
+    assertThat(safeJoin(result).getState()).isNotEqualTo(finalizedBlockAndState.getState());
+    assertThat(safeJoin(result).getState().getSlot())
         .isEqualTo(finalizedBlockAndState.getSlot().plus(1));
   }
 
@@ -304,10 +305,10 @@ public class StoreTransactionTest extends AbstractStoreTest {
 
     final SafeFuture<CheckpointState> result = tx.retrieveFinalizedCheckpointAndState();
     assertThat(result).isCompleted();
-    assertThat(result.join().getCheckpoint()).isEqualTo(finalizedCheckpoint);
-    assertThat(result.join().getRoot()).isEqualTo(finalizedBlockAndState.getRoot());
-    assertThat(result.join().getState()).isNotEqualTo(finalizedBlockAndState.getState());
-    assertThat(result.join().getState().getSlot())
+    assertThat(safeJoin(result).getCheckpoint()).isEqualTo(finalizedCheckpoint);
+    assertThat(safeJoin(result).getRoot()).isEqualTo(finalizedBlockAndState.getRoot());
+    assertThat(safeJoin(result).getState()).isNotEqualTo(finalizedBlockAndState.getState());
+    assertThat(safeJoin(result).getState().getSlot())
         .isEqualTo(finalizedBlockAndState.getSlot().plus(1));
   }
 
@@ -329,10 +330,10 @@ public class StoreTransactionTest extends AbstractStoreTest {
 
     final SafeFuture<CheckpointState> result = tx.retrieveFinalizedCheckpointAndState();
     assertThat(result).isCompleted();
-    assertThat(result.join().getCheckpoint()).isEqualTo(finalizedCheckpoint);
-    assertThat(result.join().getRoot()).isEqualTo(finalizedBlockAndState.getRoot());
-    assertThat(result.join().getState()).isNotEqualTo(finalizedBlockAndState.getState());
-    assertThat(result.join().getState().getSlot())
+    assertThat(safeJoin(result).getCheckpoint()).isEqualTo(finalizedCheckpoint);
+    assertThat(safeJoin(result).getRoot()).isEqualTo(finalizedBlockAndState.getRoot());
+    assertThat(safeJoin(result).getState()).isNotEqualTo(finalizedBlockAndState.getState());
+    assertThat(safeJoin(result).getState().getSlot())
         .isEqualTo(finalizedBlockAndState.getSlot().plus(1));
   }
 
@@ -373,9 +374,9 @@ public class StoreTransactionTest extends AbstractStoreTest {
     // Check response from tx1 for finalized value
     final SafeFuture<CheckpointState> result = tx.retrieveFinalizedCheckpointAndState();
     assertThat(result).isCompleted();
-    assertThat(result.join().getCheckpoint()).isEqualTo(newerFinalizedCheckpoint);
-    assertThat(result.join().getRoot()).isEqualTo(newerFinalizedBlockAndState.getRoot());
-    assertThat(result.join().getState()).isEqualTo(newerFinalizedBlockAndState.getState());
+    assertThat(safeJoin(result).getCheckpoint()).isEqualTo(newerFinalizedCheckpoint);
+    assertThat(safeJoin(result).getRoot()).isEqualTo(newerFinalizedBlockAndState.getRoot());
+    assertThat(safeJoin(result).getState()).isEqualTo(newerFinalizedBlockAndState.getState());
   }
 
   @Test

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/ProductionResult.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/ProductionResult.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.validator.client.duties;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -73,7 +74,9 @@ public class ProductionResult<T> {
       final Function<List<T>, SafeFuture<List<SubmitDataError>>> submitFunction) {
     // Split into results that produced a message to send vs those that failed already
     final List<ProductionResult<T>> messageCreated =
-        results.stream().filter(ProductionResult::producedMessage).collect(Collectors.toList());
+        results.stream()
+            .filter(ProductionResult::producedMessage)
+            .collect(Collectors.toCollection(ArrayList::new)); // mutable List is required
     final DutyResult combinedFailures =
         combineResults(results.stream().filter(ProductionResult::failedToProduceMessage).toList());
 

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/SyncCommitteeDutyLoaderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/SyncCommitteeDutyLoaderTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThatSafeFuture;
+import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 
 import it.unimi.dsi.fastutil.ints.IntSet;
 import java.util.List;
@@ -152,6 +153,6 @@ class SyncCommitteeDutyLoaderTest {
     final SafeFuture<Optional<SyncCommitteeScheduledDuties>> result =
         dutyLoader.loadDutiesForEpoch(epoch);
     assertThatSafeFuture(result).isCompletedWithNonEmptyOptional();
-    return result.join().orElseThrow();
+    return safeJoin(result).orElseThrow();
   }
 }

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/AggregationDutyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/AggregationDutyTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.async.SafeFuture.completedFuture;
 import static tech.pegasys.teku.infrastructure.async.SafeFuture.failedFuture;
+import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 
 import java.util.Collections;
 import java.util.List;
@@ -307,6 +308,6 @@ class AggregationDutyTest {
   private void performAndReportDuty() {
     final SafeFuture<DutyResult> result = duty.performDuty();
     assertThat(result).isCompleted();
-    result.join().report(TYPE, SLOT, validatorLogger);
+    safeJoin(result).report(TYPE, SLOT, validatorLogger);
   }
 }

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/AttestationProductionDutyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/AttestationProductionDutyTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.async.SafeFuture.completedFuture;
 import static tech.pegasys.teku.infrastructure.async.SafeFuture.failedFuture;
+import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 
 import java.util.Collections;
 import java.util.List;
@@ -446,6 +447,6 @@ class AttestationProductionDutyTest {
   private void performAndReportDuty() {
     final SafeFuture<DutyResult> result = duty.performDuty();
     assertThat(result).isCompleted();
-    result.join().report(TYPE, SLOT, validatorLogger);
+    safeJoin(result).report(TYPE, SLOT, validatorLogger);
   }
 }

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/BlockProductionDutyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/BlockProductionDutyTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.async.SafeFuture.completedFuture;
 import static tech.pegasys.teku.infrastructure.async.SafeFuture.failedFuture;
+import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 
 import java.util.List;
@@ -408,7 +409,7 @@ class BlockProductionDutyTest {
   private void performAndReportDuty(final UInt64 slot) {
     final SafeFuture<DutyResult> result = duty.performDuty();
     assertThat(result).isCompleted();
-    result.join().report(TYPE, slot, validatorLogger);
+    safeJoin(result).report(TYPE, slot, validatorLogger);
   }
 
   static class PayloadSummary implements ExecutionPayloadSummary {

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/DutyResultTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/DutyResultTest.java
@@ -17,6 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 
 import java.util.List;
 import java.util.Optional;
@@ -165,7 +166,7 @@ class DutyResultTest {
                 SafeFuture.completedFuture(DutyResult.success(root2))));
 
     assertThat(combinedFuture).isCompleted();
-    combinedFuture.join().report(TYPE, SLOT, validatorLogger);
+    safeJoin(combinedFuture).report(TYPE, SLOT, validatorLogger);
     verify(validatorLogger).dutyCompleted(TYPE, SLOT, 2, Set.of(root1, root2), Optional.empty());
     verify(validatorLogger).dutyFailed(TYPE, SLOT, validatorId, exception1);
     verify(validatorLogger).dutyFailed(TYPE, SLOT, Set.of(), exception2);
@@ -187,7 +188,7 @@ class DutyResultTest {
     future2.complete(DutyResult.success(root));
     assertThat(combinedFuture).isCompleted();
 
-    combinedFuture.join().report(TYPE, SLOT, validatorLogger);
+    safeJoin(combinedFuture).report(TYPE, SLOT, validatorLogger);
     verify(validatorLogger).dutyCompleted(TYPE, SLOT, 2, Set.of(root), Optional.empty());
     verifyNoMoreInteractions(validatorLogger);
   }

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/ProductionResultTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/ProductionResultTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThatSafeFuture;
+import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 
 import java.util.Collection;
@@ -86,7 +87,7 @@ class ProductionResultTest {
         ProductionResult.send(List.of(prodResult1, prodResult2, prodResult3), sendFunction);
 
     assertThatSafeFuture(result).isCompleted();
-    final DutyResult dutyResult = result.join();
+    final DutyResult dutyResult = safeJoin(result);
     dutyResult.report(PRODUCED_TYPE, SLOT, validatorLogger);
 
     verify(validatorLogger)
@@ -114,7 +115,7 @@ class ProductionResultTest {
         ProductionResult.send(List.of(prodResult1, prodResult2), sendFunction);
 
     assertThatSafeFuture(result).isCompleted();
-    final DutyResult dutyResult = result.join();
+    final DutyResult dutyResult = safeJoin(result);
     dutyResult.report(PRODUCED_TYPE, SLOT, validatorLogger);
 
     verify(validatorLogger)

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/attestations/BatchAttestationSendingStrategyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/attestations/BatchAttestationSendingStrategyTest.java
@@ -19,6 +19,7 @@ import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 
 import java.util.List;
 import java.util.stream.Stream;
@@ -76,7 +77,7 @@ class BatchAttestationSendingStrategyTest {
         ProductionResult.success(
             dataStructureUtil.randomPublicKey(), dataStructureUtil.randomBytes32(), attestation2));
     assertThat(result).isCompleted();
-    assertThat(result.join().getSuccessCount()).isEqualTo(3);
+    assertThat(safeJoin(result).getSuccessCount()).isEqualTo(3);
     verify(validatorApiChannel)
         .sendSignedAttestations(List.of(attestation1, attestation2, attestation3));
   }

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeAggregationDutyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeAggregationDutyTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 
 import it.unimi.dsi.fastutil.ints.IntList;
 import java.util.List;
@@ -281,6 +282,6 @@ class SyncCommitteeAggregationDutyTest {
   private void produceAggregatesAndReport(final SyncCommitteeAggregationDuty duty) {
     final SafeFuture<DutyResult> result = duty.produceAggregates(slot, beaconBlockRoot);
     assertThat(result).isCompleted();
-    result.join().report(TYPE, slot, validatorLogger);
+    safeJoin(result).report(TYPE, slot, validatorLogger);
   }
 }

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeProductionDutyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeProductionDutyTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import java.util.Arrays;
@@ -229,7 +230,7 @@ class SyncCommitteeProductionDutyTest {
       final SyncCommitteeProductionDuty duties, final UInt64 slot) {
     final SafeFuture<DutyResult> result = duties.produceMessages(slot, blockRoot);
     assertThat(result).isCompleted();
-    result.join().report(MESSAGE_TYPE, slot, validatorLogger);
+    safeJoin(result).report(MESSAGE_TYPE, slot, validatorLogger);
   }
 
   private SyncCommitteeProductionDuty createDuty(

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeScheduledDutiesTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeScheduledDutiesTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 
 import it.unimi.dsi.fastutil.ints.IntSet;
 import java.util.Collections;
@@ -247,7 +248,7 @@ class SyncCommitteeScheduledDutiesTest {
 
   private void reportDutyResult(final UInt64 slot, final SafeFuture<DutyResult> result) {
     assertThat(result).isCompleted();
-    result.join().report(TYPE, slot, validatorLogger);
+    safeJoin(result).report(TYPE, slot, validatorLogger);
   }
 
   private Validator createValidator() {

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThatSafeFuture;
+import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_BAD_REQUEST;
 import static tech.pegasys.teku.infrastructure.ssz.SszDataAssert.assertThatSszData;
 import static tech.pegasys.teku.spec.config.SpecConfig.FAR_FUTURE_EPOCH;
@@ -155,7 +156,7 @@ class RemoteValidatorApiHandlerTest {
 
     asyncRunner.executeQueuedActions();
     assertThat(future).isCompleted();
-    assertThat(future.join()).isEmpty();
+    assertThat(safeJoin(future)).isEmpty();
   }
 
   @Test
@@ -176,7 +177,7 @@ class RemoteValidatorApiHandlerTest {
 
     asyncRunner.executeQueuedActions();
     assertThat(future).isCompleted();
-    assertThat(future.join()).containsOnly(entry(key1, 1), entry(key2, 2));
+    assertThat(safeJoin(future)).containsOnly(entry(key1, 1), entry(key2, 2));
     verify(apiClient).getValidators(expectedValidatorIds);
   }
 
@@ -216,7 +217,7 @@ class RemoteValidatorApiHandlerTest {
 
     asyncRunner.executeQueuedActions();
     assertThat(future).isCompleted();
-    assertThat(future.join())
+    assertThat(safeJoin(future))
         .containsOnly(
             entry(allKeys.get(0), 10),
             entry(allKeys.get(3), 11),


### PR DESCRIPTION
Let's use `safeJoin` instead of `join` in all Unit Tests.

Also added explicit mutable collection when we need a **mutable** List from a Stream (`Collectors.toList()` doesn't guarantee it, in theory). Checkout https://github.com/Consensys/teku/pull/7514/commits/373650a858342b37202f0fa301b7ecc30ec6bf90

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
