### PR TITLE
Force installing libc deps on docker image

### DIFF
--- a/docker/jdk17/Dockerfile
+++ b/docker/jdk17/Dockerfile
@@ -14,8 +14,7 @@ ENV JAVA_HOME=/opt/java/openjdk
 ENV PATH "${JAVA_HOME}/bin:${PATH}"
 COPY --from=jre-build /javaruntime $JAVA_HOME
 
-RUN apt-get -y update && apt-get -y upgrade && apt-get -y install curl
-RUN rm -rf /var/lib/api/lists/*
+RUN apt-get -y update && apt-get -y upgrade && apt-get -y install curl libc-bin libc6 && rm -rf /var/lib/api/lists/*
 RUN adduser --disabled-password --gecos "" --home /opt/teku teku && \
     chown teku:teku /opt/teku && \
     chmod 0755 /opt/teku


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
- Forces installation of libc-bin and libc6

## Fixed Issue(s)
N/A

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
