### PR TITLE
Avoid creating tracker for known blocks

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/BlobSidecarPoolImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/BlobSidecarPoolImpl.java
@@ -168,6 +168,9 @@ public class BlobSidecarPoolImpl extends AbstractIgnoringFutureHistoricalSlot
     if (block.getMessage().getBody().toVersionDeneb().isEmpty()) {
       return;
     }
+    if (recentChainData.containsBlock(block.getRoot())) {
+      return;
+    }
     if (shouldIgnoreItemAtSlot(block.getSlot())) {
       return;
     }
@@ -195,6 +198,9 @@ public class BlobSidecarPoolImpl extends AbstractIgnoringFutureHistoricalSlot
   @Override
   public synchronized void onCompletedBlockAndBlobSidecars(
       final SignedBeaconBlock block, final List<BlobSidecar> blobSidecars) {
+    if (recentChainData.containsBlock(block.getRoot())) {
+      return;
+    }
     final SlotAndBlockRoot slotAndBlockRoot = block.getSlotAndBlockRoot();
 
     final BlockBlobSidecarsTracker blobSidecarsTracker =
@@ -247,7 +253,13 @@ public class BlobSidecarPoolImpl extends AbstractIgnoringFutureHistoricalSlot
   public void onSlot(final UInt64 slot) {
     super.onSlot(slot);
 
-    LOG.trace("Trackers: {}", blockBlobSidecarsTrackers);
+    LOG.trace(
+        "Trackers: {}",
+        () -> {
+          synchronized (this) {
+            return blockBlobSidecarsTrackers.toString();
+          }
+        });
   }
 
   @VisibleForTesting

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/BlobSidecarPoolImplTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/BlobSidecarPoolImplTest.java
@@ -186,7 +186,8 @@ public class BlobSidecarPoolImplTest {
   }
 
   @Test
-  public void onNewBlobSidecar_shouldIgnoreBlobsForAlreadyImportedBlocks() {
+  public void
+      onNewBlobSidecar_onNewBlock_onCompletedBlockAndBlobSidecars_shouldIgnoreAlreadyImportedBlocks() {
     final SignedBeaconBlock block = dataStructureUtil.randomSignedBeaconBlock(currentSlot);
     final BlobSidecar blobSidecar =
         dataStructureUtil
@@ -197,6 +198,8 @@ public class BlobSidecarPoolImplTest {
     when(recentChainData.containsBlock(blobSidecar.getBlockRoot())).thenReturn(true);
 
     blobSidecarPool.onNewBlobSidecar(blobSidecar);
+    blobSidecarPool.onNewBlock(block);
+    blobSidecarPool.onCompletedBlockAndBlobSidecars(block, List.of(blobSidecar));
 
     assertThat(blobSidecarPool.containsBlock(block.getRoot())).isFalse();
     assertThat(requiredBlockRootEvents).isEmpty();


### PR DESCRIPTION
Avoids creating trackers that could remain for several slots in memory.
It applies especially to forward sync.  Noticed that we could import a batch a second time after it has been already imported. This happens when we are close to the head (so it is the last batch or so).

I also noticed that we can have a concurrency issue when tracing blockBlobSidecarsTrackers content, added a synchronization.

related to #7712 

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
