### PR TITLE
Remove deprecated methods from (Signed)BlockContainer

### DIFF
--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/BatchImporter.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/BatchImporter.java
@@ -116,7 +116,7 @@ public class BatchImporter {
         blockRoot);
     // Add blob sidecars to the pool in order for them to be available when the block is being
     // imported
-    blobSidecarPool.onCompletedBlockAndBlobSidecars(block, blobSidecars);
+    blobSidecarPool.onCompletedBlockAndBlobSidecarsOld(block, blobSidecars);
     return importBlock(block, source);
   }
 

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/singlepeer/PeerSync.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/singlepeer/PeerSync.java
@@ -343,7 +343,7 @@ public class PeerSync {
     // Add blob sidecars to the pool in order for them to be available when the block is being
     // imported
     maybeBlobSidecars.ifPresent(
-        blobSidecars -> blobSidecarPool.onCompletedBlockAndBlobSidecars(block, blobSidecars));
+        blobSidecars -> blobSidecarPool.onCompletedBlockAndBlobSidecarsOld(block, blobSidecars));
 
     return blockImporter
         .importBlock(block)

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/BatchImporterTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/multipeer/BatchImporterTest.java
@@ -250,7 +250,7 @@ class BatchImporterTest {
 
   private void blobSidecarsImportedSuccessfully(
       final SignedBeaconBlock block, final List<BlobSidecarOld> blobSidecars) {
-    verify(blobSidecarPool).onCompletedBlockAndBlobSidecars(block, blobSidecars);
+    verify(blobSidecarPool).onCompletedBlockAndBlobSidecarsOld(block, blobSidecars);
     verifyNoMoreInteractions(blobSidecarPool);
   }
 

--- a/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/singlepeer/PeerSyncTest.java
+++ b/beacon/sync/src/test/java/tech/pegasys/teku/beacon/sync/forward/singlepeer/PeerSyncTest.java
@@ -558,7 +558,7 @@ public class PeerSyncTest extends AbstractSyncTest {
         Assertions.fail("Blob sidecars for slot %s is missing", slot);
       }
       verify(blobSidecarPool)
-          .onCompletedBlockAndBlobSidecars(any(), eq(blobSidecarsBySlot.get(slot)));
+          .onCompletedBlockAndBlobSidecarsOld(any(), eq(blobSidecarsBySlot.get(slot)));
     }
   }
 

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisherDeneb.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisherDeneb.java
@@ -52,12 +52,8 @@ public class BlockPublisherDeneb extends AbstractBlockPublisher {
       final SignedBlockContainer blockContainer,
       final BroadcastValidationLevel broadcastValidationLevel) {
     final SignedBeaconBlock block = blockContainer.getSignedBlock();
-
-    blockContainer
-        .getSignedBlobSidecars()
-        .ifPresent(
-            signedBlobSidecars ->
-                blobSidecarPool.onCompletedBlockAndSignedBlobSidecars(block, signedBlobSidecars));
+    // TODO: import blob sidecars with inclusion proof
+    blobSidecarPool.onCompletedBlockAndBlobSidecars(block, List.of());
     return blockImportChannel.importBlock(block, broadcastValidationLevel);
   }
 

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryDenebTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryDenebTest.java
@@ -109,8 +109,6 @@ public class BlockFactoryDenebTest extends AbstractBlockFactoryTest {
     assertThat(unblindedBlockContainer).isInstanceOf(SignedBlockContents.class);
     assertThat(unblindedBlockContainer.isBlinded()).isFalse();
     assertThat(unblindedBlockContainer.getSignedBlock()).isEqualTo(unblindedBeaconBlock);
-    assertThat(unblindedBlockContainer.getSignedBlobSidecars())
-        .hasValueSatisfying(blobSidecars -> assertThat(blobSidecars).isEmpty());
   }
 
   @Override

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryDenebTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryDenebTest.java
@@ -109,6 +109,7 @@ public class BlockFactoryDenebTest extends AbstractBlockFactoryTest {
     assertThat(unblindedBlockContainer).isInstanceOf(SignedBlockContents.class);
     assertThat(unblindedBlockContainer.isBlinded()).isFalse();
     assertThat(unblindedBlockContainer.getSignedBlock()).isEqualTo(unblindedBeaconBlock);
+    // TODO: add assertions for blobs and proofs
   }
 
   @Override

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -839,7 +839,7 @@ class ValidatorApiHandlerTest {
 
     // TODO: fix assertion for blob sidecars
     verify(blobSidecarGossipChannel).publishBlobSidecars(List.of());
-
+    verify(blobSidecarPool).onCompletedBlockAndBlobSidecars(block, List.of());
     verify(blockGossipChannel).publishBlock(block);
     verify(blockImportChannel).importBlock(block, NOT_REQUIRED);
     assertThat(result).isCompletedWithValue(SendSignedBlockResult.success(block.getRoot()));
@@ -859,7 +859,7 @@ class ValidatorApiHandlerTest {
 
     // TODO: fix assertion for blob sidecars
     verify(blobSidecarGossipChannel).publishBlobSidecars(List.of());
-
+    verify(blobSidecarPool).onCompletedBlockAndBlobSidecars(block, List.of());
     verify(blockGossipChannel).publishBlock(block);
     verify(blockImportChannel).importBlock(block, NOT_REQUIRED);
     assertThat(result)
@@ -881,7 +881,7 @@ class ValidatorApiHandlerTest {
 
     // TODO: fix assertion for blob sidecars
     verify(blobSidecarGossipChannel).publishBlobSidecars(List.of());
-
+    verify(blobSidecarPool).onCompletedBlockAndBlobSidecars(block, List.of());
     verify(blockGossipChannel).publishBlock(block);
     verify(blockImportChannel).importBlock(block, NOT_REQUIRED);
     assertThat(result).isCompletedWithValue(SendSignedBlockResult.success(block.getRoot()));
@@ -898,8 +898,8 @@ class ValidatorApiHandlerTest {
         validatorApiHandler.sendSignedBlock(block, NOT_REQUIRED);
     safeJoin(result);
 
-    verifyNoInteractions(blobSidecarPool);
     // TODO: fix assertion for blob sidecars (there should be no interactions)
+    verify(blobSidecarPool).onCompletedBlockAndBlobSidecars(block, List.of());
     verify(blobSidecarGossipChannel).publishBlobSidecars(List.of());
     verify(blockGossipChannel).publishBlock(block);
     verify(blockImportChannel).importBlock(block, NOT_REQUIRED);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/BlockContainer.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/BlockContainer.java
@@ -13,14 +13,12 @@
 
 package tech.pegasys.teku.spec.datastructures.blocks;
 
-import java.util.List;
 import java.util.Optional;
 import tech.pegasys.teku.infrastructure.ssz.SszContainer;
 import tech.pegasys.teku.infrastructure.ssz.SszData;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.Blob;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.versions.deneb.BlockContents;
 import tech.pegasys.teku.spec.datastructures.type.SszKZGProof;
 
@@ -35,11 +33,6 @@ public interface BlockContainer extends SszData, SszContainer {
 
   default UInt64 getSlot() {
     return getBlock().getSlot();
-  }
-
-  @Deprecated
-  default Optional<List<BlobSidecarOld>> getBlobSidecars() {
-    return Optional.empty();
   }
 
   default Optional<SszList<SszKZGProof>> getKzgProofs() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBlockContainer.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/SignedBlockContainer.java
@@ -13,7 +13,6 @@
 
 package tech.pegasys.teku.spec.datastructures.blocks;
 
-import java.util.List;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.ssz.SszContainer;
@@ -21,7 +20,6 @@ import tech.pegasys.teku.infrastructure.ssz.SszData;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.Blob;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.versions.deneb.SignedBlockContents;
 import tech.pegasys.teku.spec.datastructures.type.SszKZGProof;
 
@@ -40,11 +38,6 @@ public interface SignedBlockContainer extends SszData, SszContainer {
 
   default Bytes32 getRoot() {
     return getSignedBlock().getRoot();
-  }
-
-  @Deprecated
-  default Optional<List<SignedBlobSidecarOld>> getSignedBlobSidecars() {
-    return Optional.empty();
   }
 
   default Optional<SszList<SszKZGProof>> getKzgProofs() {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blobs/BlobSidecarPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blobs/BlobSidecarPool.java
@@ -20,8 +20,8 @@ import java.util.Set;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.ethereum.events.SlotEventsChannel;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.SignedBlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BlobIdentifier;
 
@@ -39,8 +39,12 @@ public interface BlobSidecarPool extends SlotEventsChannel {
         public void onNewBlock(final SignedBeaconBlock block) {}
 
         @Override
-        public void onCompletedBlockAndBlobSidecars(
+        public void onCompletedBlockAndBlobSidecarsOld(
             final SignedBeaconBlock block, final List<BlobSidecarOld> blobSidecars) {}
+
+        @Override
+        public void onCompletedBlockAndBlobSidecars(
+            final SignedBeaconBlock block, final List<BlobSidecar> blobSidecars) {}
 
         @Override
         public void removeAllForBlock(final Bytes32 blockRoot) {}
@@ -96,13 +100,11 @@ public interface BlobSidecarPool extends SlotEventsChannel {
 
   void onNewBlock(SignedBeaconBlock block);
 
-  default void onCompletedBlockAndSignedBlobSidecars(
-      SignedBeaconBlock block, List<SignedBlobSidecarOld> signedBlobSidecars) {
-    onCompletedBlockAndBlobSidecars(
-        block, signedBlobSidecars.stream().map(SignedBlobSidecarOld::getBlobSidecar).toList());
-  }
+  @Deprecated
+  void onCompletedBlockAndBlobSidecarsOld(
+      SignedBeaconBlock block, List<BlobSidecarOld> blobSidecars);
 
-  void onCompletedBlockAndBlobSidecars(SignedBeaconBlock block, List<BlobSidecarOld> blobSidecars);
+  void onCompletedBlockAndBlobSidecars(SignedBeaconBlock block, List<BlobSidecar> blobSidecars);
 
   void removeAllForBlock(Bytes32 blockRoot);
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/BlobSidecarPoolImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/BlobSidecarPoolImpl.java
@@ -36,6 +36,7 @@ import tech.pegasys.teku.infrastructure.subscribers.Subscribers;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
@@ -186,7 +187,7 @@ public class BlobSidecarPoolImpl extends AbstractIgnoringFutureHistoricalSlot
   }
 
   @Override
-  public synchronized void onCompletedBlockAndBlobSidecars(
+  public synchronized void onCompletedBlockAndBlobSidecarsOld(
       final SignedBeaconBlock block, final List<BlobSidecarOld> blobSidecars) {
     final SlotAndBlockRoot slotAndBlockRoot = block.getSlotAndBlockRoot();
 
@@ -214,6 +215,12 @@ public class BlobSidecarPoolImpl extends AbstractIgnoringFutureHistoricalSlot
     if (orderedBlobSidecarsTrackers.add(slotAndBlockRoot)) {
       sizeGauge.set(orderedBlobSidecarsTrackers.size(), GAUGE_BLOB_SIDECARS_TRACKERS_LABEL);
     }
+  }
+
+  @Override
+  public void onCompletedBlockAndBlobSidecars(
+      final SignedBeaconBlock block, final List<BlobSidecar> blobSidecars) {
+    throw new UnsupportedOperationException("Not yet implemented");
   }
 
   @Override

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/BlobSidecarPoolImplTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/BlobSidecarPoolImplTest.java
@@ -301,7 +301,7 @@ public class BlobSidecarPoolImplTest {
 
     final List<BlobSidecarOld> blobSidecars = dataStructureUtil.randomBlobSidecarsForBlock(block);
 
-    blobSidecarPool.onCompletedBlockAndBlobSidecars(block, blobSidecars);
+    blobSidecarPool.onCompletedBlockAndBlobSidecarsOld(block, blobSidecars);
 
     assertThat(asyncRunner.hasDelayedActions()).isFalse();
 
@@ -331,7 +331,7 @@ public class BlobSidecarPoolImplTest {
 
     final List<BlobSidecarOld> blobSidecars = List.of();
 
-    blobSidecarPool.onCompletedBlockAndBlobSidecars(block, blobSidecars);
+    blobSidecarPool.onCompletedBlockAndBlobSidecarsOld(block, blobSidecars);
 
     assertThat(asyncRunner.hasDelayedActions()).isFalse();
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

- Remove deprecated getters from `SignedBlockContainer` and `BlockContainer`
- Add `onCompletedBlockAndBlobSidecars` to `BlobSidecarPool`

## Fixed Issue(s)
helps with block production/publishing flow for #7654 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
