### PR TITLE
Fallback to GET validators from state on 400 POST response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,6 @@ the [releases page](https://github.com/Consensys/teku/releases).
 ### Breaking Changes
 
 ### Additions and Improvements
-- Fix incompatibility between Teku validator client and beacon nodes whose `/eth/v1/beacon/states/{state_id}/validators` POST endpoint is returning status code 400
 
 ### Bug Fixes
+- Fix incompatibility between Teku validator client and Lighthouse beacon nodes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,5 +12,6 @@ the [releases page](https://github.com/Consensys/teku/releases).
 ### Breaking Changes
 
 ### Additions and Improvements
+- Fix incompatibility between Teku validator client and beacon nodes whose `/eth/v1/beacon/states/{state_id}/validators` POST endpoint is returning status code 400
 
 ### Bug Fixes

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorClientOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorClientOptions.java
@@ -69,6 +69,7 @@ public class ValidatorClientOptions {
       paramLabel = "<BOOLEAN>",
       description = "Use the POST endpoint when getting validators from state",
       hidden = true,
+      showDefaultValue = CommandLine.Help.Visibility.ALWAYS,
       arity = "0..1",
       fallbackValue = "true")
   private boolean validatorClientUsePostValidatorsEndpointEnabled =

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorClientOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorClientOptions.java
@@ -64,6 +64,16 @@ public class ValidatorClientOptions {
       fallbackValue = "true")
   private boolean validatorClientSszBlocksEnabled = DEFAULT_VALIDATOR_CLIENT_SSZ_BLOCKS_ENABLED;
 
+  @CommandLine.Option(
+      names = {"--Xuse-post-validators-endpoint-enabled"},
+      paramLabel = "<BOOLEAN>",
+      description = "Use the POST endpoint when getting validators from state.",
+      hidden = true,
+      arity = "0..1",
+      fallbackValue = "true")
+  private boolean validatorClientUsePostValidatorsEndpointEnabled =
+      ValidatorConfig.DEFAULT_VALIDATOR_CLIENT_USE_POST_VALIDATORS_ENDPOINT_ENABLED;
+
   public void configure(TekuConfiguration.Builder builder) {
     configureBeaconNodeApiEndpoints();
 
@@ -72,6 +82,8 @@ public class ValidatorClientOptions {
             config
                 .beaconNodeApiEndpoints(getBeaconNodeApiEndpoints())
                 .validatorClientUseSszBlocksEnabled(validatorClientSszBlocksEnabled)
+                .validatorClientUsePostValidatorsEndpointEnabled(
+                    validatorClientUsePostValidatorsEndpointEnabled)
                 .failoversSendSubnetSubscriptionsEnabled(failoversSendSubnetSubscriptionsEnabled)
                 .failoversPublishSignedDutiesEnabled(failoversPublishSignedDutiesEnabled)
                 .sentryNodeConfigurationFile(exclusiveParams.sentryConfigFile));

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorClientOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorClientOptions.java
@@ -67,7 +67,7 @@ public class ValidatorClientOptions {
   @CommandLine.Option(
       names = {"--Xuse-post-validators-endpoint-enabled"},
       paramLabel = "<BOOLEAN>",
-      description = "Use the POST endpoint when getting validators from state.",
+      description = "Use the POST endpoint when getting validators from state",
       hidden = true,
       arity = "0..1",
       fallbackValue = "true")

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
@@ -48,6 +48,7 @@ public class ValidatorConfig {
   public static final boolean DEFAULT_BLOCK_V3_ENABLED = false;
   public static final boolean DEFAULT_EXIT_WHEN_NO_VALIDATOR_KEYS_ENABLED = false;
   public static final boolean DEFAULT_VALIDATOR_CLIENT_SSZ_BLOCKS_ENABLED = true;
+  public static final boolean DEFAULT_VALIDATOR_CLIENT_USE_POST_VALIDATORS_ENDPOINT_ENABLED = true;
   public static final boolean DEFAULT_DOPPELGANGER_DETECTION_ENABLED = false;
   public static final boolean DEFAULT_VALIDATOR_IS_LOCAL_SLASHING_PROTECTION_SYNCHRONIZED_ENABLED =
       true;
@@ -86,6 +87,7 @@ public class ValidatorConfig {
   private final boolean blindedBeaconBlocksEnabled;
   private final boolean builderRegistrationDefaultEnabled;
   private final boolean validatorClientUseSszBlocksEnabled;
+  private final boolean validatorClientUsePostValidatorsEndpointEnabled;
   private final boolean doppelgangerDetectionEnabled;
   private final boolean failoversSendSubnetSubscriptionsEnabled;
   private final boolean failoversPublishSignedDutiesEnabled;
@@ -125,6 +127,7 @@ public class ValidatorConfig {
       final boolean builderRegistrationDefaultEnabled,
       final boolean blindedBeaconBlocksEnabled,
       final boolean validatorClientUseSszBlocksEnabled,
+      final boolean validatorClientUsePostValidatorsEndpointEnabled,
       final boolean doppelgangerDetectionEnabled,
       final boolean failoversSendSubnetSubscriptionsEnabled,
       final boolean failoversPublishSignedDutiesEnabled,
@@ -163,6 +166,8 @@ public class ValidatorConfig {
     this.blindedBeaconBlocksEnabled = blindedBeaconBlocksEnabled;
     this.builderRegistrationDefaultEnabled = builderRegistrationDefaultEnabled;
     this.validatorClientUseSszBlocksEnabled = validatorClientUseSszBlocksEnabled;
+    this.validatorClientUsePostValidatorsEndpointEnabled =
+        validatorClientUsePostValidatorsEndpointEnabled;
     this.doppelgangerDetectionEnabled = doppelgangerDetectionEnabled;
     this.failoversSendSubnetSubscriptionsEnabled = failoversSendSubnetSubscriptionsEnabled;
     this.failoversPublishSignedDutiesEnabled = failoversPublishSignedDutiesEnabled;
@@ -282,6 +287,10 @@ public class ValidatorConfig {
     return validatorClientUseSszBlocksEnabled;
   }
 
+  public boolean isValidatorClientUsePostValidatorsEndpointEnabled() {
+    return validatorClientUsePostValidatorsEndpointEnabled;
+  }
+
   public boolean isDoppelgangerDetectionEnabled() {
     return doppelgangerDetectionEnabled;
   }
@@ -360,6 +369,8 @@ public class ValidatorConfig {
         DEFAULT_BUILDER_REGISTRATION_DEFAULT_ENABLED;
     private boolean blindedBlocksEnabled = DEFAULT_VALIDATOR_BLINDED_BLOCKS_ENABLED;
     private boolean validatorClientSszBlocksEnabled = DEFAULT_VALIDATOR_CLIENT_SSZ_BLOCKS_ENABLED;
+    private boolean validatorClientUsePostValidatorsEndpointEnabled =
+        DEFAULT_VALIDATOR_CLIENT_USE_POST_VALIDATORS_ENDPOINT_ENABLED;
     private boolean doppelgangerDetectionEnabled = DEFAULT_DOPPELGANGER_DETECTION_ENABLED;
     private boolean failoversSendSubnetSubscriptionsEnabled =
         DEFAULT_FAILOVERS_SEND_SUBNET_SUBSCRIPTIONS_ENABLED;
@@ -525,6 +536,13 @@ public class ValidatorConfig {
       return this;
     }
 
+    public Builder validatorClientUsePostValidatorsEndpointEnabled(
+        final boolean validatorClientUsePostValidatorsEndpointEnabled) {
+      this.validatorClientUsePostValidatorsEndpointEnabled =
+          validatorClientUsePostValidatorsEndpointEnabled;
+      return this;
+    }
+
     public Builder doppelgangerDetectionEnabled(final boolean doppelgangerDetectionEnabled) {
       this.doppelgangerDetectionEnabled = doppelgangerDetectionEnabled;
       return this;
@@ -635,6 +653,7 @@ public class ValidatorConfig {
           validatorsRegistrationDefaultEnabled,
           blindedBlocksEnabled,
           validatorClientSszBlocksEnabled,
+          validatorClientUsePostValidatorsEndpointEnabled,
           doppelgangerDetectionEnabled,
           failoversSendSubnetSubscriptionsEnabled,
           failoversPublishSignedDutiesEnabled,

--- a/validator/remote/src/integration-test/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClientTest.java
+++ b/validator/remote/src/integration-test/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClientTest.java
@@ -171,7 +171,7 @@ class OkHttpValidatorRestApiClientTest {
   }
 
   @ParameterizedTest
-  @ValueSource(ints = {SC_NOT_FOUND, SC_METHOD_NOT_ALLOWED})
+  @ValueSource(ints = {SC_BAD_REQUEST, SC_NOT_FOUND, SC_METHOD_NOT_ALLOWED})
   public void postValidators_WhenNotExisting_ThrowsException(final int responseCode) {
     mockWebServer.enqueue(new MockResponse().setResponseCode(responseCode));
 

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApi.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteBeaconNodeApi.java
@@ -85,6 +85,7 @@ public class RemoteBeaconNodeApi implements BeaconNodeApi {
             okHttpClient,
             spec,
             validatorConfig.isValidatorClientUseSszBlocksEnabled(),
+            validatorConfig.isValidatorClientUsePostValidatorsEndpointEnabled(),
             asyncRunner);
     final List<? extends RemoteValidatorApiChannel> failoverValidatorApis =
         failoverEndpoints.stream()
@@ -95,6 +96,7 @@ public class RemoteBeaconNodeApi implements BeaconNodeApi {
                         okHttpClient,
                         spec,
                         validatorConfig.isValidatorClientUseSszBlocksEnabled(),
+                        validatorConfig.isValidatorClientUsePostValidatorsEndpointEnabled(),
                         asyncRunner))
             .toList();
 

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
@@ -89,25 +89,26 @@ public class RemoteValidatorApiHandler implements RemoteValidatorApiChannel {
   static final int MAX_PUBLIC_KEY_BATCH_SIZE = 50;
   static final int MAX_RATE_LIMITING_RETRIES = 3;
 
-  private final AtomicBoolean usePostValidatorsEndpoint = new AtomicBoolean(true);
-
   private final HttpUrl endpoint;
   private final Spec spec;
   private final ValidatorRestApiClient apiClient;
   private final OkHttpValidatorTypeDefClient typeDefClient;
   private final AsyncRunner asyncRunner;
+  private final AtomicBoolean usePostValidatorsEndpoint;
 
   public RemoteValidatorApiHandler(
       final HttpUrl endpoint,
       final Spec spec,
       final ValidatorRestApiClient apiClient,
       final OkHttpValidatorTypeDefClient typeDefClient,
-      final AsyncRunner asyncRunner) {
+      final AsyncRunner asyncRunner,
+      final boolean usePostValidatorsEndpoint) {
     this.endpoint = endpoint;
     this.spec = spec;
     this.apiClient = apiClient;
     this.asyncRunner = asyncRunner;
     this.typeDefClient = typeDefClient;
+    this.usePostValidatorsEndpoint = new AtomicBoolean(usePostValidatorsEndpoint);
   }
 
   @Override
@@ -527,11 +528,13 @@ public class RemoteValidatorApiHandler implements RemoteValidatorApiChannel {
       final OkHttpClient httpClient,
       final Spec spec,
       final boolean preferSszBlockEncoding,
+      final boolean usePostValidatorsEndpoint,
       final AsyncRunner asyncRunner) {
     final OkHttpValidatorRestApiClient apiClient =
         new OkHttpValidatorRestApiClient(endpoint, httpClient);
     final OkHttpValidatorTypeDefClient typeDefClient =
         new OkHttpValidatorTypeDefClient(httpClient, endpoint, spec, preferSszBlockEncoding);
-    return new RemoteValidatorApiHandler(endpoint, spec, apiClient, typeDefClient, asyncRunner);
+    return new RemoteValidatorApiHandler(
+        endpoint, spec, apiClient, typeDefClient, asyncRunner, usePostValidatorsEndpoint);
   }
 }

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/apiclient/OkHttpValidatorRestApiClient.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.validator.remote.apiclient;
 
 import static java.util.Collections.emptyMap;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_BAD_REQUEST;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_METHOD_NOT_ALLOWED;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_NOT_FOUND;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_AGGREGATE;
@@ -154,6 +155,7 @@ public class OkHttpValidatorRestApiClient implements ValidatorRestApiClient {
                     (request, response) -> {
                       throw new PostStateValidatorsNotExistingException();
                     },
+                    SC_BAD_REQUEST,
                     SC_NOT_FOUND,
                     SC_METHOD_NOT_ALLOWED))
         .map(response -> response.data);

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/sentry/SentryBeaconNodeApi.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/sentry/SentryBeaconNodeApi.java
@@ -180,6 +180,7 @@ public class SentryBeaconNodeApi implements BeaconNodeApi {
         httpClient,
         spec,
         validatorConfig.isValidatorClientUseSszBlocksEnabled(),
+        validatorConfig.isValidatorClientUsePostValidatorsEndpointEnabled(),
         asyncRunner);
   }
 
@@ -198,6 +199,7 @@ public class SentryBeaconNodeApi implements BeaconNodeApi {
                         httpClient,
                         spec,
                         validatorConfig.isValidatorClientUseSszBlocksEnabled(),
+                        validatorConfig.isValidatorClientUsePostValidatorsEndpointEnabled(),
                         asyncRunner))
             .toList();
 

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
@@ -109,7 +109,7 @@ class RemoteValidatorApiHandlerTest {
   @BeforeEach
   public void beforeEach() {
     apiHandler =
-        new RemoteValidatorApiHandler(endpoint, spec, apiClient, typeDefClient, asyncRunner);
+        new RemoteValidatorApiHandler(endpoint, spec, apiClient, typeDefClient, asyncRunner, true);
   }
 
   @Test


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
We are handling fallback to `GET` validators from state on status codes 404 and 405 in https://github.com/Consensys/teku/pull/7786, but LH seems to be returning 400, so handling that case as well, which should cover all scenarios.

```
│ teku java.util.concurrent.CompletionException: tech.pegasys.teku.validator.remote.FailoverRequestException: Remote request (get_validator_statuses) failed on all configured Beacon Node endpoints 
│ teku ...: java.lang.IllegalArgumentException: Invalid params response from Beacon Node API (url = ...)
│ ...:5051/eth/v1/beacon/states/head/validators, status = 400, message = BAD_REQUEST: Unsupported endpoint version: v1)
```

Also add flag `--Xuse-post-validators-endpoint-enabled` until all clients implement this endpoint.
## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
