### PR TITLE
kzgNoop in MinimalEth2NetworkOptions

### DIFF
--- a/teku/src/main/java/tech/pegasys/teku/cli/options/MinimalEth2NetworkOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/MinimalEth2NetworkOptions.java
@@ -36,6 +36,6 @@ public class MinimalEth2NetworkOptions {
   }
 
   private Eth2NetworkConfiguration getConfig() {
-    return Eth2NetworkConfiguration.builder(network).build();
+    return Eth2NetworkConfiguration.builder(network).kzgNoop(true).build();
   }
 }


### PR DESCRIPTION
Fix a missing kzgNoop in `MinimalEth2NetworkOptions` preventing genesis command to ignore kzg config, which could lead to a failure during.

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
