### PR TITLE
Changed default value for batch signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,5 +15,6 @@ the [releases page](https://github.com/Consensys/teku/releases).
 ### Additions and Improvements
  - Updated dependencies.
  - Added `validator_duty_timer` metrics recording the time to perform `block_production`, `attestation_production` and `attestation_aggregation` duties.
+ - Updated the default number of threads for batch signature verification based on CPUs available to help larger instances that may have more processing power available.
 
 ### Bug Fixes

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/P2PConfig.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/P2PConfig.java
@@ -33,7 +33,8 @@ public class P2PConfig {
   public static final int DEFAULT_P2P_TARGET_SUBNET_SUBSCRIBER_COUNT = 2;
   public static final boolean DEFAULT_SUBSCRIBE_ALL_SUBNETS_ENABLED = false;
   public static final boolean DEFAULT_GOSSIP_SCORING_ENABLED = true;
-  public static final int DEFAULT_BATCH_VERIFY_MAX_THREADS = 2;
+  public static final int DEFAULT_BATCH_VERIFY_MAX_THREADS =
+      Math.max(2, Runtime.getRuntime().availableProcessors() / 2);
   public static final int DEFAULT_BATCH_VERIFY_QUEUE_CAPACITY = 15_000;
   public static final int DEFAULT_BATCH_VERIFY_MAX_BATCH_SIZE = 250;
   public static final boolean DEFAULT_BATCH_VERIFY_STRICT_THREAD_LIMIT_ENABLED = false;


### PR DESCRIPTION
On larger infra, especially subscribed to all subnets, more threads can be helpful when batch processing signatures, and reduce contention on the p2p queue.

While it's possible to manually adjust via development flag, it's' time to improve defaulting on this configuration.

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
