### PR TITLE
[spike] Avoid block hashing when moving blocks from hot db to finalized

### DIFF
--- a/ethereum/dataproviders/src/main/java/tech/pegasys/teku/dataproviders/lookup/BlockProvider.java
+++ b/ethereum/dataproviders/src/main/java/tech/pegasys/teku/dataproviders/lookup/BlockProvider.java
@@ -15,10 +15,10 @@ package tech.pegasys.teku.dataproviders.lookup;
 
 import com.google.common.collect.Sets;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
@@ -33,17 +33,17 @@ public interface BlockProvider {
 
   BlockProvider NOOP = (roots) -> SafeFuture.completedFuture(Collections.emptyMap());
 
+  /** assumes that maps are blockRoot -> SignedBeaconBlock */
   static BlockProvider fromDynamicMap(Supplier<Map<Bytes32, SignedBeaconBlock>> mapSupplier) {
     return (roots) -> fromMap(mapSupplier.get()).getBlocks(roots);
   }
 
+  /**
+   * assumes that maps are blockRoot -> SignedBeaconBlock. Moreover, it makes sure the returned map
+   * is mutable
+   */
   static BlockProvider fromMap(final Map<Bytes32, SignedBeaconBlock> blockMap) {
-    return (roots) ->
-        SafeFuture.completedFuture(
-            roots.stream()
-                .map(blockMap::get)
-                .filter(Objects::nonNull)
-                .collect(Collectors.toMap(SignedBeaconBlock::getRoot, Function.identity())));
+    return (roots) -> SafeFuture.completedFuture(new HashMap<>(blockMap));
   }
 
   static BlockProvider fromList(final List<SignedBeaconBlock> blockAndStates) {

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
@@ -667,6 +667,12 @@ public class CombinedKvStoreDao<S extends SchemaCombined>
     }
 
     @Override
+    public void addFinalizedBlock(final Bytes32 blockRoot, final SignedBeaconBlock block) {
+      transaction.put(schema.getColumnSlotsByFinalizedRoot(), blockRoot, block.getSlot());
+      transaction.put(schema.getColumnFinalizedBlocksBySlot(), block.getSlot(), block);
+    }
+
+    @Override
     public void addNonCanonicalBlock(final SignedBeaconBlock block) {
       transaction.put(schema.getColumnNonCanonicalBlocksByRoot(), block.getRoot(), block);
     }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDao.java
@@ -222,6 +222,8 @@ public interface KvStoreCombinedDao extends AutoCloseable {
 
     void addFinalizedBlock(final SignedBeaconBlock block);
 
+    void addFinalizedBlock(final Bytes32 blockRoot, final SignedBeaconBlock block);
+
     void addNonCanonicalBlock(final SignedBeaconBlock block);
 
     void deleteFinalizedBlock(final UInt64 slot, final Bytes32 blockRoot);

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoAdapter.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoAdapter.java
@@ -518,6 +518,11 @@ public class KvStoreCombinedDaoAdapter implements KvStoreCombinedDao, V4Migratab
     }
 
     @Override
+    public void addFinalizedBlock(final Bytes32 blockRoot, final SignedBeaconBlock block) {
+      finalizedUpdater.addFinalizedBlock(blockRoot, block);
+    }
+
+    @Override
     public void addNonCanonicalBlock(final SignedBeaconBlock block) {
       finalizedUpdater.addNonCanonicalBlock(block);
     }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4FinalizedKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4FinalizedKvStoreDao.java
@@ -296,6 +296,12 @@ public class V4FinalizedKvStoreDao {
     }
 
     @Override
+    public void addFinalizedBlock(final Bytes32 blockRoot, final SignedBeaconBlock block) {
+      transaction.put(schema.getColumnSlotsByFinalizedRoot(), blockRoot, block.getSlot());
+      transaction.put(schema.getColumnFinalizedBlocksBySlot(), block.getSlot(), block);
+    }
+
+    @Override
     public void addNonCanonicalBlock(final SignedBeaconBlock block) {
       transaction.put(schema.getColumnNonCanonicalBlocksByRoot(), block.getRoot(), block);
     }


### PR DESCRIPTION
This just to see how good is avoiding hashing.

We could further improve by being able to get rawData (bytes) and write Raw data as well to even avoid serialization\deserialization.

<img width="1144" alt="image" src="https://github.com/Consensys/teku/assets/15999009/487556a6-b7d6-44d7-92b7-62f5e9926ca2">

```
2023-10-27 15:17:12.541 WARN  - DB operation KvStoreDatabase::doUpdate took too long: 1522 ms. The alert threshold is set to: 1 ms. Additional info: Finalized data updated time: 306 ms - Hot data updated time: 1216 ms of which latest finalized state updated time: 318 ms
```

related to #7622

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
