### PR TITLE
Add blob sidecars cache in Store + usage

### DIFF
--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/GetBlobSidecarsIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/GetBlobSidecarsIntegrationTest.java
@@ -63,7 +63,7 @@ public class GetBlobSidecarsIntegrationTest extends AbstractDataBackedRestAPIInt
     final SignedBlockAndState lastBlock = chainUpdater.advanceChainUntil(targetSlot);
     chainUpdater.updateBestBlock(lastBlock);
     final List<BlobSidecar> expected =
-        recentChainData.retrieveBlobSidecars(lastBlock.getSlotAndBlockRoot()).get();
+        recentChainData.getBlobSidecars(lastBlock.getSlotAndBlockRoot()).get();
 
     final Response responseAll = get("head");
     assertThat(responseAll.code()).isEqualTo(SC_OK);
@@ -116,7 +116,7 @@ public class GetBlobSidecarsIntegrationTest extends AbstractDataBackedRestAPIInt
     final SignedBlockAndState lastBlock = chainUpdater.advanceChainUntil(targetSlot);
     chainUpdater.updateBestBlock(lastBlock);
     final List<BlobSidecar> expected =
-        recentChainData.retrieveBlobSidecars(lastBlock.getSlotAndBlockRoot()).get();
+        recentChainData.getBlobSidecars(lastBlock.getSlotAndBlockRoot()).get();
 
     final Response response = get("head", OCTET_STREAM);
     assertThat(response.code()).isEqualTo(SC_OK);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/MutableStore.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/MutableStore.java
@@ -13,7 +13,6 @@
 
 package tech.pegasys.teku.spec.datastructures.forkchoice;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
@@ -43,7 +42,7 @@ public interface MutableStore extends ReadOnlyStore {
       SignedBeaconBlock block,
       BeaconState state,
       BlockCheckpoints checkpoints,
-      List<BlobSidecar> blobSidecars,
+      Optional<List<BlobSidecar>> blobSidecars,
       Optional<UInt64> earliestBlobSidecarSlot);
 
   default void putBlockAndState(
@@ -52,7 +51,7 @@ public interface MutableStore extends ReadOnlyStore {
         blockAndState.getBlock(),
         blockAndState.getState(),
         checkpoints,
-        Collections.emptyList(),
+        Optional.empty(),
         Optional.empty());
   }
 
