### PR TITLE
Fix post block endpoints returning 202 in case of unexpected errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,4 @@ the [releases page](https://github.com/Consensys/teku/releases).
 
 ### Bug Fixes
 - Fix incompatibility between Teku validator client and Lighthouse beacon nodes
+- Fix a block publishing endpoints issue where `202` status code could be returned but block hasn't been broadcast

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.validator.coordinator;
 
 import static java.util.stream.Collectors.toMap;
 import static tech.pegasys.teku.infrastructure.exceptions.ExceptionUtil.getMessageOrSimpleName;
+import static tech.pegasys.teku.infrastructure.exceptions.ExceptionUtil.getRootCauseMessage;
 import static tech.pegasys.teku.infrastructure.logging.ValidatorLogger.VALIDATOR_LOGGER;
 import static tech.pegasys.teku.infrastructure.metrics.Validator.DutyType.ATTESTATION_PRODUCTION;
 import static tech.pegasys.teku.infrastructure.metrics.Validator.ValidatorDutyMetricUtils.startTimer;
@@ -618,7 +619,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
         .sendSignedBlock(maybeBlindedBlockContainer, broadcastValidationLevel)
         .exceptionally(
             ex -> {
-              final String reason = getMessageOrSimpleName(ex);
+              final String reason = getRootCauseMessage(ex);
               return SendSignedBlockResult.rejected(reason);
             });
   }

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -616,7 +616,11 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
       final BroadcastValidationLevel broadcastValidationLevel) {
     return blockPublisher
         .sendSignedBlock(maybeBlindedBlockContainer, broadcastValidationLevel)
-        .exceptionally(ex -> SendSignedBlockResult.rejected(ex.getMessage()));
+        .exceptionally(
+            ex -> {
+              final String reason = getMessageOrSimpleName(ex);
+              return SendSignedBlockResult.rejected(reason);
+            });
   }
 
   @Override

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/AbstractPostBlock.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/AbstractPostBlock.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Consensys Software Inc., 2023
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.beaconrestapi.handlers.v1.beacon;
+
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_ACCEPTED;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_INTERNAL_SERVER_ERROR;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
+
+import tech.pegasys.teku.api.SyncDataProvider;
+import tech.pegasys.teku.api.ValidatorDataProvider;
+import tech.pegasys.teku.infrastructure.restapi.endpoints.AsyncApiResponse;
+import tech.pegasys.teku.infrastructure.restapi.endpoints.EndpointMetadata;
+import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiEndpoint;
+import tech.pegasys.teku.validator.api.SendSignedBlockResult;
+
+public abstract class AbstractPostBlock extends RestApiEndpoint {
+
+  protected final ValidatorDataProvider validatorDataProvider;
+  protected final SyncDataProvider syncDataProvider;
+
+  public AbstractPostBlock(
+      final ValidatorDataProvider validatorDataProvider,
+      final SyncDataProvider syncDataProvider,
+      final EndpointMetadata metadata) {
+    super(metadata);
+    this.validatorDataProvider = validatorDataProvider;
+    this.syncDataProvider = syncDataProvider;
+  }
+
+  protected AsyncApiResponse processSendSignedBlockResult(final SendSignedBlockResult result) {
+    return result
+        .getRejectionReason()
+        .map(
+            rejectionReason -> {
+              if (result.isPublished()) {
+                return AsyncApiResponse.respondWithCode(SC_ACCEPTED);
+              }
+              return AsyncApiResponse.respondWithError(SC_INTERNAL_SERVER_ERROR, rejectionReason);
+            })
+        .orElse(AsyncApiResponse.respondWithCode(SC_OK));
+  }
+}

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostBlindedBlock.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostBlindedBlock.java
@@ -16,7 +16,6 @@ package tech.pegasys.teku.beaconrestapi.handlers.v1.beacon;
 import static tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.MilestoneDependentTypesUtil.getSchemaDefinitionForAllSupportedMilestones;
 import static tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.MilestoneDependentTypesUtil.slotBasedSelector;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_ACCEPTED;
