### PR TITLE
Notify fCu subscribers only when fCu will be sent to EL

### DIFF
--- a/beacon/sync/src/testFixtures/java/tech/pegasys/teku/beacon/sync/SyncingNodeManager.java
+++ b/beacon/sync/src/testFixtures/java/tech/pegasys/teku/beacon/sync/SyncingNodeManager.java
@@ -64,7 +64,7 @@ import tech.pegasys.teku.statetransition.block.BlockImporter;
 import tech.pegasys.teku.statetransition.block.BlockManager;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
 import tech.pegasys.teku.statetransition.forkchoice.MergeTransitionBlockValidator;
-import tech.pegasys.teku.statetransition.forkchoice.StubForkChoiceNotifier;
+import tech.pegasys.teku.statetransition.forkchoice.NoopForkChoiceNotifier;
 import tech.pegasys.teku.statetransition.util.FutureItems;
 import tech.pegasys.teku.statetransition.util.PendingPool;
 import tech.pegasys.teku.statetransition.util.PoolFactory;
@@ -122,7 +122,7 @@ public class SyncingNodeManager {
             new InlineEventThread(),
             recentChainData,
             BlobSidecarManager.NOOP,
-            new StubForkChoiceNotifier(),
+            new NoopForkChoiceNotifier(),
             transitionBlockValidator,
             new StubMetricsSystem());
 

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/AbstractDataBackedRestAPIIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/AbstractDataBackedRestAPIIntegrationTest.java
@@ -79,8 +79,8 @@ import tech.pegasys.teku.statetransition.block.BlockManager;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceNotifier;
 import tech.pegasys.teku.statetransition.forkchoice.MergeTransitionBlockValidator;
+import tech.pegasys.teku.statetransition.forkchoice.NoopForkChoiceNotifier;
 import tech.pegasys.teku.statetransition.forkchoice.ProposersDataManager;
-import tech.pegasys.teku.statetransition.forkchoice.StubForkChoiceNotifier;
 import tech.pegasys.teku.statetransition.synccommittee.SyncCommitteeContributionPool;
 import tech.pegasys.teku.statetransition.validation.SignedBlsToExecutionChangeValidator;
 import tech.pegasys.teku.statetransition.validatorcache.ActiveValidatorCache;
@@ -204,7 +204,7 @@ public abstract class AbstractDataBackedRestAPIIntegrationTest {
                 new InlineEventThread(),
                 recentChainData,
                 BlobSidecarManager.NOOP,
-                new StubForkChoiceNotifier(),
+                new NoopForkChoiceNotifier(),
                 new MergeTransitionBlockValidator(
                     spec, recentChainData, ExecutionLayerChannel.NOOP),
                 storageSystem.getMetricsSystem());

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManager.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManager.java
@@ -33,7 +33,6 @@ import tech.pegasys.teku.api.SyncDataProvider;
 import tech.pegasys.teku.api.response.v1.EventType;
 import tech.pegasys.teku.beacon.sync.events.SyncState;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
-import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.events.EventChannels;
 import tech.pegasys.teku.infrastructure.json.JsonUtil;
 import tech.pegasys.teku.infrastructure.restapi.endpoints.ListQueryParameterUtils;
@@ -50,8 +49,6 @@ import tech.pegasys.teku.spec.datastructures.operations.SignedBlsToExecutionChan
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SignedContributionAndProof;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
-import tech.pegasys.teku.spec.executionlayer.ForkChoiceUpdatedResult;
-import tech.pegasys.teku.spec.executionlayer.PayloadBuildingAttributes;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceUpdatedResultSubscriber.ForkChoiceUpdatedResultNotification;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
 import tech.pegasys.teku.storage.api.ChainHeadChannel;
