### PR TITLE
add block/selector root selector factories

### DIFF
--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateRootTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateRootTest.java
@@ -22,11 +22,12 @@ import static tech.pegasys.teku.infrastructure.restapi.MetadataTestUtil.verifyMe
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.io.IOException;
+import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.beaconrestapi.AbstractMigratedBeaconHandlerWithChainDataProviderTest;
 import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.datastructures.metadata.StateAndMetaData;
+import tech.pegasys.teku.spec.datastructures.metadata.ObjectAndMetaData;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 
 public class GetStateRootTest extends AbstractMigratedBeaconHandlerWithChainDataProviderTest {
@@ -42,12 +43,11 @@ public class GetStateRootTest extends AbstractMigratedBeaconHandlerWithChainData
   @Test
   public void shouldReturnRootInfo() throws Exception {
     final BeaconState state = recentChainData.getBestState().orElseThrow().get();
-
     handler.handleRequest(request);
-
     assertThat(request.getResponseCode()).isEqualTo(SC_OK);
-    StateAndMetaData expectedBody =
-        new StateAndMetaData(state, spec.getGenesisSpec().getMilestone(), false, true, true);
+    ObjectAndMetaData<Bytes32> expectedBody =
+        new ObjectAndMetaData<>(
+            state.hashTreeRoot(), spec.getGenesisSpec().getMilestone(), false, true, true);
     assertThat(request.getResponseBody()).isEqualTo(expectedBody);
   }
 
@@ -63,9 +63,9 @@ public class GetStateRootTest extends AbstractMigratedBeaconHandlerWithChainData
 
   @Test
   void metadata_shouldHandle200() throws IOException {
-    final StateAndMetaData responseData =
-        new StateAndMetaData(
-            dataStructureUtil.randomBeaconState(),
+    final ObjectAndMetaData<Bytes32> responseData =
+        new ObjectAndMetaData<>(
+            dataStructureUtil.randomBytes32(),
             spec.getGenesisSpec().getMilestone(),
             false,
             true,
@@ -74,7 +74,7 @@ public class GetStateRootTest extends AbstractMigratedBeaconHandlerWithChainData
     String expected =
         String.format(
             "{\"execution_optimistic\":false,\"finalized\":false,\"data\":{\"root\":\"%s\"}}",
-            responseData.getData().hashTreeRoot());
+            responseData.getData());
     assertThat(data).isEqualTo(expected);
   }
 }

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
@@ -51,6 +51,7 @@ import tech.pegasys.teku.api.response.v1.beacon.ValidatorStatus;
 import tech.pegasys.teku.api.rewards.EpochAttestationRewardsCalculator;
 import tech.pegasys.teku.api.schema.BeaconState;
 import tech.pegasys.teku.api.schema.Fork;
+import tech.pegasys.teku.api.staterootselector.StateRootSelectorFactory;
 import tech.pegasys.teku.api.stateselector.StateSelectorFactory;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -84,6 +85,7 @@ public class ChainDataProvider {
   private final BlockSelectorFactory blockSelectorFactory;
   private final BlockRootSelectorFactory blockRootSelectorFactory;
   private final StateSelectorFactory stateSelectorFactory;
+  private final StateRootSelectorFactory stateRootSelectorFactory;
   private final BlobSidecarSelectorFactory blobSidecarSelectorFactory;
   private final Spec spec;
   private final CombinedChainDataClient combinedChainDataClient;
@@ -103,6 +105,7 @@ public class ChainDataProvider {
         new BlockSelectorFactory(spec, combinedChainDataClient),
         new BlockRootSelectorFactory(spec, combinedChainDataClient),
         new StateSelectorFactory(spec, combinedChainDataClient),
+        new StateRootSelectorFactory(spec, combinedChainDataClient),
         new BlobSidecarSelectorFactory(combinedChainDataClient),
         rewardCalculator);
   }
@@ -115,6 +118,7 @@ public class ChainDataProvider {
       final BlockSelectorFactory blockSelectorFactory,
       final BlockRootSelectorFactory blockRootSelectorFactory,
       final StateSelectorFactory stateSelectorFactory,
+      final StateRootSelectorFactory stateRootSelectorFactory,
       final BlobSidecarSelectorFactory blobSidecarSelectorFactory,
       final RewardCalculator rewardCalculator) {
     this.spec = spec;
@@ -124,6 +128,7 @@ public class ChainDataProvider {
     this.blockSelectorFactory = blockSelectorFactory;
     this.blockRootSelectorFactory = blockRootSelectorFactory;
     this.stateSelectorFactory = stateSelectorFactory;
+    this.stateRootSelectorFactory = stateRootSelectorFactory;
     this.blobSidecarSelectorFactory = blobSidecarSelectorFactory;
     this.rewardCalculator = rewardCalculator;
   }
@@ -198,6 +203,10 @@ public class ChainDataProvider {
 
   public SafeFuture<Optional<ObjectAndMetaData<Bytes32>>> getBlockRoot(final String blockIdParam) {
     return blockRootSelectorFactory.createSelectorForBlockId(blockIdParam).getBlockRoot();
+  }
+
+  public SafeFuture<Optional<ObjectAndMetaData<Bytes32>>> getStateRoot(final String blockIdParam) {
+    return stateRootSelectorFactory.createSelectorForBlockId(blockIdParam).getStateRoot();
   }
 
   public SafeFuture<Optional<ObjectAndMetaData<List<Attestation>>>> getBlockAttestations(

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
@@ -34,6 +34,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.bytes.Bytes48;
 import tech.pegasys.teku.api.blobselector.BlobSidecarSelectorFactory;
+import tech.pegasys.teku.api.blockrootselector.BlockRootSelectorFactory;
 import tech.pegasys.teku.api.blockselector.BlockSelectorFactory;
 import tech.pegasys.teku.api.exceptions.BadRequestException;
 import tech.pegasys.teku.api.exceptions.ServiceUnavailableException;
@@ -81,6 +82,7 @@ import tech.pegasys.teku.storage.client.RecentChainData;
 public class ChainDataProvider {
   private static final Logger LOG = LogManager.getLogger();
   private final BlockSelectorFactory blockSelectorFactory;
+  private final BlockRootSelectorFactory blockRootSelectorFactory;
   private final StateSelectorFactory stateSelectorFactory;
   private final BlobSidecarSelectorFactory blobSidecarSelectorFactory;
   private final Spec spec;
@@ -99,6 +101,7 @@ public class ChainDataProvider {
         recentChainData,
         combinedChainDataClient,
         new BlockSelectorFactory(spec, combinedChainDataClient),
+        new BlockRootSelectorFactory(spec, combinedChainDataClient),
         new StateSelectorFactory(spec, combinedChainDataClient),
         new BlobSidecarSelectorFactory(combinedChainDataClient),
         rewardCalculator);
@@ -110,6 +113,7 @@ public class ChainDataProvider {
       final RecentChainData recentChainData,
       final CombinedChainDataClient combinedChainDataClient,
       final BlockSelectorFactory blockSelectorFactory,
+      final BlockRootSelectorFactory blockRootSelectorFactory,
       final StateSelectorFactory stateSelectorFactory,
       final BlobSidecarSelectorFactory blobSidecarSelectorFactory,
       final RewardCalculator rewardCalculator) {
@@ -118,6 +122,7 @@ public class ChainDataProvider {
     this.recentChainData = recentChainData;
     this.schemaObjectProvider = new SchemaObjectProvider(spec);
     this.blockSelectorFactory = blockSelectorFactory;
+    this.blockRootSelectorFactory = blockRootSelectorFactory;
     this.stateSelectorFactory = stateSelectorFactory;
     this.blobSidecarSelectorFactory = blobSidecarSelectorFactory;
     this.rewardCalculator = rewardCalculator;
@@ -192,7 +197,7 @@ public class ChainDataProvider {
   }
 
   public SafeFuture<Optional<ObjectAndMetaData<Bytes32>>> getBlockRoot(final String blockIdParam) {
-    return fromBlock(blockIdParam, SignedBeaconBlock::getRoot);
+    return blockRootSelectorFactory.createSelectorForBlockId(blockIdParam).getBlockRoot();
   }
 
   public SafeFuture<Optional<ObjectAndMetaData<List<Attestation>>>> getBlockAttestations(

--- a/data/provider/src/main/java/tech/pegasys/teku/api/blockrootselector/BlockRootSelector.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/blockrootselector/BlockRootSelector.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Consensys Software Inc., 2023
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.api.blockrootselector;
+
+import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.spec.datastructures.metadata.ObjectAndMetaData;
+
+public interface BlockRootSelector {
+
+  SafeFuture<Optional<ObjectAndMetaData<Bytes32>>> getBlockRoot();
+}

--- a/data/provider/src/main/java/tech/pegasys/teku/api/blockrootselector/BlockRootSelectorFactory.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/blockrootselector/BlockRootSelectorFactory.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright Consensys Software Inc., 2023
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.api.blockrootselector;
+
+import static tech.pegasys.teku.spec.config.SpecConfig.GENESIS_SLOT;
+
+import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.api.AbstractSelectorFactory;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.metadata.ObjectAndMetaData;
+import tech.pegasys.teku.storage.client.ChainHead;
+import tech.pegasys.teku.storage.client.CombinedChainDataClient;
+
+public class BlockRootSelectorFactory extends AbstractSelectorFactory<BlockRootSelector> {
+
+  private final Spec spec;
+
+  public BlockRootSelectorFactory(final Spec spec, CombinedChainDataClient client) {
+    super(client);
+    this.spec = spec;
+  }
+
+  @Override
+  public BlockRootSelector blockRootSelector(final Bytes32 blockRoot) {
+    return () -> client.getBlockByBlockRoot(blockRoot).thenApply(this::fromBlock);
+  }
+
+  @Override
+  public BlockRootSelector headSelector() {
+    return () ->
+        client
+            .getChainHead()
+            .map(this::fromChainHead)
+            .orElse(SafeFuture.completedFuture(Optional.empty()));
+  }
+
+  @Override
+  public BlockRootSelector finalizedSelector() {
+    return () ->
+        SafeFuture.completedFuture(
+            lookupBlockRootData(client.getFinalizedBlock(), client.isChainHeadOptimistic()));
+  }
+
+  @Override
+  public BlockRootSelector genesisSelector() {
+    return () ->
+        client
+            .getBlockRootAtSlotExact(GENESIS_SLOT)
+            .thenApply(maybeBlock -> lookupBlockRootData(maybeBlock, false, GENESIS_SLOT));
+  }
+
+  @Override
+  public BlockRootSelector slotSelector(final UInt64 slot) {
+    return () -> forSlot(client.getChainHead(), slot);
+  }
+
+  private Optional<ObjectAndMetaData<Bytes32>> fromBlock(
+      final Optional<SignedBeaconBlock> maybeBlock) {
+    final Optional<ChainHead> chainHead = client.getChainHead();
+    if (maybeBlock.isEmpty() || chainHead.isEmpty()) {
+      return Optional.empty();
+    }
+    return maybeBlock.map(
+        block ->
+            lookupBlockRootData(
+                block.getRoot(),
+                block.getSlot(),
+                chainHead.get().isOptimistic(),
+                client.isCanonicalBlock(
+                    block.getSlot(), block.getRoot(), chainHead.get().getRoot()),
+                client.isFinalized(block.getSlot())));
+  }
+
+  private SafeFuture<Optional<ObjectAndMetaData<Bytes32>>> fromChainHead(final ChainHead head) {
+    return head.getBlock()
+        .thenApply(maybeBlock -> lookupBlockRootData(maybeBlock, head.isOptimistic()));
+  }
+
+  private SafeFuture<Optional<ObjectAndMetaData<Bytes32>>> forSlot(
+      final Optional<ChainHead> maybeHead, final UInt64 slot) {
+    return maybeHead
+        .map(head -> forSlot(head, slot))
+        .orElse(SafeFuture.completedFuture(Optional.empty()));
+  }
+
+  private SafeFuture<Optional<ObjectAndMetaData<Bytes32>>> forSlot(
+      final ChainHead head, final UInt64 slot) {
+    return client
+        .getBlockRootAtSlotExact(slot)
+        .thenApply(
+            maybeBlockRoot -> lookupBlockRootData(maybeBlockRoot, head.isOptimistic(), slot));
+  }
+
+  private Optional<ObjectAndMetaData<Bytes32>> lookupBlockRootData(
+      final Optional<Bytes32> maybeBlockRoot, final boolean isOptimistic, final UInt64 slot) {
+    return maybeBlockRoot.map(
+        blockRoot ->
+            lookupBlockRootData(blockRoot, slot, isOptimistic, true, client.isFinalized(slot)));
+  }
+
+  private Optional<ObjectAndMetaData<Bytes32>> lookupBlockRootData(
+      final Optional<SignedBeaconBlock> maybeBlock, final boolean isOptimistic) {
+    return maybeBlock.map(
+        block ->
+            lookupBlockRootData(
+                block.getRoot(),
+                block.getSlot(),
+                isOptimistic,
+                true,
+                client.isFinalized(block.getSlot())));
+  }
+
+  private ObjectAndMetaData<Bytes32> lookupBlockRootData(
+      final Bytes32 blockRoot,
+      final UInt64 slot,
+      final boolean isOptimistic,
+      final boolean isCanonical,
+      final boolean finalized) {
+    return new ObjectAndMetaData<>(
+        blockRoot, spec.atSlot(slot).getMilestone(), isOptimistic, isCanonical, finalized);
+  }
+}

--- a/data/provider/src/main/java/tech/pegasys/teku/api/blockrootselector/BlockRootSelectorFactory.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/blockrootselector/BlockRootSelectorFactory.java
@@ -30,7 +30,7 @@ public class BlockRootSelectorFactory extends AbstractSelectorFactory<BlockRootS
 
   private final Spec spec;
 
-  public BlockRootSelectorFactory(final Spec spec, CombinedChainDataClient client) {
+  public BlockRootSelectorFactory(final Spec spec, final CombinedChainDataClient client) {
     super(client);
     this.spec = spec;
   }

--- a/data/provider/src/main/java/tech/pegasys/teku/api/staterootselector/StateRootSelector.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/staterootselector/StateRootSelector.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Consensys Software Inc., 2023
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.api.staterootselector;
+
+import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.spec.datastructures.metadata.ObjectAndMetaData;
+
+public interface StateRootSelector {
+  SafeFuture<Optional<ObjectAndMetaData<Bytes32>>> getStateRoot();
+}

--- a/data/provider/src/main/java/tech/pegasys/teku/api/staterootselector/StateRootSelectorFactory.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/staterootselector/StateRootSelectorFactory.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright Consensys Software Inc., 2023
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.api.staterootselector;
+
+import static tech.pegasys.teku.spec.config.SpecConfig.GENESIS_SLOT;
+
+import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.api.AbstractSelectorFactory;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockHeader;
+import tech.pegasys.teku.spec.datastructures.metadata.ObjectAndMetaData;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.storage.client.ChainHead;
+import tech.pegasys.teku.storage.client.CombinedChainDataClient;
+
+public class StateRootSelectorFactory extends AbstractSelectorFactory<StateRootSelector> {
+  private final Spec spec;
+
+  public StateRootSelectorFactory(final Spec spec, final CombinedChainDataClient client) {
+    super(client);
+    this.spec = spec;
+  }
+
+  @Override
+  public StateRootSelector stateRootSelector(final Bytes32 stateRoot) {
+    return () -> client.getStateByBlockRoot(stateRoot).thenApply(this::fromState);
+  }
+
+  @Override
+  public StateRootSelector headSelector() {
+    return () ->
+        client
+            .getChainHead()
+            .map(this::fromChainHead)
+            .orElse(SafeFuture.completedFuture(Optional.empty()));
+  }
+
+  @Override
+  public StateRootSelector finalizedSelector() {
+    return () -> {
+      final Optional<Bytes32> maybeFinalizedStateRoot = client.getFinalizedStateRoot();
+      final Optional<UInt64> maybeFinalizedSlot = client.getFinalizedStateSlot();
+      if (maybeFinalizedStateRoot.isPresent() && maybeFinalizedSlot.isPresent()) {
+        return SafeFuture.completedFuture(
+            Optional.of(
+                lookupStateRootData(
+                    maybeFinalizedStateRoot.get(),
+                    maybeFinalizedSlot.get(),
+                    client.isChainHeadOptimistic(),
+                    true,
+                    true)));
+      } else {
+        return SafeFuture.completedFuture(
+            client
+                .getFinalizedState()
+                .map(
+                    finalizedState ->
+                        lookupCanonicalStateRootData(
+                            finalizedState, client.isChainHeadOptimistic())));
+      }
+    };
+  }
+
+  @Override
+  public StateRootSelector genesisSelector() {
+    return () ->
+        client
+            .getStateAtSlotExact(GENESIS_SLOT)
+            .thenApply(
+                maybeBeaconState ->
+                    maybeBeaconState.map(
+                        beaconState -> lookupCanonicalStateRootData(beaconState, false)));
+  }
+
+  @Override
+  public StateRootSelector slotSelector(final UInt64 slot) {
+    return () -> forSlot(client.getChainHead(), slot);
+  }
+
+  private SafeFuture<Optional<ObjectAndMetaData<Bytes32>>> forSlot(
+      final Optional<ChainHead> maybeHead, final UInt64 slot) {
+    return maybeHead
+        .map(head -> forSlot(head, slot))
+        .orElse(SafeFuture.completedFuture(Optional.empty()));
+  }
+
+  private SafeFuture<Optional<ObjectAndMetaData<Bytes32>>> forSlot(
+      final ChainHead head, final UInt64 slot) {
+    return client
+        .getStateAtSlotExact(slot)
+        .thenApply(
+            maybeBeaconState ->
+                maybeBeaconState.map(
+                    beaconState -> lookupCanonicalStateRootData(beaconState, head.isOptimistic())));
+  }
+
+  private SafeFuture<Optional<ObjectAndMetaData<Bytes32>>> fromChainHead(final ChainHead head) {
+    return head.getState()
+        .thenApply(beaconState -> lookupCanonicalStateRootData(beaconState, head.isOptimistic()))
+        .thenApply(Optional::of);
+  }
+
+  private Optional<ObjectAndMetaData<Bytes32>> fromState(
+      final Optional<BeaconState> maybeBeaconState) {
+    final Optional<ChainHead> chainHead = client.getChainHead();
+    if (maybeBeaconState.isEmpty() || chainHead.isEmpty()) {
+      return Optional.empty();
+    }
+    return maybeBeaconState.map(
+        beaconState ->
+            lookupStateRootData(
+                beaconState.hashTreeRoot(),
+                beaconState.getSlot(),
+                chainHead.get().isOptimistic(),
+                client.isCanonicalBlock(
+                    beaconState.getSlot(),
+                    BeaconBlockHeader.fromState(beaconState).getRoot(),
+                    chainHead.get().getRoot()),
+                client.isFinalized(beaconState.getSlot())));
+  }
+
+  private ObjectAndMetaData<Bytes32> lookupStateRootData(
+      final Bytes32 stateRoot,
+      final UInt64 slot,
+      final boolean isOptimistic,
+      final boolean isCanonical,
+      final boolean finalized) {
+    return new ObjectAndMetaData<>(
+        stateRoot, spec.atSlot(slot).getMilestone(), isOptimistic, isCanonical, finalized);
+  }
+
+  private ObjectAndMetaData<Bytes32> lookupCanonicalStateRootData(
+      final BeaconState beaconState, final boolean isOptimistic) {
+    return lookupStateRootData(
+        beaconState.hashTreeRoot(),
+        beaconState.getSlot(),
+        isOptimistic,
+        true,
+        client.isFinalized(beaconState.getSlot()));
+  }
+}

--- a/data/provider/src/test/java/tech/pegasys/teku/api/AbstractChainDataProviderTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/AbstractChainDataProviderTest.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import tech.pegasys.teku.api.blobselector.BlobSidecarSelectorFactory;
+import tech.pegasys.teku.api.blockrootselector.BlockRootSelectorFactory;
 import tech.pegasys.teku.api.blockselector.BlockSelectorFactory;
 import tech.pegasys.teku.api.stateselector.StateSelectorFactory;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -56,6 +57,7 @@ public abstract class AbstractChainDataProviderTest {
   protected RecentChainData recentChainData;
   protected CombinedChainDataClient combinedChainDataClient;
   protected BlockSelectorFactory blockSelectorFactory;
+  protected BlockRootSelectorFactory blockRootSelectorFactory;
   protected BlobSidecarSelectorFactory blobSidecarSelectorFactory;
   protected StateSelectorFactory stateSelectorFactory;
   protected BeaconState beaconStateInternal;
@@ -102,6 +104,8 @@ public abstract class AbstractChainDataProviderTest {
   protected ChainDataProvider setupBySpec(
       final Spec spec, final DataStructureUtil dataStructureUtil, final int validatorCount) {
     this.blockSelectorFactory = spy(new BlockSelectorFactory(spec, mockCombinedChainDataClient));
+    this.blockRootSelectorFactory =
+        spy(new BlockRootSelectorFactory(spec, mockCombinedChainDataClient));
     this.stateSelectorFactory = spy(new StateSelectorFactory(spec, mockCombinedChainDataClient));
     this.blobSidecarSelectorFactory =
         spy(new BlobSidecarSelectorFactory(mockCombinedChainDataClient));
@@ -111,6 +115,7 @@ public abstract class AbstractChainDataProviderTest {
             recentChainData,
             mockCombinedChainDataClient,
             blockSelectorFactory,
+            blockRootSelectorFactory,
             stateSelectorFactory,
             blobSidecarSelectorFactory,
             rewardCalculatorMock);

--- a/data/provider/src/test/java/tech/pegasys/teku/api/AbstractChainDataProviderTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/AbstractChainDataProviderTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.BeforeEach;
 import tech.pegasys.teku.api.blobselector.BlobSidecarSelectorFactory;
 import tech.pegasys.teku.api.blockrootselector.BlockRootSelectorFactory;
 import tech.pegasys.teku.api.blockselector.BlockSelectorFactory;
+import tech.pegasys.teku.api.staterootselector.StateRootSelectorFactory;
 import tech.pegasys.teku.api.stateselector.StateSelectorFactory;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
@@ -60,6 +61,7 @@ public abstract class AbstractChainDataProviderTest {
   protected BlockRootSelectorFactory blockRootSelectorFactory;
   protected BlobSidecarSelectorFactory blobSidecarSelectorFactory;
   protected StateSelectorFactory stateSelectorFactory;
+  protected StateRootSelectorFactory stateRootSelectorFactory;
   protected BeaconState beaconStateInternal;
   protected SignedBlockAndState bestBlock;
   protected Bytes32 blockRoot;
@@ -107,6 +109,8 @@ public abstract class AbstractChainDataProviderTest {
     this.blockRootSelectorFactory =
         spy(new BlockRootSelectorFactory(spec, mockCombinedChainDataClient));
     this.stateSelectorFactory = spy(new StateSelectorFactory(spec, mockCombinedChainDataClient));
+    this.stateRootSelectorFactory =
+        spy(new StateRootSelectorFactory(spec, mockCombinedChainDataClient));
     this.blobSidecarSelectorFactory =
         spy(new BlobSidecarSelectorFactory(mockCombinedChainDataClient));
     final ChainDataProvider provider =
@@ -117,6 +121,7 @@ public abstract class AbstractChainDataProviderTest {
             blockSelectorFactory,
             blockRootSelectorFactory,
             stateSelectorFactory,
+            stateRootSelectorFactory,
             blobSidecarSelectorFactory,
             rewardCalculatorMock);
 

--- a/data/provider/src/test/java/tech/pegasys/teku/api/blockrootselector/BlockRootSelectorFactoryTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/blockrootselector/BlockRootSelectorFactoryTest.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright Consensys Software Inc., 2023
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.api.blockrootselector;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Stream;
+import org.apache.tuweni.bytes.Bytes32;
+import org.assertj.core.api.AssertionsForClassTypes;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import tech.pegasys.teku.api.exceptions.BadRequestException;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
+import tech.pegasys.teku.spec.datastructures.metadata.ObjectAndMetaData;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.storage.client.ChainHead;
+import tech.pegasys.teku.storage.client.CombinedChainDataClient;
+
+public class BlockRootSelectorFactoryTest {
+
+  private static final Spec SPEC = TestSpecFactory.createDefault();
+  private static final DataStructureUtil DATA_STRUCTURE_UTIL = new DataStructureUtil(SPEC);
+  private static final SignedBeaconBlock BLOCK = DATA_STRUCTURE_UTIL.randomSignedBeaconBlock(100);
+  private final SpecMilestone milestone = SPEC.getGenesisSpec().getMilestone();
+  private final CombinedChainDataClient client = mock(CombinedChainDataClient.class);
+  private BlockRootSelectorFactory blockRootSelectorFactory =
+      new BlockRootSelectorFactory(SPEC, client);
+
+  public static Stream<Arguments> finalizedBlockFallbackParams() {
+    return Stream.of(
+        Arguments.of(Optional.empty(), Optional.of(BLOCK.getSlot())),
+        Arguments.of(Optional.of(BLOCK.getRoot()), Optional.empty()),
+        Arguments.of(Optional.empty(), Optional.empty()));
+  }
+
+  @Test
+  public void headSelector_shouldGetBestBlockRoot()
+      throws ExecutionException, InterruptedException {
+    final SignedBlockAndState blockAndState = DATA_STRUCTURE_UTIL.randomSignedBlockAndState(100);
+    when(client.getChainHead()).thenReturn(Optional.of(ChainHead.create(blockAndState)));
+    when(client.isFinalized(blockAndState.getSlot())).thenReturn(true);
+    final Optional<ObjectAndMetaData<Bytes32>> maybeBlockRootAndMetaData =
+        blockRootSelectorFactory.headSelector().getBlockRoot().get();
+    verify(client).getChainHead();
+    verify(client).isFinalized(blockAndState.getSlot());
+    assertThat(maybeBlockRootAndMetaData)
+        .contains(withMetaData(blockAndState.getBlock().getRoot(), false, true, true));
+  }
+
+  @Test
+  public void finalizedSelector_shouldGetFinalizedBlockRoot()
+      throws ExecutionException, InterruptedException {
+    when(client.getFinalizedBlockRoot()).thenReturn(Optional.of(BLOCK.getRoot()));
+    when(client.getFinalizedBlockSlot()).thenReturn(Optional.of(BLOCK.getSlot()));
+    when(client.isChainHeadOptimistic()).thenReturn(false);
+    final Optional<ObjectAndMetaData<Bytes32>> maybeBlockRootAndMetaData =
+        blockRootSelectorFactory.finalizedSelector().getBlockRoot().get();
+    verify(client).getFinalizedBlockRoot();
+    verify(client).getFinalizedBlockSlot();
+    verify(client, never()).getFinalizedBlock();
+    verify(client).isChainHeadOptimistic();
+    assertThat(maybeBlockRootAndMetaData)
+        .contains(withMetaData(BLOCK.getRoot(), false, true, true));
+  }
+
+  @ParameterizedTest
+  @MethodSource("finalizedBlockFallbackParams")
+  public void finalizedSelector_shouldGetFinalizedBlockRoot_fromFinalizedBlock(
+      final Optional<Bytes32> maybeBlockRoot, final Optional<UInt64> maybeSlot)
+      throws ExecutionException, InterruptedException {
+    when(client.getFinalizedBlockRoot()).thenReturn(maybeBlockRoot);
+    when(client.getFinalizedBlockSlot()).thenReturn(maybeSlot);
+    when(client.getFinalizedBlock()).thenReturn(Optional.of(BLOCK));
+    when(client.isChainHeadOptimistic()).thenReturn(false);
+    when(client.isFinalized(BLOCK.getSlot())).thenReturn(true);
+    final Optional<ObjectAndMetaData<Bytes32>> maybeBlockRootAndMetaData =
+        blockRootSelectorFactory.finalizedSelector().getBlockRoot().get();
+    verify(client).getFinalizedBlockRoot();
+    verify(client).getFinalizedBlockSlot();
+    verify(client).getFinalizedBlock();
+    verify(client).isChainHeadOptimistic();
+    assertThat(maybeBlockRootAndMetaData)
+        .contains(withMetaData(BLOCK.getRoot(), false, true, true));
+  }
+
+  @Test
+  public void genesisSelector_shouldGetSlotZero() throws ExecutionException, InterruptedException {
+    when(client.getBlockRootAtSlotExact(UInt64.ZERO))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(BLOCK.getRoot())));
+    when(client.isFinalized(UInt64.ZERO)).thenReturn(true);
+    final Optional<ObjectAndMetaData<Bytes32>> maybeBlockRootAndMetaData =
+        blockRootSelectorFactory.genesisSelector().getBlockRoot().get();
+    verify(client).getBlockRootAtSlotExact(UInt64.ZERO);
+    verify(client).isFinalized(UInt64.ZERO);
+    AssertionsForClassTypes.assertThat(maybeBlockRootAndMetaData)
+        .contains(withMetaData(BLOCK.getRoot(), false, true, true));
+  }
+
+  @Test
+  public void blockRootSelector_shouldGetBlockRootByRoot()
+      throws ExecutionException, InterruptedException {
+    when(client.getBlockByBlockRoot(any()))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(BLOCK)));
+    final SignedBlockAndState head =
+        DATA_STRUCTURE_UTIL.randomSignedBlockAndState(BLOCK.getSlot().plus(3), BLOCK.getRoot());
+    final ChainHead chainHead = ChainHead.create(head);
+    when(client.getChainHead()).thenReturn(Optional.of(chainHead));
+    when(client.isCanonicalBlock(BLOCK.getSlot(), BLOCK.getRoot(), chainHead.getRoot()))
+        .thenReturn(true);
+    when(client.isFinalized(BLOCK.getSlot())).thenReturn(false);
+    final Optional<ObjectAndMetaData<Bytes32>> maybeBlockRootAndMetaData =
+        blockRootSelectorFactory.blockRootSelector(BLOCK.getRoot()).getBlockRoot().get();
+    verify(client).getBlockByBlockRoot(BLOCK.getRoot());
+    verify(client).getChainHead();
+    verify(client).isCanonicalBlock(BLOCK.getSlot(), BLOCK.getRoot(), chainHead.getRoot());
+    verify(client).isFinalized(BLOCK.getSlot());
+    AssertionsForClassTypes.assertThat(maybeBlockRootAndMetaData)
+        .contains(withMetaData(BLOCK.getRoot(), false, true, false));
+  }
+
+  @Test
+  public void slotSelector_shouldGetBlockRootAtSlotExact()
+      throws ExecutionException, InterruptedException {
+    final SignedBlockAndState head = DATA_STRUCTURE_UTIL.randomSignedBlockAndState(100);
+    when(client.getChainHead()).thenReturn(Optional.of(ChainHead.create(head)));
+    when(client.getBlockRootAtSlotExact(BLOCK.getSlot()))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(BLOCK.getRoot())));
+    when(client.isFinalized(BLOCK.getSlot())).thenReturn(false);
+    final Optional<ObjectAndMetaData<Bytes32>> maybeBlockRootAndMetaData =
+        blockRootSelectorFactory.slotSelector(BLOCK.getSlot()).getBlockRoot().get();
+    verify(client).getChainHead();
+    verify(client).getBlockRootAtSlotExact(BLOCK.getSlot());
+    verify(client, never()).getBlockAtSlotExact(BLOCK.getSlot());
+    AssertionsForClassTypes.assertThat(maybeBlockRootAndMetaData)
+        .contains(withMetaData(BLOCK.getRoot(), false, true, false));
+  }
+
+  @Test
+  public void createSelectorForBlockId_shouldThrowBadRequestException() {
+    assertThrows(
+        BadRequestException.class, () -> blockRootSelectorFactory.createSelectorForBlockId("a"));
+  }
+
+  @Test
+  public void stateRootSelector_shouldThrowUnsupportedOperationException() {
+    assertThrows(
+        UnsupportedOperationException.class,
+        () -> blockRootSelectorFactory.stateRootSelector(DATA_STRUCTURE_UTIL.randomBytes32()));
+  }
+
+  @Test
+  public void createSelectorForBlockId_shouldThrowBadRequestExceptionOnJustifiedKeyword() {
+    assertThrows(
+        BadRequestException.class,
+        () -> blockRootSelectorFactory.createSelectorForBlockId("justified"));
+  }
+
+  @Test
+  public void justifiedSelector_shouldThrowUnsupportedOperationException() {
+    assertThrows(UnsupportedOperationException.class, blockRootSelectorFactory::justifiedSelector);
+  }
+
+  private ObjectAndMetaData<Bytes32> withMetaData(
+      final Bytes32 blockRoot,
+      final boolean isOptimistic,
+      final boolean isCanonical,
+      final boolean isFinalized) {
+    return new ObjectAndMetaData<>(blockRoot, milestone, isOptimistic, isCanonical, isFinalized);
+  }
+}

--- a/data/provider/src/test/java/tech/pegasys/teku/api/staterootselector/StateRootSelectorFactoryTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/staterootselector/StateRootSelectorFactoryTest.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright Consensys Software Inc., 2023
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.api.staterootselector;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Stream;
+import org.apache.tuweni.bytes.Bytes32;
+import org.assertj.core.api.AssertionsForClassTypes;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import tech.pegasys.teku.api.exceptions.BadRequestException;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockHeader;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
+import tech.pegasys.teku.spec.datastructures.metadata.ObjectAndMetaData;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.storage.client.ChainHead;
+import tech.pegasys.teku.storage.client.CombinedChainDataClient;
+
+public class StateRootSelectorFactoryTest {
+
+  private static final Spec SPEC = TestSpecFactory.createDefault();
+  private static final DataStructureUtil DATA_STRUCTURE_UTIL = new DataStructureUtil(SPEC);
+  private static final BeaconState STATE = DATA_STRUCTURE_UTIL.randomBeaconState(100);
+  private final SpecMilestone milestone = SPEC.getGenesisSpec().getMilestone();
+  private final CombinedChainDataClient client = mock(CombinedChainDataClient.class);
+  private StateRootSelectorFactory stateRootSelectorFactory =
+      new StateRootSelectorFactory(SPEC, client);
+
+  public static Stream<Arguments> finalizedBlockFallbackParams() {
+    return Stream.of(
+        Arguments.of(Optional.empty(), Optional.of(STATE.getSlot())),
+        Arguments.of(Optional.of(STATE.hashTreeRoot()), Optional.empty()),
+        Arguments.of(Optional.empty(), Optional.empty()));
+  }
+
+  @Test
+  public void headSelector_shouldGetBestStateRoot()
+      throws ExecutionException, InterruptedException {
+    final SignedBlockAndState blockAndState = DATA_STRUCTURE_UTIL.randomSignedBlockAndState(100);
+    final ChainHead chainHead = ChainHead.create(blockAndState);
+    when(client.getChainHead()).thenReturn(Optional.of(chainHead));
+    when(client.isFinalized(blockAndState.getSlot())).thenReturn(true);
+    final Optional<ObjectAndMetaData<Bytes32>> maybeStateRootAndMetaData =
+        stateRootSelectorFactory.headSelector().getStateRoot().get();
+    verify(client).getChainHead();
+    verify(client).isFinalized(chainHead.getSlot());
+    assertThat(maybeStateRootAndMetaData)
+        .contains(withMetaData(chainHead.getStateRoot(), false, true, true));
+  }
+
+  @Test
+  public void finalizedSelector_shouldGetFinalizedStateRoot()
+      throws ExecutionException, InterruptedException {
+    when(client.getFinalizedStateRoot()).thenReturn(Optional.of(STATE.hashTreeRoot()));
+    when(client.getFinalizedStateSlot()).thenReturn(Optional.of(STATE.getSlot()));
+    when(client.isChainHeadOptimistic()).thenReturn(false);
+    final Optional<ObjectAndMetaData<Bytes32>> maybeStateRootAndMetaData =
+        stateRootSelectorFactory.finalizedSelector().getStateRoot().get();
+    verify(client).getFinalizedStateRoot();
+    verify(client).getFinalizedStateSlot();
+    verify(client, never()).getFinalizedState();
+    verify(client).isChainHeadOptimistic();
+    assertThat(maybeStateRootAndMetaData)
+        .contains(withMetaData(STATE.hashTreeRoot(), false, true, true));
+  }
+
+  @ParameterizedTest
+  @MethodSource("finalizedBlockFallbackParams")
+  public void finalizedSelector_shouldGetFinalizedStateRoot_fromFinalizedState(
+      final Optional<Bytes32> maybeStateRoot, final Optional<UInt64> maybeSlot)
+      throws ExecutionException, InterruptedException {
+    when(client.getFinalizedStateRoot()).thenReturn(maybeStateRoot);
+    when(client.getFinalizedBlockSlot()).thenReturn(maybeSlot);
+    when(client.getFinalizedState()).thenReturn(Optional.of(STATE));
+    when(client.isChainHeadOptimistic()).thenReturn(false);
+    when(client.isFinalized(STATE.getSlot())).thenReturn(true);
+    final Optional<ObjectAndMetaData<Bytes32>> maybeBlockRootAndMetaData =
+        stateRootSelectorFactory.finalizedSelector().getStateRoot().get();
+    verify(client).getFinalizedStateRoot();
+    verify(client).getFinalizedStateSlot();
+    verify(client).getFinalizedState();
+    verify(client).isChainHeadOptimistic();
+    assertThat(maybeBlockRootAndMetaData)
+        .contains(withMetaData(STATE.hashTreeRoot(), false, true, true));
+  }
+
+  @Test
+  public void genesisSelector_shouldGetSlotZero() throws ExecutionException, InterruptedException {
+    when(client.getStateAtSlotExact(UInt64.ZERO))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(STATE)));
+    when(client.isFinalized(STATE.getSlot())).thenReturn(true);
+    final Optional<ObjectAndMetaData<Bytes32>> maybeStateRootAndMetaData =
+        stateRootSelectorFactory.genesisSelector().getStateRoot().get();
+    verify(client).getStateAtSlotExact(UInt64.ZERO);
+    verify(client).isFinalized(STATE.getSlot());
+    AssertionsForClassTypes.assertThat(maybeStateRootAndMetaData)
+        .contains(withMetaData(STATE.hashTreeRoot(), false, true, true));
+  }
+
+  @Test
+  public void stateRootSelector_shouldGetStateRootByRoot()
+      throws ExecutionException, InterruptedException {
+    when(client.getStateByBlockRoot(any()))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(STATE)));
+    final SignedBlockAndState head =
+        DATA_STRUCTURE_UTIL.randomSignedBlockAndState(
+            STATE.getSlot().plus(3), STATE.hashTreeRoot());
+    final ChainHead chainHead = ChainHead.create(head);
+    when(client.getChainHead()).thenReturn(Optional.of(chainHead));
+    when(client.isCanonicalBlock(
+            STATE.getSlot(), BeaconBlockHeader.fromState(STATE).getRoot(), chainHead.getRoot()))
+        .thenReturn(true);
+    when(client.isFinalized(STATE.getSlot())).thenReturn(false);
+    final Optional<ObjectAndMetaData<Bytes32>> maybeBlockRootAndMetaData =
+        stateRootSelectorFactory.stateRootSelector(STATE.hashTreeRoot()).getStateRoot().get();
+    verify(client).getStateByBlockRoot(STATE.hashTreeRoot());
+    verify(client).getChainHead();
+    verify(client)
+        .isCanonicalBlock(
+            STATE.getSlot(), BeaconBlockHeader.fromState(STATE).getRoot(), chainHead.getRoot());
+    verify(client).isFinalized(STATE.getSlot());
+    AssertionsForClassTypes.assertThat(maybeBlockRootAndMetaData)
+        .contains(withMetaData(STATE.hashTreeRoot(), false, true, false));
+  }
+
+  @Test
+  public void slotSelector_shouldGetBlockRootAtSlotExact()
+      throws ExecutionException, InterruptedException {
+    final SignedBlockAndState head = DATA_STRUCTURE_UTIL.randomSignedBlockAndState(100);
+    ChainHead chainHead = ChainHead.create(head);
+    when(client.getChainHead()).thenReturn(Optional.of(chainHead));
+    when(client.getStateAtSlotExact(STATE.getSlot()))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(STATE)));
+    when(client.isFinalized(STATE.getSlot())).thenReturn(false);
+    final Optional<ObjectAndMetaData<Bytes32>> maybeBlockRootAndMetaData =
+        stateRootSelectorFactory.slotSelector(STATE.getSlot()).getStateRoot().get();
+    verify(client).getChainHead();
+    verify(client).getStateAtSlotExact(STATE.getSlot());
+    AssertionsForClassTypes.assertThat(maybeBlockRootAndMetaData)
+        .contains(withMetaData(STATE.hashTreeRoot(), false, true, false));
+  }
+
+  @Test
+  public void createSelectorForBlockId_shouldThrowBadRequestException() {
+    assertThrows(
+        BadRequestException.class, () -> stateRootSelectorFactory.createSelectorForStateId("a"));
+  }
+
+  @Test
+  public void blockRootSelector_shouldThrowUnsupportedOperationException() {
+    assertThrows(
+        UnsupportedOperationException.class,
+        () -> stateRootSelectorFactory.blockRootSelector(DATA_STRUCTURE_UTIL.randomBytes32()));
+  }
+
+  @Test
+  public void createSelectorForBlockId_shouldThrowBadRequestExceptionOnJustifiedKeyword() {
+    assertThrows(
+        BadRequestException.class,
+        () -> stateRootSelectorFactory.createSelectorForStateId("justified"));
+  }
+
+  @Test
+  public void justifiedSelector_shouldThrowUnsupportedOperationException() {
+    assertThrows(UnsupportedOperationException.class, stateRootSelectorFactory::justifiedSelector);
+  }
+
+  private ObjectAndMetaData<Bytes32> withMetaData(
+      final Bytes32 stateRoot,
+      final boolean isOptimistic,
+      final boolean isCanonical,
+      final boolean isFinalized) {
+    return new ObjectAndMetaData<>(stateRoot, milestone, isOptimistic, isCanonical, isFinalized);
+  }
+}

--- a/data/provider/src/test/java/tech/pegasys/teku/api/staterootselector/StateRootSelectorFactoryTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/staterootselector/StateRootSelectorFactoryTest.java
@@ -128,7 +128,7 @@ public class StateRootSelectorFactoryTest {
   @Test
   public void stateRootSelector_shouldGetStateRootByRoot()
       throws ExecutionException, InterruptedException {
-    when(client.getStateByBlockRoot(any()))
+    when(client.getStateByStateRoot(any()))
         .thenReturn(SafeFuture.completedFuture(Optional.of(STATE)));
     final SignedBlockAndState head =
         DATA_STRUCTURE_UTIL.randomSignedBlockAndState(
@@ -141,7 +141,7 @@ public class StateRootSelectorFactoryTest {
     when(client.isFinalized(STATE.getSlot())).thenReturn(false);
     final Optional<ObjectAndMetaData<Bytes32>> maybeBlockRootAndMetaData =
         stateRootSelectorFactory.stateRootSelector(STATE.hashTreeRoot()).getStateRoot().get();
-    verify(client).getStateByBlockRoot(STATE.hashTreeRoot());
+    verify(client).getStateByStateRoot(STATE.hashTreeRoot());
     verify(client).getChainHead();
     verify(client)
         .isCanonicalBlock(
@@ -157,13 +157,13 @@ public class StateRootSelectorFactoryTest {
     final SignedBlockAndState head = DATA_STRUCTURE_UTIL.randomSignedBlockAndState(100);
     ChainHead chainHead = ChainHead.create(head);
     when(client.getChainHead()).thenReturn(Optional.of(chainHead));
-    when(client.getStateAtSlotExact(STATE.getSlot()))
-        .thenReturn(SafeFuture.completedFuture(Optional.of(STATE)));
+    when(client.getStateRootAtSlotExact(STATE.getSlot()))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(STATE.hashTreeRoot())));
     when(client.isFinalized(STATE.getSlot())).thenReturn(false);
     final Optional<ObjectAndMetaData<Bytes32>> maybeBlockRootAndMetaData =
         stateRootSelectorFactory.slotSelector(STATE.getSlot()).getStateRoot().get();
     verify(client).getChainHead();
-    verify(client).getStateAtSlotExact(STATE.getSlot());
+    verify(client).getStateRootAtSlotExact(STATE.getSlot());
     AssertionsForClassTypes.assertThat(maybeBlockRootAndMetaData)
         .contains(withMetaData(STATE.hashTreeRoot(), false, true, false));
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ReadOnlyForkChoiceStrategy.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/forkchoice/ReadOnlyForkChoiceStrategy.java
@@ -39,6 +39,8 @@ public interface ReadOnlyForkChoiceStrategy {
 
   List<ProtoNodeData> getChainHeads(boolean includeNonViableHeads);
 
+  Optional<Bytes32> getStateRootAtSlot(final UInt64 slot);
+
   Optional<Bytes32> getOptimisticallySyncedTransitionBlockRoot(Bytes32 head);
 
   List<ProtoNodeData> getBlockData();

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/datastructures/forkchoice/TestStoreImpl.java
@@ -177,6 +177,10 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
     return blockStates.get(blockRoot);
   }
 
+  private Optional<BeaconState> getBlockState(final UInt64 slot) {
+    return blockStates.values().stream().filter(state -> state.getSlot().equals(slot)).findFirst();
+  }
+
   private Optional<BeaconState> getCheckpointState(final Checkpoint checkpoint) {
     return Optional.ofNullable(checkpointStates.get(checkpoint));
   }
@@ -430,6 +434,11 @@ public class TestStoreImpl implements MutableStore, VoteUpdater {
                 headsByRoot.remove(block.getParentRoot());
               });
       return new ArrayList<>(headsByRoot.values());
+    }
+
+    @Override
+    public Optional<Bytes32> getStateRootAtSlot(UInt64 slot) {
+      return getBlockState(slot).map(BeaconState::hashTreeRoot);
     }
 
     @Override

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/RandomChainBuilderForkChoiceStrategy.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/RandomChainBuilderForkChoiceStrategy.java
@@ -98,6 +98,11 @@ public class RandomChainBuilderForkChoiceStrategy implements ReadOnlyForkChoiceS
         .orElse(Collections.emptyList());
   }
 
+  @Override
+  public Optional<Bytes32> getStateRootAtSlot(UInt64 slot) {
+    return chainBuilder.getBlockAndState(slot).map(SignedBlockAndState::getStateRoot);
+  }
+
   private static ProtoNodeData asProtoNodeData(final SignedBlockAndState blockAndState) {
     return new ProtoNodeData(
         blockAndState.getSlot(),

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
@@ -629,6 +629,14 @@ public class CombinedChainDataClient {
     return Optional.of(getStore().getLatestFinalizedBlockSlot());
   }
 
+  public Optional<UInt64> getFinalizedStateSlot() {
+    if (recentChainData.isPreGenesis()) {
+      return Optional.empty();
+    }
+
+    return Optional.of(getStore().getLatestFinalized().getState().getSlot());
+  }
+
   public Optional<SignedBeaconBlock> getFinalizedBlock() {
     if (recentChainData.isPreGenesis()) {
       return Optional.empty();
@@ -642,6 +650,22 @@ public class CombinedChainDataClient {
       return Optional.empty();
     }
     return Optional.of(getStore().getLatestFinalized().getRoot());
+  }
+
+  public Optional<BeaconState> getFinalizedState() {
+    if (recentChainData.isPreGenesis()) {
+      return Optional.empty();
+    }
+
+    return Optional.of(getStore().getLatestFinalized().getState());
+  }
+
+  public Optional<Bytes32> getFinalizedStateRoot() {
+    if (recentChainData.isPreGenesis()) {
+      return Optional.empty();
+    }
+
+    return Optional.of(getStore().getLatestFinalized().getStateRoot());
   }
 
   public Optional<AnchorPoint> getLatestFinalized() {

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/CombinedChainDataClient.java
@@ -637,11 +637,10 @@ public class CombinedChainDataClient {
     return getStore().getLatestFinalized().getSignedBeaconBlock();
   }
 
-  public Optional<Bytes32> getFinalizedBlockHashTreeRoot() {
+  public Optional<Bytes32> getFinalizedBlockRoot() {
     if (recentChainData.isPreGenesis()) {
       return Optional.empty();
     }
-
     return Optional.of(getStore().getLatestFinalized().getRoot());
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/protoarray/ForkChoiceStrategy.java
@@ -181,6 +181,19 @@ public class ForkChoiceStrategy implements BlockMetadataStore, ReadOnlyForkChoic
     }
   }
 
+  @Override
+  public Optional<Bytes32> getStateRootAtSlot(final UInt64 slot) {
+    protoArrayLock.readLock().lock();
+    try {
+      return protoArray.getNodes().stream()
+          .filter(protoNode -> protoNode.getBlockSlot().equals(slot))
+          .map(ProtoNode::getStateRoot)
+          .findFirst();
+    } finally {
+      protoArrayLock.readLock().unlock();
+    }
+  }
+
   public ForkChoiceState getForkChoiceState(
       final UInt64 currentEpoch,
       final Checkpoint justifiedCheckpoint,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Avoid loading full block/state when requesting block/state root:
Add `BlockRootSelectorFactory` and  `StateRootSelectorFactory` which get the block/state root directly when possible and load the full block/state otherwise

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
fixes #5870 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