-import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_INTERNAL_SERVER_ERROR;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_SERVICE_UNAVAILABLE;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.TAG_BEACON;
@@ -28,9 +27,7 @@ import java.util.Optional;
 import tech.pegasys.teku.api.DataProvider;
 import tech.pegasys.teku.api.SyncDataProvider;
 import tech.pegasys.teku.api.ValidatorDataProvider;
-import tech.pegasys.teku.infrastructure.restapi.endpoints.AsyncApiResponse;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.EndpointMetadata;
-import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiEndpoint;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiRequest;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
@@ -38,11 +35,8 @@ import tech.pegasys.teku.spec.datastructures.validator.BroadcastValidationLevel;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionCache;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
 
-public class PostBlindedBlock extends RestApiEndpoint {
+public class PostBlindedBlock extends AbstractPostBlock {
   public static final String ROUTE = "/eth/v1/beacon/blinded_blocks";
-
-  private final ValidatorDataProvider validatorDataProvider;
-  private final SyncDataProvider syncDataProvider;
 
   public PostBlindedBlock(
       final DataProvider dataProvider,
@@ -60,9 +54,7 @@ public class PostBlindedBlock extends RestApiEndpoint {
       final SyncDataProvider syncDataProvider,
       final Spec spec,
       final SchemaDefinitionCache schemaDefinitionCache) {
-    super(getEndpointMetaData(spec, schemaDefinitionCache));
-    this.validatorDataProvider = validatorDataProvider;
-    this.syncDataProvider = syncDataProvider;
+    super(validatorDataProvider, syncDataProvider, createMetadata(spec, schemaDefinitionCache));
   }
 
   @Override
@@ -77,22 +69,10 @@ public class PostBlindedBlock extends RestApiEndpoint {
     request.respondAsync(
         validatorDataProvider
             .submitSignedBlindedBlock(requestBody, BroadcastValidationLevel.NOT_REQUIRED)
-            .thenApply(
-                result ->
-                    result
-                        .getRejectionReason()
-                        .map(
-                            rejectionReason -> {
-                              if (result.isPublished()) {
-                                return AsyncApiResponse.respondWithCode(SC_ACCEPTED);
-                              }
-                              return AsyncApiResponse.respondWithError(
-                                  SC_INTERNAL_SERVER_ERROR, rejectionReason);
-                            })
-                        .orElse(AsyncApiResponse.respondWithCode(SC_OK))));
+            .thenApply(this::processSendSignedBlockResult));
   }
 
-  private static EndpointMetadata getEndpointMetaData(
+  private static EndpointMetadata createMetadata(
       final Spec spec, final SchemaDefinitionCache schemaDefinitionCache) {
     return EndpointMetadata.post(ROUTE)
         .operationId("publishBlindedBlock")

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostBlock.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostBlock.java
@@ -16,7 +16,6 @@ package tech.pegasys.teku.beaconrestapi.handlers.v1.beacon;
 import static tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.MilestoneDependentTypesUtil.getSchemaDefinitionForAllSupportedMilestones;
 import static tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.MilestoneDependentTypesUtil.slotBasedSelector;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_ACCEPTED;
-import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_INTERNAL_SERVER_ERROR;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_SERVICE_UNAVAILABLE;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.SERVICE_UNAVAILABLE;
@@ -29,9 +28,7 @@ import java.util.Optional;
 import tech.pegasys.teku.api.DataProvider;
 import tech.pegasys.teku.api.SyncDataProvider;
 import tech.pegasys.teku.api.ValidatorDataProvider;
-import tech.pegasys.teku.infrastructure.restapi.endpoints.AsyncApiResponse;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.EndpointMetadata;
-import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiEndpoint;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiRequest;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
@@ -39,19 +36,18 @@ import tech.pegasys.teku.spec.datastructures.validator.BroadcastValidationLevel;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionCache;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
 
-public class PostBlock extends RestApiEndpoint {
+public class PostBlock extends AbstractPostBlock {
   public static final String ROUTE = "/eth/v1/beacon/blocks";
-
-  private final ValidatorDataProvider validatorDataProvider;
-  private final SyncDataProvider syncDataProvider;
 
   public PostBlock(
       final DataProvider dataProvider,
       final Spec spec,
       final SchemaDefinitionCache schemaDefinitionCache) {
-    super(createMetadata(spec, schemaDefinitionCache));
-    this.validatorDataProvider = dataProvider.getValidatorDataProvider();
-    this.syncDataProvider = dataProvider.getSyncDataProvider();
+    this(
+        dataProvider.getValidatorDataProvider(),
+        dataProvider.getSyncDataProvider(),
+        spec,
+        schemaDefinitionCache);
   }
 
   PostBlock(
@@ -59,9 +55,22 @@ public class PostBlock extends RestApiEndpoint {
       final SyncDataProvider syncDataProvider,
       final Spec spec,
       final SchemaDefinitionCache schemaDefinitionCache) {
-    super(createMetadata(spec, schemaDefinitionCache));
-    this.validatorDataProvider = validatorDataProvider;
-    this.syncDataProvider = syncDataProvider;
+    super(validatorDataProvider, syncDataProvider, createMetadata(spec, schemaDefinitionCache));
+  }
+
+  @Override
+  public void handleRequest(final RestApiRequest request) throws JsonProcessingException {
+    if (syncDataProvider.isSyncing()) {
+      request.respondError(SC_SERVICE_UNAVAILABLE, SERVICE_UNAVAILABLE);
+      return;
+    }
+
+    final SignedBlockContainer requestBody = request.getRequestBody();
+
+    request.respondAsync(
+        validatorDataProvider
+            .submitSignedBlock(requestBody, BroadcastValidationLevel.NOT_REQUIRED)
+            .thenApply(this::processSendSignedBlockResult));
   }
 
   private static EndpointMetadata createMetadata(
@@ -97,32 +106,5 @@ public class PostBlock extends RestApiEndpoint {
         .response(
             SC_SERVICE_UNAVAILABLE, "Beacon node is currently syncing.", HTTP_ERROR_RESPONSE_TYPE)
         .build();
-  }
-
-  @Override
-  public void handleRequest(final RestApiRequest request) throws JsonProcessingException {
-    if (syncDataProvider.isSyncing()) {
-      request.respondError(SC_SERVICE_UNAVAILABLE, SERVICE_UNAVAILABLE);
-      return;
-    }
-
-    final SignedBlockContainer requestBody = request.getRequestBody();
-
-    request.respondAsync(
-        validatorDataProvider
-            .submitSignedBlock(requestBody, BroadcastValidationLevel.NOT_REQUIRED)
-            .thenApply(
-                result ->
-                    result
-                        .getRejectionReason()
-                        .map(
-                            rejectionReason -> {
-                              if (result.isPublished()) {
-                                return AsyncApiResponse.respondWithCode(SC_ACCEPTED);
-                              }
-                              return AsyncApiResponse.respondWithError(
-                                  SC_INTERNAL_SERVER_ERROR, rejectionReason);
-                            })
-                        .orElse(AsyncApiResponse.respondWithCode(SC_OK))));
   }
 }

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostBlock.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostBlock.java
@@ -112,17 +112,17 @@ public class PostBlock extends RestApiEndpoint {
         validatorDataProvider
             .submitSignedBlock(requestBody, BroadcastValidationLevel.NOT_REQUIRED)
             .thenApply(
-                result -> {
-                  if (result.isSuccessful()) {
-                    return AsyncApiResponse.respondWithCode(SC_OK);
-                  }
-                  if (result.isNotImportedDueToInternalError()) {
-                    return AsyncApiResponse.respondWithError(
-                        SC_INTERNAL_SERVER_ERROR,
-                        "An internal error occurred, check the server logs for more details.");
-                  } else {
-                    return AsyncApiResponse.respondWithCode(SC_ACCEPTED);
-                  }
-                }));
+                result ->
+                    result
+                        .getRejectionReason()
+                        .map(
+                            rejectionReason -> {
+                              if (result.isPublished()) {
+                                return AsyncApiResponse.respondWithCode(SC_ACCEPTED);
+                              }
+                              return AsyncApiResponse.respondWithError(
+                                  SC_INTERNAL_SERVER_ERROR, rejectionReason);
+                            })
+                        .orElse(AsyncApiResponse.respondWithCode(SC_OK))));
   }
 }

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v2/beacon/AbstractPostBlockV2.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v2/beacon/AbstractPostBlockV2.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Consensys Software Inc., 2023
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.beaconrestapi.handlers.v2.beacon;
+
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_ACCEPTED;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_BAD_REQUEST;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_INTERNAL_SERVER_ERROR;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
+
+import tech.pegasys.teku.api.SyncDataProvider;
+import tech.pegasys.teku.api.ValidatorDataProvider;
+import tech.pegasys.teku.infrastructure.restapi.endpoints.AsyncApiResponse;
+import tech.pegasys.teku.infrastructure.restapi.endpoints.EndpointMetadata;
+import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiEndpoint;
+import tech.pegasys.teku.validator.api.SendSignedBlockResult;
+
+public abstract class AbstractPostBlockV2 extends RestApiEndpoint {
+
+  protected final ValidatorDataProvider validatorDataProvider;
+  protected final SyncDataProvider syncDataProvider;
+
+  public AbstractPostBlockV2(
+      final ValidatorDataProvider validatorDataProvider,
+      final SyncDataProvider syncDataProvider,
+      final EndpointMetadata metadata) {
+    super(metadata);
+    this.validatorDataProvider = validatorDataProvider;
+    this.syncDataProvider = syncDataProvider;
+  }
+
+  protected AsyncApiResponse processSendSignedBlockResult(final SendSignedBlockResult result) {
+    return result
+        .getRejectionReason()
+        .map(
+            rejectionReason -> {
+              if (result.isRejectedDueToBroadcastValidationFailure()) {
+                return AsyncApiResponse.respondWithError(SC_BAD_REQUEST, rejectionReason);
+              }
+              if (result.isPublished()) {
+                return AsyncApiResponse.respondWithCode(SC_ACCEPTED);
+              }
+              return AsyncApiResponse.respondWithError(SC_INTERNAL_SERVER_ERROR, rejectionReason);
+            })
+        .orElse(AsyncApiResponse.respondWithCode(SC_OK));
+  }
+}

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v2/beacon/PostBlindedBlockV2.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v2/beacon/PostBlindedBlockV2.java
@@ -90,24 +90,22 @@ public class PostBlindedBlockV2 extends RestApiEndpoint {
         validatorDataProvider
             .submitSignedBlindedBlock(requestBody, broadcastValidationLevel)
             .thenApply(
-                result -> {
-                  if (result.isSuccessful()) {
-                    return AsyncApiResponse.respondWithCode(SC_OK);
-                  }
-
-                  if (result.isRejectedDueToBroadcastValidationFailure()) {
-                    return AsyncApiResponse.respondWithError(
-                        SC_BAD_REQUEST, result.getRejectionReason().orElse(""));
-                  }
-
-                  if (result.isNotImportedDueToInternalError()) {
-                    return AsyncApiResponse.respondWithError(
-                        SC_INTERNAL_SERVER_ERROR,
-                        "An internal error occurred, check the server logs for more details.");
-                  }
-
-                  return AsyncApiResponse.respondWithCode(SC_ACCEPTED);
-                }));
+                result ->
+                    result
+                        .getRejectionReason()
+                        .map(
+                            rejectionReason -> {
+                              if (result.isRejectedDueToBroadcastValidationFailure()) {
+                                return AsyncApiResponse.respondWithError(
+                                    SC_BAD_REQUEST, rejectionReason);
+                              }
+                              if (result.isPublished()) {
+                                return AsyncApiResponse.respondWithCode(SC_ACCEPTED);
+                              }
+                              return AsyncApiResponse.respondWithError(
+                                  SC_INTERNAL_SERVER_ERROR, rejectionReason);
+                            })
+                        .orElse(AsyncApiResponse.respondWithCode(SC_OK))));
   }
 
   private static EndpointMetadata getEndpointMetaData(

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v2/beacon/PostBlindedBlockV2.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v2/beacon/PostBlindedBlockV2.java
@@ -17,8 +17,6 @@ import static tech.pegasys.teku.beaconrestapi.BeaconRestApiTypes.PARAMETER_BROAD
 import static tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.MilestoneDependentTypesUtil.getSchemaDefinitionForAllSupportedMilestones;
 import static tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.MilestoneDependentTypesUtil.slotBasedSelector;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_ACCEPTED;
-import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_BAD_REQUEST;
-import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_INTERNAL_SERVER_ERROR;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_SERVICE_UNAVAILABLE;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.TAG_BEACON;
@@ -31,9 +29,7 @@ import tech.pegasys.teku.api.DataProvider;
 import tech.pegasys.teku.api.SyncDataProvider;
 import tech.pegasys.teku.api.ValidatorDataProvider;
 import tech.pegasys.teku.beaconrestapi.BeaconRestApiTypes.BroadcastValidationParameter;
-import tech.pegasys.teku.infrastructure.restapi.endpoints.AsyncApiResponse;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.EndpointMetadata;
-import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiEndpoint;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiRequest;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
@@ -41,11 +37,8 @@ import tech.pegasys.teku.spec.datastructures.validator.BroadcastValidationLevel;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionCache;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
 
-public class PostBlindedBlockV2 extends RestApiEndpoint {
+public class PostBlindedBlockV2 extends AbstractPostBlockV2 {
   public static final String ROUTE = "/eth/v2/beacon/blinded_blocks";
-
-  private final ValidatorDataProvider validatorDataProvider;
-  private final SyncDataProvider syncDataProvider;
 
   public PostBlindedBlockV2(
       final DataProvider dataProvider,
@@ -63,9 +56,7 @@ public class PostBlindedBlockV2 extends RestApiEndpoint {
       final SyncDataProvider syncDataProvider,
       final Spec spec,
       final SchemaDefinitionCache schemaDefinitionCache) {
-    super(getEndpointMetaData(spec, schemaDefinitionCache));
-    this.validatorDataProvider = validatorDataProvider;
-    this.syncDataProvider = syncDataProvider;
+    super(validatorDataProvider, syncDataProvider, createMetadata(spec, schemaDefinitionCache));
   }
 
   @Override
@@ -89,26 +80,10 @@ public class PostBlindedBlockV2 extends RestApiEndpoint {
     request.respondAsync(
         validatorDataProvider
             .submitSignedBlindedBlock(requestBody, broadcastValidationLevel)
-            .thenApply(
-                result ->
-                    result
-                        .getRejectionReason()
-                        .map(
-                            rejectionReason -> {
-                              if (result.isRejectedDueToBroadcastValidationFailure()) {
-                                return AsyncApiResponse.respondWithError(
-                                    SC_BAD_REQUEST, rejectionReason);
-                              }
-                              if (result.isPublished()) {
-                                return AsyncApiResponse.respondWithCode(SC_ACCEPTED);
-                              }
-                              return AsyncApiResponse.respondWithError(
-                                  SC_INTERNAL_SERVER_ERROR, rejectionReason);
-                            })
-                        .orElse(AsyncApiResponse.respondWithCode(SC_OK))));
+            .thenApply(this::processSendSignedBlockResult));
   }
 
-  private static EndpointMetadata getEndpointMetaData(
+  private static EndpointMetadata createMetadata(
       final Spec spec, final SchemaDefinitionCache schemaDefinitionCache) {
     return EndpointMetadata.post(ROUTE)
         .operationId("publishBlindedBlockV2")

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v2/beacon/PostBlockV2.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v2/beacon/PostBlockV2.java
@@ -17,8 +17,6 @@ import static tech.pegasys.teku.beaconrestapi.BeaconRestApiTypes.PARAMETER_BROAD
 import static tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.MilestoneDependentTypesUtil.getSchemaDefinitionForAllSupportedMilestones;
 import static tech.pegasys.teku.beaconrestapi.handlers.v1.beacon.MilestoneDependentTypesUtil.slotBasedSelector;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_ACCEPTED;
-import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_BAD_REQUEST;
-import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_INTERNAL_SERVER_ERROR;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_SERVICE_UNAVAILABLE;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.SERVICE_UNAVAILABLE;
@@ -32,9 +30,7 @@ import tech.pegasys.teku.api.DataProvider;
 import tech.pegasys.teku.api.SyncDataProvider;
 import tech.pegasys.teku.api.ValidatorDataProvider;
 import tech.pegasys.teku.beaconrestapi.BeaconRestApiTypes.BroadcastValidationParameter;
-import tech.pegasys.teku.infrastructure.restapi.endpoints.AsyncApiResponse;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.EndpointMetadata;
-import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiEndpoint;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.RestApiRequest;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
@@ -42,19 +38,18 @@ import tech.pegasys.teku.spec.datastructures.validator.BroadcastValidationLevel;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionCache;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
 
-public class PostBlockV2 extends RestApiEndpoint {
+public class PostBlockV2 extends AbstractPostBlockV2 {
   public static final String ROUTE = "/eth/v2/beacon/blocks";
-
-  private final ValidatorDataProvider validatorDataProvider;
-  private final SyncDataProvider syncDataProvider;
 
   public PostBlockV2(
       final DataProvider dataProvider,
       final Spec spec,
       final SchemaDefinitionCache schemaDefinitionCache) {
-    super(createMetadata(spec, schemaDefinitionCache));
-    this.validatorDataProvider = dataProvider.getValidatorDataProvider();
-    this.syncDataProvider = dataProvider.getSyncDataProvider();
+    this(
+        dataProvider.getValidatorDataProvider(),
+        dataProvider.getSyncDataProvider(),
+        spec,
+        schemaDefinitionCache);
   }
 
   PostBlockV2(
@@ -62,9 +57,31 @@ public class PostBlockV2 extends RestApiEndpoint {
       final SyncDataProvider syncDataProvider,
       final Spec spec,
       final SchemaDefinitionCache schemaDefinitionCache) {
-    super(createMetadata(spec, schemaDefinitionCache));
-    this.validatorDataProvider = validatorDataProvider;
-    this.syncDataProvider = syncDataProvider;
+    super(validatorDataProvider, syncDataProvider, createMetadata(spec, schemaDefinitionCache));
+  }
+
+  @Override
+  public void handleRequest(final RestApiRequest request) throws JsonProcessingException {
+    if (syncDataProvider.isSyncing()) {
+      request.respondError(SC_SERVICE_UNAVAILABLE, SERVICE_UNAVAILABLE);
+      return;
+    }
+
+    final Optional<BroadcastValidationParameter> maybeBroadcastValidation =
+        request.getOptionalQueryParameter(PARAMETER_BROADCAST_VALIDATION);
+
+    // Default to gossip validation as per spec
+    final BroadcastValidationLevel broadcastValidationLevel =
+        maybeBroadcastValidation
+            .map(BroadcastValidationParameter::toInternal)
+            .orElse(BroadcastValidationLevel.GOSSIP);
+
+    final SignedBlockContainer requestBody = request.getRequestBody();
+
+    request.respondAsync(
+        validatorDataProvider
+            .submitSignedBlock(requestBody, broadcastValidationLevel)
+            .thenApply(this::processSendSignedBlockResult));
   }
 
   private static EndpointMetadata createMetadata(
@@ -108,45 +125,5 @@ public class PostBlockV2 extends RestApiEndpoint {
         .response(
             SC_SERVICE_UNAVAILABLE, "Beacon node is currently syncing.", HTTP_ERROR_RESPONSE_TYPE)
         .build();
-  }
-
-  @Override
-  public void handleRequest(final RestApiRequest request) throws JsonProcessingException {
-    if (syncDataProvider.isSyncing()) {
-      request.respondError(SC_SERVICE_UNAVAILABLE, SERVICE_UNAVAILABLE);
-      return;
-    }
-
-    final Optional<BroadcastValidationParameter> maybeBroadcastValidation =
-        request.getOptionalQueryParameter(PARAMETER_BROADCAST_VALIDATION);
-
-    // Default to gossip validation as per spec
-    final BroadcastValidationLevel broadcastValidationLevel =
-        maybeBroadcastValidation
-            .map(BroadcastValidationParameter::toInternal)
-            .orElse(BroadcastValidationLevel.GOSSIP);
-
-    final SignedBlockContainer requestBody = request.getRequestBody();
-
-    request.respondAsync(
-        validatorDataProvider
-            .submitSignedBlock(requestBody, broadcastValidationLevel)
-            .thenApply(
-                result ->
-                    result
-                        .getRejectionReason()
-                        .map(
-                            rejectionReason -> {
-                              if (result.isRejectedDueToBroadcastValidationFailure()) {
-                                return AsyncApiResponse.respondWithError(
-                                    SC_BAD_REQUEST, rejectionReason);
-                              }
-                              if (result.isPublished()) {
-                                return AsyncApiResponse.respondWithCode(SC_ACCEPTED);
-                              }
-                              return AsyncApiResponse.respondWithError(
-                                  SC_INTERNAL_SERVER_ERROR, rejectionReason);
-                            })
-                        .orElse(AsyncApiResponse.respondWithCode(SC_OK))));
   }
 }

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v2/beacon/PostBlockV2.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v2/beacon/PostBlockV2.java
@@ -132,23 +132,21 @@ public class PostBlockV2 extends RestApiEndpoint {
         validatorDataProvider
             .submitSignedBlock(requestBody, broadcastValidationLevel)
             .thenApply(
-                result -> {
-                  if (result.isSuccessful()) {
-                    return AsyncApiResponse.respondWithCode(SC_OK);
-                  }
-
-                  if (result.isRejectedDueToBroadcastValidationFailure()) {
-                    return AsyncApiResponse.respondWithError(
-                        SC_BAD_REQUEST, result.getRejectionReason().orElse(""));
-                  }
-
-                  if (result.isNotImportedDueToInternalError()) {
-                    return AsyncApiResponse.respondWithError(
-                        SC_INTERNAL_SERVER_ERROR,
-                        "An internal error occurred, check the server logs for more details.");
-                  }
-
-                  return AsyncApiResponse.respondWithCode(SC_ACCEPTED);
-                }));
+                result ->
+                    result
+                        .getRejectionReason()
+                        .map(
+                            rejectionReason -> {
+                              if (result.isRejectedDueToBroadcastValidationFailure()) {
+                                return AsyncApiResponse.respondWithError(
+                                    SC_BAD_REQUEST, rejectionReason);
+                              }
+                              if (result.isPublished()) {
+                                return AsyncApiResponse.respondWithCode(SC_ACCEPTED);
+                              }
+                              return AsyncApiResponse.respondWithError(
+                                  SC_INTERNAL_SERVER_ERROR, rejectionReason);
+                            })
+                        .orElse(AsyncApiResponse.respondWithCode(SC_OK))));
   }
 }

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/SendSignedBlockResult.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/SendSignedBlockResult.java
@@ -57,20 +57,10 @@ public class SendSignedBlockResult {
     return published;
   }
 
-  public boolean isSuccessful() {
-    return rejectionReason.isEmpty();
-  }
-
   public boolean isRejectedDueToBroadcastValidationFailure() {
     return !published
         && rejectionReason.isPresent()
         && rejectionReason.get().startsWith(FailureReason.FAILED_BROADCAST_VALIDATION.name());
-  }
-
-  public boolean isNotImportedDueToInternalError() {
-    return published
-        && rejectionReason.isPresent()
-        && rejectionReason.get().startsWith(FailureReason.INTERNAL_ERROR.name());
   }
 
   @Override


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Fixes following:

- Teku fails to broadcast the block but still returns a 202 status code to the VC, which the VC inteprets to mean "invalid but published". IMO this is a minor Teku bug, as Teku should have returned a 400 when it couldn't unblind the block: https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/ValidatorRequiredApi/publishBlindedBlockV2.

The PR makes will make unblinding (and any other unexpected error) return 500. Unblinding is done before validation, so 500 makes more sense in my opinion.

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
