### PR TITLE
Upgrade snappy to 1.1.10.4

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -129,7 +129,7 @@ dependencyManagement {
       entry 'crypto'
     }
 
-    dependency 'org.xerial.snappy:snappy-java:1.1.10.3'
+    dependency 'org.xerial.snappy:snappy-java:1.1.10.4'
 
     dependency 'io.prometheus:simpleclient:0.9.0'
 


### PR DESCRIPTION
## PR Description

Upgrade snappy from 1.1.10.3 to 1.1.10.4.

Addresses a CVE reported by Trivy (https://avd.aquasec.com/nvd/cve-2023-43642)

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