@@ -225,24 +222,19 @@ public class EventSubscriptionManager implements ChainHeadChannel, FinalizedChec
 
   protected void onForkChoiceUpdatedResult(
       final ForkChoiceUpdatedResultNotification forkChoiceUpdatedResultNotification) {
-    final Optional<PayloadBuildingAttributes> maybePayloadAttributes =
-        forkChoiceUpdatedResultNotification.payloadAttributes();
-    // no payload attributes
-    if (maybePayloadAttributes.isEmpty()) {
-      return;
-    }
-    final SafeFuture<Optional<ForkChoiceUpdatedResult>> forkChoiceUpdatedResult =
-        forkChoiceUpdatedResultNotification.forkChoiceUpdatedResult();
-    // no fCu has been sent
-    if (forkChoiceUpdatedResult.isCompletedNormally() && forkChoiceUpdatedResult.join().isEmpty()) {
-      return;
-    }
-    final PayloadBuildingAttributes payloadAttributes = maybePayloadAttributes.get();
-    final SpecMilestone milestone = spec.atSlot(payloadAttributes.getProposalSlot()).getMilestone();
-    final PayloadAttributesEvent payloadAttributesEvent =
-        PayloadAttributesEvent.create(
-            milestone, payloadAttributes, forkChoiceUpdatedResultNotification.forkChoiceState());
-    notifySubscribersOfEvent(EventType.payload_attributes, payloadAttributesEvent);
+    forkChoiceUpdatedResultNotification
+        .payloadAttributes()
+        .ifPresent(
+            payloadAttributes -> {
+              final SpecMilestone milestone =
+                  spec.atSlot(payloadAttributes.getProposalSlot()).getMilestone();
+              final PayloadAttributesEvent payloadAttributesEvent =
+                  PayloadAttributesEvent.create(
+                      milestone,
+                      payloadAttributes,
+                      forkChoiceUpdatedResultNotification.forkChoiceState());
+              notifySubscribersOfEvent(EventType.payload_attributes, payloadAttributesEvent);
+            });
   }
 
   @Override

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManagerTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManagerTest.java
@@ -58,9 +58,7 @@ import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SignedContributionAndProof;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.executionlayer.ForkChoiceState;
-import tech.pegasys.teku.spec.executionlayer.ForkChoiceUpdatedResult;
 import tech.pegasys.teku.spec.executionlayer.PayloadBuildingAttributes;
-import tech.pegasys.teku.spec.executionlayer.PayloadStatus;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceUpdatedResultSubscriber.ForkChoiceUpdatedResultNotification;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
@@ -150,10 +148,7 @@ public class EventSubscriptionManagerTest {
               false),
           Optional.of(samplePayloadAttributes),
           false,
-          SafeFuture.completedFuture(
-              Optional.of(
-                  new ForkChoiceUpdatedResult(
-                      PayloadStatus.VALID, Optional.of(data.randomBytes8())))));
+          new SafeFuture<>());
 
   private final AsyncContext async = mock(AsyncContext.class);
   private final EventChannels channels = mock(EventChannels.class);

--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/EpochTransitionBenchmark.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/EpochTransitionBenchmark.java
@@ -59,7 +59,7 @@ import tech.pegasys.teku.statetransition.block.BlockImportNotifications;
 import tech.pegasys.teku.statetransition.block.BlockImporter;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
 import tech.pegasys.teku.statetransition.forkchoice.MergeTransitionBlockValidator;
-import tech.pegasys.teku.statetransition.forkchoice.StubForkChoiceNotifier;
+import tech.pegasys.teku.statetransition.forkchoice.NoopForkChoiceNotifier;
 import tech.pegasys.teku.storage.client.MemoryOnlyRecentChainData;
 import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.weaksubjectivity.WeakSubjectivityFactory;
@@ -118,7 +118,7 @@ public class EpochTransitionBenchmark {
             new InlineEventThread(),
             recentChainData,
             BlobSidecarManager.NOOP,
-            new StubForkChoiceNotifier(),
+            new NoopForkChoiceNotifier(),
             transitionBlockValidator,
             metricsSystem);
     localChain = BeaconChainUtil.create(spec, recentChainData, validatorKeys, false);

--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/ProfilingRun.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/ProfilingRun.java
@@ -51,7 +51,7 @@ import tech.pegasys.teku.statetransition.block.BlockImportNotifications;
 import tech.pegasys.teku.statetransition.block.BlockImporter;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
 import tech.pegasys.teku.statetransition.forkchoice.MergeTransitionBlockValidator;
-import tech.pegasys.teku.statetransition.forkchoice.StubForkChoiceNotifier;
+import tech.pegasys.teku.statetransition.forkchoice.NoopForkChoiceNotifier;
 import tech.pegasys.teku.storage.client.MemoryOnlyRecentChainData;
 import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.weaksubjectivity.WeakSubjectivityFactory;
