### PR TITLE
Enable RemoteValidatorCompatibility acceptance tests

### DIFF
--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/RemoteValidatorCompatibilityAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/RemoteValidatorCompatibilityAcceptanceTest.java
@@ -27,7 +27,7 @@ public class RemoteValidatorCompatibilityAcceptanceTest extends AcceptanceTestBa
 
   @Test
   void shouldRunUpdatedValidatorAgainstOldBeaconNode() throws Exception {
-    verifyCompatibility(TekuDockerVersion.V23_6_1, TekuDockerVersion.LOCAL_BUILD);
+    verifyCompatibility(TekuDockerVersion.V23_9_0, TekuDockerVersion.LOCAL_BUILD);
   }
 
   @Test

--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/RemoteValidatorCompatibilityAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/RemoteValidatorCompatibilityAcceptanceTest.java
@@ -13,7 +13,6 @@
 
 package tech.pegasys.teku.test.acceptance;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.test.acceptance.dsl.AcceptanceTestBase;
 import tech.pegasys.teku.test.acceptance.dsl.TekuDockerVersion;
@@ -27,13 +26,11 @@ public class RemoteValidatorCompatibilityAcceptanceTest extends AcceptanceTestBa
   private TekuValidatorNode validatorClient;
 
   @Test
-  @Disabled("TODO: Update version and enable after release")
   void shouldRunUpdatedValidatorAgainstOldBeaconNode() throws Exception {
     verifyCompatibility(TekuDockerVersion.V23_6_1, TekuDockerVersion.LOCAL_BUILD);
   }
 
   @Test
-  @Disabled("TODO: Enable after release when new config is part of the release")
   void shouldRunUpdatedValidatorAgainstLastReleaseBeaconNode() throws Exception {
     verifyCompatibility(TekuDockerVersion.LAST_RELEASE, TekuDockerVersion.LOCAL_BUILD);
   }

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuDockerVersion.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuDockerVersion.java
@@ -16,7 +16,7 @@ package tech.pegasys.teku.test.acceptance.dsl;
 public enum TekuDockerVersion {
   LOCAL_BUILD("develop"),
   LAST_RELEASE("latest"),
-  V23_6_1("23.6.1");
+  V23_9_0("23.9.0");
 
   private final String version;
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Enable couple of disabled acceptance tests. Upgraded the hardcoded teku version to 23.9.0 which is the last release that is compatible with a local validator.

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
