### PR TITLE
Fix blobsidecar-by-range validating proxy

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeListenerValidatingProxy.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeListenerValidatingProxy.java
@@ -88,20 +88,22 @@ public class BlobSidecarsByRangeListenerValidatingProxy extends AbstractBlobSide
         lastBlobSidecarSummary -> {
           // we have a previous blobSidecar, let's check current against it
 
+          final UInt64 lastBlobSidecarNextSlot = lastBlobSidecarSummary.slot.increment();
+
           if (blobSidecarSummary.inTheSameBlock(lastBlobSidecarSummary)) {
-            if (!blobSidecarSummary.index().equals(lastBlobSidecarSummary.index().plus(1))) {
+            if (!blobSidecarSummary.index.equals(lastBlobSidecarNextSlot)) {
               throw new BlobSidecarsResponseInvalidResponseException(
                   peer, BLOB_SIDECAR_UNEXPECTED_INDEX);
             }
           } else {
             // not in the same block
 
-            if (!blobSidecarSummary.index().equals(UInt64.ZERO)) {
+            if (!blobSidecarSummary.index.isZero()) {
               throw new BlobSidecarsResponseInvalidResponseException(
                   peer, BLOB_SIDECAR_UNEXPECTED_INDEX);
             }
 
-            if (blobSidecarSummary.slot.isGreaterThan(lastBlobSidecarSummary.slot.increment())) {
+            if (blobSidecarSummary.slot.isGreaterThan(lastBlobSidecarNextSlot)) {
               // a slot has been skipped, we can't check the parent
               return;
             }
@@ -111,7 +113,7 @@ public class BlobSidecarsByRangeListenerValidatingProxy extends AbstractBlobSide
                   peer, BLOB_SIDECAR_UNEXPECTED_SLOT);
             }
 
-            if (!blobSidecarSummary.blockParentRoot().equals(lastBlobSidecarSummary.blockRoot())) {
+            if (!blobSidecarSummary.blockParentRoot.equals(lastBlobSidecarSummary.blockRoot)) {
               throw new BlobSidecarsResponseInvalidResponseException(
                   peer, BLOB_SIDECAR_UNKNOWN_PARENT);
             }
@@ -119,7 +121,7 @@ public class BlobSidecarsByRangeListenerValidatingProxy extends AbstractBlobSide
         },
         () -> {
           // first blobSidecar
-          if (!blobSidecarSummary.index().equals(UInt64.ZERO)) {
+          if (!blobSidecarSummary.index.isZero()) {
             throw new BlobSidecarsResponseInvalidResponseException(
                 peer, BLOB_SIDECAR_UNEXPECTED_INDEX);
           }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeListenerValidatingProxy.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeListenerValidatingProxy.java
@@ -88,10 +88,8 @@ public class BlobSidecarsByRangeListenerValidatingProxy extends AbstractBlobSide
         lastBlobSidecarSummary -> {
           // we have a previous blobSidecar, let's check current against it
 
-          final UInt64 lastBlobSidecarNextSlot = lastBlobSidecarSummary.slot.increment();
-
           if (blobSidecarSummary.inTheSameBlock(lastBlobSidecarSummary)) {
-            if (!blobSidecarSummary.index.equals(lastBlobSidecarNextSlot)) {
+            if (!blobSidecarSummary.index.equals(lastBlobSidecarSummary.index.increment())) {
               throw new BlobSidecarsResponseInvalidResponseException(
                   peer, BLOB_SIDECAR_UNEXPECTED_INDEX);
             }
@@ -103,7 +101,7 @@ public class BlobSidecarsByRangeListenerValidatingProxy extends AbstractBlobSide
                   peer, BLOB_SIDECAR_UNEXPECTED_INDEX);
             }
 
-            if (blobSidecarSummary.slot.isGreaterThan(lastBlobSidecarNextSlot)) {
+            if (blobSidecarSummary.slot.isGreaterThan(lastBlobSidecarSummary.slot.increment())) {
               // a slot has been skipped, we can't check the parent
               return;
             }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeListenerValidatingProxyTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeListenerValidatingProxyTest.java
@@ -19,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
@@ -159,10 +160,10 @@ public class BlobSidecarsByRangeListenerValidatingProxyTest {
         dataStructureUtil.randomBlobSidecarOld(
             UInt64.valueOf(9), blockRoot5, blockRoot4, UInt64.ZERO);
 
-    listenerWrapper.onResponse(blobSidecar1).join();
-    listenerWrapper.onResponse(blobSidecar2).join();
-    listenerWrapper.onResponse(blobSidecar3).join();
-    listenerWrapper.onResponse(blobSidecar4).join();
+    safeJoin(listenerWrapper.onResponse(blobSidecar1));
+    safeJoin(listenerWrapper.onResponse(blobSidecar2));
+    safeJoin(listenerWrapper.onResponse(blobSidecar3));
+    safeJoin(listenerWrapper.onResponse(blobSidecar4));
 
     final SafeFuture<?> result = listenerWrapper.onResponse(blobSidecar5);
     assertThat(result).isCompletedExceptionally();
@@ -191,7 +192,7 @@ public class BlobSidecarsByRangeListenerValidatingProxyTest {
         dataStructureUtil.randomBlobSidecarOld(
             UInt64.valueOf(2), blockRoot2, dataStructureUtil.randomBytes32(), UInt64.ZERO);
 
-    listenerWrapper.onResponse(blobSidecar1).join();
+    safeJoin(listenerWrapper.onResponse(blobSidecar1));
 
     final SafeFuture<?> result = listenerWrapper.onResponse(blobSidecar2);
     assertThat(result).isCompletedExceptionally();
@@ -234,12 +235,12 @@ public class BlobSidecarsByRangeListenerValidatingProxyTest {
         dataStructureUtil.randomBlobSidecarOld(
             UInt64.ONE, blockRoot1, Bytes32.ZERO, UInt64.valueOf(6));
 
-    listenerWrapper.onResponse(blobSidecar1).join();
-    listenerWrapper.onResponse(blobSidecar2).join();
-    listenerWrapper.onResponse(blobSidecar3).join();
-    listenerWrapper.onResponse(blobSidecar4).join();
-    listenerWrapper.onResponse(blobSidecar5).join();
-    listenerWrapper.onResponse(blobSidecar6).join();
+    safeJoin(listenerWrapper.onResponse(blobSidecar1));
+    safeJoin(listenerWrapper.onResponse(blobSidecar2));
+    safeJoin(listenerWrapper.onResponse(blobSidecar3));
+    safeJoin(listenerWrapper.onResponse(blobSidecar4));
+    safeJoin(listenerWrapper.onResponse(blobSidecar5));
+    safeJoin(listenerWrapper.onResponse(blobSidecar6));
 
     final SafeFuture<?> result = listenerWrapper.onResponse(blobSidecar7);
     assertThat(result).isCompletedExceptionally();
@@ -270,8 +271,8 @@ public class BlobSidecarsByRangeListenerValidatingProxyTest {
         dataStructureUtil.randomBlobSidecarOld(
             UInt64.ONE, blockRoot1, Bytes32.ZERO, UInt64.valueOf(3));
 
-    listenerWrapper.onResponse(blobSidecar1).join();
-    listenerWrapper.onResponse(blobSidecar2).join();
+    safeJoin(listenerWrapper.onResponse(blobSidecar1));
+    safeJoin(listenerWrapper.onResponse(blobSidecar2));
 
     final SafeFuture<?> result = listenerWrapper.onResponse(blobSidecar3);
     assertThat(result).isCompletedExceptionally();
@@ -282,6 +283,30 @@ public class BlobSidecarsByRangeListenerValidatingProxyTest {
             BlobSidecarsResponseInvalidResponseException.InvalidResponseType
                 .BLOB_SIDECAR_UNEXPECTED_INDEX
                 .describe());
+  }
+
+  @Test
+  void isFirstBlobSidecarAfterAnEmptyBlobsBlock() {
+    final UInt64 startSlot = UInt64.valueOf(1);
+    final UInt64 count = UInt64.valueOf(4);
+
+    listenerWrapper =
+        new BlobSidecarsByRangeListenerValidatingProxy(
+            spec, peer, listener, maxBlobsPerBlock, kzg, startSlot, count);
+
+    final Bytes32 blockRoot1 = dataStructureUtil.randomBytes32();
+    final Bytes32 blockRoot3 = dataStructureUtil.randomBytes32();
+    final BlobSidecarOld blobSidecar1 =
+        dataStructureUtil.randomBlobSidecar(UInt64.ONE, blockRoot1, Bytes32.ZERO, UInt64.ZERO);
+    final BlobSidecarOld blobSidecar2 =
+        dataStructureUtil.randomBlobSidecar(UInt64.ONE, blockRoot1, Bytes32.ZERO, UInt64.ONE);
+    final BlobSidecarOld blobSidecar3 =
+        dataStructureUtil.randomBlobSidecar(
+            UInt64.valueOf(3), blockRoot3, Bytes32.ZERO, UInt64.ZERO);
+
+    safeJoin(listenerWrapper.onResponse(blobSidecar1));
+    safeJoin(listenerWrapper.onResponse(blobSidecar2));
+    safeJoin(listenerWrapper.onResponse(blobSidecar3));
   }
 
   @Test
@@ -354,8 +379,8 @@ public class BlobSidecarsByRangeListenerValidatingProxyTest {
         dataStructureUtil.randomBlobSidecarOld(
             UInt64.ONE, blockRoot1, Bytes32.ZERO, UInt64.valueOf(3));
 
-    listenerWrapper.onResponse(blobSidecar1).join();
-    listenerWrapper.onResponse(blobSidecar2).join();
+    safeJoin(listenerWrapper.onResponse(blobSidecar1));
+    safeJoin(listenerWrapper.onResponse(blobSidecar2));
 
     final SafeFuture<?> result = listenerWrapper.onResponse(blobSidecar4);
     assertThat(result).isCompletedExceptionally();

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeListenerValidatingProxyTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/BlobSidecarsByRangeListenerValidatingProxyTest.java
@@ -297,11 +297,11 @@ public class BlobSidecarsByRangeListenerValidatingProxyTest {
     final Bytes32 blockRoot1 = dataStructureUtil.randomBytes32();
     final Bytes32 blockRoot3 = dataStructureUtil.randomBytes32();
     final BlobSidecarOld blobSidecar1 =
-        dataStructureUtil.randomBlobSidecar(UInt64.ONE, blockRoot1, Bytes32.ZERO, UInt64.ZERO);
+        dataStructureUtil.randomBlobSidecarOld(UInt64.ONE, blockRoot1, Bytes32.ZERO, UInt64.ZERO);
     final BlobSidecarOld blobSidecar2 =
-        dataStructureUtil.randomBlobSidecar(UInt64.ONE, blockRoot1, Bytes32.ZERO, UInt64.ONE);
+        dataStructureUtil.randomBlobSidecarOld(UInt64.ONE, blockRoot1, Bytes32.ZERO, UInt64.ONE);
     final BlobSidecarOld blobSidecar3 =
-        dataStructureUtil.randomBlobSidecar(
+        dataStructureUtil.randomBlobSidecarOld(
             UInt64.valueOf(3), blockRoot3, Bytes32.ZERO, UInt64.ZERO);
 
     safeJoin(listenerWrapper.onResponse(blobSidecar1));


### PR DESCRIPTION
Fixes a bug in `BlobSidecarsByRangeListenerValidatingProxy` when there are blocks with no blob_sidecars.


This is the `onResponse` sequence that shows the issue:
```
received: block 94345b..a77c (107380), index 0, blob 001611aa000000, commitment 0x99b7f6bf8193b2326e4669bb52a9e933d5826236e04c77837b5228281e42e3af7d6fa76569c3b744ca4f2e73edeb9b96, proof 80d7fa7

received: block 94345b..a77c (107380), index 1, blob 001611aa000000, commitment 0x8cb99c383cf0b5e91caae37be70844dc5ba25099d5bfff462367c274f2a5cc12f3eef382ca3dfac6a4403ada6dce4f98, proof 984d7a2

received: block 94345b..a77c (107380), index 2, blob 001611aa000000, commitment 0xb927f4f8277b7cc110af3d30db9c75115ce6222d9bc2d4c6ea3d54471ecb2a1cab54e2068410fe8ca1ed48e371cd8407, proof 8c209af

received: block 94345b..a77c (107380), index 3, blob 001611aa000000, commitment 0x9870c81c0c23fbf59f8619ba975fe021139a6196ba1847ebf2c9c5cae59b1e3a0d0b904caeadfde8c85de3582b78c995, proof 8485d62

received: block 94345b..a77c (107380), index 4, blob 001611aa000000, commitment 0xa6eb0e1dfc522345f19352071215df0ad1d9cf631a61312ec7a760cb401c5a1b940ff8e976041117d62aeb95420f1873, proof 94480f5

received: block 94345b..a77c (107380), index 5, blob 001611aa000000, commitment 0xb0f5b026f4943abc0345afecf21d8d243cc633dfe1ec8738c3bce8bfbdddfb43db0172dce80f460ee272ca7f72dc54b3, proof b9be7be

received: block f85885..9aab (107381), index 0, blob 001611aa000000, commitment 0xb13ebe22ff76e600fcfab75ffa7d28d382bd443cafa8d9774c6bcda24a247ebad42667616c9a23acbfa36583b89b54a3, proof 8a5abd3

received: block f85885..9aab (107381), index 1, blob 001611aa000000, commitment 0xafad63403ee42dfd91d9a36827f0faf9d9eab82290b86c0abaf52a46d053a9df5ab971fd0b8dc9aa6ec760367e037aad, proof 8c269dd

received: block f85885..9aab (107381), index 2, blob 001611aa000000, commitment 0xb2e55d740ab13b173c606e68f6f80d05d45d5eae117cd4b1d6743698790c3c3a7007e72955674cb9dad7a8925e991e9a, proof b87cc8a

received: block db6e48..206a (107383), index 0, blob 001611aa000000, commitment 0x8d594e3a2ec6fdaaf2601f72936c5300192269065ece9de81eca195e78a245c0183cb2138c6868d4482f6a1e0ca34b2f, proof 95e5f3c
error: Received invalid response from peer DefaultEth2Peer{id=16Uiu2HAmMeUoMQ9pGyg7TUeWjqK3xGDpGHmLy9fbLB1DbBCYigtq, remoteStatus=Optional[PeerStatus{forkDigest=0xee7b3a32, finalizedRoot=0x7c3f341f39b6bde511862bea4a565309591535fb3b85048ff1cb3ad5aa314982, finalizedEpoch=3361, headRoot=0x2d7f8ac082085d00a41993c751cf127b031db48b341a1b43e296035b7498897d, headSlot=107626}]}: BlobSidecar parent blockRoot doesn't match previous blobSidecar blockRoot maybeLastBlobSidecarSummary: Optional[BlobSidecarSummary[blockRoot=0xf85885dda4da23c22cb8657a98a537233f0463a5f3b5ec078f3ef16f56689aab, index=2, slot=107381, blockParentRoot=0x94345bb0f6099ee5dabca324f4bb35bf2bec2de53d30e62428dd0e470139a77c]]
```

`107382` has no blobs, once we get blob_sidecar `0` for `107383` we do the wrong check

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
