### PR TITLE
Fix Metrics exception in SyncCommitteeDutyLoader

### DIFF
--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/SyncCommitteeDutyLoaderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/SyncCommitteeDutyLoaderTest.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.validator.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -155,8 +156,9 @@ class SyncCommitteeDutyLoaderTest {
     when(validatorApiChannel.getSyncCommitteeDuties(epoch, validatorIndices))
         .thenReturn(
             SafeFuture.completedFuture(Optional.of(new SyncCommitteeDuties(false, List.of()))));
-    final SyncCommitteeScheduledDuties duties1 = loadDuties(epoch);
-    final SyncCommitteeScheduledDuties duties2 = loadDuties(epoch);
+    loadDuties(epoch);
+
+    assertThatCode(() -> loadDuties(epoch)).doesNotThrowAnyException();
   }
 
   private SyncCommitteeScheduledDuties loadDuties(final UInt64 epoch) {

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/SyncCommitteeDutyLoaderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/SyncCommitteeDutyLoaderTest.java
@@ -149,6 +149,16 @@ class SyncCommitteeDutyLoaderTest {
         .isEqualTo(63.0);
   }
 
+  @Test
+  void shouldCreateJustASingleMetricsGauge() {
+    final UInt64 epoch = UInt64.valueOf(56);
+    when(validatorApiChannel.getSyncCommitteeDuties(epoch, validatorIndices))
+        .thenReturn(
+            SafeFuture.completedFuture(Optional.of(new SyncCommitteeDuties(false, List.of()))));
+    final SyncCommitteeScheduledDuties duties1 = loadDuties(epoch);
+    final SyncCommitteeScheduledDuties duties2 = loadDuties(epoch);
+  }
+
   private SyncCommitteeScheduledDuties loadDuties(final UInt64 epoch) {
     final SafeFuture<Optional<SyncCommitteeScheduledDuties>> result =
         dutyLoader.loadDutiesForEpoch(epoch);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

With a minimal validator set setup getting the following exceptions: 
```
2023-10-02 19:18:43.000+04:00 | validator-async-10 | ERROR | RetryingDutyLoader | Failed to request validator duties for epoch 95. Retrying after delay.
java.util.concurrent.CompletionException: java.lang.IllegalArgumentException: Collector already registered that provides name: validator_current_sync_committee_last_epoch
at java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:315) ~[?:?]
at java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:320) ~[?:?]
at java.util.concurrent.CompletableFuture$UniCompose.tryFire(CompletableFuture.java:1159) ~[?:?]
at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:510) ~[?:?]
at java.util.concurrent.CompletableFuture.complete(CompletableFuture.java:2147) ~[?:?]
at tech.pegasys.teku.infrastructure.async.SafeFuture.lambda$propagateResult$3(SafeFuture.java:146) ~[async-develop.jar:23.9.1+1-g0f3caadecb]
at java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:863) ~[?:?]
at java.util.concurrent.CompletableFuture.uniWhenCompleteStage(CompletableFuture.java:887) ~[?:?]
at java.util.concurrent.CompletableFuture.whenComplete(CompletableFuture.java:2325) ~[?:?]
at tech.pegasys.teku.infrastructure.async.SafeFuture.whenComplete(SafeFuture.java:623) ~[async-develop.jar:23.9.1+1-g0f3caadecb]
at tech.pegasys.teku.infrastructure.async.SafeFuture.whenComplete(SafeFuture.java:31) ~[async-develop.jar:23.9.1+1-g0f3caadecb]
at tech.pegasys.teku.infrastructure.async.SafeFuture.propagateResult(SafeFuture.java:141) ~[async-develop.jar:23.9.1+1-g0f3caadecb]
at tech.pegasys.teku.infrastructure.async.SafeFuture.lambda$exceptionallyCompose$34(SafeFuture.java:423) ~[async-develop.jar:23.9.1+1-g0f3caadecb]
at java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:863) ~[?:?]
at java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:841) ~[?:?]
at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:510) ~[?:?]
at java.util.concurrent.CompletableFuture.complete(CompletableFuture.java:2147) ~[?:?]
at tech.pegasys.teku.infrastructure.async.SafeFuture.lambda$propagateResult$3(SafeFuture.java:146) ~[async-develop.jar:23.9.1+1-g0f3caadecb]
at java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:863) ~[?:?]
at java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:841) ~[?:?]
at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:510) ~[?:?]
at java.util.concurrent.CompletableFuture.complete(CompletableFuture.java:2147) ~[?:?]
at tech.pegasys.teku.infrastructure.async.SafeFuture.lambda$propagateToAsync$20(SafeFuture.java:323) ~[async-develop.jar:23.9.1+1-g0f3caadecb]
at tech.pegasys.teku.infrastructure.async.SafeFuture.of(SafeFuture.java:80) ~[async-develop.jar:23.9.1+1-g0f3caadecb]
at tech.pegasys.teku.infrastructure.async.AsyncRunner.lambda$runAsync$2(AsyncRunner.java:47) ~[async-develop.jar:23.9.1+1-g0f3caadecb]
at tech.pegasys.teku.infrastructure.async.SafeFuture.of(SafeFuture.java:72) ~[async-develop.jar:23.9.1+1-g0f3caadecb]
at tech.pegasys.teku.infrastructure.async.ScheduledExecutorAsyncRunner.lambda$createRunnableForAction$1(ScheduledExecutorAsyncRunner.java:124) ~[async-develop.jar:23.9.1+1-g0f3caadecb]
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[?:?]
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[?:?]
at java.lang.Thread.run(Thread.java:833) ~[?:?]
Caused by: java.lang.IllegalArgumentException: Collector already registered that provides name: validator_current_sync_committee_last_epoch
at io.prometheus.client.CollectorRegistry.register(CollectorRegistry.java:54) ~[simpleclient-0.9.0.jar:?]
at io.prometheus.client.Collector.register(Collector.java:139) ~[simpleclient-0.9.0.jar:?]
at org.hyperledger.besu.metrics.prometheus.PrometheusMetricsSystem.addCollectorUnchecked(PrometheusMetricsSystem.java:168) ~[metrics-core-22.4.2.jar:22.4.2]
at org.hyperledger.besu.metrics.prometheus.PrometheusMetricsSystem.createGauge(PrometheusMetricsSystem.java:141) ~[metrics-core-22.4.2.jar:22.4.2]
at org.hyperledger.besu.plugin.services.MetricsSystem.createIntegerGauge(MetricsSystem.java:116) ~[plugin-api-22.4.2.jar:22.4.2]
at tech.pegasys.teku.validator.client.SyncCommitteeDutyLoader.scheduleAllDuties(SyncCommitteeDutyLoader.java:93) ~[client-develop.jar:23.9.1+1-g0f3caadecb]
at tech.pegasys.teku.validator.client.SyncCommitteeDutyLoader.scheduleAllDuties(SyncCommitteeDutyLoader.java:31) ~[client-develop.jar:23.9.1+1-g0f3caadecb]
at tech.pegasys.teku.validator.client.AbstractDutyLoader.lambda$loadDutiesForEpoch$2(AbstractDutyLoader.java:55) ~[client-develop.jar:23.9.1+1-g0f3caadecb]
at java.util.concurrent.CompletableFuture$UniCompose.tryFire(CompletableFuture.java:1150) ~[?:?]
```

Happens because `SyncCommitteeDutyLoader` creates a `Metrcis` gauge every time a sync duty is scheduled

The gauge needs to be created just once and then updated 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
