### PR TITLE
Don't use FailoverValidatorApiHandler if no failovers configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ the [releases page](https://github.com/Consensys/teku/releases).
 
 ### Breaking Changes
 - By default, Teku won't allow syncing from genesis, users should use `--checkpoint-sync-url` when starting a new node. It is possible to revert back to the previous behaviour using the flag `--ignore-weak-subjectivity-period-enabled`.
+- `validator_remote_beacon_nodes_requests_total` metric for the validator client would not be available if there are no failovers configured. In that case `validator_beacon_node_requests_total` can be used instead.
 
 ### Additions and Improvements
 - Support to new Beacon APIs `publishBlindedBlockV2` and `publishBlockV2` which introduce broadcast validation parameter. 

--- a/validator/eventadapter/build.gradle
+++ b/validator/eventadapter/build.gradle
@@ -16,7 +16,4 @@ dependencies {
   implementation 'com.google.guava:guava'
   implementation 'org.apache.logging.log4j:log4j-api'
   implementation 'org.apache.commons:commons-lang3'
-
-  testImplementation 'org.mockito:mockito-core'
-  testImplementation testFixtures(project(':ethereum:spec'))
 }

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandler.java
@@ -96,7 +96,7 @@ public class FailoverValidatorApiHandler implements ValidatorApiChannel {
         metricsSystem.createLabelledCounter(
             TekuMetricCategory.VALIDATOR,
             REMOTE_BEACON_NODES_REQUESTS_COUNTER_NAME,
-            "Counter recording the number of requests sent to the configured Beacon Nodes endpoints",
+            "Counter recording the number of requests sent to the primary and failover Beacon Nodes endpoints",
             "endpoint",
             "method",
             "outcome");

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandler.java
@@ -96,7 +96,7 @@ public class FailoverValidatorApiHandler implements ValidatorApiChannel {
         metricsSystem.createLabelledCounter(
             TekuMetricCategory.VALIDATOR,
             REMOTE_BEACON_NODES_REQUESTS_COUNTER_NAME,
-            "Counter recording the number of requests sent to the primary and failover Beacon Nodes endpoints",
+            "Counter recording the number of remote requests sent to the primary and failover Beacon Nodes",
             "endpoint",
             "method",
             "outcome");


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

- Essentially use the `RemoteValidatorApiHandler` instead of the `FailoverValidatorApiHandler`, when there are no failovers configured. There is a very small overhead and I assume most users don't have failovers configured by default.
- In that case, `validator_remote_beacon_nodes_requests_total` metric would not be used when there are no failovers configured. Added a line to the `CHANGELOG`. It makes sense because both metrics are replicated in case of a single BN configured and don't provide much value
- Includes some refactoring changes in `RemoteBeaconNodeApi` and `SentryBeaconNodeApi`


## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
