### PR TITLE
Fix payloadValueResult in builderGetHeader should be set to won payload

### DIFF
--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionBuilderModule.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionBuilderModule.java
@@ -91,7 +91,8 @@ public class ExecutionBuilderModule {
   private Optional<SafeFuture<HeaderWithFallbackData>> validateBuilderGetHeader(
       final ExecutionPayloadContext executionPayloadContext,
       final BeaconState state,
-      final SafeFuture<GetPayloadResponse> localGetPayloadResponse) {
+      final SafeFuture<GetPayloadResponse> localGetPayloadResponse,
+      final SafeFuture<UInt256> payloadValueResult) {
     final Optional<SignedValidatorRegistration> validatorRegistration =
         executionPayloadContext.getPayloadBuildingAttributes().getValidatorRegistration();
 
@@ -116,7 +117,7 @@ public class ExecutionBuilderModule {
     if (fallbackReason != null) {
       return Optional.of(
           getResultFromLocalGetPayloadResponse(
-              localGetPayloadResponse, state.getSlot(), fallbackReason));
+              localGetPayloadResponse, state.getSlot(), fallbackReason, payloadValueResult));
     }
 
     return Optional.empty();
@@ -125,18 +126,14 @@ public class ExecutionBuilderModule {
   public SafeFuture<HeaderWithFallbackData> builderGetHeader(
       final ExecutionPayloadContext executionPayloadContext,
       final BeaconState state,
-      final SafeFuture<UInt256> localPayloadValueResult) {
+      final SafeFuture<UInt256> payloadValueResult) {
 
     final SafeFuture<GetPayloadResponse> localGetPayloadResponse =
-        executionLayerManager
-            .engineGetPayloadForFallback(executionPayloadContext, state.getSlot())
-            .thenPeek(
-                getPayloadResponse ->
-                    localPayloadValueResult.complete(getPayloadResponse.getExecutionPayloadValue()))
-            .whenException(ex -> localPayloadValueResult.complete(UInt256.ZERO));
+        executionLayerManager.engineGetPayloadForFallback(executionPayloadContext, state.getSlot());
 
     final Optional<SafeFuture<HeaderWithFallbackData>> validationResult =
-        validateBuilderGetHeader(executionPayloadContext, state, localGetPayloadResponse);
+        validateBuilderGetHeader(
+            executionPayloadContext, state, localGetPayloadResponse, payloadValueResult);
     if (validationResult.isPresent()) {
       return validationResult.get();
     }
@@ -176,7 +173,10 @@ public class ExecutionBuilderModule {
             (signedBuilderBidMaybe, maybeLocalGetPayloadResponse) -> {
               if (signedBuilderBidMaybe.isEmpty()) {
                 return getResultFromLocalGetPayloadResponse(
-                    localGetPayloadResponse, slot, FallbackReason.BUILDER_HEADER_NOT_AVAILABLE);
+                    localGetPayloadResponse,
+                    slot,
+                    FallbackReason.BUILDER_HEADER_NOT_AVAILABLE,
+                    payloadValueResult);
               } else {
                 // Treat the shouldOverrideBuilder flag as false if local payload is unavailable
                 final boolean shouldOverrideBuilder =
@@ -187,7 +187,8 @@ public class ExecutionBuilderModule {
                   return getResultFromLocalGetPayloadResponse(
                       localGetPayloadResponse,
                       slot,
-                      FallbackReason.SHOULD_OVERRIDE_BUILDER_FLAG_IS_TRUE);
+                      FallbackReason.SHOULD_OVERRIDE_BUILDER_FLAG_IS_TRUE,
+                      payloadValueResult);
                 }
 
                 final SignedBuilderBid signedBuilderBid = signedBuilderBidMaybe.get();
@@ -203,7 +204,10 @@ public class ExecutionBuilderModule {
                 if (isLocalPayloadValueWinning(builderBidValue, localBlockValue)) {
                   logLocalPayloadWin(builderBidValue, localBlockValue);
                   return getResultFromLocalGetPayloadResponse(
-                      localGetPayloadResponse, slot, FallbackReason.LOCAL_BLOCK_VALUE_WON);
+                      localGetPayloadResponse,
+                      slot,
+                      FallbackReason.LOCAL_BLOCK_VALUE_WON,
+                      payloadValueResult);
                 }
 
                 final Optional<ExecutionPayload> localExecutionPayload =
@@ -212,7 +216,8 @@ public class ExecutionBuilderModule {
                     signedBuilderBidMaybe.get(),
                     state,
                     validatorRegistration.get(),
-                    localExecutionPayload);
+                    localExecutionPayload,
+                    payloadValueResult);
               }
             })
         .exceptionallyCompose(
@@ -221,7 +226,7 @@ public class ExecutionBuilderModule {
                   "Unable to obtain a valid bid from builder. Falling back to local execution engine.",
                   error);
               return getResultFromLocalGetPayloadResponse(
-                  localGetPayloadResponse, slot, FallbackReason.BUILDER_ERROR);
+                  localGetPayloadResponse, slot, FallbackReason.BUILDER_ERROR, payloadValueResult);
             });
   }
 
