### PR TITLE
Don't send empty list of validator registrations to the Beacon node

### DIFF
--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/SignedValidatorRegistrationFactory.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/SignedValidatorRegistrationFactory.java
@@ -62,7 +62,7 @@ public class SignedValidatorRegistrationFactory {
             .orElseGet(
                 () -> {
                   LOG.warn(
-                      "Fee recipient not configured for {}. Will use a burn address for the validator registration",
+                      "Fee recipient not configured for {}. Will use a burn address for the validator registration.",
                       validator.getPublicKey());
                   return Eth1Address.ZERO;
                 });

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/SignedValidatorRegistrationFactory.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/SignedValidatorRegistrationFactory.java
@@ -46,13 +46,6 @@ public class SignedValidatorRegistrationFactory {
       final Validator validator,
       final Optional<SignedValidatorRegistration> oldValidatorRegistration,
       final Consumer<Throwable> errorHandler) {
-    return createSignedValidatorRegistration(validator, oldValidatorRegistration)
-        .whenException(errorHandler);
-  }
-
-  private SafeFuture<SignedValidatorRegistration> createSignedValidatorRegistration(
-      final Validator validator,
-      final Optional<SignedValidatorRegistration> oldValidatorRegistration) {
 
     final BLSPublicKey publicKey = validator.getPublicKey();
 
@@ -98,7 +91,8 @@ public class SignedValidatorRegistrationFactory {
             () -> {
               final Signer signer = validator.getSigner();
               return signAndCacheValidatorRegistration(publicKey, validatorRegistration, signer);
-            });
+            })
+        .whenException(errorHandler);
   }
 
   private SafeFuture<SignedValidatorRegistration> signAndCacheValidatorRegistration(

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/SignedValidatorRegistrationFactory.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/SignedValidatorRegistrationFactory.java
@@ -13,7 +13,7 @@
 
 package tech.pegasys.teku.validator.client;
 
-import static tech.pegasys.teku.validator.client.ValidatorRegistrator.VALIDATOR_BUILDER_PUBLICKEY;
+import static tech.pegasys.teku.validator.client.ValidatorRegistrator.VALIDATOR_BUILDER_PUBLIC_KEY;
 
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -32,13 +32,13 @@ import tech.pegasys.teku.spec.signatures.Signer;
 public class SignedValidatorRegistrationFactory {
   private static final Logger LOG = LogManager.getLogger();
 
-  private final ProposerConfigPropertiesProvider validatorRegistrationPropertiesProvider;
+  private final ProposerConfigPropertiesProvider proposerConfigPropertiesProvider;
   private final TimeProvider timeProvider;
 
   public SignedValidatorRegistrationFactory(
-      final ProposerConfigPropertiesProvider validatorRegistrationPropertiesProvider,
+      final ProposerConfigPropertiesProvider proposerConfigPropertiesProvider,
       final TimeProvider timeProvider) {
-    this.validatorRegistrationPropertiesProvider = validatorRegistrationPropertiesProvider;
+    this.proposerConfigPropertiesProvider = proposerConfigPropertiesProvider;
     this.timeProvider = timeProvider;
   }
 
@@ -56,16 +56,8 @@ public class SignedValidatorRegistrationFactory {
 
     final BLSPublicKey publicKey = validator.getPublicKey();
 
-    final boolean builderEnabled =
-        validatorRegistrationPropertiesProvider.isBuilderEnabled(publicKey);
-
-    if (!builderEnabled) {
-      LOG.trace("Validator registration is disabled for {}", publicKey);
-      return Optional.empty();
-    }
-
     final Optional<Eth1Address> maybeFeeRecipient =
-        validatorRegistrationPropertiesProvider.getFeeRecipient(publicKey);
+        proposerConfigPropertiesProvider.getFeeRecipient(publicKey);
 
     if (maybeFeeRecipient.isEmpty()) {
       LOG.debug(
@@ -75,14 +67,14 @@ public class SignedValidatorRegistrationFactory {
     }
 
     final Eth1Address feeRecipient = maybeFeeRecipient.get();
-    final UInt64 gasLimit = validatorRegistrationPropertiesProvider.getGasLimit(publicKey);
+    final UInt64 gasLimit = proposerConfigPropertiesProvider.getGasLimit(publicKey);
 
     final Optional<UInt64> maybeTimestampOverride =
-        validatorRegistrationPropertiesProvider.getBuilderRegistrationTimestampOverride(publicKey);
+        proposerConfigPropertiesProvider.getBuilderRegistrationTimestampOverride(publicKey);
 
     final ValidatorRegistration validatorRegistration =
         createValidatorRegistration(
-            VALIDATOR_BUILDER_PUBLICKEY.apply(validator, validatorRegistrationPropertiesProvider),
+            VALIDATOR_BUILDER_PUBLIC_KEY.apply(validator, proposerConfigPropertiesProvider),
             feeRecipient,
             gasLimit,
             maybeTimestampOverride.orElse(timeProvider.getTimeInSeconds()));

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/SignedValidatorRegistrationFactoryTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/SignedValidatorRegistrationFactoryTest.java
@@ -62,8 +62,6 @@ class SignedValidatorRegistrationFactoryTest {
     gasLimit = dataStructureUtil.randomUInt64();
     validator = new Validator(dataStructureUtil.randomPublicKey(), signer, Optional::empty);
 
-    when(proposerConfigPropertiesProvider.isBuilderEnabled(any())).thenReturn(true);
-
     when(proposerConfigPropertiesProvider.isReadyToProvideProperties()).thenReturn(true);
     when(proposerConfigPropertiesProvider.getFeeRecipient(any()))
         .thenReturn(Optional.of(feeRecipient));
@@ -315,19 +313,6 @@ class SignedValidatorRegistrationFactoryTest {
     // no fee recipient provided
     when(proposerConfigPropertiesProvider.getFeeRecipient(validator.getPublicKey()))
         .thenReturn(Optional.empty());
-
-    final Optional<SafeFuture<SignedValidatorRegistration>> maybeSignedValidatorRegistration =
-        signedValidatorRegistrationFactory.createSignedValidatorRegistration(
-            validator, Optional.empty(), throwable -> {});
-    verify(signer, never()).signValidatorRegistration(any());
-    assertThat(maybeSignedValidatorRegistration).isEmpty();
-  }
-
-  @TestTemplate
-  void doesNotCreateWhenValidatorRegistrationNotEnabled() {
-    // validator registration is disabled for validator2
-    when(proposerConfigPropertiesProvider.isBuilderEnabled(validator.getPublicKey()))
-        .thenReturn(false);
 
     final Optional<SafeFuture<SignedValidatorRegistration>> maybeSignedValidatorRegistration =
         signedValidatorRegistrationFactory.createSignedValidatorRegistration(

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/SignedValidatorRegistrationFactoryTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/SignedValidatorRegistrationFactoryTest.java
@@ -80,14 +80,11 @@ class SignedValidatorRegistrationFactoryTest {
 
   @TestTemplate
   public void whenCreateCalled_thenSigningRegistrationIsReturned() {
-    final Optional<SafeFuture<SignedValidatorRegistration>> maybeSignedValidatorRegistration =
+    final SafeFuture<SignedValidatorRegistration> signedValidatorRegistration =
         signedValidatorRegistrationFactory.createSignedValidatorRegistration(
             validator, Optional.empty(), throwable -> {});
 
     verify(signer).signValidatorRegistration(any());
-    assertThat(maybeSignedValidatorRegistration).isPresent();
-    final SafeFuture<SignedValidatorRegistration> signedValidatorRegistration =
-        maybeSignedValidatorRegistration.get();
     assertThat(signedValidatorRegistration)
         .isCompletedWithValueMatching(
             result -> result.getMessage().getPublicKey().equals(validator.getPublicKey()));
@@ -97,14 +94,11 @@ class SignedValidatorRegistrationFactoryTest {
   public void whenOldRegistrationDoesNotNeedToBeUpdated_thenSignerIsNotCalled() {
     final SignedValidatorRegistration oldSignedValidatorRegistration =
         createSignedValidatorRegistration(validator.getPublicKey(), feeRecipient);
-    final Optional<SafeFuture<SignedValidatorRegistration>> maybeSignedValidatorRegistration =
+    final SafeFuture<SignedValidatorRegistration> signedValidatorRegistration =
         signedValidatorRegistrationFactory.createSignedValidatorRegistration(
             validator, Optional.of(oldSignedValidatorRegistration), throwable -> {});
 
     verify(signer, never()).signValidatorRegistration(any());
-    assertThat(maybeSignedValidatorRegistration).isPresent();
-    final SafeFuture<SignedValidatorRegistration> signedValidatorRegistration =
-        maybeSignedValidatorRegistration.get();
     assertThat(signedValidatorRegistration)
         .isCompletedWithValueMatching(
             result -> result.getMessage().getPublicKey().equals(validator.getPublicKey()));
@@ -116,14 +110,11 @@ class SignedValidatorRegistrationFactoryTest {
     final SignedValidatorRegistration oldSignedValidatorRegistration =
         createSignedValidatorRegistration(
             validator.getPublicKey(), dataStructureUtil.randomEth1Address());
-    final Optional<SafeFuture<SignedValidatorRegistration>> maybeSignedValidatorRegistration =
+    final SafeFuture<SignedValidatorRegistration> signedValidatorRegistration =
         signedValidatorRegistrationFactory.createSignedValidatorRegistration(
             validator, Optional.of(oldSignedValidatorRegistration), throwable -> {});
 
     verify(signer).signValidatorRegistration(any());
-    assertThat(maybeSignedValidatorRegistration).isPresent();
-    final SafeFuture<SignedValidatorRegistration> signedValidatorRegistration =
-        maybeSignedValidatorRegistration.get();
     assertThat(signedValidatorRegistration)
         .isCompletedWithValueMatching(
             result ->
@@ -135,14 +126,11 @@ class SignedValidatorRegistrationFactoryTest {
   public void whenSigningIsCompletedExceptionally_thenExceptionIsPropagated() {
     when(signer.signValidatorRegistration(any()))
         .thenReturn(SafeFuture.failedFuture(new RuntimeException("oops")));
-    final Optional<SafeFuture<SignedValidatorRegistration>> maybeSignedValidatorRegistration =
+    final SafeFuture<SignedValidatorRegistration> signedValidatorRegistration =
         signedValidatorRegistrationFactory.createSignedValidatorRegistration(
             validator, Optional.empty(), throwable -> {});
 
     verify(signer).signValidatorRegistration(any());
-    assertThat(maybeSignedValidatorRegistration).isPresent();
-    final SafeFuture<SignedValidatorRegistration> signedValidatorRegistration =
-        maybeSignedValidatorRegistration.get();
     assertThat(signedValidatorRegistration).isCompletedExceptionally();
   }
 
@@ -154,13 +142,10 @@ class SignedValidatorRegistrationFactoryTest {
             validator.getPublicKey()))
         .thenReturn(Optional.of(timestampOverride));
 
-    final Optional<SafeFuture<SignedValidatorRegistration>> maybeSignedValidatorRegistration =
+    final SafeFuture<SignedValidatorRegistration> signedValidatorRegistration =
         signedValidatorRegistrationFactory.createSignedValidatorRegistration(
             validator, Optional.empty(), throwable -> {});
     verify(signer).signValidatorRegistration(any());
-    assertThat(maybeSignedValidatorRegistration).isPresent();
-    final SafeFuture<SignedValidatorRegistration> signedValidatorRegistration =
-        maybeSignedValidatorRegistration.get();
     assertThat(signedValidatorRegistration)
         .isCompletedWithValueMatching(
             result ->
@@ -175,13 +160,10 @@ class SignedValidatorRegistrationFactoryTest {
             validator.getPublicKey()))
         .thenReturn(Optional.of(publicKeyOverride));
 
-    final Optional<SafeFuture<SignedValidatorRegistration>> maybeSignedValidatorRegistration =
+    final SafeFuture<SignedValidatorRegistration> signedValidatorRegistration =
         signedValidatorRegistrationFactory.createSignedValidatorRegistration(
             validator, Optional.empty(), throwable -> {});
     verify(signer).signValidatorRegistration(any());
-    assertThat(maybeSignedValidatorRegistration).isPresent();
-    final SafeFuture<SignedValidatorRegistration> signedValidatorRegistration =
-        maybeSignedValidatorRegistration.get();
     assertThat(signedValidatorRegistration)
         .isCompletedWithValueMatching(
             result -> result.getMessage().getPublicKey().equals(publicKeyOverride));
@@ -198,13 +180,10 @@ class SignedValidatorRegistrationFactoryTest {
         .thenReturn(validator2GasLimit);
 
     // Verify validator
-    final Optional<SafeFuture<SignedValidatorRegistration>> maybeSignedValidatorRegistration =
+    final SafeFuture<SignedValidatorRegistration> signedValidatorRegistration =
         signedValidatorRegistrationFactory.createSignedValidatorRegistration(
             validator, Optional.empty(), throwable -> {});
     verify(signer).signValidatorRegistration(any());
-    assertThat(maybeSignedValidatorRegistration).isPresent();
-    final SafeFuture<SignedValidatorRegistration> signedValidatorRegistration =
-        maybeSignedValidatorRegistration.get();
     assertThat(signedValidatorRegistration)
         .isCompletedWithValueMatching(
             result ->
@@ -212,13 +191,10 @@ class SignedValidatorRegistrationFactoryTest {
                     && result.getMessage().getGasLimit().equals(gasLimit));
 
     // Verify validator2
-    final Optional<SafeFuture<SignedValidatorRegistration>> maybeSignedValidatorRegistration2 =
+    final SafeFuture<SignedValidatorRegistration> signedValidatorRegistration2 =
         signedValidatorRegistrationFactory.createSignedValidatorRegistration(
             validator2, Optional.empty(), throwable -> {});
     verify(signer, times(2)).signValidatorRegistration(any());
-    assertThat(maybeSignedValidatorRegistration2).isPresent();
-    final SafeFuture<SignedValidatorRegistration> signedValidatorRegistration2 =
-        maybeSignedValidatorRegistration2.get();
     assertThat(signedValidatorRegistration2)
         .isCompletedWithValueMatching(
             result ->
@@ -238,13 +214,10 @@ class SignedValidatorRegistrationFactoryTest {
         .thenReturn(Optional.of(validator2Timestamp));
 
     // Verify validator
-    final Optional<SafeFuture<SignedValidatorRegistration>> maybeSignedValidatorRegistration =
+    final SafeFuture<SignedValidatorRegistration> signedValidatorRegistration =
         signedValidatorRegistrationFactory.createSignedValidatorRegistration(
             validator, Optional.empty(), throwable -> {});
     verify(signer).signValidatorRegistration(any());
-    assertThat(maybeSignedValidatorRegistration).isPresent();
-    final SafeFuture<SignedValidatorRegistration> signedValidatorRegistration =
-        maybeSignedValidatorRegistration.get();
     assertThat(signedValidatorRegistration)
         .isCompletedWithValueMatching(
             result ->
@@ -255,13 +228,10 @@ class SignedValidatorRegistrationFactoryTest {
                         .equals(stubTimeProvider.getTimeInSeconds()));
 
     // Verify validator2
-    final Optional<SafeFuture<SignedValidatorRegistration>> maybeSignedValidatorRegistration2 =
+    final SafeFuture<SignedValidatorRegistration> signedValidatorRegistration2 =
         signedValidatorRegistrationFactory.createSignedValidatorRegistration(
             validator2, Optional.empty(), throwable -> {});
     verify(signer, times(2)).signValidatorRegistration(any());
-    assertThat(maybeSignedValidatorRegistration2).isPresent();
-    final SafeFuture<SignedValidatorRegistration> signedValidatorRegistration2 =
-        maybeSignedValidatorRegistration2.get();
     assertThat(signedValidatorRegistration2)
         .isCompletedWithValueMatching(
             result ->
@@ -280,13 +250,10 @@ class SignedValidatorRegistrationFactoryTest {
         .thenReturn(Optional.of(validator2FeeRecipient));
 
     // Verify validator
-    final Optional<SafeFuture<SignedValidatorRegistration>> maybeSignedValidatorRegistration =
+    final SafeFuture<SignedValidatorRegistration> signedValidatorRegistration =
         signedValidatorRegistrationFactory.createSignedValidatorRegistration(
             validator, Optional.empty(), throwable -> {});
     verify(signer).signValidatorRegistration(any());
-    assertThat(maybeSignedValidatorRegistration).isPresent();
-    final SafeFuture<SignedValidatorRegistration> signedValidatorRegistration =
-        maybeSignedValidatorRegistration.get();
     assertThat(signedValidatorRegistration)
         .isCompletedWithValueMatching(
             result ->
@@ -294,13 +261,10 @@ class SignedValidatorRegistrationFactoryTest {
                     && result.getMessage().getFeeRecipient().equals(feeRecipient));
 
     // Verify validator2
-    final Optional<SafeFuture<SignedValidatorRegistration>> maybeSignedValidatorRegistration2 =
+    final SafeFuture<SignedValidatorRegistration> signedValidatorRegistration2 =
         signedValidatorRegistrationFactory.createSignedValidatorRegistration(
             validator2, Optional.empty(), throwable -> {});
     verify(signer, times(2)).signValidatorRegistration(any());
-    assertThat(maybeSignedValidatorRegistration2).isPresent();
-    final SafeFuture<SignedValidatorRegistration> signedValidatorRegistration2 =
-        maybeSignedValidatorRegistration2.get();
     assertThat(signedValidatorRegistration2)
         .isCompletedWithValueMatching(
             result ->
@@ -309,16 +273,20 @@ class SignedValidatorRegistrationFactoryTest {
   }
 
   @TestTemplate
-  void doesNotCreateWhenFeeRecipientNotSpecified() {
+  void usesBurnAddressWhenFeeRecipientNotSpecified() {
     // no fee recipient provided
     when(proposerConfigPropertiesProvider.getFeeRecipient(validator.getPublicKey()))
         .thenReturn(Optional.empty());
 
-    final Optional<SafeFuture<SignedValidatorRegistration>> maybeSignedValidatorRegistration =
+    final SafeFuture<SignedValidatorRegistration> signedValidatorRegistration =
         signedValidatorRegistrationFactory.createSignedValidatorRegistration(
             validator, Optional.empty(), throwable -> {});
-    verify(signer, never()).signValidatorRegistration(any());
-    assertThat(maybeSignedValidatorRegistration).isEmpty();
+    verify(signer).signValidatorRegistration(any());
+    assertThat(signedValidatorRegistration)
+        .isCompletedWithValueMatching(
+            result ->
+                result.getMessage().getPublicKey().equals(validator.getPublicKey())
+                    && result.getMessage().getFeeRecipient().equals(Eth1Address.ZERO));
   }
 
   private SignedValidatorRegistration createSignedValidatorRegistration(

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorRegistratorTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorRegistratorTest.java
@@ -115,9 +115,8 @@ class ValidatorRegistratorTest {
         .thenAnswer(
             args -> {
               final Validator validator = (Validator) args.getArguments()[0];
-              return Optional.of(
-                  SafeFuture.completedFuture(
-                      createSignedValidatorRegistration(validator.getPublicKey())));
+              return SafeFuture.completedFuture(
+                  createSignedValidatorRegistration(validator.getPublicKey()));
             });
 
     when(proposerConfigPropertiesProvider.isReadyToProvideProperties()).thenReturn(true);
@@ -251,11 +250,10 @@ class ValidatorRegistratorTest {
             args -> {
               final Validator validator = (Validator) args.getArguments()[0];
               if (validator.equals(validator2)) {
-                return Optional.of(SafeFuture.failedFuture(new IllegalStateException("oopsy")));
+                return SafeFuture.failedFuture(new IllegalStateException("oopsy"));
               }
-              return Optional.of(
-                  SafeFuture.completedFuture(
-                      createSignedValidatorRegistration(validator.getPublicKey())));
+              return SafeFuture.completedFuture(
+                  createSignedValidatorRegistration(validator.getPublicKey()));
             });
     runRegistrationFlowWithSubscription(0);
 
@@ -264,9 +262,8 @@ class ValidatorRegistratorTest {
         .thenAnswer(
             args -> {
               final Validator validator = (Validator) args.getArguments()[0];
-              return Optional.of(
-                  SafeFuture.completedFuture(
-                      createSignedValidatorRegistration(validator.getPublicKey())));
+              return SafeFuture.completedFuture(
+                  createSignedValidatorRegistration(validator.getPublicKey()));
             });
     runRegistrationFlowWithSubscription(1);
 

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorRegistratorTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorRegistratorTest.java
@@ -274,10 +274,10 @@ class ValidatorRegistratorTest {
   }
 
   @TestTemplate
-  void doesNotRegister_ifValidatorIsNotEnabled() {
+  void doesNotRegister_ifValidatorBuilderFlowIsNotEnabled() {
     setOwnedValidators(validator1, validator2, validator3);
 
-    // validator 1 is not enabled
+    // disable builder flow for validator 1
     when(proposerConfigPropertiesProvider.isBuilderEnabled(validator1.getPublicKey()))
         .thenReturn(false);
 

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorRegistratorTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorRegistratorTest.java
@@ -241,7 +241,7 @@ class ValidatorRegistratorTest {
   }
 
   @TestTemplate
-  void registerValidatorsEvenIfOneRegistrationSigningFails() {
+  void registerValidatorsEvenIfOneRegistrationCreationFails() {
     setOwnedValidators(validator1, validator2, validator3);
 
     reset(signedValidatorRegistrationFactory);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
An issue discovered by a discord user: https://discord.com/channels/697535391594446898/697539289042649190/1163444580415455283

Because we are checking if builder is enabled for a specific validator after creating the batches of validators, we can end up calling `validatorApiChannel.registerValidators` with an empty list. This PR filters the validators which are not enabled in the beginning of the flow.

Also changed `SignedValidatorRegistrationFactory` to not return an Optional. I think this class should be agnostic to whether builder is enabled or not for a validator. Also fee recipient should pretty much never be not specified so changed it to throw an exception and raise a warning in the logs. This also removes the need of `Pair` usage in the `ValidatorRegistrator`.

- Moved `proposerConfigPropertiesProvider.refresh()` on top because it is used before the `registerValidators` method as well.

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