@@ -103,7 +103,7 @@ public class ProfilingRun {
               new InlineEventThread(),
               recentChainData,
               BlobSidecarManager.NOOP,
-              new StubForkChoiceNotifier(),
+              new NoopForkChoiceNotifier(),
               transitionBlockValidator,
               metricsSystem);
       BeaconChainUtil localChain =
@@ -196,7 +196,7 @@ public class ProfilingRun {
               new InlineEventThread(),
               recentChainData,
               BlobSidecarManager.NOOP,
-              new StubForkChoiceNotifier(),
+              new NoopForkChoiceNotifier(),
               transitionBlockValidator,
               metricsSystem);
       BlockImporter blockImporter =

--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/TransitionBenchmark.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/TransitionBenchmark.java
@@ -48,7 +48,7 @@ import tech.pegasys.teku.statetransition.block.BlockImportNotifications;
 import tech.pegasys.teku.statetransition.block.BlockImporter;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
 import tech.pegasys.teku.statetransition.forkchoice.MergeTransitionBlockValidator;
-import tech.pegasys.teku.statetransition.forkchoice.StubForkChoiceNotifier;
+import tech.pegasys.teku.statetransition.forkchoice.NoopForkChoiceNotifier;
 import tech.pegasys.teku.storage.client.MemoryOnlyRecentChainData;
 import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.weaksubjectivity.WeakSubjectivityFactory;
@@ -96,7 +96,7 @@ public abstract class TransitionBenchmark {
             new InlineEventThread(),
             recentChainData,
             BlobSidecarManager.NOOP,
-            new StubForkChoiceNotifier(),
+            new NoopForkChoiceNotifier(),
             transitionBlockValidator,
             new StubMetricsSystem());
     localChain = BeaconChainUtil.create(spec, recentChainData, validatorKeys, false);

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/forkchoice/ForkChoiceTestExecutor.java
@@ -69,7 +69,7 @@ import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportRe
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceStateProvider;
 import tech.pegasys.teku.statetransition.forkchoice.MergeTransitionBlockValidator;
-import tech.pegasys.teku.statetransition.forkchoice.StubForkChoiceNotifier;
+import tech.pegasys.teku.statetransition.forkchoice.NoopForkChoiceNotifier;
 import tech.pegasys.teku.statetransition.forkchoice.TickProcessor;
 import tech.pegasys.teku.statetransition.validation.BlockBroadcastValidator;
 import tech.pegasys.teku.statetransition.validation.InternalValidationResult;