@@ -238,12 +243,14 @@ public class ExecutionBuilderModule {
       final SignedBuilderBid signedBuilderBid,
       final BeaconState state,
       final SignedValidatorRegistration validatorRegistration,
-      final Optional<ExecutionPayload> localExecutionPayload) {
+      final Optional<ExecutionPayload> localExecutionPayload,
+      final SafeFuture<UInt256> payloadValueResult) {
     final ExecutionPayloadHeader executionPayloadHeader =
         builderBidValidator.validateAndGetPayloadHeader(
             spec, signedBuilderBid, validatorRegistration, state, localExecutionPayload);
     final Optional<BlindedBlobsBundle> blindedBlobsBundle =
         signedBuilderBid.getMessage().getOptionalBlindedBlobsBundle();
+    payloadValueResult.complete(signedBuilderBid.getMessage().getValue());
     return SafeFuture.completedFuture(
         HeaderWithFallbackData.create(executionPayloadHeader, blindedBlobsBundle));
   }
@@ -330,9 +337,11 @@ public class ExecutionBuilderModule {
   private SafeFuture<HeaderWithFallbackData> getResultFromLocalGetPayloadResponse(
       final SafeFuture<GetPayloadResponse> localGetPayloadResponse,
       final UInt64 slot,
-      final FallbackReason reason) {
+      final FallbackReason reason,
+      final SafeFuture<UInt256> payloadValueResult) {
     return localGetPayloadResponse.thenApply(
         getPayloadResponse -> {
+          payloadValueResult.complete(getPayloadResponse.getExecutionPayloadValue());
           final SchemaDefinitions schemaDefinitions = spec.atSlot(slot).getSchemaDefinitions();
           final ExecutionPayload executionPayload = getPayloadResponse.getExecutionPayload();
           final ExecutionPayloadHeader executionPayloadHeader =

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
@@ -250,9 +250,9 @@ public class ExecutionLayerManagerImpl implements ExecutionLayerManager {
   public SafeFuture<HeaderWithFallbackData> builderGetHeader(
       final ExecutionPayloadContext executionPayloadContext,
       final BeaconState state,
-      final SafeFuture<UInt256> localPayloadValueResult) {
+      final SafeFuture<UInt256> payloadValueResult) {
     return executionBuilderModule.builderGetHeader(
-        executionPayloadContext, state, localPayloadValueResult);
+        executionPayloadContext, state, payloadValueResult);
   }
 
   @VisibleForTesting

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerStub.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerStub.java
@@ -52,8 +52,8 @@ public class ExecutionLayerManagerStub extends ExecutionLayerChannelStub
   public SafeFuture<HeaderWithFallbackData> builderGetHeader(
       final ExecutionPayloadContext executionPayloadContext,
       final BeaconState state,
-      final SafeFuture<UInt256> localPayloadValueResult) {
+      final SafeFuture<UInt256> payloadValueResult) {
     LOG.info("Builder Circuit Breaker isEngaged: " + builderCircuitBreaker.isEngaged(state));
-    return super.builderGetHeader(executionPayloadContext, state, localPayloadValueResult);
+    return super.builderGetHeader(executionPayloadContext, state, payloadValueResult);
   }
 }

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerBlockProductionManagerImplTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerBlockProductionManagerImplTest.java
@@ -171,7 +171,7 @@ class ExecutionLayerBlockProductionManagerImplTest {
     assertThat(headerWithFallbackDataFuture.get()).isEqualTo(expectedResult);
     final SafeFuture<UInt256> executionPayloadValueFuture =
         executionPayloadResult.getExecutionPayloadValueFuture().orElseThrow();
-    assertThat(executionPayloadValueFuture.get()).isEqualTo(executionPayloadValue);
+    assertThat(executionPayloadValueFuture.get()).isEqualTo(builderBid.getValue());
 
     // we expect both builder and local engine have been called
     verifyBuilderCalled(slot, executionPayloadContext);

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImplTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImplTest.java
@@ -77,6 +77,7 @@ class ExecutionLayerManagerImplTest {
   private ExecutionLayerManagerImpl executionLayerManager;
 
   private final UInt256 localExecutionPayloadValue = UInt256.valueOf(1234);
+  private final UInt256 builderExecutionPayloadValue = UInt256.valueOf(2345);
 
   @BeforeEach
   public void setup() {
@@ -162,7 +163,7 @@ class ExecutionLayerManagerImplTest {
     final UInt64 slot = executionPayloadContext.getForkChoiceState().getHeadBlockSlot();
 
     final GetPayloadResponse getPayloadResponse =
-        prepareEngineGetPayloadResponse(executionPayloadContext, UInt256.ZERO, slot);
+        prepareEngineGetPayloadResponse(executionPayloadContext, localExecutionPayloadValue, slot);
 
     assertThat(executionLayerManager.engineGetPayload(executionPayloadContext, slot))
         .isCompletedWithValue(getPayloadResponse);
@@ -183,7 +184,7 @@ class ExecutionLayerManagerImplTest {
     final UInt64 slot = executionPayloadContext.getForkChoiceState().getHeadBlockSlot();
 
     final GetPayloadResponse getPayloadResponse =
-        prepareEngineGetPayloadResponse(executionPayloadContext, UInt256.ZERO, slot);
+        prepareEngineGetPayloadResponse(executionPayloadContext, localExecutionPayloadValue, slot);
 
     assertThat(executionLayerManager.engineGetPayload(executionPayloadContext, slot))
         .isCompletedWithValue(getPayloadResponse);
@@ -204,7 +205,9 @@ class ExecutionLayerManagerImplTest {
     final BeaconState state = dataStructureUtil.randomBeaconState(slot);
 
     final ExecutionPayloadHeader header =
-        prepareBuilderGetHeaderResponse(executionPayloadContext, false).getHeader();
+        prepareBuilderGetHeaderResponse(
+                executionPayloadContext, false, builderExecutionPayloadValue)
+            .getHeader();
     prepareEngineGetPayloadResponse(executionPayloadContext, localExecutionPayloadValue, slot);
 
     final SafeFuture<UInt256> blockValueResult = new SafeFuture<>();
@@ -214,7 +217,7 @@ class ExecutionLayerManagerImplTest {
             executionLayerManager.builderGetHeader(
                 executionPayloadContext, state, blockValueResult))
         .isCompletedWithValue(HeaderWithFallbackData.create(header));
-    assertThat(blockValueResult).isCompletedWithValue(localExecutionPayloadValue);
+    assertThat(blockValueResult).isCompletedWithValue(builderExecutionPayloadValue);
 
     // we expect both builder and local engine have been called
     verifyBuilderCalled(slot, executionPayloadContext);
@@ -248,7 +251,9 @@ class ExecutionLayerManagerImplTest {
     final BeaconState state = dataStructureUtil.randomBeaconState(slot);
 
     final ExecutionPayloadHeader header =
-        prepareBuilderGetHeaderResponse(executionPayloadContext, false).getHeader();
+        prepareBuilderGetHeaderResponse(
+                executionPayloadContext, false, builderExecutionPayloadValue)
+            .getHeader();
     prepareEngineFailedPayloadResponse(executionPayloadContext, slot);
 
     final SafeFuture<UInt256> blockValueResult = new SafeFuture<>();
@@ -258,7 +263,7 @@ class ExecutionLayerManagerImplTest {
             executionLayerManager.builderGetHeader(
                 executionPayloadContext, state, blockValueResult))
         .isCompletedWithValue(HeaderWithFallbackData.create(header));
-    assertThat(blockValueResult).isCompletedWithValue(UInt256.ZERO);
+    assertThat(blockValueResult).isCompletedWithValue(builderExecutionPayloadValue);
 
     // we expect both builder and local engine have been called
     verifyBuilderCalled(slot, executionPayloadContext);
@@ -292,9 +297,12 @@ class ExecutionLayerManagerImplTest {
     final BeaconState state = dataStructureUtil.randomBeaconState(slot);
 
     final UInt256 builderValue =
-        prepareBuilderGetHeaderResponse(executionPayloadContext, false).getValue();
+        prepareBuilderGetHeaderResponse(
+                executionPayloadContext, false, builderExecutionPayloadValue)
+            .getValue();
+    final UInt256 localValueOverride = builderValue.multiply(2);
     final ExecutionPayload localExecutionPayload =
-        prepareEngineGetPayloadResponse(executionPayloadContext, builderValue, slot)
+        prepareEngineGetPayloadResponse(executionPayloadContext, localValueOverride, slot)
             .getExecutionPayload();
 
     // we expect result from the local engine
@@ -311,12 +319,12 @@ class ExecutionLayerManagerImplTest {
         HeaderWithFallbackData.create(
             expectedHeader,
             new FallbackData(localExecutionPayload, FallbackReason.LOCAL_BLOCK_VALUE_WON));
+    final SafeFuture<UInt256> blockValueResult = new SafeFuture<>();
     assertThat(
             executionLayerManager.builderGetHeader(
-                executionPayloadContext,
-                state,
-                SafeFuture.completedFuture(localExecutionPayloadValue)))
+                executionPayloadContext, state, blockValueResult))
         .isCompletedWithValue(expectedResult);
+    assertThat(blockValueResult).isCompletedWithValue(localValueOverride);
     verifyFallbackToLocalEL(slot, executionPayloadContext, expectedResult);
   }
 
@@ -333,10 +341,12 @@ class ExecutionLayerManagerImplTest {
     final BeaconState state = dataStructureUtil.randomBeaconState(slot);
 
     final UInt256 builderValue =
-        prepareBuilderGetHeaderResponse(executionPayloadContext, false).getValue();
+        prepareBuilderGetHeaderResponse(
+                executionPayloadContext, false, builderExecutionPayloadValue)
+            .getValue();
+    final UInt256 localValueOverride = builderValue.multiply(51).divide(100);
     final ExecutionPayload localExecutionPayload =
-        prepareEngineGetPayloadResponse(
-                executionPayloadContext, builderValue.multiply(51).divide(100), slot)
+        prepareEngineGetPayloadResponse(executionPayloadContext, localValueOverride, slot)
             .getExecutionPayload();
 
     // we expect result from the local engine
@@ -353,12 +363,12 @@ class ExecutionLayerManagerImplTest {
         HeaderWithFallbackData.create(
             expectedHeader,
             new FallbackData(localExecutionPayload, FallbackReason.LOCAL_BLOCK_VALUE_WON));
+    final SafeFuture<UInt256> blockValueResult = new SafeFuture<>();
     assertThat(
             executionLayerManager.builderGetHeader(
-                executionPayloadContext,
-                state,
-                SafeFuture.completedFuture(localExecutionPayloadValue)))
+                executionPayloadContext, state, blockValueResult))
         .isCompletedWithValue(expectedResult);
+    assertThat(blockValueResult).isCompletedWithValue(localValueOverride);
     verifyFallbackToLocalEL(slot, executionPayloadContext, expectedResult);
   }
 
@@ -373,19 +383,21 @@ class ExecutionLayerManagerImplTest {
     final UInt64 slot = executionPayloadContext.getForkChoiceState().getHeadBlockSlot();
     final BeaconState state = dataStructureUtil.randomBeaconState(slot);
 
-    final BuilderBid builderBid = prepareBuilderGetHeaderResponse(executionPayloadContext, false);
+    final BuilderBid builderBid =
+        prepareBuilderGetHeaderResponse(
+            executionPayloadContext, false, builderExecutionPayloadValue);
     prepareEngineGetPayloadResponse(
         executionPayloadContext, builderBid.getValue().multiply(49).divide(100), slot);
 
     // we expect result from the builder
     final ExecutionPayloadHeader builderHeader = builderBid.getHeader();
     final HeaderWithFallbackData expectedResult = HeaderWithFallbackData.create(builderHeader);
+    final SafeFuture<UInt256> blockValueResult = new SafeFuture<>();
     assertThat(
             executionLayerManager.builderGetHeader(
-                executionPayloadContext,
-                state,
-                SafeFuture.completedFuture(localExecutionPayloadValue)))
+                executionPayloadContext, state, blockValueResult))
         .isCompletedWithValue(expectedResult);
+    assertThat(blockValueResult).isCompletedWithValue(builderExecutionPayloadValue);
   }
 
   @Test
@@ -400,7 +412,9 @@ class ExecutionLayerManagerImplTest {
     final UInt64 slot = executionPayloadContext.getForkChoiceState().getHeadBlockSlot();
     final BeaconState state = dataStructureUtil.randomBeaconState(slot);
 
-    final BuilderBid builderBid = prepareBuilderGetHeaderResponse(executionPayloadContext, false);
+    final BuilderBid builderBid =
+        prepareBuilderGetHeaderResponse(
+            executionPayloadContext, false, builderExecutionPayloadValue);
     prepareEngineGetPayloadResponse(
         // something tasty, but we should ignore it
         executionPayloadContext, builderBid.getValue().multiply(100), slot);
@@ -408,12 +422,12 @@ class ExecutionLayerManagerImplTest {
     // we expect result from the builder
     final ExecutionPayloadHeader builderHeader = builderBid.getHeader();
     final HeaderWithFallbackData expectedResult = HeaderWithFallbackData.create(builderHeader);
+    final SafeFuture<UInt256> blockValueResult = new SafeFuture<>();
     assertThat(
             executionLayerManager.builderGetHeader(
-                executionPayloadContext,
-                state,
-                SafeFuture.completedFuture(localExecutionPayloadValue)))
+                executionPayloadContext, state, blockValueResult))
         .isCompletedWithValue(expectedResult);
+    assertThat(blockValueResult).isCompletedWithValue(builderExecutionPayloadValue);
   }
 
   @Test
@@ -428,9 +442,9 @@ class ExecutionLayerManagerImplTest {
     final UInt64 slot = executionPayloadContext.getForkChoiceState().getHeadBlockSlot();
     final BeaconState state = dataStructureUtil.randomBeaconState(slot);
 
-    prepareBuilderGetHeaderResponse(executionPayloadContext, false);
+    prepareBuilderGetHeaderResponse(executionPayloadContext, false, builderExecutionPayloadValue);
     final ExecutionPayload payload =
-        prepareEngineGetPayloadResponse(executionPayloadContext, UInt256.ZERO, slot)
+        prepareEngineGetPayloadResponse(executionPayloadContext, localExecutionPayloadValue, slot)
             .getExecutionPayload();
 
     final ExecutionPayloadHeader header =
@@ -445,12 +459,12 @@ class ExecutionLayerManagerImplTest {
     final HeaderWithFallbackData expectedResult =
         HeaderWithFallbackData.create(
             header, new FallbackData(payload, FallbackReason.BUILDER_ERROR));
+    final SafeFuture<UInt256> blockValueResult = new SafeFuture<>();
     assertThat(
             executionLayerManager.builderGetHeader(
-                executionPayloadContext,
-                state,
-                SafeFuture.completedFuture(localExecutionPayloadValue)))
+                executionPayloadContext, state, blockValueResult))
         .isCompletedWithValue(expectedResult);
+    assertThat(blockValueResult).isCompletedWithValue(localExecutionPayloadValue);
 
     verifyFallbackToLocalEL(slot, executionPayloadContext, expectedResult);
   }
@@ -466,7 +480,7 @@ class ExecutionLayerManagerImplTest {
 
     prepareBuilderGetHeaderFailure(executionPayloadContext);
     final ExecutionPayload payload =
-        prepareEngineGetPayloadResponse(executionPayloadContext, UInt256.ZERO, slot)
+        prepareEngineGetPayloadResponse(executionPayloadContext, localExecutionPayloadValue, slot)
             .getExecutionPayload();
 
     final ExecutionPayloadHeader header =
@@ -481,12 +495,12 @@ class ExecutionLayerManagerImplTest {
     HeaderWithFallbackData expectedResult =
         HeaderWithFallbackData.create(
             header, new FallbackData(payload, FallbackReason.BUILDER_ERROR));
+    final SafeFuture<UInt256> blockValueResult = new SafeFuture<>();
     assertThat(
             executionLayerManager.builderGetHeader(
-                executionPayloadContext,
-                state,
-                SafeFuture.completedFuture(localExecutionPayloadValue)))
+                executionPayloadContext, state, blockValueResult))
         .isCompletedWithValue(expectedResult);
+    assertThat(blockValueResult).isCompletedWithValue(localExecutionPayloadValue);
 
     // we expect both builder and local engine have been called
     verifyBuilderCalled(slot, executionPayloadContext);
@@ -528,10 +542,11 @@ class ExecutionLayerManagerImplTest {
     final UInt64 slot = executionPayloadContext.getForkChoiceState().getHeadBlockSlot();
     final BeaconState state = dataStructureUtil.randomBeaconState(slot);
 
-    prepareBuilderGetHeaderResponse(executionPayloadContext, false);
+    prepareBuilderGetHeaderResponse(executionPayloadContext, false, builderExecutionPayloadValue);
 
     final GetPayloadResponse getPayloadResponse =
-        prepareEngineGetPayloadResponse(executionPayloadContext, UInt256.ZERO, true, slot);
+        prepareEngineGetPayloadResponse(
+            executionPayloadContext, localExecutionPayloadValue, true, slot);
 
     // we expect result from the local engine
     final ExecutionPayloadHeader expectedHeader =
@@ -558,12 +573,12 @@ class ExecutionLayerManagerImplTest {
                 getPayloadResponse.getExecutionPayload(),
                 getPayloadResponse.getBlobsBundle(),
                 FallbackReason.SHOULD_OVERRIDE_BUILDER_FLAG_IS_TRUE));
+    final SafeFuture<UInt256> blockValueResult = new SafeFuture<>();
     assertThat(
             executionLayerManager.builderGetHeader(
-                executionPayloadContext,
-                state,
-                SafeFuture.completedFuture(localExecutionPayloadValue)))
+                executionPayloadContext, state, blockValueResult))
         .isCompletedWithValue(expectedResult);
+    assertThat(blockValueResult).isCompletedWithValue(localExecutionPayloadValue);
     verifyFallbackToLocalEL(slot, executionPayloadContext, expectedResult);
   }
 
@@ -578,9 +593,9 @@ class ExecutionLayerManagerImplTest {
     final UInt64 slot = executionPayloadContext.getForkChoiceState().getHeadBlockSlot();
     final BeaconState state = dataStructureUtil.randomBeaconState(slot);
 
-    prepareBuilderGetHeaderResponse(executionPayloadContext, false);
+    prepareBuilderGetHeaderResponse(executionPayloadContext, false, builderExecutionPayloadValue);
     final ExecutionPayload payload =
-        prepareEngineGetPayloadResponse(executionPayloadContext, UInt256.ZERO, slot)
+        prepareEngineGetPayloadResponse(executionPayloadContext, localExecutionPayloadValue, slot)
             .getExecutionPayload();
 
     final ExecutionPayloadHeader header =
@@ -595,12 +610,12 @@ class ExecutionLayerManagerImplTest {
     final HeaderWithFallbackData expectedResult =
         HeaderWithFallbackData.create(
             header, new FallbackData(payload, FallbackReason.BUILDER_ERROR));
+    final SafeFuture<UInt256> blockValueResult = new SafeFuture<>();
     assertThat(
             executionLayerManager.builderGetHeader(
-                executionPayloadContext,
-                state,
-                SafeFuture.completedFuture(localExecutionPayloadValue)))
+                executionPayloadContext, state, blockValueResult))
         .isCompletedWithValue(expectedResult);
+    assertThat(blockValueResult).isCompletedWithValue(localExecutionPayloadValue);
 
     verifyFallbackToLocalEL(slot, executionPayloadContext, expectedResult);
   }
