### PR TITLE
Improve the two "key" serializers in kvstore

### DIFF
--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/serialization/SlotAndBlockRootAndBlobIndexKeySerializer.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/serialization/SlotAndBlockRootAndBlobIndexKeySerializer.java
@@ -41,9 +41,9 @@ class SlotAndBlockRootAndBlobIndexKeySerializer
   @Override
   public SlotAndBlockRootAndBlobIndex deserialize(final byte[] data) {
     checkArgument(data.length == DATA_SIZE);
-    final UInt64 slot = deserializeUInt64(data, SLOT_OFFSET);
+    final UInt64 slot = UInt64Serializer.deserialize(data, SLOT_OFFSET);
     final Bytes32 blockRoot = Bytes32.wrap(data, BLOCK_ROOT_OFFSET);
-    final UInt64 blobIndex = deserializeUInt64(data, BLOB_INDEX_OFFSET);
+    final UInt64 blobIndex = UInt64Serializer.deserialize(data, BLOB_INDEX_OFFSET);
     return new SlotAndBlockRootAndBlobIndex(slot, blockRoot, blobIndex);
   }
 
@@ -54,10 +54,5 @@ class SlotAndBlockRootAndBlobIndexKeySerializer
             value.getBlockRoot(),
             Bytes.wrap(Longs.toByteArray(value.getBlobIndex().longValue())))
         .toArrayUnsafe();
-  }
-
-  private UInt64 deserializeUInt64(final byte[] data, int offset) {
-    final Bytes uint64Bytes = Bytes.wrap(data, offset, Long.BYTES);
-    return UInt64.fromLongBits(Longs.fromByteArray(uint64Bytes.toArray()));
   }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/serialization/SlotAndBlockRootKeySerializer.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/serialization/SlotAndBlockRootKeySerializer.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.teku.storage.server.kvstore.serialization;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.google.common.primitives.Longs;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
@@ -25,20 +27,30 @@ import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
  * to quickly lookup most recent\oldest values by slot as well as perform pruning based on slot
  */
 class SlotAndBlockRootKeySerializer implements KvStoreSerializer<SlotAndBlockRoot> {
+  static final int SLOT_SIZE = Long.BYTES;
+  static final int BLOCK_ROOT_SIZE = Bytes32.SIZE;
+
+  static final int SLOT_OFFSET = 0;
+  static final int BLOCK_ROOT_OFFSET = SLOT_OFFSET + SLOT_SIZE;
+  static final int DATA_SIZE = BLOCK_ROOT_OFFSET + BLOCK_ROOT_SIZE;
+
   @Override
   public SlotAndBlockRoot deserialize(final byte[] data) {
-    return new SlotAndBlockRoot(
-        UInt64.fromLongBits(
-            Longs.fromBytes(
-                data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7])),
-        Bytes32.wrap(data, 8));
+    checkArgument(data.length == DATA_SIZE);
+    final UInt64 slot = deserializeUInt64(data, SLOT_OFFSET);
+    final Bytes32 blockRoot = Bytes32.wrap(data, BLOCK_ROOT_OFFSET);
+    return new SlotAndBlockRoot(slot, blockRoot);
   }
 
   @Override
   public byte[] serialize(final SlotAndBlockRoot value) {
-
     return Bytes.concatenate(
             Bytes.wrap(Longs.toByteArray(value.getSlot().longValue())), value.getBlockRoot())
         .toArrayUnsafe();
+  }
+
+  private UInt64 deserializeUInt64(final byte[] data, int offset) {
+    final Bytes uint64Bytes = Bytes.wrap(data, offset, Long.BYTES);
+    return UInt64.fromLongBits(Longs.fromByteArray(uint64Bytes.toArray()));
   }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/serialization/SlotAndBlockRootKeySerializer.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/serialization/SlotAndBlockRootKeySerializer.java
@@ -37,7 +37,7 @@ class SlotAndBlockRootKeySerializer implements KvStoreSerializer<SlotAndBlockRoo
   @Override
   public SlotAndBlockRoot deserialize(final byte[] data) {
     checkArgument(data.length == DATA_SIZE);
-    final UInt64 slot = deserializeUInt64(data, SLOT_OFFSET);
+    final UInt64 slot = UInt64Serializer.deserialize(data, SLOT_OFFSET);
     final Bytes32 blockRoot = Bytes32.wrap(data, BLOCK_ROOT_OFFSET);
     return new SlotAndBlockRoot(slot, blockRoot);
   }
@@ -47,10 +47,5 @@ class SlotAndBlockRootKeySerializer implements KvStoreSerializer<SlotAndBlockRoo
     return Bytes.concatenate(
             Bytes.wrap(Longs.toByteArray(value.getSlot().longValue())), value.getBlockRoot())
         .toArrayUnsafe();