@@ -134,7 +134,7 @@ public class ForkChoiceTestExecutor implements TestExecutor {
             eventThread,
             recentChainData,
             blobSidecarManager,
-            new StubForkChoiceNotifier(),
+            new NoopForkChoiceNotifier(),
             new ForkChoiceStateProvider(eventThread, recentChainData),
             new TickProcessor(spec, recentChainData),
             transitionBlockValidator,

--- a/ethereum/statetransition/src/integration-test/java/tech/pegasys/teku/statetransition/attestation/AttestationManagerIntegrationTest.java
+++ b/ethereum/statetransition/src/integration-test/java/tech/pegasys/teku/statetransition/attestation/AttestationManagerIntegrationTest.java
@@ -45,7 +45,7 @@ import tech.pegasys.teku.spec.generator.AggregateGenerator;
 import tech.pegasys.teku.statetransition.blobs.BlobSidecarManager;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
 import tech.pegasys.teku.statetransition.forkchoice.MergeTransitionBlockValidator;
-import tech.pegasys.teku.statetransition.forkchoice.StubForkChoiceNotifier;
+import tech.pegasys.teku.statetransition.forkchoice.NoopForkChoiceNotifier;
 import tech.pegasys.teku.statetransition.util.FutureItems;
 import tech.pegasys.teku.statetransition.util.PendingPool;
 import tech.pegasys.teku.statetransition.util.PoolFactory;
@@ -84,7 +84,7 @@ class AttestationManagerIntegrationTest {
           new InlineEventThread(),
           recentChainData,
           BlobSidecarManager.NOOP,
-          new StubForkChoiceNotifier(),
+          new NoopForkChoiceNotifier(),
           transitionBlockValidator,
           storageSystem.getMetricsSystem());
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -166,22 +166,20 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
     forkChoiceUpdatedResultNotification
         .forkChoiceUpdatedResult()
         .thenAccept(
-            maybeForkChoiceUpdatedResult ->
-                maybeForkChoiceUpdatedResult.ifPresent(
-                    forkChoiceUpdatedResult -> {
-                      if (forkChoiceUpdatedResultNotification.isTerminalBlockCall()
-                          && forkChoiceUpdatedResult.getPayloadStatus().hasInvalidStatus()) {
-                        LOG.error(
-                            "Execution engine considers INVALID recently provided terminal block {}",
-                            forkChoiceUpdatedResultNotification
-                                .forkChoiceState()
-                                .getHeadExecutionBlockHash());
-                        return;
-                      }
-                      onExecutionPayloadResult(
-                          forkChoiceUpdatedResultNotification.forkChoiceState().getHeadBlockRoot(),
-                          forkChoiceUpdatedResult.getPayloadStatus());
-                    }))
+            forkChoiceUpdatedResult -> {
+              if (forkChoiceUpdatedResultNotification.isTerminalBlockCall()
+                  && forkChoiceUpdatedResult.getPayloadStatus().hasInvalidStatus()) {
+                LOG.error(
+                    "Execution engine considers INVALID recently provided terminal block {}",
+                    forkChoiceUpdatedResultNotification
+                        .forkChoiceState()
+                        .getHeadExecutionBlockHash());
+                return;
+              }
+              onExecutionPayloadResult(
+                  forkChoiceUpdatedResultNotification.forkChoiceState().getHeadBlockRoot(),
+                  forkChoiceUpdatedResult.getPayloadStatus());
+            })
         .finish(
             error -> {
               final String errorMessage = "Failed to update fork choice. ";

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -164,7 +164,7 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
   public void onForkChoiceUpdatedResult(
       final ForkChoiceUpdatedResultNotification forkChoiceUpdatedResultNotification) {
     forkChoiceUpdatedResultNotification
-        .forkChoiceUpdatedResult()
+        .forkChoiceUpdatedResultFuture()
         .thenAccept(
             forkChoiceUpdatedResult -> {
               if (forkChoiceUpdatedResultNotification.isTerminalBlockCall()

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifier.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifier.java
@@ -21,6 +21,7 @@ import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
 import tech.pegasys.teku.spec.executionlayer.ForkChoiceState;
 
 public interface ForkChoiceNotifier {
+
   void onForkChoiceUpdated(ForkChoiceState forkChoiceState, Optional<UInt64> proposingSlot);
 
   void onAttestationsDue(UInt64 slot);

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierImpl.java
@@ -241,14 +241,14 @@ public class ForkChoiceNotifierImpl implements ForkChoiceNotifier, ProposersData
     forkChoiceUpdateData
         .send(executionLayerChannel, timeProvider.getTimeInMillis())
         .ifPresent(
-            forkChoiceUpdatedResult ->
+            forkChoiceUpdatedResultFuture ->
                 forkChoiceUpdatedSubscribers.deliver(
                     ForkChoiceUpdatedResultSubscriber::onForkChoiceUpdatedResult,
                     new ForkChoiceUpdatedResultNotification(
                         forkChoiceUpdateData.getForkChoiceState(),
                         forkChoiceUpdateData.getPayloadBuildingAttributes(),
                         forkChoiceUpdateData.hasTerminalBlockHash(),
-                        forkChoiceUpdatedResult)));
+                        forkChoiceUpdatedResultFuture)));
   }
 
   private void updatePayloadAttributes(final UInt64 blockSlot) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierImpl.java
@@ -27,7 +27,6 @@ import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
 import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannel;
 import tech.pegasys.teku.spec.executionlayer.ForkChoiceState;
-import tech.pegasys.teku.spec.executionlayer.ForkChoiceUpdatedResult;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceUpdatedResultSubscriber.ForkChoiceUpdatedResultNotification;
 import tech.pegasys.teku.statetransition.forkchoice.ProposersDataManager.ProposersDataManagerSubscriber;
 import tech.pegasys.teku.storage.client.RecentChainData;
@@ -239,15 +238,17 @@ public class ForkChoiceNotifierImpl implements ForkChoiceNotifier, ProposersData
   }
 
   private void sendForkChoiceUpdated() {
-    final SafeFuture<Optional<ForkChoiceUpdatedResult>> forkChoiceUpdatedResult =
-        forkChoiceUpdateData.send(executionLayerChannel, timeProvider.getTimeInMillis());
-    forkChoiceUpdatedSubscribers.deliver(
-        ForkChoiceUpdatedResultSubscriber::onForkChoiceUpdatedResult,
-        new ForkChoiceUpdatedResultNotification(
-            forkChoiceUpdateData.getForkChoiceState(),
-            forkChoiceUpdateData.getPayloadBuildingAttributes(),
-            forkChoiceUpdateData.hasTerminalBlockHash(),
-            forkChoiceUpdatedResult));
+    forkChoiceUpdateData
+        .send(executionLayerChannel, timeProvider.getTimeInMillis())
+        .ifPresent(
+            forkChoiceUpdatedResult ->
+                forkChoiceUpdatedSubscribers.deliver(
+                    ForkChoiceUpdatedResultSubscriber::onForkChoiceUpdatedResult,
+                    new ForkChoiceUpdatedResultNotification(
+                        forkChoiceUpdateData.getForkChoiceState(),
+                        forkChoiceUpdateData.getPayloadBuildingAttributes(),
+                        forkChoiceUpdateData.hasTerminalBlockHash(),
+                        forkChoiceUpdatedResult)));
   }
 
   private void updatePayloadAttributes(final UInt64 blockSlot) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceUpdateData.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceUpdateData.java
@@ -160,17 +160,17 @@ public class ForkChoiceUpdateData {
     return executionPayloadContext;
   }
 
-  public SafeFuture<Optional<ForkChoiceUpdatedResult>> send(
+  public Optional<SafeFuture<ForkChoiceUpdatedResult>> send(
       final ExecutionLayerChannel executionLayer, final UInt64 currentTimestamp) {
     if (!shouldBeSent(currentTimestamp)) {
-      return SafeFuture.completedFuture(Optional.empty());
+      return Optional.empty();
     }
     toBeSentAtTime = currentTimestamp.plus(RESEND_AFTER_MILLIS);
 
     if (forkChoiceState.getHeadExecutionBlockHash().isZero()) {
       LOG.debug("send - getHeadBlockHash is zero - returning empty");
       executionPayloadContext.complete(Optional.empty());
-      return SafeFuture.completedFuture(Optional.empty());
+      return Optional.empty();
     }
 
     logSendingForkChoiceUpdated();
@@ -193,7 +193,7 @@ public class ForkChoiceUpdateData {
                             payloadBuildingAttributes.orElseThrow())))
         .propagateTo(executionPayloadContext);
 
-    return forkChoiceUpdatedResult.thenApply(Optional::of);
+    return Optional.of(forkChoiceUpdatedResult);
   }
 
   private void logSendForkChoiceUpdatedComplete(Optional<Bytes8> payloadId) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceUpdatedResultSubscriber.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceUpdatedResultSubscriber.java
@@ -29,5 +29,5 @@ public interface ForkChoiceUpdatedResultSubscriber {
       ForkChoiceState forkChoiceState,
       Optional<PayloadBuildingAttributes> payloadAttributes,
       boolean isTerminalBlockCall,
-      SafeFuture<ForkChoiceUpdatedResult> forkChoiceUpdatedResult) {}
+      SafeFuture<ForkChoiceUpdatedResult> forkChoiceUpdatedResultFuture) {}
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceUpdatedResultSubscriber.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceUpdatedResultSubscriber.java
@@ -29,5 +29,5 @@ public interface ForkChoiceUpdatedResultSubscriber {
       ForkChoiceState forkChoiceState,
       Optional<PayloadBuildingAttributes> payloadAttributes,
       boolean isTerminalBlockCall,
-      SafeFuture<Optional<ForkChoiceUpdatedResult>> forkChoiceUpdatedResult) {}
+      SafeFuture<ForkChoiceUpdatedResult> forkChoiceUpdatedResult) {}
 }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockImporterTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockImporterTest.java