@@ -615,7 +630,7 @@ class ExecutionLayerManagerImplTest {
     final BeaconState state = dataStructureUtil.randomBeaconState(slot);
 
     final ExecutionPayload payload =
-        prepareEngineGetPayloadResponse(executionPayloadContext, UInt256.ZERO, slot)
+        prepareEngineGetPayloadResponse(executionPayloadContext, localExecutionPayloadValue, slot)
             .getExecutionPayload();
 
     final ExecutionPayloadHeader header =
@@ -630,12 +645,12 @@ class ExecutionLayerManagerImplTest {
     final HeaderWithFallbackData expectedResult =
         HeaderWithFallbackData.create(
             header, new FallbackData(payload, FallbackReason.BUILDER_NOT_AVAILABLE));
+    final SafeFuture<UInt256> blockValueResult = new SafeFuture<>();
     assertThat(
             executionLayerManager.builderGetHeader(
-                executionPayloadContext,
-                state,
-                SafeFuture.completedFuture(localExecutionPayloadValue)))
+                executionPayloadContext, state, blockValueResult))
         .isCompletedWithValue(expectedResult);
+    assertThat(blockValueResult).isCompletedWithValue(localExecutionPayloadValue);
 
     verifyFallbackToLocalEL(slot, executionPayloadContext, expectedResult);
   }
