### PR TITLE
Early fail on 0 active validators when computing sync committees

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/helpers/BeaconStateAccessorsAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/helpers/BeaconStateAccessorsAltair.java
@@ -101,9 +101,7 @@ public class BeaconStateAccessorsAltair extends BeaconStateAccessors {
     final UInt64 epoch = getCurrentEpoch(state).plus(1);
     final IntList activeValidatorIndices = getActiveValidatorIndices(state, epoch);
     final int activeValidatorCount = activeValidatorIndices.size();
-    checkArgument(
-        activeValidatorCount > 0,
-        "Provided state should have active validators, 0 validators are active");
+    checkArgument(activeValidatorCount > 0, "Provided state has no active validators");
 
     final Bytes32 seed = getSeed(state, epoch, Domain.SYNC_COMMITTEE);
     int i = 0;

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/helpers/BeaconStateAccessorsAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/helpers/BeaconStateAccessorsAltair.java
@@ -101,6 +101,10 @@ public class BeaconStateAccessorsAltair extends BeaconStateAccessors {
     final UInt64 epoch = getCurrentEpoch(state).plus(1);
     final IntList activeValidatorIndices = getActiveValidatorIndices(state, epoch);
     final int activeValidatorCount = activeValidatorIndices.size();
+    checkArgument(
+        activeValidatorCount > 0,
+        "Provided state should have active validators, 0 validators are active");
+
     final Bytes32 seed = getSeed(state, epoch, Domain.SYNC_COMMITTEE);
     int i = 0;
     final SszList<Validator> validators = state.getValidators();


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
I think it will be cleaner with that fix rather than arithmetic exception. Though I have small concern if it's possible to make some testnet with 0 sync committee size.
Actual stacktrace from devnet-9
```
2023-10-09 11:51:18.582 ERROR - Failed to calculate payload attributes for slot 72557
java.util.concurrent.CompletionException: java.lang.ArithmeticException: / by zero
at java.util.concurrent.CompletableFuture.encodeThrowable(Unknown Source) ~[?:?]
at java.util.concurrent.CompletableFuture.uniApplyNow(Unknown Source) ~[?:?]
at java.util.concurrent.CompletableFuture.uniApplyStage(Unknown Source) ~[?:?]
at java.util.concurrent.CompletableFuture.thenApply(Unknown Source) ~[?:?]
at tech.pegasys.teku.infrastructure.async.SafeFuture.thenApply(SafeFuture.java:464) ~[teku-infrastructure-async-develop.jar:23.9.1+27-gd77470ab23]
at tech.pegasys.teku.dataproviders.generators.StateAtSlotTask.performTask(StateAtSlotTask.java:96) ~[teku-ethereum-dataproviders-develop.jar:23.9.1+27-gd77470ab23]
at tech.pegasys.teku.infrastructure.async.SafeFuture.of(SafeFuture.java:72) ~[teku-infrastructure-async-develop.jar:23.9.1+27-gd77470ab23]
at tech.pegasys.teku.infrastructure.async.ScheduledExecutorAsyncRunner.lambda$createRunnableForAction$1(ScheduledExecutorAsyncRunner.java:124) ~[teku-infrastructure-async-develop.jar:23.9.1+27-gd77470ab23]
at java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source) [?:?]
at java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source) [?:?]
at java.lang.Thread.run(Unknown Source) [?:?]
Caused by: java.lang.ArithmeticException: / by zero
at tech.pegasys.teku.spec.logic.versions.altair.helpers.BeaconStateAccessorsAltair.getNextSyncCommitteeIndices(BeaconStateAccessorsAltair.java:114) ~[teku-ethereum-spec-develop.jar:23.9.1+27-gd77470ab23]
at tech.pegasys.teku.spec.logic.versions.altair.helpers.BeaconStateAccessorsAltair.getNextSyncCommittee(BeaconStateAccessorsAltair.java:150) ~[teku-ethereum-spec-develop.jar:23.9.1+27-gd77470ab23]
at tech.pegasys.teku.spec.logic.versions.altair.statetransition.epoch.EpochProcessorAltair.processSyncCommitteeUpdates(EpochProcessorAltair.java:128) ~[teku-ethereum-spec-develop.jar:23.9.1+27-gd77470ab23]
at tech.pegasys.teku.spec.logic.common.statetransition.epoch.AbstractEpochProcessor.processEpoch(AbstractEpochProcessor.java:122) ~[teku-ethereum-spec-develop.jar:23.9.1+27-gd77470ab23]
at tech.pegasys.teku.spec.logic.common.statetransition.epoch.AbstractEpochProcessor.lambda$processEpoch$0(AbstractEpochProcessor.java:93) ~[teku-ethereum-spec-develop.jar:23.9.1+27-gd77470ab23]
at tech.pegasys.teku.spec.datastructures.state.beaconstate.common.AbstractBeaconState.updated(AbstractBeaconState.java:64) ~[teku-ethereum-spec-develop.jar:23.9.1+27-gd77470ab23]
at tech.pegasys.teku.spec.logic.common.statetransition.epoch.AbstractEpochProcessor.processEpoch(AbstractEpochProcessor.java:93) ~[teku-ethereum-spec-develop.jar:23.9.1+27-gd77470ab23]
at tech.pegasys.teku.spec.logic.StateTransition.processSlots(StateTransition.java:59) ~[teku-ethereum-spec-develop.jar:23.9.1+27-gd77470ab23]
at tech.pegasys.teku.spec.Spec.processSlots(Spec.java:692) ~[teku-ethereum-spec-develop.jar:23.9.1+27-gd77470ab23]
at tech.pegasys.teku.dataproviders.generators.StateAtSlotTask.regenerateFromState(StateAtSlotTask.java:117) ~[teku-ethereum-dataproviders-develop.jar:23.9.1+27-gd77470ab23]
at java.util.Optional.map(Unknown Source) ~[?:?]
at tech.pegasys.teku.dataproviders.generators.StateAtSlotTask.lambda$performTask$3(StateAtSlotTask.java:96) ~[teku-ethereum-dataproviders-develop.jar:23.9.1+27-gd77470ab23]
... 10 more
```

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