@@ -69,7 +69,7 @@ import tech.pegasys.teku.statetransition.blobs.BlobSidecarManager;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceNotifier;
 import tech.pegasys.teku.statetransition.forkchoice.MergeTransitionBlockValidator;
-import tech.pegasys.teku.statetransition.forkchoice.StubForkChoiceNotifier;
+import tech.pegasys.teku.statetransition.forkchoice.NoopForkChoiceNotifier;
 import tech.pegasys.teku.storage.client.MemoryOnlyRecentChainData;
 import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystemBuilder;
@@ -90,7 +90,7 @@ public class BlockImporterTest {
       MemoryOnlyRecentChainData.builder().specProvider(spec).build();
   private final WeakSubjectivityValidator weakSubjectivityValidator =
       mock(WeakSubjectivityValidator.class);
-  private final ForkChoiceNotifier forkChoiceNotifier = new StubForkChoiceNotifier();
+  private final ForkChoiceNotifier forkChoiceNotifier = new NoopForkChoiceNotifier();
   private final MergeTransitionBlockValidator transitionBlockValidator =
       new MergeTransitionBlockValidator(spec, recentChainData, ExecutionLayerChannel.NOOP);
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockManagerTest.java
@@ -92,7 +92,7 @@ import tech.pegasys.teku.statetransition.block.BlockImportChannel.BlockImportAnd
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceNotifier;
 import tech.pegasys.teku.statetransition.forkchoice.MergeTransitionBlockValidator;
-import tech.pegasys.teku.statetransition.forkchoice.StubForkChoiceNotifier;
+import tech.pegasys.teku.statetransition.forkchoice.NoopForkChoiceNotifier;
 import tech.pegasys.teku.statetransition.util.FutureItems;
 import tech.pegasys.teku.statetransition.util.PendingPool;
 import tech.pegasys.teku.statetransition.util.PoolFactory;
@@ -127,7 +127,7 @@ public class BlockManagerTest {
   private StorageSystem localChain;
   private RecentChainData localRecentChainData = mock(RecentChainData.class);
 
-  private final ForkChoiceNotifier forkChoiceNotifier = new StubForkChoiceNotifier();
+  private final ForkChoiceNotifier forkChoiceNotifier = new NoopForkChoiceNotifier();
   private MergeTransitionBlockValidator transitionBlockValidator;
   private final BlobSidecarManager blobSidecarManager = mock(BlobSidecarManager.class);
   private ForkChoice forkChoice;

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
@@ -32,6 +32,7 @@ import static tech.pegasys.teku.statetransition.forkchoice.ForkChoiceUpdateData.
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -260,7 +261,9 @@ class ForkChoiceNotifierTest {
             Bytes32.ZERO,
             Bytes32.ZERO,
             Bytes32.ZERO,
-            false));
+            false),
+        Optional.empty(),
+        notification -> assertThat(notification).isNull());
 
     verifyNoInteractions(executionLayerChannel);
   }
