### PR TITLE
Sort endpoints and schemas in swagger UI

### DIFF
--- a/infrastructure/http/src/main/java/tech/pegasys/teku/infrastructure/http/RestApiConstants.java
+++ b/infrastructure/http/src/main/java/tech/pegasys/teku/infrastructure/http/RestApiConstants.java
@@ -24,6 +24,8 @@ import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_PARTIAL_C
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_SERVICE_UNAVAILABLE;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_UNSUPPORTED_MEDIA_TYPE;
 
+import java.util.List;
+
 public class RestApiConstants {
 
   public static final String SLOT = "slot";
@@ -55,6 +57,21 @@ public class RestApiConstants {
   public static final String TAG_REWARDS = "Rewards";
   public static final String TAG_DEBUG = "Debug";
   public static final String TAG_TEKU = "Teku";
+
+  // Preferred tags order in Swagger UI
+  public static final List<String> PREFERRED_DISPLAY_TAGS_ORDER =
+      List.of(
+          TAG_BEACON,
+          TAG_VALIDATOR_REQUIRED,
+          TAG_VALIDATOR,
+          TAG_BUILDER,
+          TAG_REWARDS,
+          TAG_EVENTS,
+          TAG_CONFIG,
+          TAG_NODE,
+          TAG_TEKU,
+          TAG_DEBUG,
+          TAG_EXPERIMENTAL);
 
   // Use "" + instead of Integer.toString so they are constants and can be used in annotations
   public static final String RES_OK = "" + SC_OK;

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/openapi/OpenApiDocBuilder.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/openapi/OpenApiDocBuilder.java
@@ -14,17 +14,7 @@
 package tech.pegasys.teku.infrastructure.restapi.openapi;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static tech.pegasys.teku.infrastructure.http.RestApiConstants.TAG_BEACON;
-import static tech.pegasys.teku.infrastructure.http.RestApiConstants.TAG_BUILDER;
-import static tech.pegasys.teku.infrastructure.http.RestApiConstants.TAG_CONFIG;
-import static tech.pegasys.teku.infrastructure.http.RestApiConstants.TAG_DEBUG;
-import static tech.pegasys.teku.infrastructure.http.RestApiConstants.TAG_EVENTS;
-import static tech.pegasys.teku.infrastructure.http.RestApiConstants.TAG_EXPERIMENTAL;
-import static tech.pegasys.teku.infrastructure.http.RestApiConstants.TAG_NODE;
-import static tech.pegasys.teku.infrastructure.http.RestApiConstants.TAG_REWARDS;
-import static tech.pegasys.teku.infrastructure.http.RestApiConstants.TAG_TEKU;
-import static tech.pegasys.teku.infrastructure.http.RestApiConstants.TAG_VALIDATOR;
-import static tech.pegasys.teku.infrastructure.http.RestApiConstants.TAG_VALIDATOR_REQUIRED;
+import static tech.pegasys.teku.infrastructure.http.RestApiConstants.PREFERRED_DISPLAY_TAGS_ORDER;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -151,20 +141,8 @@ public class OpenApiDocBuilder {
 
     // fill desired order for tags
     final Map<String, Integer> tagOrder = new HashMap<>();
-    final List<String> tags =
-        List.of(
-            TAG_BEACON,
-            TAG_VALIDATOR_REQUIRED,
-            TAG_VALIDATOR,
-            TAG_BUILDER,
-            TAG_REWARDS,
-            TAG_EVENTS,
-            TAG_CONFIG,
-            TAG_NODE,
-            TAG_TEKU,
-            TAG_DEBUG,
-            TAG_EXPERIMENTAL);
-    IntStream.range(0, tags.size()).forEach(i -> tagOrder.put(tags.get(i), i));
+    IntStream.range(0, PREFERRED_DISPLAY_TAGS_ORDER.size())
+        .forEach(i -> tagOrder.put(PREFERRED_DISPLAY_TAGS_ORDER.get(i), i));
 
     // sort by tag, then by path, tag order is not guaranteed, endpoint could have several tags,
     // first appearance of any tag defines its order on UI


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Noticed that it looks weird and sort both endpoints and schemas. 
We cannot have any tag order but I did my best to make it more or less with some idea.
Schemas are sorted also, looks especially better.
Sorry that code looks ugly, it's frontend.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
