### PR TITLE
Fix minor issue in BlocksByRange slot check

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeListenerValidatingProxy.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeListenerValidatingProxy.java
@@ -50,7 +50,7 @@ public class BlobSidecarsByRangeListenerValidatingProxy extends AbstractBlobSide
     this.blobSidecarResponseListener = blobSidecarResponseListener;
     this.maxBlobsPerBlock = maxBlobsPerBlock;
     this.startSlot = startSlot;
-    this.endSlot = startSlot.plus(count);
+    this.endSlot = startSlot.plus(count).minusMinZero(1);
   }
 
   @Override

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlocksByRangeListenerWrapper.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlocksByRangeListenerWrapper.java
@@ -80,7 +80,7 @@ public class BlocksByRangeListenerWrapper implements RpcResponseListener<SignedB
   }
 
   private boolean blockSlotIsInRange(UInt64 blockSlot) {
-    return blockSlot.compareTo(startSlot) >= 0 && blockSlot.compareTo(endSlot) <= 0;
+    return blockSlot.compareTo(startSlot) >= 0 && blockSlot.compareTo(endSlot) < 0;
   }
 
   private boolean blockSlotMatchesTheStep(UInt64 blockSlot) {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlocksByRangeListenerWrapper.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlocksByRangeListenerWrapper.java
@@ -46,7 +46,7 @@ public class BlocksByRangeListenerWrapper implements RpcResponseListener<SignedB
     this.blockResponseListener = blockResponseListener;
     this.startSlot = startSlot;
     this.step = UInt64.ONE;
-    this.endSlot = startSlot.plus(step.times(count));
+    this.endSlot = startSlot.plus(step.times(count)).minusMinZero(1);
   }
 
   @Override
