### PR TITLE
Create CLI option to always send payloadAttributes to EL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,6 @@ the [releases page](https://github.com/Consensys/teku/releases).
 
 - Added a hidden flag `--Xfork-choice-updated-always-send-payload-attributes` which would cause
 payload attributes to be calculated and sent with every fcU. This could be useful for builders
-consuming the `payload_attributes` SSE event.
+consuming the `payload_attributes` SSE events.
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,4 +13,8 @@ the [releases page](https://github.com/Consensys/teku/releases).
 
 ### Additions and Improvements
 
+- Added a hidden flag `--Xfork-choice-updated-always-send-payload-attributes` which would cause
+payload attributes to be calculated and sent with every fcU. This could be useful for builders
+consuming the `payload_attributes` SSE event.
+
 ### Bug Fixes

--- a/ethereum/networks/src/main/java/tech/pegasys/teku/networks/Eth2NetworkConfiguration.java
+++ b/ethereum/networks/src/main/java/tech/pegasys/teku/networks/Eth2NetworkConfiguration.java
@@ -52,7 +52,8 @@ public class Eth2NetworkConfiguration {
   public static final boolean DEFAULT_FORK_CHOICE_UPDATE_HEAD_ON_BLOCK_IMPORT_ENABLED = false;
 
   public static final boolean DEFAULT_FORK_CHOICE_LATE_BLOCK_REORG_ENABLED = false;
-  public static final boolean DEFAULT_FORK_CHOICE_PROPOSER_BOOST_UNIQUENESS_ENABLED = true;
+
+  public static final boolean DEFAULT_FORK_CHOICE_UPDATED_ALWAYS_SEND_PAYLOAD_ATTRIBUTES = false;
 
   public static final int DEFAULT_ASYNC_P2P_MAX_THREADS = 10;
 
@@ -99,6 +100,7 @@ public class Eth2NetworkConfiguration {
   private final int asyncBeaconChainMaxQueue;
   private final int asyncP2pMaxQueue;
   private final boolean forkChoiceLateBlockReorgEnabled;
+  private final boolean forkChoiceUpdatedAlwaysSendPayloadAttributes;
 
   private Eth2NetworkConfiguration(
       final Spec spec,
@@ -126,7 +128,8 @@ public class Eth2NetworkConfiguration {
       final int asyncP2pMaxQueue,
       final int asyncBeaconChainMaxThreads,
       final int asyncBeaconChainMaxQueue,
-      final boolean forkChoiceLateBlockReorgEnabled) {
+      final boolean forkChoiceLateBlockReorgEnabled,
+      final boolean forkChoiceUpdatedAlwaysSendPayloadAttributes) {
     this.spec = spec;
     this.constants = constants;
     this.initialState = initialState;
@@ -156,6 +159,8 @@ public class Eth2NetworkConfiguration {
     this.asyncBeaconChainMaxThreads = asyncBeaconChainMaxThreads;
     this.asyncBeaconChainMaxQueue = asyncBeaconChainMaxQueue;
     this.forkChoiceLateBlockReorgEnabled = forkChoiceLateBlockReorgEnabled;
+    this.forkChoiceUpdatedAlwaysSendPayloadAttributes =
+        forkChoiceUpdatedAlwaysSendPayloadAttributes;
   }
 
   public static Eth2NetworkConfiguration.Builder builder(final String network) {
@@ -273,6 +278,10 @@ public class Eth2NetworkConfiguration {
     return forkChoiceLateBlockReorgEnabled;
   }
 
+  public boolean isForkChoiceUpdatedAlwaysSendPayloadAttributes() {
+    return forkChoiceUpdatedAlwaysSendPayloadAttributes;
+  }
+
   @Override
   public String toString() {
     return constants;
@@ -307,6 +316,8 @@ public class Eth2NetworkConfiguration {
     private boolean forkChoiceUpdateHeadOnBlockImportEnabled =
         DEFAULT_FORK_CHOICE_UPDATE_HEAD_ON_BLOCK_IMPORT_ENABLED;
     private boolean forkChoiceLateBlockReorgEnabled = DEFAULT_FORK_CHOICE_LATE_BLOCK_REORG_ENABLED;
+    private boolean forkChoiceUpdatedAlwaysSendPayloadAttributes =
+        DEFAULT_FORK_CHOICE_UPDATED_ALWAYS_SEND_PAYLOAD_ATTRIBUTES;
 
     public void spec(Spec spec) {
       this.spec = spec;
@@ -381,7 +392,8 @@ public class Eth2NetworkConfiguration {
           asyncP2pMaxQueue,
           asyncBeaconChainMaxThreads,
           asyncBeaconChainMaxQueue,
-          forkChoiceLateBlockReorgEnabled);
+          forkChoiceLateBlockReorgEnabled,
+          forkChoiceUpdatedAlwaysSendPayloadAttributes);
     }
 
     private void validateCommandLineParameters() {
@@ -836,6 +848,13 @@ public class Eth2NetworkConfiguration {
 
     public Builder forkChoiceLateBlockReorgEnabled(boolean forkChoiceLateBlockReorgEnabled) {
       this.forkChoiceLateBlockReorgEnabled = forkChoiceLateBlockReorgEnabled;
+      return this;
+    }
+
+    public Builder forkChoiceUpdatedAlwaysSendPayloadAttributes(
+        boolean forkChoiceUpdatedAlwaysSendPayloadAttributes) {
+      this.forkChoiceUpdatedAlwaysSendPayloadAttributes =
+          forkChoiceUpdatedAlwaysSendPayloadAttributes;
       return this;
     }
   }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoiceNotifierTest.java
@@ -266,8 +266,10 @@ class ForkChoiceNotifierTest {
     final ForkChoiceState forkChoiceState = getCurrentForkChoiceState();
     final BeaconState headState = getHeadState();
     final UInt64 blockSlot = headState.getSlot().plus(1);
+    // not proposer but should still calculate payload attributes with the default fee recipient
     final PayloadBuildingAttributes payloadBuildingAttributes =
-        withProposerForSlot(forkChoiceState, headState, blockSlot);
+        withProposerForSlotButDoNotPrepare(
+            forkChoiceState, headState, blockSlot, defaultFeeRecipient);
 
     final int notTheNextProposer = spec.getBeaconProposerIndex(headState, blockSlot) + 1;
     proposersDataManager.updatePreparedProposers(

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ProposerDataManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ProposerDataManagerTest.java
@@ -60,7 +60,8 @@ public class ProposerDataManagerTest implements ProposersDataManagerSubscriber {
           metricsSystem,
           executionLayerChannel,
           recentChainData,
-          defaultFeeRecipient);
+          defaultFeeRecipient,
+          false);
 
   private final BeaconState state = dataStructureUtil.randomBeaconState();
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ProposersDataManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/ProposersDataManagerTest.java
@@ -50,7 +50,8 @@ class ProposersDataManagerTest {
           metricsSystem,
           channel,
           recentChainData,
-          Optional.of(defaultAddress));
+          Optional.of(defaultAddress),
+          false);
 
   final List<BeaconPreparableProposer> proposers =
       List.of(

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -1280,7 +1280,8 @@ public class BeaconChainController extends Service implements BeaconChainControl
             metricsSystem,
             executionLayer,
             recentChainData,
-            getProposerDefaultFeeRecipient());
+            getProposerDefaultFeeRecipient(),
+            beaconConfig.eth2NetworkConfig().isForkChoiceUpdatedAlwaysSendPayloadAttributes());
     eventChannels.subscribe(SlotEventsChannel.class, proposersDataManager);
     forkChoiceNotifier =
         new ForkChoiceNotifierImpl(

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/Eth2NetworkOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/Eth2NetworkOptions.java
@@ -102,6 +102,18 @@ public class Eth2NetworkOptions {
       Eth2NetworkConfiguration.DEFAULT_FORK_CHOICE_LATE_BLOCK_REORG_ENABLED;
 
   @Option(
+      names = {"--Xfork-choice-updated-always-send-payload-attributes"},
+      paramLabel = "<BOOLEAN>",
+      description =
+          "Calculate and send payload attributes on every forkChoiceUpdated regardless if a connected validator is due to be a block proposer or not.",
+      arity = "0..1",
+      fallbackValue = "true",
+      showDefaultValue = Visibility.ALWAYS,
+      hidden = true)
+  private boolean forkChoiceUpdatedAlwaysSendPayloadAttributes =
+      Eth2NetworkConfiguration.DEFAULT_FORK_CHOICE_UPDATED_ALWAYS_SEND_PAYLOAD_ATTRIBUTES;
+
+  @Option(
       names = {"--Xnetwork-altair-fork-epoch"},
       hidden = true,
       paramLabel = "<epoch>",
@@ -325,7 +337,8 @@ public class Eth2NetworkOptions {
         .asyncBeaconChainMaxQueue(asyncBeaconChainMaxQueue)
         .forkChoiceUpdateHeadOnBlockImportEnabled(forkChoiceUpdateHeadOnBlockImportEnabled)
         .forkChoiceLateBlockReorgEnabled(forkChoiceLateBlockReorgEnabled)
-        .epochsStoreBlobs(epochsStoreBlobs);
+        .epochsStoreBlobs(epochsStoreBlobs)
+        .forkChoiceUpdatedAlwaysSendPayloadAttributes(forkChoiceUpdatedAlwaysSendPayloadAttributes);
   }
 
   public String getNetwork() {

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/Eth2NetworkOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/Eth2NetworkOptionsTest.java
@@ -136,6 +136,22 @@ class Eth2NetworkOptionsTest extends AbstractBeaconNodeCommandTest {
   }
 
   @Test
+  void shouldUseDefaultAlwaysSendPayloadAttributesIfUnspecified() {
+    final TekuConfiguration config = getTekuConfigurationFromArguments();
+    assertThat(config.eth2NetworkConfiguration().isForkChoiceUpdatedAlwaysSendPayloadAttributes())
+        .isEqualTo(false);
+  }
+
+  @Test
+  void shouldUseAlwaysSendPayloadAttributesIfSpecified() {
+    final TekuConfiguration config =
+        getTekuConfigurationFromArguments(
+            "--Xfork-choice-updated-always-send-payload-attributes", "true");
+    assertThat(config.eth2NetworkConfiguration().isForkChoiceUpdatedAlwaysSendPayloadAttributes())
+        .isEqualTo(true);
+  }
+
+  @Test
   void shouldMergeTransitionsOverrideBeEmptyByDefault() {
     final TekuConfiguration config = getTekuConfigurationFromArguments();
     assertThat(config.eth2NetworkConfiguration().getTotalTerminalDifficultyOverride())


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Introduce `--Xfork-choice-updated-always-send-payload-attributes` to always calculate payload attributes and send to EL (which in turn will send `payload_attributes` event on every slot)

## Fixed Issue(s)
fixes #7847 

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
