### PR TITLE
Disable Peer Exchange in PRUNE message

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -30,7 +30,7 @@ dependencyManagement {
     dependency 'io.javalin:javalin:5.6.3'
     dependency 'io.javalin:javalin-rendering:5.6.2'
 
-    dependency 'io.libp2p:jvm-libp2p:1.0.1-RELEASE'
+    dependency 'io.libp2p:jvm-libp2p:1.1.0-RELEASE'
     dependency 'tech.pegasys:jblst:0.3.11'
     dependency 'tech.pegasys:jc-kzg-4844:0.8.0'
 

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/MuxFirewall.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/MuxFirewall.java
@@ -179,7 +179,7 @@ public class MuxFirewall implements ChannelVisitor<Connection> {
               yamuxFrame.getType() == YamuxType.DATA
                   || yamuxFrame.getType() == YamuxType.WINDOW_UPDATE;
           return isDataOrWindowUpdate
-              && (yamuxFlags.contains(YamuxFlag.SYN) || (yamuxFlags.contains(YamuxFlag.ACK)));
+              && (yamuxFlags.contains(YamuxFlag.SYN) || yamuxFlags.contains(YamuxFlag.ACK));
         }
 
         @Override

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/MuxFirewall.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/MuxFirewall.java
@@ -19,7 +19,7 @@ import io.libp2p.core.Connection;
 import io.libp2p.etc.util.netty.mux.MuxId;
 import io.libp2p.mux.mplex.MplexFlag;
 import io.libp2p.mux.mplex.MplexFrame;
-import io.libp2p.mux.yamux.YamuxFlags;
+import io.libp2p.mux.yamux.YamuxFlag;
 import io.libp2p.mux.yamux.YamuxFrame;
 import io.libp2p.mux.yamux.YamuxType;
 import io.netty.channel.ChannelDuplexHandler;
@@ -166,7 +166,7 @@ public class MuxFirewall implements ChannelVisitor<Connection> {
     if (msg instanceof YamuxFrame yamuxFrame) {
       return new MuxFrame() {
 
-        private final int yamuxFlags = yamuxFrame.getFlags();
+        private final Set<YamuxFlag> yamuxFlags = yamuxFrame.getFlags();
 
         @Override
         public MuxId getId() {
@@ -179,17 +179,17 @@ public class MuxFirewall implements ChannelVisitor<Connection> {
               yamuxFrame.getType() == YamuxType.DATA
                   || yamuxFrame.getType() == YamuxType.WINDOW_UPDATE;
           return isDataOrWindowUpdate
-              && (yamuxFlags == YamuxFlags.SYN || yamuxFlags == YamuxFlags.ACK);
+              && (yamuxFlags.contains(YamuxFlag.SYN) || (yamuxFlags.contains(YamuxFlag.ACK)));
         }
 
         @Override
         public boolean indicatesStreamClosing() {
-          return yamuxFlags == YamuxFlags.FIN;
+          return yamuxFlags.contains(YamuxFlag.FIN);
         }
 
         @Override
         public boolean indicatesStreamResetting() {
-          return yamuxFlags == YamuxFlags.RST;
+          return yamuxFlags.contains(YamuxFlag.RST);
         }
       };
     }

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/config/LibP2PParamsFactory.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/libp2p/config/LibP2PParamsFactory.java
@@ -73,7 +73,8 @@ public class LibP2PParamsFactory {
         .maxSubscriptions(MAX_SUBSCRIPTIONS_PER_MESSAGE)
         .maxGraftMessages(200)
         .maxPruneMessages(200)
-        .maxPeersPerPruneMessage(1000)
+        .maxPeersSentInPruneMsg(0)
+        .maxPeersAcceptedInPruneMsg(Integer.MAX_VALUE)
         .maxIHaveLength(5000)
         .maxIWantMessageIds(5000);
   }

--- a/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/libp2p/MuxFirewallTest.java
+++ b/networking/p2p/src/test/java/tech/pegasys/teku/networking/p2p/libp2p/MuxFirewallTest.java
@@ -21,7 +21,7 @@ import io.libp2p.core.transport.Transport;
 import io.libp2p.mux.mplex.MplexFlag;
 import io.libp2p.mux.mplex.MplexFrame;
 import io.libp2p.mux.mplex.MplexId;
-import io.libp2p.mux.yamux.YamuxFlags;
+import io.libp2p.mux.yamux.YamuxFlag;
 import io.libp2p.mux.yamux.YamuxFrame;
 import io.libp2p.mux.yamux.YamuxId;
 import io.libp2p.mux.yamux.YamuxType;
@@ -39,6 +39,7 @@ import it.unimi.dsi.fastutil.ints.IntLists;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -242,7 +243,7 @@ public class MuxFirewallTest {
     return switch (muxType) {
       case MPLEX -> new MplexFrame(createMplexId(id), MplexFlag.NewStream, Unpooled.EMPTY_BUFFER);
       case YAMUX -> new YamuxFrame(
-          createYamuxId(id), YamuxType.DATA, YamuxFlags.ACK, 0, Unpooled.EMPTY_BUFFER);
+          createYamuxId(id), YamuxType.DATA, Set.of(YamuxFlag.ACK), 0, Unpooled.EMPTY_BUFFER);
     };
   }
 
@@ -251,7 +252,7 @@ public class MuxFirewallTest {
       case MPLEX -> new MplexFrame(
           createMplexId(id), MplexFlag.CloseInitiator, Unpooled.EMPTY_BUFFER);
       case YAMUX -> new YamuxFrame(
-          createYamuxId(id), YamuxType.DATA, YamuxFlags.FIN, 0, Unpooled.EMPTY_BUFFER);
+          createYamuxId(id), YamuxType.DATA, Set.of(YamuxFlag.FIN), 0, Unpooled.EMPTY_BUFFER);
     };
   }
 
