### PR TITLE
Add more ATs on ExitWhenNoValidatorKeysEnabled

### DIFF
--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/tools/ValidatorKeysApi.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/tools/ValidatorKeysApi.java
@@ -152,6 +152,13 @@ public class ValidatorKeysApi {
     checkReadOnly(data, false);
   }
 
+  public void assertLocalValidatorCount(final int expectedCount) throws IOException {
+    final JsonNode result = jsonProvider.getObjectMapper().readTree(getLocalValidatorListing());
+    final JsonNode data = result.get("data");
+    assertThat(data.isArray()).isTrue();
+    Assertions.assertThat(data.size()).isEqualTo(expectedCount);
+  }
+
   public void assertRemoteValidatorListing(final List<BLSPublicKey> expectedKeys)
       throws IOException {
     final JsonNode result = jsonProvider.getObjectMapper().readTree(getRemoteValidatorListing());


### PR DESCRIPTION
Additional ATs checking keys with unknown status

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
