### PR TITLE
Implemented get_proposer_head for late block reorg

### DIFF
--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
@@ -464,14 +464,10 @@ public class ForkChoiceTestExecutor implements TestExecutor {
 
           case "get_proposer_head" -> {
             final Bytes32 expectedProposerHead = getBytes32(checks, checkType);
-            final Optional<Bytes32> boostedRoot = recentChainData.getBestBlockRoot();
-            if (expectedProposerHead.isZero()) {
-              assertThat(boostedRoot).describedAs("get_proposer_head").isEmpty();
-            } else {
-              assertThat(boostedRoot)
-                  .describedAs("get_proposer_head")
-                  .contains(expectedProposerHead);
-            }
+            final Bytes32 root =
+                recentChainData.getProposerHead(
+                    expectedProposerHead, recentChainData.getHeadSlot().increment());
+            assertThat(root).describedAs("get_proposer_head").isEqualTo(expectedProposerHead);
           }
 
           case "should_override_forkchoice_update" -> {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ReadOnlyStore.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ReadOnlyStore.java
@@ -136,10 +136,10 @@ public interface ReadOnlyStore {
       Checkpoint checkpoint, BeaconState latestStateAtEpoch);
 
   // implements is_head_weak from fork-choice Consensus Spec
-  SafeFuture<Optional<Boolean>> isHeadWeak(final Bytes32 root);
+  boolean isHeadWeak(BeaconState justifiedState, Bytes32 root);
 
   // implements is_parent_strong from fork-choice Consensus Spec
-  SafeFuture<Optional<Boolean>> isParentStrong(final Bytes32 parentRoot);
+  boolean isParentStrong(BeaconState justifiedState, Bytes32 parentRoot);
 
   // implements is_ffg_competitive from Consensus Spec
   Optional<Boolean> isFfgCompetitive(final Bytes32 headRoot, final Bytes32 parentRoot);

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
@@ -247,13 +247,13 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
   }
 
   @Override
-  public SafeFuture<Optional<Boolean>> isHeadWeak(Bytes32 root) {
-    return SafeFuture.completedFuture(Optional.empty());
+  public boolean isHeadWeak(BeaconState justifiedState, Bytes32 root) {
+    return false;
   }
 
   @Override
-  public SafeFuture<Optional<Boolean>> isParentStrong(Bytes32 parentRoot) {
-    return SafeFuture.completedFuture(Optional.empty());
+  public boolean isParentStrong(BeaconState justifiedState, Bytes32 parentRoot) {
+    return false;
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
@@ -535,94 +535,55 @@ class Store extends CacheableStore {
   }
 
   @Override
-  public SafeFuture<Optional<Boolean>> isHeadWeak(final Bytes32 root) {
-
+  public boolean isHeadWeak(final BeaconState justifiedState, final Bytes32 root) {
     final Optional<ProtoNodeData> maybeBlockData = getBlockDataFromForkChoiceStrategy(root);
-    if (maybeBlockData.isEmpty()) {
-      LOG.trace("isHeadWeak {}: no block data in protoArray, returning false", root);
-      return SafeFuture.completedFuture(Optional.empty());
-    }
+    return maybeBlockData
+        .map(
+            blockData -> {
+              final UInt64 headWeight = blockData.getWeight();
 
-    final UInt64 headWeight = maybeBlockData.get().getWeight();
+              final SpecVersion specVersion = spec.atSlot(justifiedState.getSlot());
+              final BeaconStateAccessors beaconStateAccessors = specVersion.beaconStateAccessors();
+              final UInt64 reorgThreshold =
+                  beaconStateAccessors.calculateCommitteeFraction(
+                      justifiedState, specVersion.getConfig().getReorgHeadWeightThreshold());
+              final boolean result = headWeight.isLessThan(reorgThreshold);
 
-    final SafeFuture<Optional<BeaconState>> futureMaybeJustifiedState =
-        retrieveCheckpointState(justifiedCheckpoint);
-
-    return futureMaybeJustifiedState
-        .thenApply(
-            maybeJustifiedState ->
-                maybeJustifiedState.map(
-                    justifiedState -> {
-                      final SpecVersion specVersion = spec.atSlot(justifiedState.getSlot());
-                      final BeaconStateAccessors beaconStateAccessors =
-                          specVersion.beaconStateAccessors();
-                      final UInt64 reorgThreashold =
-                          beaconStateAccessors.calculateCommitteeFraction(
-                              justifiedState,
-                              specVersion.getConfig().getReorgHeadWeightThreshold());
-                      final boolean result = headWeight.isLessThan(reorgThreashold);
-
-                      LOG.trace(
-                          "isHeadWeak {}: headWeight: {}, reorgThreshold: {}, result: {}",
-                          root,
-                          headWeight,
-                          reorgThreashold,
-                          result);
-                      return result;
-                    }))
-        .exceptionallyCompose(
-            err -> {
-              LOG.error(
-                  "Failed to retrieve justified state when checking head weight for block {}.",
+              LOG.trace(
+                  "isHeadWeak {}: headWeight: {}, reorgThreshold: {}, result: {}",
                   root,
-                  err);
-              return SafeFuture.completedFuture(Optional.empty());
-            });
+                  headWeight,
+                  reorgThreshold,
+                  result);
+              return result;
+            })
+        .orElse(false);
   }
 
   @Override
-  public SafeFuture<Optional<Boolean>> isParentStrong(final Bytes32 parentRoot) {
+  public boolean isParentStrong(final BeaconState justifiedState, final Bytes32 parentRoot) {
     final Optional<ProtoNodeData> maybeBlockData = getBlockDataFromForkChoiceStrategy(parentRoot);
-    if (maybeBlockData.isEmpty()) {
-      LOG.trace("isParentStrong {}: no block data in protoArray, returning false", parentRoot);
-      return SafeFuture.completedFuture(Optional.empty());
-    }
+    return maybeBlockData
+        .map(
+            blockData -> {
+              final UInt64 parentWeight = blockData.getWeight();
 
-    final UInt64 parentWeight = maybeBlockData.get().getWeight();
+              final SpecVersion specVersion = spec.atSlot(justifiedState.getSlot());
+              final BeaconStateAccessors beaconStateAccessors = specVersion.beaconStateAccessors();
+              final UInt64 parentThreshold =
+                  beaconStateAccessors.calculateCommitteeFraction(
+                      justifiedState, specVersion.getConfig().getReorgParentWeightThreshold());
+              final boolean result = parentWeight.isGreaterThan(parentThreshold);
 
-    final SafeFuture<Optional<BeaconState>> futureMaybeJustifiedState =
-        retrieveCheckpointState(justifiedCheckpoint);
-
-    return futureMaybeJustifiedState
-        .thenApply(
-            maybeJustifiedState ->
-                maybeJustifiedState.map(
-                    justifiedState -> {
-                      final SpecVersion specVersion = spec.atSlot(justifiedState.getSlot());
-                      final BeaconStateAccessors beaconStateAccessors =
-                          specVersion.beaconStateAccessors();
-                      final UInt64 parentThreshold =
-                          beaconStateAccessors.calculateCommitteeFraction(
-                              justifiedState,
-                              specVersion.getConfig().getReorgParentWeightThreshold());
-                      final boolean result = parentWeight.isGreaterThan(parentThreshold);
-
-                      LOG.trace(
-                          "isParentStrong {}: parentWeight: {}, parentThreshold: {}, result: {}",
-                          parentRoot,
-                          parentWeight,
-                          parentThreshold,
-                          result);
-                      return result;
-                    }))
-        .exceptionallyCompose(
-            err -> {
-              LOG.error(
-                  "Failed to retrieve justified state when checking weight for parent {}.",
+              LOG.debug(
+                  "isParentStrong {}: parentWeight: {}, parentThreshold: {}, result: {}",
                   parentRoot,
-                  err);
-              return SafeFuture.completedFuture(Optional.empty());
-            });
+                  parentWeight,
+                  parentThreshold,
+                  result);
+              return result;
+            })
+        .orElse(false);
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransaction.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransaction.java
@@ -452,13 +452,13 @@ class StoreTransaction implements UpdatableStore.StoreTransaction {
   }
 
   @Override
-  public SafeFuture<Optional<Boolean>> isHeadWeak(Bytes32 root) {
-    return store.isHeadWeak(root);
+  public boolean isHeadWeak(BeaconState justifiedState, Bytes32 root) {
+    return store.isHeadWeak(justifiedState, root);
   }
 
   @Override
-  public SafeFuture<Optional<Boolean>> isParentStrong(Bytes32 parentRoot) {
-    return store.isParentStrong(parentRoot);
+  public boolean isParentStrong(BeaconState justifiedState, Bytes32 parentRoot) {
+    return store.isParentStrong(justifiedState, parentRoot);
   }
 
   @Override

--- a/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTest.java
@@ -100,8 +100,7 @@ class StoreTest extends AbstractStoreTest {
     processChainHeadWithMockForkChoiceStrategy(
         (store, blockAndState) -> {
           final Bytes32 root = blockAndState.getRoot();
-          final SafeFuture<Optional<Boolean>> isHeadWeakFuture = store.isHeadWeak(root);
-          assertThat(safeJoin(isHeadWeakFuture)).isEmpty();
+          assertThat(store.isHeadWeak(justifiedState(store), root)).isFalse();
         });
   }
 
@@ -112,8 +111,7 @@ class StoreTest extends AbstractStoreTest {
           final Bytes32 root = blockAndState.getRoot();
           setProtoNodeDataForBlock(blockAndState, UInt64.valueOf("2400000001"), UInt64.MAX_VALUE);
 
-          final SafeFuture<Optional<Boolean>> isHeadWeakFuture = store.isHeadWeak(root);
-          assertThat(safeJoin(isHeadWeakFuture)).contains(false);
+          assertThat(store.isHeadWeak(justifiedState(store), root)).isFalse();
         });
   }
 
@@ -124,8 +122,7 @@ class StoreTest extends AbstractStoreTest {
           final Bytes32 root = blockAndState.getRoot();
           setProtoNodeDataForBlock(blockAndState, UInt64.valueOf("2399999999"), UInt64.MAX_VALUE);
 
-          final SafeFuture<Optional<Boolean>> isHeadWeakFuture = store.isHeadWeak(root);
-          assertThat(safeJoin(isHeadWeakFuture)).contains(true);
+          assertThat(store.isHeadWeak(justifiedState(store), root)).isTrue();
         });
   }
 
@@ -136,8 +133,7 @@ class StoreTest extends AbstractStoreTest {
           final Bytes32 root = blockAndState.getRoot();
           setProtoNodeDataForBlock(blockAndState, UInt64.valueOf("1000000000"), UInt64.MAX_VALUE);
 
-          final SafeFuture<Optional<Boolean>> isHeadWeakFuture = store.isHeadWeak(root);
-          assertThat(safeJoin(isHeadWeakFuture)).contains(true);
+          assertThat(store.isHeadWeak(justifiedState(store), root)).isTrue();
         });
   }
 
@@ -146,8 +142,7 @@ class StoreTest extends AbstractStoreTest {
     processChainHeadWithMockForkChoiceStrategy(
         (store, blockAndState) -> {
           final Bytes32 root = blockAndState.getBlock().getParentRoot();
-          final SafeFuture<Optional<Boolean>> isParentStrongFuture = store.isParentStrong(root);
-          assertThat(safeJoin(isParentStrongFuture)).isEmpty();
+          assertThat(store.isParentStrong(justifiedState(store), root)).isFalse();
         });
   }
 
@@ -157,8 +152,7 @@ class StoreTest extends AbstractStoreTest {
         (store, blockAndState) -> {
           final Bytes32 root = blockAndState.getBlock().getParentRoot();
           setProtoNodeDataForBlock(blockAndState, UInt64.ZERO, UInt64.valueOf("19200000001"));
-          final SafeFuture<Optional<Boolean>> isParentStrongFuture = store.isParentStrong(root);
-          assertThat(safeJoin(isParentStrongFuture)).contains(true);
+          assertThat(store.isParentStrong(justifiedState(store), root)).isTrue();
         });
   }
 
@@ -168,8 +162,7 @@ class StoreTest extends AbstractStoreTest {
         (store, blockAndState) -> {
           final Bytes32 root = blockAndState.getBlock().getParentRoot();
           setProtoNodeDataForBlock(blockAndState, UInt64.ZERO, UInt64.valueOf("19200000000"));
-          final SafeFuture<Optional<Boolean>> isParentStrongFuture = store.isParentStrong(root);
-          assertThat(safeJoin(isParentStrongFuture)).contains(false);
+          assertThat(store.isParentStrong(justifiedState(store), root)).isFalse();
         });
   }
 
@@ -179,8 +172,7 @@ class StoreTest extends AbstractStoreTest {
         (store, blockAndState) -> {
           final Bytes32 root = blockAndState.getBlock().getParentRoot();
           setProtoNodeDataForBlock(blockAndState, UInt64.ZERO, UInt64.ZERO);
-          final SafeFuture<Optional<Boolean>> isParentStrongFuture = store.isParentStrong(root);
-          assertThat(safeJoin(isParentStrongFuture)).contains(false);
+          assertThat(store.isParentStrong(justifiedState(store), root)).isFalse();
         });
   }
 
@@ -523,6 +515,10 @@ class StoreTest extends AbstractStoreTest {
     for (final SignedBlockAndState signedBlockAndState : last32) {
       assertThat(store.getBlockIfAvailable(signedBlockAndState.getRoot())).isPresent();
     }
+  }
+
+  private BeaconState justifiedState(final UpdatableStore store) {
+    return safeJoin(store.retrieveCheckpointState(store.getJustifiedCheckpoint())).orElseThrow();
   }
 
   private void testApplyChangesWhenTransactionCommits(final boolean withInterleavedTransaction) {


### PR DESCRIPTION
Implemented get_proposer_head function, and tested results via the reftests.

It's going to be more efficient to get the justified state once, so have refactored isHeadWeak and isParentStrong.

The ordering of checks was cheapest -> most expensive, we can avoid fetching state if any of the lighter tests fail.

Currently this function is only accessed in reftests.

partially addresses #6595

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
