### PR TITLE
Refactor AbstractBlockPublisher to simplify blob sidecars publishing

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactory.java
@@ -19,7 +19,7 @@ import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockContainer;
-import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 
 public interface BlockFactory {
@@ -38,6 +38,5 @@ public interface BlockFactory {
       BLSSignature randaoReveal,
       Optional<Bytes32> optionalGraffiti);
 
-  SafeFuture<SignedBlockContainer> unblindSignedBlockIfBlinded(
-      SignedBlockContainer maybeBlindedBlockContainer);
+  SafeFuture<SignedBeaconBlock> unblindSignedBlockIfBlinded(SignedBeaconBlock maybeBlindedBlock);
 }

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactoryPhase0.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactoryPhase0.java
@@ -96,7 +96,7 @@ public class BlockFactoryPhase0 implements BlockFactory {
 
   @Override
   public SafeFuture<SignedBeaconBlock> unblindSignedBlockIfBlinded(
-      SignedBeaconBlock maybeBlindedBlock) {
+      final SignedBeaconBlock maybeBlindedBlock) {
     if (maybeBlindedBlock.isBlinded()) {
       return spec.unblindSignedBeaconBlock(
           maybeBlindedBlock.getSignedBlock(), operationSelector.createBlockUnblinderSelector());

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactoryPhase0.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactoryPhase0.java
@@ -16,7 +16,6 @@ package tech.pegasys.teku.validator.coordinator;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import java.util.Optional;
-import java.util.function.Function;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -24,7 +23,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockContainer;
-import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 
 public class BlockFactoryPhase0 implements BlockFactory {
@@ -96,14 +95,12 @@ public class BlockFactoryPhase0 implements BlockFactory {
   }
 
   @Override
-  public SafeFuture<SignedBlockContainer> unblindSignedBlockIfBlinded(
-      SignedBlockContainer maybeBlindedBlockContainer) {
-    if (maybeBlindedBlockContainer.isBlinded()) {
+  public SafeFuture<SignedBeaconBlock> unblindSignedBlockIfBlinded(
+      SignedBeaconBlock maybeBlindedBlock) {
+    if (maybeBlindedBlock.isBlinded()) {
       return spec.unblindSignedBeaconBlock(
-              maybeBlindedBlockContainer.getSignedBlock(),
-              operationSelector.createBlockUnblinderSelector())
-          .thenApply(Function.identity());
+          maybeBlindedBlock.getSignedBlock(), operationSelector.createBlockUnblinderSelector());
     }
-    return SafeFuture.completedFuture(maybeBlindedBlockContainer);
+    return SafeFuture.completedFuture(maybeBlindedBlock);
   }
 }

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
@@ -31,8 +31,8 @@ import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarOld
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecarSchemaOld;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.Eth1Data;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlockUnblinder;
-import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodyBuilder;
 import tech.pegasys.teku.spec.datastructures.builder.BuilderPayload;
 import tech.pegasys.teku.spec.datastructures.execution.BlobsBundle;
@@ -302,10 +302,9 @@ public class BlockOperationSelectorFactory {
 
   public Consumer<SignedBeaconBlockUnblinder> createBlockUnblinderSelector() {
     return bodyUnblinder -> {
-      final SignedBlockContainer signedBlindedBlockContainer =
-          bodyUnblinder.getSignedBlindedBeaconBlock();
+      final SignedBeaconBlock signedBlindedBlock = bodyUnblinder.getSignedBlindedBeaconBlock();
 
-      final BeaconBlock block = signedBlindedBlockContainer.getSignedBlock().getMessage();
+      final BeaconBlock block = signedBlindedBlock.getMessage();
 
       if (block
           .getBody()
@@ -324,7 +323,7 @@ public class BlockOperationSelectorFactory {
         bodyUnblinder.setExecutionPayloadSupplier(
             () ->
                 executionLayerBlockProductionManager
-                    .getUnblindedPayload(signedBlindedBlockContainer)
+                    .getUnblindedPayload(signedBlindedBlock)
                     .thenApply(BuilderPayload::getExecutionPayload));
       }
     };

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/MilestoneBasedBlockFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/MilestoneBasedBlockFactory.java
@@ -25,7 +25,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockContainer;
-import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 
 public class MilestoneBasedBlockFactory implements BlockFactory {
@@ -83,12 +83,10 @@ public class MilestoneBasedBlockFactory implements BlockFactory {
   }
 
   @Override
-  public SafeFuture<SignedBlockContainer> unblindSignedBlockIfBlinded(
-      final SignedBlockContainer maybeBlindedBlockContainer) {
-    final SpecMilestone milestone = getMilestone(maybeBlindedBlockContainer.getSlot());
-    return registeredFactories
-        .get(milestone)
-        .unblindSignedBlockIfBlinded(maybeBlindedBlockContainer);
+  public SafeFuture<SignedBeaconBlock> unblindSignedBlockIfBlinded(
+      final SignedBeaconBlock maybeBlindedBlock) {
+    final SpecMilestone milestone = getMilestone(maybeBlindedBlock.getSlot());
+    return registeredFactories.get(milestone).unblindSignedBlockIfBlinded(maybeBlindedBlock);
   }
 
   private SpecMilestone getMilestone(final UInt64 slot) {

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/performance/DefaultPerformanceTracker.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/performance/DefaultPerformanceTracker.java
@@ -47,7 +47,6 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
-import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeMessage;
@@ -416,11 +415,11 @@ public class DefaultPerformanceTracker implements PerformanceTracker {
   }
 
   @Override
-  public void saveProducedBlock(final SignedBlockContainer blockContainer) {
-    final UInt64 epoch = spec.computeEpochAtSlot(blockContainer.getSlot());
+  public void saveProducedBlock(final SignedBeaconBlock block) {
+    final UInt64 epoch = spec.computeEpochAtSlot(block.getSlot());
     final Set<SlotAndBlockRoot> blocksInEpoch =
         producedBlocksByEpoch.computeIfAbsent(epoch, __ -> concurrentSet());
-    blocksInEpoch.add(blockContainer.getSignedBlock().getSlotAndBlockRoot());
+    blocksInEpoch.add(block.getSlotAndBlockRoot());
   }
 
   @Override

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/performance/NoOpPerformanceTracker.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/performance/NoOpPerformanceTracker.java
@@ -15,7 +15,7 @@ package tech.pegasys.teku.validator.coordinator.performance;
 
 import it.unimi.dsi.fastutil.ints.IntSet;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeMessage;
 
@@ -28,7 +28,7 @@ public class NoOpPerformanceTracker implements PerformanceTracker {
   public void saveProducedAttestation(final Attestation attestation) {}
 
   @Override
-  public void saveProducedBlock(final SignedBlockContainer blockContainer) {}
+  public void saveProducedBlock(final SignedBeaconBlock block) {}
 
   @Override
   public void reportBlockProductionAttempt(final UInt64 epoch) {}

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/performance/PerformanceTracker.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/performance/PerformanceTracker.java
@@ -16,7 +16,7 @@ package tech.pegasys.teku.validator.coordinator.performance;
 import it.unimi.dsi.fastutil.ints.IntSet;
 import tech.pegasys.teku.ethereum.events.SlotEventsChannel;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeMessage;
 
@@ -26,7 +26,7 @@ public interface PerformanceTracker extends SlotEventsChannel {
 
   void saveProducedAttestation(Attestation attestation);
 
-  void saveProducedBlock(SignedBlockContainer blockContainer);
+  void saveProducedBlock(SignedBeaconBlock block);
 
   void reportBlockProductionAttempt(UInt64 epoch);
 

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisher.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisher.java
@@ -18,7 +18,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
 import tech.pegasys.teku.spec.datastructures.validator.BroadcastValidationLevel;
 import tech.pegasys.teku.validator.api.SendSignedBlockResult;
 
-/** Used to publish blocks (and blob sidecars) */
+/** Used to publish blocks (unblinded and blinded) and blob sidecars */
 public interface BlockPublisher {
   SafeFuture<SendSignedBlockResult> sendSignedBlock(
       SignedBlockContainer blockContainer, BroadcastValidationLevel broadcastValidationLevel);

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisher.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisher.java
@@ -18,8 +18,8 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
 import tech.pegasys.teku.spec.datastructures.validator.BroadcastValidationLevel;
 import tech.pegasys.teku.validator.api.SendSignedBlockResult;
 
+/** Used to publish blocks (and blob sidecars) */
 public interface BlockPublisher {
   SafeFuture<SendSignedBlockResult> sendSignedBlock(
-      SignedBlockContainer maybeBlindedBlockContainer,
-      BroadcastValidationLevel broadcastValidationLevel);
+      SignedBlockContainer blockContainer, BroadcastValidationLevel broadcastValidationLevel);
 }

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisherDeneb.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisherDeneb.java
@@ -52,6 +52,7 @@ public class BlockPublisherDeneb extends AbstractBlockPublisher {
       final SignedBeaconBlock block,
       final List<BlobSidecar> blobSidecars,
       final BroadcastValidationLevel broadcastValidationLevel) {
+    // provide blobs for the block before importing it
     blobSidecarPool.onCompletedBlockAndBlobSidecars(block, blobSidecars);
     return blockImportChannel.importBlock(block, broadcastValidationLevel);
   }

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisherDeneb.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisherDeneb.java
@@ -17,8 +17,8 @@ import java.util.List;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.networking.eth2.gossip.BlobSidecarGossipChannel;
 import tech.pegasys.teku.networking.eth2.gossip.BlockGossipChannel;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
-import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
 import tech.pegasys.teku.spec.datastructures.validator.BroadcastValidationLevel;
 import tech.pegasys.teku.statetransition.blobs.BlobSidecarPool;
 import tech.pegasys.teku.statetransition.block.BlockImportChannel;
@@ -48,19 +48,18 @@ public class BlockPublisherDeneb extends AbstractBlockPublisher {
   }
 
   @Override
-  protected SafeFuture<BlockImportAndBroadcastValidationResults> importBlock(
-      final SignedBlockContainer blockContainer,
+  SafeFuture<BlockImportAndBroadcastValidationResults> importBlockAndBlobSidecars(
+      final SignedBeaconBlock block,
+      final List<BlobSidecar> blobSidecars,
       final BroadcastValidationLevel broadcastValidationLevel) {
-    final SignedBeaconBlock block = blockContainer.getSignedBlock();
-    // TODO: import blob sidecars with inclusion proof
-    blobSidecarPool.onCompletedBlockAndBlobSidecars(block, List.of());
+    blobSidecarPool.onCompletedBlockAndBlobSidecars(block, blobSidecars);
     return blockImportChannel.importBlock(block, broadcastValidationLevel);
   }
 
   @Override
-  void publishBlock(final SignedBlockContainer blockContainer) {
-    // TODO: publish blob sidecars with inclusion proof
-    blobSidecarGossipChannel.publishBlobSidecars(List.of());
-    blockGossipChannel.publishBlock(blockContainer.getSignedBlock());
+  void publishBlockAndBlobSidecars(
+      final SignedBeaconBlock block, final List<BlobSidecar> blobSidecars) {
+    blockGossipChannel.publishBlock(block);
+    blobSidecarGossipChannel.publishBlobSidecars(blobSidecars);
   }
 }

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisherPhase0.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisherPhase0.java
@@ -13,9 +13,11 @@
 
 package tech.pegasys.teku.validator.coordinator.publisher;
 
+import java.util.List;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.networking.eth2.gossip.BlockGossipChannel;
-import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.validator.BroadcastValidationLevel;
 import tech.pegasys.teku.statetransition.block.BlockImportChannel;
 import tech.pegasys.teku.statetransition.block.BlockImportChannel.BlockImportAndBroadcastValidationResults;
@@ -37,15 +39,16 @@ public class BlockPublisherPhase0 extends AbstractBlockPublisher {
   }
 
   @Override
-  protected SafeFuture<BlockImportAndBroadcastValidationResults> importBlock(
-      final SignedBlockContainer blockContainer,
+  SafeFuture<BlockImportAndBroadcastValidationResults> importBlockAndBlobSidecars(
+      final SignedBeaconBlock block,
+      final List<BlobSidecar> blobSidecars,
       final BroadcastValidationLevel broadcastValidationLevel) {
-    return blockImportChannel.importBlock(
-        blockContainer.getSignedBlock(), broadcastValidationLevel);
+    return blockImportChannel.importBlock(block, broadcastValidationLevel);
   }
 
   @Override
-  void publishBlock(final SignedBlockContainer blockContainer) {
-    blockGossipChannel.publishBlock(blockContainer.getSignedBlock());
+  void publishBlockAndBlobSidecars(
+      final SignedBeaconBlock block, final List<BlobSidecar> blobSidecars) {
+    blockGossipChannel.publishBlock(block);
   }
 }

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/MilestoneBasedBlockPublisher.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/MilestoneBasedBlockPublisher.java
@@ -78,12 +78,11 @@ public class MilestoneBasedBlockPublisher implements BlockPublisher {
 
   @Override
   public SafeFuture<SendSignedBlockResult> sendSignedBlock(
-      final SignedBlockContainer maybeBlindedBlockContainer,
+      final SignedBlockContainer blockContainer,
       final BroadcastValidationLevel broadcastValidationLevel) {
-    final SpecMilestone blockMilestone =
-        spec.atSlot(maybeBlindedBlockContainer.getSlot()).getMilestone();
+    final SpecMilestone blockMilestone = spec.atSlot(blockContainer.getSlot()).getMilestone();
     return registeredPublishers
         .get(blockMilestone)
-        .sendSignedBlock(maybeBlindedBlockContainer, broadcastValidationLevel);
+        .sendSignedBlock(blockContainer, broadcastValidationLevel);
   }
 }

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/AbstractBlockFactoryTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/AbstractBlockFactoryTest.java
@@ -407,19 +407,6 @@ public abstract class AbstractBlockFactoryTest {
         .thenAnswer(__ -> Optional.of(cachedExecutionPayloadResult));
   }
 
-  private void setupCachedBlobsBundle(final UInt64 slot) {
-    // only BlobsBundle is required
-    final ExecutionPayloadResult executionPayloadResult =
-        new ExecutionPayloadResult(
-            null,
-            Optional.empty(),
-            Optional.of(SafeFuture.completedFuture(blobsBundle)),
-            Optional.empty(),
-            Optional.empty());
-    when(executionLayer.getCachedPayloadResult(slot))
-        .thenReturn(Optional.of(executionPayloadResult));
-  }
-
   private List<SszKZGCommitment> getCommitmentsFromBlobsBundle() {
     return blobsBundle
         .map(

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryDenebTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryDenebTest.java
@@ -26,15 +26,12 @@ import tech.pegasys.teku.spec.datastructures.blocks.BlockContainer;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.versions.deneb.BlockContents;
 import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
-import tech.pegasys.teku.spec.schemas.SchemaDefinitionsDeneb;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class BlockFactoryDenebTest extends AbstractBlockFactoryTest {
 
   private final Spec spec = TestSpecFactory.createMinimalDeneb();
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
-  private final SchemaDefinitionsDeneb schemaDefinitions =
-      SchemaDefinitionsDeneb.required(spec.getGenesisSchemaDefinitions());
 
   @Test
   void shouldCreateBlockContents() {

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryDenebTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockFactoryDenebTest.java
@@ -14,23 +14,17 @@
 package tech.pegasys.teku.validator.coordinator;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
 
-import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.mockito.InOrder;
-import org.mockito.Mockito;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockContainer;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
-import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
 import tech.pegasys.teku.spec.datastructures.blocks.versions.deneb.BlockContents;
-import tech.pegasys.teku.spec.datastructures.blocks.versions.deneb.SignedBlockContents;
-import tech.pegasys.teku.spec.datastructures.execution.BlobsBundle;
 import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsDeneb;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
@@ -53,7 +47,7 @@ public class BlockFactoryDenebTest extends AbstractBlockFactoryTest {
     assertThat(blockContainer).isInstanceOf(BlockContents.class);
     assertThat(blockContainer.getBlock().getBody().getOptionalBlobKzgCommitments())
         .hasValueSatisfying(blobKzgCommitments -> assertThat(blobKzgCommitments).hasSize(3));
-    // TODO Add test for blobs and kzg proofs once added
+    // TODO Add assertions for blobs and proofs
   }
 
   @Test
@@ -71,45 +65,31 @@ public class BlockFactoryDenebTest extends AbstractBlockFactoryTest {
   }
 
   @Test
-  void unblindSignedBlock_shouldPassthroughUnblindedBlockContents() {
+  void unblindSignedBlock_shouldPassthroughUnblindedBlock() {
 
-    final SignedBlockContents signedBlockContents = dataStructureUtil.randomSignedBlockContents();
+    final SignedBeaconBlock signedBlock = dataStructureUtil.randomSignedBeaconBlock();
 
-    final SignedBlockContainer unblindedSignedBlockContainer =
-        assertBlockUnblinded(signedBlockContents, spec);
+    final SignedBeaconBlock unblindedSignedBlock = assertBlockUnblinded(signedBlock, spec);
 
-    assertThat(unblindedSignedBlockContainer).isEqualTo(signedBlockContents);
+    assertThat(unblindedSignedBlock).isEqualTo(signedBlock);
   }
 
   @Test
-  @Disabled(
-      "enable when block production flow for blob sidecar inclusion proof spec is implemented")
   void unblindSignedBlock_shouldUnblindBeaconBlock() {
 
-    final BlobsBundle blobsBundle = prepareBlobsBundle(spec, 3);
-    // let the unblinder verify the kzg commitments
-    blobKzgCommitments =
-        Optional.of(
-            schemaDefinitions.getBlobKzgCommitmentsSchema().createFromBlobsBundle(blobsBundle));
-
-    final SignedBeaconBlock unblindedBeaconBlock = dataStructureUtil.randomSignedBeaconBlock();
-    final SignedBeaconBlock blindedBlock = assertBlockBlinded(unblindedBeaconBlock, spec);
+    final SignedBeaconBlock expectedUnblindedBlock = dataStructureUtil.randomSignedBeaconBlock();
+    final SignedBeaconBlock blindedBlock = assertBlockBlinded(expectedUnblindedBlock, spec);
 
     // let the unblinder return a consistent execution payload
     executionPayload =
-        unblindedBeaconBlock.getMessage().getBody().getOptionalExecutionPayload().orElseThrow();
+        expectedUnblindedBlock.getMessage().getBody().getOptionalExecutionPayload().orElseThrow();
 
-    final SignedBlockContainer unblindedBlockContainer = assertBlockUnblinded(blindedBlock, spec);
+    final SignedBeaconBlock unblindedBlock = assertBlockUnblinded(blindedBlock, spec);
 
-    // make sure getCachedUnblindedPayload is second in order of method calling
-    final InOrder inOrder = Mockito.inOrder(executionLayer);
-    inOrder.verify(executionLayer).getUnblindedPayload(unblindedBlockContainer);
-    inOrder.verify(executionLayer).getCachedUnblindedPayload(unblindedBlockContainer.getSlot());
+    verify(executionLayer).getUnblindedPayload(unblindedBlock);
 
-    assertThat(unblindedBlockContainer).isInstanceOf(SignedBlockContents.class);
-    assertThat(unblindedBlockContainer.isBlinded()).isFalse();
-    assertThat(unblindedBlockContainer.getSignedBlock()).isEqualTo(unblindedBeaconBlock);
-    // TODO: add assertions for blobs and proofs
+    assertThat(unblindedBlock.isBlinded()).isFalse();
+    assertThat(unblindedBlock).isEqualTo(expectedUnblindedBlock);
   }
 
   @Override

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/publisher/AbstractBlockPublisherTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/publisher/AbstractBlockPublisherTest.java
@@ -40,6 +40,7 @@ import tech.pegasys.teku.validator.coordinator.BlockFactory;
 import tech.pegasys.teku.validator.coordinator.DutyMetrics;
 import tech.pegasys.teku.validator.coordinator.performance.PerformanceTracker;
 
+// TODO: test blob sidecars passing when implemented
 public class AbstractBlockPublisherTest {
   private final Spec spec = TestSpecFactory.createMinimalDeneb();
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/versions/deneb/BlockContentsSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/versions/deneb/BlockContentsSchema.java
@@ -40,14 +40,13 @@ public class BlockContentsSchema
       final String containerName,
       final SpecConfigDeneb specConfig,
       final BeaconBlockSchema beaconBlockSchema,
-      final SszKZGProofSchema sszKZGProofSchema,
       final BlobSchema blobSchema) {
     super(
         containerName,
         namedSchema("block", beaconBlockSchema),
         namedSchema(
             FIELD_KZG_PROOFS,
-            SszListSchema.create(sszKZGProofSchema, specConfig.getMaxBlobsPerBlock())),
+            SszListSchema.create(SszKZGProofSchema.INSTANCE, specConfig.getMaxBlobsPerBlock())),
         namedSchema(
             FIELD_BLOBS, SszListSchema.create(blobSchema, specConfig.getMaxBlobsPerBlock())));
   }
@@ -55,11 +54,9 @@ public class BlockContentsSchema
   public static BlockContentsSchema create(
       final SpecConfigDeneb specConfig,
       final BeaconBlockSchema beaconBlockSchema,
-      final SszKZGProofSchema sszKZGProofSchema,
       final BlobSchema blobSchema,
       final String containerName) {
-    return new BlockContentsSchema(
-        containerName, specConfig, beaconBlockSchema, sszKZGProofSchema, blobSchema);
+    return new BlockContentsSchema(containerName, specConfig, beaconBlockSchema, blobSchema);
   }
 
   public BlockContents create(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/versions/deneb/SignedBlockContentsSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/versions/deneb/SignedBlockContentsSchema.java
@@ -41,14 +41,13 @@ public class SignedBlockContentsSchema
       final String containerName,
       final SpecConfigDeneb specConfig,
       final SignedBeaconBlockSchema signedBeaconBlockSchema,
-      final SszKZGProofSchema sszKZGProofSchema,
       final BlobSchema blobSchema) {
     super(
         containerName,
         namedSchema("signed_block", signedBeaconBlockSchema),
         namedSchema(
             FIELD_KZG_PROOFS,
-            SszListSchema.create(sszKZGProofSchema, specConfig.getMaxBlobsPerBlock())),
+            SszListSchema.create(SszKZGProofSchema.INSTANCE, specConfig.getMaxBlobsPerBlock())),
         namedSchema(
             FIELD_BLOBS, SszListSchema.create(blobSchema, specConfig.getMaxBlobsPerBlock())));
   }
@@ -56,11 +55,10 @@ public class SignedBlockContentsSchema
   public static SignedBlockContentsSchema create(
       final SpecConfigDeneb specConfig,
       final SignedBeaconBlockSchema signedBeaconBlockSchema,
-      final SszKZGProofSchema sszKZGProofSchema,
       final BlobSchema blobSchema,
       final String containerName) {
     return new SignedBlockContentsSchema(
-        containerName, specConfig, signedBeaconBlockSchema, sszKZGProofSchema, blobSchema);
+        containerName, specConfig, signedBeaconBlockSchema, blobSchema);
   }
 
   public SignedBlockContents create(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsDeneb.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsDeneb.java
@@ -55,7 +55,6 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchema
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.deneb.BeaconStateDeneb;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.deneb.BeaconStateSchemaDeneb;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.deneb.MutableBeaconStateDeneb;
-import tech.pegasys.teku.spec.datastructures.type.SszKZGProofSchema;
 
 public class SchemaDefinitionsDeneb extends SchemaDefinitionsCapella {
 
@@ -81,7 +80,6 @@ public class SchemaDefinitionsDeneb extends SchemaDefinitionsCapella {
   private final SszListSchema<Blob, ? extends SszList<Blob>> blobsInBlockSchema;
   private final BlobSidecarSchema blobSidecarSchema;
   private final BlobSidecarSchemaOld blobSidecarOldSchema;
-  private final SszKZGProofSchema sszKZGProofSchema;
   private final SignedBlobSidecarSchemaOld signedBlobSidecarOldSchema;
   private final BlockContentsSchema blockContentsSchema;
   private final SignedBlockContentsSchema signedBlockContentsSchema;
@@ -134,18 +132,12 @@ public class SchemaDefinitionsDeneb extends SchemaDefinitionsCapella {
             blobSchema,
             specConfig.getKzgCommitmentInclusionProofDepth());
     this.blobSidecarOldSchema = BlobSidecarSchemaOld.create(blobSchema);
-    this.sszKZGProofSchema = SszKZGProofSchema.INSTANCE;
     this.signedBlobSidecarOldSchema = SignedBlobSidecarSchemaOld.create(blobSidecarOldSchema);
     this.blockContentsSchema =
-        BlockContentsSchema.create(
-            specConfig, beaconBlockSchema, sszKZGProofSchema, blobSchema, "BlockContentsDeneb");
+        BlockContentsSchema.create(specConfig, beaconBlockSchema, blobSchema, "BlockContentsDeneb");
     this.signedBlockContentsSchema =
         SignedBlockContentsSchema.create(
-            specConfig,
-            signedBeaconBlockSchema,
-            sszKZGProofSchema,
-            blobSchema,
-            "SignedBlockContentsDeneb");
+            specConfig, signedBeaconBlockSchema, blobSchema, "SignedBlockContentsDeneb");
     this.blobsBundleSchema =
         new BlobsBundleSchema("BlobsBundleDeneb", blobSchema, blobKzgCommitmentsSchema, specConfig);
     this.executionPayloadAndBlobsBundleSchema =

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceBlobSidecarsAvailabilityCheckerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceBlobSidecarsAvailabilityCheckerTest.java
@@ -491,7 +491,7 @@ public class ForkChoiceBlobSidecarsAvailabilityCheckerTest {
       final Optional<SignedBeaconBlock> providedBlock,
       final Duration timeout) {
     block = providedBlock.orElse(dataStructureUtil.randomSignedBeaconBlockWithCommitments(4));
-    blobSidecarsComplete = dataStructureUtil.randomBlobSidecarsForBlock(block);
+    blobSidecarsComplete = dataStructureUtil.randomBlobSidecarsForBlockOld(block);
     kzgCommitmentsComplete =
         block
             .getBeaconBlock()
@@ -602,7 +602,7 @@ public class ForkChoiceBlobSidecarsAvailabilityCheckerTest {
 
   private void prepareBlockAndBlobSidecarsOutsideAvailabilityWindow() {
     block = dataStructureUtil.randomSignedBeaconBlock();
-    blobSidecarsComplete = dataStructureUtil.randomBlobSidecarsForBlock(block);
+    blobSidecarsComplete = dataStructureUtil.randomBlobSidecarsForBlockOld(block);
 
     final ImmutableSortedMap.Builder<UInt64, BlobSidecar> mapBuilder =
         ImmutableSortedMap.naturalOrder();

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceBlobSidecarsAvailabilityCheckerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceBlobSidecarsAvailabilityCheckerTest.java
@@ -491,7 +491,7 @@ public class ForkChoiceBlobSidecarsAvailabilityCheckerTest {
       final Optional<SignedBeaconBlock> providedBlock,
       final Duration timeout) {
     block = providedBlock.orElse(dataStructureUtil.randomSignedBeaconBlockWithCommitments(4));
-    blobSidecarsComplete = dataStructureUtil.randomBlobSidecarsForBlockOld(block);
+    blobSidecarsComplete = dataStructureUtil.randomBlobSidecarsForBlock(block);
     kzgCommitmentsComplete =
         block
             .getBeaconBlock()
@@ -602,7 +602,7 @@ public class ForkChoiceBlobSidecarsAvailabilityCheckerTest {
 
   private void prepareBlockAndBlobSidecarsOutsideAvailabilityWindow() {
     block = dataStructureUtil.randomSignedBeaconBlock();
-    blobSidecarsComplete = dataStructureUtil.randomBlobSidecarsForBlockOld(block);
+    blobSidecarsComplete = dataStructureUtil.randomBlobSidecarsForBlock(block);
 
     final ImmutableSortedMap.Builder<UInt64, BlobSidecar> mapBuilder =
         ImmutableSortedMap.naturalOrder();


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

- Changed `BlockFactory.unblindSignedBlockIfBlinded` to accept and return `SignedBeaconBlock` and use same implementation for Phase0, Deneb
- Changed `AbstractBlockPublisher` and its implementations to import and publish block and blob sidecars separately
- The other changes are mostly in tests

## Fixed Issue(s)
helps with block publishing flow for https://github.com/Consensys/teku/issues/7654

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
