### PR TITLE
Fix example for KZG_COMMITMENT_TYPE

### DIFF
--- a/ethereum/json-types/src/main/java/tech/pegasys/teku/ethereum/json/types/EthereumTypes.java
+++ b/ethereum/json-types/src/main/java/tech/pegasys/teku/ethereum/json/types/EthereumTypes.java
@@ -75,8 +75,9 @@ public class EthereumTypes {
           .formatter(KZGCommitment::toHexString)
           .parser(KZGCommitment::fromHexString)
           .example(
-              "0x1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505cc411d61252fb6cb3fa0017b679f8bb2305b26a285fa2737f175668d0dff91cc1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505")
-          .description("KZG Commitments")
+              "0xb09ce4964278eff81a976fbc552488cb84fc4a102f004c87"
+                  + "179cb912f49904d1e785ecaf5d184522a58e9035875440ef")
+          .description("KZG Commitment")
           .format("byte")
           .build();
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

Noticed that the example for `KZG_COMMITMENT_TYPE`, which was added yesterday (#7561), was wrong. A (compressed) KZG commitment is 48 bytes. The example was 96 bytes. I replaced the example with a value from the spec tests:

* https://github.com/ethereum/consensus-spec-tests/blob/master/tests/general/deneb/kzg/blob_to_kzg_commitment/kzg-mainnet/blob_to_kzg_commitment_case_valid_blob_19b3f3f8c98ea31e/data.yaml

I also changed the description from plural to singular. I think this was the intention.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