@@ -260,7 +261,7 @@ public class MuxFirewallTest {
       case MPLEX -> new MplexFrame(
           createMplexId(id), MplexFlag.CloseReceiver, Unpooled.EMPTY_BUFFER);
       case YAMUX -> new YamuxFrame(
-          createYamuxId(id), YamuxType.DATA, YamuxFlags.FIN, 0, Unpooled.EMPTY_BUFFER);
+          createYamuxId(id), YamuxType.DATA, Set.of(YamuxFlag.FIN), 0, Unpooled.EMPTY_BUFFER);
     };
   }
 
@@ -269,7 +270,11 @@ public class MuxFirewallTest {
     return switch (muxType) {
       case MPLEX -> new MplexFrame(createMplexId(id), MplexFlag.MessageReceiver, slicedByteBuf);
       case YAMUX -> new YamuxFrame(
-          createYamuxId(id), YamuxType.DATA, 0, slicedByteBuf.readableBytes(), slicedByteBuf);
+          createYamuxId(id),
+          YamuxType.DATA,
+          Set.of(),
+          slicedByteBuf.readableBytes(),
+          slicedByteBuf);
     };
   }
 
@@ -278,7 +283,7 @@ public class MuxFirewallTest {
       case MPLEX -> new MplexFrame(
           createMplexId(id), MplexFlag.ResetInitiator, Unpooled.EMPTY_BUFFER);
       case YAMUX -> new YamuxFrame(
-          createYamuxId(id), YamuxType.DATA, YamuxFlags.RST, 0, Unpooled.EMPTY_BUFFER);
+          createYamuxId(id), YamuxType.DATA, Set.of(YamuxFlag.RST), 0, Unpooled.EMPTY_BUFFER);
     };
   }
 
@@ -287,7 +292,7 @@ public class MuxFirewallTest {
       case MPLEX -> new MplexFrame(
           createMplexId(id), MplexFlag.ResetReceiver, Unpooled.EMPTY_BUFFER);
       case YAMUX -> new YamuxFrame(
-          createYamuxId(id), YamuxType.DATA, YamuxFlags.RST, 0, Unpooled.EMPTY_BUFFER);
+          createYamuxId(id), YamuxType.DATA, Set.of(YamuxFlag.RST), 0, Unpooled.EMPTY_BUFFER);
     };
   }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Update `jvm-libp2p` to 1.1.0-RELEASE and set `maxPeersSentInPruneMsg` and `maxPeersAcceptedInPruneMsg`

## Fixed Issue(s)
fixes #7860 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
