### PR TITLE
Support null in JSON parsing as an empty array

### DIFF
--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/rewards/GetSyncCommitteeRewardsIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/rewards/GetSyncCommitteeRewardsIntegrationTest.java
@@ -62,7 +62,7 @@ public class GetSyncCommitteeRewardsIntegrationTest
   @Test
   public void handleEmptyRequestBodyList() throws IOException {
     final List<String> requestBody = List.of();
-    Response response =
+    Response response1 =
         post(
             GetSyncCommitteeRewards.ROUTE.replace("{block_id}", "head"),
             jsonProvider.objectToJSON(requestBody));
@@ -86,15 +86,12 @@ public class GetSyncCommitteeRewardsIntegrationTest
     data.increaseReward(15, 0L);
     final String expectedResponse = serialize(data, GetSyncCommitteeRewards.RESPONSE_TYPE);
 
-    assertThat(response.code()).isEqualTo(SC_OK);
-    assertThat(response.body().string()).isEqualTo(expectedResponse);
-  }
+    assertThat(response1.code()).isEqualTo(SC_OK);
+    assertThat(response1.body().string()).isEqualTo(expectedResponse);
 
-  @Test
-  public void shouldGiveDecentErrorIfNoBody() throws IOException {
-    Response response = post(GetSyncCommitteeRewards.ROUTE.replace("{block_id}", "head"), "");
-    assertThat(response.code()).isEqualTo(SC_BAD_REQUEST);
-    assertThat(response.body().string()).contains("Array expected but got null");
+    Response response2 = post(GetSyncCommitteeRewards.ROUTE.replace("{block_id}", "head"), "");
+    assertThat(response2.code()).isEqualTo(SC_OK);
+    assertThat(response2.body().string()).isEqualTo(expectedResponse);
   }
 
   @Test

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/validator/PostAttesterDutiesIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/validator/PostAttesterDutiesIntegrationTest.java
@@ -36,6 +36,7 @@ public class PostAttesterDutiesIntegrationTest extends AbstractDataBackedRestAPI
     Response response = post(PostAttesterDuties.ROUTE.replace("{epoch}", "1"), "");
 
     assertThat(response.code()).isEqualTo(SC_BAD_REQUEST);
-    assertThat(response.body().string()).contains("Array expected but got null");
+    assertThat(response.body().string())
+        .contains("At least one validator index should be provided");
   }
 }

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostAttesterDuties.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostAttesterDuties.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.beaconrestapi.handlers.v1.validator;
 
 import static tech.pegasys.teku.beaconrestapi.BeaconRestApiTypes.EPOCH_PARAMETER;
 import static tech.pegasys.teku.ethereum.json.types.EthereumTypes.PUBLIC_KEY_TYPE;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_BAD_REQUEST;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_SERVICE_UNAVAILABLE;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.EXECUTION_OPTIMISTIC;
@@ -118,6 +119,10 @@ public class PostAttesterDuties extends RestApiEndpoint {
     final UInt64 epoch = request.getPathParameter(EPOCH_PARAMETER);
     final List<Integer> requestBody = request.getRequestBody();
     final IntList indices = IntArrayList.toList(requestBody.stream().mapToInt(Integer::intValue));
+    if (indices.isEmpty()) {
+      request.respondError(SC_BAD_REQUEST, "At least one validator index should be provided.");
+      return;
+    }
 
     SafeFuture<Optional<AttesterDuties>> future =
         validatorDataProvider.getAttesterDuties(epoch, indices);

--- a/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/DeserializableArrayTypeDefinition.java
+++ b/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/DeserializableArrayTypeDefinition.java
@@ -13,11 +13,14 @@
 
 package tech.pegasys.teku.infrastructure.json.types;
 
+import static com.fasterxml.jackson.core.JsonToken.VALUE_NULL;
+
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
@@ -49,6 +52,9 @@ public class DeserializableArrayTypeDefinition<ItemT, CollectionT extends Iterab
   @Override
   public CollectionT deserialize(final JsonParser parser) throws IOException {
     if (!parser.isExpectedStartArrayToken()) {
+      if (parser.currentToken().equals(VALUE_NULL)) {
+        return createFromList.apply(Collections.emptyList());
+      }
       throw MismatchedInputException.from(
           parser, String.class, "Array expected but got " + parser.getCurrentToken());
     }

--- a/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/DeserializableArrayTypeDefinition.java
+++ b/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/DeserializableArrayTypeDefinition.java
@@ -52,7 +52,7 @@ public class DeserializableArrayTypeDefinition<ItemT, CollectionT extends Iterab
   @Override
   public CollectionT deserialize(final JsonParser parser) throws IOException {
     if (!parser.isExpectedStartArrayToken()) {
-      if (parser.currentToken().equals(VALUE_NULL)) {
+      if (!parser.hasCurrentToken() || parser.currentToken().equals(VALUE_NULL)) {
         return createFromList.apply(Collections.emptyList());
       }
       throw MismatchedInputException.from(

--- a/infrastructure/json/src/test/java/tech/pegasys/teku/infrastructure/json/JsonUtilTest.java
+++ b/infrastructure/json/src/test/java/tech/pegasys/teku/infrastructure/json/JsonUtilTest.java
@@ -15,11 +15,14 @@ package tech.pegasys.teku.infrastructure.json;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.STRING_TYPE;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.json.types.CoreTypes;
+import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 import tech.pegasys.teku.infrastructure.json.types.OneOfTypeTestTypeDefinition;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
@@ -83,6 +86,16 @@ class JsonUtilTest {
             CoreTypes.UINT64_TYPE,
             "slot");
     assertThat(result).contains(UInt64.valueOf(1234));
+  }
+
+  @Test
+  void getAttribute_handlesNullAsEmptyList() throws Exception {
+    final Optional<List<String>> result =
+        JsonUtil.getAttribute(
+            "{\"data\": { \"slot\": \"1\"}," + "\"meta\": null," + " \"slot\":\"1234\"}",
+            DeserializableTypeDefinition.listOf(STRING_TYPE),
+            "meta");
+    assertThat(result).contains(List.of());
   }
 
   @Test

--- a/infrastructure/json/src/test/java/tech/pegasys/teku/infrastructure/json/types/DeserializableArrayTypeDefinitionTest.java
+++ b/infrastructure/json/src/test/java/tech/pegasys/teku/infrastructure/json/types/DeserializableArrayTypeDefinitionTest.java
@@ -42,4 +42,11 @@ class DeserializableArrayTypeDefinitionTest {
 
     assertThat(result).isEqualTo(value);
   }
+
+  @Test
+  void shouldHandleNullAsEmptyList() throws Exception {
+    final List<String> result = JsonUtil.parse("null", stringListType);
+
+    assertThat(result).isEqualTo(emptyList());
+  }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Compliment to #7786 
`GetSyncCommitteeRewardsIntegrationTest`:
Test removed and logic extended because it's per spec, see https://github.com/ethereum/beacon-APIs/blob/master/apis/beacon/rewards/sync_committee.yaml#L15-L17
It's safe to test no currentToken because if we are inside some object we will throw on the next step not able to find closing, if the whole empty object is array type, it's legit to be ""
`PostAttesterDutiesIntegrationTest`:
Spec requires at least one index https://github.com/ethereum/beacon-APIs/blob/master/apis/validator/duties/attester.yaml#L33-L39 which was not checked. Though the field is required by spec, I think it's acceptable to fail a bit afterwards

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