@@ -650,10 +665,10 @@ class ExecutionLayerManagerImplTest {
     final UInt64 slot = executionPayloadContext.getForkChoiceState().getHeadBlockSlot();
     final BeaconState state = dataStructureUtil.randomBeaconState(slot);
 
-    prepareBuilderGetHeaderResponse(executionPayloadContext, true);
+    prepareBuilderGetHeaderResponse(executionPayloadContext, true, builderExecutionPayloadValue);
 
     final ExecutionPayload payload =
-        prepareEngineGetPayloadResponse(executionPayloadContext, UInt256.ZERO, slot)
+        prepareEngineGetPayloadResponse(executionPayloadContext, localExecutionPayloadValue, slot)
             .getExecutionPayload();
 
     final ExecutionPayloadHeader header =
@@ -668,12 +683,12 @@ class ExecutionLayerManagerImplTest {
     final HeaderWithFallbackData expectedResult =
         HeaderWithFallbackData.create(
             header, new FallbackData(payload, FallbackReason.BUILDER_HEADER_NOT_AVAILABLE));
+    final SafeFuture<UInt256> blockValueResult = new SafeFuture<>();
     assertThat(
             executionLayerManager.builderGetHeader(
-                executionPayloadContext,
-                state,
-                SafeFuture.completedFuture(localExecutionPayloadValue)))
+                executionPayloadContext, state, blockValueResult))
         .isCompletedWithValue(expectedResult);
