### PR TITLE
Fix Documentation Textual and Grammatical Errors

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -10,7 +10,7 @@ Individual Contributor License Agreement.
 2. Make an account on [GitHub] if you don't already have one.
 
 3. After creating your first pull request, you will see a merge
-   pre-requisite requiring to you read and sign the CLA.
+   pre-requisite requiring you to read and sign the CLA.
 
 If you have any questions, you can reach us on [Discord].
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,7 +98,7 @@ Include details about your configuration and environment:
   * **For Linux - What kernel are you running?** You can get the exact version by running `uname -a` in your terminal.
 * **Are you running in a virtual machine?** If so, which VM software are you using and which operating systems and versions are used for the host and the guest?
 * **Are you running in a docker container?** If so, what version of docker?
-* **Are you running in a a Cloud?** If so, which one, and what type/size of VM is it?
+* **Are you running in a Cloud?** If so, which one, and what type/size of VM is it?
 * **What version of Java are you running?** You can get the exact version by looking at the Teku logfile during startup.
 
 # Style Guides

--- a/test-network/README.md
+++ b/test-network/README.md
@@ -27,4 +27,4 @@ Persistent Data
 
 The teku nodes store data and logs in `data/node<X>/`. It is safe to delete the entire `data` directory to start from scratch.
 
-Grafana stores it's data in `grafana/data` so changes made to dashboards are persisted across runs.
+Grafana stores its data in `grafana/data` so changes made to dashboards are persisted across runs.


### PR DESCRIPTION
This pull request addresses several typos and grammatical errors found in various documentation files. Each commit targets a specific file and type of error for easy tracking and review.

### Commits Included:

1. **Commit:** d9d70fd7a2c35b2dddb7fa16317e11eab65fb6ce
   **File Affected:** `test-network/README.md`
   **Description:** Fixed a typo in the 'Persistent Data' section. Changed "it's" to "its" to correct the possessive form in the sentence describing Grafana data storage.

2. **Commit:** 99b7ea8a49272e7317d3e28697c04e7a57e9a988
   **File Affected:** `CONTRIBUTING.md`
   **Description:** Corrected a typo in the 'Architectural Best Practices' section. Removed the redundant 'a' in the sentence about running in a cloud environment.

3. **Commit:** 0eb46c41e76ec90b932777662c18f936b26b4299
   **File Affected:** `CLA.md`
   **Description:** Fixed a grammatical error in the CLA requirement instructions, improving the clarity of the sentence about the merge pre-requisite.

These minor but important fixes enhance the readability and professionalism of our project's documentation.
