### PR TITLE
RPC blob sidecars validating refactor

### DIFF
--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/logic/versions/deneb/helpers/CKZG4844PropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/logic/versions/deneb/helpers/CKZG4844PropertyTest.java
@@ -31,6 +31,20 @@ import tech.pegasys.teku.spec.propertytest.suppliers.type.KZGProofSupplier;
 
 @AddLifecycleHook(KzgResolver.class)
 public class CKZG4844PropertyTest {
+
+  @Property(tries = 100)
+  void fuzzVerifyBlobKzgProof(
+      final KZG kzg,
+      @ForAll(supplier = DiverseBlobBytesSupplier.class) final Bytes blob,
+      @ForAll(supplier = KZGCommitmentSupplier.class) final KZGCommitment commitment,
+      @ForAll(supplier = KZGProofSupplier.class) final KZGProof proof) {
+    try {
+      kzg.verifyBlobKzgProof(blob, commitment, proof);
+    } catch (Exception e) {
+      assertThat(e).isInstanceOf(KZGException.class);
+    }
+  }
+
   @Property(tries = 100)
   void fuzzVerifyBlobKzgProofBatch(
       final KZG kzg,

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/DefaultEth2Peer.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/DefaultEth2Peer.java
@@ -35,9 +35,9 @@ import tech.pegasys.teku.infrastructure.subscribers.Subscribers;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.networking.eth2.rpc.beaconchain.BeaconChainMethods;
-import tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.BlobSidecarByRootValidator;
 import tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.BlobSidecarsByRangeListenerValidatingProxy;
 import tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.BlobSidecarsByRootListenerValidatingProxy;
+import tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.BlobSidecarsByRootValidator;
 import tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.BlocksByRangeListenerWrapper;
 import tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.MetadataMessagesFactory;
 import tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.StatusMessageFactory;
@@ -290,10 +290,10 @@ class DefaultEth2Peer extends DelegatingPeer implements Eth2Peer {
                         maybeBlobSidecar ->
                             maybeBlobSidecar.ifPresent(
                                 blobSidecar -> {
-                                  final BlobSidecarByRootValidator blobSidecarByRootValidator =
-                                      new BlobSidecarByRootValidator(
+                                  final BlobSidecarsByRootValidator validator =
+                                      new BlobSidecarsByRootValidator(
                                           this, spec, kzg, Set.of(blobIdentifier));
-                                  blobSidecarByRootValidator.validateBlobSidecar(blobSidecar);
+                                  validator.validate(blobSidecar);
                                 })))
         .orElse(failWithUnsupportedMethodException("BlobSidecarsByRoot"));
   }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/AbstractBlobSidecarsValidator.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/AbstractBlobSidecarsValidator.java
@@ -27,9 +27,8 @@ public class AbstractBlobSidecarsValidator {
   private static final Logger LOG = LogManager.getLogger();
 
   protected final Peer peer;
-
-  private final Spec spec;
-  private final KZG kzg;
+  protected final Spec spec;
+  protected final KZG kzg;
 
   public AbstractBlobSidecarsValidator(final Peer peer, final Spec spec, final KZG kzg) {
     this.peer = peer;
@@ -37,7 +36,7 @@ public class AbstractBlobSidecarsValidator {
     this.kzg = kzg;
   }
 
-  void verifyKzg(final BlobSidecar blobSidecar) {
+  protected void verifyKzg(final BlobSidecar blobSidecar) {
     if (!verifyBlobKzgProof(blobSidecar)) {
       throw new BlobSidecarsResponseInvalidResponseException(
           peer, BLOB_SIDECAR_KZG_VERIFICATION_FAILED);

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/AbstractBlobSidecarsValidator.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/AbstractBlobSidecarsValidator.java
@@ -13,10 +13,12 @@
 
 package tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods;
 
+import static tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.BlobSidecarsResponseInvalidResponseException.InvalidResponseType.BLOB_SIDECAR_KZG_VERIFICATION_FAILED;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.kzg.KZG;
-import tech.pegasys.teku.kzg.KZGException;
+import tech.pegasys.teku.networking.p2p.peer.Peer;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 
@@ -24,20 +26,31 @@ public class AbstractBlobSidecarsValidator {
 
   private static final Logger LOG = LogManager.getLogger();
 
-  protected final Spec spec;
-  protected final KZG kzg;
+  protected final Peer peer;
 
-  public AbstractBlobSidecarsValidator(final Spec spec, final KZG kzg) {
+  private final Spec spec;
+  private final KZG kzg;
+
+  public AbstractBlobSidecarsValidator(final Peer peer, final Spec spec, final KZG kzg) {
+    this.peer = peer;
     this.spec = spec;
     this.kzg = kzg;
   }
 
-  boolean verifyBlobSidecarKzg(final BlobSidecar blobSidecar) {
+  void verifyKzg(final BlobSidecar blobSidecar) {
+    if (!verifyBlobKzgProof(blobSidecar)) {
+      throw new BlobSidecarsResponseInvalidResponseException(
+          peer, BLOB_SIDECAR_KZG_VERIFICATION_FAILED);
+    }
+  }
+
+  private boolean verifyBlobKzgProof(final BlobSidecar blobSidecar) {
     try {
       return spec.atSlot(blobSidecar.getSlot()).miscHelpers().verifyBlobKzgProof(kzg, blobSidecar);
-    } catch (final KZGException ex) {
+    } catch (final Exception ex) {
       LOG.debug("KZG verification failed for BlobSidecar {}", blobSidecar.toLogString());
-      return false;
+      throw new BlobSidecarsResponseInvalidResponseException(
+          peer, BLOB_SIDECAR_KZG_VERIFICATION_FAILED, ex);
     }
   }
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeListenerValidatingProxy.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeListenerValidatingProxy.java
@@ -13,7 +13,6 @@
 
 package tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods;
 
-import static tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.BlobSidecarsResponseInvalidResponseException.InvalidResponseType.BLOB_SIDECAR_KZG_VERIFICATION_FAILED;
 import static tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.BlobSidecarsResponseInvalidResponseException.InvalidResponseType.BLOB_SIDECAR_SLOT_NOT_IN_RANGE;
 import static tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.BlobSidecarsResponseInvalidResponseException.InvalidResponseType.BLOB_SIDECAR_UNEXPECTED_INDEX;
 import static tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.BlobSidecarsResponseInvalidResponseException.InvalidResponseType.BLOB_SIDECAR_UNEXPECTED_SLOT;
@@ -32,7 +31,6 @@ import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 public class BlobSidecarsByRangeListenerValidatingProxy extends AbstractBlobSidecarsValidator
     implements RpcResponseListener<BlobSidecar> {
 
-  private final Peer peer;
   private final RpcResponseListener<BlobSidecar> blobSidecarResponseListener;
   private final Integer maxBlobsPerBlock;
   private final UInt64 startSlot;
@@ -48,8 +46,7 @@ public class BlobSidecarsByRangeListenerValidatingProxy extends AbstractBlobSide
       final KZG kzg,
       final UInt64 startSlot,
       final UInt64 count) {
-    super(spec, kzg);
-    this.peer = peer;
+    super(peer, spec, kzg);
     this.blobSidecarResponseListener = blobSidecarResponseListener;
     this.maxBlobsPerBlock = maxBlobsPerBlock;
     this.startSlot = startSlot;
@@ -74,10 +71,7 @@ public class BlobSidecarsByRangeListenerValidatingProxy extends AbstractBlobSide
           final BlobSidecarSummary blobSidecarSummary = BlobSidecarSummary.create(blobSidecar);
           verifyBlobSidecarIsAfterLast(blobSidecarSummary);
 
-          if (!verifyBlobSidecarKzg(blobSidecar)) {
-            throw new BlobSidecarsResponseInvalidResponseException(
-                peer, BLOB_SIDECAR_KZG_VERIFICATION_FAILED);
-          }
+          verifyKzg(blobSidecar);
 
           maybeLastBlobSidecarSummary = Optional.of(blobSidecarSummary);
           return blobSidecarResponseListener.onResponse(blobSidecar);

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootListenerValidatingProxy.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootListenerValidatingProxy.java
@@ -13,7 +13,6 @@
 
 package tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods;
 
-import java.util.HashSet;
 import java.util.List;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.kzg.KZG;
@@ -34,7 +33,7 @@ public class BlobSidecarsByRootListenerValidatingProxy extends BlobSidecarsByRoo
       final RpcResponseListener<BlobSidecar> delegate,
       final KZG kzg,
       final List<BlobIdentifier> expectedBlobIdentifiers) {
-    super(peer, spec, kzg, new HashSet<>(expectedBlobIdentifiers));
+    super(peer, spec, kzg, expectedBlobIdentifiers);
     this.delegate = delegate;
   }
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootListenerValidatingProxy.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootListenerValidatingProxy.java
@@ -25,16 +25,16 @@ import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BlobIdentifie
 public class BlobSidecarsByRootListenerValidatingProxy extends BlobSidecarsByRootValidator
     implements RpcResponseListener<BlobSidecar> {
 
-  private final RpcResponseListener<BlobSidecar> delegate;
+  private final RpcResponseListener<BlobSidecar> listener;
 
   public BlobSidecarsByRootListenerValidatingProxy(
       final Peer peer,
       final Spec spec,
-      final RpcResponseListener<BlobSidecar> delegate,
+      final RpcResponseListener<BlobSidecar> listener,
       final KZG kzg,
       final List<BlobIdentifier> expectedBlobIdentifiers) {
     super(peer, spec, kzg, expectedBlobIdentifiers);
-    this.delegate = delegate;
+    this.listener = listener;
   }
 
   @Override
@@ -42,7 +42,7 @@ public class BlobSidecarsByRootListenerValidatingProxy extends BlobSidecarsByRoo
     return SafeFuture.of(
         () -> {
           validate(blobSidecar);
-          return delegate.onResponse(blobSidecar);
+          return listener.onResponse(blobSidecar);
         });
   }
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootValidator.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootValidator.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods;
 
 import java.util.List;
+import java.util.Set;
 import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.BlobSidecarsResponseInvalidResponseException.InvalidResponseType;
 import tech.pegasys.teku.networking.p2p.peer.Peer;
@@ -23,7 +24,7 @@ import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BlobIdentifie
 
 public class BlobSidecarsByRootValidator extends AbstractBlobSidecarsValidator {
 
-  private final List<BlobIdentifier> expectedBlobIdentifiers;
+  private final Set<BlobIdentifier> expectedBlobIdentifiers;
 
   public BlobSidecarsByRootValidator(
       final Peer peer,
@@ -31,7 +32,7 @@ public class BlobSidecarsByRootValidator extends AbstractBlobSidecarsValidator {
       final KZG kzg,
       final List<BlobIdentifier> expectedBlobIdentifiers) {
     super(peer, spec, kzg);
-    this.expectedBlobIdentifiers = expectedBlobIdentifiers;
+    this.expectedBlobIdentifiers = Set.copyOf(expectedBlobIdentifiers);
   }
 
   public void validate(final BlobSidecar blobSidecar) {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootValidator.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootValidator.java
@@ -13,42 +13,35 @@
 
 package tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods;
 
-import static tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.BlobSidecarsResponseInvalidResponseException.InvalidResponseType.BLOB_SIDECAR_KZG_VERIFICATION_FAILED;
-import static tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.BlobSidecarsResponseInvalidResponseException.InvalidResponseType.BLOB_SIDECAR_UNEXPECTED_IDENTIFIER;
-
 import java.util.Set;
 import tech.pegasys.teku.kzg.KZG;
+import tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.BlobSidecarsResponseInvalidResponseException.InvalidResponseType;
 import tech.pegasys.teku.networking.p2p.peer.Peer;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BlobIdentifier;
 
-public class BlobSidecarByRootValidator extends AbstractBlobSidecarsValidator {
+public class BlobSidecarsByRootValidator extends AbstractBlobSidecarsValidator {
 
-  private final Peer peer;
   private final Set<BlobIdentifier> expectedBlobIdentifiers;
 
-  public BlobSidecarByRootValidator(
+  public BlobSidecarsByRootValidator(
       final Peer peer,
       final Spec spec,
       final KZG kzg,
       final Set<BlobIdentifier> expectedBlobIdentifiers) {
-    super(spec, kzg);
-    this.peer = peer;
+    super(peer, spec, kzg);
     this.expectedBlobIdentifiers = expectedBlobIdentifiers;
   }
 
-  public void validateBlobSidecar(final BlobSidecar blobSidecar) {
+  public void validate(final BlobSidecar blobSidecar) {
     final BlobIdentifier blobIdentifier =
         new BlobIdentifier(blobSidecar.getBlockRoot(), blobSidecar.getIndex());
     if (!expectedBlobIdentifiers.contains(blobIdentifier)) {
       throw new BlobSidecarsResponseInvalidResponseException(
-          peer, BLOB_SIDECAR_UNEXPECTED_IDENTIFIER);
+          peer, InvalidResponseType.BLOB_SIDECAR_UNEXPECTED_IDENTIFIER);
     }
 
-    if (!verifyBlobSidecarKzg(blobSidecar)) {
-      throw new BlobSidecarsResponseInvalidResponseException(
-          peer, BLOB_SIDECAR_KZG_VERIFICATION_FAILED);
-    }
+    verifyKzg(blobSidecar);
   }
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootValidator.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootValidator.java
@@ -13,7 +13,7 @@
 
 package tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods;
 
-import java.util.Set;
+import java.util.List;
 import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.BlobSidecarsResponseInvalidResponseException.InvalidResponseType;
 import tech.pegasys.teku.networking.p2p.peer.Peer;
@@ -23,13 +23,13 @@ import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BlobIdentifie
 
 public class BlobSidecarsByRootValidator extends AbstractBlobSidecarsValidator {
 
-  private final Set<BlobIdentifier> expectedBlobIdentifiers;
+  private final List<BlobIdentifier> expectedBlobIdentifiers;
 
   public BlobSidecarsByRootValidator(
       final Peer peer,
       final Spec spec,
       final KZG kzg,
-      final Set<BlobIdentifier> expectedBlobIdentifiers) {
+      final List<BlobIdentifier> expectedBlobIdentifiers) {
     super(peer, spec, kzg);
     this.expectedBlobIdentifiers = expectedBlobIdentifiers;
   }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsResponseInvalidResponseException.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsResponseInvalidResponseException.java
@@ -19,18 +19,22 @@ import tech.pegasys.teku.networking.p2p.peer.Peer;
 public class BlobSidecarsResponseInvalidResponseException extends InvalidResponseException {
 
   public BlobSidecarsResponseInvalidResponseException(
-      Peer peer, InvalidResponseType invalidResponseType) {
+      final Peer peer, final InvalidResponseType invalidResponseType) {
     super(
         String.format(
             "Received invalid response from peer %s: %s", peer, invalidResponseType.describe()));
   }
 
-  public BlobSidecarsResponseInvalidResponseException(InvalidResponseType invalidResponseType) {
-    super("Received invalid response: " + invalidResponseType.describe());
+  public BlobSidecarsResponseInvalidResponseException(
+      final Peer peer, final InvalidResponseType invalidResponseType, final Exception cause) {
+    super(
+        String.format(
+            "Received invalid response from peer %s: %s", peer, invalidResponseType.describe()),
+        cause);
   }
 
   public enum InvalidResponseType {
-    BLOB_SIDECAR_KZG_VERIFICATION_FAILED("KZG verification for BlobSidecar is failed"),
+    BLOB_SIDECAR_KZG_VERIFICATION_FAILED("KZG verification for BlobSidecar has failed"),
     BLOB_SIDECAR_SLOT_NOT_IN_RANGE("BlobSidecar slot not in requested range"),
     BLOB_SIDECAR_UNEXPECTED_INDEX("BlobSidecar with unexpected index"),
     BLOB_SIDECAR_UNKNOWN_PARENT(

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlocksByRangeResponseInvalidResponseException.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlocksByRangeResponseInvalidResponseException.java
@@ -19,13 +19,14 @@ import tech.pegasys.teku.networking.p2p.peer.Peer;
 public class BlocksByRangeResponseInvalidResponseException extends InvalidResponseException {
 
   public BlocksByRangeResponseInvalidResponseException(
-      Peer peer, InvalidResponseType invalidResponseType) {
+      final Peer peer, final InvalidResponseType invalidResponseType) {
     super(
         String.format(
             "Received invalid response from peer %s: %s", peer, invalidResponseType.describe()));
   }
 
-  public BlocksByRangeResponseInvalidResponseException(InvalidResponseType invalidResponseType) {
+  public BlocksByRangeResponseInvalidResponseException(
+      final InvalidResponseType invalidResponseType) {
     super("Received invalid response: " + invalidResponseType.describe());
   }
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/InvalidResponseException.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/InvalidResponseException.java
@@ -18,4 +18,8 @@ public class InvalidResponseException extends RuntimeException {
   public InvalidResponseException(final String message) {
     super(message);
   }
+
+  public InvalidResponseException(final String message, final Exception cause) {
+    super(message, cause);
+  }
 }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootValidatorTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootValidatorTest.java
@@ -32,10 +32,10 @@ import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BlobIdentifier;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
-public class BlobSidecarByRootValidatorTest {
+public class BlobSidecarsByRootValidatorTest {
   private final Spec spec = TestSpecFactory.createMainnetDeneb();
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
-  private BlobSidecarByRootValidator validator;
+  private BlobSidecarsByRootValidator validator;
   private final Eth2Peer peer = mock(Eth2Peer.class);
   private final KZG kzg = mock(KZG.class);
 
@@ -51,8 +51,8 @@ public class BlobSidecarByRootValidatorTest {
     final BlobSidecar blobSidecar1 =
         dataStructureUtil.randomBlobSidecar(UInt64.ONE, blockRoot1, Bytes32.ZERO, UInt64.ZERO);
 
-    validator = new BlobSidecarByRootValidator(peer, spec, kzg, Set.of(blobIdentifier1));
-    assertDoesNotThrow(() -> validator.validateBlobSidecar(blobSidecar1));
+    validator = new BlobSidecarsByRootValidator(peer, spec, kzg, Set.of(blobIdentifier1));
+    assertDoesNotThrow(() -> validator.validate(blobSidecar1));
   }
 
   @Test
@@ -63,8 +63,8 @@ public class BlobSidecarByRootValidatorTest {
     final BlobSidecar blobSidecar1 =
         dataStructureUtil.randomBlobSidecar(UInt64.ONE, blockRoot1, Bytes32.ZERO, UInt64.ZERO);
 
-    validator = new BlobSidecarByRootValidator(peer, spec, kzg, Set.of(blobIdentifier2));
-    assertThatThrownBy(() -> validator.validateBlobSidecar(blobSidecar1))
+    validator = new BlobSidecarsByRootValidator(peer, spec, kzg, Set.of(blobIdentifier2));
+    assertThatThrownBy(() -> validator.validate(blobSidecar1))
         .isExactlyInstanceOf(BlobSidecarsResponseInvalidResponseException.class)
         .hasMessageContaining(
             BlobSidecarsResponseInvalidResponseException.InvalidResponseType
@@ -80,8 +80,8 @@ public class BlobSidecarByRootValidatorTest {
     final BlobSidecar blobSidecar1 =
         dataStructureUtil.randomBlobSidecar(UInt64.ONE, blockRoot1, Bytes32.ZERO, UInt64.ZERO);
 
-    validator = new BlobSidecarByRootValidator(peer, spec, kzg, Set.of(blobIdentifier1));
-    assertThatThrownBy(() -> validator.validateBlobSidecar(blobSidecar1))
+    validator = new BlobSidecarsByRootValidator(peer, spec, kzg, Set.of(blobIdentifier1));
+    assertThatThrownBy(() -> validator.validate(blobSidecar1))
         .isExactlyInstanceOf(BlobSidecarsResponseInvalidResponseException.class)
         .hasMessageContaining(
             BlobSidecarsResponseInvalidResponseException.InvalidResponseType

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootValidatorTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootValidatorTest.java
@@ -19,7 +19,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.util.Set;
+import java.util.List;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -51,7 +51,7 @@ public class BlobSidecarsByRootValidatorTest {
     final BlobSidecar blobSidecar1 =
         dataStructureUtil.randomBlobSidecar(UInt64.ONE, blockRoot1, Bytes32.ZERO, UInt64.ZERO);
 
-    validator = new BlobSidecarsByRootValidator(peer, spec, kzg, Set.of(blobIdentifier1));
+    validator = new BlobSidecarsByRootValidator(peer, spec, kzg, List.of(blobIdentifier1));
     assertDoesNotThrow(() -> validator.validate(blobSidecar1));
   }
 
@@ -63,7 +63,7 @@ public class BlobSidecarsByRootValidatorTest {
     final BlobSidecar blobSidecar1 =
         dataStructureUtil.randomBlobSidecar(UInt64.ONE, blockRoot1, Bytes32.ZERO, UInt64.ZERO);
 
-    validator = new BlobSidecarsByRootValidator(peer, spec, kzg, Set.of(blobIdentifier2));
+    validator = new BlobSidecarsByRootValidator(peer, spec, kzg, List.of(blobIdentifier2));
     assertThatThrownBy(() -> validator.validate(blobSidecar1))
         .isExactlyInstanceOf(BlobSidecarsResponseInvalidResponseException.class)
         .hasMessageContaining(
@@ -80,7 +80,7 @@ public class BlobSidecarsByRootValidatorTest {
     final BlobSidecar blobSidecar1 =
         dataStructureUtil.randomBlobSidecar(UInt64.ONE, blockRoot1, Bytes32.ZERO, UInt64.ZERO);
 
-    validator = new BlobSidecarsByRootValidator(peer, spec, kzg, Set.of(blobIdentifier1));
+    validator = new BlobSidecarsByRootValidator(peer, spec, kzg, List.of(blobIdentifier1));
     assertThatThrownBy(() -> validator.validate(blobSidecar1))
         .isExactlyInstanceOf(BlobSidecarsResponseInvalidResponseException.class)
         .hasMessageContaining(


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Just a small refactor.

- Make `BlobSidecarsByRootListenerValidatingProxy` extend `BlobSidecarsByRootValidator` instead of new object created within it.
- Some renamings
- `verifyKzg` inside `AbstractBlobSidecarsValidator` throws the exceptions (so void instead of boolean)
- Add missed fuzzing test

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
