### PR TITLE
Add `id` claim to the execution engine JWT payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,5 +12,6 @@ the [releases page](https://github.com/Consensys/teku/releases).
 ### Breaking Changes
 
 ### Additions and Improvements
+- Added `--ee-jwt-secret-id` command line option to provide `id` claim to the execution engine JWT payload
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,6 @@ the [releases page](https://github.com/Consensys/teku/releases).
 ### Breaking Changes
 
 ### Additions and Improvements
-- Added `--ee-jwt-secret-id` command line option to provide `id` claim to the execution engine JWT payload
+- Added `--ee-jwt-claim-id` command line option to provide `id` to the execution engine JWT claims
 
 ### Bug Fixes

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/auth/JwtConfig.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/auth/JwtConfig.java
@@ -32,21 +32,30 @@ public class JwtConfig {
   public static final long EXPIRES_IN_SECONDS = TOLERANCE_IN_SECONDS - 2;
 
   private final SecretKey key;
+  private final Optional<String> secretId;
 
-  public JwtConfig(final SecretKey key) {
+  public JwtConfig(final SecretKey key, final Optional<String> secretId) {
     this.key = key;
+    this.secretId = secretId;
   }
 
   public SecretKey getKey() {
     return key;
   }
 
+  public Optional<String> getSecretId() {
+    return secretId;
+  }
+
   public static Optional<JwtConfig> createIfNeeded(
-      final boolean needed, final Optional<String> jwtSecretFile, final Path beaconDataDirectory) {
+      final boolean needed,
+      final Optional<String> jwtSecretFile,
+      final Optional<String> jwtSecretId,
+      final Path beaconDataDirectory) {
     if (needed) {
       final JwtSecretKeyLoader keyLoader =
           new JwtSecretKeyLoader(jwtSecretFile, beaconDataDirectory);
-      return Optional.of(new JwtConfig(keyLoader.getSecretKey()));
+      return Optional.of(new JwtConfig(keyLoader.getSecretKey(), jwtSecretId));
     } else {
       return Optional.empty();
     }

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/auth/JwtConfig.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/auth/JwtConfig.java
@@ -32,30 +32,30 @@ public class JwtConfig {
   public static final long EXPIRES_IN_SECONDS = TOLERANCE_IN_SECONDS - 2;
 
   private final SecretKey key;
-  private final Optional<String> secretId;
+  private final Optional<String> claimId;
 
-  public JwtConfig(final SecretKey key, final Optional<String> secretId) {
+  public JwtConfig(final SecretKey key, final Optional<String> claimId) {
     this.key = key;
-    this.secretId = secretId;
+    this.claimId = claimId;
   }
 
   public SecretKey getKey() {
     return key;
   }
 
-  public Optional<String> getSecretId() {
-    return secretId;
+  public Optional<String> getClaimId() {
+    return claimId;
   }
 
   public static Optional<JwtConfig> createIfNeeded(
       final boolean needed,
       final Optional<String> jwtSecretFile,
-      final Optional<String> jwtSecretId,
+      final Optional<String> jwtClaimId,
       final Path beaconDataDirectory) {
     if (needed) {
       final JwtSecretKeyLoader keyLoader =
           new JwtSecretKeyLoader(jwtSecretFile, beaconDataDirectory);
-      return Optional.of(new JwtConfig(keyLoader.getSecretKey(), jwtSecretId));
+      return Optional.of(new JwtConfig(keyLoader.getSecretKey(), jwtClaimId));
     } else {
       return Optional.empty();
     }

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/auth/TokenProvider.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/auth/TokenProvider.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.ethereum.executionclient.auth;
 
+import io.jsonwebtoken.JwtBuilder;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.Jwts.SIG;
 import io.jsonwebtoken.jackson.io.JacksonSerializer;
@@ -33,12 +34,14 @@ public class TokenProvider {
     final long expiresInMillis = TimeUnit.SECONDS.toMillis(JwtConfig.EXPIRES_IN_SECONDS);
     final UInt64 expiry = instantInMillis.plus(expiresInMillis);
 
-    final String jwtToken =
-        Jwts.builder()
-            .issuedAt(Date.from(Instant.ofEpochMilli(instantInMillis.longValue())))
-            .signWith(jwtConfig.getKey(), SIG.HS256)
-            .json(new JacksonSerializer<>())
-            .compact();
+    final JwtBuilder jwtBuilder =
+        Jwts.builder().signWith(jwtConfig.getKey(), SIG.HS256).json(new JacksonSerializer<>());
+
+    // https://github.com/ethereum/execution-apis/blob/main/src/engine/authentication.md#jwt-claims
+    jwtBuilder.issuedAt(Date.from(Instant.ofEpochMilli(instantInMillis.longValue())));
+    jwtConfig.getSecretId().ifPresent(secretId -> jwtBuilder.claim("id", secretId));
+
+    final String jwtToken = jwtBuilder.compact();
     return Optional.of(new Token(jwtToken, expiry));
   }
 }

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/auth/TokenProvider.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/auth/TokenProvider.java
@@ -39,7 +39,7 @@ public class TokenProvider {
 
     // https://github.com/ethereum/execution-apis/blob/main/src/engine/authentication.md#jwt-claims
     jwtBuilder.issuedAt(Date.from(Instant.ofEpochMilli(instantInMillis.longValue())));
-    jwtConfig.getSecretId().ifPresent(secretId -> jwtBuilder.claim("id", secretId));
+    jwtConfig.getClaimId().ifPresent(claimId -> jwtBuilder.claim("id", claimId));
 
     final String jwtToken = jwtBuilder.compact();
     return Optional.of(new Token(jwtToken, expiry));

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/RestClientProvider.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/RestClientProvider.java
@@ -44,6 +44,7 @@ public interface RestClientProvider {
       final Duration timeout,
       final boolean jwtSupported,
       final Optional<String> jwtSecretFile,
+      final Optional<String> jwtSecretId,
       final Path beaconDataDirectory,
       final TimeProvider timeProvider) {
     if (endpoint.startsWith(PREVIOUS_STUB_ENDPOINT_PREFIX)) {
@@ -53,7 +54,7 @@ public interface RestClientProvider {
       return STUB;
     } else {
       final Optional<JwtConfig> jwtConfig =
-          JwtConfig.createIfNeeded(jwtSupported, jwtSecretFile, beaconDataDirectory);
+          JwtConfig.createIfNeeded(jwtSupported, jwtSecretFile, jwtSecretId, beaconDataDirectory);
       return new OkHttpRestClientProvider(endpoint, timeout, jwtConfig, timeProvider);
     }
   }

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/RestClientProvider.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/RestClientProvider.java
@@ -44,7 +44,7 @@ public interface RestClientProvider {
       final Duration timeout,
       final boolean jwtSupported,
       final Optional<String> jwtSecretFile,
-      final Optional<String> jwtSecretId,
+      final Optional<String> jwtClaimId,
       final Path beaconDataDirectory,
       final TimeProvider timeProvider) {
     if (endpoint.startsWith(PREVIOUS_STUB_ENDPOINT_PREFIX)) {
@@ -54,7 +54,7 @@ public interface RestClientProvider {
       return STUB;
     } else {
       final Optional<JwtConfig> jwtConfig =
-          JwtConfig.createIfNeeded(jwtSupported, jwtSecretFile, jwtSecretId, beaconDataDirectory);
+          JwtConfig.createIfNeeded(jwtSupported, jwtSecretFile, jwtClaimId, beaconDataDirectory);
       return new OkHttpRestClientProvider(endpoint, timeout, jwtConfig, timeProvider);
     }
   }

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/ExecutionWeb3jClientProvider.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/ExecutionWeb3jClientProvider.java
@@ -54,7 +54,7 @@ public interface ExecutionWeb3jClientProvider {
       final Duration timeout,
       final boolean jwtSupported,
       final Optional<String> jwtSecretFile,
-      final Optional<String> jwtSecretId,
+      final Optional<String> jwtClaimId,
       final Path beaconDataDirectory,
       final TimeProvider timeProvider,
       final ExecutionClientEventsChannel executionClientEventsPublisher) {
@@ -65,7 +65,7 @@ public interface ExecutionWeb3jClientProvider {
       return STUB;
     } else {
       final Optional<JwtConfig> jwtConfig =
-          JwtConfig.createIfNeeded(jwtSupported, jwtSecretFile, jwtSecretId, beaconDataDirectory);
+          JwtConfig.createIfNeeded(jwtSupported, jwtSecretFile, jwtClaimId, beaconDataDirectory);
       return new DefaultExecutionWeb3jClientProvider(
           endpoint, timeout, jwtConfig, timeProvider, executionClientEventsPublisher);
     }

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/ExecutionWeb3jClientProvider.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/ExecutionWeb3jClientProvider.java
@@ -54,6 +54,7 @@ public interface ExecutionWeb3jClientProvider {
       final Duration timeout,
       final boolean jwtSupported,
       final Optional<String> jwtSecretFile,
+      final Optional<String> jwtSecretId,
       final Path beaconDataDirectory,
       final TimeProvider timeProvider,
       final ExecutionClientEventsChannel executionClientEventsPublisher) {
@@ -64,7 +65,7 @@ public interface ExecutionWeb3jClientProvider {
       return STUB;
     } else {
       final Optional<JwtConfig> jwtConfig =
-          JwtConfig.createIfNeeded(jwtSupported, jwtSecretFile, beaconDataDirectory);
+          JwtConfig.createIfNeeded(jwtSupported, jwtSecretFile, jwtSecretId, beaconDataDirectory);
       return new DefaultExecutionWeb3jClientProvider(
           endpoint, timeout, jwtConfig, timeProvider, executionClientEventsPublisher);
     }

--- a/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/auth/JwtAuthWebsocketHelperTest.java
+++ b/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/auth/JwtAuthWebsocketHelperTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.ethereum.executionclient.auth.JwtTestHelper.generateJwtSecret;
 
 import com.google.common.net.HttpHeaders;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 import org.web3j.protocol.websocket.WebSocketClient;
@@ -31,7 +32,7 @@ public class JwtAuthWebsocketHelperTest {
 
   @Test
   public void shouldSetTimedAuthHeader() {
-    JwtConfig jwtConfig = new JwtConfig(generateJwtSecret());
+    JwtConfig jwtConfig = new JwtConfig(generateJwtSecret(), Optional.empty());
     TokenProvider tokenProvider = new TokenProvider(jwtConfig);
     WebSocketClient webSocketClient = mock(WebSocketClient.class);
     final JwtAuthWebsocketHelper jwtAuthWebsocketHelper =

--- a/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/auth/SafeTokenProviderTest.java
+++ b/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/auth/SafeTokenProviderTest.java
@@ -78,12 +78,13 @@ class SafeTokenProviderTest {
 
     final UInt64 timeInMillis = UInt64.valueOf(System.currentTimeMillis());
     final Optional<Token> token = safeTokenProvider.token(timeInMillis);
+    assertThat(token).isPresent();
 
     final Claims payload =
         Jwts.parser()
             .verifyWith(jwtSecretKey)
             .build()
-            .parseSignedClaims(token.orElseThrow().getJwtToken())
+            .parseSignedClaims(token.get().getJwtToken())
             .getPayload();
 
     assertThat(payload.get("id")).isEqualTo(idClaim);
@@ -101,13 +102,13 @@ class SafeTokenProviderTest {
       final Optional<Token> optionalToken,
       final UInt64 instantInMillis) {
     Assertions.assertThat(optionalToken).isPresent();
-    final Claims payload =
+    final long issuedAtInSeconds =
         Jwts.parser()
             .verifyWith(jwtSecretKey)
             .build()
             .parseSignedClaims(optionalToken.get().getJwtToken())
-            .getPayload();
-    final long issuedAtInSeconds = payload.get(Claims.ISSUED_AT, Long.class);
+            .getPayload()
+            .get(Claims.ISSUED_AT, Long.class);
     assertThat(instantInMillis.plus(TimeUnit.SECONDS.toMillis(TOLERANCE_IN_SECONDS)))
         .isGreaterThan(UInt64.valueOf(TimeUnit.SECONDS.toMillis(issuedAtInSeconds)));
     assertThat(instantInMillis.minus(TimeUnit.SECONDS.toMillis(TOLERANCE_IN_SECONDS)))

--- a/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/auth/SafeTokenProviderTest.java
+++ b/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/auth/SafeTokenProviderTest.java
@@ -70,7 +70,7 @@ class SafeTokenProviderTest {
   }
 
   @Test
-  void testGetToken_addsIdClaimWhenConfigured() {
+  void testGetToken_addsIdToClaimsWhenConfigured() {
     final String claimId = "foobar";
 
     safeTokenProvider =

--- a/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/auth/SafeTokenProviderTest.java
+++ b/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/auth/SafeTokenProviderTest.java
@@ -71,23 +71,23 @@ class SafeTokenProviderTest {
 
   @Test
   void testGetToken_addsIdClaimWhenConfigured() {
-    final String idClaim = "foobar";
+    final String claimId = "foobar";
 
     safeTokenProvider =
-        new SafeTokenProvider(new TokenProvider(new JwtConfig(jwtSecretKey, Optional.of(idClaim))));
+        new SafeTokenProvider(new TokenProvider(new JwtConfig(jwtSecretKey, Optional.of(claimId))));
 
     final UInt64 timeInMillis = UInt64.valueOf(System.currentTimeMillis());
     final Optional<Token> token = safeTokenProvider.token(timeInMillis);
     assertThat(token).isPresent();
 
-    final Claims payload =
+    final Claims claims =
         Jwts.parser()
             .verifyWith(jwtSecretKey)
             .build()
             .parseSignedClaims(token.get().getJwtToken())
             .getPayload();
 
-    assertThat(payload.get("id")).isEqualTo(idClaim);
+    assertThat(claims.get("id")).isEqualTo(claimId);
   }
 
   public static void validateTokenAtInstant(

--- a/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/rest/RestClientProviderTest.java
+++ b/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/rest/RestClientProviderTest.java
@@ -39,6 +39,7 @@ class RestClientProviderTest {
             TIMEOUT,
             false,
             Optional.empty(),
+            Optional.empty(),
             tempDir,
             STUB_TIME_PROVIDER);
 
@@ -55,6 +56,7 @@ class RestClientProviderTest {
             "http://127.0.0.1:28545",
             TIMEOUT,
             false,
+            Optional.empty(),
             Optional.empty(),
             tempDir,
             STUB_TIME_PROVIDER);

--- a/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerConfiguration.java
+++ b/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerConfiguration.java
@@ -42,7 +42,7 @@ public class ExecutionLayerConfiguration {
   private final Spec spec;
   private final Optional<String> engineEndpoint;
   private final Optional<String> engineJwtSecretFile;
-  private final Optional<String> engineJwtSecretId;
+  private final Optional<String> engineJwtClaimId;
   private final Optional<String> builderEndpoint;
   private final boolean isBuilderCircuitBreakerEnabled;
   private final int builderCircuitBreakerWindow;
@@ -57,7 +57,7 @@ public class ExecutionLayerConfiguration {
       final Spec spec,
       final Optional<String> engineEndpoint,
       final Optional<String> engineJwtSecretFile,
-      final Optional<String> engineJwtSecretId,
+      final Optional<String> engineJwtClaimId,
       final Optional<String> builderEndpoint,
       final boolean isBuilderCircuitBreakerEnabled,
       final int builderCircuitBreakerWindow,
@@ -70,7 +70,7 @@ public class ExecutionLayerConfiguration {
     this.spec = spec;
     this.engineEndpoint = engineEndpoint;
     this.engineJwtSecretFile = engineJwtSecretFile;
-    this.engineJwtSecretId = engineJwtSecretId;
+    this.engineJwtClaimId = engineJwtClaimId;
     this.builderEndpoint = builderEndpoint;
     this.isBuilderCircuitBreakerEnabled = isBuilderCircuitBreakerEnabled;
     this.builderCircuitBreakerWindow = builderCircuitBreakerWindow;
@@ -106,8 +106,8 @@ public class ExecutionLayerConfiguration {
     return engineJwtSecretFile;
   }
 
-  public Optional<String> getEngineJwtSecretId() {
-    return engineJwtSecretId;
+  public Optional<String> getEngineJwtClaimId() {
+    return engineJwtClaimId;
   }
 
   public Optional<String> getBuilderEndpoint() {
@@ -150,7 +150,7 @@ public class ExecutionLayerConfiguration {
     private Spec spec;
     private Optional<String> engineEndpoint = Optional.empty();
     private Optional<String> engineJwtSecretFile = Optional.empty();
-    private Optional<String> engineJwtSecretId = Optional.empty();
+    private Optional<String> engineJwtClaimId = Optional.empty();
     private Optional<String> builderEndpoint = Optional.empty();
     private boolean isBuilderCircuitBreakerEnabled = DEFAULT_BUILDER_CIRCUIT_BREAKER_ENABLED;
     private int builderCircuitBreakerWindow = DEFAULT_BUILDER_CIRCUIT_BREAKER_WINDOW;
@@ -190,7 +190,7 @@ public class ExecutionLayerConfiguration {
           spec,
           engineEndpoint,
           engineJwtSecretFile,
-          engineJwtSecretId,
+          engineJwtClaimId,
           builderEndpoint,
           isBuilderCircuitBreakerEnabled,
           builderCircuitBreakerWindow,
@@ -217,8 +217,8 @@ public class ExecutionLayerConfiguration {
       return this;
     }
 
-    public Builder engineJwtSecretId(final String jwtSecretId) {
-      this.engineJwtSecretId = Optional.ofNullable(jwtSecretId).filter(StringUtils::isNotBlank);
+    public Builder engineJwtClaimId(final String jwtClaimId) {
+      this.engineJwtClaimId = Optional.ofNullable(jwtClaimId).filter(StringUtils::isNotBlank);
       return this;
     }
 

--- a/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerConfiguration.java
+++ b/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerConfiguration.java
@@ -42,6 +42,7 @@ public class ExecutionLayerConfiguration {
   private final Spec spec;
   private final Optional<String> engineEndpoint;
   private final Optional<String> engineJwtSecretFile;
+  private final Optional<String> engineJwtSecretId;
   private final Optional<String> builderEndpoint;
   private final boolean isBuilderCircuitBreakerEnabled;
   private final int builderCircuitBreakerWindow;
@@ -56,6 +57,7 @@ public class ExecutionLayerConfiguration {
       final Spec spec,
       final Optional<String> engineEndpoint,
       final Optional<String> engineJwtSecretFile,
+      final Optional<String> engineJwtSecretId,
       final Optional<String> builderEndpoint,
       final boolean isBuilderCircuitBreakerEnabled,
       final int builderCircuitBreakerWindow,
@@ -68,6 +70,7 @@ public class ExecutionLayerConfiguration {
     this.spec = spec;
     this.engineEndpoint = engineEndpoint;
     this.engineJwtSecretFile = engineJwtSecretFile;
+    this.engineJwtSecretId = engineJwtSecretId;
     this.builderEndpoint = builderEndpoint;
     this.isBuilderCircuitBreakerEnabled = isBuilderCircuitBreakerEnabled;
     this.builderCircuitBreakerWindow = builderCircuitBreakerWindow;
@@ -101,6 +104,10 @@ public class ExecutionLayerConfiguration {
 
   public Optional<String> getEngineJwtSecretFile() {
     return engineJwtSecretFile;
+  }
+
+  public Optional<String> getEngineJwtSecretId() {
+    return engineJwtSecretId;
   }
 
   public Optional<String> getBuilderEndpoint() {
@@ -143,6 +150,7 @@ public class ExecutionLayerConfiguration {
     private Spec spec;
     private Optional<String> engineEndpoint = Optional.empty();
     private Optional<String> engineJwtSecretFile = Optional.empty();
+    private Optional<String> engineJwtSecretId = Optional.empty();
     private Optional<String> builderEndpoint = Optional.empty();
     private boolean isBuilderCircuitBreakerEnabled = DEFAULT_BUILDER_CIRCUIT_BREAKER_ENABLED;
     private int builderCircuitBreakerWindow = DEFAULT_BUILDER_CIRCUIT_BREAKER_WINDOW;
@@ -182,6 +190,7 @@ public class ExecutionLayerConfiguration {
           spec,
           engineEndpoint,
           engineJwtSecretFile,
+          engineJwtSecretId,
           builderEndpoint,
           isBuilderCircuitBreakerEnabled,
           builderCircuitBreakerWindow,
@@ -205,6 +214,11 @@ public class ExecutionLayerConfiguration {
 
     public Builder engineJwtSecretFile(final String jwtSecretFile) {
       this.engineJwtSecretFile = Optional.ofNullable(jwtSecretFile).filter(StringUtils::isNotBlank);
+      return this;
+    }
+
+    public Builder engineJwtSecretId(final String jwtSecretId) {
+      this.engineJwtSecretId = Optional.ofNullable(jwtSecretId).filter(StringUtils::isNotBlank);
       return this;
     }
 

--- a/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerService.java
+++ b/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerService.java
@@ -71,6 +71,7 @@ public class ExecutionLayerService extends Service {
             EL_ENGINE_BLOCK_EXECUTION_TIMEOUT,
             true,
             config.getEngineJwtSecretFile(),
+            config.getEngineJwtSecretId(),
             beaconDataDirectory,
             timeProvider,
             executionClientEventsPublisher);
@@ -84,6 +85,7 @@ public class ExecutionLayerService extends Service {
                         builderEndpoint,
                         BUILDER_CALL_TIMEOUT,
                         false,
+                        Optional.empty(),
                         Optional.empty(),
                         beaconDataDirectory,
                         timeProvider));

--- a/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerService.java
+++ b/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerService.java
@@ -71,7 +71,7 @@ public class ExecutionLayerService extends Service {
             EL_ENGINE_BLOCK_EXECUTION_TIMEOUT,
             true,
             config.getEngineJwtSecretFile(),
-            config.getEngineJwtSecretId(),
+            config.getEngineJwtClaimId(),
             beaconDataDirectory,
             timeProvider,
             executionClientEventsPublisher);

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ExecutionLayerOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ExecutionLayerOptions.java
@@ -48,12 +48,12 @@ public class ExecutionLayerOptions {
   private String engineJwtSecretFile = null;
 
   @Option(
-      names = {"--ee-jwt-secret-id"},
+      names = {"--ee-jwt-claim-id"},
       paramLabel = "<STRING>",
       description =
-          "A unique identifier for the consensus layer client which will be added in the JWT payload",
+          "A unique identifier for the consensus layer client. This identifier will be added to the JWT claims as an 'id' claim.",
       arity = "1")
-  private String engineJwtSecretId = null;
+  private String engineJwtClaimId = null;
 
   @Option(
       names = {"--builder-endpoint"},
@@ -151,7 +151,7 @@ public class ExecutionLayerOptions {
         b ->
             b.engineEndpoint(executionEngineEndpoint)
                 .engineJwtSecretFile(engineJwtSecretFile)
-                .engineJwtSecretId(engineJwtSecretId)
+                .engineJwtClaimId(engineJwtClaimId)
                 .builderEndpoint(builderEndpoint)
                 .isBuilderCircuitBreakerEnabled(builderCircuitBreakerEnabled)
                 .builderCircuitBreakerWindow(builderCircuitBreakerWindow)

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ExecutionLayerOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ExecutionLayerOptions.java
@@ -48,6 +48,14 @@ public class ExecutionLayerOptions {
   private String engineJwtSecretFile = null;
 
   @Option(
+      names = {"--ee-jwt-secret-id"},
+      paramLabel = "<STRING>",
+      description =
+          "A unique identifier for the consensus layer client which will be added in the JWT payload",
+      arity = "1")
+  private String engineJwtSecretId = null;
+
+  @Option(
       names = {"--builder-endpoint"},
       paramLabel = "<NETWORK>",
       description = "URL for an external Builder node (optional).",
@@ -143,6 +151,7 @@ public class ExecutionLayerOptions {
         b ->
             b.engineEndpoint(executionEngineEndpoint)
                 .engineJwtSecretFile(engineJwtSecretFile)
+                .engineJwtSecretId(engineJwtSecretId)
                 .builderEndpoint(builderEndpoint)
                 .isBuilderCircuitBreakerEnabled(builderCircuitBreakerEnabled)
                 .builderCircuitBreakerWindow(builderCircuitBreakerWindow)

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/ExecutionLayerOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/ExecutionLayerOptionsTest.java
@@ -155,4 +155,17 @@ public class ExecutionLayerOptionsTest extends AbstractBeaconNodeCommandTest {
     assertThatThrownBy(config.executionLayer()::getEngineEndpoint)
         .isInstanceOf(InvalidConfigurationException.class);
   }
+
+  @Test
+  void shouldNotSetJwtClaimIdIfNotConfigured() {
+    final TekuConfiguration config = getTekuConfigurationFromArguments();
+    assertThat(config.executionLayer().getEngineJwtClaimId()).isEmpty();
+  }
+
+  @Test
+  void shouldSetJwtClaimIdIfConfigured() {
+    final String[] args = {"--ee-jwt-claim-id", "foobar"};
+    final TekuConfiguration config = getTekuConfigurationFromArguments(args);
+    assertThat(config.executionLayer().getEngineJwtClaimId()).hasValue("foobar");
+  }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Adds `id` to the JWT payload for the execution engine.

Tested with `ee-jwt-claim-id: foobar` and the decoded JWT payload looked like:

```json
{
  "iat": 1702385661,
  "id": "foobar"
}
```

## Fixed Issue(s)
fixes #7567 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
