### PR TITLE
Silencing unecessary warning when handling sync committee messages

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeMessagePool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeMessagePool.java
@@ -25,6 +25,8 @@ import java.util.NavigableMap;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.TreeMap;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.bls.BLS;
 import tech.pegasys.teku.bls.BLSSignature;
@@ -40,6 +42,9 @@ import tech.pegasys.teku.statetransition.OperationAddedSubscriber;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
 
 public class SyncCommitteeMessagePool implements SlotEventsChannel {
+
+  private static final Logger LOG = LogManager.getLogger();
+
   private final Subscribers<OperationAddedSubscriber<ValidatableSyncCommitteeMessage>> subscribers =
       Subscribers.create(true);
 
@@ -176,10 +181,13 @@ public class SyncCommitteeMessagePool implements SlotEventsChannel {
       IntIterator iterator = participationIndices.iterator();
       while (iterator.hasNext()) {
         int index = iterator.nextInt();
-        if (!this.participationIndices.add(index)) {
-          throw new IllegalStateException("Already added " + index);
+        if (this.participationIndices.add(index)) {
+          this.signatures.add(signature);
+        } else {
+          LOG.debug(
+              "Ignoring already aggregated signature from subcommittee participant index = {}",
+              participationIndices);
         }
-        this.signatures.add(signature);
       }
     }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeMessagePool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeMessagePool.java
@@ -185,7 +185,8 @@ public class SyncCommitteeMessagePool implements SlotEventsChannel {
           this.signatures.add(signature);
         } else {
           LOG.trace(
-              "Ignoring already aggregated signature from subcommittee participant index = {}", index);
+              "Ignoring already aggregated signature from subcommittee participant index = {}",
+              index);
         }
       }
     }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeMessagePool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeMessagePool.java
@@ -180,13 +180,12 @@ public class SyncCommitteeMessagePool implements SlotEventsChannel {
     public void add(final IntSet participationIndices, final BLSSignature signature) {
       IntIterator iterator = participationIndices.iterator();
       while (iterator.hasNext()) {
-        int index = iterator.nextInt();
+        final int index = iterator.nextInt();
         if (this.participationIndices.add(index)) {
           this.signatures.add(signature);
         } else {
           LOG.debug(
-              "Ignoring already aggregated signature from subcommittee participant index = {}",
-              participationIndices);
+              "Ignoring already aggregated signature from subcommittee participant index = {}", index);
         }
       }
     }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeMessagePool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeMessagePool.java
@@ -184,7 +184,7 @@ public class SyncCommitteeMessagePool implements SlotEventsChannel {
         if (this.participationIndices.add(index)) {
           this.signatures.add(signature);
         } else {
-          LOG.debug(
+          LOG.trace(
               "Ignoring already aggregated signature from subcommittee participant index = {}", index);
         }
       }


### PR DESCRIPTION

## PR Description
There is no need to thrown an IllegalState in a scenario where we are handling the aggregation logic for duplicates correctly.

## Fixed Issue(s)
fixes #7534

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
