### PR TITLE
Rename blob sidecar data structures to Old

### DIFF
--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/fetch/FetchBlobSidecarTask.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/fetch/FetchBlobSidecarTask.java
@@ -20,10 +20,10 @@ import tech.pegasys.teku.beacon.sync.fetch.FetchResult.Status;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.teku.networking.p2p.network.P2PNetwork;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BlobIdentifier;
 
-public class FetchBlobSidecarTask extends AbstractFetchTask<BlobIdentifier, BlobSidecar> {
+public class FetchBlobSidecarTask extends AbstractFetchTask<BlobIdentifier, BlobSidecarOld> {
 
   private static final Logger LOG = LogManager.getLogger();
 
@@ -49,7 +49,7 @@ public class FetchBlobSidecarTask extends AbstractFetchTask<BlobIdentifier, Blob
   }
 
   @Override
-  SafeFuture<FetchResult<BlobSidecar>> fetch(final Eth2Peer peer) {
+  SafeFuture<FetchResult<BlobSidecarOld>> fetch(final Eth2Peer peer) {
     return peer.requestBlobSidecarByRoot(blobIdentifier)
         .thenApply(
             maybeBlobSidecar ->

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/BatchImporter.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/BatchImporter.java
@@ -27,7 +27,7 @@ import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.networking.eth2.peers.SyncSource;
 import tech.pegasys.teku.networking.p2p.peer.DisconnectReason;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
 import tech.pegasys.teku.statetransition.blobs.BlobSidecarPool;
@@ -60,7 +60,7 @@ public class BatchImporter {
   public SafeFuture<BatchImportResult> importBatch(final Batch batch) {
     // Copy the data from batch as we're going to use them from off the event thread.
     final List<SignedBeaconBlock> blocks = new ArrayList<>(batch.getBlocks());
-    final Map<Bytes32, List<BlobSidecar>> blobSidecarsByBlockRoot =
+    final Map<Bytes32, List<BlobSidecarOld>> blobSidecarsByBlockRoot =
         Map.copyOf(batch.getBlobSidecarsByBlockRoot());
 
     final Optional<SyncSource> source = batch.getSource();
@@ -103,13 +103,13 @@ public class BatchImporter {
 
   private SafeFuture<BlockImportResult> importBlockAndBlobSidecars(
       final SignedBeaconBlock block,
-      final Map<Bytes32, List<BlobSidecar>> blobSidecarsByBlockRoot,
+      final Map<Bytes32, List<BlobSidecarOld>> blobSidecarsByBlockRoot,
       final SyncSource source) {
     final Bytes32 blockRoot = block.getRoot();
     if (!blobSidecarsByBlockRoot.containsKey(blockRoot)) {
       return importBlock(block, source);
     }
-    final List<BlobSidecar> blobSidecars = blobSidecarsByBlockRoot.get(blockRoot);
+    final List<BlobSidecarOld> blobSidecars = blobSidecarsByBlockRoot.get(blockRoot);
     LOG.debug(
         "Sending {} blob sidecars to the pool for block with root {}",
         blobSidecars.size(),

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/Batch.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/Batch.java
@@ -20,7 +20,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.beacon.sync.forward.multipeer.chains.TargetChain;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.peers.SyncSource;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 
 /** A section of a particular target chain that can be downloaded in parallel. */
@@ -37,7 +37,7 @@ public interface Batch {
 
   List<SignedBeaconBlock> getBlocks();
 
-  Map<Bytes32, List<BlobSidecar>> getBlobSidecarsByBlockRoot();
+  Map<Bytes32, List<BlobSidecarOld>> getBlobSidecarsByBlockRoot();
 
   Optional<SyncSource> getSource();
 

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/EventThreadOnlyBatch.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/EventThreadOnlyBatch.java
@@ -22,7 +22,7 @@ import tech.pegasys.teku.beacon.sync.forward.multipeer.chains.TargetChain;
 import tech.pegasys.teku.infrastructure.async.eventthread.EventThread;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.peers.SyncSource;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 
 public class EventThreadOnlyBatch implements Batch {
@@ -71,7 +71,7 @@ public class EventThreadOnlyBatch implements Batch {
   }
 
   @Override
-  public Map<Bytes32, List<BlobSidecar>> getBlobSidecarsByBlockRoot() {
+  public Map<Bytes32, List<BlobSidecarOld>> getBlobSidecarsByBlockRoot() {
     eventThread.checkOnEventThread();
     return delegate.getBlobSidecarsByBlockRoot();
   }

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/SyncSourceBatch.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/SyncSourceBatch.java
@@ -40,7 +40,7 @@ import tech.pegasys.teku.networking.eth2.peers.SyncSource;
 import tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.BlocksByRangeResponseInvalidResponseException;
 import tech.pegasys.teku.networking.p2p.peer.PeerDisconnectedException;
 import tech.pegasys.teku.networking.p2p.rpc.RpcResponseListener;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.MinimalBeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.deneb.BeaconBlockBodyDeneb;
@@ -65,7 +65,7 @@ public class SyncSourceBatch implements Batch {
   private boolean awaitingBlocks = false;
 
   private final List<SignedBeaconBlock> blocks = new ArrayList<>();
-  private final Map<Bytes32, List<BlobSidecar>> blobSidecarsByBlockRoot = new HashMap<>();
+  private final Map<Bytes32, List<BlobSidecarOld>> blobSidecarsByBlockRoot = new HashMap<>();
 
   SyncSourceBatch(
       final EventThread eventThread,
@@ -117,7 +117,7 @@ public class SyncSourceBatch implements Batch {
   }
 
   @Override
-  public Map<Bytes32, List<BlobSidecar>> getBlobSidecarsByBlockRoot() {
+  public Map<Bytes32, List<BlobSidecarOld>> getBlobSidecarsByBlockRoot() {
     return blobSidecarsByBlockRoot;
   }
 
@@ -318,7 +318,7 @@ public class SyncSourceBatch implements Batch {
     blocks.addAll(newBlocks);
 
     if (maybeBlobSidecarRequestHandler.isPresent()) {
-      final Map<Bytes32, List<BlobSidecar>> newBlobSidecarsByBlockRoot =
+      final Map<Bytes32, List<BlobSidecarOld>> newBlobSidecarsByBlockRoot =
           maybeBlobSidecarRequestHandler.get().complete();
       if (!validateNewBlobSidecars(newBlocks, newBlobSidecarsByBlockRoot)) {
         markAsInvalid();
@@ -373,11 +373,11 @@ public class SyncSourceBatch implements Batch {
 
   private boolean validateNewBlobSidecars(
       final List<SignedBeaconBlock> newBlocks,
-      final Map<Bytes32, List<BlobSidecar>> newBlobSidecarsByBlockRoot) {
+      final Map<Bytes32, List<BlobSidecarOld>> newBlobSidecarsByBlockRoot) {
     final Set<Bytes32> blockRootsWithKzgCommitments = new HashSet<>(newBlocks.size());
     for (final SignedBeaconBlock block : newBlocks) {
       final Bytes32 blockRoot = block.getRoot();
-      final List<BlobSidecar> blobSidecars =
+      final List<BlobSidecarOld> blobSidecars =
           newBlobSidecarsByBlockRoot.getOrDefault(blockRoot, List.of());
       final int numberOfKzgCommitments =
           block
@@ -399,7 +399,7 @@ public class SyncSourceBatch implements Batch {
         return false;
       }
       final UInt64 blockSlot = block.getSlot();
-      for (final BlobSidecar blobSidecar : blobSidecars) {
+      for (final BlobSidecarOld blobSidecar : blobSidecars) {
         if (!blobSidecar.getSlot().equals(blockSlot)) {
           LOG.debug(
               "Marking batch invalid because blob sidecar for root {} was received with slot {} which is different than the block slot {}",
@@ -446,19 +446,19 @@ public class SyncSourceBatch implements Batch {
     }
   }
 
-  private static class BlobSidecarRequestHandler implements RpcResponseListener<BlobSidecar> {
-    private final Map<Bytes32, List<BlobSidecar>> blobSidecarsByBlockRoot = new HashMap<>();
+  private static class BlobSidecarRequestHandler implements RpcResponseListener<BlobSidecarOld> {
+    private final Map<Bytes32, List<BlobSidecarOld>> blobSidecarsByBlockRoot = new HashMap<>();
 
     @Override
-    public SafeFuture<?> onResponse(final BlobSidecar blobSidecar) {
-      final List<BlobSidecar> blobSidecars =
+    public SafeFuture<?> onResponse(final BlobSidecarOld blobSidecar) {
+      final List<BlobSidecarOld> blobSidecars =
           blobSidecarsByBlockRoot.computeIfAbsent(
               blobSidecar.getBlockRoot(), __ -> new ArrayList<>());
       blobSidecars.add(blobSidecar);
       return SafeFuture.COMPLETE;
     }
 
-    public Map<Bytes32, List<BlobSidecar>> complete() {
+    public Map<Bytes32, List<BlobSidecarOld>> complete() {
       return blobSidecarsByBlockRoot;
     }
   }

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/chains/ThrottlingSyncSource.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/chains/ThrottlingSyncSource.java
@@ -72,7 +72,9 @@ public class ThrottlingSyncSource implements SyncSource {
 
   @Override
   public SafeFuture<Void> requestBlobSidecarsByRange(
-      final UInt64 startSlot, final UInt64 count, final RpcResponseListener<BlobSidecarOld> listener) {
+      final UInt64 startSlot,
+      final UInt64 count,
+      final RpcResponseListener<BlobSidecarOld> listener) {
     if (blobSidecarsRateTracker.approveObjectsRequest(count.longValue()).isPresent()) {
       LOG.debug("Sending request for {} blob sidecars", count);
       return delegate.requestBlobSidecarsByRange(startSlot, count, listener);

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/chains/ThrottlingSyncSource.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/chains/ThrottlingSyncSource.java
@@ -26,7 +26,7 @@ import tech.pegasys.teku.networking.eth2.peers.SyncSource;
 import tech.pegasys.teku.networking.p2p.peer.DisconnectReason;
 import tech.pegasys.teku.networking.p2p.reputation.ReputationAdjustment;
 import tech.pegasys.teku.networking.p2p.rpc.RpcResponseListener;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 
 public class ThrottlingSyncSource implements SyncSource {
@@ -72,7 +72,7 @@ public class ThrottlingSyncSource implements SyncSource {
 
   @Override
   public SafeFuture<Void> requestBlobSidecarsByRange(
-      final UInt64 startSlot, final UInt64 count, final RpcResponseListener<BlobSidecar> listener) {
+      final UInt64 startSlot, final UInt64 count, final RpcResponseListener<BlobSidecarOld> listener) {
     if (blobSidecarsRateTracker.approveObjectsRequest(count.longValue()).isPresent()) {
       LOG.debug("Sending request for {} blob sidecars", count);
       return delegate.requestBlobSidecarsByRange(startSlot, count, listener);

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/singlepeer/PeerSync.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/singlepeer/PeerSync.java
@@ -35,7 +35,7 @@ import tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.BlocksByRangeRe
 import tech.pegasys.teku.networking.eth2.rpc.core.RpcException;
 import tech.pegasys.teku.networking.p2p.peer.DisconnectReason;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult.FailureReason;
 import tech.pegasys.teku.statetransition.blobs.BlobSidecarManager;
@@ -194,7 +194,7 @@ public class PeerSync {
                       requestContext.count,
                       block -> {
                         // at this point, blob sidecars (if any) have been received
-                        final Optional<List<BlobSidecar>> blobSidecars =
+                        final Optional<List<BlobSidecarOld>> blobSidecars =
                             blobSidecarListener.getReceivedBlobSidecars(block.getSlot());
                         return importBlock(block, blobSidecars);
                       });
@@ -336,7 +336,7 @@ public class PeerSync {
   }
 
   private SafeFuture<Void> importBlock(
-      final SignedBeaconBlock block, final Optional<List<BlobSidecar>> maybeBlobSidecars) {
+      final SignedBeaconBlock block, final Optional<List<BlobSidecarOld>> maybeBlobSidecars) {
     if (stopped.get()) {
       throw new CancellationException("Peer sync was cancelled");
     }

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/singlepeer/PeerSyncBlobSidecarListener.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/singlepeer/PeerSyncBlobSidecarListener.java
@@ -21,11 +21,11 @@ import java.util.Optional;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.p2p.rpc.RpcResponseListener;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 
-public class PeerSyncBlobSidecarListener implements RpcResponseListener<BlobSidecar> {
+public class PeerSyncBlobSidecarListener implements RpcResponseListener<BlobSidecarOld> {
 
-  private final Map<UInt64, List<BlobSidecar>> blobSidecarsBySlot = new HashMap<>();
+  private final Map<UInt64, List<BlobSidecarOld>> blobSidecarsBySlot = new HashMap<>();
 
   private final UInt64 startSlot;
   private final UInt64 endSlot;
@@ -36,7 +36,7 @@ public class PeerSyncBlobSidecarListener implements RpcResponseListener<BlobSide
   }
 
   @Override
-  public SafeFuture<?> onResponse(final BlobSidecar blobSidecar) {
+  public SafeFuture<?> onResponse(final BlobSidecarOld blobSidecar) {
     final UInt64 sidecarSlot = blobSidecar.getSlot();
     if (sidecarSlot.isLessThan(startSlot) || sidecarSlot.isGreaterThan(endSlot)) {
       final String exceptionMessage =
@@ -45,13 +45,13 @@ public class PeerSyncBlobSidecarListener implements RpcResponseListener<BlobSide
               sidecarSlot, startSlot, endSlot);
       return SafeFuture.failedFuture(new IllegalArgumentException(exceptionMessage));
     }
-    final List<BlobSidecar> blobSidecars =
+    final List<BlobSidecarOld> blobSidecars =
         blobSidecarsBySlot.computeIfAbsent(sidecarSlot, __ -> new ArrayList<>());
     blobSidecars.add(blobSidecar);
     return SafeFuture.COMPLETE;
   }
 
-  public Optional<List<BlobSidecar>> getReceivedBlobSidecars(final UInt64 slot) {
+  public Optional<List<BlobSidecarOld>> getReceivedBlobSidecars(final UInt64 slot) {
     return Optional.ofNullable(blobSidecarsBySlot.get(slot));
   }
 

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/gossip/blobs/BlobSidecarSubscriber.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/gossip/blobs/BlobSidecarSubscriber.java
@@ -13,9 +13,9 @@
 
 package tech.pegasys.teku.beacon.sync.gossip.blobs;
 
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 
 public interface BlobSidecarSubscriber {
 
-  void onBlobSidecar(BlobSidecar blobSidecar);
+  void onBlobSidecar(BlobSidecarOld blobSidecar);
 }

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/gossip/blobs/RecentBlobSidecarsFetchService.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/gossip/blobs/RecentBlobSidecarsFetchService.java
@@ -24,12 +24,12 @@ import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.subscribers.Subscribers;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BlobIdentifier;
 import tech.pegasys.teku.statetransition.blobs.BlobSidecarPool;
 
 public class RecentBlobSidecarsFetchService
-    extends AbstractFetchService<BlobIdentifier, FetchBlobSidecarTask, BlobSidecar>
+    extends AbstractFetchService<BlobIdentifier, FetchBlobSidecarTask, BlobSidecarOld>
     implements RecentBlobSidecarsFetcher {
 
   private static final Logger LOG = LogManager.getLogger();
@@ -127,7 +127,7 @@ public class RecentBlobSidecarsFetchService
   }
 
   @Override
-  public void processFetchedResult(final FetchBlobSidecarTask task, final BlobSidecar result) {
+  public void processFetchedResult(final FetchBlobSidecarTask task, final BlobSidecarOld result) {
     LOG.trace("Successfully fetched blob sidecar: {}", result);
     blobSidecarSubscribers.forEach(s -> s.onBlobSidecar(result));
     // After retrieved blob sidecar has been processed, stop tracking it

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/historical/HistoricalBatchFetcher.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/historical/HistoricalBatchFetcher.java
@@ -44,7 +44,7 @@ import tech.pegasys.teku.networking.p2p.peer.DisconnectReason;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.constants.Domain;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
@@ -74,7 +74,7 @@ public class HistoricalBatchFetcher {
   private final BlobSidecarManager blobSidecarManager;
   private final SafeFuture<BeaconBlockSummary> future = new SafeFuture<>();
   private final Deque<SignedBeaconBlock> blocksToImport = new ConcurrentLinkedDeque<>();
-  private final Map<SlotAndBlockRoot, List<BlobSidecar>> blobSidecarsBySlotToImport =
+  private final Map<SlotAndBlockRoot, List<BlobSidecarOld>> blobSidecarsBySlotToImport =
       new ConcurrentHashMap<>();
   private Optional<UInt64> maybeEarliestBlobSidecarSlot = Optional.empty();
   private final AtomicInteger requestCount = new AtomicInteger(0);
@@ -247,7 +247,7 @@ public class HistoricalBatchFetcher {
         .thenApply(__ -> shouldRetryBlocksAndBlobSidecarsByRangeRequest());
   }
 
-  private void processBlobSidecar(final BlobSidecar blobSidecar) {
+  private void processBlobSidecar(final BlobSidecarOld blobSidecar) {
     blobSidecarsBySlotToImport
         .computeIfAbsent(blobSidecar.getSlotAndBlockRoot(), __ -> new ArrayList<>())
         .add(blobSidecar);
@@ -399,7 +399,7 @@ public class HistoricalBatchFetcher {
   }
 
   private void validateBlobSidecars(final SignedBeaconBlock block) {
-    final List<BlobSidecar> blobSidecars =
+    final List<BlobSidecarOld> blobSidecars =
         blobSidecarsBySlotToImport.getOrDefault(
             block.getSlotAndBlockRoot(), Collections.emptyList());
     LOG.trace("Validating {} blob sidecars for block {}", blobSidecars.size(), block.getRoot());
@@ -455,7 +455,7 @@ public class HistoricalBatchFetcher {
     private final Bytes32 lastBlockRoot;
     private final Optional<SignedBeaconBlock> previousBlock;
     private final Consumer<SignedBeaconBlock> blockProcessor;
-    private final Consumer<BlobSidecar> blobSidecarProcessor;
+    private final Consumer<BlobSidecarOld> blobSidecarProcessor;
 
     private final AtomicInteger blocksReceived = new AtomicInteger(0);
     private final AtomicBoolean foundLastBlock = new AtomicBoolean(false);
@@ -464,7 +464,7 @@ public class HistoricalBatchFetcher {
         final Bytes32 lastBlockRoot,
         final Optional<SignedBeaconBlock> previousBlock,
         final Consumer<SignedBeaconBlock> blockProcessor,
-        final Consumer<BlobSidecar> blobSidecarProcessor) {
+        final Consumer<BlobSidecarOld> blobSidecarProcessor) {
       this.lastBlockRoot = lastBlockRoot;
       this.previousBlock = previousBlock;
       this.blockProcessor = blockProcessor;
@@ -493,7 +493,7 @@ public class HistoricalBatchFetcher {
           });
     }
 
-    private SafeFuture<?> processBlobSidecar(final BlobSidecar blobSidecar) {
+    private SafeFuture<?> processBlobSidecar(final BlobSidecarOld blobSidecar) {
       blobSidecarProcessor.accept(blobSidecar);
       return SafeFuture.COMPLETE;
     }

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/fetch/FetchBlobSidecarTaskTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/fetch/FetchBlobSidecarTaskTest.java
@@ -21,14 +21,14 @@ import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.beacon.sync.fetch.FetchResult.Status;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BlobIdentifier;
 
 public class FetchBlobSidecarTaskTest extends AbstractFetchTaskTest {
 
   @Test
   public void run_successful() {
-    final BlobSidecar blobSidecar = dataStructureUtil.randomBlobSidecar();
+    final BlobSidecarOld blobSidecar = dataStructureUtil.randomBlobSidecar();
     final BlobIdentifier blobIdentifier =
         new BlobIdentifier(blobSidecar.getBlockRoot(), blobSidecar.getIndex());
     final FetchBlobSidecarTask task = new FetchBlobSidecarTask(eth2P2PNetwork, blobIdentifier);
@@ -38,9 +38,9 @@ public class FetchBlobSidecarTaskTest extends AbstractFetchTaskTest {
     when(peer.requestBlobSidecarByRoot(blobIdentifier))
         .thenReturn(SafeFuture.completedFuture(Optional.of(blobSidecar)));
 
-    final SafeFuture<FetchResult<BlobSidecar>> result = task.run();
+    final SafeFuture<FetchResult<BlobSidecarOld>> result = task.run();
     assertThat(result).isDone();
-    final FetchResult<BlobSidecar> fetchResult = result.getNow(null);
+    final FetchResult<BlobSidecarOld> fetchResult = result.getNow(null);
     assertThat(fetchResult.getPeer()).hasValue(peer);
     assertThat(fetchResult.isSuccessful()).isTrue();
     assertThat(fetchResult.getResult()).hasValue(blobSidecar);
@@ -48,14 +48,14 @@ public class FetchBlobSidecarTaskTest extends AbstractFetchTaskTest {
 
   @Test
   public void run_noPeers() {
-    final BlobSidecar blobSidecar = dataStructureUtil.randomBlobSidecar();
+    final BlobSidecarOld blobSidecar = dataStructureUtil.randomBlobSidecar();
     final BlobIdentifier blobIdentifier =
         new BlobIdentifier(blobSidecar.getBlockRoot(), blobSidecar.getIndex());
     final FetchBlobSidecarTask task = new FetchBlobSidecarTask(eth2P2PNetwork, blobIdentifier);
 
-    final SafeFuture<FetchResult<BlobSidecar>> result = task.run();
+    final SafeFuture<FetchResult<BlobSidecarOld>> result = task.run();
     assertThat(result).isDone();
-    final FetchResult<BlobSidecar> fetchResult = result.getNow(null);
+    final FetchResult<BlobSidecarOld> fetchResult = result.getNow(null);
     assertThat(fetchResult.getPeer()).isEmpty();
     assertThat(fetchResult.isSuccessful()).isFalse();
     assertThat(fetchResult.getStatus()).isEqualTo(Status.NO_AVAILABLE_PEERS);
@@ -63,7 +63,7 @@ public class FetchBlobSidecarTaskTest extends AbstractFetchTaskTest {
 
   @Test
   public void run_failAndRetryWithNoNewPeers() {
-    final BlobSidecar blobSidecar = dataStructureUtil.randomBlobSidecar();
+    final BlobSidecarOld blobSidecar = dataStructureUtil.randomBlobSidecar();
     final BlobIdentifier blobIdentifier =
         new BlobIdentifier(blobSidecar.getBlockRoot(), blobSidecar.getIndex());
     final FetchBlobSidecarTask task = new FetchBlobSidecarTask(eth2P2PNetwork, blobIdentifier);
@@ -72,18 +72,18 @@ public class FetchBlobSidecarTaskTest extends AbstractFetchTaskTest {
     when(peer.requestBlobSidecarByRoot(blobIdentifier))
         .thenReturn(SafeFuture.failedFuture(new RuntimeException("whoops")));
 
-    final SafeFuture<FetchResult<BlobSidecar>> result = task.run();
+    final SafeFuture<FetchResult<BlobSidecarOld>> result = task.run();
     assertThat(result).isDone();
-    final FetchResult<BlobSidecar> fetchResult = result.getNow(null);
+    final FetchResult<BlobSidecarOld> fetchResult = result.getNow(null);
     assertThat(fetchResult.getPeer()).hasValue(peer);
     assertThat(fetchResult.isSuccessful()).isFalse();
     assertThat(fetchResult.getStatus()).isEqualTo(Status.FETCH_FAILED);
     assertThat(task.getNumberOfRetries()).isEqualTo(0);
 
     // Retry
-    final SafeFuture<FetchResult<BlobSidecar>> result2 = task.run();
+    final SafeFuture<FetchResult<BlobSidecarOld>> result2 = task.run();
     assertThat(result).isDone();
-    final FetchResult<BlobSidecar> fetchResult2 = result2.getNow(null);
+    final FetchResult<BlobSidecarOld> fetchResult2 = result2.getNow(null);
     assertThat(fetchResult2.getPeer()).isEmpty();
     assertThat(fetchResult2.isSuccessful()).isFalse();
     assertThat(fetchResult2.getStatus()).isEqualTo(Status.NO_AVAILABLE_PEERS);
@@ -92,7 +92,7 @@ public class FetchBlobSidecarTaskTest extends AbstractFetchTaskTest {
 
   @Test
   public void run_failAndRetryWithNewPeer() {
-    final BlobSidecar blobSidecar = dataStructureUtil.randomBlobSidecar();
+    final BlobSidecarOld blobSidecar = dataStructureUtil.randomBlobSidecar();
     final BlobIdentifier blobIdentifier =
         new BlobIdentifier(blobSidecar.getBlockRoot(), blobSidecar.getIndex());
     final FetchBlobSidecarTask task = new FetchBlobSidecarTask(eth2P2PNetwork, blobIdentifier);
@@ -101,9 +101,9 @@ public class FetchBlobSidecarTaskTest extends AbstractFetchTaskTest {
     when(peer.requestBlobSidecarByRoot(blobIdentifier))
         .thenReturn(SafeFuture.failedFuture(new RuntimeException("whoops")));
 
-    final SafeFuture<FetchResult<BlobSidecar>> result = task.run();
+    final SafeFuture<FetchResult<BlobSidecarOld>> result = task.run();
     assertThat(result).isDone();
-    final FetchResult<BlobSidecar> fetchResult = result.getNow(null);
+    final FetchResult<BlobSidecarOld> fetchResult = result.getNow(null);
     assertThat(fetchResult.getPeer()).hasValue(peer);
     assertThat(fetchResult.isSuccessful()).isFalse();
     assertThat(fetchResult.getStatus()).isEqualTo(Status.FETCH_FAILED);
@@ -115,9 +115,9 @@ public class FetchBlobSidecarTaskTest extends AbstractFetchTaskTest {
         .thenReturn(SafeFuture.completedFuture(Optional.of(blobSidecar)));
 
     // Retry
-    final SafeFuture<FetchResult<BlobSidecar>> result2 = task.run();
+    final SafeFuture<FetchResult<BlobSidecarOld>> result2 = task.run();
     assertThat(result).isDone();
-    final FetchResult<BlobSidecar> fetchResult2 = result2.getNow(null);
+    final FetchResult<BlobSidecarOld> fetchResult2 = result2.getNow(null);
     assertThat(fetchResult2.getPeer()).hasValue(peer2);
     assertThat(fetchResult2.isSuccessful()).isTrue();
     assertThat(fetchResult2.getResult()).hasValue(blobSidecar);
@@ -126,7 +126,7 @@ public class FetchBlobSidecarTaskTest extends AbstractFetchTaskTest {
 
   @Test
   public void run_withMultiplesPeersAvailable() {
-    final BlobSidecar blobSidecar = dataStructureUtil.randomBlobSidecar();
+    final BlobSidecarOld blobSidecar = dataStructureUtil.randomBlobSidecar();
     final BlobIdentifier blobIdentifier =
         new BlobIdentifier(blobSidecar.getBlockRoot(), blobSidecar.getIndex());
     final FetchBlobSidecarTask task = new FetchBlobSidecarTask(eth2P2PNetwork, blobIdentifier);
@@ -142,9 +142,9 @@ public class FetchBlobSidecarTaskTest extends AbstractFetchTaskTest {
     when(peer2.getOutstandingRequests()).thenReturn(0);
 
     // We should choose the peer that is less busy, which successfully returns the blob sidecar
-    final SafeFuture<FetchResult<BlobSidecar>> result = task.run();
+    final SafeFuture<FetchResult<BlobSidecarOld>> result = task.run();
     assertThat(result).isDone();
-    final FetchResult<BlobSidecar> fetchResult = result.getNow(null);
+    final FetchResult<BlobSidecarOld> fetchResult = result.getNow(null);
     assertThat(fetchResult.getPeer()).hasValue(peer2);
     assertThat(fetchResult.isSuccessful()).isTrue();
     assertThat(fetchResult.getResult()).hasValue(blobSidecar);
@@ -153,7 +153,7 @@ public class FetchBlobSidecarTaskTest extends AbstractFetchTaskTest {
   @Test
   public void run_withPreferredPeer() {
     final Eth2Peer preferredPeer = createNewPeer(1);
-    final BlobSidecar blobSidecar = dataStructureUtil.randomBlobSidecar();
+    final BlobSidecarOld blobSidecar = dataStructureUtil.randomBlobSidecar();
     final BlobIdentifier blobIdentifier =
         new BlobIdentifier(blobSidecar.getBlockRoot(), blobSidecar.getIndex());
     when(preferredPeer.requestBlobSidecarByRoot(blobIdentifier))
@@ -165,9 +165,9 @@ public class FetchBlobSidecarTaskTest extends AbstractFetchTaskTest {
     // Add a peer
     registerNewPeer(2);
 
-    final SafeFuture<FetchResult<BlobSidecar>> result = task.run();
+    final SafeFuture<FetchResult<BlobSidecarOld>> result = task.run();
     assertThat(result).isDone();
-    final FetchResult<BlobSidecar> fetchResult = result.getNow(null);
+    final FetchResult<BlobSidecarOld> fetchResult = result.getNow(null);
     assertThat(fetchResult.getPeer()).hasValue(preferredPeer);
     assertThat(fetchResult.isSuccessful()).isTrue();
     assertThat(fetchResult.getResult()).hasValue(blobSidecar);
@@ -176,7 +176,7 @@ public class FetchBlobSidecarTaskTest extends AbstractFetchTaskTest {
   @Test
   public void run_withRandomPeerWhenFetchingWithPreferredPeerFails() {
     final Eth2Peer preferredPeer = createNewPeer(1);
-    final BlobSidecar blobSidecar = dataStructureUtil.randomBlobSidecar();
+    final BlobSidecarOld blobSidecar = dataStructureUtil.randomBlobSidecar();
     final BlobIdentifier blobIdentifier =
         new BlobIdentifier(blobSidecar.getBlockRoot(), blobSidecar.getIndex());
     when(preferredPeer.requestBlobSidecarByRoot(blobIdentifier))
@@ -185,9 +185,9 @@ public class FetchBlobSidecarTaskTest extends AbstractFetchTaskTest {
     final FetchBlobSidecarTask task =
         new FetchBlobSidecarTask(eth2P2PNetwork, Optional.of(preferredPeer), blobIdentifier);
 
-    final SafeFuture<FetchResult<BlobSidecar>> result = task.run();
+    final SafeFuture<FetchResult<BlobSidecarOld>> result = task.run();
     assertThat(result).isDone();
-    final FetchResult<BlobSidecar> fetchResult = result.getNow(null);
+    final FetchResult<BlobSidecarOld> fetchResult = result.getNow(null);
     assertThat(fetchResult.getPeer()).hasValue(preferredPeer);
     assertThat(fetchResult.isSuccessful()).isFalse();
     assertThat(fetchResult.getStatus()).isEqualTo(Status.FETCH_FAILED);
@@ -199,9 +199,9 @@ public class FetchBlobSidecarTaskTest extends AbstractFetchTaskTest {
         .thenReturn(SafeFuture.completedFuture(Optional.of(blobSidecar)));
 
     // Retry
-    final SafeFuture<FetchResult<BlobSidecar>> result2 = task.run();
+    final SafeFuture<FetchResult<BlobSidecarOld>> result2 = task.run();
     assertThat(result).isDone();
-    final FetchResult<BlobSidecar> fetchResult2 = result2.getNow(null);
+    final FetchResult<BlobSidecarOld> fetchResult2 = result2.getNow(null);
     assertThat(fetchResult2.getPeer()).hasValue(peer);
     assertThat(fetchResult2.isSuccessful()).isTrue();
     assertThat(fetchResult2.getResult()).hasValue(blobSidecar);
@@ -210,7 +210,7 @@ public class FetchBlobSidecarTaskTest extends AbstractFetchTaskTest {
 
   @Test
   public void cancel() {
-    final BlobSidecar blobSidecar = dataStructureUtil.randomBlobSidecar();
+    final BlobSidecarOld blobSidecar = dataStructureUtil.randomBlobSidecar();
     final BlobIdentifier blobIdentifier =
         new BlobIdentifier(blobSidecar.getBlockRoot(), blobSidecar.getIndex());
     final FetchBlobSidecarTask task = new FetchBlobSidecarTask(eth2P2PNetwork, blobIdentifier);
@@ -220,9 +220,9 @@ public class FetchBlobSidecarTaskTest extends AbstractFetchTaskTest {
         .thenReturn(SafeFuture.completedFuture(Optional.of(blobSidecar)));
 
     task.cancel();
-    final SafeFuture<FetchResult<BlobSidecar>> result = task.run();
+    final SafeFuture<FetchResult<BlobSidecarOld>> result = task.run();
     assertThat(result).isDone();
-    final FetchResult<BlobSidecar> fetchResult = result.getNow(null);
+    final FetchResult<BlobSidecarOld> fetchResult = result.getNow(null);
     assertThat(fetchResult.getPeer()).isEmpty();
     assertThat(fetchResult.isSuccessful()).isFalse();
     assertThat(fetchResult.getStatus()).isEqualTo(Status.CANCELLED);

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/BatchImporterTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/BatchImporterTest.java
@@ -38,7 +38,7 @@ import tech.pegasys.teku.networking.eth2.peers.SyncSource;
 import tech.pegasys.teku.networking.p2p.peer.DisconnectReason;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
@@ -107,14 +107,14 @@ class BatchImporterTest {
     final SignedBeaconBlock block1 = dataStructureUtil.randomSignedBeaconBlock(1);
     final SignedBeaconBlock block2 = dataStructureUtil.randomSignedBeaconBlock(2);
 
-    final List<BlobSidecar> blobSidecars1 = dataStructureUtil.randomBlobSidecarsForBlock(block1);
-    final List<BlobSidecar> blobSidecars2 = dataStructureUtil.randomBlobSidecarsForBlock(block2);
+    final List<BlobSidecarOld> blobSidecars1 = dataStructureUtil.randomBlobSidecarsForBlock(block1);
+    final List<BlobSidecarOld> blobSidecars2 = dataStructureUtil.randomBlobSidecarsForBlock(block2);
 
     final SafeFuture<BlockImportResult> importResult1 = new SafeFuture<>();
     final SafeFuture<BlockImportResult> importResult2 = new SafeFuture<>();
 
     final List<SignedBeaconBlock> blocks = new ArrayList<>(List.of(block1, block2));
-    final Map<Bytes32, List<BlobSidecar>> blobSidecars =
+    final Map<Bytes32, List<BlobSidecarOld>> blobSidecars =
         Map.of(block1.getRoot(), blobSidecars1, block2.getRoot(), blobSidecars2);
 
     when(batch.getBlocks()).thenReturn(blocks);
@@ -249,7 +249,7 @@ class BatchImporterTest {
   }
 
   private void blobSidecarsImportedSuccessfully(
-      final SignedBeaconBlock block, final List<BlobSidecar> blobSidecars) {
+      final SignedBeaconBlock block, final List<BlobSidecarOld> blobSidecars) {
     verify(blobSidecarPool).onCompletedBlockAndBlobSidecars(block, blobSidecars);
     verifyNoMoreInteractions(blobSidecarPool);
   }

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/SyncSourceBatchTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/batches/SyncSourceBatchTest.java
@@ -44,7 +44,7 @@ import tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.BlocksByRangeRe
 import tech.pegasys.teku.networking.p2p.peer.PeerDisconnectedException;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.deneb.BeaconBlockBodyDeneb;
@@ -146,7 +146,7 @@ public class SyncSourceBatchTest {
 
     // only receiving last block (70 + 50 - 1)
     final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(119);
-    final List<BlobSidecar> blobSidecars = dataStructureUtil.randomBlobSidecarsForBlock(block);
+    final List<BlobSidecarOld> blobSidecars = dataStructureUtil.randomBlobSidecarsForBlock(block);
 
     receiveBlocks(batch, block);
     receiveBlobSidecars(batch, blobSidecars);
@@ -240,7 +240,7 @@ public class SyncSourceBatchTest {
 
     final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(19);
 
-    final List<BlobSidecar> blobSidecars =
+    final List<BlobSidecarOld> blobSidecars =
         new ArrayList<>(dataStructureUtil.randomBlobSidecarsForBlock(block));
     // receiving more sidecars than expected
     blobSidecars.add(
@@ -266,7 +266,7 @@ public class SyncSourceBatchTest {
     final int numberOfKzgCommitments =
         BeaconBlockBodyDeneb.required(block.getMessage().getBody()).getBlobKzgCommitments().size();
     // receiving sidecars with different slot than the block
-    final List<BlobSidecar> blobSidecars =
+    final List<BlobSidecarOld> blobSidecars =
         IntStream.range(0, numberOfKzgCommitments)
             .mapToObj(
                 index ->
@@ -294,8 +294,8 @@ public class SyncSourceBatchTest {
 
     final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(19);
 
-    final List<BlobSidecar> blobSidecars = dataStructureUtil.randomBlobSidecarsForBlock(block);
-    final List<BlobSidecar> unexpectedBlobSidecars = new ArrayList<>(blobSidecars);
+    final List<BlobSidecarOld> blobSidecars = dataStructureUtil.randomBlobSidecarsForBlock(block);
+    final List<BlobSidecarOld> unexpectedBlobSidecars = new ArrayList<>(blobSidecars);
     // receiving sidecars with unknown roots
     unexpectedBlobSidecars.addAll(
         dataStructureUtil.randomBlobSidecarsForBlock(
@@ -363,8 +363,8 @@ public class SyncSourceBatchTest {
     getSyncSource(batch).receiveBlocks(blocks);
   }
 
-  protected void receiveBlobSidecars(final Batch batch, final List<BlobSidecar> blobSidecars) {
-    getSyncSource(batch).receiveBlobSidecars(blobSidecars.toArray(new BlobSidecar[] {}));
+  protected void receiveBlobSidecars(final Batch batch, final List<BlobSidecarOld> blobSidecars) {
+    getSyncSource(batch).receiveBlobSidecars(blobSidecars.toArray(new BlobSidecarOld[] {}));
   }
 
   protected void requestError(final Batch batch, final Throwable error) {

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/chains/ThrottlingSyncSourceTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/chains/ThrottlingSyncSourceTest.java
@@ -29,7 +29,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.peers.SyncSource;
 import tech.pegasys.teku.networking.p2p.peer.DisconnectReason;
 import tech.pegasys.teku.networking.p2p.rpc.RpcResponseListener;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 
 class ThrottlingSyncSourceTest {
@@ -45,7 +45,7 @@ class ThrottlingSyncSourceTest {
       mock(RpcResponseListener.class);
 
   @SuppressWarnings("unchecked")
-  private final RpcResponseListener<BlobSidecar> blobSidecarsListener =
+  private final RpcResponseListener<BlobSidecarOld> blobSidecarsListener =
       mock(RpcResponseListener.class);
 
   private final ThrottlingSyncSource source =

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/singlepeer/AbstractSyncTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/singlepeer/AbstractSyncTest.java
@@ -36,7 +36,7 @@ import tech.pegasys.teku.networking.eth2.peers.PeerStatus;
 import tech.pegasys.teku.networking.p2p.rpc.RpcResponseListener;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.StatusMessage;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
@@ -69,7 +69,7 @@ public abstract class AbstractSyncTest {
       blockResponseListenerArgumentCaptor = ArgumentCaptor.forClass(RpcResponseListener.class);
 
   @SuppressWarnings("unchecked")
-  protected final ArgumentCaptor<RpcResponseListener<BlobSidecar>>
+  protected final ArgumentCaptor<RpcResponseListener<BlobSidecarOld>>
       blobSidecarResponseListenerArgumentCaptor =
           ArgumentCaptor.forClass(RpcResponseListener.class);
 
@@ -93,15 +93,15 @@ public abstract class AbstractSyncTest {
     asyncRunner.executeQueuedActions();
   }
 
-  protected Map<UInt64, List<BlobSidecar>> completeRequestWithBlobSidecarsAtSlots(
+  protected Map<UInt64, List<BlobSidecarOld>> completeRequestWithBlobSidecarsAtSlots(
       final SafeFuture<Void> request, final UInt64 startSlot, final UInt64 count) {
     // Capture latest response listener
     verify(peer, atLeastOnce())
         .requestBlobSidecarsByRange(
             any(), any(), blobSidecarResponseListenerArgumentCaptor.capture());
-    final RpcResponseListener<BlobSidecar> responseListener =
+    final RpcResponseListener<BlobSidecarOld> responseListener =
         blobSidecarResponseListenerArgumentCaptor.getValue();
-    final Map<UInt64, List<BlobSidecar>> blobSidecarsBySlot =
+    final Map<UInt64, List<BlobSidecarOld>> blobSidecarsBySlot =
         respondWithBlobSidecarsAtSlots(request, responseListener, startSlot, count);
     request.complete(null);
     asyncRunner.executeQueuedActions();
@@ -129,22 +129,22 @@ public abstract class AbstractSyncTest {
     return blocks;
   }
 
-  protected Map<UInt64, List<BlobSidecar>> respondWithBlobSidecarsAtSlots(
+  protected Map<UInt64, List<BlobSidecarOld>> respondWithBlobSidecarsAtSlots(
       final SafeFuture<Void> request,
-      final RpcResponseListener<BlobSidecar> responseListener,
+      final RpcResponseListener<BlobSidecarOld> responseListener,
       final UInt64 startSlot,
       final UInt64 count) {
     return respondWithBlobSidecarsAtSlots(
         request, responseListener, getSlotsRange(startSlot, count));
   }
 
-  protected Map<UInt64, List<BlobSidecar>> respondWithBlobSidecarsAtSlots(
+  protected Map<UInt64, List<BlobSidecarOld>> respondWithBlobSidecarsAtSlots(
       final SafeFuture<Void> request,
-      final RpcResponseListener<BlobSidecar> responseListener,
+      final RpcResponseListener<BlobSidecarOld> responseListener,
       final UInt64... slots) {
-    final Map<UInt64, List<BlobSidecar>> blobSidecarsBySlot = new HashMap<>();
+    final Map<UInt64, List<BlobSidecarOld>> blobSidecarsBySlot = new HashMap<>();
     for (final UInt64 slot : slots) {
-      final BlobSidecar blobSidecar =
+      final BlobSidecarOld blobSidecar =
           dataStructureUtil.createRandomBlobSidecarBuilder().slot(slot).build();
       blobSidecarsBySlot.computeIfAbsent(slot, __ -> new ArrayList<>()).add(blobSidecar);
       responseListener.onResponse(blobSidecar).propagateExceptionTo(request);

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/singlepeer/PeerSyncTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/singlepeer/PeerSyncTest.java
@@ -46,7 +46,7 @@ import tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.BlocksByRangeRe
 import tech.pegasys.teku.networking.eth2.rpc.core.RpcException.DecompressFailedException;
 import tech.pegasys.teku.networking.p2p.peer.DisconnectReason;
 import tech.pegasys.teku.networking.p2p.rpc.RpcResponseListener;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.StatusMessage;
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.StateTransitionException;
@@ -534,7 +534,7 @@ public class PeerSyncTest extends AbstractSyncTest {
 
     verify(peer).requestBlobSidecarsByRange(eq(denebSecondSlot), eq(denebPeerSlotsAhead), any());
 
-    final Map<UInt64, List<BlobSidecar>> blobSidecarsBySlot =
+    final Map<UInt64, List<BlobSidecarOld>> blobSidecarsBySlot =
         completeRequestWithBlobSidecarsAtSlots(
             blobSidecarsRequestFuture, denebSecondSlot, denebPeerSlotsAhead);
 
@@ -552,7 +552,7 @@ public class PeerSyncTest extends AbstractSyncTest {
   private void verifyBlobSidecarsAddedToPool(
       final UInt64 startSlot,
       final UInt64 count,
-      final Map<UInt64, List<BlobSidecar>> blobSidecarsBySlot) {
+      final Map<UInt64, List<BlobSidecarOld>> blobSidecarsBySlot) {
     for (UInt64 slot : getSlotsRange(startSlot, count)) {
       if (!blobSidecarsBySlot.containsKey(slot)) {
         Assertions.fail("Blob sidecars for slot %s is missing", slot);

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/gossip/blobs/RecentBlobSidecarsFetchServiceTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/gossip/blobs/RecentBlobSidecarsFetchServiceTest.java
@@ -40,7 +40,7 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BlobIdentifier;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.blobs.BlobSidecarPool;
@@ -62,8 +62,8 @@ class RecentBlobSidecarsFetchServiceTest {
   private final StubAsyncRunner asyncRunner = new StubAsyncRunner();
 
   private final List<FetchBlobSidecarTask> tasks = new ArrayList<>();
-  private final List<SafeFuture<FetchResult<BlobSidecar>>> taskFutures = new ArrayList<>();
-  private final List<BlobSidecar> importedBlobSidecars = new ArrayList<>();
+  private final List<SafeFuture<FetchResult<BlobSidecarOld>>> taskFutures = new ArrayList<>();
+  private final List<BlobSidecarOld> importedBlobSidecars = new ArrayList<>();
 
   private RecentBlobSidecarsFetchService recentBlobSidecarsFetcher;
 
@@ -88,8 +88,8 @@ class RecentBlobSidecarsFetchServiceTest {
     assertTaskCounts(1, 1, 0);
     assertThat(importedBlobSidecars).isEmpty();
 
-    final SafeFuture<FetchResult<BlobSidecar>> future = taskFutures.get(0);
-    final BlobSidecar blobSidecar = dataStructureUtil.randomBlobSidecar(blobIdentifier);
+    final SafeFuture<FetchResult<BlobSidecarOld>> future = taskFutures.get(0);
+    final BlobSidecarOld blobSidecar = dataStructureUtil.randomBlobSidecar(blobIdentifier);
     future.complete(FetchResult.createSuccessful(blobSidecar));
 
     assertThat(importedBlobSidecars).containsExactly(blobSidecar);
@@ -106,8 +106,8 @@ class RecentBlobSidecarsFetchServiceTest {
     assertTaskCounts(1, 1, 0);
     assertThat(importedBlobSidecars).isEmpty();
 
-    final SafeFuture<FetchResult<BlobSidecar>> future = taskFutures.get(0);
-    final BlobSidecar blobSidecar = dataStructureUtil.randomBlobSidecar(blobIdentifier);
+    final SafeFuture<FetchResult<BlobSidecarOld>> future = taskFutures.get(0);
+    final BlobSidecarOld blobSidecar = dataStructureUtil.randomBlobSidecar(blobIdentifier);
     future.complete(FetchResult.createSuccessful(blobSidecar));
 
     assertThat(importedBlobSidecars).containsExactly(blobSidecar);
@@ -147,7 +147,7 @@ class RecentBlobSidecarsFetchServiceTest {
     assertTaskCounts(1, 1, 0);
     assertThat(importedBlobSidecars).isEmpty();
 
-    final SafeFuture<FetchResult<BlobSidecar>> future = taskFutures.get(0);
+    final SafeFuture<FetchResult<BlobSidecarOld>> future = taskFutures.get(0);
     future.complete(FetchResult.createFailed(Status.FETCH_FAILED));
 
     // Task should be queued for a retry via the scheduled executor
@@ -169,7 +169,7 @@ class RecentBlobSidecarsFetchServiceTest {
     assertTaskCounts(1, 1, 0);
     assertThat(importedBlobSidecars).isEmpty();
 
-    final SafeFuture<FetchResult<BlobSidecar>> future = taskFutures.get(0);
+    final SafeFuture<FetchResult<BlobSidecarOld>> future = taskFutures.get(0);
     future.complete(FetchResult.createFailed(Status.FETCH_FAILED));
 
     // Task should be queued for a retry via the scheduled executor
@@ -196,7 +196,7 @@ class RecentBlobSidecarsFetchServiceTest {
     assertTaskCounts(1, 1, 0);
     assertThat(importedBlobSidecars).isEmpty();
 
-    final SafeFuture<FetchResult<BlobSidecar>> future = taskFutures.get(0);
+    final SafeFuture<FetchResult<BlobSidecarOld>> future = taskFutures.get(0);
     future.complete(FetchResult.createFailed(Status.NO_AVAILABLE_PEERS));
 
     // Task should be queued for a retry via the scheduled executor
@@ -221,8 +221,8 @@ class RecentBlobSidecarsFetchServiceTest {
     assertTaskCounts(taskCount, taskCount - 1, 1);
 
     // Complete first task
-    final SafeFuture<FetchResult<BlobSidecar>> future = taskFutures.get(0);
-    final BlobSidecar blobSidecar = dataStructureUtil.randomBlobSidecar();
+    final SafeFuture<FetchResult<BlobSidecarOld>> future = taskFutures.get(0);
+    final BlobSidecarOld blobSidecar = dataStructureUtil.randomBlobSidecar();
     future.complete(FetchResult.createSuccessful(blobSidecar));
 
     // After first task completes, remaining pending count should become active
@@ -263,7 +263,7 @@ class RecentBlobSidecarsFetchServiceTest {
 
     lenient().when(task.getKey()).thenReturn(blobIdentifier);
     lenient().when(task.getNumberOfRetries()).thenReturn(0);
-    final SafeFuture<FetchResult<BlobSidecar>> future = new SafeFuture<>();
+    final SafeFuture<FetchResult<BlobSidecarOld>> future = new SafeFuture<>();
     lenient().when(task.run()).thenReturn(future);
     taskFutures.add(future);
     tasks.add(task);

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/historical/HistoricalBatchFetcherTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/historical/HistoricalBatchFetcherTest.java
@@ -41,7 +41,7 @@ import tech.pegasys.teku.networking.eth2.peers.RespondingEth2Peer;
 import tech.pegasys.teku.networking.eth2.rpc.core.InvalidResponseException;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
@@ -73,7 +73,7 @@ public class HistoricalBatchFetcherTest {
       ArgumentCaptor.forClass(Collection.class);
 
   @SuppressWarnings("unchecked")
-  private final ArgumentCaptor<Map<SlotAndBlockRoot, List<BlobSidecar>>> blobSidecarCaptor =
+  private final ArgumentCaptor<Map<SlotAndBlockRoot, List<BlobSidecarOld>>> blobSidecarCaptor =
       ArgumentCaptor.forClass(Map.class);
 
   @SuppressWarnings("unchecked")
@@ -84,7 +84,7 @@ public class HistoricalBatchFetcherTest {
 
   private final int maxRequests = 5;
   private List<SignedBeaconBlock> blockBatch;
-  private Map<SlotAndBlockRoot, List<BlobSidecar>> blobSidecarsBatch;
+  private Map<SlotAndBlockRoot, List<BlobSidecarOld>> blobSidecarsBatch;
   private SignedBeaconBlock firstBlockInBatch;
   private SignedBeaconBlock lastBlockInBatch;
   private HistoricalBatchFetcher fetcher;
@@ -332,7 +332,7 @@ public class HistoricalBatchFetcherTest {
             blobSidecarCaptor.capture(),
             earliestBlobSidecarSlotCaptor.capture());
     assertThat(blockCaptor.getValue()).containsExactly(lastBlockInBatch);
-    final Map<SlotAndBlockRoot, List<BlobSidecar>> blobSidecars = blobSidecarCaptor.getValue();
+    final Map<SlotAndBlockRoot, List<BlobSidecarOld>> blobSidecars = blobSidecarCaptor.getValue();
     if (blobSidecarsRequired) {
       assertThat(blobSidecars).isEmpty();
       // start slot is in availability window, it's the earliest known blob sidecar slot

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactoryDeneb.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactoryDeneb.java
@@ -24,9 +24,9 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlindedBlobSidecar;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlindedBlobSidecar;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockContainer;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
@@ -123,7 +123,7 @@ public class BlockFactoryDeneb extends BlockFactoryPhase0 {
   }
 
   private BlockContents createBlockContents(
-      final BeaconBlock block, final List<BlobSidecar> blobSidecars) {
+      final BeaconBlock block, final List<BlobSidecarOld> blobSidecars) {
     return schemaDefinitionsDeneb.getBlockContentsSchema().create(block, blobSidecars);
   }
 
@@ -141,7 +141,7 @@ public class BlockFactoryDeneb extends BlockFactoryPhase0 {
         .thenApply(SignedBlockContainer::getSignedBlock);
   }
 
-  private SafeFuture<List<SignedBlobSidecar>> unblindBlobSidecars(
+  private SafeFuture<List<SignedBlobSidecarOld>> unblindBlobSidecars(
       final SignedBlockContainer blindedBlockContainer) {
     final UInt64 slot = blindedBlockContainer.getSlot();
     final List<SignedBlindedBlobSidecar> blindedBlobSidecars =
@@ -154,7 +154,7 @@ public class BlockFactoryDeneb extends BlockFactoryPhase0 {
   }
 
   private SignedBlockContents createUnblindedSignedBlockContents(
-      final SignedBeaconBlock signedBlock, final List<SignedBlobSidecar> signedBlobSidecars) {
+      final SignedBeaconBlock signedBlock, final List<SignedBlobSidecarOld> signedBlobSidecars) {
     return schemaDefinitionsDeneb
         .getSignedBlockContentsSchema()
         .create(signedBlock, signedBlobSidecars);

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
@@ -31,8 +31,8 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blobs.SignedBlobSidecarsUnblinder;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlindedBlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlindedBlobSidecarSchema;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarSchema;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarSchemaOld;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.Eth1Data;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlockUnblinder;
@@ -370,9 +370,9 @@ public class BlockOperationSelectorFactory {
             });
   }
 
-  public Function<BeaconBlock, SafeFuture<List<BlobSidecar>>> createBlobSidecarsSelector() {
+  public Function<BeaconBlock, SafeFuture<List<BlobSidecarOld>>> createBlobSidecarsSelector() {
     return block -> {
-      final BlobSidecarSchema blobSidecarSchema =
+      final BlobSidecarSchemaOld blobSidecarSchema =
           SchemaDefinitionsDeneb.required(spec.atSlot(block.getSlot()).getSchemaDefinitions())
               .getBlobSidecarSchema();
       return getCachedBlobsBundle(block.getSlot())

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryDenebTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryDenebTest.java
@@ -26,9 +26,9 @@ import tech.pegasys.teku.infrastructure.ssz.primitive.SszBytes32;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlindedBlobSidecar;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlindedBlobSidecar;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.BlindedBlockContainer;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockContainer;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
@@ -65,7 +65,7 @@ public class BlockFactoryDenebTest extends AbstractBlockFactoryTest {
             blobSidecars ->
                 assertThat(blobSidecars)
                     .hasSize(3)
-                    .map(BlobSidecar::getBlob)
+                    .map(BlobSidecarOld::getBlob)
                     .hasSameElementsAs(blobsBundle.getBlobs()));
   }
 
@@ -144,7 +144,7 @@ public class BlockFactoryDenebTest extends AbstractBlockFactoryTest {
         .hasValueSatisfying(
             blobSidecars ->
                 assertThat(blobSidecars)
-                    .map(SignedBlobSidecar::getBlobSidecar)
+                    .map(SignedBlobSidecarOld::getBlobSidecar)
                     .map(
                         blobSidecar ->
                             schemaDefinitions.getBlindedBlobSidecarSchema().create(blobSidecar))

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryTest.java
@@ -38,8 +38,8 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blobs.SignedBlobSidecarsUnblinder;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlindedBlobSidecar;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.Eth1Data;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
@@ -502,7 +502,7 @@ class BlockOperationSelectorFactoryTest {
         dataStructureUtil.randomPayloadExecutionContext(false),
         blobsBundle);
 
-    final List<BlobSidecar> blobSidecars =
+    final List<BlobSidecarOld> blobSidecars =
         safeJoin(factory.createBlobSidecarsSelector().apply(block));
 
     assertThat(blobSidecars)
@@ -827,7 +827,7 @@ class BlockOperationSelectorFactoryTest {
     }
 
     @Override
-    public SafeFuture<List<SignedBlobSidecar>> unblind() {
+    public SafeFuture<List<SignedBlobSidecarOld>> unblind() {
       return null;
     }
   }

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -73,7 +73,7 @@ import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.config.SpecConfigAltair;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockContainer;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
@@ -822,7 +822,7 @@ class ValidatorApiHandlerTest {
     final SignedBlockContents blockContents =
         dataStructureUtil.randomSignedBlockContents(UInt64.valueOf(5));
     final SignedBeaconBlock block = blockContents.getSignedBlock();
-    final List<SignedBlobSidecar> blobSidecars =
+    final List<SignedBlobSidecarOld> blobSidecars =
         blockContents.getSignedBlobSidecars().orElseThrow();
 
     when(blockImportChannel.importBlock(block))
@@ -843,7 +843,7 @@ class ValidatorApiHandlerTest {
     final SignedBlockContents blockContents =
         dataStructureUtil.randomSignedBlockContents(UInt64.valueOf(5));
     final SignedBeaconBlock block = blockContents.getSignedBlock();
-    final List<SignedBlobSidecar> blobSidecars =
+    final List<SignedBlobSidecarOld> blobSidecars =
         blockContents.getSignedBlobSidecars().orElseThrow();
 
     when(blockImportChannel.importBlock(block))
@@ -866,7 +866,7 @@ class ValidatorApiHandlerTest {
     final SignedBlockContents blockContents =
         dataStructureUtil.randomSignedBlockContents(UInt64.valueOf(5));
     final SignedBeaconBlock block = blockContents.getSignedBlock();
-    final List<SignedBlobSidecar> blobSidecars =
+    final List<SignedBlobSidecarOld> blobSidecars =
         blockContents.getSignedBlobSidecars().orElseThrow();
 
     when(blockImportChannel.importBlock(block))

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/tekuv1/beacon/GetAllBlobSidecarsAtSlotIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/tekuv1/beacon/GetAllBlobSidecarsAtSlotIntegrationTest.java
@@ -39,8 +39,8 @@ import tech.pegasys.teku.infrastructure.ssz.schema.SszListSchema;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.config.SpecConfigDeneb;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarSchema;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarSchemaOld;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.generator.ChainBuilder;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsDeneb;
@@ -64,13 +64,13 @@ public class GetAllBlobSidecarsAtSlotIntegrationTest
     final ChainBuilder fork = chainBuilder.fork();
     final SignedBlockAndState nonCanonicalBlock = fork.generateNextBlock(chainUpdater.blockOptions);
 
-    final List<BlobSidecar> nonCanonicalBlobSidecars =
+    final List<BlobSidecarOld> nonCanonicalBlobSidecars =
         fork.getBlobSidecars(nonCanonicalBlock.getRoot());
     chainUpdater.saveBlock(nonCanonicalBlock, nonCanonicalBlobSidecars);
 
     final SignedBlockAndState canonicalBlock =
         chainBuilder.generateNextBlock(1, chainUpdater.blockOptions);
-    final List<BlobSidecar> canonicalBlobSidecars =
+    final List<BlobSidecarOld> canonicalBlobSidecars =
         chainBuilder.getBlobSidecars(canonicalBlock.getRoot());
     chainUpdater.saveBlock(canonicalBlock, canonicalBlobSidecars);
     chainUpdater.updateBestBlock(canonicalBlock);
@@ -83,14 +83,14 @@ public class GetAllBlobSidecarsAtSlotIntegrationTest
 
     assertThat(nonCanonicalBlobSidecarResponse.code()).isEqualTo(SC_OK);
 
-    final List<BlobSidecar> nonCanonicalResult = parseBlobSidecars(nonCanonicalBlobSidecarResponse);
+    final List<BlobSidecarOld> nonCanonicalResult = parseBlobSidecars(nonCanonicalBlobSidecarResponse);
     assertThat(nonCanonicalResult).isEqualTo(nonCanonicalBlobSidecars);
 
     final Response canonicalBlobSidecarResponse = get(canonicalBlock.getSlot());
 
     assertThat(canonicalBlobSidecarResponse.code()).isEqualTo(SC_OK);
 
-    final List<BlobSidecar> canonicalResult = parseBlobSidecars(canonicalBlobSidecarResponse);
+    final List<BlobSidecarOld> canonicalResult = parseBlobSidecars(canonicalBlobSidecarResponse);
     assertThat(canonicalResult).isEqualTo(canonicalBlobSidecars);
   }
 
@@ -105,13 +105,13 @@ public class GetAllBlobSidecarsAtSlotIntegrationTest
     final ChainBuilder fork = chainBuilder.fork();
     final SignedBlockAndState nonCanonicalBlock = fork.generateNextBlock(chainUpdater.blockOptions);
 
-    final List<BlobSidecar> nonCanonicalBlobSidecars =
+    final List<BlobSidecarOld> nonCanonicalBlobSidecars =
         fork.getBlobSidecars(nonCanonicalBlock.getRoot());
     chainUpdater.saveBlock(nonCanonicalBlock, nonCanonicalBlobSidecars);
 
     final SignedBlockAndState canonicalBlock =
         chainBuilder.generateNextBlock(1, chainUpdater.blockOptions);
-    final List<BlobSidecar> canonicalBlobSidecars =
+    final List<BlobSidecarOld> canonicalBlobSidecars =
         chainBuilder.getBlobSidecars(canonicalBlock.getRoot());
     chainUpdater.saveBlock(canonicalBlock, canonicalBlobSidecars);
     chainUpdater.updateBestBlock(canonicalBlock);
@@ -124,7 +124,7 @@ public class GetAllBlobSidecarsAtSlotIntegrationTest
             OCTET_STREAM);
     assertThat(nonCanonicalBlobSidecarResponse.code()).isEqualTo(SC_OK);
 
-    final List<BlobSidecar> nonCanonicalResult =
+    final List<BlobSidecarOld> nonCanonicalResult =
         parseBlobSidecarsFromSsz(nonCanonicalBlobSidecarResponse);
     assertThat(nonCanonicalResult).isEqualTo(nonCanonicalBlobSidecars);
 
@@ -132,7 +132,7 @@ public class GetAllBlobSidecarsAtSlotIntegrationTest
 
     assertThat(canonicalBlobSidecarResponse.code()).isEqualTo(SC_OK);
 
-    final List<BlobSidecar> canonicalResult = parseBlobSidecars(canonicalBlobSidecarResponse);
+    final List<BlobSidecarOld> canonicalResult = parseBlobSidecars(canonicalBlobSidecarResponse);
     assertThat(canonicalResult).isEqualTo(canonicalBlobSidecars);
   }
 
@@ -164,25 +164,25 @@ public class GetAllBlobSidecarsAtSlotIntegrationTest
     return getResponse(GetAllBlobSidecarsAtSlot.ROUTE.replace("{slot}", slot.toString()));
   }
 
-  private List<BlobSidecar> parseBlobSidecars(final Response response) throws IOException {
-    final DeserializableTypeDefinition<BlobSidecar> blobSidecarTypeDefinition =
+  private List<BlobSidecarOld> parseBlobSidecars(final Response response) throws IOException {
+    final DeserializableTypeDefinition<BlobSidecarOld> blobSidecarTypeDefinition =
         SchemaDefinitionsDeneb.required(spec.getGenesisSchemaDefinitions())
             .getBlobSidecarSchema()
             .getJsonTypeDefinition();
-    final DeserializableTypeDefinition<List<BlobSidecar>> jsonTypeDefinition =
+    final DeserializableTypeDefinition<List<BlobSidecarOld>> jsonTypeDefinition =
         SharedApiTypes.withDataWrapper("blobSidecars", listOf(blobSidecarTypeDefinition));
 
-    final List<BlobSidecar> result = JsonUtil.parse(response.body().string(), jsonTypeDefinition);
+    final List<BlobSidecarOld> result = JsonUtil.parse(response.body().string(), jsonTypeDefinition);
     return result;
   }
 
-  private List<BlobSidecar> parseBlobSidecarsFromSsz(final Response response) throws IOException {
-    final BlobSidecarSchema blobSidecarSchema =
+  private List<BlobSidecarOld> parseBlobSidecarsFromSsz(final Response response) throws IOException {
+    final BlobSidecarSchemaOld blobSidecarSchema =
         SchemaDefinitionsDeneb.required(spec.getGenesisSchemaDefinitions()).getBlobSidecarSchema();
-    SszListSchema<BlobSidecar, ? extends SszList<BlobSidecar>> blobSidecarSszListSchema =
+    SszListSchema<BlobSidecarOld, ? extends SszList<BlobSidecarOld>> blobSidecarSszListSchema =
         SszListSchema.create(
             blobSidecarSchema, SpecConfigDeneb.required(specConfig).getMaxBlobsPerBlock());
-    final List<BlobSidecar> result =
+    final List<BlobSidecarOld> result =
         blobSidecarSszListSchema.sszDeserialize(Bytes.of(response.body().bytes())).asList();
 
     return result;

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/tekuv1/beacon/GetAllBlobSidecarsAtSlotIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/tekuv1/beacon/GetAllBlobSidecarsAtSlotIntegrationTest.java
@@ -83,7 +83,8 @@ public class GetAllBlobSidecarsAtSlotIntegrationTest
 
     assertThat(nonCanonicalBlobSidecarResponse.code()).isEqualTo(SC_OK);
 
-    final List<BlobSidecarOld> nonCanonicalResult = parseBlobSidecars(nonCanonicalBlobSidecarResponse);
+    final List<BlobSidecarOld> nonCanonicalResult =
+        parseBlobSidecars(nonCanonicalBlobSidecarResponse);
     assertThat(nonCanonicalResult).isEqualTo(nonCanonicalBlobSidecars);
 
     final Response canonicalBlobSidecarResponse = get(canonicalBlock.getSlot());
@@ -172,11 +173,13 @@ public class GetAllBlobSidecarsAtSlotIntegrationTest
     final DeserializableTypeDefinition<List<BlobSidecarOld>> jsonTypeDefinition =
         SharedApiTypes.withDataWrapper("blobSidecars", listOf(blobSidecarTypeDefinition));
 
-    final List<BlobSidecarOld> result = JsonUtil.parse(response.body().string(), jsonTypeDefinition);
+    final List<BlobSidecarOld> result =
+        JsonUtil.parse(response.body().string(), jsonTypeDefinition);
     return result;
   }
 
-  private List<BlobSidecarOld> parseBlobSidecarsFromSsz(final Response response) throws IOException {
+  private List<BlobSidecarOld> parseBlobSidecarsFromSsz(final Response response)
+      throws IOException {
     final BlobSidecarSchemaOld blobSidecarSchema =
         SchemaDefinitionsDeneb.required(spec.getGenesisSchemaDefinitions()).getBlobSidecarSchema();
     SszListSchema<BlobSidecarOld, ? extends SszList<BlobSidecarOld>> blobSidecarSszListSchema =

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/GetBlobSidecarsIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/GetBlobSidecarsIntegrationTest.java
@@ -39,8 +39,8 @@ import tech.pegasys.teku.infrastructure.ssz.schema.SszListSchema;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.config.SpecConfigDeneb;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarSchema;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarSchemaOld;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.generator.ChainBuilder;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsDeneb;
@@ -62,20 +62,20 @@ public class GetBlobSidecarsIntegrationTest extends AbstractDataBackedRestAPIInt
     final UInt64 targetSlot = UInt64.valueOf(3);
     final SignedBlockAndState lastBlock = chainUpdater.advanceChainUntil(targetSlot);
     chainUpdater.updateBestBlock(lastBlock);
-    final List<BlobSidecar> expected =
+    final List<BlobSidecarOld> expected =
         recentChainData.getBlobSidecars(lastBlock.getSlotAndBlockRoot()).get();
 
     final Response responseAll = get("head");
     assertThat(responseAll.code()).isEqualTo(SC_OK);
 
-    final List<BlobSidecar> actualAll = parseBlobSidecars(responseAll);
+    final List<BlobSidecarOld> actualAll = parseBlobSidecars(responseAll);
     assertThat(actualAll).hasSize(expected.size());
     assertThat(actualAll).isEqualTo(expected);
 
     final Response responseFiltered = get("head", List.of(UInt64.ZERO, UInt64.valueOf(2)));
     assertThat(responseFiltered.code()).isEqualTo(SC_OK);
 
-    final List<BlobSidecar> actualFiltered = parseBlobSidecars(responseFiltered);
+    final List<BlobSidecarOld> actualFiltered = parseBlobSidecars(responseFiltered);
     assertThat(actualFiltered).hasSize(2);
     assertThat(actualFiltered).isEqualTo(List.of(expected.get(0), expected.get(2)));
   }
@@ -89,12 +89,12 @@ public class GetBlobSidecarsIntegrationTest extends AbstractDataBackedRestAPIInt
 
     final Response responseAll = get("head");
     assertThat(responseAll.code()).isEqualTo(SC_OK);
-    final List<BlobSidecar> actualAll = parseBlobSidecars(responseAll);
+    final List<BlobSidecarOld> actualAll = parseBlobSidecars(responseAll);
     assertThat(actualAll).isEmpty();
 
     final Response responseFiltered = get("head", List.of(UInt64.ZERO, UInt64.valueOf(2)));
     assertThat(responseFiltered.code()).isEqualTo(SC_OK);
-    final List<BlobSidecar> actualFiltered = parseBlobSidecars(responseFiltered);
+    final List<BlobSidecarOld> actualFiltered = parseBlobSidecars(responseFiltered);
     assertThat(actualFiltered).isEmpty();
   }
 
@@ -115,13 +115,13 @@ public class GetBlobSidecarsIntegrationTest extends AbstractDataBackedRestAPIInt
     final UInt64 targetSlot = UInt64.valueOf(3);
     final SignedBlockAndState lastBlock = chainUpdater.advanceChainUntil(targetSlot);
     chainUpdater.updateBestBlock(lastBlock);
-    final List<BlobSidecar> expected =
+    final List<BlobSidecarOld> expected =
         recentChainData.getBlobSidecars(lastBlock.getSlotAndBlockRoot()).get();
 
     final Response response = get("head", OCTET_STREAM);
     assertThat(response.code()).isEqualTo(SC_OK);
 
-    final List<BlobSidecar> result = parseBlobSidecarsFromSsz(response);
+    final List<BlobSidecarOld> result = parseBlobSidecarsFromSsz(response);
     assertThat(result).isEqualTo(expected);
   }
 
@@ -135,7 +135,7 @@ public class GetBlobSidecarsIntegrationTest extends AbstractDataBackedRestAPIInt
     final Response response = get("head", OCTET_STREAM);
     assertThat(response.code()).isEqualTo(SC_OK);
 
-    final List<BlobSidecar> result = parseBlobSidecarsFromSsz(response);
+    final List<BlobSidecarOld> result = parseBlobSidecarsFromSsz(response);
     assertThat(result).isEmpty();
   }
 
@@ -149,7 +149,7 @@ public class GetBlobSidecarsIntegrationTest extends AbstractDataBackedRestAPIInt
     final ChainBuilder fork = chainBuilder.fork();
     final SignedBlockAndState nonCanonicalBlock = fork.generateNextBlock(chainUpdater.blockOptions);
 
-    final List<BlobSidecar> nonCanonicalBlobSidecars =
+    final List<BlobSidecarOld> nonCanonicalBlobSidecars =
         fork.getBlobSidecars(nonCanonicalBlock.getRoot());
     chainUpdater.saveBlock(nonCanonicalBlock, nonCanonicalBlobSidecars);
 
@@ -165,7 +165,7 @@ public class GetBlobSidecarsIntegrationTest extends AbstractDataBackedRestAPIInt
 
     assertThat(byRootResponse.code()).isEqualTo(SC_OK);
 
-    final List<BlobSidecar> byRootBlobSidecars = parseBlobSidecars(byRootResponse);
+    final List<BlobSidecarOld> byRootBlobSidecars = parseBlobSidecars(byRootResponse);
     assertThat(byRootBlobSidecars).isEqualTo(nonCanonicalBlobSidecars);
 
     final Response bySlotResponse =
@@ -192,25 +192,25 @@ public class GetBlobSidecarsIntegrationTest extends AbstractDataBackedRestAPIInt
             indices.stream().map(UInt64::toString).collect(Collectors.joining(","))));
   }
 
-  private List<BlobSidecar> parseBlobSidecars(final Response response) throws IOException {
-    final DeserializableTypeDefinition<BlobSidecar> blobSidecarTypeDefinition =
+  private List<BlobSidecarOld> parseBlobSidecars(final Response response) throws IOException {
+    final DeserializableTypeDefinition<BlobSidecarOld> blobSidecarTypeDefinition =
         SchemaDefinitionsDeneb.required(spec.getGenesisSchemaDefinitions())
             .getBlobSidecarSchema()
             .getJsonTypeDefinition();
-    final DeserializableTypeDefinition<List<BlobSidecar>> jsonTypeDefinition =
+    final DeserializableTypeDefinition<List<BlobSidecarOld>> jsonTypeDefinition =
         SharedApiTypes.withDataWrapper("blobSidecars", listOf(blobSidecarTypeDefinition));
 
-    final List<BlobSidecar> result = JsonUtil.parse(response.body().string(), jsonTypeDefinition);
+    final List<BlobSidecarOld> result = JsonUtil.parse(response.body().string(), jsonTypeDefinition);
     return result;
   }
 
-  private List<BlobSidecar> parseBlobSidecarsFromSsz(final Response response) throws IOException {
-    final BlobSidecarSchema blobSidecarSchema =
+  private List<BlobSidecarOld> parseBlobSidecarsFromSsz(final Response response) throws IOException {
+    final BlobSidecarSchemaOld blobSidecarSchema =
         SchemaDefinitionsDeneb.required(spec.getGenesisSchemaDefinitions()).getBlobSidecarSchema();
-    SszListSchema<BlobSidecar, ? extends SszList<BlobSidecar>> blobSidecarSszListSchema =
+    SszListSchema<BlobSidecarOld, ? extends SszList<BlobSidecarOld>> blobSidecarSszListSchema =
         SszListSchema.create(
             blobSidecarSchema, SpecConfigDeneb.required(specConfig).getMaxBlobsPerBlock());
-    final List<BlobSidecar> result =
+    final List<BlobSidecarOld> result =
         blobSidecarSszListSchema.sszDeserialize(Bytes.of(response.body().bytes())).asList();
 
     return result;

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/GetBlobSidecarsIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/beacon/GetBlobSidecarsIntegrationTest.java
@@ -200,11 +200,13 @@ public class GetBlobSidecarsIntegrationTest extends AbstractDataBackedRestAPIInt
     final DeserializableTypeDefinition<List<BlobSidecarOld>> jsonTypeDefinition =
         SharedApiTypes.withDataWrapper("blobSidecars", listOf(blobSidecarTypeDefinition));
 
-    final List<BlobSidecarOld> result = JsonUtil.parse(response.body().string(), jsonTypeDefinition);
+    final List<BlobSidecarOld> result =
+        JsonUtil.parse(response.body().string(), jsonTypeDefinition);
     return result;
   }
 
-  private List<BlobSidecarOld> parseBlobSidecarsFromSsz(final Response response) throws IOException {
+  private List<BlobSidecarOld> parseBlobSidecarsFromSsz(final Response response)
+      throws IOException {
     final BlobSidecarSchemaOld blobSidecarSchema =
         SchemaDefinitionsDeneb.required(spec.getGenesisSchemaDefinitions()).getBlobSidecarSchema();
     SszListSchema<BlobSidecarOld, ? extends SszList<BlobSidecarOld>> blobSidecarSszListSchema =

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/beacon/GetAllBlobSidecarsAtSlot.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/beacon/GetAllBlobSidecarsAtSlot.java
@@ -37,7 +37,7 @@ import tech.pegasys.teku.infrastructure.restapi.openapi.response.OctetStreamResp
 import tech.pegasys.teku.infrastructure.restapi.openapi.response.ResponseContentTypeDefinition;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionCache;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsDeneb;
 
@@ -74,7 +74,7 @@ public class GetAllBlobSidecarsAtSlot extends RestApiEndpoint {
   @Override
   public void handleRequest(RestApiRequest request) throws JsonProcessingException {
     final List<UInt64> indices = request.getQueryParameterList(BLOB_INDICES_PARAMETER);
-    final SafeFuture<Optional<List<BlobSidecar>>> future =
+    final SafeFuture<Optional<List<BlobSidecarOld>>> future =
         chainDataProvider.getAllBlobSidecarsAtSlot(
             request.getPathParameter(SLOT_PARAMETER), indices);
 
@@ -86,20 +86,20 @@ public class GetAllBlobSidecarsAtSlot extends RestApiEndpoint {
                     .orElse(AsyncApiResponse.respondNotFound())));
   }
 
-  private static SerializableTypeDefinition<List<BlobSidecar>> getResponseType(
+  private static SerializableTypeDefinition<List<BlobSidecarOld>> getResponseType(
       final SchemaDefinitionCache schemaCache) {
-    final DeserializableTypeDefinition<BlobSidecar> blobSidecarType =
+    final DeserializableTypeDefinition<BlobSidecarOld> blobSidecarType =
         SchemaDefinitionsDeneb.required(schemaCache.getSchemaDefinition(SpecMilestone.DENEB))
             .getBlobSidecarSchema()
             .getJsonTypeDefinition();
-    return SerializableTypeDefinition.<List<BlobSidecar>>object()
+    return SerializableTypeDefinition.<List<BlobSidecarOld>>object()
         .name("GetAllBlobSidecarsAtSlotResponse")
         .withField("data", listOf(blobSidecarType), Function.identity())
         .build();
   }
 
-  private static ResponseContentTypeDefinition<List<BlobSidecar>> getSszResponseType() {
-    final OctetStreamResponseContentTypeDefinition.OctetStreamSerializer<List<BlobSidecar>>
+  private static ResponseContentTypeDefinition<List<BlobSidecarOld>> getSszResponseType() {
+    final OctetStreamResponseContentTypeDefinition.OctetStreamSerializer<List<BlobSidecarOld>>
         serializer = (data, out) -> data.forEach(blobSidecar -> blobSidecar.sszSerialize(out));
 
     return new OctetStreamResponseContentTypeDefinition<>(serializer, __ -> Collections.emptyMap());

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetBlobSidecars.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetBlobSidecars.java
@@ -37,7 +37,7 @@ import tech.pegasys.teku.infrastructure.restapi.openapi.response.OctetStreamResp
 import tech.pegasys.teku.infrastructure.restapi.openapi.response.ResponseContentTypeDefinition;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionCache;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsDeneb;
 
@@ -75,7 +75,7 @@ public class GetBlobSidecars extends RestApiEndpoint {
   @Override
   public void handleRequest(RestApiRequest request) throws JsonProcessingException {
     final List<UInt64> indices = request.getQueryParameterList(BLOB_INDICES_PARAMETER);
-    final SafeFuture<Optional<List<BlobSidecar>>> future =
+    final SafeFuture<Optional<List<BlobSidecarOld>>> future =
         chainDataProvider.getBlobSidecars(request.getPathParameter(PARAMETER_BLOCK_ID), indices);
 
     request.respondAsync(
@@ -86,20 +86,20 @@ public class GetBlobSidecars extends RestApiEndpoint {
                     .orElse(AsyncApiResponse.respondNotFound())));
   }
 
-  private static SerializableTypeDefinition<List<BlobSidecar>> getResponseType(
+  private static SerializableTypeDefinition<List<BlobSidecarOld>> getResponseType(
       final SchemaDefinitionCache schemaCache) {
-    final DeserializableTypeDefinition<BlobSidecar> blobSidecarType =
+    final DeserializableTypeDefinition<BlobSidecarOld> blobSidecarType =
         SchemaDefinitionsDeneb.required(schemaCache.getSchemaDefinition(SpecMilestone.DENEB))
             .getBlobSidecarSchema()
             .getJsonTypeDefinition();
-    return SerializableTypeDefinition.<List<BlobSidecar>>object()
+    return SerializableTypeDefinition.<List<BlobSidecarOld>>object()
         .name("GetBlobSidecarsResponse")
         .withField("data", listOf(blobSidecarType), Function.identity())
         .build();
   }
 
-  private static ResponseContentTypeDefinition<List<BlobSidecar>> getSszResponseType() {
-    final OctetStreamResponseContentTypeDefinition.OctetStreamSerializer<List<BlobSidecar>>
+  private static ResponseContentTypeDefinition<List<BlobSidecarOld>> getSszResponseType() {
+    final OctetStreamResponseContentTypeDefinition.OctetStreamSerializer<List<BlobSidecarOld>>
         serializer = (data, out) -> data.forEach(blobSidecar -> blobSidecar.sszSerialize(out));
 
     return new OctetStreamResponseContentTypeDefinition<>(serializer, __ -> Collections.emptyMap());

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/BlobSidecarEvent.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/BlobSidecarEvent.java
@@ -24,7 +24,7 @@ import tech.pegasys.teku.infrastructure.json.types.SerializableTypeDefinition;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.kzg.KZGCommitment;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.logic.versions.deneb.types.VersionedHash;
 
 public class BlobSidecarEvent extends Event<BlobSidecarData> {
@@ -50,7 +50,7 @@ public class BlobSidecarEvent extends Event<BlobSidecarData> {
         new BlobSidecarData(blockRoot, index, slot, kzgCommitment, versionedHash));
   }
 
-  public static BlobSidecarEvent create(final Spec spec, final BlobSidecar blobSidecar) {
+  public static BlobSidecarEvent create(final Spec spec, final BlobSidecarOld blobSidecar) {
     return new BlobSidecarEvent(
         blobSidecar.getBlockRoot(),
         blobSidecar.getIndex(),

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManager.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManager.java
@@ -40,7 +40,7 @@ import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.operations.SignedBlsToExecutionChange;
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
@@ -188,7 +188,7 @@ public class EventSubscriptionManager implements ChainHeadChannel, FinalizedChec
     notifySubscribersOfEvent(EventType.block, blockEvent);
   }
 
-  protected void onNewBlobSidecar(final BlobSidecar blobSidecar) {
+  protected void onNewBlobSidecar(final BlobSidecarOld blobSidecar) {
     final BlobSidecarEvent blobSidecarEvent = BlobSidecarEvent.create(spec, blobSidecar);
     notifySubscribersOfEvent(EventType.blob_sidecar, blobSidecarEvent);
   }

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/beacon/GetAllBlobSidecarsAtSlotTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/beacon/GetAllBlobSidecarsAtSlotTest.java
@@ -37,7 +37,7 @@ import tech.pegasys.teku.beaconrestapi.AbstractMigratedBeaconHandlerTest;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class GetAllBlobSidecarsAtSlotTest extends AbstractMigratedBeaconHandlerTest {
@@ -57,7 +57,7 @@ public class GetAllBlobSidecarsAtSlotTest extends AbstractMigratedBeaconHandlerT
 
   @Test
   void shouldReturnAllBlobSidecarsAtSlot() throws JsonProcessingException {
-    final List<BlobSidecar> nonCanonicalBlobSidecars = dataStructureUtil.randomBlobSidecars(4);
+    final List<BlobSidecarOld> nonCanonicalBlobSidecars = dataStructureUtil.randomBlobSidecars(4);
     when(chainDataProvider.getAllBlobSidecarsAtSlot(eq(UInt64.ONE), eq(indices)))
         .thenReturn(SafeFuture.completedFuture(Optional.of(nonCanonicalBlobSidecars)));
 
@@ -84,7 +84,7 @@ public class GetAllBlobSidecarsAtSlotTest extends AbstractMigratedBeaconHandlerT
 
   @Test
   void metadata_shouldHandle200() throws IOException {
-    final List<BlobSidecar> nonCanonicalBlobSidecars = dataStructureUtil.randomBlobSidecars(4);
+    final List<BlobSidecarOld> nonCanonicalBlobSidecars = dataStructureUtil.randomBlobSidecars(4);
 
     final String data = getResponseStringFromMetadata(handler, SC_OK, nonCanonicalBlobSidecars);
     final String expected =

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetBlobSidecarsTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetBlobSidecarsTest.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.beaconrestapi.AbstractMigratedBeaconHandlerWithChainDataProviderTest;
 import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.metadata.ObjectAndMetaData;
 
@@ -52,7 +52,7 @@ class GetBlobSidecarsTest extends AbstractMigratedBeaconHandlerWithChainDataProv
       throws JsonProcessingException, ExecutionException, InterruptedException {
     final ObjectAndMetaData<SignedBeaconBlock> blockAndMetaData =
         chainDataProvider.getBlock("head").get().orElseThrow();
-    final List<BlobSidecar> blobSidecars =
+    final List<BlobSidecarOld> blobSidecars =
         combinedChainDataClient
             .getBlobSidecars(
                 blockAndMetaData.getData().getSlotAndBlockRoot(), Collections.emptyList())
@@ -81,7 +81,7 @@ class GetBlobSidecarsTest extends AbstractMigratedBeaconHandlerWithChainDataProv
 
   @Test
   void metadata_shouldHandle200() throws IOException {
-    final List<BlobSidecar> blobSidecars = dataStructureUtil.randomBlobSidecars(3);
+    final List<BlobSidecarOld> blobSidecars = dataStructureUtil.randomBlobSidecars(3);
 
     final String data = getResponseStringFromMetadata(handler, SC_OK, blobSidecars);
     final String expected =

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManagerTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManagerTest.java
@@ -44,7 +44,7 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.SignedBlsToExecutionChange;
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
@@ -95,7 +95,7 @@ public class EventSubscriptionManagerTest {
   private final SyncState sampleSyncState = SyncState.IN_SYNC;
   private final SignedBeaconBlock sampleBlock =
       SignedBeaconBlock.create(data.randomSignedBeaconBlock(0));
-  private final BlobSidecar sampleBlobSidecar = data.randomBlobSidecar();
+  private final BlobSidecarOld sampleBlobSidecar = data.randomBlobSidecar();
   private final Attestation sampleAttestation = data.randomAttestation(0);
   private final SignedVoluntaryExit sampleVoluntaryExit = data.randomSignedVoluntaryExit();
   private final SignedBlsToExecutionChange sampleBlsToExecutionChange =

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
@@ -58,7 +58,7 @@ import tech.pegasys.teku.infrastructure.ssz.Merkleizable;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.execution.versions.capella.Withdrawal;
@@ -179,14 +179,14 @@ public class ChainDataProvider {
     return fromBlock(blockIdParam, Function.identity());
   }
 
-  public SafeFuture<Optional<List<BlobSidecar>>> getBlobSidecars(
+  public SafeFuture<Optional<List<BlobSidecarOld>>> getBlobSidecars(
       final String blockIdParam, final List<UInt64> indices) {
     return blobSidecarSelectorFactory
         .createSelectorForBlockId(blockIdParam)
         .getBlobSidecars(indices);
   }
 
-  public SafeFuture<Optional<List<BlobSidecar>>> getAllBlobSidecarsAtSlot(
+  public SafeFuture<Optional<List<BlobSidecarOld>>> getAllBlobSidecarsAtSlot(
       final UInt64 slot, final List<UInt64> indices) {
     return blobSidecarSelectorFactory.slotSelectorForAll(slot).getBlobSidecars(indices);
   }

--- a/data/provider/src/main/java/tech/pegasys/teku/api/blobselector/BlobSidecarSelector.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/blobselector/BlobSidecarSelector.java
@@ -17,8 +17,8 @@ import java.util.List;
 import java.util.Optional;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 
 public interface BlobSidecarSelector {
-  SafeFuture<Optional<List<BlobSidecar>>> getBlobSidecars(List<UInt64> indices);
+  SafeFuture<Optional<List<BlobSidecarOld>>> getBlobSidecars(List<UInt64> indices);
 }

--- a/data/provider/src/main/java/tech/pegasys/teku/api/blobselector/BlobSidecarSelectorFactory.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/blobselector/BlobSidecarSelectorFactory.java
@@ -22,7 +22,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.api.AbstractSelectorFactory;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.deneb.BeaconBlockBodyDeneb;
@@ -99,7 +99,7 @@ public class BlobSidecarSelectorFactory extends AbstractSelectorFactory<BlobSide
                     blobSidecars.isEmpty() ? Optional.empty() : Optional.of(blobSidecars));
   }
 
-  private SafeFuture<Optional<List<BlobSidecar>>> getBlobSidecarsForBlock(
+  private SafeFuture<Optional<List<BlobSidecarOld>>> getBlobSidecarsForBlock(
       final Optional<SignedBeaconBlock> maybeBlock, final List<UInt64> indices) {
     if (maybeBlock.isEmpty()) {
       return SafeFuture.completedFuture(Optional.empty());
@@ -116,12 +116,12 @@ public class BlobSidecarSelectorFactory extends AbstractSelectorFactory<BlobSide
     return getBlobSidecars(block.getSlotAndBlockRoot(), indices);
   }
 
-  private SafeFuture<Optional<List<BlobSidecar>>> getBlobSidecars(
+  private SafeFuture<Optional<List<BlobSidecarOld>>> getBlobSidecars(
       final SlotAndBlockRoot slotAndBlockRoot, final List<UInt64> indices) {
     return client.getBlobSidecars(slotAndBlockRoot, indices).thenApply(Optional::of);
   }
 
-  private SafeFuture<Optional<List<BlobSidecar>>> getBlobSidecars(
+  private SafeFuture<Optional<List<BlobSidecarOld>>> getBlobSidecars(
       final UInt64 slot, final List<UInt64> indices) {
     return client.getBlobSidecars(slot, indices).thenApply(Optional::of);
   }

--- a/data/provider/src/test/java/tech/pegasys/teku/api/blobselector/BlobSidecarSelectorFactoryTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/blobselector/BlobSidecarSelectorFactoryTest.java
@@ -35,7 +35,7 @@ import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecContext;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.TestSpecInvocationContextProvider;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
@@ -52,7 +52,7 @@ public class BlobSidecarSelectorFactoryTest {
   private final DataStructureUtil data = new DataStructureUtil(spec);
   private final List<UInt64> indices = List.of(UInt64.ZERO, UInt64.ONE);
   private final SignedBeaconBlock block = data.randomSignedBeaconBlock();
-  private final List<BlobSidecar> blobSidecars = data.randomBlobSidecars(3);
+  private final List<BlobSidecarOld> blobSidecars = data.randomBlobSidecars(3);
 
   private final BlobSidecarSelectorFactory blobSidecarSelectorFactory =
       new BlobSidecarSelectorFactory(client);
@@ -66,7 +66,7 @@ public class BlobSidecarSelectorFactoryTest {
     when(client.getBlobSidecars(blockAndState.getSlotAndBlockRoot(), indices))
         .thenReturn(SafeFuture.completedFuture(blobSidecars));
 
-    final Optional<List<BlobSidecar>> result =
+    final Optional<List<BlobSidecarOld>> result =
         blobSidecarSelectorFactory.headSelector().getBlobSidecars(indices).get();
     assertThat(result).hasValue(blobSidecars);
   }
@@ -80,7 +80,7 @@ public class BlobSidecarSelectorFactoryTest {
     when(client.getBlobSidecars(anchorPoint.getSlotAndBlockRoot(), indices))
         .thenReturn(SafeFuture.completedFuture(blobSidecars));
 
-    final Optional<List<BlobSidecar>> result =
+    final Optional<List<BlobSidecarOld>> result =
         blobSidecarSelectorFactory.finalizedSelector().getBlobSidecars(indices).get();
     assertThat(result).hasValue(blobSidecars);
   }
@@ -93,7 +93,7 @@ public class BlobSidecarSelectorFactoryTest {
     when(client.getBlobSidecars(block.getSlotAndBlockRoot(), indices))
         .thenReturn(SafeFuture.completedFuture(blobSidecars));
 
-    final Optional<List<BlobSidecar>> result =
+    final Optional<List<BlobSidecarOld>> result =
         blobSidecarSelectorFactory.genesisSelector().getBlobSidecars(indices).get();
     assertThat(result).hasValue(blobSidecars);
   }
@@ -107,7 +107,7 @@ public class BlobSidecarSelectorFactoryTest {
     when(client.getBlobSidecars(new SlotAndBlockRoot(finalizedSlot, block.getRoot()), indices))
         .thenReturn(SafeFuture.completedFuture(blobSidecars));
 
-    final Optional<List<BlobSidecar>> result =
+    final Optional<List<BlobSidecarOld>> result =
         blobSidecarSelectorFactory
             .blockRootSelector(block.getRoot())
             .getBlobSidecars(indices)
@@ -125,7 +125,7 @@ public class BlobSidecarSelectorFactoryTest {
     when(client.getBlobSidecars(block.getSlotAndBlockRoot(), indices))
         .thenReturn(SafeFuture.completedFuture(blobSidecars));
 
-    final Optional<List<BlobSidecar>> result =
+    final Optional<List<BlobSidecarOld>> result =
         blobSidecarSelectorFactory
             .blockRootSelector(block.getRoot())
             .getBlobSidecars(indices)
@@ -140,7 +140,7 @@ public class BlobSidecarSelectorFactoryTest {
     when(client.getBlobSidecars(block.getSlot(), indices))
         .thenReturn(SafeFuture.completedFuture(blobSidecars));
 
-    final Optional<List<BlobSidecar>> result =
+    final Optional<List<BlobSidecarOld>> result =
         blobSidecarSelectorFactory.slotSelector(block.getSlot()).getBlobSidecars(indices).get();
     assertThat(result).hasValue(blobSidecars);
   }
@@ -154,7 +154,7 @@ public class BlobSidecarSelectorFactoryTest {
     when(client.getBlobSidecars(block.getSlotAndBlockRoot(), indices))
         .thenReturn(SafeFuture.completedFuture(blobSidecars));
 
-    final Optional<List<BlobSidecar>> result =
+    final Optional<List<BlobSidecarOld>> result =
         blobSidecarSelectorFactory.slotSelector(block.getSlot()).getBlobSidecars(indices).get();
     assertThat(result).hasValue(blobSidecars);
   }
@@ -193,7 +193,7 @@ public class BlobSidecarSelectorFactoryTest {
     when(client.isFinalized(blockWithEmptyCommitments.getSlot())).thenReturn(false);
     when(client.getBlockAtSlotExact(blockWithEmptyCommitments.getSlot()))
         .thenReturn(SafeFuture.completedFuture(Optional.of(blockWithEmptyCommitments)));
-    Optional<List<BlobSidecar>> maybeBlobsidecars =
+    Optional<List<BlobSidecarOld>> maybeBlobsidecars =
         blobSidecarSelectorFactory
             .slotSelector(blockWithEmptyCommitments.getSlot())
             .getBlobSidecars(indices)

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/deneb/BlindedBlobSidecar.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/deneb/BlindedBlobSidecar.java
@@ -20,7 +20,7 @@ import tech.pegasys.teku.api.schema.KZGProof;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.SpecVersion;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlindedBlobSidecarSchema;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 
 public record BlindedBlobSidecar(
     @JsonProperty("block_root") Bytes32 blockRoot,
@@ -45,7 +45,7 @@ public record BlindedBlobSidecar(
         new KZGProof(sidecar.getKZGProof()));
   }
 
-  public static BlindedBlobSidecar fromInternalBlobSidecar(final BlobSidecar sidecar) {
+  public static BlindedBlobSidecar fromInternalBlobSidecar(final BlobSidecarOld sidecar) {
     return new BlindedBlobSidecar(
         sidecar.getBlockRoot(),
         sidecar.getIndex(),

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/StubBlobSidecarManager.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/StubBlobSidecarManager.java
@@ -55,7 +55,7 @@ class StubBlobSidecarManager implements BlobSidecarManager {
 
   @Override
   public SafeFuture<InternalValidationResult> validateAndPrepareForBlockImport(
-          final SignedBlobSidecarOld signedBlobSidecar, final Optional<UInt64> arrivalTimestamp) {
+      final SignedBlobSidecarOld signedBlobSidecar, final Optional<UInt64> arrivalTimestamp) {
     return SafeFuture.failedFuture(
         new UnsupportedOperationException("Not available in fork choice reference tests"));
   }

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/StubBlobSidecarManager.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/StubBlobSidecarManager.java
@@ -26,8 +26,8 @@ import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.kzg.KZGCommitment;
 import tech.pegasys.teku.kzg.KZGProof;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.Blob;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.deneb.BeaconBlockBodyDeneb;
 import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
@@ -55,13 +55,13 @@ class StubBlobSidecarManager implements BlobSidecarManager {
 
   @Override
   public SafeFuture<InternalValidationResult> validateAndPrepareForBlockImport(
-      final SignedBlobSidecar signedBlobSidecar, final Optional<UInt64> arrivalTimestamp) {
+          final SignedBlobSidecarOld signedBlobSidecar, final Optional<UInt64> arrivalTimestamp) {
     return SafeFuture.failedFuture(
         new UnsupportedOperationException("Not available in fork choice reference tests"));
   }
 
   @Override
-  public void prepareForBlockImport(final BlobSidecar blobSidecar) {
+  public void prepareForBlockImport(final BlobSidecarOld blobSidecar) {
     // NOOP
   }
 
@@ -101,7 +101,7 @@ class StubBlobSidecarManager implements BlobSidecarManager {
 
       @Override
       public BlobSidecarsAndValidationResult validateImmediately(
-          final List<BlobSidecar> blobSidecars) {
+          final List<BlobSidecarOld> blobSidecars) {
         throw new UnsupportedOperationException("Not available in fork choice reference tests");
       }
 
@@ -128,7 +128,7 @@ class StubBlobSidecarManager implements BlobSidecarManager {
 
   @Override
   public BlobSidecarsAndValidationResult createAvailabilityCheckerAndValidateImmediately(
-      final SignedBeaconBlock block, final List<BlobSidecar> blobSidecars) {
+      final SignedBeaconBlock block, final List<BlobSidecarOld> blobSidecars) {
     throw new UnsupportedOperationException("Not available in fork choice reference tests");
   }
 

--- a/ethereum/dataproviders/src/main/java/tech/pegasys/teku/dataproviders/lookup/BlobSidecarsProvider.java
+++ b/ethereum/dataproviders/src/main/java/tech/pegasys/teku/dataproviders/lookup/BlobSidecarsProvider.java
@@ -16,16 +16,16 @@ package tech.pegasys.teku.dataproviders.lookup;
 import java.util.Collections;
 import java.util.List;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 
 public interface BlobSidecarsProvider {
   BlobSidecarsProvider NOOP = (block) -> SafeFuture.completedFuture(Collections.emptyList());
 
-  default SafeFuture<List<BlobSidecar>> getBlobSidecars(final SignedBeaconBlock block) {
+  default SafeFuture<List<BlobSidecarOld>> getBlobSidecars(final SignedBeaconBlock block) {
     return getBlobSidecars(block.getSlotAndBlockRoot());
   }
 
-  SafeFuture<List<BlobSidecar>> getBlobSidecars(SlotAndBlockRoot slotAndBlockRoot);
+  SafeFuture<List<BlobSidecarOld>> getBlobSidecars(SlotAndBlockRoot slotAndBlockRoot);
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -53,9 +53,9 @@ import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
 import tech.pegasys.teku.spec.datastructures.blobs.SignedBlobSidecarsUnblinder;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlindedBlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.Blob;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlindedBlobSidecar;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockHeader;
@@ -388,7 +388,7 @@ public class Spec {
         .sszDeserialize(serializedBlobs);
   }
 
-  public BlobSidecar deserializeBlobSidecar(final Bytes serializedBlobSidecar, final UInt64 slot) {
+  public BlobSidecarOld deserializeBlobSidecar(final Bytes serializedBlobSidecar, final UInt64 slot) {
     return atSlot(slot)
         .getSchemaDefinitions()
         .toVersionDeneb()
@@ -441,7 +441,7 @@ public class Spec {
     return atBlock(block).miscHelpers().computeSigningRoot(block, domain);
   }
 
-  public Bytes computeSigningRoot(BlobSidecar blobSidecar, Bytes32 domain) {
+  public Bytes computeSigningRoot(BlobSidecarOld blobSidecar, Bytes32 domain) {
     return atSlot(blobSidecar.getSlot()).miscHelpers().computeSigningRoot(blobSidecar, domain);
   }
 
@@ -755,7 +755,7 @@ public class Spec {
             });
   }
 
-  public SafeFuture<List<SignedBlobSidecar>> unblindSignedBlindedBlobSidecars(
+  public SafeFuture<List<SignedBlobSidecarOld>> unblindSignedBlindedBlobSidecars(
       final UInt64 slot,
       final List<SignedBlindedBlobSidecar> blindedBlobSidecars,
       final Consumer<SignedBlobSidecarsUnblinder> blobSidecarsUnblinderConsumer) {
@@ -969,7 +969,7 @@ public class Spec {
     return getSpecConfigDeneb(slot).map(SpecConfigDeneb::getMaxBlobsPerBlock);
   }
 
-  public UInt64 computeSubnetForBlobSidecar(final SignedBlobSidecar signedBlobSidecar) {
+  public UInt64 computeSubnetForBlobSidecar(final SignedBlobSidecarOld signedBlobSidecar) {
     final SpecConfig config = atSlot(signedBlobSidecar.getSlot()).getConfig();
     final SpecConfigDeneb specConfigDeneb = SpecConfigDeneb.required(config);
     return signedBlobSidecar

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -388,7 +388,8 @@ public class Spec {
         .sszDeserialize(serializedBlobs);
   }
 
-  public BlobSidecarOld deserializeBlobSidecar(final Bytes serializedBlobSidecar, final UInt64 slot) {
+  public BlobSidecarOld deserializeBlobSidecar(
+      final Bytes serializedBlobSidecar, final UInt64 slot) {
     return atSlot(slot)
         .getSchemaDefinitions()
         .toVersionDeneb()

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/SignedBlobSidecarsUnblinder.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/SignedBlobSidecarsUnblinder.java
@@ -16,7 +16,7 @@ package tech.pegasys.teku.spec.datastructures.blobs;
 import java.util.List;
 import java.util.function.Supplier;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.builder.BlobsBundle;
 
 /**
@@ -35,5 +35,5 @@ public interface SignedBlobSidecarsUnblinder {
 
   void setBlobsBundleSupplier(Supplier<SafeFuture<BlobsBundle>> blobsBundleSupplier);
 
-  SafeFuture<List<SignedBlobSidecar>> unblind();
+  SafeFuture<List<SignedBlobSidecarOld>> unblind();
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/versions/deneb/BlindedBlobSidecarSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/versions/deneb/BlindedBlobSidecarSchema.java
@@ -98,7 +98,7 @@ public class BlindedBlobSidecarSchema
         kzgProof);
   }
 
-  public BlindedBlobSidecar create(final BlobSidecar blobSidecar) {
+  public BlindedBlobSidecar create(final BlobSidecarOld blobSidecar) {
     return new BlindedBlobSidecar(
         this,
         blobSidecar.getBlockRoot(),

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/versions/deneb/BlobSidecarOld.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/versions/deneb/BlobSidecarOld.java
@@ -26,9 +26,9 @@ import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.spec.datastructures.type.SszKZGProof;
 
-public class BlobSidecar
+public class BlobSidecarOld
     extends Container8<
-        BlobSidecar,
+        BlobSidecarOld,
         SszBytes32,
         SszUInt64,
         SszUInt64,
@@ -38,12 +38,12 @@ public class BlobSidecar
         SszKZGCommitment,
         SszKZGProof> {
 
-  BlobSidecar(final BlobSidecarSchema blobSidecarSchema, final TreeNode backingTreeNode) {
+  BlobSidecarOld(final BlobSidecarSchemaOld blobSidecarSchema, final TreeNode backingTreeNode) {
     super(blobSidecarSchema, backingTreeNode);
   }
 
-  public BlobSidecar(
-      BlobSidecarSchema schema,
+  public BlobSidecarOld(
+      BlobSidecarSchemaOld schema,
       Bytes32 blockRoot,
       UInt64 index,
       UInt64 slot,

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/versions/deneb/BlobSidecarSchemaOld.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/versions/deneb/BlobSidecarSchemaOld.java
@@ -31,9 +31,9 @@ import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitmentSchema;
 import tech.pegasys.teku.spec.datastructures.type.SszKZGProof;
 import tech.pegasys.teku.spec.datastructures.type.SszKZGProofSchema;
 
-public class BlobSidecarSchema
+public class BlobSidecarSchemaOld
     extends ContainerSchema8<
-        BlobSidecar,
+        BlobSidecarOld,
         SszBytes32,
         SszUInt64,
         SszUInt64,
@@ -45,7 +45,7 @@ public class BlobSidecarSchema
 
   static final SszFieldName FIELD_BLOB = () -> "blob";
 
-  BlobSidecarSchema(final BlobSchema blobSchema) {
+  BlobSidecarSchemaOld(final BlobSchema blobSchema) {
     super(
         "BlobSidecar",
         namedSchema("block_root", SszPrimitiveSchemas.BYTES32_SCHEMA),
@@ -67,7 +67,7 @@ public class BlobSidecarSchema
     return (BlobSchema) getBlobSszSchema();
   }
 
-  public BlobSidecar create(
+  public BlobSidecarOld create(
       final Bytes32 blockRoot,
       final UInt64 index,
       final UInt64 slot,
@@ -87,7 +87,7 @@ public class BlobSidecarSchema
         KZGProof.fromBytesCompressed(kzgProof));
   }
 
-  public BlobSidecar create(
+  public BlobSidecarOld create(
       final Bytes32 blockRoot,
       final UInt64 index,
       final UInt64 slot,
@@ -96,7 +96,7 @@ public class BlobSidecarSchema
       final Blob blob,
       final KZGCommitment kzgCommitment,
       final KZGProof kzgProof) {
-    return new BlobSidecar(
+    return new BlobSidecarOld(
         this,
         blockRoot,
         index,
@@ -108,12 +108,12 @@ public class BlobSidecarSchema
         kzgProof);
   }
 
-  public static BlobSidecarSchema create(final BlobSchema blobSchema) {
-    return new BlobSidecarSchema(blobSchema);
+  public static BlobSidecarSchemaOld create(final BlobSchema blobSchema) {
+    return new BlobSidecarSchemaOld(blobSchema);
   }
 
   @Override
-  public BlobSidecar createFromBackingNode(TreeNode node) {
-    return new BlobSidecar(this, node);
+  public BlobSidecarOld createFromBackingNode(TreeNode node) {
+    return new BlobSidecarOld(this, node);
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/versions/deneb/SignedBlobSidecarOld.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/versions/deneb/SignedBlobSidecarOld.java
@@ -19,24 +19,24 @@ import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.type.SszSignature;
 
-public class SignedBlobSidecar extends Container2<SignedBlobSidecar, BlobSidecar, SszSignature> {
+public class SignedBlobSidecarOld extends Container2<SignedBlobSidecarOld, BlobSidecarOld, SszSignature> {
 
-  SignedBlobSidecar(final SignedBlobSidecarSchema type, final TreeNode backingNode) {
+  SignedBlobSidecarOld(final SignedBlobSidecarSchemaOld type, final TreeNode backingNode) {
     super(type, backingNode);
   }
 
-  public SignedBlobSidecar(
-      final SignedBlobSidecarSchema schema,
-      final BlobSidecar blobSidecar,
+  public SignedBlobSidecarOld(
+      final SignedBlobSidecarSchemaOld schema,
+      final BlobSidecarOld blobSidecar,
       final BLSSignature signature) {
     super(schema, blobSidecar, new SszSignature(signature));
   }
 
-  public BlobSidecar getMessage() {
+  public BlobSidecarOld getMessage() {
     return getField0();
   }
 
-  public BlobSidecar getBlobSidecar() {
+  public BlobSidecarOld getBlobSidecar() {
     return getField0();
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/versions/deneb/SignedBlobSidecarOld.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/versions/deneb/SignedBlobSidecarOld.java
@@ -19,7 +19,8 @@ import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.type.SszSignature;
 
-public class SignedBlobSidecarOld extends Container2<SignedBlobSidecarOld, BlobSidecarOld, SszSignature> {
+public class SignedBlobSidecarOld
+    extends Container2<SignedBlobSidecarOld, BlobSidecarOld, SszSignature> {
 
   SignedBlobSidecarOld(final SignedBlobSidecarSchemaOld type, final TreeNode backingNode) {
     super(type, backingNode);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/versions/deneb/SignedBlobSidecarSchemaOld.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/versions/deneb/SignedBlobSidecarSchemaOld.java
@@ -20,26 +20,26 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlockFields;
 import tech.pegasys.teku.spec.datastructures.type.SszSignature;
 import tech.pegasys.teku.spec.datastructures.type.SszSignatureSchema;
 
-public class SignedBlobSidecarSchema
-    extends ContainerSchema2<SignedBlobSidecar, BlobSidecar, SszSignature> {
+public class SignedBlobSidecarSchemaOld
+    extends ContainerSchema2<SignedBlobSidecarOld, BlobSidecarOld, SszSignature> {
 
-  SignedBlobSidecarSchema(final BlobSidecarSchema blobSidecarSchema) {
+  SignedBlobSidecarSchemaOld(final BlobSidecarSchemaOld blobSidecarSchema) {
     super(
         "SignedBlobSidecar",
         namedSchema("message", blobSidecarSchema),
         namedSchema(SignedBeaconBlockFields.SIGNATURE, SszSignatureSchema.INSTANCE));
   }
 
-  public static SignedBlobSidecarSchema create(final BlobSidecarSchema blobSidecarSchema) {
-    return new SignedBlobSidecarSchema(blobSidecarSchema);
+  public static SignedBlobSidecarSchemaOld create(final BlobSidecarSchemaOld blobSidecarSchema) {
+    return new SignedBlobSidecarSchemaOld(blobSidecarSchema);
   }
 
-  public SignedBlobSidecar create(final BlobSidecar blobSidecar, final BLSSignature signature) {
-    return new SignedBlobSidecar(this, blobSidecar, signature);
+  public SignedBlobSidecarOld create(final BlobSidecarOld blobSidecar, final BLSSignature signature) {
+    return new SignedBlobSidecarOld(this, blobSidecar, signature);
   }
 
   @Override
-  public SignedBlobSidecar createFromBackingNode(final TreeNode node) {
-    return new SignedBlobSidecar(this, node);
+  public SignedBlobSidecarOld createFromBackingNode(final TreeNode node) {
+    return new SignedBlobSidecarOld(this, node);
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/versions/deneb/SignedBlobSidecarSchemaOld.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/versions/deneb/SignedBlobSidecarSchemaOld.java
@@ -34,7 +34,8 @@ public class SignedBlobSidecarSchemaOld
     return new SignedBlobSidecarSchemaOld(blobSidecarSchema);
   }
 
-  public SignedBlobSidecarOld create(final BlobSidecarOld blobSidecar, final BLSSignature signature) {
+  public SignedBlobSidecarOld create(
+      final BlobSidecarOld blobSidecar, final BLSSignature signature) {
     return new SignedBlobSidecarOld(this, blobSidecar, signature);
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/versions/deneb/SignedBlobSidecarsUnblinderDeneb.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/versions/deneb/SignedBlobSidecarsUnblinderDeneb.java
@@ -24,8 +24,8 @@ import tech.pegasys.teku.spec.schemas.SchemaDefinitionsDeneb;
 
 public class SignedBlobSidecarsUnblinderDeneb implements SignedBlobSidecarsUnblinder {
 
-  private final BlobSidecarSchema blobSidecarSchema;
-  private final SignedBlobSidecarSchema signedBlobSidecarSchema;
+  private final BlobSidecarSchemaOld blobSidecarSchema;
+  private final SignedBlobSidecarSchemaOld signedBlobSidecarSchema;
   private final List<SignedBlindedBlobSidecar> signedBlindedBlobSidecars;
 
   private volatile SafeFuture<BlobsBundle> blobsBundleFuture;
@@ -44,7 +44,7 @@ public class SignedBlobSidecarsUnblinderDeneb implements SignedBlobSidecarsUnbli
   }
 
   @Override
-  public SafeFuture<List<SignedBlobSidecar>> unblind() {
+  public SafeFuture<List<SignedBlobSidecarOld>> unblind() {
     return blobsBundleFuture.thenApply(
         blobsBundle ->
             signedBlindedBlobSidecars.stream()
@@ -54,11 +54,11 @@ public class SignedBlobSidecarsUnblinderDeneb implements SignedBlobSidecarsUnbli
                 .toList());
   }
 
-  private SignedBlobSidecar unblindSignedBlindedBlobSidecar(
+  private SignedBlobSidecarOld unblindSignedBlindedBlobSidecar(
       final SignedBlindedBlobSidecar signedBlindedBlobSidecar, final BlobsBundle blobsBundle) {
     final BlindedBlobSidecar blindedBlobSidecar = signedBlindedBlobSidecar.getBlindedBlobSidecar();
     final Blob blob = findBlobByIndex(blobsBundle, blindedBlobSidecar);
-    final BlobSidecar unblindedBlobSidecar =
+    final BlobSidecarOld unblindedBlobSidecar =
         blobSidecarSchema.create(
             blindedBlobSidecar.getBlockRoot(),
             blindedBlobSidecar.getIndex(),

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/BlockContainer.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/BlockContainer.java
@@ -18,7 +18,7 @@ import java.util.Optional;
 import tech.pegasys.teku.infrastructure.ssz.SszContainer;
 import tech.pegasys.teku.infrastructure.ssz.SszData;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.versions.deneb.BlockContents;
 
 /**
@@ -34,7 +34,7 @@ public interface BlockContainer extends SszData, SszContainer {
     return getBlock().getSlot();
   }
 
-  default Optional<List<BlobSidecar>> getBlobSidecars() {
+  default Optional<List<BlobSidecarOld>> getBlobSidecars() {
     return Optional.empty();
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBlockContainer.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBlockContainer.java
@@ -19,7 +19,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.ssz.SszContainer;
 import tech.pegasys.teku.infrastructure.ssz.SszData;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.versions.deneb.SignedBlockContents;
 
 /**
@@ -39,7 +39,7 @@ public interface SignedBlockContainer extends SszData, SszContainer {
     return getSignedBlock().getRoot();
   }
 
-  default Optional<List<SignedBlobSidecar>> getSignedBlobSidecars() {
+  default Optional<List<SignedBlobSidecarOld>> getSignedBlobSidecars() {
     return Optional.empty();
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/versions/deneb/BlockContents.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/versions/deneb/BlockContents.java
@@ -18,11 +18,11 @@ import java.util.Optional;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.ssz.containers.Container2;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockContainer;
 
-public class BlockContents extends Container2<BlockContents, BeaconBlock, SszList<BlobSidecar>>
+public class BlockContents extends Container2<BlockContents, BeaconBlock, SszList<BlobSidecarOld>>
     implements BlockContainer {
 
   BlockContents(final BlockContentsSchema type, final TreeNode backingNode) {
@@ -32,7 +32,7 @@ public class BlockContents extends Container2<BlockContents, BeaconBlock, SszLis
   public BlockContents(
       final BlockContentsSchema schema,
       final BeaconBlock beaconBlock,
-      final List<BlobSidecar> blobSidecars) {
+      final List<BlobSidecarOld> blobSidecars) {
     super(schema, beaconBlock, schema.getBlobSidecarsSchema().createFromElements(blobSidecars));
   }
 
@@ -42,7 +42,7 @@ public class BlockContents extends Container2<BlockContents, BeaconBlock, SszLis
   }
 
   @Override
-  public Optional<List<BlobSidecar>> getBlobSidecars() {
+  public Optional<List<BlobSidecarOld>> getBlobSidecars() {
     return Optional.of(getField1().asList());
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/versions/deneb/BlockContentsSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/versions/deneb/BlockContentsSchema.java
@@ -53,7 +53,8 @@ public class BlockContentsSchema
     return new BlockContentsSchema(containerName, specConfig, beaconBlockSchema, blobSidecarSchema);
   }
 
-  public BlockContents create(final BeaconBlock beaconBlock, final List<BlobSidecarOld> blobSidecars) {
+  public BlockContents create(
+      final BeaconBlock beaconBlock, final List<BlobSidecarOld> blobSidecars) {
     return new BlockContents(this, beaconBlock, blobSidecars);
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/versions/deneb/BlockContentsSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/versions/deneb/BlockContentsSchema.java
@@ -20,14 +20,14 @@ import tech.pegasys.teku.infrastructure.ssz.schema.SszFieldName;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszListSchema;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.spec.config.SpecConfigDeneb;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarSchema;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarSchemaOld;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSchema;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockContainerSchema;
 
 public class BlockContentsSchema
-    extends ContainerSchema2<BlockContents, BeaconBlock, SszList<BlobSidecar>>
+    extends ContainerSchema2<BlockContents, BeaconBlock, SszList<BlobSidecarOld>>
     implements BlockContainerSchema<BlockContents> {
 
   static final SszFieldName FIELD_BLOB_SIDECARS = () -> "blob_sidecars";
@@ -36,7 +36,7 @@ public class BlockContentsSchema
       final String containerName,
       final SpecConfigDeneb specConfig,
       final BeaconBlockSchema beaconBlockSchema,
-      final BlobSidecarSchema blobSidecarSchema) {
+      final BlobSidecarSchemaOld blobSidecarSchema) {
     super(
         containerName,
         namedSchema("block", beaconBlockSchema),
@@ -48,12 +48,12 @@ public class BlockContentsSchema
   public static BlockContentsSchema create(
       final SpecConfigDeneb specConfig,
       final BeaconBlockSchema beaconBlockSchema,
-      final BlobSidecarSchema blobSidecarSchema,
+      final BlobSidecarSchemaOld blobSidecarSchema,
       final String containerName) {
     return new BlockContentsSchema(containerName, specConfig, beaconBlockSchema, blobSidecarSchema);
   }
 
-  public BlockContents create(final BeaconBlock beaconBlock, final List<BlobSidecar> blobSidecars) {
+  public BlockContents create(final BeaconBlock beaconBlock, final List<BlobSidecarOld> blobSidecars) {
     return new BlockContents(this, beaconBlock, blobSidecars);
   }
 
@@ -63,7 +63,7 @@ public class BlockContentsSchema
   }
 
   @SuppressWarnings("unchecked")
-  public SszListSchema<BlobSidecar, ?> getBlobSidecarsSchema() {
-    return (SszListSchema<BlobSidecar, ?>) getChildSchema(getFieldIndex(FIELD_BLOB_SIDECARS));
+  public SszListSchema<BlobSidecarOld, ?> getBlobSidecarsSchema() {
+    return (SszListSchema<BlobSidecarOld, ?>) getChildSchema(getFieldIndex(FIELD_BLOB_SIDECARS));
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/versions/deneb/SignedBlockContents.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/versions/deneb/SignedBlockContents.java
@@ -18,12 +18,12 @@ import java.util.Optional;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.ssz.containers.Container2;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
 
 public class SignedBlockContents
-    extends Container2<SignedBlockContents, SignedBeaconBlock, SszList<SignedBlobSidecar>>
+    extends Container2<SignedBlockContents, SignedBeaconBlock, SszList<SignedBlobSidecarOld>>
     implements SignedBlockContainer {
 
   SignedBlockContents(final SignedBlockContentsSchema type, final TreeNode backingNode) {
@@ -33,7 +33,7 @@ public class SignedBlockContents
   public SignedBlockContents(
       final SignedBlockContentsSchema schema,
       final SignedBeaconBlock signedBeaconBlock,
-      final List<SignedBlobSidecar> signedBlobSidecars) {
+      final List<SignedBlobSidecarOld> signedBlobSidecars) {
     super(
         schema,
         signedBeaconBlock,
@@ -46,7 +46,7 @@ public class SignedBlockContents
   }
 
   @Override
-  public Optional<List<SignedBlobSidecar>> getSignedBlobSidecars() {
+  public Optional<List<SignedBlobSidecarOld>> getSignedBlobSidecars() {
     return Optional.of(getField1().asList());
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/versions/deneb/SignedBlockContentsSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/versions/deneb/SignedBlockContentsSchema.java
@@ -55,7 +55,8 @@ public class SignedBlockContentsSchema
   }
 
   public SignedBlockContents create(
-      final SignedBeaconBlock signedBeaconBlock, final List<SignedBlobSidecarOld> signedBlobSidecars) {
+      final SignedBeaconBlock signedBeaconBlock,
+      final List<SignedBlobSidecarOld> signedBlobSidecars) {
     return new SignedBlockContents(this, signedBeaconBlock, signedBlobSidecars);
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/versions/deneb/SignedBlockContentsSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/versions/deneb/SignedBlockContentsSchema.java
@@ -20,14 +20,14 @@ import tech.pegasys.teku.infrastructure.ssz.schema.SszFieldName;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszListSchema;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.spec.config.SpecConfigDeneb;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecar;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecarSchema;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecarOld;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecarSchemaOld;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlockSchema;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainerSchema;
 
 public class SignedBlockContentsSchema
-    extends ContainerSchema2<SignedBlockContents, SignedBeaconBlock, SszList<SignedBlobSidecar>>
+    extends ContainerSchema2<SignedBlockContents, SignedBeaconBlock, SszList<SignedBlobSidecarOld>>
     implements SignedBlockContainerSchema<SignedBlockContents> {
 
   static final SszFieldName FIELD_SIGNED_BLOB_SIDECARS = () -> "signed_blob_sidecars";
@@ -35,7 +35,7 @@ public class SignedBlockContentsSchema
   SignedBlockContentsSchema(
       final String containerName,
       final SpecConfigDeneb specConfig,
-      final SignedBlobSidecarSchema signedBlobSidecarSchema,
+      final SignedBlobSidecarSchemaOld signedBlobSidecarSchema,
       final SignedBeaconBlockSchema signedBeaconBlockSchema) {
     super(
         containerName,
@@ -47,7 +47,7 @@ public class SignedBlockContentsSchema
 
   public static SignedBlockContentsSchema create(
       final SpecConfigDeneb specConfig,
-      final SignedBlobSidecarSchema signedBlobSidecarSchema,
+      final SignedBlobSidecarSchemaOld signedBlobSidecarSchema,
       final SignedBeaconBlockSchema signedBeaconBlockSchema,
       final String containerName) {
     return new SignedBlockContentsSchema(
@@ -55,7 +55,7 @@ public class SignedBlockContentsSchema
   }
 
   public SignedBlockContents create(
-      final SignedBeaconBlock signedBeaconBlock, final List<SignedBlobSidecar> signedBlobSidecars) {
+      final SignedBeaconBlock signedBeaconBlock, final List<SignedBlobSidecarOld> signedBlobSidecars) {
     return new SignedBlockContents(this, signedBeaconBlock, signedBlobSidecars);
   }
 
@@ -69,8 +69,8 @@ public class SignedBlockContentsSchema
   }
 
   @SuppressWarnings("unchecked")
-  public SszListSchema<SignedBlobSidecar, ?> getSignedBlobSidecarsSchema() {
-    return (SszListSchema<SignedBlobSidecar, ?>)
+  public SszListSchema<SignedBlobSidecarOld, ?> getSignedBlobSidecarsSchema() {
+    return (SszListSchema<SignedBlobSidecarOld, ?>)
         getChildSchema(getFieldIndex(FIELD_SIGNED_BLOB_SIDECARS));
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/MutableStore.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/MutableStore.java
@@ -17,7 +17,7 @@ import java.util.List;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
@@ -42,7 +42,7 @@ public interface MutableStore extends ReadOnlyStore {
       SignedBeaconBlock block,
       BeaconState state,
       BlockCheckpoints checkpoints,
-      Optional<List<BlobSidecar>> blobSidecars,
+      Optional<List<BlobSidecarOld>> blobSidecars,
       Optional<UInt64> earliestBlobSidecarSlot);
 
   default void putBlockAndState(
@@ -57,7 +57,7 @@ public interface MutableStore extends ReadOnlyStore {
 
   default void putBlockAndState(
       final SignedBlockAndState blockAndState,
-      final List<BlobSidecar> blobSidecars,
+      final List<BlobSidecarOld> blobSidecars,
       final BlockCheckpoints checkpoints) {
     putBlockAndState(
         blockAndState.getBlock(),

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ReadOnlyStore.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ReadOnlyStore.java
@@ -22,7 +22,7 @@ import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
@@ -110,7 +110,7 @@ public interface ReadOnlyStore {
    */
   Optional<SignedBeaconBlock> getBlockIfAvailable(final Bytes32 blockRoot);
 
-  Optional<List<BlobSidecar>> getBlobSidecarsIfAvailable(SlotAndBlockRoot slotAndBlockRoot);
+  Optional<List<BlobSidecarOld>> getBlobSidecarsIfAvailable(SlotAndBlockRoot slotAndBlockRoot);
 
   default SafeFuture<Optional<BeaconBlock>> retrieveBlock(Bytes32 blockRoot) {
     return retrieveSignedBlock(blockRoot).thenApply(res -> res.map(SignedBeaconBlock::getMessage));

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
@@ -38,7 +38,7 @@ import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.kzg.KZGCommitment;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.constants.NetworkConstants;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.state.ForkData;
 import tech.pegasys.teku.spec.datastructures.state.SigningData;
@@ -344,23 +344,23 @@ public class MiscHelpers {
     return false;
   }
 
-  public boolean verifyBlobKzgProof(final KZG kzg, final BlobSidecar blobSidecar) {
+  public boolean verifyBlobKzgProof(final KZG kzg, final BlobSidecarOld blobSidecar) {
     return false;
   }
 
-  public boolean verifyBlobKzgProofBatch(final KZG kzg, final List<BlobSidecar> blobSidecars) {
+  public boolean verifyBlobKzgProofBatch(final KZG kzg, final List<BlobSidecarOld> blobSidecars) {
     return false;
   }
 
   public void validateBlobSidecarsBatchAgainstBlock(
-      final List<BlobSidecar> blobSidecars,
+      final List<BlobSidecarOld> blobSidecars,
       final BeaconBlock block,
       final List<KZGCommitment> kzgCommitmentsFromBlock) {
     throw new UnsupportedOperationException("No Blob Sidecars before Deneb");
   }
 
   public void verifyBlobSidecarCompleteness(
-      final List<BlobSidecar> verifiedBlobSidecars,
+      final List<BlobSidecarOld> verifiedBlobSidecars,
       final List<KZGCommitment> kzgCommitmentsFromBlock)
       throws IllegalArgumentException {
     throw new UnsupportedOperationException("No Blob Sidecars before Deneb");

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/BlindBlockUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/BlindBlockUtil.java
@@ -19,7 +19,7 @@ import java.util.function.Consumer;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.spec.datastructures.blobs.SignedBlobSidecarsUnblinder;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlindedBlobSidecar;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlockBlinder;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlockUnblinder;
@@ -36,7 +36,7 @@ public abstract class BlindBlockUtil {
     return beaconBlockUnblinder.unblind();
   }
 
-  public SafeFuture<List<SignedBlobSidecar>> unblindSignedBlobSidecars(
+  public SafeFuture<List<SignedBlobSidecarOld>> unblindSignedBlobSidecars(
       final List<SignedBlindedBlobSidecar> signedBlindedBlobSidecars,
       final Consumer<SignedBlobSidecarsUnblinder> blobSidecarsUnblinderConsumer) {
     final SignedBlobSidecarsUnblinder blobSidecarsUnblinder =

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
@@ -27,7 +27,7 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.config.SpecConfigBellatrix;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
@@ -383,7 +383,7 @@ public class ForkChoiceUtil {
       final SignedBeaconBlock signedBlock,
       final BeaconState postState,
       final boolean isBlockOptimistic,
-      final Optional<List<BlobSidecar>> blobSidecars,
+      final Optional<List<BlobSidecarOld>> blobSidecars,
       final Optional<UInt64> earliestBlobSidecarsSlot) {
 
     BlockCheckpoints blockCheckpoints = epochProcessor.calculateBlockCheckpoints(postState);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/blobs/BlobSidecarsAndValidationResult.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/blobs/BlobSidecarsAndValidationResult.java
@@ -19,12 +19,12 @@ import java.util.Objects;
 import java.util.Optional;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.exceptions.ExceptionUtil;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 
 public class BlobSidecarsAndValidationResult {
 
   private final BlobSidecarsValidationResult validationResult;
-  private final List<BlobSidecar> blobSidecars;
+  private final List<BlobSidecarOld> blobSidecars;
   private final Optional<Throwable> cause;
 
   public static final BlobSidecarsAndValidationResult NOT_AVAILABLE =
@@ -38,19 +38,19 @@ public class BlobSidecarsAndValidationResult {
   public static final SafeFuture<BlobSidecarsAndValidationResult> NOT_REQUIRED_RESULT_FUTURE =
       SafeFuture.completedFuture(NOT_REQUIRED);
 
-  public static BlobSidecarsAndValidationResult validResult(final List<BlobSidecar> blobSidecars) {
+  public static BlobSidecarsAndValidationResult validResult(final List<BlobSidecarOld> blobSidecars) {
     return new BlobSidecarsAndValidationResult(
         BlobSidecarsValidationResult.VALID, blobSidecars, Optional.empty());
   }
 
   public static BlobSidecarsAndValidationResult invalidResult(
-      final List<BlobSidecar> blobSidecars) {
+      final List<BlobSidecarOld> blobSidecars) {
     return new BlobSidecarsAndValidationResult(
         BlobSidecarsValidationResult.INVALID, blobSidecars, Optional.empty());
   }
 
   public static BlobSidecarsAndValidationResult invalidResult(
-      final List<BlobSidecar> blobSidecars, final Throwable cause) {
+          final List<BlobSidecarOld> blobSidecars, final Throwable cause) {
     return new BlobSidecarsAndValidationResult(
         BlobSidecarsValidationResult.INVALID, blobSidecars, Optional.of(cause));
   }
@@ -62,7 +62,7 @@ public class BlobSidecarsAndValidationResult {
 
   private BlobSidecarsAndValidationResult(
       final BlobSidecarsValidationResult validationResult,
-      final List<BlobSidecar> blobSidecars,
+      final List<BlobSidecarOld> blobSidecars,
       final Optional<Throwable> cause) {
     this.validationResult = validationResult;
     this.blobSidecars = blobSidecars;
@@ -73,7 +73,7 @@ public class BlobSidecarsAndValidationResult {
     return validationResult;
   }
 
-  public List<BlobSidecar> getBlobSidecars() {
+  public List<BlobSidecarOld> getBlobSidecars() {
     return blobSidecars;
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/blobs/BlobSidecarsAndValidationResult.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/blobs/BlobSidecarsAndValidationResult.java
@@ -38,7 +38,8 @@ public class BlobSidecarsAndValidationResult {
   public static final SafeFuture<BlobSidecarsAndValidationResult> NOT_REQUIRED_RESULT_FUTURE =
       SafeFuture.completedFuture(NOT_REQUIRED);
 
-  public static BlobSidecarsAndValidationResult validResult(final List<BlobSidecarOld> blobSidecars) {
+  public static BlobSidecarsAndValidationResult validResult(
+      final List<BlobSidecarOld> blobSidecars) {
     return new BlobSidecarsAndValidationResult(
         BlobSidecarsValidationResult.VALID, blobSidecars, Optional.empty());
   }
@@ -50,7 +51,7 @@ public class BlobSidecarsAndValidationResult {
   }
 
   public static BlobSidecarsAndValidationResult invalidResult(
-          final List<BlobSidecarOld> blobSidecars, final Throwable cause) {
+      final List<BlobSidecarOld> blobSidecars, final Throwable cause) {
     return new BlobSidecarsAndValidationResult(
         BlobSidecarsValidationResult.INVALID, blobSidecars, Optional.of(cause));
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/blobs/BlobSidecarsAvailabilityChecker.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/blobs/BlobSidecarsAvailabilityChecker.java
@@ -17,7 +17,7 @@ import static tech.pegasys.teku.spec.logic.versions.deneb.blobs.BlobSidecarsAndV
 
 import java.util.List;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
 import tech.pegasys.teku.spec.datastructures.execution.NewPayloadRequest;
 import tech.pegasys.teku.spec.logic.versions.bellatrix.block.OptimisticExecutionPayloadExecutor;
@@ -38,7 +38,7 @@ public interface BlobSidecarsAvailabilityChecker {
 
         @Override
         public BlobSidecarsAndValidationResult validateImmediately(
-            final List<BlobSidecar> blobSidecars) {
+            final List<BlobSidecarOld> blobSidecars) {
           return BlobSidecarsAndValidationResult.NOT_REQUIRED;
         }
       };
@@ -57,5 +57,5 @@ public interface BlobSidecarsAvailabilityChecker {
   SafeFuture<BlobSidecarsAndValidationResult> getAvailabilityCheckResult();
 
   /** Perform the data availability check immediately on the provided blob sidecars */
-  BlobSidecarsAndValidationResult validateImmediately(List<BlobSidecar> blobSidecars);
+  BlobSidecarsAndValidationResult validateImmediately(List<BlobSidecarOld> blobSidecars);
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/helpers/MiscHelpersDeneb.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/helpers/MiscHelpersDeneb.java
@@ -28,7 +28,7 @@ import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.kzg.KZGCommitment;
 import tech.pegasys.teku.kzg.KZGProof;
 import tech.pegasys.teku.spec.config.SpecConfigDeneb;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.deneb.BeaconBlockBodyDeneb;
@@ -62,7 +62,7 @@ public class MiscHelpersDeneb extends MiscHelpersCapella {
    * @return true if blob sidecar is valid
    */
   @Override
-  public boolean verifyBlobKzgProof(final KZG kzg, final BlobSidecar blobSidecar) {
+  public boolean verifyBlobKzgProof(final KZG kzg, final BlobSidecarOld blobSidecar) {
     return kzg.verifyBlobKzgProof(
         blobSidecar.getBlob().getBytes(),
         blobSidecar.getKZGCommitment(),
@@ -79,7 +79,7 @@ public class MiscHelpersDeneb extends MiscHelpersCapella {
    * @return true if all blob sidecars are valid
    */
   @Override
-  public boolean verifyBlobKzgProofBatch(final KZG kzg, final List<BlobSidecar> blobSidecars) {
+  public boolean verifyBlobKzgProofBatch(final KZG kzg, final List<BlobSidecarOld> blobSidecars) {
     final List<Bytes> blobs = new ArrayList<>();
     final List<KZGCommitment> kzgCommitments = new ArrayList<>();
     final List<KZGProof> kzgProofs = new ArrayList<>();
@@ -104,7 +104,7 @@ public class MiscHelpersDeneb extends MiscHelpersCapella {
    */
   @Override
   public void validateBlobSidecarsBatchAgainstBlock(
-      final List<BlobSidecar> blobSidecars,
+      final List<BlobSidecarOld> blobSidecars,
       final BeaconBlock block,
       final List<KZGCommitment> kzgCommitmentsFromBlock) {
 
@@ -165,7 +165,7 @@ public class MiscHelpersDeneb extends MiscHelpersCapella {
    */
   @Override
   public void verifyBlobSidecarCompleteness(
-      final List<BlobSidecar> completeVerifiedBlobSidecars,
+      final List<BlobSidecarOld> completeVerifiedBlobSidecars,
       final List<KZGCommitment> kzgCommitmentsFromBlock)
       throws IllegalArgumentException {
     checkArgument(
@@ -175,7 +175,7 @@ public class MiscHelpersDeneb extends MiscHelpersCapella {
     IntStream.range(0, completeVerifiedBlobSidecars.size())
         .forEach(
             index -> {
-              final BlobSidecar blobSidecar = completeVerifiedBlobSidecars.get(index);
+              final BlobSidecarOld blobSidecar = completeVerifiedBlobSidecars.get(index);
               final UInt64 blobIndex = blobSidecar.getIndex();
 
               checkArgument(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsDeneb.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsDeneb.java
@@ -22,9 +22,9 @@ import tech.pegasys.teku.spec.config.SpecConfigDeneb;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlindedBlobSidecarSchema;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.Blob;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSchema;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarSchema;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarSchemaOld;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlindedBlobSidecarSchema;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecarSchema;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecarSchemaOld;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSchema;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockContainer;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockContainerSchema;
@@ -78,8 +78,8 @@ public class SchemaDefinitionsDeneb extends SchemaDefinitionsCapella {
 
   private final BlobSchema blobSchema;
   private final SszListSchema<Blob, ? extends SszList<Blob>> blobsInBlockSchema;
-  private final BlobSidecarSchema blobSidecarSchema;
-  private final SignedBlobSidecarSchema signedBlobSidecarSchema;
+  private final BlobSidecarSchemaOld blobSidecarSchema;
+  private final SignedBlobSidecarSchemaOld signedBlobSidecarSchema;
   private final BlindedBlobSidecarSchema blindedBlobSidecarSchema;
   private final SignedBlindedBlobSidecarSchema signedBlindedBlobSidecarSchema;
   private final BlockContentsSchema blockContentsSchema;
@@ -128,8 +128,8 @@ public class SchemaDefinitionsDeneb extends SchemaDefinitionsCapella {
 
     this.blobSchema = new BlobSchema(specConfig);
     this.blobsInBlockSchema = SszListSchema.create(blobSchema, specConfig.getMaxBlobsPerBlock());
-    this.blobSidecarSchema = BlobSidecarSchema.create(blobSchema);
-    this.signedBlobSidecarSchema = SignedBlobSidecarSchema.create(blobSidecarSchema);
+    this.blobSidecarSchema = BlobSidecarSchemaOld.create(blobSchema);
+    this.signedBlobSidecarSchema = SignedBlobSidecarSchemaOld.create(blobSidecarSchema);
     this.blindedBlobSidecarSchema = BlindedBlobSidecarSchema.create();
     this.signedBlindedBlobSidecarSchema =
         SignedBlindedBlobSidecarSchema.create(blindedBlobSidecarSchema);
@@ -259,11 +259,11 @@ public class SchemaDefinitionsDeneb extends SchemaDefinitionsCapella {
     return blobsInBlockSchema;
   }
 
-  public BlobSidecarSchema getBlobSidecarSchema() {
+  public BlobSidecarSchemaOld getBlobSidecarSchema() {
     return blobSidecarSchema;
   }
 
-  public SignedBlobSidecarSchema getSignedBlobSidecarSchema() {
+  public SignedBlobSidecarSchemaOld getSignedBlobSidecarSchema() {
     return signedBlobSidecarSchema;
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/signatures/DeletableSigner.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/signatures/DeletableSigner.java
@@ -67,7 +67,7 @@ public class DeletableSigner implements Signer {
 
   @Override
   public SafeFuture<BLSSignature> signBlobSidecar(
-          final BlobSidecarOld blobSidecar, final ForkInfo forkInfo) {
+      final BlobSidecarOld blobSidecar, final ForkInfo forkInfo) {
     return sign(() -> delegate.signBlobSidecar(blobSidecar, forkInfo));
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/signatures/DeletableSigner.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/signatures/DeletableSigner.java
@@ -24,7 +24,7 @@ import tech.pegasys.teku.infrastructure.async.ExceptionThrowingFutureSupplier;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlindedBlobSidecar;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.builder.ValidatorRegistration;
 import tech.pegasys.teku.spec.datastructures.operations.AggregateAndProof;
@@ -67,7 +67,7 @@ public class DeletableSigner implements Signer {
 
   @Override
   public SafeFuture<BLSSignature> signBlobSidecar(
-      final BlobSidecar blobSidecar, final ForkInfo forkInfo) {
+          final BlobSidecarOld blobSidecar, final ForkInfo forkInfo) {
     return sign(() -> delegate.signBlobSidecar(blobSidecar, forkInfo));
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/signatures/LocalSigner.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/signatures/LocalSigner.java
@@ -126,7 +126,7 @@ public class LocalSigner implements Signer {
 
   @Override
   public SafeFuture<BLSSignature> signBlobSidecar(
-          final BlobSidecarOld blobSidecar, final ForkInfo forkInfo) {
+      final BlobSidecarOld blobSidecar, final ForkInfo forkInfo) {
     return sign(signingRootUtil.signingRootForBlobSidecar(blobSidecar, forkInfo));
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/signatures/LocalSigner.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/signatures/LocalSigner.java
@@ -26,7 +26,7 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlindedBlobSidecar;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.builder.ValidatorRegistration;
 import tech.pegasys.teku.spec.datastructures.operations.AggregateAndProof;
@@ -126,7 +126,7 @@ public class LocalSigner implements Signer {
 
   @Override
   public SafeFuture<BLSSignature> signBlobSidecar(
-      final BlobSidecar blobSidecar, final ForkInfo forkInfo) {
+          final BlobSidecarOld blobSidecar, final ForkInfo forkInfo) {
     return sign(signingRootUtil.signingRootForBlobSidecar(blobSidecar, forkInfo));
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/signatures/Signer.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/signatures/Signer.java
@@ -20,7 +20,7 @@ import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlindedBlobSidecar;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.builder.ValidatorRegistration;
 import tech.pegasys.teku.spec.datastructures.operations.AggregateAndProof;
@@ -38,7 +38,7 @@ public interface Signer {
 
   SafeFuture<BLSSignature> signBlock(BeaconBlock block, ForkInfo forkInfo);
 
-  SafeFuture<BLSSignature> signBlobSidecar(BlobSidecar blobSidecar, ForkInfo forkInfo);
+  SafeFuture<BLSSignature> signBlobSidecar(BlobSidecarOld blobSidecar, ForkInfo forkInfo);
 
   SafeFuture<BLSSignature> signBlindedBlobSidecar(
       BlindedBlobSidecar blindedBlobSidecar, ForkInfo forkInfo);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/signatures/SigningRootUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/signatures/SigningRootUtil.java
@@ -20,7 +20,7 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecVersion;
 import tech.pegasys.teku.spec.constants.Domain;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlindedBlobSidecar;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockHeader;
 import tech.pegasys.teku.spec.datastructures.builder.ValidatorRegistration;
@@ -49,7 +49,7 @@ public class SigningRootUtil {
     return spec.computeSigningRoot(block, getDomainForSignBlock(block.getSlot(), forkInfo));
   }
 
-  public Bytes signingRootForBlobSidecar(final BlobSidecar blobSidecar, final ForkInfo forkInfo) {
+  public Bytes signingRootForBlobSidecar(final BlobSidecarOld blobSidecar, final ForkInfo forkInfo) {
     final Bytes32 domain =
         spec.getDomain(
             Domain.DOMAIN_BLOB_SIDECAR,

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/signatures/SigningRootUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/signatures/SigningRootUtil.java
@@ -49,7 +49,8 @@ public class SigningRootUtil {
     return spec.computeSigningRoot(block, getDomainForSignBlock(block.getSlot(), forkInfo));
   }
 
-  public Bytes signingRootForBlobSidecar(final BlobSidecarOld blobSidecar, final ForkInfo forkInfo) {
+  public Bytes signingRootForBlobSidecar(
+      final BlobSidecarOld blobSidecar, final ForkInfo forkInfo) {
     final Bytes32 domain =
         spec.getDomain(
             Domain.DOMAIN_BLOB_SIDECAR,

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/signatures/SlashingProtectedSigner.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/signatures/SlashingProtectedSigner.java
@@ -67,7 +67,7 @@ public class SlashingProtectedSigner implements Signer {
 
   @Override
   public SafeFuture<BLSSignature> signBlobSidecar(
-          final BlobSidecarOld blobSidecar, final ForkInfo forkInfo) {
+      final BlobSidecarOld blobSidecar, final ForkInfo forkInfo) {
     return delegate.signBlobSidecar(blobSidecar, forkInfo);
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/signatures/SlashingProtectedSigner.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/signatures/SlashingProtectedSigner.java
@@ -23,7 +23,7 @@ import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlindedBlobSidecar;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.builder.ValidatorRegistration;
 import tech.pegasys.teku.spec.datastructures.operations.AggregateAndProof;
@@ -67,7 +67,7 @@ public class SlashingProtectedSigner implements Signer {
 
   @Override
   public SafeFuture<BLSSignature> signBlobSidecar(
-      final BlobSidecar blobSidecar, final ForkInfo forkInfo) {
+          final BlobSidecarOld blobSidecar, final ForkInfo forkInfo) {
     return delegate.signBlobSidecar(blobSidecar, forkInfo);
   }
 

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blobs/versions/deneb/BlobSidecarPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blobs/versions/deneb/BlobSidecarPropertyTest.java
@@ -24,14 +24,14 @@ import tech.pegasys.teku.spec.propertytest.suppliers.blobs.versions.deneb.BlobSi
 public class BlobSidecarPropertyTest {
 
   @Property
-  void roundTrip(@ForAll(supplier = BlobSidecarSupplier.class) final BlobSidecar blobSidecar)
+  void roundTrip(@ForAll(supplier = BlobSidecarSupplier.class) final BlobSidecarOld blobSidecar)
       throws JsonProcessingException {
     assertRoundTrip(blobSidecar);
   }
 
   @Property
   void deserializeMutated(
-      @ForAll(supplier = BlobSidecarSupplier.class) final BlobSidecar blobSidecar,
+      @ForAll(supplier = BlobSidecarSupplier.class) final BlobSidecarOld blobSidecar,
       @ForAll final int seed) {
     assertDeserializeMutatedThrowsExpected(blobSidecar, seed);
   }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blobs/versions/deneb/SignedBlobSidecarPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blobs/versions/deneb/SignedBlobSidecarPropertyTest.java
@@ -25,14 +25,16 @@ public class SignedBlobSidecarPropertyTest {
 
   @Property
   void roundTrip(
-      @ForAll(supplier = SignedBlobSidecarSupplier.class) final SignedBlobSidecarOld signedBlobSidecar)
+      @ForAll(supplier = SignedBlobSidecarSupplier.class)
+          final SignedBlobSidecarOld signedBlobSidecar)
       throws JsonProcessingException {
     assertRoundTrip(signedBlobSidecar);
   }
 
   @Property
   void deserializeMutated(
-      @ForAll(supplier = SignedBlobSidecarSupplier.class) final SignedBlobSidecarOld signedBlobSidecar,
+      @ForAll(supplier = SignedBlobSidecarSupplier.class)
+          final SignedBlobSidecarOld signedBlobSidecar,
       @ForAll final int seed) {
     assertDeserializeMutatedThrowsExpected(signedBlobSidecar, seed);
   }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blobs/versions/deneb/SignedBlobSidecarPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/blobs/versions/deneb/SignedBlobSidecarPropertyTest.java
@@ -25,14 +25,14 @@ public class SignedBlobSidecarPropertyTest {
 
   @Property
   void roundTrip(
-      @ForAll(supplier = SignedBlobSidecarSupplier.class) final SignedBlobSidecar signedBlobSidecar)
+      @ForAll(supplier = SignedBlobSidecarSupplier.class) final SignedBlobSidecarOld signedBlobSidecar)
       throws JsonProcessingException {
     assertRoundTrip(signedBlobSidecar);
   }
 
   @Property
   void deserializeMutated(
-      @ForAll(supplier = SignedBlobSidecarSupplier.class) final SignedBlobSidecar signedBlobSidecar,
+      @ForAll(supplier = SignedBlobSidecarSupplier.class) final SignedBlobSidecarOld signedBlobSidecar,
       @ForAll final int seed) {
     assertDeserializeMutatedThrowsExpected(signedBlobSidecar, seed);
   }

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/logic/versions/deneb/helpers/MiscHelpersDenebPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/logic/versions/deneb/helpers/MiscHelpersDenebPropertyTest.java
@@ -26,7 +26,7 @@ import tech.pegasys.teku.kzg.KZGCommitment;
 import tech.pegasys.teku.kzg.KZGException;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.config.SpecConfigDeneb;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.propertytest.suppliers.SpecSupplier;
 import tech.pegasys.teku.spec.propertytest.suppliers.blobs.versions.deneb.BlobSidecarSupplier;
@@ -52,7 +52,7 @@ public class MiscHelpersDenebPropertyTest {
   @AddLifecycleHook(KzgResolver.class)
   @Property(tries = 100)
   void fuzzVerifyBlobKzgProof(
-      final KZG kzg, @ForAll(supplier = BlobSidecarSupplier.class) BlobSidecar blobSidecar) {
+      final KZG kzg, @ForAll(supplier = BlobSidecarSupplier.class) BlobSidecarOld blobSidecar) {
     try {
       miscHelpers.verifyBlobKzgProof(kzg, blobSidecar);
     } catch (Exception e) {
@@ -64,7 +64,7 @@ public class MiscHelpersDenebPropertyTest {
   @Property(tries = 100)
   void fuzzVerifyBlobKzgProofBatch(
       final KZG kzg,
-      @ForAll final List<@From(supplier = BlobSidecarSupplier.class) BlobSidecar> blobSidecars) {
+      @ForAll final List<@From(supplier = BlobSidecarSupplier.class) BlobSidecarOld> blobSidecars) {
     try {
       miscHelpers.verifyBlobKzgProofBatch(kzg, blobSidecars);
     } catch (Exception e) {
@@ -74,7 +74,7 @@ public class MiscHelpersDenebPropertyTest {
 
   @Property(tries = 100)
   void fuzzValidateBlobSidecarsBatchAgainstBlock(
-      @ForAll final List<@From(supplier = BlobSidecarSupplier.class) BlobSidecar> blobSidecars,
+      @ForAll final List<@From(supplier = BlobSidecarSupplier.class) BlobSidecarOld> blobSidecars,
       @ForAll(supplier = BeaconBlockSupplier.class) final BeaconBlock block,
       @ForAll
           final List<@From(supplier = KZGCommitmentSupplier.class) KZGCommitment> kzgCommitments) {
@@ -87,7 +87,7 @@ public class MiscHelpersDenebPropertyTest {
 
   @Property(tries = 100)
   void fuzzVerifyBlobSidecarCompleteness(
-      @ForAll final List<@From(supplier = BlobSidecarSupplier.class) BlobSidecar> blobSidecars,
+      @ForAll final List<@From(supplier = BlobSidecarSupplier.class) BlobSidecarOld> blobSidecars,
       @ForAll
           final List<@From(supplier = KZGCommitmentSupplier.class) KZGCommitment> kzgCommitments) {
     try {

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/deneb/SignedBlobSidecarTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/deneb/SignedBlobSidecarTest.java
@@ -20,9 +20,9 @@ import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecar;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecarSchema;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecarOld;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecarSchemaOld;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
@@ -32,17 +32,17 @@ public class SignedBlobSidecarTest {
       new DataStructureUtil(TestSpecFactory.createMinimal(SpecMilestone.DENEB));
   final SchemaDefinitions schemaDefinitions =
       dataStructureUtil.getSpec().getGenesisSchemaDefinitions();
-  private final SignedBlobSidecarSchema signedBlobSidecarSchema =
+  private final SignedBlobSidecarSchemaOld signedBlobSidecarSchema =
       schemaDefinitions.toVersionDeneb().orElseThrow().getSignedBlobSidecarSchema();
-  private final BlobSidecar blobSidecar = dataStructureUtil.randomBlobSidecar();
+  private final BlobSidecarOld blobSidecar = dataStructureUtil.randomBlobSidecar();
 
   private final BLSSignature signature = dataStructureUtil.randomSignature();
 
   @Test
   public void objectEquality() {
-    final SignedBlobSidecar signedBlobSidecar1 =
+    final SignedBlobSidecarOld signedBlobSidecar1 =
         signedBlobSidecarSchema.create(blobSidecar, signature);
-    final SignedBlobSidecar signedBlobSidecar2 =
+    final SignedBlobSidecarOld signedBlobSidecar2 =
         signedBlobSidecarSchema.create(blobSidecar, signature);
 
     assertThat(signedBlobSidecar1).isEqualTo(signedBlobSidecar2);
@@ -50,7 +50,7 @@ public class SignedBlobSidecarTest {
 
   @Test
   public void objectAccessorMethods() {
-    final SignedBlobSidecar signedBlobSidecar =
+    final SignedBlobSidecarOld signedBlobSidecar =
         signedBlobSidecarSchema.create(blobSidecar, signature);
 
     assertThat(signedBlobSidecar.getBlobSidecar()).isEqualTo(blobSidecar);
@@ -59,11 +59,11 @@ public class SignedBlobSidecarTest {
 
   @Test
   public void roundTripSSZ() {
-    final SignedBlobSidecar signedBlobSidecar =
+    final SignedBlobSidecarOld signedBlobSidecar =
         signedBlobSidecarSchema.create(blobSidecar, signature);
 
     final Bytes sszSignedBlobSidecarBytes = signedBlobSidecar.sszSerialize();
-    final SignedBlobSidecar deserializedObject =
+    final SignedBlobSidecarOld deserializedObject =
         signedBlobSidecarSchema.sszDeserialize(sszSignedBlobSidecarBytes);
 
     assertThat(signedBlobSidecar).isEqualTo(deserializedObject);

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/deneb/helpers/MiscHelpersDenebTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/deneb/helpers/MiscHelpersDenebTest.java
@@ -26,7 +26,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.kzg.KZGCommitment;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.deneb.BeaconBlockBodyDeneb;
 import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
@@ -58,7 +58,7 @@ class MiscHelpersDenebTest {
   @Test
   void validateBlobSidecarsAgainstBlock_shouldNotThrowOnValidBlobSidecar() {
     final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock();
-    final List<BlobSidecar> blobSidecars = dataStructureUtil.randomBlobSidecarsForBlock(block);
+    final List<BlobSidecarOld> blobSidecars = dataStructureUtil.randomBlobSidecarsForBlock(block);
 
     // make sure we are testing something
     assertThat(blobSidecars).isNotEmpty();
@@ -90,7 +90,7 @@ class MiscHelpersDenebTest {
         Math.toIntExact(dataStructureUtil.randomPositiveLong(kzgCommitments.size()));
 
     // let's create blobs with only one altered with the given alteration
-    final List<BlobSidecar> blobSidecars =
+    final List<BlobSidecarOld> blobSidecars =
         dataStructureUtil.randomBlobSidecarsForBlock(
             block,
             (index, randomBlobSidecarBuilder) -> {
@@ -154,7 +154,7 @@ class MiscHelpersDenebTest {
 
   @Test
   void verifyBlobSidecarCompleteness_shouldThrowWhenBlobSidecarIndexIsWrong() {
-    final List<BlobSidecar> blobSidecars = dataStructureUtil.randomBlobSidecars(1);
+    final List<BlobSidecarOld> blobSidecars = dataStructureUtil.randomBlobSidecars(1);
     assertThatThrownBy(
             () ->
                 miscHelpersDeneb.verifyBlobSidecarCompleteness(

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/signatures/DeletableSignerTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/signatures/DeletableSignerTest.java
@@ -31,7 +31,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlindedBlobSidecar;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.builder.ValidatorRegistration;
 import tech.pegasys.teku.spec.datastructures.operations.AggregateAndProof;
@@ -76,7 +76,7 @@ public class DeletableSignerTest {
   @Test
   void signBlobSidecar_shouldSignWhenActive() {
     final BeaconBlock block = dataStructureUtilDeneb.randomBeaconBlock(6);
-    final BlobSidecar blobSidecar =
+    final BlobSidecarOld blobSidecar =
         dataStructureUtilDeneb.randomBlobSidecar(block.getRoot(), UInt64.valueOf(2));
     when(delegate.signBlobSidecar(blobSidecar, forkInfo)).thenReturn(signatureFuture);
     assertThatSafeFuture(signer.signBlobSidecar(blobSidecar, forkInfo))
@@ -86,7 +86,7 @@ public class DeletableSignerTest {
   @Test
   void signBlobSidecar_shouldNotSignWhenDisabled() {
     final BeaconBlock block = dataStructureUtilDeneb.randomBeaconBlock(6);
-    final BlobSidecar blobSidecar =
+    final BlobSidecarOld blobSidecar =
         dataStructureUtilDeneb.randomBlobSidecar(block.getRoot(), UInt64.valueOf(2));
     signer.delete();
     assertThatSafeFuture(signer.signBlobSidecar(blobSidecar, forkInfo))

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/signatures/LocalSignerTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/signatures/LocalSignerTest.java
@@ -26,7 +26,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlindedBlobSidecar;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.builder.ValidatorRegistration;
 import tech.pegasys.teku.spec.datastructures.operations.AggregateAndProof;
@@ -92,7 +92,7 @@ class LocalSignerTest {
   public void shouldSignBlobSidecar() {
     final UInt64 slot = UInt64.valueOf(10);
     final BeaconBlock block = dataStructureUtilDeneb.randomBlindedBeaconBlock(slot);
-    final BlobSidecar blobSidecar =
+    final BlobSidecarOld blobSidecar =
         dataStructureUtilDeneb
             .createRandomBlobSidecarBuilder()
             .forBlock(block)

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/signatures/SlashingProtectedSignerTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/signatures/SlashingProtectedSignerTest.java
@@ -26,7 +26,7 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlindedBlobSidecar;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.builder.ValidatorRegistration;
 import tech.pegasys.teku.spec.datastructures.operations.AggregateAndProof;
@@ -78,7 +78,7 @@ class SlashingProtectedSignerTest {
   @Test
   void signBlobSidecar_shouldAlwaysSign() {
     final BeaconBlock block = dataStructureUtilDeneb.randomBeaconBlock(6);
-    final BlobSidecar blobSidecar =
+    final BlobSidecarOld blobSidecar =
         dataStructureUtilDeneb.randomBlobSidecar(block.getRoot(), UInt64.valueOf(2));
     when(delegate.signBlobSidecar(blobSidecar, forkInfo)).thenReturn(signatureFuture);
     assertThatSafeFuture(signer.signBlobSidecar(blobSidecar, forkInfo))

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreFactory.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreFactory.java
@@ -24,7 +24,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.config.SpecConfig;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
@@ -96,7 +96,7 @@ public class TestStoreFactory {
     Map<Bytes32, BeaconState> blockStates = new HashMap<>();
     Map<Checkpoint, BeaconState> checkpointStates = new HashMap<>();
     Map<UInt64, VoteTracker> votes = new HashMap<>();
-    Map<SlotAndBlockRoot, List<BlobSidecar>> blobSidecars = new HashMap<>();
+    Map<SlotAndBlockRoot, List<BlobSidecarOld>> blobSidecars = new HashMap<>();
 
     blocks.put(anchorRoot, anchor.getSignedBeaconBlock().orElseThrow());
     blockStates.put(anchorRoot, anchorState);

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
@@ -26,7 +26,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
@@ -52,7 +52,7 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
   protected Map<Bytes32, BlockCheckpoints> blockCheckpoints;
   protected Map<Checkpoint, BeaconState> checkpointStates;
   protected Map<UInt64, VoteTracker> votes;
-  protected Map<SlotAndBlockRoot, List<BlobSidecar>> blobSidecars;
+  protected Map<SlotAndBlockRoot, List<BlobSidecarOld>> blobSidecars;
   protected Optional<UInt64> earliestBlobSidecarSlot;
   protected Optional<Bytes32> proposerBoostRoot = Optional.empty();
   protected final TestReadOnlyForkChoiceStrategy forkChoiceStrategy =
@@ -71,7 +71,7 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
       final Map<Bytes32, BlockCheckpoints> blockCheckpoints,
       final Map<Checkpoint, BeaconState> checkpointStates,
       final Map<UInt64, VoteTracker> votes,
-      final Map<SlotAndBlockRoot, List<BlobSidecar>> blobSidecars,
+      final Map<SlotAndBlockRoot, List<BlobSidecarOld>> blobSidecars,
       final Optional<UInt64> maybeEarliestBlobSidecarSlot) {
     this.spec = spec;
     this.timeMillis = secondsToMillis(time);
@@ -247,7 +247,7 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
   }
 
   @Override
-  public Optional<List<BlobSidecar>> getBlobSidecarsIfAvailable(
+  public Optional<List<BlobSidecarOld>> getBlobSidecarsIfAvailable(
       final SlotAndBlockRoot slotAndBlockRoot) {
     return Optional.ofNullable(blobSidecars.get(slotAndBlockRoot));
   }
@@ -263,7 +263,7 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
       final SignedBeaconBlock block,
       final BeaconState state,
       final BlockCheckpoints checkpoints,
-      final Optional<List<BlobSidecar>> blobSidecars,
+      final Optional<List<BlobSidecarOld>> blobSidecars,
       final Optional<UInt64> maybeEarliestBlobSidecarSlot) {
     blocks.put(block.getRoot(), block);
     blockStates.put(block.getRoot(), state);

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/signatures/NoOpSigner.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/signatures/NoOpSigner.java
@@ -20,7 +20,7 @@ import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlindedBlobSidecar;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.builder.ValidatorRegistration;
 import tech.pegasys.teku.spec.datastructures.operations.AggregateAndProof;
@@ -50,7 +50,7 @@ public abstract class NoOpSigner implements Signer {
 
   @Override
   public SafeFuture<BLSSignature> signBlobSidecar(
-      final BlobSidecar blobSidecar, final ForkInfo forkInfo) {
+          final BlobSidecarOld blobSidecar, final ForkInfo forkInfo) {
     return new SafeFuture<>();
   }
 

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/signatures/NoOpSigner.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/signatures/NoOpSigner.java
@@ -50,7 +50,7 @@ public abstract class NoOpSigner implements Signer {
 
   @Override
   public SafeFuture<BLSSignature> signBlobSidecar(
-          final BlobSidecarOld blobSidecar, final ForkInfo forkInfo) {
+      final BlobSidecarOld blobSidecar, final ForkInfo forkInfo) {
     return new SafeFuture<>();
   }
 

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/propertytest/suppliers/blobs/versions/deneb/BlobSidecarSupplier.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/propertytest/suppliers/blobs/versions/deneb/BlobSidecarSupplier.java
@@ -14,11 +14,11 @@
 package tech.pegasys.teku.spec.propertytest.suppliers.blobs.versions.deneb;
 
 import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.propertytest.suppliers.DataStructureUtilSupplier;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
-public class BlobSidecarSupplier extends DataStructureUtilSupplier<BlobSidecar> {
+public class BlobSidecarSupplier extends DataStructureUtilSupplier<BlobSidecarOld> {
 
   public BlobSidecarSupplier() {
     super(DataStructureUtil::randomBlobSidecar, SpecMilestone.DENEB);

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/propertytest/suppliers/blobs/versions/deneb/SignedBlobSidecarSupplier.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/propertytest/suppliers/blobs/versions/deneb/SignedBlobSidecarSupplier.java
@@ -14,11 +14,11 @@
 package tech.pegasys.teku.spec.propertytest.suppliers.blobs.versions.deneb;
 
 import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecarOld;
 import tech.pegasys.teku.spec.propertytest.suppliers.DataStructureUtilSupplier;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
-public class SignedBlobSidecarSupplier extends DataStructureUtilSupplier<SignedBlobSidecar> {
+public class SignedBlobSidecarSupplier extends DataStructureUtilSupplier<SignedBlobSidecarOld> {
 
   public SignedBlobSidecarSupplier() {
     super(DataStructureUtil::randomSignedBlobSidecar, SpecMilestone.DENEB);

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/propertytest/suppliers/execution/versions/deneb/BlobSidecarSupplier.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/propertytest/suppliers/execution/versions/deneb/BlobSidecarSupplier.java
@@ -14,11 +14,11 @@
 package tech.pegasys.teku.spec.propertytest.suppliers.execution.versions.deneb;
 
 import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.propertytest.suppliers.DataStructureUtilSupplier;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
-public class BlobSidecarSupplier extends DataStructureUtilSupplier<BlobSidecar> {
+public class BlobSidecarSupplier extends DataStructureUtilSupplier<BlobSidecarOld> {
 
   public BlobSidecarSupplier() {
     super(DataStructureUtil::randomBlobSidecar, SpecMilestone.DENEB);

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -89,12 +89,12 @@ import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlindedBlobSid
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlindedBlobSidecarSchema;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.Blob;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSchema;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarSchema;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarSchemaOld;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlindedBlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlindedBlobSidecarSchema;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecar;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecarSchema;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecarOld;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecarSchemaOld;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockHeader;
@@ -2134,19 +2134,19 @@ public final class DataStructureUtil {
     return randomBlob().getBytes();
   }
 
-  public List<BlobSidecar> randomBlobSidecarsForBlock(final SignedBeaconBlock block) {
+  public List<BlobSidecarOld> randomBlobSidecarsForBlock(final SignedBeaconBlock block) {
     return randomBlobSidecarsForBlock(block, (__, builder) -> builder);
   }
 
-  public List<BlobSidecar> randomBlobSidecarsForBlock(
+  public List<BlobSidecarOld> randomBlobSidecarsForBlock(
       final SignedBeaconBlock block,
       final BiFunction<Integer, RandomBlobSidecarBuilder, RandomBlobSidecarBuilder> modifier) {
     return randomSignedBlobSidecarsForBlock(block, modifier).stream()
-        .map(SignedBlobSidecar::getBlobSidecar)
+        .map(SignedBlobSidecarOld::getBlobSidecar)
         .collect(toList());
   }
 
-  public List<SignedBlobSidecar> randomSignedBlobSidecarsForBlock(
+  public List<SignedBlobSidecarOld> randomSignedBlobSidecarsForBlock(
       final SignedBeaconBlock block,
       final BiFunction<Integer, RandomBlobSidecarBuilder, RandomBlobSidecarBuilder> modifier) {
     final SszList<SszKZGCommitment> blobKzgCommitments =
@@ -2170,31 +2170,31 @@ public final class DataStructureUtil {
         .collect(toList());
   }
 
-  public BlobSidecar randomBlobSidecar() {
+  public BlobSidecarOld randomBlobSidecar() {
     return new RandomBlobSidecarBuilder().build();
   }
 
-  public BlobSidecar randomBlobSidecar(final BlobIdentifier blobIdentifier) {
+  public BlobSidecarOld randomBlobSidecar(final BlobIdentifier blobIdentifier) {
     return new RandomBlobSidecarBuilder()
         .index(blobIdentifier.getIndex())
         .blockRoot(blobIdentifier.getBlockRoot())
         .build();
   }
 
-  public List<BlobSidecar> randomBlobSidecars(int count) {
-    List<BlobSidecar> blobSidecars = new ArrayList<>();
+  public List<BlobSidecarOld> randomBlobSidecars(int count) {
+    List<BlobSidecarOld> blobSidecars = new ArrayList<>();
     for (int i = 0; i < count; i++) {
       blobSidecars.add(new RandomBlobSidecarBuilder().build());
     }
     return blobSidecars;
   }
 
-  public BlobSidecar randomBlobSidecar(
+  public BlobSidecarOld randomBlobSidecar(
       final UInt64 slot, final Bytes32 blockRoot, final UInt64 index) {
     return new RandomBlobSidecarBuilder().slot(slot).index(index).blockRoot(blockRoot).build();
   }
 
-  public BlobSidecar randomBlobSidecar(
+  public BlobSidecarOld randomBlobSidecar(
       final UInt64 slot,
       final Bytes32 blockRoot,
       final Bytes32 parentBlockRoot,
@@ -2207,7 +2207,7 @@ public final class DataStructureUtil {
         .build();
   }
 
-  public BlobSidecar randomBlobSidecar(final Bytes32 blockRoot, final UInt64 index) {
+  public BlobSidecarOld randomBlobSidecar(final Bytes32 blockRoot, final UInt64 index) {
     return new RandomBlobSidecarBuilder().index(index).blockRoot(blockRoot).build();
   }
 
@@ -2279,7 +2279,7 @@ public final class DataStructureUtil {
             .collect(toList()));
   }
 
-  public SignedBlobSidecar randomSignedBlobSidecar() {
+  public SignedBlobSidecarOld randomSignedBlobSidecar() {
     return new RandomBlobSidecarBuilder().buildSigned();
   }
 
@@ -2299,8 +2299,8 @@ public final class DataStructureUtil {
     return blindedBlobSidecars;
   }
 
-  public List<SignedBlobSidecar> randomSignedBlobSidecars(final int count) {
-    final List<SignedBlobSidecar> signedBlobSidecars = new ArrayList<>();
+  public List<SignedBlobSidecarOld> randomSignedBlobSidecars(final int count) {
+    final List<SignedBlobSidecarOld> signedBlobSidecars = new ArrayList<>();
     for (int i = 0; i < count; i++) {
       signedBlobSidecars.add(new RandomBlobSidecarBuilder().buildSigned());
     }
@@ -2335,7 +2335,7 @@ public final class DataStructureUtil {
   }
 
   public SignedBlockContents randomSignedBlockContents(final UInt64 slot) {
-    final List<SignedBlobSidecar> signedBlobSidecars =
+    final List<SignedBlobSidecarOld> signedBlobSidecars =
         randomSignedBlobSidecars(randomNumberOfBlobsPerBlock());
     final SignedBeaconBlock signedBeaconBlock = randomSignedBeaconBlock(slot);
     return getDenebSchemaDefinitions(slot)
@@ -2348,7 +2348,7 @@ public final class DataStructureUtil {
   }
 
   public BlockContents randomBlockContents(final UInt64 slot) {
-    final List<BlobSidecar> blobSidecarList = randomBlobSidecars(randomNumberOfBlobsPerBlock());
+    final List<BlobSidecarOld> blobSidecarList = randomBlobSidecars(randomNumberOfBlobsPerBlock());
     final BeaconBlock beaconBlock = randomBeaconBlock(slot);
     return getDenebSchemaDefinitions(slot)
         .getBlockContentsSchema()
@@ -2391,7 +2391,7 @@ public final class DataStructureUtil {
         .create(signedBlindedBeaconBlock, signedBlindedBlobSidecars);
   }
 
-  public SignedBlobSidecar randomSignedBlobSidecar(final UInt64 index) {
+  public SignedBlobSidecarOld randomSignedBlobSidecar(final UInt64 index) {
     return new RandomBlobSidecarBuilder().index(index).buildSigned();
   }
 
@@ -2480,8 +2480,8 @@ public final class DataStructureUtil {
       return this;
     }
 
-    public BlobSidecar build() {
-      final BlobSidecarSchema blobSidecarSchema =
+    public BlobSidecarOld build() {
+      final BlobSidecarSchemaOld blobSidecarSchema =
           getDenebSchemaDefinitions(slot.orElse(randomUInt64())).getBlobSidecarSchema();
 
       return blobSidecarSchema.create(
@@ -2495,16 +2495,16 @@ public final class DataStructureUtil {
           kzgProof.orElse(randomBytes48()));
     }
 
-    public SignedBlobSidecar buildSigned(final Optional<BLSSignature> blsSignature) {
-      BlobSidecar blobSidecar = build();
-      final SignedBlobSidecarSchema blobSidecarSchema =
+    public SignedBlobSidecarOld buildSigned(final Optional<BLSSignature> blsSignature) {
+      BlobSidecarOld blobSidecar = build();
+      final SignedBlobSidecarSchemaOld blobSidecarSchema =
           getDenebSchemaDefinitions(slot.orElse(randomUInt64())).getSignedBlobSidecarSchema();
 
       return blobSidecarSchema.create(blobSidecar, blsSignature.orElse(randomSignature()));
     }
 
     public BlindedBlobSidecar buildBlinded() {
-      BlobSidecar blobSidecar = build();
+      BlobSidecarOld blobSidecar = build();
       final BlindedBlobSidecarSchema blindedBlobSidecarSchema =
           getDenebSchemaDefinitions(slot.orElse(randomUInt64())).getBlindedBlobSidecarSchema();
 
@@ -2521,7 +2521,7 @@ public final class DataStructureUtil {
           blindedBlobSidecar, blsSignature.orElse(randomSignature()));
     }
 
-    public SignedBlobSidecar buildSigned() {
+    public SignedBlobSidecarOld buildSigned() {
       return buildSigned(Optional.empty());
     }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blobs/BlobSidecarManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blobs/BlobSidecarManager.java
@@ -17,8 +17,8 @@ import java.util.List;
 import java.util.Optional;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.logic.versions.deneb.blobs.BlobSidecarsAndValidationResult;
 import tech.pegasys.teku.spec.logic.versions.deneb.blobs.BlobSidecarsAvailabilityChecker;
@@ -30,12 +30,12 @@ public interface BlobSidecarManager {
 
         @Override
         public SafeFuture<InternalValidationResult> validateAndPrepareForBlockImport(
-            final SignedBlobSidecar signedBlobSidecar, final Optional<UInt64> arrivalTimestamp) {
+                final SignedBlobSidecarOld signedBlobSidecar, final Optional<UInt64> arrivalTimestamp) {
           return SafeFuture.completedFuture(InternalValidationResult.ACCEPT);
         }
 
         @Override
-        public void prepareForBlockImport(final BlobSidecar blobSidecar) {}
+        public void prepareForBlockImport(final BlobSidecarOld blobSidecar) {}
 
         @Override
         public void subscribeToReceivedBlobSidecar(
@@ -54,15 +54,15 @@ public interface BlobSidecarManager {
 
         @Override
         public BlobSidecarsAndValidationResult createAvailabilityCheckerAndValidateImmediately(
-            final SignedBeaconBlock block, final List<BlobSidecar> blobSidecars) {
+            final SignedBeaconBlock block, final List<BlobSidecarOld> blobSidecars) {
           return BlobSidecarsAndValidationResult.NOT_REQUIRED;
         }
       };
 
   SafeFuture<InternalValidationResult> validateAndPrepareForBlockImport(
-      SignedBlobSidecar signedBlobSidecar, Optional<UInt64> arrivalTimestamp);
+          SignedBlobSidecarOld signedBlobSidecar, Optional<UInt64> arrivalTimestamp);
 
-  void prepareForBlockImport(BlobSidecar blobSidecar);
+  void prepareForBlockImport(BlobSidecarOld blobSidecar);
 
   void subscribeToReceivedBlobSidecar(ReceivedBlobSidecarListener receivedBlobSidecarListener);
 
@@ -71,9 +71,9 @@ public interface BlobSidecarManager {
   BlobSidecarsAvailabilityChecker createAvailabilityChecker(SignedBeaconBlock block);
 
   BlobSidecarsAndValidationResult createAvailabilityCheckerAndValidateImmediately(
-      SignedBeaconBlock block, List<BlobSidecar> blobSidecars);
+      SignedBeaconBlock block, List<BlobSidecarOld> blobSidecars);
 
   interface ReceivedBlobSidecarListener {
-    void onBlobSidecarReceived(BlobSidecar blobSidecar);
+    void onBlobSidecarReceived(BlobSidecarOld blobSidecar);
   }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blobs/BlobSidecarManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blobs/BlobSidecarManager.java
@@ -30,7 +30,7 @@ public interface BlobSidecarManager {
 
         @Override
         public SafeFuture<InternalValidationResult> validateAndPrepareForBlockImport(
-                final SignedBlobSidecarOld signedBlobSidecar, final Optional<UInt64> arrivalTimestamp) {
+            final SignedBlobSidecarOld signedBlobSidecar, final Optional<UInt64> arrivalTimestamp) {
           return SafeFuture.completedFuture(InternalValidationResult.ACCEPT);
         }
 
@@ -60,7 +60,7 @@ public interface BlobSidecarManager {
       };
 
   SafeFuture<InternalValidationResult> validateAndPrepareForBlockImport(
-          SignedBlobSidecarOld signedBlobSidecar, Optional<UInt64> arrivalTimestamp);
+      SignedBlobSidecarOld signedBlobSidecar, Optional<UInt64> arrivalTimestamp);
 
   void prepareForBlockImport(BlobSidecarOld blobSidecar);
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blobs/BlobSidecarManagerImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blobs/BlobSidecarManagerImpl.java
@@ -24,8 +24,8 @@ import tech.pegasys.teku.infrastructure.subscribers.Subscribers;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.logic.versions.deneb.blobs.BlobSidecarsAndValidationResult;
 import tech.pegasys.teku.spec.logic.versions.deneb.blobs.BlobSidecarsAvailabilityChecker;
@@ -43,7 +43,7 @@ public class BlobSidecarManagerImpl implements BlobSidecarManager, SlotEventsCha
   private final BlobSidecarGossipValidator validator;
   private final KZG kzg;
   private final BlobSidecarPool blobSidecarPool;
-  private final FutureItems<SignedBlobSidecar> futureBlobSidecars;
+  private final FutureItems<SignedBlobSidecarOld> futureBlobSidecars;
   private final Map<Bytes32, InternalValidationResult> invalidBlobSidecarRoots;
 
   private final Subscribers<ReceivedBlobSidecarListener> receivedBlobSidecarSubscribers =
@@ -56,7 +56,7 @@ public class BlobSidecarManagerImpl implements BlobSidecarManager, SlotEventsCha
       final BlobSidecarPool blobSidecarPool,
       final BlobSidecarGossipValidator validator,
       final KZG kzg,
-      final FutureItems<SignedBlobSidecar> futureBlobSidecars,
+      final FutureItems<SignedBlobSidecarOld> futureBlobSidecars,
       final Map<Bytes32, InternalValidationResult> invalidBlobSidecarRoots) {
     this.spec = spec;
     this.asyncRunner = asyncRunner;
@@ -71,7 +71,7 @@ public class BlobSidecarManagerImpl implements BlobSidecarManager, SlotEventsCha
   @Override
   @SuppressWarnings("FutureReturnValueIgnored")
   public SafeFuture<InternalValidationResult> validateAndPrepareForBlockImport(
-      final SignedBlobSidecar signedBlobSidecar, final Optional<UInt64> arrivalTimestamp) {
+          final SignedBlobSidecarOld signedBlobSidecar, final Optional<UInt64> arrivalTimestamp) {
 
     final Optional<InternalValidationResult> maybeInvalid =
         Optional.ofNullable(
@@ -97,7 +97,7 @@ public class BlobSidecarManagerImpl implements BlobSidecarManager, SlotEventsCha
               futureBlobSidecars.add(signedBlobSidecar);
               break;
             case ACCEPT:
-              final BlobSidecar blobSidecar = signedBlobSidecar.getBlobSidecar();
+              final BlobSidecarOld blobSidecar = signedBlobSidecar.getBlobSidecar();
               prepareForBlockImport(blobSidecar);
               break;
           }
@@ -107,7 +107,7 @@ public class BlobSidecarManagerImpl implements BlobSidecarManager, SlotEventsCha
   }
 
   @Override
-  public void prepareForBlockImport(final BlobSidecar blobSidecar) {
+  public void prepareForBlockImport(final BlobSidecarOld blobSidecar) {
     blobSidecarPool.onNewBlobSidecar(blobSidecar);
     receivedBlobSidecarSubscribers.forEach(s -> s.onBlobSidecarReceived(blobSidecar));
   }
@@ -139,7 +139,7 @@ public class BlobSidecarManagerImpl implements BlobSidecarManager, SlotEventsCha
 
   @Override
   public BlobSidecarsAndValidationResult createAvailabilityCheckerAndValidateImmediately(
-      final SignedBeaconBlock block, final List<BlobSidecar> blobSidecars) {
+      final SignedBeaconBlock block, final List<BlobSidecarOld> blobSidecars) {
     // Block is pre-Deneb, blobs are not supported yet
     if (block.getMessage().getBody().toVersionDeneb().isEmpty()) {
       return BlobSidecarsAndValidationResult.NOT_REQUIRED;

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blobs/BlobSidecarManagerImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blobs/BlobSidecarManagerImpl.java
@@ -71,7 +71,7 @@ public class BlobSidecarManagerImpl implements BlobSidecarManager, SlotEventsCha
   @Override
   @SuppressWarnings("FutureReturnValueIgnored")
   public SafeFuture<InternalValidationResult> validateAndPrepareForBlockImport(
-          final SignedBlobSidecarOld signedBlobSidecar, final Optional<UInt64> arrivalTimestamp) {
+      final SignedBlobSidecarOld signedBlobSidecar, final Optional<UInt64> arrivalTimestamp) {
 
     final Optional<InternalValidationResult> maybeInvalid =
         Optional.ofNullable(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blobs/BlobSidecarPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blobs/BlobSidecarPool.java
@@ -20,8 +20,8 @@ import java.util.Set;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.ethereum.events.SlotEventsChannel;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BlobIdentifier;
 
@@ -33,14 +33,14 @@ public interface BlobSidecarPool extends SlotEventsChannel {
         public void onSlot(final UInt64 slot) {}
 
         @Override
-        public void onNewBlobSidecar(final BlobSidecar blobSidecar) {}
+        public void onNewBlobSidecar(final BlobSidecarOld blobSidecar) {}
 
         @Override
         public void onNewBlock(final SignedBeaconBlock block) {}
 
         @Override
         public void onCompletedBlockAndBlobSidecars(
-            final SignedBeaconBlock block, final List<BlobSidecar> blobSidecars) {}
+            final SignedBeaconBlock block, final List<BlobSidecarOld> blobSidecars) {}
 
         @Override
         public void removeAllForBlock(final Bytes32 blockRoot) {}
@@ -92,17 +92,17 @@ public interface BlobSidecarPool extends SlotEventsChannel {
         public void subscribeNewBlobSidecar(NewBlobSidecarSubscriber newBlobSidecarSubscriber) {}
       };
 
-  void onNewBlobSidecar(BlobSidecar blobSidecar);
+  void onNewBlobSidecar(BlobSidecarOld blobSidecar);
 
   void onNewBlock(SignedBeaconBlock block);
 
   default void onCompletedBlockAndSignedBlobSidecars(
-      SignedBeaconBlock block, List<SignedBlobSidecar> signedBlobSidecars) {
+      SignedBeaconBlock block, List<SignedBlobSidecarOld> signedBlobSidecars) {
     onCompletedBlockAndBlobSidecars(
-        block, signedBlobSidecars.stream().map(SignedBlobSidecar::getBlobSidecar).toList());
+        block, signedBlobSidecars.stream().map(SignedBlobSidecarOld::getBlobSidecar).toList());
   }
 
-  void onCompletedBlockAndBlobSidecars(SignedBeaconBlock block, List<BlobSidecar> blobSidecars);
+  void onCompletedBlockAndBlobSidecars(SignedBeaconBlock block, List<BlobSidecarOld> blobSidecars);
 
   void removeAllForBlock(Bytes32 blockRoot);
 
@@ -145,6 +145,6 @@ public interface BlobSidecarPool extends SlotEventsChannel {
   }
 
   interface NewBlobSidecarSubscriber {
-    void onNewBlobSidecar(BlobSidecar blobSidecar);
+    void onNewBlobSidecar(BlobSidecarOld blobSidecar);
   }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blobs/BlockBlobSidecarsTracker.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blobs/BlockBlobSidecarsTracker.java
@@ -30,7 +30,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
@@ -49,7 +49,7 @@ public class BlockBlobSidecarsTracker {
   private final AtomicReference<Optional<BeaconBlock>> block =
       new AtomicReference<>(Optional.empty());
 
-  private final NavigableMap<UInt64, BlobSidecar> blobSidecars = new ConcurrentSkipListMap<>();
+  private final NavigableMap<UInt64, BlobSidecarOld> blobSidecars = new ConcurrentSkipListMap<>();
   private final SafeFuture<Void> blobSidecarsComplete = new SafeFuture<>();
 
   private volatile boolean fetchTriggered = false;
@@ -78,7 +78,7 @@ public class BlockBlobSidecarsTracker {
     }
   }
 
-  public SortedMap<UInt64, BlobSidecar> getBlobSidecars() {
+  public SortedMap<UInt64, BlobSidecarOld> getBlobSidecars() {
     return Collections.unmodifiableSortedMap(blobSidecars);
   }
 
@@ -125,7 +125,7 @@ public class BlockBlobSidecarsTracker {
         .map(blobIndex -> new BlobIdentifier(slotAndBlockRoot.getBlockRoot(), blobIndex));
   }
 
-  public boolean add(final BlobSidecar blobSidecar) {
+  public boolean add(final BlobSidecarOld blobSidecar) {
     checkArgument(
         blobSidecar.getBlockRoot().equals(slotAndBlockRoot.getBlockRoot()),
         "Wrong blobSidecar block root");
@@ -200,7 +200,7 @@ public class BlockBlobSidecarsTracker {
         .ifPresent(count -> blobSidecars.tailMap(UInt64.valueOf(count), true).clear());
   }
 
-  private boolean isExcessiveBlobSidecar(final BlobSidecar blobSidecar) {
+  private boolean isExcessiveBlobSidecar(final BlobSidecarOld blobSidecar) {
     return getBlockKzgCommitmentsCount()
         .map(count -> blobSidecar.getIndex().isGreaterThanOrEqualTo(count))
         .orElse(false);

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -41,7 +41,7 @@ import tech.pegasys.teku.spec.SpecVersion;
 import tech.pegasys.teku.spec.cache.CapturingIndexedAttestationCache;
 import tech.pegasys.teku.spec.cache.IndexedAttestationCache;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
@@ -539,7 +539,7 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
     final StoreTransaction transaction = recentChainData.startStoreTransaction();
     addParentStateRoots(spec, blockSlotState, transaction);
 
-    final Optional<List<BlobSidecar>> blobSidecars;
+    final Optional<List<BlobSidecarOld>> blobSidecars;
     if (blobSidecarsAndValidationResult.isNotRequired()) {
       // Outside availability window or pre-Deneb
       blobSidecars = Optional.empty();

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceBlobSidecarsAvailabilityChecker.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceBlobSidecarsAvailabilityChecker.java
@@ -118,7 +118,8 @@ public class ForkChoiceBlobSidecarsAvailabilityChecker implements BlobSidecarsAv
   }
 
   @Override
-  public BlobSidecarsAndValidationResult validateImmediately(final List<BlobSidecarOld> blobSidecars) {
+  public BlobSidecarsAndValidationResult validateImmediately(
+      final List<BlobSidecarOld> blobSidecars) {
 
     final List<KZGCommitment> kzgCommitmentsFromBlock = kzgCommitmentsFromBlockSupplier.get();
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceBlobSidecarsAvailabilityChecker.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceBlobSidecarsAvailabilityChecker.java
@@ -36,7 +36,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.kzg.KZGCommitment;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.deneb.BeaconBlockBodyDeneb;
@@ -60,7 +60,7 @@ public class ForkChoiceBlobSidecarsAvailabilityChecker implements BlobSidecarsAv
   private final BlockBlobSidecarsTracker blockBlobSidecarsTracker;
   private final KZG kzg;
 
-  private final NavigableMap<UInt64, BlobSidecar> validatedBlobSidecars =
+  private final NavigableMap<UInt64, BlobSidecarOld> validatedBlobSidecars =
       new ConcurrentSkipListMap<>();
 
   private final SafeFuture<BlobSidecarsAndValidationResult> validationResult = new SafeFuture<>();
@@ -118,7 +118,7 @@ public class ForkChoiceBlobSidecarsAvailabilityChecker implements BlobSidecarsAv
   }
 
   @Override
-  public BlobSidecarsAndValidationResult validateImmediately(final List<BlobSidecar> blobSidecars) {
+  public BlobSidecarsAndValidationResult validateImmediately(final List<BlobSidecarOld> blobSidecars) {
 
     final List<KZGCommitment> kzgCommitmentsFromBlock = kzgCommitmentsFromBlockSupplier.get();
 
@@ -142,7 +142,7 @@ public class ForkChoiceBlobSidecarsAvailabilityChecker implements BlobSidecarsAv
     return BlobSidecarsAndValidationResult.NOT_AVAILABLE;
   }
 
-  private BlobSidecarsAndValidationResult validateBatch(final List<BlobSidecar> blobSidecars) {
+  private BlobSidecarsAndValidationResult validateBatch(final List<BlobSidecarOld> blobSidecars) {
     final BeaconBlock block = blockBlobSidecarsTracker.getBlock().orElseThrow();
     final SlotAndBlockRoot slotAndBlockRoot = blockBlobSidecarsTracker.getSlotAndBlockRoot();
 
@@ -174,7 +174,7 @@ public class ForkChoiceBlobSidecarsAvailabilityChecker implements BlobSidecarsAv
   private Optional<BlobSidecarsAndValidationResult> validateImmediatelyAvailable() {
     final List<KZGCommitment> kzgCommitmentsInBlock = kzgCommitmentsFromBlockSupplier.get();
 
-    final List<BlobSidecar> blobSidecarsToValidate;
+    final List<BlobSidecarOld> blobSidecarsToValidate;
 
     final boolean performCompleteValidation = blockBlobSidecarsTracker.isCompleted();
 
@@ -273,10 +273,10 @@ public class ForkChoiceBlobSidecarsAvailabilityChecker implements BlobSidecarsAv
         blockBlobSidecarsTracker.isCompleted(),
         "BlobSidecar tracker assumed to be completed but it is not.");
 
-    final List<BlobSidecar> additionalBlobSidecarsToBeValidated = new ArrayList<>();
+    final List<BlobSidecarOld> additionalBlobSidecarsToBeValidated = new ArrayList<>();
 
     final List<KZGCommitment> kzgCommitmentsInBlock = kzgCommitmentsFromBlockSupplier.get();
-    final SortedMap<UInt64, BlobSidecar> completeBlobSidecars =
+    final SortedMap<UInt64, BlobSidecarOld> completeBlobSidecars =
         blockBlobSidecarsTracker.getBlobSidecars();
 
     UInt64.range(UInt64.ZERO, UInt64.valueOf(kzgCommitmentsInBlock.size()))
@@ -319,7 +319,7 @@ public class ForkChoiceBlobSidecarsAvailabilityChecker implements BlobSidecarsAv
         .getBlobSidecars()
         .forEach(blobSidecar -> validatedBlobSidecars.put(blobSidecar.getIndex(), blobSidecar));
 
-    final List<BlobSidecar> completeValidatedBlobSidecars =
+    final List<BlobSidecarOld> completeValidatedBlobSidecars =
         new ArrayList<>(validatedBlobSidecars.values());
 
     return BlobSidecarsAndValidationResult.validResult(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/BlobSidecarPoolImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/BlobSidecarPoolImpl.java
@@ -36,7 +36,7 @@ import tech.pegasys.teku.infrastructure.subscribers.Subscribers;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BlobIdentifier;
@@ -138,7 +138,7 @@ public class BlobSidecarPoolImpl extends AbstractIgnoringFutureHistoricalSlot
   }
 
   @Override
-  public synchronized void onNewBlobSidecar(final BlobSidecar blobSidecar) {
+  public synchronized void onNewBlobSidecar(final BlobSidecarOld blobSidecar) {
     if (recentChainData.containsBlock(blobSidecar.getBlockRoot())) {
       return;
     }
@@ -187,7 +187,7 @@ public class BlobSidecarPoolImpl extends AbstractIgnoringFutureHistoricalSlot
 
   @Override
   public synchronized void onCompletedBlockAndBlobSidecars(
-      final SignedBeaconBlock block, final List<BlobSidecar> blobSidecars) {
+      final SignedBeaconBlock block, final List<BlobSidecarOld> blobSidecars) {
     final SlotAndBlockRoot slotAndBlockRoot = block.getSlotAndBlockRoot();
 
     final BlockBlobSidecarsTracker blobSidecarsTracker =

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlobSidecarGossipValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlobSidecarGossipValidator.java
@@ -78,7 +78,8 @@ public class BlobSidecarGossipValidator {
     this.receivedValidBlobSidecarInfoSet = receivedValidBlobSidecarInfoSet;
   }
 
-  public SafeFuture<InternalValidationResult> validate(final SignedBlobSidecarOld signedBlobSidecar) {
+  public SafeFuture<InternalValidationResult> validate(
+      final SignedBlobSidecarOld signedBlobSidecar) {
     final BlobSidecarOld blobSidecar = signedBlobSidecar.getBlobSidecar();
 
     /*

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlobSidecarGossipValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlobSidecarGossipValidator.java
@@ -32,8 +32,8 @@ import tech.pegasys.teku.infrastructure.collections.LimitedSet;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.constants.Domain;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
 
@@ -78,8 +78,8 @@ public class BlobSidecarGossipValidator {
     this.receivedValidBlobSidecarInfoSet = receivedValidBlobSidecarInfoSet;
   }
 
-  public SafeFuture<InternalValidationResult> validate(final SignedBlobSidecar signedBlobSidecar) {
-    final BlobSidecar blobSidecar = signedBlobSidecar.getBlobSidecar();
+  public SafeFuture<InternalValidationResult> validate(final SignedBlobSidecarOld signedBlobSidecar) {
+    final BlobSidecarOld blobSidecar = signedBlobSidecar.getBlobSidecar();
 
     /*
     [REJECT] The sidecar is for the correct subnet -- i.e. compute_subnet_for_blob_sidecar(sidecar.index) == subnet_id.
@@ -209,7 +209,7 @@ public class BlobSidecarGossipValidator {
   }
 
   private boolean verifyBlobSidecarSignature(
-      final BeaconState state, final SignedBlobSidecar signedBlobSidecar) {
+      final BeaconState state, final SignedBlobSidecarOld signedBlobSidecar) {
 
     final Bytes32 domain =
         spec.getDomain(
@@ -226,7 +226,7 @@ public class BlobSidecarGossipValidator {
         state);
   }
 
-  private boolean isFirstWithValidSignatureForIndexAndBlockRoot(final BlobSidecar blobSidecar) {
+  private boolean isFirstWithValidSignatureForIndexAndBlockRoot(final BlobSidecarOld blobSidecar) {
     return !receivedValidBlobSidecarInfoSet.contains(
         new IndexAndBlockRoot(blobSidecar.getIndex(), blobSidecar.getBlockRoot()));
   }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/blobs/BlobSidecarManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/blobs/BlobSidecarManagerTest.java
@@ -35,8 +35,8 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.logic.versions.deneb.blobs.BlobSidecarsAndValidationResult;
 import tech.pegasys.teku.spec.logic.versions.deneb.blobs.BlobSidecarsAvailabilityChecker;
@@ -62,7 +62,7 @@ public class BlobSidecarManagerTest {
   private final Map<Bytes32, InternalValidationResult> invalidBlobSidecarRoots = new HashMap<>();
 
   @SuppressWarnings("unchecked")
-  private final FutureItems<SignedBlobSidecar> futureBlobSidecars = mock(FutureItems.class);
+  private final FutureItems<SignedBlobSidecarOld> futureBlobSidecars = mock(FutureItems.class);
 
   private final BlobSidecarManagerImpl blobSidecarManager =
       new BlobSidecarManagerImpl(
@@ -78,8 +78,8 @@ public class BlobSidecarManagerTest {
   private final ReceivedBlobSidecarListener receivedBlobSidecarListener =
       mock(ReceivedBlobSidecarListener.class);
 
-  private final SignedBlobSidecar signedBlobSidecar = dataStructureUtil.randomSignedBlobSidecar();
-  private final BlobSidecar blobSidecar = signedBlobSidecar.getBlobSidecar();
+  private final SignedBlobSidecarOld signedBlobSidecar = dataStructureUtil.randomSignedBlobSidecar();
+  private final BlobSidecarOld blobSidecar = signedBlobSidecar.getBlobSidecar();
 
   @BeforeEach
   void setUp() {
@@ -184,7 +184,7 @@ public class BlobSidecarManagerTest {
 
   @Test
   void onSlot_shouldInteractWithPoolAndFutureBlobs() {
-    final List<SignedBlobSidecar> futureBlobSidecarsList =
+    final List<SignedBlobSidecarOld> futureBlobSidecarsList =
         List.of(dataStructureUtil.randomSignedBlobSidecar());
 
     when(futureBlobSidecars.prune(UInt64.ONE)).thenReturn(futureBlobSidecarsList);

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/blobs/BlobSidecarManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/blobs/BlobSidecarManagerTest.java
@@ -78,7 +78,8 @@ public class BlobSidecarManagerTest {
   private final ReceivedBlobSidecarListener receivedBlobSidecarListener =
       mock(ReceivedBlobSidecarListener.class);
 
-  private final SignedBlobSidecarOld signedBlobSidecar = dataStructureUtil.randomSignedBlobSidecar();
+  private final SignedBlobSidecarOld signedBlobSidecar =
+      dataStructureUtil.randomSignedBlobSidecar();
   private final BlobSidecarOld blobSidecar = signedBlobSidecar.getBlobSidecar();
 
   @BeforeEach

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/blobs/BlockBlobSidecarsTrackerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/blobs/BlockBlobSidecarsTrackerTest.java
@@ -30,7 +30,7 @@ import tech.pegasys.teku.infrastructure.async.Waiter;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BlobIdentifier;
@@ -44,7 +44,7 @@ public class BlockBlobSidecarsTrackerTest {
   private final SignedBeaconBlock block =
       dataStructureUtil.randomSignedBeaconBlockWithCommitments(maxBlobsPerBlock.intValue());
   private final SlotAndBlockRoot slotAndBlockRoot = block.getSlotAndBlockRoot();
-  private final List<BlobSidecar> blobSidecarsForBlock =
+  private final List<BlobSidecarOld> blobSidecarsForBlock =
       dataStructureUtil.randomBlobSidecarsForBlock(block);
   private final List<BlobIdentifier> blobIdentifiersForBlock =
       blobSidecarsForBlock.stream()
@@ -159,8 +159,8 @@ public class BlockBlobSidecarsTrackerTest {
   void add_shouldWorkTillCompletionWhenAddingBlobsBeforeBlockIsSet() {
     final BlockBlobSidecarsTracker blockBlobSidecarsTracker =
         new BlockBlobSidecarsTracker(slotAndBlockRoot, maxBlobsPerBlock.plus(1));
-    final BlobSidecar toAdd = blobSidecarsForBlock.get(0);
-    final Map<UInt64, BlobSidecar> added = new HashMap<>();
+    final BlobSidecarOld toAdd = blobSidecarsForBlock.get(0);
+    final Map<UInt64, BlobSidecarOld> added = new HashMap<>();
     final SafeFuture<Void> completionFuture = blockBlobSidecarsTracker.getCompletionFuture();
 
     added.put(toAdd.getIndex(), toAdd);
@@ -191,7 +191,7 @@ public class BlockBlobSidecarsTrackerTest {
     // let's complete with missing blobs
     for (int idx = 1; idx < blobIdentifiersForBlock.size(); idx++) {
 
-      BlobSidecar blobSidecar = blobSidecarsForBlock.get(idx);
+      BlobSidecarOld blobSidecar = blobSidecarsForBlock.get(idx);
 
       blockBlobSidecarsTracker.add(blobSidecar);
       added.put(blobSidecar.getIndex(), blobSidecar);
@@ -219,8 +219,8 @@ public class BlockBlobSidecarsTrackerTest {
 
     blockBlobSidecarsTracker.setBlock(block);
 
-    final BlobSidecar toAdd = blobSidecarsForBlock.get(0);
-    final Map<UInt64, BlobSidecar> added = new HashMap<>();
+    final BlobSidecarOld toAdd = blobSidecarsForBlock.get(0);
+    final Map<UInt64, BlobSidecarOld> added = new HashMap<>();
 
     final List<BlobIdentifier> stillMissing =
         blobIdentifiersForBlock.subList(1, blobIdentifiersForBlock.size());
@@ -257,7 +257,7 @@ public class BlockBlobSidecarsTrackerTest {
   void getMissingBlobSidecars_shouldReturnPartialBlobsIdentifierWhenBlockIsUnknown() {
     final BlockBlobSidecarsTracker blockBlobSidecarsTracker =
         new BlockBlobSidecarsTracker(slotAndBlockRoot, maxBlobsPerBlock);
-    final BlobSidecar toAdd = blobSidecarsForBlock.get(2);
+    final BlobSidecarOld toAdd = blobSidecarsForBlock.get(2);
 
     blockBlobSidecarsTracker.add(toAdd);
 
@@ -329,7 +329,7 @@ public class BlockBlobSidecarsTrackerTest {
   void getMissingBlobSidecars_shouldRespectMaxBlobsPerBlock() {
     final BlockBlobSidecarsTracker blockBlobSidecarsTracker =
         new BlockBlobSidecarsTracker(slotAndBlockRoot, maxBlobsPerBlock);
-    final BlobSidecar toAdd =
+    final BlobSidecarOld toAdd =
         dataStructureUtil
             .createRandomBlobSidecarBuilder()
             .blockRoot(slotAndBlockRoot.getBlockRoot())
@@ -351,11 +351,11 @@ public class BlockBlobSidecarsTrackerTest {
     final BlockBlobSidecarsTracker blockBlobSidecarsTracker =
         new BlockBlobSidecarsTracker(slotAndBlockRoot, maxBlobsPerBlock);
 
-    final BlobSidecar legitBlobSidecar = createBlobSidecar(UInt64.valueOf(2));
-    final BlobSidecar excessiveBlobSidecar1 = createBlobSidecar(maxBlobsPerBlock);
-    final BlobSidecar excessiveBlobSidecar2 = createBlobSidecar(maxBlobsPerBlock.plus(1));
+    final BlobSidecarOld legitBlobSidecar = createBlobSidecar(UInt64.valueOf(2));
+    final BlobSidecarOld excessiveBlobSidecar1 = createBlobSidecar(maxBlobsPerBlock);
+    final BlobSidecarOld excessiveBlobSidecar2 = createBlobSidecar(maxBlobsPerBlock.plus(1));
 
-    final List<BlobSidecar> toAddAltered =
+    final List<BlobSidecarOld> toAddAltered =
         List.of(legitBlobSidecar, excessiveBlobSidecar1, excessiveBlobSidecar2);
 
     toAddAltered.forEach(
@@ -377,9 +377,9 @@ public class BlockBlobSidecarsTrackerTest {
 
     blockBlobSidecarsTracker.setBlock(block);
 
-    final BlobSidecar legitBlobSidecar = createBlobSidecar(UInt64.valueOf(2));
-    final BlobSidecar excessiveBlobSidecar1 = createBlobSidecar(maxBlobsPerBlock);
-    final BlobSidecar excessiveBlobSidecar2 = createBlobSidecar(maxBlobsPerBlock.plus(1));
+    final BlobSidecarOld legitBlobSidecar = createBlobSidecar(UInt64.valueOf(2));
+    final BlobSidecarOld excessiveBlobSidecar1 = createBlobSidecar(maxBlobsPerBlock);
+    final BlobSidecarOld excessiveBlobSidecar2 = createBlobSidecar(maxBlobsPerBlock.plus(1));
 
     assertThat(blockBlobSidecarsTracker.add(legitBlobSidecar)).isTrue();
     assertThat(blockBlobSidecarsTracker.add(excessiveBlobSidecar1)).isFalse();
@@ -388,7 +388,7 @@ public class BlockBlobSidecarsTrackerTest {
     assertThat(blockBlobSidecarsTracker.getBlobSidecars().size()).isEqualTo(1);
   }
 
-  private BlobSidecar createBlobSidecar(final UInt64 index) {
+  private BlobSidecarOld createBlobSidecar(final UInt64 index) {
     return dataStructureUtil
         .createRandomBlobSidecarBuilder()
         .blockRoot(slotAndBlockRoot.getBlockRoot())

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockManagerTest.java
@@ -70,7 +70,7 @@ import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.ImportedBlockListener;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
@@ -796,7 +796,7 @@ public class BlockManagerTest {
         localChain
             .chainBuilder()
             .generateBlockAtSlot(currentSlot, BlockOptions.create().setGenerateRandomBlobs(true));
-    final List<BlobSidecar> blobSidecars1 =
+    final List<BlobSidecarOld> blobSidecars1 =
         localChain.chainBuilder().getBlobSidecars(signedBlockAndState1.getRoot());
     assertThatNothingStoredForSlotRoot(signedBlockAndState1.getSlotAndBlockRoot());
     assertThat(blobSidecars1).isNotEmpty();
@@ -820,7 +820,7 @@ public class BlockManagerTest {
             .chainBuilder()
             .generateBlockAtSlot(
                 incrementSlot(), BlockOptions.create().setGenerateRandomBlobs(true));
-    final List<BlobSidecar> blobSidecars2 =
+    final List<BlobSidecarOld> blobSidecars2 =
         localChain.chainBuilder().getBlobSidecars(signedBlockAndState2.getRoot());
     assertThat(signedBlockAndState2.getSlot()).isEqualTo(signedBlockAndState1.getSlot().plus(1));
     assertThat(blobSidecars2).isNotEmpty();
@@ -844,7 +844,7 @@ public class BlockManagerTest {
             .chainBuilder()
             .generateBlockAtSlot(
                 incrementSlot(), BlockOptions.create().setBlobSidecars(Collections.emptyList()));
-    final List<BlobSidecar> blobSidecars3 =
+    final List<BlobSidecarOld> blobSidecars3 =
         localChain.chainBuilder().getBlobSidecars(signedBlockAndState3.getRoot());
     assertThat(signedBlockAndState3.getSlot()).isEqualTo(signedBlockAndState2.getSlot().plus(1));
     assertThat(blobSidecars3).isEmpty();
@@ -872,7 +872,7 @@ public class BlockManagerTest {
         localChain
             .chainBuilder()
             .generateBlockAtSlot(currentSlot, BlockOptions.create().setGenerateRandomBlobs(true));
-    final List<BlobSidecar> blobSidecars1 =
+    final List<BlobSidecarOld> blobSidecars1 =
         localChain.chainBuilder().getBlobSidecars(signedBlockAndState1.getRoot());
     assertThat(blobSidecars1).isNotEmpty();
 
@@ -902,7 +902,7 @@ public class BlockManagerTest {
         localChain
             .chainBuilder()
             .generateBlockAtSlot(currentSlot, BlockOptions.create().setGenerateRandomBlobs(true));
-    final List<BlobSidecar> blobSidecars1 =
+    final List<BlobSidecarOld> blobSidecars1 =
         localChain.chainBuilder().getBlobSidecars(signedBlockAndState1.getRoot());
     assertThat(blobSidecars1).isNotEmpty();
 
@@ -930,7 +930,7 @@ public class BlockManagerTest {
         localChain
             .chainBuilder()
             .generateBlockAtSlot(currentSlot, BlockOptions.create().setGenerateRandomBlobs(true));
-    final List<BlobSidecar> blobSidecars1 =
+    final List<BlobSidecarOld> blobSidecars1 =
         localChain.chainBuilder().getBlobSidecars(signedBlockAndState1.getRoot());
     assertThatNothingStoredForSlotRoot(signedBlockAndState1.getSlotAndBlockRoot());
     assertThat(blobSidecars1).isNotEmpty();
@@ -968,7 +968,7 @@ public class BlockManagerTest {
             .generateBlockAtSlot(
                 currentSlot.increment(), BlockOptions.create().setGenerateRandomBlobs(true));
 
-    final List<BlobSidecar> blobSidecars1 =
+    final List<BlobSidecarOld> blobSidecars1 =
         localChain.chainBuilder().getBlobSidecars(signedBlockAndState1.getRoot());
     assertThatNothingStoredForSlotRoot(signedBlockAndState1.getSlotAndBlockRoot());
     assertThat(blobSidecars1).isNotEmpty();
@@ -1008,7 +1008,7 @@ public class BlockManagerTest {
         localChain
             .chainBuilder()
             .generateBlockAtSlot(currentSlot, BlockOptions.create().setGenerateRandomBlobs(true));
-    final List<BlobSidecar> blobSidecars1 =
+    final List<BlobSidecarOld> blobSidecars1 =
         localChain.chainBuilder().getBlobSidecars(signedBlockAndState1.getRoot());
     assertThatNothingStoredForSlotRoot(signedBlockAndState1.getSlotAndBlockRoot());
     assertThat(blobSidecars1).isNotEmpty();
@@ -1038,7 +1038,7 @@ public class BlockManagerTest {
             .chainBuilder()
             .generateBlockAtSlot(
                 incrementSlot(), BlockOptions.create().setGenerateRandomBlobs(true));
-    final List<BlobSidecar> blobSidecars1 =
+    final List<BlobSidecarOld> blobSidecars1 =
         localChain.chainBuilder().getBlobSidecars(signedBlockAndState1.getRoot());
     assertThatNothingStoredForSlotRoot(signedBlockAndState1.getSlotAndBlockRoot());
     assertThat(blobSidecars1).isEmpty();
@@ -1061,7 +1061,7 @@ public class BlockManagerTest {
   }
 
   private BlobSidecarsAvailabilityChecker createAvailabilityCheckerWithValidBlobSidecars(
-      final SignedBeaconBlock block, final List<BlobSidecar> blobSidecars) {
+      final SignedBeaconBlock block, final List<BlobSidecarOld> blobSidecars) {
     reset(blobSidecarManager);
     final BlobSidecarsAvailabilityChecker blobSidecarsAvailabilityChecker =
         mock(BlobSidecarsAvailabilityChecker.class);
@@ -1098,7 +1098,7 @@ public class BlockManagerTest {
   }
 
   private BlobSidecarsAvailabilityChecker createAvailabilityCheckerWithInvalidBlobSidecars(
-      final SignedBeaconBlock block, final List<BlobSidecar> blobSidecars) {
+      final SignedBeaconBlock block, final List<BlobSidecarOld> blobSidecars) {
     reset(blobSidecarManager);
     final BlobSidecarsAvailabilityChecker blobSidecarsAvailabilityChecker =
         mock(BlobSidecarsAvailabilityChecker.class);
@@ -1113,7 +1113,7 @@ public class BlockManagerTest {
   }
 
   private void assertThatStored(
-      final BeaconBlock beaconBlock, final List<BlobSidecar> blobSidecars) {
+      final BeaconBlock beaconBlock, final List<BlobSidecarOld> blobSidecars) {
     assertThat(localRecentChainData.retrieveBlockByRoot(beaconBlock.getRoot()))
         .isCompletedWithValue(Optional.of(beaconBlock));
     assertThat(localRecentChainData.getBlobSidecars(beaconBlock.getSlotAndBlockRoot()))

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceBlobSidecarsAvailabilityCheckerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceBlobSidecarsAvailabilityCheckerTest.java
@@ -548,7 +548,7 @@ public class ForkChoiceBlobSidecarsAvailabilityCheckerTest {
   }
 
   private void throwWhenValidatingBlobSidecarsBatchAgainstBlock(
-          final List<BlobSidecarOld> blobSidecars, final Throwable cause) {
+      final List<BlobSidecarOld> blobSidecars, final Throwable cause) {
     doThrow(cause)
         .when(miscHelpers)
         .validateBlobSidecarsBatchAgainstBlock(
@@ -560,7 +560,7 @@ public class ForkChoiceBlobSidecarsAvailabilityCheckerTest {
   }
 
   private void throwWhenVerifyingBlobSidecarCompleteness(
-          final List<BlobSidecarOld> blobSidecars, final Throwable cause) {
+      final List<BlobSidecarOld> blobSidecars, final Throwable cause) {
     doThrow(cause)
         .when(miscHelpers)
         .verifyBlobSidecarCompleteness(
@@ -571,7 +571,7 @@ public class ForkChoiceBlobSidecarsAvailabilityCheckerTest {
   }
 
   private void verifyValidationAndDataAvailabilityCall(
-          final List<BlobSidecarOld> blobSidecars, final boolean isFinalValidation) {
+      final List<BlobSidecarOld> blobSidecars, final boolean isFinalValidation) {
     verify(miscHelpers, times(1))
         .validateBlobSidecarsBatchAgainstBlock(
             eq(blobSidecars),

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceBlobSidecarsAvailabilityCheckerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceBlobSidecarsAvailabilityCheckerTest.java
@@ -51,7 +51,7 @@ import tech.pegasys.teku.kzg.KZGCommitment;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecVersion;
 import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
@@ -78,11 +78,11 @@ public class ForkChoiceBlobSidecarsAvailabilityCheckerTest {
   private final RecentChainData recentChainData = mock(RecentChainData.class);
 
   private SignedBeaconBlock block;
-  private List<BlobSidecar> blobSidecarsComplete;
+  private List<BlobSidecarOld> blobSidecarsComplete;
   private List<KZGCommitment> kzgCommitmentsComplete;
 
-  private List<BlobSidecar> blobSidecarsInitial;
-  private List<BlobSidecar> blobSidecarsAdditional;
+  private List<BlobSidecarOld> blobSidecarsInitial;
+  private List<BlobSidecarOld> blobSidecarsAdditional;
 
   private final SafeFuture<Void> trackerCompletionFuture = new SafeFuture<>();
 
@@ -315,11 +315,11 @@ public class ForkChoiceBlobSidecarsAvailabilityCheckerTest {
     verifyValidationAndDataAvailabilityCall(blobSidecarsInitial, false);
 
     // we complete the blobs without index 3
-    final List<BlobSidecar> partialBlobs = blobSidecarsComplete.subList(1, 2);
+    final List<BlobSidecarOld> partialBlobs = blobSidecarsComplete.subList(1, 2);
     // we lie on availability check too (not actually possible)
     whenDataAvailability(partialBlobs).thenReturn(true);
 
-    final List<BlobSidecar> expectedIncompleteBlobSidecar = new ArrayList<>();
+    final List<BlobSidecarOld> expectedIncompleteBlobSidecar = new ArrayList<>();
     expectedIncompleteBlobSidecar.add(blobSidecarsComplete.get(0)); // blob 0
     expectedIncompleteBlobSidecar.add(blobSidecarsComplete.get(1)); // blob 1
     expectedIncompleteBlobSidecar.add(blobSidecarsComplete.get(2)); // blob 2
@@ -409,7 +409,7 @@ public class ForkChoiceBlobSidecarsAvailabilityCheckerTest {
 
   private void assertInvalid(
       final SafeFuture<BlobSidecarsAndValidationResult> availabilityOrValidityCheck,
-      final List<BlobSidecar> invalidBlobs,
+      final List<BlobSidecarOld> invalidBlobs,
       final Optional<Throwable> cause) {
     assertThat(availabilityOrValidityCheck)
         .isCompletedWithValueMatching(result -> !result.isValid(), "is not valid")
@@ -521,7 +521,7 @@ public class ForkChoiceBlobSidecarsAvailabilityCheckerTest {
       }
     }
 
-    final ImmutableSortedMap.Builder<UInt64, BlobSidecar> mapBuilder =
+    final ImmutableSortedMap.Builder<UInt64, BlobSidecarOld> mapBuilder =
         ImmutableSortedMap.naturalOrder();
     blobSidecarsInitial.forEach(blobSidecar -> mapBuilder.put(blobSidecar.getIndex(), blobSidecar));
 
@@ -534,8 +534,8 @@ public class ForkChoiceBlobSidecarsAvailabilityCheckerTest {
             spec, asyncRunner, recentChainData, blockBlobSidecarsTracker, kzg, timeout);
   }
 
-  private void completeTrackerWith(final List<BlobSidecar> blobSidecars) {
-    final ImmutableSortedMap.Builder<UInt64, BlobSidecar> mapBuilder =
+  private void completeTrackerWith(final List<BlobSidecarOld> blobSidecars) {
+    final ImmutableSortedMap.Builder<UInt64, BlobSidecarOld> mapBuilder =
         ImmutableSortedMap.naturalOrder();
     blobSidecars.forEach(blobSidecar -> mapBuilder.put(blobSidecar.getIndex(), blobSidecar));
     when(blockBlobSidecarsTracker.getBlobSidecars()).thenReturn(mapBuilder.build());
@@ -543,12 +543,12 @@ public class ForkChoiceBlobSidecarsAvailabilityCheckerTest {
     trackerCompletionFuture.complete(null);
   }
 
-  private OngoingStubbing<Boolean> whenDataAvailability(final List<BlobSidecar> blobSidecars) {
+  private OngoingStubbing<Boolean> whenDataAvailability(final List<BlobSidecarOld> blobSidecars) {
     return when(miscHelpers.verifyBlobKzgProofBatch(kzg, blobSidecars));
   }
 
   private void throwWhenValidatingBlobSidecarsBatchAgainstBlock(
-      final List<BlobSidecar> blobSidecars, final Throwable cause) {
+          final List<BlobSidecarOld> blobSidecars, final Throwable cause) {
     doThrow(cause)
         .when(miscHelpers)
         .validateBlobSidecarsBatchAgainstBlock(
@@ -560,7 +560,7 @@ public class ForkChoiceBlobSidecarsAvailabilityCheckerTest {
   }
 
   private void throwWhenVerifyingBlobSidecarCompleteness(
-      final List<BlobSidecar> blobSidecars, final Throwable cause) {
+          final List<BlobSidecarOld> blobSidecars, final Throwable cause) {
     doThrow(cause)
         .when(miscHelpers)
         .verifyBlobSidecarCompleteness(
@@ -571,7 +571,7 @@ public class ForkChoiceBlobSidecarsAvailabilityCheckerTest {
   }
 
   private void verifyValidationAndDataAvailabilityCall(
-      final List<BlobSidecar> blobSidecars, final boolean isFinalValidation) {
+          final List<BlobSidecarOld> blobSidecars, final boolean isFinalValidation) {
     verify(miscHelpers, times(1))
         .validateBlobSidecarsBatchAgainstBlock(
             eq(blobSidecars),
@@ -604,7 +604,7 @@ public class ForkChoiceBlobSidecarsAvailabilityCheckerTest {
     block = dataStructureUtil.randomSignedBeaconBlock();
     blobSidecarsComplete = dataStructureUtil.randomBlobSidecarsForBlock(block);
 
-    final ImmutableSortedMap.Builder<UInt64, BlobSidecar> mapBuilder =
+    final ImmutableSortedMap.Builder<UInt64, BlobSidecarOld> mapBuilder =
         ImmutableSortedMap.naturalOrder();
     blobSidecarsComplete.forEach(
         blobSidecar -> mapBuilder.put(blobSidecar.getIndex(), blobSidecar));

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
@@ -64,7 +64,7 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.Eth1Data;
 import tech.pegasys.teku.spec.datastructures.blocks.MinimalBeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
@@ -183,7 +183,7 @@ class ForkChoiceTest {
     if (spec.isMilestoneSupported(SpecMilestone.DENEB)) {
       when(blobSidecarManager.createAvailabilityChecker(any()))
           .thenReturn(blobSidecarsAvailabilityChecker);
-      final List<BlobSidecar> blobSidecars = dataStructureUtil.randomBlobSidecars(2);
+      final List<BlobSidecarOld> blobSidecars = dataStructureUtil.randomBlobSidecars(2);
       when(blobSidecarsAvailabilityChecker.getAvailabilityCheckResult())
           .thenReturn(
               SafeFuture.completedFuture(

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/BlobSidecarPoolImplTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/BlobSidecarPoolImplTest.java
@@ -44,7 +44,7 @@ import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BlobIdentifier;
@@ -80,7 +80,7 @@ public class BlobSidecarPoolImplTest {
   private final List<Bytes32> requiredBlockRootDroppedEvents = new ArrayList<>();
   private final List<BlobIdentifier> requiredBlobSidecarEvents = new ArrayList<>();
   private final List<BlobIdentifier> requiredBlobSidecarDroppedEvents = new ArrayList<>();
-  private final List<BlobSidecar> newBlobSidecarEvents = new ArrayList<>();
+  private final List<BlobSidecarOld> newBlobSidecarEvents = new ArrayList<>();
 
   private Optional<Function<SlotAndBlockRoot, BlockBlobSidecarsTracker>> mockedTrackersFactory =
       Optional.empty();
@@ -124,7 +124,7 @@ public class BlobSidecarPoolImplTest {
 
   @Test
   public void onNewBlobSidecar_addTrackerWithBlobSidecarIgnoringDuplicates() {
-    final BlobSidecar blobSidecar =
+    final BlobSidecarOld blobSidecar =
         dataStructureUtil.createRandomBlobSidecarBuilder().slot(currentSlot).build();
 
     blobSidecarPool.onNewBlobSidecar(blobSidecar);
@@ -143,7 +143,7 @@ public class BlobSidecarPoolImplTest {
 
   @Test
   public void onNewBlobSidecar_shouldIgnoreDuplicates() {
-    final BlobSidecar blobSidecar =
+    final BlobSidecarOld blobSidecar =
         dataStructureUtil.createRandomBlobSidecarBuilder().slot(currentSlot).build();
 
     blobSidecarPool.onNewBlobSidecar(blobSidecar);
@@ -182,7 +182,7 @@ public class BlobSidecarPoolImplTest {
   @Test
   public void onNewBlobSidecar_shouldIgnoreBlobsForAlreadyImportedBlocks() {
     final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(currentSlot);
-    final BlobSidecar blobSidecar =
+    final BlobSidecarOld blobSidecar =
         dataStructureUtil
             .createRandomBlobSidecarBuilder()
             .slot(currentSlot)
@@ -207,7 +207,7 @@ public class BlobSidecarPoolImplTest {
   @Test
   public void onNewBlobSidecarOnNewBlock_addTrackerWithBothBlockAndBlobSidecar() {
     final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(currentSlot);
-    final BlobSidecar blobSidecar = dataStructureUtil.randomBlobSidecarsForBlock(block).get(0);
+    final BlobSidecarOld blobSidecar = dataStructureUtil.randomBlobSidecarsForBlock(block).get(0);
 
     blobSidecarPool.onNewBlobSidecar(blobSidecar);
     blobSidecarPool.onNewBlock(block);
@@ -228,7 +228,7 @@ public class BlobSidecarPoolImplTest {
   public void twoOnNewBlobSidecar_addTrackerWithBothBlobSidecars() {
     final Bytes32 blockRoot = dataStructureUtil.randomBytes32();
 
-    final BlobSidecar blobSidecar0 =
+    final BlobSidecarOld blobSidecar0 =
         dataStructureUtil
             .createRandomBlobSidecarBuilder()
             .slot(currentSlot)
@@ -236,7 +236,7 @@ public class BlobSidecarPoolImplTest {
             .index(UInt64.ZERO)
             .build();
 
-    final BlobSidecar blobSidecar1 =
+    final BlobSidecarOld blobSidecar1 =
         dataStructureUtil
             .createRandomBlobSidecarBuilder()
             .slot(currentSlot)
@@ -244,7 +244,7 @@ public class BlobSidecarPoolImplTest {
             .index(UInt64.ONE)
             .build();
 
-    final BlobSidecar blobSidecar1bis =
+    final BlobSidecarOld blobSidecar1bis =
         dataStructureUtil
             .createRandomBlobSidecarBuilder()
             .slot(currentSlot)
@@ -299,7 +299,7 @@ public class BlobSidecarPoolImplTest {
 
     final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(slot);
 
-    final List<BlobSidecar> blobSidecars = dataStructureUtil.randomBlobSidecarsForBlock(block);
+    final List<BlobSidecarOld> blobSidecars = dataStructureUtil.randomBlobSidecarsForBlock(block);
 
     blobSidecarPool.onCompletedBlockAndBlobSidecars(block, blobSidecars);
 
@@ -329,7 +329,7 @@ public class BlobSidecarPoolImplTest {
 
     final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(currentSlot);
 
-    final List<BlobSidecar> blobSidecars = List.of();
+    final List<BlobSidecarOld> blobSidecars = List.of();
 
     blobSidecarPool.onCompletedBlockAndBlobSidecars(block, blobSidecars);
 
@@ -392,7 +392,7 @@ public class BlobSidecarPoolImplTest {
   @Test
   public void shouldApplyIgnoreForBlobSidecar() {
     final UInt64 slot = currentSlot.plus(futureTolerance).plus(UInt64.ONE);
-    final BlobSidecar blobSidecar =
+    final BlobSidecarOld blobSidecar =
         dataStructureUtil.createRandomBlobSidecarBuilder().slot(slot).build();
 
     blobSidecarPool.onNewBlobSidecar(blobSidecar);
@@ -499,7 +499,7 @@ public class BlobSidecarPoolImplTest {
   void shouldFetchMissingBlockAndBlobSidecars() {
     final SlotAndBlockRoot slotAndBlockRoot =
         new SlotAndBlockRoot(currentSlot, dataStructureUtil.randomBytes32());
-    final BlobSidecar blobSidecar =
+    final BlobSidecarOld blobSidecar =
         dataStructureUtil
             .createRandomBlobSidecarBuilder()
             .blockRoot(slotAndBlockRoot.getBlockRoot())
@@ -539,7 +539,7 @@ public class BlobSidecarPoolImplTest {
     final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(currentSlot);
 
     final SlotAndBlockRoot slotAndBlockRoot = new SlotAndBlockRoot(currentSlot, block.getRoot());
-    final BlobSidecar blobSidecar =
+    final BlobSidecarOld blobSidecar =
         dataStructureUtil
             .createRandomBlobSidecarBuilder()
             .blockRoot(slotAndBlockRoot.getBlockRoot())
@@ -577,7 +577,7 @@ public class BlobSidecarPoolImplTest {
     final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(currentSlot);
 
     final SlotAndBlockRoot slotAndBlockRoot = new SlotAndBlockRoot(currentSlot, block.getRoot());
-    final BlobSidecar blobSidecar =
+    final BlobSidecarOld blobSidecar =
         dataStructureUtil
             .createRandomBlobSidecarBuilder()
             .blockRoot(slotAndBlockRoot.getBlockRoot())
@@ -623,7 +623,7 @@ public class BlobSidecarPoolImplTest {
   @Test
   public void shouldFetchContentWhenBlobSidecarIsNotForCurrentSlot() {
     final UInt64 slot = currentSlot.minus(UInt64.ONE);
-    final BlobSidecar blobSidecar =
+    final BlobSidecarOld blobSidecar =
         dataStructureUtil.createRandomBlobSidecarBuilder().slot(slot).build();
 
     blobSidecarPool.onNewBlobSidecar(blobSidecar);
@@ -669,7 +669,7 @@ public class BlobSidecarPoolImplTest {
   void shouldDropPossiblyFetchedBlock() {
     final SlotAndBlockRoot slotAndBlockRoot =
         new SlotAndBlockRoot(currentSlot, dataStructureUtil.randomBytes32());
-    final BlobSidecar blobSidecar =
+    final BlobSidecarOld blobSidecar =
         dataStructureUtil
             .createRandomBlobSidecarBuilder()
             .blockRoot(slotAndBlockRoot.getBlockRoot())
@@ -704,7 +704,7 @@ public class BlobSidecarPoolImplTest {
   void shouldNotDropPossiblyFetchedBlockIfFetchHasNotOccurred() {
     final SlotAndBlockRoot slotAndBlockRoot =
         new SlotAndBlockRoot(currentSlot, dataStructureUtil.randomBytes32());
-    final BlobSidecar blobSidecar =
+    final BlobSidecarOld blobSidecar =
         dataStructureUtil
             .createRandomBlobSidecarBuilder()
             .blockRoot(slotAndBlockRoot.getBlockRoot())
@@ -876,7 +876,7 @@ public class BlobSidecarPoolImplTest {
     return new Checkpoint(epoch, root);
   }
 
-  private static BlobIdentifier blobIdentifierFromBlobSidecar(final BlobSidecar blobSidecar) {
+  private static BlobIdentifier blobIdentifierFromBlobSidecar(final BlobSidecarOld blobSidecar) {
     return new BlobIdentifier(blobSidecar.getBlockRoot(), blobSidecar.getIndex());
   }
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/BlobSidecarGossipValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/BlobSidecarGossipValidatorTest.java
@@ -31,7 +31,7 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecContext;
 import tech.pegasys.teku.spec.TestSpecInvocationContextProvider.SpecContext;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
@@ -52,7 +52,7 @@ public class BlobSidecarGossipValidatorTest {
   private Bytes32 blockRoot;
   private Bytes32 blockParentRoot;
 
-  private SignedBlobSidecar signedBlobSidecar;
+  private SignedBlobSidecarOld signedBlobSidecar;
 
   @BeforeEach
   void setUp(final SpecContext specContext) {

--- a/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/AbstractRpcMethodIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/AbstractRpcMethodIntegrationTest.java
@@ -29,7 +29,7 @@ import tech.pegasys.teku.networking.eth2.rpc.core.encodings.RpcEncoding;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.BeaconBlockBodyAltair;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.bellatrix.BeaconBlockBodyBellatrix;
@@ -230,7 +230,7 @@ public abstract class AbstractRpcMethodIntegrationTest {
     return Arrays.stream(SpecMilestone.values()).map(Arguments::of);
   }
 
-  protected List<BlobSidecar> retrieveCanonicalBlobSidecarsFromPeerStorage(
+  protected List<BlobSidecarOld> retrieveCanonicalBlobSidecarsFromPeerStorage(
       final Stream<UInt64> slots) {
 
     return slots
@@ -246,7 +246,7 @@ public abstract class AbstractRpcMethodIntegrationTest {
         .toList();
   }
 
-  private List<BlobSidecar> safeRetrieveBlobSidecars(final SlotAndBlockRoot slotAndBlockRoot) {
+  private List<BlobSidecarOld> safeRetrieveBlobSidecars(final SlotAndBlockRoot slotAndBlockRoot) {
     try {
       return Waiter.waitFor(
           peerStorage.chainStorage().getBlobSidecarsBySlotAndBlockRoot(slotAndBlockRoot));

--- a/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/BlobSidecarsByRangeIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/BlobSidecarsByRangeIntegrationTest.java
@@ -113,7 +113,8 @@ public class BlobSidecarsByRangeIntegrationTest extends AbstractRpcMethodIntegra
 
     final UInt64 slotCount = targetSlot.minus(startSlot).increment();
     // call and check
-    final List<BlobSidecarOld> blobSidecars = requestBlobSidecarsByRange(peer, startSlot, slotCount);
+    final List<BlobSidecarOld> blobSidecars =
+        requestBlobSidecarsByRange(peer, startSlot, slotCount);
     assertThat(blobSidecars).containsExactlyInAnyOrderElementsOf(expectedCanonicalBlobSidecars);
     assertThat(blobSidecars).doesNotContainAnyElementsOf(nonCanonicalBlobSidecars);
   }

--- a/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/BlobSidecarsByRangeIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/BlobSidecarsByRangeIntegrationTest.java
@@ -27,7 +27,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.teku.networking.p2p.rpc.RpcResponseListener;
 import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.generator.ChainBuilder;
@@ -46,7 +46,7 @@ public class BlobSidecarsByRangeIntegrationTest extends AbstractRpcMethodIntegra
   public void requestBlobSidecars_shouldReturnEmptyBlobSidecarsOnDenebMilestone()
       throws ExecutionException, InterruptedException, TimeoutException {
     final Eth2Peer peer = createPeer(TestSpecFactory.createMinimalDeneb());
-    final List<BlobSidecar> blobSidecars =
+    final List<BlobSidecarOld> blobSidecars =
         requestBlobSidecarsByRange(peer, UInt64.ONE, UInt64.valueOf(10));
     assertThat(blobSidecars).isEmpty();
   }
@@ -66,7 +66,7 @@ public class BlobSidecarsByRangeIntegrationTest extends AbstractRpcMethodIntegra
             .finalizeCurrentChain(Optional.of(peerStorage.chainUpdater().blockOptions));
     finalizedBlocksAndStates.forEach(
         blockAndState -> {
-          final List<BlobSidecar> blobSidecars =
+          final List<BlobSidecarOld> blobSidecars =
               peerStorage.chainBuilder().getBlobSidecars(blockAndState.getRoot());
           peerStorage.chainUpdater().saveBlock(blockAndState, blobSidecars);
           peerStorage.chainUpdater().updateBestBlock(blockAndState);
@@ -89,10 +89,10 @@ public class BlobSidecarsByRangeIntegrationTest extends AbstractRpcMethodIntegra
     final List<SignedBlockAndState> nonCanonicalBlocksAndStates =
         fork.generateBlocksUpToSlot(targetSlot.intValue(), peerStorage.chainUpdater().blockOptions);
 
-    final List<BlobSidecar> nonCanonicalBlobSidecars = new ArrayList<>();
+    final List<BlobSidecarOld> nonCanonicalBlobSidecars = new ArrayList<>();
     nonCanonicalBlocksAndStates.forEach(
         signedBlockAndState -> {
-          final List<BlobSidecar> blobSidecars =
+          final List<BlobSidecarOld> blobSidecars =
               fork.getBlobSidecars(signedBlockAndState.getRoot());
           nonCanonicalBlobSidecars.addAll(blobSidecars);
           peerStorage.chainUpdater().saveBlock(signedBlockAndState, blobSidecars);
@@ -108,20 +108,20 @@ public class BlobSidecarsByRangeIntegrationTest extends AbstractRpcMethodIntegra
     final UInt64 startSlot = finalizedSlot.minus(5);
 
     // grab expected blobs from storage
-    final List<BlobSidecar> expectedCanonicalBlobSidecars =
+    final List<BlobSidecarOld> expectedCanonicalBlobSidecars =
         retrieveCanonicalBlobSidecarsFromPeerStorage(UInt64.rangeClosed(startSlot, targetSlot));
 
     final UInt64 slotCount = targetSlot.minus(startSlot).increment();
     // call and check
-    final List<BlobSidecar> blobSidecars = requestBlobSidecarsByRange(peer, startSlot, slotCount);
+    final List<BlobSidecarOld> blobSidecars = requestBlobSidecarsByRange(peer, startSlot, slotCount);
     assertThat(blobSidecars).containsExactlyInAnyOrderElementsOf(expectedCanonicalBlobSidecars);
     assertThat(blobSidecars).doesNotContainAnyElementsOf(nonCanonicalBlobSidecars);
   }
 
-  private List<BlobSidecar> requestBlobSidecarsByRange(
+  private List<BlobSidecarOld> requestBlobSidecarsByRange(
       final Eth2Peer peer, final UInt64 from, final UInt64 count)
       throws InterruptedException, ExecutionException, TimeoutException {
-    final List<BlobSidecar> blobSidecars = new ArrayList<>();
+    final List<BlobSidecarOld> blobSidecars = new ArrayList<>();
     waitFor(
         peer.requestBlobSidecarsByRange(from, count, RpcResponseListener.from(blobSidecars::add)));
     waitFor(() -> assertThat(peer.getOutstandingRequests()).isEqualTo(0));

--- a/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/BlobSidecarsByRootIntegrationTest.java
+++ b/networking/eth2/src/integration-test/java/tech/pegasys/teku/networking/eth2/BlobSidecarsByRootIntegrationTest.java
@@ -30,7 +30,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.teku.networking.p2p.rpc.RpcResponseListener;
 import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BlobIdentifier;
 
 public class BlobSidecarsByRootIntegrationTest extends AbstractRpcMethodIntegrationTest {
@@ -56,7 +56,7 @@ public class BlobSidecarsByRootIntegrationTest extends AbstractRpcMethodIntegrat
   public void requestBlobSidecars_shouldReturnEmptyBlobSidecarsOnDenebMilestone()
       throws ExecutionException, InterruptedException, TimeoutException {
     final Eth2Peer peer = createPeer(TestSpecFactory.createMinimalDeneb());
-    final Optional<BlobSidecar> blobSidecar =
+    final Optional<BlobSidecarOld> blobSidecar =
         requestBlobSidecarByRoot(peer, new BlobIdentifier(Bytes32.ZERO, UInt64.ZERO));
     assertThat(blobSidecar).isEmpty();
   }
@@ -75,7 +75,7 @@ public class BlobSidecarsByRootIntegrationTest extends AbstractRpcMethodIntegrat
     peerStorage.chainUpdater().advanceChainUntil(targetSlot);
 
     // grab expected blobs from storage
-    final List<BlobSidecar> expectedBlobSidecars =
+    final List<BlobSidecarOld> expectedBlobSidecars =
         retrieveCanonicalBlobSidecarsFromPeerStorage(Stream.of(UInt64.ONE, UInt64.valueOf(3)));
 
     // request all expected plus a non existing
@@ -86,15 +86,15 @@ public class BlobSidecarsByRootIntegrationTest extends AbstractRpcMethodIntegrat
                     .map(sidecar -> new BlobIdentifier(sidecar.getBlockRoot(), sidecar.getIndex())))
             .collect(Collectors.toUnmodifiableList());
 
-    final List<BlobSidecar> blobSidecars = requestBlobSidecarsByRoot(peer, requestedBlobIds);
+    final List<BlobSidecarOld> blobSidecars = requestBlobSidecarsByRoot(peer, requestedBlobIds);
 
     assertThat(blobSidecars).containsExactlyInAnyOrderElementsOf(expectedBlobSidecars);
   }
 
-  private List<BlobSidecar> requestBlobSidecarsByRoot(
+  private List<BlobSidecarOld> requestBlobSidecarsByRoot(
       final Eth2Peer peer, final List<BlobIdentifier> blobIdentifiers)
       throws InterruptedException, ExecutionException, TimeoutException {
-    final List<BlobSidecar> blobSidecars = new ArrayList<>();
+    final List<BlobSidecarOld> blobSidecars = new ArrayList<>();
     waitFor(
         peer.requestBlobSidecarsByRoot(
             blobIdentifiers, RpcResponseListener.from(blobSidecars::add)));
@@ -102,10 +102,10 @@ public class BlobSidecarsByRootIntegrationTest extends AbstractRpcMethodIntegrat
     return blobSidecars;
   }
 
-  private Optional<BlobSidecar> requestBlobSidecarByRoot(
+  private Optional<BlobSidecarOld> requestBlobSidecarByRoot(
       final Eth2Peer peer, final BlobIdentifier blobIdentifier)
       throws ExecutionException, InterruptedException, TimeoutException {
-    final Optional<BlobSidecar> blobSidecar =
+    final Optional<BlobSidecarOld> blobSidecar =
         waitFor(peer.requestBlobSidecarByRoot(blobIdentifier));
     assertThat(peer.getOutstandingRequests()).isEqualTo(0);
     return blobSidecar;

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkBuilder.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkBuilder.java
@@ -68,7 +68,7 @@ import tech.pegasys.teku.networking.p2p.rpc.RpcMethod;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.config.Constants;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
@@ -96,7 +96,7 @@ public class Eth2P2PNetworkBuilder {
   protected EventChannels eventChannels;
   protected CombinedChainDataClient combinedChainDataClient;
   protected OperationProcessor<SignedBeaconBlock> gossipedBlockProcessor;
-  protected OperationProcessor<SignedBlobSidecar> gossipedBlobSidecarProcessor;
+  protected OperationProcessor<SignedBlobSidecarOld> gossipedBlobSidecarProcessor;
   protected OperationProcessor<ValidatableAttestation> gossipedAttestationConsumer;
   protected OperationProcessor<ValidatableAttestation> gossipedAggregateProcessor;
   protected OperationProcessor<AttesterSlashing> gossipedAttesterSlashingConsumer;
@@ -444,7 +444,7 @@ public class Eth2P2PNetworkBuilder {
   }
 
   public Eth2P2PNetworkBuilder gossipedBlobSidecarProcessor(
-      final OperationProcessor<SignedBlobSidecar> blobSidecarProcessor) {
+      final OperationProcessor<SignedBlobSidecarOld> blobSidecarProcessor) {
     checkNotNull(blobSidecarProcessor);
     this.gossipedBlobSidecarProcessor = blobSidecarProcessor;
     return this;

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/BlobSidecarGossipChannel.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/BlobSidecarGossipChannel.java
@@ -15,15 +15,15 @@ package tech.pegasys.teku.networking.eth2.gossip;
 
 import java.util.List;
 import tech.pegasys.teku.infrastructure.events.VoidReturningChannelInterface;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecarOld;
 
 public interface BlobSidecarGossipChannel extends VoidReturningChannelInterface {
 
   BlobSidecarGossipChannel NOOP = blobSidecar -> {};
 
-  default void publishBlobSidecars(final List<SignedBlobSidecar> blobSidecars) {
+  default void publishBlobSidecars(final List<SignedBlobSidecarOld> blobSidecars) {
     blobSidecars.forEach(this::publishBlobSidecar);
   }
 
-  void publishBlobSidecar(SignedBlobSidecar blobSidecar);
+  void publishBlobSidecar(SignedBlobSidecarOld blobSidecar);
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/BlobSidecarGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/BlobSidecarGossipManager.java
@@ -159,7 +159,9 @@ public class BlobSidecarGossipManager implements GossipManager {
     private final OperationProcessor<SignedBlobSidecarOld> delegate;
 
     private TopicSubnetIdAwareOperationProcessor(
-        final Spec spec, final int subnetId, final OperationProcessor<SignedBlobSidecarOld> delegate) {
+        final Spec spec,
+        final int subnetId,
+        final OperationProcessor<SignedBlobSidecarOld> delegate) {
       this.spec = spec;
       this.subnetId = subnetId;
       this.delegate = delegate;
@@ -167,7 +169,7 @@ public class BlobSidecarGossipManager implements GossipManager {
 
     @Override
     public SafeFuture<InternalValidationResult> process(
-            final SignedBlobSidecarOld blobSidecar, final Optional<UInt64> arrivalTimestamp) {
+        final SignedBlobSidecarOld blobSidecar, final Optional<UInt64> arrivalTimestamp) {
       final int blobSidecarSubnet = spec.computeSubnetForBlobSidecar(blobSidecar).intValue();
       if (blobSidecarSubnet != subnetId) {
         return SafeFuture.completedFuture(

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/forks/GossipForkManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/forks/GossipForkManager.java
@@ -32,7 +32,7 @@ import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
@@ -163,7 +163,7 @@ public class GossipForkManager {
     publishMessage(block.getSlot(), block, "block", GossipForkSubscriptions::publishBlock);
   }
 
-  public synchronized void publishBlobSidecar(final SignedBlobSidecar blobSidecar) {
+  public synchronized void publishBlobSidecar(final SignedBlobSidecarOld blobSidecar) {
     publishMessage(
         blobSidecar.getBlobSidecar().getSlot(),
         blobSidecar,

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/forks/GossipForkSubscriptions.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/forks/GossipForkSubscriptions.java
@@ -16,7 +16,7 @@ package tech.pegasys.teku.networking.eth2.gossip.forks;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
@@ -39,7 +39,7 @@ public interface GossipForkSubscriptions {
 
   void publishBlock(SignedBeaconBlock block);
 
-  default void publishBlobSidecar(SignedBlobSidecar blobSidecar) {
+  default void publishBlobSidecar(SignedBlobSidecarOld blobSidecar) {
     // since Deneb
   }
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/forks/versions/GossipForkSubscriptionsDeneb.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/forks/versions/GossipForkSubscriptionsDeneb.java
@@ -22,7 +22,7 @@ import tech.pegasys.teku.networking.eth2.gossip.topics.OperationProcessor;
 import tech.pegasys.teku.networking.p2p.discovery.DiscoveryNetwork;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
@@ -36,7 +36,7 @@ import tech.pegasys.teku.storage.client.RecentChainData;
 
 public class GossipForkSubscriptionsDeneb extends GossipForkSubscriptionsCapella {
 
-  private final OperationProcessor<SignedBlobSidecar> blobSidecarProcessor;
+  private final OperationProcessor<SignedBlobSidecarOld> blobSidecarProcessor;
 
   private BlobSidecarGossipManager blobSidecarGossipManager;
 
@@ -50,7 +50,7 @@ public class GossipForkSubscriptionsDeneb extends GossipForkSubscriptionsCapella
       final RecentChainData recentChainData,
       final GossipEncoding gossipEncoding,
       final OperationProcessor<SignedBeaconBlock> blockProcessor,
-      final OperationProcessor<SignedBlobSidecar> blobSidecarProcessor,
+      final OperationProcessor<SignedBlobSidecarOld> blobSidecarProcessor,
       final OperationProcessor<ValidatableAttestation> attestationProcessor,
       final OperationProcessor<ValidatableAttestation> aggregateProcessor,
       final OperationProcessor<AttesterSlashing> attesterSlashingProcessor,
@@ -103,7 +103,7 @@ public class GossipForkSubscriptionsDeneb extends GossipForkSubscriptionsCapella
   }
 
   @Override
-  public void publishBlobSidecar(final SignedBlobSidecar blobSidecar) {
+  public void publishBlobSidecar(final SignedBlobSidecarOld blobSidecar) {
     blobSidecarGossipManager.publishBlobSidecar(blobSidecar);
   }
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/DefaultEth2Peer.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/DefaultEth2Peer.java
@@ -51,7 +51,7 @@ import tech.pegasys.teku.networking.p2p.rpc.RpcResponseListener;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.config.SpecConfigDeneb;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BeaconBlocksByRangeRequestMessage;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BeaconBlocksByRootRequestMessage;
@@ -239,7 +239,7 @@ class DefaultEth2Peer extends DelegatingPeer implements Eth2Peer {
 
   @Override
   public SafeFuture<Void> requestBlobSidecarsByRoot(
-      final List<BlobIdentifier> blobIdentifiers, final RpcResponseListener<BlobSidecar> listener) {
+      final List<BlobIdentifier> blobIdentifiers, final RpcResponseListener<BlobSidecarOld> listener) {
     return rpcMethods
         .blobSidecarsByRoot()
         .map(
@@ -274,7 +274,7 @@ class DefaultEth2Peer extends DelegatingPeer implements Eth2Peer {
   }
 
   @Override
-  public SafeFuture<Optional<BlobSidecar>> requestBlobSidecarByRoot(
+  public SafeFuture<Optional<BlobSidecarOld>> requestBlobSidecarByRoot(
       final BlobIdentifier blobIdentifier) {
     return rpcMethods
         .blobSidecarsByRoot()
@@ -314,7 +314,7 @@ class DefaultEth2Peer extends DelegatingPeer implements Eth2Peer {
 
   @Override
   public SafeFuture<Void> requestBlobSidecarsByRange(
-      final UInt64 startSlot, final UInt64 count, final RpcResponseListener<BlobSidecar> listener) {
+      final UInt64 startSlot, final UInt64 count, final RpcResponseListener<BlobSidecarOld> listener) {
     return rpcMethods
         .blobSidecarsByRange()
         .map(
@@ -373,7 +373,7 @@ class DefaultEth2Peer extends DelegatingPeer implements Eth2Peer {
 
   @Override
   public Optional<RequestApproval> approveBlobSidecarsRequest(
-      final ResponseCallback<BlobSidecar> callback, long blobSidecarsCount) {
+          final ResponseCallback<BlobSidecarOld> callback, long blobSidecarsCount) {
     return approveObjectsRequest(
         "blob sidecars", blobSidecarsRequestTracker, blobSidecarsCount, callback);
   }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/DefaultEth2Peer.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/DefaultEth2Peer.java
@@ -239,7 +239,8 @@ class DefaultEth2Peer extends DelegatingPeer implements Eth2Peer {
 
   @Override
   public SafeFuture<Void> requestBlobSidecarsByRoot(
-      final List<BlobIdentifier> blobIdentifiers, final RpcResponseListener<BlobSidecarOld> listener) {
+      final List<BlobIdentifier> blobIdentifiers,
+      final RpcResponseListener<BlobSidecarOld> listener) {
     return rpcMethods
         .blobSidecarsByRoot()
         .map(
@@ -314,7 +315,9 @@ class DefaultEth2Peer extends DelegatingPeer implements Eth2Peer {
 
   @Override
   public SafeFuture<Void> requestBlobSidecarsByRange(
-      final UInt64 startSlot, final UInt64 count, final RpcResponseListener<BlobSidecarOld> listener) {
+      final UInt64 startSlot,
+      final UInt64 count,
+      final RpcResponseListener<BlobSidecarOld> listener) {
     return rpcMethods
         .blobSidecarsByRange()
         .map(
@@ -373,7 +376,7 @@ class DefaultEth2Peer extends DelegatingPeer implements Eth2Peer {
 
   @Override
   public Optional<RequestApproval> approveBlobSidecarsRequest(
-          final ResponseCallback<BlobSidecarOld> callback, long blobSidecarsCount) {
+      final ResponseCallback<BlobSidecarOld> callback, long blobSidecarsCount) {
     return approveObjectsRequest(
         "blob sidecars", blobSidecarsRequestTracker, blobSidecarsCount, callback);
   }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2Peer.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2Peer.java
@@ -110,7 +110,7 @@ public interface Eth2Peer extends Peer, SyncSource {
   void adjustBlocksRequest(RequestApproval blocksRequest, long returnedBlocksCount);
 
   Optional<RequestApproval> approveBlobSidecarsRequest(
-          ResponseCallback<BlobSidecarOld> callback, long blobSidecarsCount);
+      ResponseCallback<BlobSidecarOld> callback, long blobSidecarsCount);
 
   void adjustBlobSidecarsRequest(
       RequestApproval blobSidecarsRequest, long returnedBlobSidecarsCount);

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2Peer.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2Peer.java
@@ -30,7 +30,7 @@ import tech.pegasys.teku.networking.eth2.rpc.core.methods.Eth2RpcMethod;
 import tech.pegasys.teku.networking.p2p.peer.Peer;
 import tech.pegasys.teku.networking.p2p.rpc.RpcResponseListener;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BlobIdentifier;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.RpcRequest;
@@ -91,13 +91,13 @@ public interface Eth2Peer extends Peer, SyncSource {
       throws RpcException;
 
   SafeFuture<Void> requestBlobSidecarsByRoot(
-      List<BlobIdentifier> blobIdentifiers, RpcResponseListener<BlobSidecar> listener);
+      List<BlobIdentifier> blobIdentifiers, RpcResponseListener<BlobSidecarOld> listener);
 
   SafeFuture<Optional<SignedBeaconBlock>> requestBlockBySlot(UInt64 slot);
 
   SafeFuture<Optional<SignedBeaconBlock>> requestBlockByRoot(Bytes32 blockRoot);
 
-  SafeFuture<Optional<BlobSidecar>> requestBlobSidecarByRoot(BlobIdentifier blobIdentifier);
+  SafeFuture<Optional<BlobSidecarOld>> requestBlobSidecarByRoot(BlobIdentifier blobIdentifier);
 
   SafeFuture<MetadataMessage> requestMetadata();
 
@@ -110,7 +110,7 @@ public interface Eth2Peer extends Peer, SyncSource {
   void adjustBlocksRequest(RequestApproval blocksRequest, long returnedBlocksCount);
 
   Optional<RequestApproval> approveBlobSidecarsRequest(
-      ResponseCallback<BlobSidecar> callback, long blobSidecarsCount);
+          ResponseCallback<BlobSidecarOld> callback, long blobSidecarsCount);
 
   void adjustBlobSidecarsRequest(
       RequestApproval blobSidecarsRequest, long returnedBlobSidecarsCount);

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/SyncSource.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/SyncSource.java
@@ -18,7 +18,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.p2p.peer.DisconnectReason;
 import tech.pegasys.teku.networking.p2p.reputation.ReputationAdjustment;
 import tech.pegasys.teku.networking.p2p.rpc.RpcResponseListener;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 
 /**
@@ -30,7 +30,7 @@ public interface SyncSource {
       UInt64 startSlot, UInt64 count, RpcResponseListener<SignedBeaconBlock> listener);
 
   SafeFuture<Void> requestBlobSidecarsByRange(
-      UInt64 startSlot, UInt64 count, RpcResponseListener<BlobSidecar> listener);
+      UInt64 startSlot, UInt64 count, RpcResponseListener<BlobSidecarOld> listener);
 
   void adjustReputation(final ReputationAdjustment adjustment);
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/BeaconChainMethods.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/BeaconChainMethods.java
@@ -43,7 +43,7 @@ import tech.pegasys.teku.networking.p2p.rpc.RpcMethod;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.config.SpecConfigDeneb;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BeaconBlocksByRangeRequestMessage;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BeaconBlocksByRangeRequestMessage.BeaconBlocksByRangeRequestMessageSchema;
@@ -70,9 +70,9 @@ public class BeaconChainMethods {
       beaconBlocksByRoot;
   private final Eth2RpcMethod<BeaconBlocksByRangeRequestMessage, SignedBeaconBlock>
       beaconBlocksByRange;
-  private final Optional<Eth2RpcMethod<BlobSidecarsByRootRequestMessage, BlobSidecar>>
+  private final Optional<Eth2RpcMethod<BlobSidecarsByRootRequestMessage, BlobSidecarOld>>
       blobSidecarsByRoot;
-  private final Optional<Eth2RpcMethod<BlobSidecarsByRangeRequestMessage, BlobSidecar>>
+  private final Optional<Eth2RpcMethod<BlobSidecarsByRangeRequestMessage, BlobSidecarOld>>
       blobSidecarsByRange;
   private final Eth2RpcMethod<EmptyMessage, MetadataMessage> getMetadata;
   private final Eth2RpcMethod<PingMessage, PingMessage> ping;
@@ -84,9 +84,9 @@ public class BeaconChainMethods {
       final Eth2RpcMethod<GoodbyeMessage, GoodbyeMessage> goodBye,
       final Eth2RpcMethod<BeaconBlocksByRootRequestMessage, SignedBeaconBlock> beaconBlocksByRoot,
       final Eth2RpcMethod<BeaconBlocksByRangeRequestMessage, SignedBeaconBlock> beaconBlocksByRange,
-      final Optional<Eth2RpcMethod<BlobSidecarsByRootRequestMessage, BlobSidecar>>
+      final Optional<Eth2RpcMethod<BlobSidecarsByRootRequestMessage, BlobSidecarOld>>
           blobSidecarsByRoot,
-      final Optional<Eth2RpcMethod<BlobSidecarsByRangeRequestMessage, BlobSidecar>>
+      final Optional<Eth2RpcMethod<BlobSidecarsByRangeRequestMessage, BlobSidecarOld>>
           blobSidecarsByRange,
       final Eth2RpcMethod<EmptyMessage, MetadataMessage> getMetadata,
       final Eth2RpcMethod<PingMessage, PingMessage> ping) {
@@ -267,7 +267,7 @@ public class BeaconChainMethods {
         rpcEncoding, requestType, expectResponseToRequest, List.of(v2Method));
   }
 
-  private static Optional<Eth2RpcMethod<BlobSidecarsByRootRequestMessage, BlobSidecar>>
+  private static Optional<Eth2RpcMethod<BlobSidecarsByRootRequestMessage, BlobSidecarOld>>
       createBlobSidecarsByRoot(
           final Spec spec,
           final MetricsSystem metricsSystem,
@@ -280,7 +280,7 @@ public class BeaconChainMethods {
       return Optional.empty();
     }
 
-    final RpcContextCodec<Bytes4, BlobSidecar> forkDigestContextCodec =
+    final RpcContextCodec<Bytes4, BlobSidecarOld> forkDigestContextCodec =
         RpcContextCodec.forkDigest(spec, recentChainData, ForkDigestPayloadContext.BLOB_SIDECAR);
 
     final BlobSidecarsByRootMessageHandler blobSidecarsByRootHandler =
@@ -305,7 +305,7 @@ public class BeaconChainMethods {
             spec.getNetworkingConfig()));
   }
 
-  private static Optional<Eth2RpcMethod<BlobSidecarsByRangeRequestMessage, BlobSidecar>>
+  private static Optional<Eth2RpcMethod<BlobSidecarsByRangeRequestMessage, BlobSidecarOld>>
       createBlobSidecarsByRange(
           final Spec spec,
           final MetricsSystem metricsSystem,
@@ -322,7 +322,7 @@ public class BeaconChainMethods {
     final BlobSidecarsByRangeRequestMessage.BlobSidecarsByRangeRequestMessageSchema requestType =
         BlobSidecarsByRangeRequestMessage.SSZ_SCHEMA;
 
-    final RpcContextCodec<Bytes4, BlobSidecar> forkDigestContextCodec =
+    final RpcContextCodec<Bytes4, BlobSidecarOld> forkDigestContextCodec =
         RpcContextCodec.forkDigest(spec, recentChainData, ForkDigestPayloadContext.BLOB_SIDECAR);
 
     final BlobSidecarsByRangeMessageHandler blobSidecarsByRangeHandler =
@@ -450,12 +450,12 @@ public class BeaconChainMethods {
     return beaconBlocksByRange;
   }
 
-  public Optional<Eth2RpcMethod<BlobSidecarsByRootRequestMessage, BlobSidecar>>
+  public Optional<Eth2RpcMethod<BlobSidecarsByRootRequestMessage, BlobSidecarOld>>
       blobSidecarsByRoot() {
     return blobSidecarsByRoot;
   }
 
-  public Optional<Eth2RpcMethod<BlobSidecarsByRangeRequestMessage, BlobSidecar>>
+  public Optional<Eth2RpcMethod<BlobSidecarsByRangeRequestMessage, BlobSidecarOld>>
       blobSidecarsByRange() {
     return blobSidecarsByRange;
   }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/AbstractBlobSidecarsValidator.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/AbstractBlobSidecarsValidator.java
@@ -20,7 +20,7 @@ import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.networking.p2p.peer.Peer;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 
 public class AbstractBlobSidecarsValidator {
 
@@ -36,14 +36,14 @@ public class AbstractBlobSidecarsValidator {
     this.kzg = kzg;
   }
 
-  protected void verifyKzg(final BlobSidecar blobSidecar) {
+  protected void verifyKzg(final BlobSidecarOld blobSidecar) {
     if (!verifyBlobKzgProof(blobSidecar)) {
       throw new BlobSidecarsResponseInvalidResponseException(
           peer, BLOB_SIDECAR_KZG_VERIFICATION_FAILED);
     }
   }
 
-  private boolean verifyBlobKzgProof(final BlobSidecar blobSidecar) {
+  private boolean verifyBlobKzgProof(final BlobSidecarOld blobSidecar) {
     try {
       return spec.atSlot(blobSidecar.getSlot()).miscHelpers().verifyBlobKzgProof(kzg, blobSidecar);
     } catch (final Exception ex) {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeListenerValidatingProxy.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeListenerValidatingProxy.java
@@ -26,12 +26,12 @@ import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.networking.p2p.peer.Peer;
 import tech.pegasys.teku.networking.p2p.rpc.RpcResponseListener;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 
 public class BlobSidecarsByRangeListenerValidatingProxy extends AbstractBlobSidecarsValidator
-    implements RpcResponseListener<BlobSidecar> {
+    implements RpcResponseListener<BlobSidecarOld> {
 
-  private final RpcResponseListener<BlobSidecar> blobSidecarResponseListener;
+  private final RpcResponseListener<BlobSidecarOld> blobSidecarResponseListener;
   private final Integer maxBlobsPerBlock;
   private final UInt64 startSlot;
   private final UInt64 endSlot;
@@ -41,7 +41,7 @@ public class BlobSidecarsByRangeListenerValidatingProxy extends AbstractBlobSide
   public BlobSidecarsByRangeListenerValidatingProxy(
       final Spec spec,
       final Peer peer,
-      final RpcResponseListener<BlobSidecar> blobSidecarResponseListener,
+      final RpcResponseListener<BlobSidecarOld> blobSidecarResponseListener,
       final Integer maxBlobsPerBlock,
       final KZG kzg,
       final UInt64 startSlot,
@@ -54,7 +54,7 @@ public class BlobSidecarsByRangeListenerValidatingProxy extends AbstractBlobSide
   }
 
   @Override
-  public SafeFuture<?> onResponse(final BlobSidecar blobSidecar) {
+  public SafeFuture<?> onResponse(final BlobSidecarOld blobSidecar) {
     return SafeFuture.of(
         () -> {
           final UInt64 blobSidecarSlot = blobSidecar.getSlot();
@@ -114,7 +114,7 @@ public class BlobSidecarsByRangeListenerValidatingProxy extends AbstractBlobSide
   }
 
   record BlobSidecarSummary(Bytes32 blockRoot, UInt64 index, UInt64 slot, Bytes32 blockParentRoot) {
-    public static BlobSidecarSummary create(final BlobSidecar blobSidecar) {
+    public static BlobSidecarSummary create(final BlobSidecarOld blobSidecar) {
       return new BlobSidecarSummary(
           blobSidecar.getBlockRoot(),
           blobSidecar.getIndex(),

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandler.java
@@ -42,7 +42,7 @@ import tech.pegasys.teku.networking.eth2.rpc.core.RpcException.ResourceUnavailab
 import tech.pegasys.teku.networking.p2p.rpc.StreamClosedException;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.config.SpecConfigDeneb;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BlobSidecarsByRangeRequestMessage;
 import tech.pegasys.teku.spec.datastructures.util.SlotAndBlockRootAndBlobIndex;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
@@ -53,7 +53,7 @@ import tech.pegasys.teku.storage.client.CombinedChainDataClient;
  * v1</a>
  */
 public class BlobSidecarsByRangeMessageHandler
-    extends PeerRequiredLocalMessageHandler<BlobSidecarsByRangeRequestMessage, BlobSidecar> {
+    extends PeerRequiredLocalMessageHandler<BlobSidecarsByRangeRequestMessage, BlobSidecarOld> {
 
   private static final Logger LOG = LogManager.getLogger();
 
@@ -89,7 +89,7 @@ public class BlobSidecarsByRangeMessageHandler
       final String protocolId,
       final Eth2Peer peer,
       final BlobSidecarsByRangeRequestMessage message,
-      final ResponseCallback<BlobSidecar> callback) {
+      final ResponseCallback<BlobSidecarOld> callback) {
     final UInt64 startSlot = message.getStartSlot();
     final UInt64 endSlot = message.getMaxSlot();
 
@@ -207,7 +207,7 @@ public class BlobSidecarsByRangeMessageHandler
   }
 
   private void handleProcessingRequestError(
-      final Throwable error, final ResponseCallback<BlobSidecar> callback) {
+      final Throwable error, final ResponseCallback<BlobSidecarOld> callback) {
     final Throwable rootCause = Throwables.getRootCause(error);
     if (rootCause instanceof RpcException) {
       LOG.trace("Rejecting blob sidecars by range request", error);
@@ -227,7 +227,7 @@ public class BlobSidecarsByRangeMessageHandler
   class RequestState {
 
     private final AtomicInteger sentBlobSidecars = new AtomicInteger(0);
-    private final ResponseCallback<BlobSidecar> callback;
+    private final ResponseCallback<BlobSidecarOld> callback;
     private final UInt64 maxRequestBlobSidecars;
     private final UInt64 startSlot;
     private final UInt64 endSlot;
@@ -240,7 +240,7 @@ public class BlobSidecarsByRangeMessageHandler
         Optional.empty();
 
     RequestState(
-        final ResponseCallback<BlobSidecar> callback,
+        final ResponseCallback<BlobSidecarOld> callback,
         final UInt64 maxRequestBlobSidecars,
         final UInt64 startSlot,
         final UInt64 endSlot,
@@ -254,11 +254,11 @@ public class BlobSidecarsByRangeMessageHandler
       this.canonicalHotRoots = canonicalHotRoots;
     }
 
-    SafeFuture<Void> sendBlobSidecar(final BlobSidecar blobSidecar) {
+    SafeFuture<Void> sendBlobSidecar(final BlobSidecarOld blobSidecar) {
       return callback.respond(blobSidecar).thenRun(sentBlobSidecars::incrementAndGet);
     }
 
-    SafeFuture<Optional<BlobSidecar>> loadNextBlobSidecar() {
+    SafeFuture<Optional<BlobSidecarOld>> loadNextBlobSidecar() {
       if (blobSidecarKeysIterator.isEmpty()) {
         return combinedChainDataClient
             .getBlobSidecarKeys(startSlot, endSlot, maxRequestBlobSidecars)
@@ -272,7 +272,7 @@ public class BlobSidecarsByRangeMessageHandler
       }
     }
 
-    private SafeFuture<Optional<BlobSidecar>> getNextBlobSidecar(
+    private SafeFuture<Optional<BlobSidecarOld>> getNextBlobSidecar(
         final Iterator<SlotAndBlockRootAndBlobIndex> blobSidecarKeysIterator) {
       if (blobSidecarKeysIterator.hasNext()) {
         final SlotAndBlockRootAndBlobIndex slotAndBlockRootAndBlobIndex =

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootListenerValidatingProxy.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootListenerValidatingProxy.java
@@ -19,18 +19,18 @@ import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.networking.p2p.peer.Peer;
 import tech.pegasys.teku.networking.p2p.rpc.RpcResponseListener;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BlobIdentifier;
 
 public class BlobSidecarsByRootListenerValidatingProxy extends BlobSidecarsByRootValidator
-    implements RpcResponseListener<BlobSidecar> {
+    implements RpcResponseListener<BlobSidecarOld> {
 
-  private final RpcResponseListener<BlobSidecar> listener;
+  private final RpcResponseListener<BlobSidecarOld> listener;
 
   public BlobSidecarsByRootListenerValidatingProxy(
       final Peer peer,
       final Spec spec,
-      final RpcResponseListener<BlobSidecar> listener,
+      final RpcResponseListener<BlobSidecarOld> listener,
       final KZG kzg,
       final List<BlobIdentifier> expectedBlobIdentifiers) {
     super(peer, spec, kzg, expectedBlobIdentifiers);
@@ -38,7 +38,7 @@ public class BlobSidecarsByRootListenerValidatingProxy extends BlobSidecarsByRoo
   }
 
   @Override
-  public SafeFuture<?> onResponse(final BlobSidecar blobSidecar) {
+  public SafeFuture<?> onResponse(final BlobSidecarOld blobSidecar) {
     return SafeFuture.of(
         () -> {
           validate(blobSidecar);

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandler.java
@@ -199,7 +199,8 @@ public class BlobSidecarsByRootMessageHandler
             });
   }
 
-  private SafeFuture<Optional<BlobSidecarOld>> retrieveBlobSidecar(final BlobIdentifier identifier) {
+  private SafeFuture<Optional<BlobSidecarOld>> retrieveBlobSidecar(
+      final BlobIdentifier identifier) {
     return combinedChainDataClient.getBlobSidecarByBlockRootAndIndex(
         identifier.getBlockRoot(), identifier.getIndex());
   }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandler.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandler.java
@@ -35,7 +35,7 @@ import tech.pegasys.teku.networking.eth2.rpc.core.RpcException;
 import tech.pegasys.teku.networking.p2p.rpc.StreamClosedException;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.config.SpecConfigDeneb;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BlobIdentifier;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BlobSidecarsByRootRequestMessage;
@@ -47,7 +47,7 @@ import tech.pegasys.teku.storage.client.CombinedChainDataClient;
  * v1</a>
  */
 public class BlobSidecarsByRootMessageHandler
-    extends PeerRequiredLocalMessageHandler<BlobSidecarsByRootRequestMessage, BlobSidecar> {
+    extends PeerRequiredLocalMessageHandler<BlobSidecarsByRootRequestMessage, BlobSidecarOld> {
 
   private static final Logger LOG = LogManager.getLogger();
 
@@ -100,7 +100,7 @@ public class BlobSidecarsByRootMessageHandler
       final String protocolId,
       final Eth2Peer peer,
       final BlobSidecarsByRootRequestMessage message,
-      final ResponseCallback<BlobSidecar> callback) {
+      final ResponseCallback<BlobSidecarOld> callback) {
 
     LOG.trace(
         "Peer {} requested {} blob sidecars with blob identifiers: {}",
@@ -173,7 +173,7 @@ public class BlobSidecarsByRootMessageHandler
    */
   private SafeFuture<Void> validateMinimumRequestEpoch(
       final BlobIdentifier identifier,
-      final Optional<BlobSidecar> maybeSidecar,
+      final Optional<BlobSidecarOld> maybeSidecar,
       final UInt64 finalizedEpoch) {
     return maybeSidecar
         .map(sidecar -> SafeFuture.completedFuture(Optional.of(sidecar.getSlot())))
@@ -199,12 +199,12 @@ public class BlobSidecarsByRootMessageHandler
             });
   }
 
-  private SafeFuture<Optional<BlobSidecar>> retrieveBlobSidecar(final BlobIdentifier identifier) {
+  private SafeFuture<Optional<BlobSidecarOld>> retrieveBlobSidecar(final BlobIdentifier identifier) {
     return combinedChainDataClient.getBlobSidecarByBlockRootAndIndex(
         identifier.getBlockRoot(), identifier.getIndex());
   }
 
-  private void handleError(final ResponseCallback<BlobSidecar> callback, final Throwable error) {
+  private void handleError(final ResponseCallback<BlobSidecarOld> callback, final Throwable error) {
     final Throwable rootCause = Throwables.getRootCause(error);
     if (rootCause instanceof RpcException) {
       LOG.trace("Rejecting blob sidecars by root request", error);

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootValidator.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootValidator.java
@@ -19,7 +19,7 @@ import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.BlobSidecarsResponseInvalidResponseException.InvalidResponseType;
 import tech.pegasys.teku.networking.p2p.peer.Peer;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BlobIdentifier;
 
 public class BlobSidecarsByRootValidator extends AbstractBlobSidecarsValidator {
@@ -35,7 +35,7 @@ public class BlobSidecarsByRootValidator extends AbstractBlobSidecarsValidator {
     this.expectedBlobIdentifiers = Set.copyOf(expectedBlobIdentifiers);
   }
 
-  public void validate(final BlobSidecar blobSidecar) {
+  public void validate(final BlobSidecarOld blobSidecar) {
     final BlobIdentifier blobIdentifier =
         new BlobIdentifier(blobSidecar.getBlockRoot(), blobSidecar.getIndex());
     if (!expectedBlobIdentifiers.contains(blobIdentifier)) {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/encodings/context/ForkDigestPayloadContext.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/core/encodings/context/ForkDigestPayloadContext.java
@@ -16,7 +16,7 @@ package tech.pegasys.teku.networking.eth2.rpc.core.encodings.context;
 import tech.pegasys.teku.infrastructure.ssz.SszData;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszSchema;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
 
@@ -36,15 +36,15 @@ public interface ForkDigestPayloadContext<TPayload extends SszData> {
         }
       };
 
-  ForkDigestPayloadContext<BlobSidecar> BLOB_SIDECAR =
+  ForkDigestPayloadContext<BlobSidecarOld> BLOB_SIDECAR =
       new ForkDigestPayloadContext<>() {
         @Override
-        public UInt64 getSlotFromPayload(final BlobSidecar responsePayload) {
+        public UInt64 getSlotFromPayload(final BlobSidecarOld responsePayload) {
           return responsePayload.getSlot();
         }
 
         @Override
-        public SszSchema<BlobSidecar> getSchemaFromSchemaDefinitions(
+        public SszSchema<BlobSidecarOld> getSchemaFromSchemaDefinitions(
             final SchemaDefinitions schemaDefinitions) {
           return schemaDefinitions.toVersionDeneb().orElseThrow().getBlobSidecarSchema();
         }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/BlobSidecarGossipManagerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/BlobSidecarGossipManagerTest.java
@@ -44,7 +44,7 @@ import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.config.SpecConfigDeneb;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
@@ -60,7 +60,7 @@ public class BlobSidecarGossipManagerTest {
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
 
   @SuppressWarnings("unchecked")
-  private final OperationProcessor<SignedBlobSidecar> processor = mock(OperationProcessor.class);
+  private final OperationProcessor<SignedBlobSidecarOld> processor = mock(OperationProcessor.class);
 
   private final GossipNetwork gossipNetwork = mock(GossipNetwork.class);
   private final GossipEncoding gossipEncoding = GossipEncoding.SSZ_SNAPPY;
@@ -109,7 +109,7 @@ public class BlobSidecarGossipManagerTest {
 
   @Test
   public void testGossipingBlobSidecarPublishesToCorrectSubnet() {
-    final SignedBlobSidecar blobSidecar = dataStructureUtil.randomSignedBlobSidecar(UInt64.ONE);
+    final SignedBlobSidecarOld blobSidecar = dataStructureUtil.randomSignedBlobSidecar(UInt64.ONE);
     final Bytes serialized = gossipEncoding.encode(blobSidecar);
 
     blobSidecarGossipManager.publishBlobSidecar(blobSidecar);
@@ -126,7 +126,7 @@ public class BlobSidecarGossipManagerTest {
 
   @Test
   public void testGossipingBlobSidecarWithLargeIndexGossipToCorrectSubnet() {
-    final SignedBlobSidecar blobSidecar =
+    final SignedBlobSidecarOld blobSidecar =
         dataStructureUtil.randomSignedBlobSidecar(UInt64.valueOf(10));
     final Bytes serialized = gossipEncoding.encode(blobSidecar);
 
@@ -159,11 +159,11 @@ public class BlobSidecarGossipManagerTest {
   @Test
   public void testAcceptingSidecarGossipIfOnTheCorrectTopic() {
     // topic handler for blob sidecars with subnet_id 1
-    final Eth2TopicHandler<SignedBlobSidecar> topicHandler =
+    final Eth2TopicHandler<SignedBlobSidecarOld> topicHandler =
         blobSidecarGossipManager.getTopicHandler(1);
 
     // processing blob sidecar with subnet_id 1 should be accepted
-    final SignedBlobSidecar blobSidecar = dataStructureUtil.randomSignedBlobSidecar(UInt64.ONE);
+    final SignedBlobSidecarOld blobSidecar = dataStructureUtil.randomSignedBlobSidecar(UInt64.ONE);
     final InternalValidationResult validationResult =
         SafeFutureAssert.safeJoin(
             topicHandler.getProcessor().process(blobSidecar, Optional.empty()));
@@ -174,11 +174,11 @@ public class BlobSidecarGossipManagerTest {
   @Test
   public void testRejectingSidecarGossipIfNotOnTheCorrectTopic() {
     // topic handler for blob sidecars with subnet_id 1
-    final Eth2TopicHandler<SignedBlobSidecar> topicHandler =
+    final Eth2TopicHandler<SignedBlobSidecarOld> topicHandler =
         blobSidecarGossipManager.getTopicHandler(1);
 
     // processing blob sidecar with subnet_id 2 should be rejected
-    final SignedBlobSidecar blobSidecar =
+    final SignedBlobSidecarOld blobSidecar =
         dataStructureUtil.randomSignedBlobSidecar(UInt64.valueOf(2));
     final InternalValidationResult validationResult =
         SafeFutureAssert.safeJoin(

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerTest.java
@@ -167,8 +167,8 @@ class Eth2PeerTest {
   @SuppressWarnings({"unchecked", "FutureReturnValueIgnored"})
   public void shouldModifyRequestSpanningTheDenebForkTransition() {
 
-    final Eth2RpcMethod<BlobSidecarsByRangeRequestMessage, BlobSidecarOld> blobSidecarsByRangeMethod =
-        mock(Eth2RpcMethod.class);
+    final Eth2RpcMethod<BlobSidecarsByRangeRequestMessage, BlobSidecarOld>
+        blobSidecarsByRangeMethod = mock(Eth2RpcMethod.class);
 
     final RpcStreamController<RpcRequestHandler> rpcStreamController =
         mock(RpcStreamController.class);
@@ -197,8 +197,8 @@ class Eth2PeerTest {
   @SuppressWarnings({"unchecked", "FutureReturnValueIgnored"})
   public void shouldSetCountToZeroWhenRequestIsPreDeneb() {
 
-    final Eth2RpcMethod<BlobSidecarsByRangeRequestMessage, BlobSidecarOld> blobSidecarsByRangeMethod =
-        mock(Eth2RpcMethod.class);
+    final Eth2RpcMethod<BlobSidecarsByRangeRequestMessage, BlobSidecarOld>
+        blobSidecarsByRangeMethod = mock(Eth2RpcMethod.class);
 
     final RpcStreamController<RpcRequestHandler> rpcStreamController =
         mock(RpcStreamController.class);

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerTest.java
@@ -39,7 +39,7 @@ import tech.pegasys.teku.networking.p2p.rpc.RpcRequestHandler;
 import tech.pegasys.teku.networking.p2p.rpc.RpcStreamController;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BlobSidecarsByRangeRequestMessage;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
@@ -167,7 +167,7 @@ class Eth2PeerTest {
   @SuppressWarnings({"unchecked", "FutureReturnValueIgnored"})
   public void shouldModifyRequestSpanningTheDenebForkTransition() {
 
-    final Eth2RpcMethod<BlobSidecarsByRangeRequestMessage, BlobSidecar> blobSidecarsByRangeMethod =
+    final Eth2RpcMethod<BlobSidecarsByRangeRequestMessage, BlobSidecarOld> blobSidecarsByRangeMethod =
         mock(Eth2RpcMethod.class);
 
     final RpcStreamController<RpcRequestHandler> rpcStreamController =
@@ -197,7 +197,7 @@ class Eth2PeerTest {
   @SuppressWarnings({"unchecked", "FutureReturnValueIgnored"})
   public void shouldSetCountToZeroWhenRequestIsPreDeneb() {
 
-    final Eth2RpcMethod<BlobSidecarsByRangeRequestMessage, BlobSidecar> blobSidecarsByRangeMethod =
+    final Eth2RpcMethod<BlobSidecarsByRangeRequestMessage, BlobSidecarOld> blobSidecarsByRangeMethod =
         mock(Eth2RpcMethod.class);
 
     final RpcStreamController<RpcRequestHandler> rpcStreamController =

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeListenerValidatingProxyTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeListenerValidatingProxyTest.java
@@ -30,7 +30,7 @@ import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.teku.networking.p2p.rpc.RpcResponseListener;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class BlobSidecarsByRangeListenerValidatingProxyTest {
@@ -42,7 +42,7 @@ public class BlobSidecarsByRangeListenerValidatingProxyTest {
   private final KZG kzg = mock(KZG.class);
 
   @SuppressWarnings("unchecked")
-  private final RpcResponseListener<BlobSidecar> listener = mock(RpcResponseListener.class);
+  private final RpcResponseListener<BlobSidecarOld> listener = mock(RpcResponseListener.class);
 
   @BeforeEach
   void setUp() {
@@ -60,7 +60,7 @@ public class BlobSidecarsByRangeListenerValidatingProxyTest {
             spec, peer, listener, maxBlobsPerBlock, kzg, startSlot, count);
 
     final Bytes32 blockRoot1 = dataStructureUtil.randomBytes32();
-    final BlobSidecar blobSidecar1 =
+    final BlobSidecarOld blobSidecar1 =
         dataStructureUtil.randomBlobSidecar(UInt64.ONE, blockRoot1, Bytes32.ZERO, UInt64.ZERO);
 
     final SafeFuture<?> result = listenerWrapper.onResponse(blobSidecar1);
@@ -82,7 +82,7 @@ public class BlobSidecarsByRangeListenerValidatingProxyTest {
         new BlobSidecarsByRangeListenerValidatingProxy(
             spec, peer, listener, maxBlobsPerBlock, kzg, startSlot, count);
 
-    final BlobSidecar blobSidecar0 =
+    final BlobSidecarOld blobSidecar0 =
         dataStructureUtil.randomBlobSidecar(
             UInt64.ZERO, dataStructureUtil.randomBytes32(), UInt64.ZERO);
 
@@ -106,18 +106,18 @@ public class BlobSidecarsByRangeListenerValidatingProxyTest {
             spec, peer, listener, maxBlobsPerBlock, kzg, startSlot, count);
 
     final Bytes32 blockRoot1 = dataStructureUtil.randomBytes32();
-    final BlobSidecar blobSidecar10 =
+    final BlobSidecarOld blobSidecar10 =
         dataStructureUtil.randomBlobSidecar(UInt64.ONE, blockRoot1, Bytes32.ZERO, UInt64.ZERO);
-    final BlobSidecar blobSidecar11 =
+    final BlobSidecarOld blobSidecar11 =
         dataStructureUtil.randomBlobSidecar(UInt64.ONE, blockRoot1, Bytes32.ZERO, UInt64.ONE);
     final Bytes32 blockRoot2 = dataStructureUtil.randomBytes32();
-    final BlobSidecar blobSidecar2 =
+    final BlobSidecarOld blobSidecar2 =
         dataStructureUtil.randomBlobSidecar(UInt64.valueOf(2), blockRoot2, blockRoot1, UInt64.ZERO);
     final Bytes32 blockRoot3 = dataStructureUtil.randomBytes32();
-    final BlobSidecar blobSidecar3 =
+    final BlobSidecarOld blobSidecar3 =
         dataStructureUtil.randomBlobSidecar(UInt64.valueOf(3), blockRoot3, blockRoot2, UInt64.ZERO);
     final Bytes32 blockRoot4 = dataStructureUtil.randomBytes32();
-    final BlobSidecar blobSidecar4 =
+    final BlobSidecarOld blobSidecar4 =
         dataStructureUtil.randomBlobSidecar(UInt64.valueOf(4), blockRoot4, blockRoot3, UInt64.ZERO);
 
     assertDoesNotThrow(() -> listenerWrapper.onResponse(blobSidecar10).join());
@@ -137,19 +137,19 @@ public class BlobSidecarsByRangeListenerValidatingProxyTest {
             spec, peer, listener, maxBlobsPerBlock, kzg, startSlot, count);
 
     final Bytes32 blockRoot1 = dataStructureUtil.randomBytes32();
-    final BlobSidecar blobSidecar1 =
+    final BlobSidecarOld blobSidecar1 =
         dataStructureUtil.randomBlobSidecar(UInt64.ONE, blockRoot1, Bytes32.ZERO, UInt64.ZERO);
     final Bytes32 blockRoot2 = dataStructureUtil.randomBytes32();
-    final BlobSidecar blobSidecar2 =
+    final BlobSidecarOld blobSidecar2 =
         dataStructureUtil.randomBlobSidecar(UInt64.valueOf(3), blockRoot2, blockRoot1, UInt64.ZERO);
     final Bytes32 blockRoot3 = dataStructureUtil.randomBytes32();
-    final BlobSidecar blobSidecar3 =
+    final BlobSidecarOld blobSidecar3 =
         dataStructureUtil.randomBlobSidecar(UInt64.valueOf(5), blockRoot3, blockRoot2, UInt64.ZERO);
     final Bytes32 blockRoot4 = dataStructureUtil.randomBytes32();
-    final BlobSidecar blobSidecar4 =
+    final BlobSidecarOld blobSidecar4 =
         dataStructureUtil.randomBlobSidecar(UInt64.valueOf(8), blockRoot4, blockRoot3, UInt64.ZERO);
     final Bytes32 blockRoot5 = dataStructureUtil.randomBytes32();
-    final BlobSidecar blobSidecar5 =
+    final BlobSidecarOld blobSidecar5 =
         dataStructureUtil.randomBlobSidecar(UInt64.valueOf(9), blockRoot5, blockRoot4, UInt64.ZERO);
 
     listenerWrapper.onResponse(blobSidecar1).join();
@@ -177,10 +177,10 @@ public class BlobSidecarsByRangeListenerValidatingProxyTest {
             spec, peer, listener, maxBlobsPerBlock, kzg, startSlot, count);
 
     final Bytes32 blockRoot1 = dataStructureUtil.randomBytes32();
-    final BlobSidecar blobSidecar1 =
+    final BlobSidecarOld blobSidecar1 =
         dataStructureUtil.randomBlobSidecar(UInt64.ONE, blockRoot1, Bytes32.ZERO, UInt64.ZERO);
     final Bytes32 blockRoot2 = dataStructureUtil.randomBytes32();
-    final BlobSidecar blobSidecar2 =
+    final BlobSidecarOld blobSidecar2 =
         dataStructureUtil.randomBlobSidecar(
             UInt64.valueOf(2), blockRoot2, dataStructureUtil.randomBytes32(), UInt64.ZERO);
 
@@ -207,23 +207,23 @@ public class BlobSidecarsByRangeListenerValidatingProxyTest {
             spec, peer, listener, maxBlobsPerBlock, kzg, startSlot, count);
 
     final Bytes32 blockRoot1 = dataStructureUtil.randomBytes32();
-    final BlobSidecar blobSidecar1 =
+    final BlobSidecarOld blobSidecar1 =
         dataStructureUtil.randomBlobSidecar(UInt64.ONE, blockRoot1, Bytes32.ZERO, UInt64.ZERO);
-    final BlobSidecar blobSidecar2 =
+    final BlobSidecarOld blobSidecar2 =
         dataStructureUtil.randomBlobSidecar(UInt64.ONE, blockRoot1, Bytes32.ZERO, UInt64.ONE);
-    final BlobSidecar blobSidecar3 =
+    final BlobSidecarOld blobSidecar3 =
         dataStructureUtil.randomBlobSidecar(
             UInt64.ONE, blockRoot1, Bytes32.ZERO, UInt64.valueOf(2));
-    final BlobSidecar blobSidecar4 =
+    final BlobSidecarOld blobSidecar4 =
         dataStructureUtil.randomBlobSidecar(
             UInt64.ONE, blockRoot1, Bytes32.ZERO, UInt64.valueOf(3));
-    final BlobSidecar blobSidecar5 =
+    final BlobSidecarOld blobSidecar5 =
         dataStructureUtil.randomBlobSidecar(
             UInt64.ONE, blockRoot1, Bytes32.ZERO, UInt64.valueOf(4));
-    final BlobSidecar blobSidecar6 =
+    final BlobSidecarOld blobSidecar6 =
         dataStructureUtil.randomBlobSidecar(
             UInt64.ONE, blockRoot1, Bytes32.ZERO, UInt64.valueOf(5));
-    final BlobSidecar blobSidecar7 =
+    final BlobSidecarOld blobSidecar7 =
         dataStructureUtil.randomBlobSidecar(
             UInt64.ONE, blockRoot1, Bytes32.ZERO, UInt64.valueOf(6));
 
@@ -255,11 +255,11 @@ public class BlobSidecarsByRangeListenerValidatingProxyTest {
             spec, peer, listener, maxBlobsPerBlock, kzg, startSlot, count);
 
     final Bytes32 blockRoot1 = dataStructureUtil.randomBytes32();
-    final BlobSidecar blobSidecar1 =
+    final BlobSidecarOld blobSidecar1 =
         dataStructureUtil.randomBlobSidecar(UInt64.ONE, blockRoot1, Bytes32.ZERO, UInt64.ZERO);
-    final BlobSidecar blobSidecar2 =
+    final BlobSidecarOld blobSidecar2 =
         dataStructureUtil.randomBlobSidecar(UInt64.ONE, blockRoot1, Bytes32.ZERO, UInt64.ONE);
-    final BlobSidecar blobSidecar3 =
+    final BlobSidecarOld blobSidecar3 =
         dataStructureUtil.randomBlobSidecar(
             UInt64.ONE, blockRoot1, Bytes32.ZERO, UInt64.valueOf(3));
 
@@ -286,7 +286,7 @@ public class BlobSidecarsByRangeListenerValidatingProxyTest {
             spec, peer, listener, maxBlobsPerBlock, kzg, startSlot, count);
 
     final Bytes32 blockRoot1 = dataStructureUtil.randomBytes32();
-    final BlobSidecar blobSidecar1 =
+    final BlobSidecarOld blobSidecar1 =
         dataStructureUtil.randomBlobSidecar(UInt64.ONE, blockRoot1, UInt64.ONE);
 
     final SafeFuture<?> result = listenerWrapper.onResponse(blobSidecar1);
@@ -309,10 +309,10 @@ public class BlobSidecarsByRangeListenerValidatingProxyTest {
             spec, peer, listener, maxBlobsPerBlock, kzg, startSlot, count);
 
     final Bytes32 blockRoot1 = dataStructureUtil.randomBytes32();
-    final BlobSidecar blobSidecar1 =
+    final BlobSidecarOld blobSidecar1 =
         dataStructureUtil.randomBlobSidecar(UInt64.ONE, blockRoot1, Bytes32.ZERO, UInt64.ZERO);
     final Bytes32 blockRoot2 = dataStructureUtil.randomBytes32();
-    final BlobSidecar blobSidecar2 =
+    final BlobSidecarOld blobSidecar2 =
         dataStructureUtil.randomBlobSidecar(UInt64.valueOf(2), blockRoot2, blockRoot1, UInt64.ONE);
 
     assertDoesNotThrow(() -> listenerWrapper.onResponse(blobSidecar1).join());
@@ -338,11 +338,11 @@ public class BlobSidecarsByRangeListenerValidatingProxyTest {
             spec, peer, listener, maxBlobsPerBlock, kzg, startSlot, count);
 
     final Bytes32 blockRoot1 = dataStructureUtil.randomBytes32();
-    final BlobSidecar blobSidecar1 =
+    final BlobSidecarOld blobSidecar1 =
         dataStructureUtil.randomBlobSidecar(UInt64.ONE, blockRoot1, Bytes32.ZERO, UInt64.ZERO);
-    final BlobSidecar blobSidecar2 =
+    final BlobSidecarOld blobSidecar2 =
         dataStructureUtil.randomBlobSidecar(UInt64.ONE, blockRoot1, Bytes32.ZERO, UInt64.ONE);
-    final BlobSidecar blobSidecar4 =
+    final BlobSidecarOld blobSidecar4 =
         dataStructureUtil.randomBlobSidecar(
             UInt64.ONE, blockRoot1, Bytes32.ZERO, UInt64.valueOf(3));
 
@@ -369,10 +369,10 @@ public class BlobSidecarsByRangeListenerValidatingProxyTest {
             spec, peer, listener, maxBlobsPerBlock, kzg, startSlot, count);
 
     final Bytes32 blockRoot1 = dataStructureUtil.randomBytes32();
-    final BlobSidecar blobSidecar1 =
+    final BlobSidecarOld blobSidecar1 =
         dataStructureUtil.randomBlobSidecar(UInt64.ONE, blockRoot1, Bytes32.ZERO, UInt64.ZERO);
     final Bytes32 blockRoot2 = dataStructureUtil.randomBytes32();
-    final BlobSidecar blobSidecar2 =
+    final BlobSidecarOld blobSidecar2 =
         dataStructureUtil.randomBlobSidecar(UInt64.ONE, blockRoot2, blockRoot1, UInt64.ZERO);
 
     assertDoesNotThrow(() -> listenerWrapper.onResponse(blobSidecar1).join());

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandlerTest.java
@@ -261,7 +261,8 @@ public class BlobSidecarsByRangeMessageHandlerTest {
     final BlobSidecarsByRangeRequestMessage request =
         new BlobSidecarsByRangeRequestMessage(startSlot, count, maxBlobsPerBlock);
 
-    final List<BlobSidecarOld> expectedSent = setUpBlobSidecarsData(startSlot, request.getMaxSlot());
+    final List<BlobSidecarOld> expectedSent =
+        setUpBlobSidecarsData(startSlot, request.getMaxSlot());
 
     handler.onIncomingMessage(protocolId, peer, request, listener);
 
@@ -273,7 +274,8 @@ public class BlobSidecarsByRangeMessageHandlerTest {
         .adjustBlobSidecarsRequest(
             eq(allowedObjectsRequest.get()), eq(Long.valueOf(expectedSent.size())));
 
-    final ArgumentCaptor<BlobSidecarOld> argumentCaptor = ArgumentCaptor.forClass(BlobSidecarOld.class);
+    final ArgumentCaptor<BlobSidecarOld> argumentCaptor =
+        ArgumentCaptor.forClass(BlobSidecarOld.class);
 
     verify(listener, times(expectedSent.size())).respond(argumentCaptor.capture());
 
@@ -331,7 +333,8 @@ public class BlobSidecarsByRangeMessageHandlerTest {
         .adjustBlobSidecarsRequest(
             eq(allowedObjectsRequest.get()), eq(Long.valueOf(expectedSent.size())));
 
-    final ArgumentCaptor<BlobSidecarOld> argumentCaptor = ArgumentCaptor.forClass(BlobSidecarOld.class);
+    final ArgumentCaptor<BlobSidecarOld> argumentCaptor =
+        ArgumentCaptor.forClass(BlobSidecarOld.class);
 
     verify(listener, times(expectedSent.size())).respond(argumentCaptor.capture());
 
@@ -357,7 +360,8 @@ public class BlobSidecarsByRangeMessageHandlerTest {
     // no adjustment
     verify(peer, never()).adjustBlobSidecarsRequest(any(), anyLong());
 
-    final ArgumentCaptor<BlobSidecarOld> argumentCaptor = ArgumentCaptor.forClass(BlobSidecarOld.class);
+    final ArgumentCaptor<BlobSidecarOld> argumentCaptor =
+        ArgumentCaptor.forClass(BlobSidecarOld.class);
 
     verify(listener, never()).respond(argumentCaptor.capture());
 
@@ -385,7 +389,8 @@ public class BlobSidecarsByRangeMessageHandlerTest {
     // no adjustment
     verify(peer, never()).adjustBlobSidecarsRequest(any(), anyLong());
 
-    final ArgumentCaptor<BlobSidecarOld> argumentCaptor = ArgumentCaptor.forClass(BlobSidecarOld.class);
+    final ArgumentCaptor<BlobSidecarOld> argumentCaptor =
+        ArgumentCaptor.forClass(BlobSidecarOld.class);
 
     verify(listener, never()).respond(argumentCaptor.capture());
 

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeMessageHandlerTest.java
@@ -52,7 +52,7 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.config.SpecConfigDeneb;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BlobSidecarsByRangeRequestMessage;
@@ -99,7 +99,7 @@ public class BlobSidecarsByRangeMessageHandlerTest {
       spec.forMilestone(SpecMilestone.DENEB).miscHelpers().toVersionDeneb().orElseThrow();
 
   @SuppressWarnings("unchecked")
-  private final ResponseCallback<BlobSidecar> listener = mock(ResponseCallback.class);
+  private final ResponseCallback<BlobSidecarOld> listener = mock(ResponseCallback.class);
 
   private final CombinedChainDataClient combinedChainDataClient =
       mock(CombinedChainDataClient.class);
@@ -261,7 +261,7 @@ public class BlobSidecarsByRangeMessageHandlerTest {
     final BlobSidecarsByRangeRequestMessage request =
         new BlobSidecarsByRangeRequestMessage(startSlot, count, maxBlobsPerBlock);
 
-    final List<BlobSidecar> expectedSent = setUpBlobSidecarsData(startSlot, request.getMaxSlot());
+    final List<BlobSidecarOld> expectedSent = setUpBlobSidecarsData(startSlot, request.getMaxSlot());
 
     handler.onIncomingMessage(protocolId, peer, request, listener);
 
@@ -273,11 +273,11 @@ public class BlobSidecarsByRangeMessageHandlerTest {
         .adjustBlobSidecarsRequest(
             eq(allowedObjectsRequest.get()), eq(Long.valueOf(expectedSent.size())));
 
-    final ArgumentCaptor<BlobSidecar> argumentCaptor = ArgumentCaptor.forClass(BlobSidecar.class);
+    final ArgumentCaptor<BlobSidecarOld> argumentCaptor = ArgumentCaptor.forClass(BlobSidecarOld.class);
 
     verify(listener, times(expectedSent.size())).respond(argumentCaptor.capture());
 
-    final List<BlobSidecar> actualSent = argumentCaptor.getAllValues();
+    final List<BlobSidecarOld> actualSent = argumentCaptor.getAllValues();
 
     verify(listener).completeSuccessfully();
 
@@ -294,7 +294,7 @@ public class BlobSidecarsByRangeMessageHandlerTest {
     final BlobSidecarsByRangeRequestMessage request =
         new BlobSidecarsByRangeRequestMessage(startSlot, count, maxBlobsPerBlock);
 
-    final List<BlobSidecar> allAvailableBlobs =
+    final List<BlobSidecarOld> allAvailableBlobs =
         setUpBlobSidecarsData(startSlot, request.getMaxSlot());
 
     // we simulate that the canonical non-finalized chain only contains blobs from last
@@ -302,7 +302,7 @@ public class BlobSidecarsByRangeMessageHandlerTest {
     final SlotAndBlockRoot canonicalSlotAndBlockRoot =
         allAvailableBlobs.get(allAvailableBlobs.size() - 1).getSlotAndBlockRoot();
 
-    final List<BlobSidecar> expectedSent =
+    final List<BlobSidecarOld> expectedSent =
         allAvailableBlobs.stream()
             .filter(
                 blobSidecar ->
@@ -331,11 +331,11 @@ public class BlobSidecarsByRangeMessageHandlerTest {
         .adjustBlobSidecarsRequest(
             eq(allowedObjectsRequest.get()), eq(Long.valueOf(expectedSent.size())));
 
-    final ArgumentCaptor<BlobSidecar> argumentCaptor = ArgumentCaptor.forClass(BlobSidecar.class);
+    final ArgumentCaptor<BlobSidecarOld> argumentCaptor = ArgumentCaptor.forClass(BlobSidecarOld.class);
 
     verify(listener, times(expectedSent.size())).respond(argumentCaptor.capture());
 
-    final List<BlobSidecar> actualSent = argumentCaptor.getAllValues();
+    final List<BlobSidecarOld> actualSent = argumentCaptor.getAllValues();
 
     verify(listener).completeSuccessfully();
 
@@ -357,11 +357,11 @@ public class BlobSidecarsByRangeMessageHandlerTest {
     // no adjustment
     verify(peer, never()).adjustBlobSidecarsRequest(any(), anyLong());
 
-    final ArgumentCaptor<BlobSidecar> argumentCaptor = ArgumentCaptor.forClass(BlobSidecar.class);
+    final ArgumentCaptor<BlobSidecarOld> argumentCaptor = ArgumentCaptor.forClass(BlobSidecarOld.class);
 
     verify(listener, never()).respond(argumentCaptor.capture());
 
-    final List<BlobSidecar> actualSent = argumentCaptor.getAllValues();
+    final List<BlobSidecarOld> actualSent = argumentCaptor.getAllValues();
 
     verify(listener).completeSuccessfully();
 
@@ -385,11 +385,11 @@ public class BlobSidecarsByRangeMessageHandlerTest {
     // no adjustment
     verify(peer, never()).adjustBlobSidecarsRequest(any(), anyLong());
 
-    final ArgumentCaptor<BlobSidecar> argumentCaptor = ArgumentCaptor.forClass(BlobSidecar.class);
+    final ArgumentCaptor<BlobSidecarOld> argumentCaptor = ArgumentCaptor.forClass(BlobSidecarOld.class);
 
     verify(listener, never()).respond(argumentCaptor.capture());
 
-    final List<BlobSidecar> actualSent = argumentCaptor.getAllValues();
+    final List<BlobSidecarOld> actualSent = argumentCaptor.getAllValues();
 
     verify(listener).completeSuccessfully();
 
@@ -402,7 +402,7 @@ public class BlobSidecarsByRangeMessageHandlerTest {
             spec.getSlotStartTime(currentEpoch.times(spec.getSlotsPerEpoch(ZERO)), genesisTime));
   }
 
-  private List<BlobSidecar> setUpBlobSidecarsData(final UInt64 startSlot, final UInt64 maxSlot) {
+  private List<BlobSidecarOld> setUpBlobSidecarsData(final UInt64 startSlot, final UInt64 maxSlot) {
     final List<SlotAndBlockRootAndBlobIndex> keys = setupKeyList(startSlot, maxSlot);
     when(combinedChainDataClient.getBlobSidecarKeys(eq(startSlot), eq(maxSlot), any()))
         .thenAnswer(
@@ -432,8 +432,8 @@ public class BlobSidecarsByRangeMessageHandlerTest {
     return keys;
   }
 
-  private BlobSidecar setUpBlobSidecarDataForKey(final SlotAndBlockRootAndBlobIndex key) {
-    final BlobSidecar blobSidecar =
+  private BlobSidecarOld setUpBlobSidecarDataForKey(final SlotAndBlockRootAndBlobIndex key) {
+    final BlobSidecarOld blobSidecar =
         dataStructureUtil
             .createRandomBlobSidecarBuilder()
             .blockRoot(key.getBlockRoot())

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootListenerValidatingProxyTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootListenerValidatingProxyTest.java
@@ -31,7 +31,7 @@ import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.teku.networking.p2p.rpc.RpcResponseListener;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BlobIdentifier;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
@@ -43,7 +43,7 @@ public class BlobSidecarsByRootListenerValidatingProxyTest {
   private final KZG kzg = mock(KZG.class);
 
   @SuppressWarnings("unchecked")
-  private final RpcResponseListener<BlobSidecar> listener = mock(RpcResponseListener.class);
+  private final RpcResponseListener<BlobSidecarOld> listener = mock(RpcResponseListener.class);
 
   @BeforeEach
   void setUp() {
@@ -68,15 +68,15 @@ public class BlobSidecarsByRootListenerValidatingProxyTest {
     listenerWrapper =
         new BlobSidecarsByRootListenerValidatingProxy(peer, spec, listener, kzg, blobIdentifiers);
 
-    final BlobSidecar blobSidecar10 =
+    final BlobSidecarOld blobSidecar10 =
         dataStructureUtil.randomBlobSidecar(UInt64.ONE, blockRoot1, Bytes32.ZERO, UInt64.ZERO);
-    final BlobSidecar blobSidecar11 =
+    final BlobSidecarOld blobSidecar11 =
         dataStructureUtil.randomBlobSidecar(UInt64.ONE, blockRoot1, Bytes32.ZERO, UInt64.ONE);
-    final BlobSidecar blobSidecar2 =
+    final BlobSidecarOld blobSidecar2 =
         dataStructureUtil.randomBlobSidecar(UInt64.valueOf(2), blockRoot2, blockRoot1, UInt64.ZERO);
-    final BlobSidecar blobSidecar3 =
+    final BlobSidecarOld blobSidecar3 =
         dataStructureUtil.randomBlobSidecar(UInt64.valueOf(3), blockRoot3, blockRoot2, UInt64.ZERO);
-    final BlobSidecar blobSidecar4 =
+    final BlobSidecarOld blobSidecar4 =
         dataStructureUtil.randomBlobSidecar(UInt64.valueOf(4), blockRoot4, blockRoot3, UInt64.ZERO);
 
     assertDoesNotThrow(() -> listenerWrapper.onResponse(blobSidecar10).join());
@@ -97,11 +97,11 @@ public class BlobSidecarsByRootListenerValidatingProxyTest {
     listenerWrapper =
         new BlobSidecarsByRootListenerValidatingProxy(peer, spec, listener, kzg, blobIdentifiers);
 
-    final BlobSidecar blobSidecar10 =
+    final BlobSidecarOld blobSidecar10 =
         dataStructureUtil.randomBlobSidecar(UInt64.ONE, blockRoot1, Bytes32.ZERO, UInt64.ZERO);
-    final BlobSidecar blobSidecar11 =
+    final BlobSidecarOld blobSidecar11 =
         dataStructureUtil.randomBlobSidecar(UInt64.ONE, blockRoot1, Bytes32.ZERO, UInt64.ONE);
-    final BlobSidecar blobSidecar2 =
+    final BlobSidecarOld blobSidecar2 =
         dataStructureUtil.randomBlobSidecar(UInt64.valueOf(2), blockRoot2, blockRoot1, UInt64.ZERO);
 
     assertDoesNotThrow(() -> listenerWrapper.onResponse(blobSidecar10).join());
@@ -126,7 +126,7 @@ public class BlobSidecarsByRootListenerValidatingProxyTest {
         new BlobSidecarsByRootListenerValidatingProxy(
             peer, spec, listener, kzg, List.of(blobIdentifier));
 
-    final BlobSidecar blobSidecar1 =
+    final BlobSidecarOld blobSidecar1 =
         dataStructureUtil.randomBlobSidecar(UInt64.ONE, blockRoot1, Bytes32.ZERO, UInt64.ZERO);
 
     final SafeFuture<?> result = listenerWrapper.onResponse(blobSidecar1);

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandlerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootMessageHandlerTest.java
@@ -48,7 +48,7 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.config.SpecConfigDeneb;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BlobIdentifier;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BlobSidecarsByRootRequestMessage;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BlobSidecarsByRootRequestMessageSchema;
@@ -78,14 +78,14 @@ public class BlobSidecarsByRootMessageHandlerTest {
 
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
 
-  private final ArgumentCaptor<BlobSidecar> blobSidecarCaptor =
-      ArgumentCaptor.forClass(BlobSidecar.class);
+  private final ArgumentCaptor<BlobSidecarOld> blobSidecarCaptor =
+      ArgumentCaptor.forClass(BlobSidecarOld.class);
 
   private final ArgumentCaptor<RpcException> rpcExceptionCaptor =
       ArgumentCaptor.forClass(RpcException.class);
 
   @SuppressWarnings("unchecked")
-  private final ResponseCallback<BlobSidecar> callback = mock(ResponseCallback.class);
+  private final ResponseCallback<BlobSidecarOld> callback = mock(ResponseCallback.class);
 
   private final CombinedChainDataClient combinedChainDataClient =
       mock(CombinedChainDataClient.class);
@@ -221,7 +221,7 @@ public class BlobSidecarsByRootMessageHandlerTest {
 
     final List<Bytes32> respondedBlobSidecarBlockRoots =
         blobSidecarCaptor.getAllValues().stream()
-            .map(BlobSidecar::getBlockRoot)
+            .map(BlobSidecarOld::getBlockRoot)
             .collect(Collectors.toUnmodifiableList());
     final List<Bytes32> blobIdentifiersBlockRoots =
         List.of(
@@ -281,7 +281,7 @@ public class BlobSidecarsByRootMessageHandlerTest {
 
     // let first blobSidecar slot will be earlier than the minimum_request_epoch (for this test it
     // is denebForkEpoch)
-    final BlobSidecar blobSidecar = mock(BlobSidecar.class);
+    final BlobSidecarOld blobSidecar = mock(BlobSidecarOld.class);
     when(blobSidecar.getSlot()).thenReturn(UInt64.ONE);
     when(combinedChainDataClient.getBlobSidecarByBlockRootAndIndex(
             blobIdentifiers.get(0).getBlockRoot(), blobIdentifiers.get(0).getIndex()))
@@ -323,7 +323,7 @@ public class BlobSidecarsByRootMessageHandlerTest {
 
     verify(callback, times(5)).respond(blobSidecarCaptor.capture());
 
-    final List<BlobSidecar> sentBlobSidecars = blobSidecarCaptor.getAllValues();
+    final List<BlobSidecarOld> sentBlobSidecars = blobSidecarCaptor.getAllValues();
 
     // Requesting 5 blob sidecars
     verify(peer, times(1)).approveBlobSidecarsRequest(any(), eq(Long.valueOf(5)));
@@ -335,7 +335,7 @@ public class BlobSidecarsByRootMessageHandlerTest {
         .forEach(
             index -> {
               final BlobIdentifier identifier = blobIdentifiers.get(index);
-              final BlobSidecar blobSidecar = sentBlobSidecars.get(index);
+              final BlobSidecarOld blobSidecar = sentBlobSidecars.get(index);
               assertThat(blobSidecar.getBlockRoot()).isEqualTo(identifier.getBlockRoot());
               assertThat(blobSidecar.getIndex()).isEqualTo(identifier.getIndex());
             });

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootValidatorTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRootValidatorTest.java
@@ -28,7 +28,7 @@ import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BlobIdentifier;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
@@ -48,7 +48,7 @@ public class BlobSidecarsByRootValidatorTest {
   void blobSidecarIsCorrect() {
     final Bytes32 blockRoot1 = dataStructureUtil.randomBytes32();
     final BlobIdentifier blobIdentifier1 = new BlobIdentifier(blockRoot1, UInt64.ZERO);
-    final BlobSidecar blobSidecar1 =
+    final BlobSidecarOld blobSidecar1 =
         dataStructureUtil.randomBlobSidecar(UInt64.ONE, blockRoot1, Bytes32.ZERO, UInt64.ZERO);
 
     validator = new BlobSidecarsByRootValidator(peer, spec, kzg, List.of(blobIdentifier1));
@@ -60,7 +60,7 @@ public class BlobSidecarsByRootValidatorTest {
     final Bytes32 blockRoot1 = dataStructureUtil.randomBytes32();
     final BlobIdentifier blobIdentifier2 =
         new BlobIdentifier(dataStructureUtil.randomBytes32(), UInt64.ZERO);
-    final BlobSidecar blobSidecar1 =
+    final BlobSidecarOld blobSidecar1 =
         dataStructureUtil.randomBlobSidecar(UInt64.ONE, blockRoot1, Bytes32.ZERO, UInt64.ZERO);
 
     validator = new BlobSidecarsByRootValidator(peer, spec, kzg, List.of(blobIdentifier2));
@@ -77,7 +77,7 @@ public class BlobSidecarsByRootValidatorTest {
     when(kzg.verifyBlobKzgProof(any(), any(), any())).thenReturn(false);
     final Bytes32 blockRoot1 = dataStructureUtil.randomBytes32();
     final BlobIdentifier blobIdentifier1 = new BlobIdentifier(blockRoot1, UInt64.ZERO);
-    final BlobSidecar blobSidecar1 =
+    final BlobSidecarOld blobSidecar1 =
         dataStructureUtil.randomBlobSidecar(UInt64.ONE, blockRoot1, Bytes32.ZERO, UInt64.ZERO);
 
     validator = new BlobSidecarsByRootValidator(peer, spec, kzg, List.of(blobIdentifier1));

--- a/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkFactory.java
+++ b/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkFactory.java
@@ -83,7 +83,7 @@ import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.config.Constants;
 import tech.pegasys.teku.spec.datastructures.attestation.ProcessedAttestationListener;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
@@ -132,7 +132,7 @@ public class Eth2P2PNetworkFactory {
     protected RecentChainData recentChainData;
     protected StorageQueryChannel historicalChainData = new StubStorageQueryChannel();
     protected OperationProcessor<SignedBeaconBlock> gossipedBlockProcessor;
-    protected OperationProcessor<SignedBlobSidecar> gossipedBlobSidecarProcessor;
+    protected OperationProcessor<SignedBlobSidecarOld> gossipedBlobSidecarProcessor;
     protected OperationProcessor<ValidatableAttestation> gossipedAttestationProcessor;
     protected OperationProcessor<ValidatableAttestation> gossipedAggregateProcessor;
     protected OperationProcessor<AttesterSlashing> attesterSlashingProcessor;
@@ -589,7 +589,7 @@ public class Eth2P2PNetworkFactory {
     }
 
     public Eth2P2PNetworkBuilder gossipedBlobSidecarProcessor(
-        final OperationProcessor<SignedBlobSidecar> gossipedBlobSidecarProcessor) {
+        final OperationProcessor<SignedBlobSidecarOld> gossipedBlobSidecarProcessor) {
       checkNotNull(gossipedBlobSidecarProcessor);
       this.gossipedBlobSidecarProcessor = gossipedBlobSidecarProcessor;
       return this;

--- a/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/peers/RespondingEth2Peer.java
+++ b/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/peers/RespondingEth2Peer.java
@@ -48,7 +48,7 @@ import tech.pegasys.teku.networking.p2p.rpc.RpcResponseHandler;
 import tech.pegasys.teku.networking.p2p.rpc.RpcResponseListener;
 import tech.pegasys.teku.networking.p2p.rpc.RpcStreamController;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
@@ -213,10 +213,10 @@ public class RespondingEth2Peer implements Eth2Peer {
 
   @Override
   public SafeFuture<Void> requestBlobSidecarsByRange(
-      final UInt64 startSlot, final UInt64 count, final RpcResponseListener<BlobSidecar> listener) {
+      final UInt64 startSlot, final UInt64 count, final RpcResponseListener<BlobSidecarOld> listener) {
     final long lastSlotExclusive = startSlot.longValue() + count.longValue();
 
-    final PendingRequestHandler<Void, BlobSidecar> handler =
+    final PendingRequestHandler<Void, BlobSidecarOld> handler =
         PendingRequestHandler.createForBatchBlobSidecarRequest(
             listener,
             () ->
@@ -244,8 +244,8 @@ public class RespondingEth2Peer implements Eth2Peer {
 
   @Override
   public SafeFuture<Void> requestBlobSidecarsByRoot(
-      final List<BlobIdentifier> blobIdentifiers, final RpcResponseListener<BlobSidecar> listener) {
-    final PendingRequestHandler<Void, BlobSidecar> handler =
+      final List<BlobIdentifier> blobIdentifiers, final RpcResponseListener<BlobSidecarOld> listener) {
+    final PendingRequestHandler<Void, BlobSidecarOld> handler =
         PendingRequestHandler.createForBatchBlobSidecarRequest(
             listener,
             () ->
@@ -275,9 +275,9 @@ public class RespondingEth2Peer implements Eth2Peer {
   }
 
   @Override
-  public SafeFuture<Optional<BlobSidecar>> requestBlobSidecarByRoot(
+  public SafeFuture<Optional<BlobSidecarOld>> requestBlobSidecarByRoot(
       final BlobIdentifier blobIdentifier) {
-    final PendingRequestHandler<Optional<BlobSidecar>, BlobSidecar> handler =
+    final PendingRequestHandler<Optional<BlobSidecarOld>, BlobSidecarOld> handler =
         PendingRequestHandler.createForSingleBlobSidecarRequest(
             () -> findBlobSidecarByBlobIdentifier(blobIdentifier));
 
@@ -295,8 +295,8 @@ public class RespondingEth2Peer implements Eth2Peer {
   }
 
   private <T> SafeFuture<T> createPendingBlobSidecarRequest(
-      final PendingRequestHandler<T, BlobSidecar> handler) {
-    final PendingRequest<T, BlobSidecar> request = new PendingRequest<>(handler);
+      final PendingRequestHandler<T, BlobSidecarOld> handler) {
+    final PendingRequest<T, BlobSidecarOld> request = new PendingRequest<>(handler);
     pendingRequests.add(request);
     return request.getFuture();
   }
@@ -331,7 +331,7 @@ public class RespondingEth2Peer implements Eth2Peer {
 
   @Override
   public Optional<RequestApproval> approveBlobSidecarsRequest(
-      final ResponseCallback<BlobSidecar> callback, final long blobSidecarsCount) {
+          final ResponseCallback<BlobSidecarOld> callback, final long blobSidecarsCount) {
     return Optional.of(
         new RequestApproval.RequestApprovalBuilder().timeSeconds(ZERO).objectsCount(0).build());
   }
@@ -446,7 +446,7 @@ public class RespondingEth2Peer implements Eth2Peer {
     return findObjectByKey(root, ChainBuilder::getBlock);
   }
 
-  private Optional<BlobSidecar> findBlobSidecarByBlobIdentifier(
+  private Optional<BlobSidecarOld> findBlobSidecarByBlobIdentifier(
       final BlobIdentifier blobIdentifier) {
     return findObjectByKey(blobIdentifier, ChainBuilder::getBlobSidecar);
   }
@@ -527,9 +527,9 @@ public class RespondingEth2Peer implements Eth2Peer {
       return createForSingleRequest(blockSupplier);
     }
 
-    static PendingRequestHandler<Optional<BlobSidecar>, BlobSidecar>
+    static PendingRequestHandler<Optional<BlobSidecarOld>, BlobSidecarOld>
         createForSingleBlobSidecarRequest(
-            final Supplier<Optional<BlobSidecar>> blobSidecarSupplier) {
+            final Supplier<Optional<BlobSidecarOld>> blobSidecarSupplier) {
       return createForSingleRequest(blobSidecarSupplier);
     }
 
@@ -559,9 +559,9 @@ public class RespondingEth2Peer implements Eth2Peer {
       return createForBatchRequest(listener, blocksSupplier);
     }
 
-    static PendingRequestHandler<Void, BlobSidecar> createForBatchBlobSidecarRequest(
-        final RpcResponseListener<BlobSidecar> listener,
-        final Supplier<List<BlobSidecar>> blobSidecarsSupplier) {
+    static PendingRequestHandler<Void, BlobSidecarOld> createForBatchBlobSidecarRequest(
+        final RpcResponseListener<BlobSidecarOld> listener,
+        final Supplier<List<BlobSidecarOld>> blobSidecarsSupplier) {
       return createForBatchRequest(listener, blobSidecarsSupplier);
     }
   }

--- a/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/peers/RespondingEth2Peer.java
+++ b/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/peers/RespondingEth2Peer.java
@@ -213,7 +213,9 @@ public class RespondingEth2Peer implements Eth2Peer {
 
   @Override
   public SafeFuture<Void> requestBlobSidecarsByRange(
-      final UInt64 startSlot, final UInt64 count, final RpcResponseListener<BlobSidecarOld> listener) {
+      final UInt64 startSlot,
+      final UInt64 count,
+      final RpcResponseListener<BlobSidecarOld> listener) {
     final long lastSlotExclusive = startSlot.longValue() + count.longValue();
 
     final PendingRequestHandler<Void, BlobSidecarOld> handler =
@@ -244,7 +246,8 @@ public class RespondingEth2Peer implements Eth2Peer {
 
   @Override
   public SafeFuture<Void> requestBlobSidecarsByRoot(
-      final List<BlobIdentifier> blobIdentifiers, final RpcResponseListener<BlobSidecarOld> listener) {
+      final List<BlobIdentifier> blobIdentifiers,
+      final RpcResponseListener<BlobSidecarOld> listener) {
     final PendingRequestHandler<Void, BlobSidecarOld> handler =
         PendingRequestHandler.createForBatchBlobSidecarRequest(
             listener,
@@ -331,7 +334,7 @@ public class RespondingEth2Peer implements Eth2Peer {
 
   @Override
   public Optional<RequestApproval> approveBlobSidecarsRequest(
-          final ResponseCallback<BlobSidecarOld> callback, final long blobSidecarsCount) {
+      final ResponseCallback<BlobSidecarOld> callback, final long blobSidecarsCount) {
     return Optional.of(
         new RequestApproval.RequestApprovalBuilder().timeSeconds(ZERO).objectsCount(0).build());
   }

--- a/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/peers/StubSyncSource.java
+++ b/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/peers/StubSyncSource.java
@@ -38,7 +38,8 @@ public class StubSyncSource implements SyncSource {
   private Optional<RpcResponseListener<SignedBeaconBlock>> currentBlockListener = Optional.empty();
 
   private Optional<SafeFuture<Void>> currentBlobSidecarRequest = Optional.empty();
-  private Optional<RpcResponseListener<BlobSidecarOld>> currentBlobSidecarListener = Optional.empty();
+  private Optional<RpcResponseListener<BlobSidecarOld>> currentBlobSidecarListener =
+      Optional.empty();
 
   public void receiveBlocks(final SignedBeaconBlock... blocks) {
     final RpcResponseListener<SignedBeaconBlock> listener = currentBlockListener.orElseThrow();
@@ -72,7 +73,9 @@ public class StubSyncSource implements SyncSource {
 
   @Override
   public SafeFuture<Void> requestBlobSidecarsByRange(
-      final UInt64 startSlot, final UInt64 count, final RpcResponseListener<BlobSidecarOld> listener) {
+      final UInt64 startSlot,
+      final UInt64 count,
+      final RpcResponseListener<BlobSidecarOld> listener) {
     checkArgument(count.isGreaterThan(UInt64.ZERO), "Count must be greater than zero");
     blobSidecarsRequests.add(new Request(startSlot, count));
     final SafeFuture<Void> request = new SafeFuture<>();

--- a/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/peers/StubSyncSource.java
+++ b/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/peers/StubSyncSource.java
@@ -26,7 +26,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.p2p.peer.DisconnectReason;
 import tech.pegasys.teku.networking.p2p.reputation.ReputationAdjustment;
 import tech.pegasys.teku.networking.p2p.rpc.RpcResponseListener;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 
 public class StubSyncSource implements SyncSource {
@@ -38,7 +38,7 @@ public class StubSyncSource implements SyncSource {
   private Optional<RpcResponseListener<SignedBeaconBlock>> currentBlockListener = Optional.empty();
 
   private Optional<SafeFuture<Void>> currentBlobSidecarRequest = Optional.empty();
-  private Optional<RpcResponseListener<BlobSidecar>> currentBlobSidecarListener = Optional.empty();
+  private Optional<RpcResponseListener<BlobSidecarOld>> currentBlobSidecarListener = Optional.empty();
 
   public void receiveBlocks(final SignedBeaconBlock... blocks) {
     final RpcResponseListener<SignedBeaconBlock> listener = currentBlockListener.orElseThrow();
@@ -46,8 +46,8 @@ public class StubSyncSource implements SyncSource {
     currentBlockRequest.orElseThrow().complete(null);
   }
 
-  public void receiveBlobSidecars(final BlobSidecar... blobSidecars) {
-    final RpcResponseListener<BlobSidecar> listener = currentBlobSidecarListener.orElseThrow();
+  public void receiveBlobSidecars(final BlobSidecarOld... blobSidecars) {
+    final RpcResponseListener<BlobSidecarOld> listener = currentBlobSidecarListener.orElseThrow();
     Stream.of(blobSidecars)
         .forEach(response -> assertThat(listener.onResponse(response)).isCompleted());
     currentBlobSidecarRequest.orElseThrow().complete(null);
@@ -72,7 +72,7 @@ public class StubSyncSource implements SyncSource {
 
   @Override
   public SafeFuture<Void> requestBlobSidecarsByRange(
-      final UInt64 startSlot, final UInt64 count, final RpcResponseListener<BlobSidecar> listener) {
+      final UInt64 startSlot, final UInt64 count, final RpcResponseListener<BlobSidecarOld> listener) {
     checkArgument(count.isGreaterThan(UInt64.ZERO), "Count must be greater than zero");
     blobSidecarsRequests.add(new Request(startSlot, count));
     final SafeFuture<Void> request = new SafeFuture<>();

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -89,7 +89,7 @@ import tech.pegasys.teku.services.timer.TimerService;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodySchema;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.capella.BeaconBlockBodySchemaCapella;
@@ -492,8 +492,8 @@ public class BeaconChainController extends Service implements BeaconChainControl
 
   protected void initBlobSidecarManager() {
     if (spec.isMilestoneSupported(SpecMilestone.DENEB)) {
-      final FutureItems<SignedBlobSidecar> futureBlobSidecars =
-          FutureItems.create(SignedBlobSidecar::getSlot, futureItemsMetric, "blob_sidecars");
+      final FutureItems<SignedBlobSidecarOld> futureBlobSidecars =
+          FutureItems.create(SignedBlobSidecarOld::getSlot, futureItemsMetric, "blob_sidecars");
 
       final Map<Bytes32, InternalValidationResult> invalidBlobSidecarRoots =
           LimitedMap.createSynchronized(500);

--- a/storage/api/src/main/java/tech/pegasys/teku/storage/api/StorageQueryChannel.java
+++ b/storage/api/src/main/java/tech/pegasys/teku/storage/api/StorageQueryChannel.java
@@ -22,7 +22,7 @@ import tech.pegasys.teku.ethereum.pow.api.DepositTreeSnapshot;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.events.ChannelInterface;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
@@ -67,7 +67,7 @@ public interface StorageQueryChannel extends ChannelInterface {
    */
   SafeFuture<Map<Bytes32, SignedBeaconBlock>> getHotBlocksByRoot(Set<Bytes32> blockRoots);
 
-  SafeFuture<List<BlobSidecar>> getBlobSidecarsBySlotAndBlockRoot(
+  SafeFuture<List<BlobSidecarOld>> getBlobSidecarsBySlotAndBlockRoot(
       SlotAndBlockRoot slotAndBlockRoot);
 
   SafeFuture<Optional<SlotAndBlockRoot>> getSlotAndBlockRootByStateRoot(Bytes32 stateRoot);
@@ -93,9 +93,9 @@ public interface StorageQueryChannel extends ChannelInterface {
    */
   SafeFuture<Optional<UInt64>> getEarliestAvailableBlobSidecarSlot();
 
-  SafeFuture<Optional<BlobSidecar>> getBlobSidecar(SlotAndBlockRootAndBlobIndex key);
+  SafeFuture<Optional<BlobSidecarOld>> getBlobSidecar(SlotAndBlockRootAndBlobIndex key);
 
-  SafeFuture<Optional<BlobSidecar>> getNonCanonicalBlobSidecar(SlotAndBlockRootAndBlobIndex key);
+  SafeFuture<Optional<BlobSidecarOld>> getNonCanonicalBlobSidecar(SlotAndBlockRootAndBlobIndex key);
 
   /** This method could return non-canonical blob sidecar keys if the slot is not finalized */
   SafeFuture<List<SlotAndBlockRootAndBlobIndex>> getBlobSidecarKeys(UInt64 slot);

--- a/storage/api/src/main/java/tech/pegasys/teku/storage/api/StorageUpdate.java
+++ b/storage/api/src/main/java/tech/pegasys/teku/storage/api/StorageUpdate.java
@@ -25,7 +25,7 @@ import java.util.Map;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockAndCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
@@ -42,7 +42,7 @@ public class StorageUpdate {
   private final Map<Bytes32, BlockAndCheckpoints> hotBlocks;
   private final Map<Bytes32, BeaconState> hotStates;
   private final Map<Bytes32, UInt64> deletedHotBlocks;
-  private final Map<SlotAndBlockRoot, List<BlobSidecar>> blobSidecars;
+  private final Map<SlotAndBlockRoot, List<BlobSidecarOld>> blobSidecars;
   private final Optional<UInt64> maybeEarliestBlobSidecarSlot;
   private final boolean optimisticTransitionBlockRootSet;
   private final Optional<Bytes32> optimisticTransitionBlockRoot;
@@ -56,7 +56,7 @@ public class StorageUpdate {
       final Optional<Checkpoint> bestJustifiedCheckpoint,
       final Map<Bytes32, BlockAndCheckpoints> hotBlocks,
       final Map<Bytes32, BeaconState> hotStates,
-      final Map<SlotAndBlockRoot, List<BlobSidecar>> blobSidecars,
+      final Map<SlotAndBlockRoot, List<BlobSidecarOld>> blobSidecars,
       final Optional<UInt64> maybeEarliestBlobSidecarSlot,
       final Map<Bytes32, UInt64> deletedHotBlocks,
       final Map<Bytes32, SlotAndBlockRoot> stateRoots,
@@ -118,7 +118,7 @@ public class StorageUpdate {
     return hotBlocks;
   }
 
-  public Map<SlotAndBlockRoot, List<BlobSidecar>> getBlobSidecars() {
+  public Map<SlotAndBlockRoot, List<BlobSidecarOld>> getBlobSidecars() {
     return blobSidecars;
   }
 

--- a/storage/api/src/main/java/tech/pegasys/teku/storage/api/StorageUpdateChannel.java
+++ b/storage/api/src/main/java/tech/pegasys/teku/storage/api/StorageUpdateChannel.java
@@ -22,7 +22,7 @@ import tech.pegasys.teku.ethereum.pow.api.DepositTreeSnapshot;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.events.ChannelInterface;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
@@ -34,7 +34,7 @@ public interface StorageUpdateChannel extends ChannelInterface {
 
   SafeFuture<Void> onFinalizedBlocks(
       Collection<SignedBeaconBlock> finalizedBlocks,
-      Map<SlotAndBlockRoot, List<BlobSidecar>> blobSidecarsBySlot,
+      Map<SlotAndBlockRoot, List<BlobSidecarOld>> blobSidecarsBySlot,
       Optional<UInt64> maybeEarliestBlobSidecarSlot);
 
   SafeFuture<Void> onFinalizedState(BeaconState finalizedState, Bytes32 blockRoot);

--- a/storage/src/integration-test/java/tech/pegasys/teku/storage/server/kvstore/DatabaseTest.java
+++ b/storage/src/integration-test/java/tech/pegasys/teku/storage/server/kvstore/DatabaseTest.java
@@ -63,7 +63,7 @@ import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
@@ -203,21 +203,21 @@ public class DatabaseTest {
     // no blobs, earliest slot 0, because of genesis Deneb
     assertThat(database.getEarliestBlobSidecarSlot()).contains(ZERO);
 
-    final BlobSidecar blobSidecar1 =
+    final BlobSidecarOld blobSidecar1 =
         dataStructureUtil.randomBlobSidecar(
             UInt64.valueOf(1), dataStructureUtil.randomBytes32(), UInt64.valueOf(0));
-    final BlobSidecar blobSidecar2 =
+    final BlobSidecarOld blobSidecar2 =
         dataStructureUtil.randomBlobSidecar(UInt64.valueOf(2), Bytes32.ZERO, UInt64.valueOf(0));
-    final BlobSidecar blobSidecar2bis =
+    final BlobSidecarOld blobSidecar2bis =
         dataStructureUtil.randomBlobSidecar(
             UInt64.valueOf(2), Bytes32.fromHexString("0x01"), UInt64.valueOf(1));
-    final BlobSidecar blobSidecar3 =
+    final BlobSidecarOld blobSidecar3 =
         dataStructureUtil.randomBlobSidecar(
             UInt64.valueOf(3), dataStructureUtil.randomBytes32(), UInt64.valueOf(0));
-    final BlobSidecar blobSidecar5 =
+    final BlobSidecarOld blobSidecar5 =
         dataStructureUtil.randomBlobSidecar(
             UInt64.valueOf(5), dataStructureUtil.randomBytes32(), UInt64.valueOf(0));
-    final BlobSidecar blobSidecarNotAdded = dataStructureUtil.randomBlobSidecar();
+    final BlobSidecarOld blobSidecarNotAdded = dataStructureUtil.randomBlobSidecar();
 
     // add blobs out of order
     database.storeBlobSidecar(blobSidecar2);
@@ -344,21 +344,21 @@ public class DatabaseTest {
   public void verifyNonCanonicalBlobsLifecycle(final DatabaseContext context) throws IOException {
     initialize(context);
 
-    final BlobSidecar blobSidecar1 =
+    final BlobSidecarOld blobSidecar1 =
         dataStructureUtil.randomBlobSidecar(
             UInt64.valueOf(1), dataStructureUtil.randomBytes32(), UInt64.valueOf(0));
-    final BlobSidecar blobSidecar2 =
+    final BlobSidecarOld blobSidecar2 =
         dataStructureUtil.randomBlobSidecar(UInt64.valueOf(2), Bytes32.ZERO, UInt64.valueOf(0));
-    final BlobSidecar blobSidecar2bis =
+    final BlobSidecarOld blobSidecar2bis =
         dataStructureUtil.randomBlobSidecar(
             UInt64.valueOf(2), Bytes32.fromHexString("0x01"), UInt64.valueOf(1));
-    final BlobSidecar blobSidecar3 =
+    final BlobSidecarOld blobSidecar3 =
         dataStructureUtil.randomBlobSidecar(
             UInt64.valueOf(3), dataStructureUtil.randomBytes32(), UInt64.valueOf(0));
-    final BlobSidecar blobSidecar5 =
+    final BlobSidecarOld blobSidecar5 =
         dataStructureUtil.randomBlobSidecar(
             UInt64.valueOf(5), dataStructureUtil.randomBytes32(), UInt64.valueOf(0));
-    final BlobSidecar blobSidecarNotAdded = dataStructureUtil.randomBlobSidecar();
+    final BlobSidecarOld blobSidecarNotAdded = dataStructureUtil.randomBlobSidecar();
 
     // add non-canonical blobs out of order
     database.storeNonCanonicalBlobSidecar(blobSidecar2);
@@ -1323,11 +1323,11 @@ public class DatabaseTest {
     primaryChain.generateBlockAtSlot(5, randomBlobsOptions);
     final ChainBuilder secondFork = primaryChain.fork();
 
-    final BlobSidecar blobSidecarPrimary2Slot2Index0 =
+    final BlobSidecarOld blobSidecarPrimary2Slot2Index0 =
         dataStructureUtil.randomBlobSidecar(
             UInt64.valueOf(2), primaryChain.getBlockAtSlot(2).getRoot(), UInt64.valueOf(0));
     database.storeBlobSidecar(blobSidecarPrimary2Slot2Index0);
-    final BlobSidecar blobSidecarPrimary2Slot2Index1 =
+    final BlobSidecarOld blobSidecarPrimary2Slot2Index1 =
         dataStructureUtil.randomBlobSidecar(
             UInt64.valueOf(2), primaryChain.getBlockAtSlot(2).getRoot(), UInt64.valueOf(1));
     database.storeBlobSidecar(blobSidecarPrimary2Slot2Index1);
@@ -1353,7 +1353,7 @@ public class DatabaseTest {
                 secondFork.streamBlocksAndStates())
             .collect(Collectors.toSet());
 
-    final List<BlobSidecar> allBlocksSidecars =
+    final List<BlobSidecarOld> allBlocksSidecars =
         Streams.concat(
                 primaryChain.streamBlobSidecars(),
                 forkChain.streamBlobSidecars(),
@@ -1398,7 +1398,7 @@ public class DatabaseTest {
         .forEach(
             key -> {
               // retrieve expected blobSidecar from allBlocksSidecars
-              final BlobSidecar blobSidecar =
+              final BlobSidecarOld blobSidecar =
                   allBlocksSidecars.stream()
                       .filter(sidecar -> blobSidecarToKey(sidecar).equals(key))
                       .findFirst()
@@ -2477,7 +2477,7 @@ public class DatabaseTest {
   }
 
   private void addBlocksAndBlobSidecars(
-      final List<SignedBlockAndState> blocks, final List<BlobSidecar> blobSidecars) {
+      final List<SignedBlockAndState> blocks, final List<BlobSidecarOld> blobSidecars) {
     final StoreTransaction transaction = recentChainData.startStoreTransaction();
     for (SignedBlockAndState block : blocks) {
       transaction.putBlockAndState(
@@ -2495,7 +2495,7 @@ public class DatabaseTest {
   }
 
   private void add(
-      final Collection<SignedBlockAndState> blocks, final List<BlobSidecar> blobSidecars) {
+      final Collection<SignedBlockAndState> blocks, final List<BlobSidecarOld> blobSidecars) {
     final StoreTransaction transaction = recentChainData.startStoreTransaction();
     add(transaction, blocks, blobSidecars);
     commit(transaction);
@@ -2504,7 +2504,7 @@ public class DatabaseTest {
   private void add(
       final StoreTransaction transaction,
       final Collection<SignedBlockAndState> blocksAndStates,
-      final List<BlobSidecar> blobSidecars) {
+      final List<BlobSidecarOld> blobSidecars) {
     blocksAndStates.stream()
         .sorted(Comparator.comparing(SignedBlockAndState::getSlot))
         .forEach(
@@ -2627,20 +2627,20 @@ public class DatabaseTest {
     }
   }
 
-  private void assertBlobSidecars(final Map<UInt64, List<BlobSidecar>> blobSidecars) {
+  private void assertBlobSidecars(final Map<UInt64, List<BlobSidecarOld>> blobSidecars) {
     final List<UInt64> slots = blobSidecars.keySet().stream().sorted().collect(toList());
     if (slots.isEmpty()) {
       return;
     }
 
-    final Map<UInt64, List<BlobSidecar>> blobSidecarsDb = new HashMap<>();
+    final Map<UInt64, List<BlobSidecarOld>> blobSidecarsDb = new HashMap<>();
     try (final Stream<SlotAndBlockRootAndBlobIndex> blobSidecarsStream =
         database.streamBlobSidecarKeys(slots.get(0), slots.get(slots.size() - 1))) {
 
       for (final Iterator<SlotAndBlockRootAndBlobIndex> iterator = blobSidecarsStream.iterator();
           iterator.hasNext(); ) {
         final SlotAndBlockRootAndBlobIndex key = iterator.next();
-        final List<BlobSidecar> currentSlotBlobs =
+        final List<BlobSidecarOld> currentSlotBlobs =
             blobSidecarsDb.computeIfAbsent(key.getSlot(), __ -> new ArrayList<>());
         currentSlotBlobs.add(database.getBlobSidecar(key).orElseThrow());
       }
@@ -2649,20 +2649,20 @@ public class DatabaseTest {
     assertThat(blobSidecarsDb).isEqualTo(blobSidecars);
   }
 
-  private void assertNonCanonicalBlobSidecars(final Map<UInt64, List<BlobSidecar>> blobSidecars) {
+  private void assertNonCanonicalBlobSidecars(final Map<UInt64, List<BlobSidecarOld>> blobSidecars) {
     final List<UInt64> slots = blobSidecars.keySet().stream().sorted().collect(toList());
     if (slots.isEmpty()) {
       return;
     }
 
-    final Map<UInt64, List<BlobSidecar>> blobSidecarsDb = new HashMap<>();
+    final Map<UInt64, List<BlobSidecarOld>> blobSidecarsDb = new HashMap<>();
     try (final Stream<SlotAndBlockRootAndBlobIndex> blobSidecarsStream =
         database.streamNonCanonicalBlobSidecarKeys(slots.get(0), slots.get(slots.size() - 1))) {
 
       for (final Iterator<SlotAndBlockRootAndBlobIndex> iterator = blobSidecarsStream.iterator();
           iterator.hasNext(); ) {
         final SlotAndBlockRootAndBlobIndex key = iterator.next();
-        final List<BlobSidecar> currentSlotBlobs =
+        final List<BlobSidecarOld> currentSlotBlobs =
             blobSidecarsDb.computeIfAbsent(key.getSlot(), __ -> new ArrayList<>());
         currentSlotBlobs.add(database.getNonCanonicalBlobSidecar(key).orElseThrow());
       }
@@ -2689,7 +2689,7 @@ public class DatabaseTest {
     }
   }
 
-  private static SlotAndBlockRootAndBlobIndex blobSidecarToKey(final BlobSidecar blobSidecar) {
+  private static SlotAndBlockRootAndBlobIndex blobSidecarToKey(final BlobSidecarOld blobSidecar) {
     return new SlotAndBlockRootAndBlobIndex(
         blobSidecar.getSlot(), blobSidecar.getBlockRoot(), blobSidecar.getIndex());
   }

--- a/storage/src/integration-test/java/tech/pegasys/teku/storage/server/kvstore/DatabaseTest.java
+++ b/storage/src/integration-test/java/tech/pegasys/teku/storage/server/kvstore/DatabaseTest.java
@@ -2649,7 +2649,8 @@ public class DatabaseTest {
     assertThat(blobSidecarsDb).isEqualTo(blobSidecars);
   }
 
-  private void assertNonCanonicalBlobSidecars(final Map<UInt64, List<BlobSidecarOld>> blobSidecars) {
+  private void assertNonCanonicalBlobSidecars(
+      final Map<UInt64, List<BlobSidecarOld>> blobSidecars) {
     final List<UInt64> slots = blobSidecars.keySet().stream().sorted().collect(toList());
     if (slots.isEmpty()) {
       return;

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
@@ -30,7 +30,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.blocks.MinimalBeaconBlockSummary;
@@ -168,7 +168,7 @@ public class CombinedChainDataClient {
    * Retrieves blob sidecars for the given slot. If the slot is not finalized, it could return
    * non-canonical blob sidecars.
    */
-  public SafeFuture<List<BlobSidecar>> getBlobSidecars(
+  public SafeFuture<List<BlobSidecarOld>> getBlobSidecars(
       final UInt64 slot, final List<UInt64> indices) {
     return historicalChainData
         .getBlobSidecarKeys(slot)
@@ -176,9 +176,9 @@ public class CombinedChainDataClient {
         .thenCompose(this::getBlobSidecars);
   }
 
-  public SafeFuture<List<BlobSidecar>> getBlobSidecars(
+  public SafeFuture<List<BlobSidecarOld>> getBlobSidecars(
       final SlotAndBlockRoot slotAndBlockRoot, final List<UInt64> indices) {
-    final Optional<List<BlobSidecar>> maybeBlobSidecars =
+    final Optional<List<BlobSidecarOld>> maybeBlobSidecars =
         recentChainData.getBlobSidecars(slotAndBlockRoot);
     if (maybeBlobSidecars.isPresent()) {
       return SafeFuture.completedFuture(filterBlobSidecars(maybeBlobSidecars.get(), indices));
@@ -189,7 +189,7 @@ public class CombinedChainDataClient {
         .thenCompose(this::getBlobSidecars);
   }
 
-  public SafeFuture<List<BlobSidecar>> getAllBlobSidecars(
+  public SafeFuture<List<BlobSidecarOld>> getAllBlobSidecars(
       final UInt64 slot, final List<UInt64> indices) {
     return historicalChainData
         .getAllBlobSidecarKeys(slot)
@@ -197,8 +197,8 @@ public class CombinedChainDataClient {
         .thenCompose(this::getAllBlobSidecars);
   }
 
-  private List<BlobSidecar> filterBlobSidecars(
-      final List<BlobSidecar> blobSidecars, final List<UInt64> indices) {
+  private List<BlobSidecarOld> filterBlobSidecars(
+          final List<BlobSidecarOld> blobSidecars, final List<UInt64> indices) {
     if (indices.isEmpty()) {
       return blobSidecars;
     }
@@ -213,13 +213,13 @@ public class CombinedChainDataClient {
     return keys.stream().filter(key -> indices.contains(key.getBlobIndex()));
   }
 
-  private SafeFuture<List<BlobSidecar>> getBlobSidecars(
+  private SafeFuture<List<BlobSidecarOld>> getBlobSidecars(
       final Stream<SlotAndBlockRootAndBlobIndex> keys) {
     return SafeFuture.collectAll(keys.map(this::getAllBlobSidecarByKey))
         .thenApply(blobSidecars -> blobSidecars.stream().flatMap(Optional::stream).toList());
   }
 
-  private SafeFuture<List<BlobSidecar>> getAllBlobSidecars(
+  private SafeFuture<List<BlobSidecarOld>> getAllBlobSidecars(
       final Stream<SlotAndBlockRootAndBlobIndex> keys) {
     return SafeFuture.collectAll(keys.map(this::getAllBlobSidecarByKey))
         .thenApply(blobSidecars -> blobSidecars.stream().flatMap(Optional::stream).toList());
@@ -569,7 +569,7 @@ public class CombinedChainDataClient {
     return historicalChainData.getEarliestAvailableBlobSidecarSlot();
   }
 
-  public SafeFuture<Optional<BlobSidecar>> getBlobSidecarByBlockRootAndIndex(
+  public SafeFuture<Optional<BlobSidecarOld>> getBlobSidecarByBlockRootAndIndex(
       final Bytes32 blockRoot, final UInt64 index) {
     final Optional<UInt64> hotSlotForBlockRoot = recentChainData.getSlotForBlockRoot(blockRoot);
     if (hotSlotForBlockRoot.isPresent()) {
@@ -590,9 +590,9 @@ public class CombinedChainDataClient {
             });
   }
 
-  public SafeFuture<Optional<BlobSidecar>> getBlobSidecarByKey(
+  public SafeFuture<Optional<BlobSidecarOld>> getBlobSidecarByKey(
       final SlotAndBlockRootAndBlobIndex key) {
-    final Optional<List<BlobSidecar>> maybeBlobSidecars =
+    final Optional<List<BlobSidecarOld>> maybeBlobSidecars =
         recentChainData.getBlobSidecars(key.getSlotAndBlockRoot());
     if (maybeBlobSidecars.isPresent()) {
       return key.getBlobIndex().isLessThan(maybeBlobSidecars.get().size())
@@ -690,7 +690,7 @@ public class CombinedChainDataClient {
     return recentChainData;
   }
 
-  private SafeFuture<Optional<BlobSidecar>> getAllBlobSidecarByKey(
+  private SafeFuture<Optional<BlobSidecarOld>> getAllBlobSidecarByKey(
       final SlotAndBlockRootAndBlobIndex key) {
     return historicalChainData
         .getBlobSidecar(key)

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
@@ -198,7 +198,7 @@ public class CombinedChainDataClient {
   }
 
   private List<BlobSidecarOld> filterBlobSidecars(
-          final List<BlobSidecarOld> blobSidecars, final List<UInt64> indices) {
+      final List<BlobSidecarOld> blobSidecars, final List<UInt64> indices) {
     if (indices.isEmpty()) {
       return blobSidecars;
     }

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
@@ -39,7 +39,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.SpecVersion;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.MinimalBeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
@@ -500,7 +500,7 @@ public abstract class RecentChainData implements StoreUpdateHandler {
     return getForkChoiceStrategy().flatMap(forkChoice -> forkChoice.executionBlockHash(root));
   }
 
-  public Optional<List<BlobSidecar>> getBlobSidecars(final SlotAndBlockRoot slotAndBlockRoot) {
+  public Optional<List<BlobSidecarOld>> getBlobSidecars(final SlotAndBlockRoot slotAndBlockRoot) {
     return Optional.ofNullable(store)
         .flatMap(s -> store.getBlobSidecarsIfAvailable(slotAndBlockRoot));
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/ChainStorage.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/ChainStorage.java
@@ -307,7 +307,8 @@ public class ChainStorage
   }
 
   @Override
-  public SafeFuture<Optional<BlobSidecarOld>> getBlobSidecar(final SlotAndBlockRootAndBlobIndex key) {
+  public SafeFuture<Optional<BlobSidecarOld>> getBlobSidecar(
+      final SlotAndBlockRootAndBlobIndex key) {
     return SafeFuture.of(() -> database.getBlobSidecar(key));
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/ChainStorage.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/ChainStorage.java
@@ -27,7 +27,7 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.config.SpecConfig;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockHeader;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
@@ -118,7 +118,7 @@ public class ChainStorage
   @Override
   public SafeFuture<Void> onFinalizedBlocks(
       final Collection<SignedBeaconBlock> finalizedBlocks,
-      final Map<SlotAndBlockRoot, List<BlobSidecar>> blobSidecarsBySlot,
+      final Map<SlotAndBlockRoot, List<BlobSidecarOld>> blobSidecarsBySlot,
       final Optional<UInt64> maybeEarliestBlobSidecarSlot) {
     return SafeFuture.fromRunnable(
         () ->
@@ -216,11 +216,11 @@ public class ChainStorage
   }
 
   @Override
-  public SafeFuture<List<BlobSidecar>> getBlobSidecarsBySlotAndBlockRoot(
+  public SafeFuture<List<BlobSidecarOld>> getBlobSidecarsBySlotAndBlockRoot(
       final SlotAndBlockRoot slotAndBlockRoot) {
     return SafeFuture.of(
         () -> {
-          try (final Stream<BlobSidecar> blobSidecarStream =
+          try (final Stream<BlobSidecarOld> blobSidecarStream =
               database.streamBlobSidecars(slotAndBlockRoot)) {
             return blobSidecarStream.toList();
           }
@@ -307,12 +307,12 @@ public class ChainStorage
   }
 
   @Override
-  public SafeFuture<Optional<BlobSidecar>> getBlobSidecar(final SlotAndBlockRootAndBlobIndex key) {
+  public SafeFuture<Optional<BlobSidecarOld>> getBlobSidecar(final SlotAndBlockRootAndBlobIndex key) {
     return SafeFuture.of(() -> database.getBlobSidecar(key));
   }
 
   @Override
-  public SafeFuture<Optional<BlobSidecar>> getNonCanonicalBlobSidecar(
+  public SafeFuture<Optional<BlobSidecarOld>> getNonCanonicalBlobSidecar(
       final SlotAndBlockRootAndBlobIndex key) {
     return SafeFuture.of(() -> database.getNonCanonicalBlobSidecar(key));
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/CombinedStorageChannelSplitter.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/CombinedStorageChannelSplitter.java
@@ -23,7 +23,7 @@ import tech.pegasys.teku.ethereum.pow.api.DepositTreeSnapshot;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
@@ -71,7 +71,7 @@ public class CombinedStorageChannelSplitter implements CombinedStorageChannel {
   @Override
   public SafeFuture<Void> onFinalizedBlocks(
       final Collection<SignedBeaconBlock> finalizedBlocks,
-      final Map<SlotAndBlockRoot, List<BlobSidecar>> blobSidecarsBySlot,
+      final Map<SlotAndBlockRoot, List<BlobSidecarOld>> blobSidecarsBySlot,
       final Optional<UInt64> maybeEarliestBlobSidecarSlot) {
     return updateDelegate.onFinalizedBlocks(
         finalizedBlocks, blobSidecarsBySlot, maybeEarliestBlobSidecarSlot);
@@ -161,7 +161,7 @@ public class CombinedStorageChannelSplitter implements CombinedStorageChannel {
   }
 
   @Override
-  public SafeFuture<List<BlobSidecar>> getBlobSidecarsBySlotAndBlockRoot(
+  public SafeFuture<List<BlobSidecarOld>> getBlobSidecarsBySlotAndBlockRoot(
       final SlotAndBlockRoot slotAndBlockRoot) {
     return asyncRunner.runAsync(
         () -> queryDelegate.getBlobSidecarsBySlotAndBlockRoot(slotAndBlockRoot));
@@ -219,12 +219,12 @@ public class CombinedStorageChannelSplitter implements CombinedStorageChannel {
   }
 
   @Override
-  public SafeFuture<Optional<BlobSidecar>> getBlobSidecar(final SlotAndBlockRootAndBlobIndex key) {
+  public SafeFuture<Optional<BlobSidecarOld>> getBlobSidecar(final SlotAndBlockRootAndBlobIndex key) {
     return asyncRunner.runAsync(() -> queryDelegate.getBlobSidecar(key));
   }
 
   @Override
-  public SafeFuture<Optional<BlobSidecar>> getNonCanonicalBlobSidecar(
+  public SafeFuture<Optional<BlobSidecarOld>> getNonCanonicalBlobSidecar(
       final SlotAndBlockRootAndBlobIndex key) {
     return asyncRunner.runAsync(() -> queryDelegate.getNonCanonicalBlobSidecar(key));
   }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/CombinedStorageChannelSplitter.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/CombinedStorageChannelSplitter.java
@@ -219,7 +219,8 @@ public class CombinedStorageChannelSplitter implements CombinedStorageChannel {
   }
 
   @Override
-  public SafeFuture<Optional<BlobSidecarOld>> getBlobSidecar(final SlotAndBlockRootAndBlobIndex key) {
+  public SafeFuture<Optional<BlobSidecarOld>> getBlobSidecar(
+      final SlotAndBlockRootAndBlobIndex key) {
     return asyncRunner.runAsync(() -> queryDelegate.getBlobSidecar(key));
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
@@ -26,7 +26,7 @@ import tech.pegasys.teku.ethereum.pow.api.DepositTreeSnapshot;
 import tech.pegasys.teku.ethereum.pow.api.DepositsFromBlockEvent;
 import tech.pegasys.teku.ethereum.pow.api.MinGenesisTimeBlockEvent;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
@@ -49,7 +49,7 @@ public interface Database extends AutoCloseable {
 
   void storeFinalizedBlocks(
       Collection<SignedBeaconBlock> blocks,
-      Map<SlotAndBlockRoot, List<BlobSidecar>> blobSidecarsBySlot,
+      Map<SlotAndBlockRoot, List<BlobSidecarOld>> blobSidecarsBySlot,
       Optional<UInt64> maybeEarliestBlobSidecarSlot);
 
   void storeFinalizedState(BeaconState state, Bytes32 blockRoot);
@@ -58,13 +58,13 @@ public interface Database extends AutoCloseable {
 
   void updateWeakSubjectivityState(WeakSubjectivityUpdate weakSubjectivityUpdate);
 
-  void storeBlobSidecar(BlobSidecar blobSidecar);
+  void storeBlobSidecar(BlobSidecarOld blobSidecar);
 
-  void storeNonCanonicalBlobSidecar(BlobSidecar blobSidecar);
+  void storeNonCanonicalBlobSidecar(BlobSidecarOld blobSidecar);
 
-  Optional<BlobSidecar> getBlobSidecar(SlotAndBlockRootAndBlobIndex key);
+  Optional<BlobSidecarOld> getBlobSidecar(SlotAndBlockRootAndBlobIndex key);
 
-  Optional<BlobSidecar> getNonCanonicalBlobSidecar(SlotAndBlockRootAndBlobIndex key);
+  Optional<BlobSidecarOld> getNonCanonicalBlobSidecar(SlotAndBlockRootAndBlobIndex key);
 
   void removeBlobSidecars(SlotAndBlockRoot slotAndBlockRoot);
 
@@ -102,7 +102,7 @@ public interface Database extends AutoCloseable {
   }
 
   @MustBeClosed
-  Stream<BlobSidecar> streamBlobSidecars(SlotAndBlockRoot slotAndBlockRoot);
+  Stream<BlobSidecarOld> streamBlobSidecars(SlotAndBlockRoot slotAndBlockRoot);
 
   List<SlotAndBlockRootAndBlobIndex> getBlobSidecarKeys(SlotAndBlockRoot slotAndBlockRoot);
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/RetryingStorageUpdateChannel.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/RetryingStorageUpdateChannel.java
@@ -29,7 +29,7 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.exceptions.FatalServiceFailureException;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
@@ -89,7 +89,7 @@ public class RetryingStorageUpdateChannel implements StorageUpdateChannel {
   @Override
   public SafeFuture<Void> onFinalizedBlocks(
       final Collection<SignedBeaconBlock> finalizedBlocks,
-      final Map<SlotAndBlockRoot, List<BlobSidecar>> blobSidecarsBySlot,
+      final Map<SlotAndBlockRoot, List<BlobSidecarOld>> blobSidecarsBySlot,
       final Optional<UInt64> maybeEarliestBlobSidecarSlot) {
     return retry(
         () ->

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
@@ -802,7 +802,8 @@ public class KvStoreDatabase implements Database {
   }
 
   @Override
-  public Optional<BlobSidecarOld> getNonCanonicalBlobSidecar(final SlotAndBlockRootAndBlobIndex key) {
+  public Optional<BlobSidecarOld> getNonCanonicalBlobSidecar(
+      final SlotAndBlockRootAndBlobIndex key) {
     final Optional<Bytes> maybePayload = dao.getNonCanonicalBlobSidecar(key);
     return maybePayload.map(payload -> spec.deserializeBlobSidecar(payload, key.getSlot()));
   }
@@ -1019,7 +1020,8 @@ public class KvStoreDatabase implements Database {
   }
 
   private void updateBlobSidecarData(
-      final Optional<UInt64> getEarliestBlobSidecarSlot, final Stream<BlobSidecarOld> blobSidecars) {
+      final Optional<UInt64> getEarliestBlobSidecarSlot,
+      final Stream<BlobSidecarOld> blobSidecars) {
     LOG.trace("Applying blob sidecar updates");
 
     try (final FinalizedUpdater updater = finalizedUpdater()) {

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
@@ -50,7 +50,7 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockHeader;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockAndCheckpoints;
@@ -307,7 +307,7 @@ public class KvStoreDatabase implements Database {
 
   protected void storeFinalizedBlocksToDao(
       final Collection<SignedBeaconBlock> blocks,
-      final Map<SlotAndBlockRoot, List<BlobSidecar>> finalizedBlobSidecarsBySlot,
+      final Map<SlotAndBlockRoot, List<BlobSidecarOld>> finalizedBlobSidecarsBySlot,
       final Optional<UInt64> maybeEarliestBlobSidecar) {
     try (final FinalizedUpdater updater = finalizedUpdater()) {
       blocks.forEach(
@@ -537,7 +537,7 @@ public class KvStoreDatabase implements Database {
   @Override
   public void storeFinalizedBlocks(
       final Collection<SignedBeaconBlock> blocks,
-      final Map<SlotAndBlockRoot, List<BlobSidecar>> blobSidecarsBySlot,
+      final Map<SlotAndBlockRoot, List<BlobSidecarOld>> blobSidecarsBySlot,
       final Optional<UInt64> maybeEarliestBlobSidecarSlot) {
     if (blocks.isEmpty()) {
       return;
@@ -780,7 +780,7 @@ public class KvStoreDatabase implements Database {
   }
 
   @Override
-  public void storeBlobSidecar(final BlobSidecar blobSidecar) {
+  public void storeBlobSidecar(final BlobSidecarOld blobSidecar) {
     try (final FinalizedUpdater updater = finalizedUpdater()) {
       updater.addBlobSidecar(blobSidecar);
       updater.commit();
@@ -788,7 +788,7 @@ public class KvStoreDatabase implements Database {
   }
 
   @Override
-  public void storeNonCanonicalBlobSidecar(final BlobSidecar blobSidecar) {
+  public void storeNonCanonicalBlobSidecar(final BlobSidecarOld blobSidecar) {
     try (final FinalizedUpdater updater = finalizedUpdater()) {
       updater.addNonCanonicalBlobSidecar(blobSidecar);
       updater.commit();
@@ -796,13 +796,13 @@ public class KvStoreDatabase implements Database {
   }
 
   @Override
-  public Optional<BlobSidecar> getBlobSidecar(final SlotAndBlockRootAndBlobIndex key) {
+  public Optional<BlobSidecarOld> getBlobSidecar(final SlotAndBlockRootAndBlobIndex key) {
     final Optional<Bytes> maybePayload = dao.getBlobSidecar(key);
     return maybePayload.map(payload -> spec.deserializeBlobSidecar(payload, key.getSlot()));
   }
 
   @Override
-  public Optional<BlobSidecar> getNonCanonicalBlobSidecar(final SlotAndBlockRootAndBlobIndex key) {
+  public Optional<BlobSidecarOld> getNonCanonicalBlobSidecar(final SlotAndBlockRootAndBlobIndex key) {
     final Optional<Bytes> maybePayload = dao.getNonCanonicalBlobSidecar(key);
     return maybePayload.map(payload -> spec.deserializeBlobSidecar(payload, key.getSlot()));
   }
@@ -886,7 +886,7 @@ public class KvStoreDatabase implements Database {
 
   @MustBeClosed
   @Override
-  public Stream<BlobSidecar> streamBlobSidecars(final SlotAndBlockRoot slotAndBlockRoot) {
+  public Stream<BlobSidecarOld> streamBlobSidecars(final SlotAndBlockRoot slotAndBlockRoot) {
     return dao.streamBlobSidecars(slotAndBlockRoot)
         .map(payload -> spec.deserializeBlobSidecar(payload, slotAndBlockRoot.getSlot()));
   }
@@ -1019,7 +1019,7 @@ public class KvStoreDatabase implements Database {
   }
 
   private void updateBlobSidecarData(
-      final Optional<UInt64> getEarliestBlobSidecarSlot, final Stream<BlobSidecar> blobSidecars) {
+      final Optional<UInt64> getEarliestBlobSidecarSlot, final Stream<BlobSidecarOld> blobSidecars) {
     LOG.trace("Applying blob sidecar updates");
 
     try (final FinalizedUpdater updater = finalizedUpdater()) {

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
@@ -32,7 +32,7 @@ import tech.pegasys.teku.ethereum.pow.api.DepositTreeSnapshot;
 import tech.pegasys.teku.ethereum.pow.api.DepositsFromBlockEvent;
 import tech.pegasys.teku.ethereum.pow.api.MinGenesisTimeBlockEvent;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockAndCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
@@ -721,7 +721,7 @@ public class CombinedKvStoreDao<S extends SchemaCombined>
     }
 
     @Override
-    public void addBlobSidecar(final BlobSidecar blobSidecar) {
+    public void addBlobSidecar(final BlobSidecarOld blobSidecar) {
       transaction.put(
           schema.getColumnBlobSidecarBySlotRootBlobIndex(),
           new SlotAndBlockRootAndBlobIndex(
@@ -730,7 +730,7 @@ public class CombinedKvStoreDao<S extends SchemaCombined>
     }
 
     @Override
-    public void addNonCanonicalBlobSidecar(final BlobSidecar blobSidecar) {
+    public void addNonCanonicalBlobSidecar(final BlobSidecarOld blobSidecar) {
       transaction.put(
           schema.getColumnNonCanonicalBlobSidecarBySlotRootBlobIndex(),
           new SlotAndBlockRootAndBlobIndex(

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDao.java
@@ -26,7 +26,7 @@ import tech.pegasys.teku.ethereum.pow.api.DepositTreeSnapshot;
 import tech.pegasys.teku.ethereum.pow.api.DepositsFromBlockEvent;
 import tech.pegasys.teku.ethereum.pow.api.MinGenesisTimeBlockEvent;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockAndCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
@@ -238,9 +238,9 @@ public interface KvStoreCombinedDao extends AutoCloseable {
 
     void addNonCanonicalRootAtSlot(final UInt64 slot, final Set<Bytes32> blockRoots);
 
-    void addBlobSidecar(BlobSidecar blobSidecar);
+    void addBlobSidecar(BlobSidecarOld blobSidecar);
 
-    void addNonCanonicalBlobSidecar(BlobSidecar blobSidecar);
+    void addNonCanonicalBlobSidecar(BlobSidecarOld blobSidecar);
 
     void addNonCanonicalBlobSidecarRaw(Bytes blobSidecarBytes, SlotAndBlockRootAndBlobIndex key);
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoAdapter.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoAdapter.java
@@ -28,7 +28,7 @@ import tech.pegasys.teku.ethereum.pow.api.DepositTreeSnapshot;
 import tech.pegasys.teku.ethereum.pow.api.DepositsFromBlockEvent;
 import tech.pegasys.teku.ethereum.pow.api.MinGenesisTimeBlockEvent;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockAndCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
@@ -441,12 +441,12 @@ public class KvStoreCombinedDaoAdapter implements KvStoreCombinedDao, V4Migratab
     }
 
     @Override
-    public void addBlobSidecar(final BlobSidecar blobSidecar) {
+    public void addBlobSidecar(final BlobSidecarOld blobSidecar) {
       finalizedUpdater.addBlobSidecar(blobSidecar);
     }
 
     @Override
-    public void addNonCanonicalBlobSidecar(final BlobSidecar blobSidecar) {
+    public void addNonCanonicalBlobSidecar(final BlobSidecarOld blobSidecar) {
       finalizedUpdater.addNonCanonicalBlobSidecar(blobSidecar);
     }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4FinalizedKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4FinalizedKvStoreDao.java
@@ -29,7 +29,7 @@ import java.util.stream.Stream;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
@@ -345,7 +345,7 @@ public class V4FinalizedKvStoreDao {
     }
 
     @Override
-    public void addBlobSidecar(final BlobSidecar blobSidecar) {
+    public void addBlobSidecar(final BlobSidecarOld blobSidecar) {
       transaction.put(
           schema.getColumnBlobSidecarBySlotRootBlobIndex(),
           new SlotAndBlockRootAndBlobIndex(
@@ -354,7 +354,7 @@ public class V4FinalizedKvStoreDao {
     }
 
     @Override
-    public void addNonCanonicalBlobSidecar(final BlobSidecar blobSidecar) {
+    public void addNonCanonicalBlobSidecar(final BlobSidecarOld blobSidecar) {
       transaction.put(
           schema.getColumnNonCanonicalBlobSidecarBySlotRootBlobIndex(),
           new SlotAndBlockRootAndBlobIndex(

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
@@ -29,7 +29,7 @@ import tech.pegasys.teku.ethereum.pow.api.DepositTreeSnapshot;
 import tech.pegasys.teku.ethereum.pow.api.DepositsFromBlockEvent;
 import tech.pegasys.teku.ethereum.pow.api.MinGenesisTimeBlockEvent;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
@@ -58,7 +58,7 @@ public class NoOpDatabase implements Database {
   @Override
   public void storeFinalizedBlocks(
       final Collection<SignedBeaconBlock> blocks,
-      final Map<SlotAndBlockRoot, List<BlobSidecar>> blobSidecarsBySlot,
+      final Map<SlotAndBlockRoot, List<BlobSidecarOld>> blobSidecarsBySlot,
       final Optional<UInt64> maybeEarliestBlobSidecarSlot) {}
 
   @Override
@@ -276,18 +276,18 @@ public class NoOpDatabase implements Database {
   public void deleteHotBlocks(final Set<Bytes32> blockRootsToDelete) {}
 
   @Override
-  public void storeBlobSidecar(final BlobSidecar blobSidecar) {}
+  public void storeBlobSidecar(final BlobSidecarOld blobSidecar) {}
 
   @Override
-  public void storeNonCanonicalBlobSidecar(final BlobSidecar blobSidecar) {}
+  public void storeNonCanonicalBlobSidecar(final BlobSidecarOld blobSidecar) {}
 
   @Override
-  public Optional<BlobSidecar> getBlobSidecar(final SlotAndBlockRootAndBlobIndex key) {
+  public Optional<BlobSidecarOld> getBlobSidecar(final SlotAndBlockRootAndBlobIndex key) {
     return Optional.empty();
   }
 
   @Override
-  public Optional<BlobSidecar> getNonCanonicalBlobSidecar(final SlotAndBlockRootAndBlobIndex key) {
+  public Optional<BlobSidecarOld> getNonCanonicalBlobSidecar(final SlotAndBlockRootAndBlobIndex key) {
     return Optional.empty();
   }
 
@@ -307,7 +307,7 @@ public class NoOpDatabase implements Database {
   }
 
   @Override
-  public Stream<BlobSidecar> streamBlobSidecars(final SlotAndBlockRoot slotAndBlockRoot) {
+  public Stream<BlobSidecarOld> streamBlobSidecars(final SlotAndBlockRoot slotAndBlockRoot) {
     return Stream.empty();
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
@@ -287,7 +287,8 @@ public class NoOpDatabase implements Database {
   }
 
   @Override
-  public Optional<BlobSidecarOld> getNonCanonicalBlobSidecar(final SlotAndBlockRootAndBlobIndex key) {
+  public Optional<BlobSidecarOld> getNonCanonicalBlobSidecar(
+      final SlotAndBlockRootAndBlobIndex key) {
     return Optional.empty();
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/CacheableStore.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/CacheableStore.java
@@ -20,7 +20,7 @@ import java.util.Optional;
 import java.util.function.Predicate;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockAndCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.blocks.StateAndBlockSummary;
@@ -40,7 +40,7 @@ public abstract class CacheableStore implements UpdatableStore {
 
   abstract void cacheStates(Map<Bytes32, StateAndBlockSummary> stateAndBlockSummaries);
 
-  abstract void cacheBlobSidecars(Map<SlotAndBlockRoot, List<BlobSidecar>> blobSidecarsMap);
+  abstract void cacheBlobSidecars(Map<SlotAndBlockRoot, List<BlobSidecarOld>> blobSidecarsMap);
 
   abstract void cacheFinalizedOptimisticTransitionPayload(
       Optional<SlotAndExecutionPayloadSummary> finalizedOptimisticTransitionPayload);

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
@@ -52,7 +52,7 @@ import tech.pegasys.teku.infrastructure.metrics.SettableGauge;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockAndCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
@@ -101,7 +101,7 @@ class Store extends CacheableStore {
   private final CachingTaskQueue<Bytes32, StateAndBlockSummary> states;
   private final Map<Bytes32, SignedBeaconBlock> blocks;
   private final CachingTaskQueue<SlotAndBlockRoot, BeaconState> checkpointStates;
-  private final Map<SlotAndBlockRoot, List<BlobSidecar>> blobSidecars;
+  private final Map<SlotAndBlockRoot, List<BlobSidecarOld>> blobSidecars;
   private UInt64 timeMillis;
   private UInt64 genesisTime;
   private AnchorPoint finalizedAnchor;
@@ -133,7 +133,7 @@ class Store extends CacheableStore {
       final Map<Bytes32, SignedBeaconBlock> blocks,
       final CachingTaskQueue<SlotAndBlockRoot, BeaconState> checkpointStates,
       final Optional<Map<Bytes32, StateAndBlockSummary>> maybeEpochStates,
-      final Map<SlotAndBlockRoot, List<BlobSidecar>> blobSidecars) {
+      final Map<SlotAndBlockRoot, List<BlobSidecarOld>> blobSidecars) {
     checkArgument(
         time.isGreaterThanOrEqualTo(genesisTime),
         "Time must be greater than or equal to genesisTime");
@@ -218,7 +218,7 @@ class Store extends CacheableStore {
         config.getEpochStateCacheSize() > 0
             ? Optional.of(LimitedMap.createSynchronized(config.getEpochStateCacheSize()))
             : Optional.empty();
-    final Map<SlotAndBlockRoot, List<BlobSidecar>> blobSidecars =
+    final Map<SlotAndBlockRoot, List<BlobSidecarOld>> blobSidecars =
         LimitedMap.createSynchronized(config.getBlockCacheSize());
 
     final UInt64 currentEpoch = spec.computeEpochAtSlot(spec.getCurrentSlot(time, genesisTime));
@@ -571,7 +571,7 @@ class Store extends CacheableStore {
   }
 
   @Override
-  public Optional<List<BlobSidecar>> getBlobSidecarsIfAvailable(
+  public Optional<List<BlobSidecarOld>> getBlobSidecarsIfAvailable(
       final SlotAndBlockRoot slotAndBlockRoot) {
     readLock.lock();
     try {
@@ -624,7 +624,7 @@ class Store extends CacheableStore {
 
   /** Non-synchronized, no lock, unsafe if Store is not locked externally */
   @Override
-  void cacheBlobSidecars(final Map<SlotAndBlockRoot, List<BlobSidecar>> blobSidecarsMap) {
+  void cacheBlobSidecars(final Map<SlotAndBlockRoot, List<BlobSidecarOld>> blobSidecarsMap) {
     blobSidecarsMap.entrySet().stream()
         .sorted(Map.Entry.comparingByKey())
         .forEach(entry -> blobSidecars.put(entry.getKey(), entry.getValue()));

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransaction.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransaction.java
@@ -35,7 +35,7 @@ import tech.pegasys.teku.dataproviders.generators.StateAtSlotTask;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
@@ -71,7 +71,7 @@ class StoreTransaction implements UpdatableStore.StoreTransaction {
   Map<Bytes32, SlotAndBlockRoot> stateRoots = new HashMap<>();
   Set<Bytes32> pulledUpBlockCheckpoints = new HashSet<>();
   Map<Bytes32, TransactionBlockData> blockData = new HashMap<>();
-  Map<SlotAndBlockRoot, List<BlobSidecar>> blobSidecars = new HashMap<>();
+  Map<SlotAndBlockRoot, List<BlobSidecarOld>> blobSidecars = new HashMap<>();
   Optional<UInt64> maybeEarliestBlobSidecarTransactionSlot = Optional.empty();
   private final UpdatableStore.StoreUpdateHandler updateHandler;
 
@@ -93,7 +93,7 @@ class StoreTransaction implements UpdatableStore.StoreTransaction {
       final SignedBeaconBlock block,
       final BeaconState state,
       final BlockCheckpoints blockCheckpoints,
-      final Optional<List<BlobSidecar>> blobSidecars,
+      final Optional<List<BlobSidecarOld>> blobSidecars,
       final Optional<UInt64> maybeEarliestBlobSidecarSlot) {
     blockData.put(block.getRoot(), new TransactionBlockData(block, state, blockCheckpoints));
     if (!blobSidecars.isEmpty()) {
@@ -459,7 +459,7 @@ class StoreTransaction implements UpdatableStore.StoreTransaction {
   }
 
   @Override
-  public Optional<List<BlobSidecar>> getBlobSidecarsIfAvailable(
+  public Optional<List<BlobSidecarOld>> getBlobSidecarsIfAvailable(
       final SlotAndBlockRoot slotAndBlockRoot) {
     return Optional.ofNullable(blobSidecars.get(slotAndBlockRoot))
         .or(() -> store.getBlobSidecarsIfAvailable(slotAndBlockRoot));

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransactionUpdates.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransactionUpdates.java
@@ -21,7 +21,7 @@ import java.util.Map;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockAndCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
@@ -39,7 +39,7 @@ class StoreTransactionUpdates {
   private final Map<Bytes32, SignedBlockAndState> hotBlockAndStates;
   // A subset of hot states to be persisted to disk
   private final Map<Bytes32, BeaconState> hotStatesToPersist;
-  private final Map<SlotAndBlockRoot, List<BlobSidecar>> blobSidecars;
+  private final Map<SlotAndBlockRoot, List<BlobSidecarOld>> blobSidecars;
   private final Optional<UInt64> maybeEarliestBlobSidecarSlot;
   private final Map<Bytes32, SlotAndBlockRoot> stateRoots;
   private final Map<Bytes32, UInt64> prunedHotBlockRoots;
@@ -53,7 +53,7 @@ class StoreTransactionUpdates {
       final Map<Bytes32, BlockAndCheckpoints> hotBlocks,
       final Map<Bytes32, SignedBlockAndState> hotBlockAndStates,
       final Map<Bytes32, BeaconState> hotStatesToPersist,
-      final Map<SlotAndBlockRoot, List<BlobSidecar>> blobSidecars,
+      final Map<SlotAndBlockRoot, List<BlobSidecarOld>> blobSidecars,
       final Optional<UInt64> maybeEarliestBlobSidecarSlot,
       final Map<Bytes32, UInt64> prunedHotBlockRoots,
       final Map<Bytes32, SlotAndBlockRoot> stateRoots,

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransactionUpdatesFactory.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransactionUpdatesFactory.java
@@ -27,7 +27,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockAndCheckpoints;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
@@ -47,7 +47,7 @@ class StoreTransactionUpdatesFactory {
 
   private final Map<Bytes32, BlockAndCheckpoints> hotBlocks;
   private final Map<Bytes32, SignedBlockAndState> hotBlockAndStates;
-  private final Map<SlotAndBlockRoot, List<BlobSidecar>> blobSidecars;
+  private final Map<SlotAndBlockRoot, List<BlobSidecarOld>> blobSidecars;
   private final Optional<UInt64> maybeEarliestBlobSidecarSlot;
   private final Map<Bytes32, SlotAndBlockRoot> stateRoots;
   private final AnchorPoint latestFinalized;

--- a/storage/src/test/java/tech/pegasys/teku/storage/client/CombinedChainDataClientTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/client/CombinedChainDataClientTest.java
@@ -30,7 +30,7 @@ import tech.pegasys.teku.infrastructure.time.SystemTimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.metadata.BlockAndMetaData;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
@@ -59,7 +59,7 @@ class CombinedChainDataClientTest {
   final List<SignedBeaconBlock> nonCanonicalBlocks = new ArrayList<>();
   final SignedBeaconBlock firstBlock = dataStructureUtil.randomSignedBeaconBlock(1);
   final SignedBeaconBlock secondBlock = dataStructureUtil.randomSignedBeaconBlock(1);
-  final BlobSidecar sidecar = dataStructureUtil.randomBlobSidecar();
+  final BlobSidecarOld sidecar = dataStructureUtil.randomBlobSidecar();
 
   @BeforeEach
   void setUp() {
@@ -155,11 +155,11 @@ class CombinedChainDataClientTest {
         new SlotAndBlockRootAndBlobIndex(sidecar.getSlot(), blockRoot, sidecar.getIndex());
     setupGetBlobSidecar(correctKey, sidecar);
 
-    final Optional<BlobSidecar> correctResult =
+    final Optional<BlobSidecarOld> correctResult =
         SafeFutureAssert.safeJoin(client.getBlobSidecarByKey(correctKey));
     assertThat(correctResult).hasValue(sidecar);
 
-    final Optional<BlobSidecar> incorrectResult =
+    final Optional<BlobSidecarOld> incorrectResult =
         SafeFutureAssert.safeJoin(client.getBlobSidecarByKey(incorrectKey));
     assertThat(incorrectResult).isEmpty();
   }
@@ -172,20 +172,20 @@ class CombinedChainDataClientTest {
     setupGetBlobSidecar(key, sidecar);
     setupGetSlotForBlockRoot(sidecar.getBlockRoot(), sidecar.getSlot());
 
-    final Optional<BlobSidecar> result =
+    final Optional<BlobSidecarOld> result =
         SafeFutureAssert.safeJoin(
             client.getBlobSidecarByBlockRootAndIndex(sidecar.getBlockRoot(), sidecar.getIndex()));
     assertThat(result).hasValue(sidecar);
 
     final Bytes32 blockRoot = setupGetBlockByBlockRoot(sidecar.getSlot().plus(1));
-    final Optional<BlobSidecar> incorrectResult =
+    final Optional<BlobSidecarOld> incorrectResult =
         SafeFutureAssert.safeJoin(
             client.getBlobSidecarByBlockRootAndIndex(blockRoot, sidecar.getIndex()));
     assertThat(incorrectResult).isEmpty();
   }
 
   private void setupGetBlobSidecar(
-      final SlotAndBlockRootAndBlobIndex key, final BlobSidecar result) {
+      final SlotAndBlockRootAndBlobIndex key, final BlobSidecarOld result) {
     when(historicalChainData.getBlobSidecar(any()))
         .thenAnswer(
             args -> {

--- a/storage/src/test/java/tech/pegasys/teku/storage/client/RecentChainDataTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/client/RecentChainDataTest.java
@@ -39,7 +39,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.config.SpecConfig;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.MinimalBeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
@@ -799,11 +799,11 @@ class RecentChainDataTest {
     final SignedBlockAndState block =
         chainBuilder.generateBlockAtSlot(
             UInt64.valueOf(1), BlockOptions.create().setGenerateRandomBlobs(true));
-    final List<BlobSidecar> blobSidecars = chainBuilder.getBlobSidecars(block.getRoot());
+    final List<BlobSidecarOld> blobSidecars = chainBuilder.getBlobSidecars(block.getRoot());
     assertThat(blobSidecars).isNotEmpty();
     storageSystem.chainUpdater().saveBlock(block, blobSidecars);
 
-    final Optional<List<BlobSidecar>> maybeBlobSidecars =
+    final Optional<List<BlobSidecarOld>> maybeBlobSidecars =
         recentChainData.getBlobSidecars(block.getSlotAndBlockRoot());
     assertThat(maybeBlobSidecars).contains(blobSidecars);
   }
@@ -813,11 +813,11 @@ class RecentChainDataTest {
     initPostGenesis();
 
     final SignedBlockAndState block = chainBuilder.generateBlockAtSlot(UInt64.valueOf(1));
-    final List<BlobSidecar> blobSidecars = chainBuilder.getBlobSidecars(block.getRoot());
+    final List<BlobSidecarOld> blobSidecars = chainBuilder.getBlobSidecars(block.getRoot());
     storageSystem.chainUpdater().saveBlock(block, blobSidecars);
     assertThat(blobSidecars).isEmpty();
 
-    final Optional<List<BlobSidecar>> maybeBlobSidecars =
+    final Optional<List<BlobSidecarOld>> maybeBlobSidecars =
         recentChainData.getBlobSidecars(block.getSlotAndBlockRoot());
     assertThat(maybeBlobSidecars).contains(blobSidecars);
   }
@@ -829,7 +829,7 @@ class RecentChainDataTest {
     final SignedBlockAndState block1 =
         chainBuilder.generateBlockAtSlot(
             UInt64.valueOf(1), BlockOptions.create().setGenerateRandomBlobs(true));
-    final List<BlobSidecar> blobSidecars1 = chainBuilder.getBlobSidecars(block1.getRoot());
+    final List<BlobSidecarOld> blobSidecars1 = chainBuilder.getBlobSidecars(block1.getRoot());
     storageSystem.chainUpdater().saveBlock(block1, blobSidecars1, UInt64.valueOf(1));
     // 0 from genesis
     assertThat(recentChainData.retrieveEarliestBlobSidecarSlot())

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/ChainStorageTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/ChainStorageTest.java
@@ -33,7 +33,7 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
@@ -173,11 +173,11 @@ public class ChainStorageTest {
             .map(SignedBlockAndState::getBlock)
             .collect(Collectors.toList());
 
-    final Map<SlotAndBlockRoot, List<BlobSidecar>> missingHistoricalBlobSidecars =
+    final Map<SlotAndBlockRoot, List<BlobSidecarOld>> missingHistoricalBlobSidecars =
         chainBuilder
             .streamBlobSidecars(0, firstMissingBlockSlot)
             .flatMap(entry -> entry.getValue().stream())
-            .collect(Collectors.groupingBy(BlobSidecar::getSlotAndBlockRoot));
+            .collect(Collectors.groupingBy(BlobSidecarOld::getSlotAndBlockRoot));
 
     // Sanity check - blocks and blob sidecars should be unavailable initially
     for (SignedBeaconBlock missingHistoricalBlock : missingHistoricalBlocks) {
@@ -192,7 +192,7 @@ public class ChainStorageTest {
       assertThatSafeFuture(sidecarKeysResult).isCompletedWithValueMatching(List::isEmpty);
     }
 
-    final Map<SlotAndBlockRoot, List<BlobSidecar>> finalizedBlobSidecars =
+    final Map<SlotAndBlockRoot, List<BlobSidecarOld>> finalizedBlobSidecars =
         testBlobSidecars ? missingHistoricalBlobSidecars : Map.of();
     assertThat(chainStorage.getEarliestAvailableBlobSidecarSlot())
         .isCompletedWithValueMatching(Optional::isEmpty);
@@ -228,7 +228,7 @@ public class ChainStorageTest {
       final SafeFuture<Optional<SignedBeaconBlock>> blockResult =
           chainStorage.getBlockByBlockRoot(missingHistoricalBlock.getRoot());
       assertThatSafeFuture(blockResult).isCompletedWithOptionalContaining(missingHistoricalBlock);
-      final SafeFuture<List<BlobSidecar>> sidecarsResult =
+      final SafeFuture<List<BlobSidecarOld>> sidecarsResult =
           chainStorage
               .getBlobSidecarKeys(
                   missingHistoricalBlock.getSlot(),
@@ -295,11 +295,11 @@ public class ChainStorageTest {
             .map(SignedBlockAndState::getBlock)
             .collect(Collectors.toList());
 
-    final Map<SlotAndBlockRoot, List<BlobSidecar>> missingHistoricalBlobSidecars =
+    final Map<SlotAndBlockRoot, List<BlobSidecarOld>> missingHistoricalBlobSidecars =
         chainBuilder
             .streamBlobSidecars(0, firstMissingBlockSlot)
             .flatMap(entry -> entry.getValue().stream())
-            .collect(Collectors.groupingBy(BlobSidecar::getSlotAndBlockRoot));
+            .collect(Collectors.groupingBy(BlobSidecarOld::getSlotAndBlockRoot));
 
     // Sanity check - blocks and blob sidecars should be unavailable initially
     for (SignedBeaconBlock missingHistoricalBlock : missingHistoricalBlocks) {

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/RetryingStorageUpdateChannelTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/RetryingStorageUpdateChannelTest.java
@@ -35,7 +35,7 @@ import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.exceptions.FatalServiceFailureException;
 import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
@@ -68,7 +68,7 @@ class RetryingStorageUpdateChannelTest {
   @Test
   void onFinalizedBlocks_shouldRetryUntilSuccess() {
     final List<SignedBeaconBlock> blocks = Collections.emptyList();
-    final Map<SlotAndBlockRoot, List<BlobSidecar>> blobSidecarsBySlot = Map.of();
+    final Map<SlotAndBlockRoot, List<BlobSidecarOld>> blobSidecarsBySlot = Map.of();
     when(delegate.onFinalizedBlocks(blocks, blobSidecarsBySlot, Optional.empty()))
         .thenReturn(SafeFuture.failedFuture(new RuntimeException("Failed 1")))
         .thenReturn(SafeFuture.failedFuture(new RuntimeException("Failed 2")))

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageQueryChannel.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageQueryChannel.java
@@ -139,7 +139,8 @@ public class StubStorageQueryChannel implements StorageQueryChannel {
   }
 
   @Override
-  public SafeFuture<Optional<BlobSidecarOld>> getBlobSidecar(final SlotAndBlockRootAndBlobIndex key) {
+  public SafeFuture<Optional<BlobSidecarOld>> getBlobSidecar(
+      final SlotAndBlockRootAndBlobIndex key) {
     return SafeFuture.completedFuture(Optional.empty());
   }
 

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageQueryChannel.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageQueryChannel.java
@@ -23,7 +23,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.ethereum.pow.api.DepositTreeSnapshot;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
@@ -139,12 +139,12 @@ public class StubStorageQueryChannel implements StorageQueryChannel {
   }
 
   @Override
-  public SafeFuture<Optional<BlobSidecar>> getBlobSidecar(final SlotAndBlockRootAndBlobIndex key) {
+  public SafeFuture<Optional<BlobSidecarOld>> getBlobSidecar(final SlotAndBlockRootAndBlobIndex key) {
     return SafeFuture.completedFuture(Optional.empty());
   }
 
   @Override
-  public SafeFuture<Optional<BlobSidecar>> getNonCanonicalBlobSidecar(
+  public SafeFuture<Optional<BlobSidecarOld>> getNonCanonicalBlobSidecar(
       final SlotAndBlockRootAndBlobIndex key) {
     return SafeFuture.completedFuture(Optional.empty());
   }
@@ -172,7 +172,7 @@ public class StubStorageQueryChannel implements StorageQueryChannel {
   }
 
   @Override
-  public SafeFuture<List<BlobSidecar>> getBlobSidecarsBySlotAndBlockRoot(
+  public SafeFuture<List<BlobSidecarOld>> getBlobSidecarsBySlotAndBlockRoot(
       final SlotAndBlockRoot slotAndBlockRoot) {
     return SafeFuture.completedFuture(Collections.emptyList());
   }

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageUpdateChannel.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageUpdateChannel.java
@@ -21,7 +21,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.ethereum.pow.api.DepositTreeSnapshot;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
@@ -37,7 +37,7 @@ public class StubStorageUpdateChannel implements StorageUpdateChannel {
   @Override
   public SafeFuture<Void> onFinalizedBlocks(
       final Collection<SignedBeaconBlock> finalizedBlocks,
-      final Map<SlotAndBlockRoot, List<BlobSidecar>> blobSidecarsBySlot,
+      final Map<SlotAndBlockRoot, List<BlobSidecarOld>> blobSidecarsBySlot,
       final Optional<UInt64> maybeEarliestBlobSidecarSlot) {
     return SafeFuture.COMPLETE;
   }

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageUpdateChannelWithDelays.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageUpdateChannelWithDelays.java
@@ -22,7 +22,7 @@ import tech.pegasys.teku.ethereum.pow.api.DepositTreeSnapshot;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
@@ -43,7 +43,7 @@ public class StubStorageUpdateChannelWithDelays implements StorageUpdateChannel 
   @Override
   public SafeFuture<Void> onFinalizedBlocks(
       final Collection<SignedBeaconBlock> finalizedBlocks,
-      final Map<SlotAndBlockRoot, List<BlobSidecar>> blobSidecarsBySlot,
+      final Map<SlotAndBlockRoot, List<BlobSidecarOld>> blobSidecarsBySlot,
       final Optional<UInt64> maybeEarliestBlobSidecarSlot) {
     return asyncRunner.runAsync(() -> SafeFuture.COMPLETE);
   }

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/client/ChainUpdater.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/client/ChainUpdater.java
@@ -22,7 +22,7 @@ import java.util.Optional;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
@@ -236,7 +236,7 @@ public class ChainUpdater {
 
   public SignedBlockAndState advanceChain(final UInt64 slot) {
     final SignedBlockAndState block = chainBuilder.generateBlockAtSlot(slot, blockOptions);
-    final List<BlobSidecar> blobSidecars = chainBuilder.getBlobSidecars(block.getRoot());
+    final List<BlobSidecarOld> blobSidecars = chainBuilder.getBlobSidecars(block.getRoot());
     if (blobSidecars.isEmpty()) {
       saveBlock(block);
     } else {
@@ -276,13 +276,13 @@ public class ChainUpdater {
     saveBlockTime(block);
   }
 
-  public void saveBlock(final SignedBlockAndState block, final List<BlobSidecar> blobSidecars) {
+  public void saveBlock(final SignedBlockAndState block, final List<BlobSidecarOld> blobSidecars) {
     saveBlock(block, blobSidecars, block.getSlot());
   }
 
   public void saveBlock(
       final SignedBlockAndState block,
-      final List<BlobSidecar> blobSidecars,
+      final List<BlobSidecarOld> blobSidecars,
       final UInt64 earliestBlobSidecarSlot) {
     final StoreTransaction tx = recentChainData.startStoreTransaction();
     tx.putBlockAndState(

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugDbCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugDbCommand.java
@@ -47,7 +47,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networks.Eth2NetworkConfiguration;
 import tech.pegasys.teku.service.serviceutils.layout.DataDirLayout;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockInvariants;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
@@ -415,7 +415,7 @@ public class DebugDbCommand implements Runnable {
         for (final Iterator<SlotAndBlockRootAndBlobIndex> it = keyStream.iterator();
             it.hasNext(); ) {
           final SlotAndBlockRootAndBlobIndex key = it.next();
-          final BlobSidecar blobSidecar = database.getBlobSidecar(key).orElseThrow();
+          final BlobSidecarOld blobSidecar = database.getBlobSidecar(key).orElseThrow();
           out.putNextEntry(
               new ZipEntry(
                   blobSidecar.getSlot()

--- a/validator/client/src/integration-test/java/tech/pegasys/teku/validator/client/signer/ExternalSignerDenebIntegrationTest.java
+++ b/validator/client/src/integration-test/java/tech/pegasys/teku/validator/client/signer/ExternalSignerDenebIntegrationTest.java
@@ -29,7 +29,7 @@ import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlindedBlobSidecar;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 
 public class ExternalSignerDenebIntegrationTest extends AbstractExternalSignerIntegrationTest {
 
@@ -40,7 +40,7 @@ public class ExternalSignerDenebIntegrationTest extends AbstractExternalSignerIn
 
   @Test
   void shouldSignBlobSidecar() throws Exception {
-    final BlobSidecar blobSidecar = dataStructureUtil.randomBlobSidecar();
+    final BlobSidecarOld blobSidecar = dataStructureUtil.randomBlobSidecar();
     final BLSSignature expectedSignature =
         BLSSignature.fromBytesCompressed(
             Bytes.fromBase64String(

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/signer/BlockContainerSignerDeneb.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/signer/BlockContainerSignerDeneb.java
@@ -18,9 +18,9 @@ import java.util.List;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlindedBlobSidecar;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlindedBlobSidecar;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockContainer;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
@@ -61,7 +61,7 @@ public class BlockContainerSignerDeneb implements BlockContainerSigner {
         .orElseGet(
             // Unblinded flow
             () -> {
-              final List<BlobSidecar> blobSidecars =
+              final List<BlobSidecarOld> blobSidecars =
                   unsignedBlockContainer.getBlobSidecars().orElse(Collections.emptyList());
               return signBlock(unsignedBlock, validator, forkInfo)
                   .thenCombine(
@@ -71,7 +71,7 @@ public class BlockContainerSignerDeneb implements BlockContainerSigner {
   }
 
   private SignedBlockContainer createSignedBlockContents(
-      final SignedBeaconBlock signedBlock, final List<SignedBlobSidecar> signedBlobSidecars) {
+      final SignedBeaconBlock signedBlock, final List<SignedBlobSidecarOld> signedBlobSidecars) {
     return schemaDefinitions.getSignedBlockContentsSchema().create(signedBlock, signedBlobSidecars);
   }
 
@@ -91,8 +91,8 @@ public class BlockContainerSignerDeneb implements BlockContainerSigner {
         .thenApply(signature -> SignedBeaconBlock.create(spec, unsignedBlock, signature));
   }
 
-  private SafeFuture<List<SignedBlobSidecar>> signBlobSidecars(
-      final List<BlobSidecar> unsignedBlobSidecars,
+  private SafeFuture<List<SignedBlobSidecarOld>> signBlobSidecars(
+      final List<BlobSidecarOld> unsignedBlobSidecars,
       final Validator validator,
       final ForkInfo forkInfo) {
     return SafeFuture.collectAll(
@@ -100,8 +100,8 @@ public class BlockContainerSignerDeneb implements BlockContainerSigner {
             .map(unsignedBlobSidecar -> signBlobSidecar(unsignedBlobSidecar, validator, forkInfo)));
   }
 
-  private SafeFuture<SignedBlobSidecar> signBlobSidecar(
-      final BlobSidecar unsignedBlobSidecar, final Validator validator, final ForkInfo forkInfo) {
+  private SafeFuture<SignedBlobSidecarOld> signBlobSidecar(
+          final BlobSidecarOld unsignedBlobSidecar, final Validator validator, final ForkInfo forkInfo) {
     return validator
         .getSigner()
         .signBlobSidecar(unsignedBlobSidecar, forkInfo)

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/signer/BlockContainerSignerDeneb.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/signer/BlockContainerSignerDeneb.java
@@ -101,7 +101,9 @@ public class BlockContainerSignerDeneb implements BlockContainerSigner {
   }
 
   private SafeFuture<SignedBlobSidecarOld> signBlobSidecar(
-          final BlobSidecarOld unsignedBlobSidecar, final Validator validator, final ForkInfo forkInfo) {
+      final BlobSidecarOld unsignedBlobSidecar,
+      final Validator validator,
+      final ForkInfo forkInfo) {
     return validator
         .getSigner()
         .signBlobSidecar(unsignedBlobSidecar, forkInfo)

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/signer/ExternalSigner.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/signer/ExternalSigner.java
@@ -131,7 +131,7 @@ public class ExternalSigner implements Signer {
 
   @Override
   public SafeFuture<BLSSignature> signBlobSidecar(
-          final BlobSidecarOld blobSidecar, final ForkInfo forkInfo) {
+      final BlobSidecarOld blobSidecar, final ForkInfo forkInfo) {
     return sign(
         signingRootUtil.signingRootForBlobSidecar(blobSidecar, forkInfo),
         SignType.BLOB_SIDECAR, // both blobSidecar and blindedBlobSidecar uses same SignType

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/signer/ExternalSigner.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/signer/ExternalSigner.java
@@ -49,7 +49,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.provider.JsonProvider;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlindedBlobSidecar;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.builder.ValidatorRegistration;
 import tech.pegasys.teku.spec.datastructures.operations.AggregateAndProof;
@@ -131,7 +131,7 @@ public class ExternalSigner implements Signer {
 
   @Override
   public SafeFuture<BLSSignature> signBlobSidecar(
-      final BlobSidecar blobSidecar, final ForkInfo forkInfo) {
+          final BlobSidecarOld blobSidecar, final ForkInfo forkInfo) {
     return sign(
         signingRootUtil.signingRootForBlobSidecar(blobSidecar, forkInfo),
         SignType.BLOB_SIDECAR, // both blobSidecar and blindedBlobSidecar uses same SignType

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/BlockProductionDutyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/BlockProductionDutyTest.java
@@ -52,9 +52,9 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlindedBlobSidecar;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlindedBlobSidecar;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
@@ -186,9 +186,9 @@ class BlockProductionDutyTest {
     // can create BlockContents only post-Deneb
     final BlockContents unsignedBlockContents = dataStructureUtil.randomBlockContents(denebSlot);
     final BeaconBlock unsignedBlock = unsignedBlockContents.getBlock();
-    final List<BlobSidecar> unsignedBlobSidecars =
+    final List<BlobSidecarOld> unsignedBlobSidecars =
         unsignedBlockContents.getBlobSidecars().orElseThrow();
-    final Map<BlobSidecar, BLSSignature> blobSidecarsSignatures =
+    final Map<BlobSidecarOld, BLSSignature> blobSidecarsSignatures =
         unsignedBlobSidecars.stream()
             .collect(
                 Collectors.toMap(Function.identity(), __ -> dataStructureUtil.randomSignature()));
@@ -201,7 +201,7 @@ class BlockProductionDutyTest {
         .thenAnswer(
             invocation ->
                 completedFuture(
-                    blobSidecarsSignatures.get((BlobSidecar) invocation.getArgument(0))));
+                    blobSidecarsSignatures.get((BlobSidecarOld) invocation.getArgument(0))));
     when(validatorApiChannel.createUnsignedBlock(
             denebSlot, randaoReveal, Optional.of(graffiti), false))
         .thenReturn(completedFuture(Optional.of(unsignedBlockContents)));
@@ -233,7 +233,7 @@ class BlockProductionDutyTest {
 
     assertThat(signedBlockContents.getSignedBlobSidecars().isPresent()).isTrue();
 
-    final List<SignedBlobSidecar> signedBlobSidecars =
+    final List<SignedBlobSidecarOld> signedBlobSidecars =
         signedBlockContents.getSignedBlobSidecars().get();
 
     assertThat(signedBlobSidecars).isNotEmpty();
@@ -241,8 +241,8 @@ class BlockProductionDutyTest {
     IntStream.range(0, signedBlobSidecars.size())
         .forEach(
             index -> {
-              final SignedBlobSidecar signedBlobSidecar = signedBlobSidecars.get(index);
-              final BlobSidecar unsignedBlobSidecar = unsignedBlobSidecars.get(index);
+              final SignedBlobSidecarOld signedBlobSidecar = signedBlobSidecars.get(index);
+              final BlobSidecarOld unsignedBlobSidecar = unsignedBlobSidecars.get(index);
               assertThat(signedBlobSidecar.getMessage()).isEqualTo(unsignedBlobSidecar);
               assertThat(signedBlobSidecar.getSignature())
                   .isEqualTo(blobSidecarsSignatures.get(unsignedBlobSidecar));
@@ -502,9 +502,9 @@ class BlockProductionDutyTest {
     // can create BlockContents only post-Deneb
     final BlockContents unsignedBlockContents = dataStructureUtil.randomBlockContents(denebSlot);
     final BeaconBlock unsignedBlock = unsignedBlockContents.getBlock();
-    final List<BlobSidecar> unsignedBlobSidecars =
+    final List<BlobSidecarOld> unsignedBlobSidecars =
         unsignedBlockContents.getBlobSidecars().orElseThrow();
-    final Map<BlobSidecar, BLSSignature> blobSidecarsSignatures =
+    final Map<BlobSidecarOld, BLSSignature> blobSidecarsSignatures =
         unsignedBlobSidecars.stream()
             .collect(
                 Collectors.toMap(Function.identity(), __ -> dataStructureUtil.randomSignature()));
@@ -517,7 +517,7 @@ class BlockProductionDutyTest {
         .thenAnswer(
             invocation ->
                 completedFuture(
-                    blobSidecarsSignatures.get((BlobSidecar) invocation.getArgument(0))));
+                    blobSidecarsSignatures.get((BlobSidecarOld) invocation.getArgument(0))));
     when(validatorApiChannel.createUnsignedBlock(denebSlot, randaoReveal, Optional.of(graffiti)))
         .thenReturn(completedFuture(Optional.of(unsignedBlockContents)));
     when(validatorApiChannel.sendSignedBlock(any()))
@@ -550,7 +550,7 @@ class BlockProductionDutyTest {
 
     assertThat(signedBlockContents.getSignedBlobSidecars().isPresent()).isTrue();
 
-    final List<SignedBlobSidecar> signedBlobSidecars =
+    final List<SignedBlobSidecarOld> signedBlobSidecars =
         signedBlockContents.getSignedBlobSidecars().get();
 
     assertThat(signedBlobSidecars).isNotEmpty();
@@ -558,8 +558,8 @@ class BlockProductionDutyTest {
     IntStream.range(0, signedBlobSidecars.size())
         .forEach(
             index -> {
-              final SignedBlobSidecar signedBlobSidecar = signedBlobSidecars.get(index);
-              final BlobSidecar unsignedBlobSidecar = unsignedBlobSidecars.get(index);
+              final SignedBlobSidecarOld signedBlobSidecar = signedBlobSidecars.get(index);
+              final BlobSidecarOld unsignedBlobSidecar = unsignedBlobSidecars.get(index);
               assertThat(signedBlobSidecar.getMessage()).isEqualTo(unsignedBlobSidecar);
               assertThat(signedBlobSidecar.getSignature())
                   .isEqualTo(blobSidecarsSignatures.get(unsignedBlobSidecar));


### PR DESCRIPTION
Renamed `BlobSidecar`,  `BlobSidecarSchema`, `SignedBlobSidecar` and `SignedBlobSidecarSchema` to `*Old`

Related to #7654 
