### PR TITLE
Pass only the block to `getUnblindedPayload` call

### DIFF
--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/BuilderBidValidator.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/BuilderBidValidator.java
@@ -15,19 +15,19 @@ package tech.pegasys.teku.ethereum.executionlayer;
 
 import java.util.Optional;
 import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.datastructures.builder.BuilderBid;
 import tech.pegasys.teku.spec.datastructures.builder.SignedBuilderBid;
 import tech.pegasys.teku.spec.datastructures.builder.SignedValidatorRegistration;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
-import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 
 @FunctionalInterface
 public interface BuilderBidValidator {
   BuilderBidValidator NOOP =
       (spec, signedBuilderBid, signedValidatorRegistration, state, localExecutionPayload) ->
-          signedBuilderBid.getMessage().getHeader();
+          signedBuilderBid.getMessage();
 
-  ExecutionPayloadHeader validateAndGetPayloadHeader(
+  BuilderBid validateAndGetBuilderBid(
       final Spec spec,
       final SignedBuilderBid signedBuilderBid,
       final SignedValidatorRegistration signedValidatorRegistration,

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/BuilderBidValidator.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/BuilderBidValidator.java
@@ -14,8 +14,6 @@
 package tech.pegasys.teku.ethereum.executionlayer;
 
 import java.util.Optional;
-import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.datastructures.builder.BuilderBid;
 import tech.pegasys.teku.spec.datastructures.builder.SignedBuilderBid;
 import tech.pegasys.teku.spec.datastructures.builder.SignedValidatorRegistration;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
@@ -24,13 +22,11 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 @FunctionalInterface
 public interface BuilderBidValidator {
   BuilderBidValidator NOOP =
-      (spec, signedBuilderBid, signedValidatorRegistration, state, localExecutionPayload) ->
-          signedBuilderBid.getMessage();
+      (signedBuilderBid, signedValidatorRegistration, state, localExecutionPayload) -> {};
 
-  BuilderBid validateAndGetBuilderBid(
-      final Spec spec,
-      final SignedBuilderBid signedBuilderBid,
-      final SignedValidatorRegistration signedValidatorRegistration,
-      final BeaconState state,
-      final Optional<ExecutionPayload> localExecutionPayload);
+  void validateBuilderBid(
+      SignedBuilderBid signedBuilderBid,
+      SignedValidatorRegistration signedValidatorRegistration,
+      BeaconState state,
+      Optional<ExecutionPayload> localExecutionPayload);
 }

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/BuilderBidValidatorImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/BuilderBidValidatorImpl.java
@@ -115,7 +115,8 @@ public class BuilderBidValidatorImpl implements BuilderBidValidator {
           validatorRegistration.getPublicKey());
     }
 
-    // checking payload gas limit
+    // checking payload gas limit against the validator gas limit preference (if there is an
+    // inconsistency, there would be a log warning only instead of an exception)
     final UInt64 parentGasLimit =
         state.toVersionBellatrix().orElseThrow().getLatestExecutionPayloadHeader().getGasLimit();
     final UInt64 preferredGasLimit = validatorRegistration.getGasLimit();

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionBuilderModule.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionBuilderModule.java
@@ -388,7 +388,7 @@ public class ExecutionBuilderModule {
   }
 
   private SafeFuture<BuilderPayload> getPayloadFromBuilderOrFallbackData(
-      final SignedBeaconBlock signedBeaconBlock,
+      final SignedBeaconBlock signedBlindedBeaconBlock,
       final SafeFuture<HeaderWithFallbackData> headerWithFallbackDataFuture) {
     // note: we don't do any particular consistency check here.
     // the header/payload compatibility check is done by SignedBeaconBlockUnblinder
@@ -397,7 +397,7 @@ public class ExecutionBuilderModule {
     return headerWithFallbackDataFuture.thenCompose(
         headerWithFallbackData -> {
           if (headerWithFallbackData.getFallbackData().isEmpty()) {
-            return getPayloadFromBuilder(signedBeaconBlock);
+            return getPayloadFromBuilder(signedBlindedBeaconBlock);
           } else {
             final FallbackData fallbackData = headerWithFallbackData.getFallbackData().get();
             logFallbackToLocalExecutionPayloadAndBlobsBundle(fallbackData);
@@ -410,7 +410,8 @@ public class ExecutionBuilderModule {
                         executionBlobsBundle -> {
                           final SchemaDefinitionsDeneb schemaDefinitions =
                               SchemaDefinitionsDeneb.required(
-                                  spec.atSlot(signedBeaconBlock.getSlot()).getSchemaDefinitions());
+                                  spec.atSlot(signedBlindedBeaconBlock.getSlot())
+                                      .getSchemaDefinitions());
                           final BlobsBundle blobsBundle =
                               schemaDefinitions
                                   .getBlobsBundleSchema()

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionBuilderModule.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionBuilderModule.java
@@ -245,10 +245,10 @@ public class ExecutionBuilderModule {
       final SignedValidatorRegistration validatorRegistration,
       final Optional<ExecutionPayload> localExecutionPayload,
       final SafeFuture<UInt256> payloadValueResult) {
-    final BuilderBid builderBid =
-        builderBidValidator.validateAndGetBuilderBid(
-            spec, signedBuilderBid, validatorRegistration, state, localExecutionPayload);
-    payloadValueResult.complete(signedBuilderBid.getMessage().getValue());
+    builderBidValidator.validateBuilderBid(
+        signedBuilderBid, validatorRegistration, state, localExecutionPayload);
+    final BuilderBid builderBid = signedBuilderBid.getMessage();
+    payloadValueResult.complete(builderBid.getValue());
     return SafeFuture.completedFuture(
         HeaderWithFallbackData.create(
             builderBid.getHeader(), builderBid.getOptionalBlobKzgCommitments()));

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerBlockProductionManagerImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerBlockProductionManagerImpl.java
@@ -20,7 +20,7 @@ import org.apache.tuweni.units.bigints.UInt256;
 import tech.pegasys.teku.ethereum.events.SlotEventsChannel;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.builder.BuilderPayload;
 import tech.pegasys.teku.spec.datastructures.execution.BlobsBundle;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
@@ -123,13 +123,11 @@ public class ExecutionLayerBlockProductionManagerImpl
   }
 
   @Override
-  public SafeFuture<BuilderPayload> getUnblindedPayload(
-      final SignedBlockContainer signedBlockContainer) {
+  public SafeFuture<BuilderPayload> getUnblindedPayload(final SignedBeaconBlock signedBeaconBlock) {
     return executionLayerChannel
-        .builderGetPayload(signedBlockContainer, this::getCachedPayloadResult)
+        .builderGetPayload(signedBeaconBlock, this::getCachedPayloadResult)
         .thenPeek(
-            builderPayload ->
-                builderResultCache.put(signedBlockContainer.getSlot(), builderPayload));
+            builderPayload -> builderResultCache.put(signedBeaconBlock.getSlot(), builderPayload));
   }
 
   @Override

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
@@ -45,7 +45,7 @@ import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.builder.BuilderPayload;
 import tech.pegasys.teku.spec.datastructures.builder.SignedValidatorRegistration;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
@@ -232,10 +232,10 @@ public class ExecutionLayerManagerImpl implements ExecutionLayerManager {
 
   @Override
   public SafeFuture<BuilderPayload> builderGetPayload(
-      final SignedBlockContainer signedBlockContainer,
+      final SignedBeaconBlock signedBeaconBlock,
       final Function<UInt64, Optional<ExecutionPayloadResult>> getCachedPayloadResultFunction) {
     return executionBuilderModule.builderGetPayload(
-        signedBlockContainer, getCachedPayloadResultFunction);
+        signedBeaconBlock, getCachedPayloadResultFunction);
   }
 
   @Override

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/BuilderBidValidatorTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/BuilderBidValidatorTest.java
@@ -13,7 +13,6 @@
 
 package tech.pegasys.teku.ethereum.executionlayer;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
@@ -62,7 +61,10 @@ public class BuilderBidValidatorTest {
   private final EventLogger eventLogger = mock(EventLogger.class);
 
   private final BuilderBidValidatorImpl builderBidValidator =
-      new BuilderBidValidatorImpl(eventLogger);
+      new BuilderBidValidatorImpl(spec, eventLogger);
+
+  private final BuilderBidValidatorImpl builderBidValidatorWithMockSpec =
+      new BuilderBidValidatorImpl(specMock, eventLogger);
 
   private BeaconState state = dataStructureUtil.randomBeaconState();
 
@@ -98,8 +100,8 @@ public class BuilderBidValidatorTest {
 
     assertThatThrownBy(
             () ->
-                builderBidValidator.validateAndGetBuilderBid(
-                    spec, signedBuilderBid, validatorRegistration, state, Optional.empty()))
+                builderBidValidator.validateBuilderBid(
+                    signedBuilderBid, validatorRegistration, state, Optional.empty()))
         .isExactlyInstanceOf(BuilderBidValidationException.class)
         .hasMessage("Invalid Bid Signature");
   }
@@ -111,8 +113,8 @@ public class BuilderBidValidatorTest {
 
     assertThatThrownBy(
             () ->
-                builderBidValidator.validateAndGetBuilderBid(
-                    spec, signedBuilderBid, validatorRegistration, state, Optional.empty()))
+                builderBidValidator.validateBuilderBid(
+                    signedBuilderBid, validatorRegistration, state, Optional.empty()))
         .isExactlyInstanceOf(BuilderBidValidationException.class)
         .hasMessage("Invalid proposed payload with respect to consensus.")
         .hasCauseInstanceOf(BlockProcessingException.class);
@@ -120,15 +122,8 @@ public class BuilderBidValidatorTest {
 
   @Test
   void shouldBeValidIfLocalPayloadWithdrawalsRootMatchesTheRootOfTheBid() {
-    final BuilderBid result =
-        builderBidValidator.validateAndGetBuilderBid(
-            specMock,
-            signedBuilderBid,
-            validatorRegistration,
-            state,
-            Optional.of(localExecutionPayload));
-
-    assertThat(result).isEqualTo(signedBuilderBid.getMessage());
+    builderBidValidatorWithMockSpec.validateBuilderBid(
+        signedBuilderBid, validatorRegistration, state, Optional.of(localExecutionPayload));
   }
 
   @Test
@@ -137,8 +132,7 @@ public class BuilderBidValidatorTest {
 
     assertThatThrownBy(
             () ->
-                builderBidValidator.validateAndGetBuilderBid(
-                    specMock,
+                builderBidValidatorWithMockSpec.validateBuilderBid(
                     dodgySignedBuilderBid,
                     validatorRegistration,
                     state,
@@ -159,8 +153,8 @@ public class BuilderBidValidatorTest {
 
     prepareGasLimit(UInt64.valueOf(1024_000), UInt64.valueOf(1022_000), UInt64.valueOf(1023_000));
 
-    builderBidValidator.validateAndGetBuilderBid(
-        specMock, signedBuilderBid, validatorRegistration, state, Optional.empty());
+    builderBidValidatorWithMockSpec.validateBuilderBid(
+        signedBuilderBid, validatorRegistration, state, Optional.empty());
 
     verifyNoInteractions(eventLogger);
   }
@@ -170,8 +164,8 @@ public class BuilderBidValidatorTest {
 
     prepareGasLimit(UInt64.valueOf(1024_000), UInt64.valueOf(1025_000), UInt64.valueOf(2048_000));
 
-    builderBidValidator.validateAndGetBuilderBid(
-        specMock, signedBuilderBid, validatorRegistration, state, Optional.empty());
+    builderBidValidatorWithMockSpec.validateBuilderBid(
+        signedBuilderBid, validatorRegistration, state, Optional.empty());
 
     verifyNoInteractions(eventLogger);
   }
@@ -181,8 +175,8 @@ public class BuilderBidValidatorTest {
 
     prepareGasLimit(UInt64.valueOf(1024_000), UInt64.valueOf(1024_000), UInt64.valueOf(1024_000));
 
-    builderBidValidator.validateAndGetBuilderBid(
-        specMock, signedBuilderBid, validatorRegistration, state, Optional.empty());
+    builderBidValidatorWithMockSpec.validateBuilderBid(
+        signedBuilderBid, validatorRegistration, state, Optional.empty());
 
     verifyNoInteractions(eventLogger);
   }
@@ -192,8 +186,8 @@ public class BuilderBidValidatorTest {
 
     prepareGasLimit(UInt64.valueOf(1024_000), UInt64.valueOf(1024_000), UInt64.valueOf(1023_100));
 
-    builderBidValidator.validateAndGetBuilderBid(
-        specMock, signedBuilderBid, validatorRegistration, state, Optional.empty());
+    builderBidValidatorWithMockSpec.validateBuilderBid(
+        signedBuilderBid, validatorRegistration, state, Optional.empty());
 
     verify(eventLogger)
         .builderBidNotHonouringGasLimit(
@@ -205,8 +199,8 @@ public class BuilderBidValidatorTest {
 
     prepareGasLimit(UInt64.valueOf(1024_000), UInt64.valueOf(1020_000), UInt64.valueOf(1024_100));
 
-    builderBidValidator.validateAndGetBuilderBid(
-        specMock, signedBuilderBid, validatorRegistration, state, Optional.empty());
+    builderBidValidatorWithMockSpec.validateBuilderBid(
+        signedBuilderBid, validatorRegistration, state, Optional.empty());
 
     verify(eventLogger)
         .builderBidNotHonouringGasLimit(

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/BuilderBidValidatorTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/BuilderBidValidatorTest.java
@@ -98,7 +98,7 @@ public class BuilderBidValidatorTest {
 
     assertThatThrownBy(
             () ->
-                builderBidValidator.validateAndGetPayloadHeader(
+                builderBidValidator.validateAndGetBuilderBid(
                     spec, signedBuilderBid, validatorRegistration, state, Optional.empty()))
         .isExactlyInstanceOf(BuilderBidValidationException.class)
         .hasMessage("Invalid Bid Signature");
@@ -111,7 +111,7 @@ public class BuilderBidValidatorTest {
 
     assertThatThrownBy(
             () ->
-                builderBidValidator.validateAndGetPayloadHeader(
+                builderBidValidator.validateAndGetBuilderBid(
                     spec, signedBuilderBid, validatorRegistration, state, Optional.empty()))
         .isExactlyInstanceOf(BuilderBidValidationException.class)
         .hasMessage("Invalid proposed payload with respect to consensus.")
@@ -120,15 +120,15 @@ public class BuilderBidValidatorTest {
 
   @Test
   void shouldBeValidIfLocalPayloadWithdrawalsRootMatchesTheRootOfTheBid() {
-    final ExecutionPayloadHeader result =
-        builderBidValidator.validateAndGetPayloadHeader(
+    final BuilderBid result =
+        builderBidValidator.validateAndGetBuilderBid(
             specMock,
             signedBuilderBid,
             validatorRegistration,
             state,
             Optional.of(localExecutionPayload));
 
-    assertThat(result).isEqualTo(signedBuilderBid.getMessage().getHeader());
+    assertThat(result).isEqualTo(signedBuilderBid.getMessage());
   }
 
   @Test
@@ -137,7 +137,7 @@ public class BuilderBidValidatorTest {
 
     assertThatThrownBy(
             () ->
-                builderBidValidator.validateAndGetPayloadHeader(
+                builderBidValidator.validateAndGetBuilderBid(
                     specMock,
                     dodgySignedBuilderBid,
                     validatorRegistration,
@@ -159,7 +159,7 @@ public class BuilderBidValidatorTest {
 
     prepareGasLimit(UInt64.valueOf(1024_000), UInt64.valueOf(1022_000), UInt64.valueOf(1023_000));
 
-    builderBidValidator.validateAndGetPayloadHeader(
+    builderBidValidator.validateAndGetBuilderBid(
         specMock, signedBuilderBid, validatorRegistration, state, Optional.empty());
 
     verifyNoInteractions(eventLogger);
@@ -170,7 +170,7 @@ public class BuilderBidValidatorTest {
 
     prepareGasLimit(UInt64.valueOf(1024_000), UInt64.valueOf(1025_000), UInt64.valueOf(2048_000));
 
-    builderBidValidator.validateAndGetPayloadHeader(
+    builderBidValidator.validateAndGetBuilderBid(
         specMock, signedBuilderBid, validatorRegistration, state, Optional.empty());
 
     verifyNoInteractions(eventLogger);
@@ -181,7 +181,7 @@ public class BuilderBidValidatorTest {
 
     prepareGasLimit(UInt64.valueOf(1024_000), UInt64.valueOf(1024_000), UInt64.valueOf(1024_000));
 
-    builderBidValidator.validateAndGetPayloadHeader(
+    builderBidValidator.validateAndGetBuilderBid(
         specMock, signedBuilderBid, validatorRegistration, state, Optional.empty());
 
     verifyNoInteractions(eventLogger);
@@ -192,7 +192,7 @@ public class BuilderBidValidatorTest {
 
     prepareGasLimit(UInt64.valueOf(1024_000), UInt64.valueOf(1024_000), UInt64.valueOf(1023_100));
 
-    builderBidValidator.validateAndGetPayloadHeader(
+    builderBidValidator.validateAndGetBuilderBid(
         specMock, signedBuilderBid, validatorRegistration, state, Optional.empty());
 
     verify(eventLogger)
@@ -205,7 +205,7 @@ public class BuilderBidValidatorTest {
 
     prepareGasLimit(UInt64.valueOf(1024_000), UInt64.valueOf(1020_000), UInt64.valueOf(1024_100));
 
-    builderBidValidator.validateAndGetPayloadHeader(
+    builderBidValidator.validateAndGetBuilderBid(
         specMock, signedBuilderBid, validatorRegistration, state, Optional.empty());
 
     verify(eventLogger)

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerBlockProductionManagerImplTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerBlockProductionManagerImplTest.java
@@ -527,7 +527,7 @@ class ExecutionLayerBlockProductionManagerImplTest {
         spec,
         stubMetricsSystem,
         builderValidatorEnabled
-            ? new BuilderBidValidatorImpl(eventLogger)
+            ? new BuilderBidValidatorImpl(spec, eventLogger)
             : BuilderBidValidator.NOOP,
         builderCircuitBreaker,
         Optional.of(100),

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImplTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImplTest.java
@@ -42,7 +42,6 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
-import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
 import tech.pegasys.teku.spec.datastructures.builder.BuilderBid;
 import tech.pegasys.teku.spec.datastructures.builder.BuilderPayload;
 import tech.pegasys.teku.spec.datastructures.builder.SignedBuilderBid;
@@ -959,13 +958,13 @@ class ExecutionLayerManagerImplTest {
                 })
             .orElse(fallbackData.getExecutionPayload());
 
-    final SignedBlockContainer signedBlindedBlockContainer =
+    final SignedBeaconBlock signedBlindedBeaconBlock =
         dataStructureUtil.randomSignedBlindedBeaconBlock(slot);
 
     // we expect result from the cached payload
     assertThat(
             executionLayerManager.builderGetPayload(
-                signedBlindedBlockContainer,
+                signedBlindedBeaconBlock,
                 (aSlot) ->
                     Optional.of(
                         new ExecutionPayloadResult(

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImplTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImplTest.java
@@ -1056,7 +1056,7 @@ class ExecutionLayerManagerImplTest {
         spec,
         stubMetricsSystem,
         builderValidatorEnabled
-            ? new BuilderBidValidatorImpl(eventLogger)
+            ? new BuilderBidValidatorImpl(spec, eventLogger)
             : BuilderBidValidator.NOOP,
         builderCircuitBreaker,
         builderBidCompareFactor,

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerBlockProductionManager.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerBlockProductionManager.java
@@ -16,7 +16,7 @@ package tech.pegasys.teku.spec.executionlayer;
 import java.util.Optional;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.builder.BuilderPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadResult;
@@ -54,7 +54,7 @@ public interface ExecutionLayerBlockProductionManager {
 
         @Override
         public SafeFuture<BuilderPayload> getUnblindedPayload(
-            final SignedBlockContainer signedBlockContainer) {
+            final SignedBeaconBlock signedBeaconBlock) {
           return SafeFuture.completedFuture(null);
         }
 
@@ -89,11 +89,11 @@ public interface ExecutionLayerBlockProductionManager {
 
   Optional<ExecutionPayloadResult> getCachedPayloadResult(UInt64 slot);
 
-  SafeFuture<BuilderPayload> getUnblindedPayload(SignedBlockContainer signedBlockContainer);
+  SafeFuture<BuilderPayload> getUnblindedPayload(SignedBeaconBlock signedBeaconBlock);
 
   /**
-   * Requires {@link #getUnblindedPayload( SignedBlockContainer)} to have been called first in order
-   * for a value to be present
+   * Requires {@link #getUnblindedPayload(SignedBeaconBlock)} to have been called first in order for
+   * a value to be present
    */
   @SuppressWarnings("unused")
   Optional<BuilderPayload> getCachedUnblindedPayload(UInt64 slot);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannel.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannel.java
@@ -21,7 +21,7 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.events.ChannelInterface;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.builder.BuilderPayload;
 import tech.pegasys.teku.spec.datastructures.builder.SignedValidatorRegistration;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
@@ -76,7 +76,7 @@ public interface ExecutionLayerChannel extends ChannelInterface {
 
         @Override
         public SafeFuture<BuilderPayload> builderGetPayload(
-            final SignedBlockContainer signedBlockContainer,
+            final SignedBeaconBlock signedBeaconBlock,
             final Function<UInt64, Optional<ExecutionPayloadResult>>
                 getCachedPayloadResultFunction) {
           return SafeFuture.completedFuture(null);
@@ -117,11 +117,11 @@ public interface ExecutionLayerChannel extends ChannelInterface {
       SszList<SignedValidatorRegistration> signedValidatorRegistrations, UInt64 slot);
 
   /**
-   * This is low level method, use {@link ExecutionLayerBlockProductionManager#getUnblindedPayload(
-   * SignedBlockContainer)} instead
+   * This is low level method, use {@link
+   * ExecutionLayerBlockProductionManager#getUnblindedPayload(SignedBeaconBlock)} instead
    */
   SafeFuture<BuilderPayload> builderGetPayload(
-      SignedBlockContainer signedBlockContainer,
+      SignedBeaconBlock signedBeaconBlock,
       Function<UInt64, Optional<ExecutionPayloadResult>> getCachedPayloadResultFunction);
 
   /**

--- a/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerService.java
+++ b/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerService.java
@@ -201,7 +201,7 @@ public class ExecutionLayerService extends Service {
         builderClient,
         config.getSpec(),
         metricsSystem,
-        new BuilderBidValidatorImpl(EVENT_LOG),
+        new BuilderBidValidatorImpl(config.getSpec(), EVENT_LOG),
         builderCircuitBreaker,
         config.getBuilderBidCompareFactor(),
         config.getUseShouldOverrideBuilderFlag());


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

- Small cleanup. Pass `SignedBeaconBlock` instead of `SignedBlockContainer` to `ExecutionLayerBlockProductionManager.getUnblindedPayload` (aka builder only needs the block)
- Also made `BuilderBidValidator` be void and no `spec` passed

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
