### PR TITLE
Improve hot->finalized block during epoch transition

### DIFF
--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/BeaconBlockInvariantsTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/BeaconBlockInvariantsTest.java
@@ -15,14 +15,17 @@ package tech.pegasys.teku.spec.datastructures.blocks;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.versions.deneb.SignedBlindedBlockContents;
 import tech.pegasys.teku.spec.datastructures.blocks.versions.deneb.SignedBlockContents;
+import tech.pegasys.teku.spec.networks.Eth2Network;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 class BeaconBlockInvariantsTest {
@@ -79,6 +82,13 @@ class BeaconBlockInvariantsTest {
         .isEqualTo(slot);
   }
 
+  @ParameterizedTest
+  @MethodSource("blocksFromMilestones")
+  void shouldExtractSlotFromAllMilestones(final SignedBeaconBlock block) {
+    assertThat(BeaconBlockInvariants.extractSignedBlockContainerSlot(block.sszSerialize()))
+        .isEqualTo(block.getSlot());
+  }
+
   static List<Arguments> slotNumbers() {
     return List.of(
         Arguments.of(UInt64.ZERO),
@@ -86,5 +96,14 @@ class BeaconBlockInvariantsTest {
         Arguments.of(UInt64.MAX_VALUE),
         Arguments.of(UInt64.valueOf(1234582)),
         Arguments.of(UInt64.valueOf(42)));
+  }
+
+  static List<Arguments> blocksFromMilestones() {
+    return Arrays.stream(SpecMilestone.values())
+        .map(milestone -> TestSpecFactory.create(milestone, Eth2Network.MINIMAL))
+        .map(DataStructureUtil::new)
+        .map(DataStructureUtil::randomSignedBeaconBlock)
+        .map(Arguments::of)
+        .toList();
   }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
@@ -96,7 +96,7 @@ public class CombinedKvStoreDao<S extends SchemaCombined>
   }
 
   @Override
-  public Optional<Bytes> getHotBlockAsSsz(Bytes32 root) {
+  public Optional<Bytes> getHotBlockAsSsz(final Bytes32 root) {
     return db.getRaw(schema.getColumnHotBlocksByRoot(), root);
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
@@ -96,6 +96,11 @@ public class CombinedKvStoreDao<S extends SchemaCombined>
   }
 
   @Override
+  public Optional<Bytes> getHotBlockAsSsz(Bytes32 root) {
+    return db.getRaw(schema.getColumnHotBlocksByRoot(), root);
+  }
+
+  @Override
   public Optional<BlockCheckpoints> getHotBlockCheckpointEpochs(final Bytes32 root) {
     return db.get(schema.getColumnHotBlockCheckpointEpochsByRoot(), root);
   }
@@ -664,6 +669,18 @@ public class CombinedKvStoreDao<S extends SchemaCombined>
     public void addFinalizedBlock(final SignedBeaconBlock block) {
       transaction.put(schema.getColumnSlotsByFinalizedRoot(), block.getRoot(), block.getSlot());
       transaction.put(schema.getColumnFinalizedBlocksBySlot(), block.getSlot(), block);
+    }
+
+    @Override
+    public void addFinalizedBlockRaw(
+        final UInt64 slot, final Bytes32 blockRoot, final Bytes blockBytes) {
+      transaction.put(schema.getColumnSlotsByFinalizedRoot(), blockRoot, slot);
+      final KvStoreColumn<UInt64, SignedBeaconBlock> columnFinalizedBlocksBySlot =
+          schema.getColumnFinalizedBlocksBySlot();
+      transaction.putRaw(
+          columnFinalizedBlocksBySlot,
+          Bytes.wrap(columnFinalizedBlocksBySlot.getKeySerializer().serialize(slot)),
+          blockBytes);
     }
 
     @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDao.java
@@ -52,6 +52,8 @@ public interface KvStoreCombinedDao extends AutoCloseable {
 
   Optional<SignedBeaconBlock> getHotBlock(Bytes32 root);
 
+  Optional<Bytes> getHotBlockAsSsz(Bytes32 root);
+
   @MustBeClosed
   Stream<SignedBeaconBlock> streamHotBlocks();
 
@@ -221,6 +223,8 @@ public interface KvStoreCombinedDao extends AutoCloseable {
   interface FinalizedUpdater extends AutoCloseable {
 
     void addFinalizedBlock(final SignedBeaconBlock block);
+
+    void addFinalizedBlockRaw(final UInt64 slot, final Bytes32 blockRoot, final Bytes blockBytes);
 
     void addNonCanonicalBlock(final SignedBeaconBlock block);
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDao.java
@@ -224,7 +224,7 @@ public interface KvStoreCombinedDao extends AutoCloseable {
 
     void addFinalizedBlock(final SignedBeaconBlock block);
 
-    void addFinalizedBlockRaw(final UInt64 slot, final Bytes32 blockRoot, final Bytes blockBytes);
+    void addFinalizedBlockRaw(UInt64 slot, Bytes32 blockRoot, Bytes blockBytes);
 
     void addNonCanonicalBlock(final SignedBeaconBlock block);
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoAdapter.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoAdapter.java
@@ -94,6 +94,11 @@ public class KvStoreCombinedDaoAdapter implements KvStoreCombinedDao, V4Migratab
   }
 
   @Override
+  public Optional<Bytes> getHotBlockAsSsz(final Bytes32 root) {
+    return hotDao.getHotBlockRaw(root);
+  }
+
+  @Override
   public Optional<BlockCheckpoints> getHotBlockCheckpointEpochs(final Bytes32 root) {
     return hotDao.getHotBlockCheckpointEpochs(root);
   }
@@ -515,6 +520,12 @@ public class KvStoreCombinedDaoAdapter implements KvStoreCombinedDao, V4Migratab
     @Override
     public void addFinalizedBlock(final SignedBeaconBlock block) {
       finalizedUpdater.addFinalizedBlock(block);
+    }
+
+    @Override
+    public void addFinalizedBlockRaw(
+        final UInt64 slot, final Bytes32 blockRoot, final Bytes blockBytes) {
+      finalizedUpdater.addFinalizedBlockRaw(slot, blockRoot, blockBytes);
     }
 
     @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4FinalizedKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4FinalizedKvStoreDao.java
@@ -296,6 +296,18 @@ public class V4FinalizedKvStoreDao {
     }
 
     @Override
+    public void addFinalizedBlockRaw(
+        final UInt64 slot, final Bytes32 blockRoot, final Bytes blockBytes) {
+      transaction.put(schema.getColumnSlotsByFinalizedRoot(), blockRoot, slot);
+      final KvStoreColumn<UInt64, SignedBeaconBlock> columnFinalizedBlocksBySlot =
+          schema.getColumnFinalizedBlocksBySlot();
+      transaction.putRaw(
+          columnFinalizedBlocksBySlot,
+          Bytes.wrap(columnFinalizedBlocksBySlot.getKeySerializer().serialize(slot)),
+          blockBytes);
+    }
+
+    @Override
     public void addNonCanonicalBlock(final SignedBeaconBlock block) {
       transaction.put(schema.getColumnNonCanonicalBlocksByRoot(), block.getRoot(), block);
     }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4HotKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4HotKvStoreDao.java
@@ -75,6 +75,10 @@ public class V4HotKvStoreDao {
     return db.get(schema.getColumnHotBlocksByRoot(), root);
   }
 
+  public Optional<Bytes> getHotBlockRaw(final Bytes32 root) {
+    return db.getRaw(schema.getColumnHotBlocksByRoot(), root);
+  }
+
   public Optional<BlockCheckpoints> getHotBlockCheckpointEpochs(final Bytes32 root) {
     return db.get(schema.getColumnHotBlockCheckpointEpochsByRoot(), root);
   }


### PR DESCRIPTION
Implements a hot -> finalized move of blocks during epoch transition avoiding block serialization/deserialization/hashing.

It obtains a measurable speedup (new on the left, old on the right)

<img width="964" alt="image" src="https://github.com/Consensys/teku/assets/15999009/7c768adb-718a-4f4e-af11-03bcbe8a081d">

related to https://github.com/Consensys/teku/issues/7622


## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