@@ -64,7 +63,7 @@ public interface MutableStore extends ReadOnlyStore {
         blockAndState.getBlock(),
         blockAndState.getState(),
         checkpoints,
-        blobSidecars,
+        Optional.of(blobSidecars),
         Optional.empty());
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/MutableStore.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/MutableStore.java
@@ -33,8 +33,8 @@ public interface MutableStore extends ReadOnlyStore {
    * @param block Block
    * @param state Corresponding state
    * @param checkpoints Checkpoints
-   * @param blobSidecars empty list for pre-Deneb blocks or out of availability window, otherwise
-   *     actual data
+   * @param blobSidecars Optional.empty() for pre-Deneb blocks or out of availability window,
+   *     otherwise actual data
    * @param earliestBlobSidecarSlot not required even post-Deneb, saved only if the new value is
    *     smaller
    */

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ReadOnlyStore.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ReadOnlyStore.java
@@ -108,6 +108,8 @@ public interface ReadOnlyStore {
    */
   Optional<SignedBeaconBlock> getBlockIfAvailable(final Bytes32 blockRoot);
 
+  Optional<List<BlobSidecar>> getBlobSidecarsIfAvailable(SlotAndBlockRoot slotAndBlockRoot);
+
   default SafeFuture<Optional<BeaconBlock>> retrieveBlock(Bytes32 blockRoot) {
     return retrieveSignedBlock(blockRoot).thenApply(res -> res.map(SignedBeaconBlock::getMessage));
   }
@@ -123,8 +125,6 @@ public interface ReadOnlyStore {
   SafeFuture<Optional<BeaconState>> retrieveCheckpointState(Checkpoint checkpoint);
 
   SafeFuture<Optional<BeaconState>> retrieveStateAtSlot(SlotAndBlockRoot checkpoint);
-
-  SafeFuture<List<BlobSidecar>> retrieveBlobSidecars(SlotAndBlockRoot slotAndBlockRoot);
 
   SafeFuture<Optional<UInt64>> retrieveEarliestBlobSidecarSlot();
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
@@ -384,7 +384,7 @@ public class ForkChoiceUtil {
       final SignedBeaconBlock signedBlock,
       final BeaconState postState,
       final boolean isBlockOptimistic,
-      final List<BlobSidecar> blobSidecars,
+      final Optional<List<BlobSidecar>> blobSidecars,
       final Optional<UInt64> earliestBlobSidecarsSlot) {
 
     BlockCheckpoints blockCheckpoints = epochProcessor.calculateBlockCheckpoints(postState);

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
@@ -17,7 +17,6 @@ import static java.util.stream.Collectors.toList;
 import static tech.pegasys.teku.infrastructure.time.TimeUtilities.secondsToMillis;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -248,10 +247,9 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
   }
 
   @Override
-  public SafeFuture<List<BlobSidecar>> retrieveBlobSidecars(
+  public Optional<List<BlobSidecar>> getBlobSidecarsIfAvailable(
       final SlotAndBlockRoot slotAndBlockRoot) {
-    return SafeFuture.completedFuture(
-        Optional.ofNullable(blobSidecars.get(slotAndBlockRoot)).orElse(Collections.emptyList()));
+    return Optional.ofNullable(blobSidecars.get(slotAndBlockRoot));
   }
 
   @Override
@@ -265,14 +263,13 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
       final SignedBeaconBlock block,
       final BeaconState state,
       final BlockCheckpoints checkpoints,
-      final List<BlobSidecar> blobSidecars,
+      final Optional<List<BlobSidecar>> blobSidecars,
       final Optional<UInt64> maybeEarliestBlobSidecarSlot) {
     blocks.put(block.getRoot(), block);
     blockStates.put(block.getRoot(), state);
     blockCheckpoints.put(block.getRoot(), checkpoints);
-    if (!blobSidecars.isEmpty()) {
-      this.blobSidecars.put(block.getSlotAndBlockRoot(), blobSidecars);
-    }
+    blobSidecars.ifPresent(
+        sidecars -> this.blobSidecars.put(block.getSlotAndBlockRoot(), sidecars));
     if (earliestBlobSidecarSlot.isEmpty()) {
       earliestBlobSidecarSlot = maybeEarliestBlobSidecarSlot;
     }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -22,7 +22,6 @@ import static tech.pegasys.teku.statetransition.forkchoice.StateRootCollector.ad
 import com.google.common.base.Throwables;
 import java.net.ConnectException;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import org.apache.logging.log4j.LogManager;
@@ -540,12 +539,12 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
     final StoreTransaction transaction = recentChainData.startStoreTransaction();
     addParentStateRoots(spec, blockSlotState, transaction);
 
-    final List<BlobSidecar> blobSidecars;
+    final Optional<List<BlobSidecar>> blobSidecars;
     if (blobSidecarsAndValidationResult.isNotRequired()) {
       // Outside availability window or pre-Deneb
-      blobSidecars = Collections.emptyList();
+      blobSidecars = Optional.empty();
     } else if (blobSidecarsAndValidationResult.isValid()) {
-      blobSidecars = blobSidecarsAndValidationResult.getBlobSidecars();
+      blobSidecars = Optional.of(blobSidecarsAndValidationResult.getBlobSidecars());
     } else {
       throw new IllegalStateException(
           String.format(

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockManagerTest.java
@@ -941,8 +941,7 @@ public class BlockManagerTest {
     verify(blobSidecarsAvailabilityChecker1).getAvailabilityCheckResult();
     assertThat(localRecentChainData.retrieveBlockByRoot(block1.getRoot()))
         .isCompletedWithValue(Optional.of(block1.getMessage()));
-    assertThat(localRecentChainData.retrieveBlobSidecars(block1.getSlotAndBlockRoot()))
-        .isCompletedWithValue(Collections.emptyList());
+    assertThat(localRecentChainData.getBlobSidecars(block1.getSlotAndBlockRoot())).isEmpty();
     assertThat(localRecentChainData.retrieveEarliestBlobSidecarSlot())
         .isCompletedWithValueMatching(Optional::isEmpty);
   }
@@ -981,8 +980,7 @@ public class BlockManagerTest {
     verify(blobSidecarsAvailabilityChecker1).getAvailabilityCheckResult();
     assertThat(localRecentChainData.retrieveBlockByRoot(block1.getRoot()))
         .isCompletedWithValue(Optional.empty());
-    assertThat(localRecentChainData.retrieveBlobSidecars(block1.getSlotAndBlockRoot()))
-        .isCompletedWithValue(Collections.emptyList());
+    assertThat(localRecentChainData.getBlobSidecars(block1.getSlotAndBlockRoot())).isEmpty();
     assertThat(localRecentChainData.retrieveEarliestBlobSidecarSlot())
         .isCompletedWithValueMatching(Optional::isEmpty);
 
@@ -1022,8 +1020,7 @@ public class BlockManagerTest {
     verify(blobSidecarsAvailabilityChecker1).getAvailabilityCheckResult();
     assertThat(localRecentChainData.retrieveBlockByRoot(block1.getRoot()))
         .isCompletedWithValue(Optional.empty());
-    assertThat(localRecentChainData.retrieveBlobSidecars(block1.getSlotAndBlockRoot()))
-        .isCompletedWithValue(Collections.emptyList());
+    assertThat(localRecentChainData.getBlobSidecars(block1.getSlotAndBlockRoot())).isEmpty();
     assertThat(localRecentChainData.retrieveEarliestBlobSidecarSlot())
         .isCompletedWithValueMatching(Optional::isEmpty);
   }
@@ -1053,8 +1050,7 @@ public class BlockManagerTest {
     verify(blobSidecarsAvailabilityChecker1).getAvailabilityCheckResult();
     assertThat(localRecentChainData.retrieveBlockByRoot(block1.getRoot()))
         .isCompletedWithValue(Optional.of(block1.getMessage()));
-    assertThat(localRecentChainData.retrieveBlobSidecars(block1.getSlotAndBlockRoot()))
-        .isCompletedWithValue(Collections.emptyList());
+    assertThat(localRecentChainData.getBlobSidecars(block1.getSlotAndBlockRoot())).isEmpty();
     assertThat(localRecentChainData.retrieveEarliestBlobSidecarSlot())
         .isCompletedWithValueMatching(Optional::isEmpty);
   }
@@ -1115,15 +1111,14 @@ public class BlockManagerTest {
       final BeaconBlock beaconBlock, final List<BlobSidecar> blobSidecars) {
     assertThat(localRecentChainData.retrieveBlockByRoot(beaconBlock.getRoot()))
         .isCompletedWithValue(Optional.of(beaconBlock));
-    assertThat(localRecentChainData.retrieveBlobSidecars(beaconBlock.getSlotAndBlockRoot()))
-        .isCompletedWithValue(blobSidecars);
+    assertThat(localRecentChainData.getBlobSidecars(beaconBlock.getSlotAndBlockRoot()))
+        .contains(blobSidecars);
   }
 
   private void assertThatNothingStoredForSlotRoot(final SlotAndBlockRoot slotAndBlockRoot) {
     assertThat(localRecentChainData.retrieveBlockByRoot(slotAndBlockRoot.getBlockRoot()))
         .isCompletedWithValueMatching(Optional::isEmpty);
-    assertThat(localRecentChainData.retrieveBlobSidecars(slotAndBlockRoot))
-        .isCompletedWithValueMatching(List::isEmpty);
+    assertThat(localRecentChainData.getBlobSidecars(slotAndBlockRoot)).isEmpty();
   }
 
   private void assertImportBlockWithResult(

--- a/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/AbstractRpcMethodIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/AbstractRpcMethodIntegrationTest.java
@@ -19,7 +19,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.params.provider.Arguments;
@@ -261,12 +260,13 @@ public abstract class AbstractRpcMethodIntegrationTest {
         .flatMap(Optional::stream)
         .map(this::safeRetrieveBlobSidecars)
         .flatMap(Collection::stream)
-        .collect(Collectors.toUnmodifiableList());
+        .toList();
   }
 
   private List<BlobSidecar> safeRetrieveBlobSidecars(final SlotAndBlockRoot slotAndBlockRoot) {
     try {
-      return Waiter.waitFor(peerStorage.recentChainData().retrieveBlobSidecars(slotAndBlockRoot));
+      return Waiter.waitFor(
+          peerStorage.chainStorage().getBlobSidecarsBySlotAndBlockRoot(slotAndBlockRoot));
     } catch (Exception e) {
       throw new RuntimeException(e);
     }

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/StorageBackedRecentChainData.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/StorageBackedRecentChainData.java
@@ -22,7 +22,6 @@ import java.util.concurrent.TimeoutException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
-import tech.pegasys.teku.dataproviders.lookup.BlobSidecarsProvider;
 import tech.pegasys.teku.dataproviders.lookup.BlockProvider;
 import tech.pegasys.teku.dataproviders.lookup.StateAndBlockSummaryProvider;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
@@ -43,7 +42,6 @@ public class StorageBackedRecentChainData extends RecentChainData {
   private static final Logger LOG = LogManager.getLogger();
   private final BlockProvider blockProvider;
   private final StateAndBlockSummaryProvider stateProvider;
-  private final BlobSidecarsProvider blobSidecarsProvider;
   private final StorageQueryChannel storageQueryChannel;
   private final StoreConfig storeConfig;
 
@@ -63,7 +61,6 @@ public class StorageBackedRecentChainData extends RecentChainData {
         storeConfig,
         storageQueryChannel::getHotBlocksByRoot,
         storageQueryChannel::getHotStateAndBlockSummaryByBlockRoot,
-        storageQueryChannel::getBlobSidecarsBySlotAndBlockRoot,
         storageQueryChannel::getEarliestAvailableBlobSidecarSlot,
         storageUpdateChannel,
         voteUpdateChannel,
@@ -74,7 +71,6 @@ public class StorageBackedRecentChainData extends RecentChainData {
     this.storageQueryChannel = storageQueryChannel;
     this.blockProvider = storageQueryChannel::getHotBlocksByRoot;
     this.stateProvider = storageQueryChannel::getHotStateAndBlockSummaryByBlockRoot;
-    this.blobSidecarsProvider = storageQueryChannel::getBlobSidecarsBySlotAndBlockRoot;
   }
 
   public static SafeFuture<RecentChainData> create(
@@ -158,7 +154,6 @@ public class StorageBackedRecentChainData extends RecentChainData {
                   .asyncRunner(asyncRunner)
                   .blockProvider(blockProvider)
                   .stateProvider(stateProvider)
-                  .blobSidecarsProvider(blobSidecarsProvider)
                   .storeConfig(storeConfig)
                   .build();
           setStore(store);

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/CacheableStore.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/CacheableStore.java
@@ -14,11 +14,13 @@
 package tech.pegasys.teku.storage.store;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Predicate;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockAndCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
@@ -37,6 +39,8 @@ public abstract class CacheableStore implements UpdatableStore {
   abstract void cacheBlocks(Collection<BlockAndCheckpoints> blockAndCheckpoints);
 
   abstract void cacheStates(Map<Bytes32, StateAndBlockSummary> stateAndBlockSummaries);
+
+  abstract void cacheBlobSidecars(Map<SlotAndBlockRoot, List<BlobSidecar>> blobSidecarsMap);
 
   abstract void cacheFinalizedOptimisticTransitionPayload(
       Optional<SlotAndExecutionPayloadSummary> finalizedOptimisticTransitionPayload);

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/EmptyStoreResults.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/EmptyStoreResults.java
@@ -13,13 +13,10 @@
 
 package tech.pegasys.teku.storage.store;
 
-import java.util.Collections;
-import java.util.List;
 import java.util.Optional;
 import tech.pegasys.teku.dataproviders.generators.StateGenerationTask;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
@@ -41,9 +38,6 @@ public abstract class EmptyStoreResults {
 
   public static final SafeFuture<Optional<StateGenerationTask>> EMPTY_STATE_GENERATION_TASK =
       SafeFuture.completedFuture(Optional.empty());
-
-  public static final SafeFuture<List<BlobSidecar>> NO_BLOB_SIDECARS_FUTURE =
-      SafeFuture.completedFuture(Collections.emptyList());
 
   public static final SafeFuture<Optional<UInt64>> NO_EARLIEST_BLOB_SIDECAR_SLOT_FUTURE =
       SafeFuture.completedFuture(Optional.empty());

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
@@ -312,8 +312,8 @@ class Store extends CacheableStore {
               SettableGauge.create(
                   metricsSystem,
                   TekuMetricCategory.STORAGE,
-                  "memory_blob_sidecars_blocks_count",
-                  "Number of complete blob sidecars blocks held in the in-memory store"));
+                  "memory_blocks_with_cached_blobs_count",
+                  "Number of beacon blocks with complete blobs held in the in-memory store"));
 
       if (maybeEpochStates.isPresent()) {
         epochStatesCountGauge =

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
@@ -42,7 +42,6 @@ import tech.pegasys.teku.dataproviders.generators.CachingTaskQueue;
 import tech.pegasys.teku.dataproviders.generators.StateAtSlotTask;
 import tech.pegasys.teku.dataproviders.generators.StateGenerationTask;
 import tech.pegasys.teku.dataproviders.generators.StateRegenerationBaseSelector;
-import tech.pegasys.teku.dataproviders.lookup.BlobSidecarsProvider;
 import tech.pegasys.teku.dataproviders.lookup.BlockProvider;
 import tech.pegasys.teku.dataproviders.lookup.EarliestBlobSidecarSlotProvider;
 import tech.pegasys.teku.dataproviders.lookup.StateAndBlockSummaryProvider;
@@ -87,15 +86,14 @@ class Store extends CacheableStore {
 
   private final MetricsSystem metricsSystem;
   private Optional<SettableGauge> blockCountGauge = Optional.empty();
-
   private Optional<SettableGauge> epochStatesCountGauge = Optional.empty();
+  private Optional<SettableGauge> blobSidecarsBlocksCountGauge = Optional.empty();
 
   private final Optional<Map<Bytes32, StateAndBlockSummary>> maybeEpochStates;
 
   private final Spec spec;
   private final StateAndBlockSummaryProvider stateProvider;
   private final BlockProvider blockProvider;
-  private final BlobSidecarsProvider blobSidecarsProvider;
   private final EarliestBlobSidecarSlotProvider earliestBlobSidecarSlotProvider;
   private final ForkChoiceStrategy forkChoiceStrategy;
 
@@ -103,6 +101,7 @@ class Store extends CacheableStore {
   private final CachingTaskQueue<Bytes32, StateAndBlockSummary> states;
   private final Map<Bytes32, SignedBeaconBlock> blocks;
   private final CachingTaskQueue<SlotAndBlockRoot, BeaconState> checkpointStates;
+  private final Map<SlotAndBlockRoot, List<BlobSidecar>> blobSidecars;
   private UInt64 timeMillis;
   private UInt64 genesisTime;
   private AnchorPoint finalizedAnchor;
@@ -119,7 +118,6 @@ class Store extends CacheableStore {
       final int hotStatePersistenceFrequencyInEpochs,
       final BlockProvider blockProvider,
       final StateAndBlockSummaryProvider stateProvider,
-      final BlobSidecarsProvider blobSidecarsProvider,
       final EarliestBlobSidecarSlotProvider earliestBlobSidecarSlotProvider,
       final CachingTaskQueue<Bytes32, StateAndBlockSummary> states,
       final Optional<Checkpoint> initialCheckpoint,
@@ -133,7 +131,8 @@ class Store extends CacheableStore {
       final Map<UInt64, VoteTracker> votes,
       final Map<Bytes32, SignedBeaconBlock> blocks,
       final CachingTaskQueue<SlotAndBlockRoot, BeaconState> checkpointStates,
-      final Optional<Map<Bytes32, StateAndBlockSummary>> maybeEpochStates) {
+      final Optional<Map<Bytes32, StateAndBlockSummary>> maybeEpochStates,
+      final Map<SlotAndBlockRoot, List<BlobSidecar>> blobSidecars) {
     checkArgument(
         time.isGreaterThanOrEqualTo(genesisTime),
         "Time must be greater than or equal to genesisTime");
@@ -157,6 +156,7 @@ class Store extends CacheableStore {
     this.justifiedCheckpoint = justifiedCheckpoint;
     this.bestJustifiedCheckpoint = bestJustifiedCheckpoint;
     this.blocks = blocks;
+    this.blobSidecars = blobSidecars;
     this.highestVotedValidatorIndex =
         votes.keySet().stream().max(Comparator.naturalOrder()).orElse(UInt64.ZERO);
     this.votes =
@@ -180,7 +180,6 @@ class Store extends CacheableStore {
                         .orElseGet(Collections::emptyMap)),
             fromMap(this.blocks),
             blockProvider);
-    this.blobSidecarsProvider = blobSidecarsProvider;
     this.earliestBlobSidecarSlotProvider = earliestBlobSidecarSlotProvider;
   }
 
@@ -190,7 +189,6 @@ class Store extends CacheableStore {
       final Spec spec,
       final BlockProvider blockProvider,
       final StateAndBlockSummaryProvider stateAndBlockProvider,
-      final BlobSidecarsProvider blobSidecarsProvider,
       final EarliestBlobSidecarSlotProvider earliestBlobSidecarSlotProvider,
       final Optional<Checkpoint> initialCheckpoint,
       final UInt64 time,
@@ -215,11 +213,12 @@ class Store extends CacheableStore {
     final CachingTaskQueue<Bytes32, StateAndBlockSummary> stateTaskQueue =
         CachingTaskQueue.create(
             asyncRunner, metricsSystem, "memory_states", config.getStateCacheSize());
-
     final Optional<Map<Bytes32, StateAndBlockSummary>> maybeEpochStates =
         config.getEpochStateCacheSize() > 0
             ? Optional.of(LimitedMap.createSynchronized(config.getEpochStateCacheSize()))
             : Optional.empty();
+    final Map<SlotAndBlockRoot, List<BlobSidecar>> blobSidecars =
+        LimitedMap.createSynchronized(config.getBlockCacheSize());
 
     final UInt64 currentEpoch = spec.computeEpochAtSlot(spec.getCurrentSlot(time, genesisTime));
     final ForkChoiceStrategy forkChoiceStrategy =
@@ -239,7 +238,6 @@ class Store extends CacheableStore {
         config.getHotStatePersistenceFrequencyInEpochs(),
         blockProvider,
         stateAndBlockProvider,
-        blobSidecarsProvider,
         earliestBlobSidecarSlotProvider,
         stateTaskQueue,
         initialCheckpoint,
@@ -253,7 +251,8 @@ class Store extends CacheableStore {
         votes,
         blocks,
         checkpointStateTaskQueue,
-        maybeEpochStates);
+        maybeEpochStates,
+        blobSidecars);
   }
 
   private static ProtoArray buildProtoArray(
@@ -308,6 +307,13 @@ class Store extends CacheableStore {
                   TekuMetricCategory.STORAGE,
                   "memory_block_count",
                   "Number of beacon blocks held in the in-memory store"));
+      blobSidecarsBlocksCountGauge =
+          Optional.of(
+              SettableGauge.create(
+                  metricsSystem,
+                  TekuMetricCategory.STORAGE,
+                  "memory_blob_sidecars_blocks_count",
+                  "Number of complete blob sidecars blocks held in the in-memory store"));
 
       if (maybeEpochStates.isPresent()) {
         epochStatesCountGauge =
@@ -497,7 +503,7 @@ class Store extends CacheableStore {
       return SafeFuture.completedFuture(inMemoryBlock);
     }
 
-    // Retrieve and cache block
+    // Retrieve block
     return blockProvider.getBlock(blockRoot);
   }
 
@@ -568,9 +574,14 @@ class Store extends CacheableStore {
   }
 
   @Override
-  public SafeFuture<List<BlobSidecar>> retrieveBlobSidecars(
+  public Optional<List<BlobSidecar>> getBlobSidecarsIfAvailable(
       final SlotAndBlockRoot slotAndBlockRoot) {
-    return blobSidecarsProvider.getBlobSidecars(slotAndBlockRoot);
+    readLock.lock();
+    try {
+      return Optional.ofNullable(blobSidecars.get(slotAndBlockRoot));
+    } finally {
+      readLock.unlock();
+    }
   }
 
   @Override
@@ -612,6 +623,15 @@ class Store extends CacheableStore {
   @Override
   void cacheStates(final Map<Bytes32, StateAndBlockSummary> stateAndBlockSummaries) {
     states.cacheAll(stateAndBlockSummaries);
+  }
+
+  /** Non-synchronized, no lock, unsafe if Store is not locked externally */
+  @Override
+  void cacheBlobSidecars(final Map<SlotAndBlockRoot, List<BlobSidecar>> blobSidecarsMap) {
+    blobSidecarsMap.entrySet().stream()
+        .sorted(Map.Entry.comparingByKey())
+        .forEach(entry -> blobSidecars.put(entry.getKey(), entry.getValue()));
+    blobSidecarsBlocksCountGauge.ifPresent(gauge -> gauge.set(blobSidecars.size()));
   }
 
   /** Non-synchronized, no lock, unsafe if Store is not locked externally */

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreBuilder.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreBuilder.java
@@ -21,7 +21,6 @@ import java.util.Map;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
-import tech.pegasys.teku.dataproviders.lookup.BlobSidecarsProvider;
 import tech.pegasys.teku.dataproviders.lookup.BlockProvider;
 import tech.pegasys.teku.dataproviders.lookup.EarliestBlobSidecarSlotProvider;
 import tech.pegasys.teku.dataproviders.lookup.StateAndBlockSummaryProvider;
@@ -41,7 +40,6 @@ public class StoreBuilder {
   private Spec spec;
   private BlockProvider blockProvider;
   private StateAndBlockSummaryProvider stateAndBlockProvider;
-  private BlobSidecarsProvider blobSidecarsProvider;
   private EarliestBlobSidecarSlotProvider earliestBlobSidecarSlotProvider;
   private StoreConfig storeConfig = StoreConfig.createDefault();
 
@@ -112,7 +110,6 @@ public class StoreBuilder {
         spec,
         blockProvider,
         stateAndBlockProvider,
-        blobSidecarsProvider,
         earliestBlobSidecarSlotProvider,
         anchor,
         time,
@@ -173,12 +170,6 @@ public class StoreBuilder {
   public StoreBuilder stateProvider(final StateAndBlockSummaryProvider stateProvider) {
     checkNotNull(stateProvider);
     this.stateAndBlockProvider = stateProvider;
-    return this;
-  }
-
-  public StoreBuilder blobSidecarsProvider(final BlobSidecarsProvider blobSidecarsProvider) {
-    checkNotNull(blobSidecarsProvider);
-    this.blobSidecarsProvider = blobSidecarsProvider;
     return this;
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransaction.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransaction.java
@@ -93,11 +93,11 @@ class StoreTransaction implements UpdatableStore.StoreTransaction {
       final SignedBeaconBlock block,
       final BeaconState state,
       final BlockCheckpoints blockCheckpoints,
-      final List<BlobSidecar> blobSidecars,
+      final Optional<List<BlobSidecar>> blobSidecars,
       final Optional<UInt64> maybeEarliestBlobSidecarSlot) {
     blockData.put(block.getRoot(), new TransactionBlockData(block, state, blockCheckpoints));
     if (!blobSidecars.isEmpty()) {
-      this.blobSidecars.put(block.getSlotAndBlockRoot(), blobSidecars);
+      this.blobSidecars.put(block.getSlotAndBlockRoot(), blobSidecars.get());
     }
     if (needToUpdateEarliestBlobSidecarSlot(maybeEarliestBlobSidecarSlot)) {
       this.maybeEarliestBlobSidecarTransactionSlot = maybeEarliestBlobSidecarSlot;
@@ -459,13 +459,10 @@ class StoreTransaction implements UpdatableStore.StoreTransaction {
   }
 
   @Override
-  public SafeFuture<List<BlobSidecar>> retrieveBlobSidecars(
+  public Optional<List<BlobSidecar>> getBlobSidecarsIfAvailable(
       final SlotAndBlockRoot slotAndBlockRoot) {
-    final Optional<List<BlobSidecar>> maybeBlobSidecars =
-        Optional.ofNullable(blobSidecars.get(slotAndBlockRoot));
-    return maybeBlobSidecars
-        .map(SafeFuture::completedFuture)
-        .orElseGet(() -> store.retrieveBlobSidecars(slotAndBlockRoot));
+    return Optional.ofNullable(blobSidecars.get(slotAndBlockRoot))
+        .or(() -> store.getBlobSidecarsIfAvailable(slotAndBlockRoot));
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransactionUpdates.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransactionUpdates.java
@@ -109,6 +109,7 @@ class StoreTransactionUpdates {
     tx.bestJustifiedCheckpoint.ifPresent(store::updateBestJustifiedCheckpoint);
     store.cacheBlocks(hotBlocks.values());
     store.cacheStates(Maps.transformValues(hotBlockAndStates, this::blockAndStateAsSummary));
+    store.cacheBlobSidecars(blobSidecars);
     if (optimisticTransitionBlockRootSet) {
       store.cacheFinalizedOptimisticTransitionPayload(
           updateResult.getFinalizedOptimisticTransitionPayload());

--- a/storage/src/test/java/tech/pegasys/teku/storage/client/RecentChainDataTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/client/RecentChainDataTest.java
@@ -803,9 +803,9 @@ class RecentChainDataTest {
     assertThat(blobSidecars).isNotEmpty();
     storageSystem.chainUpdater().saveBlock(block, blobSidecars);
 
-    final SafeFuture<List<BlobSidecar>> blobSidecarsFuture =
-        recentChainData.retrieveBlobSidecars(block.getSlotAndBlockRoot());
-    assertThat(blobSidecarsFuture).isCompletedWithValue(blobSidecars);
+    final Optional<List<BlobSidecar>> maybeBlobSidecars =
+        recentChainData.getBlobSidecars(block.getSlotAndBlockRoot());
+    assertThat(maybeBlobSidecars).contains(blobSidecars);
   }
 
   @Test
@@ -817,9 +817,9 @@ class RecentChainDataTest {
     storageSystem.chainUpdater().saveBlock(block, blobSidecars);
     assertThat(blobSidecars).isEmpty();
 
-    final SafeFuture<List<BlobSidecar>> blobSidecarsFuture =
-        recentChainData.retrieveBlobSidecars(block.getSlotAndBlockRoot());
-    assertThat(blobSidecarsFuture).isCompletedWithValue(blobSidecars);
+    final Optional<List<BlobSidecar>> maybeBlobSidecars =
+        recentChainData.getBlobSidecars(block.getSlotAndBlockRoot());
+    assertThat(maybeBlobSidecars).contains(blobSidecars);
   }
 
   @Test

--- a/storage/src/test/java/tech/pegasys/teku/storage/client/StorageBackedRecentChainDataTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/client/StorageBackedRecentChainDataTest.java
@@ -26,7 +26,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.Test;
-import tech.pegasys.teku.dataproviders.lookup.BlobSidecarsProvider;
 import tech.pegasys.teku.dataproviders.lookup.BlockProvider;
 import tech.pegasys.teku.dataproviders.lookup.StateAndBlockSummaryProvider;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -106,7 +105,6 @@ public class StorageBackedRecentChainDataTest {
             .specProvider(spec)
             .blockProvider(BlockProvider.NOOP)
             .stateProvider(StateAndBlockSummaryProvider.NOOP)
-            .blobSidecarsProvider(BlobSidecarsProvider.NOOP)
             .storeConfig(storeConfig)
             .build();
     StoreAssertions.assertStoresMatch(client.get().getStore(), expectedStore);
@@ -154,7 +152,6 @@ public class StorageBackedRecentChainDataTest {
             .specProvider(spec)
             .blockProvider(BlockProvider.NOOP)
             .stateProvider(StateAndBlockSummaryProvider.NOOP)
-            .blobSidecarsProvider(BlobSidecarsProvider.NOOP)
             .storeConfig(storeConfig)
             .build();
     client.get().initializeFromGenesis(initialState, UInt64.ZERO);
@@ -202,8 +199,7 @@ public class StorageBackedRecentChainDataTest {
             .metricsSystem(new StubMetricsSystem())
             .specProvider(spec)
             .blockProvider(BlockProvider.NOOP)
-            .stateProvider(StateAndBlockSummaryProvider.NOOP)
-            .blobSidecarsProvider(BlobSidecarsProvider.NOOP);
+            .stateProvider(StateAndBlockSummaryProvider.NOOP);
     storeRequestFuture.complete(Optional.of(storeData));
     assertThat(client).isCompleted();
     assertStoreInitialized(client.get());

--- a/storage/src/test/java/tech/pegasys/teku/storage/store/AbstractStoreTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/store/AbstractStoreTest.java
@@ -25,7 +25,6 @@ import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import tech.pegasys.teku.dataproviders.lookup.BlobSidecarsProvider;
 import tech.pegasys.teku.dataproviders.lookup.BlockProvider;
 import tech.pegasys.teku.dataproviders.lookup.EarliestBlobSidecarSlotProvider;
 import tech.pegasys.teku.dataproviders.lookup.StateAndBlockSummaryProvider;
@@ -143,7 +142,6 @@ public abstract class AbstractStoreTest {
         .metricsSystem(new StubMetricsSystem())
         .specProvider(spec)
         .blockProvider(blockProviderFromChainBuilder())
-        .blobSidecarsProvider(blobSidecarsProviderFromChainBuilder())
         .earliestBlobSidecarSlotProvider(earliestBlobSidecarSlotProviderFromChainBuilder())
         .stateProvider(StateAndBlockSummaryProvider.NOOP)
         .anchor(Optional.empty())
@@ -174,11 +172,6 @@ public abstract class AbstractStoreTest {
                 .map(chainBuilder::getBlock)
                 .flatMap(Optional::stream)
                 .collect(Collectors.toMap(SignedBeaconBlock::getRoot, Function.identity())));
-  }
-
-  protected BlobSidecarsProvider blobSidecarsProviderFromChainBuilder() {
-    return (slotAndBlockRoot) ->
-        SafeFuture.completedFuture(chainBuilder.getBlobSidecars(slotAndBlockRoot.getBlockRoot()));
   }
 
   protected EarliestBlobSidecarSlotProvider earliestBlobSidecarSlotProviderFromChainBuilder() {

--- a/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTest.java
@@ -26,7 +26,6 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
-import tech.pegasys.teku.dataproviders.lookup.BlobSidecarsProvider;
 import tech.pegasys.teku.dataproviders.lookup.EarliestBlobSidecarSlotProvider;
 import tech.pegasys.teku.dataproviders.lookup.StateAndBlockSummaryProvider;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -62,7 +61,6 @@ class StoreTest extends AbstractStoreTest {
                     spec,
                     blockProviderFromChainBuilder(),
                     StateAndBlockSummaryProvider.NOOP,
-                    BlobSidecarsProvider.NOOP,
                     EarliestBlobSidecarSlotProvider.NOOP,
                     Optional.empty(),
                     genesisTime.minus(1),

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/client/ChainUpdater.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/client/ChainUpdater.java
@@ -17,7 +17,6 @@ import static com.google.common.base.Preconditions.checkState;
 import static org.assertj.core.api.Assertions.assertThat;
 import static tech.pegasys.teku.infrastructure.time.TimeUtilities.secondsToMillis;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -252,7 +251,7 @@ public class ChainUpdater {
         block.getBlock(),
         block.getState(),
         spec.calculateBlockCheckpoints(block.getState()),
-        Collections.emptyList(),
+        Optional.empty(),
         Optional.empty());
     assertThat(tx.commit()).isCompleted();
     recentChainData
@@ -271,7 +270,7 @@ public class ChainUpdater {
         block.getBlock(),
         block.getState(),
         spec.calculateBlockCheckpoints(block.getState()),
-        Collections.emptyList(),
+        Optional.empty(),
         Optional.empty());
     assertThat(tx.commit()).isCompleted();
     saveBlockTime(block);
@@ -290,7 +289,7 @@ public class ChainUpdater {
         block.getBlock(),
         block.getState(),
         spec.calculateBlockCheckpoints(block.getState()),
-        blobSidecars,
+        Optional.of(blobSidecars),
         Optional.of(earliestBlobSidecarSlot));
     assertThat(tx.commit()).isCompleted();
     recentChainData

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/client/MemoryOnlyRecentChainData.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/client/MemoryOnlyRecentChainData.java
@@ -18,7 +18,6 @@ import static tech.pegasys.teku.infrastructure.async.SyncAsyncRunner.SYNC_RUNNER
 
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
-import tech.pegasys.teku.dataproviders.lookup.BlobSidecarsProvider;
 import tech.pegasys.teku.dataproviders.lookup.BlockProvider;
 import tech.pegasys.teku.dataproviders.lookup.EarliestBlobSidecarSlotProvider;
 import tech.pegasys.teku.dataproviders.lookup.StateAndBlockSummaryProvider;
@@ -51,7 +50,6 @@ public class MemoryOnlyRecentChainData extends RecentChainData {
         storeConfig,
         BlockProvider.NOOP,
         StateAndBlockSummaryProvider.NOOP,
-        BlobSidecarsProvider.NOOP,
         EarliestBlobSidecarSlotProvider.NOOP,
         storageUpdateChannel,
         voteUpdateChannel,

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/store/StoreAssertions.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/store/StoreAssertions.java
@@ -55,7 +55,9 @@ public class StoreAssertions {
             "checkpointStates",
             "forkChoiceStrategy",
             "maybeEpochStates",
-            "epochStatesCountGauge")
+            "epochStatesCountGauge",
+            "blobSidecars",
+            "blobSidecarsBlocksCountGauge")
         .isEqualTo(expectedState);
     assertThat(actualState.getOrderedBlockRoots())
         .containsExactlyElementsOf(expectedState.getOrderedBlockRoots());


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Some considerations when making this:
1. `Store` is tied with `RecentChainData` and it was actually incorrect when we were actually using it as historical storage for blobSidecars. Now it will return only cached blobSidecars which is not on par with blocks where we have hotBlocks, but at least we somehow separate recent and historical chain data.
2. To clarify presence of `blobSidecars` I was forced to return back to `Optional` wrap which we removed previously for simplicity, we'd better keep it to avoid unneeded db lookups.
3. I've used block size cache configuration, I think we could go without separate settings, at least in the beginning
4. I've added some usage of cache, where it could be useful, not other clear places were found for using this cache
5. `earliestBlobSidecarSlot` definitely needs caching too, will detach in separate PR, should be not small because pruning is on Database layer and we should handle this somehow
6. `BlobSidecarsProvider` was removed, it's unnecessary when we don't serve recentChainData as historical

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
