### PR TITLE
Attempt #2 to fix flaky `cannotAccessSameValidatorConcurrently`

### DIFF
--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/signatures/LocalSlashingProtectorTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/signatures/LocalSlashingProtectorTest.java
@@ -187,7 +187,8 @@ class LocalSlashingProtectorTest {
     secondSigner.get(50, TimeUnit.MILLISECONDS);
     assertThat(secondSigner).isCompleted();
     releaseLock.set(true);
-    firstSigner.get(50, TimeUnit.MILLISECONDS);
+    // flaky on Windows
+    firstSigner.get(500, TimeUnit.MILLISECONDS);
     assertThat(firstSigner).isCompleted();
   }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
The test is still failing sometimes under Windows.
Though the order should be guaranteed, so if second task is running, first is definitely already running and thread is not returned to the pool on sleep, let's give it a try. There is some magic in Windows happening in this test and I'm not sure where exactly.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
