### PR TITLE
Teku fails to start when Validator API cannot read password file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ the [releases page](https://github.com/Consensys/teku/releases).
 
 ### Breaking Changes
 - By default, Teku won't allow syncing from genesis, users should use `--checkpoint-sync-url` when starting a new node. It is possible to revert back to the previous behaviour using the flag `--ignore-weak-subjectivity-period-enabled`.
-- Teku will fail to start if the Validator API cannot read the password file used for authorization.
+- Teku will fail to start if the Validator API cannot read the password file used for authorization. Previously, if the Validator API was enabled but Teku couldn't read the password file, it would start but no request to the Validator API would be served. 
 
 ### Additions and Improvements
 - Support to new Beacon APIs `publishBlindedBlockV2` and `publishBlockV2` which introduce broadcast validation parameter. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ the [releases page](https://github.com/Consensys/teku/releases).
 
 ### Breaking Changes
 - By default, Teku won't allow syncing from genesis, users should use `--checkpoint-sync-url` when starting a new node. It is possible to revert back to the previous behaviour using the flag `--ignore-weak-subjectivity-period-enabled`.
+- Teku will fail to start if the Validator API cannot read the password file used for authorization.
 
 ### Additions and Improvements
 - Support to new Beacon APIs `publishBlindedBlockV2` and `publishBlockV2` which introduce broadcast validation parameter. 

--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/AuthorizationManager.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/AuthorizationManager.java
@@ -29,11 +29,12 @@ import java.util.Set;
 import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import tech.pegasys.teku.infrastructure.exceptions.InvalidConfigurationException;
 
 public class AuthorizationManager implements AccessManager {
   private static final Logger LOG = LogManager.getLogger();
   private static final String BEARER_PREFIX = "Bearer ";
-  private String bearer;
+  private final String bearer;
 
   public AuthorizationManager(final Path path) {
     bearer = readPasswordFile(path);
@@ -48,21 +49,21 @@ public class AuthorizationManager implements AccessManager {
       errorMessage.append(
           String.format("password file %s does not exist", passwordFile.getAbsolutePath()));
       LOG.error(errorMessage);
-      throw new IllegalStateException(errorMessage.toString());
+      throw new InvalidConfigurationException(errorMessage.toString());
     }
 
     if (!passwordFile.canRead()) {
       errorMessage.append(
           String.format("cannot read password file %s", passwordFile.getAbsolutePath()));
       LOG.error(errorMessage);
-      throw new IllegalStateException(errorMessage.toString());
+      throw new InvalidConfigurationException(errorMessage.toString());
     }
 
     if (passwordFile.isDirectory()) {
       errorMessage.append(
           String.format("password file %s is a directory", passwordFile.getAbsolutePath()));
       LOG.error(errorMessage);
-      throw new IllegalStateException(errorMessage.toString());
+      throw new InvalidConfigurationException(errorMessage.toString());
     }
 
     try (Stream<String> lines = Files.lines(path)) {
@@ -74,12 +75,12 @@ public class AuthorizationManager implements AccessManager {
                 errorMessage.append(
                     String.format("password file %s is empty", passwordFile.getAbsolutePath()));
                 LOG.error(errorMessage);
-                return new IllegalStateException(errorMessage.toString());
+                return new InvalidConfigurationException(errorMessage.toString());
               });
     } catch (IOException e) {
       errorMessage.append(String.format(e.getMessage(), passwordFile.getAbsolutePath()));
       LOG.error(errorMessage);
-      throw new IllegalStateException(errorMessage.toString());
+      throw new InvalidConfigurationException(errorMessage.toString());
     }
   }
 

--- a/infrastructure/restapi/src/test/java/tech/pegasys/teku/infrastructure/restapi/AuthorizationManagerTest.java
+++ b/infrastructure/restapi/src/test/java/tech/pegasys/teku/infrastructure/restapi/AuthorizationManagerTest.java
@@ -30,6 +30,7 @@ import java.nio.file.Path;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import tech.pegasys.teku.infrastructure.exceptions.InvalidConfigurationException;
 
 public class AuthorizationManagerTest {
   private static final String PASS = "secure";
@@ -114,7 +115,7 @@ public class AuthorizationManagerTest {
     final Path directory = Path.of("/foo/bar");
 
     assertThatThrownBy(() -> new AuthorizationManager(directory))
-        .isInstanceOf(IllegalStateException.class)
+        .isInstanceOf(InvalidConfigurationException.class)
         .hasMessageContaining(
             "password file %s does not exist", directory.toFile().getAbsolutePath());
   }
@@ -126,7 +127,7 @@ public class AuthorizationManagerTest {
     unreadableFilePath.toFile().setReadable(false);
 
     assertThatThrownBy(() -> new AuthorizationManager(unreadableFilePath))
-        .isInstanceOf(IllegalStateException.class)
+        .isInstanceOf(InvalidConfigurationException.class)
         .hasMessageContaining(
             "cannot read password file %s", unreadableFilePath.toFile().getAbsolutePath());
   }
@@ -137,7 +138,7 @@ public class AuthorizationManagerTest {
     final Path directory = Files.createDirectories(tempDir);
 
     assertThatThrownBy(() -> new AuthorizationManager(directory))
-        .isInstanceOf(IllegalStateException.class)
+        .isInstanceOf(InvalidConfigurationException.class)
         .hasMessageContaining(
             "password file %s is a directory", directory.toFile().getAbsolutePath());
   }
@@ -148,7 +149,7 @@ public class AuthorizationManagerTest {
     final Path directory = Files.writeString(tempDir.resolve("passwd"), "");
 
     assertThatThrownBy(() -> new AuthorizationManager(directory))
-        .isInstanceOf(IllegalStateException.class)
+        .isInstanceOf(InvalidConfigurationException.class)
         .hasMessageContaining("password file %s is empty", directory.toFile().getAbsolutePath());
   }
 

--- a/infrastructure/restapi/src/test/java/tech/pegasys/teku/infrastructure/restapi/AuthorizationManagerTest.java
+++ b/infrastructure/restapi/src/test/java/tech/pegasys/teku/infrastructure/restapi/AuthorizationManagerTest.java
@@ -124,12 +124,18 @@ public class AuthorizationManagerTest {
   public void createAuthorizationManagerShouldFailWhenCannotReadPasswordFile(
       @TempDir final Path tempDir) throws IOException {
     final Path unreadableFilePath = Files.createFile(tempDir.resolve("unreadable_file"));
-    unreadableFilePath.toFile().setReadable(false);
 
-    assertThatThrownBy(() -> new AuthorizationManager(unreadableFilePath))
-        .isInstanceOf(InvalidConfigurationException.class)
-        .hasMessageContaining(
-            "cannot read password file %s", unreadableFilePath.toFile().getAbsolutePath());
+    if (!unreadableFilePath.toFile().setReadable(false)) {
+      // If the underlying OS does not support setting file permissions we ignore the check on the
+      // error message
+      assertThatThrownBy(() -> new AuthorizationManager(unreadableFilePath))
+          .isInstanceOf(InvalidConfigurationException.class);
+    } else {
+      assertThatThrownBy(() -> new AuthorizationManager(unreadableFilePath))
+          .isInstanceOf(InvalidConfigurationException.class)
+          .hasMessageContaining(
+              "cannot read password file %s", unreadableFilePath.toFile().getAbsolutePath());
+    }
   }
 
   @Test

--- a/infrastructure/restapi/src/test/java/tech/pegasys/teku/infrastructure/restapi/AuthorizationManagerTest.java
+++ b/infrastructure/restapi/src/test/java/tech/pegasys/teku/infrastructure/restapi/AuthorizationManagerTest.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.infrastructure.restapi;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -83,31 +84,6 @@ public class AuthorizationManagerTest {
   }
 
   @Test
-  void shouldDenyAccessIfServerBearerMissing(@TempDir final Path tempDir) throws Exception {
-    when(context.method()).thenReturn(HandlerType.GET);
-    when(context.matchedPath()).thenReturn("/aPath");
-    when(context.header("Authorization")).thenReturn(null);
-    AuthorizationManager manager = new AuthorizationManager(tempDir.resolve("passwd"));
-    manager.manage(handler, context, roles);
-    verify(handler, times(0)).handle(context);
-    verify(context).status(401);
-    verify(context).json(any());
-  }
-
-  @Test
-  void shouldDenyAccessIfServerBearerEmpty(@TempDir final Path tempDir) throws Exception {
-    Files.createFile(tempDir.resolve("passwd"));
-    when(context.method()).thenReturn(HandlerType.GET);
-    when(context.matchedPath()).thenReturn("/aPath");
-    when(context.header("Authorization")).thenReturn(null);
-    AuthorizationManager manager = new AuthorizationManager(tempDir.resolve("passwd"));
-    manager.manage(handler, context, roles);
-    verify(handler, times(0)).handle(context);
-    verify(context).status(401);
-    verify(context).json(any());
-  }
-
-  @Test
   void shouldDenyAccessIfHeaderIsNotBearer(@TempDir final Path tempDir) throws Exception {
     setupPasswordFile(tempDir);
     when(context.method()).thenReturn(HandlerType.GET);
@@ -131,6 +107,49 @@ public class AuthorizationManagerTest {
     verify(handler, times(0)).handle(context);
     verify(context).status(401);
     verify(context).json(any());
+  }
+
+  @Test
+  public void createAuthorizationManagerShouldFailWhenPasswordFileDoesNotExist() {
+    final Path directory = Path.of("/foo/bar");
+
+    assertThatThrownBy(() -> new AuthorizationManager(directory))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining(
+            "password file %s does not exist", directory.toFile().getAbsolutePath());
+  }
+
+  @Test
+  public void createAuthorizationManagerShouldFailWhenCannotReadPasswordFile(
+      @TempDir final Path tempDir) throws IOException {
+    final Path unreadableFilePath = Files.createFile(tempDir.resolve("unreadable_file"));
+    unreadableFilePath.toFile().setReadable(false);
+
+    assertThatThrownBy(() -> new AuthorizationManager(unreadableFilePath))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining(
+            "cannot read password file %s", unreadableFilePath.toFile().getAbsolutePath());
+  }
+
+  @Test
+  public void createAuthorizationManagerShouldFailWhenPasswordFileIsADirectory(
+      @TempDir final Path tempDir) throws IOException {
+    final Path directory = Files.createDirectories(tempDir);
+
+    assertThatThrownBy(() -> new AuthorizationManager(directory))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining(
+            "password file %s is a directory", directory.toFile().getAbsolutePath());
+  }
+
+  @Test
+  public void createAuthorizationManagerShouldFailWhenPasswordFileIsEmpty(
+      @TempDir final Path tempDir) throws IOException {
+    final Path directory = Files.writeString(tempDir.resolve("passwd"), "");
+
+    assertThatThrownBy(() -> new AuthorizationManager(directory))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("password file %s is empty", directory.toFile().getAbsolutePath());
   }
 
   private void setupPasswordFile(final Path tempDir) throws IOException {

--- a/teku/src/test/java/tech/pegasys/teku/cli/subcommand/ValidatorClientCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/subcommand/ValidatorClientCommandTest.java
@@ -40,7 +40,7 @@ public class ValidatorClientCommandTest extends AbstractBeaconNodeCommandTest {
           "--network", "auto", "vc",
         };
     int parseResult = beaconNodeCommand.parse(argsNetworkOptOnParent);
-    assertThat(parseResult).isEqualTo(1);
+    assertThat(parseResult).isEqualTo(2);
     String cmdOutput = getCommandLineOutput();
     assertThat(cmdOutput)
         .contains("--network option should not be specified before the validator-client command");
@@ -203,7 +203,7 @@ public class ValidatorClientCommandTest extends AbstractBeaconNodeCommandTest {
     };
 
     int parseResult = beaconNodeCommand.parse(args);
-    assertThat(parseResult).isEqualTo(1);
+    assertThat(parseResult).isEqualTo(2);
     String cmdOutput = getCommandLineOutput();
     assertThat(cmdOutput)
         .contains(


### PR DESCRIPTION
## PR Description
Before this change, if Teku couldn't read the password file for any reason, it would start up but it wouldn't serve any Validator API requests. This can be misleading so we decided to fail-fast and don't startup if something is wrong (likely to be a configuration issue).

## Fixed Issue(s)
fixes #7708 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
