### PR TITLE
Apply proposer boost to first block in case of equivocation

### DIFF
--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
@@ -17,6 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 import static tech.pegasys.teku.infrastructure.time.TimeUtilities.secondsToMillis;
+import static tech.pegasys.teku.networks.Eth2NetworkConfiguration.DEFAULT_FORK_CHOICE_PROPOSER_BOOST_UNIQUENESS_ENABLED;
 import static tech.pegasys.teku.networks.Eth2NetworkConfiguration.DEFAULT_FORK_CHOICE_UPDATE_HEAD_ON_BLOCK_IMPORT_ENABLED;
 
 import com.google.common.collect.ImmutableMap;
@@ -128,6 +129,7 @@ public class ForkChoiceTestExecutor implements TestExecutor {
             new TickProcessor(spec, recentChainData),
             transitionBlockValidator,
             DEFAULT_FORK_CHOICE_UPDATE_HEAD_ON_BLOCK_IMPORT_ENABLED,
+            DEFAULT_FORK_CHOICE_PROPOSER_BOOST_UNIQUENESS_ENABLED,
             storageSystem.getMetricsSystem());
     final ExecutionLayerChannelStub executionLayer =
         new ExecutionLayerChannelStub(spec, false, Optional.empty());

--- a/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/TestDefinition.java
+++ b/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/TestDefinition.java
@@ -60,37 +60,21 @@ public class TestDefinition {
   }
 
   private void createSpec() {
-    final Eth2Network network;
-    final SpecMilestone highestSupportedMilestone;
-    switch (configName) {
-      case TestSpecConfig.MAINNET:
-        network = Eth2Network.MAINNET;
-        break;
-      case TestSpecConfig.MINIMAL:
-        network = Eth2Network.MINIMAL;
-        break;
-      default:
-        throw new IllegalArgumentException("Unknown configName: " + configName);
-    }
-    switch (fork) {
-      case TestFork.PHASE0:
-        highestSupportedMilestone = SpecMilestone.PHASE0;
-        break;
-      case TestFork.ALTAIR:
-        highestSupportedMilestone = SpecMilestone.ALTAIR;
-        break;
-      case TestFork.BELLATRIX:
-        highestSupportedMilestone = SpecMilestone.BELLATRIX;
-        break;
-      case TestFork.CAPELLA:
-        highestSupportedMilestone = SpecMilestone.CAPELLA;
-        break;
-      case TestFork.DENEB:
-        highestSupportedMilestone = SpecMilestone.DENEB;
-        break;
-      default:
-        throw new IllegalArgumentException("Unknown fork: " + fork);
-    }
+    final Eth2Network network =
+        switch (configName) {
+          case TestSpecConfig.MAINNET -> Eth2Network.MAINNET;
+          case TestSpecConfig.MINIMAL -> Eth2Network.MINIMAL;
+          default -> throw new IllegalArgumentException("Unknown configName: " + configName);
+        };
+    final SpecMilestone highestSupportedMilestone =
+        switch (fork) {
+          case TestFork.PHASE0 -> SpecMilestone.PHASE0;
+          case TestFork.ALTAIR -> SpecMilestone.ALTAIR;
+          case TestFork.BELLATRIX -> SpecMilestone.BELLATRIX;
+          case TestFork.CAPELLA -> SpecMilestone.CAPELLA;
+          case TestFork.DENEB -> SpecMilestone.DENEB;
+          default -> throw new IllegalArgumentException("Unknown fork: " + fork);
+        };
     spec = TestSpecFactory.create(highestSupportedMilestone, network);
   }
 

