### PR TITLE
Consolidate interfaces related to BlockV3, moving from deprecated method to Optional<Boolean> blinded

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactory.java
@@ -27,19 +27,12 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 
 public interface BlockFactory {
 
-  @Deprecated
   SafeFuture<BlockContainer> createUnsignedBlock(
       BeaconState blockSlotState,
       UInt64 newSlot,
       BLSSignature randaoReveal,
       Optional<Bytes32> optionalGraffiti,
-      boolean blinded);
-
-  SafeFuture<BlockContainer> createUnsignedBlock(
-      BeaconState blockSlotState,
-      UInt64 newSlot,
-      BLSSignature randaoReveal,
-      Optional<Bytes32> optionalGraffiti);
+      final Optional<Boolean> blinded);
 
   SafeFuture<SignedBeaconBlock> unblindSignedBlockIfBlinded(SignedBeaconBlock maybeBlindedBlock);
 

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactoryDeneb.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactoryDeneb.java
@@ -41,37 +41,15 @@ public class BlockFactoryDeneb extends BlockFactoryPhase0 {
             spec.forMilestone(SpecMilestone.DENEB).getSchemaDefinitions());
   }
 
-  @Deprecated
   @Override
   public SafeFuture<BlockContainer> createUnsignedBlock(
       final BeaconState blockSlotState,
       final UInt64 newSlot,
       final BLSSignature randaoReveal,
       final Optional<Bytes32> optionalGraffiti,
-      final boolean blinded) {
+      final Optional<Boolean> blinded) {
     return super.createUnsignedBlock(
             blockSlotState, newSlot, randaoReveal, optionalGraffiti, blinded)
-        .thenApply(BlockContainer::getBlock)
-        .thenCompose(
-            block -> {
-              if (block.isBlinded()) {
-                return SafeFuture.completedFuture(block);
-              }
-              // The execution BlobsBundle has been cached as part of the block creation
-              return operationSelector
-                  .createBlobsBundleSelector()
-                  .apply(block)
-                  .thenApply(blobsBundle -> createBlockContents(block, blobsBundle));
-            });
-  }
-
-  @Override
-  public SafeFuture<BlockContainer> createUnsignedBlock(
-      final BeaconState blockSlotState,
-      final UInt64 newSlot,
-      final BLSSignature randaoReveal,
-      final Optional<Bytes32> optionalGraffiti) {
-    return super.createUnsignedBlock(blockSlotState, newSlot, randaoReveal, optionalGraffiti)
         .thenApply(BlockContainer::getBlock)
         .thenCompose(
             block -> {

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactoryPhase0.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactoryPhase0.java
@@ -41,14 +41,13 @@ public class BlockFactoryPhase0 implements BlockFactory {
     this.operationSelector = operationSelector;
   }
 
-  @Deprecated
   @Override
   public SafeFuture<BlockContainer> createUnsignedBlock(
       final BeaconState blockSlotState,
       final UInt64 newSlot,
       final BLSSignature randaoReveal,
       final Optional<Bytes32> optionalGraffiti,
-      final boolean blinded) {
+      final Optional<Boolean> blinded) {
     checkArgument(
         blockSlotState.getSlot().equals(newSlot),
         "Block slot state for slot %s but should be for slot %s",
@@ -68,33 +67,6 @@ public class BlockFactoryPhase0 implements BlockFactory {
             operationSelector.createSelector(
                 parentRoot, blockSlotState, randaoReveal, optionalGraffiti),
             blinded)
-        .thenApply(BeaconBlockAndState::getBlock);
-  }
-
-  @Override
-  public SafeFuture<BlockContainer> createUnsignedBlock(
-      final BeaconState blockSlotState,
-      final UInt64 newSlot,
-      final BLSSignature randaoReveal,
-      final Optional<Bytes32> optionalGraffiti) {
-    checkArgument(
-        blockSlotState.getSlot().equals(newSlot),
-        "Block slot state for slot %s but should be for slot %s",
-        blockSlotState.getSlot(),
-        newSlot);
-
-    // Process empty slots up to the one before the new block slot
-    final UInt64 slotBeforeBlock = newSlot.minus(UInt64.ONE);
-
-    final Bytes32 parentRoot = spec.getBlockRootAtSlot(blockSlotState, slotBeforeBlock);
-
-    return spec.createNewUnsignedBlock(
-            newSlot,
-            spec.getBeaconProposerIndex(blockSlotState, newSlot),
-            blockSlotState,
-            parentRoot,
-            operationSelector.createSelector(
-                parentRoot, blockSlotState, randaoReveal, optionalGraffiti))
         .thenApply(BeaconBlockAndState::getBlock);
   }
 

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/MilestoneBasedBlockFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/MilestoneBasedBlockFactory.java
@@ -59,30 +59,17 @@ public class MilestoneBasedBlockFactory implements BlockFactory {
             });
   }
 
-  @Deprecated
   @Override
   public SafeFuture<BlockContainer> createUnsignedBlock(
       final BeaconState blockSlotState,
       final UInt64 newSlot,
       final BLSSignature randaoReveal,
       final Optional<Bytes32> optionalGraffiti,
-      final boolean blinded) {
+      final Optional<Boolean> blinded) {
     final SpecMilestone milestone = getMilestone(newSlot);
     return registeredFactories
         .get(milestone)
         .createUnsignedBlock(blockSlotState, newSlot, randaoReveal, optionalGraffiti, blinded);
-  }
-
-  @Override
-  public SafeFuture<BlockContainer> createUnsignedBlock(
-      final BeaconState blockSlotState,
-      final UInt64 newSlot,
-      final BLSSignature randaoReveal,
-      final Optional<Bytes32> optionalGraffiti) {
-    final SpecMilestone milestone = getMilestone(newSlot);
-    return registeredFactories
-        .get(milestone)
-        .createUnsignedBlock(blockSlotState, newSlot, randaoReveal, optionalGraffiti);
   }
 
   @Override

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/AbstractBlockFactoryTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/AbstractBlockFactoryTest.java
@@ -204,7 +204,7 @@ public abstract class AbstractBlockFactoryTest {
     final BlockContainer blockContainer =
         safeJoin(
             blockFactory.createUnsignedBlock(
-                blockSlotState, newSlot, randaoReveal, Optional.empty(), blinded));
+                blockSlotState, newSlot, randaoReveal, Optional.empty(), Optional.of(blinded)));
 
     final BeaconBlock block = blockContainer.getBlock();
 

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -481,7 +481,7 @@ class ValidatorApiHandlerTest {
     nodeIsSyncing();
     final SafeFuture<Optional<BlockContainer>> result =
         validatorApiHandler.createUnsignedBlock(
-            ONE, dataStructureUtil.randomSignature(), Optional.empty(), false);
+            ONE, dataStructureUtil.randomSignature(), Optional.empty(), Optional.of(false));
 
     assertThat(result).isCompletedExceptionally();
     assertThatThrownBy(result::get).hasRootCauseInstanceOf(NodeSyncingException.class);
@@ -498,7 +498,7 @@ class ValidatorApiHandlerTest {
 
     final SafeFuture<Optional<BlockContainer>> result =
         validatorApiHandler.createUnsignedBlock(
-            newSlot, dataStructureUtil.randomSignature(), Optional.empty(), false);
+            newSlot, dataStructureUtil.randomSignature(), Optional.empty(), Optional.of(false));
 
     assertThat(result).isCompletedExceptionally();
     assertThatThrownBy(result::get).hasRootCauseInstanceOf(NodeSyncingException.class);
@@ -515,14 +515,16 @@ class ValidatorApiHandlerTest {
     when(chainDataClient.getStateAtSlotExact(newSlot))
         .thenReturn(SafeFuture.completedFuture(Optional.of(blockSlotState)));
     when(blockFactory.createUnsignedBlock(
-            blockSlotState, newSlot, randaoReveal, Optional.empty(), false))
+            blockSlotState, newSlot, randaoReveal, Optional.empty(), Optional.of(false)))
         .thenReturn(SafeFuture.completedFuture(createdBlock));
 
     final SafeFuture<Optional<BlockContainer>> result =