+    assertThat(blockValueResult).isCompletedWithValue(localExecutionPayloadValue);
 
     verifyFallbackToLocalEL(slot, executionPayloadContext, expectedResult);
   }
@@ -689,7 +704,7 @@ class ExecutionLayerManagerImplTest {
     final BeaconState state = dataStructureUtil.randomBeaconStatePreMerge(slot);
 
     final ExecutionPayload payload =
-        prepareEngineGetPayloadResponse(executionPayloadContext, UInt256.ZERO, slot)
+        prepareEngineGetPayloadResponse(executionPayloadContext, localExecutionPayloadValue, slot)
             .getExecutionPayload();
 
     final ExecutionPayloadHeader header =
@@ -704,12 +719,12 @@ class ExecutionLayerManagerImplTest {
     final HeaderWithFallbackData expectedResult =
         HeaderWithFallbackData.create(
             header, new FallbackData(payload, FallbackReason.TRANSITION_NOT_FINALIZED));
+    final SafeFuture<UInt256> blockValueResult = new SafeFuture<>();
     assertThat(
             executionLayerManager.builderGetHeader(
-                executionPayloadContext,
-                state,
-                SafeFuture.completedFuture(localExecutionPayloadValue)))
+                executionPayloadContext, state, blockValueResult))
         .isCompletedWithValue(expectedResult);
