### PR TITLE
Fix rest api bind error message

### DIFF
--- a/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/RestApi.java
+++ b/infrastructure/restapi/src/main/java/tech/pegasys/teku/infrastructure/restapi/RestApi.java
@@ -17,8 +17,8 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.common.base.Throwables;
 import io.javalin.Javalin;
+import io.javalin.util.JavalinBindException;
 import java.io.IOException;
-import java.net.BindException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
@@ -55,12 +55,9 @@ public class RestApi extends Service {
       app.start();
       LOG.info("Listening on {}", app.jettyServer().server().getURI());
     } catch (final RuntimeException e) {
-      if (Throwables.getRootCause(e) instanceof BindException) {
-        throw new InvalidConfigurationException(
-            String.format(
-                "TCP Port %d is already in use. "
-                    + "You may need to stop another process or change the HTTP port for this process.",
-                app.port()));
+      if (e instanceof JavalinBindException) {
+        // The message in JavalinBindException has the port number in conflict
+        throw new InvalidConfigurationException(e.getMessage());
       } else if (e instanceof IllegalStateException
           || Throwables.getRootCause(e) instanceof IllegalStateException) {
         // IllegalStateException is a sign that something needed has failed to be initialised.

--- a/infrastructure/restapi/src/test/java/tech/pegasys/teku/infrastructure/restapi/RestApiTest.java
+++ b/infrastructure/restapi/src/test/java/tech/pegasys/teku/infrastructure/restapi/RestApiTest.java
@@ -39,12 +39,14 @@ class RestApiTest {
 
   @Test
   void start_shouldThrowInvalidConfigurationExceptionWhenPortInUse() {
-    // When there is a port conflict, Javalin will throw a JavalinBindException that has a useful message including
+    // When there is a port conflict, Javalin will throw a JavalinBindException that has a useful
+    // message including
     // the port it failed to bind to. Here we are testing that we are forwarding the message from
     // JavalinBindException into our InvalidConfigurationException.
     final String javalinBindExceptionMessage = "Javalin msg with port";
     when(app.start())
-        .thenThrow(new JavalinBindException(javalinBindExceptionMessage, new BindException("ouch")));
+        .thenThrow(
+            new JavalinBindException(javalinBindExceptionMessage, new BindException("ouch")));
     assertThatThrownBy(restApi::start)
         .isInstanceOf(InvalidConfigurationException.class)
         .hasMessage(javalinBindExceptionMessage);

--- a/infrastructure/restapi/src/test/java/tech/pegasys/teku/infrastructure/restapi/RestApiTest.java
+++ b/infrastructure/restapi/src/test/java/tech/pegasys/teku/infrastructure/restapi/RestApiTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.javalin.Javalin;
+import io.javalin.util.JavalinBindException;
 import java.io.IOException;
 import java.net.BindException;
 import java.nio.file.Files;
@@ -38,8 +39,15 @@ class RestApiTest {
 
   @Test
   void start_shouldThrowInvalidConfigurationExceptionWhenPortInUse() {
-    when(app.start()).thenThrow(new RuntimeException("Oh no", new BindException("Port in use")));
-    assertThatThrownBy(restApi::start).isInstanceOf(InvalidConfigurationException.class);
+    // When there is a port conflict, Javalin will throw a JavalinBindException that has a useful message including
+    // the port it failed to bind to. Here we are testing that we are forwarding the message from
+    // JavalinBindException into our InvalidConfigurationException.
+    final String javalinBindExceptionMessage = "Javalin msg with port";
+    when(app.start())
+        .thenThrow(new JavalinBindException(javalinBindExceptionMessage, new BindException("ouch")));
+    assertThatThrownBy(restApi::start)
+        .isInstanceOf(InvalidConfigurationException.class)
+        .hasMessage(javalinBindExceptionMessage);
     assertThat(restApi.getRestApiDocs()).isEmpty();
   }
 


### PR DESCRIPTION
## PR Description

When Javalin can't bind to a port that is already in use. The Javalin `app` object will not contain a port, it will have it as -1.
Because of this, the error message that we are getting looks like:

```
TCP Port -1 is already in use. You may need to stop another process or change the HTTP port for this process.
```

To fix this, we can use Javalin's `JavalinBindException` message that already has the port. It looks like: 

```
Port already in use. Make sure no other process is using port 5000 and try again.
```

## Fixed Issue(s)
N/A

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