-        validatorApiHandler.createUnsignedBlock(newSlot, randaoReveal, Optional.empty(), false);
+        validatorApiHandler.createUnsignedBlock(
+            newSlot, randaoReveal, Optional.empty(), Optional.of(false));
 
     verify(blockFactory)
-        .createUnsignedBlock(blockSlotState, newSlot, randaoReveal, Optional.empty(), false);
+        .createUnsignedBlock(
+            blockSlotState, newSlot, randaoReveal, Optional.empty(), Optional.of(false));
     assertThat(result).isCompletedWithValue(Optional.of(createdBlock));
   }
 

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/validator/GetNewBlockIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/validator/GetNewBlockIntegrationTest.java
@@ -72,7 +72,7 @@ public class GetNewBlockIntegrationTest extends AbstractDataBackedRestAPIIntegra
   void shouldGetUnsignedBlock_asJson(final String route, final boolean isBlindedBlock)
       throws IOException {
     when(validatorApiChannel.createUnsignedBlock(
-            eq(UInt64.ONE), eq(signature), any(), eq(isBlindedBlock)))
+            eq(UInt64.ONE), eq(signature), any(), eq(Optional.of(isBlindedBlock))))
         .thenReturn(SafeFuture.completedFuture(Optional.of(randomBlock)));
     Response response = get(route, signature, ContentTypes.JSON);
     assertThat(response.code()).isEqualTo(SC_OK);
@@ -88,7 +88,7 @@ public class GetNewBlockIntegrationTest extends AbstractDataBackedRestAPIIntegra
   void shouldGetUnsignedBlock_asOctet(final String route, final boolean isBlindedBlock)
       throws IOException {
     when(validatorApiChannel.createUnsignedBlock(
-            eq(UInt64.ONE), eq(signature), any(), eq(isBlindedBlock)))
+            eq(UInt64.ONE), eq(signature), any(), eq(Optional.of(isBlindedBlock))))
         .thenReturn(SafeFuture.completedFuture(Optional.of(randomBlock)));
     Response response = get(route, signature, ContentTypes.OCTET_STREAM);
     assertThat(response.code()).isEqualTo(SC_OK);
@@ -100,7 +100,7 @@ public class GetNewBlockIntegrationTest extends AbstractDataBackedRestAPIIntegra
   @MethodSource("getNewBlockCases")
   void shouldShowNoContent(final String route, final boolean isBlindedBlock) throws IOException {
     when(validatorApiChannel.createUnsignedBlock(
-            eq(UInt64.ONE), eq(signature), any(), eq(isBlindedBlock)))
+            eq(UInt64.ONE), eq(signature), any(), eq(Optional.of(isBlindedBlock))))
         .thenReturn(SafeFuture.failedFuture(new ChainDataUnavailableException()));
     Response response = get(route, signature, ContentTypes.OCTET_STREAM);
     assertThat(response.code()).isEqualTo(SC_NO_CONTENT);
@@ -111,7 +111,7 @@ public class GetNewBlockIntegrationTest extends AbstractDataBackedRestAPIIntegra
   @MethodSource("getNewBlockCases")
   void shouldShowUnavailable(final String route, final boolean isBlindedBlock) throws IOException {
     when(validatorApiChannel.createUnsignedBlock(
-            eq(UInt64.ONE), eq(signature), any(), eq(isBlindedBlock)))
+            eq(UInt64.ONE), eq(signature), any(), eq(Optional.of(isBlindedBlock))))
         .thenReturn(SafeFuture.failedFuture(new ServiceUnavailableException()));
     Response response = get(route, signature, ContentTypes.OCTET_STREAM);
     assertThat(response.code()).isEqualTo(SC_SERVICE_UNAVAILABLE);
@@ -125,7 +125,7 @@ public class GetNewBlockIntegrationTest extends AbstractDataBackedRestAPIIntegra
   void shouldNotStackTraceForMissingDeposits(final String route, final boolean isBlindedBlock)
       throws IOException {
     when(validatorApiChannel.createUnsignedBlock(
-            eq(UInt64.ONE), eq(signature), any(), eq(isBlindedBlock)))
+            eq(UInt64.ONE), eq(signature), any(), eq(Optional.of(isBlindedBlock))))
         .thenReturn(
             SafeFuture.failedFuture(
                 MissingDepositsException.missingRange(UInt64.valueOf(1), UInt64.valueOf(10))));

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v3/GetNewBlockV3IntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v3/GetNewBlockV3IntegrationTest.java
@@ -93,7 +93,7 @@ public class GetNewBlockV3IntegrationTest extends AbstractDataBackedRestAPIInteg
     assumeThat(specMilestone).isLessThan(DENEB);
     final BeaconBlock beaconBlock = dataStructureUtil.randomBeaconBlock(ONE);
     final BLSSignature signature = beaconBlock.getBlock().getBody().getRandaoReveal();
