### PR TITLE
Fix potential PendingPool concurrent mod exception

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/PendingPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/PendingPool.java
@@ -97,6 +97,7 @@ public class PendingPool<T> extends AbstractIgnoringFutureHistoricalSlot {
 
     final Bytes32 itemRoot = hashTreeRootFunction.apply(item);
     final Collection<Bytes32> requiredRoots = requiredBlockRootsFunction.apply(item);
+    final ArrayList<Bytes32> newRequiredRoots = new ArrayList<>();
 
     requiredRoots.forEach(
         requiredRoot ->
@@ -106,11 +107,14 @@ public class PendingPool<T> extends AbstractIgnoringFutureHistoricalSlot {
                     requiredRoot,
                     (key) -> {
                       final Set<Bytes32> dependants = new HashSet<>();
-                      requiredBlockRootSubscribers.forEach(
-                          c -> c.onRequiredBlockRoot(requiredRoot));
+                      newRequiredRoots.add(requiredRoot);
                       return dependants;
                     })
                 .add(itemRoot));
+
+    newRequiredRoots.forEach(
+        requiredRoot ->
+            requiredBlockRootSubscribers.forEach(s -> s.onRequiredBlockRoot(requiredRoot)));
 
     // Index item by root
     if (pendingItems.putIfAbsent(itemRoot, item) == null) {

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/PendingPoolTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/util/PendingPoolTest.java
@@ -60,6 +60,25 @@ public class PendingPoolTest {
   }
 
   @Test
+  public void add_shouldDeferSubscribersCallToAvoidConcurrentModificationException() {
+    final SignedBeaconBlock block =
+        dataStructureUtil.randomSignedBeaconBlock(currentSlot.longValue());
+
+    final SignedBeaconBlock block2 =
+        dataStructureUtil.randomSignedBeaconBlock(currentSlot.longValue());
+
+    pendingPool.subscribeRequiredBlockRoot(
+        blockRoot -> {
+          if (blockRoot.equals(block.getParentRoot())) {
+            pendingPool.add(block2);
+          }
+        });
+    pendingPool.add(block);
+
+    assertThat(pendingPool.contains(block2)).isTrue();
+  }
+
+  @Test
   public void add_blockForCurrentSlot() {
     final SignedBeaconBlock block =
         dataStructureUtil.randomSignedBeaconBlock(currentSlot.longValue());


### PR DESCRIPTION
Removes the possibility that a subscriber to requiredBlockRoot could synchronously interact again with the Pool causing `ConcurrentModificationException`

```
Caused by: java.util.ConcurrentModificationException
at java.util.HashMap.computeIfAbsent(HashMap.java:1221) ~[?:?]
at tech.pegasys.teku.statetransition.util.PendingPool.lambda$add$2(PendingPool.java:105) ~[teku-ethereum-statetransition-develop.jar:23.10.0+16-gd418f8dae7]
at java.util.Collections$SingletonSet.forEach(Collections.java:4905) ~[?:?]
at tech.pegasys.teku.statetransition.util.PendingPool.add(PendingPool.java:101) ~[teku-ethereum-statetransition-develop.jar:23.10.0+16-gd418f8dae7]
at tech.pegasys.teku.statetransition.block.BlockManager.lambda$handleBlockImport$12(BlockManager.java:299) 
at tech.pegasys.teku.infrastructure.async.SafeFuture.lambda$thenPeek$37(SafeFuture.java:490) ~[teku-infrastructure-async-develop.jar:23.10.0+16-gd418f8dae7]
at java.util.concurrent.CompletableFuture.uniApplyNow(CompletableFuture.java:684) ~[?:?]
```

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
