### PR TITLE
Improve slow db warning

### DIFF
--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/DbLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/DbLogger.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.infrastructure.logging;
 
 import static tech.pegasys.teku.infrastructure.logging.ColorConsolePrinter.print;
 
+import java.util.function.Supplier;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.infrastructure.logging.ColorConsolePrinter.Color;
@@ -33,14 +34,17 @@ public class DbLogger {
   }
 
   public void onDbOpAlertThreshold(
-      final String opName, final long startTimeMillis, final long endTimeMillis) {
+      final String opName,
+      final Supplier<String> additionalInfo,
+      final long startTimeMillis,
+      final long endTimeMillis) {
     final long duration = endTimeMillis - startTimeMillis;
     if (dbOpAlertThresholdMillis > 0 && duration >= dbOpAlertThresholdMillis) {
       logger.warn(
           print(
               String.format(
-                  "DB operation %s took too long: %d ms. The alert threshold is set to: %d ms",
-                  opName, duration, dbOpAlertThresholdMillis),
+                  "DB operation %s took too long: %d ms. The alert threshold is set to: %d ms. Additional info: %s",
+                  opName, duration, dbOpAlertThresholdMillis, additionalInfo.get()),
               Color.YELLOW));
     }
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
@@ -946,6 +946,7 @@ public class KvStoreDatabase implements Database {
 
   private UpdateResult doUpdate(final StorageUpdate update) {
     LOG.trace("Applying finalized updates");
+    long startTime = System.currentTimeMillis();
     // Update finalized blocks and states
     final Optional<SlotAndExecutionPayloadSummary> finalizedOptimisticExecutionPayload =
         updateFinalizedData(
@@ -964,9 +965,11 @@ public class KvStoreDatabase implements Database {
           update.getEarliestBlobSidecarSlot(),
           update.getBlobSidecars().values().stream().flatMap(Collection::stream));
     }
+    long finalizedDataUpdatedTime = System.currentTimeMillis();
 
     LOG.trace("Applying hot updates");
-    long startTime = System.currentTimeMillis();
+    final long latestFinalizedStateUpdateStartTime;
+    final long latestFinalizedStateUpdateEndTime;
     try (final HotUpdater updater = hotUpdater()) {
       // Store new hot data
       update.getGenesisTime().ifPresent(updater::setGenesisTime);
@@ -983,7 +986,9 @@ public class KvStoreDatabase implements Database {
 
       update.getJustifiedCheckpoint().ifPresent(updater::setJustifiedCheckpoint);
       update.getBestJustifiedCheckpoint().ifPresent(updater::setBestJustifiedCheckpoint);
+      latestFinalizedStateUpdateStartTime = System.currentTimeMillis();
       update.getLatestFinalizedState().ifPresent(updater::setLatestFinalizedState);
+      latestFinalizedStateUpdateEndTime = System.currentTimeMillis();
 
       updateHotBlocks(updater, update.getHotBlocks(), update.getDeletedHotBlocks().keySet());
       updater.addHotStates(update.getHotStates());
@@ -999,7 +1004,16 @@ public class KvStoreDatabase implements Database {
     }
 
     long endTime = System.currentTimeMillis();
-    DB_LOGGER.onDbOpAlertThreshold("KvStoreDatabase::doUpdate", startTime, endTime);
+    DB_LOGGER.onDbOpAlertThreshold(
+        "KvStoreDatabase::doUpdate",
+        () ->
+            String.format(
+                "Finalized data updated time: %d ms - Hot data updated time: %d ms of which finalized state updated time: %d ms",
+                finalizedDataUpdatedTime - startTime,
+                endTime - finalizedDataUpdatedTime,
+                latestFinalizedStateUpdateEndTime - latestFinalizedStateUpdateStartTime),
+        startTime,
+        endTime);
     LOG.trace("Update complete");
     return new UpdateResult(finalizedOptimisticExecutionPayload);
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
@@ -1008,7 +1008,7 @@ public class KvStoreDatabase implements Database {
         "KvStoreDatabase::doUpdate",
         () ->
             String.format(
-                "Finalized data updated time: %d ms - Hot data updated time: %d ms of which finalized state updated time: %d ms",
+                "Finalized data updated time: %d ms - Hot data updated time: %d ms of which latest finalized state updated time: %d ms",
                 finalizedDataUpdatedTime - startTime,
                 endTime - finalizedDataUpdatedTime,
                 latestFinalizedStateUpdateEndTime - latestFinalizedStateUpdateStartTime),

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/leveldb/LevelDbTransaction.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/leveldb/LevelDbTransaction.java
@@ -96,7 +96,7 @@ public class LevelDbTransaction implements KvStoreTransaction {
             long startTime = System.currentTimeMillis();
             db.write(writeBatch);
             long endTime = System.currentTimeMillis();
-            DB_LOGGER.onDbOpAlertThreshold("LevelDbTransaction::commit", startTime, endTime);
+            DB_LOGGER.onDbOpAlertThreshold("LevelDbTransaction::commit", () -> "N/A", startTime, endTime);
           } finally {
             close();
           }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/leveldb/LevelDbTransaction.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/leveldb/LevelDbTransaction.java
@@ -96,7 +96,8 @@ public class LevelDbTransaction implements KvStoreTransaction {
             long startTime = System.currentTimeMillis();
             db.write(writeBatch);
             long endTime = System.currentTimeMillis();
-            DB_LOGGER.onDbOpAlertThreshold("LevelDbTransaction::commit", () -> "N/A", startTime, endTime);
+            DB_LOGGER.onDbOpAlertThreshold(
+                "LevelDbTransaction::commit", () -> "N/A", startTime, endTime);
           } finally {
             close();
           }


### PR DESCRIPTION
Consider the whole `doUpdate` method timings to consider an update as "slow".
Provide additional info when `doUpdate` is "slow".

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
