### PR TITLE
Add exit on no validator keys loaded if configured

### DIFF
--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
@@ -220,11 +220,7 @@ public class ValidatorClientService extends Service {
             () -> validatorClientService.initializeValidators(validatorApiChannel, asyncRunner))
         .thenCompose(
             __ -> {
-              if (validatorConfig.isExitWhenNoValidatorKeysEnabled()
-                  && validatorLoader.getOwnedValidators().getActiveValidators().isEmpty()) {
-                STATUS_LOG.exitOnNoValidatorKeys();
-                System.exit(2);
-              }
+              checkNoKeysLoaded(validatorConfig, validatorLoader);
 
               if (validatorConfig.isDoppelgangerDetectionEnabled()) {
                 validatorClientService.initializeDoppelgangerDetector(
@@ -274,11 +270,21 @@ public class ValidatorClientService extends Service {
               } else {
                 LOG.error("Error was encountered during validator client service start up.", error);
               }
+              checkNoKeysLoaded(validatorConfig, validatorLoader);
               return null;
             })
         .always(() -> LOG.trace("Finished starting validator client service."));
 
     return validatorClientService;
+  }
+
+  private static void checkNoKeysLoaded(
+      final ValidatorConfig validatorConfig, final ValidatorLoader validatorLoader) {
+    if (validatorConfig.isExitWhenNoValidatorKeysEnabled()
+        && validatorLoader.getOwnedValidators().getActiveValidators().isEmpty()) {
+      STATUS_LOG.exitOnNoValidatorKeys();
+      System.exit(2);
+    }
   }
 
   private void initializeDoppelgangerDetector(

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
@@ -281,7 +281,7 @@ public class ValidatorClientService extends Service {
   private static void checkNoKeysLoaded(
       final ValidatorConfig validatorConfig, final ValidatorLoader validatorLoader) {
     if (validatorConfig.isExitWhenNoValidatorKeysEnabled()
-        && validatorLoader.getOwnedValidators().getActiveValidators().isEmpty()) {
+        && validatorLoader.getOwnedValidators().hasNoValidators()) {
       STATUS_LOG.exitOnNoValidatorKeys();
       System.exit(2);
     }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
In case of exception.
Example case:
```
2023-12-14 09:34:47.787+00:00 | validator-async-0 | WARN  | ValidatorClientService | Invalid configuration. Password file for keystore /validator-keys/node-1-keystores/nimbus-keys/0xac97a570a795d24af13ef32709d71a37c0fb90a49581e735d635721581c5553c10eb15f43531121b6026f55d603d73f7/keystore.json either doesn't exist or isn't readable. Expected to find it at /validator-keys/node-1-keystores/secrets/0xac97a570a795d24af13ef32709d71a37c0fb90a49581e735d635721581c5553c10eb15f43531121b6026f55d603d73f7/keystore.txt
2023-12-14 09:34:47.789+00:00 | main | INFO  | MetricsHttpService | Starting metrics http service on 0.0.0.0:5064
```
Shouldn't be unconditional because of things like #7422 

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