@@ -842,10 +845,17 @@ class ForkChoiceNotifierTest {
 
   private void notifyForkChoiceUpdated(
       final ForkChoiceState forkChoiceState, final Optional<UInt64> proposingSlot) {
+    notifyForkChoiceUpdated(
+        forkChoiceState, proposingSlot, notification -> assertThat(notification).isNotNull());
+  }
+
+  private void notifyForkChoiceUpdated(
+      final ForkChoiceState forkChoiceState,
+      final Optional<UInt64> proposingSlot,
+      final Consumer<ForkChoiceUpdatedResultNotification> requirements) {
     forkChoiceUpdatedResultNotification = null;
     notifier.onForkChoiceUpdated(forkChoiceState, proposingSlot);
-    assertThat(forkChoiceUpdatedResultNotification).isNotNull();
-    assertThat(forkChoiceUpdatedResultNotification.forkChoiceUpdatedResult()).isCompleted();
+    requirements.accept(forkChoiceUpdatedResultNotification);
   }
 
   private void validateGetPayloadIdOnTheFlyRetrieval(

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/BeaconChainUtil.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/BeaconChainUtil.java
@@ -49,7 +49,7 @@ import tech.pegasys.teku.spec.signatures.Signer;
 import tech.pegasys.teku.statetransition.blobs.BlobSidecarManager;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
 import tech.pegasys.teku.statetransition.forkchoice.MergeTransitionBlockValidator;
-import tech.pegasys.teku.statetransition.forkchoice.StubForkChoiceNotifier;
+import tech.pegasys.teku.statetransition.forkchoice.NoopForkChoiceNotifier;
 import tech.pegasys.teku.statetransition.validation.BlockBroadcastValidator;
 import tech.pegasys.teku.storage.client.ChainHead;
 import tech.pegasys.teku.storage.client.RecentChainData;
@@ -107,7 +107,7 @@ public class BeaconChainUtil {
             new InlineEventThread(),
             storageClient,
             BlobSidecarManager.NOOP,
-            new StubForkChoiceNotifier(),
+            new NoopForkChoiceNotifier(),
             new MergeTransitionBlockValidator(spec, storageClient, ExecutionLayerChannel.NOOP),
             new StubMetricsSystem()),
         true);
@@ -127,7 +127,7 @@ public class BeaconChainUtil {
             new InlineEventThread(),
             storageClient,
             BlobSidecarManager.NOOP,
-            new StubForkChoiceNotifier(),
+            new NoopForkChoiceNotifier(),
             new MergeTransitionBlockValidator(spec, storageClient, ExecutionLayerChannel.NOOP),
             new StubMetricsSystem()),
         signDeposits);
