### PR TITLE
7707 validator slashing protection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,6 @@ the [releases page](https://github.com/Consensys/teku/releases).
 - Added Deneb (aka Dencun) configuration for Chiado network for epoch 516608 (2024-01-31 18:15:40 UTC).
 - Added Deneb (aka Dencun) configuration for Holesky network for epoch 29696 (2024-02-07 11:34:24 UTC).
 - Generate key at `—p2p-private-key-file` path if specified file doesn't exist.
-- Added `--stop-vc-when-validator-slashed` option to stop the VC when a validator is slashed
+- Added `--stop-vc-when-validator-slashed-enabled` option to stop the VC when a validator is slashed
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,5 +24,6 @@ the [releases page](https://github.com/Consensys/teku/releases).
 - Added Deneb (aka Dencun) configuration for Chiado network for epoch 516608 (2024-01-31 18:15:40 UTC).
 - Added Deneb (aka Dencun) configuration for Holesky network for epoch 29696 (2024-02-07 11:34:24 UTC).
 - Generate key at `—p2p-private-key-file` path if specified file doesn't exist.
+- Added `--stop-vc-when-validator-slashed` option to stop the VC when a validator is slashed
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,6 @@ the [releases page](https://github.com/Consensys/teku/releases).
 - Added Deneb (aka Dencun) configuration for Chiado network for epoch 516608 (2024-01-31 18:15:40 UTC).
 - Added Deneb (aka Dencun) configuration for Holesky network for epoch 29696 (2024-02-07 11:34:24 UTC).
 - Generate key at `—p2p-private-key-file` path if specified file doesn't exist.
-- Added `--stop-vc-when-validator-slashed-enabled` option to stop the VC when a validator is slashed
+- Added `--shutdown-when-validator-slashed-enabled` option to shut down Teku client when a validator is slashed
 
 ### Bug Fixes

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/AttesterSlashingEvent.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/AttesterSlashingEvent.java
@@ -16,7 +16,7 @@ package tech.pegasys.teku.beaconrestapi.handlers.v1.events;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 
 public class AttesterSlashingEvent extends Event<AttesterSlashing> {
-  AttesterSlashingEvent(AttesterSlashing attesterSlashing) {
+  AttesterSlashingEvent(final AttesterSlashing attesterSlashing) {
     super(attesterSlashing.getSchema().getJsonTypeDefinition(), attesterSlashing);
   }
 }

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/ProposerSlashingEvent.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/ProposerSlashingEvent.java
@@ -16,7 +16,7 @@ package tech.pegasys.teku.beaconrestapi.handlers.v1.events;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 
 public class ProposerSlashingEvent extends Event<ProposerSlashing> {
-  ProposerSlashingEvent(ProposerSlashing proposerSlashing) {
+  ProposerSlashingEvent(final ProposerSlashing proposerSlashing) {
     super(proposerSlashing.getSchema().getJsonTypeDefinition(), proposerSlashing);
   }
 }

--- a/data/provider/src/main/java/tech/pegasys/teku/api/NodeDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/NodeDataProvider.java
@@ -168,37 +168,40 @@ public class NodeDataProvider {
             });
   }
 
-  public void subscribeToReceivedBlocks(ImportedBlockListener listener) {
+  public void subscribeToReceivedBlocks(final ImportedBlockListener listener) {
     blockManager.subscribeToReceivedBlocks(listener);
   }
 
-  public void subscribeToReceivedBlobSidecar(NewBlobSidecarSubscriber listener) {
+  public void subscribeToReceivedBlobSidecar(final NewBlobSidecarSubscriber listener) {
     blockBlobSidecarsTrackersPool.subscribeNewBlobSidecar(listener);
   }
 
-  public void subscribeToAttesterSlashing(OperationAddedSubscriber<AttesterSlashing> listener) {
+  public void subscribeToAttesterSlashing(
+      final OperationAddedSubscriber<AttesterSlashing> listener) {
     attesterSlashingPool.subscribeOperationAdded(listener);
   }
 
-  public void subscribeToProposerSlashing(OperationAddedSubscriber<ProposerSlashing> listener) {
+  public void subscribeToProposerSlashing(
+      final OperationAddedSubscriber<ProposerSlashing> listener) {
     proposerSlashingPool.subscribeOperationAdded(listener);
   }
 
-  public void subscribeToValidAttestations(ProcessedAttestationListener listener) {
+  public void subscribeToValidAttestations(final ProcessedAttestationListener listener) {
     attestationManager.subscribeToAllValidAttestations(listener);
   }
 
-  public void subscribeToNewVoluntaryExits(OperationAddedSubscriber<SignedVoluntaryExit> listener) {
+  public void subscribeToNewVoluntaryExits(
+      final OperationAddedSubscriber<SignedVoluntaryExit> listener) {
     voluntaryExitPool.subscribeOperationAdded(listener);
   }
 
   public void subscribeToNewBlsToExecutionChanges(
-      OperationAddedSubscriber<SignedBlsToExecutionChange> listener) {
+      final OperationAddedSubscriber<SignedBlsToExecutionChange> listener) {
     blsToExecutionChangePool.subscribeOperationAdded(listener);
   }
 
   public void subscribeToSyncCommitteeContributions(
-      OperationAddedSubscriber<SignedContributionAndProof> listener) {
+      final OperationAddedSubscriber<SignedContributionAndProof> listener) {
     syncCommitteeContributionPool.subscribeOperationAdded(listener);
   }
 

--- a/data/provider/src/main/java/tech/pegasys/teku/api/NodeDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/NodeDataProvider.java
@@ -168,7 +168,7 @@ public class NodeDataProvider {
             });
   }
 
-  public void subscribeToReceivedBlocks(final ImportedBlockListener listener) {
+  public void subscribeToReceivedBlocks(ImportedBlockListener listener) {
     blockManager.subscribeToReceivedBlocks(listener);
   }
 

--- a/data/provider/src/main/java/tech/pegasys/teku/api/NodeDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/NodeDataProvider.java
@@ -172,7 +172,7 @@ public class NodeDataProvider {
     blockManager.subscribeToReceivedBlocks(listener);
   }
 
-  public void subscribeToReceivedBlobSidecar(final NewBlobSidecarSubscriber listener) {
+  public void subscribeToReceivedBlobSidecar(NewBlobSidecarSubscriber listener) {
     blockBlobSidecarsTrackersPool.subscribeNewBlobSidecar(listener);
   }
 
@@ -186,22 +186,21 @@ public class NodeDataProvider {
     proposerSlashingPool.subscribeOperationAdded(listener);
   }
 
-  public void subscribeToValidAttestations(final ProcessedAttestationListener listener) {
+  public void subscribeToValidAttestations(ProcessedAttestationListener listener) {
     attestationManager.subscribeToAllValidAttestations(listener);
   }
 
-  public void subscribeToNewVoluntaryExits(
-      final OperationAddedSubscriber<SignedVoluntaryExit> listener) {
+  public void subscribeToNewVoluntaryExits(OperationAddedSubscriber<SignedVoluntaryExit> listener) {
     voluntaryExitPool.subscribeOperationAdded(listener);
   }
 
   public void subscribeToNewBlsToExecutionChanges(
-      final OperationAddedSubscriber<SignedBlsToExecutionChange> listener) {
+      OperationAddedSubscriber<SignedBlsToExecutionChange> listener) {
     blsToExecutionChangePool.subscribeOperationAdded(listener);
   }
 
   public void subscribeToSyncCommitteeContributions(
-      final OperationAddedSubscriber<SignedContributionAndProof> listener) {
+      OperationAddedSubscriber<SignedContributionAndProof> listener) {
     syncCommitteeContributionPool.subscribeOperationAdded(listener);
   }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeContributionPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeContributionPool.java
@@ -51,7 +51,7 @@ public class SyncCommitteeContributionPool implements SlotEventsChannel {
   }
 
   public void subscribeOperationAdded(
-      final OperationAddedSubscriber<SignedContributionAndProof> subscriber) {
+      OperationAddedSubscriber<SignedContributionAndProof> subscriber) {
     subscribers.subscribe(subscriber);
   }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeContributionPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/synccommittee/SyncCommitteeContributionPool.java
@@ -51,7 +51,7 @@ public class SyncCommitteeContributionPool implements SlotEventsChannel {
   }
 
   public void subscribeOperationAdded(
-      OperationAddedSubscriber<SignedContributionAndProof> subscriber) {
+      final OperationAddedSubscriber<SignedContributionAndProof> subscriber) {
     subscribers.subscribe(subscriber);
   }
 

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
@@ -249,7 +249,6 @@ public class StatusLogger {
   public void validatorSlashedAlert(final Set<String> slashedValidatorPublicKeys) {
     log.fatal(
         "Validator(s) with public key(s) {} got slashed",
-        slashedValidatorPublicKeys.size(),
         String.join(", ", slashedValidatorPublicKeys));
   }
 

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
@@ -248,7 +248,7 @@ public class StatusLogger {
 
   public void validatorSlashedAlert(final Set<String> slashedValidatorPublicKeys) {
     log.fatal(
-        "Validator(s) with public key(s) {} got slashed",
+        "Validator(s) with public key(s) {} got slashed. Shutting down validator client...",
         String.join(", ", slashedValidatorPublicKeys));
   }
 

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
@@ -248,7 +248,7 @@ public class StatusLogger {
 
   public void validatorSlashedAlert(final Set<String> slashedValidatorPublicKeys) {
     log.fatal(
-        "Validator(s) with public key(s) {} got slashed. Shutting down validator client...",
+        "Validator(s) with public key(s) {} got slashed. Shutting down...",
         String.join(", ", slashedValidatorPublicKeys));
   }
 

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
@@ -246,6 +246,13 @@ public class StatusLogger {
         "No loaded validators when --exit-when-no-validator-keys-enabled option is true. Shutting down...");
   }
 
+  public void validatorSlashedAlert(final Set<String> slashedValidatorPublicKeys) {
+    log.fatal(
+        "Validator(s) with public key(s) {} got slashed",
+        slashedValidatorPublicKeys.size(),
+        String.join(", ", slashedValidatorPublicKeys));
+  }
+
   public void beginInitializingChainData() {
     log.info("Initializing storage");
   }

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -180,6 +180,7 @@ import tech.pegasys.teku.storage.store.StoreConfig;
 import tech.pegasys.teku.validator.api.InteropConfig;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 import tech.pegasys.teku.validator.api.ValidatorPerformanceTrackingMode;
+import tech.pegasys.teku.validator.api.ValidatorTimingChannel;
 import tech.pegasys.teku.validator.coordinator.ActiveValidatorTracker;
 import tech.pegasys.teku.validator.coordinator.BlockFactory;
 import tech.pegasys.teku.validator.coordinator.BlockOperationSelectorFactory;
@@ -642,6 +643,11 @@ public class BeaconChainController extends Service implements BeaconChainControl
                 .reversed());
     blockImporter.subscribeToVerifiedBlockAttesterSlashings(attesterSlashingPool::removeAll);
     attesterSlashingPool.subscribeOperationAdded(forkChoice::onAttesterSlashing);
+    final ValidatorTimingChannel validatorTimingChannel =
+        eventChannels.getPublisher(ValidatorTimingChannel.class);
+    attesterSlashingPool.subscribeOperationAdded(
+        (operation, validationStatus, fromNetwork) ->
+            validatorTimingChannel.onAttesterSlashing(operation));
   }
 
   protected void initProposerSlashingPool() {
@@ -654,6 +660,11 @@ public class BeaconChainController extends Service implements BeaconChainControl
             beaconBlockSchemaSupplier.andThen(BeaconBlockBodySchema::getProposerSlashingsSchema),
             validator);
     blockImporter.subscribeToVerifiedBlockProposerSlashings(proposerSlashingPool::removeAll);
+    final ValidatorTimingChannel validatorTimingChannel =
+        eventChannels.getPublisher(ValidatorTimingChannel.class);
+    proposerSlashingPool.subscribeOperationAdded(
+        (operation, validationStatus, fromNetwork) ->
+            validatorTimingChannel.onProposerSlashing(operation));
   }
 
   protected void initVoluntaryExitPool() {

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
@@ -15,8 +15,8 @@ package tech.pegasys.teku.cli.options;
 
 import static tech.pegasys.teku.networks.Eth2NetworkConfiguration.DEFAULT_VALIDATOR_EXECUTOR_THREADS;
 import static tech.pegasys.teku.validator.api.ValidatorConfig.DEFAULT_DOPPELGANGER_DETECTION_ENABLED;
+import static tech.pegasys.teku.validator.api.ValidatorConfig.DEFAULT_STOP_VC_WHEN_VALIDATOR_SLASHED_ENABLED;
 import static tech.pegasys.teku.validator.api.ValidatorConfig.DEFAULT_VALIDATOR_IS_LOCAL_SLASHING_PROTECTION_SYNCHRONIZED_ENABLED;
-import static tech.pegasys.teku.validator.api.ValidatorConfig.DEFAULT_VALIDATOR_SLASHING_PROTECTION_ENABLED;
 
 import java.nio.file.Path;
 import java.util.Optional;
@@ -154,15 +154,14 @@ public class ValidatorOptions {
       DEFAULT_VALIDATOR_IS_LOCAL_SLASHING_PROTECTION_SYNCHRONIZED_ENABLED;
 
   @Option(
-      names = {"--validator-slashing-protection-enabled"},
+      names = {"--stop-vc-when-validator-slashed-enabled"},
       paramLabel = "<BOOLEAN>",
       description =
           "If an owned validator key is detected as slashed, the validator-client should terminate. In this case, the service should not be restarted",
       showDefaultValue = CommandLine.Help.Visibility.ALWAYS,
       arity = "0..1",
       fallbackValue = "true")
-  private boolean validatorSlashingProtectionEnabled =
-      DEFAULT_VALIDATOR_SLASHING_PROTECTION_ENABLED;
+  private boolean stopVcWhenValidatorSlashed = DEFAULT_STOP_VC_WHEN_VALIDATOR_SLASHED_ENABLED;
 
   public void configure(TekuConfiguration.Builder builder) {
     builder.validator(
@@ -183,7 +182,7 @@ public class ValidatorOptions {
                 .executorThreads(executorThreads)
                 .blockV3enabled(blockV3Enabled)
                 .exitWhenNoValidatorKeysEnabled(exitWhenNoValidatorKeysEnabled)
-                .validatorSlashingProtectionEnabled(validatorSlashingProtectionEnabled));
+                .stopVcWhenValidatorSlashedEnabled(stopVcWhenValidatorSlashed));
     validatorProposerOptions.configure(builder);
     validatorKeysOptions.configure(builder);
   }

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
@@ -157,7 +157,7 @@ public class ValidatorOptions {
       names = {"--stop-vc-when-validator-slashed-enabled"},
       paramLabel = "<BOOLEAN>",
       description =
-          "If an owned validator key is detected as slashed, the validator-client should terminate. In this case, the service should not be restarted",
+          "If an owned validator key is detected as slashed, the validator-client should terminate. In this case, the service should not be restarted.",
       showDefaultValue = CommandLine.Help.Visibility.ALWAYS,
       arity = "0..1",
       fallbackValue = "true")

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
@@ -157,7 +157,7 @@ public class ValidatorOptions {
       names = {"--stop-vc-when-validator-slashed-enabled"},
       paramLabel = "<BOOLEAN>",
       description =
-          "If an owned validator key is detected as slashed, the validator-client should terminate. In this case, the service should not be restarted.",
+          "If an owned validator key is detected as slashed, the validator-client or the teku node (if running the beacon-node and the validator-client in a single process) should terminate with exit code 2. In this case, the service should not be restarted.",
       showDefaultValue = CommandLine.Help.Visibility.ALWAYS,
       arity = "0..1",
       fallbackValue = "true")

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
@@ -15,8 +15,8 @@ package tech.pegasys.teku.cli.options;
 
 import static tech.pegasys.teku.networks.Eth2NetworkConfiguration.DEFAULT_VALIDATOR_EXECUTOR_THREADS;
 import static tech.pegasys.teku.validator.api.ValidatorConfig.DEFAULT_DOPPELGANGER_DETECTION_ENABLED;
-import static tech.pegasys.teku.validator.api.ValidatorConfig.DEFAULT_STOP_VC_WHEN_VALIDATOR_SLASHED_ENABLED;
 import static tech.pegasys.teku.validator.api.ValidatorConfig.DEFAULT_VALIDATOR_IS_LOCAL_SLASHING_PROTECTION_SYNCHRONIZED_ENABLED;
+import static tech.pegasys.teku.validator.api.ValidatorConfig.DEFAULT_VALIDATOR_SLASHING_PROTECTION_ENABLED;
 
 import java.nio.file.Path;
 import java.util.Optional;
@@ -154,14 +154,15 @@ public class ValidatorOptions {
       DEFAULT_VALIDATOR_IS_LOCAL_SLASHING_PROTECTION_SYNCHRONIZED_ENABLED;
 
   @Option(
-      names = {"--stop-vc-when-validator-slashed"},
+      names = {"--validator-slashing-protection-enabled"},
       paramLabel = "<BOOLEAN>",
-      description = "Enable stopping the VC when a validator gets slashed",
+      description =
+          "If a validator key is detected as slashed, the validator-client should terminate. In this case, the service should not be restarted",
       showDefaultValue = CommandLine.Help.Visibility.ALWAYS,
       arity = "0..1",
       fallbackValue = "true")
-  private boolean stopVcWhenValidatorSlashedEnabled =
-      DEFAULT_STOP_VC_WHEN_VALIDATOR_SLASHED_ENABLED;
+  private boolean validatorSlashingProtectionEnabled =
+      DEFAULT_VALIDATOR_SLASHING_PROTECTION_ENABLED;
 
   public void configure(TekuConfiguration.Builder builder) {
     builder.validator(
@@ -182,7 +183,7 @@ public class ValidatorOptions {
                 .executorThreads(executorThreads)
                 .blockV3enabled(blockV3Enabled)
                 .exitWhenNoValidatorKeysEnabled(exitWhenNoValidatorKeysEnabled)
-                .stopVcWhenValidatorSlashedEnabled(stopVcWhenValidatorSlashedEnabled));
+                .validatorSlashingProtectionEnabled(validatorSlashingProtectionEnabled));
     validatorProposerOptions.configure(builder);
     validatorKeysOptions.configure(builder);
   }

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
@@ -157,7 +157,7 @@ public class ValidatorOptions {
       names = {"--validator-slashing-protection-enabled"},
       paramLabel = "<BOOLEAN>",
       description =
-          "If a validator key is detected as slashed, the validator-client should terminate. In this case, the service should not be restarted",
+          "If an owned validator key is detected as slashed, the validator-client should terminate. In this case, the service should not be restarted",
       showDefaultValue = CommandLine.Help.Visibility.ALWAYS,
       arity = "0..1",
       fallbackValue = "true")

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
@@ -15,7 +15,7 @@ package tech.pegasys.teku.cli.options;
 
 import static tech.pegasys.teku.networks.Eth2NetworkConfiguration.DEFAULT_VALIDATOR_EXECUTOR_THREADS;
 import static tech.pegasys.teku.validator.api.ValidatorConfig.DEFAULT_DOPPELGANGER_DETECTION_ENABLED;
-import static tech.pegasys.teku.validator.api.ValidatorConfig.DEFAULT_STOP_WHEN_VALIDATOR_SLASHED_ENABLED;
+import static tech.pegasys.teku.validator.api.ValidatorConfig.DEFAULT_STOP_VC_WHEN_VALIDATOR_SLASHED_ENABLED;
 import static tech.pegasys.teku.validator.api.ValidatorConfig.DEFAULT_VALIDATOR_IS_LOCAL_SLASHING_PROTECTION_SYNCHRONIZED_ENABLED;
 
 import java.nio.file.Path;
@@ -156,11 +156,12 @@ public class ValidatorOptions {
   @Option(
       names = {"--stop-vc-when-validator-slashed"},
       paramLabel = "<BOOLEAN>",
-      description = "Enable stopping the VC when a validator is slashed",
+      description = "Enable stopping the VC when a validator gets slashed",
       showDefaultValue = CommandLine.Help.Visibility.ALWAYS,
       arity = "0..1",
       fallbackValue = "true")
-  private boolean stopWhenValidatorSlashedEnabled = DEFAULT_STOP_WHEN_VALIDATOR_SLASHED_ENABLED;
+  private boolean stopVcWhenValidatorSlashedEnabled =
+      DEFAULT_STOP_VC_WHEN_VALIDATOR_SLASHED_ENABLED;
 
   public void configure(TekuConfiguration.Builder builder) {
     builder.validator(
@@ -181,7 +182,7 @@ public class ValidatorOptions {
                 .executorThreads(executorThreads)
                 .blockV3enabled(blockV3Enabled)
                 .exitWhenNoValidatorKeysEnabled(exitWhenNoValidatorKeysEnabled)
-                .stopWhenValidatorSlashedEnabled(stopWhenValidatorSlashedEnabled));
+                .stopVcWhenValidatorSlashedEnabled(stopVcWhenValidatorSlashedEnabled));
     validatorProposerOptions.configure(builder);
     validatorKeysOptions.configure(builder);
   }

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.cli.options;
 
 import static tech.pegasys.teku.networks.Eth2NetworkConfiguration.DEFAULT_VALIDATOR_EXECUTOR_THREADS;
 import static tech.pegasys.teku.validator.api.ValidatorConfig.DEFAULT_DOPPELGANGER_DETECTION_ENABLED;
+import static tech.pegasys.teku.validator.api.ValidatorConfig.DEFAULT_STOP_WHEN_VALIDATOR_SLASHED_ENABLED;
 import static tech.pegasys.teku.validator.api.ValidatorConfig.DEFAULT_VALIDATOR_IS_LOCAL_SLASHING_PROTECTION_SYNCHRONIZED_ENABLED;
 
 import java.nio.file.Path;
@@ -152,6 +153,15 @@ public class ValidatorOptions {
   private boolean isLocalSlashingProtectionSynchronizedEnabled =
       DEFAULT_VALIDATOR_IS_LOCAL_SLASHING_PROTECTION_SYNCHRONIZED_ENABLED;
 
+  @Option(
+      names = {"--Xstop-vc-when-validator-slashed"},
+      paramLabel = "<BOOLEAN>",
+      description = "Enable stopping the Vc when a validator is slashed",
+      showDefaultValue = CommandLine.Help.Visibility.ALWAYS,
+      arity = "0..1",
+      fallbackValue = "true")
+  private boolean stopWhenValidatorSlashedEnabled = DEFAULT_STOP_WHEN_VALIDATOR_SLASHED_ENABLED;
+
   public void configure(TekuConfiguration.Builder builder) {
     builder.validator(
         config ->
@@ -170,7 +180,8 @@ public class ValidatorOptions {
                 .doppelgangerDetectionEnabled(doppelgangerDetectionEnabled)
                 .executorThreads(executorThreads)
                 .blockV3enabled(blockV3Enabled)
-                .exitWhenNoValidatorKeysEnabled(exitWhenNoValidatorKeysEnabled));
+                .exitWhenNoValidatorKeysEnabled(exitWhenNoValidatorKeysEnabled)
+                .stopWhenValidatorSlashedEnabled(stopWhenValidatorSlashedEnabled));
     validatorProposerOptions.configure(builder);
     validatorKeysOptions.configure(builder);
   }

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
@@ -154,9 +154,9 @@ public class ValidatorOptions {
       DEFAULT_VALIDATOR_IS_LOCAL_SLASHING_PROTECTION_SYNCHRONIZED_ENABLED;
 
   @Option(
-      names = {"--Xstop-vc-when-validator-slashed"},
+      names = {"--stop-vc-when-validator-slashed"},
       paramLabel = "<BOOLEAN>",
-      description = "Enable stopping the Vc when a validator is slashed",
+      description = "Enable stopping the VC when a validator is slashed",
       showDefaultValue = CommandLine.Help.Visibility.ALWAYS,
       arity = "0..1",
       fallbackValue = "true")

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
@@ -15,7 +15,7 @@ package tech.pegasys.teku.cli.options;
 
 import static tech.pegasys.teku.networks.Eth2NetworkConfiguration.DEFAULT_VALIDATOR_EXECUTOR_THREADS;
 import static tech.pegasys.teku.validator.api.ValidatorConfig.DEFAULT_DOPPELGANGER_DETECTION_ENABLED;
-import static tech.pegasys.teku.validator.api.ValidatorConfig.DEFAULT_STOP_VC_WHEN_VALIDATOR_SLASHED_ENABLED;
+import static tech.pegasys.teku.validator.api.ValidatorConfig.DEFAULT_SHUTDOWN_WHEN_VALIDATOR_SLASHED_ENABLED;
 import static tech.pegasys.teku.validator.api.ValidatorConfig.DEFAULT_VALIDATOR_IS_LOCAL_SLASHING_PROTECTION_SYNCHRONIZED_ENABLED;
 
 import java.nio.file.Path;
@@ -154,14 +154,14 @@ public class ValidatorOptions {
       DEFAULT_VALIDATOR_IS_LOCAL_SLASHING_PROTECTION_SYNCHRONIZED_ENABLED;
 
   @Option(
-      names = {"--stop-vc-when-validator-slashed-enabled"},
+      names = {"--shut-down-when-validator-slashed-enabled"},
       paramLabel = "<BOOLEAN>",
       description =
           "If an owned validator key is detected as slashed, the validator-client or the teku node (if running the beacon-node and the validator-client in a single process) should terminate with exit code 2. In this case, the service should not be restarted.",
       showDefaultValue = CommandLine.Help.Visibility.ALWAYS,
       arity = "0..1",
       fallbackValue = "true")
-  private boolean stopVcWhenValidatorSlashed = DEFAULT_STOP_VC_WHEN_VALIDATOR_SLASHED_ENABLED;
+  private boolean shutdownWhenValidatorSlashed = DEFAULT_SHUTDOWN_WHEN_VALIDATOR_SLASHED_ENABLED;
 
   public void configure(TekuConfiguration.Builder builder) {
     builder.validator(
@@ -182,7 +182,7 @@ public class ValidatorOptions {
                 .executorThreads(executorThreads)
                 .blockV3enabled(blockV3Enabled)
                 .exitWhenNoValidatorKeysEnabled(exitWhenNoValidatorKeysEnabled)
-                .stopVcWhenValidatorSlashedEnabled(stopVcWhenValidatorSlashed));
+                .shutdownWhenValidatorSlashedEnabled(shutdownWhenValidatorSlashed));
     validatorProposerOptions.configure(builder);
     validatorKeysOptions.configure(builder);
   }

--- a/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugToolsCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/subcommand/debug/DebugToolsCommand.java
@@ -45,9 +45,9 @@ import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 import tech.pegasys.teku.validator.beaconnode.GenesisDataProvider;
 import tech.pegasys.teku.validator.client.KeyManager;
 import tech.pegasys.teku.validator.client.NoOpKeyManager;
-import tech.pegasys.teku.validator.client.doppelganger.DoppelgangerDetectionAlert;
 import tech.pegasys.teku.validator.client.restapi.ValidatorRestApi;
 import tech.pegasys.teku.validator.client.restapi.ValidatorRestApiConfig;
+import tech.pegasys.teku.validator.client.slashingriskactions.DoppelgangerDetectionAlert;
 
 @Command(
     name = "debug-tools",

--- a/teku/src/main/java/tech/pegasys/teku/services/BeaconNodeServiceController.java
+++ b/teku/src/main/java/tech/pegasys/teku/services/BeaconNodeServiceController.java
@@ -56,7 +56,7 @@ public class BeaconNodeServiceController extends ServiceController {
         .ifPresent(services::add);
 
     final Optional<SlashingRiskDetectionAction> maybeValidatorSlashedAction =
-        tekuConfig.validatorClient().getValidatorConfig().isStopVcWhenValidatorSlashedEnabled()
+        tekuConfig.validatorClient().getValidatorConfig().isValidatorSlashingProtectionEnabled()
             ? Optional.of(new SlashedValidatorShutDown())
             : Optional.empty();
 

--- a/teku/src/main/java/tech/pegasys/teku/services/BeaconNodeServiceController.java
+++ b/teku/src/main/java/tech/pegasys/teku/services/BeaconNodeServiceController.java
@@ -56,7 +56,7 @@ public class BeaconNodeServiceController extends ServiceController {
         .ifPresent(services::add);
 
     final Optional<SlashingRiskDetectionAction> maybeValidatorSlashedAction =
-        tekuConfig.validatorClient().getValidatorConfig().isStopVcWhenValidatorSlashedEnabled()
+        tekuConfig.validatorClient().getValidatorConfig().isShutdownWhenValidatorSlashedEnabled()
             ? Optional.of(new SlashedValidatorShutDown())
             : Optional.empty();
 

--- a/teku/src/main/java/tech/pegasys/teku/services/BeaconNodeServiceController.java
+++ b/teku/src/main/java/tech/pegasys/teku/services/BeaconNodeServiceController.java
@@ -24,7 +24,6 @@ import tech.pegasys.teku.services.executionlayer.ExecutionLayerService;
 import tech.pegasys.teku.services.powchain.PowchainService;
 import tech.pegasys.teku.validator.client.ValidatorClientService;
 import tech.pegasys.teku.validator.client.slashingriskactions.DoppelgangerDetectionShutDown;
-import tech.pegasys.teku.validator.client.slashingriskactions.SlashedValidatorAlert;
 import tech.pegasys.teku.validator.client.slashingriskactions.SlashedValidatorShutDown;
 import tech.pegasys.teku.validator.client.slashingriskactions.SlashingRiskDetectionAction;
 
@@ -55,16 +54,18 @@ public class BeaconNodeServiceController extends ServiceController {
             tekuConfig.discovery().isDiscoveryEnabled()));
     powchainService(tekuConfig, serviceConfig, maybeExecutionWeb3jClientProvider)
         .ifPresent(services::add);
-    final SlashingRiskDetectionAction validatorSlashedAction =
+
+    final Optional<SlashingRiskDetectionAction> maybeValidatorSlashedAction =
         tekuConfig.validatorClient().getValidatorConfig().isStopWhenValidatorSlashedEnabled()
-            ? new SlashedValidatorShutDown()
-            : new SlashedValidatorAlert();
+            ? Optional.of(new SlashedValidatorShutDown())
+            : Optional.empty();
+
     services.add(
         ValidatorClientService.create(
             serviceConfig,
             tekuConfig.validatorClient(),
             new DoppelgangerDetectionShutDown(),
-            validatorSlashedAction));
+            maybeValidatorSlashedAction));
   }
 
   private Optional<PowchainService> powchainService(

--- a/teku/src/main/java/tech/pegasys/teku/services/BeaconNodeServiceController.java
+++ b/teku/src/main/java/tech/pegasys/teku/services/BeaconNodeServiceController.java
@@ -56,7 +56,7 @@ public class BeaconNodeServiceController extends ServiceController {
         .ifPresent(services::add);
 
     final Optional<SlashingRiskDetectionAction> maybeValidatorSlashedAction =
-        tekuConfig.validatorClient().getValidatorConfig().isValidatorSlashingProtectionEnabled()
+        tekuConfig.validatorClient().getValidatorConfig().isStopVcWhenValidatorSlashedEnabled()
             ? Optional.of(new SlashedValidatorShutDown())
             : Optional.empty();
 

--- a/teku/src/main/java/tech/pegasys/teku/services/BeaconNodeServiceController.java
+++ b/teku/src/main/java/tech/pegasys/teku/services/BeaconNodeServiceController.java
@@ -56,7 +56,7 @@ public class BeaconNodeServiceController extends ServiceController {
         .ifPresent(services::add);
 
     final Optional<SlashingRiskDetectionAction> maybeValidatorSlashedAction =
-        tekuConfig.validatorClient().getValidatorConfig().isStopWhenValidatorSlashedEnabled()
+        tekuConfig.validatorClient().getValidatorConfig().isStopVcWhenValidatorSlashedEnabled()
             ? Optional.of(new SlashedValidatorShutDown())
             : Optional.empty();
 

--- a/teku/src/main/java/tech/pegasys/teku/services/ValidatorNodeServiceController.java
+++ b/teku/src/main/java/tech/pegasys/teku/services/ValidatorNodeServiceController.java
@@ -13,11 +13,11 @@
 
 package tech.pegasys.teku.services;
 
+import java.util.Optional;
 import tech.pegasys.teku.config.TekuConfiguration;
 import tech.pegasys.teku.service.serviceutils.ServiceConfig;
 import tech.pegasys.teku.validator.client.ValidatorClientService;
 import tech.pegasys.teku.validator.client.slashingriskactions.DoppelgangerDetectionShutDown;
-import tech.pegasys.teku.validator.client.slashingriskactions.SlashedValidatorAlert;
 import tech.pegasys.teku.validator.client.slashingriskactions.SlashedValidatorShutDown;
 import tech.pegasys.teku.validator.client.slashingriskactions.SlashingRiskDetectionAction;
 
@@ -25,15 +25,15 @@ public class ValidatorNodeServiceController extends ServiceController {
 
   public ValidatorNodeServiceController(
       final TekuConfiguration tekuConfig, final ServiceConfig serviceConfig) {
-    final SlashingRiskDetectionAction validatorSlashedAction =
+    final Optional<SlashingRiskDetectionAction> maybeValidatorSlashedAction =
         tekuConfig.validatorClient().getValidatorConfig().isStopWhenValidatorSlashedEnabled()
-            ? new SlashedValidatorShutDown()
-            : new SlashedValidatorAlert();
+            ? Optional.of(new SlashedValidatorShutDown())
+            : Optional.empty();
     this.services.add(
         ValidatorClientService.create(
             serviceConfig,
             tekuConfig.validatorClient(),
             new DoppelgangerDetectionShutDown(),
-            validatorSlashedAction));
+            maybeValidatorSlashedAction));
   }
 }

--- a/teku/src/main/java/tech/pegasys/teku/services/ValidatorNodeServiceController.java
+++ b/teku/src/main/java/tech/pegasys/teku/services/ValidatorNodeServiceController.java
@@ -26,7 +26,7 @@ public class ValidatorNodeServiceController extends ServiceController {
   public ValidatorNodeServiceController(
       final TekuConfiguration tekuConfig, final ServiceConfig serviceConfig) {
     final Optional<SlashingRiskDetectionAction> maybeValidatorSlashedAction =
-        tekuConfig.validatorClient().getValidatorConfig().isStopVcWhenValidatorSlashedEnabled()
+        tekuConfig.validatorClient().getValidatorConfig().isValidatorSlashingProtectionEnabled()
             ? Optional.of(new SlashedValidatorShutDown())
             : Optional.empty();
     this.services.add(

--- a/teku/src/main/java/tech/pegasys/teku/services/ValidatorNodeServiceController.java
+++ b/teku/src/main/java/tech/pegasys/teku/services/ValidatorNodeServiceController.java
@@ -26,7 +26,7 @@ public class ValidatorNodeServiceController extends ServiceController {
   public ValidatorNodeServiceController(
       final TekuConfiguration tekuConfig, final ServiceConfig serviceConfig) {
     final Optional<SlashingRiskDetectionAction> maybeValidatorSlashedAction =
-        tekuConfig.validatorClient().getValidatorConfig().isValidatorSlashingProtectionEnabled()
+        tekuConfig.validatorClient().getValidatorConfig().isStopVcWhenValidatorSlashedEnabled()
             ? Optional.of(new SlashedValidatorShutDown())
             : Optional.empty();
     this.services.add(

--- a/teku/src/main/java/tech/pegasys/teku/services/ValidatorNodeServiceController.java
+++ b/teku/src/main/java/tech/pegasys/teku/services/ValidatorNodeServiceController.java
@@ -26,7 +26,7 @@ public class ValidatorNodeServiceController extends ServiceController {
   public ValidatorNodeServiceController(
       final TekuConfiguration tekuConfig, final ServiceConfig serviceConfig) {
     final Optional<SlashingRiskDetectionAction> maybeValidatorSlashedAction =
-        tekuConfig.validatorClient().getValidatorConfig().isStopWhenValidatorSlashedEnabled()
+        tekuConfig.validatorClient().getValidatorConfig().isStopVcWhenValidatorSlashedEnabled()
             ? Optional.of(new SlashedValidatorShutDown())
             : Optional.empty();
     this.services.add(

--- a/teku/src/main/java/tech/pegasys/teku/services/ValidatorNodeServiceController.java
+++ b/teku/src/main/java/tech/pegasys/teku/services/ValidatorNodeServiceController.java
@@ -26,7 +26,7 @@ public class ValidatorNodeServiceController extends ServiceController {
   public ValidatorNodeServiceController(
       final TekuConfiguration tekuConfig, final ServiceConfig serviceConfig) {
     final Optional<SlashingRiskDetectionAction> maybeValidatorSlashedAction =
-        tekuConfig.validatorClient().getValidatorConfig().isStopVcWhenValidatorSlashedEnabled()
+        tekuConfig.validatorClient().getValidatorConfig().isShutdownWhenValidatorSlashedEnabled()
             ? Optional.of(new SlashedValidatorShutDown())
             : Optional.empty();
     this.services.add(

--- a/teku/src/main/java/tech/pegasys/teku/services/ValidatorNodeServiceController.java
+++ b/teku/src/main/java/tech/pegasys/teku/services/ValidatorNodeServiceController.java
@@ -16,14 +16,24 @@ package tech.pegasys.teku.services;
 import tech.pegasys.teku.config.TekuConfiguration;
 import tech.pegasys.teku.service.serviceutils.ServiceConfig;
 import tech.pegasys.teku.validator.client.ValidatorClientService;
-import tech.pegasys.teku.validator.client.doppelganger.DoppelgangerDetectionShutDown;
+import tech.pegasys.teku.validator.client.slashingriskactions.DoppelgangerDetectionShutDown;
+import tech.pegasys.teku.validator.client.slashingriskactions.SlashedValidatorAlert;
+import tech.pegasys.teku.validator.client.slashingriskactions.SlashedValidatorShutDown;
+import tech.pegasys.teku.validator.client.slashingriskactions.SlashingRiskDetectionAction;
 
 public class ValidatorNodeServiceController extends ServiceController {
 
   public ValidatorNodeServiceController(
       final TekuConfiguration tekuConfig, final ServiceConfig serviceConfig) {
+    final SlashingRiskDetectionAction validatorSlashedAction =
+        tekuConfig.validatorClient().getValidatorConfig().isStopWhenValidatorSlashedEnabled()
+            ? new SlashedValidatorShutDown()
+            : new SlashedValidatorAlert();
     this.services.add(
         ValidatorClientService.create(
-            serviceConfig, tekuConfig.validatorClient(), new DoppelgangerDetectionShutDown()));
+            serviceConfig,
+            tekuConfig.validatorClient(),
+            new DoppelgangerDetectionShutDown(),
+            validatorSlashedAction));
   }
 }

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
@@ -50,6 +50,7 @@ public class ValidatorConfig {
   public static final boolean DEFAULT_VALIDATOR_CLIENT_SSZ_BLOCKS_ENABLED = true;
   public static final boolean DEFAULT_VALIDATOR_CLIENT_USE_POST_VALIDATORS_ENDPOINT_ENABLED = true;
   public static final boolean DEFAULT_DOPPELGANGER_DETECTION_ENABLED = false;
+  public static final boolean DEFAULT_STOP_WHEN_VALIDATOR_SLASHED_ENABLED = false;
   public static final boolean DEFAULT_VALIDATOR_IS_LOCAL_SLASHING_PROTECTION_SYNCHRONIZED_ENABLED =
       true;
   public static final int DEFAULT_EXECUTOR_MAX_QUEUE_SIZE = 20_000;
@@ -93,6 +94,7 @@ public class ValidatorConfig {
   private final boolean failoversPublishSignedDutiesEnabled;
   private final boolean blockV3Enabled;
   private final boolean exitWhenNoValidatorKeysEnabled;
+  private final boolean stopWhenValidatorSlashedEnabled;
   private final UInt64 builderRegistrationDefaultGasLimit;
   private final int builderRegistrationSendingBatchSize;
   private final Optional<UInt64> builderRegistrationTimestampOverride;
@@ -133,6 +135,7 @@ public class ValidatorConfig {
       final boolean failoversPublishSignedDutiesEnabled,
       final boolean blockV3Enabled,
       final boolean exitWhenNoValidatorKeysEnabled,
+      final boolean stopWhenValidatorSlashedEnabled,
       final UInt64 builderRegistrationDefaultGasLimit,
       final int builderRegistrationSendingBatchSize,
       final Optional<UInt64> builderRegistrationTimestampOverride,
@@ -173,6 +176,7 @@ public class ValidatorConfig {
     this.failoversPublishSignedDutiesEnabled = failoversPublishSignedDutiesEnabled;
     this.blockV3Enabled = blockV3Enabled;
     this.exitWhenNoValidatorKeysEnabled = exitWhenNoValidatorKeysEnabled;
+    this.stopWhenValidatorSlashedEnabled = stopWhenValidatorSlashedEnabled;
     this.builderRegistrationDefaultGasLimit = builderRegistrationDefaultGasLimit;
     this.builderRegistrationSendingBatchSize = builderRegistrationSendingBatchSize;
     this.builderRegistrationTimestampOverride = builderRegistrationTimestampOverride;
@@ -311,6 +315,10 @@ public class ValidatorConfig {
     return exitWhenNoValidatorKeysEnabled;
   }
 
+  public boolean isStopWhenValidatorSlashedEnabled() {
+    return stopWhenValidatorSlashedEnabled;
+  }
+
   public boolean isBuilderRegistrationDefaultEnabled() {
     return builderRegistrationDefaultEnabled;
   }
@@ -378,6 +386,7 @@ public class ValidatorConfig {
         DEFAULT_FAILOVERS_PUBLISH_SIGNED_DUTIES_ENABLED;
     private boolean blockV3Enabled = DEFAULT_BLOCK_V3_ENABLED;
     private boolean exitWhenNoValidatorKeysEnabled = DEFAULT_EXIT_WHEN_NO_VALIDATOR_KEYS_ENABLED;
+    private boolean stopWhenValidatorSlashedEnabled = DEFAULT_STOP_WHEN_VALIDATOR_SLASHED_ENABLED;
     private UInt64 builderRegistrationDefaultGasLimit = DEFAULT_BUILDER_REGISTRATION_GAS_LIMIT;
     private int builderRegistrationSendingBatchSize =
         DEFAULT_VALIDATOR_REGISTRATION_SENDING_BATCH_SIZE;
@@ -580,6 +589,11 @@ public class ValidatorConfig {
       return this;
     }
 
+    public Builder stopWhenValidatorSlashedEnabled(final boolean stopWhenValidatorSlashedEnabled) {
+      this.stopWhenValidatorSlashedEnabled = stopWhenValidatorSlashedEnabled;
+      return this;
+    }
+
     public Builder builderRegistrationDefaultGasLimit(
         final UInt64 builderRegistrationDefaultGasLimit) {
       this.builderRegistrationDefaultGasLimit = builderRegistrationDefaultGasLimit;
@@ -659,6 +673,7 @@ public class ValidatorConfig {
           failoversPublishSignedDutiesEnabled,
           blockV3Enabled,
           exitWhenNoValidatorKeysEnabled,
+          stopWhenValidatorSlashedEnabled,
           builderRegistrationDefaultGasLimit,
           builderRegistrationSendingBatchSize,
           builderRegistrationTimestampOverride,

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
@@ -50,9 +50,9 @@ public class ValidatorConfig {
   public static final boolean DEFAULT_VALIDATOR_CLIENT_SSZ_BLOCKS_ENABLED = true;
   public static final boolean DEFAULT_VALIDATOR_CLIENT_USE_POST_VALIDATORS_ENDPOINT_ENABLED = true;
   public static final boolean DEFAULT_DOPPELGANGER_DETECTION_ENABLED = false;
-  public static final boolean DEFAULT_STOP_WHEN_VALIDATOR_SLASHED_ENABLED = false;
   public static final boolean DEFAULT_VALIDATOR_IS_LOCAL_SLASHING_PROTECTION_SYNCHRONIZED_ENABLED =
       true;
+  public static final boolean DEFAULT_STOP_VC_WHEN_VALIDATOR_SLASHED_ENABLED = false;
   public static final int DEFAULT_EXECUTOR_MAX_QUEUE_SIZE = 20_000;
   public static final Duration DEFAULT_VALIDATOR_EXTERNAL_SIGNER_TIMEOUT = Duration.ofSeconds(5);
   public static final int DEFAULT_VALIDATOR_EXTERNAL_SIGNER_CONCURRENT_REQUEST_LIMIT = 32;
@@ -94,7 +94,7 @@ public class ValidatorConfig {
   private final boolean failoversPublishSignedDutiesEnabled;
   private final boolean blockV3Enabled;
   private final boolean exitWhenNoValidatorKeysEnabled;
-  private final boolean stopWhenValidatorSlashedEnabled;
+  private final boolean stopVcWhenValidatorSlashedEnabled;
   private final UInt64 builderRegistrationDefaultGasLimit;
   private final int builderRegistrationSendingBatchSize;
   private final Optional<UInt64> builderRegistrationTimestampOverride;
@@ -135,7 +135,7 @@ public class ValidatorConfig {
       final boolean failoversPublishSignedDutiesEnabled,
       final boolean blockV3Enabled,
       final boolean exitWhenNoValidatorKeysEnabled,
-      final boolean stopWhenValidatorSlashedEnabled,
+      final boolean stopVcWhenValidatorSlashedEnabled,
       final UInt64 builderRegistrationDefaultGasLimit,
       final int builderRegistrationSendingBatchSize,
       final Optional<UInt64> builderRegistrationTimestampOverride,
@@ -176,7 +176,7 @@ public class ValidatorConfig {
     this.failoversPublishSignedDutiesEnabled = failoversPublishSignedDutiesEnabled;
     this.blockV3Enabled = blockV3Enabled;
     this.exitWhenNoValidatorKeysEnabled = exitWhenNoValidatorKeysEnabled;
-    this.stopWhenValidatorSlashedEnabled = stopWhenValidatorSlashedEnabled;
+    this.stopVcWhenValidatorSlashedEnabled = stopVcWhenValidatorSlashedEnabled;
     this.builderRegistrationDefaultGasLimit = builderRegistrationDefaultGasLimit;
     this.builderRegistrationSendingBatchSize = builderRegistrationSendingBatchSize;
     this.builderRegistrationTimestampOverride = builderRegistrationTimestampOverride;
@@ -315,8 +315,8 @@ public class ValidatorConfig {
     return exitWhenNoValidatorKeysEnabled;
   }
 
-  public boolean isStopWhenValidatorSlashedEnabled() {
-    return stopWhenValidatorSlashedEnabled;
+  public boolean isStopVcWhenValidatorSlashedEnabled() {
+    return stopVcWhenValidatorSlashedEnabled;
   }
 
   public boolean isBuilderRegistrationDefaultEnabled() {
@@ -386,7 +386,8 @@ public class ValidatorConfig {
         DEFAULT_FAILOVERS_PUBLISH_SIGNED_DUTIES_ENABLED;
     private boolean blockV3Enabled = DEFAULT_BLOCK_V3_ENABLED;
     private boolean exitWhenNoValidatorKeysEnabled = DEFAULT_EXIT_WHEN_NO_VALIDATOR_KEYS_ENABLED;
-    private boolean stopWhenValidatorSlashedEnabled = DEFAULT_STOP_WHEN_VALIDATOR_SLASHED_ENABLED;
+    private boolean stopVcWhenValidatorSlashedEnabled =
+        DEFAULT_STOP_VC_WHEN_VALIDATOR_SLASHED_ENABLED;
     private UInt64 builderRegistrationDefaultGasLimit = DEFAULT_BUILDER_REGISTRATION_GAS_LIMIT;
     private int builderRegistrationSendingBatchSize =
         DEFAULT_VALIDATOR_REGISTRATION_SENDING_BATCH_SIZE;
@@ -589,8 +590,9 @@ public class ValidatorConfig {
       return this;
     }
 
-    public Builder stopWhenValidatorSlashedEnabled(final boolean stopWhenValidatorSlashedEnabled) {
-      this.stopWhenValidatorSlashedEnabled = stopWhenValidatorSlashedEnabled;
+    public Builder stopVcWhenValidatorSlashedEnabled(
+        final boolean stopVcWhenValidatorSlashedEnabled) {
+      this.stopVcWhenValidatorSlashedEnabled = stopVcWhenValidatorSlashedEnabled;
       return this;
     }
 
@@ -673,7 +675,7 @@ public class ValidatorConfig {
           failoversPublishSignedDutiesEnabled,
           blockV3Enabled,
           exitWhenNoValidatorKeysEnabled,
-          stopWhenValidatorSlashedEnabled,
+          stopVcWhenValidatorSlashedEnabled,
           builderRegistrationDefaultGasLimit,
           builderRegistrationSendingBatchSize,
           builderRegistrationTimestampOverride,

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
@@ -53,7 +53,6 @@ public class ValidatorConfig {
   public static final boolean DEFAULT_VALIDATOR_IS_LOCAL_SLASHING_PROTECTION_SYNCHRONIZED_ENABLED =
       true;
   public static final boolean DEFAULT_STOP_VC_WHEN_VALIDATOR_SLASHED_ENABLED = false;
-  public static final boolean DEFAULT_VALIDATOR_SLASHING_PROTECTION_ENABLED = false;
   public static final int DEFAULT_EXECUTOR_MAX_QUEUE_SIZE = 20_000;
   public static final Duration DEFAULT_VALIDATOR_EXTERNAL_SIGNER_TIMEOUT = Duration.ofSeconds(5);
   public static final int DEFAULT_VALIDATOR_EXTERNAL_SIGNER_CONCURRENT_REQUEST_LIMIT = 32;
@@ -95,7 +94,7 @@ public class ValidatorConfig {
   private final boolean failoversPublishSignedDutiesEnabled;
   private final boolean blockV3Enabled;
   private final boolean exitWhenNoValidatorKeysEnabled;
-  private final boolean validatorSlashingProtectionEnabled;
+  private final boolean stopVcWhenValidatorSlashedEnabled;
   private final UInt64 builderRegistrationDefaultGasLimit;
   private final int builderRegistrationSendingBatchSize;
   private final Optional<UInt64> builderRegistrationTimestampOverride;
@@ -136,7 +135,7 @@ public class ValidatorConfig {
       final boolean failoversPublishSignedDutiesEnabled,
       final boolean blockV3Enabled,
       final boolean exitWhenNoValidatorKeysEnabled,
-      final boolean validatorSlashingProtectionEnabled,
+      final boolean stopVcWhenValidatorSlashedEnabled,
       final UInt64 builderRegistrationDefaultGasLimit,
       final int builderRegistrationSendingBatchSize,
       final Optional<UInt64> builderRegistrationTimestampOverride,
@@ -177,7 +176,7 @@ public class ValidatorConfig {
     this.failoversPublishSignedDutiesEnabled = failoversPublishSignedDutiesEnabled;
     this.blockV3Enabled = blockV3Enabled;
     this.exitWhenNoValidatorKeysEnabled = exitWhenNoValidatorKeysEnabled;
-    this.validatorSlashingProtectionEnabled = validatorSlashingProtectionEnabled;
+    this.stopVcWhenValidatorSlashedEnabled = stopVcWhenValidatorSlashedEnabled;
     this.builderRegistrationDefaultGasLimit = builderRegistrationDefaultGasLimit;
     this.builderRegistrationSendingBatchSize = builderRegistrationSendingBatchSize;
     this.builderRegistrationTimestampOverride = builderRegistrationTimestampOverride;
@@ -316,8 +315,8 @@ public class ValidatorConfig {
     return exitWhenNoValidatorKeysEnabled;
   }
 
-  public boolean isValidatorSlashingProtectionEnabled() {
-    return validatorSlashingProtectionEnabled;
+  public boolean isStopVcWhenValidatorSlashedEnabled() {
+    return stopVcWhenValidatorSlashedEnabled;
   }
 
   public boolean isBuilderRegistrationDefaultEnabled() {
@@ -387,8 +386,8 @@ public class ValidatorConfig {
         DEFAULT_FAILOVERS_PUBLISH_SIGNED_DUTIES_ENABLED;
     private boolean blockV3Enabled = DEFAULT_BLOCK_V3_ENABLED;
     private boolean exitWhenNoValidatorKeysEnabled = DEFAULT_EXIT_WHEN_NO_VALIDATOR_KEYS_ENABLED;
-    private boolean validatorSlashingProtectionEnabled =
-        DEFAULT_VALIDATOR_SLASHING_PROTECTION_ENABLED;
+    private boolean stopVcWhenValidatorSlashedEnabled =
+        DEFAULT_STOP_VC_WHEN_VALIDATOR_SLASHED_ENABLED;
     private UInt64 builderRegistrationDefaultGasLimit = DEFAULT_BUILDER_REGISTRATION_GAS_LIMIT;
     private int builderRegistrationSendingBatchSize =
         DEFAULT_VALIDATOR_REGISTRATION_SENDING_BATCH_SIZE;
@@ -591,9 +590,9 @@ public class ValidatorConfig {
       return this;
     }
 
-    public Builder validatorSlashingProtectionEnabled(
-        final boolean validatorSlashingProtectionEnabled) {
-      this.validatorSlashingProtectionEnabled = validatorSlashingProtectionEnabled;
+    public Builder stopVcWhenValidatorSlashedEnabled(
+        final boolean stopVcWhenValidatorSlashedEnabled) {
+      this.stopVcWhenValidatorSlashedEnabled = stopVcWhenValidatorSlashedEnabled;
       return this;
     }
 
@@ -676,7 +675,7 @@ public class ValidatorConfig {
           failoversPublishSignedDutiesEnabled,
           blockV3Enabled,
           exitWhenNoValidatorKeysEnabled,
-          validatorSlashingProtectionEnabled,
+          stopVcWhenValidatorSlashedEnabled,
           builderRegistrationDefaultGasLimit,
           builderRegistrationSendingBatchSize,
           builderRegistrationTimestampOverride,

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
@@ -52,7 +52,7 @@ public class ValidatorConfig {
   public static final boolean DEFAULT_DOPPELGANGER_DETECTION_ENABLED = false;
   public static final boolean DEFAULT_VALIDATOR_IS_LOCAL_SLASHING_PROTECTION_SYNCHRONIZED_ENABLED =
       true;
-  public static final boolean DEFAULT_STOP_VC_WHEN_VALIDATOR_SLASHED_ENABLED = false;
+  public static final boolean DEFAULT_SHUTDOWN_WHEN_VALIDATOR_SLASHED_ENABLED = false;
   public static final int DEFAULT_EXECUTOR_MAX_QUEUE_SIZE = 20_000;
   public static final Duration DEFAULT_VALIDATOR_EXTERNAL_SIGNER_TIMEOUT = Duration.ofSeconds(5);
   public static final int DEFAULT_VALIDATOR_EXTERNAL_SIGNER_CONCURRENT_REQUEST_LIMIT = 32;
@@ -94,7 +94,7 @@ public class ValidatorConfig {
   private final boolean failoversPublishSignedDutiesEnabled;
   private final boolean blockV3Enabled;
   private final boolean exitWhenNoValidatorKeysEnabled;
-  private final boolean stopVcWhenValidatorSlashedEnabled;
+  private final boolean shutdownWhenValidatorSlashedEnabled;
   private final UInt64 builderRegistrationDefaultGasLimit;
   private final int builderRegistrationSendingBatchSize;
   private final Optional<UInt64> builderRegistrationTimestampOverride;
@@ -135,7 +135,7 @@ public class ValidatorConfig {
       final boolean failoversPublishSignedDutiesEnabled,
       final boolean blockV3Enabled,
       final boolean exitWhenNoValidatorKeysEnabled,
-      final boolean stopVcWhenValidatorSlashedEnabled,
+      final boolean shutdownWhenValidatorSlashedEnabled,
       final UInt64 builderRegistrationDefaultGasLimit,
       final int builderRegistrationSendingBatchSize,
       final Optional<UInt64> builderRegistrationTimestampOverride,
@@ -176,7 +176,7 @@ public class ValidatorConfig {
     this.failoversPublishSignedDutiesEnabled = failoversPublishSignedDutiesEnabled;
     this.blockV3Enabled = blockV3Enabled;
     this.exitWhenNoValidatorKeysEnabled = exitWhenNoValidatorKeysEnabled;
-    this.stopVcWhenValidatorSlashedEnabled = stopVcWhenValidatorSlashedEnabled;
+    this.shutdownWhenValidatorSlashedEnabled = shutdownWhenValidatorSlashedEnabled;
     this.builderRegistrationDefaultGasLimit = builderRegistrationDefaultGasLimit;
     this.builderRegistrationSendingBatchSize = builderRegistrationSendingBatchSize;
     this.builderRegistrationTimestampOverride = builderRegistrationTimestampOverride;
@@ -315,8 +315,8 @@ public class ValidatorConfig {
     return exitWhenNoValidatorKeysEnabled;
   }
 
-  public boolean isStopVcWhenValidatorSlashedEnabled() {
-    return stopVcWhenValidatorSlashedEnabled;
+  public boolean isShutdownWhenValidatorSlashedEnabled() {
+    return shutdownWhenValidatorSlashedEnabled;
   }
 
   public boolean isBuilderRegistrationDefaultEnabled() {
@@ -386,8 +386,8 @@ public class ValidatorConfig {
         DEFAULT_FAILOVERS_PUBLISH_SIGNED_DUTIES_ENABLED;
     private boolean blockV3Enabled = DEFAULT_BLOCK_V3_ENABLED;
     private boolean exitWhenNoValidatorKeysEnabled = DEFAULT_EXIT_WHEN_NO_VALIDATOR_KEYS_ENABLED;
-    private boolean stopVcWhenValidatorSlashedEnabled =
-        DEFAULT_STOP_VC_WHEN_VALIDATOR_SLASHED_ENABLED;
+    private boolean shutdownWhenValidatorSlashedEnabled =
+        DEFAULT_SHUTDOWN_WHEN_VALIDATOR_SLASHED_ENABLED;
     private UInt64 builderRegistrationDefaultGasLimit = DEFAULT_BUILDER_REGISTRATION_GAS_LIMIT;
     private int builderRegistrationSendingBatchSize =
         DEFAULT_VALIDATOR_REGISTRATION_SENDING_BATCH_SIZE;
@@ -590,9 +590,9 @@ public class ValidatorConfig {
       return this;
     }
 
-    public Builder stopVcWhenValidatorSlashedEnabled(
-        final boolean stopVcWhenValidatorSlashedEnabled) {
-      this.stopVcWhenValidatorSlashedEnabled = stopVcWhenValidatorSlashedEnabled;
+    public Builder shutdownWhenValidatorSlashedEnabled(
+        final boolean shutdownWhenValidatorSlashedEnabled) {
+      this.shutdownWhenValidatorSlashedEnabled = shutdownWhenValidatorSlashedEnabled;
       return this;
     }
 
@@ -675,7 +675,7 @@ public class ValidatorConfig {
           failoversPublishSignedDutiesEnabled,
           blockV3Enabled,
           exitWhenNoValidatorKeysEnabled,
-          stopVcWhenValidatorSlashedEnabled,
+          shutdownWhenValidatorSlashedEnabled,
           builderRegistrationDefaultGasLimit,
           builderRegistrationSendingBatchSize,
           builderRegistrationTimestampOverride,

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
@@ -53,6 +53,7 @@ public class ValidatorConfig {
   public static final boolean DEFAULT_VALIDATOR_IS_LOCAL_SLASHING_PROTECTION_SYNCHRONIZED_ENABLED =
       true;
   public static final boolean DEFAULT_STOP_VC_WHEN_VALIDATOR_SLASHED_ENABLED = false;
+  public static final boolean DEFAULT_VALIDATOR_SLASHING_PROTECTION_ENABLED = false;
   public static final int DEFAULT_EXECUTOR_MAX_QUEUE_SIZE = 20_000;
   public static final Duration DEFAULT_VALIDATOR_EXTERNAL_SIGNER_TIMEOUT = Duration.ofSeconds(5);
   public static final int DEFAULT_VALIDATOR_EXTERNAL_SIGNER_CONCURRENT_REQUEST_LIMIT = 32;
@@ -94,7 +95,7 @@ public class ValidatorConfig {
   private final boolean failoversPublishSignedDutiesEnabled;
   private final boolean blockV3Enabled;
   private final boolean exitWhenNoValidatorKeysEnabled;
-  private final boolean stopVcWhenValidatorSlashedEnabled;
+  private final boolean validatorSlashingProtectionEnabled;
   private final UInt64 builderRegistrationDefaultGasLimit;
   private final int builderRegistrationSendingBatchSize;
   private final Optional<UInt64> builderRegistrationTimestampOverride;
@@ -135,7 +136,7 @@ public class ValidatorConfig {
       final boolean failoversPublishSignedDutiesEnabled,
       final boolean blockV3Enabled,
       final boolean exitWhenNoValidatorKeysEnabled,
-      final boolean stopVcWhenValidatorSlashedEnabled,
+      final boolean validatorSlashingProtectionEnabled,
       final UInt64 builderRegistrationDefaultGasLimit,
       final int builderRegistrationSendingBatchSize,
       final Optional<UInt64> builderRegistrationTimestampOverride,
@@ -176,7 +177,7 @@ public class ValidatorConfig {
     this.failoversPublishSignedDutiesEnabled = failoversPublishSignedDutiesEnabled;
     this.blockV3Enabled = blockV3Enabled;
     this.exitWhenNoValidatorKeysEnabled = exitWhenNoValidatorKeysEnabled;
-    this.stopVcWhenValidatorSlashedEnabled = stopVcWhenValidatorSlashedEnabled;
+    this.validatorSlashingProtectionEnabled = validatorSlashingProtectionEnabled;
     this.builderRegistrationDefaultGasLimit = builderRegistrationDefaultGasLimit;
     this.builderRegistrationSendingBatchSize = builderRegistrationSendingBatchSize;
     this.builderRegistrationTimestampOverride = builderRegistrationTimestampOverride;
@@ -315,8 +316,8 @@ public class ValidatorConfig {
     return exitWhenNoValidatorKeysEnabled;
   }
 
-  public boolean isStopVcWhenValidatorSlashedEnabled() {
-    return stopVcWhenValidatorSlashedEnabled;
+  public boolean isValidatorSlashingProtectionEnabled() {
+    return validatorSlashingProtectionEnabled;
   }
 
   public boolean isBuilderRegistrationDefaultEnabled() {
@@ -386,8 +387,8 @@ public class ValidatorConfig {
         DEFAULT_FAILOVERS_PUBLISH_SIGNED_DUTIES_ENABLED;
     private boolean blockV3Enabled = DEFAULT_BLOCK_V3_ENABLED;
     private boolean exitWhenNoValidatorKeysEnabled = DEFAULT_EXIT_WHEN_NO_VALIDATOR_KEYS_ENABLED;
-    private boolean stopVcWhenValidatorSlashedEnabled =
-        DEFAULT_STOP_VC_WHEN_VALIDATOR_SLASHED_ENABLED;
+    private boolean validatorSlashingProtectionEnabled =
+        DEFAULT_VALIDATOR_SLASHING_PROTECTION_ENABLED;
     private UInt64 builderRegistrationDefaultGasLimit = DEFAULT_BUILDER_REGISTRATION_GAS_LIMIT;
     private int builderRegistrationSendingBatchSize =
         DEFAULT_VALIDATOR_REGISTRATION_SENDING_BATCH_SIZE;
@@ -590,9 +591,9 @@ public class ValidatorConfig {
       return this;
     }
 
-    public Builder stopVcWhenValidatorSlashedEnabled(
-        final boolean stopVcWhenValidatorSlashedEnabled) {
-      this.stopVcWhenValidatorSlashedEnabled = stopVcWhenValidatorSlashedEnabled;
+    public Builder validatorSlashingProtectionEnabled(
+        final boolean validatorSlashingProtectionEnabled) {
+      this.validatorSlashingProtectionEnabled = validatorSlashingProtectionEnabled;
       return this;
     }
 
@@ -675,7 +676,7 @@ public class ValidatorConfig {
           failoversPublishSignedDutiesEnabled,
           blockV3Enabled,
           exitWhenNoValidatorKeysEnabled,
-          stopVcWhenValidatorSlashedEnabled,
+          validatorSlashingProtectionEnabled,
           builderRegistrationDefaultGasLimit,
           builderRegistrationSendingBatchSize,
           builderRegistrationTimestampOverride,

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/KeyManager.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/KeyManager.java
@@ -18,12 +18,12 @@ import java.util.List;
 import java.util.Optional;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.data.SlashingProtectionImporter;
-import tech.pegasys.teku.validator.client.doppelganger.DoppelgangerDetectionAction;
 import tech.pegasys.teku.validator.client.doppelganger.DoppelgangerDetector;
 import tech.pegasys.teku.validator.client.restapi.apis.schema.DeleteKeysResponse;
 import tech.pegasys.teku.validator.client.restapi.apis.schema.DeleteRemoteKeysResponse;
 import tech.pegasys.teku.validator.client.restapi.apis.schema.ExternalValidator;
 import tech.pegasys.teku.validator.client.restapi.apis.schema.PostKeyResult;
+import tech.pegasys.teku.validator.client.slashingriskactions.SlashingRiskDetectionAction;
 
 public interface KeyManager {
   List<Validator> getLocalValidatorKeys();
@@ -42,10 +42,10 @@ public interface KeyManager {
       final List<String> passwords,
       final Optional<SlashingProtectionImporter> slashingProtectionImporter,
       final Optional<DoppelgangerDetector> doppelgangerDetector,
-      final DoppelgangerDetectionAction doppelgangerDetectionAction);
+      final SlashingRiskDetectionAction doppelgangerDetectionAction);
 
   List<PostKeyResult> importExternalValidators(
       final List<ExternalValidator> validators,
       final Optional<DoppelgangerDetector> doppelgangerDetector,
-      final DoppelgangerDetectionAction doppelgangerDetectionAction);
+      final SlashingRiskDetectionAction doppelgangerDetectionAction);
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/NoOpKeyManager.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/NoOpKeyManager.java
@@ -19,12 +19,12 @@ import java.util.List;
 import java.util.Optional;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.data.SlashingProtectionImporter;
-import tech.pegasys.teku.validator.client.doppelganger.DoppelgangerDetectionAction;
 import tech.pegasys.teku.validator.client.doppelganger.DoppelgangerDetector;
 import tech.pegasys.teku.validator.client.restapi.apis.schema.DeleteKeysResponse;
 import tech.pegasys.teku.validator.client.restapi.apis.schema.DeleteRemoteKeysResponse;
 import tech.pegasys.teku.validator.client.restapi.apis.schema.ExternalValidator;
 import tech.pegasys.teku.validator.client.restapi.apis.schema.PostKeyResult;
+import tech.pegasys.teku.validator.client.slashingriskactions.SlashingRiskDetectionAction;
 
 public class NoOpKeyManager implements KeyManager {
 
@@ -60,7 +60,7 @@ public class NoOpKeyManager implements KeyManager {
       final List<String> passwords,
       final Optional<SlashingProtectionImporter> slashingProtectionImporter,
       final Optional<DoppelgangerDetector> maybeDoppelgangerDetector,
-      final DoppelgangerDetectionAction doppelgangerDetectionAction) {
+      final SlashingRiskDetectionAction doppelgangerDetectionAction) {
     return Collections.emptyList();
   }
 
@@ -68,7 +68,7 @@ public class NoOpKeyManager implements KeyManager {
   public List<PostKeyResult> importExternalValidators(
       List<ExternalValidator> validators,
       final Optional<DoppelgangerDetector> maybeDoppelgangerDetector,
-      final DoppelgangerDetectionAction doppelgangerDetectionAction) {
+      final SlashingRiskDetectionAction doppelgangerDetectionAction) {
     return Collections.emptyList();
   }
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/OwnedKeyManager.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/OwnedKeyManager.java
@@ -33,7 +33,6 @@ import tech.pegasys.teku.data.SlashingProtectionIncrementalExporter;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.signatures.Signer;
 import tech.pegasys.teku.validator.api.ValidatorTimingChannel;
-import tech.pegasys.teku.validator.client.doppelganger.DoppelgangerDetectionAction;
 import tech.pegasys.teku.validator.client.doppelganger.DoppelgangerDetector;
 import tech.pegasys.teku.validator.client.loader.ValidatorLoader;
 import tech.pegasys.teku.validator.client.restapi.apis.schema.DeleteKeyResult;
@@ -43,6 +42,7 @@ import tech.pegasys.teku.validator.client.restapi.apis.schema.DeletionStatus;
 import tech.pegasys.teku.validator.client.restapi.apis.schema.ExternalValidator;
 import tech.pegasys.teku.validator.client.restapi.apis.schema.ImportStatus;
 import tech.pegasys.teku.validator.client.restapi.apis.schema.PostKeyResult;
+import tech.pegasys.teku.validator.client.slashingriskactions.SlashingRiskDetectionAction;
 
 public class OwnedKeyManager implements KeyManager {
   private static final String EXPORT_FAILED =
@@ -227,7 +227,7 @@ public class OwnedKeyManager implements KeyManager {
       final List<String> passwords,
       final Optional<SlashingProtectionImporter> slashingProtectionImporter,
       final Optional<DoppelgangerDetector> maybeDoppelgangerDetector,
-      final DoppelgangerDetectionAction doppelgangerDetectionAction) {
+      final SlashingRiskDetectionAction doppelgangerDetectionAction) {
     final List<LocalValidatorImportResult> importResults = new ArrayList<>();
     boolean reloadRequired;
 
@@ -262,7 +262,7 @@ public class OwnedKeyManager implements KeyManager {
   }
 
   private void handleValidatorsDoppelgangers(
-      final DoppelgangerDetectionAction doppelgangerDetectionAction,
+      final SlashingRiskDetectionAction doppelgangerDetectionAction,
       final List<LocalValidatorImportResult> importResults,
       final Map<UInt64, BLSPublicKey> doppelgangers) {
     final List<BLSPublicKey> doppelgangerList = new ArrayList<>(doppelgangers.values());
@@ -382,7 +382,7 @@ public class OwnedKeyManager implements KeyManager {
   public List<PostKeyResult> importExternalValidators(
       final List<ExternalValidator> validators,
       final Optional<DoppelgangerDetector> maybeDoppelgangerDetector,
-      final DoppelgangerDetectionAction doppelgangerDetectionAction) {
+      final SlashingRiskDetectionAction doppelgangerDetectionAction) {
     final List<ExternalValidatorImportResult> importResults = new ArrayList<>();
     boolean reloadRequired = false;
 
@@ -448,7 +448,7 @@ public class OwnedKeyManager implements KeyManager {
   }
 
   private void handleExternalValidatorDoppelgangers(
-      final DoppelgangerDetectionAction doppelgangerDetectionAction,
+      final SlashingRiskDetectionAction doppelgangerDetectionAction,
       final List<ExternalValidatorImportResult> importResults,
       final Map<UInt64, BLSPublicKey> doppelgangers) {
     final List<BLSPublicKey> doppelgangerList = new ArrayList<>(doppelgangers.values());

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/OwnedValidatorStatusProvider.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/OwnedValidatorStatusProvider.java
@@ -115,19 +115,19 @@ public class OwnedValidatorStatusProvider implements ValidatorStatusProvider {
   }
 
   @Override
-  public void onBlockProductionDue(final UInt64 slot) {}
+  public void onBlockProductionDue(UInt64 slot) {}
 
   @Override
-  public void onAttestationCreationDue(final UInt64 slot) {}
+  public void onAttestationCreationDue(UInt64 slot) {}
 
   @Override
-  public void onAttestationAggregationDue(final UInt64 slot) {}
+  public void onAttestationAggregationDue(UInt64 slot) {}
 
   @Override
-  public void onAttesterSlashing(final AttesterSlashing attesterSlashing) {}
+  public void onAttesterSlashing(AttesterSlashing attesterSlashing) {}
 
   @Override
-  public void onProposerSlashing(final ProposerSlashing proposerSlashing) {}
+  public void onProposerSlashing(ProposerSlashing proposerSlashing) {}
 
   @Override
   public void subscribeValidatorStatusesUpdates(final ValidatorStatusSubscriber subscriber) {

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/OwnedValidatorStatusProvider.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/OwnedValidatorStatusProvider.java
@@ -115,19 +115,19 @@ public class OwnedValidatorStatusProvider implements ValidatorStatusProvider {
   }
 
   @Override
-  public void onBlockProductionDue(UInt64 slot) {}
+  public void onBlockProductionDue(final UInt64 slot) {}
 
   @Override
-  public void onAttestationCreationDue(UInt64 slot) {}
+  public void onAttestationCreationDue(final UInt64 slot) {}
 
   @Override
-  public void onAttestationAggregationDue(UInt64 slot) {}
+  public void onAttestationAggregationDue(final UInt64 slot) {}
 
   @Override
-  public void onAttesterSlashing(AttesterSlashing attesterSlashing) {}
+  public void onAttesterSlashing(final AttesterSlashing attesterSlashing) {}
 
   @Override
-  public void onProposerSlashing(ProposerSlashing proposerSlashing) {}
+  public void onProposerSlashing(final ProposerSlashing proposerSlashing) {}
 
   @Override
   public void subscribeValidatorStatusesUpdates(final ValidatorStatusSubscriber subscriber) {

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
@@ -95,7 +95,7 @@ public class ValidatorClientService extends Service {
   private ValidatorIndexProvider validatorIndexProvider;
   private Optional<DoppelgangerDetector> maybeDoppelgangerDetector = Optional.empty();
   private final SlashingRiskDetectionAction doppelgangerDetectionAction;
-  private final SlashingRiskDetectionAction validatorSlashedAction;
+  private final Optional<SlashingRiskDetectionAction> maybeValidatorSlashedAction;
   private Optional<RestApi> maybeValidatorRestApi = Optional.empty();
   private final Optional<BeaconProposerPreparer> beaconProposerPreparer;
   private final Optional<ValidatorRegistrator> validatorRegistrator;
@@ -117,7 +117,7 @@ public class ValidatorClientService extends Service {
       final Spec spec,
       final MetricsSystem metricsSystem,
       final SlashingRiskDetectionAction doppelgangerDetectionAction,
-      final SlashingRiskDetectionAction validatorSlashedAction) {
+      final Optional<SlashingRiskDetectionAction> maybeValidatorSlashedAction) {
     this.eventChannels = eventChannels;
     this.validatorLoader = validatorLoader;
     this.beaconNodeApi = beaconNodeApi;
@@ -129,14 +129,14 @@ public class ValidatorClientService extends Service {
     this.spec = spec;
     this.metricsSystem = metricsSystem;
     this.doppelgangerDetectionAction = doppelgangerDetectionAction;
-    this.validatorSlashedAction = validatorSlashedAction;
+    this.maybeValidatorSlashedAction = maybeValidatorSlashedAction;
   }
 
   public static ValidatorClientService create(
       final ServiceConfig services,
       final ValidatorClientConfiguration config,
       final SlashingRiskDetectionAction doppelgangerDetectionAction,
-      final SlashingRiskDetectionAction validatorSlashingAction) {
+      final Optional<SlashingRiskDetectionAction> maybeValidatorSlashingAction) {
     final EventChannels eventChannels = services.getEventChannels();
     final ValidatorConfig validatorConfig = config.getValidatorConfig();
 
@@ -219,7 +219,7 @@ public class ValidatorClientService extends Service {
             config.getSpec(),
             services.getMetricsSystem(),
             doppelgangerDetectionAction,
-            validatorSlashingAction);
+            maybeValidatorSlashingAction);
 
     asyncRunner
         .runAsync(
@@ -573,7 +573,7 @@ public class ValidatorClientService extends Service {
                       validatorTimingChannels,
                       spec,
                       metricsSystem,
-                      validatorSlashedAction));
+                      maybeValidatorSlashedAction));
               validatorStatusProvider.start().ifExceptionGetsHereRaiseABug();
               return beaconNodeApi.subscribeToEvents();
             });

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorIndexProvider.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorIndexProvider.java
@@ -21,6 +21,7 @@ import it.unimi.dsi.fastutil.ints.IntCollection;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -97,6 +98,13 @@ public class ValidatorIndexProvider {
                   .map(entry -> entry.getKey().toString() + "=" + entry.getValue())
                   .collect(joining(", ")));
     }
+  }
+
+  public Optional<BLSPublicKey> getPublicKey(final Integer index) {
+    return validatorIndicesByPublicKey.entrySet().stream()
+        .filter(entry -> entry.getValue().equals(index))
+        .findFirst()
+        .map(Map.Entry::getKey);
   }
 
   public boolean containsPublicKey(BLSPublicKey publicKey) {

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorTimingActions.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorTimingActions.java
@@ -122,13 +122,13 @@ public class ValidatorTimingActions implements ValidatorTimingChannel {
 
   @Override
   public void onProposerSlashing(final ProposerSlashing proposerSlashing) {
-    delegates.forEach(delegates -> delegates.onProposerSlashing(proposerSlashing));
-    final UInt64 slashedIndex = proposerSlashing.getHeader1().getMessage().getProposerIndex();
-    validatorIndexProvider
-        .getPublicKey(slashedIndex.intValue())
-        .ifPresent(
-            slashedPubKey ->
-                maybeValidatorSlashedAction.ifPresent(
-                    validatorSlashingAction -> validatorSlashingAction.perform(slashedPubKey)));
+    maybeValidatorSlashedAction.ifPresent(
+        validatorSlashedAction -> {
+          delegates.forEach(delegates -> delegates.onProposerSlashing(proposerSlashing));
+          final UInt64 slashedIndex = proposerSlashing.getHeader1().getMessage().getProposerIndex();
+          validatorIndexProvider
+              .getPublicKey(slashedIndex.intValue())
+              .ifPresent(slashedPubKey -> maybeValidatorSlashedAction.get().perform(slashedPubKey));
+        });
   }
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorTimingActions.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorTimingActions.java
@@ -106,9 +106,9 @@ public class ValidatorTimingActions implements ValidatorTimingChannel {
 
   @Override
   public void onAttesterSlashing(final AttesterSlashing attesterSlashing) {
+    delegates.forEach(delegates -> delegates.onAttesterSlashing(attesterSlashing));
     maybeValidatorSlashedAction.ifPresent(
         validatorSlashingAction -> {
-          delegates.forEach(delegates -> delegates.onAttesterSlashing(attesterSlashing));
           final Set<UInt64> slashedIndices = attesterSlashing.getIntersectingValidatorIndices();
           final List<BLSPublicKey> slashedPublicKeys =
               slashedIndices.stream()
@@ -122,9 +122,9 @@ public class ValidatorTimingActions implements ValidatorTimingChannel {
 
   @Override
   public void onProposerSlashing(final ProposerSlashing proposerSlashing) {
+    delegates.forEach(delegates -> delegates.onProposerSlashing(proposerSlashing));
     maybeValidatorSlashedAction.ifPresent(
         validatorSlashedAction -> {
-          delegates.forEach(delegates -> delegates.onProposerSlashing(proposerSlashing));
           final UInt64 slashedIndex = proposerSlashing.getHeader1().getMessage().getProposerIndex();
           validatorIndexProvider
               .getPublicKey(slashedIndex.intValue())

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorTimingActions.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorTimingActions.java
@@ -106,10 +106,10 @@ public class ValidatorTimingActions implements ValidatorTimingChannel {
 
   @Override
   public void onAttesterSlashing(final AttesterSlashing attesterSlashing) {
-    delegates.forEach(delegates -> delegates.onAttesterSlashing(attesterSlashing));
-    final Set<UInt64> slashedIndices = attesterSlashing.getIntersectingValidatorIndices();
     maybeValidatorSlashedAction.ifPresent(
         validatorSlashingAction -> {
+          delegates.forEach(delegates -> delegates.onAttesterSlashing(attesterSlashing));
+          final Set<UInt64> slashedIndices = attesterSlashing.getIntersectingValidatorIndices();
           final List<BLSPublicKey> slashedPublicKeys =
               slashedIndices.stream()
                   .map(slashedIndex -> validatorIndexProvider.getPublicKey(slashedIndex.intValue()))

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorTimingActions.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorTimingActions.java
@@ -108,14 +108,16 @@ public class ValidatorTimingActions implements ValidatorTimingChannel {
   public void onAttesterSlashing(final AttesterSlashing attesterSlashing) {
     delegates.forEach(delegates -> delegates.onAttesterSlashing(attesterSlashing));
     final Set<UInt64> slashedIndices = attesterSlashing.getIntersectingValidatorIndices();
-    final List<BLSPublicKey> slashedPublicKeys =
-        slashedIndices.stream()
-            .map(slashedIndex -> validatorIndexProvider.getPublicKey(slashedIndex.intValue()))
-            .filter(Optional::isPresent)
-            .map(Optional::get)
-            .collect(Collectors.toList());
     maybeValidatorSlashedAction.ifPresent(
-        validatorSlashingAction -> validatorSlashingAction.perform(slashedPublicKeys));
+        validatorSlashingAction -> {
+          final List<BLSPublicKey> slashedPublicKeys =
+              slashedIndices.stream()
+                  .map(slashedIndex -> validatorIndexProvider.getPublicKey(slashedIndex.intValue()))
+                  .filter(Optional::isPresent)
+                  .map(Optional::get)
+                  .collect(Collectors.toList());
+          validatorSlashingAction.perform(slashedPublicKeys);
+        });
   }
 
   @Override

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/ValidatorRestApi.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/ValidatorRestApi.java
@@ -35,7 +35,6 @@ import tech.pegasys.teku.validator.client.KeyManager;
 import tech.pegasys.teku.validator.client.ProposerConfigManager;
 import tech.pegasys.teku.validator.client.ValidatorClientService;
 import tech.pegasys.teku.validator.client.VoluntaryExitDataProvider;
-import tech.pegasys.teku.validator.client.doppelganger.DoppelgangerDetectionAction;
 import tech.pegasys.teku.validator.client.doppelganger.DoppelgangerDetector;
 import tech.pegasys.teku.validator.client.restapi.apis.DeleteFeeRecipient;
 import tech.pegasys.teku.validator.client.restapi.apis.DeleteGasLimit;
@@ -50,6 +49,7 @@ import tech.pegasys.teku.validator.client.restapi.apis.PostRemoteKeys;
 import tech.pegasys.teku.validator.client.restapi.apis.PostVoluntaryExit;
 import tech.pegasys.teku.validator.client.restapi.apis.SetFeeRecipient;
 import tech.pegasys.teku.validator.client.restapi.apis.SetGasLimit;
+import tech.pegasys.teku.validator.client.slashingriskactions.SlashingRiskDetectionAction;
 
 public class ValidatorRestApi {
 
@@ -68,7 +68,7 @@ public class ValidatorRestApi {
       final DataDirLayout dataDirLayout,
       final TimeProvider timeProvider,
       final Optional<DoppelgangerDetector> maybeDoppelgangerDetector,
-      final DoppelgangerDetectionAction doppelgangerDetectionAction) {
+      final SlashingRiskDetectionAction doppelgangerDetectionAction) {
     final VoluntaryExitDataProvider voluntaryExitDataProvider =
         new VoluntaryExitDataProvider(
             spec, keyManager, validatorApiChannel, genesisDataProvider, timeProvider);

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/apis/PostKeys.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/apis/PostKeys.java
@@ -31,23 +31,23 @@ import tech.pegasys.teku.infrastructure.restapi.endpoints.EndpointMetadata;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiEndpoint;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiRequest;
 import tech.pegasys.teku.validator.client.KeyManager;
-import tech.pegasys.teku.validator.client.doppelganger.DoppelgangerDetectionAction;
 import tech.pegasys.teku.validator.client.doppelganger.DoppelgangerDetector;
 import tech.pegasys.teku.validator.client.restapi.ValidatorTypes;
 import tech.pegasys.teku.validator.client.restapi.apis.schema.PostKeysRequest;
+import tech.pegasys.teku.validator.client.slashingriskactions.SlashingRiskDetectionAction;
 
 public class PostKeys extends RestApiEndpoint {
   private final KeyManager keyManager;
   public static final String ROUTE = "/eth/v1/keystores";
   private final Path slashingProtectionPath;
   private final Optional<DoppelgangerDetector> maybeDoppelgangerDetector;
-  private final DoppelgangerDetectionAction doppelgangerDetectionAction;
+  private final SlashingRiskDetectionAction doppelgangerDetectionAction;
 
   public PostKeys(
       final KeyManager keyManager,
       final Path slashingProtectionPath,
       final Optional<DoppelgangerDetector> maybeDoppelgangerDetector,
-      final DoppelgangerDetectionAction doppelgangerDetectionAction) {
+      final SlashingRiskDetectionAction doppelgangerDetectionAction) {
     super(
         EndpointMetadata.post(ROUTE)
             .operationId("ImportKeystores")

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/apis/PostRemoteKeys.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/apis/PostRemoteKeys.java
@@ -24,11 +24,11 @@ import tech.pegasys.teku.infrastructure.restapi.endpoints.EndpointMetadata;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiEndpoint;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiRequest;
 import tech.pegasys.teku.validator.client.KeyManager;
-import tech.pegasys.teku.validator.client.doppelganger.DoppelgangerDetectionAction;
 import tech.pegasys.teku.validator.client.doppelganger.DoppelgangerDetector;
 import tech.pegasys.teku.validator.client.restapi.ValidatorTypes;
 import tech.pegasys.teku.validator.client.restapi.apis.schema.ExternalValidator;
 import tech.pegasys.teku.validator.client.restapi.apis.schema.PostRemoteKeysRequest;
+import tech.pegasys.teku.validator.client.slashingriskactions.SlashingRiskDetectionAction;
 
 public class PostRemoteKeys extends RestApiEndpoint {
   public static final String ROUTE = "/eth/v1/remotekeys";
@@ -37,12 +37,12 @@ public class PostRemoteKeys extends RestApiEndpoint {
   private final KeyManager keyManager;
 
   private final Optional<DoppelgangerDetector> maybeDoppelgangerDetector;
-  private final DoppelgangerDetectionAction doppelgangerDetectionAction;
+  private final SlashingRiskDetectionAction doppelgangerDetectionAction;
 
   public PostRemoteKeys(
       final KeyManager keyManager,
       final Optional<DoppelgangerDetector> maybeDoppelgangerDetector,
-      final DoppelgangerDetectionAction doppelgangerDetectionAction) {
+      final SlashingRiskDetectionAction doppelgangerDetectionAction) {
     super(
         EndpointMetadata.post(ROUTE)
             .operationId("ImportRemoteKeys")

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/slashingriskactions/DoppelgangerDetectionAlert.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/slashingriskactions/DoppelgangerDetectionAlert.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Consensys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.client.slashingriskactions;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.infrastructure.logging.StatusLogger;
+
+public class DoppelgangerDetectionAlert implements SlashingRiskDetectionAction {
+
+  private final StatusLogger statusLog;
+
+  public DoppelgangerDetectionAlert() {
+    this(StatusLogger.STATUS_LOG);
+  }
+
+  public DoppelgangerDetectionAlert(final StatusLogger statusLog) {
+    this.statusLog = statusLog;
+  }
+
+  @Override
+  public void perform(final List<BLSPublicKey> pubKeys) {
+    if (!pubKeys.isEmpty()) {
+      statusLog.doppelgangerDetectionAlert(
+          pubKeys.stream().map(BLSPublicKey::toAbbreviatedString).collect(Collectors.toSet()));
+    }
+  }
+}

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/slashingriskactions/DoppelgangerDetectionShutDown.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/slashingriskactions/DoppelgangerDetectionShutDown.java
@@ -28,7 +28,7 @@ public class DoppelgangerDetectionShutDown implements SlashingRiskDetectionActio
           pubKeys.stream()
               .map(BLSPublicKey::toAbbreviatedString)
               .collect(Collectors.joining(", ")));
-      System.exit(2);
+      shutDown();
     }
   }
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/slashingriskactions/DoppelgangerDetectionShutDown.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/slashingriskactions/DoppelgangerDetectionShutDown.java
@@ -28,7 +28,7 @@ public class DoppelgangerDetectionShutDown implements SlashingRiskDetectionActio
           pubKeys.stream()
               .map(BLSPublicKey::toAbbreviatedString)
               .collect(Collectors.joining(", ")));
-      shutDown();
+      shutdown();
     }
   }
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/slashingriskactions/DoppelgangerDetectionShutDown.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/slashingriskactions/DoppelgangerDetectionShutDown.java
@@ -11,12 +11,24 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.validator.client.doppelganger;
+package tech.pegasys.teku.validator.client.slashingriskactions;
+
+import static tech.pegasys.teku.infrastructure.logging.StatusLogger.STATUS_LOG;
 
 import java.util.List;
+import java.util.stream.Collectors;
 import tech.pegasys.teku.bls.BLSPublicKey;
 
-public interface DoppelgangerDetectionAction {
+public class DoppelgangerDetectionShutDown implements SlashingRiskDetectionAction {
 
-  void perform(final List<BLSPublicKey> doppelgangers);
+  @Override
+  public void perform(final List<BLSPublicKey> pubKeys) {
+    if (!pubKeys.isEmpty()) {
+      STATUS_LOG.exitOnDoppelgangerDetected(
+          pubKeys.stream()
+              .map(BLSPublicKey::toAbbreviatedString)
+              .collect(Collectors.joining(", ")));
+      System.exit(1);
+    }
+  }
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/slashingriskactions/DoppelgangerDetectionShutDown.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/slashingriskactions/DoppelgangerDetectionShutDown.java
@@ -28,7 +28,7 @@ public class DoppelgangerDetectionShutDown implements SlashingRiskDetectionActio
           pubKeys.stream()
               .map(BLSPublicKey::toAbbreviatedString)
               .collect(Collectors.joining(", ")));
-      System.exit(1);
+      System.exit(2);
     }
   }
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/slashingriskactions/SlashedValidatorAlert.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/slashingriskactions/SlashedValidatorAlert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Consensys Software Inc., 2022
+ * Copyright Consensys Software Inc., 2023
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -11,28 +11,29 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.validator.client.doppelganger;
+package tech.pegasys.teku.validator.client.slashingriskactions;
 
 import java.util.List;
 import java.util.stream.Collectors;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.infrastructure.logging.StatusLogger;
 
-public class DoppelgangerDetectionAlert implements DoppelgangerDetectionAction {
-
+public class SlashedValidatorAlert implements SlashingRiskDetectionAction {
   private final StatusLogger statusLog;
 
-  public DoppelgangerDetectionAlert() {
-    this(StatusLogger.STATUS_LOG);
+  public SlashedValidatorAlert() {
+    this.statusLog = StatusLogger.STATUS_LOG;
   }
 
-  public DoppelgangerDetectionAlert(final StatusLogger statusLog) {
+  public SlashedValidatorAlert(final StatusLogger statusLog) {
     this.statusLog = statusLog;
   }
 
   @Override
-  public void perform(final List<BLSPublicKey> doppelgangers) {
-    statusLog.doppelgangerDetectionAlert(
-        doppelgangers.stream().map(BLSPublicKey::toAbbreviatedString).collect(Collectors.toSet()));
+  public void perform(List<BLSPublicKey> pubKeys) {
+    if (!pubKeys.isEmpty()) {
+      statusLog.validatorSlashedAlert(
+          pubKeys.stream().map(BLSPublicKey::toAbbreviatedString).collect(Collectors.toSet()));
+    }
   }
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/slashingriskactions/SlashedValidatorShutDown.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/slashingriskactions/SlashedValidatorShutDown.java
@@ -31,7 +31,7 @@ public class SlashedValidatorShutDown implements SlashingRiskDetectionAction {
           pubKeys.stream()
               .map(BLSPublicKey::toAbbreviatedString)
               .collect(Collectors.joining(", ")));
-      System.exit(1);
+      System.exit(2);
     }
   }
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/slashingriskactions/SlashedValidatorShutDown.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/slashingriskactions/SlashedValidatorShutDown.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Consensys Software Inc., 2022
+ * Copyright Consensys Software Inc., 2023
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -11,21 +11,27 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.validator.client.doppelganger;
-
-import static tech.pegasys.teku.infrastructure.logging.StatusLogger.STATUS_LOG;
+package tech.pegasys.teku.validator.client.slashingriskactions;
 
 import java.util.List;
 import java.util.stream.Collectors;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.bls.BLSPublicKey;
 
-public class DoppelgangerDetectionShutDown implements DoppelgangerDetectionAction {
+public class SlashedValidatorShutDown implements SlashingRiskDetectionAction {
+
+  private static final Logger LOG = LogManager.getLogger();
+
   @Override
-  public void perform(final List<BLSPublicKey> doppelgangers) {
-    STATUS_LOG.exitOnDoppelgangerDetected(
-        doppelgangers.stream()
-            .map(BLSPublicKey::toAbbreviatedString)
-            .collect(Collectors.joining(", ")));
-    System.exit(1);
+  public void perform(List<BLSPublicKey> pubKeys) {
+    if (!pubKeys.isEmpty()) {
+      LOG.info(
+          "Validator(s) with public key(s) {} have been slashed. Shutting down...",
+          pubKeys.stream()
+              .map(BLSPublicKey::toAbbreviatedString)
+              .collect(Collectors.joining(", ")));
+      System.exit(1);
+    }
   }
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/slashingriskactions/SlashedValidatorShutDown.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/slashingriskactions/SlashedValidatorShutDown.java
@@ -13,24 +13,19 @@
 
 package tech.pegasys.teku.validator.client.slashingriskactions;
 
+import static tech.pegasys.teku.infrastructure.logging.StatusLogger.STATUS_LOG;
+
 import java.util.List;
 import java.util.stream.Collectors;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.bls.BLSPublicKey;
 
 public class SlashedValidatorShutDown implements SlashingRiskDetectionAction {
 
-  private static final Logger LOG = LogManager.getLogger();
-
   @Override
   public void perform(List<BLSPublicKey> pubKeys) {
     if (!pubKeys.isEmpty()) {
-      LOG.fatal(
-          "Validator(s) with public key(s) {} got slashed. Shutting down...",
-          pubKeys.stream()
-              .map(BLSPublicKey::toAbbreviatedString)
-              .collect(Collectors.joining(", ")));
+      STATUS_LOG.validatorSlashedAlert(
+          pubKeys.stream().map(BLSPublicKey::toAbbreviatedString).collect(Collectors.toSet()));
       System.exit(2);
     }
   }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/slashingriskactions/SlashedValidatorShutDown.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/slashingriskactions/SlashedValidatorShutDown.java
@@ -13,20 +13,29 @@
 
 package tech.pegasys.teku.validator.client.slashingriskactions;
 
-import static tech.pegasys.teku.infrastructure.logging.StatusLogger.STATUS_LOG;
-
 import java.util.List;
 import java.util.stream.Collectors;
 import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.infrastructure.logging.StatusLogger;
 
 public class SlashedValidatorShutDown implements SlashingRiskDetectionAction {
+
+  private final StatusLogger statusLog;
+
+  public SlashedValidatorShutDown() {
+    this(StatusLogger.STATUS_LOG);
+  }
+
+  public SlashedValidatorShutDown(final StatusLogger statusLog) {
+    this.statusLog = statusLog;
+  }
 
   @Override
   public void perform(List<BLSPublicKey> pubKeys) {
     if (!pubKeys.isEmpty()) {
-      STATUS_LOG.validatorSlashedAlert(
-          pubKeys.stream().map(BLSPublicKey::toAbbreviatedString).collect(Collectors.toSet()));
-      System.exit(2);
+      statusLog.validatorSlashedAlert(
+          pubKeys.stream().map(BLSPublicKey::toHexString).collect(Collectors.toSet()));
+      shutDown();
     }
   }
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/slashingriskactions/SlashedValidatorShutDown.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/slashingriskactions/SlashedValidatorShutDown.java
@@ -26,8 +26,8 @@ public class SlashedValidatorShutDown implements SlashingRiskDetectionAction {
   @Override
   public void perform(List<BLSPublicKey> pubKeys) {
     if (!pubKeys.isEmpty()) {
-      LOG.info(
-          "Validator(s) with public key(s) {} have been slashed. Shutting down...",
+      LOG.fatal(
+          "Validator(s) with public key(s) {} got slashed. Shutting down...",
           pubKeys.stream()
               .map(BLSPublicKey::toAbbreviatedString)
               .collect(Collectors.joining(", ")));

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/slashingriskactions/SlashedValidatorShutDown.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/slashingriskactions/SlashedValidatorShutDown.java
@@ -35,7 +35,7 @@ public class SlashedValidatorShutDown implements SlashingRiskDetectionAction {
     if (!pubKeys.isEmpty()) {
       statusLog.validatorSlashedAlert(
           pubKeys.stream().map(BLSPublicKey::toHexString).collect(Collectors.toSet()));
-      shutDown();
+      shutdown();
     }
   }
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/slashingriskactions/SlashingRiskDetectionAction.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/slashingriskactions/SlashingRiskDetectionAction.java
@@ -23,4 +23,8 @@ public interface SlashingRiskDetectionAction {
   default void perform(BLSPublicKey pubKey) {
     perform(List.of(pubKey));
   }
+
+  default void shutDown() {
+    System.exit(2);
+  }
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/slashingriskactions/SlashingRiskDetectionAction.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/slashingriskactions/SlashingRiskDetectionAction.java
@@ -18,9 +18,9 @@ import tech.pegasys.teku.bls.BLSPublicKey;
 
 public interface SlashingRiskDetectionAction {
 
-  void perform(final List<BLSPublicKey> pubKeys);
+  void perform(List<BLSPublicKey> pubKeys);
 
-  default void perform(final BLSPublicKey pubKey) {
+  default void perform(BLSPublicKey pubKey) {
     perform(List.of(pubKey));
   }
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/slashingriskactions/SlashingRiskDetectionAction.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/slashingriskactions/SlashingRiskDetectionAction.java
@@ -24,7 +24,7 @@ public interface SlashingRiskDetectionAction {
     perform(List.of(pubKey));
   }
 
-  default void shutDown() {
+  default void shutdown() {
     System.exit(2);
   }
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/slashingriskactions/SlashingRiskDetectionAction.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/slashingriskactions/SlashingRiskDetectionAction.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Consensys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.client.slashingriskactions;
+
+import java.util.List;
+import tech.pegasys.teku.bls.BLSPublicKey;
+
+public interface SlashingRiskDetectionAction {
+
+  void perform(final List<BLSPublicKey> pubKeys);
+
+  default void perform(final BLSPublicKey pubKey) {
+    perform(List.of(pubKey));
+  }
+}

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/OwnedKeyManagerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/OwnedKeyManagerTest.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.validator.client;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -56,7 +57,6 @@ import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.signatures.Signer;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.validator.api.ValidatorTimingChannel;
-import tech.pegasys.teku.validator.client.doppelganger.DoppelgangerDetectionAction;
 import tech.pegasys.teku.validator.client.doppelganger.DoppelgangerDetector;
 import tech.pegasys.teku.validator.client.loader.OwnedValidators;
 import tech.pegasys.teku.validator.client.loader.ValidatorLoader;
@@ -65,6 +65,7 @@ import tech.pegasys.teku.validator.client.restapi.apis.schema.DeleteKeysResponse
 import tech.pegasys.teku.validator.client.restapi.apis.schema.DeletionStatus;
 import tech.pegasys.teku.validator.client.restapi.apis.schema.ExternalValidator;
 import tech.pegasys.teku.validator.client.restapi.apis.schema.PostKeyResult;
+import tech.pegasys.teku.validator.client.slashingriskactions.SlashingRiskDetectionAction;
 
 class OwnedKeyManagerTest {
 
@@ -79,8 +80,8 @@ class OwnedKeyManagerTest {
   private final ValidatorTimingChannel channel = mock(ValidatorTimingChannel.class);
   private final OwnedKeyManager keyManager = new OwnedKeyManager(validatorLoader, channel);
   private final DoppelgangerDetector doppelgangerDetector = mock(DoppelgangerDetector.class);
-  private final DoppelgangerDetectionAction doppelgangerDetectionAction =
-      mock(DoppelgangerDetectionAction.class);
+  private final SlashingRiskDetectionAction doppelgangerDetectionAction =
+      mock(SlashingRiskDetectionAction.class);
   private final BLSPublicKey doppelgangerPublicKey =
       BLSPublicKey.fromSSZBytes(
           Bytes.fromHexString(
@@ -392,7 +393,7 @@ class OwnedKeyManagerTest {
     verify(validatorLoader, times(1))
         .addValidator(any(), eq(doppelgangerPassword), eq(doppelgangerPublicKey));
     verify(doppelgangerDetector).performDoppelgangerDetection(Set.of(doppelgangerPublicKey));
-    verify(doppelgangerDetectionAction, never()).perform(any());
+    verify(doppelgangerDetectionAction, never()).perform(anyList());
     logCaptor.assertErrorLog(
         String.format(
             "Failed to perform doppelganger detection for public keys %s",
@@ -486,7 +487,7 @@ class OwnedKeyManagerTest {
 
     verify(channel).onValidatorsAdded();
     verify(doppelgangerDetector).performDoppelgangerDetection(Set.of(doppelgangerPublicKey));
-    verify(doppelgangerDetectionAction, never()).perform(any());
+    verify(doppelgangerDetectionAction, never()).perform(anyList());
     verify(validatorLoader, times(1)).addExternalValidator(signerUrl, doppelgangerPublicKey);
     logCaptor.assertErrorLog(
         String.format(

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorTimingActionsTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorTimingActionsTest.java
@@ -32,8 +32,8 @@ import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.validator.api.ValidatorTimingChannel;
-import tech.pegasys.teku.validator.client.slashingriskactions.SlashedValidatorAlert;
 import tech.pegasys.teku.validator.client.slashingriskactions.SlashingRiskDetectionAction;
+import tech.pegasys.teku.validator.client.validatorslashingprotection.SlashedValidatorAlert;
 
 public class ValidatorTimingActionsTest {
   private final Spec spec = TestSpecFactory.createDefault();

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorTimingActionsTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorTimingActionsTest.java
@@ -74,9 +74,7 @@ public class ValidatorTimingActionsTest {
     verify(validatorIndexProvider).getPublicKey(secondSlashedIndex.intValue());
     verify(statusLogger)
         .validatorSlashedAlert(
-            Set.of(
-                firstSlashedPublicKey.toAbbreviatedString(),
-                secondSlashedPublicKey.toAbbreviatedString()));
+            Set.of(firstSlashedPublicKey.toHexString(), secondSlashedPublicKey.toHexString()));
   }
 
   @Test
@@ -92,7 +90,7 @@ public class ValidatorTimingActionsTest {
     validatorTimingActions.onProposerSlashing(proposerSlashing);
     verify(delegate).onProposerSlashing(proposerSlashing);
     verify(validatorIndexProvider).getPublicKey(firstSlashedIndex.intValue());
-    verify(statusLogger).validatorSlashedAlert(Set.of(firstSlashedPublicKey.toAbbreviatedString()));
+    verify(statusLogger).validatorSlashedAlert(Set.of(firstSlashedPublicKey.toHexString()));
   }
 
   @Test

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorTimingActionsTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorTimingActionsTest.java
@@ -133,7 +133,7 @@ public class ValidatorTimingActionsTest {
         dataStructureUtil.randomAttesterSlashing(
             dataStructureUtil.randomValidatorIndex(), dataStructureUtil.randomValidatorIndex());
     validatorTimingActions.onAttesterSlashing(attesterSlashing);
-    verifyNoInteractions(delegate);
+    verify(delegate).onAttesterSlashing(attesterSlashing);
     verifyNoInteractions(validatorIndexProvider);
     verifyNoInteractions(statusLogger);
   }
@@ -147,7 +147,7 @@ public class ValidatorTimingActionsTest {
         dataStructureUtil.randomProposerSlashing(
             dataStructureUtil.randomSlot(), dataStructureUtil.randomValidatorIndex());
     validatorTimingActions.onProposerSlashing(proposerSlashing);
-    verifyNoInteractions(delegate);
+    verify(delegate).onProposerSlashing(proposerSlashing);
     verifyNoInteractions(validatorIndexProvider);
     verifyNoInteractions(statusLogger);
   }

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorTimingActionsTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorTimingActionsTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Consensys Software Inc., 2023
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.client;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.hyperledger.besu.plugin.services.MetricsSystem;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.infrastructure.logging.StatusLogger;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
+import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.validator.api.ValidatorTimingChannel;
+import tech.pegasys.teku.validator.client.slashingriskactions.SlashedValidatorAlert;
+import tech.pegasys.teku.validator.client.slashingriskactions.SlashingRiskDetectionAction;
+
+public class ValidatorTimingActionsTest {
+  private final Spec spec = TestSpecFactory.createDefault();
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+  private final ValidatorIndexProvider validatorIndexProvider = mock(ValidatorIndexProvider.class);
+  private final ValidatorTimingChannel delegate = mock(ValidatorTimingChannel.class);
+  private final List<ValidatorTimingChannel> delegates = List.of(delegate);
+  private final MetricsSystem metricsSystem = mock(MetricsSystem.class);
+  private final UInt64 firstSlashedIndex = UInt64.valueOf(254);
+  private final BLSPublicKey firstSlashedPublicKey = dataStructureUtil.randomPublicKey();
+  private final UInt64 secondSlashedIndex = UInt64.valueOf(54654);
+  private final BLSPublicKey secondSlashedPublicKey = dataStructureUtil.randomPublicKey();
+  private final StatusLogger statusLogger = mock(StatusLogger.class);
+  private final SlashingRiskDetectionAction slashedAttesterValidator =
+      new SlashedValidatorAlert(statusLogger);
+
+  @Test
+  public void shouldPrintAlertForSlashedAttestingValidators() {
+    final ValidatorTimingActions validatorTimingActions =
+        new ValidatorTimingActions(
+            validatorIndexProvider, delegates, spec, metricsSystem, slashedAttesterValidator);
+    final AttesterSlashing attesterSlashing =
+        dataStructureUtil.randomAttesterSlashing(
+            dataStructureUtil.randomValidatorIndex(),
+            firstSlashedIndex,
+            secondSlashedIndex,
+            dataStructureUtil.randomValidatorIndex());
+    when(validatorIndexProvider.getPublicKey(any())).thenReturn(Optional.empty());
+    when(validatorIndexProvider.getPublicKey(firstSlashedIndex.intValue()))
+        .thenReturn(Optional.of(firstSlashedPublicKey));
+    when(validatorIndexProvider.getPublicKey(secondSlashedIndex.intValue()))
+        .thenReturn(Optional.of(secondSlashedPublicKey));
+    validatorTimingActions.onAttesterSlashing(attesterSlashing);
+    verify(validatorIndexProvider).getPublicKey(firstSlashedIndex.intValue());
+    verify(validatorIndexProvider).getPublicKey(secondSlashedIndex.intValue());
+    verify(statusLogger)
+        .validatorSlashedAlert(
+            Set.of(
+                firstSlashedPublicKey.toAbbreviatedString(),
+                secondSlashedPublicKey.toAbbreviatedString()));
+  }
+
+  @Test
+  public void shouldPrintAlertForSlashedProposingValidator() {
+    final ValidatorTimingActions validatorTimingActions =
+        new ValidatorTimingActions(
+            validatorIndexProvider, delegates, spec, metricsSystem, slashedAttesterValidator);
+    final ProposerSlashing proposerSlashing =
+        dataStructureUtil.randomProposerSlashing(
+            dataStructureUtil.randomValidatorIndex(), firstSlashedIndex);
+    when(validatorIndexProvider.getPublicKey(any())).thenReturn(Optional.empty());
+    when(validatorIndexProvider.getPublicKey(firstSlashedIndex.intValue()))
+        .thenReturn(Optional.of(firstSlashedPublicKey));
+    validatorTimingActions.onProposerSlashing(proposerSlashing);
+    verify(validatorIndexProvider).getPublicKey(firstSlashedIndex.intValue());
+    verify(statusLogger).validatorSlashedAlert(Set.of(firstSlashedPublicKey.toAbbreviatedString()));
+  }
+}

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorTimingActionsTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/ValidatorTimingActionsTest.java
@@ -47,14 +47,14 @@ public class ValidatorTimingActionsTest {
   private final UInt64 secondSlashedIndex = UInt64.valueOf(54654);
   private final BLSPublicKey secondSlashedPublicKey = dataStructureUtil.randomPublicKey();
   private final StatusLogger statusLogger = mock(StatusLogger.class);
-  private final SlashingRiskDetectionAction slashedAttesterValidator =
-      new SlashedValidatorAlert(statusLogger);
+  private final Optional<SlashingRiskDetectionAction> maybeSlashedAttesterValidator =
+      Optional.of(new SlashedValidatorAlert(statusLogger));
 
   @Test
   public void shouldPrintAlertForSlashedAttestingValidators() {
     final ValidatorTimingActions validatorTimingActions =
         new ValidatorTimingActions(
-            validatorIndexProvider, delegates, spec, metricsSystem, slashedAttesterValidator);
+            validatorIndexProvider, delegates, spec, metricsSystem, maybeSlashedAttesterValidator);
     final AttesterSlashing attesterSlashing =
         dataStructureUtil.randomAttesterSlashing(
             dataStructureUtil.randomValidatorIndex(),
@@ -80,7 +80,7 @@ public class ValidatorTimingActionsTest {
   public void shouldPrintAlertForSlashedProposingValidator() {
     final ValidatorTimingActions validatorTimingActions =
         new ValidatorTimingActions(
-            validatorIndexProvider, delegates, spec, metricsSystem, slashedAttesterValidator);
+            validatorIndexProvider, delegates, spec, metricsSystem, maybeSlashedAttesterValidator);
     final ProposerSlashing proposerSlashing =
         dataStructureUtil.randomProposerSlashing(
             dataStructureUtil.randomValidatorIndex(), firstSlashedIndex);

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/restapi/ValidatorOpenApiTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/restapi/ValidatorOpenApiTest.java
@@ -35,7 +35,7 @@ import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 import tech.pegasys.teku.validator.beaconnode.GenesisDataProvider;
 import tech.pegasys.teku.validator.client.OwnedKeyManager;
 import tech.pegasys.teku.validator.client.ProposerConfigManager;
-import tech.pegasys.teku.validator.client.doppelganger.DoppelgangerDetectionAction;
+import tech.pegasys.teku.validator.client.slashingriskactions.SlashingRiskDetectionAction;
 
 class ValidatorOpenApiTest {
   private final ValidatorRestApiConfig config = mock(ValidatorRestApiConfig.class);
@@ -45,8 +45,8 @@ class ValidatorOpenApiTest {
   private final OpenApiTestUtil<ValidatorOpenApiTest> util =
       new OpenApiTestUtil<>(ValidatorOpenApiTest.class);
   private JsonNode jsonNode;
-  private DoppelgangerDetectionAction doppelgangerDetectionAction =
-      mock(DoppelgangerDetectionAction.class);
+  private SlashingRiskDetectionAction doppelgangerDetectionAction =
+      mock(SlashingRiskDetectionAction.class);
 
   @BeforeEach
   void setup() throws IOException {

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/restapi/apis/PostKeysTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/restapi/apis/PostKeysTest.java
@@ -30,14 +30,14 @@ import org.junit.jupiter.api.io.TempDir;
 import tech.pegasys.teku.api.exceptions.BadRequestException;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiRequest;
 import tech.pegasys.teku.validator.client.OwnedKeyManager;
-import tech.pegasys.teku.validator.client.doppelganger.DoppelgangerDetectionAction;
 import tech.pegasys.teku.validator.client.restapi.apis.schema.PostKeysRequest;
+import tech.pegasys.teku.validator.client.slashingriskactions.SlashingRiskDetectionAction;
 
 public class PostKeysTest {
   private final OwnedKeyManager keyManager = mock(OwnedKeyManager.class);
   private final RestApiRequest request = mock(RestApiRequest.class);
-  private final DoppelgangerDetectionAction doppelgangerDetectionAction =
-      mock(DoppelgangerDetectionAction.class);
+  private final SlashingRiskDetectionAction doppelgangerDetectionAction =
+      mock(SlashingRiskDetectionAction.class);
 
   @Test
   void shouldRespondBadRequestIfPasswordsAndKeystoresMisMatch(@TempDir final Path tempDir)

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/restapi/apis/PostRemoteKeysTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/restapi/apis/PostRemoteKeysTest.java
@@ -32,16 +32,16 @@ import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.bls.BLSTestUtil;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiRequest;
 import tech.pegasys.teku.validator.client.OwnedKeyManager;
-import tech.pegasys.teku.validator.client.doppelganger.DoppelgangerDetectionAction;
 import tech.pegasys.teku.validator.client.restapi.apis.schema.ExternalValidator;
 import tech.pegasys.teku.validator.client.restapi.apis.schema.PostKeyResult;
 import tech.pegasys.teku.validator.client.restapi.apis.schema.PostRemoteKeysRequest;
+import tech.pegasys.teku.validator.client.slashingriskactions.SlashingRiskDetectionAction;
 
 public class PostRemoteKeysTest {
   private final OwnedKeyManager keyManager = mock(OwnedKeyManager.class);
   private final RestApiRequest request = mock(RestApiRequest.class);
-  private final DoppelgangerDetectionAction doppelgangerDetectionAction =
-      mock(DoppelgangerDetectionAction.class);
+  private final SlashingRiskDetectionAction doppelgangerDetectionAction =
+      mock(SlashingRiskDetectionAction.class);
   final PostRemoteKeys handler =
       new PostRemoteKeys(keyManager, Optional.empty(), doppelgangerDetectionAction);
 

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/validatorslashingprotection/SlashedValidatorAlert.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/validatorslashingprotection/SlashedValidatorAlert.java
@@ -13,24 +13,14 @@
 
 package tech.pegasys.teku.validator.client.validatorslashingprotection;
 
-import java.util.List;
-import java.util.stream.Collectors;
-import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.infrastructure.logging.StatusLogger;
-import tech.pegasys.teku.validator.client.slashingriskactions.SlashingRiskDetectionAction;
+import tech.pegasys.teku.validator.client.slashingriskactions.SlashedValidatorShutDown;
 
-public class SlashedValidatorAlert implements SlashingRiskDetectionAction {
-  private final StatusLogger statusLog;
-
+public class SlashedValidatorAlert extends SlashedValidatorShutDown {
   public SlashedValidatorAlert(final StatusLogger statusLog) {
-    this.statusLog = statusLog;
+    super(statusLog);
   }
 
   @Override
-  public void perform(List<BLSPublicKey> pubKeys) {
-    if (!pubKeys.isEmpty()) {
-      statusLog.validatorSlashedAlert(
-          pubKeys.stream().map(BLSPublicKey::toAbbreviatedString).collect(Collectors.toSet()));
-    }
-  }
+  public void shutDown() {}
 }

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/validatorslashingprotection/SlashedValidatorAlert.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/validatorslashingprotection/SlashedValidatorAlert.java
@@ -22,5 +22,5 @@ public class SlashedValidatorAlert extends SlashedValidatorShutDown {
   }
 
   @Override
-  public void shutDown() {}
+  public void shutdown() {}
 }

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/validatorslashingprotection/SlashedValidatorAlert.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/validatorslashingprotection/SlashedValidatorAlert.java
@@ -11,19 +11,16 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.validator.client.slashingriskactions;
+package tech.pegasys.teku.validator.client.validatorslashingprotection;
 
 import java.util.List;
 import java.util.stream.Collectors;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.infrastructure.logging.StatusLogger;
+import tech.pegasys.teku.validator.client.slashingriskactions.SlashingRiskDetectionAction;
 
 public class SlashedValidatorAlert implements SlashingRiskDetectionAction {
   private final StatusLogger statusLog;
-
-  public SlashedValidatorAlert() {
-    this.statusLog = StatusLogger.STATUS_LOG;
-  }
 
   public SlashedValidatorAlert(final StatusLogger statusLog) {
     this.statusLog = statusLog;

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessManager.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessManager.java
@@ -113,10 +113,10 @@ public class BeaconNodeReadinessManager extends Service implements ValidatorTimi
   }
 
   @Override
-  public void onAttesterSlashing(AttesterSlashing attesterSlashing) {}
+  public void onAttesterSlashing(final AttesterSlashing attesterSlashing) {}
 
   @Override
-  public void onProposerSlashing(ProposerSlashing proposerSlashing) {}
+  public void onProposerSlashing(final ProposerSlashing proposerSlashing) {}
 
   private SafeFuture<Void> performReadinessCheckAgainstAllNodes() {
     // no readiness check needed when no failovers are configured

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApi.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApi.java
@@ -150,7 +150,7 @@ public class RemoteBeaconNodeApi implements BeaconNodeApi {
             metricsSystem,
             validatorConfig.generateEarlyAttestations(),
             spec,
-            validatorConfig.isValidatorSlashingProtectionEnabled());
+            validatorConfig.isStopVcWhenValidatorSlashedEnabled());
 
     eventChannels.subscribe(BeaconNodeReadinessChannel.class, beaconChainEventAdapter);
 

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApi.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApi.java
@@ -149,7 +149,7 @@ public class RemoteBeaconNodeApi implements BeaconNodeApi {
             validatorTimingChannel,
             metricsSystem,
             validatorConfig.generateEarlyAttestations(),
-            validatorConfig.isStopVcWhenValidatorSlashedEnabled(),
+            validatorConfig.isShutdownWhenValidatorSlashedEnabled(),
             spec);
 
     eventChannels.subscribe(BeaconNodeReadinessChannel.class, beaconChainEventAdapter);

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApi.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApi.java
@@ -150,7 +150,7 @@ public class RemoteBeaconNodeApi implements BeaconNodeApi {
             metricsSystem,
             validatorConfig.generateEarlyAttestations(),
             spec,
-            validatorConfig.isStopWhenValidatorSlashedEnabled());
+            validatorConfig.isStopVcWhenValidatorSlashedEnabled());
 
     eventChannels.subscribe(BeaconNodeReadinessChannel.class, beaconChainEventAdapter);
 

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApi.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApi.java
@@ -150,7 +150,7 @@ public class RemoteBeaconNodeApi implements BeaconNodeApi {
             metricsSystem,
             validatorConfig.generateEarlyAttestations(),
             spec,
-            validatorConfig.isStopVcWhenValidatorSlashedEnabled());
+            validatorConfig.isValidatorSlashingProtectionEnabled());
 
     eventChannels.subscribe(BeaconNodeReadinessChannel.class, beaconChainEventAdapter);
 

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApi.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApi.java
@@ -149,8 +149,8 @@ public class RemoteBeaconNodeApi implements BeaconNodeApi {
             validatorTimingChannel,
             metricsSystem,
             validatorConfig.generateEarlyAttestations(),
-            spec,
-            validatorConfig.isStopVcWhenValidatorSlashedEnabled());
+            validatorConfig.isStopVcWhenValidatorSlashedEnabled(),
+            spec);
 
     eventChannels.subscribe(BeaconNodeReadinessChannel.class, beaconChainEventAdapter);
 

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApi.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApi.java
@@ -149,7 +149,8 @@ public class RemoteBeaconNodeApi implements BeaconNodeApi {
             validatorTimingChannel,
             metricsSystem,
             validatorConfig.generateEarlyAttestations(),
-            spec);
+            spec,
+            validatorConfig.isStopWhenValidatorSlashedEnabled());
 
     eventChannels.subscribe(BeaconNodeReadinessChannel.class, beaconChainEventAdapter);
 

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/eventsource/EventSourceBeaconChainEventAdapter.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/eventsource/EventSourceBeaconChainEventAdapter.java
@@ -74,8 +74,8 @@ public class EventSourceBeaconChainEventAdapter
       final ValidatorTimingChannel validatorTimingChannel,
       final MetricsSystem metricsSystem,
       final boolean generateEarlyAttestations,
-      final Spec spec,
-      final boolean stopVcWhenValidatorSlashedEnabled) {
+      final boolean stopVcWhenValidatorSlashedEnabled,
+      final Spec spec) {
     this.beaconNodeReadinessManager = beaconNodeReadinessManager;
     this.primaryBeaconNodeApi = primaryBeaconNodeApi;
     this.failoverBeaconNodeApis = failoverBeaconNodeApis;

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/eventsource/EventSourceBeaconChainEventAdapter.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/eventsource/EventSourceBeaconChainEventAdapter.java
@@ -62,7 +62,7 @@ public class EventSourceBeaconChainEventAdapter
   private final ValidatorLogger validatorLogger;
   private final BeaconChainEventAdapter timeBasedEventAdapter;
   private final EventSourceHandler eventSourceHandler;
-  private final boolean stopVcWhenValidatorSlashedEnabled;
+  private final boolean shutdownWhenValidatorSlashedEnabled;
 
   public EventSourceBeaconChainEventAdapter(
       final BeaconNodeReadinessManager beaconNodeReadinessManager,
@@ -74,7 +74,7 @@ public class EventSourceBeaconChainEventAdapter
       final ValidatorTimingChannel validatorTimingChannel,
       final MetricsSystem metricsSystem,
       final boolean generateEarlyAttestations,
-      final boolean stopVcWhenValidatorSlashedEnabled,
+      final boolean shutdownWhenValidatorSlashedEnabled,
       final Spec spec) {
     this.beaconNodeReadinessManager = beaconNodeReadinessManager;
     this.primaryBeaconNodeApi = primaryBeaconNodeApi;
@@ -85,7 +85,7 @@ public class EventSourceBeaconChainEventAdapter
     this.eventSourceHandler =
         new EventSourceHandler(
             validatorTimingChannel, metricsSystem, generateEarlyAttestations, spec);
-    this.stopVcWhenValidatorSlashedEnabled = stopVcWhenValidatorSlashedEnabled;
+    this.shutdownWhenValidatorSlashedEnabled = shutdownWhenValidatorSlashedEnabled;
   }
 
   @Override
@@ -134,7 +134,7 @@ public class EventSourceBeaconChainEventAdapter
   private BackgroundEventSource createEventSource(final RemoteValidatorApiChannel beaconNodeApi) {
     final List<EventType> eventTypes = new ArrayList<>();
     eventTypes.add(EventType.head);
-    if (stopVcWhenValidatorSlashedEnabled) {
+    if (shutdownWhenValidatorSlashedEnabled) {
       eventTypes.add(EventType.attester_slashing);
       eventTypes.add(EventType.proposer_slashing);
     }

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/eventsource/EventSourceBeaconChainEventAdapter.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/eventsource/EventSourceBeaconChainEventAdapter.java
@@ -128,7 +128,7 @@ public class EventSourceBeaconChainEventAdapter
   }
 
   private BackgroundEventSource createEventSource(final RemoteValidatorApiChannel beaconNodeApi) {
-    final HttpUrl eventSourceUrl = createHeadEventSourceUrl(beaconNodeApi.getEndpoint());
+    final HttpUrl eventSourceUrl = createEventStreamSourceUrl(beaconNodeApi.getEndpoint());
     final EventSource.Builder eventSourceBuilder =
         new EventSource.Builder(ConnectStrategy.http(eventSourceUrl).httpClient(okHttpClient))
             .retryDelayStrategy(
@@ -143,10 +143,16 @@ public class EventSourceBeaconChainEventAdapter
         .build();
   }
 
-  private HttpUrl createHeadEventSourceUrl(final HttpUrl endpoint) {
+  private HttpUrl createEventStreamSourceUrl(final HttpUrl endpoint) {
     final HttpUrl eventSourceUrl =
         endpoint.resolve(
-            ValidatorApiMethod.EVENTS.getPath(emptyMap()) + "?topics=" + EventType.head);
+            ValidatorApiMethod.EVENTS.getPath(emptyMap())
+                + "?topics="
+                + String.join(
+                    ",",
+                    EventType.head.name(),
+                    EventType.attester_slashing.name(),
+                    EventType.proposer_slashing.name()));
     return Preconditions.checkNotNull(eventSourceUrl);
   }
 

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/eventsource/EventSourceBeaconChainEventAdapter.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/eventsource/EventSourceBeaconChainEventAdapter.java
@@ -62,7 +62,7 @@ public class EventSourceBeaconChainEventAdapter
   private final ValidatorLogger validatorLogger;
   private final BeaconChainEventAdapter timeBasedEventAdapter;
   private final EventSourceHandler eventSourceHandler;
-  private final boolean validatorSlashingMonitoringEnabled;
+  private final boolean validatorSlashingProtectionEnabled;
 
   public EventSourceBeaconChainEventAdapter(
       final BeaconNodeReadinessManager beaconNodeReadinessManager,
@@ -75,7 +75,7 @@ public class EventSourceBeaconChainEventAdapter
       final MetricsSystem metricsSystem,
       final boolean generateEarlyAttestations,
       final Spec spec,
-      final boolean validatorSlashingMonitoringEnabled) {
+      final boolean validatorSlashingProtectionEnabled) {
     this.beaconNodeReadinessManager = beaconNodeReadinessManager;
     this.primaryBeaconNodeApi = primaryBeaconNodeApi;
     this.failoverBeaconNodeApis = failoverBeaconNodeApis;
@@ -85,7 +85,7 @@ public class EventSourceBeaconChainEventAdapter
     this.eventSourceHandler =
         new EventSourceHandler(
             validatorTimingChannel, metricsSystem, generateEarlyAttestations, spec);
-    this.validatorSlashingMonitoringEnabled = validatorSlashingMonitoringEnabled;
+    this.validatorSlashingProtectionEnabled = validatorSlashingProtectionEnabled;
   }
 
   @Override
@@ -133,7 +133,7 @@ public class EventSourceBeaconChainEventAdapter
 
   private BackgroundEventSource createEventSource(final RemoteValidatorApiChannel beaconNodeApi) {
     final HttpUrl eventSourceUrl =
-        validatorSlashingMonitoringEnabled
+        validatorSlashingProtectionEnabled
             ? createEventStreamSourceUrl(
                 beaconNodeApi.getEndpoint(),
                 EventType.head,

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/eventsource/EventSourceBeaconChainEventAdapter.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/eventsource/EventSourceBeaconChainEventAdapter.java
@@ -62,7 +62,7 @@ public class EventSourceBeaconChainEventAdapter
   private final ValidatorLogger validatorLogger;
   private final BeaconChainEventAdapter timeBasedEventAdapter;
   private final EventSourceHandler eventSourceHandler;
-  private final boolean validatorSlashingProtectionEnabled;
+  private final boolean stopVcWhenValidatorSlashedEnabled;
 
   public EventSourceBeaconChainEventAdapter(
       final BeaconNodeReadinessManager beaconNodeReadinessManager,
@@ -75,7 +75,7 @@ public class EventSourceBeaconChainEventAdapter
       final MetricsSystem metricsSystem,
       final boolean generateEarlyAttestations,
       final Spec spec,
-      final boolean validatorSlashingProtectionEnabled) {
+      final boolean stopVcWhenValidatorSlashedEnabled) {
     this.beaconNodeReadinessManager = beaconNodeReadinessManager;
     this.primaryBeaconNodeApi = primaryBeaconNodeApi;
     this.failoverBeaconNodeApis = failoverBeaconNodeApis;
@@ -85,7 +85,7 @@ public class EventSourceBeaconChainEventAdapter
     this.eventSourceHandler =
         new EventSourceHandler(
             validatorTimingChannel, metricsSystem, generateEarlyAttestations, spec);
-    this.validatorSlashingProtectionEnabled = validatorSlashingProtectionEnabled;
+    this.stopVcWhenValidatorSlashedEnabled = stopVcWhenValidatorSlashedEnabled;
   }
 
   @Override
@@ -134,7 +134,7 @@ public class EventSourceBeaconChainEventAdapter
   private BackgroundEventSource createEventSource(final RemoteValidatorApiChannel beaconNodeApi) {
     final List<EventType> eventTypes = new ArrayList<>();
     eventTypes.add(EventType.head);
-    if (validatorSlashingProtectionEnabled) {
+    if (stopVcWhenValidatorSlashedEnabled) {
       eventTypes.add(EventType.attester_slashing);
       eventTypes.add(EventType.proposer_slashing);
     }

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/sentry/SentryBeaconNodeApi.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/sentry/SentryBeaconNodeApi.java
@@ -162,7 +162,7 @@ public class SentryBeaconNodeApi implements BeaconNodeApi {
             serviceConfig.getMetricsSystem(),
             validatorConfig.generateEarlyAttestations(),
             spec,
-            validatorConfig.isValidatorSlashingProtectionEnabled());
+            validatorConfig.isStopVcWhenValidatorSlashedEnabled());
 
     eventChannels.subscribe(BeaconNodeReadinessChannel.class, beaconChainEventAdapter);
 

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/sentry/SentryBeaconNodeApi.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/sentry/SentryBeaconNodeApi.java
@@ -161,7 +161,8 @@ public class SentryBeaconNodeApi implements BeaconNodeApi {
             validatorTimingChannel,
             serviceConfig.getMetricsSystem(),
             validatorConfig.generateEarlyAttestations(),
-            spec);
+            spec,
+            validatorConfig.isStopWhenValidatorSlashedEnabled());
 
     eventChannels.subscribe(BeaconNodeReadinessChannel.class, beaconChainEventAdapter);
 

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/sentry/SentryBeaconNodeApi.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/sentry/SentryBeaconNodeApi.java
@@ -161,8 +161,8 @@ public class SentryBeaconNodeApi implements BeaconNodeApi {
             validatorTimingChannel,
             serviceConfig.getMetricsSystem(),
             validatorConfig.generateEarlyAttestations(),
-            spec,
-            validatorConfig.isStopVcWhenValidatorSlashedEnabled());
+            validatorConfig.isStopVcWhenValidatorSlashedEnabled(),
+            spec);
 
     eventChannels.subscribe(BeaconNodeReadinessChannel.class, beaconChainEventAdapter);
 

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/sentry/SentryBeaconNodeApi.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/sentry/SentryBeaconNodeApi.java
@@ -162,7 +162,7 @@ public class SentryBeaconNodeApi implements BeaconNodeApi {
             serviceConfig.getMetricsSystem(),
             validatorConfig.generateEarlyAttestations(),
             spec,
-            validatorConfig.isStopWhenValidatorSlashedEnabled());
+            validatorConfig.isStopVcWhenValidatorSlashedEnabled());
 
     eventChannels.subscribe(BeaconNodeReadinessChannel.class, beaconChainEventAdapter);
 

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/sentry/SentryBeaconNodeApi.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/sentry/SentryBeaconNodeApi.java
@@ -162,7 +162,7 @@ public class SentryBeaconNodeApi implements BeaconNodeApi {
             serviceConfig.getMetricsSystem(),
             validatorConfig.generateEarlyAttestations(),
             spec,
-            validatorConfig.isStopVcWhenValidatorSlashedEnabled());
+            validatorConfig.isValidatorSlashingProtectionEnabled());
 
     eventChannels.subscribe(BeaconNodeReadinessChannel.class, beaconChainEventAdapter);
 

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/sentry/SentryBeaconNodeApi.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/sentry/SentryBeaconNodeApi.java
@@ -161,7 +161,7 @@ public class SentryBeaconNodeApi implements BeaconNodeApi {
             validatorTimingChannel,
             serviceConfig.getMetricsSystem(),
             validatorConfig.generateEarlyAttestations(),
-            validatorConfig.isStopVcWhenValidatorSlashedEnabled(),
+            validatorConfig.isShutdownWhenValidatorSlashedEnabled(),
             spec);
 
     eventChannels.subscribe(BeaconNodeReadinessChannel.class, beaconChainEventAdapter);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Add `--shut-down-when-validator-slashed-enabled` option to enable Teku shutdown when a validator gets slashed.
When using a remote BN, this option requires the BN to support the new `attester_slashing` and `proposer_slashing` SSE events.
When running VC only, in order to ensure BN backward compatibility, the VC will subscribe to the `attester_slashing` and `proposer_slashing` SSE events only when the `--shut-down-when-validator-slashed-enabled` is enabled (in addition to the `head` events) otherwise it will only subscribe to the `head` events.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
fixes #7707 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
