### PR TITLE
Add `inactivity` field to `total_rewards` in Attestation Rewards API response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ For information on changes in released versions of Teku, see the [releases page]
 ## Unreleased Changes
 
 ### Breaking Changes
+- Added new `inactivity` field to `total_rewards` in `/eth/v1/beacon/rewards/attestations/{epoch}` endpoint response.
 
 ### Additions and Improvements
 

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/GetAttestationRewards.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/schema/GetAttestationRewards.json
@@ -31,11 +31,11 @@
               "source"
             ],
             "properties": {
-              "effective_balance" : {
-                "type" : "string",
-                "description" : "unsigned 64 bit integer",
-                "example" : "1",
-                "format" : "uint64"
+              "effective_balance": {
+                "type": "string",
+                "description": "unsigned 64 bit integer",
+                "example": "1",
+                "format": "uint64"
               },
               "head": {
                 "type": "string",
@@ -66,7 +66,8 @@
               "validator_index",
               "head",
               "target",
-              "source"
+              "source",
+              "inactivity"
             ],
             "properties": {
               "validator_index": {
@@ -93,11 +94,17 @@
                 "example": "1",
                 "format": "long"
               },
-              "inclusion_delay" : {
-                "type" : "string",
-                "description" : "unsigned 64 bit integer",
-                "example" : "1",
-                "format" : "uint64"
+              "inclusion_delay": {
+                "type": "string",
+                "description": "unsigned 64 bit integer",
+                "example": "1",
+                "format": "uint64"
+              },
+              "inactivity": {
+                "type": "string",
+                "description": "unsigned 64 bit integer",
+                "example": "1",
+                "format": "uint64"
               }
             }
           }

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/rewards/GetAttestationRewards.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/rewards/GetAttestationRewards.java
@@ -61,6 +61,7 @@ public class GetAttestationRewards extends RestApiEndpoint {
           .withField("source", LONG_TYPE, TotalAttestationReward::getSource)
           .withOptionalField(
               "inclusion_delay", UINT64_TYPE, TotalAttestationReward::getInclusionDelay)
+          .withField("inactivity", UINT64_TYPE, TotalAttestationReward::getInactivity)
           .build();
 
   private static final SerializableTypeDefinition<AttestationRewardsData> DATA_TYPE =

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/rewards/GetAttestationRewardsTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/rewards/GetAttestationRewardsTest.java
@@ -51,7 +51,8 @@ class GetAttestationRewardsTest extends AbstractMigratedBeaconHandlerTest {
       idealAttestationReward.addSource(5000L);
     }
     TotalAttestationReward totalAttestationReward =
-        new TotalAttestationReward(0L, 2000L, 2000L, 4000L, Optional.of(UInt64.valueOf(2000L)));
+        new TotalAttestationReward(
+            0L, 2000L, 2000L, 4000L, Optional.of(UInt64.valueOf(2000L)), UInt64.valueOf(300));
     AttestationRewardsData attestationRewardsData =
         new AttestationRewardsData(
             List.of(idealAttestationReward), List.of(totalAttestationReward));

--- a/data/beaconrestapi/src/test/resources/tech/pegasys/teku/beaconrestapi/handlers/v1/rewards/getAttestationRewards.json
+++ b/data/beaconrestapi/src/test/resources/tech/pegasys/teku/beaconrestapi/handlers/v1/rewards/getAttestationRewards.json
@@ -1,1 +1,1 @@
-{"execution_optimistic":false,"finalized":false,"data":{"ideal_rewards":[{"effective_balance":"1000000000","head":"2500","target":"5000","source":"5000"}],"total_rewards":[{"validator_index":"0","head":"2000","target":"2000","source":"4000","inclusion_delay":"2000"}]}}
+{"execution_optimistic":false,"finalized":false,"data":{"ideal_rewards":[{"effective_balance":"1000000000","head":"2500","target":"5000","source":"5000"}],"total_rewards":[{"validator_index":"0","head":"2000","target":"2000","source":"4000","inclusion_delay":"2000","inactivity":"300"}]}}

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/migrated/TotalAttestationReward.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/migrated/TotalAttestationReward.java
@@ -28,14 +28,21 @@ public class TotalAttestationReward {
   private final long target;
   private final long source;
   private final Optional<UInt64> inclusionDelay;
+  private final UInt64 inactivity;
 
   public TotalAttestationReward(
-      long validatorIndex, long head, long target, long source, Optional<UInt64> inclusionDelay) {
+      long validatorIndex,
+      long head,
+      long target,
+      long source,
+      Optional<UInt64> inclusionDelay,
+      UInt64 inactivity) {
     this.validatorIndex = validatorIndex;
     this.head = head;
     this.target = target;
     this.source = source;
     this.inclusionDelay = inclusionDelay;
+    this.inactivity = inactivity;
   }
 
   public TotalAttestationReward(long validatorIndex, final RewardAndPenalty rewardAndPenalty) {
@@ -59,6 +66,10 @@ public class TotalAttestationReward {
         detailedRewardAndPenalty.getReward(RewardComponent.SOURCE).longValue()
             - detailedRewardAndPenalty.getPenalty(RewardComponent.SOURCE).longValue();
     this.inclusionDelay = Optional.empty();
+    this.inactivity =
+        detailedRewardAndPenalty
+            .getReward(RewardComponent.INACTIVITY)
+            .minus(detailedRewardAndPenalty.getPenalty(RewardComponent.INACTIVITY));
   }
 
   public long getValidatorIndex() {
@@ -79,6 +90,10 @@ public class TotalAttestationReward {
 
   public Optional<UInt64> getInclusionDelay() {
     return inclusionDelay;
+  }
+
+  public UInt64 getInactivity() {
+    return inactivity;
   }
 
   @Override


### PR DESCRIPTION
fixes #7553 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