--- a/ethereum/networks/src/main/java/tech/pegasys/teku/networks/Eth2NetworkConfiguration.java
+++ b/ethereum/networks/src/main/java/tech/pegasys/teku/networks/Eth2NetworkConfiguration.java
@@ -48,6 +48,7 @@ public class Eth2NetworkConfiguration {
   private static final int DEFAULT_STARTUP_TIMEOUT_SECONDS = 30;
 
   public static final boolean DEFAULT_FORK_CHOICE_UPDATE_HEAD_ON_BLOCK_IMPORT_ENABLED = false;
+  public static final boolean DEFAULT_FORK_CHOICE_PROPOSER_BOOST_UNIQUENESS_ENABLED = true;
 
   public static final String INITIAL_STATE_URL_PATH = "eth/v2/debug/beacon/states/finalized";
   // 26 thousand years should be enough
@@ -70,6 +71,7 @@ public class Eth2NetworkConfiguration {
   private final Optional<String> trustedSetup;
 
   private final boolean forkChoiceUpdateHeadOnBlockImportEnabled;
+  private final boolean forkChoiceProposerBoostUniquenessEnabled;
   private final Optional<Bytes32> terminalBlockHashOverride;
   private final Optional<UInt256> totalTerminalDifficultyOverride;
   private final Optional<UInt64> terminalBlockHashEpochOverride;
@@ -89,6 +91,7 @@ public class Eth2NetworkConfiguration {
       final Optional<UInt64> eth1DepositContractDeployBlock,
       final Optional<String> trustedSetup,
       final boolean forkChoiceUpdateHeadOnBlockImportEnabled,
+      final boolean forkChoiceProposerBoostUniquenessEnabled,
       final Optional<UInt64> altairForkEpoch,
       final Optional<UInt64> bellatrixForkEpoch,
       final Optional<UInt64> capellaForkEpoch,
@@ -117,6 +120,7 @@ public class Eth2NetworkConfiguration {
     this.eth1DepositContractDeployBlock = eth1DepositContractDeployBlock;
     this.trustedSetup = trustedSetup;
     this.forkChoiceUpdateHeadOnBlockImportEnabled = forkChoiceUpdateHeadOnBlockImportEnabled;
+    this.forkChoiceProposerBoostUniquenessEnabled = forkChoiceProposerBoostUniquenessEnabled;
     this.terminalBlockHashOverride = terminalBlockHashOverride;
     this.totalTerminalDifficultyOverride = totalTerminalDifficultyOverride;
     this.terminalBlockHashEpochOverride = terminalBlockHashEpochOverride;
@@ -189,6 +193,10 @@ public class Eth2NetworkConfiguration {
     return forkChoiceUpdateHeadOnBlockImportEnabled;
   }
 
+  public boolean isForkChoiceProposerBoostUniquenessEnabled() {
+    return forkChoiceProposerBoostUniquenessEnabled;
+  }
+
   public Optional<UInt64> getForkEpoch(final SpecMilestone specMilestone) {
     return switch (specMilestone) {
       case ALTAIR -> altairForkEpoch;
@@ -248,6 +256,8 @@ public class Eth2NetworkConfiguration {
     private Spec spec;
     private boolean forkChoiceUpdateHeadOnBlockImportEnabled =
         DEFAULT_FORK_CHOICE_UPDATE_HEAD_ON_BLOCK_IMPORT_ENABLED;
+    private boolean forkChoiceProposerBoostUniquenessEnabled =
+        DEFAULT_FORK_CHOICE_PROPOSER_BOOST_UNIQUENESS_ENABLED;
 
     public void spec(Spec spec) {
       this.spec = spec;
@@ -310,6 +320,7 @@ public class Eth2NetworkConfiguration {
           eth1DepositContractDeployBlock,
           trustedSetup,
           forkChoiceUpdateHeadOnBlockImportEnabled,
+          forkChoiceProposerBoostUniquenessEnabled,
           altairForkEpoch,
           bellatrixForkEpoch,
           capellaForkEpoch,
@@ -412,6 +423,12 @@ public class Eth2NetworkConfiguration {
     public Builder forkChoiceUpdateHeadOnBlockImportEnabled(
         final boolean forkChoiceUpdateHeadOnBlockImportEnabled) {
       this.forkChoiceUpdateHeadOnBlockImportEnabled = forkChoiceUpdateHeadOnBlockImportEnabled;
+      return this;
+    }
+
+    public Builder forkChoiceProposerBoostUniquenessEnabled(
+        final boolean forkChoiceProposerBoostUniquenessEnabled) {
+      this.forkChoiceProposerBoostUniquenessEnabled = forkChoiceProposerBoostUniquenessEnabled;
       return this;
     }
 

--- a/ethereum/networks/src/main/java/tech/pegasys/teku/networks/Eth2NetworkConfiguration.java
+++ b/ethereum/networks/src/main/java/tech/pegasys/teku/networks/Eth2NetworkConfiguration.java
@@ -48,7 +48,7 @@ public class Eth2NetworkConfiguration {
   private static final int DEFAULT_STARTUP_TIMEOUT_SECONDS = 30;
 
   public static final boolean DEFAULT_FORK_CHOICE_UPDATE_HEAD_ON_BLOCK_IMPORT_ENABLED = false;
-  public static final boolean DEFAULT_FORK_CHOICE_PROPOSER_BOOST_UNIQUENESS_ENABLED = true;
+  public static final boolean DEFAULT_FORK_CHOICE_PROPOSER_BOOST_UNIQUENESS_ENABLED = false;
 
   public static final String INITIAL_STATE_URL_PATH = "eth/v2/debug/beacon/states/finalized";
   // 26 thousand years should be enough

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/AttesterSlashingGenerator.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/AttesterSlashingGenerator.java
@@ -50,7 +50,10 @@ public class AttesterSlashingGenerator {
   public AttesterSlashing createAttesterSlashingForAttestation(
       final Attestation goodAttestation, final SignedBlockAndState blockAndState) {
     if (!goodAttestation.getData().getSlot().equals(blockAndState.getSlot())) {
-      throw new RuntimeException("Good attestation slot and input block slot should match");
+      throw new RuntimeException(
+          String.format(
+              "Good attestation slot %s and input block slot %s should match",
+              goodAttestation.getData().getSlot(), blockAndState.getSlot()));
     }
     AttestationUtil attestationUtil = spec.atSlot(blockAndState.getSlot()).getAttestationUtil();
     IndexedAttestation indexedGoodAttestation =

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/ChainBuilder.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/ChainBuilder.java
@@ -353,7 +353,7 @@ public class ChainBuilder {
     final List<SignedBlockAndState> generated = new ArrayList<>();
 
     SignedBlockAndState latestBlock = getLatestBlockAndState();
-    while (latestBlock.getState().getSlot().compareTo(slot) < 0) {
+    while (latestBlock.getState().getSlot().isLessThan(slot)) {
       latestBlock = generateNextBlock();
       generated.add(latestBlock);
     }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -587,7 +587,7 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
       if (isBeforeAttestingInterval(millisPerSlot, timeIntoSlotMillis)) {
         if (forkChoiceProposerBoostUniquenessEnabled) {
           // is_first_block
-          return transaction.getProposerBoostRoot().isEmpty();
+          return recentChainData.getStore().getProposerBoostRoot().isEmpty();
         }
         return true;
       }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -586,6 +586,7 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
 
       if (isBeforeAttestingInterval(millisPerSlot, timeIntoSlotMillis)) {
         if (forkChoiceProposerBoostUniquenessEnabled) {
+          // is_first_block
           return transaction.getProposerBoostRoot().isEmpty();
         }
         return true;

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -579,23 +579,22 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
   }
 
   // from consensus-specs/fork-choice:
-  // get_current_slot(store) == block.slot and is_before_attesting_interval and is_first_block
   private boolean shouldApplyProposerBoost(
       final SignedBeaconBlock block, final StoreTransaction transaction) {
+    // get_current_slot(store) == block.slot
     if (!spec.getCurrentSlot(transaction).equals(block.getSlot())) {
       return false;
     }
-
+    // is_before_attesting_interval
     final UInt64 millisPerSlot = spec.getMillisPerSlot(block.getSlot());
     final UInt64 timeIntoSlotMillis = getMillisIntoSlot(transaction, millisPerSlot);
     if (!isBeforeAttestingInterval(millisPerSlot, timeIntoSlotMillis)) {
       return false;
     }
-
+    // is_first_block
     if (forkChoiceProposerBoostUniquenessEnabled) {
       return transaction.getProposerBoostRoot().isEmpty();
     }
-
     return true;
   }
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
@@ -1094,11 +1094,9 @@ class ForkChoiceTest {
             ZERO);
     executionLayer.addPowBlock(terminalBlock);
     executionLayer.addPowBlock(terminalParentBlock);
-    final SignedBlockAndState epoch4Block =
-        chainBuilder.generateBlockAtSlot(
-            storageSystem.chainUpdater().getHeadSlot().plus(1),
-            BlockOptions.create().setTerminalBlockHash(terminalBlockHash));
-    return epoch4Block;
+    return chainBuilder.generateBlockAtSlot(
+        storageSystem.chainUpdater().getHeadSlot().plus(1),
+        BlockOptions.create().setTerminalBlockHash(terminalBlockHash));
   }
 
   @Test

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
@@ -155,8 +155,8 @@ class ForkChoiceTest {
             new TickProcessor(spec, recentChainData),
             transitionBlockValidator,
             DEFAULT_FORK_CHOICE_UPDATE_HEAD_ON_BLOCK_IMPORT_ENABLED,
-            // will use the static const parameter in an upcoming PR which will update the ref tests
-            // and set the const to true
+            // will use DEFAULT_FORK_CHOICE_PROPOSER_BOOST_UNIQUENESS_ENABLED in an upcoming PR
+            // which will update to the new ref tests and set the const to true
             true,
             metricsSystem);
 
@@ -366,50 +366,49 @@ class ForkChoiceTest {
   @Test
   void onBlock_shouldUpdateVotesBasedOnAttestationsInBlocks() {
     final ChainBuilder forkChain = chainBuilder.fork();
-    final SignedBlockAndState forkBlock1 =
+    final SignedBlockAndState forkBlock =
         forkChain.generateBlockAtSlot(
             ONE,
             BlockOptions.create()
                 .setEth1Data(new Eth1Data(Bytes32.ZERO, UInt64.valueOf(6), Bytes32.ZERO)));
-    final SignedBlockAndState betterBlock1 = chainBuilder.generateBlockAtSlot(1);
+    // eventually better chain with an empty block
+    final SignedBlockAndState betterBlock = chainBuilder.generateNextBlock(1);
 
-    importBlock(forkBlock1);
-    // Should automatically follow the fork as its the first child block
-    assertThat(recentChainData.getBestBlockRoot()).contains(forkBlock1.getRoot());
+    importBlock(forkBlock);
+    // Should automatically follow the fork as it is the only one imported
+    assertThat(recentChainData.getBestBlockRoot()).contains(forkBlock.getRoot());
 
     // Add an attestation for the fork so that it initially has higher weight
     // Otherwise ties are split based on the hash which is too hard to control in the test
     final BlockOptions forkBlockOptions = BlockOptions.create();
     forkChain
-        .streamValidAttestationsWithTargetBlock(forkBlock1)
+        .streamValidAttestationsWithTargetBlock(forkBlock)
         .limit(1)
         .forEach(forkBlockOptions::addAttestation);
-    final SignedBlockAndState forkBlock2 =
-        forkChain.generateBlockAtSlot(forkBlock1.getSlot().plus(1), forkBlockOptions);
-    importBlock(forkBlock2);
+    final SignedBlockAndState forkBlock1 = forkChain.generateNextBlock(forkBlockOptions);
+    importBlock(forkBlock1);
 
     // The fork is still the only option so gets selected
-    assertThat(recentChainData.getBestBlockRoot()).contains(forkBlock2.getRoot());
+    assertThat(recentChainData.getBestBlockRoot()).contains(forkBlock1.getRoot());
 
     // Now import what will become the canonical chain
-    importBlock(betterBlock1);
+    importBlock(betterBlock);
     // Process head to ensure we clear any additional proposer weighting for this first block.
     // Should still pick forkBlock as it's the best option even though we have a competing chain
     processHead(ONE);
-    assertThat(recentChainData.getBestBlockRoot()).contains(forkBlock2.getRoot());
+    assertThat(recentChainData.getBestBlockRoot()).contains(forkBlock1.getRoot());
 
     // Import a block with two attestations which makes this chain better than the fork
     final BlockOptions options = BlockOptions.create();
     chainBuilder
-        .streamValidAttestationsWithTargetBlock(betterBlock1)
+        .streamValidAttestationsWithTargetBlock(betterBlock)
         .limit(2)
         .forEach(options::addAttestation);
-    final SignedBlockAndState blockWithAttestations =
-        chainBuilder.generateBlockAtSlot(UInt64.valueOf(2), options);
+    final SignedBlockAndState blockWithAttestations = chainBuilder.generateNextBlock(options);
     importBlock(blockWithAttestations);
 
     // Haven't run fork choice so won't have re-orged yet - fork still has more applied votes
-    assertThat(recentChainData.getBestBlockRoot()).contains(forkBlock2.getRoot());
+    assertThat(recentChainData.getBestBlockRoot()).contains(forkBlock1.getRoot());
 
     // When attestations are applied we should switch away from the fork to our better chain
     processHead(blockWithAttestations.getSlot());
@@ -418,70 +417,67 @@ class ForkChoiceTest {
 
   @Test
   void onBlock_shouldUpdateVotesBasedOnAttesterSlashingEquivocationsInBlocks() {
+    final SignedBlockAndState commonBlock = chainBuilder.generateNextBlock();
+    importBlock(commonBlock);
     final ChainBuilder forkChain = chainBuilder.fork();
-    final SignedBlockAndState forkBlock1 =
-        forkChain.generateBlockAtSlot(
-            ONE,
+    final SignedBlockAndState forkBlock =
+        forkChain.generateNextBlock(
             BlockOptions.create()
                 .setEth1Data(new Eth1Data(Bytes32.ZERO, UInt64.valueOf(6), Bytes32.ZERO)));
-    final SignedBlockAndState betterBlock1 = chainBuilder.generateBlockAtSlot(1);
+    // eventually better chain with an empty block
+    final SignedBlockAndState betterBlock = chainBuilder.generateNextBlock(1);
 
-    importBlock(forkBlock1);
-    // Should automatically follow the fork as its the first child block
-    assertThat(recentChainData.getBestBlockRoot()).contains(forkBlock1.getRoot());
+    importBlock(forkBlock);
+
+    // Should automatically follow the fork as it is the only one imported
+    assertThat(recentChainData.getBestBlockRoot()).contains(forkBlock.getRoot());
 
     // Add an attestation for the fork so that it initially has higher weight
     // Otherwise ties are split based on the hash which is too hard to control in the test
     final BlockOptions forkBlockOptions = BlockOptions.create();
-    List<Attestation> forkAttestations =
-        forkChain
-            .streamValidAttestationsWithTargetBlock(forkBlock1)
-            .limit(2)
-            .collect(Collectors.toList());
+    final List<Attestation> forkAttestations =
+        forkChain.streamValidAttestationsWithTargetBlock(forkBlock).limit(2).toList();
     forkAttestations.forEach(forkBlockOptions::addAttestation);
-    final SignedBlockAndState forkBlock2 =
-        forkChain.generateBlockAtSlot(forkBlock1.getSlot().plus(1), forkBlockOptions);
-    importBlock(forkBlock2);
+    final SignedBlockAndState forkBlock1 = forkChain.generateNextBlock(forkBlockOptions);
+    importBlock(forkBlock1);
 
     // The fork is still the only option so gets selected
-    assertThat(recentChainData.getBestBlockRoot()).contains(forkBlock2.getRoot());
+    assertThat(recentChainData.getBestBlockRoot()).contains(forkBlock1.getRoot());
 
     // Now import what will become the canonical chain
-    importBlock(betterBlock1);
+    importBlock(betterBlock);
     // Process head to ensure we clear any additional proposer weighting for this first block.
     // Should still pick forkBlock as it's the best option even though we have a competing chain
     processHead(ONE);
-    assertThat(recentChainData.getBestBlockRoot()).contains(forkBlock2.getRoot());
+    assertThat(recentChainData.getBestBlockRoot()).contains(forkBlock1.getRoot());
 
     // Import a block with one attestation on what will be better chain
     final BlockOptions options = BlockOptions.create();
     chainBuilder
-        .streamValidAttestationsWithTargetBlock(betterBlock1)
+        .streamValidAttestationsWithTargetBlock(betterBlock)
         .limit(1)
         .forEach(options::addAttestation);
-    final SignedBlockAndState blockWithAttestations =
-        chainBuilder.generateBlockAtSlot(UInt64.valueOf(2), options);
+    final SignedBlockAndState blockWithAttestations = chainBuilder.generateNextBlock(options);
     importBlock(blockWithAttestations);
 
     // Haven't run fork choice so won't have re-orged yet - fork still has more applied votes
-    assertThat(recentChainData.getBestBlockRoot()).contains(forkBlock2.getRoot());
+    assertThat(recentChainData.getBestBlockRoot()).contains(forkBlock1.getRoot());
 
     // Verify that fork is still better
     processHead(blockWithAttestations.getSlot());
-    assertThat(recentChainData.getBestBlockRoot()).contains(forkBlock2.getRoot());
+    assertThat(recentChainData.getBestBlockRoot()).contains(forkBlock1.getRoot());
 
     // Add 2 AttesterSlashing on betterBlock chain, so it will become finally better
     final BlockOptions options2 = BlockOptions.create();
     forkAttestations.forEach(
         attestation ->
             options2.addAttesterSlashing(
-                chainBuilder.createAttesterSlashingForAttestation(attestation, forkBlock1)));
-    final SignedBlockAndState blockWithAttesterSlashings =
-        chainBuilder.generateBlockAtSlot(UInt64.valueOf(3), options2);
+                chainBuilder.createAttesterSlashingForAttestation(attestation, forkBlock)));
+    final SignedBlockAndState blockWithAttesterSlashings = chainBuilder.generateNextBlock(options2);
     importBlock(blockWithAttesterSlashings);
 
     // Haven't run fork choice so won't have re-orged yet - fork still has more applied votes
-    assertThat(recentChainData.getBestBlockRoot()).contains(forkBlock2.getRoot());
+    assertThat(recentChainData.getBestBlockRoot()).contains(forkBlock1.getRoot());
 
     // When attester slashings are applied we should switch away from the fork to our better chain
     processHead(blockWithAttesterSlashings.getSlot());

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
@@ -155,7 +155,9 @@ class ForkChoiceTest {
             new TickProcessor(spec, recentChainData),
             transitionBlockValidator,
             DEFAULT_FORK_CHOICE_UPDATE_HEAD_ON_BLOCK_IMPORT_ENABLED,
-            DEFAULT_FORK_CHOICE_PROPOSER_BOOST_UNIQUENESS_ENABLED,
+            // will use the static const parameter in an upcoming PR which will update the ref tests
+            // and set the const to true
+            true,
             metricsSystem);
 
     // Starting and mocks

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
@@ -29,6 +29,7 @@ import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
+import static tech.pegasys.teku.networks.Eth2NetworkConfiguration.DEFAULT_FORK_CHOICE_PROPOSER_BOOST_UNIQUENESS_ENABLED;
 import static tech.pegasys.teku.networks.Eth2NetworkConfiguration.DEFAULT_FORK_CHOICE_UPDATE_HEAD_ON_BLOCK_IMPORT_ENABLED;
 import static tech.pegasys.teku.statetransition.forkchoice.ForkChoice.BLOCK_CREATION_TOLERANCE_MS;
 
@@ -154,6 +155,7 @@ class ForkChoiceTest {
             new TickProcessor(spec, recentChainData),
             transitionBlockValidator,
             DEFAULT_FORK_CHOICE_UPDATE_HEAD_ON_BLOCK_IMPORT_ENABLED,
+            DEFAULT_FORK_CHOICE_PROPOSER_BOOST_UNIQUENESS_ENABLED,
             metricsSystem);
 
     // Starting and mocks
@@ -303,6 +305,7 @@ class ForkChoiceTest {
             new TickProcessor(spec, recentChainData),
             transitionBlockValidator,
             DEFAULT_FORK_CHOICE_UPDATE_HEAD_ON_BLOCK_IMPORT_ENABLED,
+            DEFAULT_FORK_CHOICE_PROPOSER_BOOST_UNIQUENESS_ENABLED,
             metricsSystem);
 
     final UInt64 currentSlot = recentChainData.getCurrentSlot().orElseThrow();

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -678,6 +678,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
             new TickProcessor(spec, recentChainData),
             new MergeTransitionBlockValidator(spec, recentChainData, executionLayer),
             beaconConfig.eth2NetworkConfig().isForkChoiceUpdateHeadOnBlockImportEnabled(),
+            beaconConfig.eth2NetworkConfig().isForkChoiceProposerBoostUniquenessEnabled(),
             metricsSystem);
     forkChoiceTrigger = new ForkChoiceTrigger(forkChoice);
   }

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/Eth2NetworkOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/Eth2NetworkOptions.java
@@ -166,6 +166,19 @@ public class Eth2NetworkOptions {
   private boolean forkChoiceUpdateHeadOnBlockImportEnabled =
       Eth2NetworkConfiguration.DEFAULT_FORK_CHOICE_UPDATE_HEAD_ON_BLOCK_IMPORT_ENABLED;
 
+  // can be removed after all clients have rolled out the spec change:
+  // https://github.com/ethereum/consensus-specs/pull/3352
+  @Option(
+      names = {"--Xfork-choice-proposer-boost-uniqueness-enabled"},
+      paramLabel = "<BOOLEAN>",
+      description = "Apply proposer boost to first block in case of equivocation.",
+      arity = "0..1",
+      fallbackValue = "true",
+      showDefaultValue = Visibility.ALWAYS,
+      hidden = true)
+  private boolean forkChoiceProposerBoostUniquenessEnabled =
+      Eth2NetworkConfiguration.DEFAULT_FORK_CHOICE_PROPOSER_BOOST_UNIQUENESS_ENABLED;
+
   @Option(
       names = {"--Xeth1-deposit-contract-deploy-block-override"},
       hidden = true,
@@ -246,6 +259,7 @@ public class Eth2NetworkOptions {
     builder
         .safeSlotsToImportOptimistically(safeSlotsToImportOptimistically)
         .forkChoiceUpdateHeadOnBlockImportEnabled(forkChoiceUpdateHeadOnBlockImportEnabled)
+        .forkChoiceProposerBoostUniquenessEnabled(forkChoiceProposerBoostUniquenessEnabled)
         .epochsStoreBlobs(epochsStoreBlobs);
   }
 

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/Eth2NetworkOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/Eth2NetworkOptions.java
@@ -166,8 +166,7 @@ public class Eth2NetworkOptions {
   private boolean forkChoiceUpdateHeadOnBlockImportEnabled =
       Eth2NetworkConfiguration.DEFAULT_FORK_CHOICE_UPDATE_HEAD_ON_BLOCK_IMPORT_ENABLED;
 
-  // can be removed after all clients have rolled out the spec change:
-  // https://github.com/ethereum/consensus-specs/pull/3352
+  // https://github.com/Consensys/teku/issues/7537
   @Option(
       names = {"--Xfork-choice-proposer-boost-uniqueness-enabled"},
       paramLabel = "<BOOLEAN>",


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Implements changes as per https://github.com/ethereum/consensus-specs/pull/3352

- Introduces a temporary feature flag `--Xfork-choice-proposer-boost-uniqueness-enabled` defaulting to false. Will enable in #7522  which will update the ref tests.
- Manually set the flag to true in ForkChoiceTest instead of relying on the static const to make sure unit tests are modified and passing with the flag set to true. Will use the static const in #7522 PR as well.
- Edited couple of unit tests which were checking reorg logic but they were based on having chains with same slots, which is not typically how reorgs happen unless shuffling changes and test was not working because proposer boost was applied only to first block for that slot. So changed tests to create forks with one empty slot difference.

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