-    when(validatorApiChannel.createUnsignedBlock(eq(UInt64.ONE), eq(signature), any()))
+    when(validatorApiChannel.createUnsignedBlock(eq(UInt64.ONE), eq(signature), any(), any()))
         .thenReturn(SafeFuture.completedFuture(Optional.of(beaconBlock)));
     Response response = get(signature, ContentTypes.JSON);
     assertResponseWithHeaders(response, false);
@@ -106,7 +106,7 @@ public class GetNewBlockV3IntegrationTest extends AbstractDataBackedRestAPIInteg
     assumeThat(specMilestone).isLessThan(DENEB);
     final BeaconBlock beaconBlock = dataStructureUtil.randomBeaconBlock(ONE);
     final BLSSignature signature = beaconBlock.getBlock().getBody().getRandaoReveal();
-    when(validatorApiChannel.createUnsignedBlock(eq(UInt64.ONE), eq(signature), any()))
+    when(validatorApiChannel.createUnsignedBlock(eq(UInt64.ONE), eq(signature), any(), any()))
         .thenReturn(SafeFuture.completedFuture(Optional.of(beaconBlock)));
     Response response = get(signature, ContentTypes.OCTET_STREAM);
     assertResponseWithHeaders(response, false);
@@ -122,7 +122,7 @@ public class GetNewBlockV3IntegrationTest extends AbstractDataBackedRestAPIInteg
     assumeThat(specMilestone).isGreaterThanOrEqualTo(BELLATRIX);
     final BeaconBlock blindedBeaconBlock = dataStructureUtil.randomBlindedBeaconBlock(ONE);
     final BLSSignature signature = blindedBeaconBlock.getBlock().getBody().getRandaoReveal();
-    when(validatorApiChannel.createUnsignedBlock(eq(UInt64.ONE), eq(signature), any()))
+    when(validatorApiChannel.createUnsignedBlock(eq(UInt64.ONE), eq(signature), any(), any()))
         .thenReturn(SafeFuture.completedFuture(Optional.of(blindedBeaconBlock)));
     Response response = get(signature, ContentTypes.JSON);
     assertResponseWithHeaders(response, true);
@@ -135,7 +135,7 @@ public class GetNewBlockV3IntegrationTest extends AbstractDataBackedRestAPIInteg
     assumeThat(specMilestone).isGreaterThanOrEqualTo(BELLATRIX);
     final BeaconBlock blindedBeaconBlock = dataStructureUtil.randomBlindedBeaconBlock(ONE);
     final BLSSignature signature = blindedBeaconBlock.getBlock().getBody().getRandaoReveal();
-    when(validatorApiChannel.createUnsignedBlock(eq(UInt64.ONE), eq(signature), any()))
+    when(validatorApiChannel.createUnsignedBlock(eq(UInt64.ONE), eq(signature), any(), any()))
         .thenReturn(SafeFuture.completedFuture(Optional.of(blindedBeaconBlock)));
     Response response = get(signature, ContentTypes.OCTET_STREAM);
     assertResponseWithHeaders(response, true);
@@ -151,7 +151,7 @@ public class GetNewBlockV3IntegrationTest extends AbstractDataBackedRestAPIInteg
     assumeThat(specMilestone).isEqualTo(DENEB);
     final BlockContents blockContents = dataStructureUtil.randomBlockContents(ONE);
     final BLSSignature signature = blockContents.getBlock().getBody().getRandaoReveal();
-    when(validatorApiChannel.createUnsignedBlock(eq(UInt64.ONE), eq(signature), any()))
+    when(validatorApiChannel.createUnsignedBlock(eq(UInt64.ONE), eq(signature), any(), any()))
         .thenReturn(SafeFuture.completedFuture(Optional.of(blockContents)));
     Response response = get(signature, ContentTypes.JSON);
     assertResponseWithHeaders(response, false);
@@ -164,7 +164,7 @@ public class GetNewBlockV3IntegrationTest extends AbstractDataBackedRestAPIInteg
     assumeThat(specMilestone).isEqualTo(DENEB);
     final BlockContents blockContents = dataStructureUtil.randomBlockContents(ONE);
     final BLSSignature signature = blockContents.getBlock().getBody().getRandaoReveal();
-    when(validatorApiChannel.createUnsignedBlock(eq(UInt64.ONE), eq(signature), any()))
+    when(validatorApiChannel.createUnsignedBlock(eq(UInt64.ONE), eq(signature), any(), any()))
         .thenReturn(SafeFuture.completedFuture(Optional.of(blockContents)));
     Response response = get(signature, ContentTypes.OCTET_STREAM);
     assertResponseWithHeaders(response, false);
