### PR TITLE
Add capella and deneb types to pretty-print command

### DIFF
--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/SszObjectType.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/SszObjectType.java
@@ -89,6 +89,7 @@ public enum SszObjectType {
   ExecutionPayload(bellatrixSchemas(SchemaDefinitionsBellatrix::getExecutionPayloadSchema)),
   ExecutionPayloadHeader(
       bellatrixSchemas(SchemaDefinitionsBellatrix::getExecutionPayloadHeaderSchema)),
+  BuilderBid(bellatrixSchemas(SchemaDefinitionsBellatrix::getBuilderBidSchema)),
   Withdrawal(capellaSchemas(SchemaDefinitionsCapella::getWithdrawalSchema)),
   BlsToExecutionChange(capellaSchemas(SchemaDefinitionsCapella::getBlsToExecutionChangeSchema)),
   SignedBlsToExecutionChange(

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/SszObjectType.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/SszObjectType.java
@@ -43,6 +43,8 @@ import tech.pegasys.teku.spec.datastructures.state.Validator.ValidatorSchema;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsAltair;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsBellatrix;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsCapella;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsDeneb;
 
 @SuppressWarnings("JavaCase")
 public enum SszObjectType {
@@ -86,7 +88,15 @@ public enum SszObjectType {
   HistoricalBatch(config(c -> new HistoricalBatchSchema(c.getSlotsPerHistoricalRoot()))),
   ExecutionPayload(bellatrixSchemas(SchemaDefinitionsBellatrix::getExecutionPayloadSchema)),
   ExecutionPayloadHeader(
-      bellatrixSchemas(SchemaDefinitionsBellatrix::getExecutionPayloadHeaderSchema));
+      bellatrixSchemas(SchemaDefinitionsBellatrix::getExecutionPayloadHeaderSchema)),
+  Withdrawal(capellaSchemas(SchemaDefinitionsCapella::getWithdrawalSchema)),
+  BlsToExecutionChange(capellaSchemas(SchemaDefinitionsCapella::getBlsToExecutionChangeSchema)),
+  SignedBlsToExecutionChange(
+      capellaSchemas(SchemaDefinitionsCapella::getSignedBlsToExecutionChangeSchema)),
+  BlobSidecar(denebSchemas(SchemaDefinitionsDeneb::getBlobSidecarSchema)),
+  BlobsBundle(denebSchemas(SchemaDefinitionsDeneb::getBlobsBundleSchema)),
+  ExecutionPayloadAndBlobsBundle(
+      denebSchemas(SchemaDefinitionsDeneb::getExecutionPayloadAndBlobsBundleSchema));
 
   private final Function<SpecVersion, SszSchema<?>> getSchema;
 
@@ -115,6 +125,16 @@ public enum SszObjectType {
   private static Function<SpecVersion, SszSchema<?>> bellatrixSchemas(
       final Function<SchemaDefinitionsBellatrix, SszSchema<?>> getter) {
     return spec -> getter.apply(SchemaDefinitionsBellatrix.required(spec.getSchemaDefinitions()));
+  }
+
+  private static Function<SpecVersion, SszSchema<?>> capellaSchemas(
+      final Function<SchemaDefinitionsCapella, SszSchema<?>> getter) {
+    return spec -> getter.apply(SchemaDefinitionsCapella.required(spec.getSchemaDefinitions()));
+  }
+
+  private static Function<SpecVersion, SszSchema<?>> denebSchemas(
+      final Function<SchemaDefinitionsDeneb, SszSchema<?>> getter) {
+    return spec -> getter.apply(SchemaDefinitionsDeneb.required(spec.getSchemaDefinitions()));
   }
 
   private static Function<SpecVersion, SszSchema<?>> config(


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

- Add some Capella/Deneb types to `pretty-print` command.
- Also added `BuilderBid` type

## Fixed Issue(s)
related to #7800 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