@@ -322,7 +322,7 @@ public class BeaconChainUtil {
                 forkChoiceExecutor,
                 recentChainData,
                 BlobSidecarManager.NOOP,
-                new StubForkChoiceNotifier(),
+                new NoopForkChoiceNotifier(),
                 new MergeTransitionBlockValidator(
                     spec, recentChainData, ExecutionLayerChannel.NOOP),
                 new StubMetricsSystem());

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/forkchoice/NoopForkChoiceNotifier.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/forkchoice/NoopForkChoiceNotifier.java
@@ -16,37 +16,19 @@ package tech.pegasys.teku.statetransition.forkchoice;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
-import tech.pegasys.teku.infrastructure.subscribers.Subscribers;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
 import tech.pegasys.teku.spec.executionlayer.ForkChoiceState;
-import tech.pegasys.teku.spec.executionlayer.ForkChoiceUpdatedResult;
-import tech.pegasys.teku.spec.executionlayer.PayloadStatus;
-import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceUpdatedResultSubscriber.ForkChoiceUpdatedResultNotification;
 
-public class StubForkChoiceNotifier implements ForkChoiceNotifier {
-
-  private final Subscribers<ForkChoiceUpdatedResultSubscriber> forkChoiceUpdatedSubscribers =
-      Subscribers.create(true);
-
-  private final SafeFuture<ForkChoiceUpdatedResult> forkChoiceUpdatedResult =
-      SafeFuture.completedFuture(
-          new ForkChoiceUpdatedResult(PayloadStatus.VALID, Optional.empty()));
+public class NoopForkChoiceNotifier implements ForkChoiceNotifier {
 
   @Override
   public void subscribeToForkChoiceUpdatedResult(
-      final ForkChoiceUpdatedResultSubscriber subscriber) {
-    forkChoiceUpdatedSubscribers.subscribe(subscriber);
-  }
+      final ForkChoiceUpdatedResultSubscriber subscriber) {}
 
   @Override
   public void onForkChoiceUpdated(
-      final ForkChoiceState forkChoiceState, final Optional<UInt64> proposingSlot) {
-    forkChoiceUpdatedSubscribers.deliver(
-        ForkChoiceUpdatedResultSubscriber::onForkChoiceUpdatedResult,
-        new ForkChoiceUpdatedResultNotification(
-            forkChoiceState, Optional.empty(), false, forkChoiceUpdatedResult));
-  }
+      final ForkChoiceState forkChoiceState, final Optional<UInt64> proposingSlot) {}
 
   @Override
   public void onAttestationsDue(final UInt64 slot) {}

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/forkchoice/StubForkChoiceNotifier.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/forkchoice/StubForkChoiceNotifier.java
@@ -21,6 +21,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
 import tech.pegasys.teku.spec.executionlayer.ForkChoiceState;
 import tech.pegasys.teku.spec.executionlayer.ForkChoiceUpdatedResult;
