### PR TITLE
Updated ProtoArray#nodeLeadsToViableHead to check own node viability before best descendant

### DIFF
--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArray.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArray.java
@@ -597,13 +597,14 @@ public class ProtoArray {
    * the head.
    */
   private boolean nodeLeadsToViableHead(ProtoNode node) {
-    boolean bestDescendantIsViableForHead =
-        node.getBestDescendantIndex()
-            .map(this::getNodeByIndex)
-            .map(this::nodeIsViableForHead)
-            .orElse(false);
+    if (nodeIsViableForHead(node)) {
+      return true;
+    }
 
-    return bestDescendantIsViableForHead || nodeIsViableForHead(node);
+    return node.getBestDescendantIndex()
+        .map(this::getNodeByIndex)
+        .map(this::nodeIsViableForHead)
+        .orElse(false);
   }
 
   /**

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArray.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ProtoArray.java
@@ -596,7 +596,7 @@ public class ProtoArray {
    * Indicates if the node itself is viable for the head, or if it's best descendant is viable for
    * the head.
    */
-  private boolean nodeLeadsToViableHead(ProtoNode node) {
+  private boolean nodeLeadsToViableHead(final ProtoNode node) {
     if (nodeIsViableForHead(node)) {
       return true;
     }


### PR DESCRIPTION
## PR Description

When checking the viability of a node, we consider a node to be viable if either itself or its best descendant is viable. The current implementation checks the viability of the best descendant before checking the viability of the current node.

Part of the viability check involves traversing the array, following the node's ancestry (see ProtoArray#hasAncestorAtSlot).

When we need to update descendants, we visit every node and check its viability. Consider a scenario of long non-finality and no forks, where we have n nodes, where n[i].parent = n[i-1]. When we are checking the viability of node n[i] (where i is the index of the node and 0 <= i < n), we are going to traverse the array for its best descendant which is always going to be n[n-1] (the worst case traversing the whole array).

With this change, in those scenarios, we are moving from the worst case towards the best case as we visit the nodes. This change improves the time it takes to perform the operations.

## Fixed Issue(s)
related to #7570

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
