### PR TITLE
Implement finalized checkpoint gossip rule for `blobSidecar`

### DIFF
--- a/beacon/sync/src/testFixtures/java/tech/pegasys/teku/beacon/sync/SyncingNodeManager.java
+++ b/beacon/sync/src/testFixtures/java/tech/pegasys/teku/beacon/sync/SyncingNodeManager.java
@@ -126,8 +126,7 @@ public class SyncingNodeManager {
             new StubMetricsSystem());
 
     final BlockGossipValidator blockGossipValidator =
-        new BlockGossipValidator(
-            spec, recentChainData, new GossipValidationHelper(spec, recentChainData));
+        new BlockGossipValidator(spec, new GossipValidationHelper(spec, recentChainData));
     final BlockValidator blockValidator = new BlockValidator(blockGossipValidator);
 
     final TimeProvider timeProvider = new SystemTimeProvider();

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -692,12 +692,14 @@ public class Spec {
   }
 
   public boolean blockDescendsFromLatestFinalizedBlock(
-      final BeaconBlock block,
+      final UInt64 blockSlot,
+      final Bytes32 blockParentRoot,
       final ReadOnlyStore store,
       final ReadOnlyForkChoiceStrategy forkChoiceStrategy) {
-    return atBlock(block)
+    return atSlot(blockSlot)
         .getForkChoiceUtil()
-        .blockDescendsFromLatestFinalizedBlock(block, store, forkChoiceStrategy);
+        .blockDescendsFromLatestFinalizedBlock(
+            blockSlot, blockParentRoot, store, forkChoiceStrategy);
   }
 
   public BeaconState processSlots(BeaconState preState, UInt64 slot)

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
@@ -28,7 +28,6 @@ import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.config.SpecConfigBellatrix;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
-import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
@@ -432,7 +431,8 @@ public class ForkChoiceUtil {
     if (blockIsFromFuture(store, blockSlot)) {
       return BlockImportResult.FAILED_BLOCK_IS_FROM_FUTURE;
     }
-    if (!blockDescendsFromLatestFinalizedBlock(block, store, store.getForkChoiceStrategy())) {
+    if (!blockDescendsFromLatestFinalizedBlock(
+        block.getSlot(), block.getParentRoot(), store, store.getForkChoiceStrategy())) {
       return BlockImportResult.FAILED_INVALID_ANCESTRY;
     }
     // Successful so far
@@ -444,18 +444,18 @@ public class ForkChoiceUtil {
   }
 
   public boolean blockDescendsFromLatestFinalizedBlock(
-      final BeaconBlockSummary block,
+      final UInt64 blockSlot,
+      final Bytes32 parentBlockRoot,
       final ReadOnlyStore store,
       final ReadOnlyForkChoiceStrategy forkChoiceStrategy) {
     final Checkpoint finalizedCheckpoint = store.getFinalizedCheckpoint();
-    final UInt64 blockSlot = block.getSlot();
 
     // Make sure this block's slot is after the latest finalized slot
     final UInt64 finalizedEpochStartSlot = getFinalizedCheckpointStartSlot(store);
     return blockIsAfterLatestFinalizedSlot(blockSlot, finalizedEpochStartSlot)
         && hasAncestorAtSlot(
             forkChoiceStrategy,
-            block.getParentRoot(),
+            parentBlockRoot,
             finalizedEpochStartSlot,
             finalizedCheckpoint.getRoot());
   }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blobs/BlobSidecarManagerImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blobs/BlobSidecarManagerImpl.java
@@ -30,7 +30,7 @@ import tech.pegasys.teku.spec.logic.versions.deneb.blobs.BlobSidecarsAndValidati
 import tech.pegasys.teku.spec.logic.versions.deneb.blobs.BlobSidecarsAvailabilityChecker;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceBlobSidecarsAvailabilityChecker;
 import tech.pegasys.teku.statetransition.util.FutureItems;
-import tech.pegasys.teku.statetransition.validation.BlobSidecarValidator;
+import tech.pegasys.teku.statetransition.validation.BlobSidecarGossipValidator;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
@@ -39,7 +39,7 @@ public class BlobSidecarManagerImpl implements BlobSidecarManager, SlotEventsCha
   private final Spec spec;
   private final AsyncRunner asyncRunner;
   private final RecentChainData recentChainData;
-  private final BlobSidecarValidator validator;
+  private final BlobSidecarGossipValidator validator;
   private final BlobSidecarPool blobSidecarPool;
   private final FutureItems<SignedBlobSidecar> futureBlobSidecars;
   private final Map<Bytes32, InternalValidationResult> invalidBlobSidecarRoots;
@@ -52,7 +52,7 @@ public class BlobSidecarManagerImpl implements BlobSidecarManager, SlotEventsCha
       final AsyncRunner asyncRunner,
       final RecentChainData recentChainData,
       final BlobSidecarPool blobSidecarPool,
-      final BlobSidecarValidator validator,
+      final BlobSidecarGossipValidator validator,
       final FutureItems<SignedBlobSidecar> futureBlobSidecars,
       final Map<Bytes32, InternalValidationResult> invalidBlobSidecarRoots) {
     this.spec = spec;

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -532,7 +532,7 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
     // Now that we're on the fork choice thread, make sure the block still descends from finalized
     // (which may have changed while we were processing the block)
     if (!forkChoiceUtil.blockDescendsFromLatestFinalizedBlock(
-        block, recentChainData.getStore(), forkChoiceStrategy)) {
+        block.getSlot(), block.getParentRoot(), recentChainData.getStore(), forkChoiceStrategy)) {
       return BlockImportResult.FAILED_INVALID_ANCESTRY;
     }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/GossipValidationHelper.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/GossipValidationHelper.java
@@ -79,6 +79,15 @@ public class GossipValidationHelper {
         : recentChainData.retrieveBlockState(parentBlockRoot);
   }
 
+  public boolean currentFinalizedCheckpointIsAncestorOfBlock(
+      final UInt64 blockSlot, final Bytes32 blockParentRoot) {
+    return spec.blockDescendsFromLatestFinalizedBlock(
+        blockSlot,
+        blockParentRoot,
+        recentChainData.getStore(),
+        recentChainData.getForkChoiceStrategy().orElseThrow());
+  }
+
   public boolean isProposerTheExpectedProposer(
       final UInt64 proposerIndex, final UInt64 slot, final BeaconState postState) {
     final int expectedProposerIndex = spec.getBeaconProposerIndex(postState, slot);

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/blobs/BlobSidecarManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/blobs/BlobSidecarManagerTest.java
@@ -43,7 +43,7 @@ import tech.pegasys.teku.statetransition.blobs.BlobSidecarManager.ReceivedBlobSi
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceBlobSidecarsAvailabilityChecker;
 import tech.pegasys.teku.statetransition.util.BlobSidecarPoolImpl;
 import tech.pegasys.teku.statetransition.util.FutureItems;
-import tech.pegasys.teku.statetransition.validation.BlobSidecarValidator;
+import tech.pegasys.teku.statetransition.validation.BlobSidecarGossipValidator;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
 import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.storage.store.UpdatableStore;
@@ -53,7 +53,8 @@ public class BlobSidecarManagerTest {
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
   private final StubAsyncRunner asyncRunner = new StubAsyncRunner();
   private final RecentChainData recentChainData = mock(RecentChainData.class);
-  private final BlobSidecarValidator blobSidecarValidator = mock(BlobSidecarValidator.class);
+  private final BlobSidecarGossipValidator blobSidecarValidator =
+      mock(BlobSidecarGossipValidator.class);
   private final BlobSidecarPoolImpl blobSidecarPool = mock(BlobSidecarPoolImpl.class);
   private final Map<Bytes32, InternalValidationResult> invalidBlobSidecarRoots = new HashMap<>();
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/BlockGossipValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/BlockGossipValidatorTest.java
@@ -71,8 +71,7 @@ public class BlockGossipValidatorTest {
     storageSystem.chainUpdater().initializeGenesis(false);
     recentChainData = storageSystem.recentChainData();
     blockGossipValidator =
-        new BlockGossipValidator(
-            spec, recentChainData, new GossipValidationHelper(spec, recentChainData));
+        new BlockGossipValidator(spec, new GossipValidationHelper(spec, recentChainData));
   }
 
   @TestTemplate
@@ -227,8 +226,7 @@ public class BlockGossipValidatorTest {
     final ChainUpdater chainUpdater = new ChainUpdater(localRecentChainData, chainBuilder, spec);
 
     final BlockGossipValidator blockValidator =
-        new BlockGossipValidator(
-            spec, localRecentChainData, new GossipValidationHelper(spec, localRecentChainData));
+        new BlockGossipValidator(spec, new GossipValidationHelper(spec, localRecentChainData));
     chainUpdater.initializeGenesis();
 
     chainUpdater.updateBestBlock(chainUpdater.advanceChainUntil(1));
@@ -262,8 +260,7 @@ public class BlockGossipValidatorTest {
             false, specContext.getDataStructureUtil().randomExecutionPayloadHeader());
     recentChainData = storageSystem.recentChainData();
     blockGossipValidator =
-        new BlockGossipValidator(
-            spec, recentChainData, new GossipValidationHelper(spec, recentChainData));
+        new BlockGossipValidator(spec, new GossipValidationHelper(spec, recentChainData));
 
     final UInt64 nextSlot = recentChainData.getHeadSlot().plus(ONE);
     storageSystem.chainUpdater().setCurrentSlot(nextSlot);
@@ -285,8 +282,7 @@ public class BlockGossipValidatorTest {
             false, specContext.getDataStructureUtil().randomExecutionPayloadHeader());
     recentChainData = storageSystem.recentChainData();
     blockGossipValidator =
-        new BlockGossipValidator(
-            spec, recentChainData, new GossipValidationHelper(spec, recentChainData));
+        new BlockGossipValidator(spec, new GossipValidationHelper(spec, recentChainData));
 
     final UInt64 nextSlot = recentChainData.getHeadSlot().plus(ONE);
     storageSystem.chainUpdater().setCurrentSlot(nextSlot);

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -143,7 +143,7 @@ import tech.pegasys.teku.statetransition.util.PoolFactory;
 import tech.pegasys.teku.statetransition.validation.AggregateAttestationValidator;
 import tech.pegasys.teku.statetransition.validation.AttestationValidator;
 import tech.pegasys.teku.statetransition.validation.AttesterSlashingValidator;
-import tech.pegasys.teku.statetransition.validation.BlobSidecarValidator;
+import tech.pegasys.teku.statetransition.validation.BlobSidecarGossipValidator;
 import tech.pegasys.teku.statetransition.validation.BlockGossipValidator;
 import tech.pegasys.teku.statetransition.validation.BlockValidator;
 import tech.pegasys.teku.statetransition.validation.GossipValidationHelper;
@@ -476,8 +476,8 @@ public class BeaconChainController extends Service implements BeaconChainControl
       final Map<Bytes32, InternalValidationResult> invalidBlobSidecarRoots =
           LimitedMap.createSynchronized(500);
 
-      final BlobSidecarValidator blobSidecarValidator =
-          BlobSidecarValidator.create(spec, invalidBlockRoots, gossipValidationHelper);
+      final BlobSidecarGossipValidator blobSidecarValidator =
+          BlobSidecarGossipValidator.create(spec, invalidBlockRoots, gossipValidationHelper);
       final BlobSidecarManagerImpl blobSidecarManagerImpl =
           new BlobSidecarManagerImpl(
               spec,
@@ -1072,7 +1072,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
     final FutureItems<SignedBeaconBlock> futureBlocks =
         FutureItems.create(SignedBeaconBlock::getSlot, futureItemsMetric, "blocks");
     final BlockGossipValidator blockGossipValidator =
-        new BlockGossipValidator(spec, recentChainData, gossipValidationHelper);
+        new BlockGossipValidator(spec, gossipValidationHelper);
     final BlockValidator blockValidator = new BlockValidator(blockGossipValidator);
     final Optional<BlockImportMetrics> importMetrics =
         beaconConfig.getMetricsConfig().isBlockPerformanceEnabled()


### PR DESCRIPTION
Add the new gossip rule by extracting the method implementing the check from `BlockGossipValidator` to the helper.

`BlockGossipValidatorTest` still test end-to-end, without mocking the validator helper dependency. At some point we could simplify most of the test there (and avoid some duplications)

`BlobSidecarValidator` renamed to `BlobSidecarGossipValidator` to be consistent with the Block one.

fixes #7632 

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