+import tech.pegasys.teku.spec.executionlayer.PayloadStatus;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceUpdatedResultSubscriber.ForkChoiceUpdatedResultNotification;
 
 public class StubForkChoiceNotifier implements ForkChoiceNotifier {
@@ -28,8 +29,9 @@ public class StubForkChoiceNotifier implements ForkChoiceNotifier {
   private final Subscribers<ForkChoiceUpdatedResultSubscriber> forkChoiceUpdatedSubscribers =
       Subscribers.create(true);
 
-  private final SafeFuture<Optional<ForkChoiceUpdatedResult>> forkChoiceUpdatedResultNotification =
-      SafeFuture.completedFuture(Optional.empty());
+  private final SafeFuture<ForkChoiceUpdatedResult> forkChoiceUpdatedResult =
+      SafeFuture.completedFuture(
+          new ForkChoiceUpdatedResult(PayloadStatus.VALID, Optional.empty()));
 
   @Override
   public void subscribeToForkChoiceUpdatedResult(
@@ -43,7 +45,7 @@ public class StubForkChoiceNotifier implements ForkChoiceNotifier {
     forkChoiceUpdatedSubscribers.deliver(
         ForkChoiceUpdatedResultSubscriber::onForkChoiceUpdatedResult,
         new ForkChoiceUpdatedResultNotification(
-            forkChoiceState, Optional.empty(), false, forkChoiceUpdatedResultNotification));
+            forkChoiceState, Optional.empty(), false, forkChoiceUpdatedResult));
   }
 
   @Override

--- a/fork-choice-tests/src/integration-test/java/tech/pegasys/teku/forkChoiceTests/ForkChoiceIntegrationTest.java
+++ b/fork-choice-tests/src/integration-test/java/tech/pegasys/teku/forkChoiceTests/ForkChoiceIntegrationTest.java
@@ -55,7 +55,7 @@ import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
 import tech.pegasys.teku.statetransition.blobs.BlobSidecarManager;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoice;
 import tech.pegasys.teku.statetransition.forkchoice.MergeTransitionBlockValidator;
-import tech.pegasys.teku.statetransition.forkchoice.StubForkChoiceNotifier;
+import tech.pegasys.teku.statetransition.forkchoice.NoopForkChoiceNotifier;
 import tech.pegasys.teku.statetransition.validation.BlockBroadcastValidator;
 import tech.pegasys.teku.storage.client.MemoryOnlyRecentChainData;
 import tech.pegasys.teku.storage.client.RecentChainData;
@@ -187,7 +187,7 @@ public class ForkChoiceIntegrationTest {
             forkChoiceExecutor,
             storageClient,
             BlobSidecarManager.NOOP,
-            new StubForkChoiceNotifier(),
+            new NoopForkChoiceNotifier(),
             transitionBlockValidator,
             new StubMetricsSystem());
 

--- a/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/SlotProcessorTest.java
+++ b/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/SlotProcessorTest.java
@@ -48,7 +48,7 @@ import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.EpochCachePrimer;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceNotifier;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceTrigger;
-import tech.pegasys.teku.statetransition.forkchoice.StubForkChoiceNotifier;
+import tech.pegasys.teku.statetransition.forkchoice.NoopForkChoiceNotifier;
 import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.storage.server.StateStorageMode;
 import tech.pegasys.teku.storage.storageSystem.InMemoryStorageSystemBuilder;
@@ -70,7 +70,7 @@ public class SlotProcessorTest {
 
   private final SyncStateProvider syncStateProvider = mock(SyncStateProvider.class);
   private final ForkChoiceTrigger forkChoiceTrigger = mock(ForkChoiceTrigger.class);
-  private final ForkChoiceNotifier forkChoiceNotifier = new StubForkChoiceNotifier();
+  private final ForkChoiceNotifier forkChoiceNotifier = new NoopForkChoiceNotifier();
   private final Eth2P2PNetwork p2pNetwork = mock(Eth2P2PNetwork.class);
   private final SlotEventsChannel slotEventsChannel = mock(SlotEventsChannel.class);
   private final EpochCachePrimer epochCachePrimer = mock(EpochCachePrimer.class);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
A little optimisation after internal discussion about https://github.com/Consensys/teku/pull/7861

Basically instead of sending fCu notification to subscribers every time we check if need to send fCu `SafeFuture<Optional....>>`, we can not send notifications by changing send fCu to `Optional<SafeFuture<....>>` 

This way, notifications will be sent only when fCu will be sent to EL, which is what all subscribers check anyways `ForkChoice` , `PayloadAttributes`

Rename `StubForkChoiceNotifier` to `NoopForkChoiceNotifier` . Essentially no need to send empty notifications, which is the current behaviour of the stub.

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
