### PR TITLE
Added optional/required deposit tree snapshot resource + fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@ the [releases page](https://github.com/Consensys/teku/releases).
 
 ### Additions and Improvements
 - Improved compatibility with `/eth/v3/validator/blocks/{slot}` experimental beacon API for block production. It can now respond with blinded and unblinded content based on the block production flow. It also supports the `builder_boost_factor` parameter.
-
 - Add `block_gossip` SSE event as per https://github.com/ethereum/beacon-APIs/pull/405
-
+- - Deposit tree snapshots will be downloaded from checkpoint-sync-url when available [#7715](https://github.com/Consensys/teku/issues/7715)
 ### Bug Fixes

--- a/beacon/pow/src/main/java/tech/pegasys/teku/beacon/pow/DepositSnapshotFileLoader.java
+++ b/beacon/pow/src/main/java/tech/pegasys/teku/beacon/pow/DepositSnapshotFileLoader.java
@@ -66,14 +66,11 @@ public class DepositSnapshotFileLoader {
       final boolean isRequired = resource.required;
 
       try {
-        final Optional<DepositTreeSnapshot> depositTreeSnapshot =
-            maybeLoadDepositSnapshot(depositSnapshotResourceUrl);
-        if (depositTreeSnapshot.isPresent()) {
-          return LoadDepositSnapshotResult.create(depositTreeSnapshot);
-        } else if (isRequired) {
-          throw new InvalidConfigurationException(
-              "Failed to load deposit tree snapshot from " + sanitizedUrl);
-        }
+        STATUS_LOG.loadingDepositSnapshotResource(sanitizedUrl);
+        final DepositTreeSnapshot depositTreeSnapshot = loadFromUrl(depositSnapshotResourceUrl);
+        STATUS_LOG.onDepositSnapshot(
+            depositTreeSnapshot.getDepositCount(), depositTreeSnapshot.getExecutionBlockHash());
+        return LoadDepositSnapshotResult.create(Optional.of(depositTreeSnapshot));
       } catch (final Exception e) {
         LOG.warn("Failed to load deposit tree snapshot from " + sanitizedUrl, e);
 
@@ -85,16 +82,6 @@ public class DepositSnapshotFileLoader {
     }
 
     return LoadDepositSnapshotResult.empty();
-  }
-
-  private Optional<DepositTreeSnapshot> maybeLoadDepositSnapshot(
-      final String depositSnapshotResourceUrl) throws IOException {
-    final String sanitizedUrl = UrlSanitizer.sanitizePotentialUrl(depositSnapshotResourceUrl);
-    STATUS_LOG.loadingDepositSnapshotResource(sanitizedUrl);
-    final DepositTreeSnapshot depositSnapshot = loadFromUrl(depositSnapshotResourceUrl);
-    STATUS_LOG.onDepositSnapshot(
-        depositSnapshot.getDepositCount(), depositSnapshot.getExecutionBlockHash());
-    return Optional.of(depositSnapshot);
   }
 
   private DepositTreeSnapshot loadFromUrl(final String path) throws IOException {

--- a/beacon/pow/src/main/java/tech/pegasys/teku/beacon/pow/Eth1DepositManager.java
+++ b/beacon/pow/src/main/java/tech/pegasys/teku/beacon/pow/Eth1DepositManager.java
@@ -17,6 +17,7 @@ import static tech.pegasys.teku.beacon.pow.MinimumGenesisTimeBlockFinder.isBlock
 import static tech.pegasys.teku.beacon.pow.MinimumGenesisTimeBlockFinder.notifyMinGenesisTimeBlockReached;
 import static tech.pegasys.teku.infrastructure.logging.StatusLogger.STATUS_LOG;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import java.math.BigInteger;
 import java.util.Optional;
@@ -251,5 +252,10 @@ public class Eth1DepositManager {
     return replayDepositsResult
         .getFirstUnprocessedBlockNumber()
         .max(depositContractDeployBlock.orElse(UInt64.ZERO).bigIntegerValue());
+  }
+
+  @VisibleForTesting
+  public DepositSnapshotFileLoader getDepositSnapshotFileLoader() {
+    return depositSnapshotFileLoader;
   }
 }

--- a/beacon/pow/src/test/java/tech/pegasys/teku/beacon/pow/DepositSnapshotFileLoaderTest.java
+++ b/beacon/pow/src/test/java/tech/pegasys/teku/beacon/pow/DepositSnapshotFileLoaderTest.java
@@ -82,7 +82,7 @@ public class DepositSnapshotFileLoaderTest {
   }
 
   @Test
-  public void shouldTryAllAvailableResources() {
+  public void shouldTryAllAvailableResourcesUntilFirstNonEmptyFound() {
     final String validResourcePath = getResourceFilePath(SNAPSHOT_BEACON_API_RESOURCE);
     depositSnapshotLoader =
         new DepositSnapshotFileLoader.Builder()

--- a/beacon/pow/src/test/java/tech/pegasys/teku/beacon/pow/DepositSnapshotFileLoaderTest.java
+++ b/beacon/pow/src/test/java/tech/pegasys/teku/beacon/pow/DepositSnapshotFileLoaderTest.java
@@ -84,6 +84,10 @@ public class DepositSnapshotFileLoaderTest {
   @Test
   public void shouldTryAllAvailableResourcesUntilFirstNonEmptyFound() {
     final String validResourcePath = getResourceFilePath(SNAPSHOT_BEACON_API_RESOURCE);
+    // assertion values from SNAPSHOT_BEACON_API_RESOURCE
+    final int deposits = 1106572;
+    final int blockNumber = 18754822;
+
     depositSnapshotLoader =
         new DepositSnapshotFileLoader.Builder()
             .addOptionalResource("/foo/empty")
@@ -92,6 +96,17 @@ public class DepositSnapshotFileLoaderTest {
 
     final LoadDepositSnapshotResult result = depositSnapshotLoader.loadDepositSnapshot();
     assertThat(result.getDepositTreeSnapshot()).isPresent();
+    assertWith(
+        result,
+        snapshotResult -> {
+          assertThat(snapshotResult.getDepositTreeSnapshot().isPresent()).isTrue();
+          assertThat(snapshotResult.getDepositTreeSnapshot().get().getDepositCount())
+              .isEqualTo(deposits);
+          assertThat(snapshotResult.getReplayDepositsResult().getLastProcessedDepositIndex())
+              .contains(BigInteger.valueOf(deposits - 1));
+          assertThat(snapshotResult.getReplayDepositsResult().getLastProcessedBlockNumber())
+              .isEqualTo(blockNumber);
+        });
   }
 
   @Test

--- a/ethereum/pow/api/src/main/java/tech/pegasys/teku/ethereum/pow/api/schema/LoadDepositSnapshotResult.java
+++ b/ethereum/pow/api/src/main/java/tech/pegasys/teku/ethereum/pow/api/schema/LoadDepositSnapshotResult.java
@@ -33,6 +33,10 @@ public class LoadDepositSnapshotResult implements Comparable<LoadDepositSnapshot
     this.replayDepositsResult = replayDepositsResult;
   }
 
+  public static LoadDepositSnapshotResult empty() {
+    return LoadDepositSnapshotResult.EMPTY;
+  }
+
   public static LoadDepositSnapshotResult create(
       final Optional<DepositTreeSnapshot> depositTreeSnapshot) {
     if (depositTreeSnapshot.isEmpty() || depositTreeSnapshot.get().getDepositCount() == 0) {

--- a/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/DepositTreeSnapshotConfiguration.java
+++ b/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/DepositTreeSnapshotConfiguration.java
@@ -19,17 +19,17 @@ public class DepositTreeSnapshotConfiguration {
   private final Optional<String> customDepositSnapshotPath;
   private final Optional<String> checkpointSyncDepositSnapshotUrl;
   private final Optional<String> bundledDepositSnapshotPath;
-  private final boolean depositSnapshotEnabled;
+  private final boolean isBundledDepositSnapshotEnabled;
 
   DepositTreeSnapshotConfiguration(
       final Optional<String> customDepositSnapshotPath,
       final Optional<String> checkpointSyncDepositSnapshotUrl,
       final Optional<String> bundledDepositSnapshotPath,
-      final boolean depositSnapshotEnabled) {
+      final boolean isBundledDepositSnapshotEnabled) {
     this.customDepositSnapshotPath = customDepositSnapshotPath;
     this.checkpointSyncDepositSnapshotUrl = checkpointSyncDepositSnapshotUrl;
     this.bundledDepositSnapshotPath = bundledDepositSnapshotPath;
-    this.depositSnapshotEnabled = depositSnapshotEnabled;
+    this.isBundledDepositSnapshotEnabled = isBundledDepositSnapshotEnabled;
   }
 
   public Optional<String> getCustomDepositSnapshotPath() {
@@ -44,7 +44,7 @@ public class DepositTreeSnapshotConfiguration {
     return bundledDepositSnapshotPath;
   }
 
-  public boolean isDepositSnapshotEnabled() {
-    return depositSnapshotEnabled;
+  public boolean isBundledDepositSnapshotEnabled() {
+    return isBundledDepositSnapshotEnabled;
   }
 }

--- a/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/DepositTreeSnapshotConfiguration.java
+++ b/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/DepositTreeSnapshotConfiguration.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.services.powchain;
+
+import java.util.Optional;
+
+public class DepositTreeSnapshotConfiguration {
+  private final Optional<String> customDepositSnapshotPath;
+  private final Optional<String> checkpointSyncDepositSnapshotUrl;
+  private final Optional<String> bundledDepositSnapshotPath;
+  private final boolean depositSnapshotEnabled;
+
+  DepositTreeSnapshotConfiguration(
+      final Optional<String> customDepositSnapshotPath,
+      final Optional<String> checkpointSyncDepositSnapshotUrl,
+      final Optional<String> bundledDepositSnapshotPath,
+      final boolean depositSnapshotEnabled) {
+    this.customDepositSnapshotPath = customDepositSnapshotPath;
+    this.checkpointSyncDepositSnapshotUrl = checkpointSyncDepositSnapshotUrl;
+    this.bundledDepositSnapshotPath = bundledDepositSnapshotPath;
+    this.depositSnapshotEnabled = depositSnapshotEnabled;
+  }
+
+  public Optional<String> getCustomDepositSnapshotPath() {
+    return customDepositSnapshotPath;
+  }
+
+  public Optional<String> getCheckpointSyncDepositSnapshotUrl() {
+    return checkpointSyncDepositSnapshotUrl;
+  }
+
+  public Optional<String> getBundledDepositSnapshotPath() {
+    return bundledDepositSnapshotPath;
+  }
+
+  public boolean isDepositSnapshotEnabled() {
+    return depositSnapshotEnabled;
+  }
+}

--- a/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/PowchainConfiguration.java
+++ b/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/PowchainConfiguration.java
@@ -111,7 +111,7 @@ public class PowchainConfiguration {
     public PowchainConfiguration build() {
       validate();
 
-      boolean isBundledSnapshotEnabled =
+      final boolean isBundledSnapshotEnabled =
           this.depositSnapshotEnabled && this.customDepositSnapshotPath.isEmpty();
 
       return new PowchainConfiguration(

--- a/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/PowchainConfiguration.java
+++ b/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/PowchainConfiguration.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
 import tech.pegasys.teku.ethereum.execution.types.Eth1Address;
 import tech.pegasys.teku.infrastructure.exceptions.InvalidConfigurationException;
+import tech.pegasys.teku.infrastructure.http.UrlSanitizer;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.networks.Eth2Network;
@@ -30,31 +31,29 @@ public class PowchainConfiguration {
   public static final int DEFAULT_ETH1_LOGS_MAX_BLOCK_RANGE = 10_000;
   public static final boolean DEFAULT_USE_MISSING_DEPOSIT_EVENT_LOGGING = false;
   public static final boolean DEFAULT_DEPOSIT_SNAPSHOT_ENABLED = true;
+  public static final String DEPOSIT_SNAPSHOT_URL_PATH = "/eth/v1/beacon/deposit_snapshot";
 
   private final Spec spec;
   private final List<String> eth1Endpoints;
   private final Eth1Address depositContract;
   private final Optional<UInt64> depositContractDeployBlock;
-  private final Optional<String> depositSnapshotPath;
+  private final DepositTreeSnapshotConfiguration depositTreeSnapshotConfiguration;
   private final int eth1LogsMaxBlockRange;
   private final boolean useMissingDepositEventLogging;
-  private final boolean depositSnapshotEnabled;
 
   private PowchainConfiguration(
       final Spec spec,
       final List<String> eth1Endpoints,
       final Eth1Address depositContract,
       final Optional<UInt64> depositContractDeployBlock,
-      final Optional<String> depositSnapshotPath,
+      final DepositTreeSnapshotConfiguration depositTreeSnapshotConfiguration,
       final int eth1LogsMaxBlockRange,
-      final boolean useMissingDepositEventLogging,
-      final boolean depositSnapshotEnabled) {
+      final boolean useMissingDepositEventLogging) {
     this.spec = spec;
     this.eth1Endpoints = eth1Endpoints;
     this.depositContract = depositContract;
     this.depositContractDeployBlock = depositContractDeployBlock;
-    this.depositSnapshotPath = depositSnapshotPath;
-    this.depositSnapshotEnabled = depositSnapshotEnabled;
+    this.depositTreeSnapshotConfiguration = depositTreeSnapshotConfiguration;
     this.eth1LogsMaxBlockRange = eth1LogsMaxBlockRange;
     this.useMissingDepositEventLogging = useMissingDepositEventLogging;
   }
@@ -83,12 +82,8 @@ public class PowchainConfiguration {
     return depositContractDeployBlock;
   }
 
-  public Optional<String> getDepositSnapshotPath() {
-    return depositSnapshotPath;
-  }
-
-  public boolean isDepositSnapshotEnabled() {
-    return depositSnapshotEnabled;
+  public DepositTreeSnapshotConfiguration getDepositTreeSnapshotConfiguration() {
+    return depositTreeSnapshotConfiguration;
   }
 
   public int getEth1LogsMaxBlockRange() {
@@ -104,7 +99,9 @@ public class PowchainConfiguration {
     private List<String> eth1Endpoints = new ArrayList<>();
     private Eth1Address depositContract;
     private Optional<UInt64> depositContractDeployBlock = Optional.empty();
-    private Optional<String> depositSnapshotPath = Optional.empty();
+    private Optional<String> customDepositSnapshotPath = Optional.empty();
+    private Optional<String> checkpointSyncDepositSnapshotUrl = Optional.empty();
+    private Optional<String> bundledDepositSnapshotPath = Optional.empty();
     private int eth1LogsMaxBlockRange = DEFAULT_ETH1_LOGS_MAX_BLOCK_RANGE;
     private boolean useMissingDepositEventLogging = DEFAULT_USE_MISSING_DEPOSIT_EVENT_LOGGING;
     private boolean depositSnapshotEnabled = DEFAULT_DEPOSIT_SNAPSHOT_ENABLED;
@@ -118,10 +115,13 @@ public class PowchainConfiguration {
           eth1Endpoints,
           depositContract,
           depositContractDeployBlock,
-          depositSnapshotPath,
+          new DepositTreeSnapshotConfiguration(
+              customDepositSnapshotPath,
+              checkpointSyncDepositSnapshotUrl,
+              bundledDepositSnapshotPath,
+              depositSnapshotEnabled),
           eth1LogsMaxBlockRange,
-          useMissingDepositEventLogging,
-          depositSnapshotEnabled);
+          useMissingDepositEventLogging);
     }
 
     private void validate() {
@@ -173,9 +173,9 @@ public class PowchainConfiguration {
       return this;
     }
 
-    public Builder depositSnapshotPath(final String depositSnapshotPath) {
+    public Builder customDepositSnapshotPath(final String depositSnapshotPath) {
       if (StringUtils.isNotBlank(depositSnapshotPath)) {
-        this.depositSnapshotPath = Optional.of(depositSnapshotPath);
+        this.customDepositSnapshotPath = Optional.of(depositSnapshotPath);
       }
       return this;
     }
@@ -185,15 +185,19 @@ public class PowchainConfiguration {
       if (eth2Network.isPresent()
           && this.depositSnapshotEnabled
           && DEFAULT_SNAPSHOT_RESOURCE_PATHS.containsKey(eth2Network.get())) {
-        if (depositSnapshotPath.isPresent()) {
-          throw new InvalidConfigurationException(
-              "Use either custom deposit tree snapshot path or snapshot bundle");
-        }
-        this.depositSnapshotPath =
+        this.bundledDepositSnapshotPath =
             Optional.of(
                 PowchainConfiguration.class
                     .getResource(DEFAULT_SNAPSHOT_RESOURCE_PATHS.get(eth2Network.get()))
                     .toExternalForm());
+      }
+      return this;
+    }
+
+    public Builder checkpointSyncDepositSnapshotUrl(final String checkpointSyncUrl) {
+      if (StringUtils.isNotBlank(checkpointSyncUrl)) {
+        this.checkpointSyncDepositSnapshotUrl =
+            Optional.of(UrlSanitizer.appendPath(checkpointSyncUrl, DEPOSIT_SNAPSHOT_URL_PATH));
       }
       return this;
     }

--- a/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/PowchainConfiguration.java
+++ b/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/PowchainConfiguration.java
@@ -110,6 +110,10 @@ public class PowchainConfiguration {
 
     public PowchainConfiguration build() {
       validate();
+
+      boolean isBundledSnapshotEnabled =
+          this.depositSnapshotEnabled && this.customDepositSnapshotPath.isEmpty();
+
       return new PowchainConfiguration(
           spec,
           eth1Endpoints,
@@ -119,7 +123,7 @@ public class PowchainConfiguration {
               customDepositSnapshotPath,
               checkpointSyncDepositSnapshotUrl,
               bundledDepositSnapshotPath,
-              depositSnapshotEnabled),
+              isBundledSnapshotEnabled),
           eth1LogsMaxBlockRange,
           useMissingDepositEventLogging);
     }

--- a/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/PowchainService.java
+++ b/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/PowchainService.java
@@ -33,7 +33,6 @@ import tech.pegasys.teku.beacon.pow.DepositEventsAccessor;
 import tech.pegasys.teku.beacon.pow.DepositFetcher;
 import tech.pegasys.teku.beacon.pow.DepositProcessingController;
 import tech.pegasys.teku.beacon.pow.DepositSnapshotFileLoader;
-import tech.pegasys.teku.beacon.pow.DepositSnapshotFileLoader.Builder;
 import tech.pegasys.teku.beacon.pow.DepositSnapshotStorageLoader;
 import tech.pegasys.teku.beacon.pow.Eth1BlockFetcher;
 import tech.pegasys.teku.beacon.pow.Eth1DepositManager;
@@ -197,7 +196,8 @@ public class PowchainService extends Service {
 
   private DepositSnapshotFileLoader createDepositSnapshotFileLoader(
       final DepositTreeSnapshotConfiguration depositTreeSnapshotConfiguration) {
-    final DepositSnapshotFileLoader.Builder depositSnapshotFileLoaderBuilder = new Builder();
+    final DepositSnapshotFileLoader.Builder depositSnapshotFileLoaderBuilder =
+        new DepositSnapshotFileLoader.Builder();
 
     if (depositTreeSnapshotConfiguration.getCustomDepositSnapshotPath().isPresent()) {
       depositSnapshotFileLoaderBuilder.addRequiredResource(

--- a/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/PowchainService.java
+++ b/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/PowchainService.java
@@ -176,7 +176,8 @@ public class PowchainService extends Service {
         serviceConfig.getEventChannels().getPublisher(CombinedStorageChannel.class, asyncRunner);
     final DepositSnapshotStorageLoader depositSnapshotStorageLoader =
         new DepositSnapshotStorageLoader(
-            depositTreeSnapshotConfiguration.isDepositSnapshotEnabled(), storageQueryChannel);
+            depositTreeSnapshotConfiguration.isBundledDepositSnapshotEnabled(),
+            storageQueryChannel);
 
     eth1DepositManager =
         new Eth1DepositManager(
@@ -187,7 +188,7 @@ public class PowchainService extends Service {
             eth1DepositStorageChannel,
             depositSnapshotFileLoader,
             depositSnapshotStorageLoader,
-            depositTreeSnapshotConfiguration.isDepositSnapshotEnabled(),
+            depositTreeSnapshotConfiguration.isBundledDepositSnapshotEnabled(),
             depositProcessingController,
             new MinimumGenesisTimeBlockFinder(config, eth1Provider, eth1DepositContractDeployBlock),
             eth1DepositContractDeployBlock,

--- a/services/powchain/src/test/java/tech/pegasys/teku/services/powchain/DepositSnapshotsBundleTest.java
+++ b/services/powchain/src/test/java/tech/pegasys/teku/services/powchain/DepositSnapshotsBundleTest.java
@@ -60,7 +60,7 @@ public class DepositSnapshotsBundleTest {
     assumeThat(
             powchainConfiguration
                 .getDepositTreeSnapshotConfiguration()
-                .getCustomDepositSnapshotPath())
+                .getBundledDepositSnapshotPath())
         .describedAs("No built-in snapshot for network %s", eth2Network)
         .isPresent();
 
@@ -69,7 +69,7 @@ public class DepositSnapshotsBundleTest {
             .addRequiredResource(
                 powchainConfiguration
                     .getDepositTreeSnapshotConfiguration()
-                    .getCustomDepositSnapshotPath()
+                    .getBundledDepositSnapshotPath()
                     .get())
             .build();
 
@@ -98,7 +98,7 @@ public class DepositSnapshotsBundleTest {
     final String depositSnapshotPath =
         powchainConfiguration
             .getDepositTreeSnapshotConfiguration()
-            .getCustomDepositSnapshotPath()
+            .getBundledDepositSnapshotPath()
             .orElseThrow();
     final DepositSnapshotFileLoader depositSnapshotLoader =
         new DepositSnapshotFileLoader.Builder().addRequiredResource(depositSnapshotPath).build();

--- a/services/powchain/src/test/java/tech/pegasys/teku/services/powchain/DepositSnapshotsBundleTest.java
+++ b/services/powchain/src/test/java/tech/pegasys/teku/services/powchain/DepositSnapshotsBundleTest.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.services.powchain;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 import okhttp3.ConnectionPool;
@@ -57,12 +58,20 @@ public class DepositSnapshotsBundleTest {
         .depositSnapshotEnabled(true)
         .setDepositSnapshotPathForNetwork(Optional.of(eth2Network));
     final PowchainConfiguration powchainConfiguration = powchainConfigBuilder.build();
-    assumeThat(powchainConfiguration.getDepositSnapshotPath())
+    assumeThat(
+            powchainConfiguration
+                .getDepositTreeSnapshotConfiguration()
+                .getCustomDepositSnapshotPath())
         .describedAs("No built-in snapshot for network %s", eth2Network)
         .isPresent();
 
     final DepositSnapshotFileLoader depositSnapshotLoader =
-        new DepositSnapshotFileLoader(powchainConfiguration.getDepositSnapshotPath());
+        new DepositSnapshotFileLoader(
+            List.of(
+                powchainConfiguration
+                    .getDepositTreeSnapshotConfiguration()
+                    .getCustomDepositSnapshotPath()
+                    .get()));
     final DepositTreeSnapshot depositTreeSnapshot =
         depositSnapshotLoader.loadDepositSnapshot().getDepositTreeSnapshot().orElseThrow();
     final DepositTree depositTree = DepositTree.fromSnapshot(depositTreeSnapshot);
@@ -85,9 +94,13 @@ public class DepositSnapshotsBundleTest {
         .setDepositSnapshotPathForNetwork(Optional.of(eth2Network));
     final PowchainConfiguration powchainConfiguration = powchainConfigBuilder.build();
 
-    final String depositSnapshotPath = powchainConfiguration.getDepositSnapshotPath().orElseThrow();
+    final String depositSnapshotPath =
+        powchainConfiguration
+            .getDepositTreeSnapshotConfiguration()
+            .getCustomDepositSnapshotPath()
+            .orElseThrow();
     final DepositSnapshotFileLoader depositSnapshotLoader =
-        new DepositSnapshotFileLoader(Optional.of(depositSnapshotPath));
+        new DepositSnapshotFileLoader(List.of(depositSnapshotPath));
 
     // Snapshot
     final DepositTreeSnapshot depositTreeSnapshot =

--- a/services/powchain/src/test/java/tech/pegasys/teku/services/powchain/DepositSnapshotsBundleTest.java
+++ b/services/powchain/src/test/java/tech/pegasys/teku/services/powchain/DepositSnapshotsBundleTest.java
@@ -16,7 +16,6 @@ package tech.pegasys.teku.services.powchain;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
-import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 import okhttp3.ConnectionPool;
@@ -66,12 +65,14 @@ public class DepositSnapshotsBundleTest {
         .isPresent();
 
     final DepositSnapshotFileLoader depositSnapshotLoader =
-        new DepositSnapshotFileLoader(
-            List.of(
+        new DepositSnapshotFileLoader.Builder()
+            .addRequiredResource(
                 powchainConfiguration
                     .getDepositTreeSnapshotConfiguration()
                     .getCustomDepositSnapshotPath()
-                    .get()));
+                    .get())
+            .build();
+
     final DepositTreeSnapshot depositTreeSnapshot =
         depositSnapshotLoader.loadDepositSnapshot().getDepositTreeSnapshot().orElseThrow();
     final DepositTree depositTree = DepositTree.fromSnapshot(depositTreeSnapshot);
@@ -100,7 +101,7 @@ public class DepositSnapshotsBundleTest {
             .getCustomDepositSnapshotPath()
             .orElseThrow();
     final DepositSnapshotFileLoader depositSnapshotLoader =
-        new DepositSnapshotFileLoader(List.of(depositSnapshotPath));
+        new DepositSnapshotFileLoader.Builder().addRequiredResource(depositSnapshotPath).build();
 
     // Snapshot
     final DepositTreeSnapshot depositTreeSnapshot =

--- a/services/powchain/src/test/java/tech/pegasys/teku/services/powchain/PowchainConfigurationTest.java
+++ b/services/powchain/src/test/java/tech/pegasys/teku/services/powchain/PowchainConfigurationTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.services.powchain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.networks.Eth2Network;
+
+class PowchainConfigurationTest {
+
+  private final Spec spec = TestSpecFactory.createDefault();
+
+  @Test
+  public void buildShouldSetSeparateDepositSnapshotPathAndBundledDepositSnapshotPath() {
+    final PowchainConfiguration config =
+        PowchainConfiguration.builder()
+            .specProvider(spec)
+            .customDepositSnapshotPath("/tmp/foo")
+            .setDepositSnapshotPathForNetwork(Optional.of(Eth2Network.MAINNET))
+            .build();
+
+    final DepositTreeSnapshotConfiguration depositTreeSnapshotConfiguration =
+        config.getDepositTreeSnapshotConfiguration();
+    assertThat(depositTreeSnapshotConfiguration.getCustomDepositSnapshotPath())
+        .contains("/tmp/foo");
+    assertThat(depositTreeSnapshotConfiguration.getBundledDepositSnapshotPath())
+        .asString()
+        .contains("mainnet.ssz");
+  }
+
+  @Test
+  public void emptyNetworkShouldHaveEmptyBundledDepositSnapshotPath() {
+    final PowchainConfiguration config =
+        PowchainConfiguration.builder()
+            .specProvider(spec)
+            .setDepositSnapshotPathForNetwork(Optional.empty())
+            .build();
+
+    assertThat(config.getDepositTreeSnapshotConfiguration().getBundledDepositSnapshotPath())
+        .isEmpty();
+  }
+
+  @Test
+  public void whenDepositSnapshotIsDisabledBundledDepositSnapshotMustBeEmpty() {
+    final PowchainConfiguration config =
+        PowchainConfiguration.builder()
+            .specProvider(spec)
+            .depositSnapshotEnabled(false)
+            // even though we are setting the value, because depositSnapshotEnabled = false it won't
+            // be set
+            .setDepositSnapshotPathForNetwork(Optional.of(Eth2Network.MAINNET))
+            .build();
+
+    assertThat(config.getDepositTreeSnapshotConfiguration().getBundledDepositSnapshotPath())
+        .isEmpty();
+  }
+}

--- a/services/powchain/src/test/java/tech/pegasys/teku/services/powchain/PowchainConfigurationTest.java
+++ b/services/powchain/src/test/java/tech/pegasys/teku/services/powchain/PowchainConfigurationTest.java
@@ -68,5 +68,7 @@ class PowchainConfigurationTest {
 
     assertThat(config.getDepositTreeSnapshotConfiguration().getBundledDepositSnapshotPath())
         .isEmpty();
+    assertThat(config.getDepositTreeSnapshotConfiguration().isBundledDepositSnapshotEnabled())
+        .isFalse();
   }
 }

--- a/services/powchain/src/test/java/tech/pegasys/teku/services/powchain/PowchainServiceTest.java
+++ b/services/powchain/src/test/java/tech/pegasys/teku/services/powchain/PowchainServiceTest.java
@@ -153,6 +153,20 @@ public class PowchainServiceTest {
   }
 
   @Test
+  public void shouldUseCustomDepositSnapshotPathEvenWhenCheckpointSyncIsPresent() {
+    when(depositTreeSnapshotConfiguration.getCustomDepositSnapshotPath())
+        .thenReturn(Optional.of("/foo/custom"));
+    when(depositTreeSnapshotConfiguration.getCustomDepositSnapshotPath())
+        .thenReturn(Optional.of("/foo/chackpoint"));
+
+    final PowchainService powchainService =
+        new PowchainService(serviceConfig, powConfig, Optional.of(engineWeb3jClientProvider));
+
+    verifyExpectedOrderOfDepositSnapshotPathResources(
+        powchainService, List.of(new DepositSnapshotResource("/foo/custom", true)));
+  }
+
+  @Test
   public void shouldHaveNoDepositSnapshotPathWhenNoneIsAvailable() {
     when(depositTreeSnapshotConfiguration.getCustomDepositSnapshotPath())
         .thenReturn(Optional.empty());

--- a/services/powchain/src/test/java/tech/pegasys/teku/services/powchain/PowchainServiceTest.java
+++ b/services/powchain/src/test/java/tech/pegasys/teku/services/powchain/PowchainServiceTest.java
@@ -156,8 +156,8 @@ public class PowchainServiceTest {
   public void shouldUseCustomDepositSnapshotPathEvenWhenCheckpointSyncIsPresent() {
     when(depositTreeSnapshotConfiguration.getCustomDepositSnapshotPath())
         .thenReturn(Optional.of("/foo/custom"));
-    when(depositTreeSnapshotConfiguration.getCustomDepositSnapshotPath())
-        .thenReturn(Optional.of("/foo/chackpoint"));
+    when(depositTreeSnapshotConfiguration.getCheckpointSyncDepositSnapshotUrl())
+        .thenReturn(Optional.of("/foo/checkpoint"));
 
     final PowchainService powchainService =
         new PowchainService(serviceConfig, powConfig, Optional.of(engineWeb3jClientProvider));

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/DepositOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/DepositOptions.java
@@ -19,7 +19,6 @@ import picocli.CommandLine;
 import picocli.CommandLine.Help.Visibility;
 import picocli.CommandLine.Option;
 import tech.pegasys.teku.config.TekuConfiguration;
-import tech.pegasys.teku.infrastructure.exceptions.InvalidConfigurationException;
 import tech.pegasys.teku.services.powchain.PowchainConfiguration;
 
 public class DepositOptions {
@@ -69,21 +68,7 @@ public class DepositOptions {
       fallbackValue = "true")
   private boolean depositSnapshotEnabled = PowchainConfiguration.DEFAULT_DEPOSIT_SNAPSHOT_ENABLED;
 
-  @CommandLine.Spec CommandLine.Model.CommandSpec commandSpec;
-
   public void configure(final TekuConfiguration.Builder builder) {
-    final CommandLine.ParseResult parseResult = commandSpec.commandLine().getParseResult();
-
-    if (parseResult.hasMatchedOption("--Xdeposit-snapshot")) {
-      if (parseResult.hasMatchedOption("--deposit-snapshot-enabled")
-          && parseResult.matchedOptionValue("--deposit-snapshot-enabled", Boolean.TRUE)) {
-        throw new InvalidConfigurationException(
-            "Use either custom deposit tree snapshot path or snapshot bundle");
-      }
-
-      depositSnapshotEnabled = false;
-    }
-
     builder.powchain(
         b -> {
           b.eth1Endpoints(eth1Endpoints);

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/DepositOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/DepositOptions.java
@@ -19,6 +19,7 @@ import picocli.CommandLine;
 import picocli.CommandLine.Help.Visibility;
 import picocli.CommandLine.Option;
 import tech.pegasys.teku.config.TekuConfiguration;
+import tech.pegasys.teku.infrastructure.exceptions.InvalidConfigurationException;
 import tech.pegasys.teku.services.powchain.PowchainConfiguration;
 
 public class DepositOptions {
@@ -68,17 +69,28 @@ public class DepositOptions {
       fallbackValue = "true")
   private boolean depositSnapshotEnabled = PowchainConfiguration.DEFAULT_DEPOSIT_SNAPSHOT_ENABLED;
 
-  public void configure(final TekuConfiguration.Builder builder) {
-    builder.powchain(
-        b ->
-            b.eth1Endpoints(eth1Endpoints)
-                .eth1LogsMaxBlockRange(eth1LogsMaxBlockRange)
-                .useMissingDepositEventLogging(useMissingDepositEventLogging)
-                .depositSnapshotPath(depositSnapshotPath)
-                .depositSnapshotEnabled(parseDepositSnapshotEnabled()));
-  }
+  @CommandLine.Spec CommandLine.Model.CommandSpec commandSpec;
 
-  private boolean parseDepositSnapshotEnabled() {
-    return depositSnapshotEnabled;
+  public void configure(final TekuConfiguration.Builder builder) {
+    final CommandLine.ParseResult parseResult = commandSpec.commandLine().getParseResult();
+
+    if (parseResult.hasMatchedOption("--Xdeposit-snapshot")) {
+      if (parseResult.hasMatchedOption("--deposit-snapshot-enabled")
+          && parseResult.matchedOptionValue("--deposit-snapshot-enabled", Boolean.TRUE)) {
+        throw new InvalidConfigurationException(
+            "Use either custom deposit tree snapshot path or snapshot bundle");
+      }
+
+      depositSnapshotEnabled = false;
+    }
+
+    builder.powchain(
+        b -> {
+          b.eth1Endpoints(eth1Endpoints);
+          b.eth1LogsMaxBlockRange(eth1LogsMaxBlockRange);
+          b.useMissingDepositEventLogging(useMissingDepositEventLogging);
+          b.customDepositSnapshotPath(depositSnapshotPath);
+          b.depositSnapshotEnabled(depositSnapshotEnabled);
+        });
   }
 }

--- a/teku/src/main/java/tech/pegasys/teku/config/TekuConfiguration.java
+++ b/teku/src/main/java/tech/pegasys/teku/config/TekuConfiguration.java
@@ -223,7 +223,7 @@ public class TekuConfiguration {
       eth2NetworkConfiguration
           .getNetworkBoostrapConfig()
           .getCheckpointSyncUrl()
-          .map(powchainConfigBuilder::checkpointSyncDepositSnapshotUrl);
+          .ifPresent(powchainConfigBuilder::checkpointSyncDepositSnapshotUrl);
       p2pConfigBuilder.discovery(
           b -> b.bootnodesDefault(eth2NetworkConfiguration.getDiscoveryBootnodes()));
       restApiBuilder.eth1DepositContractAddressDefault(depositContractAddress);

--- a/teku/src/main/java/tech/pegasys/teku/config/TekuConfiguration.java
+++ b/teku/src/main/java/tech/pegasys/teku/config/TekuConfiguration.java
@@ -220,6 +220,10 @@ public class TekuConfiguration {
       powchainConfigBuilder.depositContractDeployBlockDefault(depositContractDeployBlock);
       powchainConfigBuilder.setDepositSnapshotPathForNetwork(
           eth2NetworkConfiguration.getEth2Network());
+      eth2NetworkConfiguration
+          .getNetworkBoostrapConfig()
+          .getCheckpointSyncUrl()
+          .map(powchainConfigBuilder::checkpointSyncDepositSnapshotUrl);
       p2pConfigBuilder.discovery(
           b -> b.bootnodesDefault(eth2NetworkConfiguration.getDiscoveryBootnodes()));
       restApiBuilder.eth1DepositContractAddressDefault(depositContractAddress);

--- a/teku/src/main/java/tech/pegasys/teku/services/BeaconNodeServiceController.java
+++ b/teku/src/main/java/tech/pegasys/teku/services/BeaconNodeServiceController.java
@@ -36,7 +36,7 @@ public class BeaconNodeServiceController extends ServiceController {
         new StorageService(
             serviceConfig,
             tekuConfig.storageConfiguration(),
-            tekuConfig.powchain().isDepositSnapshotEnabled(),
+            tekuConfig.powchain().getDepositTreeSnapshotConfiguration().isDepositSnapshotEnabled(),
             tekuConfig.metricsConfig().isBlobSidecarsStorageCountersEnabled()));
     Optional<ExecutionWeb3jClientProvider> maybeExecutionWeb3jClientProvider = Optional.empty();
     if (tekuConfig.executionLayer().isEnabled()) {

--- a/teku/src/main/java/tech/pegasys/teku/services/BeaconNodeServiceController.java
+++ b/teku/src/main/java/tech/pegasys/teku/services/BeaconNodeServiceController.java
@@ -36,7 +36,10 @@ public class BeaconNodeServiceController extends ServiceController {
         new StorageService(
             serviceConfig,
             tekuConfig.storageConfiguration(),
-            tekuConfig.powchain().getDepositTreeSnapshotConfiguration().isDepositSnapshotEnabled(),
+            tekuConfig
+                .powchain()
+                .getDepositTreeSnapshotConfiguration()
+                .isBundledDepositSnapshotEnabled(),
             tekuConfig.metricsConfig().isBlobSidecarsStorageCountersEnabled()));
     Optional<ExecutionWeb3jClientProvider> maybeExecutionWeb3jClientProvider = Optional.empty();
     if (tekuConfig.executionLayer().isEnabled()) {

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/DepositOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/DepositOptionsTest.java
@@ -191,4 +191,18 @@ public class DepositOptionsTest extends AbstractBeaconNodeCommandTest {
     assertThat(depositTreeSnapshotConfiguration.getCheckpointSyncDepositSnapshotUrl())
         .hasValue("http://checkpoint-sync.com" + DEPOSIT_SNAPSHOT_URL_PATH);
   }
+
+  @Test
+  public void
+      shouldDisableBundledDepositSnapshotWhenUsingCustomDepositSnapshotWithCheckpointSyncUrl() {
+    final String[] args = {
+      "--Xdeposit-snapshot", "/foo/bar", "--checkpoint-sync-url", "http://checkpoint-sync.com"
+    };
+    final TekuConfiguration config = getTekuConfigurationFromArguments(args);
+    final DepositTreeSnapshotConfiguration depositTreeSnapshotConfiguration =
+        config.powchain().getDepositTreeSnapshotConfiguration();
+    assertThat(depositTreeSnapshotConfiguration.isBundledDepositSnapshotEnabled()).isFalse();
+    assertThat(depositTreeSnapshotConfiguration.getCustomDepositSnapshotPath())
+        .hasValue("/foo/bar");
+  }
 }

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/DepositOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/DepositOptionsTest.java
@@ -119,7 +119,11 @@ public class DepositOptionsTest extends AbstractBeaconNodeCommandTest {
   public void shouldSetDefaultBundleSnapshotPathForSupportedNetwork(final String network) {
     final String[] args = {"--network=" + network, "--deposit-snapshot-enabled"};
     final TekuConfiguration config = getTekuConfigurationFromArguments(args);
-    assertThat(config.powchain().getDepositTreeSnapshotConfiguration().isDepositSnapshotEnabled())
+    assertThat(
+            config
+                .powchain()
+                .getDepositTreeSnapshotConfiguration()
+                .isBundledDepositSnapshotEnabled())
         .isTrue();
     assertThat(
             config.powchain().getDepositTreeSnapshotConfiguration().getBundledDepositSnapshotPath())
@@ -135,7 +139,11 @@ public class DepositOptionsTest extends AbstractBeaconNodeCommandTest {
   public void shouldHaveDepositSnapshotEnabledByDefault() {
     final String[] args = {};
     final TekuConfiguration config = getTekuConfigurationFromArguments(args);
-    assertThat(config.powchain().getDepositTreeSnapshotConfiguration().isDepositSnapshotEnabled())
+    assertThat(
+            config
+                .powchain()
+                .getDepositTreeSnapshotConfiguration()
+                .isBundledDepositSnapshotEnabled())
         .isTrue();
   }
 
@@ -145,7 +153,7 @@ public class DepositOptionsTest extends AbstractBeaconNodeCommandTest {
     final TekuConfiguration config = getTekuConfigurationFromArguments(args);
     final DepositTreeSnapshotConfiguration depositTreeSnapshotConfiguration =
         config.powchain().getDepositTreeSnapshotConfiguration();
-    assertThat(depositTreeSnapshotConfiguration.isDepositSnapshotEnabled()).isTrue();
+    assertThat(depositTreeSnapshotConfiguration.isBundledDepositSnapshotEnabled()).isTrue();
     assertThat(depositTreeSnapshotConfiguration.getCustomDepositSnapshotPath()).isEmpty();
   }
 
@@ -153,7 +161,11 @@ public class DepositOptionsTest extends AbstractBeaconNodeCommandTest {
   public void shouldRespectDepositSnapshotFlagWhenDisabled() {
     final String[] args = {"--deposit-snapshot-enabled", "false"};
     final TekuConfiguration config = getTekuConfigurationFromArguments(args);
-    assertThat(config.powchain().getDepositTreeSnapshotConfiguration().isDepositSnapshotEnabled())
+    assertThat(
+            config
+                .powchain()
+                .getDepositTreeSnapshotConfiguration()
+                .isBundledDepositSnapshotEnabled())
         .isFalse();
   }
 
@@ -163,7 +175,7 @@ public class DepositOptionsTest extends AbstractBeaconNodeCommandTest {
     final TekuConfiguration config = getTekuConfigurationFromArguments(args);
     final DepositTreeSnapshotConfiguration depositTreeSnapshotConfiguration =
         config.powchain().getDepositTreeSnapshotConfiguration();
-    assertThat(depositTreeSnapshotConfiguration.isDepositSnapshotEnabled()).isFalse();
+    assertThat(depositTreeSnapshotConfiguration.isBundledDepositSnapshotEnabled()).isFalse();
     assertThat(depositTreeSnapshotConfiguration.getCustomDepositSnapshotPath())
         .hasValue("/foo/bar");
   }
@@ -174,7 +186,7 @@ public class DepositOptionsTest extends AbstractBeaconNodeCommandTest {
     final TekuConfiguration config = getTekuConfigurationFromArguments(args);
     final DepositTreeSnapshotConfiguration depositTreeSnapshotConfiguration =
         config.powchain().getDepositTreeSnapshotConfiguration();
-    assertThat(depositTreeSnapshotConfiguration.isDepositSnapshotEnabled()).isTrue();
+    assertThat(depositTreeSnapshotConfiguration.isBundledDepositSnapshotEnabled()).isTrue();
     assertThat(depositTreeSnapshotConfiguration.getCheckpointSyncDepositSnapshotUrl())
         .hasValue("http://checkpoint-sync.com" + DEPOSIT_SNAPSHOT_URL_PATH);
   }
@@ -186,7 +198,7 @@ public class DepositOptionsTest extends AbstractBeaconNodeCommandTest {
     final TekuConfiguration config = getTekuConfigurationFromArguments(args);
     final DepositTreeSnapshotConfiguration depositTreeSnapshotConfiguration =
         config.powchain().getDepositTreeSnapshotConfiguration();
-    assertThat(depositTreeSnapshotConfiguration.isDepositSnapshotEnabled()).isFalse();
+    assertThat(depositTreeSnapshotConfiguration.isBundledDepositSnapshotEnabled()).isFalse();
     assertThat(depositTreeSnapshotConfiguration.getCustomDepositSnapshotPath())
         .hasValue("/foo/bar");
   }

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/DepositOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/DepositOptionsTest.java
@@ -14,8 +14,8 @@
 package tech.pegasys.teku.cli.options;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static tech.pegasys.teku.beacon.pow.DepositSnapshotFileLoader.DEFAULT_SNAPSHOT_RESOURCE_PATHS;
+import static tech.pegasys.teku.services.powchain.PowchainConfiguration.DEPOSIT_SNAPSHOT_URL_PATH;
 
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -23,7 +23,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import tech.pegasys.teku.cli.AbstractBeaconNodeCommandTest;
 import tech.pegasys.teku.config.TekuConfiguration;
-import tech.pegasys.teku.infrastructure.exceptions.InvalidConfigurationException;
+import tech.pegasys.teku.services.powchain.DepositTreeSnapshotConfiguration;
 import tech.pegasys.teku.services.powchain.PowchainConfiguration;
 import tech.pegasys.teku.spec.networks.Eth2Network;
 
@@ -119,8 +119,10 @@ public class DepositOptionsTest extends AbstractBeaconNodeCommandTest {
   public void shouldSetDefaultBundleSnapshotPathForSupportedNetwork(final String network) {
     final String[] args = {"--network=" + network, "--deposit-snapshot-enabled"};
     final TekuConfiguration config = getTekuConfigurationFromArguments(args);
-    assertThat(config.powchain().isDepositSnapshotEnabled()).isTrue();
-    assertThat(config.powchain().getDepositSnapshotPath())
+    assertThat(config.powchain().getDepositTreeSnapshotConfiguration().isDepositSnapshotEnabled())
+        .isTrue();
+    assertThat(
+            config.powchain().getDepositTreeSnapshotConfiguration().getBundledDepositSnapshotPath())
         .contains(
             PowchainConfiguration.class
                 .getResource(
@@ -130,22 +132,61 @@ public class DepositOptionsTest extends AbstractBeaconNodeCommandTest {
   }
 
   @Test
-  public void shouldIgnoreBundleSnapshotPathForNotSupportedNetwork() {
-    final String[] args = {"--network=swift", "--deposit-snapshot-enabled"};
+  public void shouldHaveDepositSnapshotEnabledByDefault() {
+    final String[] args = {};
     final TekuConfiguration config = getTekuConfigurationFromArguments(args);
-    assertThat(config.powchain().isDepositSnapshotEnabled()).isTrue();
-    assertThat(config.powchain().getDepositSnapshotPath()).isEmpty();
+    assertThat(config.powchain().getDepositTreeSnapshotConfiguration().isDepositSnapshotEnabled())
+        .isTrue();
   }
 
   @Test
-  public void shouldThrowErrorIfSnapshotPathProvidedWithBundleSnapshot() {
-    assertThatThrownBy(
-            () ->
-                createConfigBuilder()
-                    .eth2NetworkConfig(b -> b.applyNetworkDefaults(Eth2Network.MAINNET))
-                    .powchain(b -> b.depositSnapshotEnabled(true).depositSnapshotPath("/some/path"))
-                    .build())
-        .isInstanceOf(InvalidConfigurationException.class)
-        .hasMessage("Use either custom deposit tree snapshot path or snapshot bundle");
+  public void shouldIgnoreBundleSnapshotPathForNotSupportedNetwork() {
+    final String[] args = {"--network=swift", "--deposit-snapshot-enabled"};
+    final TekuConfiguration config = getTekuConfigurationFromArguments(args);
+    final DepositTreeSnapshotConfiguration depositTreeSnapshotConfiguration =
+        config.powchain().getDepositTreeSnapshotConfiguration();
+    assertThat(depositTreeSnapshotConfiguration.isDepositSnapshotEnabled()).isTrue();
+    assertThat(depositTreeSnapshotConfiguration.getCustomDepositSnapshotPath()).isEmpty();
+  }
+
+  @Test
+  public void shouldRespectDepositSnapshotFlagWhenDisabled() {
+    final String[] args = {"--deposit-snapshot-enabled", "false"};
+    final TekuConfiguration config = getTekuConfigurationFromArguments(args);
+    assertThat(config.powchain().getDepositTreeSnapshotConfiguration().isDepositSnapshotEnabled())
+        .isFalse();
+  }
+
+  @Test
+  public void shouldSetUseDepositSnapshotToFalseWhenCustomDepositSnapshotIsProvided() {
+    final String[] args = {"--Xdeposit-snapshot", "/foo/bar"};
+    final TekuConfiguration config = getTekuConfigurationFromArguments(args);
+    final DepositTreeSnapshotConfiguration depositTreeSnapshotConfiguration =
+        config.powchain().getDepositTreeSnapshotConfiguration();
+    assertThat(depositTreeSnapshotConfiguration.isDepositSnapshotEnabled()).isFalse();
+    assertThat(depositTreeSnapshotConfiguration.getCustomDepositSnapshotPath())
+        .hasValue("/foo/bar");
+  }
+
+  @Test
+  public void shouldSetCheckpointSyncDepositSnapshotUrlWhenUsingCheckpointSyncUrl() {
+    final String[] args = {"--checkpoint-sync-url", "http://checkpoint-sync.com"};
+    final TekuConfiguration config = getTekuConfigurationFromArguments(args);
+    final DepositTreeSnapshotConfiguration depositTreeSnapshotConfiguration =
+        config.powchain().getDepositTreeSnapshotConfiguration();
+    assertThat(depositTreeSnapshotConfiguration.isDepositSnapshotEnabled()).isTrue();
+    assertThat(depositTreeSnapshotConfiguration.getCheckpointSyncDepositSnapshotUrl())
+        .hasValue("http://checkpoint-sync.com" + DEPOSIT_SNAPSHOT_URL_PATH);
+  }
+
+  @Test
+  public void shouldThrowErrorIfUsingCustomSnapshotAndExplicitlyEnablingBundled() {
+    final String[] args = {"--Xdeposit-snapshot", "/foo/bar", "--deposit-snapshot-enabled"};
+
+    int parseResult = beaconNodeCommand.parse(args);
+    assertThat(parseResult).isEqualTo(2);
+
+    final String output = getCommandLineOutput();
+    assertThat(output).contains("Use either custom deposit tree snapshot path or snapshot bundle");
   }
 }

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/DepositOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/DepositOptionsTest.java
@@ -155,6 +155,7 @@ public class DepositOptionsTest extends AbstractBeaconNodeCommandTest {
         config.powchain().getDepositTreeSnapshotConfiguration();
     assertThat(depositTreeSnapshotConfiguration.isBundledDepositSnapshotEnabled()).isTrue();
     assertThat(depositTreeSnapshotConfiguration.getCustomDepositSnapshotPath()).isEmpty();
+    assertThat(depositTreeSnapshotConfiguration.getBundledDepositSnapshotPath()).isEmpty();
   }
 
   @Test
@@ -170,7 +171,7 @@ public class DepositOptionsTest extends AbstractBeaconNodeCommandTest {
   }
 
   @Test
-  public void shouldSetUseDepositSnapshotToFalseWhenCustomDepositSnapshotIsProvided() {
+  public void shouldDisableBundledDepositSnapshotWhenUsingCustomDepositSnapshotPath() {
     final String[] args = {"--Xdeposit-snapshot", "/foo/bar"};
     final TekuConfiguration config = getTekuConfigurationFromArguments(args);
     final DepositTreeSnapshotConfiguration depositTreeSnapshotConfiguration =
@@ -189,17 +190,5 @@ public class DepositOptionsTest extends AbstractBeaconNodeCommandTest {
     assertThat(depositTreeSnapshotConfiguration.isBundledDepositSnapshotEnabled()).isTrue();
     assertThat(depositTreeSnapshotConfiguration.getCheckpointSyncDepositSnapshotUrl())
         .hasValue("http://checkpoint-sync.com" + DEPOSIT_SNAPSHOT_URL_PATH);
-  }
-
-  @Test
-  public void shouldDisableBundledDepositSnapshotWhenUsingCustomDepositSnapshotPath() {
-    final String[] args = {"--Xdeposit-snapshot", "/foo/bar"};
-
-    final TekuConfiguration config = getTekuConfigurationFromArguments(args);
-    final DepositTreeSnapshotConfiguration depositTreeSnapshotConfiguration =
-        config.powchain().getDepositTreeSnapshotConfiguration();
-    assertThat(depositTreeSnapshotConfiguration.isBundledDepositSnapshotEnabled()).isFalse();
-    assertThat(depositTreeSnapshotConfiguration.getCustomDepositSnapshotPath())
-        .hasValue("/foo/bar");
   }
 }

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/DepositOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/DepositOptionsTest.java
@@ -180,13 +180,14 @@ public class DepositOptionsTest extends AbstractBeaconNodeCommandTest {
   }
 
   @Test
-  public void shouldThrowErrorIfUsingCustomSnapshotAndExplicitlyEnablingBundled() {
-    final String[] args = {"--Xdeposit-snapshot", "/foo/bar", "--deposit-snapshot-enabled"};
+  public void shouldDisableBundledDepositSnapshotWhenUsingCustomDepositSnapshotPath() {
+    final String[] args = {"--Xdeposit-snapshot", "/foo/bar"};
 
-    int parseResult = beaconNodeCommand.parse(args);
-    assertThat(parseResult).isEqualTo(2);
-
-    final String output = getCommandLineOutput();
-    assertThat(output).contains("Use either custom deposit tree snapshot path or snapshot bundle");
+    final TekuConfiguration config = getTekuConfigurationFromArguments(args);
+    final DepositTreeSnapshotConfiguration depositTreeSnapshotConfiguration =
+        config.powchain().getDepositTreeSnapshotConfiguration();
+    assertThat(depositTreeSnapshotConfiguration.isDepositSnapshotEnabled()).isFalse();
+    assertThat(depositTreeSnapshotConfiguration.getCustomDepositSnapshotPath())
+        .hasValue("/foo/bar");
   }
 }


### PR DESCRIPTION
## PR Description

The core idea in this PR is that `DepositSnapshotFileLoader` now has multiple resources to load (instead of a single URL). Each resource can be set as required (can't fail) or optional (can fail).

In our current implementation, when using `--Xdeposit-snapshot` to provide a custom deposit tree snapshot to Teku, we will set it as the only resource, and mark it as required. Therefore, if it fails to load, Teku will exit with an error.

For known networks like Mainnet or Testnets (networks that we have a bundled snapshot of the deposit tree), we will also set the bundled version as a required resource (there is no reason for it to fail).

Last but not least, if the user is using `--checkpoint-sync-url`, we will add an extra optional resource that takes precedence over the bundled resource. If it fails loading, we will fallback into the bundled one.

When configuring `DepositSnapshotFileLoader` through its builder, we keep the order of insertion, what reflects the order we use when evaluating resources.

## Fixed Issue(s)
fixes #7715 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