+    assertThat(blockValueResult).isCompletedWithValue(localExecutionPayloadValue);
 
     verifyFallbackToLocalEL(slot, executionPayloadContext, expectedResult);
   }
@@ -725,7 +740,7 @@ class ExecutionLayerManagerImplTest {
     final BeaconState state = dataStructureUtil.randomBeaconState(slot);
 
     final ExecutionPayload payload =
-        prepareEngineGetPayloadResponse(executionPayloadContext, UInt256.ZERO, slot)
+        prepareEngineGetPayloadResponse(executionPayloadContext, localExecutionPayloadValue, slot)
             .getExecutionPayload();
 
     final ExecutionPayloadHeader header =
@@ -742,12 +757,12 @@ class ExecutionLayerManagerImplTest {
     final HeaderWithFallbackData expectedResult =
         HeaderWithFallbackData.create(
             header, new FallbackData(payload, FallbackReason.CIRCUIT_BREAKER_ENGAGED));
+    final SafeFuture<UInt256> blockValueResult = new SafeFuture<>();
     assertThat(
             executionLayerManager.builderGetHeader(
-                executionPayloadContext,
-                state,
-                SafeFuture.completedFuture(localExecutionPayloadValue)))
+                executionPayloadContext, state, blockValueResult))
         .isCompletedWithValue(expectedResult);
