### PR TITLE
Implemented should_override_fork_choice for late block reorg

### DIFF
--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
@@ -93,7 +93,7 @@ public class ForkChoiceTestExecutor implements TestExecutor {
           .put("sync/optimistic", new ForkChoiceTestExecutor())
           // TODO: following tests are related to late block reorgs.
           //  Must be re-enabled once implementation #6595 is done
-          .put("fork_choice/should_override_forkchoice_update", new ForkChoiceTestExecutor())
+          .put("fork_choice/should_override_forkchoice_update", IGNORE_TESTS)
           .put("fork_choice/get_proposer_head", new ForkChoiceTestExecutor("basic_is_parent_root"))
           .build();
 

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
@@ -93,7 +93,7 @@ public class ForkChoiceTestExecutor implements TestExecutor {
           .put("sync/optimistic", new ForkChoiceTestExecutor())
           // TODO: following tests are related to late block reorgs.
           //  Must be re-enabled once implementation #6595 is done
-          .put("fork_choice/should_override_forkchoice_update", IGNORE_TESTS)
+          .put("fork_choice/should_override_forkchoice_update", new ForkChoiceTestExecutor())
           .put("fork_choice/get_proposer_head", new ForkChoiceTestExecutor("basic_is_parent_root"))
           .build();
 
@@ -475,9 +475,12 @@ public class ForkChoiceTestExecutor implements TestExecutor {
             final boolean expectedResult = shouldOverrideForkChoiceUpdateCheck.get("result");
             final boolean expectedValidatorIsConnected =
                 shouldOverrideForkChoiceUpdateCheck.get("validator_is_connected");
-            // only currently handle result == true
-            assertThat(expectedResult).isTrue();
-            // only currently handle validatorIsConnected == true
+            final boolean shouldOverrideChainHead =
+                recentChainData.shouldOverrideForkChoiceUpdate(
+                    recentChainData.getBestBlockRoot().orElseThrow());
+            assertThat(shouldOverrideChainHead).isEqualTo(expectedResult);
+            // We've currently only handled the validatorIsConnected 'true' case in reftests,
+            // lets validate we're dealing with that and don't have to extend tests further.
             assertThat(expectedValidatorIsConnected).isTrue();
           }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ReadOnlyStore.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ReadOnlyStore.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
@@ -34,18 +35,11 @@ import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.CheckpointState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 
-public interface ReadOnlyStore {
+public interface ReadOnlyStore extends TimeProvider {
 
   default UInt64 getTimeSeconds() {
-    return millisToSeconds(getTimeMillis());
+    return millisToSeconds(getTimeInMillis());
   }
-
-  /**
-   * Returns time in milliseconds to allow for more fine-grained time calculations
-   *
-   * @return the time in milliseconds
-   */
-  UInt64 getTimeMillis();
 
   UInt64 getGenesisTime();
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtil.java
@@ -218,7 +218,7 @@ public class ForkChoiceUtil {
   public void onTick(final MutableStore store, final UInt64 timeMillis) {
     // To be extra safe check both time and genesisTime, although time should always be >=
     // genesisTime
-    if (store.getTimeMillis().isGreaterThan(timeMillis)
+    if (store.getTimeInMillis().isGreaterThan(timeMillis)
         || store.getGenesisTimeMillis().isGreaterThan(timeMillis)) {
       return;
     }

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtilTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/ForkChoiceUtilTest.java
@@ -227,7 +227,7 @@ class ForkChoiceUtilTest {
   void onTick_shouldExitImmediatelyWhenCurrentTimeIsBeforeGenesisTime() {
     final MutableStore store = mock(MutableStore.class);
     when(store.getGenesisTimeMillis()).thenReturn(UInt64.valueOf(3000000));
-    when(store.getTimeMillis()).thenReturn(UInt64.ZERO);
+    when(store.getTimeInMillis()).thenReturn(UInt64.ZERO);
     forkChoiceUtil.onTick(store, UInt64.valueOf(2000000));
 
     verify(store, never()).setTimeMillis(any());
@@ -237,7 +237,7 @@ class ForkChoiceUtilTest {
   void onTick_shouldExitImmediatelyWhenCurrentTimeIsBeforeStoreTime() {
     final MutableStore store = mock(MutableStore.class);
     when(store.getGenesisTimeMillis()).thenReturn(UInt64.valueOf(3000000));
-    when(store.getTimeMillis()).thenReturn(UInt64.valueOf(5000000));
+    when(store.getTimeInMillis()).thenReturn(UInt64.valueOf(5000000));
     forkChoiceUtil.onTick(store, UInt64.valueOf(4000000));
 
     verify(store, never()).setTimeMillis(any());
@@ -246,9 +246,9 @@ class ForkChoiceUtilTest {
   @Test
   void onTick_setsStoreTimeMillis() {
     final TestStoreImpl store = new TestStoreFactory(spec).createGenesisStore();
-    final UInt64 expectedMillis = store.getTimeMillis().plus(123456);
+    final UInt64 expectedMillis = store.getTimeInMillis().plus(123456);
     forkChoiceUtil.onTick(store, expectedMillis);
-    assertThat(store.getTimeMillis()).isEqualTo(expectedMillis);
+    assertThat(store.getTimeInMillis()).isEqualTo(expectedMillis);
   }
 
   @Test
@@ -277,7 +277,7 @@ class ForkChoiceUtilTest {
         spec.getSlotStartTimeMillis(
             spec.computeStartSlotAtEpoch(UInt64.valueOf(3)), store.getGenesisTimeMillis());
     forkChoiceUtil.onTick(store, finalMillis);
-    assertThat(store.getTimeMillis()).isEqualTo(finalMillis);
+    assertThat(store.getTimeInMillis()).isEqualTo(finalMillis);
 
     // Check the pull-up for epoch 2 was still performed
     assertThat(store.getJustifiedCheckpoint())

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
@@ -91,7 +91,7 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
 
   // Readonly methods
   @Override
-  public UInt64 getTimeMillis() {
+  public UInt64 getTimeInMillis() {
     return timeMillis;
   }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -202,6 +202,7 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
       final Optional<BlockImportPerformance> blockImportPerformance,
       final BlockBroadcastValidator blockBroadcastValidator,
       final ExecutionLayerChannel executionLayer) {
+    recentChainData.setBlockTimelinessIfEmpty(block);
     return recentChainData
         .retrieveStateAtSlot(new SlotAndBlockRoot(block.getSlot(), block.getParentRoot()))
         .thenPeek(__ -> blockImportPerformance.ifPresent(BlockImportPerformance::preStateRetrieved))
@@ -668,7 +669,7 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
 
   private UInt64 getMillisIntoSlot(StoreTransaction transaction, UInt64 millisPerSlot) {
     return transaction
-        .getTimeMillis()
+        .getTimeInMillis()
         .minus(secondsToMillis(transaction.getGenesisTime()))
         .mod(millisPerSlot);
   }
@@ -843,7 +844,7 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
   SafeFuture<Void> prepareForBlockProduction(final UInt64 slot) {
     final UInt64 slotStartTimeMillis =
         spec.getSlotStartTimeMillis(slot, recentChainData.getGenesisTimeMillis());
-    final UInt64 currentTime = recentChainData.getStore().getTimeMillis();
+    final UInt64 currentTime = recentChainData.getStore().getTimeInMillis();
     // We haven't yet transitioned into this slot but will do very soon, so make it happen now
     if (!currentTime
         .plus(BLOCK_CREATION_TOLERANCE_MS)

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AttestationValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AttestationValidator.java
@@ -97,7 +97,7 @@ public class AttestationValidator {
     }
 
     final UInt64 genesisTime = recentChainData.getGenesisTime();
-    final UInt64 currentTimeMillis = recentChainData.getStore().getTimeMillis();
+    final UInt64 currentTimeMillis = recentChainData.getStore().getTimeInMillis();
 
     final Optional<SlotInclusionGossipValidationResult> slotInclusionGossipValidationResult =
         spec.atSlot(data.getSlot())

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceTest.java
@@ -453,7 +453,7 @@ class ForkChoiceTest {
     if (advanceTimeSlotMillis > 0) {
       StoreTransaction transaction = recentChainData.startStoreTransaction();
       UInt64 timeIntoSlotMillis =
-          recentChainData.getStore().getTimeMillis().plus(advanceTimeSlotMillis);
+          recentChainData.getStore().getTimeInMillis().plus(advanceTimeSlotMillis);
       transaction.setTimeMillis(timeIntoSlotMillis);
       safeJoin(transaction.commit());
     }

--- a/fork-choice-tests/build.gradle
+++ b/fork-choice-tests/build.gradle
@@ -8,6 +8,7 @@ dependencies {
     integrationTestImplementation project(':infrastructure:ssz')
     integrationTestImplementation project(':storage')
     integrationTestImplementation project(':infrastructure:async')
+    integrationTestImplementation project(':infrastructure:time')
 
     integrationTestImplementation testFixtures(project(':ethereum:networks'))
     integrationTestImplementation testFixtures(project(':ethereum:statetransition'))

--- a/fork-choice-tests/src/integration-test/java/tech/pegasys/teku/forkChoiceTests/ForkChoiceIntegrationTest.java
+++ b/fork-choice-tests/src/integration-test/java/tech/pegasys/teku/forkChoiceTests/ForkChoiceIntegrationTest.java
@@ -202,7 +202,7 @@ public class ForkChoiceIntegrationTest {
       if (step instanceof UInt64) {
         UpdatableStore.StoreTransaction transaction = storageClient.startStoreTransaction();
         while (SPEC.getCurrentSlot(transaction).compareTo((UInt64) step) < 0) {
-          SPEC.onTick(transaction, transaction.getTimeMillis().plus(1000));
+          SPEC.onTick(transaction, transaction.getTimeInMillis().plus(1000));
         }
         assertEquals(step, SPEC.getCurrentSlot(transaction));
         transaction.commit().join();

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -407,6 +407,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
                     voteUpdateChannel,
                     eventChannels.getPublisher(FinalizedCheckpointChannel.class, beaconAsyncRunner),
                     coalescingChainHeadChannel,
+                    new ValidatorIsConenctedProviderImpl(forkChoiceNotifier),
                     spec))
         .thenCompose(
             client -> {

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -407,7 +407,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
                     voteUpdateChannel,
                     eventChannels.getPublisher(FinalizedCheckpointChannel.class, beaconAsyncRunner),
                     coalescingChainHeadChannel,
-                    new ValidatorIsConenctedProviderImpl(forkChoiceNotifier),
+                    new ValidatorIsConnectedProviderImpl(forkChoiceNotifier),
                     spec))
         .thenCompose(
             client -> {

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/ValidatorIsConenctedProviderImpl.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/ValidatorIsConenctedProviderImpl.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Consensys Software Inc., 2023
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.services.beaconchain;
+
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceNotifier;
+import tech.pegasys.teku.storage.client.ValidatorIsConnectedProvider;
+
+public class ValidatorIsConenctedProviderImpl implements ValidatorIsConnectedProvider {
+  private final ForkChoiceNotifier forkChoiceNotifier;
+
+  public ValidatorIsConenctedProviderImpl(ForkChoiceNotifier forkChoiceNotifier) {
+    this.forkChoiceNotifier = forkChoiceNotifier;
+  }
+
+  @Override
+  public boolean isValidatorConnected(int validatorId, UInt64 slot) {
+    return forkChoiceNotifier.validatorIsConnected(UInt64.valueOf(validatorId), slot);
+  }
+}

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/ValidatorIsConnectedProviderImpl.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/ValidatorIsConnectedProviderImpl.java
@@ -17,10 +17,10 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceNotifier;
 import tech.pegasys.teku.storage.client.ValidatorIsConnectedProvider;
 
-public class ValidatorIsConenctedProviderImpl implements ValidatorIsConnectedProvider {
+public class ValidatorIsConnectedProviderImpl implements ValidatorIsConnectedProvider {
   private final ForkChoiceNotifier forkChoiceNotifier;
 
-  public ValidatorIsConenctedProviderImpl(ForkChoiceNotifier forkChoiceNotifier) {
+  public ValidatorIsConnectedProviderImpl(ForkChoiceNotifier forkChoiceNotifier) {
     this.forkChoiceNotifier = forkChoiceNotifier;
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
@@ -638,7 +638,7 @@ public abstract class RecentChainData implements StoreUpdateHandler {
     final boolean isHeadLate = isBlockLate(headRoot);
     final Optional<SignedBeaconBlock> maybeHead = store.getBlockIfAvailable(headRoot);
 
-    // to return parent root, we need all of (isHeadLate, isShufflingStable, isFfgCompetetive,
+    // to return parent root, we need all of (isHeadLate, isShufflingStable, isFfgCompetitive,
     // isFinalizationOk, isProposingOnTime, isSingleSlotReorg, isHeadWeak, isParentStrong)
 
     // cheap checks of that list:
@@ -709,7 +709,7 @@ public abstract class RecentChainData implements StoreUpdateHandler {
     }
     final SignedBeaconBlock head = maybeHead.get();
     final UInt64 currentSlot = maybeCurrentSlot.get();
-    final UInt64 proposalSlot = currentSlot.increment();
+    final UInt64 proposalSlot = maybeHead.get().getSlot().increment();
     final boolean isShufflingStable =
         spec.atSlot(proposalSlot).getForkChoiceUtil().isShufflingStable(proposalSlot);
 
@@ -729,7 +729,7 @@ public abstract class RecentChainData implements StoreUpdateHandler {
     final boolean isProposingOnTime = isProposingOnTime(proposalSlot);
     final boolean isCurrentTimeOk =
         head.getSlot().equals(currentSlot)
-            || (currentSlot.increment().equals(proposalSlot) && isProposingOnTime);
+            || (currentSlot.equals(proposalSlot) && isProposingOnTime);
     final boolean isHeadWeak;
     final boolean isParentStrong;
     if (currentSlot.isGreaterThan(head.getSlot())) {

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/StorageBackedRecentChainData.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/StorageBackedRecentChainData.java
@@ -56,6 +56,7 @@ public class StorageBackedRecentChainData extends RecentChainData {
       final VoteUpdateChannel voteUpdateChannel,
       final FinalizedCheckpointChannel finalizedCheckpointChannel,
       final ChainHeadChannel chainHeadChannel,
+      final ValidatorIsConnectedProvider validatorIsConnectedProvider,
       final Spec spec) {
     super(
         asyncRunner,
@@ -69,6 +70,7 @@ public class StorageBackedRecentChainData extends RecentChainData {
         voteUpdateChannel,
         finalizedCheckpointChannel,
         chainHeadChannel,
+        validatorIsConnectedProvider,
         spec);
     this.storeConfig = storeConfig;
     this.storageQueryChannel = storageQueryChannel;
@@ -86,6 +88,7 @@ public class StorageBackedRecentChainData extends RecentChainData {
       final VoteUpdateChannel voteUpdateChannel,
       final FinalizedCheckpointChannel finalizedCheckpointChannel,
       final ChainHeadChannel chainHeadChannel,
+      final ValidatorIsConnectedProvider validatorIsConnectedProvider,
       final Spec spec) {
     StorageBackedRecentChainData client =
         new StorageBackedRecentChainData(
@@ -98,6 +101,7 @@ public class StorageBackedRecentChainData extends RecentChainData {
             voteUpdateChannel,
             finalizedCheckpointChannel,
             chainHeadChannel,
+            validatorIsConnectedProvider,
             spec);
 
     return client.initializeFromStorageWithRetry(asyncRunner);
@@ -114,6 +118,7 @@ public class StorageBackedRecentChainData extends RecentChainData {
       final VoteUpdateChannel voteUpdateChannel,
       final FinalizedCheckpointChannel finalizedCheckpointChannel,
       final ChainHeadChannel chainHeadChannel,
+      final ValidatorIsConnectedProvider validatorIsConnectedProvider,
       final Spec spec) {
     StorageBackedRecentChainData client =
         new StorageBackedRecentChainData(
@@ -126,6 +131,7 @@ public class StorageBackedRecentChainData extends RecentChainData {
             voteUpdateChannel,
             finalizedCheckpointChannel,
             chainHeadChannel,
+            validatorIsConnectedProvider,
             spec);
 
     return client.initializeFromStorage().join();

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/ValidatorIsConnectedProvider.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/ValidatorIsConnectedProvider.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Consensys Software Inc., 2023
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.storage.client;
+
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+public interface ValidatorIsConnectedProvider {
+  ValidatorIsConnectedProvider NOOP = (validatorId, slot) -> true;
+
+  boolean isValidatorConnected(int validatorId, UInt64 slot);
+}

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/Store.java
@@ -403,7 +403,7 @@ class Store extends CacheableStore {
   }
 
   @Override
-  public UInt64 getTimeMillis() {
+  public UInt64 getTimeInMillis() {
     readLock.lock();
     try {
       return timeMillis;

--- a/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransaction.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/store/StoreTransaction.java
@@ -136,7 +136,7 @@ class StoreTransaction implements UpdatableStore.StoreTransaction {
 
   @Override
   public void setTimeMillis(UInt64 timeMillis) {
-    final UInt64 storeTimeMillis = store.getTimeMillis();
+    final UInt64 storeTimeMillis = store.getTimeInMillis();
     checkArgument(
         timeMillis.isGreaterThanOrEqualTo(storeTimeMillis),
         "Cannot revert time (millis) from %s to %s",
@@ -240,8 +240,8 @@ class StoreTransaction implements UpdatableStore.StoreTransaction {
   }
 
   @Override
-  public UInt64 getTimeMillis() {
-    return timeMillis.orElseGet(store::getTimeMillis);
+  public UInt64 getTimeInMillis() {
+    return timeMillis.orElseGet(store::getTimeInMillis);
   }
 
   @Override

--- a/storage/src/test/java/tech/pegasys/teku/storage/client/StorageBackedRecentChainDataTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/client/StorageBackedRecentChainDataTest.java
@@ -64,6 +64,9 @@ public class StorageBackedRecentChainDataTest {
   private final ChainHeadChannel chainHeadChannel = new StubChainHeadChannel();
   private final StubAsyncRunner asyncRunner = new StubAsyncRunner();
 
+  private final ValidatorIsConnectedProvider validatorIsConnectedProvider =
+      ValidatorIsConnectedProvider.NOOP;
+
   @Test
   public void storageBackedClient_storeInitializeViaGetStoreRequest()
       throws ExecutionException, InterruptedException {
@@ -83,6 +86,7 @@ public class StorageBackedRecentChainDataTest {
             voteUpdateChannel,
             finalizedCheckpointChannel,
             chainHeadChannel,
+            validatorIsConnectedProvider,
             spec);
 
     // We should have posted a request to get the store from storage
@@ -131,6 +135,7 @@ public class StorageBackedRecentChainDataTest {
             voteUpdateChannel,
             finalizedCheckpointChannel,
             chainHeadChannel,
+            validatorIsConnectedProvider,
             spec);
 
     // We should have posted a request to get the store from storage
@@ -182,6 +187,7 @@ public class StorageBackedRecentChainDataTest {
             voteUpdateChannel,
             finalizedCheckpointChannel,
             chainHeadChannel,
+            validatorIsConnectedProvider,
             spec);
 
     // We should have posted a request to get the store from storage
@@ -229,6 +235,7 @@ public class StorageBackedRecentChainDataTest {
             voteUpdateChannel,
             finalizedCheckpointChannel,
             chainHeadChannel,
+            validatorIsConnectedProvider,
             spec);
 
     // We should have posted a request to get the store from storage

--- a/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTest.java
@@ -528,7 +528,7 @@ class StoreTest extends AbstractStoreTest {
     chainBuilder.generateBlocksUpToSlot(epoch3Slot);
 
     final Checkpoint genesisCheckpoint = store.getFinalizedCheckpoint();
-    final UInt64 initialTimeMillis = store.getTimeMillis();
+    final UInt64 initialTimeMillis = store.getTimeInMillis();
     final UInt64 genesisTime = store.getGenesisTime();
 
     final Checkpoint checkpoint1 = chainBuilder.getCurrentCheckpointForEpoch(UInt64.valueOf(1));
@@ -567,7 +567,7 @@ class StoreTest extends AbstractStoreTest {
     assertThat(store.getFinalizedCheckpoint()).isEqualTo(genesisCheckpoint);
     // Check time
     assertThat(store.getTimeSeconds()).isEqualTo(millisToSeconds(initialTimeMillis));
-    assertThat(store.getTimeMillis()).isEqualTo(initialTimeMillis);
+    assertThat(store.getTimeInMillis()).isEqualTo(initialTimeMillis);
     assertThat(store.getGenesisTime()).isEqualTo(genesisTime);
 
     // Check that transaction is updated
@@ -583,7 +583,7 @@ class StoreTest extends AbstractStoreTest {
     assertThat(tx.getBestJustifiedCheckpoint()).isEqualTo(checkpoint3);
     // Check time
     assertThat(tx.getTimeSeconds()).isEqualTo(millisToSeconds(firstUpdateTimeMillis));
-    assertThat(tx.getTimeMillis()).isEqualTo(firstUpdateTimeMillis);
+    assertThat(tx.getTimeInMillis()).isEqualTo(firstUpdateTimeMillis);
     assertThat(tx.getGenesisTime()).isEqualTo(updatedGenesisTime);
 
     // Commit transaction
@@ -624,7 +624,7 @@ class StoreTest extends AbstractStoreTest {
     assertThat(finalizedCheckpointState).isCompleted();
     assertThat(safeJoin(finalizedCheckpointState).getCheckpoint()).isEqualTo(checkpoint1);
     // Check time
-    assertThat(store.getTimeMillis()).isEqualTo(expectedTimeMillis);
+    assertThat(store.getTimeInMillis()).isEqualTo(expectedTimeMillis);
     assertThat(store.getTimeSeconds()).isEqualTo(millisToSeconds(expectedTimeMillis));
     assertThat(store.getGenesisTime()).isEqualTo(updatedGenesisTime);
 

--- a/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTransactionTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/store/StoreTransactionTest.java
@@ -43,14 +43,14 @@ public class StoreTransactionTest extends AbstractStoreTest {
     final UpdatableStore store = createGenesisStore();
 
     // Make sure time is non-zero
-    setTime(store, store.getTimeMillis().plus(10));
+    setTime(store, store.getTimeInMillis().plus(10));
 
-    final UInt64 invalidTime = store.getTimeMillis().minus(1);
+    final UInt64 invalidTime = store.getTimeInMillis().minus(1);
     assertThatThrownBy(() -> setTime(store, invalidTime))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining(
             String.format(
-                "Cannot revert time (millis) from %s to %s", store.getTimeMillis(), invalidTime));
+                "Cannot revert time (millis) from %s to %s", store.getTimeInMillis(), invalidTime));
   }
 
   @Test
@@ -58,18 +58,18 @@ public class StoreTransactionTest extends AbstractStoreTest {
     final UpdatableStore store = createGenesisStore();
 
     // Make sure time is non-zero
-    setTime(store, store.getTimeMillis().plus(10));
+    setTime(store, store.getTimeInMillis().plus(10));
 
     final StoreTransaction txA = store.startTransaction(storageUpdateChannel);
-    final UInt64 timeA = store.getTimeMillis().plus(1);
+    final UInt64 timeA = store.getTimeInMillis().plus(1);
 
     final UInt64 timeB = timeA.plus(1);
     setTime(store, timeB);
-    assertThat(store.getTimeMillis()).isEqualTo(timeB);
+    assertThat(store.getTimeInMillis()).isEqualTo(timeB);
 
     // Commit tx, time should not be updated
     assertThat(txA.commit()).isCompleted();
-    assertThat(store.getTimeMillis()).isEqualTo(timeB);
+    assertThat(store.getTimeInMillis()).isEqualTo(timeB);
   }
 
   @Test

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/client/MemoryOnlyRecentChainData.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/client/MemoryOnlyRecentChainData.java
@@ -46,6 +46,7 @@ public class MemoryOnlyRecentChainData extends RecentChainData {
       final VoteUpdateChannel voteUpdateChannel,
       final FinalizedCheckpointChannel finalizedCheckpointChannel,
       final ChainHeadChannel chainHeadChannel,
+      final ValidatorIsConnectedProvider validatorIsConnectedProvider,
       final Spec spec) {
     super(
         asyncRunner,
@@ -59,6 +60,7 @@ public class MemoryOnlyRecentChainData extends RecentChainData {
         voteUpdateChannel,
         finalizedCheckpointChannel,
         chainHeadChannel,
+        validatorIsConnectedProvider,
         spec);
   }
 
@@ -86,6 +88,9 @@ public class MemoryOnlyRecentChainData extends RecentChainData {
         new StubFinalizedCheckpointChannel();
     private ChainHeadChannel chainHeadChannel = new StubChainHeadChannel();
 
+    private ValidatorIsConnectedProvider validatorIsConnectedProvider =
+        ValidatorIsConnectedProvider.NOOP;
+
     public RecentChainData build() {
       return new MemoryOnlyRecentChainData(
           SYNC_RUNNER,
@@ -96,6 +101,7 @@ public class MemoryOnlyRecentChainData extends RecentChainData {
           votes -> {},
           finalizedCheckpointChannel,
           chainHeadChannel,
+          validatorIsConnectedProvider,
           spec);
     }
 
@@ -114,6 +120,12 @@ public class MemoryOnlyRecentChainData extends RecentChainData {
     public Builder storageUpdateChannel(final StorageUpdateChannel storageUpdateChannel) {
       checkNotNull(storageUpdateChannel);
       this.storageUpdateChannel = storageUpdateChannel;
+      return this;
+    }
+
+    public Builder validatorIsConnectedProvider(
+        final ValidatorIsConnectedProvider validatorIsConnectedProvider) {
+      this.validatorIsConnectedProvider = validatorIsConnectedProvider;
       return this;
     }
 

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/storageSystem/StorageSystem.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/storageSystem/StorageSystem.java
@@ -32,6 +32,7 @@ import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 import tech.pegasys.teku.storage.client.EarliestAvailableBlockSlot;
 import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.storage.client.StorageBackedRecentChainData;
+import tech.pegasys.teku.storage.client.ValidatorIsConnectedProvider;
 import tech.pegasys.teku.storage.server.ChainStorage;
 import tech.pegasys.teku.storage.server.Database;
 import tech.pegasys.teku.storage.server.DepositStorage;
@@ -109,6 +110,7 @@ public class StorageSystem implements AutoCloseable {
             chainStorageServer,
             finalizedCheckpointChannel,
             chainHeadChannel,
+            ValidatorIsConnectedProvider.NOOP,
             spec);
 
     // Create combined client


### PR DESCRIPTION
Implemented should_override_fork_choice function, and tested results via the reftests.

There's a level of duplication in the 'should_override_fork_choice' and 'get_proposer_head', but I've stayed true to the spec, while fixing ordering a little to do cheaper tests first.

Ultimately, the function will exit fast once it finds a mis-match, and if it gets to the end then things pass.

Also had to adjust timeliness to use store time, and I made the Store implement the TimeProvider to fix an issue with using a system time provider when store time was needed.

Finally, while I did successfully run the reftests, I have to leave the reftests disabled until we get a release that doesnt contain backwards ticks. It's possible to remove the ticks to run the tests, but they won't run out of the box.

partially addresses #6595

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
