### PR TITLE
Simplify loading/freeing trusted setup

### DIFF
--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
@@ -42,13 +42,10 @@ import tech.pegasys.teku.ethtests.finder.TestDefinition;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.eventthread.InlineEventThread;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.kzg.KZGProof;
 import tech.pegasys.teku.reference.TestDataUtils;
 import tech.pegasys.teku.reference.TestExecutor;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.SpecVersion;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.Blob;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
@@ -66,9 +63,7 @@ import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannel;
 import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannelStub;
 import tech.pegasys.teku.spec.executionlayer.ExecutionPayloadStatus;
 import tech.pegasys.teku.spec.executionlayer.PayloadStatus;
-import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
-import tech.pegasys.teku.spec.logic.versions.deneb.helpers.MiscHelpersDeneb;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceStateProvider;
 import tech.pegasys.teku.statetransition.forkchoice.MergeTransitionBlockValidator;
@@ -161,8 +156,6 @@ public class ForkChoiceTestExecutor implements TestExecutor {
               + "\nProtoarray data:\n"
               + protoArrayData,
           e);
-    } finally {
-      freeTrustedSetupIfRequired(spec);
     }
   }
 
@@ -487,14 +480,6 @@ public class ForkChoiceTestExecutor implements TestExecutor {
     assertThat(actual)
         .describedAs(checkpointType)
         .isEqualTo(new Checkpoint(expectedEpoch, expectedRoot));
-  }
-
-  private void freeTrustedSetupIfRequired(final Spec spec) {
-    Optional.ofNullable(spec.forMilestone(SpecMilestone.DENEB))
-        .map(SpecVersion::miscHelpers)
-        .flatMap(MiscHelpers::toVersionDeneb)
-        .map(MiscHelpersDeneb::getKzg)
-        .ifPresent(KZG::freeTrustedSetup);
   }
 
   @SuppressWarnings({"unchecked", "TypeParameterUnusedInFormals"})

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/kzg/KzgTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/kzg/KzgTestExecutor.java
@@ -40,11 +40,9 @@ public abstract class KzgTestExecutor implements TestExecutor {
     final SpecConfigDeneb specConfigDeneb =
         SpecConfigDeneb.required(networkConfig.getSpec().getGenesisSpecConfig());
 
-    try {
+    try (kzg) {
       kzg.loadTrustedSetup(specConfigDeneb.getTrustedSetupPath().orElseThrow());
       runTestImpl(testDefinition);
-    } finally {
-      kzg.freeTrustedSetup();
     }
   }
 

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/kzg/KzgTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/kzg/KzgTestExecutor.java
@@ -40,10 +40,8 @@ public abstract class KzgTestExecutor implements TestExecutor {
     final SpecConfigDeneb specConfigDeneb =
         SpecConfigDeneb.required(networkConfig.getSpec().getGenesisSpecConfig());
 
-    try (kzg) {
-      kzg.loadTrustedSetup(specConfigDeneb.getTrustedSetupPath().orElseThrow());
-      runTestImpl(testDefinition);
-    }
+    kzg.loadTrustedSetup(specConfigDeneb.getTrustedSetupPath().orElseThrow());
+    runTestImpl(testDefinition);
   }
 
   private String extractNetwork(final String testName) {

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/kzg/KzgTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/kzg/KzgTestExecutor.java
@@ -30,7 +30,7 @@ public abstract class KzgTestExecutor implements TestExecutor {
 
   private static final Pattern TEST_NAME_PATTERN = Pattern.compile("kzg-(.+)/.+");
 
-  protected final KZG kzg = CKZG4844.createInstance();
+  protected final KZG kzg = CKZG4844.getInstance();
 
   @Override
   public final void runTest(final TestDefinition testDefinition) throws Throwable {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/helpers/MiscHelpersDeneb.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/helpers/MiscHelpersDeneb.java
@@ -51,7 +51,7 @@ public class MiscHelpersDeneb extends MiscHelpersCapella {
   private static KZG initKZG(final SpecConfigDeneb config) {
     final KZG kzg;
     if (!config.getDenebForkEpoch().equals(SpecConfig.FAR_FUTURE_EPOCH) && !config.isKZGNoop()) {
-      kzg = CKZG4844.createInstance();
+      kzg = CKZG4844.getInstance();
       kzg.loadTrustedSetup(config.getTrustedSetupPath().orElseThrow());
     } else {
       kzg = KZG.NOOP;

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/logic/versions/deneb/helpers/KzgResolver.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/logic/versions/deneb/helpers/KzgResolver.java
@@ -28,9 +28,7 @@ import tech.pegasys.teku.kzg.trusted_setups.TrustedSetups;
 
 /**
  * This class provides a KZG instance with a loaded trusted setup that will automatically free the
- * trusted setup when the property test is finished. It will re-use the same KZG instance for all
- * iterations of the test, but it will create a new instance for each method. For a class with three
- * property test methods, you can expect it to load/free three times.
+ * trusted setup when all the property tests are finished.
  */
 class KzgResolver implements ResolveParameterHook {
   public static final Tuple.Tuple2<Class<KzgResolver.KzgAutoLoadFree>, String> STORE_IDENTIFIER =
@@ -49,7 +47,7 @@ class KzgResolver implements ResolveParameterHook {
 
   private KZG getKzgWithTrustedSetup() {
     final Store<KzgResolver.KzgAutoLoadFree> kzgStore =
-        Store.getOrCreate(STORE_IDENTIFIER, Lifespan.PROPERTY, KzgResolver.KzgAutoLoadFree::new);
+        Store.getOrCreate(STORE_IDENTIFIER, Lifespan.RUN, KzgResolver.KzgAutoLoadFree::new);
     return kzgStore.get().kzg;
   }
 
@@ -64,8 +62,8 @@ class KzgResolver implements ResolveParameterHook {
     }
 
     @Override
-    public void close() throws Exception {
-      kzg.close();
+    public void close() {
+      kzg.freeTrustedSetup();
     }
   }
 }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/logic/versions/deneb/helpers/KzgResolver.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/logic/versions/deneb/helpers/KzgResolver.java
@@ -55,7 +55,7 @@ class KzgResolver implements ResolveParameterHook {
     private static final String TRUSTED_SETUP =
         Resources.getResource(TrustedSetups.class, "trusted_setup.txt").toExternalForm();
 
-    private final KZG kzg = CKZG4844.createInstance();
+    private final KZG kzg = CKZG4844.getInstance();
 
     private KzgAutoLoadFree() {
       kzg.loadTrustedSetup(TRUSTED_SETUP);

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/logic/versions/deneb/helpers/KzgResolver.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/logic/versions/deneb/helpers/KzgResolver.java
@@ -56,6 +56,7 @@ class KzgResolver implements ResolveParameterHook {
   private static class KzgAutoLoadFree implements Store.CloseOnReset {
     private static final String TRUSTED_SETUP =
         Resources.getResource(TrustedSetups.class, "trusted_setup.txt").toExternalForm();
+
     private final KZG kzg = CKZG4844.createInstance();
 
     private KzgAutoLoadFree() {
@@ -63,8 +64,8 @@ class KzgResolver implements ResolveParameterHook {
     }
 
     @Override
-    public void close() {
-      kzg.freeTrustedSetup();
+    public void close() throws Exception {
+      kzg.close();
     }
   }
 }

--- a/infrastructure/kzg/src/main/java/tech/pegasys/teku/kzg/KZG.java
+++ b/infrastructure/kzg/src/main/java/tech/pegasys/teku/kzg/KZG.java
@@ -20,13 +20,16 @@ import org.apache.tuweni.bytes.Bytes;
  * This interface specifies all the KZG functions needed for the Deneb specification and is the
  * entry-point for all KZG operations in Teku.
  */
-public interface KZG extends AutoCloseable {
+public interface KZG {
 
   KZG NOOP =
       new KZG() {
 
         @Override
         public void loadTrustedSetup(final String trustedSetupFile) throws KZGException {}
+
+        @Override
+        public void freeTrustedSetup() throws KZGException {}
 
         @Override
         public boolean verifyBlobKzgProofBatch(
@@ -47,12 +50,11 @@ public interface KZG extends AutoCloseable {
             throws KZGException {
           return KZGProof.INFINITY;
         }
-
-        @Override
-        public void close() {}
       };
 
   void loadTrustedSetup(String trustedSetupFile) throws KZGException;
+
+  void freeTrustedSetup() throws KZGException;
 
   boolean verifyBlobKzgProofBatch(
       List<Bytes> blobs, List<KZGCommitment> kzgCommitments, List<KZGProof> kzgProofs)

--- a/infrastructure/kzg/src/main/java/tech/pegasys/teku/kzg/KZG.java
+++ b/infrastructure/kzg/src/main/java/tech/pegasys/teku/kzg/KZG.java
@@ -20,15 +20,13 @@ import org.apache.tuweni.bytes.Bytes;
  * This interface specifies all the KZG functions needed for the Deneb specification and is the
  * entry-point for all KZG operations in Teku.
  */
-public interface KZG {
+public interface KZG extends AutoCloseable {
 
   KZG NOOP =
       new KZG() {
-        @Override
-        public void loadTrustedSetup(final String trustedSetupFile) throws KZGException {}
 
         @Override
-        public void freeTrustedSetup() throws KZGException {}
+        public void loadTrustedSetup(final String trustedSetupFile) throws KZGException {}
 
         @Override
         public boolean verifyBlobKzgProofBatch(
@@ -49,11 +47,12 @@ public interface KZG {
             throws KZGException {
           return KZGProof.INFINITY;
         }
+
+        @Override
+        public void close() {}
       };
 
   void loadTrustedSetup(String trustedSetupFile) throws KZGException;
-
-  void freeTrustedSetup() throws KZGException;
 
   boolean verifyBlobKzgProofBatch(
       List<Bytes> blobs, List<KZGCommitment> kzgCommitments, List<KZGProof> kzgProofs)

--- a/infrastructure/kzg/src/main/java/tech/pegasys/teku/kzg/ckzg4844/CKZG4844.java
+++ b/infrastructure/kzg/src/main/java/tech/pegasys/teku/kzg/ckzg4844/CKZG4844.java
@@ -87,7 +87,7 @@ public final class CKZG4844 implements KZG {
   }
 
   @Override
-  public void freeTrustedSetup() throws KZGException {
+  public synchronized void freeTrustedSetup() throws KZGException {
     try {
       CKZG4844JNI.freeTrustedSetup();
       loadedTrustedSetupFile = Optional.empty();

--- a/infrastructure/kzg/src/main/java/tech/pegasys/teku/kzg/ckzg4844/CKZG4844.java
+++ b/infrastructure/kzg/src/main/java/tech/pegasys/teku/kzg/ckzg4844/CKZG4844.java
@@ -87,6 +87,17 @@ public final class CKZG4844 implements KZG {
   }
 
   @Override
+  public void freeTrustedSetup() throws KZGException {
+    try {
+      CKZG4844JNI.freeTrustedSetup();
+      loadedTrustedSetupFile = Optional.empty();
+      LOG.debug("Trusted setup was freed");
+    } catch (final Exception ex) {
+      throw new KZGException("Failed to free trusted setup", ex);
+    }
+  }
+
+  @Override
   public boolean verifyBlobKzgProofBatch(
       final List<Bytes> blobs,
       final List<KZGCommitment> kzgCommitments,
@@ -124,22 +135,6 @@ public final class CKZG4844 implements KZG {
     } catch (final Exception ex) {
       throw new KZGException(
           "Failed to compute KZG proof for blob with commitment " + kzgCommitment, ex);
-    }
-  }
-
-  /** Frees the current trusted setup if any is loaded */
-  @Override
-  public void close() {
-    loadedTrustedSetupFile.ifPresent(__ -> freeTrustedSetup());
-  }
-
-  private void freeTrustedSetup() throws KZGException {
-    try {
-      CKZG4844JNI.freeTrustedSetup();
-      loadedTrustedSetupFile = Optional.empty();
-      LOG.debug("Trusted setup was freed");
-    } catch (final Exception ex) {
-      throw new KZGException("Failed to free trusted setup", ex);
     }
   }
 }

--- a/infrastructure/kzg/src/main/java/tech/pegasys/teku/kzg/ckzg4844/CKZG4844.java
+++ b/infrastructure/kzg/src/main/java/tech/pegasys/teku/kzg/ckzg4844/CKZG4844.java
@@ -59,7 +59,7 @@ public final class CKZG4844 implements KZG {
   public synchronized void loadTrustedSetup(final String trustedSetupFile) throws KZGException {
     if (loadedTrustedSetupFile.isPresent()
         && loadedTrustedSetupFile.get().equals(trustedSetupFile)) {
-      LOG.trace("Trusted setup from file {} is already loaded.", trustedSetupFile);
+      LOG.trace("Trusted setup from {} is already loaded", trustedSetupFile);
       return;
     }
     try {
@@ -79,10 +79,10 @@ public final class CKZG4844 implements KZG {
           g1Points.size(),
           CKZG4844Utils.flattenG2Points(g2Points),
           g2Points.size());
-      LOG.debug("Loaded trusted setup from file {}", trustedSetupFile);
+      LOG.debug("Loaded trusted setup from {}", trustedSetupFile);
       loadedTrustedSetupFile = Optional.of(trustedSetupFile);
     } catch (final Exception ex) {
-      throw new KZGException("Failed to load trusted setup from file " + trustedSetupFile, ex);
+      throw new KZGException("Failed to load trusted setup from " + trustedSetupFile, ex);
     }
   }
 

--- a/infrastructure/kzg/src/main/java/tech/pegasys/teku/kzg/ckzg4844/CKZG4844.java
+++ b/infrastructure/kzg/src/main/java/tech/pegasys/teku/kzg/ckzg4844/CKZG4844.java
@@ -38,7 +38,7 @@ public final class CKZG4844 implements KZG {
 
   private Optional<String> loadedTrustedSetupFile = Optional.empty();
 
-  public static synchronized CKZG4844 createInstance() {
+  public static synchronized CKZG4844 getInstance() {
     if (instance == null) {
       instance = new CKZG4844();
     }

--- a/infrastructure/kzg/src/test/java/tech/pegasys/teku/kzg/KZGTest.java
+++ b/infrastructure/kzg/src/test/java/tech/pegasys/teku/kzg/KZGTest.java
@@ -55,15 +55,15 @@ public final class KZGTest {
     loadTrustedSetup();
   }
 
-  @AfterAll
-  public static void cleanUp() {
-    KZG.freeTrustedSetup();
-  }
-
   private static void loadTrustedSetup() {
     final String trustedSetup =
         Resources.getResource(TrustedSetups.class, TRUSTED_SETUP_PATH).toExternalForm();
     KZG.loadTrustedSetup(trustedSetup);
+  }
+
+  @AfterAll
+  public static void cleanUp() {
+    KZG.freeTrustedSetup();
   }
 
   @Test

--- a/infrastructure/kzg/src/test/java/tech/pegasys/teku/kzg/ckzg4844/CKZG4844Test.java
+++ b/infrastructure/kzg/src/test/java/tech/pegasys/teku/kzg/ckzg4844/CKZG4844Test.java
@@ -51,7 +51,7 @@ public final class CKZG4844Test {
   private static final Random RND = new Random(RANDOM_SEED);
   private static final String TRUSTED_SETUP_PATH = "trusted_setup.txt";
 
-  private static final CKZG4844 KZG = CKZG4844.createInstance();
+  private static final CKZG4844 KZG = CKZG4844.getInstance();
 
   @BeforeEach
   public void setUp() {

--- a/infrastructure/kzg/src/test/java/tech/pegasys/teku/kzg/ckzg4844/CKZG4844Test.java
+++ b/infrastructure/kzg/src/test/java/tech/pegasys/teku/kzg/ckzg4844/CKZG4844Test.java
@@ -11,7 +11,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.kzg;
+package tech.pegasys.teku.kzg.ckzg4844;
 
 import static ethereum.ckzg4844.CKZG4844JNI.BLS_MODULUS;
 import static ethereum.ckzg4844.CKZG4844JNI.BYTES_PER_BLOB;
@@ -39,16 +39,19 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import tech.pegasys.teku.kzg.ckzg4844.CKZG4844;
+import tech.pegasys.teku.kzg.KZGCommitment;
+import tech.pegasys.teku.kzg.KZGException;
+import tech.pegasys.teku.kzg.KZGProof;
+import tech.pegasys.teku.kzg.TrustedSetup;
 import tech.pegasys.teku.kzg.trusted_setups.TrustedSetups;
 
-public final class KZGTest {
+public final class CKZG4844Test {
 
   private static final int RANDOM_SEED = 5566;
   private static final Random RND = new Random(RANDOM_SEED);
   private static final String TRUSTED_SETUP_PATH = "trusted_setup.txt";
 
-  private static final KZG KZG = CKZG4844.createInstance();
+  private static final CKZG4844 KZG = CKZG4844.createInstance();
 
   @BeforeEach
   public void setUp() {

--- a/infrastructure/kzg/src/test/java/tech/pegasys/teku/kzg/ckzg4844/CKZG4844Test.java
+++ b/infrastructure/kzg/src/test/java/tech/pegasys/teku/kzg/ckzg4844/CKZG4844Test.java
@@ -65,8 +65,12 @@ public final class CKZG4844Test {
   }
 
   @AfterAll
-  public static void cleanUp() {
-    KZG.freeTrustedSetup();
+  public static void cleanUp() throws KZGException {
+    try {
+      KZG.freeTrustedSetup();
+    } catch (KZGException ex) {
+      // NOOP
+    }
   }
 
   @Test


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

- Allow reloading different trusted setup without need to free the current one. 
- Simplify tests (not reload trusted setups all the time)

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