@@ -80,7 +80,7 @@ public class BlocksByRangeListenerWrapper implements RpcResponseListener<SignedB
   }
 
   private boolean blockSlotIsInRange(UInt64 blockSlot) {
-    return blockSlot.compareTo(startSlot) >= 0 && blockSlot.compareTo(endSlot) < 0;
+    return blockSlot.compareTo(startSlot) >= 0 && blockSlot.compareTo(endSlot) <= 0;
   }
 
   private boolean blockSlotMatchesTheStep(UInt64 blockSlot) {

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeListenerValidatingProxyTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeListenerValidatingProxyTest.java
@@ -131,7 +131,7 @@ public class BlobSidecarsByRangeListenerValidatingProxyTest {
   void blobSidecarSlotGreaterThanToSlot() {
     final UInt64 startSlot = UInt64.valueOf(1);
     final UInt64 count = UInt64.valueOf(8);
-    // end slot is 9 (1 + 8), so slot 10 will be unexpected
+    // This requests 8 slots (1, 2, 3, 4, 5, 6, 7, 8) so 9 will be unexpected.
     listenerWrapper =
         new BlobSidecarsByRangeListenerValidatingProxy(
             spec, peer, listener, maxBlobsPerBlock, kzg, startSlot, count);
@@ -147,11 +147,10 @@ public class BlobSidecarsByRangeListenerValidatingProxyTest {
         dataStructureUtil.randomBlobSidecar(UInt64.valueOf(5), blockRoot3, blockRoot2, UInt64.ZERO);
     final Bytes32 blockRoot4 = dataStructureUtil.randomBytes32();
     final BlobSidecar blobSidecar4 =
-        dataStructureUtil.randomBlobSidecar(UInt64.valueOf(9), blockRoot4, blockRoot3, UInt64.ZERO);
+        dataStructureUtil.randomBlobSidecar(UInt64.valueOf(8), blockRoot4, blockRoot3, UInt64.ZERO);
     final Bytes32 blockRoot5 = dataStructureUtil.randomBytes32();
     final BlobSidecar blobSidecar5 =
-        dataStructureUtil.randomBlobSidecar(
-            UInt64.valueOf(10), blockRoot5, blockRoot4, UInt64.ZERO);
+        dataStructureUtil.randomBlobSidecar(UInt64.valueOf(9), blockRoot5, blockRoot4, UInt64.ZERO);
 
     listenerWrapper.onResponse(blobSidecar1).join();
     listenerWrapper.onResponse(blobSidecar2).join();

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlocksByRangeListenerWrapperTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlocksByRangeListenerWrapperTest.java
@@ -84,15 +84,15 @@ public class BlocksByRangeListenerWrapperTest {
   void blockSlotGreaterThanToSlot() {
     UInt64 startSlot = UInt64.valueOf(1);
     UInt64 count = UInt64.valueOf(8);
-    // end slot is 9 (1 + 8), so slot 10 will be unexpected
+    // This requests 8 slots (1, 2, 3, 4, 5, 6, 7, 8) so 9 will be unexpected.
     listenerWrapper = new BlocksByRangeListenerWrapper(peer, listener, startSlot, count);
 
     final SignedBeaconBlock block1 = dataStructureUtil.randomSignedBeaconBlock(1);
     final SignedBeaconBlock block2 = dataStructureUtil.randomSignedBeaconBlock(2, block1.getRoot());
     final SignedBeaconBlock block3 = dataStructureUtil.randomSignedBeaconBlock(5, block2.getRoot());
-    final SignedBeaconBlock block4 = dataStructureUtil.randomSignedBeaconBlock(9, block3.getRoot());
+    final SignedBeaconBlock block4 = dataStructureUtil.randomSignedBeaconBlock(8, block3.getRoot());
     final SignedBeaconBlock block5 =
-        dataStructureUtil.randomSignedBeaconBlock(10, block4.getRoot());
+        dataStructureUtil.randomSignedBeaconBlock(9, block4.getRoot());
     listenerWrapper.onResponse(block1).join();
     listenerWrapper.onResponse(block2).join();
     listenerWrapper.onResponse(block3).join();
@@ -113,7 +113,6 @@ public class BlocksByRangeListenerWrapperTest {
   void blockParentRootDoesNotMatch() {
     UInt64 startSlot = UInt64.valueOf(1);
     UInt64 count = UInt64.valueOf(4);
-    // end slot is 9
     listenerWrapper = new BlocksByRangeListenerWrapper(peer, listener, startSlot, count);
 
     final SignedBeaconBlock block1 = dataStructureUtil.randomSignedBeaconBlock(1);
@@ -136,7 +135,6 @@ public class BlocksByRangeListenerWrapperTest {
   void blockSlotGreaterThanPreviousBlockSlot() {
     UInt64 startSlot = UInt64.valueOf(1);
     UInt64 count = UInt64.valueOf(4);
-    // end slot is 9
     listenerWrapper = new BlocksByRangeListenerWrapper(peer, listener, startSlot, count);
 
     final SignedBeaconBlock block1 = dataStructureUtil.randomSignedBeaconBlock(1);

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlocksByRangeListenerWrapperTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlocksByRangeListenerWrapperTest.java
@@ -91,8 +91,7 @@ public class BlocksByRangeListenerWrapperTest {
     final SignedBeaconBlock block2 = dataStructureUtil.randomSignedBeaconBlock(2, block1.getRoot());
     final SignedBeaconBlock block3 = dataStructureUtil.randomSignedBeaconBlock(5, block2.getRoot());
     final SignedBeaconBlock block4 = dataStructureUtil.randomSignedBeaconBlock(8, block3.getRoot());
-    final SignedBeaconBlock block5 =
-        dataStructureUtil.randomSignedBeaconBlock(9, block4.getRoot());
+    final SignedBeaconBlock block5 = dataStructureUtil.randomSignedBeaconBlock(9, block4.getRoot());
     listenerWrapper.onResponse(block1).join();
     listenerWrapper.onResponse(block2).join();
     listenerWrapper.onResponse(block3).join();


### PR DESCRIPTION
## PR Description

Really minor fix here, but BlocksByRange shouldn't allow the `startSlot + count` slot.

> Requests beacon blocks in the slot range `[start_slot, start_slot + count)`, leading up to the current head block as selected by fork choice. For example, requesting blocks starting at `start_slot=2` and `count=4` would return the blocks at slots `[2, 3, 4, 5]`.

https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/p2p-interface.md#beaconblocksbyrange

Also, remove old comments about end slot being 9. I think it's from when `step` was 2.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
