### PR TITLE
Ensure TekuCLIException is also handled on TekuDefaultExceptionHandler

### DIFF
--- a/infrastructure/exceptions/src/main/java/tech/pegasys/teku/infrastructure/exceptions/TekuCLIException.java
+++ b/infrastructure/exceptions/src/main/java/tech/pegasys/teku/infrastructure/exceptions/TekuCLIException.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Consensys Software Inc., 2023
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.exceptions;
+
+public class TekuCLIException extends RuntimeException {
+  private final int resultCode;
+
+  public TekuCLIException(int resultCode) {
+    super("Unable to start Teku. Exit code: " + resultCode);
+    this.resultCode = resultCode;
+  }
+
+  public int getResultCode() {
+    return resultCode;
+  }
+}

--- a/teku/src/main/java/tech/pegasys/teku/TekuDefaultExceptionHandler.java
+++ b/teku/src/main/java/tech/pegasys/teku/TekuDefaultExceptionHandler.java
@@ -25,6 +25,7 @@ import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.infrastructure.events.ChannelExceptionHandler;
 import tech.pegasys.teku.infrastructure.exceptions.ExceptionUtil;
 import tech.pegasys.teku.infrastructure.exceptions.FatalServiceFailureException;
+import tech.pegasys.teku.infrastructure.exceptions.TekuCLIException;
 import tech.pegasys.teku.infrastructure.logging.StatusLogger;
 import tech.pegasys.teku.storage.server.DatabaseStorageException;
 import tech.pegasys.teku.storage.server.ShuttingDownException;
@@ -91,6 +92,8 @@ public final class TekuDefaultExceptionHandler
           "Unexpected rejected execution due to full task queue in {}", subscriberDescription);
     } else if (isSpecFailure(exception)) {
       statusLog.specificationFailure(subscriberDescription, exception);
+    } else if (exception instanceof TekuCLIException cliEx) {
+      System.exit(cliEx.getResultCode());
     } else {
       statusLog.unexpectedFailure(subscriberDescription, exception);
     }


### PR DESCRIPTION
## PR Description

We could do some work on our exception handler. But as a first step we can make sure that `TekuCLIException` (former `CLIException`) is also handled in `TekuDefaultExceptionHandler`.

## Fixed Issue(s)
N/A

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
