### PR TITLE
return empty blob sidecar list when no kzg commitments

### DIFF
--- a/data/provider/src/main/java/tech/pegasys/teku/api/blobselector/BlobSidecarSelectorFactory.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/blobselector/BlobSidecarSelectorFactory.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.api.blobselector;
 
 import static tech.pegasys.teku.spec.config.SpecConfig.GENESIS_SLOT;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
@@ -105,8 +106,11 @@ public class BlobSidecarSelectorFactory extends AbstractSelectorFactory<BlobSide
     }
     final Optional<BeaconBlockBodyDeneb> maybeDenebBlock =
         maybeBlock.get().getMessage().getBody().toVersionDeneb();
-    if (maybeDenebBlock.isEmpty() || maybeDenebBlock.get().getBlobKzgCommitments().isEmpty()) {
+    if (maybeDenebBlock.isEmpty()) {
       return SafeFuture.completedFuture(Optional.empty());
+    }
+    if (maybeDenebBlock.get().getBlobKzgCommitments().isEmpty()) {
+      return SafeFuture.completedFuture(Optional.of(Collections.emptyList()));
     }
     final SignedBeaconBlock block = maybeBlock.get();
     return getBlobSidecars(block.getSlotAndBlockRoot(), indices);

--- a/data/provider/src/test/java/tech/pegasys/teku/api/blobselector/BlobSidecarSelectorFactoryTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/blobselector/BlobSidecarSelectorFactoryTest.java
@@ -193,11 +193,14 @@ public class BlobSidecarSelectorFactoryTest {
     when(client.isFinalized(blockWithEmptyCommitments.getSlot())).thenReturn(false);
     when(client.getBlockAtSlotExact(blockWithEmptyCommitments.getSlot()))
         .thenReturn(SafeFuture.completedFuture(Optional.of(blockWithEmptyCommitments)));
-    blobSidecarSelectorFactory
-        .slotSelector(blockWithEmptyCommitments.getSlot())
-        .getBlobSidecars(indices)
-        .get();
+    Optional<List<BlobSidecar>> maybeBlobsidecars =
+        blobSidecarSelectorFactory
+            .slotSelector(blockWithEmptyCommitments.getSlot())
+            .getBlobSidecars(indices)
+            .get();
     verify(client, never()).getBlobSidecars(any(SlotAndBlockRoot.class), anyList());
+    assertThat(maybeBlobsidecars).isPresent();
+    assertThat(maybeBlobsidecars.get()).isEmpty();
   }
 
   @TestTemplate


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Return an empty blob sidecars list instead of an empty Optional when the block is not finalised and doesn't contain kzg commitments
## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
#7635 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