+    assertThat(blockValueResult).isCompletedWithValue(localExecutionPayloadValue);
 
     verifyFallbackToLocalEL(slot, executionPayloadContext, expectedResult);
   }
@@ -763,7 +778,7 @@ class ExecutionLayerManagerImplTest {
     final BeaconState state = dataStructureUtil.randomBeaconState(slot);
 
     final ExecutionPayload payload =
-        prepareEngineGetPayloadResponse(executionPayloadContext, UInt256.ZERO, slot)
+        prepareEngineGetPayloadResponse(executionPayloadContext, localExecutionPayloadValue, slot)
             .getExecutionPayload();
 
     final ExecutionPayloadHeader header =
@@ -780,12 +795,12 @@ class ExecutionLayerManagerImplTest {
     final HeaderWithFallbackData expectedResult =
         HeaderWithFallbackData.create(
             header, new FallbackData(payload, FallbackReason.CIRCUIT_BREAKER_ENGAGED));
+    final SafeFuture<UInt256> blockValueResult = new SafeFuture<>();
     assertThat(
             executionLayerManager.builderGetHeader(
-                executionPayloadContext,
-                state,
-                SafeFuture.completedFuture(localExecutionPayloadValue)))
+                executionPayloadContext, state, blockValueResult))
         .isCompletedWithValue(expectedResult);
+    assertThat(blockValueResult).isCompletedWithValue(localExecutionPayloadValue);
 
     verifyFallbackToLocalEL(slot, executionPayloadContext, expectedResult);
   }
@@ -801,7 +816,7 @@ class ExecutionLayerManagerImplTest {
     final BeaconState state = dataStructureUtil.randomBeaconState(slot);
 
     final ExecutionPayload payload =
-        prepareEngineGetPayloadResponse(executionPayloadContext, UInt256.ZERO, slot)
+        prepareEngineGetPayloadResponse(executionPayloadContext, localExecutionPayloadValue, slot)
             .getExecutionPayload();
 
     final ExecutionPayloadHeader header =
@@ -816,12 +831,12 @@ class ExecutionLayerManagerImplTest {
     final HeaderWithFallbackData expectedResult =
         HeaderWithFallbackData.create(
             header, new FallbackData(payload, FallbackReason.VALIDATOR_NOT_REGISTERED));
+    final SafeFuture<UInt256> blockValueResult = new SafeFuture<>();
     assertThat(
             executionLayerManager.builderGetHeader(
-                executionPayloadContext,
-                state,
-                SafeFuture.completedFuture(localExecutionPayloadValue)))
+                executionPayloadContext, state, blockValueResult))
         .isCompletedWithValue(expectedResult);
+    assertThat(blockValueResult).isCompletedWithValue(localExecutionPayloadValue);
 
     verifyFallbackToLocalEL(slot, executionPayloadContext, expectedResult);
   }
