### PR TITLE
Change `BlobSidecarGossipManager` to use the new BlobSidecar type

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisherDeneb.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisherDeneb.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.validator.coordinator.publisher;
 
+import java.util.List;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.networking.eth2.gossip.BlobSidecarGossipChannel;
 import tech.pegasys.teku.networking.eth2.gossip.BlockGossipChannel;
@@ -62,7 +63,8 @@ public class BlockPublisherDeneb extends AbstractBlockPublisher {
 
   @Override
   void publishBlock(final SignedBlockContainer blockContainer) {
-    blockContainer.getSignedBlobSidecars().ifPresent(blobSidecarGossipChannel::publishBlobSidecars);
+    // TODO: publish blob sidecars with inclusion proof
+    blobSidecarGossipChannel.publishBlobSidecars(List.of());
     blockGossipChannel.publishBlock(blockContainer.getSignedBlock());
   }
 }

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -906,7 +906,8 @@ class ValidatorApiHandlerTest {
     safeJoin(result);
 
     verifyNoInteractions(blobSidecarPool);
-    verifyNoInteractions(blobSidecarGossipChannel);
+    // TODO: fix assertion for blob sidecars (there should be no interactions)
+    verify(blobSidecarGossipChannel).publishBlobSidecars(List.of());
     verify(blockGossipChannel).publishBlock(block);
     verify(blockImportChannel).importBlock(block, NOT_REQUIRED);
     assertThat(result).isCompletedWithValue(SendSignedBlockResult.success(block.getRoot()));

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -840,7 +840,8 @@ class ValidatorApiHandlerTest {
     final SafeFuture<SendSignedBlockResult> result =
         validatorApiHandler.sendSignedBlock(blockContents, NOT_REQUIRED);
 
-    verify(blobSidecarGossipChannel).publishBlobSidecars(blobSidecars);
+    // TODO: fix assertion for blob sidecars
+    verify(blobSidecarGossipChannel).publishBlobSidecars(List.of());
     verify(blobSidecarPool).onCompletedBlockAndSignedBlobSidecars(block, blobSidecars);
     verify(blockGossipChannel).publishBlock(block);
     verify(blockImportChannel).importBlock(block, NOT_REQUIRED);
@@ -861,7 +862,8 @@ class ValidatorApiHandlerTest {
     final SafeFuture<SendSignedBlockResult> result =
         validatorApiHandler.sendSignedBlock(blockContents, NOT_REQUIRED);
 
-    verify(blobSidecarGossipChannel).publishBlobSidecars(blobSidecars);
+    // TODO: fix assertion for blob sidecars
+    verify(blobSidecarGossipChannel).publishBlobSidecars(List.of());
     verify(blobSidecarPool).onCompletedBlockAndSignedBlobSidecars(block, blobSidecars);
     verify(blockGossipChannel).publishBlock(block);
     verify(blockImportChannel).importBlock(block, NOT_REQUIRED);
@@ -884,7 +886,8 @@ class ValidatorApiHandlerTest {
     final SafeFuture<SendSignedBlockResult> result =
         validatorApiHandler.sendSignedBlock(blockContents, NOT_REQUIRED);
 
-    verify(blobSidecarGossipChannel).publishBlobSidecars(blobSidecars);
+    // TODO: fix assertion for blob sidecars
+    verify(blobSidecarGossipChannel).publishBlobSidecars(List.of());
     verify(blobSidecarPool).onCompletedBlockAndSignedBlobSidecars(block, blobSidecars);
     verify(blockGossipChannel).publishBlock(block);
     verify(blockImportChannel).importBlock(block, NOT_REQUIRED);

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/StubBlobSidecarManager.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/StubBlobSidecarManager.java
@@ -26,6 +26,7 @@ import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.kzg.KZGCommitment;
 import tech.pegasys.teku.kzg.KZGProof;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.Blob;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
@@ -56,6 +57,13 @@ class StubBlobSidecarManager implements BlobSidecarManager {
   @Override
   public SafeFuture<InternalValidationResult> validateAndPrepareForBlockImport(
       final SignedBlobSidecarOld signedBlobSidecar, final Optional<UInt64> arrivalTimestamp) {
+    return SafeFuture.failedFuture(
+        new UnsupportedOperationException("Not available in fork choice reference tests"));
+  }
+
+  @Override
+  public SafeFuture<InternalValidationResult> validateAndPrepareForBlockImport(
+      final BlobSidecar blobSidecar, final Optional<UInt64> arrivalTimestamp) {
     return SafeFuture.failedFuture(
         new UnsupportedOperationException("Not available in fork choice reference tests"));
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -51,8 +51,8 @@ import tech.pegasys.teku.spec.config.SpecConfigDeneb;
 import tech.pegasys.teku.spec.constants.Domain;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.Blob;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockHeader;
@@ -940,13 +940,10 @@ public class Spec {
     return getSpecConfigDeneb(slot).map(SpecConfigDeneb::getMaxBlobsPerBlock);
   }
 
-  public UInt64 computeSubnetForBlobSidecar(final SignedBlobSidecarOld signedBlobSidecar) {
-    final SpecConfig config = atSlot(signedBlobSidecar.getSlot()).getConfig();
+  public UInt64 computeSubnetForBlobSidecar(final BlobSidecar blobSidecar) {
+    final SpecConfig config = atSlot(blobSidecar.getSlot()).getConfig();
     final SpecConfigDeneb specConfigDeneb = SpecConfigDeneb.required(config);
-    return signedBlobSidecar
-        .getBlobSidecar()
-        .getIndex()
-        .mod(specConfigDeneb.getBlobSidecarSubnetCount());
+    return blobSidecar.getIndex().mod(specConfigDeneb.getBlobSidecarSubnetCount());
   }
 
   public Optional<UInt64> computeFirstSlotWithBlobSupport() {

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -2288,10 +2288,6 @@ public final class DataStructureUtil {
         .create(beaconBlock, blobSidecarList);
   }
 
-  public SignedBlobSidecarOld randomSignedBlobSidecar(final UInt64 index) {
-    return new RandomBlobSidecarOldBuilder().index(index).buildSigned();
-  }
-
   public RandomBlobSidecarOldBuilder createRandomBlobSidecarBuilderOld() {
     return new RandomBlobSidecarOldBuilder();
   }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blobs/BlobSidecarManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blobs/BlobSidecarManager.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Optional;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
@@ -31,6 +32,12 @@ public interface BlobSidecarManager {
         @Override
         public SafeFuture<InternalValidationResult> validateAndPrepareForBlockImport(
             final SignedBlobSidecarOld signedBlobSidecar, final Optional<UInt64> arrivalTimestamp) {
+          return SafeFuture.completedFuture(InternalValidationResult.ACCEPT);
+        }
+
+        @Override
+        public SafeFuture<InternalValidationResult> validateAndPrepareForBlockImport(
+            final BlobSidecar blobSidecar, final Optional<UInt64> arrivalTimestamp) {
           return SafeFuture.completedFuture(InternalValidationResult.ACCEPT);
         }
 
@@ -59,8 +66,12 @@ public interface BlobSidecarManager {
         }
       };
 
+  @Deprecated
   SafeFuture<InternalValidationResult> validateAndPrepareForBlockImport(
       SignedBlobSidecarOld signedBlobSidecar, Optional<UInt64> arrivalTimestamp);
+
+  SafeFuture<InternalValidationResult> validateAndPrepareForBlockImport(
+      BlobSidecar blobSidecar, Optional<UInt64> arrivalTimestamp);
 
   void prepareForBlockImport(BlobSidecarOld blobSidecar);
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blobs/BlobSidecarManagerImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blobs/BlobSidecarManagerImpl.java
@@ -24,6 +24,7 @@ import tech.pegasys.teku.infrastructure.subscribers.Subscribers;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
@@ -104,6 +105,12 @@ public class BlobSidecarManagerImpl implements BlobSidecarManager, SlotEventsCha
         });
 
     return validationResult;
+  }
+
+  @Override
+  public SafeFuture<InternalValidationResult> validateAndPrepareForBlockImport(
+      final BlobSidecar blobSidecar, final Optional<UInt64> arrivalTimestamp) {
+    throw new UnsupportedOperationException("Not yet implemented");
   }
 
   @Override

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkBuilder.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkBuilder.java
@@ -68,7 +68,7 @@ import tech.pegasys.teku.networking.p2p.rpc.RpcMethod;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.config.Constants;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecarOld;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
@@ -96,7 +96,7 @@ public class Eth2P2PNetworkBuilder {
   protected EventChannels eventChannels;
   protected CombinedChainDataClient combinedChainDataClient;
   protected OperationProcessor<SignedBeaconBlock> gossipedBlockProcessor;
-  protected OperationProcessor<SignedBlobSidecarOld> gossipedBlobSidecarProcessor;
+  protected OperationProcessor<BlobSidecar> gossipedBlobSidecarProcessor;
   protected OperationProcessor<ValidatableAttestation> gossipedAttestationConsumer;
   protected OperationProcessor<ValidatableAttestation> gossipedAggregateProcessor;
   protected OperationProcessor<AttesterSlashing> gossipedAttesterSlashingConsumer;
@@ -444,7 +444,7 @@ public class Eth2P2PNetworkBuilder {
   }
 
   public Eth2P2PNetworkBuilder gossipedBlobSidecarProcessor(
-      final OperationProcessor<SignedBlobSidecarOld> blobSidecarProcessor) {
+      final OperationProcessor<BlobSidecar> blobSidecarProcessor) {
     checkNotNull(blobSidecarProcessor);
     this.gossipedBlobSidecarProcessor = blobSidecarProcessor;
     return this;

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/BlobSidecarGossipChannel.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/BlobSidecarGossipChannel.java
@@ -15,15 +15,15 @@ package tech.pegasys.teku.networking.eth2.gossip;
 
 import java.util.List;
 import tech.pegasys.teku.infrastructure.events.VoidReturningChannelInterface;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecarOld;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 
 public interface BlobSidecarGossipChannel extends VoidReturningChannelInterface {
 
   BlobSidecarGossipChannel NOOP = blobSidecar -> {};
 
-  default void publishBlobSidecars(final List<SignedBlobSidecarOld> blobSidecars) {
+  default void publishBlobSidecars(final List<BlobSidecar> blobSidecars) {
     blobSidecars.forEach(this::publishBlobSidecar);
   }
 
-  void publishBlobSidecar(SignedBlobSidecarOld blobSidecar);
+  void publishBlobSidecar(BlobSidecar blobSidecar);
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/BlobSidecarGossipManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/BlobSidecarGossipManager.java
@@ -31,8 +31,8 @@ import tech.pegasys.teku.networking.p2p.gossip.TopicChannel;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecVersion;
 import tech.pegasys.teku.spec.config.SpecConfigDeneb;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecarOld;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecarSchemaOld;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarSchema;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsDeneb;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
@@ -43,7 +43,7 @@ public class BlobSidecarGossipManager implements GossipManager {
   private final Spec spec;
   private final GossipNetwork gossipNetwork;
   private final GossipEncoding gossipEncoding;
-  private final Int2ObjectMap<Eth2TopicHandler<SignedBlobSidecarOld>> subnetIdToTopicHandler;
+  private final Int2ObjectMap<Eth2TopicHandler<BlobSidecar>> subnetIdToTopicHandler;
 
   private final Int2ObjectMap<TopicChannel> subnetIdToChannel = new Int2ObjectOpenHashMap<>();
 
@@ -54,18 +54,18 @@ public class BlobSidecarGossipManager implements GossipManager {
       final GossipNetwork gossipNetwork,
       final GossipEncoding gossipEncoding,
       final ForkInfo forkInfo,
-      final OperationProcessor<SignedBlobSidecarOld> processor) {
+      final OperationProcessor<BlobSidecar> processor) {
     final SpecVersion forkSpecVersion = spec.atEpoch(forkInfo.getFork().getEpoch());
-    final SignedBlobSidecarSchemaOld gossipType =
+    final BlobSidecarSchema gossipType =
         SchemaDefinitionsDeneb.required(forkSpecVersion.getSchemaDefinitions())
-            .getSignedBlobSidecarOldSchema();
-    final Int2ObjectMap<Eth2TopicHandler<SignedBlobSidecarOld>> subnetIdToTopicHandler =
+            .getBlobSidecarSchema();
+    final Int2ObjectMap<Eth2TopicHandler<BlobSidecar>> subnetIdToTopicHandler =
         new Int2ObjectOpenHashMap<>();
     final SpecConfigDeneb specConfigDeneb = SpecConfigDeneb.required(forkSpecVersion.getConfig());
     IntStream.range(0, specConfigDeneb.getBlobSidecarSubnetCount())
         .forEach(
             subnetId -> {
-              final Eth2TopicHandler<SignedBlobSidecarOld> topicHandler =
+              final Eth2TopicHandler<BlobSidecar> topicHandler =
                   createBlobSidecarTopicHandler(
                       subnetId,
                       recentChainData,
@@ -85,21 +85,21 @@ public class BlobSidecarGossipManager implements GossipManager {
       final Spec spec,
       final GossipNetwork gossipNetwork,
       final GossipEncoding gossipEncoding,
-      final Int2ObjectMap<Eth2TopicHandler<SignedBlobSidecarOld>> subnetIdToTopicHandler) {
+      final Int2ObjectMap<Eth2TopicHandler<BlobSidecar>> subnetIdToTopicHandler) {
     this.spec = spec;
     this.gossipNetwork = gossipNetwork;
     this.gossipEncoding = gossipEncoding;
     this.subnetIdToTopicHandler = subnetIdToTopicHandler;
   }
 
-  public void publishBlobSidecar(final SignedBlobSidecarOld message) {
+  public void publishBlobSidecar(final BlobSidecar message) {
     final int subnetId = spec.computeSubnetForBlobSidecar(message).intValue();
     Optional.ofNullable(subnetIdToChannel.get(subnetId))
         .ifPresent(channel -> channel.gossip(gossipEncoding.encode(message)));
   }
 
   @VisibleForTesting
-  Eth2TopicHandler<SignedBlobSidecarOld> getTopicHandler(final int subnetId) {
+  Eth2TopicHandler<BlobSidecar> getTopicHandler(final int subnetId) {
     return subnetIdToTopicHandler.get(subnetId);
   }
 
@@ -109,7 +109,7 @@ public class BlobSidecarGossipManager implements GossipManager {
         .int2ObjectEntrySet()
         .forEach(
             entry -> {
-              final Eth2TopicHandler<SignedBlobSidecarOld> topicHandler = entry.getValue();
+              final Eth2TopicHandler<BlobSidecar> topicHandler = entry.getValue();
               final TopicChannel channel =
                   gossipNetwork.subscribe(topicHandler.getTopic(), topicHandler);
               subnetIdToChannel.put(entry.getIntKey(), channel);
@@ -127,15 +127,15 @@ public class BlobSidecarGossipManager implements GossipManager {
     return true;
   }
 
-  private static Eth2TopicHandler<SignedBlobSidecarOld> createBlobSidecarTopicHandler(
+  private static Eth2TopicHandler<BlobSidecar> createBlobSidecarTopicHandler(
       final int subnetId,
       final RecentChainData recentChainData,
       final Spec spec,
       final AsyncRunner asyncRunner,
-      final OperationProcessor<SignedBlobSidecarOld> processor,
+      final OperationProcessor<BlobSidecar> processor,
       final GossipEncoding gossipEncoding,
       final ForkInfo forkInfo,
-      final SignedBlobSidecarSchemaOld gossipType) {
+      final BlobSidecarSchema gossipType) {
     return new Eth2TopicHandler<>(
         recentChainData,
         asyncRunner,
@@ -146,30 +146,18 @@ public class BlobSidecarGossipManager implements GossipManager {
         new OperationMilestoneValidator<>(
             spec,
             forkInfo.getFork(),
-            blobSidecar -> spec.computeEpochAtSlot(blobSidecar.getBlobSidecar().getSlot())),
+            blobSidecar -> spec.computeEpochAtSlot(blobSidecar.getSlot())),
         gossipType,
         spec.getNetworkingConfig());
   }
 
-  private static class TopicSubnetIdAwareOperationProcessor
-      implements OperationProcessor<SignedBlobSidecarOld> {
-
-    private final Spec spec;
-    private final int subnetId;
-    private final OperationProcessor<SignedBlobSidecarOld> delegate;
-
-    private TopicSubnetIdAwareOperationProcessor(
-        final Spec spec,
-        final int subnetId,
-        final OperationProcessor<SignedBlobSidecarOld> delegate) {
-      this.spec = spec;
-      this.subnetId = subnetId;
-      this.delegate = delegate;
-    }
+  private record TopicSubnetIdAwareOperationProcessor(
+      Spec spec, int subnetId, OperationProcessor<BlobSidecar> delegate)
+      implements OperationProcessor<BlobSidecar> {
 
     @Override
     public SafeFuture<InternalValidationResult> process(
-        final SignedBlobSidecarOld blobSidecar, final Optional<UInt64> arrivalTimestamp) {
+        final BlobSidecar blobSidecar, final Optional<UInt64> arrivalTimestamp) {
       final int blobSidecarSubnet = spec.computeSubnetForBlobSidecar(blobSidecar).intValue();
       if (blobSidecarSubnet != subnetId) {
         return SafeFuture.completedFuture(

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/forks/GossipForkManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/forks/GossipForkManager.java
@@ -32,7 +32,7 @@ import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecarOld;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
@@ -163,9 +163,9 @@ public class GossipForkManager {
     publishMessage(block.getSlot(), block, "block", GossipForkSubscriptions::publishBlock);
   }
 
-  public synchronized void publishBlobSidecar(final SignedBlobSidecarOld blobSidecar) {
+  public synchronized void publishBlobSidecar(final BlobSidecar blobSidecar) {
     publishMessage(
-        blobSidecar.getBlobSidecar().getSlot(),
+        blobSidecar.getSlot(),
         blobSidecar,
         "blob sidecar",
         GossipForkSubscriptions::publishBlobSidecar);

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/forks/GossipForkSubscriptions.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/forks/GossipForkSubscriptions.java
@@ -16,7 +16,7 @@ package tech.pegasys.teku.networking.eth2.gossip.forks;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecarOld;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
@@ -39,7 +39,7 @@ public interface GossipForkSubscriptions {
 
   void publishBlock(SignedBeaconBlock block);
 
-  default void publishBlobSidecar(SignedBlobSidecarOld blobSidecar) {
+  default void publishBlobSidecar(BlobSidecar blobSidecar) {
     // since Deneb
   }
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/forks/versions/GossipForkSubscriptionsDeneb.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/forks/versions/GossipForkSubscriptionsDeneb.java
@@ -22,7 +22,7 @@ import tech.pegasys.teku.networking.eth2.gossip.topics.OperationProcessor;
 import tech.pegasys.teku.networking.p2p.discovery.DiscoveryNetwork;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecarOld;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
@@ -36,7 +36,7 @@ import tech.pegasys.teku.storage.client.RecentChainData;
 
 public class GossipForkSubscriptionsDeneb extends GossipForkSubscriptionsCapella {
 
-  private final OperationProcessor<SignedBlobSidecarOld> blobSidecarProcessor;
+  private final OperationProcessor<BlobSidecar> blobSidecarProcessor;
 
   private BlobSidecarGossipManager blobSidecarGossipManager;
 
@@ -50,7 +50,7 @@ public class GossipForkSubscriptionsDeneb extends GossipForkSubscriptionsCapella
       final RecentChainData recentChainData,
       final GossipEncoding gossipEncoding,
       final OperationProcessor<SignedBeaconBlock> blockProcessor,
-      final OperationProcessor<SignedBlobSidecarOld> blobSidecarProcessor,
+      final OperationProcessor<BlobSidecar> blobSidecarProcessor,
       final OperationProcessor<ValidatableAttestation> attestationProcessor,
       final OperationProcessor<ValidatableAttestation> aggregateProcessor,
       final OperationProcessor<AttesterSlashing> attesterSlashingProcessor,
@@ -103,7 +103,7 @@ public class GossipForkSubscriptionsDeneb extends GossipForkSubscriptionsCapella
   }
 
   @Override
-  public void publishBlobSidecar(final SignedBlobSidecarOld blobSidecar) {
+  public void publishBlobSidecar(final BlobSidecar blobSidecar) {
     blobSidecarGossipManager.publishBlobSidecar(blobSidecar);
   }
 }

--- a/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkFactory.java
+++ b/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkFactory.java
@@ -83,7 +83,7 @@ import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.config.Constants;
 import tech.pegasys.teku.spec.datastructures.attestation.ProcessedAttestationListener;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecarOld;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
@@ -132,7 +132,7 @@ public class Eth2P2PNetworkFactory {
     protected RecentChainData recentChainData;
     protected StorageQueryChannel historicalChainData = new StubStorageQueryChannel();
     protected OperationProcessor<SignedBeaconBlock> gossipedBlockProcessor;
-    protected OperationProcessor<SignedBlobSidecarOld> gossipedBlobSidecarProcessor;
+    protected OperationProcessor<BlobSidecar> gossipedBlobSidecarProcessor;
     protected OperationProcessor<ValidatableAttestation> gossipedAttestationProcessor;
     protected OperationProcessor<ValidatableAttestation> gossipedAggregateProcessor;
     protected OperationProcessor<AttesterSlashing> attesterSlashingProcessor;
@@ -589,7 +589,7 @@ public class Eth2P2PNetworkFactory {
     }
 
     public Eth2P2PNetworkBuilder gossipedBlobSidecarProcessor(
-        final OperationProcessor<SignedBlobSidecarOld> gossipedBlobSidecarProcessor) {
+        final OperationProcessor<BlobSidecar> gossipedBlobSidecarProcessor) {
       checkNotNull(gossipedBlobSidecarProcessor);
       this.gossipedBlobSidecarProcessor = gossipedBlobSidecarProcessor;
       return this;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

- Essentially change `BlobSidecarGossipManager` to use the new `BlobSidecar` container
- Add new method `validateAndPrepareForBlockImport` in BlobSidecarManager and deprecate the old one. Will implement in future PR.
- Change `publishBlobSidecars`in `BlobSidecarGossipChannel` to use the new `BlobSidecar` container and used it in `BlockPublisherDeneb` sending an empty list. Will implement in future PR.

## Fixed Issue(s)
helps with gossip flow for https://github.com/Consensys/teku/issues/7654

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
