### PR TITLE
Fix voluntary exit flaky acceptance test

### DIFF
--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/VoluntaryExitAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/VoluntaryExitAcceptanceTest.java
@@ -35,9 +35,9 @@ public class VoluntaryExitAcceptanceTest extends AcceptanceTestBase {
 
     final TekuDepositSender depositSender = createTekuDepositSender(networkName);
     final ValidatorKeystores validatorKeysToExit = depositSender.generateValidatorKeys(4);
-    // network of 32 validators (4 of them will exit)
+    // network of 8 validators (4 of them will exit)
     final ValidatorKeystores validatorKeys =
-        ValidatorKeystores.add(validatorKeysToExit, depositSender.generateValidatorKeys(28));
+        ValidatorKeystores.add(validatorKeysToExit, depositSender.generateValidatorKeys(4));
     // 1 unknown key to the network
     final ValidatorKeystores unknownKeys = depositSender.generateValidatorKeys(1);
 

--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/VoluntaryExitAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/VoluntaryExitAcceptanceTest.java
@@ -21,6 +21,7 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.test.acceptance.dsl.AcceptanceTestBase;
 import tech.pegasys.teku.test.acceptance.dsl.GenesisGenerator.InitialStateData;
+import tech.pegasys.teku.test.acceptance.dsl.TekuDepositSender;
 import tech.pegasys.teku.test.acceptance.dsl.TekuNode;
 import tech.pegasys.teku.test.acceptance.dsl.TekuValidatorNode;
 import tech.pegasys.teku.test.acceptance.dsl.TekuVoluntaryExit;
@@ -32,15 +33,13 @@ public class VoluntaryExitAcceptanceTest extends AcceptanceTestBase {
   void shouldChangeValidatorStatusAfterSubmittingVoluntaryExit() throws Exception {
     final String networkName = "swift";
 
-    final ValidatorKeystores validatorKeysToExit =
-        createTekuDepositSender(networkName).generateValidatorKeys(4);
+    final TekuDepositSender depositSender = createTekuDepositSender(networkName);
+    final ValidatorKeystores validatorKeysToExit = depositSender.generateValidatorKeys(4);
     // network of 32 validators (4 of them will exit)
     final ValidatorKeystores validatorKeys =
-        ValidatorKeystores.add(
-            createTekuDepositSender(networkName).generateValidatorKeys(28), validatorKeysToExit);
+        ValidatorKeystores.add(depositSender.generateValidatorKeys(28), validatorKeysToExit);
     // 1 unknown key to the network
-    final ValidatorKeystores unknownKeys =
-        createTekuDepositSender(networkName).generateValidatorKeys(1);
+    final ValidatorKeystores unknownKeys = depositSender.generateValidatorKeys(1);
 
     final InitialStateData genesis =
         createGenesisGenerator().network(networkName).validatorKeys(validatorKeys).generate();

--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/VoluntaryExitAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/VoluntaryExitAcceptanceTest.java
@@ -37,7 +37,7 @@ public class VoluntaryExitAcceptanceTest extends AcceptanceTestBase {
     final ValidatorKeystores validatorKeysToExit = depositSender.generateValidatorKeys(4);
     // network of 32 validators (4 of them will exit)
     final ValidatorKeystores validatorKeys =
-        ValidatorKeystores.add(depositSender.generateValidatorKeys(28), validatorKeysToExit);
+        ValidatorKeystores.add(validatorKeysToExit, depositSender.generateValidatorKeys(28));
     // 1 unknown key to the network
     final ValidatorKeystores unknownKeys = depositSender.generateValidatorKeys(1);
 

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuDepositSender.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuDepositSender.java
@@ -74,9 +74,7 @@ public class TekuDepositSender extends Node {
         new DepositSenderService(
             spec, eth1Node.getExternalJsonRpcUrl(), eth1Credentials, eth1Address, amount)) {
       final List<SafeFuture<TransactionReceipt>> transactionReceipts =
-          validatorKeys.getValidatorKeys().stream()
-              .map(depositSenderService::sendDeposit)
-              .collect(Collectors.toList());
+          validatorKeys.getValidatorKeys().stream().map(depositSenderService::sendDeposit).toList();
       final SafeFuture<Void> future =
           SafeFuture.allOf(transactionReceipts.toArray(SafeFuture[]::new));
       Waiter.waitFor(future, Duration.ofMinutes(2));


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

```
2023-11-08 15:22:33.016 ERROR - Failed to request validator duties for epoch 9. Retrying after delay.
java.util.concurrent.CompletionException: java.lang.IllegalArgumentException: Invalid params response from Beacon Node API (url = http://tekunode11:9051/eth/v1/validator/duties/proposer/9, status = 400, message = compute_proposer_index indices must not be empty)
```

Essentially there was a chance the test to get `compute_proposer_index indices must not be empty` when requesting duties, because all validators have exited. So, just added few of validators on top of the ones who will exit to ensure the VC doesn't fail.

## Fixed Issue(s)
fixes #7684 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
