### PR TITLE
Fix potentially skipping validator status updates

### DIFF
--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/VoluntaryExitAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/VoluntaryExitAcceptanceTest.java
@@ -37,9 +37,9 @@ public class VoluntaryExitAcceptanceTest extends AcceptanceTestBase {
 
     final TekuDepositSender depositSender = createTekuDepositSender(networkName);
     final ValidatorKeystores validatorKeysToExit = depositSender.generateValidatorKeys(4);
-    // network of 5 validators (4 of them will exit)
+    // network of 8 validators (4 of them will exit)
     final ValidatorKeystores validatorKeys =
-        ValidatorKeystores.add(validatorKeysToExit, depositSender.generateValidatorKeys(1));
+        ValidatorKeystores.add(validatorKeysToExit, depositSender.generateValidatorKeys(4));
     // 1 unknown key to the network
     final ValidatorKeystores unknownKeys = depositSender.generateValidatorKeys(1);
 

--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/VoluntaryExitAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/VoluntaryExitAcceptanceTest.java
@@ -29,15 +29,17 @@ import tech.pegasys.teku.test.acceptance.dsl.tools.deposits.ValidatorKeystores;
 
 public class VoluntaryExitAcceptanceTest extends AcceptanceTestBase {
 
+  private static final String DOCKER_IMAGE_LINE_SEPARATOR = "\n"; // Unix line separator
+
   @Test
   void shouldChangeValidatorStatusAfterSubmittingVoluntaryExit() throws Exception {
     final String networkName = "swift";
 
     final TekuDepositSender depositSender = createTekuDepositSender(networkName);
     final ValidatorKeystores validatorKeysToExit = depositSender.generateValidatorKeys(4);
-    // network of 8 validators (4 of them will exit)
+    // network of 5 validators (4 of them will exit)
     final ValidatorKeystores validatorKeys =
-        ValidatorKeystores.add(validatorKeysToExit, depositSender.generateValidatorKeys(4));
+        ValidatorKeystores.add(validatorKeysToExit, depositSender.generateValidatorKeys(1));
     // 1 unknown key to the network
     final ValidatorKeystores unknownKeys = depositSender.generateValidatorKeys(1);
 
@@ -81,7 +83,8 @@ public class VoluntaryExitAcceptanceTest extends AcceptanceTestBase {
     voluntaryExitProcessFailing.waitForExit();
     voluntaryExitProcessSuccessful.waitForExit();
     final List<Integer> validatorIds =
-        Arrays.stream(voluntaryExitProcessFailing.getLoggedErrors().split(System.lineSeparator()))
+        Arrays.stream(
+                voluntaryExitProcessFailing.getLoggedErrors().split(DOCKER_IMAGE_LINE_SEPARATOR))
             .filter(s -> s.contains("Validator cannot exit until epoch 3"))
             .map(s -> Integer.parseInt(s.substring(19, 20)))
             .collect(Collectors.toList());

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/OwnedValidatorStatusProvider.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/OwnedValidatorStatusProvider.java
@@ -189,6 +189,7 @@ public class OwnedValidatorStatusProvider implements ValidatorStatusProvider {
           validatorStatusSubscribers.forEach(
               s -> s.onValidatorStatuses(latestValidatorStatuses.get(), true));
         }
+        lookupInProgress.set(false);
         return;
       }
       validatorApiChannel


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Essentially in `updateValidatorStatuses` there was a case where `lookupInProgress` was not set to false, which resulted in acceptance tests failing like https://app.circleci.com/pipelines/github/Consensys/teku/28584/workflows/014e54b7-02d1-4891-81d8-dfcbaba29b4c/jobs/210650/tests#failed-test-0 

Ran locally using `@RepeatedTest(value = 20)`

![image](https://github.com/Consensys/teku/assets/14827647/319fd0c5-2c2a-42ea-8b77-263ba3a1b934)


## Fixed Issue(s)
fixes #7684 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
