### PR TITLE
Added more utilities for late block reorg

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ReadOnlyStore.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ReadOnlyStore.java
@@ -140,4 +140,7 @@ public interface ReadOnlyStore {
 
   // implements is_parent_strong from fork-choice Consensus Spec
   SafeFuture<Optional<Boolean>> isParentStrong(final Bytes32 parentRoot);
+
+  // implements is_ffg_competitive from Consensus Spec
+  Optional<Boolean> isFfgCompetitive(final Bytes32 headRoot, final Bytes32 parentRoot);
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ReadOnlyStore.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ReadOnlyStore.java
@@ -134,4 +134,10 @@ public interface ReadOnlyStore {
 
   SafeFuture<Optional<BeaconState>> retrieveCheckpointState(
       Checkpoint checkpoint, BeaconState latestStateAtEpoch);
+
+  // implements is_head_weak from fork-choice Consensus Spec
+  SafeFuture<Optional<Boolean>> isHeadWeak(final Bytes32 root);
+
+  // implements is_parent_strong from fork-choice Consensus Spec
+  SafeFuture<Optional<Boolean>> isParentStrong(final Bytes32 parentRoot);
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java
@@ -170,7 +170,7 @@ public abstract class BeaconStateAccessors {
    * @return
    */
   public UInt64 calculateCommitteeFraction(
-      final BeaconState beaconState, final UInt64 committeePercent) {
+      final BeaconState beaconState, final int committeePercent) {
     final UInt64 committeeWeight =
         getTotalActiveBalance(beaconState).dividedBy(config.getSlotsPerEpoch());
     return committeeWeight.times(committeePercent).dividedBy(100);

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessorsTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessorsTest.java
@@ -137,8 +137,7 @@ public class BeaconStateAccessorsTest {
         spec.atSlot(state.getSlot()).beaconStateAccessors().getTotalActiveBalance(state);
     final UInt64 totalActiveBalancePerSlot =
         totalActiveBalance.dividedBy(spec.getGenesisSpec().getSlotsPerEpoch());
-    final UInt64 fraction =
-        beaconStateAccessors.calculateCommitteeFraction(state, UInt64.valueOf(100));
+    final UInt64 fraction = beaconStateAccessors.calculateCommitteeFraction(state, 100);
     // at its simplest, if we've divided by slots in the function, this should be
     // totalActiveBalance/slots (because fraction is 100%)
     assertThat(fraction).isEqualTo(totalActiveBalancePerSlot);
@@ -151,7 +150,7 @@ public class BeaconStateAccessorsTest {
         spec.atSlot(state.getSlot()).beaconStateAccessors().getTotalActiveBalance(state);
     final UInt64 totalActiveBalancePerSlot =
         totalActiveBalance.dividedBy(spec.getGenesisSpec().getSlotsPerEpoch());
-    final UInt64 fraction = beaconStateAccessors.calculateCommitteeFraction(state, UInt64.ONE);
+    final UInt64 fraction = beaconStateAccessors.calculateCommitteeFraction(state, 1);
     // should be 1% of balance per slot...
     assertThat(fraction).isEqualTo(totalActiveBalancePerSlot.dividedBy(100));
   }

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
@@ -247,6 +247,16 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
   }
 
   @Override
+  public SafeFuture<Optional<Boolean>> isHeadWeak(Bytes32 root) {
+    return SafeFuture.completedFuture(Optional.empty());
+  }
+
+  @Override
+  public SafeFuture<Optional<Boolean>> isParentStrong(Bytes32 parentRoot) {
+    return SafeFuture.completedFuture(Optional.empty());
+  }
+
+  @Override
   public Optional<List<BlobSidecar>> getBlobSidecarsIfAvailable(
       final SlotAndBlockRoot slotAndBlockRoot) {
     return Optional.ofNullable(blobSidecars.get(slotAndBlockRoot));

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
@@ -257,6 +257,11 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
   }
 
   @Override
+  public Optional<Boolean> isFfgCompetitive(Bytes32 headRoot, Bytes32 parentRoot) {
+    return Optional.empty();
+  }
+
+  @Override
   public Optional<List<BlobSidecar>> getBlobSidecarsIfAvailable(
       final SlotAndBlockRoot slotAndBlockRoot) {
     return Optional.ofNullable(blobSidecars.get(slotAndBlockRoot));

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
@@ -624,7 +624,12 @@ public abstract class RecentChainData implements StoreUpdateHandler {
     blockTimelinessTracker.setBlockTimelinessFromArrivalTime(block, arrivalTime);
   }
 
-  public Optional<Boolean> getBlockTimeliness(final Bytes32 blockRoot) {
-    return blockTimelinessTracker.isBlockTimely(blockRoot);
+  // implements is_head_late from consensus spec
+  public boolean isBlockLate(final Bytes32 blockRoot) {
+    return blockTimelinessTracker.isBlockLate(blockRoot);
+  }
+
+  public boolean isProposingOnTime(final UInt64 slot) {
+    return blockTimelinessTracker.isProposingOnTime(slot);
   }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
@@ -625,6 +625,25 @@ class Store extends CacheableStore {
             });
   }
 
+  @Override
+  public Optional<Boolean> isFfgCompetitive(Bytes32 headRoot, Bytes32 parentRoot) {
+    final Optional<ProtoNodeData> maybeHeadData = getBlockDataFromForkChoiceStrategy(headRoot);
+    final Optional<ProtoNodeData> maybeParentData = getBlockDataFromForkChoiceStrategy(parentRoot);
+    if (maybeParentData.isEmpty() || maybeHeadData.isEmpty()) {
+      return Optional.empty();
+    }
+    final Checkpoint headUnrealizedJustifiedCheckpoint =
+        maybeHeadData.get().getCheckpoints().getUnrealizedJustifiedCheckpoint();
+    final Checkpoint parentUnrealizedJustifiedCheckpoint =
+        maybeParentData.get().getCheckpoints().getUnrealizedJustifiedCheckpoint();
+    LOG.debug(
+        "head {}, compared to parent {}",
+        headUnrealizedJustifiedCheckpoint,
+        parentUnrealizedJustifiedCheckpoint);
+    return Optional.of(
+        headUnrealizedJustifiedCheckpoint.equals(parentUnrealizedJustifiedCheckpoint));
+  }
+
   private Optional<ProtoNodeData> getBlockDataFromForkChoiceStrategy(final Bytes32 root) {
     readLock.lock();
     try {

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
@@ -562,7 +562,7 @@ class Store extends CacheableStore {
                               specVersion.getConfig().getReorgHeadWeightThreshold());
                       final boolean result = headWeight.isLessThan(reorgThreashold);
 
-                      LOG.debug(
+                      LOG.trace(
                           "isHeadWeak {}: headWeight: {}, reorgThreshold: {}, result: {}",
                           root,
                           headWeight,
@@ -607,7 +607,7 @@ class Store extends CacheableStore {
                               specVersion.getConfig().getReorgParentWeightThreshold());
                       final boolean result = parentWeight.isGreaterThan(parentThreshold);
 
-                      LOG.debug(
+                      LOG.trace(
                           "isParentStrong {}: parentWeight: {}, parentThreshold: {}, result: {}",
                           parentRoot,
                           parentWeight,
@@ -636,7 +636,7 @@ class Store extends CacheableStore {
         maybeHeadData.get().getCheckpoints().getUnrealizedJustifiedCheckpoint();
     final Checkpoint parentUnrealizedJustifiedCheckpoint =
         maybeParentData.get().getCheckpoints().getUnrealizedJustifiedCheckpoint();
-    LOG.debug(
+    LOG.trace(
         "head {}, compared to parent {}",
         headUnrealizedJustifiedCheckpoint,
         parentUnrealizedJustifiedCheckpoint);

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreBuilder.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreBuilder.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.storage.store;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -33,6 +34,7 @@ import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.storage.api.OnDiskStoreData;
 import tech.pegasys.teku.storage.api.StoredBlockMetadata;
+import tech.pegasys.teku.storage.protoarray.ForkChoiceStrategy;
 
 public class StoreBuilder {
   private AsyncRunner asyncRunner;
@@ -53,6 +55,7 @@ public class StoreBuilder {
   private Map<UInt64, VoteTracker> votes;
   private Optional<SlotAndExecutionPayloadSummary> finalizedOptimisticTransitionPayload =
       Optional.empty();
+  private ForkChoiceStrategy forkChoiceStrategy = null;
 
   private StoreBuilder() {}
 
@@ -104,6 +107,26 @@ public class StoreBuilder {
   public UpdatableStore build() {
     assertValid();
 
+    if (forkChoiceStrategy != null) {
+      return Store.create(
+          asyncRunner,
+          metricsSystem,
+          spec,
+          blockProvider,
+          stateAndBlockProvider,
+          earliestBlobSidecarSlotProvider,
+          anchor,
+          time,
+          genesisTime,
+          latestFinalized,
+          finalizedOptimisticTransitionPayload,
+          justifiedCheckpoint,
+          bestJustifiedCheckpoint,
+          blockInfoByRoot,
+          votes,
+          storeConfig,
+          forkChoiceStrategy);
+    }
     return Store.create(
         asyncRunner,
         metricsSystem,
@@ -230,6 +253,12 @@ public class StoreBuilder {
 
   public StoreBuilder blockInformation(final Map<Bytes32, StoredBlockMetadata> blockInformation) {
     this.blockInfoByRoot.putAll(blockInformation);
+    return this;
+  }
+
+  @VisibleForTesting
+  StoreBuilder forkChoiceStrategy(final ForkChoiceStrategy forkChoiceStrategy) {
+    this.forkChoiceStrategy = forkChoiceStrategy;
     return this;
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransaction.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransaction.java
@@ -462,6 +462,11 @@ class StoreTransaction implements UpdatableStore.StoreTransaction {
   }
 
   @Override
+  public Optional<Boolean> isFfgCompetitive(Bytes32 headRoot, Bytes32 parentRoot) {
+    return store.isFfgCompetitive(headRoot, parentRoot);
+  }
+
+  @Override
   public Optional<SignedBeaconBlock> getBlockIfAvailable(final Bytes32 blockRoot) {
     return Optional.ofNullable(blockData.get(blockRoot))
         .map(SignedBlockAndState::getBlock)

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransaction.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransaction.java
@@ -452,6 +452,16 @@ class StoreTransaction implements UpdatableStore.StoreTransaction {
   }
 
   @Override
+  public SafeFuture<Optional<Boolean>> isHeadWeak(Bytes32 root) {
+    return store.isHeadWeak(root);
+  }
+
+  @Override
+  public SafeFuture<Optional<Boolean>> isParentStrong(Bytes32 parentRoot) {
+    return store.isParentStrong(parentRoot);
+  }
+
+  @Override
   public Optional<SignedBeaconBlock> getBlockIfAvailable(final Bytes32 blockRoot) {
     return Optional.ofNullable(blockData.get(blockRoot))
         .map(SignedBlockAndState::getBlock)


### PR DESCRIPTION
 - is_parent_strong
 - is_head_weak
 - is_proposing_on_time
 - is_ffg_competitive

The head_weak and parent_strong functions I put into store ultimately, as it has all the context needed. It did mean a little restructuring to enable testing, but I think it currently is a sensible home for it.

partially addresses #6595


## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
