### PR TITLE
Don't use FailoverValidatorApiHandler if no failovers configured

### DIFF
--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/RemoteValidatorAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/RemoteValidatorAcceptanceTest.java
@@ -51,7 +51,7 @@ public class RemoteValidatorAcceptanceTest extends AcceptanceTestBase {
     beaconNode.start();
     validatorClient.start();
 
-    waitForValidatorDutiesToComplete();
+    waitForValidatorDutiesToComplete(beaconNode);
   }
 
   @Test
@@ -63,7 +63,7 @@ public class RemoteValidatorAcceptanceTest extends AcceptanceTestBase {
     beaconNode.start();
 
     waitForSuccessfulEventStreamConnection();
-    waitForValidatorDutiesToComplete();
+    waitForValidatorDutiesToComplete(beaconNode);
   }
 
   @Test
@@ -91,15 +91,14 @@ public class RemoteValidatorAcceptanceTest extends AcceptanceTestBase {
     validatorClient.start();
 
     waitForSuccessfulEventStreamConnection();
-    waitForValidatorDutiesToComplete();
+    waitForValidatorDutiesToComplete(beaconNode);
 
     beaconNode.stop();
 
     validatorClient.waitForLogMessageContaining(
         "Switching to failover beacon node for event streaming");
     waitForSuccessfulEventStreamConnection();
-    waitForValidatorDutiesToComplete();
-    waitForDutiesRequestedFromAndPublishedTo(failoverBeaconNode);
+    waitForValidatorDutiesToComplete(failoverBeaconNode);
 
     // primary beacon node recovers
     beaconNode.start();
@@ -107,8 +106,7 @@ public class RemoteValidatorAcceptanceTest extends AcceptanceTestBase {
     validatorClient.waitForLogMessageContaining(
         "Switching back to the primary beacon node for event streaming");
     waitForSuccessfulEventStreamConnection();
-    waitForValidatorDutiesToComplete();
-    waitForDutiesRequestedFromAndPublishedTo(beaconNode);
+    waitForValidatorDutiesToComplete(beaconNode);
   }
 
   @Test
@@ -140,8 +138,7 @@ public class RemoteValidatorAcceptanceTest extends AcceptanceTestBase {
     validatorClient.waitForLogMessageContaining(
         "Switching to failover beacon node for event streaming");
     waitForSuccessfulEventStreamConnection();
-    waitForValidatorDutiesToComplete();
-    waitForDutiesRequestedFromAndPublishedTo(beaconNode);
+    waitForValidatorDutiesToComplete(beaconNode);
   }
 
   private void waitForSuccessfulEventStreamConnection() {
@@ -149,15 +146,12 @@ public class RemoteValidatorAcceptanceTest extends AcceptanceTestBase {
         "Successfully connected to beacon node event stream");
   }
 
-  private void waitForValidatorDutiesToComplete() {
+  private void waitForValidatorDutiesToComplete(final TekuNode beaconNode) {
     validatorClient.waitForLogMessageContaining("Published block");
     validatorClient.waitForLogMessageContaining("Published attestation");
     validatorClient.waitForLogMessageContaining("Published aggregate");
     validatorClient.waitForLogMessageContaining("Published sync_signature");
     validatorClient.waitForLogMessageContaining("Published sync_contribution");
-  }
-
-  private void waitForDutiesRequestedFromAndPublishedTo(final TekuNode beaconNode) {
     validatorClient.waitForDutiesRequestedFrom(beaconNode);
     validatorClient.waitForAttestationPublishedTo(beaconNode);
     validatorClient.waitForBlockPublishedTo(beaconNode);

--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/RemoteValidatorAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/RemoteValidatorAcceptanceTest.java
@@ -99,6 +99,7 @@ public class RemoteValidatorAcceptanceTest extends AcceptanceTestBase {
         "Switching to failover beacon node for event streaming");
     waitForSuccessfulEventStreamConnection();
     waitForValidatorDutiesToComplete();
+    waitForDutiesRequestedFromAndPublishedTo(failoverBeaconNode);
 
     // primary beacon node recovers
     beaconNode.start();
@@ -107,6 +108,7 @@ public class RemoteValidatorAcceptanceTest extends AcceptanceTestBase {
         "Switching back to the primary beacon node for event streaming");
     waitForSuccessfulEventStreamConnection();
     waitForValidatorDutiesToComplete();
+    waitForDutiesRequestedFromAndPublishedTo(beaconNode);
   }
 
   @Test
@@ -139,6 +141,7 @@ public class RemoteValidatorAcceptanceTest extends AcceptanceTestBase {
         "Switching to failover beacon node for event streaming");
     waitForSuccessfulEventStreamConnection();
     waitForValidatorDutiesToComplete();
+    waitForDutiesRequestedFromAndPublishedTo(beaconNode);
   }
 
   private void waitForSuccessfulEventStreamConnection() {
@@ -152,5 +155,11 @@ public class RemoteValidatorAcceptanceTest extends AcceptanceTestBase {
     validatorClient.waitForLogMessageContaining("Published aggregate");
     validatorClient.waitForLogMessageContaining("Published sync_signature");
     validatorClient.waitForLogMessageContaining("Published sync_contribution");
+  }
+
+  private void waitForDutiesRequestedFromAndPublishedTo(final TekuNode beaconNode) {
+    validatorClient.waitForDutiesRequestedFrom(beaconNode);
+    validatorClient.waitForAttestationPublishedTo(beaconNode);
+    validatorClient.waitForBlockPublishedTo(beaconNode);
   }
 }

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuValidatorNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuValidatorNode.java
@@ -149,7 +149,7 @@ public class TekuValidatorNode extends Node {
 
   public void waitForDutiesRequestedFrom(final TekuNode node) {
     waitForMetric(
-        withNameEqualsTo("validator_remote_beacon_nodes_requests_total"),
+        withNameEqualsTo("validator_beacon_node_requests_total"),
         withLabelsContaining(
             Map.of(
                 "endpoint", node.getBeaconRestApiUrl() + "/",
@@ -160,7 +160,7 @@ public class TekuValidatorNode extends Node {
 
   public void waitForAttestationPublishedTo(final TekuNode node) {
     waitForMetric(
-        withNameEqualsTo("validator_remote_beacon_nodes_requests_total"),
+        withNameEqualsTo("validator_beacon_node_requests_total"),
         withLabelsContaining(
             Map.of(
                 "endpoint", node.getBeaconRestApiUrl() + "/",

--- a/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
+++ b/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
@@ -60,6 +60,8 @@ import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 
 public abstract class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
 
+  public static final String BEACON_NODE_REQUESTS_COUNTER_NAME = "beacon_node_requests_total";
+
   protected final LabelledMetric<Counter> beaconNodeRequestsCounter;
 
   private final ValidatorApiChannel delegate;

--- a/validator/eventadapter/build.gradle
+++ b/validator/eventadapter/build.gradle
@@ -18,5 +18,5 @@ dependencies {
   implementation 'org.apache.commons:commons-lang3'
 
   testImplementation 'org.mockito:mockito-core'
-  testImplementation testFixtures(project(':ethereum:spec'))
+  testImplementation testFixtures(project(':infrastructure:metrics'))
 }

--- a/validator/eventadapter/src/main/java/tech/pegasys/teku/validator/eventadapter/InProcessBeaconNodeApi.java
+++ b/validator/eventadapter/src/main/java/tech/pegasys/teku/validator/eventadapter/InProcessBeaconNodeApi.java
@@ -27,7 +27,6 @@ import tech.pegasys.teku.validator.beaconnode.BeaconChainEventAdapter;
 import tech.pegasys.teku.validator.beaconnode.BeaconNodeApi;
 import tech.pegasys.teku.validator.beaconnode.GenesisDataProvider;
 import tech.pegasys.teku.validator.beaconnode.TimeBasedEventAdapter;
-import tech.pegasys.teku.validator.beaconnode.metrics.MetricRecordingValidatorApiChannel;
 
 public class InProcessBeaconNodeApi implements BeaconNodeApi {
 
@@ -49,7 +48,7 @@ public class InProcessBeaconNodeApi implements BeaconNodeApi {
     final MetricsSystem metricsSystem = services.getMetricsSystem();
     final EventChannels eventChannels = services.getEventChannels();
     final ValidatorApiChannel validatorApiChannel =
-        new MetricRecordingValidatorApiChannel(
+        new InProcessMetricRecordingValidatorApiChannel(
             metricsSystem, eventChannels.getPublisher(ValidatorApiChannel.class, asyncRunner));
     final ValidatorTimingChannel validatorTimingChannel =
         eventChannels.getPublisher(ValidatorTimingChannel.class);

--- a/validator/eventadapter/src/main/java/tech/pegasys/teku/validator/eventadapter/InProcessMetricRecordingValidatorApiChannel.java
+++ b/validator/eventadapter/src/main/java/tech/pegasys/teku/validator/eventadapter/InProcessMetricRecordingValidatorApiChannel.java
@@ -11,28 +11,23 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.validator.remote;
+package tech.pegasys.teku.validator.eventadapter;
 
-import okhttp3.HttpUrl;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.plugin.services.metrics.Counter;
 import org.hyperledger.besu.plugin.services.metrics.LabelledMetric;
-import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
-import tech.pegasys.teku.validator.api.required.SyncingStatus;
+import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 import tech.pegasys.teku.validator.beaconnode.metrics.MetricRecordingValidatorApiChannel;
 
-public class RemoteMetricRecordingValidatorApiChannel extends MetricRecordingValidatorApiChannel
-    implements RemoteValidatorApiChannel {
+public class InProcessMetricRecordingValidatorApiChannel
+    extends MetricRecordingValidatorApiChannel {
 
-  static final String BEACON_NODE_REQUESTS_COUNTER_NAME = "remote_beacon_nodes_requests_total";
+  static final String BEACON_NODE_REQUESTS_COUNTER_NAME = "beacon_node_requests_total";
 
-  private final RemoteValidatorApiChannel delegate;
-
-  public RemoteMetricRecordingValidatorApiChannel(
-      final MetricsSystem metricsSystem, final RemoteValidatorApiChannel delegate) {
+  public InProcessMetricRecordingValidatorApiChannel(
+      final MetricsSystem metricsSystem, final ValidatorApiChannel delegate) {
     super(metricsSystem, delegate);
-    this.delegate = delegate;
   }
 
   @Override
@@ -40,26 +35,13 @@ public class RemoteMetricRecordingValidatorApiChannel extends MetricRecordingVal
     return metricsSystem.createLabelledCounter(
         TekuMetricCategory.VALIDATOR,
         BEACON_NODE_REQUESTS_COUNTER_NAME,
-        "Counter recording the number of remote requests sent to the beacon node(s)",
-        "endpoint",
+        "Counter recording the number of requests sent to the beacon node",
         "method",
         "outcome");
   }
 
   @Override
   public void recordRequest(final String methodLabel, final RequestOutcome outcome) {
-    beaconNodeRequestsCounter
-        .labels(getEndpoint().toString(), methodLabel, outcome.toString())
-        .inc();
-  }
-
-  @Override
-  public HttpUrl getEndpoint() {
-    return delegate.getEndpoint();
-  }
-
-  @Override
-  public SafeFuture<SyncingStatus> getSyncingStatus() {
-    return delegate.getSyncingStatus();
+    beaconNodeRequestsCounter.labels(methodLabel, outcome.toString()).inc();
   }
 }

--- a/validator/eventadapter/src/main/java/tech/pegasys/teku/validator/eventadapter/InProcessMetricRecordingValidatorApiChannel.java
+++ b/validator/eventadapter/src/main/java/tech/pegasys/teku/validator/eventadapter/InProcessMetricRecordingValidatorApiChannel.java
@@ -23,8 +23,6 @@ import tech.pegasys.teku.validator.beaconnode.metrics.MetricRecordingValidatorAp
 public class InProcessMetricRecordingValidatorApiChannel
     extends MetricRecordingValidatorApiChannel {
 
-  static final String BEACON_NODE_REQUESTS_COUNTER_NAME = "beacon_node_requests_total";
-
   public InProcessMetricRecordingValidatorApiChannel(
       final MetricsSystem metricsSystem, final ValidatorApiChannel delegate) {
     super(metricsSystem, delegate);

--- a/validator/eventadapter/src/test/java/tech/pegasys/teku/validator/eventadapter/InProcessMetricRecordingValidatorApiChannelTest.java
+++ b/validator/eventadapter/src/test/java/tech/pegasys/teku/validator/eventadapter/InProcessMetricRecordingValidatorApiChannelTest.java
@@ -15,7 +15,7 @@ package tech.pegasys.teku.validator.eventadapter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
-import static tech.pegasys.teku.validator.eventadapter.InProcessMetricRecordingValidatorApiChannel.BEACON_NODE_REQUESTS_COUNTER_NAME;
+import static tech.pegasys.teku.validator.beaconnode.metrics.MetricRecordingValidatorApiChannel.BEACON_NODE_REQUESTS_COUNTER_NAME;
 
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;

--- a/validator/eventadapter/src/test/java/tech/pegasys/teku/validator/eventadapter/InProcessMetricRecordingValidatorApiChannelTest.java
+++ b/validator/eventadapter/src/test/java/tech/pegasys/teku/validator/eventadapter/InProcessMetricRecordingValidatorApiChannelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Consensys Software Inc., 2023
+ * Copyright Consensys Software Inc., 2022
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -11,33 +11,25 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.validator.remote;
+package tech.pegasys.teku.validator.eventadapter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-import static tech.pegasys.teku.validator.remote.RemoteMetricRecordingValidatorApiChannel.BEACON_NODE_REQUESTS_COUNTER_NAME;
+import static tech.pegasys.teku.validator.eventadapter.InProcessMetricRecordingValidatorApiChannel.BEACON_NODE_REQUESTS_COUNTER_NAME;
 
-import okhttp3.HttpUrl;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
+import tech.pegasys.teku.validator.api.ValidatorApiChannel;
+import tech.pegasys.teku.validator.beaconnode.metrics.MetricRecordingValidatorApiChannel;
 import tech.pegasys.teku.validator.beaconnode.metrics.MetricRecordingValidatorApiChannel.RequestOutcome;
 
-public class RemoteMetricRecordingValidatorApiChannelTest {
+class InProcessMetricRecordingValidatorApiChannelTest {
 
-  private static final String DELEGATE_ENDPOINT = "http://delegate.com/";
-
-  private final RemoteValidatorApiChannel delegate = mock(RemoteValidatorApiChannel.class);
+  private final ValidatorApiChannel delegate = mock(ValidatorApiChannel.class);
   private final StubMetricsSystem metricsSystem = new StubMetricsSystem();
-  private final RemoteMetricRecordingValidatorApiChannel apiChannel =
-      new RemoteMetricRecordingValidatorApiChannel(metricsSystem, delegate);
-
-  @BeforeEach
-  public void setup() {
-    when(delegate.getEndpoint()).thenReturn(HttpUrl.get(DELEGATE_ENDPOINT));
-  }
+  private final MetricRecordingValidatorApiChannel apiChannel =
+      new InProcessMetricRecordingValidatorApiChannel(metricsSystem, delegate);
 
   @Test
   public void recordsRequest() {
@@ -52,6 +44,6 @@ public class RemoteMetricRecordingValidatorApiChannelTest {
   private long getCounterValue(final String methodLabel, final RequestOutcome outcome) {
     return metricsSystem
         .getCounter(TekuMetricCategory.VALIDATOR, BEACON_NODE_REQUESTS_COUNTER_NAME)
-        .getValue(DELEGATE_ENDPOINT, methodLabel, outcome.toString());
+        .getValue(methodLabel, outcome.toString());
   }
 }

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverRequestException.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverRequestException.java
@@ -19,15 +19,14 @@ import java.util.stream.Collectors;
 public class FailoverRequestException extends RuntimeException {
 
   public FailoverRequestException(
-      final String method, final Map<RemoteValidatorApiChannel, Throwable> capturedExceptions) {
-    super(createErrorMessage(method, capturedExceptions));
+      final Map<RemoteValidatorApiChannel, Throwable> capturedExceptions) {
+    super(createErrorMessage(capturedExceptions));
   }
 
   private static String createErrorMessage(
-      final String method, final Map<RemoteValidatorApiChannel, Throwable> capturedExceptions) {
+      final Map<RemoteValidatorApiChannel, Throwable> capturedExceptions) {
     final String prefix =
-        String.format(
-            "Remote request (%s) failed on all configured Beacon Node endpoints%n", method);
+        String.format("Remote request failed on all configured Beacon Node endpoints%n");
     final String errorSummary =
         capturedExceptions.entrySet().stream()
             .map(entry -> entry.getKey().getEndpoint() + ": " + entry.getValue())

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandler.java
@@ -309,7 +309,8 @@ public class FailoverValidatorApiHandler implements ValidatorApiChannel {
                   "Remote request which is sent to all configured Beacon Node endpoints failed on the primary Beacon Node {}. Will try to use a response from a failover.",
                   primaryDelegate.getEndpoint());
               return getFirstSuccessfulResponseFromFailovers(failoverResponses, capturedExceptions);
-            });
+            })
+        .thenPeek(__ -> LOG.debug("Received a successful response from a failover"));
   }
 
   private <T> SafeFuture<T> getFirstSuccessfulResponseFromFailovers(

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandler.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.validator.remote;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import it.unimi.dsi.fastutil.ints.IntCollection;
 import java.util.Collection;
 import java.util.HashMap;
@@ -26,16 +27,12 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
-import org.hyperledger.besu.plugin.services.MetricsSystem;
-import org.hyperledger.besu.plugin.services.metrics.Counter;
-import org.hyperledger.besu.plugin.services.metrics.LabelledMetric;
 import tech.pegasys.teku.api.migrated.ValidatorLivenessAtEpoch;
 import tech.pegasys.teku.api.response.v1.beacon.ValidatorStatus;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.collections.LimitedMap;
-import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockContainer;
@@ -59,14 +56,10 @@ import tech.pegasys.teku.validator.api.SubmitDataError;
 import tech.pegasys.teku.validator.api.SyncCommitteeDuties;
 import tech.pegasys.teku.validator.api.SyncCommitteeSubnetSubscription;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
-import tech.pegasys.teku.validator.beaconnode.metrics.BeaconNodeRequestLabels;
 
 public class FailoverValidatorApiHandler implements ValidatorApiChannel {
 
   private static final Logger LOG = LogManager.getLogger();
-
-  static final String REMOTE_BEACON_NODES_REQUESTS_COUNTER_NAME =
-      "remote_beacon_nodes_requests_total";
 
   private final Map<UInt64, ValidatorApiChannel> blindedBlockCreatorCache =
       LimitedMap.createSynchronizedLRU(2);
@@ -76,73 +69,56 @@ public class FailoverValidatorApiHandler implements ValidatorApiChannel {
   private final List<? extends RemoteValidatorApiChannel> failoverDelegates;
   private final boolean failoversSendSubnetSubscriptions;
   private final boolean failoversPublishSignedDuties;
-  private final LabelledMetric<Counter> failoverBeaconNodesRequestsCounter;
 
   public FailoverValidatorApiHandler(
       final BeaconNodeReadinessManager beaconNodeReadinessManager,
       final RemoteValidatorApiChannel primaryDelegate,
       final List<? extends RemoteValidatorApiChannel> failoverDelegates,
       final boolean failoversSendSubnetSubscriptions,
-      final boolean failoversPublishSignedDuties,
-      final MetricsSystem metricsSystem) {
+      final boolean failoversPublishSignedDuties) {
+    Preconditions.checkState(!failoverDelegates.isEmpty(), "No failovers are configured");
     this.beaconNodeReadinessManager = beaconNodeReadinessManager;
     this.primaryDelegate = primaryDelegate;
     this.failoverDelegates = failoverDelegates;
     this.failoversSendSubnetSubscriptions = failoversSendSubnetSubscriptions;
     this.failoversPublishSignedDuties = failoversPublishSignedDuties;
-    failoverBeaconNodesRequestsCounter =
-        metricsSystem.createLabelledCounter(
-            TekuMetricCategory.VALIDATOR,
-            REMOTE_BEACON_NODES_REQUESTS_COUNTER_NAME,
-            "Counter recording the number of requests sent to the configured Beacon Nodes endpoint(s)",
-            "endpoint",
-            "method",
-            "outcome");
   }
 
   @Override
   public SafeFuture<Optional<GenesisData>> getGenesisData() {
-    return tryRequestUntilSuccess(
-        ValidatorApiChannel::getGenesisData, BeaconNodeRequestLabels.GET_GENESIS_METHOD);
+    return tryRequestUntilSuccess(ValidatorApiChannel::getGenesisData);
   }
 
   @Override
   public SafeFuture<Map<BLSPublicKey, Integer>> getValidatorIndices(
       final Collection<BLSPublicKey> publicKeys) {
-    return tryRequestUntilSuccess(
-        apiChannel -> apiChannel.getValidatorIndices(publicKeys),
-        BeaconNodeRequestLabels.GET_VALIDATOR_INDICES_METHOD);
+    return tryRequestUntilSuccess(apiChannel -> apiChannel.getValidatorIndices(publicKeys));
   }
 
   @Override
   public SafeFuture<Optional<Map<BLSPublicKey, ValidatorStatus>>> getValidatorStatuses(
       final Collection<BLSPublicKey> validatorIdentifiers) {
     return tryRequestUntilSuccess(
-        apiChannel -> apiChannel.getValidatorStatuses(validatorIdentifiers),
-        BeaconNodeRequestLabels.GET_VALIDATOR_STATUSES_METHOD);
+        apiChannel -> apiChannel.getValidatorStatuses(validatorIdentifiers));
   }
 
   @Override
   public SafeFuture<Optional<AttesterDuties>> getAttestationDuties(
       final UInt64 epoch, final IntCollection validatorIndices) {
     return tryRequestUntilSuccess(
-        apiChannel -> apiChannel.getAttestationDuties(epoch, validatorIndices),
-        BeaconNodeRequestLabels.GET_ATTESTATION_DUTIES_METHOD);
+        apiChannel -> apiChannel.getAttestationDuties(epoch, validatorIndices));
   }
 
   @Override
   public SafeFuture<Optional<SyncCommitteeDuties>> getSyncCommitteeDuties(
       final UInt64 epoch, final IntCollection validatorIndices) {
     return tryRequestUntilSuccess(
-        apiChannel -> apiChannel.getSyncCommitteeDuties(epoch, validatorIndices),
-        BeaconNodeRequestLabels.GET_SYNC_COMMITTEE_DUTIES_METHOD);
+        apiChannel -> apiChannel.getSyncCommitteeDuties(epoch, validatorIndices));
   }
 
   @Override
   public SafeFuture<Optional<ProposerDuties>> getProposerDuties(final UInt64 epoch) {
-    return tryRequestUntilSuccess(
-        apiChannel -> apiChannel.getProposerDuties(epoch),
-        BeaconNodeRequestLabels.GET_PROPOSER_DUTIES_REQUESTS_METHOD);
+    return tryRequestUntilSuccess(apiChannel -> apiChannel.getProposerDuties(epoch));
   }
 
   @Deprecated
@@ -157,13 +133,11 @@ public class FailoverValidatorApiHandler implements ValidatorApiChannel {
             apiChannel
                 .createUnsignedBlock(slot, randaoReveal, graffiti, blinded)
                 .thenPeek(
-                    blockContainer -> {
-                      if (!failoverDelegates.isEmpty()
-                          && blockContainer.map(BlockContainer::isBlinded).orElse(false)) {
-                        blindedBlockCreatorCache.put(slot, apiChannel);
-                      }
-                    });
-    return tryRequestUntilSuccess(request, BeaconNodeRequestLabels.CREATE_UNSIGNED_BLOCK_METHOD);
+                    blockContainer ->
+                        blockContainer
+                            .filter(BlockContainer::isBlinded)
+                            .ifPresent(__ -> blindedBlockCreatorCache.put(slot, apiChannel)));
+    return tryRequestUntilSuccess(request);
   }
 
   @Override
@@ -174,29 +148,25 @@ public class FailoverValidatorApiHandler implements ValidatorApiChannel {
             apiChannel
                 .createUnsignedBlock(slot, randaoReveal, graffiti)
                 .thenPeek(
-                    blockContainer -> {
-                      if (!failoverDelegates.isEmpty()
-                          && blockContainer.map(BlockContainer::isBlinded).orElse(false)) {
-                        blindedBlockCreatorCache.put(slot, apiChannel);
-                      }
-                    });
-    return tryRequestUntilSuccess(request, BeaconNodeRequestLabels.CREATE_UNSIGNED_BLOCK_METHOD);
+                    blockContainer ->
+                        blockContainer
+                            .filter(BlockContainer::isBlinded)
+                            .ifPresent(__ -> blindedBlockCreatorCache.put(slot, apiChannel)));
+    return tryRequestUntilSuccess(request);
   }
 
   @Override
   public SafeFuture<Optional<AttestationData>> createAttestationData(
       final UInt64 slot, final int committeeIndex) {
     return tryRequestUntilSuccess(
-        apiChannel -> apiChannel.createAttestationData(slot, committeeIndex),
-        BeaconNodeRequestLabels.CREATE_ATTESTATION_METHOD);
+        apiChannel -> apiChannel.createAttestationData(slot, committeeIndex));
   }
 
   @Override
   public SafeFuture<Optional<Attestation>> createAggregate(
       final UInt64 slot, final Bytes32 attestationHashTreeRoot) {
     return tryRequestUntilSuccess(
-        apiChannel -> apiChannel.createAggregate(slot, attestationHashTreeRoot),
-        BeaconNodeRequestLabels.CREATE_AGGREGATE_METHOD);
+        apiChannel -> apiChannel.createAggregate(slot, attestationHashTreeRoot));
   }
 
   @Override
@@ -204,15 +174,13 @@ public class FailoverValidatorApiHandler implements ValidatorApiChannel {
       final UInt64 slot, final int subcommitteeIndex, final Bytes32 beaconBlockRoot) {
     return tryRequestUntilSuccess(
         apiChannel ->
-            apiChannel.createSyncCommitteeContribution(slot, subcommitteeIndex, beaconBlockRoot),
-        BeaconNodeRequestLabels.CREATE_SYNC_COMMITTEE_CONTRIBUTION_METHOD);
+            apiChannel.createSyncCommitteeContribution(slot, subcommitteeIndex, beaconBlockRoot));
   }
 
   @Override
   public SafeFuture<Void> subscribeToBeaconCommittee(List<CommitteeSubscriptionRequest> requests) {
     return relayRequest(
         apiChannel -> apiChannel.subscribeToBeaconCommittee(requests),
-        BeaconNodeRequestLabels.BEACON_COMMITTEE_SUBSCRIPTION_METHOD,
         failoversSendSubnetSubscriptions);
   }
 
@@ -221,7 +189,6 @@ public class FailoverValidatorApiHandler implements ValidatorApiChannel {
       Collection<SyncCommitteeSubnetSubscription> subscriptions) {
     return relayRequest(
         apiChannel -> apiChannel.subscribeToSyncCommitteeSubnets(subscriptions),
-        BeaconNodeRequestLabels.SYNC_COMMITTEE_SUBNET_SUBSCRIPTION_METHOD,
         failoversSendSubnetSubscriptions);
   }
 
@@ -230,7 +197,6 @@ public class FailoverValidatorApiHandler implements ValidatorApiChannel {
       Set<SubnetSubscription> subnetSubscriptions) {
     return relayRequest(
         apiChannel -> apiChannel.subscribeToPersistentSubnets(subnetSubscriptions),
-        BeaconNodeRequestLabels.PERSISTENT_SUBNETS_SUBSCRIPTION_METHOD,
         failoversSendSubnetSubscriptions);
   }
 
@@ -238,7 +204,6 @@ public class FailoverValidatorApiHandler implements ValidatorApiChannel {
   public SafeFuture<List<SubmitDataError>> sendSignedAttestations(List<Attestation> attestations) {
     return relayRequest(
         apiChannel -> apiChannel.sendSignedAttestations(attestations),
-        BeaconNodeRequestLabels.PUBLISH_ATTESTATION_METHOD,
         failoversPublishSignedDuties);
   }
 
@@ -247,7 +212,6 @@ public class FailoverValidatorApiHandler implements ValidatorApiChannel {
       final List<SignedAggregateAndProof> aggregateAndProofs) {
     return relayRequest(
         apiChannel -> apiChannel.sendAggregateAndProofs(aggregateAndProofs),
-        BeaconNodeRequestLabels.PUBLISH_AGGREGATE_AND_PROOFS_METHOD,
         failoversPublishSignedDuties);
   }
 
@@ -265,7 +229,6 @@ public class FailoverValidatorApiHandler implements ValidatorApiChannel {
     }
     return relayRequest(
         apiChannel -> apiChannel.sendSignedBlock(blockContainer, broadcastValidationLevel),
-        BeaconNodeRequestLabels.PUBLISH_BLOCK_METHOD,
         failoversPublishSignedDuties);
   }
 
@@ -274,7 +237,6 @@ public class FailoverValidatorApiHandler implements ValidatorApiChannel {
       final List<SyncCommitteeMessage> syncCommitteeMessages) {
     return relayRequest(
         apiChannel -> apiChannel.sendSyncCommitteeMessages(syncCommitteeMessages),
-        BeaconNodeRequestLabels.SEND_SYNC_COMMITTEE_MESSAGES_METHOD,
         failoversPublishSignedDuties);
   }
 
@@ -283,240 +245,162 @@ public class FailoverValidatorApiHandler implements ValidatorApiChannel {
       final Collection<SignedContributionAndProof> signedContributionAndProofs) {
     return relayRequest(
         apiChannel -> apiChannel.sendSignedContributionAndProofs(signedContributionAndProofs),
-        BeaconNodeRequestLabels.SEND_CONTRIBUTIONS_AND_PROOFS_METHOD,
         failoversPublishSignedDuties);
   }
 
   @Override
   public SafeFuture<Void> prepareBeaconProposer(
       final Collection<BeaconPreparableProposer> beaconPreparableProposers) {
-    return relayRequest(
-        apiChannel -> apiChannel.prepareBeaconProposer(beaconPreparableProposers),
-        BeaconNodeRequestLabels.PREPARE_BEACON_PROPOSERS_METHOD);
+    return relayRequest(apiChannel -> apiChannel.prepareBeaconProposer(beaconPreparableProposers));
   }
 
   @Override
   public SafeFuture<Void> registerValidators(
       final SszList<SignedValidatorRegistration> validatorRegistrations) {
-    return relayRequest(
-        apiChannel -> apiChannel.registerValidators(validatorRegistrations),
-        BeaconNodeRequestLabels.REGISTER_VALIDATORS_METHOD);
+    return relayRequest(apiChannel -> apiChannel.registerValidators(validatorRegistrations));
   }
 
   @Override
   public SafeFuture<Optional<List<ValidatorLivenessAtEpoch>>> getValidatorsLiveness(
       final List<UInt64> validatorIndices, final UInt64 epoch) {
     return tryRequestUntilSuccess(
-        apiChannel -> apiChannel.getValidatorsLiveness(validatorIndices, epoch),
-        BeaconNodeRequestLabels.GET_VALIDATORS_LIVENESS);
+        apiChannel -> apiChannel.getValidatorsLiveness(validatorIndices, epoch));
   }
 
-  private <T> SafeFuture<T> relayRequest(
-      final ValidatorApiChannelRequest<T> request, final String method) {
-    return relayRequest(request, method, true);
+  private <T> SafeFuture<T> relayRequest(final ValidatorApiChannelRequest<T> request) {
+    return relayRequest(request, true);
   }
 
   /**
    * Relays the given request to the primary Beacon Node along with all failover Beacon Node
-   * endpoints if relayRequestToFailovers flag is true. If there are failovers configured, the
-   * request to the primary Beacon Node will be skipped if the {@link BeaconNodeReadinessManager}
-   * marked it as NOT ready.The returned {@link SafeFuture} will complete with the response from the
-   * primary Beacon Node or in case in failure or if the primary node is NOT ready, it will complete
-   * with the first successful response from a failover node. The returned {@link SafeFuture} will
-   * only complete exceptionally when the request to the primary Beacon Node and all the requests to
-   * the failover nodes fail. In this case, the returned {@link SafeFuture} will complete
-   * exceptionally with a {@link FailoverRequestException}.
+   * endpoints if relayRequestToFailovers flag is true. The request to the primary Beacon Node will
+   * be skipped if the {@link BeaconNodeReadinessManager} marked it as NOT ready.The returned {@link
+   * SafeFuture} will complete with the response from the primary Beacon Node or in case in failure
+   * or if the primary node is NOT ready, it will complete with the first successful response from a
+   * failover node. The returned {@link SafeFuture} will only complete exceptionally when the
+   * request to the primary Beacon Node and all the requests to the failover nodes fail. In this
+   * case, the returned {@link SafeFuture} will complete exceptionally with a {@link
+   * FailoverRequestException}.
    */
   private <T> SafeFuture<T> relayRequest(
-      final ValidatorApiChannelRequest<T> request,
-      final String method,
-      final boolean relayRequestToFailovers) {
-    if (failoverDelegates.isEmpty() || !relayRequestToFailovers) {
-      return runPrimaryRequest(request, method);
+      final ValidatorApiChannelRequest<T> request, final boolean relayRequestToFailovers) {
+    if (!relayRequestToFailovers) {
+      return runPrimaryRequest(request);
     }
     final Map<RemoteValidatorApiChannel, Throwable> capturedExceptions = new ConcurrentHashMap<>();
     final List<SafeFuture<T>> failoverResponses =
         failoverDelegates.stream()
             .map(
                 failover ->
-                    runRequest(failover, request, method)
+                    runRequest(failover, request)
                         .catchAndRethrow(throwable -> capturedExceptions.put(failover, throwable)))
             .toList();
     if (!beaconNodeReadinessManager.isReady(primaryDelegate)) {
       LOG.debug(
-          "Remote request ({}) will NOT be sent to the primary Beacon Node {} because it is NOT ready. Will try to use a response from a failover.",
-          method,
+          "Remote request will NOT be sent to the primary Beacon Node {} because it is NOT ready. Will try to use a response from a failover.",
           primaryDelegate.getEndpoint());
-      return getFirstSuccessfulResponseFromFailovers(failoverResponses, method, capturedExceptions);
+      return getFirstSuccessfulResponseFromFailovers(failoverResponses, capturedExceptions);
     }
-    return runPrimaryRequest(request, method)
+    return runPrimaryRequest(request)
         .exceptionallyCompose(
             primaryThrowable -> {
               capturedExceptions.put(primaryDelegate, primaryThrowable);
               LOG.debug(
-                  "Remote request ({}) which is sent to all configured Beacon Node endpoints failed on the primary Beacon Node {}. Will try to use a response from a failover.",
-                  method,
+                  "Remote request which is sent to all configured Beacon Node endpoints failed on the primary Beacon Node {}. Will try to use a response from a failover.",
                   primaryDelegate.getEndpoint());
-              return getFirstSuccessfulResponseFromFailovers(
-                  failoverResponses, method, capturedExceptions);
+              return getFirstSuccessfulResponseFromFailovers(failoverResponses, capturedExceptions);
             });
   }
 
   private <T> SafeFuture<T> getFirstSuccessfulResponseFromFailovers(
       final List<SafeFuture<T>> failoverResponses,
-      final String method,
       final Map<RemoteValidatorApiChannel, Throwable> capturedExceptions) {
     return SafeFuture.firstSuccess(failoverResponses)
         .exceptionallyCompose(
             __ -> {
               final FailoverRequestException failoverRequestException =
-                  new FailoverRequestException(method, capturedExceptions);
+                  new FailoverRequestException(capturedExceptions);
               return SafeFuture.failedFuture(failoverRequestException);
-            })
-        .thenPeek(
-            __ ->
-                LOG.debug(
-                    "Received a successful response from a failover for remote request ({})",
-                    method));
+            });
   }
 
   /**
-   * Tries the given request first with the primary Beacon Node. If there are failovers configured,
-   * the request to the primary Beacon Node will be skipped if the {@link
-   * BeaconNodeReadinessManager} marked it as NOT ready. If the request to the primary Beacon Node
-   * fails, the request will be retried against each failover Beacon Node in order of readiness
-   * determined by the {@link BeaconNodeReadinessManager} until there is a successful response. In
-   * case all the requests fail, the returned {@link SafeFuture} will complete exceptionally with a
-   * {@link FailoverRequestException}.
+   * Tries the given request first with the primary Beacon Node. The request to the primary Beacon
+   * Node will be skipped if the {@link BeaconNodeReadinessManager} marked it as NOT ready. If the
+   * request to the primary Beacon Node fails, the request will be retried against each failover
+   * Beacon Node in order of readiness determined by the {@link BeaconNodeReadinessManager} until
+   * there is a successful response. In case all the requests fail, the returned {@link SafeFuture}
+   * will complete exceptionally with a {@link FailoverRequestException}.
    */
-  private <T> SafeFuture<T> tryRequestUntilSuccess(
-      final ValidatorApiChannelRequest<T> request, final String method) {
-    if (failoverDelegates.isEmpty()) {
-      return runPrimaryRequest(request, method);
-    }
+  private <T> SafeFuture<T> tryRequestUntilSuccess(final ValidatorApiChannelRequest<T> request) {
     if (!beaconNodeReadinessManager.isReady(primaryDelegate)) {
       LOG.debug(
-          "Remote request ({}) will NOT be sent to the primary Beacon Node {} because it is NOT ready. Will try sending the request to one of the configured failovers.",
-          method,
+          "Remote request will NOT be sent to the primary Beacon Node {} because it is NOT ready. Will try sending the request to one of the configured failovers.",
           primaryDelegate.getEndpoint());
-      return makeRequestToFailoversUntilSuccess(request, method, new HashMap<>());
+      return makeRequestToFailoversUntilSuccess(request, new HashMap<>());
     }
-    return runPrimaryRequest(request, method)
+    return runPrimaryRequest(request)
         .exceptionallyCompose(
             throwable -> {
               LOG.debug(
-                  "Remote request ({}) to the primary Beacon Node {} failed. Will try sending the request to one of the configured failovers.",
-                  method,
+                  "Remote request to the primary Beacon Node {} failed. Will try sending the request to one of the configured failovers.",
                   primaryDelegate.getEndpoint());
               final Map<RemoteValidatorApiChannel, Throwable> capturedExceptions = new HashMap<>();
               capturedExceptions.put(primaryDelegate, throwable);
-              return makeRequestToFailoversUntilSuccess(request, method, capturedExceptions);
+              return makeRequestToFailoversUntilSuccess(request, capturedExceptions);
             });
   }
 
   private <T> SafeFuture<T> makeRequestToFailoversUntilSuccess(
       final ValidatorApiChannelRequest<T> request,
-      final String method,
       final Map<RemoteValidatorApiChannel, Throwable> capturedExceptions) {
     final Iterator<? extends RemoteValidatorApiChannel> failoverDelegates =
         beaconNodeReadinessManager.getFailoversInOrderOfReadiness();
     return makeRequestToFailoversUntilSuccess(
-        failoverDelegates.next(), failoverDelegates, request, method, capturedExceptions);
+        failoverDelegates.next(), failoverDelegates, request, capturedExceptions);
   }
 
   private <T> SafeFuture<T> makeRequestToFailoversUntilSuccess(
       final RemoteValidatorApiChannel currentFailoverDelegate,
       final Iterator<? extends RemoteValidatorApiChannel> failoverDelegates,
       final ValidatorApiChannelRequest<T> request,
-      final String method,
       final Map<RemoteValidatorApiChannel, Throwable> capturedExceptions) {
-    final SafeFuture<T> response = runRequest(currentFailoverDelegate, request, method);
-    return response
+    return runRequest(currentFailoverDelegate, request)
         .exceptionallyCompose(
             throwable -> {
               capturedExceptions.put(currentFailoverDelegate, throwable);
               if (!failoverDelegates.hasNext()) {
                 final FailoverRequestException failoverRequestException =
-                    new FailoverRequestException(method, capturedExceptions);
+                    new FailoverRequestException(capturedExceptions);
                 return SafeFuture.failedFuture(failoverRequestException);
               }
               final RemoteValidatorApiChannel nextFailoverDelegate = failoverDelegates.next();
               LOG.debug(
-                  "Remote request ({}) to a failover Beacon Node {} failed. Will try sending the request to another failover {}",
-                  method,
+                  "Remote request to a failover Beacon Node {} failed. Will try sending the request to another failover {}",
                   currentFailoverDelegate.getEndpoint(),
                   nextFailoverDelegate.getEndpoint());
               return makeRequestToFailoversUntilSuccess(
-                  nextFailoverDelegate, failoverDelegates, request, method, capturedExceptions);
+                  nextFailoverDelegate, failoverDelegates, request, capturedExceptions);
             })
         .thenPeek(
             __ ->
                 LOG.debug(
-                    "Remote request ({}) succeeded using a failover Beacon Node {}",
-                    method,
+                    "Remote request succeeded using a failover Beacon Node {}",
                     currentFailoverDelegate.getEndpoint()));
   }
 
-  private <T> SafeFuture<T> runPrimaryRequest(
-      final ValidatorApiChannelRequest<T> request, final String method) {
-    return runRequest(primaryDelegate, request, method);
+  private <T> SafeFuture<T> runPrimaryRequest(final ValidatorApiChannelRequest<T> request) {
+    return runRequest(primaryDelegate, request);
   }
 
   private <T> SafeFuture<T> runRequest(
-      final RemoteValidatorApiChannel delegate,
-      final ValidatorApiChannelRequest<T> request,
-      final String method) {
-    return request
-        .run(delegate)
-        .handleComposed(
-            (response, throwable) -> {
-              if (throwable != null) {
-                LOG.trace(
-                    String.format("Request (%s) to %s failed", method, delegate.getEndpoint()),
-                    throwable);
-                recordFailedRequest(delegate, method);
-                return SafeFuture.failedFuture(throwable);
-              }
-              recordSuccessfulRequest(delegate, method);
-              return SafeFuture.completedFuture(response);
-            });
-  }
-
-  private void recordSuccessfulRequest(
-      final RemoteValidatorApiChannel failover, final String method) {
-    recordRequest(failover, method, RequestOutcome.SUCCESS);
-  }
-
-  private void recordFailedRequest(final RemoteValidatorApiChannel failover, final String method) {
-    recordRequest(failover, method, RequestOutcome.ERROR);
-  }
-
-  private void recordRequest(
-      final RemoteValidatorApiChannel failover, final String method, final RequestOutcome outcome) {
-    failoverBeaconNodesRequestsCounter
-        .labels(failover.getEndpoint().toString(), method, outcome.displayName)
-        .inc();
+      final RemoteValidatorApiChannel delegate, final ValidatorApiChannelRequest<T> request) {
+    return request.run(delegate);
   }
 
   @VisibleForTesting
   @FunctionalInterface
   interface ValidatorApiChannelRequest<T> {
     SafeFuture<T> run(final ValidatorApiChannel apiChannel);
-  }
-
-  enum RequestOutcome {
-    SUCCESS("success"),
-    ERROR("error");
-
-    private final String displayName;
-
-    RequestOutcome(final String displayName) {
-      this.displayName = displayName;
-    }
-
-    @Override
-    public String toString() {
-      return displayName;
-    }
   }
 }

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApi.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApi.java
@@ -87,7 +87,7 @@ public class RemoteBeaconNodeApi implements BeaconNodeApi {
             asyncRunner,
             metricsSystem);
     final List<? extends RemoteValidatorApiChannel> failoverValidatorApis =
-        createFailoverValidatorApiChannel(
+        createFailoverValidatorApiChannels(
             validatorConfig,
             remoteBeaconNodeEndpoints,
             okHttpClient,
@@ -114,7 +114,7 @@ public class RemoteBeaconNodeApi implements BeaconNodeApi {
 
     final ValidatorApiChannel validatorApi;
 
-    if (!remoteBeaconNodeEndpoints.getFailoverEndpoints().isEmpty()) {
+    if (!failoverValidatorApis.isEmpty()) {
       LOG.info(
           "Will use {} as failover Beacon Node endpoints",
           remoteBeaconNodeEndpoints.getFailoverEndpoints());
@@ -190,7 +190,7 @@ public class RemoteBeaconNodeApi implements BeaconNodeApi {
             asyncRunner));
   }
 
-  public static List<? extends RemoteValidatorApiChannel> createFailoverValidatorApiChannel(
+  public static List<? extends RemoteValidatorApiChannel> createFailoverValidatorApiChannels(
       final ValidatorConfig validatorConfig,
       final RemoteBeaconNodeEndpoints remoteBeaconNodeEndpoints,
       final OkHttpClient httpClient,

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteMetricRecordingValidatorApiChannel.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteMetricRecordingValidatorApiChannel.java
@@ -64,7 +64,7 @@ import tech.pegasys.teku.validator.beaconnode.metrics.BeaconNodeRequestLabels;
 public class RemoteMetricRecordingValidatorApiChannel implements RemoteValidatorApiChannel {
 
   static final String REMOTE_BEACON_NODE_REQUESTS_COUNTER_NAME =
-      "remote_beacon_node_requests_total";
+      "remote_beacon_nodes_requests_total";
 
   private final RemoteValidatorApiChannel delegate;
   private final LabelledMetric<Counter> beaconNodeRequestsCounter;

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteMetricRecordingValidatorApiChannel.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteMetricRecordingValidatorApiChannel.java
@@ -25,8 +25,6 @@ import tech.pegasys.teku.validator.beaconnode.metrics.MetricRecordingValidatorAp
 public class RemoteMetricRecordingValidatorApiChannel extends MetricRecordingValidatorApiChannel
     implements RemoteValidatorApiChannel {
 
-  static final String BEACON_NODE_REQUESTS_COUNTER_NAME = "remote_beacon_nodes_requests_total";
-
   private final RemoteValidatorApiChannel delegate;
 
   public RemoteMetricRecordingValidatorApiChannel(
@@ -40,7 +38,7 @@ public class RemoteMetricRecordingValidatorApiChannel extends MetricRecordingVal
     return metricsSystem.createLabelledCounter(
         TekuMetricCategory.VALIDATOR,
         BEACON_NODE_REQUESTS_COUNTER_NAME,
-        "Counter recording the number of remote requests sent to the beacon node(s)",
+        "Counter recording the number of remote requests sent to the configured beacon node(s)",
         "endpoint",
         "method",
         "outcome");

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/sentry/SentryBeaconNodeApi.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/sentry/SentryBeaconNodeApi.java
@@ -13,7 +13,7 @@
 
 package tech.pegasys.teku.validator.remote.sentry;
 
-import static tech.pegasys.teku.validator.remote.RemoteBeaconNodeApi.createFailoverValidatorApiChannel;
+import static tech.pegasys.teku.validator.remote.RemoteBeaconNodeApi.createFailoverValidatorApiChannels;
 import static tech.pegasys.teku.validator.remote.RemoteBeaconNodeApi.createPrimaryValidatorApiChannel;
 
 import java.net.URI;
@@ -87,7 +87,7 @@ public class SentryBeaconNodeApi implements BeaconNodeApi {
             asyncRunner,
             metricsSystem);
     final List<? extends RemoteValidatorApiChannel> dutiesProviderFailoverValidatorApiChannels =
-        createFailoverValidatorApiChannel(
+        createFailoverValidatorApiChannels(
             validatorConfig,
             dutiesProviderHttpClient,
             sentryNodesHttpClient,
@@ -113,6 +113,7 @@ public class SentryBeaconNodeApi implements BeaconNodeApi {
     eventChannels.subscribe(ValidatorTimingChannel.class, beaconNodeReadinessManager);
 
     final ValidatorApiChannel dutiesProviderValidatorApi;
+
     if (!dutiesProviderFailoverValidatorApiChannels.isEmpty()) {
       dutiesProviderValidatorApi =
           new FailoverValidatorApiHandler(
@@ -200,7 +201,7 @@ public class SentryBeaconNodeApi implements BeaconNodeApi {
             asyncRunner,
             metricsSystem);
     final List<? extends RemoteValidatorApiChannel> failoverValidatorApis =
-        createFailoverValidatorApiChannel(
+        createFailoverValidatorApiChannels(
             validatorConfig,
             remoteBeaconNodeEndpoints,
             httpClient,
@@ -210,7 +211,7 @@ public class SentryBeaconNodeApi implements BeaconNodeApi {
 
     final ValidatorApiChannel validatorApi;
 
-    if (!remoteBeaconNodeEndpoints.getFailoverEndpoints().isEmpty()) {
+    if (!failoverValidatorApis.isEmpty()) {
       LOG.info(
           "Will use {} as failover Beacon Node endpoints",
           remoteBeaconNodeEndpoints.getFailoverEndpoints());

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/sentry/SentryBeaconNodeApi.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/sentry/SentryBeaconNodeApi.java
@@ -13,6 +13,9 @@
 
 package tech.pegasys.teku.validator.remote.sentry;
 
+import static tech.pegasys.teku.validator.remote.RemoteBeaconNodeApi.createFailoverValidatorApiChannel;
+import static tech.pegasys.teku.validator.remote.RemoteBeaconNodeApi.createPrimaryValidatorApiChannel;
+
 import java.net.URI;
 import java.util.List;
 import java.util.Optional;
@@ -38,9 +41,7 @@ import tech.pegasys.teku.validator.remote.BeaconNodeReadinessChannel;
 import tech.pegasys.teku.validator.remote.BeaconNodeReadinessManager;
 import tech.pegasys.teku.validator.remote.FailoverValidatorApiHandler;
 import tech.pegasys.teku.validator.remote.RemoteBeaconNodeEndpoints;
-import tech.pegasys.teku.validator.remote.RemoteMetricRecordingValidatorApiChannel;
 import tech.pegasys.teku.validator.remote.RemoteValidatorApiChannel;
-import tech.pegasys.teku.validator.remote.RemoteValidatorApiHandler;
 import tech.pegasys.teku.validator.remote.eventsource.EventSourceBeaconChainEventAdapter;
 
 public class SentryBeaconNodeApi implements BeaconNodeApi {
@@ -178,44 +179,6 @@ public class SentryBeaconNodeApi implements BeaconNodeApi {
 
     return new SentryBeaconNodeApi(
         beaconChainEventAdapter, sentryValidatorApi, beaconNodeReadinessManager);
-  }
-
-  private static RemoteValidatorApiChannel createPrimaryValidatorApiChannel(
-      final ValidatorConfig validatorConfig,
-      final RemoteBeaconNodeEndpoints remoteBeaconNodeEndpoints,
-      final OkHttpClient httpClient,
-      final Spec spec,
-      final AsyncRunner asyncRunner,
-      final MetricsSystem metricsSystem) {
-    return new RemoteMetricRecordingValidatorApiChannel(
-        metricsSystem,
-        RemoteValidatorApiHandler.create(
-            remoteBeaconNodeEndpoints.getPrimaryEndpoint(),
-            httpClient,
-            spec,
-            validatorConfig.isValidatorClientUseSszBlocksEnabled(),
-            asyncRunner));
-  }
-
-  private static List<? extends RemoteValidatorApiChannel> createFailoverValidatorApiChannel(
-      final ValidatorConfig validatorConfig,
-      final RemoteBeaconNodeEndpoints remoteBeaconNodeEndpoints,
-      final OkHttpClient httpClient,
-      final Spec spec,
-      final AsyncRunner asyncRunner,
-      final MetricsSystem metricsSystem) {
-    return remoteBeaconNodeEndpoints.getFailoverEndpoints().stream()
-        .map(
-            endpoint ->
-                new RemoteMetricRecordingValidatorApiChannel(
-                    metricsSystem,
-                    RemoteValidatorApiHandler.create(
-                        endpoint,
-                        httpClient,
-                        spec,
-                        validatorConfig.isValidatorClientUseSszBlocksEnabled(),
-                        asyncRunner)))
-        .toList();
   }
 
   private static ValidatorApiChannel createRemoteValidatorApiForRole(

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteMetricRecordingValidatorApiChannelTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteMetricRecordingValidatorApiChannelTest.java
@@ -1,0 +1,283 @@
+/*
+ * Copyright Consensys Software Inc., 2023
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.remote;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptySet;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Stream;
+import okhttp3.HttpUrl;
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
+import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.genesis.GenesisData;
+import tech.pegasys.teku.spec.datastructures.operations.Attestation;
+import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
+import tech.pegasys.teku.spec.datastructures.operations.SignedAggregateAndProof;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeMessage;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.validator.api.SubmitDataError;
+import tech.pegasys.teku.validator.api.ValidatorApiChannel;
+import tech.pegasys.teku.validator.beaconnode.metrics.BeaconNodeRequestLabels;
+import tech.pegasys.teku.validator.remote.RemoteMetricRecordingValidatorApiChannel.RequestOutcome;
+
+public class RemoteMetricRecordingValidatorApiChannelTest {
+
+  private static final String DELEGATE_ENDPOINT = "http://delegate.com/";
+
+  private final RemoteValidatorApiChannel delegate = mock(RemoteValidatorApiChannel.class);
+  private final StubMetricsSystem metricsSystem = new StubMetricsSystem();
+  private final RemoteMetricRecordingValidatorApiChannel apiChannel =
+      new RemoteMetricRecordingValidatorApiChannel(metricsSystem, delegate);
+
+  @BeforeEach
+  public void setup() {
+    when(delegate.getEndpoint()).thenReturn(HttpUrl.get(DELEGATE_ENDPOINT));
+  }
+
+  @ParameterizedTest(name = "{displayName} - {0}")
+  @MethodSource("getDataRequestArguments")
+  public void shouldRecordSuccessfulRequestForData(
+      final Function<ValidatorApiChannel, SafeFuture<Optional<Object>>> method,
+      final String methodLabel,
+      final Object value) {
+    final Optional<Object> response = Optional.of(value);
+    when(method.apply(delegate)).thenReturn(SafeFuture.completedFuture(response));
+
+    final SafeFuture<Optional<Object>> result = method.apply(apiChannel);
+
+    assertThat(result).isCompletedWithValue(response);
+
+    assertThat(getCounterValue(methodLabel, RequestOutcome.SUCCESS)).isEqualTo(1);
+    assertThat(getCounterValue(methodLabel, RequestOutcome.ERROR)).isZero();
+    assertThat(getCounterValue(methodLabel, RequestOutcome.DATA_UNAVAILABLE)).isZero();
+  }
+
+  @ParameterizedTest(name = "{displayName} - {0}")
+  @MethodSource("getDataRequestArguments")
+  public void shouldRecordFailedRequestForData(
+      final Function<ValidatorApiChannel, SafeFuture<Optional<Object>>> method,
+      final String methodLabel) {
+    final RuntimeException exception = new RuntimeException("Nope");
+    when(method.apply(delegate)).thenReturn(SafeFuture.failedFuture(exception));
+
+    final SafeFuture<Optional<Object>> result = method.apply(apiChannel);
+    assertThat(result).isCompletedExceptionally();
+    assertThatThrownBy(result::join).hasRootCause(exception);
+
+    assertThat(getCounterValue(methodLabel, RequestOutcome.ERROR)).isEqualTo(1);
+    assertThat(getCounterValue(methodLabel, RequestOutcome.SUCCESS)).isZero();
+    assertThat(getCounterValue(methodLabel, RequestOutcome.DATA_UNAVAILABLE)).isZero();
+  }
+
+  @ParameterizedTest(name = "{displayName} - {0}")
+  @MethodSource("getDataRequestArguments")
+  public void shouldRecordRequestForDataWhenDataUnavailable(
+      final Function<ValidatorApiChannel, SafeFuture<Optional<Object>>> method,
+      final String methodLabel) {
+    when(method.apply(delegate)).thenReturn(SafeFuture.completedFuture(Optional.empty()));
+
+    final SafeFuture<Optional<Object>> result = method.apply(apiChannel);
+    assertThat(result).isCompletedWithValue(Optional.empty());
+
+    assertThat(getCounterValue(methodLabel, RequestOutcome.DATA_UNAVAILABLE)).isEqualTo(1);
+    assertThat(getCounterValue(methodLabel, RequestOutcome.SUCCESS)).isZero();
+    assertThat(getCounterValue(methodLabel, RequestOutcome.ERROR)).isZero();
+  }
+
+  @ParameterizedTest(name = "{displayName} - {0}")
+  @MethodSource("getSendDataArguments")
+  void shouldRecordSuccessfulSendRequest(
+      final Function<ValidatorApiChannel, SafeFuture<List<Object>>> method,
+      final String methodLabel) {
+    when(method.apply(delegate)).thenReturn(SafeFuture.completedFuture(emptyList()));
+
+    final SafeFuture<List<Object>> result = method.apply(apiChannel);
+
+    assertThat(result).isCompletedWithValue(emptyList());
+
+    assertThat(getCounterValue(methodLabel, RequestOutcome.SUCCESS)).isEqualTo(1);
+    assertThat(getCounterValue(methodLabel, RequestOutcome.ERROR)).isZero();
+    assertThat(getCounterValue(methodLabel, RequestOutcome.DATA_UNAVAILABLE)).isZero();
+  }
+
+  @ParameterizedTest(name = "{displayName} - {0}")
+  @MethodSource("getSendDataArguments")
+  void shouldRecordFailingSendRequest(
+      final Function<ValidatorApiChannel, SafeFuture<List<Object>>> method,
+      final String methodLabel,
+      final List<Object> failures) {
+    when(method.apply(delegate)).thenReturn(SafeFuture.completedFuture(failures));
+
+    final SafeFuture<List<Object>> result = method.apply(apiChannel);
+
+    assertThat(result).isCompletedWithValue(failures);
+
+    assertThat(getCounterValue(methodLabel, RequestOutcome.SUCCESS)).isZero();
+    assertThat(getCounterValue(methodLabel, RequestOutcome.ERROR)).isEqualTo(1);
+    assertThat(getCounterValue(methodLabel, RequestOutcome.DATA_UNAVAILABLE)).isZero();
+  }
+
+  @ParameterizedTest(name = "{displayName} - {0}")
+  @MethodSource("getNoResponseCallArguments")
+  public void shouldRecordCallsWithNoResponse(
+      final Function<ValidatorApiChannel, SafeFuture<Void>> method, final String methodLabel) {
+    when(method.apply(delegate)).thenReturn(SafeFuture.COMPLETE);
+
+    final SafeFuture<Void> result = method.apply(apiChannel);
+
+    assertThat(result).isCompleted();
+
+    assertThat(getCounterValue(methodLabel, RequestOutcome.SUCCESS)).isEqualTo(1);
+    assertThat(getCounterValue(methodLabel, RequestOutcome.ERROR)).isZero();
+    assertThat(getCounterValue(methodLabel, RequestOutcome.DATA_UNAVAILABLE)).isZero();
+  }
+
+  public static Stream<Arguments> getNoResponseCallArguments() {
+    return Stream.of(
+        noResponseTest(
+            "subscribeToBeaconCommitteeForAggregation",
+            channel -> channel.subscribeToBeaconCommittee(emptyList()),
+            BeaconNodeRequestLabels.BEACON_COMMITTEE_SUBSCRIPTION_METHOD),
+        noResponseTest(
+            "subscribeToPersistentSubnets",
+            channel -> channel.subscribeToPersistentSubnets(emptySet()),
+            BeaconNodeRequestLabels.PERSISTENT_SUBNETS_SUBSCRIPTION_METHOD));
+  }
+
+  private static Arguments noResponseTest(
+      final String name,
+      final Function<ValidatorApiChannel, SafeFuture<Void>> method,
+      final String methodLabel) {
+    return Arguments.of(Named.named(name, method), methodLabel);
+  }
+
+  public static Stream<Arguments> getDataRequestArguments() {
+    final DataStructureUtil dataStructureUtil =
+        new DataStructureUtil(TestSpecFactory.createMinimalAltair());
+    final UInt64 slot = dataStructureUtil.randomUInt64();
+    final BLSSignature signature = dataStructureUtil.randomSignature();
+    final AttestationData attestationData = dataStructureUtil.randomAttestationData();
+    final int subcommitteeIndex = dataStructureUtil.randomPositiveInt();
+    final Bytes32 beaconBlockRoot = dataStructureUtil.randomBytes32();
+    final List<UInt64> validatorIndices =
+        List.of(
+            dataStructureUtil.randomUInt64(),
+            dataStructureUtil.randomUInt64(),
+            dataStructureUtil.randomUInt64());
+    final UInt64 epoch = dataStructureUtil.randomEpoch();
+    return Stream.of(
+        requestDataTest(
+            "getGenesisData",
+            ValidatorApiChannel::getGenesisData,
+            BeaconNodeRequestLabels.GET_GENESIS_METHOD,
+            new GenesisData(dataStructureUtil.randomUInt64(), Bytes32.random())),
+        requestDataTest(
+            "createUnsignedBlock",
+            channel -> channel.createUnsignedBlock(slot, signature, Optional.empty(), false),
+            BeaconNodeRequestLabels.CREATE_UNSIGNED_BLOCK_METHOD,
+            dataStructureUtil.randomBeaconBlock(slot)),
+        requestDataTest(
+            "createAttestationData",
+            channel -> channel.createAttestationData(slot, 4),
+            BeaconNodeRequestLabels.CREATE_ATTESTATION_METHOD,
+            dataStructureUtil.randomAttestationData()),
+        requestDataTest(
+            "createAggregate",
+            channel ->
+                channel.createAggregate(attestationData.getSlot(), attestationData.hashTreeRoot()),
+            BeaconNodeRequestLabels.CREATE_AGGREGATE_METHOD,
+            dataStructureUtil.randomAttestation()),
+        requestDataTest(
+            "createSyncCommitteeContribution",
+            channel ->
+                channel.createSyncCommitteeContribution(slot, subcommitteeIndex, beaconBlockRoot),
+            BeaconNodeRequestLabels.CREATE_SYNC_COMMITTEE_CONTRIBUTION_METHOD,
+            dataStructureUtil.randomSyncCommitteeContribution(slot)),
+        requestDataTest(
+            "getValidatorsLiveness",
+            channel -> channel.getValidatorsLiveness(validatorIndices, epoch),
+            BeaconNodeRequestLabels.GET_VALIDATORS_LIVENESS,
+            new ArrayList<>()));
+  }
+
+  public static Stream<Arguments> getSendDataArguments() {
+    final DataStructureUtil dataStructureUtil =
+        new DataStructureUtil(TestSpecFactory.createMinimalAltair());
+    final List<SubmitDataError> submissionErrors =
+        List.of(new SubmitDataError(UInt64.ZERO, "Nope"));
+    final List<Attestation> attestations = List.of(dataStructureUtil.randomAttestation());
+    final List<SyncCommitteeMessage> syncCommitteeMessages =
+        List.of(dataStructureUtil.randomSyncCommitteeMessage());
+    final List<SignedAggregateAndProof> aggregateAndProofs =
+        List.of(dataStructureUtil.randomSignedAggregateAndProof());
+    return Stream.of(
+        sendDataTest(
+            "sendSignedAttestations",
+            channel -> channel.sendSignedAttestations(attestations),
+            BeaconNodeRequestLabels.PUBLISH_ATTESTATION_METHOD,
+            submissionErrors),
+        sendDataTest(
+            "sendSyncCommitteeMessages",
+            channel -> channel.sendSyncCommitteeMessages(syncCommitteeMessages),
+            BeaconNodeRequestLabels.SEND_SYNC_COMMITTEE_MESSAGES_METHOD,
+            submissionErrors),
+        sendDataTest(
+            "sendAggregateAndProofs",
+            channel -> channel.sendAggregateAndProofs(aggregateAndProofs),
+            BeaconNodeRequestLabels.PUBLISH_AGGREGATE_AND_PROOFS_METHOD,
+            submissionErrors));
+  }
+
+  private static <T> Arguments requestDataTest(
+      final String name,
+      final Function<ValidatorApiChannel, SafeFuture<Optional<T>>> method,
+      final String methodLabel,
+      final T presentValue) {
+    return Arguments.of(Named.named(name, method), methodLabel, presentValue);
+  }
+
+  private static <T> Arguments sendDataTest(
+      final String name,
+      final Function<ValidatorApiChannel, SafeFuture<List<T>>> method,
+      final String methodLabel,
+      final List<T> errors) {
+    return Arguments.of(Named.named(name, method), methodLabel, errors);
+  }
+
+  private long getCounterValue(final String methodLabel, final RequestOutcome outcome) {
+    return metricsSystem
+        .getCounter(
+            TekuMetricCategory.VALIDATOR,
+            RemoteMetricRecordingValidatorApiChannel.REMOTE_BEACON_NODE_REQUESTS_COUNTER_NAME)
+        .getValue(DELEGATE_ENDPOINT, methodLabel, outcome.toString());
+  }
+}

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteMetricRecordingValidatorApiChannelTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteMetricRecordingValidatorApiChannelTest.java
@@ -16,7 +16,7 @@ package tech.pegasys.teku.validator.remote;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static tech.pegasys.teku.validator.remote.RemoteMetricRecordingValidatorApiChannel.BEACON_NODE_REQUESTS_COUNTER_NAME;
+import static tech.pegasys.teku.validator.beaconnode.metrics.MetricRecordingValidatorApiChannel.BEACON_NODE_REQUESTS_COUNTER_NAME;
 
 import okhttp3.HttpUrl;
 import org.junit.jupiter.api.BeforeEach;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Essentially, if no failovers configured, just use the primary `ValidatorApiChannel` instead of using the `FailoverValidatorApiHandler`.

Also another major change in this PR is removing metrics from the `FailoverValidatorApiHandler` and moving them to the new `RemoteMetricRecordingValidatorApiChannel` which will be attached to every remote channel. This leaves the `FailoverValidatorApiHandler` cleaner and not concerned with metrics. 

The above was achieved by making `MetricRecordingValidatorApiChannel` abstract and create two implementations `InProcessMetricRecordingValidatorApiChannel` and `RemoteMetricRecordingValidatorApiChannel` (the only difference is the addition of the endpoint label)

`TODO:` Actually not sure about this, because the dashboard uses  `beacon_node_requests_total` and even if failovers are configured and for example attestations are relayed, there will be few published attestations, so have to think about that use case. 

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
