### PR TITLE
Allow deferred blinded-unblinded schema selection in block body builder

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactory.java
@@ -33,8 +33,8 @@ public interface BlockFactory {
       UInt64 newSlot,
       BLSSignature randaoReveal,
       Optional<Bytes32> optionalGraffiti,
-      final Optional<Boolean> blinded,
-      final BlockProductionPerformance blockProductionPerformance);
+      Optional<Boolean> requestedBlinded,
+      BlockProductionPerformance blockProductionPerformance);
 
   SafeFuture<SignedBeaconBlock> unblindSignedBlockIfBlinded(SignedBeaconBlock maybeBlindedBlock);
 

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactoryDeneb.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactoryDeneb.java
@@ -48,14 +48,14 @@ public class BlockFactoryDeneb extends BlockFactoryPhase0 {
       final UInt64 newSlot,
       final BLSSignature randaoReveal,
       final Optional<Bytes32> optionalGraffiti,
-      final Optional<Boolean> blinded,
+      final Optional<Boolean> requestedBlinded,
       final BlockProductionPerformance blockProductionPerformance) {
     return super.createUnsignedBlock(
             blockSlotState,
             newSlot,
             randaoReveal,
             optionalGraffiti,
-            blinded,
+            requestedBlinded,
             blockProductionPerformance)
         .thenApply(BlockContainer::getBlock)
         .thenCompose(

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactoryPhase0.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactoryPhase0.java
@@ -48,7 +48,7 @@ public class BlockFactoryPhase0 implements BlockFactory {
       final UInt64 newSlot,
       final BLSSignature randaoReveal,
       final Optional<Bytes32> optionalGraffiti,
-      final Optional<Boolean> blinded,
+      final Optional<Boolean> requestedBlinded,
       final BlockProductionPerformance blockProductionPerformance) {
     checkArgument(
         blockSlotState.getSlot().equals(newSlot),
@@ -71,9 +71,9 @@ public class BlockFactoryPhase0 implements BlockFactory {
                 blockSlotState,
                 randaoReveal,
                 optionalGraffiti,
+                requestedBlinded,
                 blockProductionPerformance),
-            blinded,
-            blockProductionPerformance)
+                    blockProductionPerformance)
         .thenApply(BeaconBlockAndState::getBlock);
   }
 

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactoryPhase0.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactoryPhase0.java
@@ -73,7 +73,7 @@ public class BlockFactoryPhase0 implements BlockFactory {
                 optionalGraffiti,
                 requestedBlinded,
                 blockProductionPerformance),
-                    blockProductionPerformance)
+            blockProductionPerformance)
         .thenApply(BeaconBlockAndState::getBlock);
   }
 

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
@@ -113,7 +113,7 @@ public class BlockOperationSelectorFactory {
       final Optional<Boolean> requestedBlinded,
       final BlockProductionPerformance blockProductionPerformance) {
 
-    boolean blinded = requestedBlinded.orElse(ValidatorsUtil.DEFAULT_PRODUCE_BLINDED_BLOCK);
+    final boolean blinded = requestedBlinded.orElse(ValidatorsUtil.DEFAULT_PRODUCE_BLINDED_BLOCK);
 
     return bodyBuilder -> {
       final Eth1Data eth1Data = eth1DataCache.getEth1Vote(blockSlotState);

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
@@ -53,6 +53,7 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.spec.datastructures.type.SszKZGProof;
 import tech.pegasys.teku.spec.executionlayer.ExecutionLayerBlockProductionManager;
+import tech.pegasys.teku.spec.logic.common.util.ValidatorsUtil;
 import tech.pegasys.teku.spec.logic.versions.deneb.helpers.MiscHelpersDeneb;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsBellatrix;
@@ -109,7 +110,11 @@ public class BlockOperationSelectorFactory {
       final BeaconState blockSlotState,
       final BLSSignature randaoReveal,
       final Optional<Bytes32> optionalGraffiti,
+      final Optional<Boolean> requestedBlinded,
       final BlockProductionPerformance blockProductionPerformance) {
+
+    boolean blinded = requestedBlinded.orElse(ValidatorsUtil.DEFAULT_PRODUCE_BLINDED_BLOCK);
+
     return bodyBuilder -> {
       final Eth1Data eth1Data = eth1DataCache.getEth1Vote(blockSlotState);
 
@@ -171,7 +176,12 @@ public class BlockOperationSelectorFactory {
         final SchemaDefinitions schemaDefinitions =
             spec.atSlot(blockSlotState.getSlot()).getSchemaDefinitions();
         setExecutionData(
-            bodyBuilder, schemaDefinitions, parentRoot, blockSlotState, blockProductionPerformance);
+            bodyBuilder,
+            blinded,
+            schemaDefinitions,
+            parentRoot,
+            blockSlotState,
+            blockProductionPerformance);
       }
 
       blockProductionPerformance.beaconBlockPrepared();
@@ -180,6 +190,7 @@ public class BlockOperationSelectorFactory {
 
   private void setExecutionData(
       final BeaconBlockBodyBuilder bodyBuilder,
+      final boolean blinded,
       final SchemaDefinitions schemaDefinitions,
       final Bytes32 parentRoot,
       final BeaconState blockSlotState,
@@ -189,7 +200,7 @@ public class BlockOperationSelectorFactory {
 
     // Pre-Deneb: Execution Payload / Execution Payload Header
     if (!bodyBuilder.supportsKzgCommitments()) {
-      if (bodyBuilder.isBlinded()) {
+      if (blinded) {
         builderSetPayloadHeader(
             bodyBuilder,
             schemaDefinitions,
@@ -219,16 +230,17 @@ public class BlockOperationSelectorFactory {
                             new IllegalStateException(
                                 "Cannot provide kzg commitments before The Merge")),
                     blockSlotState,
-                    bodyBuilder.isBlinded(),
+                    blinded,
                     blockProductionPerformance));
-    builderSetPayloadPostMerge(bodyBuilder, executionPayloadResultFuture);
-    builderSetKzgCommitments(bodyBuilder, schemaDefinitions, executionPayloadResultFuture);
+    builderSetPayloadPostMerge(bodyBuilder, blinded, executionPayloadResultFuture);
+    builderSetKzgCommitments(bodyBuilder, blinded, schemaDefinitions, executionPayloadResultFuture);
   }
 
   private void builderSetPayloadPostMerge(
       final BeaconBlockBodyBuilder bodyBuilder,
+      final boolean blinded,
       final SafeFuture<ExecutionPayloadResult> executionPayloadResultFuture) {
-    if (bodyBuilder.isBlinded()) {
+    if (blinded) {
       bodyBuilder.executionPayloadHeader(
           executionPayloadResultFuture.thenCompose(
               executionPayloadResult ->
@@ -308,6 +320,7 @@ public class BlockOperationSelectorFactory {
 
   private void builderSetKzgCommitments(
       final BeaconBlockBodyBuilder bodyBuilder,
+      final boolean blinded,
       final SchemaDefinitions schemaDefinitions,
       final SafeFuture<ExecutionPayloadResult> executionPayloadResultFuture) {
     final SchemaDefinitionsDeneb schemaDefinitionsDeneb =
@@ -315,7 +328,7 @@ public class BlockOperationSelectorFactory {
     final SafeFuture<SszList<SszKZGCommitment>> blobKzgCommitments =
         executionPayloadResultFuture.thenCompose(
             executionPayloadResult -> {
-              if (bodyBuilder.isBlinded()) {
+              if (blinded) {
                 return getBuilderBlobKzgCommitments(executionPayloadResult);
               } else {
                 return getExecutionBlobsBundle(executionPayloadResult)

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/MilestoneBasedBlockFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/MilestoneBasedBlockFactory.java
@@ -66,7 +66,7 @@ public class MilestoneBasedBlockFactory implements BlockFactory {
       final UInt64 newSlot,
       final BLSSignature randaoReveal,
       final Optional<Bytes32> optionalGraffiti,
-      final Optional<Boolean> blinded,
+      final Optional<Boolean> requestedBlinded,
       final BlockProductionPerformance blockProductionPerformance) {
     final SpecMilestone milestone = getMilestone(newSlot);
     return registeredFactories
@@ -76,7 +76,7 @@ public class MilestoneBasedBlockFactory implements BlockFactory {
             newSlot,
             randaoReveal,
             optionalGraffiti,
-            blinded,
+            requestedBlinded,
             blockProductionPerformance);
   }
 

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryTest.java
@@ -169,9 +169,6 @@ class BlockOperationSelectorFactoryTest {
   private final CapturingBeaconBlockBodyBuilder bodyBuilder =
       new CapturingBeaconBlockBodyBuilder(false);
 
-  private final CapturingBeaconBlockBodyBuilder blindedBodyBuilder =
-      new CapturingBeaconBlockBodyBuilder(true);
-
   private final BlockOperationSelectorFactory factory =
       new BlockOperationSelectorFactory(
           spec,
@@ -215,6 +212,7 @@ class BlockOperationSelectorFactoryTest {
             blockSlotState,
             dataStructureUtil.randomSignature(),
             Optional.empty(),
+            Optional.empty(),
             BlockProductionPerformance.NOOP)
         .accept(bodyBuilder);
 
@@ -249,6 +247,7 @@ class BlockOperationSelectorFactoryTest {
             parentRoot,
             blockSlotState,
             randaoReveal,
+            Optional.empty(),
             Optional.empty(),
             BlockProductionPerformance.NOOP)
         .accept(bodyBuilder);
@@ -327,6 +326,7 @@ class BlockOperationSelectorFactoryTest {
             blockSlotState,
             randaoReveal,
             Optional.empty(),
+            Optional.empty(),
             BlockProductionPerformance.NOOP)
         .accept(bodyBuilder);
 
@@ -353,6 +353,7 @@ class BlockOperationSelectorFactoryTest {
             blockSlotState,
             dataStructureUtil.randomSignature(),
             Optional.empty(),
+            Optional.of(false),
             BlockProductionPerformance.NOOP)
         .accept(bodyBuilder);
     assertThat(bodyBuilder.executionPayload).isEqualTo(defaultExecutionPayload);
@@ -368,9 +369,10 @@ class BlockOperationSelectorFactoryTest {
             blockSlotState,
             dataStructureUtil.randomSignature(),
             Optional.empty(),
+            Optional.of(true),
             BlockProductionPerformance.NOOP)
-        .accept(blindedBodyBuilder);
-    assertThat(blindedBodyBuilder.executionPayloadHeader)
+        .accept(bodyBuilder);
+    assertThat(bodyBuilder.executionPayloadHeader)
         .isEqualTo(executionPayloadHeaderOfDefaultPayload);
   }
 
@@ -394,6 +396,7 @@ class BlockOperationSelectorFactoryTest {
             blockSlotState,
             dataStructureUtil.randomSignature(),
             Optional.empty(),
+            Optional.of(false),
             BlockProductionPerformance.NOOP)
         .accept(bodyBuilder);
 
@@ -421,10 +424,11 @@ class BlockOperationSelectorFactoryTest {
             blockSlotState,
             dataStructureUtil.randomSignature(),
             Optional.empty(),
+            Optional.of(true),
             BlockProductionPerformance.NOOP)
-        .accept(blindedBodyBuilder);
+        .accept(bodyBuilder);
 
-    assertThat(blindedBodyBuilder.executionPayloadHeader).isEqualTo(randomExecutionPayloadHeader);
+    assertThat(bodyBuilder.executionPayloadHeader).isEqualTo(randomExecutionPayloadHeader);
   }
 
   @Test
@@ -447,6 +451,7 @@ class BlockOperationSelectorFactoryTest {
             blockSlotState,
             dataStructureUtil.randomSignature(),
             Optional.empty(),
+            Optional.of(false),
             BlockProductionPerformance.NOOP)
         .accept(bodyBuilder);
 
@@ -484,8 +489,7 @@ class BlockOperationSelectorFactoryTest {
     prepareBlockAndBlobsProduction(
         randomExecutionPayload, executionPayloadContext, blockSlotState, blobsBundle);
 
-    final CapturingBeaconBlockBodyBuilder bodyBuilder =
-        new CapturingBeaconBlockBodyBuilder(false, true);
+    final CapturingBeaconBlockBodyBuilder bodyBuilder = new CapturingBeaconBlockBodyBuilder(true);
 
     factory
         .createSelector(
@@ -493,6 +497,7 @@ class BlockOperationSelectorFactoryTest {
             blockSlotState,
             dataStructureUtil.randomSignature(),
             Optional.empty(),
+            Optional.of(false),
             BlockProductionPerformance.NOOP)
         .accept(bodyBuilder);
 
@@ -519,14 +524,14 @@ class BlockOperationSelectorFactoryTest {
     prepareBlindedBlockAndBlobsProduction(
         randomExecutionPayloadHeader, executionPayloadContext, blockSlotState, blobKzgCommitments);
 
-    final CapturingBeaconBlockBodyBuilder bodyBuilder =
-        new CapturingBeaconBlockBodyBuilder(true, true);
+    final CapturingBeaconBlockBodyBuilder bodyBuilder = new CapturingBeaconBlockBodyBuilder(true);
 
     factory
         .createSelector(
             parentRoot,
             blockSlotState,
             dataStructureUtil.randomSignature(),
+            Optional.empty(),
             Optional.empty(),
             BlockProductionPerformance.NOOP)
         .accept(bodyBuilder);
@@ -757,7 +762,6 @@ class BlockOperationSelectorFactoryTest {
 
   private static class CapturingBeaconBlockBodyBuilder implements BeaconBlockBodyBuilder {
 
-    private final boolean blinded;
     private final boolean supportsKzgCommitments;
 
     protected BLSSignature randaoReveal;
@@ -771,20 +775,8 @@ class BlockOperationSelectorFactoryTest {
     protected ExecutionPayloadHeader executionPayloadHeader;
     protected SszList<SszKZGCommitment> blobKzgCommitments;
 
-    public CapturingBeaconBlockBodyBuilder(final boolean blinded) {
-      this.blinded = blinded;
-      this.supportsKzgCommitments = false;
-    }
-
-    public CapturingBeaconBlockBodyBuilder(
-        final boolean blinded, final boolean supportsKzgCommitments) {
-      this.blinded = blinded;
+    public CapturingBeaconBlockBodyBuilder(final boolean supportsKzgCommitments) {
       this.supportsKzgCommitments = supportsKzgCommitments;
-    }
-
-    @Override
-    public Boolean isBlinded() {
-      return blinded;
     }
 
     @Override

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryTest.java
@@ -882,7 +882,7 @@ class BlockOperationSelectorFactoryTest {
     }
 
     @Override
-    public SafeFuture<BeaconBlockBody> build() {
+    public SafeFuture<? extends BeaconBlockBody> build() {
       return null;
     }
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -704,7 +704,12 @@ public class Spec {
     return atSlot(newSlot)
         .getBlockProposalUtil()
         .createNewUnsignedBlock(
-            newSlot, proposerIndex, blockSlotState, parentBlockSigningRoot, bodyBuilder, blockProductionPerformance);
+            newSlot,
+            proposerIndex,
+            blockSlotState,
+            parentBlockSigningRoot,
+            bodyBuilder,
+            blockProductionPerformance);
   }
 
   // Blind Block Utils

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -700,18 +700,11 @@ public class Spec {
       final BeaconState blockSlotState,
       final Bytes32 parentBlockSigningRoot,
       final Consumer<BeaconBlockBodyBuilder> bodyBuilder,
-      final Optional<Boolean> blinded,
       final BlockProductionPerformance blockProductionPerformance) {
     return atSlot(newSlot)
         .getBlockProposalUtil()
         .createNewUnsignedBlock(
-            newSlot,
-            proposerIndex,
-            blockSlotState,
-            parentBlockSigningRoot,
-            bodyBuilder,
-            blinded,
-            blockProductionPerformance);
+            newSlot, proposerIndex, blockSlotState, parentBlockSigningRoot, bodyBuilder, blockProductionPerformance);
   }
 
   // Blind Block Utils

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/BeaconBlockBodyBuilder.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/BeaconBlockBodyBuilder.java
@@ -57,10 +57,6 @@ public interface BeaconBlockBodyBuilder {
     return false;
   }
 
-  default Boolean isBlinded() {
-    return false;
-  }
-
   BeaconBlockBodyBuilder executionPayload(SafeFuture<ExecutionPayload> executionPayload);
 
   BeaconBlockBodyBuilder executionPayloadHeader(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/altair/BeaconBlockBodyBuilderAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/altair/BeaconBlockBodyBuilderAltair.java
@@ -24,12 +24,15 @@ import tech.pegasys.teku.spec.datastructures.type.SszSignature;
 
 public class BeaconBlockBodyBuilderAltair extends BeaconBlockBodyBuilderPhase0 {
 
-  private BeaconBlockBodySchemaAltairImpl schema;
+  private final BeaconBlockBodySchemaAltairImpl schema;
   protected SyncAggregate syncAggregate;
 
-  public BeaconBlockBodyBuilderAltair schema(final BeaconBlockBodySchemaAltairImpl schema) {
+  public BeaconBlockBodyBuilderAltair() {
+    this.schema = null;
+  }
+
+  public BeaconBlockBodyBuilderAltair(final BeaconBlockBodySchemaAltairImpl schema) {
     this.schema = schema;
-    return this;
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/altair/BeaconBlockBodyBuilderAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/altair/BeaconBlockBodyBuilderAltair.java
@@ -19,20 +19,16 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszBytes32;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodyBuilder;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodySchema;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.phase0.BeaconBlockBodyBuilderPhase0;
 import tech.pegasys.teku.spec.datastructures.type.SszSignature;
 
 public class BeaconBlockBodyBuilderAltair extends BeaconBlockBodyBuilderPhase0 {
-
-  private final BeaconBlockBodySchemaAltairImpl schema;
   protected SyncAggregate syncAggregate;
 
-  public BeaconBlockBodyBuilderAltair() {
-    this.schema = null;
-  }
-
-  public BeaconBlockBodyBuilderAltair(final BeaconBlockBodySchemaAltairImpl schema) {
-    this.schema = schema;
+  public BeaconBlockBodyBuilderAltair(
+      final BeaconBlockBodySchema<? extends BeaconBlockBody> schema) {
+    super(schema);
   }
 
   @Override
@@ -47,11 +43,6 @@ public class BeaconBlockBodyBuilderAltair extends BeaconBlockBodyBuilderPhase0 {
   }
 
   @Override
-  protected void validateSchema() {
-    checkNotNull(schema, "schema must be specified");
-  }
-
-  @Override
   protected void validate() {
     super.validate();
     checkNotNull(syncAggregate, "syncAggregate must be specified");
@@ -60,6 +51,8 @@ public class BeaconBlockBodyBuilderAltair extends BeaconBlockBodyBuilderPhase0 {
   @Override
   public SafeFuture<BeaconBlockBody> build() {
     validate();
+    final BeaconBlockBodySchemaAltairImpl schema =
+        getAndValidateSchema(false, BeaconBlockBodySchemaAltairImpl.class);
 
     return SafeFuture.completedFuture(
         new BeaconBlockBodyAltairImpl(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/altair/BeaconBlockBodySchemaAltairImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/altair/BeaconBlockBodySchemaAltairImpl.java
@@ -75,7 +75,7 @@ public class BeaconBlockBodySchemaAltairImpl
         syncAggregateSchema);
   }
 
-  public static BeaconBlockBodySchemaAltair<? extends BeaconBlockBodyAltair> create(
+  public static BeaconBlockBodySchemaAltairImpl create(
       final SpecConfig specConfig,
       final AttesterSlashingSchema attesterSlashingSchema,
       final String containerName) {
@@ -111,7 +111,7 @@ public class BeaconBlockBodySchemaAltairImpl
   @Override
   public SafeFuture<BeaconBlockBody> createBlockBody(
       final Consumer<BeaconBlockBodyBuilder> builderConsumer) {
-    final BeaconBlockBodyBuilderAltair builder = new BeaconBlockBodyBuilderAltair().schema(this);
+    final BeaconBlockBodyBuilderAltair builder = new BeaconBlockBodyBuilderAltair(this);
     builderConsumer.accept(builder);
     return builder.build();
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BeaconBlockBodyBuilderBellatrix.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BeaconBlockBodyBuilderBellatrix.java
@@ -36,6 +36,7 @@ public class BeaconBlockBodyBuilderBellatrix extends BeaconBlockBodyBuilderAltai
       final BeaconBlockBodySchema<? extends BeaconBlockBodyBellatrix> schema,
       final BeaconBlockBodySchema<? extends BlindedBeaconBlockBodyBellatrix> blindedSchema) {
     super(schema);
+    checkState(schema != null || blindedSchema != null, "At least one schema must be specified");
     this.blindedSchema = blindedSchema;
   }
 
@@ -45,14 +46,15 @@ public class BeaconBlockBodyBuilderBellatrix extends BeaconBlockBodyBuilderAltai
   }
 
   @Override
-  public BeaconBlockBodyBuilder executionPayload(SafeFuture<ExecutionPayload> executionPayload) {
+  public BeaconBlockBodyBuilder executionPayload(
+      final SafeFuture<ExecutionPayload> executionPayload) {
     this.executionPayload = executionPayload;
     return this;
   }
 
   @Override
   public BeaconBlockBodyBuilder executionPayloadHeader(
-      SafeFuture<ExecutionPayloadHeader> executionPayloadHeader) {
+      final SafeFuture<ExecutionPayloadHeader> executionPayloadHeader) {
     this.executionPayloadHeader = executionPayloadHeader;
     return this;
   }
@@ -81,7 +83,7 @@ public class BeaconBlockBodyBuilderBellatrix extends BeaconBlockBodyBuilderAltai
     super.validate();
     checkState(
         executionPayload != null ^ executionPayloadHeader != null,
-        "only and only one of executionPayload or executionPayloadHeader must be set");
+        "Exactly one of 'executionPayload' or 'executionPayloadHeader' must be set");
   }
 
   protected Boolean isBlinded() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BeaconBlockBodyBuilderBellatrix.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BeaconBlockBodyBuilderBellatrix.java
@@ -20,6 +20,7 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszBytes32;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodyBuilder;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodySchema;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.BeaconBlockBodyBuilderAltair;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
@@ -42,6 +43,15 @@ public class BeaconBlockBodyBuilderBellatrix extends BeaconBlockBodyBuilderAltai
       final BlindedBeaconBlockBodySchemaBellatrixImpl blindedSchema) {
     this.schema = schema;
     this.blindedSchema = blindedSchema;
+  }
+
+  @Override
+  protected BeaconBlockBodySchema<?> getSchema() {
+    return schema;
+  }
+
+  protected BeaconBlockBodySchema<?> getBlindedSchema() {
+    return blindedSchema;
   }
 
   @Override
@@ -72,10 +82,9 @@ public class BeaconBlockBodyBuilderBellatrix extends BeaconBlockBodyBuilderAltai
   protected void validateSchema() {
     if (isBlinded()) {
       checkState(
-              blindedSchema != null, "blindedSchema must be set blinded body has been requested");
+          blindedSchema != null, "blindedSchema must be set blinded body has been requested");
     } else {
-      checkState(
-              schema != null, "schema must be set if non blinded body has been requested");
+      checkState(schema != null, "schema must be set if non blinded body has been requested");
     }
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BeaconBlockBodyBuilderBellatrix.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BeaconBlockBodyBuilderBellatrix.java
@@ -66,7 +66,7 @@ public class BeaconBlockBodyBuilderBellatrix extends BeaconBlockBodyBuilderAltai
     if (isBlinded()) {
       checkNotNull(blindedSchema, "blindedSchema must be set when blinded body has been requested");
     } else {
-      checkNotNull(schema, "schema must be set if when non blinded body has been requested");
+      checkNotNull(schema, "schema must be set when non blinded body has been requested");
     }
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BeaconBlockBodyBuilderBellatrix.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BeaconBlockBodyBuilderBellatrix.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.bellatrix;
 
+import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
 import java.util.Optional;
@@ -71,11 +72,9 @@ public class BeaconBlockBodyBuilderBellatrix extends BeaconBlockBodyBuilderAltai
   @Override
   protected void validateSchema() {
     if (isBlinded()) {
-      checkState(
-              blindedSchema != null, "blindedSchema must be set blinded body has been requested");
+      checkNotNull(blindedSchema, "blindedSchema must be set when blinded body has been requested");
     } else {
-      checkState(
-              schema != null, "schema must be set if non blinded body has been requested");
+      checkNotNull(schema, "schema must be set if when non blinded body has been requested");
     }
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BeaconBlockBodyBuilderBellatrix.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BeaconBlockBodyBuilderBellatrix.java
@@ -72,10 +72,10 @@ public class BeaconBlockBodyBuilderBellatrix extends BeaconBlockBodyBuilderAltai
   protected void validateSchema() {
     if (isBlinded()) {
       checkState(
-          blindedSchema != null && schema == null, "blindedSchema must be set with no schema");
+              blindedSchema != null, "blindedSchema must be set blinded body has been requested");
     } else {
       checkState(
-          schema != null && blindedSchema == null, "schema must be set with no blindedSchema");
+              schema != null, "schema must be set if non blinded body has been requested");
     }
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BeaconBlockBodyBuilderBellatrix.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BeaconBlockBodyBuilderBellatrix.java
@@ -20,7 +20,6 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszBytes32;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodyBuilder;
-import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodySchema;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.BeaconBlockBodyBuilderAltair;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
@@ -43,15 +42,6 @@ public class BeaconBlockBodyBuilderBellatrix extends BeaconBlockBodyBuilderAltai
       final BlindedBeaconBlockBodySchemaBellatrixImpl blindedSchema) {
     this.schema = schema;
     this.blindedSchema = blindedSchema;
-  }
-
-  @Override
-  protected BeaconBlockBodySchema<?> getSchema() {
-    return schema;
-  }
-
-  protected BeaconBlockBodySchema<?> getBlindedSchema() {
-    return blindedSchema;
   }
 
   @Override
@@ -82,9 +72,10 @@ public class BeaconBlockBodyBuilderBellatrix extends BeaconBlockBodyBuilderAltai
   protected void validateSchema() {
     if (isBlinded()) {
       checkState(
-          blindedSchema != null, "blindedSchema must be set blinded body has been requested");
+              blindedSchema != null, "blindedSchema must be set blinded body has been requested");
     } else {
-      checkState(schema != null, "schema must be set if non blinded body has been requested");
+      checkState(
+              schema != null, "schema must be set if non blinded body has been requested");
     }
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BeaconBlockBodyBuilderBellatrix.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BeaconBlockBodyBuilderBellatrix.java
@@ -62,20 +62,20 @@ public class BeaconBlockBodyBuilderBellatrix extends BeaconBlockBodyBuilderAltai
   @Override
   @SuppressWarnings("unchecked")
   protected <T> T getAndValidateSchema(final boolean blinded, final Class<T> expectedSchemaType) {
-    final BeaconBlockBodySchema<?> schema;
+    final BeaconBlockBodySchema<?> resolvedSchema;
     if (blinded) {
-      schema = this.blindedSchema;
-      checkNotNull(schema, "Blinded schema must be specified");
+      resolvedSchema = blindedSchema;
+      checkNotNull(resolvedSchema, "Blinded schema must be specified");
     } else {
-      schema = this.schema;
-      checkNotNull(schema, "Schema must be specified");
+      resolvedSchema = schema;
+      checkNotNull(resolvedSchema, "Schema must be specified");
     }
     checkArgument(
-        expectedSchemaType == schema.getClass(),
+        expectedSchemaType == resolvedSchema.getClass(),
         String.format(
             "Schema should be %s but was %s",
-            expectedSchemaType.getSimpleName(), schema.getClass().getSimpleName()));
-    return (T) schema;
+            expectedSchemaType.getSimpleName(), resolvedSchema.getClass().getSimpleName()));
+    return (T) resolvedSchema;
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BeaconBlockBodySchemaBellatrixImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BeaconBlockBodySchemaBellatrixImpl.java
@@ -122,8 +122,7 @@ public class BeaconBlockBodySchemaBellatrixImpl
   @Override
   public SafeFuture<BeaconBlockBody> createBlockBody(
       final Consumer<BeaconBlockBodyBuilder> builderConsumer) {
-    final BeaconBlockBodyBuilderBellatrix builder =
-        new BeaconBlockBodyBuilderBellatrix().schema(this);
+    final BeaconBlockBodyBuilderBellatrix builder = new BeaconBlockBodyBuilderBellatrix(this, null);
     builderConsumer.accept(builder);
     return builder.build();
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BlindedBeaconBlockBodySchemaBellatrixImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BlindedBeaconBlockBodySchemaBellatrixImpl.java
@@ -120,8 +120,7 @@ public class BlindedBeaconBlockBodySchemaBellatrixImpl
   @Override
   public SafeFuture<BeaconBlockBody> createBlockBody(
       final Consumer<BeaconBlockBodyBuilder> builderConsumer) {
-    final BeaconBlockBodyBuilderBellatrix builder =
-        new BeaconBlockBodyBuilderBellatrix().blindedSchema(this);
+    final BeaconBlockBodyBuilderBellatrix builder = new BeaconBlockBodyBuilderBellatrix(null, this);
     builderConsumer.accept(builder);
     return builder.build();
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/capella/BeaconBlockBodyBuilderCapella.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/capella/BeaconBlockBodyBuilderCapella.java
@@ -21,6 +21,7 @@ import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszBytes32;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodyBuilder;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodySchema;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.bellatrix.BeaconBlockBodyBuilderBellatrix;
 import tech.pegasys.teku.spec.datastructures.execution.versions.capella.ExecutionPayloadCapellaImpl;
 import tech.pegasys.teku.spec.datastructures.execution.versions.capella.ExecutionPayloadHeaderCapellaImpl;
@@ -45,6 +46,16 @@ public class BeaconBlockBodyBuilderCapella extends BeaconBlockBodyBuilderBellatr
     this.blindedSchema = blindedSchema;
   }
 
+  @Override
+  protected BeaconBlockBodySchema<?> getSchema() {
+    return schema;
+  }
+
+  π
+  protected BeaconBlockBodySchema<?> getBlindedSchema() {
+    return blindedSchema;
+  }
+
   protected SszList<SignedBlsToExecutionChange> getBlsToExecutionChanges() {
     return blsToExecutionChanges;
   }
@@ -59,17 +70,6 @@ public class BeaconBlockBodyBuilderCapella extends BeaconBlockBodyBuilderBellatr
       final SszList<SignedBlsToExecutionChange> blsToExecutionChanges) {
     this.blsToExecutionChanges = blsToExecutionChanges;
     return this;
-  }
-
-  @Override
-  protected void validateSchema() {
-    if (isBlinded()) {
-      checkState(
-              blindedSchema != null, "blindedSchema must be set blinded body has been requested");
-    } else {
-      checkState(
-              schema != null, "schema must be set if non blinded body has been requested");
-    }
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/capella/BeaconBlockBodyBuilderCapella.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/capella/BeaconBlockBodyBuilderCapella.java
@@ -65,7 +65,7 @@ public class BeaconBlockBodyBuilderCapella extends BeaconBlockBodyBuilderBellatr
     if (isBlinded()) {
       checkNotNull(blindedSchema, "blindedSchema must be set when blinded body has been requested");
     } else {
-      checkNotNull(schema, "schema must be set if when non blinded body has been requested");
+      checkNotNull(schema, "schema must be set when non blinded body has been requested");
     }
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/capella/BeaconBlockBodyBuilderCapella.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/capella/BeaconBlockBodyBuilderCapella.java
@@ -65,10 +65,10 @@ public class BeaconBlockBodyBuilderCapella extends BeaconBlockBodyBuilderBellatr
   protected void validateSchema() {
     if (isBlinded()) {
       checkState(
-          blindedSchema != null && schema == null, "blindedSchema must be set with no schema");
+              blindedSchema != null, "blindedSchema must be set blinded body has been requested");
     } else {
       checkState(
-          schema != null && blindedSchema == null, "schema must be set with no blindedSchema");
+              schema != null, "schema must be set if non blinded body has been requested");
     }
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/capella/BeaconBlockBodyBuilderCapella.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/capella/BeaconBlockBodyBuilderCapella.java
@@ -16,7 +16,6 @@ package tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.capella;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
-import java.util.Optional;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszBytes32;
@@ -30,21 +29,20 @@ import tech.pegasys.teku.spec.datastructures.type.SszSignature;
 
 public class BeaconBlockBodyBuilderCapella extends BeaconBlockBodyBuilderBellatrix {
 
-  private BeaconBlockBodySchemaCapellaImpl schema;
-  private BlindedBeaconBlockBodySchemaCapellaImpl blindedSchema;
+  private final BeaconBlockBodySchemaCapellaImpl schema;
+  private final BlindedBeaconBlockBodySchemaCapellaImpl blindedSchema;
   private SszList<SignedBlsToExecutionChange> blsToExecutionChanges;
 
-  public BeaconBlockBodyBuilderCapella schema(final BeaconBlockBodySchemaCapellaImpl schema) {
-    this.schema = schema;
-    this.blinded = Optional.of(false);
-    return this;
+  public BeaconBlockBodyBuilderCapella() {
+    this.schema = null;
+    this.blindedSchema = null;
   }
 
-  public BeaconBlockBodyBuilderCapella blindedSchema(
+  public BeaconBlockBodyBuilderCapella(
+      final BeaconBlockBodySchemaCapellaImpl schema,
       final BlindedBeaconBlockBodySchemaCapellaImpl blindedSchema) {
+    this.schema = schema;
     this.blindedSchema = blindedSchema;
-    this.blinded = Optional.of(true);
-    return this;
   }
 
   protected SszList<SignedBlsToExecutionChange> getBlsToExecutionChanges() {
@@ -78,14 +76,6 @@ public class BeaconBlockBodyBuilderCapella extends BeaconBlockBodyBuilderBellatr
   protected void validate() {
     super.validate();
     checkNotNull(blsToExecutionChanges, "blsToExecutionChanges must be specified");
-  }
-
-  @Override
-  public Boolean isBlinded() {
-    return blinded.orElseThrow(
-        () ->
-            new IllegalStateException(
-                "schema or blindedSchema must be set before interacting with the builder"));
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/capella/BeaconBlockBodyBuilderCapella.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/capella/BeaconBlockBodyBuilderCapella.java
@@ -14,7 +14,6 @@
 package tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.capella;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.base.Preconditions.checkState;
 
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
@@ -64,11 +63,9 @@ public class BeaconBlockBodyBuilderCapella extends BeaconBlockBodyBuilderBellatr
   @Override
   protected void validateSchema() {
     if (isBlinded()) {
-      checkState(
-              blindedSchema != null, "blindedSchema must be set blinded body has been requested");
+      checkNotNull(blindedSchema, "blindedSchema must be set when blinded body has been requested");
     } else {
-      checkState(
-              schema != null, "schema must be set if non blinded body has been requested");
+      checkNotNull(schema, "schema must be set if when non blinded body has been requested");
     }
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/capella/BeaconBlockBodyBuilderCapella.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/capella/BeaconBlockBodyBuilderCapella.java
@@ -21,7 +21,6 @@ import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszBytes32;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodyBuilder;
-import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodySchema;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.bellatrix.BeaconBlockBodyBuilderBellatrix;
 import tech.pegasys.teku.spec.datastructures.execution.versions.capella.ExecutionPayloadCapellaImpl;
 import tech.pegasys.teku.spec.datastructures.execution.versions.capella.ExecutionPayloadHeaderCapellaImpl;
@@ -46,16 +45,6 @@ public class BeaconBlockBodyBuilderCapella extends BeaconBlockBodyBuilderBellatr
     this.blindedSchema = blindedSchema;
   }
 
-  @Override
-  protected BeaconBlockBodySchema<?> getSchema() {
-    return schema;
-  }
-
-  π
-  protected BeaconBlockBodySchema<?> getBlindedSchema() {
-    return blindedSchema;
-  }
-
   protected SszList<SignedBlsToExecutionChange> getBlsToExecutionChanges() {
     return blsToExecutionChanges;
   }
@@ -70,6 +59,17 @@ public class BeaconBlockBodyBuilderCapella extends BeaconBlockBodyBuilderBellatr
       final SszList<SignedBlsToExecutionChange> blsToExecutionChanges) {
     this.blsToExecutionChanges = blsToExecutionChanges;
     return this;
+  }
+
+  @Override
+  protected void validateSchema() {
+    if (isBlinded()) {
+      checkState(
+              blindedSchema != null, "blindedSchema must be set blinded body has been requested");
+    } else {
+      checkState(
+              schema != null, "schema must be set if non blinded body has been requested");
+    }
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/capella/BeaconBlockBodySchemaCapellaImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/capella/BeaconBlockBodySchemaCapellaImpl.java
@@ -131,7 +131,7 @@ public class BeaconBlockBodySchemaCapellaImpl
   @Override
   public SafeFuture<? extends BeaconBlockBody> createBlockBody(
       final Consumer<BeaconBlockBodyBuilder> builderConsumer) {
-    final BeaconBlockBodyBuilderCapella builder = new BeaconBlockBodyBuilderCapella().schema(this);
+    final BeaconBlockBodyBuilderCapella builder = new BeaconBlockBodyBuilderCapella(this, null);
     builderConsumer.accept(builder);
     return builder.build();
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/capella/BlindedBeaconBlockBodySchemaCapellaImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/capella/BlindedBeaconBlockBodySchemaCapellaImpl.java
@@ -131,8 +131,7 @@ public class BlindedBeaconBlockBodySchemaCapellaImpl
   @Override
   public SafeFuture<BeaconBlockBody> createBlockBody(
       final Consumer<BeaconBlockBodyBuilder> builderConsumer) {
-    final BeaconBlockBodyBuilderCapella builder =
-        new BeaconBlockBodyBuilderCapella().blindedSchema(this);
+    final BeaconBlockBodyBuilderCapella builder = new BeaconBlockBodyBuilderCapella(null, this);
     builderConsumer.accept(builder);
     return builder.build();
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/deneb/BeaconBlockBodyBuilderDeneb.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/deneb/BeaconBlockBodyBuilderDeneb.java
@@ -62,7 +62,7 @@ public class BeaconBlockBodyBuilderDeneb extends BeaconBlockBodyBuilderCapella {
     if (isBlinded()) {
       checkNotNull(blindedSchema, "blindedSchema must be set when blinded body has been requested");
     } else {
-      checkNotNull(schema, "schema must be set if when non blinded body has been requested");
+      checkNotNull(schema, "schema must be set when non blinded body has been requested");
     }
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/deneb/BeaconBlockBodyBuilderDeneb.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/deneb/BeaconBlockBodyBuilderDeneb.java
@@ -64,8 +64,7 @@ public class BeaconBlockBodyBuilderDeneb extends BeaconBlockBodyBuilderCapella {
       checkState(
           blindedSchema != null, "blindedSchema must be set blinded body has been requested");
     } else {
-      checkState(
-          schema != null, "schema must be set if non blinded body has been requested");
+      checkState(schema != null, "schema must be set if non blinded body has been requested");
     }
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/deneb/BeaconBlockBodyBuilderDeneb.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/deneb/BeaconBlockBodyBuilderDeneb.java
@@ -62,10 +62,10 @@ public class BeaconBlockBodyBuilderDeneb extends BeaconBlockBodyBuilderCapella {
   protected void validateSchema() {
     if (isBlinded()) {
       checkState(
-          blindedSchema != null && schema == null, "blindedSchema must be set with no schema");
+          blindedSchema != null, "blindedSchema must be set blinded body has been requested");
     } else {
       checkState(
-          schema != null && blindedSchema == null, "schema must be set with no blindedSchema");
+          schema != null, "schema must be set if non blinded body has been requested");
     }
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/deneb/BeaconBlockBodyBuilderDeneb.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/deneb/BeaconBlockBodyBuilderDeneb.java
@@ -16,7 +16,6 @@ package tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.deneb;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
-import java.util.Optional;
 import org.apache.commons.lang3.tuple.Pair;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
@@ -31,21 +30,20 @@ import tech.pegasys.teku.spec.datastructures.type.SszSignature;
 
 public class BeaconBlockBodyBuilderDeneb extends BeaconBlockBodyBuilderCapella {
 
-  private BeaconBlockBodySchemaDenebImpl schema;
-  private BlindedBeaconBlockBodySchemaDenebImpl blindedSchema;
+  private final BeaconBlockBodySchemaDenebImpl schema;
+  private final BlindedBeaconBlockBodySchemaDenebImpl blindedSchema;
   private SafeFuture<SszList<SszKZGCommitment>> blobKzgCommitments;
 
-  public BeaconBlockBodyBuilderDeneb schema(final BeaconBlockBodySchemaDenebImpl schema) {
-    this.schema = schema;
-    this.blinded = Optional.of(false);
-    return this;
+  public BeaconBlockBodyBuilderDeneb() {
+    this.schema = null;
+    this.blindedSchema = null;
   }
 
-  public BeaconBlockBodyBuilderDeneb blindedSchema(
+  public BeaconBlockBodyBuilderDeneb(
+      final BeaconBlockBodySchemaDenebImpl schema,
       final BlindedBeaconBlockBodySchemaDenebImpl blindedSchema) {
+    this.schema = schema;
     this.blindedSchema = blindedSchema;
-    this.blinded = Optional.of(true);
-    return this;
   }
 
   @Override
@@ -75,14 +73,6 @@ public class BeaconBlockBodyBuilderDeneb extends BeaconBlockBodyBuilderCapella {
   protected void validate() {
     super.validate();
     checkNotNull(blobKzgCommitments, "blobKzgCommitments must be specified");
-  }
-
-  @Override
-  public Boolean isBlinded() {
-    return blinded.orElseThrow(
-        () ->
-            new IllegalStateException(
-                "schema or blindedSchema must be set before interacting with the builder"));
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/deneb/BeaconBlockBodyBuilderDeneb.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/deneb/BeaconBlockBodyBuilderDeneb.java
@@ -64,7 +64,8 @@ public class BeaconBlockBodyBuilderDeneb extends BeaconBlockBodyBuilderCapella {
       checkState(
           blindedSchema != null, "blindedSchema must be set blinded body has been requested");
     } else {
-      checkState(schema != null, "schema must be set if non blinded body has been requested");
+      checkState(
+          schema != null, "schema must be set if non blinded body has been requested");
     }
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/deneb/BeaconBlockBodyBuilderDeneb.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/deneb/BeaconBlockBodyBuilderDeneb.java
@@ -14,7 +14,6 @@
 package tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.deneb;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.base.Preconditions.checkState;
 
 import org.apache.commons.lang3.tuple.Pair;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -61,11 +60,9 @@ public class BeaconBlockBodyBuilderDeneb extends BeaconBlockBodyBuilderCapella {
   @Override
   protected void validateSchema() {
     if (isBlinded()) {
-      checkState(
-          blindedSchema != null, "blindedSchema must be set blinded body has been requested");
+      checkNotNull(blindedSchema, "blindedSchema must be set when blinded body has been requested");
     } else {
-      checkState(
-          schema != null, "schema must be set if non blinded body has been requested");
+      checkNotNull(schema, "schema must be set if when non blinded body has been requested");
     }
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/deneb/BeaconBlockBodySchemaDenebImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/deneb/BeaconBlockBodySchemaDenebImpl.java
@@ -137,7 +137,7 @@ public class BeaconBlockBodySchemaDenebImpl
   @Override
   public SafeFuture<? extends BeaconBlockBody> createBlockBody(
       final Consumer<BeaconBlockBodyBuilder> builderConsumer) {
-    final BeaconBlockBodyBuilderDeneb builder = new BeaconBlockBodyBuilderDeneb().schema(this);
+    final BeaconBlockBodyBuilderDeneb builder = new BeaconBlockBodyBuilderDeneb(this, null);
     builderConsumer.accept(builder);
     return builder.build();
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/deneb/BlindedBeaconBlockBodySchemaDenebImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/deneb/BlindedBeaconBlockBodySchemaDenebImpl.java
@@ -138,8 +138,7 @@ public class BlindedBeaconBlockBodySchemaDenebImpl
   @Override
   public SafeFuture<BeaconBlockBody> createBlockBody(
       final Consumer<BeaconBlockBodyBuilder> builderConsumer) {
-    final BeaconBlockBodyBuilderDeneb builder =
-        new BeaconBlockBodyBuilderDeneb().blindedSchema(this);
+    final BeaconBlockBodyBuilderDeneb builder = new BeaconBlockBodyBuilderDeneb(null, this);
     builderConsumer.accept(builder);
     return builder.build();
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/phase0/BeaconBlockBodyBuilderPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/phase0/BeaconBlockBodyBuilderPhase0.java
@@ -36,7 +36,7 @@ import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.spec.datastructures.type.SszSignature;
 
 public class BeaconBlockBodyBuilderPhase0 implements BeaconBlockBodyBuilder {
-  private BeaconBlockBodySchemaPhase0 schema;
+  private final BeaconBlockBodySchemaPhase0 schema;
   protected BLSSignature randaoReveal;
   protected Eth1Data eth1Data;
   protected Bytes32 graffiti;
@@ -45,6 +45,14 @@ public class BeaconBlockBodyBuilderPhase0 implements BeaconBlockBodyBuilder {
   protected SszList<AttesterSlashing> attesterSlashings;
   protected SszList<Deposit> deposits;
   protected SszList<SignedVoluntaryExit> voluntaryExits;
+
+  public BeaconBlockBodyBuilderPhase0() {
+    this.schema = null;
+  }
+
+  public BeaconBlockBodyBuilderPhase0(final BeaconBlockBodySchemaPhase0 schema) {
+    this.schema = schema;
+  }
 
   @Override
   public BeaconBlockBodyBuilder randaoReveal(final BLSSignature randaoReveal) {
@@ -93,11 +101,6 @@ public class BeaconBlockBodyBuilderPhase0 implements BeaconBlockBodyBuilder {
   @Override
   public BeaconBlockBodyBuilder voluntaryExits(final SszList<SignedVoluntaryExit> voluntaryExits) {
     this.voluntaryExits = voluntaryExits;
-    return this;
-  }
-
-  public BeaconBlockBodyBuilderPhase0 schema(final BeaconBlockBodySchemaPhase0 schema) {
-    this.schema = schema;
     return this;
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/phase0/BeaconBlockBodySchemaPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/phase0/BeaconBlockBodySchemaPhase0.java
@@ -105,7 +105,7 @@ public class BeaconBlockBodySchemaPhase0
   @Override
   public SafeFuture<BeaconBlockBody> createBlockBody(
       final Consumer<BeaconBlockBodyBuilder> builderConsumer) {
-    final BeaconBlockBodyBuilderPhase0 builder = new BeaconBlockBodyBuilderPhase0().schema(this);
+    final BeaconBlockBodyBuilderPhase0 builder = new BeaconBlockBodyBuilderPhase0(this);
     builderConsumer.accept(builder);
     return builder.build();
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/BlockProposalUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/BlockProposalUtil.java
@@ -52,7 +52,6 @@ public class BlockProposalUtil {
       final BeaconState blockSlotState,
       final Bytes32 parentBlockSigningRoot,
       final Consumer<BeaconBlockBodyBuilder> bodyBuilder,
-      final Optional<Boolean> blinded,
       final BlockProductionPerformance blockProductionPerformance) {
     checkArgument(
         blockSlotState.getSlot().equals(newSlot),
@@ -61,28 +60,24 @@ public class BlockProposalUtil {
         blockSlotState.getSlot());
 
     // Create block body
-    final SafeFuture<? extends BeaconBlockBody> beaconBlockBody;
-    final BeaconBlockSchema beaconBlockSchema;
-
-    if (blinded.orElse(ValidatorsUtil.DEFAULT_PRODUCE_BLINDED_BLOCK)) {
-      beaconBlockBody = createBlindedBeaconBlockBody(bodyBuilder);
-      beaconBlockSchema = schemaDefinitions.getBlindedBeaconBlockSchema();
-    } else {
-      beaconBlockBody = createBeaconBlockBody(bodyBuilder);
-      beaconBlockSchema = schemaDefinitions.getBeaconBlockSchema();
-    }
+    final SafeFuture<? extends BeaconBlockBody> beaconBlockBody = createBlockBody(bodyBuilder);
 
     // Create initial block with some stubs
     final Bytes32 tmpStateRoot = Bytes32.ZERO;
     final SafeFuture<BeaconBlock> newBlock =
         beaconBlockBody.thenApply(
-            body ->
-                beaconBlockSchema.create(
-                    newSlot,
-                    UInt64.valueOf(proposerIndex),
-                    parentBlockSigningRoot,
-                    tmpStateRoot,
-                    body));
+            body -> {
+              final BeaconBlockSchema beaconBlockSchema =
+                  body.isBlinded()
+                      ? schemaDefinitions.getBlindedBeaconBlockSchema()
+                      : schemaDefinitions.getBeaconBlockSchema();
+              return beaconBlockSchema.create(
+                  newSlot,
+                  UInt64.valueOf(proposerIndex),
+                  parentBlockSigningRoot,
+                  tmpStateRoot,
+                  body);
+            });
 
     return newBlock
         .thenApplyChecked(
@@ -117,13 +112,10 @@ public class BlockProposalUtil {
             });
   }
 
-  private SafeFuture<? extends BeaconBlockBody> createBeaconBlockBody(
-      final Consumer<BeaconBlockBodyBuilder> bodyBuilder) {
-    return schemaDefinitions.getBeaconBlockBodySchema().createBlockBody(bodyBuilder);
-  }
-
-  private SafeFuture<? extends BeaconBlockBody> createBlindedBeaconBlockBody(
-      final Consumer<BeaconBlockBodyBuilder> bodyBuilder) {
-    return schemaDefinitions.getBlindedBeaconBlockBodySchema().createBlockBody(bodyBuilder);
+  private SafeFuture<? extends BeaconBlockBody> createBlockBody(
+      final Consumer<BeaconBlockBodyBuilder> builderConsumer) {
+    final BeaconBlockBodyBuilder builder = schemaDefinitions.createBeaconBlockBodyBuilder();
+    builderConsumer.accept(builder);
+    return builder.build();
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitions.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitions.java
@@ -26,6 +26,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.BlockContainerSchema;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlockSchema;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainerSchema;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodyBuilder;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodySchema;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.BeaconBlocksByRootRequestMessage;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.metadata.MetadataMessageSchema;
@@ -85,6 +86,9 @@ public interface SchemaDefinitions {
 
   BeaconBlocksByRootRequestMessage.BeaconBlocksByRootRequestMessageSchema
       getBeaconBlocksByRootRequestMessageSchema();
+
+  @NonSchema
+  BeaconBlockBodyBuilder createBeaconBlockBodyBuilder();
 
   @NonSchema
   default Optional<SchemaDefinitionsAltair> toVersionAltair() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsAltair.java
@@ -22,8 +22,9 @@ import tech.pegasys.teku.spec.datastructures.blocks.BlockContainerSchema;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlockSchema;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainerSchema;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodyBuilder;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodySchema;
-import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.BeaconBlockBodySchemaAltair;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.BeaconBlockBodyBuilderAltair;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.BeaconBlockBodySchemaAltairImpl;
 import tech.pegasys.teku.spec.datastructures.lightclient.LightClientBootstrapSchema;
 import tech.pegasys.teku.spec.datastructures.lightclient.LightClientHeaderSchema;
@@ -42,7 +43,7 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.altair.M
 
 public class SchemaDefinitionsAltair extends AbstractSchemaDefinitions {
   private final BeaconStateSchemaAltair beaconStateSchema;
-  private final BeaconBlockBodySchemaAltair<?> beaconBlockBodySchema;
+  private final BeaconBlockBodySchemaAltairImpl beaconBlockBodySchema;
   private final BeaconBlockSchema beaconBlockSchema;
   private final SignedBeaconBlockSchema signedBeaconBlockSchema;
   private final SyncCommitteeContributionSchema syncCommitteeContributionSchema;
@@ -138,6 +139,11 @@ public class SchemaDefinitionsAltair extends AbstractSchemaDefinitions {
   @Override
   public SignedBlockContainerSchema<SignedBlockContainer> getSignedBlindedBlockContainerSchema() {
     return getSignedBlindedBeaconBlockSchema().castTypeToSignedBlockContainer();
+  }
+
+  @Override
+  public BeaconBlockBodyBuilder createBeaconBlockBodyBuilder() {
+    return new BeaconBlockBodyBuilderAltair(beaconBlockBodySchema);
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsBellatrix.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsBellatrix.java
@@ -23,10 +23,10 @@ import tech.pegasys.teku.spec.datastructures.blocks.BlockContainerSchema;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlockSchema;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainerSchema;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodyBuilder;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodySchema;
-import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.bellatrix.BeaconBlockBodySchemaBellatrix;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.bellatrix.BeaconBlockBodyBuilderBellatrix;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.bellatrix.BeaconBlockBodySchemaBellatrixImpl;
-import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.bellatrix.BlindedBeaconBlockBodySchemaBellatrix;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.bellatrix.BlindedBeaconBlockBodySchemaBellatrixImpl;
 import tech.pegasys.teku.spec.datastructures.builder.BuilderBidSchema;
 import tech.pegasys.teku.spec.datastructures.builder.BuilderPayloadSchema;
@@ -42,8 +42,8 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.bellatri
 
 public class SchemaDefinitionsBellatrix extends SchemaDefinitionsAltair {
   private final BeaconStateSchemaBellatrix beaconStateSchema;
-  private final BeaconBlockBodySchemaBellatrix<?> beaconBlockBodySchema;
-  private final BlindedBeaconBlockBodySchemaBellatrix<?> blindedBeaconBlockBodySchema;
+  private final BeaconBlockBodySchemaBellatrixImpl beaconBlockBodySchema;
+  private final BlindedBeaconBlockBodySchemaBellatrixImpl blindedBeaconBlockBodySchema;
   private final BeaconBlockSchema beaconBlockSchema;
   private final BeaconBlockSchema blindedBeaconBlockSchema;
   private final SignedBeaconBlockSchema signedBeaconBlockSchema;
@@ -141,6 +141,11 @@ public class SchemaDefinitionsBellatrix extends SchemaDefinitionsAltair {
   @Override
   public SignedBlockContainerSchema<SignedBlockContainer> getSignedBlindedBlockContainerSchema() {
     return getSignedBlindedBeaconBlockSchema().castTypeToSignedBlockContainer();
+  }
+
+  @Override
+  public BeaconBlockBodyBuilder createBeaconBlockBodyBuilder() {
+    return new BeaconBlockBodyBuilderBellatrix(beaconBlockBodySchema, blindedBeaconBlockBodySchema);
   }
 
   public ExecutionPayloadSchema<?> getExecutionPayloadSchema() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsCapella.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsCapella.java
@@ -23,10 +23,10 @@ import tech.pegasys.teku.spec.datastructures.blocks.BlockContainerSchema;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlockSchema;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainerSchema;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodyBuilder;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodySchema;
-import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.capella.BeaconBlockBodySchemaCapella;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.capella.BeaconBlockBodyBuilderCapella;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.capella.BeaconBlockBodySchemaCapellaImpl;
-import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.capella.BlindedBeaconBlockBodySchemaCapella;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.capella.BlindedBeaconBlockBodySchemaCapellaImpl;
 import tech.pegasys.teku.spec.datastructures.builder.BuilderBidSchema;
 import tech.pegasys.teku.spec.datastructures.builder.SignedBuilderBidSchema;
@@ -52,8 +52,8 @@ public class SchemaDefinitionsCapella extends SchemaDefinitionsBellatrix {
   private final ExecutionPayloadSchemaCapella executionPayloadSchemaCapella;
   private final ExecutionPayloadHeaderSchemaCapella executionPayloadHeaderSchemaCapella;
 
-  private final BeaconBlockBodySchemaCapella<?> beaconBlockBodySchema;
-  private final BlindedBeaconBlockBodySchemaCapella<?> blindedBeaconBlockBodySchema;
+  private final BeaconBlockBodySchemaCapellaImpl beaconBlockBodySchema;
+  private final BlindedBeaconBlockBodySchemaCapellaImpl blindedBeaconBlockBodySchema;
 
   private final BeaconBlockSchema beaconBlockSchema;
   private final BeaconBlockSchema blindedBeaconBlockSchema;
@@ -179,6 +179,11 @@ public class SchemaDefinitionsCapella extends SchemaDefinitionsBellatrix {
   @Override
   public ExecutionPayloadHeaderSchema<?> getExecutionPayloadHeaderSchema() {
     return executionPayloadHeaderSchemaCapella;
+  }
+
+  @Override
+  public BeaconBlockBodyBuilder createBeaconBlockBodyBuilder() {
+    return new BeaconBlockBodyBuilderCapella(beaconBlockBodySchema, blindedBeaconBlockBodySchema);
   }
 
   public WithdrawalSchema getWithdrawalSchema() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsDeneb.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsDeneb.java
@@ -30,10 +30,10 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlockHeader;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlockSchema;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainerSchema;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodyBuilder;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodySchema;
-import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.deneb.BeaconBlockBodySchemaDeneb;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.deneb.BeaconBlockBodyBuilderDeneb;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.deneb.BeaconBlockBodySchemaDenebImpl;
-import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.deneb.BlindedBeaconBlockBodySchemaDeneb;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.deneb.BlindedBeaconBlockBodySchemaDenebImpl;
 import tech.pegasys.teku.spec.datastructures.blocks.versions.deneb.BlockContentsSchema;
 import tech.pegasys.teku.spec.datastructures.blocks.versions.deneb.SignedBlockContentsSchema;
@@ -63,8 +63,8 @@ public class SchemaDefinitionsDeneb extends SchemaDefinitionsCapella {
 
   private final BlobKzgCommitmentsSchema blobKzgCommitmentsSchema;
 
-  private final BeaconBlockBodySchemaDeneb<?> beaconBlockBodySchema;
-  private final BlindedBeaconBlockBodySchemaDeneb<?> blindedBeaconBlockBodySchema;
+  private final BeaconBlockBodySchemaDenebImpl beaconBlockBodySchema;
+  private final BlindedBeaconBlockBodySchemaDenebImpl blindedBeaconBlockBodySchema;
 
   private final BeaconBlockSchema beaconBlockSchema;
   private final BeaconBlockSchema blindedBeaconBlockSchema;
@@ -228,6 +228,11 @@ public class SchemaDefinitionsDeneb extends SchemaDefinitionsCapella {
   @Override
   public BuilderPayloadSchema<?> getBuilderPayloadSchema() {
     return getExecutionPayloadAndBlobsBundleSchema();
+  }
+
+  @Override
+  public BeaconBlockBodyBuilder createBeaconBlockBodyBuilder() {
+    return new BeaconBlockBodyBuilderDeneb(beaconBlockBodySchema, blindedBeaconBlockBodySchema);
   }
 
   public BlobSchema getBlobSchema() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsPhase0.java
@@ -21,7 +21,9 @@ import tech.pegasys.teku.spec.datastructures.blocks.BlockContainerSchema;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlockSchema;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainerSchema;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodyBuilder;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodySchema;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.phase0.BeaconBlockBodyBuilderPhase0;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.phase0.BeaconBlockBodySchemaPhase0;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.metadata.versions.phase0.MetadataMessageSchemaPhase0;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchema;
@@ -29,7 +31,7 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.phase0.B
 
 public class SchemaDefinitionsPhase0 extends AbstractSchemaDefinitions {
   private final BeaconStateSchemaPhase0 beaconStateSchema;
-  private final BeaconBlockBodySchema<?> beaconBlockBodySchema;
+  private final BeaconBlockBodySchemaPhase0 beaconBlockBodySchema;
   private final MetadataMessageSchemaPhase0 metadataMessageSchema;
   private final BeaconBlockSchema beaconBlockSchema;
   private final SignedBeaconBlockSchema signedBeaconBlockSchema;
@@ -99,6 +101,11 @@ public class SchemaDefinitionsPhase0 extends AbstractSchemaDefinitions {
   @Override
   public SignedBlockContainerSchema<SignedBlockContainer> getSignedBlindedBlockContainerSchema() {
     return getSignedBlindedBeaconBlockSchema().castTypeToSignedBlockContainer();
+  }
+
+  @Override
+  public BeaconBlockBodyBuilder createBeaconBlockBodyBuilder() {
+    return new BeaconBlockBodyBuilderPhase0(beaconBlockBodySchema);
   }
 
   @Override

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/common/AbstractBeaconBlockBodyTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/common/AbstractBeaconBlockBodyTest.java
@@ -19,6 +19,7 @@ import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -60,6 +61,7 @@ public abstract class AbstractBeaconBlockBodyTest<T extends BeaconBlockBody> {
   protected T defaultBlockBody;
   protected BlindedBeaconBlockBodyBellatrix defaultBlindedBlockBody;
   protected BeaconBlockBodySchema<?> blockBodySchema;
+  protected BeaconBlockBodySchema<? extends BlindedBeaconBlockBodyBellatrix> blindedBlockBodySchema;
 
   protected void setUpBaseClass(final SpecMilestone milestone, Runnable additionalSetup) {
     spec = TestSpecFactory.createMinimal(milestone);
@@ -94,6 +96,10 @@ public abstract class AbstractBeaconBlockBodyTest<T extends BeaconBlockBody> {
     defaultBlockBody = safeJoin(createDefaultBlockBody());
     defaultBlindedBlockBody = safeJoin(createDefaultBlindedBlockBody());
     blockBodySchema = defaultBlockBody.getSchema();
+    blindedBlockBodySchema =
+        Optional.ofNullable(defaultBlindedBlockBody)
+            .map(BlindedBeaconBlockBodyBellatrix::getSchema)
+            .orElse(null);
   }
 
   protected SafeFuture<T> createBlockBody() {

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/altair/BeaconBlockBodyAltairTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/altair/BeaconBlockBodyAltairTest.java
@@ -23,6 +23,7 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodyBuilder;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.common.AbstractBeaconBlockBodyTest;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.bellatrix.BlindedBeaconBlockBodyBellatrix;
 
 class BeaconBlockBodyAltairTest extends AbstractBeaconBlockBodyTest<BeaconBlockBodyAltair> {
 
@@ -45,13 +46,25 @@ class BeaconBlockBodyAltairTest extends AbstractBeaconBlockBodyTest<BeaconBlockB
   @Override
   protected SafeFuture<BeaconBlockBodyAltair> createBlockBody(
       final Consumer<BeaconBlockBodyBuilder> contentProvider) {
-    return getBlockBodySchema()
-        .createBlockBody(contentProvider)
-        .thenApply(body -> (BeaconBlockBodyAltair) body);
+    final BeaconBlockBodyBuilder bodyBuilder = createBeaconBlockBodyBuilder();
+    contentProvider.accept(bodyBuilder);
+    return bodyBuilder.build().thenApply(body -> body.toVersionAltair().orElseThrow());
   }
 
   @Override
-  protected Consumer<BeaconBlockBodyBuilder> createContentProvider() {
-    return super.createContentProvider().andThen(builder -> builder.syncAggregate(syncAggregate));
+  protected SafeFuture<BlindedBeaconBlockBodyBellatrix> createBlindedBlockBody(
+      Consumer<BeaconBlockBodyBuilder> contentProvider) {
+    return SafeFuture.completedFuture(null);
+  }
+
+  @Override
+  protected SafeFuture<BlindedBeaconBlockBodyBellatrix> createDefaultBlindedBlockBody() {
+    return SafeFuture.completedFuture(null);
+  }
+
+  @Override
+  protected Consumer<BeaconBlockBodyBuilder> createContentProvider(final boolean blinded) {
+    return super.createContentProvider(blinded)
+        .andThen(builder -> builder.syncAggregate(syncAggregate));
   }
 }

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BeaconBlockBodyBellatrixTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BeaconBlockBodyBellatrixTest.java
@@ -70,7 +70,7 @@ class BeaconBlockBodyBellatrixTest extends AbstractBeaconBlockBodyTest<BeaconBlo
   }
 
   @Test
-  public void builderShouldFailIfNotPassingPayload() {
+  public void builderShouldFailIfNotPassingPayloadNorPayloadHeader() {
     final Exception exception =
         assertThrows(
             IllegalStateException.class,
@@ -85,7 +85,7 @@ class BeaconBlockBodyBellatrixTest extends AbstractBeaconBlockBodyTest<BeaconBlo
   }
 
   @Test
-  public void builderShouldFailIfNotPassingPayloadAndPayloadHeader() {
+  public void builderShouldFailIfPassingPayloadAndPayloadHeader() {
     final Exception exception =
         assertThrows(
             IllegalStateException.class,
@@ -94,6 +94,8 @@ class BeaconBlockBodyBellatrixTest extends AbstractBeaconBlockBodyTest<BeaconBlo
                     createContentProvider(true)
                         .andThen(
                             b ->
+                                // payload header is already set because we requested a blinded
+                                // content
                                 b.executionPayload(SafeFuture.completedFuture(executionPayload)))));
     assertEquals(
         exception.getMessage(),

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BeaconBlockBodyBellatrixTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BeaconBlockBodyBellatrixTest.java
@@ -32,11 +32,13 @@ import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodyBui
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.common.AbstractBeaconBlockBodyTest;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregate;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
 
 class BeaconBlockBodyBellatrixTest extends AbstractBeaconBlockBodyTest<BeaconBlockBodyBellatrix> {
 
   protected SyncAggregate syncAggregate;
   protected ExecutionPayload executionPayload;
+  protected ExecutionPayloadHeader executionPayloadHeader;
 
   @BeforeEach
   void setup() {
@@ -45,6 +47,7 @@ class BeaconBlockBodyBellatrixTest extends AbstractBeaconBlockBodyTest<BeaconBlo
         () -> {
           syncAggregate = dataStructureUtil.randomSyncAggregate();
           executionPayload = dataStructureUtil.randomExecutionPayload();
+          executionPayloadHeader = dataStructureUtil.randomExecutionPayloadHeader();
         });
   }
 
@@ -54,6 +57,44 @@ class BeaconBlockBodyBellatrixTest extends AbstractBeaconBlockBodyTest<BeaconBlo
     BeaconBlockBodyBellatrix testBeaconBlockBody = safeJoin(createBlockBody());
 
     assertNotEquals(defaultBlockBody, testBeaconBlockBody);
+  }
+
+  @Test
+  void equalsReturnsFalseWhenExecutionPayloadHeaderIsDifferent() {
+    executionPayloadHeader = dataStructureUtil.randomExecutionPayloadHeader();
+    BlindedBeaconBlockBodyBellatrix testBeaconBlockBody = safeJoin(createBlindedBlockBody());
+
+    assertNotEquals(defaultBlindedBlockBody, testBeaconBlockBody);
+  }
+
+  @Test
+  public void builderShouldFailIfNotPassingPayload() {
+    final Exception exception =
+        assertThrows(
+            IllegalStateException.class,
+            () ->
+                createBlockBody(
+                    createContentProvider(true)
+                        .andThen(b -> b.executionPayload(null).executionPayloadHeader(null))));
+    assertEquals(
+        exception.getMessage(),
+        "only and only one of executionPayload or executionPayloadHeader must be set");
+  }
+
+  @Test
+  public void builderShouldFailIfNotPassingPayloadAndPayloadHeader() {
+    final Exception exception =
+        assertThrows(
+            IllegalStateException.class,
+            () ->
+                createBlockBody(
+                    createContentProvider(true)
+                        .andThen(
+                            b ->
+                                b.executionPayload(SafeFuture.completedFuture(executionPayload)))));
+    assertEquals(
+        exception.getMessage(),
+        "only and only one of executionPayload or executionPayloadHeader must be set");
   }
 
   @Test
@@ -108,18 +149,30 @@ class BeaconBlockBodyBellatrixTest extends AbstractBeaconBlockBodyTest<BeaconBlo
   @Override
   protected SafeFuture<BeaconBlockBodyBellatrix> createBlockBody(
       final Consumer<BeaconBlockBodyBuilder> contentProvider) {
-    return getBlockBodySchema()
-        .createBlockBody(contentProvider)
-        .thenApply(body -> (BeaconBlockBodyBellatrix) body);
+    final BeaconBlockBodyBuilder bodyBuilder = createBeaconBlockBodyBuilder();
+    contentProvider.accept(bodyBuilder);
+    return bodyBuilder.build().thenApply(body -> body.toVersionBellatrix().orElseThrow());
   }
 
   @Override
-  protected Consumer<BeaconBlockBodyBuilder> createContentProvider() {
-    return super.createContentProvider()
+  protected SafeFuture<BlindedBeaconBlockBodyBellatrix> createBlindedBlockBody(
+      Consumer<BeaconBlockBodyBuilder> contentProvider) {
+    final BeaconBlockBodyBuilder bodyBuilder = createBeaconBlockBodyBuilder();
+    contentProvider.accept(bodyBuilder);
+    return bodyBuilder.build().thenApply(body -> body.toBlindedVersionBellatrix().orElseThrow());
+  }
+
+  @Override
+  protected Consumer<BeaconBlockBodyBuilder> createContentProvider(final boolean blinded) {
+    return super.createContentProvider(blinded)
         .andThen(
-            builder ->
-                builder
-                    .syncAggregate(syncAggregate)
-                    .executionPayload(SafeFuture.completedFuture(executionPayload)));
+            builder -> {
+              builder.syncAggregate(syncAggregate);
+              if (blinded) {
+                builder.executionPayloadHeader(SafeFuture.completedFuture(executionPayloadHeader));
+              } else {
+                builder.executionPayload(SafeFuture.completedFuture(executionPayload));
+              }
+            });
   }
 }

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BeaconBlockBodyBellatrixTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BeaconBlockBodyBellatrixTest.java
@@ -63,9 +63,10 @@ class BeaconBlockBodyBellatrixTest extends AbstractBeaconBlockBodyTest<BeaconBlo
   @Test
   void equalsReturnsFalseWhenExecutionPayloadHeaderIsDifferent() {
     executionPayloadHeader = dataStructureUtil.randomExecutionPayloadHeader();
-    BlindedBeaconBlockBodyBellatrix testBeaconBlockBody = safeJoin(createBlindedBlockBody());
+    final BlindedBeaconBlockBodyBellatrix testBlindedBeaconBlockBody =
+        safeJoin(createBlindedBlockBody());
 
-    assertNotEquals(defaultBlindedBlockBody, testBeaconBlockBody);
+    assertNotEquals(defaultBlindedBlockBody, testBlindedBeaconBlockBody);
   }
 
   @Test
@@ -75,11 +76,12 @@ class BeaconBlockBodyBellatrixTest extends AbstractBeaconBlockBodyTest<BeaconBlo
             IllegalStateException.class,
             () ->
                 createBlockBody(
-                    createContentProvider(true)
+                    createContentProvider(false)
+                        // let's erase all payloads, so we can test as if they were not set
                         .andThen(b -> b.executionPayload(null).executionPayloadHeader(null))));
     assertEquals(
         exception.getMessage(),
-        "only and only one of executionPayload or executionPayloadHeader must be set");
+        "Exactly one of 'executionPayload' or 'executionPayloadHeader' must be set");
   }
 
   @Test
@@ -95,12 +97,12 @@ class BeaconBlockBodyBellatrixTest extends AbstractBeaconBlockBodyTest<BeaconBlo
                                 b.executionPayload(SafeFuture.completedFuture(executionPayload)))));
     assertEquals(
         exception.getMessage(),
-        "only and only one of executionPayload or executionPayloadHeader must be set");
+        "Exactly one of 'executionPayload' or 'executionPayloadHeader' must be set");
   }
 
   @Test
   @SuppressWarnings("unchecked")
-  void builderShouldFailWhenOverridingBlindedSchemaWithANullSchema() {
+  void builderShouldFailWhenBlindedSchemaIsSetAndFullPayloadIsSet() {
     BeaconBlockBodyBuilderBellatrix beaconBlockBodyBuilderBellatrix =
         new BeaconBlockBodyBuilderBellatrix(null, blindedBlockBodySchema);
     Exception exception =
@@ -124,7 +126,7 @@ class BeaconBlockBodyBellatrixTest extends AbstractBeaconBlockBodyTest<BeaconBlo
 
   @Test
   @SuppressWarnings("unchecked")
-  void builderShouldFailWhenOverridingSchemaWithANullBlindedSchema() {
+  void builderShouldFailWhenNonBlindedSchemaIsSetAndPayloadHeaderIsSet() {
     BeaconBlockBodyBuilderBellatrix beaconBlockBodyBuilderBellatrix =
         new BeaconBlockBodyBuilderBellatrix(
             (BeaconBlockBodySchema<? extends BeaconBlockBodyBellatrix>) blockBodySchema, null);
@@ -157,7 +159,7 @@ class BeaconBlockBodyBellatrixTest extends AbstractBeaconBlockBodyTest<BeaconBlo
 
   @Override
   protected SafeFuture<BlindedBeaconBlockBodyBellatrix> createBlindedBlockBody(
-      Consumer<BeaconBlockBodyBuilder> contentProvider) {
+      final Consumer<BeaconBlockBodyBuilder> contentProvider) {
     final BeaconBlockBodyBuilder bodyBuilder = createBeaconBlockBodyBuilder();
     contentProvider.accept(bodyBuilder);
     return bodyBuilder.build().thenApply(body -> body.toBlindedVersionBellatrix().orElseThrow());

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BeaconBlockBodyBellatrixTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BeaconBlockBodyBellatrixTest.java
@@ -60,14 +60,13 @@ class BeaconBlockBodyBellatrixTest extends AbstractBeaconBlockBodyTest<BeaconBlo
   @SuppressWarnings("unchecked")
   void builderShouldFailWhenOverridingBlindedSchemaWithANullSchema() {
     BeaconBlockBodyBuilderBellatrix beaconBlockBodyBuilderBellatrix =
-        new BeaconBlockBodyBuilderBellatrix();
+        new BeaconBlockBodyBuilderBellatrix(
+            null, mock(BlindedBeaconBlockBodySchemaBellatrixImpl.class));
     Exception exception =
         assertThrows(
             IllegalStateException.class,
             () ->
                 beaconBlockBodyBuilderBellatrix
-                    .blindedSchema(mock(BlindedBeaconBlockBodySchemaBellatrixImpl.class))
-                    .schema((BeaconBlockBodySchemaBellatrixImpl) null)
                     .randaoReveal(mock(BLSSignature.class))
                     .eth1Data(mock(Eth1Data.class))
                     .graffiti(mock(Bytes32.class))
@@ -77,21 +76,21 @@ class BeaconBlockBodyBellatrixTest extends AbstractBeaconBlockBodyTest<BeaconBlo
                     .deposits(mock(SszList.class))
                     .voluntaryExits(mock(SszList.class))
                     .build());
-    assertEquals(exception.getMessage(), "schema must be set with no blindedSchema");
+    assertEquals(
+        exception.getMessage(),
+        "executionPayload or executionPayloadHeader must be set before interacting with the builder");
   }
 
   @Test
   @SuppressWarnings("unchecked")
   void builderShouldFailWhenOverridingSchemaWithANullBlindedSchema() {
     BeaconBlockBodyBuilderBellatrix beaconBlockBodyBuilderBellatrix =
-        new BeaconBlockBodyBuilderBellatrix();
+        new BeaconBlockBodyBuilderBellatrix(mock(BeaconBlockBodySchemaBellatrixImpl.class), null);
     Exception exception =
         assertThrows(
             IllegalStateException.class,
             () ->
                 beaconBlockBodyBuilderBellatrix
-                    .schema(mock(BeaconBlockBodySchemaBellatrixImpl.class))
-                    .blindedSchema(null)
                     .randaoReveal(mock(BLSSignature.class))
                     .eth1Data(mock(Eth1Data.class))
                     .graffiti(mock(Bytes32.class))
@@ -101,7 +100,9 @@ class BeaconBlockBodyBellatrixTest extends AbstractBeaconBlockBodyTest<BeaconBlo
                     .deposits(mock(SszList.class))
                     .voluntaryExits(mock(SszList.class))
                     .build());
-    assertEquals(exception.getMessage(), "blindedSchema must be set with no schema");
+    assertEquals(
+        exception.getMessage(),
+        "executionPayload or executionPayloadHeader must be set before interacting with the builder");
   }
 
   @Override

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BeaconBlockBodyBellatrixTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BeaconBlockBodyBellatrixTest.java
@@ -29,6 +29,7 @@ import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.blocks.Eth1Data;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodyBuilder;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodySchema;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.common.AbstractBeaconBlockBodyTest;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregate;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
@@ -101,8 +102,7 @@ class BeaconBlockBodyBellatrixTest extends AbstractBeaconBlockBodyTest<BeaconBlo
   @SuppressWarnings("unchecked")
   void builderShouldFailWhenOverridingBlindedSchemaWithANullSchema() {
     BeaconBlockBodyBuilderBellatrix beaconBlockBodyBuilderBellatrix =
-        new BeaconBlockBodyBuilderBellatrix(
-            null, mock(BlindedBeaconBlockBodySchemaBellatrixImpl.class));
+        new BeaconBlockBodyBuilderBellatrix(null, blindedBlockBodySchema);
     Exception exception =
         assertThrows(
             NullPointerException.class,
@@ -117,16 +117,17 @@ class BeaconBlockBodyBellatrixTest extends AbstractBeaconBlockBodyTest<BeaconBlo
                     .deposits(mock(SszList.class))
                     .voluntaryExits(mock(SszList.class))
                     .executionPayload(mock(SafeFuture.class))
+                    .syncAggregate(mock(SyncAggregate.class))
                     .build());
-    assertEquals(
-        exception.getMessage(), "schema must be set when non blinded body has been requested");
+    assertEquals(exception.getMessage(), "Schema must be specified");
   }
 
   @Test
   @SuppressWarnings("unchecked")
   void builderShouldFailWhenOverridingSchemaWithANullBlindedSchema() {
     BeaconBlockBodyBuilderBellatrix beaconBlockBodyBuilderBellatrix =
-        new BeaconBlockBodyBuilderBellatrix(mock(BeaconBlockBodySchemaBellatrixImpl.class), null);
+        new BeaconBlockBodyBuilderBellatrix(
+            (BeaconBlockBodySchema<? extends BeaconBlockBodyBellatrix>) blockBodySchema, null);
     Exception exception =
         assertThrows(
             NullPointerException.class,
@@ -141,9 +142,9 @@ class BeaconBlockBodyBellatrixTest extends AbstractBeaconBlockBodyTest<BeaconBlo
                     .deposits(mock(SszList.class))
                     .voluntaryExits(mock(SszList.class))
                     .executionPayloadHeader(mock(SafeFuture.class))
+                    .syncAggregate(mock(SyncAggregate.class))
                     .build());
-    assertEquals(
-        exception.getMessage(), "blindedSchema must be set when blinded body has been requested");
+    assertEquals(exception.getMessage(), "Blinded schema must be specified");
   }
 
   @Override

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BeaconBlockBodyBellatrixTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BeaconBlockBodyBellatrixTest.java
@@ -105,7 +105,7 @@ class BeaconBlockBodyBellatrixTest extends AbstractBeaconBlockBodyTest<BeaconBlo
             null, mock(BlindedBeaconBlockBodySchemaBellatrixImpl.class));
     Exception exception =
         assertThrows(
-            IllegalStateException.class,
+            NullPointerException.class,
             () ->
                 beaconBlockBodyBuilderBellatrix
                     .randaoReveal(mock(BLSSignature.class))
@@ -116,10 +116,10 @@ class BeaconBlockBodyBellatrixTest extends AbstractBeaconBlockBodyTest<BeaconBlo
                     .attesterSlashings(mock(SszList.class))
                     .deposits(mock(SszList.class))
                     .voluntaryExits(mock(SszList.class))
+                    .executionPayload(mock(SafeFuture.class))
                     .build());
     assertEquals(
-        exception.getMessage(),
-        "executionPayload or executionPayloadHeader must be set before interacting with the builder");
+        exception.getMessage(), "schema must be set when non blinded body has been requested");
   }
 
   @Test
@@ -129,7 +129,7 @@ class BeaconBlockBodyBellatrixTest extends AbstractBeaconBlockBodyTest<BeaconBlo
         new BeaconBlockBodyBuilderBellatrix(mock(BeaconBlockBodySchemaBellatrixImpl.class), null);
     Exception exception =
         assertThrows(
-            IllegalStateException.class,
+            NullPointerException.class,
             () ->
                 beaconBlockBodyBuilderBellatrix
                     .randaoReveal(mock(BLSSignature.class))
@@ -140,10 +140,10 @@ class BeaconBlockBodyBellatrixTest extends AbstractBeaconBlockBodyTest<BeaconBlo
                     .attesterSlashings(mock(SszList.class))
                     .deposits(mock(SszList.class))
                     .voluntaryExits(mock(SszList.class))
+                    .executionPayloadHeader(mock(SafeFuture.class))
                     .build());
     assertEquals(
-        exception.getMessage(),
-        "executionPayload or executionPayloadHeader must be set before interacting with the builder");
+        exception.getMessage(), "blindedSchema must be set when blinded body has been requested");
   }
 
   @Override

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/capella/BeaconBlockBodyCapellaTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/capella/BeaconBlockBodyCapellaTest.java
@@ -13,21 +13,15 @@
 
 package tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.capella;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.mock;
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 
 import java.util.function.Consumer;
-import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.datastructures.blocks.Eth1Data;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodyBuilder;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.common.AbstractBeaconBlockBodyTest;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.BeaconBlockBodyAltair;
@@ -62,55 +56,6 @@ class BeaconBlockBodyCapellaTest extends AbstractBeaconBlockBodyTest<BeaconBlock
     BeaconBlockBodyAltair testBeaconBlockBody = safeJoin(createBlockBody());
 
     assertNotEquals(defaultBlockBody, testBeaconBlockBody);
-  }
-
-  @Test
-  @SuppressWarnings("unchecked")
-  void builderShouldFailWhenOverridingBlindedSchemaWithANullSchema() {
-    BeaconBlockBodyBuilderCapella beaconBlockBodyBuilderCapella =
-        new BeaconBlockBodyBuilderCapella(
-            null, mock(BlindedBeaconBlockBodySchemaCapellaImpl.class));
-    Exception exception =
-        assertThrows(
-            IllegalStateException.class,
-            () ->
-                beaconBlockBodyBuilderCapella
-                    .randaoReveal(mock(BLSSignature.class))
-                    .eth1Data(mock(Eth1Data.class))
-                    .graffiti(mock(Bytes32.class))
-                    .attestations(mock(SszList.class))
-                    .proposerSlashings(mock(SszList.class))
-                    .attesterSlashings(mock(SszList.class))
-                    .deposits(mock(SszList.class))
-                    .voluntaryExits(mock(SszList.class))
-                    .build());
-    assertEquals(
-        exception.getMessage(),
-        "executionPayload or executionPayloadHeader must be set before interacting with the builder");
-  }
-
-  @Test
-  @SuppressWarnings("unchecked")
-  void builderShouldFailWhenOverridingSchemaWithANullBlindedSchema() {
-    BeaconBlockBodyBuilderCapella beaconBlockBodyBuilderCapella =
-        new BeaconBlockBodyBuilderCapella(mock(BeaconBlockBodySchemaCapellaImpl.class), null);
-    Exception exception =
-        assertThrows(
-            IllegalStateException.class,
-            () ->
-                beaconBlockBodyBuilderCapella
-                    .randaoReveal(mock(BLSSignature.class))
-                    .eth1Data(mock(Eth1Data.class))
-                    .graffiti(mock(Bytes32.class))
-                    .attestations(mock(SszList.class))
-                    .proposerSlashings(mock(SszList.class))
-                    .attesterSlashings(mock(SszList.class))
-                    .deposits(mock(SszList.class))
-                    .voluntaryExits(mock(SszList.class))
-                    .build());
-    assertEquals(
-        exception.getMessage(),
-        "executionPayload or executionPayloadHeader must be set before interacting with the builder");
   }
 
   @Override

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/capella/BeaconBlockBodyCapellaTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/capella/BeaconBlockBodyCapellaTest.java
@@ -64,14 +64,13 @@ class BeaconBlockBodyCapellaTest extends AbstractBeaconBlockBodyTest<BeaconBlock
   @SuppressWarnings("unchecked")
   void builderShouldFailWhenOverridingBlindedSchemaWithANullSchema() {
     BeaconBlockBodyBuilderCapella beaconBlockBodyBuilderCapella =
-        new BeaconBlockBodyBuilderCapella();
+        new BeaconBlockBodyBuilderCapella(
+            null, mock(BlindedBeaconBlockBodySchemaCapellaImpl.class));
     Exception exception =
         assertThrows(
             IllegalStateException.class,
             () ->
                 beaconBlockBodyBuilderCapella
-                    .blindedSchema(mock(BlindedBeaconBlockBodySchemaCapellaImpl.class))
-                    .schema((BeaconBlockBodySchemaCapellaImpl) null)
                     .randaoReveal(mock(BLSSignature.class))
                     .eth1Data(mock(Eth1Data.class))
                     .graffiti(mock(Bytes32.class))
@@ -81,21 +80,21 @@ class BeaconBlockBodyCapellaTest extends AbstractBeaconBlockBodyTest<BeaconBlock
                     .deposits(mock(SszList.class))
                     .voluntaryExits(mock(SszList.class))
                     .build());
-    assertEquals(exception.getMessage(), "schema must be set with no blindedSchema");
+    assertEquals(
+        exception.getMessage(),
+        "executionPayload or executionPayloadHeader must be set before interacting with the builder");
   }
 
   @Test
   @SuppressWarnings("unchecked")
   void builderShouldFailWhenOverridingSchemaWithANullBlindedSchema() {
     BeaconBlockBodyBuilderCapella beaconBlockBodyBuilderCapella =
-        new BeaconBlockBodyBuilderCapella();
+        new BeaconBlockBodyBuilderCapella(mock(BeaconBlockBodySchemaCapellaImpl.class), null);
     Exception exception =
         assertThrows(
             IllegalStateException.class,
             () ->
                 beaconBlockBodyBuilderCapella
-                    .schema(mock(BeaconBlockBodySchemaCapellaImpl.class))
-                    .blindedSchema((BlindedBeaconBlockBodySchemaCapellaImpl) null)
                     .randaoReveal(mock(BLSSignature.class))
                     .eth1Data(mock(Eth1Data.class))
                     .graffiti(mock(Bytes32.class))
@@ -105,7 +104,9 @@ class BeaconBlockBodyCapellaTest extends AbstractBeaconBlockBodyTest<BeaconBlock
                     .deposits(mock(SszList.class))
                     .voluntaryExits(mock(SszList.class))
                     .build());
-    assertEquals(exception.getMessage(), "blindedSchema must be set with no schema");
+    assertEquals(
+        exception.getMessage(),
+        "executionPayload or executionPayloadHeader must be set before interacting with the builder");
   }
 
   @Override

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/deneb/BeaconBlockBodyDenebTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/deneb/BeaconBlockBodyDenebTest.java
@@ -66,14 +66,13 @@ class BeaconBlockBodyDenebTest extends AbstractBeaconBlockBodyTest<BeaconBlockBo
   @Test
   @SuppressWarnings("unchecked")
   void builderShouldFailWhenOverridingBlindedSchemaWithANullSchema() {
-    BeaconBlockBodyBuilderDeneb beaconBlockBodyBuilderDeneb = new BeaconBlockBodyBuilderDeneb();
+    BeaconBlockBodyBuilderDeneb beaconBlockBodyBuilderDeneb =
+        new BeaconBlockBodyBuilderDeneb(null, mock(BlindedBeaconBlockBodySchemaDenebImpl.class));
     Exception exception =
         assertThrows(
             IllegalStateException.class,
             () ->
                 beaconBlockBodyBuilderDeneb
-                    .blindedSchema(mock(BlindedBeaconBlockBodySchemaDenebImpl.class))
-                    .schema((BeaconBlockBodySchemaDenebImpl) null)
                     .randaoReveal(mock(BLSSignature.class))
                     .eth1Data(mock(Eth1Data.class))
                     .graffiti(mock(Bytes32.class))
@@ -83,20 +82,21 @@ class BeaconBlockBodyDenebTest extends AbstractBeaconBlockBodyTest<BeaconBlockBo
                     .deposits(mock(SszList.class))
                     .voluntaryExits(mock(SszList.class))
                     .build());
-    assertEquals(exception.getMessage(), "schema must be set with no blindedSchema");
+    assertEquals(
+        exception.getMessage(),
+        "executionPayload or executionPayloadHeader must be set before interacting with the builder");
   }
 
   @Test
   @SuppressWarnings("unchecked")
   void builderShouldFailWhenOverridingSchemaWithANullBlindedSchema() {
-    BeaconBlockBodyBuilderDeneb beaconBlockBodyBuilderDeneb = new BeaconBlockBodyBuilderDeneb();
+    BeaconBlockBodyBuilderDeneb beaconBlockBodyBuilderDeneb =
+        new BeaconBlockBodyBuilderDeneb(mock(BeaconBlockBodySchemaDenebImpl.class), null);
     Exception exception =
         assertThrows(
             IllegalStateException.class,
             () ->
                 beaconBlockBodyBuilderDeneb
-                    .schema(mock(BeaconBlockBodySchemaDenebImpl.class))
-                    .blindedSchema((BlindedBeaconBlockBodySchemaDenebImpl) null)
                     .randaoReveal(mock(BLSSignature.class))
                     .eth1Data(mock(Eth1Data.class))
                     .graffiti(mock(Bytes32.class))
@@ -106,7 +106,9 @@ class BeaconBlockBodyDenebTest extends AbstractBeaconBlockBodyTest<BeaconBlockBo
                     .deposits(mock(SszList.class))
                     .voluntaryExits(mock(SszList.class))
                     .build());
-    assertEquals(exception.getMessage(), "blindedSchema must be set with no schema");
+    assertEquals(
+        exception.getMessage(),
+        "executionPayload or executionPayloadHeader must be set before interacting with the builder");
   }
 
   @Override

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/deneb/BeaconBlockBodyDenebTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/deneb/BeaconBlockBodyDenebTest.java
@@ -13,21 +13,15 @@
 
 package tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.deneb;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.mock;
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 
 import java.util.function.Consumer;
-import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.datastructures.blocks.Eth1Data;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodyBuilder;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.common.AbstractBeaconBlockBodyTest;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.BeaconBlockBodyAltair;
@@ -65,54 +59,6 @@ class BeaconBlockBodyDenebTest extends AbstractBeaconBlockBodyTest<BeaconBlockBo
     BeaconBlockBodyAltair testBeaconBlockBody = safeJoin(createBlockBody());
 
     assertNotEquals(defaultBlockBody, testBeaconBlockBody);
-  }
-
-  @Test
-  @SuppressWarnings("unchecked")
-  void builderShouldFailWhenOverridingBlindedSchemaWithANullSchema() {
-    BeaconBlockBodyBuilderDeneb beaconBlockBodyBuilderDeneb =
-        new BeaconBlockBodyBuilderDeneb(null, mock(BlindedBeaconBlockBodySchemaDenebImpl.class));
-    Exception exception =
-        assertThrows(
-            IllegalStateException.class,
-            () ->
-                beaconBlockBodyBuilderDeneb
-                    .randaoReveal(mock(BLSSignature.class))
-                    .eth1Data(mock(Eth1Data.class))
-                    .graffiti(mock(Bytes32.class))
-                    .attestations(mock(SszList.class))
-                    .proposerSlashings(mock(SszList.class))
-                    .attesterSlashings(mock(SszList.class))
-                    .deposits(mock(SszList.class))
-                    .voluntaryExits(mock(SszList.class))
-                    .build());
-    assertEquals(
-        exception.getMessage(),
-        "executionPayload or executionPayloadHeader must be set before interacting with the builder");
-  }
-
-  @Test
-  @SuppressWarnings("unchecked")
-  void builderShouldFailWhenOverridingSchemaWithANullBlindedSchema() {
-    BeaconBlockBodyBuilderDeneb beaconBlockBodyBuilderDeneb =
-        new BeaconBlockBodyBuilderDeneb(mock(BeaconBlockBodySchemaDenebImpl.class), null);
-    Exception exception =
-        assertThrows(
-            IllegalStateException.class,
-            () ->
-                beaconBlockBodyBuilderDeneb
-                    .randaoReveal(mock(BLSSignature.class))
-                    .eth1Data(mock(Eth1Data.class))
-                    .graffiti(mock(Bytes32.class))
-                    .attestations(mock(SszList.class))
-                    .proposerSlashings(mock(SszList.class))
-                    .attesterSlashings(mock(SszList.class))
-                    .deposits(mock(SszList.class))
-                    .voluntaryExits(mock(SszList.class))
-                    .build());
-    assertEquals(
-        exception.getMessage(),
-        "executionPayload or executionPayloadHeader must be set before interacting with the builder");
   }
 
   @Override

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/phase0/BeaconBlockBodyPhase0Test.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/phase0/BeaconBlockBodyPhase0Test.java
@@ -19,6 +19,7 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodyBuilder;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.common.AbstractBeaconBlockBodyTest;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.bellatrix.BlindedBeaconBlockBodyBellatrix;
 
 public class BeaconBlockBodyPhase0Test extends AbstractBeaconBlockBodyTest<BeaconBlockBodyPhase0> {
 
@@ -30,8 +31,14 @@ public class BeaconBlockBodyPhase0Test extends AbstractBeaconBlockBodyTest<Beaco
   @Override
   protected SafeFuture<BeaconBlockBodyPhase0> createBlockBody(
       final Consumer<BeaconBlockBodyBuilder> contentProvider) {
-    return getBlockBodySchema()
-        .createBlockBody(contentProvider)
-        .thenApply(block -> (BeaconBlockBodyPhase0) block);
+    final BeaconBlockBodyBuilder bodyBuilder = createBeaconBlockBodyBuilder();
+    contentProvider.accept(bodyBuilder);
+    return bodyBuilder.build().thenApply(body -> (BeaconBlockBodyPhase0) body);
+  }
+
+  @Override
+  protected SafeFuture<BlindedBeaconBlockBodyBellatrix> createBlindedBlockBody(
+      Consumer<BeaconBlockBodyBuilder> contentProvider) {
+    return SafeFuture.completedFuture(null);
   }
 }

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/BlockProposalTestUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/BlockProposalTestUtil.java
@@ -133,7 +133,6 @@ public class BlockProposalTestUtil {
                         kzgCommitments.orElseGet(dataStructureUtil::emptyBlobKzgCommitments)));
               }
             },
-            Optional.of(false),
             BlockProductionPerformance.NOOP)
         .thenApply(
             newBlockAndState -> {


### PR DESCRIPTION
With this PR `BeaconBlockBodyBuilder` doesn't need to be set for blinded or unblinded flow in advance. It is created with both schemas and behaviour changes based on the payload is provided. In `build()` If header has been provided, it will go for blinded block body. If full payload has been provided, unblinded block is created. So it won't expose `isBlinded` method any more.

The blinded-unblinded `BeaconBlock` will be chosen based on the "blindess" of the `BeaconBlockBody`

This PR do not change the fact that we currently return blinded by default. It only moves where the decision is made so that we will be dynamically choose based on the flow on a following up PR. 

fixes #7835

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
