### PR TITLE
Evict in natural order from last epoch Store caches for blocks and blobs

### DIFF
--- a/beacon/sync/src/testFixtures/java/tech/pegasys/teku/beacon/sync/SyncingNodeManager.java
+++ b/beacon/sync/src/testFixtures/java/tech/pegasys/teku/beacon/sync/SyncingNodeManager.java
@@ -136,7 +136,7 @@ public class SyncingNodeManager {
         poolFactory.createPendingPoolForBlocks(spec);
     final FutureItems<SignedBeaconBlock> futureBlocks =
         FutureItems.create(SignedBeaconBlock::getSlot, mock(SettableLabelledGauge.class), "blocks");
-    final Map<Bytes32, BlockImportResult> invalidBlockRoots = LimitedMap.createSynchronized(500);
+    final Map<Bytes32, BlockImportResult> invalidBlockRoots = LimitedMap.createSynchronizedLRU(500);
 
     final BlockImporter blockImporter =
         new BlockImporter(

--- a/ethereum/dataproviders/src/main/java/tech/pegasys/teku/dataproviders/generators/StateCache.java
+++ b/ethereum/dataproviders/src/main/java/tech/pegasys/teku/dataproviders/generators/StateCache.java
@@ -25,7 +25,7 @@ class StateCache {
   private final Map<Bytes32, BeaconState> knownStates;
 
   public StateCache(final int maxCachedStates, final Map<Bytes32, BeaconState> knownStates) {
-    this.cache = LimitedMap.createSynchronized(maxCachedStates);
+    this.cache = LimitedMap.createSynchronizedLRU(maxCachedStates);
     this.knownStates = knownStates;
   }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/MappedOperationPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/MappedOperationPool.java
@@ -87,7 +87,7 @@ public class MappedOperationPool<T extends MessageWithValidatorId> implements Op
       final int operationPoolSize) {
 
     this.slotToSszListSchemaSupplier = slotToSszListSchemaSupplier;
-    this.operations = LimitedMap.createSynchronized(operationPoolSize);
+    this.operations = LimitedMap.createSynchronizedLRU(operationPoolSize);
     this.operationValidator = operationValidator;
     this.metricType = metricType;
     metricsSystem.createIntegerGauge(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/SeenAggregatesCache.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/SeenAggregatesCache.java
@@ -25,7 +25,7 @@ public class SeenAggregatesCache<KeyT> {
   private final Map<KeyT, Set<SszBitSet>> seenAggregationBitsByDataRoot;
 
   public SeenAggregatesCache(final int rootCacheSize) {
-    this.seenAggregationBitsByDataRoot = LimitedMap.createSynchronized(rootCacheSize);
+    this.seenAggregationBitsByDataRoot = LimitedMap.createSynchronizedLRU(rootCacheSize);
   }
 
   public boolean add(final KeyT root, final SszBitSet aggregationBits) {

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockManagerTest.java
@@ -122,7 +122,7 @@ public class BlockManagerTest {
   private final FutureItems<SignedBeaconBlock> futureBlocks =
       FutureItems.create(SignedBeaconBlock::getSlot, mock(SettableLabelledGauge.class), "blocks");
   private final Map<Bytes32, BlockImportResult> invalidBlockRoots =
-      LimitedMap.createSynchronized(500);
+      LimitedMap.createSynchronizedLRU(500);
 
   private StorageSystem localChain;
   private RecentChainData localRecentChainData = mock(RecentChainData.class);

--- a/infrastructure/collections/src/main/java/tech/pegasys/teku/infrastructure/collections/AbstractLimitedMap.java
+++ b/infrastructure/collections/src/main/java/tech/pegasys/teku/infrastructure/collections/AbstractLimitedMap.java
@@ -23,8 +23,8 @@ import java.util.function.Function;
 
 abstract class AbstractLimitedMap<K, V> implements LimitedMap<K, V> {
 
-  protected static <K, V> Map<K, V> createLimitedMap(final int maxSize) {
-    return new LinkedHashMap<>(16, 0.75f, true) {
+  protected static <K, V> Map<K, V> createLimitedMap(final int maxSize, final boolean accessOrder) {
+    return new LinkedHashMap<>(16, 0.75f, accessOrder) {
       @Override
       protected boolean removeEldestEntry(final Map.Entry<K, V> eldest) {
         return this.size() > maxSize;

--- a/infrastructure/collections/src/main/java/tech/pegasys/teku/infrastructure/collections/LimitedMap.java
+++ b/infrastructure/collections/src/main/java/tech/pegasys/teku/infrastructure/collections/LimitedMap.java
@@ -35,7 +35,8 @@ public interface LimitedMap<K, V> extends Map<K, V> {
    * Creates a limited map.
    *
    * <p>The returned map is safe for concurrent access <strong>except iteration</strong> and evicts
-   * the least recently used items. Iteration requires synchronizing on the map instance.
+   * the least recently accessed items like LRU cache. Iteration requires synchronizing on the map
+   * instance.
    *
    * <p>Synchronized instances are generally faster than iterable versions.
    *
@@ -44,8 +45,25 @@ public interface LimitedMap<K, V> extends Map<K, V> {
    * @param <V> The value type of the map.
    * @return A map that will evict elements when the max size is exceeded.
    */
-  static <K, V> LimitedMap<K, V> createSynchronized(final int maxSize) {
-    return new SynchronizedLimitedMap<>(maxSize);
+  static <K, V> LimitedMap<K, V> createSynchronizedLRU(final int maxSize) {
+    return new SynchronizedLimitedMap<>(maxSize, true);
+  }
+
+  /**
+   * Creates a limited map.
+   *
+   * <p>The returned map is safe for concurrent access <strong>except iteration</strong> and evicts
+   * the oldest inserted items. Iteration requires synchronizing on the map instance.
+   *
+   * <p>Synchronized instances are generally faster than iterable versions.
+   *
+   * @param maxSize The maximum number of elements to keep in the map.
+   * @param <K> The key type of the map.
+   * @param <V> The value type of the map.
+   * @return A map that will evict elements when the max size is exceeded.
+   */
+  static <K, V> LimitedMap<K, V> createSynchronizedNatural(final int maxSize) {
+    return new SynchronizedLimitedMap<>(maxSize, false);
   }
 
   /**

--- a/infrastructure/collections/src/main/java/tech/pegasys/teku/infrastructure/collections/LimitedSet.java
+++ b/infrastructure/collections/src/main/java/tech/pegasys/teku/infrastructure/collections/LimitedSet.java
@@ -34,7 +34,7 @@ public final class LimitedSet {
    * @return A set that will evict elements when the max size is exceeded.
    */
   public static <T> Set<T> createSynchronized(final int maxSize) {
-    return Collections.newSetFromMap(LimitedMap.createSynchronized(maxSize));
+    return Collections.newSetFromMap(LimitedMap.createSynchronizedLRU(maxSize));
   }
 
   /**

--- a/infrastructure/collections/src/main/java/tech/pegasys/teku/infrastructure/collections/NonSynchronizedLimitedMap.java
+++ b/infrastructure/collections/src/main/java/tech/pegasys/teku/infrastructure/collections/NonSynchronizedLimitedMap.java
@@ -17,7 +17,7 @@ package tech.pegasys.teku.infrastructure.collections;
 final class NonSynchronizedLimitedMap<K, V> extends AbstractLimitedMap<K, V> {
 
   public NonSynchronizedLimitedMap(final int maxSize) {
-    super(createLimitedMap(maxSize), maxSize);
+    super(createLimitedMap(maxSize, true), maxSize);
   }
 
   @Override

--- a/infrastructure/collections/src/main/java/tech/pegasys/teku/infrastructure/collections/SynchronizedLimitedMap.java
+++ b/infrastructure/collections/src/main/java/tech/pegasys/teku/infrastructure/collections/SynchronizedLimitedMap.java
@@ -17,14 +17,16 @@ import java.util.Collections;
 
 /** Helper that creates a thread-safe map with a maximum capacity. */
 final class SynchronizedLimitedMap<K, V> extends AbstractLimitedMap<K, V> {
+  final boolean accessOrder;
 
-  public SynchronizedLimitedMap(final int maxSize) {
-    super(Collections.synchronizedMap(createLimitedMap(maxSize)), maxSize);
+  public SynchronizedLimitedMap(final int maxSize, final boolean accessOrder) {
+    super(Collections.synchronizedMap(createLimitedMap(maxSize, accessOrder)), maxSize);
+    this.accessOrder = accessOrder;
   }
 
   @Override
   public LimitedMap<K, V> copy() {
-    SynchronizedLimitedMap<K, V> map = new SynchronizedLimitedMap<>(getMaxSize());
+    SynchronizedLimitedMap<K, V> map = new SynchronizedLimitedMap<>(getMaxSize(), accessOrder);
     synchronized (delegate) {
       map.putAll(delegate);
     }

--- a/infrastructure/collections/src/test/java/tech/pegasys/teku/infrastructure/collections/LimitedMapTest.java
+++ b/infrastructure/collections/src/test/java/tech/pegasys/teku/infrastructure/collections/LimitedMapTest.java
@@ -21,8 +21,8 @@ import org.junit.jupiter.api.Test;
 public class LimitedMapTest {
 
   @Test
-  public void create_evictLeastRecentlyAccessed() {
-    final Map<Integer, Integer> map = LimitedMap.createSynchronized(2);
+  public void createSynchronizedLRU_evictLeastRecentlyAccessed() {
+    final Map<Integer, Integer> map = LimitedMap.createSynchronizedLRU(2);
     map.put(1, 1);
     assertThat(map.size()).isEqualTo(1);
     map.put(2, 2);
@@ -36,5 +36,23 @@ public class LimitedMapTest {
     // Element 2 should have been evicted
     assertThat(map.containsKey(3)).isTrue();
     assertThat(map.containsKey(1)).isTrue();
+  }
+
+  @Test
+  public void createSynchronizedNatural_evictNaturalOrder() {
+    final Map<Integer, Integer> map = LimitedMap.createSynchronizedNatural(2);
+    map.put(1, 1);
+    assertThat(map.size()).isEqualTo(1);
+    map.put(2, 2);
+    assertThat(map.size()).isEqualTo(2);
+
+    // Access element 1 then add a new element that will put us over the limit
+    map.get(1);
+
+    map.put(3, 3);
+    assertThat(map.size()).isEqualTo(2);
+    // Element 2 should have been evicted
+    assertThat(map.containsKey(3)).isTrue();
+    assertThat(map.containsKey(2)).isTrue();
   }
 }

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -503,7 +503,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
           FutureItems.create(SignedBlobSidecarOld::getSlot, futureItemsMetric, "blob_sidecars");
 
       final Map<Bytes32, InternalValidationResult> invalidBlobSidecarRoots =
-          LimitedMap.createSynchronized(500);
+          LimitedMap.createSynchronizedLRU(500);
 
       final BlobSidecarGossipValidator blobSidecarValidator =
           BlobSidecarGossipValidator.create(spec, invalidBlockRoots, gossipValidationHelper);
@@ -544,7 +544,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
     LOG.debug("BeaconChainController.initBlockPoolsAndCaches()");
     pendingBlocks = poolFactory.createPendingPoolForBlocks(spec);
     eventChannels.subscribe(FinalizedCheckpointChannel.class, pendingBlocks);
-    invalidBlockRoots = LimitedMap.createSynchronized(500);
+    invalidBlockRoots = LimitedMap.createSynchronizedLRU(500);
   }
 
   protected void initBlobSidecarPool() {

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
@@ -204,7 +204,7 @@ class Store extends CacheableStore {
 
     // Create limited collections for non-final data
     final Map<Bytes32, SignedBeaconBlock> blocks =
-        LimitedMap.createSynchronized(config.getBlockCacheSize());
+        LimitedMap.createSynchronizedNatural(config.getBlockCacheSize());
     final CachingTaskQueue<SlotAndBlockRoot, BeaconState> checkpointStateTaskQueue =
         CachingTaskQueue.create(
             asyncRunner,
@@ -216,10 +216,10 @@ class Store extends CacheableStore {
             asyncRunner, metricsSystem, "memory_states", config.getStateCacheSize());
     final Optional<Map<Bytes32, StateAndBlockSummary>> maybeEpochStates =
         config.getEpochStateCacheSize() > 0
-            ? Optional.of(LimitedMap.createSynchronized(config.getEpochStateCacheSize()))
+            ? Optional.of(LimitedMap.createSynchronizedLRU(config.getEpochStateCacheSize()))
             : Optional.empty();
     final Map<SlotAndBlockRoot, List<BlobSidecarOld>> blobSidecars =
-        LimitedMap.createSynchronized(config.getBlockCacheSize());
+        LimitedMap.createSynchronizedNatural(config.getBlockCacheSize());
 
     final UInt64 currentEpoch = spec.computeEpochAtSlot(spec.getCurrentSlot(time, genesisTime));
     final ForkChoiceStrategy forkChoiceStrategy =

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandler.java
@@ -69,7 +69,7 @@ public class FailoverValidatorApiHandler implements ValidatorApiChannel {
       "remote_beacon_nodes_requests_total";
 
   private final Map<UInt64, ValidatorApiChannel> blindedBlockCreatorCache =
-      LimitedMap.createSynchronized(2);
+      LimitedMap.createSynchronizedLRU(2);
 
   private final BeaconNodeReadinessManager beaconNodeReadinessManager;
   private final RemoteValidatorApiChannel primaryDelegate;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
These caches were designed to store the latest epoch of blocks but were found to have some weird behavior. The issue is that they were using LRU evicted map underneath, so being accessed by RPC the order was changed from the natural it was inserted and actually could hold older values while evicting the most recent blocks.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Fixes #7671 

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