-  }
-
-  private UInt64 deserializeUInt64(final byte[] data, int offset) {
-    final Bytes uint64Bytes = Bytes.wrap(data, offset, Long.BYTES);
-    return UInt64.fromLongBits(Longs.fromByteArray(uint64Bytes.toArray()));
   }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/serialization/UInt64Serializer.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/serialization/UInt64Serializer.java
@@ -29,11 +29,11 @@ class UInt64Serializer implements KvStoreSerializer<UInt64> {
   }
 
   /**
-   * Assumes data is at least 8 bytes long and offset is within bounds
+   * Assumes data is at least 8 bytes long and offset is within bounds.
    *
-   * @param data
-   * @param offset
-   * @return
+   * @param data The byte array containing the UInt64 data.
+   * @param offset The offset to the UInt64 data.
+   * @return The deserialized UInt64 value.
    */
   public static UInt64 deserialize(final byte[] data, int offset) {
     return UInt64.fromLongBits(

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/serialization/UInt64Serializer.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/serialization/UInt64Serializer.java
@@ -27,4 +27,24 @@ class UInt64Serializer implements KvStoreSerializer<UInt64> {
   public byte[] serialize(final UInt64 value) {
     return Longs.toByteArray(value.longValue());
   }
+
+  /**
+   * Assumes data is at least 8 bytes long and offset is within bounds
+   *
+   * @param data
+   * @param offset
+   * @return
+   */
+  public static UInt64 deserialize(final byte[] data, int offset) {
+    return UInt64.fromLongBits(
+        Longs.fromBytes(
+            data[offset],
+            data[offset + 1],
+            data[offset + 2],
+            data[offset + 3],
+            data[offset + 4],
+            data[offset + 5],
+            data[offset + 6],
+            data[offset + 7]));
+  }
 }

--- a/storage/src/property-test/java/tech/pegasys/teku/storage/server/kvstore/serialization/SlotAndBlockRootAndBlobIndexKeySerializerPropertyTest.java
+++ b/storage/src/property-test/java/tech/pegasys/teku/storage/server/kvstore/serialization/SlotAndBlockRootAndBlobIndexKeySerializerPropertyTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Consensys Software Inc., 2023
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.server.kvstore.serialization;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.storage.server.kvstore.serialization.KvStoreSerializer.SLOT_AND_BLOCK_ROOT_AND_BLOB_INDEX_KEY_SERIALIZER;
+
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.constraints.Size;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.util.SlotAndBlockRootAndBlobIndex;
+
+public class SlotAndBlockRootAndBlobIndexKeySerializerPropertyTest {
+  @Property
+  public void roundTrip(
+      @ForAll final long slot,
+      @ForAll @Size(32) final byte[] blockRoot,
+      @ForAll final long blobIndex) {
+    final SlotAndBlockRootAndBlobIndex value =
+        new SlotAndBlockRootAndBlobIndex(
+            UInt64.fromLongBits(slot), Bytes32.wrap(blockRoot), UInt64.fromLongBits(blobIndex));
+    final byte[] serialized = SLOT_AND_BLOCK_ROOT_AND_BLOB_INDEX_KEY_SERIALIZER.serialize(value);
+    final SlotAndBlockRootAndBlobIndex deserialized =
+        SLOT_AND_BLOCK_ROOT_AND_BLOB_INDEX_KEY_SERIALIZER.deserialize(serialized);
+    assertThat(deserialized).isEqualTo(value);
+  }
+}

--- a/storage/src/property-test/java/tech/pegasys/teku/storage/server/kvstore/serialization/SlotAndBlockRootKeySerializerPropertyTest.java
+++ b/storage/src/property-test/java/tech/pegasys/teku/storage/server/kvstore/serialization/SlotAndBlockRootKeySerializerPropertyTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Consensys Software Inc., 2023
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.server.kvstore.serialization;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.teku.storage.server.kvstore.serialization.KvStoreSerializer.SLOT_AND_BLOCK_ROOT_KEY_SERIALIZER;
+
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.constraints.Size;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
+
+public class SlotAndBlockRootKeySerializerPropertyTest {
+  @Property
+  public void roundTrip(@ForAll final long slot, @ForAll @Size(32) final byte[] blockRoot) {
+    final SlotAndBlockRoot value =
+        new SlotAndBlockRoot(UInt64.fromLongBits(slot), Bytes32.wrap(blockRoot));
+    final byte[] serialized = SLOT_AND_BLOCK_ROOT_KEY_SERIALIZER.serialize(value);
+    final SlotAndBlockRoot deserialized =
+        SLOT_AND_BLOCK_ROOT_KEY_SERIALIZER.deserialize(serialized);
+    assertThat(deserialized).isEqualTo(value);
+  }
+}


### PR DESCRIPTION
## PR Description

I was reviewing these and thought they could be a little cleaner/safer.

* Add constants for each field's size and offset.
* Add `checkArgument` to ensure the input is the right length.
* Add `UInt64Serializer::deserialize` helper function.
* Add property tests to ensure they work as intended.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
