### PR TITLE
Fix encoding of comma character in query parameters

### DIFF
--- a/validator/remote/src/integration-test/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClientTest.java
+++ b/validator/remote/src/integration-test/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClientTest.java
@@ -139,8 +139,7 @@ class OkHttpValidatorRestApiClientTest {
     final RecordedRequest request = mockWebServer.takeRequest();
     assertThat(request.getMethod()).isEqualTo("GET");
     assertThat(request.getPath()).contains(ValidatorApiMethod.GET_VALIDATORS.getPath(emptyMap()));
-    // %2C is ,
-    assertThat(request.getPath()).contains("?id=1%2C0x1234");
+    assertThat(request.getPath()).contains("?id=1,0x1234");
   }
 
   @Test


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

The Teku VC encodes the comma `,` character in its request to the `/validators` endpoint, resulting in a request like this:

`GET /eth/v1/beacon/states/head/validators?id=0x978e96b6b6b474f3f91b705a311906b14a5e2893d15e01f5a0ff210393ace5e0abc8488e844dab00f430364ba4c19b1a%2C0x99f013b0314981b0083e494bdd2989304f9fc9dfd2b0c23b40429d817b02acc78f0b4328e45e745a5c6cc48e8f0e9930 HTTP/1.1`

This is incompatible with Lodestar's BN, which handles it as one long ID containing the `%2C` string, resulting in an empty array of statuses being returned. This in turn results in the Teku VC failing to get the status for its validators (and subsequently not performing validator duties for them):

```
19:14:03.083 WARN  - Unable to retrieve status for validator 978e96b.
19:14:03.083 WARN  - Unable to retrieve status for validator 99f013b.
```

This was discussed in https://github.com/ChainSafe/lodestar/issues/5403 . The conclusion there was the comma character should not be encoded in this case.

The Teku BN API can handle both cases, regardless of whether the comma character is encoded or not, so this change is completely backwards compatible.

Looking forward to hear your thoughts on this.

## Fixed Issue(s)

I have not found an issue for this in this repository.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
