### PR TITLE
Upgrade to ref test 1.4 beta 4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -295,7 +295,7 @@ allprojects {
   }
 }
 
-def refTestVersion = 'v1.4.0-beta.3' // Arbitrary change to refresh cache number: 1
+def refTestVersion = 'v1.4.0-beta.4' // Arbitrary change to refresh cache number: 1
 def blsRefTestVersion = 'v0.1.2'
 def refTestBaseUrl = 'https://github.com/ethereum/consensus-spec-tests/releases/download'
 def blsRefTestBaseUrl = 'https://github.com/ethereum/bls12-381-tests/releases/download'

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/Eth2ReferenceTestCase.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/Eth2ReferenceTestCase.java
@@ -90,6 +90,10 @@ public abstract class Eth2ReferenceTestCase {
   }
 
   private TestExecutor getExecutorFor(final TestDefinition testDefinition) {
+    // TODO: re-enable Deneb tests once migration to inclusion proof #7654 is complete
+    if (testDefinition.getFork().equals(TestFork.DENEB)) {
+      return TestExecutor.IGNORE_TESTS;
+    }
     // Look for fork-specific tests first
     TestExecutor testExecutor =
         switch (testDefinition.getFork()) {

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
@@ -91,6 +91,10 @@ public class ForkChoiceTestExecutor implements TestExecutor {
           .put("fork_choice/on_merge_block", new ForkChoiceTestExecutor())
           .put("fork_choice/withholding", new ForkChoiceTestExecutor())
           .put("sync/optimistic", new ForkChoiceTestExecutor())
+          // TODO: following tests are related to late block reorgs.
+          //  Must be re-enabled once implementation #6595 is done
+          .put("fork_choice/should_override_forkchoice_update", IGNORE_TESTS)
+          .put("fork_choice/get_proposer_head", IGNORE_TESTS)
           .build();
 
   private final List<?> testsToSkip;


### PR DESCRIPTION
I disabled:
- Deneb tests, due to migration to proof of inclusion is required
- Late block reorg tests, needs to be implemented as well

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