@@ -837,7 +852,8 @@ class ExecutionLayerManagerImplTest {
               final ExecutionPayloadContext executionPayloadContext =
                   dataStructureUtil.randomPayloadExecutionContext(slot, false);
               final BeaconState state = dataStructureUtil.randomBeaconState(slot);
-              prepareEngineGetPayloadResponse(executionPayloadContext, UInt256.ZERO, slot);
+              prepareEngineGetPayloadResponse(
+                  executionPayloadContext, localExecutionPayloadValue, slot);
               assertThat(
                       executionLayerManager.builderGetHeader(
                           executionPayloadContext,
@@ -878,10 +894,14 @@ class ExecutionLayerManagerImplTest {
   }
 
   private BuilderBid prepareBuilderGetHeaderResponse(
-      final ExecutionPayloadContext executionPayloadContext, final boolean prepareEmptyResponse) {
+      final ExecutionPayloadContext executionPayloadContext,
+      final boolean prepareEmptyResponse,
+      final UInt256 builderBlockValue) {
     final UInt64 slot = executionPayloadContext.getForkChoiceState().getHeadBlockSlot();
 
-    final SignedBuilderBid signedBuilderBid = dataStructureUtil.randomSignedBuilderBid();
+    final BuilderBid builderBid =
+        dataStructureUtil.randomBuilderBid(dataStructureUtil.randomPublicKey(), builderBlockValue);
+    final SignedBuilderBid signedBuilderBid = dataStructureUtil.randomSignedBuilderBid(builderBid);
 
     doAnswer(
             __ -> {
@@ -992,10 +1012,10 @@ class ExecutionLayerManagerImplTest {
 
   private GetPayloadResponse prepareEngineGetPayloadResponse(
       final ExecutionPayloadContext executionPayloadContext,
-      final UInt256 blockValue,
+      final UInt256 localBlockValue,
       final UInt64 slot) {
     final ExecutionPayload payload = dataStructureUtil.randomExecutionPayload();
-    final GetPayloadResponse getPayloadResponse = new GetPayloadResponse(payload, blockValue);
+    final GetPayloadResponse getPayloadResponse = new GetPayloadResponse(payload, localBlockValue);
     when(executionClientHandler.engineGetPayload(executionPayloadContext, slot))
         .thenReturn(SafeFuture.completedFuture(getPayloadResponse));
     return getPayloadResponse;

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannel.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannel.java
@@ -86,8 +86,8 @@ public interface ExecutionLayerChannel extends ChannelInterface {
         public SafeFuture<HeaderWithFallbackData> builderGetHeader(
             final ExecutionPayloadContext executionPayloadContext,
             final BeaconState state,
-            final SafeFuture<UInt256> localPayloadValueResult) {
-          localPayloadValueResult.complete(null);
+            final SafeFuture<UInt256> payloadValueResult) {
+          payloadValueResult.complete(null);
           return SafeFuture.completedFuture(null);
         }
       };
@@ -131,10 +131,11 @@ public interface ExecutionLayerChannel extends ChannelInterface {
    *
    * @param executionPayloadContext The execution payload context
    * @param state The beacon state
-   * @param localPayloadValueResult A callback that will contain the local execution value
+   * @param payloadValueResult A callback that will contain the payload execution value (local or
+   *     builder, whichever payload is chosen)
    */
   SafeFuture<HeaderWithFallbackData> builderGetHeader(
       ExecutionPayloadContext executionPayloadContext,
       BeaconState state,
-      SafeFuture<UInt256> localPayloadValueResult);
+      SafeFuture<UInt256> payloadValueResult);
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
@@ -313,7 +313,7 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
   public SafeFuture<HeaderWithFallbackData> builderGetHeader(
       final ExecutionPayloadContext executionPayloadContext,
       final BeaconState state,
-      final SafeFuture<UInt256> localPayloadValueResult) {
+      final SafeFuture<UInt256> payloadValueResult) {
     final UInt64 slot = state.getSlot();
     LOG.info(
         "getPayloadHeader: payloadId: {} slot: {} ... delegating to getPayload ...",
@@ -326,7 +326,7 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
         .thenApply(
             getPayloadResponse -> {
               final ExecutionPayload executionPayload = getPayloadResponse.getExecutionPayload();
-              localPayloadValueResult.complete(getPayloadResponse.getExecutionPayloadValue());
+              payloadValueResult.complete(getPayloadResponse.getExecutionPayloadValue());
               LOG.info(
                   "getPayloadHeader: payloadId: {} slot: {} -> executionPayload blockHash: {}",
                   executionPayloadContext,

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -597,6 +597,14 @@ public final class DataStructureUtil {
   }
 
   public BuilderBid randomBuilderBid(final BLSPublicKey builderPublicKey) {
+    // 1 ETH is 10^18 wei, Uint256 max is more than 10^77, so just to avoid
+    // overflows in
+    // computation
+    final UInt256 value = randomUInt256().divide(1000);
+    return randomBuilderBid(builderPublicKey, value);
+  }
+
+  public BuilderBid randomBuilderBid(final BLSPublicKey builderPublicKey, final UInt256 value) {
     final SchemaDefinitionsBellatrix schemaDefinitions =
         getBellatrixSchemaDefinitions(randomSlot());
     return schemaDefinitions
@@ -605,10 +613,7 @@ public final class DataStructureUtil {
             builder -> {
               builder
                   .header(randomExecutionPayloadHeader(spec.getGenesisSpec()))
-                  // 1 ETH is 10^18 wei, Uint256 max is more than 10^77, so just to avoid
-                  // overflows in
-                  // computation
-                  .value(randomUInt256().divide(1000))
+                  .value(value)
                   .publicKey(builderPublicKey);
               schemaDefinitions
                   .toVersionDeneb()
@@ -631,6 +636,12 @@ public final class DataStructureUtil {
                   .toVersionDeneb()
                   .ifPresent(__ -> builder.blindedBlobsBundle(randomBlindedBlobsBundle()));
             });
+  }
+
+  public SignedBuilderBid randomSignedBuilderBid(final BuilderBid builderBid) {
+    return getBellatrixSchemaDefinitions(randomSlot())
+        .getSignedBuilderBidSchema()
+        .create(builderBid, randomSignature());
   }
 
   public SignedBuilderBid randomSignedBuilderBid() {


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
While reviewing #7529 I made a mistake not properly understanding the spec and asking @mehdi-aouadi to always set payload value callback to the local value, while it should be set to the value of actually included payload (which could be both local and builder). Fixing it + verification of all cases in tests.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
