### PR TITLE
Fix `FAILED_DATA_AVAILABILITY_CHECK_INVALID` handling

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/BlockManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/BlockManager.java
@@ -332,6 +332,15 @@ public class BlockManager extends Service
                     dataUnavailableSubscribers.deliver(
                         DataUnavailableSubscriber::onDataUnavailable, block);
                     break;
+                  case FAILED_DATA_AVAILABILITY_CHECK_INVALID:
+                    // Block's commitments and known blobSidecars are not matching.
+                    // To be able to recover from this situation we remove all blobSidecars from the
+                    // pool and discard.
+                    // If next block builds on top of this one, we will re-download all blobSidecars
+                    // and block again via RPC by root.
+                    LOG.warn("Unable to import block {} due to invalid data", block.toLogString());
+                    blobSidecarPool.removeAllForBlock(block.getRoot());
+                    break;
                   default:
                     LOG.trace(
                         "Unable to import block for reason {}: {}",


### PR DESCRIPTION
If block import fails with `FAILED_DATA_AVAILABILITY_CHECK_INVALID` we mark block as invalid. This is wrong because the block itself isn't invalid. What is invalid is the block's commitments WRT blobs we have received so far.
So if the majority of the network saw the correct blobs and imported the block, then the next proposer will build on top of it. In this case we must be able to recover and redownload block\blobs by root.

We could potentially cache the block somewhere and do a blobSidecar cleanup session (running kzg validation one by one to find out which one is invalid and drop it). So we could avoid re-downloading everything, but it means we should:
1- "cache" the entire block in the `blobSidecarPool` (ATM the tracker stores only the body)
2- implement the blobSidecar cleanup
3- whenever we try to retrieve a block by root via RPC we should check it if it is already in the `blobSidecarPool`, if yes just keep it from there.

This PR just implement the easy way.

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
