### PR TITLE
Fix incorrect DepositTree finalization when 0 finalized deposits

### DIFF
--- a/ethereum/pow/merkletree/src/main/java/tech/pegasys/teku/ethereum/pow/merkletree/DepositTree.java
+++ b/ethereum/pow/merkletree/src/main/java/tech/pegasys/teku/ethereum/pow/merkletree/DepositTree.java
@@ -95,6 +95,9 @@ public class DepositTree {
     checkArgument(
         totalDepositCount >= eth1Data.getDepositCount().longValue(),
         "Merkle tree does not contain all deposits to be finalized");
+    if (eth1Data.getDepositCount().equals(UInt64.ZERO)) {
+      return;
+    }
     finalizedExecutionBlock =
         Optional.of(new BlockHashAndHeight(eth1Data.getBlockHash(), blockHeight));
     finalizedDepositCount = eth1Data.getDepositCount().longValue();

--- a/ethereum/pow/merkletree/src/test/java/tech/pegasys/teku/ethereum/pow/merkletree/DepositTreeTest.java
+++ b/ethereum/pow/merkletree/src/test/java/tech/pegasys/teku/ethereum/pow/merkletree/DepositTreeTest.java
@@ -56,13 +56,7 @@ class DepositTreeTest {
 
       if (i >= nonFinalizedDepositCount) {
         final DepositTestCase finalisingTestCase = testCases.get(i - nonFinalizedDepositCount);
-        final Eth1Data correctEth1Data = finalisingTestCase.getEth1Data();
-        depositTree.finalize(
-            new Eth1Data(
-                correctEth1Data.getDepositRoot(),
-                correctEth1Data.getDepositCount().minus(1),
-                correctEth1Data.getBlockHash()),
-            finalisingTestCase.getBlockHeight());
+        depositTree.finalize(finalisingTestCase.getEth1Data(), finalisingTestCase.getBlockHeight());
         final Optional<DepositTreeSnapshot> snapshotOptional = depositTree.getSnapshot();
         assertThat(snapshotOptional).contains(finalisingTestCase.getSnapshot());
       }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
The bug exists when the size of the tree is non 0 and we try to finalize it with 0 deposits. Current master implementation mistakenly enters `BranchMerkleTree` and further and finalizes one leaf https://github.com/ConsenSys/teku/blob/f31b239f7788f07d8e9c2b6e7544c5e16b01a259/ethereum/pow/merkletree/src/main/java/tech/pegasys/teku/ethereum/pow/merkletree/LeafMerkleTree.java#L44C1-L47 leading to non zero tree finalization. Once the input is > 0, finalization logic logic looks correct, so fixing behavior at the entry point.
The test added clarifies that 0 case is fixed and finalize with other inputs follows different paths on each input.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
fixes #7626 
## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