@@ -180,7 +180,7 @@ public class GetNewBlockV3IntegrationTest extends AbstractDataBackedRestAPIInteg
   void shouldFailWhenNoBlockProduced() throws IOException {
     final BeaconBlock beaconBlock = dataStructureUtil.randomBeaconBlock(ONE);
     final BLSSignature signature = beaconBlock.getBlock().getBody().getRandaoReveal();
-    when(validatorApiChannel.createUnsignedBlock(eq(UInt64.ONE), eq(signature), any()))
+    when(validatorApiChannel.createUnsignedBlock(eq(UInt64.ONE), eq(signature), any(), any()))
         .thenReturn(SafeFuture.completedFuture(Optional.empty()));
     when(executionLayerBlockProductionManager.getCachedPayloadResult(UInt64.ONE))
         .thenReturn(

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v3/validator/GetNewBlockV3Test.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v3/validator/GetNewBlockV3Test.java
@@ -190,7 +190,7 @@ public class GetNewBlockV3Test extends AbstractMigratedBeaconHandlerTest {
       blockContainer = dataStructureUtil.randomBeaconBlock(ONE);
     }
     final ValidatorApiChannel validatorApiChannelMock = mock(ValidatorApiChannel.class);
-    when(validatorApiChannelMock.createUnsignedBlock(any(), any(), any()))
+    when(validatorApiChannelMock.createUnsignedBlock(any(), any(), any(), any()))
         .thenReturn(SafeFuture.completedFuture(Optional.of(blockContainer)));
     final CombinedChainDataClient combinedChainDataClientMock = mock(CombinedChainDataClient.class);
     when(combinedChainDataClientMock.getCurrentSlot()).thenReturn(ZERO);
@@ -251,7 +251,7 @@ public class GetNewBlockV3Test extends AbstractMigratedBeaconHandlerTest {
       blockContainer = dataStructureUtil.randomBeaconBlock(ONE);
     }
     final ValidatorApiChannel validatorApiChannelMock = mock(ValidatorApiChannel.class);
-    when(validatorApiChannelMock.createUnsignedBlock(any(), any(), any()))
+    when(validatorApiChannelMock.createUnsignedBlock(any(), any(), any(), any()))
         .thenReturn(SafeFuture.completedFuture(Optional.of(blockContainer)));
     final CombinedChainDataClient combinedChainDataClientMock = mock(CombinedChainDataClient.class);
     when(combinedChainDataClientMock.getCurrentSlot()).thenReturn(ZERO);
@@ -312,7 +312,7 @@ public class GetNewBlockV3Test extends AbstractMigratedBeaconHandlerTest {
       blockContainer = dataStructureUtil.randomBeaconBlock(ONE);
     }
     final ValidatorApiChannel validatorApiChannelMock = mock(ValidatorApiChannel.class);
-    when(validatorApiChannelMock.createUnsignedBlock(any(), any(), any()))
+    when(validatorApiChannelMock.createUnsignedBlock(any(), any(), any(), any()))
         .thenReturn(SafeFuture.completedFuture(Optional.of(blockContainer)));
     final CombinedChainDataClient combinedChainDataClientMock = mock(CombinedChainDataClient.class);
     when(combinedChainDataClientMock.getCurrentSlot()).thenReturn(ZERO);
@@ -364,7 +364,7 @@ public class GetNewBlockV3Test extends AbstractMigratedBeaconHandlerTest {
     assumeThat(specMilestone).isLessThan(ALTAIR);
     final BlockContainer blockContainer = dataStructureUtil.randomBeaconBlock(ONE);
     final ValidatorApiChannel validatorApiChannelMock = mock(ValidatorApiChannel.class);
-    when(validatorApiChannelMock.createUnsignedBlock(any(), any(), any()))
+    when(validatorApiChannelMock.createUnsignedBlock(any(), any(), any(), any()))
         .thenReturn(SafeFuture.completedFuture(Optional.of(blockContainer)));
     final BeaconState parentStateMock = mock(BeaconState.class);
     final CombinedChainDataClient combinedChainDataClientMock = mock(CombinedChainDataClient.class);

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
@@ -116,14 +116,14 @@ public class ValidatorDataProvider {
       final Optional<Bytes32> graffiti,
       final boolean isBlinded) {
     checkBlockProducingParameters(slot, randao);
-    return validatorApiChannel.createUnsignedBlock(slot, randao, graffiti, isBlinded);
+    return validatorApiChannel.createUnsignedBlock(slot, randao, graffiti, Optional.of(isBlinded));
   }
 
   public SafeFuture<Optional<BlockContainerAndMetaData<BlockContainer>>> produceBlock(
       final UInt64 slot, final BLSSignature randao, final Optional<Bytes32> graffiti) {
     checkBlockProducingParameters(slot, randao);
     return validatorApiChannel
-        .createUnsignedBlock(slot, randao, graffiti)
+        .createUnsignedBlock(slot, randao, graffiti, Optional.empty())
         .thenCompose(this::lookUpBlockValues);
   }
 

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
@@ -110,6 +110,7 @@ public class ValidatorDataProvider {
     return combinedChainDataClient.isStoreAvailable();
   }
 
+  @Deprecated
   public SafeFuture<Optional<BlockContainer>> getUnsignedBeaconBlockAtSlot(
       final UInt64 slot,
       final BLSSignature randao,

--- a/data/provider/src/test/java/tech/pegasys/teku/api/ValidatorDataProviderTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/ValidatorDataProviderTest.java
@@ -162,14 +162,15 @@ public class ValidatorDataProviderTest {
   void getUnsignedBeaconBlockAtSlot_PreDeneb_shouldCreateAnUnsignedBlock() {
     assumeThat(specMilestone).isLessThan(SpecMilestone.DENEB);
     when(combinedChainDataClient.getCurrentSlot()).thenReturn(ZERO);
-    when(validatorApiChannel.createUnsignedBlock(ONE, signatureInternal, Optional.empty(), false))
+    when(validatorApiChannel.createUnsignedBlock(
+            ONE, signatureInternal, Optional.empty(), Optional.of(false)))
         .thenReturn(completedFuture(Optional.of(blockInternal)));
 
     SafeFuture<? extends Optional<? extends SszData>> data =
         provider.getUnsignedBeaconBlockAtSlot(ONE, signatureInternal, Optional.empty());
 
     verify(validatorApiChannel)
-        .createUnsignedBlock(ONE, signatureInternal, Optional.empty(), false);
+        .createUnsignedBlock(ONE, signatureInternal, Optional.empty(), Optional.of(false));
 
     assertThat(data).isCompleted();
 
@@ -181,14 +182,15 @@ public class ValidatorDataProviderTest {
     assumeThat(specMilestone).isGreaterThanOrEqualTo(SpecMilestone.DENEB);
     when(combinedChainDataClient.getCurrentSlot()).thenReturn(ZERO);
     blockContents = dataStructureUtil.randomBlockContents();
-    when(validatorApiChannel.createUnsignedBlock(ONE, signatureInternal, Optional.empty(), false))
+    when(validatorApiChannel.createUnsignedBlock(
+            ONE, signatureInternal, Optional.empty(), Optional.of(false)))
         .thenReturn(completedFuture(Optional.of(blockContents)));
 
     SafeFuture<? extends Optional<? extends SszData>> data =
         provider.getUnsignedBeaconBlockAtSlot(ONE, signatureInternal, Optional.empty());
 
     verify(validatorApiChannel)
-        .createUnsignedBlock(ONE, signatureInternal, Optional.empty(), false);
+        .createUnsignedBlock(ONE, signatureInternal, Optional.empty(), Optional.of(false));
 
     assertThat(data).isCompleted();
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -693,30 +693,17 @@ public class Spec {
   }
 
   // Block Proposal
-  @Deprecated
   public SafeFuture<BeaconBlockAndState> createNewUnsignedBlock(
       final UInt64 newSlot,
       final int proposerIndex,
       final BeaconState blockSlotState,
       final Bytes32 parentBlockSigningRoot,
       final Consumer<BeaconBlockBodyBuilder> bodyBuilder,
-      final boolean blinded) {
+      final Optional<Boolean> blinded) {
     return atSlot(newSlot)
         .getBlockProposalUtil()
         .createNewUnsignedBlock(
             newSlot, proposerIndex, blockSlotState, parentBlockSigningRoot, bodyBuilder, blinded);
-  }
-
-  public SafeFuture<BeaconBlockAndState> createNewUnsignedBlock(
-      final UInt64 newSlot,
-      final int proposerIndex,
-      final BeaconState blockSlotState,
-      final Bytes32 parentBlockSigningRoot,
-      final Consumer<BeaconBlockBodyBuilder> bodyBuilder) {
-    return atSlot(newSlot)
-        .getBlockProposalUtil()
-        .createNewUnsignedBlock(
-            newSlot, proposerIndex, blockSlotState, parentBlockSigningRoot, bodyBuilder);
   }
 
   // Blind Block Utils

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/BlockProposalUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/BlockProposalUtil.java
@@ -51,7 +51,7 @@ public class BlockProposalUtil {
       final BeaconState blockSlotState,
       final Bytes32 parentBlockSigningRoot,
       final Consumer<BeaconBlockBodyBuilder> bodyBuilder,
-      final boolean blinded) {
+      final Optional<Boolean> blinded) {
     checkArgument(
         blockSlotState.getSlot().equals(newSlot),
         "Block slot state from incorrect slot. Expected %s but got %s",
@@ -62,7 +62,7 @@ public class BlockProposalUtil {
     final SafeFuture<? extends BeaconBlockBody> beaconBlockBody;
     final BeaconBlockSchema beaconBlockSchema;
 
-    if (blinded) {
+    if (blinded.orElse(ValidatorsUtil.DEFAULT_PRODUCE_BLINDED_BLOCK)) {
       beaconBlockBody = createBlindedBeaconBlockBody(bodyBuilder);
       beaconBlockSchema = schemaDefinitions.getBlindedBeaconBlockSchema();
     } else {
@@ -108,21 +108,6 @@ public class BlockProposalUtil {
               }
               return SafeFuture.failedFuture(error);
             });
-  }
-
-  public SafeFuture<BeaconBlockAndState> createNewUnsignedBlock(
-      final UInt64 newSlot,
-      final int proposerIndex,
-      final BeaconState blockSlotState,
-      final Bytes32 parentBlockSigningRoot,
-      final Consumer<BeaconBlockBodyBuilder> bodyBuilder) {
-    return createNewUnsignedBlock(
-        newSlot,
-        proposerIndex,
-        blockSlotState,
-        parentBlockSigningRoot,
-        bodyBuilder,
-        ValidatorsUtil.DEFAULT_PRODUCE_BLINDED_BLOCK);
   }
 
   private SafeFuture<? extends BeaconBlockBody> createBeaconBlockBody(

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/BlockProposalTestUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/BlockProposalTestUtil.java
@@ -132,7 +132,7 @@ public class BlockProposalTestUtil {
                         kzgCommitments.orElseGet(dataStructureUtil::emptyBlobKzgCommitments)));
               }
             },
-            false)
+            Optional.of(false))
         .thenApply(
             newBlockAndState -> {
               // Sign block and set block signature

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
@@ -79,16 +79,12 @@ public interface ValidatorApiChannel extends ChannelInterface {
           return SafeFuture.completedFuture(Optional.empty());
         }
 
-        @Deprecated
         @Override
         public SafeFuture<Optional<BlockContainer>> createUnsignedBlock(
-            UInt64 slot, BLSSignature randaoReveal, Optional<Bytes32> graffiti, boolean blinded) {
-          return SafeFuture.completedFuture(Optional.empty());
-        }
-
-        @Override
-        public SafeFuture<Optional<BlockContainer>> createUnsignedBlock(
-            UInt64 slot, BLSSignature randaoReveal, Optional<Bytes32> graffiti) {
+            UInt64 slot,
+            BLSSignature randaoReveal,
+            Optional<Bytes32> graffiti,
+            Optional<Boolean> blinded) {
           return SafeFuture.completedFuture(Optional.empty());
         }
 
@@ -195,12 +191,14 @@ public interface ValidatorApiChannel extends ChannelInterface {
 
   SafeFuture<Optional<ProposerDuties>> getProposerDuties(UInt64 epoch);
 
-  @Deprecated
+  /**
+   * @param blinded can be removed once block creation V2 APIs are removed in favour of V3 only
+   */
   SafeFuture<Optional<BlockContainer>> createUnsignedBlock(
-      UInt64 slot, BLSSignature randaoReveal, Optional<Bytes32> graffiti, boolean blinded);
-
-  SafeFuture<Optional<BlockContainer>> createUnsignedBlock(
-      UInt64 slot, BLSSignature randaoReveal, Optional<Bytes32> graffiti);
+      UInt64 slot,
+      BLSSignature randaoReveal,
+      Optional<Bytes32> graffiti,
+      Optional<Boolean> blinded);
 
   SafeFuture<Optional<AttestationData>> createAttestationData(UInt64 slot, int committeeIndex);
 

--- a/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
+++ b/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
@@ -125,23 +125,14 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
         BeaconNodeRequestLabels.GET_PROPOSER_DUTIES_REQUESTS_METHOD);
   }
 
-  @Deprecated
   @Override
   public SafeFuture<Optional<BlockContainer>> createUnsignedBlock(
       final UInt64 slot,
       final BLSSignature randaoReveal,
       Optional<Bytes32> graffiti,
-      final boolean blinded) {
+      final Optional<Boolean> blinded) {
     return countOptionalDataRequest(
         delegate.createUnsignedBlock(slot, randaoReveal, graffiti, blinded),
-        BeaconNodeRequestLabels.CREATE_UNSIGNED_BLOCK_METHOD);
-  }
-
-  @Override
-  public SafeFuture<Optional<BlockContainer>> createUnsignedBlock(
-      final UInt64 slot, final BLSSignature randaoReveal, Optional<Bytes32> graffiti) {
-    return countOptionalDataRequest(
-        delegate.createUnsignedBlock(slot, randaoReveal, graffiti),
         BeaconNodeRequestLabels.CREATE_UNSIGNED_BLOCK_METHOD);
   }
 

--- a/validator/beaconnode/src/test/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannelTest.java
+++ b/validator/beaconnode/src/test/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannelTest.java
@@ -192,7 +192,8 @@ class MetricRecordingValidatorApiChannelTest {
             new GenesisData(dataStructureUtil.randomUInt64(), Bytes32.random())),
         requestDataTest(
             "createUnsignedBlock",
-            channel -> channel.createUnsignedBlock(slot, signature, Optional.empty(), false),
+            channel ->
+                channel.createUnsignedBlock(slot, signature, Optional.empty(), Optional.of(false)),
             BeaconNodeRequestLabels.CREATE_UNSIGNED_BLOCK_METHOD,
             dataStructureUtil.randomBeaconBlock(slot)),
         requestDataTest(

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/BlockProductionDuty.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/BlockProductionDuty.java
@@ -109,10 +109,11 @@ public class BlockProductionDuty implements Duty {
   private SafeFuture<Optional<BlockContainer>> createUnsignedBlock(
       final BLSSignature randaoReveal) {
     if (blockV3Enabled) {
-      return validatorApiChannel.createUnsignedBlock(slot, randaoReveal, validator.getGraffiti());
+      return validatorApiChannel.createUnsignedBlock(
+          slot, randaoReveal, validator.getGraffiti(), Optional.empty());
     } else {
       return validatorApiChannel.createUnsignedBlock(
-          slot, randaoReveal, validator.getGraffiti(), useBlindedBlock);
+          slot, randaoReveal, validator.getGraffiti(), Optional.of(useBlindedBlock));
     }
   }
 

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/BlockProductionDutyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/BlockProductionDutyTest.java
@@ -137,7 +137,7 @@ class BlockProductionDutyTest {
     when(signer.createRandaoReveal(spec.computeEpochAtSlot(CAPELLA_SLOT), fork))
         .thenReturn(completedFuture(randaoReveal));
     when(validatorApiChannel.createUnsignedBlock(
-            CAPELLA_SLOT, randaoReveal, Optional.of(graffiti), isBlindedBlocksEnabled))
+            CAPELLA_SLOT, randaoReveal, Optional.of(graffiti), Optional.of(isBlindedBlocksEnabled)))
         .thenReturn(completedFuture(Optional.of(unsignedBlock)));
     when(signer.signBlock(unsignedBlock, fork)).thenReturn(completedFuture(blockSignature));
     final SignedBeaconBlock signedBlock =
@@ -193,7 +193,7 @@ class BlockProductionDutyTest {
     when(signer.signBlock(unsignedBlockContents.getBlock(), fork))
         .thenReturn(completedFuture(blockSignature));
     when(validatorApiChannel.createUnsignedBlock(
-            denebSlot, randaoReveal, Optional.of(graffiti), false))
+            denebSlot, randaoReveal, Optional.of(graffiti), Optional.of(false)))
         .thenReturn(completedFuture(Optional.of(unsignedBlockContents)));
     when(validatorApiChannel.sendSignedBlock(any(), any()))
         .thenReturn(completedFuture(SendSignedBlockResult.success(unsignedBlock.getRoot())));
@@ -275,7 +275,7 @@ class BlockProductionDutyTest {
     when(signer.signBlock(unsignedBlindedBlock.getBlock(), fork))
         .thenReturn(completedFuture(blockSignature));
     when(validatorApiChannel.createUnsignedBlock(
-            denebSlot, randaoReveal, Optional.of(graffiti), true))
+            denebSlot, randaoReveal, Optional.of(graffiti), Optional.of(true)))
         .thenReturn(completedFuture(Optional.of(unsignedBlindedBlock)));
     when(validatorApiChannel.sendSignedBlock(any(), any()))
         .thenReturn(completedFuture(SendSignedBlockResult.success(unsignedBlindedBlock.getRoot())));
@@ -343,7 +343,7 @@ class BlockProductionDutyTest {
     when(signer.signBlock(unsignedBlockContentsMock.getBlock(), fork))
         .thenReturn(completedFuture(blockSignature));
     when(validatorApiChannel.createUnsignedBlock(
-            denebSlot, randaoReveal, Optional.of(graffiti), false))
+            denebSlot, randaoReveal, Optional.of(graffiti), Optional.of(false)))
         .thenReturn(completedFuture(Optional.of(unsignedBlockContentsMock)));
     when(validatorApiChannel.sendSignedBlock(any(), any()))
         .thenReturn(completedFuture(SendSignedBlockResult.success(blockRoot)));
@@ -386,7 +386,7 @@ class BlockProductionDutyTest {
     when(signer.signBlock(unsignedBlockContentsMock.getBlock(), fork))
         .thenReturn(completedFuture(blockSignature));
     when(validatorApiChannel.createUnsignedBlock(
-            denebSlot, randaoReveal, Optional.of(graffiti), false))
+            denebSlot, randaoReveal, Optional.of(graffiti), Optional.of(false)))
         .thenReturn(completedFuture(Optional.of(unsignedBlockContentsMock)));
     when(validatorApiChannel.sendSignedBlock(any(), any()))
         .thenReturn(completedFuture(SendSignedBlockResult.success(blockRoot)));
@@ -432,7 +432,7 @@ class BlockProductionDutyTest {
     when(signer.createRandaoReveal(spec.computeEpochAtSlot(CAPELLA_SLOT), fork))
         .thenReturn(completedFuture(randaoReveal));
     when(validatorApiChannel.createUnsignedBlock(
-            CAPELLA_SLOT, randaoReveal, Optional.of(graffiti), false))
+            CAPELLA_SLOT, randaoReveal, Optional.of(graffiti), Optional.of(false)))
         .thenReturn(failedFuture(error));
 
     assertDutyFails(error);
