### PR TITLE
Fix API start up log

### DIFF
--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/RestApi.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/RestApi.java
@@ -53,11 +53,7 @@ public class RestApi extends Service {
     try {
       passwordPath.ifPresent(this::checkAccessFile);
       app.start();
-      final String serverHost = app.jettyServer().getServerHost();
-      LOG.info(
-          "Listening on http://{}:{}/",
-          serverHost != null ? serverHost : "localhost",
-          app.jettyServer().getServerPort());
+      LOG.info("Listening on {}", app.jettyServer().server().getURI());
     } catch (final RuntimeException e) {
       if (Throwables.getRootCause(e) instanceof BindException) {
         throw new InvalidConfigurationException(


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
`app.jettyServer().getServerHost()` is always returning null (in the reported issue it happened when `--validator-api-interface=0.0.0.0`) which makes the logger printing `Listening on http://localhost:5052/` instead of `Listening on https://0.0.0.0:5052/`

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