@@ -448,7 +448,7 @@ class BlockProductionDutyTest {
     when(signer.createRandaoReveal(spec.computeEpochAtSlot(CAPELLA_SLOT), fork))
         .thenReturn(completedFuture(randaoReveal));
     when(validatorApiChannel.createUnsignedBlock(
-            CAPELLA_SLOT, randaoReveal, Optional.of(graffiti), false))
+            CAPELLA_SLOT, randaoReveal, Optional.of(graffiti), Optional.of(false)))
         .thenReturn(completedFuture(Optional.empty()));
 
     performAndReportDuty();
@@ -474,7 +474,7 @@ class BlockProductionDutyTest {
     when(signer.createRandaoReveal(spec.computeEpochAtSlot(CAPELLA_SLOT), fork))
         .thenReturn(completedFuture(randaoReveal));
     when(validatorApiChannel.createUnsignedBlock(
-            CAPELLA_SLOT, randaoReveal, Optional.of(graffiti), false))
+            CAPELLA_SLOT, randaoReveal, Optional.of(graffiti), Optional.of(false)))
         .thenReturn(completedFuture(Optional.of(unsignedBlock)));
     when(signer.signBlock(unsignedBlock, fork)).thenReturn(failedFuture(error));
 
@@ -513,7 +513,8 @@ class BlockProductionDutyTest {
 
     when(signer.createRandaoReveal(spec.computeEpochAtSlot(CAPELLA_SLOT), fork))
         .thenReturn(completedFuture(randaoReveal));
-    when(validatorApiChannel.createUnsignedBlock(CAPELLA_SLOT, randaoReveal, Optional.of(graffiti)))
+    when(validatorApiChannel.createUnsignedBlock(
+            CAPELLA_SLOT, randaoReveal, Optional.of(graffiti), Optional.empty()))
         .thenReturn(completedFuture(Optional.of(unsignedBlock)));
     when(signer.signBlock(unsignedBlock, fork)).thenReturn(completedFuture(blockSignature));
     final SignedBeaconBlock signedBlock =
@@ -523,7 +524,7 @@ class BlockProductionDutyTest {
 
     performAndReportDuty();
     verify(validatorApiChannel)
-        .createUnsignedBlock(CAPELLA_SLOT, randaoReveal, Optional.of(graffiti));
+        .createUnsignedBlock(CAPELLA_SLOT, randaoReveal, Optional.of(graffiti), Optional.empty());
 
     verify(validatorApiChannel).sendSignedBlock(signedBlock, BroadcastValidationLevel.NOT_REQUIRED);
     verify(validatorLogger)
@@ -571,14 +572,16 @@ class BlockProductionDutyTest {
         .thenReturn(completedFuture(randaoReveal));
     when(signer.signBlock(unsignedBlockContents.getBlock(), fork))
         .thenReturn(completedFuture(blockSignature));
-    when(validatorApiChannel.createUnsignedBlock(denebSlot, randaoReveal, Optional.of(graffiti)))
+    when(validatorApiChannel.createUnsignedBlock(
+            denebSlot, randaoReveal, Optional.of(graffiti), Optional.empty()))
         .thenReturn(completedFuture(Optional.of(unsignedBlockContents)));
     when(validatorApiChannel.sendSignedBlock(any(), any()))
         .thenReturn(completedFuture(SendSignedBlockResult.success(unsignedBlock.getRoot())));
 
     performAndReportDuty(denebSlot);
 
-    verify(validatorApiChannel).createUnsignedBlock(denebSlot, randaoReveal, Optional.of(graffiti));
+    verify(validatorApiChannel)
+        .createUnsignedBlock(denebSlot, randaoReveal, Optional.of(graffiti), Optional.empty());
 
     final ArgumentCaptor<SignedBlockContents> signedBlockContentsArgumentCaptor =
         ArgumentCaptor.forClass(SignedBlockContents.class);

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandler.java
@@ -145,34 +145,16 @@ public class FailoverValidatorApiHandler implements ValidatorApiChannel {
         BeaconNodeRequestLabels.GET_PROPOSER_DUTIES_REQUESTS_METHOD);
   }
 
-  @Deprecated
   @Override
   public SafeFuture<Optional<BlockContainer>> createUnsignedBlock(
       final UInt64 slot,
       final BLSSignature randaoReveal,
       final Optional<Bytes32> graffiti,
-      final boolean blinded) {
+      final Optional<Boolean> blinded) {
     final ValidatorApiChannelRequest<Optional<BlockContainer>> request =
         apiChannel ->
             apiChannel
                 .createUnsignedBlock(slot, randaoReveal, graffiti, blinded)
-                .thenPeek(
-                    blockContainer -> {
-                      if (!failoverDelegates.isEmpty()
-                          && blockContainer.map(BlockContainer::isBlinded).orElse(false)) {
-                        blindedBlockCreatorCache.put(slot, apiChannel);
-                      }
-                    });
-    return tryRequestUntilSuccess(request, BeaconNodeRequestLabels.CREATE_UNSIGNED_BLOCK_METHOD);
-  }
-
-  @Override
-  public SafeFuture<Optional<BlockContainer>> createUnsignedBlock(
-      final UInt64 slot, final BLSSignature randaoReveal, final Optional<Bytes32> graffiti) {
-    final ValidatorApiChannelRequest<Optional<BlockContainer>> request =
-        apiChannel ->
-            apiChannel
-                .createUnsignedBlock(slot, randaoReveal, graffiti)
                 .thenPeek(
                     blockContainer -> {
                       if (!failoverDelegates.isEmpty()

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
@@ -263,20 +263,16 @@ public class RemoteValidatorApiHandler implements RemoteValidatorApiChannel {
                 .orElse(emptyList()));
   }
 
-  @Deprecated
   @Override
   public SafeFuture<Optional<BlockContainer>> createUnsignedBlock(
       final UInt64 slot,
       final BLSSignature randaoReveal,
       final Optional<Bytes32> graffiti,
-      final boolean blinded) {
-    return sendRequest(
-        () -> typeDefClient.createUnsignedBlock(slot, randaoReveal, graffiti, blinded));
-  }
-
-  @Override
-  public SafeFuture<Optional<BlockContainer>> createUnsignedBlock(
-      final UInt64 slot, final BLSSignature randaoReveal, final Optional<Bytes32> graffiti) {
+      final Optional<Boolean> blinded) {
+    if (blinded.isPresent()) {
+      return sendRequest(
+          () -> typeDefClient.createUnsignedBlock(slot, randaoReveal, graffiti, blinded.get()));
+    }
     return sendRequest(() -> typeDefClient.createUnsignedBlock(slot, randaoReveal, graffiti));
   }
 

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/sentry/SentryValidatorApiChannel.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/sentry/SentryValidatorApiChannel.java
@@ -98,24 +98,15 @@ public class SentryValidatorApiChannel implements ValidatorApiChannel {
     return dutiesProviderChannel.getProposerDuties(epoch);
   }
 
-  @Deprecated
   @Override
   public SafeFuture<Optional<BlockContainer>> createUnsignedBlock(
       final UInt64 slot,
       final BLSSignature randaoReveal,
       final Optional<Bytes32> graffiti,
-      final boolean blinded) {
+      final Optional<Boolean> blinded) {
     return blockHandlerChannel
         .orElse(dutiesProviderChannel)
         .createUnsignedBlock(slot, randaoReveal, graffiti, blinded);
-  }
-
-  @Override
-  public SafeFuture<Optional<BlockContainer>> createUnsignedBlock(
-      final UInt64 slot, final BLSSignature randaoReveal, final Optional<Bytes32> graffiti) {
-    return blockHandlerChannel
-        .orElse(dutiesProviderChannel)
-        .createUnsignedBlock(slot, randaoReveal, graffiti);
   }
 
   @Override

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandlerTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandlerTest.java
@@ -583,7 +583,8 @@ class FailoverValidatorApiHandlerTest {
     final BeaconBlock blindedBlock = DATA_STRUCTURE_UTIL.randomBlindedBeaconBlock(UInt64.ONE);
 
     final ValidatorApiChannelRequest<Optional<BlockContainer>> creationRequest =
-        apiChannel -> apiChannel.createUnsignedBlock(slot, randaoReveal, Optional.empty(), true);
+        apiChannel ->
+            apiChannel.createUnsignedBlock(slot, randaoReveal, Optional.empty(), Optional.of(true));
 
     setupFailures(creationRequest, primaryApiChannel);
     setupSuccesses(creationRequest, Optional.of(blindedBlock), failoverApiChannel1);
@@ -684,7 +685,8 @@ class FailoverValidatorApiHandlerTest {
         getArguments(
             "createUnsignedBlock",
             apiChannel ->
-                apiChannel.createUnsignedBlock(slot, randaoReveal, Optional.empty(), false),
+                apiChannel.createUnsignedBlock(
+                    slot, randaoReveal, Optional.empty(), Optional.of(false)),
             BeaconNodeRequestLabels.CREATE_UNSIGNED_BLOCK_METHOD,
             Optional.of(mock(BeaconBlock.class))),
         getArguments(

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
@@ -390,7 +390,7 @@ class RemoteValidatorApiHandlerTest {
 
     SafeFuture<Optional<BlockContainer>> future =
         apiHandler.createUnsignedBlock(
-            UInt64.ONE, blsSignature, Optional.of(Bytes32.random()), false);
+            UInt64.ONE, blsSignature, Optional.of(Bytes32.random()), Optional.of(false));
 
     assertThat(unwrapToOptional(future)).isEmpty();
   }
@@ -406,7 +406,7 @@ class RemoteValidatorApiHandlerTest {
         .thenReturn(Optional.of(beaconBlock));
 
     SafeFuture<Optional<BlockContainer>> future =
-        apiHandler.createUnsignedBlock(UInt64.ONE, blsSignature, graffiti, false);
+        apiHandler.createUnsignedBlock(UInt64.ONE, blsSignature, graffiti, Optional.of(false));
 
     assertThatSszData(unwrapToValue(future)).isEqualByAllMeansTo(beaconBlock);
   }
@@ -425,7 +425,7 @@ class RemoteValidatorApiHandlerTest {
         .thenReturn(Optional.of(blockContents));
 
     SafeFuture<Optional<BlockContainer>> future =
-        apiHandler.createUnsignedBlock(UInt64.ONE, blsSignature, graffiti, false);
+        apiHandler.createUnsignedBlock(UInt64.ONE, blsSignature, graffiti, Optional.of(false));
 
     assertThatSszData(unwrapToValue(future)).isEqualByAllMeansTo(blockContents);
   }

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/sentry/SentryValidatorApiChannelTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/sentry/SentryValidatorApiChannelTest.java
@@ -123,11 +123,14 @@ class SentryValidatorApiChannelTest {
   @Test
   void createUnsignedBlockShouldUseBlockHandlerChannelWhenAvailable() {
     sentryValidatorApiChannel.createUnsignedBlock(
-        UInt64.ZERO, BLSSignature.empty(), Optional.empty(), false);
+        UInt64.ZERO, BLSSignature.empty(), Optional.empty(), Optional.of(false));
 
     verify(blockHandlerChannel)
         .createUnsignedBlock(
-            eq(UInt64.ZERO), eq(BLSSignature.empty()), eq(Optional.empty()), eq(false));
+            eq(UInt64.ZERO),
+            eq(BLSSignature.empty()),
+            eq(Optional.empty()),
+            eq(Optional.of(false)));
     verifyNoInteractions(dutiesProviderChannel);
     verifyNoInteractions(attestationPublisherChannel);
   }
@@ -139,11 +142,14 @@ class SentryValidatorApiChannelTest {
             dutiesProviderChannel, Optional.empty(), Optional.of(attestationPublisherChannel));
 
     sentryValidatorApiChannel.createUnsignedBlock(
-        UInt64.ZERO, BLSSignature.empty(), Optional.empty(), false);
+        UInt64.ZERO, BLSSignature.empty(), Optional.empty(), Optional.of(false));
 
     verify(dutiesProviderChannel)
         .createUnsignedBlock(
-            eq(UInt64.ZERO), eq(BLSSignature.empty()), eq(Optional.empty()), eq(false));
+            eq(UInt64.ZERO),
+            eq(BLSSignature.empty()),
+            eq(Optional.empty()),
+            eq(Optional.of(false)));
     verifyNoInteractions(blockHandlerChannel);
     verifyNoInteractions(attestationPublisherChannel);
   }


### PR DESCRIPTION
I was adding a block production performance tracker (#7770) and I realize that there was some code duplication to apply my simple changes to.

So I decided to consolidate the interface, since probably V2 support will remain for a long time and having code duplication and `@deprecated` method for so long it doesn't make much sense to me.


## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
