### PR TITLE
Deferred dynamic blinded-unblinded block production

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
@@ -201,18 +201,19 @@ public class BlockOperationSelectorFactory {
       final BeaconState blockSlotState,
       final BlockProductionPerformance blockProductionPerformance) {
 
-    // if blinded flow is explicitly requested, we should try to use it
-    // otherwise, we should use it only if we have a validator registration
+    // if requestedBlinded has been specified, we strictly follow it otherwise, we should run
+    // Builder
+    // flow (blinded) only if we have a validator registration
     final boolean shouldTryBuilderFlow =
-        requestedBlinded.orElse(true)
-            || executionPayloadContext
-                .map(ExecutionPayloadContext::isValidatorRegistrationPresent)
-                .orElse(false);
+        requestedBlinded.orElseGet(
+            () ->
+                executionPayloadContext
+                    .map(ExecutionPayloadContext::isValidatorRegistrationPresent)
+                    .orElse(false));
 
     // we should try to return unblinded content only if we try the builder flow with no explicit
     // request
-    final boolean setUnblindedContentIfPossible =
-        shouldTryBuilderFlow && requestedBlinded.isEmpty();
+    final boolean setUnblindedContentIfPossible = requestedBlinded.isEmpty();
 
     // Pre-Deneb: Execution Payload / Execution Payload Header
     if (!bodyBuilder.supportsKzgCommitments()) {

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
@@ -201,14 +201,18 @@ public class BlockOperationSelectorFactory {
       final BeaconState blockSlotState,
       final BlockProductionPerformance blockProductionPerformance) {
 
-    // we can do builder flow if a non-blinded flow was requested, and we have a validator has a
-    // registration to builder infrastructure
+    // if blinded flow is explicitly requested, we should try to use it
+    // otherwise, we should use it only if we have a validator registration
     final boolean shouldTryBuilderFlow =
-        !requestedBlinded.orElse(false)
-            && executionPayloadContext
+        requestedBlinded.orElse(true)
+            || executionPayloadContext
                 .map(ExecutionPayloadContext::isValidatorRegistrationPresent)
                 .orElse(false);
-    final boolean setUnblindedContentIfPossible = requestedBlinded.isEmpty();
+
+    // we should try to return unblinded content only if we try the builder flow with no explicit
+    // request
+    final boolean setUnblindedContentIfPossible =
+        shouldTryBuilderFlow && requestedBlinded.isEmpty();
 
     // Pre-Deneb: Execution Payload / Execution Payload Header
     if (!bodyBuilder.supportsKzgCommitments()) {

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
@@ -20,7 +20,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.function.Supplier;
 import java.util.stream.IntStream;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.bls.BLSSignature;
@@ -30,6 +29,7 @@ import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.Blob;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobKzgCommitmentsSchema;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.Eth1Data;
@@ -39,11 +39,8 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodyBuilder;
 import tech.pegasys.teku.spec.datastructures.builder.BuilderPayload;
 import tech.pegasys.teku.spec.datastructures.execution.BlobsBundle;
-import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
-import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadResult;
-import tech.pegasys.teku.spec.datastructures.execution.HeaderWithFallbackData;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
@@ -53,7 +50,6 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.spec.datastructures.type.SszKZGProof;
 import tech.pegasys.teku.spec.executionlayer.ExecutionLayerBlockProductionManager;
-import tech.pegasys.teku.spec.logic.common.util.ValidatorsUtil;
 import tech.pegasys.teku.spec.logic.versions.deneb.helpers.MiscHelpersDeneb;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsBellatrix;
@@ -105,15 +101,13 @@ public class BlockOperationSelectorFactory {
     this.executionLayerBlockProductionManager = executionLayerBlockProductionManager;
   }
 
-  public Consumer<BeaconBlockBodyBuilder> createSelector(
+  public Function<BeaconBlockBodyBuilder, SafeFuture<Void>> createSelector(
       final Bytes32 parentRoot,
       final BeaconState blockSlotState,
       final BLSSignature randaoReveal,
       final Optional<Bytes32> optionalGraffiti,
       final Optional<Boolean> requestedBlinded,
       final BlockProductionPerformance blockProductionPerformance) {
-
-    final boolean blinded = requestedBlinded.orElse(ValidatorsUtil.DEFAULT_PRODUCE_BLINDED_BLOCK);
 
     return bodyBuilder -> {
       final Eth1Data eth1Data = eth1DataCache.getEth1Vote(blockSlotState);
@@ -172,174 +166,193 @@ public class BlockOperationSelectorFactory {
       }
 
       // Execution Payload / Execution Payload Header / KZG Commitments
+      final SafeFuture<Void> completionFuture;
       if (bodyBuilder.supportsExecutionPayload()) {
         final SchemaDefinitions schemaDefinitions =
             spec.atSlot(blockSlotState.getSlot()).getSchemaDefinitions();
-        setExecutionData(
-            bodyBuilder,
-            blinded,
-            schemaDefinitions,
-            parentRoot,
-            blockSlotState,
-            blockProductionPerformance);
+
+        completionFuture =
+            forkChoiceNotifier
+                .getPayloadId(parentRoot, blockSlotState.getSlot())
+                .thenCompose(
+                    executionPayloadContext ->
+                        setExecutionData(
+                            executionPayloadContext,
+                            bodyBuilder,
+                            requestedBlinded,
+                            schemaDefinitions,
+                            blockSlotState,
+                            blockProductionPerformance));
+      } else {
+        completionFuture = SafeFuture.COMPLETE;
       }
 
       blockProductionPerformance.beaconBlockPrepared();
+
+      return completionFuture;
     };
   }
 
-  private void setExecutionData(
+  private SafeFuture<Void> setExecutionData(
+      final Optional<ExecutionPayloadContext> executionPayloadContext,
       final BeaconBlockBodyBuilder bodyBuilder,
-      final boolean blinded,
+      final Optional<Boolean> requestedBlinded,
       final SchemaDefinitions schemaDefinitions,
-      final Bytes32 parentRoot,
       final BeaconState blockSlotState,
       final BlockProductionPerformance blockProductionPerformance) {
-    final SafeFuture<Optional<ExecutionPayloadContext>> executionPayloadContextFuture =
-        forkChoiceNotifier.getPayloadId(parentRoot, blockSlotState.getSlot());
+
+    // we can do builder flow if a non-blinded flow was requested, and we have a validator has a
+    // registration to builder infrastructure
+    final boolean shouldTryBuilderFlow =
+        !requestedBlinded.orElse(false)
+            && executionPayloadContext
+                .map(ExecutionPayloadContext::isValidatorRegistrationPresent)
+                .orElse(false);
+    final boolean setUnblindedContentIfPossible = requestedBlinded.isEmpty();
 
     // Pre-Deneb: Execution Payload / Execution Payload Header
     if (!bodyBuilder.supportsKzgCommitments()) {
-      if (blinded) {
-        builderSetPayloadHeader(
+      if (shouldTryBuilderFlow) {
+        return builderSetPayloadHeader(
+            setUnblindedContentIfPossible,
             bodyBuilder,
             schemaDefinitions,
             blockSlotState,
-            executionPayloadContextFuture,
+            executionPayloadContext,
             blockProductionPerformance);
       } else {
-        builderSetPayload(
+        return builderSetPayload(
             bodyBuilder,
             schemaDefinitions,
             blockSlotState,
-            executionPayloadContextFuture,
+            executionPayloadContext,
             blockProductionPerformance);
       }
-      return;
     }
 
     // Post-Deneb: Execution Payload / Execution Payload Header + KZG Commitments
-    final SafeFuture<ExecutionPayloadResult> executionPayloadResultFuture =
-        executionPayloadContextFuture.thenApply(
-            executionPayloadContextOptional ->
-                executionLayerBlockProductionManager.initiateBlockAndBlobsProduction(
-                    // kzg commitments are supported: we should have already merged by now, so we
-                    // can safely assume we have an executionPayloadContext
-                    executionPayloadContextOptional.orElseThrow(
-                        () ->
-                            new IllegalStateException(
-                                "Cannot provide kzg commitments before The Merge")),
-                    blockSlotState,
-                    blinded,
-                    blockProductionPerformance));
-    builderSetPayloadPostMerge(bodyBuilder, blinded, executionPayloadResultFuture);
-    builderSetKzgCommitments(bodyBuilder, blinded, schemaDefinitions, executionPayloadResultFuture);
+    final ExecutionPayloadResult executionPayloadResult =
+        executionLayerBlockProductionManager.initiateBlockAndBlobsProduction(
+            // kzg commitments are supported: we should have already merged by now, so we
+            // can safely assume we have an executionPayloadContext
+            executionPayloadContext.orElseThrow(
+                () -> new IllegalStateException("Cannot provide kzg commitments before The Merge")),
+            blockSlotState,
+            shouldTryBuilderFlow,
+            blockProductionPerformance);
+
+    return SafeFuture.allOf(
+        builderSetPayloadPostMerge(
+            bodyBuilder, setUnblindedContentIfPossible, executionPayloadResult),
+        builderSetKzgCommitments(
+            bodyBuilder, setUnblindedContentIfPossible, schemaDefinitions, executionPayloadResult));
   }
 
-  private void builderSetPayloadPostMerge(
+  private SafeFuture<Void> builderSetPayloadPostMerge(
       final BeaconBlockBodyBuilder bodyBuilder,
-      final boolean blinded,
-      final SafeFuture<ExecutionPayloadResult> executionPayloadResultFuture) {
-    if (blinded) {
-      bodyBuilder.executionPayloadHeader(
-          executionPayloadResultFuture.thenCompose(
-              executionPayloadResult ->
-                  executionPayloadResult
-                      .getHeaderWithFallbackDataFuture()
-                      .orElseThrow()
-                      .thenApply(HeaderWithFallbackData::getExecutionPayloadHeader)));
-    } else {
-      bodyBuilder.executionPayload(
-          executionPayloadResultFuture.thenCompose(
-              executionPayloadResult ->
-                  executionPayloadResult.getExecutionPayloadFuture().orElseThrow()));
+      final boolean setUnblindedPayloadIfPossible,
+      final ExecutionPayloadResult executionPayloadResult) {
+
+    if (executionPayloadResult.getExecutionPayloadFuture().isPresent()) {
+      // local flow
+      return executionPayloadResult
+          .getExecutionPayloadFuture()
+          .get()
+          .thenAccept(bodyBuilder::executionPayload);
     }
-  }
 
-  private void builderSetPayload(
-      final BeaconBlockBodyBuilder bodyBuilder,
-      final SchemaDefinitions schemaDefinitions,
-      final BeaconState blockSlotState,
-      final SafeFuture<Optional<ExecutionPayloadContext>> executionPayloadContextFuture,
-      final BlockProductionPerformance blockProductionPerformance) {
-    final Supplier<SafeFuture<ExecutionPayload>> preMergePayload =
-        () ->
-            SafeFuture.completedFuture(
-                SchemaDefinitionsBellatrix.required(schemaDefinitions)
-                    .getExecutionPayloadSchema()
-                    .getDefault());
-
-    bodyBuilder.executionPayload(
-        executionPayloadContextFuture.thenCompose(
-            executionPayloadContext ->
-                executionPayloadContext
-                    .map(
-                        payloadContext ->
-                            executionLayerBlockProductionManager
-                                .initiateBlockProduction(
-                                    payloadContext,
-                                    blockSlotState,
-                                    false,
-                                    blockProductionPerformance)
-                                .getExecutionPayloadFuture()
-                                .orElseThrow())
-                    .orElseGet(preMergePayload)));
-  }
-
-  private void builderSetPayloadHeader(
-      final BeaconBlockBodyBuilder bodyBuilder,
-      final SchemaDefinitions schemaDefinitions,
-      final BeaconState blockSlotState,
-      final SafeFuture<Optional<ExecutionPayloadContext>> executionPayloadContextFuture,
-      final BlockProductionPerformance blockProductionPerformance) {
-    final Supplier<SafeFuture<ExecutionPayloadHeader>> preMergePayloadHeader =
-        () ->
-            SafeFuture.completedFuture(
-                SchemaDefinitionsBellatrix.required(schemaDefinitions)
-                    .getExecutionPayloadHeaderSchema()
-                    .getHeaderOfDefaultPayload());
-
-    bodyBuilder.executionPayloadHeader(
-        executionPayloadContextFuture.thenCompose(
-            executionPayloadContext -> {
-              if (executionPayloadContext.isEmpty()) {
-                return preMergePayloadHeader.get();
+    // builder flow
+    return executionPayloadResult
+        .getHeaderWithFallbackDataFuture()
+        .orElseThrow()
+        .thenAccept(
+            headerWithFallbackData -> {
+              if (setUnblindedPayloadIfPossible
+                  && headerWithFallbackData.getFallbackData().isPresent()) {
+                bodyBuilder.executionPayload(
+                    headerWithFallbackData.getFallbackData().get().getExecutionPayload());
               } else {
-                return executionLayerBlockProductionManager
-                    .initiateBlockProduction(
-                        executionPayloadContext.get(),
-                        blockSlotState,
-                        true,
-                        blockProductionPerformance)
-                    .getHeaderWithFallbackDataFuture()
-                    .orElseThrow()
-                    .thenApply(HeaderWithFallbackData::getExecutionPayloadHeader);
-              }
-            }));
-  }
-
-  private void builderSetKzgCommitments(
-      final BeaconBlockBodyBuilder bodyBuilder,
-      final boolean blinded,
-      final SchemaDefinitions schemaDefinitions,
-      final SafeFuture<ExecutionPayloadResult> executionPayloadResultFuture) {
-    final SchemaDefinitionsDeneb schemaDefinitionsDeneb =
-        SchemaDefinitionsDeneb.required(schemaDefinitions);
-    final SafeFuture<SszList<SszKZGCommitment>> blobKzgCommitments =
-        executionPayloadResultFuture.thenCompose(
-            executionPayloadResult -> {
-              if (blinded) {
-                return getBuilderBlobKzgCommitments(executionPayloadResult);
-              } else {
-                return getExecutionBlobsBundle(executionPayloadResult)
-                    .thenApply(
-                        blobsBundle ->
-                            schemaDefinitionsDeneb
-                                .getBlobKzgCommitmentsSchema()
-                                .createFromBlobsBundle(blobsBundle));
+                bodyBuilder.executionPayloadHeader(
+                    headerWithFallbackData.getExecutionPayloadHeader());
               }
             });
-    bodyBuilder.blobKzgCommitments(blobKzgCommitments);
+  }
+
+  private SafeFuture<Void> builderSetPayload(
+      final BeaconBlockBodyBuilder bodyBuilder,
+      final SchemaDefinitions schemaDefinitions,
+      final BeaconState blockSlotState,
+      final Optional<ExecutionPayloadContext> executionPayloadContext,
+      final BlockProductionPerformance blockProductionPerformance) {
+    if (executionPayloadContext.isEmpty()) {
+      // preMergePayload
+      bodyBuilder.executionPayload(
+          SchemaDefinitionsBellatrix.required(schemaDefinitions)
+              .getExecutionPayloadSchema()
+              .getDefault());
+      return SafeFuture.COMPLETE;
+    }
+    return executionLayerBlockProductionManager
+        .initiateBlockProduction(
+            executionPayloadContext.get(), blockSlotState, false, blockProductionPerformance)
+        .getExecutionPayloadFuture()
+        .orElseThrow()
+        .thenAccept(bodyBuilder::executionPayload);
+  }
+
+  private SafeFuture<Void> builderSetPayloadHeader(
+      final boolean setUnblindedPayloadIfPossible,
+      final BeaconBlockBodyBuilder bodyBuilder,
+      final SchemaDefinitions schemaDefinitions,
+      final BeaconState blockSlotState,
+      final Optional<ExecutionPayloadContext> executionPayloadContext,
+      final BlockProductionPerformance blockProductionPerformance) {
+    if (executionPayloadContext.isEmpty()) {
+      // preMergePayloadHeader
+      bodyBuilder.executionPayloadHeader(
+          SchemaDefinitionsBellatrix.required(schemaDefinitions)
+              .getExecutionPayloadHeaderSchema()
+              .getHeaderOfDefaultPayload());
+      return SafeFuture.COMPLETE;
+    }
+
+    return executionLayerBlockProductionManager
+        .initiateBlockProduction(
+            executionPayloadContext.get(), blockSlotState, true, blockProductionPerformance)
+        .getHeaderWithFallbackDataFuture()
+        .orElseThrow()
+        .thenAccept(
+            headerWithFallbackData -> {
+              if (setUnblindedPayloadIfPossible
+                  && headerWithFallbackData.getFallbackData().isPresent()) {
+                bodyBuilder.executionPayload(
+                    headerWithFallbackData.getFallbackData().get().getExecutionPayload());
+                return;
+              }
+              bodyBuilder.executionPayloadHeader(
+                  headerWithFallbackData.getExecutionPayloadHeader());
+            });
+  }
+
+  private SafeFuture<Void> builderSetKzgCommitments(
+      final BeaconBlockBodyBuilder bodyBuilder,
+      final boolean setUnblindedPayloadIfPossible,
+      final SchemaDefinitions schemaDefinitions,
+      final ExecutionPayloadResult executionPayloadResult) {
+    final BlobKzgCommitmentsSchema blobKzgCommitmentsSchema =
+        SchemaDefinitionsDeneb.required(schemaDefinitions).getBlobKzgCommitmentsSchema();
+
+    if (executionPayloadResult.getExecutionPayloadFuture().isPresent()) {
+      // local flow
+      return getExecutionBlobsBundle(executionPayloadResult)
+          .thenApply(blobKzgCommitmentsSchema::createFromBlobsBundle)
+          .thenAccept(bodyBuilder::blobKzgCommitments);
+    }
+
+    // builder flow
+    return getBuilderBlobKzgCommitments(
+            blobKzgCommitmentsSchema, executionPayloadResult, setUnblindedPayloadIfPossible)
+        .thenAccept(bodyBuilder::blobKzgCommitments);
   }
 
   public Consumer<SignedBeaconBlockUnblinder> createBlockUnblinderSelector() {
@@ -446,18 +459,27 @@ public class BlockOperationSelectorFactory {
   }
 
   private SafeFuture<SszList<SszKZGCommitment>> getBuilderBlobKzgCommitments(
-      final ExecutionPayloadResult executionPayloadResult) {
+      final BlobKzgCommitmentsSchema blobKzgCommitmentsSchema,
+      final ExecutionPayloadResult executionPayloadResult,
+      final boolean setUnblindedPayloadIfPossible) {
+
     return executionPayloadResult
         .getHeaderWithFallbackDataFuture()
         .orElseThrow()
         .thenApply(
-            headerWithFallbackData ->
-                headerWithFallbackData
-                    .getBlobKzgCommitments()
-                    .orElseThrow(
-                        () ->
-                            new IllegalStateException(
-                                "builder BlobKzgCommitments are not available")));
+            headerWithFallbackData -> {
+              if (setUnblindedPayloadIfPossible
+                  && headerWithFallbackData.getFallbackData().isPresent()) {
+                return blobKzgCommitmentsSchema.createFromBlobsBundle(
+                    headerWithFallbackData.getFallbackData().get().getBlobsBundle().orElseThrow());
+              }
+              return headerWithFallbackData
+                  .getBlobKzgCommitments()
+                  .orElseThrow(
+                      () ->
+                          new IllegalStateException(
+                              "builder BlobKzgCommitments are not available"));
+            });
   }
 
   private tech.pegasys.teku.spec.datastructures.builder.BlobsBundle getCachedBuilderBlobsBundle(

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryTest.java
@@ -206,15 +206,16 @@ class BlockOperationSelectorFactoryTest {
   void shouldNotSelectOperationsWhenNoneAreAvailable() {
     final UInt64 slot = UInt64.ONE;
     final BeaconState blockSlotState = dataStructureUtil.randomBeaconState(slot);
-    factory
-        .createSelector(
-            parentRoot,
-            blockSlotState,
-            dataStructureUtil.randomSignature(),
-            Optional.empty(),
-            Optional.empty(),
-            BlockProductionPerformance.NOOP)
-        .accept(bodyBuilder);
+    safeJoin(
+        factory
+            .createSelector(
+                parentRoot,
+                blockSlotState,
+                dataStructureUtil.randomSignature(),
+                Optional.empty(),
+                Optional.empty(),
+                BlockProductionPerformance.NOOP)
+            .apply(bodyBuilder));
 
     assertThat(bodyBuilder.proposerSlashings).isEmpty();
     assertThat(bodyBuilder.attesterSlashings).isEmpty();
@@ -242,15 +243,16 @@ class BlockOperationSelectorFactoryTest {
     assertThat(contributionPool.addLocal(contribution)).isCompletedWithValue(ACCEPT);
     addToPool(blsToExecutionChangePool, blsToExecutionChange);
 
-    factory
-        .createSelector(
-            parentRoot,
-            blockSlotState,
-            randaoReveal,
-            Optional.empty(),
-            Optional.empty(),
-            BlockProductionPerformance.NOOP)
-        .accept(bodyBuilder);
+    safeJoin(
+        factory
+            .createSelector(
+                parentRoot,
+                blockSlotState,
+                randaoReveal,
+                Optional.empty(),
+                Optional.empty(),
+                BlockProductionPerformance.NOOP)
+            .apply(bodyBuilder));
 
     assertThat(bodyBuilder.randaoReveal).isEqualTo(randaoReveal);
     assertThat(bodyBuilder.graffiti).isEqualTo(defaultGraffiti);
@@ -320,15 +322,16 @@ class BlockOperationSelectorFactoryTest {
             blockSlotState, blsToExecutionChange2))
         .thenReturn(Optional.of(BlsToExecutionChangeInvalidReason.invalidValidatorIndex()));
 
-    factory
-        .createSelector(
-            parentRoot,
-            blockSlotState,
-            randaoReveal,
-            Optional.empty(),
-            Optional.empty(),
-            BlockProductionPerformance.NOOP)
-        .accept(bodyBuilder);
+    safeJoin(
+        factory
+            .createSelector(
+                parentRoot,
+                blockSlotState,
+                randaoReveal,
+                Optional.empty(),
+                Optional.empty(),
+                BlockProductionPerformance.NOOP)
+            .apply(bodyBuilder));
 
     assertThat(bodyBuilder.randaoReveal).isEqualTo(randaoReveal);
     assertThat(bodyBuilder.graffiti).isEqualTo(defaultGraffiti);
@@ -347,15 +350,16 @@ class BlockOperationSelectorFactoryTest {
   void shouldIncludeDefaultExecutionPayload() {
     final UInt64 slot = UInt64.ONE;
     final BeaconState blockSlotState = dataStructureUtil.randomBeaconStatePreMerge(slot);
-    factory
-        .createSelector(
-            parentRoot,
-            blockSlotState,
-            dataStructureUtil.randomSignature(),
-            Optional.empty(),
-            Optional.of(false),
-            BlockProductionPerformance.NOOP)
-        .accept(bodyBuilder);
+    safeJoin(
+        factory
+            .createSelector(
+                parentRoot,
+                blockSlotState,
+                dataStructureUtil.randomSignature(),
+                Optional.empty(),
+                Optional.of(false),
+                BlockProductionPerformance.NOOP)
+            .apply(bodyBuilder));
     assertThat(bodyBuilder.executionPayload).isEqualTo(defaultExecutionPayload);
   }
 
@@ -363,15 +367,16 @@ class BlockOperationSelectorFactoryTest {
   void shouldIncludeExecutionPayloadHeaderOfDefaultPayload() {
     final UInt64 slot = UInt64.ONE;
     final BeaconState blockSlotState = dataStructureUtil.randomBeaconStatePreMerge(slot);
-    factory
-        .createSelector(
-            parentRoot,
-            blockSlotState,
-            dataStructureUtil.randomSignature(),
-            Optional.empty(),
-            Optional.of(true),
-            BlockProductionPerformance.NOOP)
-        .accept(bodyBuilder);
+    safeJoin(
+        factory
+            .createSelector(
+                parentRoot,
+                blockSlotState,
+                dataStructureUtil.randomSignature(),
+                Optional.empty(),
+                Optional.of(true),
+                BlockProductionPerformance.NOOP)
+            .apply(bodyBuilder));
     assertThat(bodyBuilder.executionPayloadHeader)
         .isEqualTo(executionPayloadHeaderOfDefaultPayload);
   }
@@ -390,15 +395,16 @@ class BlockOperationSelectorFactoryTest {
     prepareBlockProductionWithPayload(
         randomExecutionPayload, executionPayloadContext, blockSlotState);
 
-    factory
-        .createSelector(
-            parentRoot,
-            blockSlotState,
-            dataStructureUtil.randomSignature(),
-            Optional.empty(),
-            Optional.of(false),
-            BlockProductionPerformance.NOOP)
-        .accept(bodyBuilder);
+    safeJoin(
+        factory
+            .createSelector(
+                parentRoot,
+                blockSlotState,
+                dataStructureUtil.randomSignature(),
+                Optional.empty(),
+                Optional.of(false),
+                BlockProductionPerformance.NOOP)
+            .apply(bodyBuilder));
 
     assertThat(bodyBuilder.executionPayload).isEqualTo(randomExecutionPayload);
   }
@@ -418,15 +424,16 @@ class BlockOperationSelectorFactoryTest {
     prepareBlockProductionWithPayloadHeader(
         randomExecutionPayloadHeader, executionPayloadContext, blockSlotState);
 
-    factory
-        .createSelector(
-            parentRoot,
-            blockSlotState,
-            dataStructureUtil.randomSignature(),
-            Optional.empty(),
-            Optional.of(true),
-            BlockProductionPerformance.NOOP)
-        .accept(bodyBuilder);
+    safeJoin(
+        factory
+            .createSelector(
+                parentRoot,
+                blockSlotState,
+                dataStructureUtil.randomSignature(),
+                Optional.empty(),
+                Optional.of(true),
+                BlockProductionPerformance.NOOP)
+            .apply(bodyBuilder));
 
     assertThat(bodyBuilder.executionPayloadHeader).isEqualTo(randomExecutionPayloadHeader);
   }
@@ -445,15 +452,16 @@ class BlockOperationSelectorFactoryTest {
     prepareBlockProductionWithPayload(
         randomExecutionPayload, executionPayloadContext, blockSlotState);
 
-    factory
-        .createSelector(
-            parentRoot,
-            blockSlotState,
-            dataStructureUtil.randomSignature(),
-            Optional.empty(),
-            Optional.of(false),
-            BlockProductionPerformance.NOOP)
-        .accept(bodyBuilder);
+    safeJoin(
+        factory
+            .createSelector(
+                parentRoot,
+                blockSlotState,
+                dataStructureUtil.randomSignature(),
+                Optional.empty(),
+                Optional.of(false),
+                BlockProductionPerformance.NOOP)
+            .apply(bodyBuilder));
 
     assertThat(bodyBuilder.executionPayload).isEqualTo(randomExecutionPayload);
   }
@@ -491,15 +499,16 @@ class BlockOperationSelectorFactoryTest {
 
     final CapturingBeaconBlockBodyBuilder bodyBuilder = new CapturingBeaconBlockBodyBuilder(true);
 
-    factory
-        .createSelector(
-            parentRoot,
-            blockSlotState,
-            dataStructureUtil.randomSignature(),
-            Optional.empty(),
-            Optional.of(false),
-            BlockProductionPerformance.NOOP)
-        .accept(bodyBuilder);
+    safeJoin(
+        factory
+            .createSelector(
+                parentRoot,
+                blockSlotState,
+                dataStructureUtil.randomSignature(),
+                Optional.empty(),
+                Optional.of(false),
+                BlockProductionPerformance.NOOP)
+            .apply(bodyBuilder));
 
     assertThat(bodyBuilder.blobKzgCommitments)
         .map(SszKZGCommitment::getKZGCommitment)
@@ -526,15 +535,16 @@ class BlockOperationSelectorFactoryTest {
 
     final CapturingBeaconBlockBodyBuilder bodyBuilder = new CapturingBeaconBlockBodyBuilder(true);
 
-    factory
-        .createSelector(
-            parentRoot,
-            blockSlotState,
-            dataStructureUtil.randomSignature(),
-            Optional.empty(),
-            Optional.empty(),
-            BlockProductionPerformance.NOOP)
-        .accept(bodyBuilder);
+    safeJoin(
+        factory
+            .createSelector(
+                parentRoot,
+                blockSlotState,
+                dataStructureUtil.randomSignature(),
+                Optional.empty(),
+                Optional.empty(),
+                BlockProductionPerformance.NOOP)
+            .apply(bodyBuilder));
 
     assertThat(bodyBuilder.blobKzgCommitments).hasSameElementsAs(blobKzgCommitments);
   }
@@ -834,16 +844,15 @@ class BlockOperationSelectorFactoryTest {
     }
 
     @Override
-    public BeaconBlockBodyBuilder executionPayload(
-        final SafeFuture<ExecutionPayload> executionPayload) {
-      this.executionPayload = safeJoin(executionPayload);
+    public BeaconBlockBodyBuilder executionPayload(final ExecutionPayload executionPayload) {
+      this.executionPayload = executionPayload;
       return this;
     }
 
     @Override
     public BeaconBlockBodyBuilder executionPayloadHeader(
-        final SafeFuture<ExecutionPayloadHeader> executionPayloadHeader) {
-      this.executionPayloadHeader = safeJoin(executionPayloadHeader);
+        final ExecutionPayloadHeader executionPayloadHeader) {
+      this.executionPayloadHeader = executionPayloadHeader;
       return this;
     }
 
@@ -876,13 +885,13 @@ class BlockOperationSelectorFactoryTest {
 
     @Override
     public BeaconBlockBodyBuilder blobKzgCommitments(
-        final SafeFuture<SszList<SszKZGCommitment>> blobKzgCommitments) {
-      this.blobKzgCommitments = safeJoin(blobKzgCommitments);
+        final SszList<SszKZGCommitment> blobKzgCommitments) {
+      this.blobKzgCommitments = blobKzgCommitments;
       return this;
     }
 
     @Override
-    public SafeFuture<? extends BeaconBlockBody> build() {
+    public BeaconBlockBody build() {
       return null;
     }
   }

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v3/GetNewBlockV3IntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v3/GetNewBlockV3IntegrationTest.java
@@ -73,13 +73,15 @@ public class GetNewBlockV3IntegrationTest extends AbstractDataBackedRestAPIInteg
     spec = specContext.getSpec();
     specMilestone = specContext.getSpecMilestone();
     startRestAPIAtGenesis(specMilestone);
-    dataStructureUtil = new DataStructureUtil(spec);
+    dataStructureUtil = specContext.getDataStructureUtil();
     when(executionLayerBlockProductionManager.getCachedPayloadResult(UInt64.ONE))
         .thenReturn(
             Optional.of(
                 new ExecutionPayloadResult(
                     mock(ExecutionPayloadContext.class),
-                    Optional.empty(),
+                    // we can provide an empty future here as we are only
+                    // preparing execution payload value
+                    Optional.of(SafeFuture.completedFuture(null)),
                     Optional.empty(),
                     Optional.empty(),
                     Optional.of(SafeFuture.completedFuture(executionPayloadValue)))));
@@ -182,15 +184,6 @@ public class GetNewBlockV3IntegrationTest extends AbstractDataBackedRestAPIInteg
     final BLSSignature signature = beaconBlock.getBlock().getBody().getRandaoReveal();
     when(validatorApiChannel.createUnsignedBlock(eq(UInt64.ONE), eq(signature), any(), any()))
         .thenReturn(SafeFuture.completedFuture(Optional.empty()));
-    when(executionLayerBlockProductionManager.getCachedPayloadResult(UInt64.ONE))
-        .thenReturn(
-            Optional.of(
-                new ExecutionPayloadResult(
-                    mock(ExecutionPayloadContext.class),
-                    Optional.empty(),
-                    Optional.empty(),
-                    Optional.empty(),
-                    Optional.of(SafeFuture.completedFuture(executionPayloadValue)))));
     Response response = get(signature, ContentTypes.JSON);
     assertThat(response.code()).isEqualTo(SC_INTERNAL_SERVER_ERROR);
     final String body = response.body().string();

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/altair/BeaconBlockBodyAltair.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/altair/BeaconBlockBodyAltair.java
@@ -18,7 +18,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
-import java.util.function.Consumer;
+import java.util.function.Function;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.api.schema.Attestation;
 import tech.pegasys.teku.api.schema.AttesterSlashing;
@@ -28,6 +28,7 @@ import tech.pegasys.teku.api.schema.Deposit;
 import tech.pegasys.teku.api.schema.Eth1Data;
 import tech.pegasys.teku.api.schema.ProposerSlashing;
 import tech.pegasys.teku.api.schema.SignedVoluntaryExit;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.spec.SpecVersion;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodyBuilder;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.BeaconBlockBodySchemaAltair;
@@ -79,20 +80,23 @@ public class BeaconBlockBodyAltair extends BeaconBlockBody {
   @Override
   public tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody
       asInternalBeaconBlockBody(
-          final SpecVersion spec, Consumer<BeaconBlockBodyBuilder> builderRef) {
+          final SpecVersion spec,
+          final Function<BeaconBlockBodyBuilder, SafeFuture<Void>> builderRef) {
     final SyncAggregateSchema syncAggregateSchema =
         getBeaconBlockBodySchema(spec).getSyncAggregateSchema();
     return super.asInternalBeaconBlockBody(
         spec,
-        (builder) -> {
-          builderRef.accept(builder);
-          builder.syncAggregate(
-              syncAggregateSchema.create(
-                  syncAggregateSchema
-                      .getSyncCommitteeBitsSchema()
-                      .fromBytes(syncAggregate.syncCommitteeBits)
-                      .getAllSetBits(),
-                  syncAggregate.syncCommitteeSignature.asInternalBLSSignature()));
-        });
+        builder ->
+            SafeFuture.allOf(
+                builderRef.apply(builder),
+                SafeFuture.of(
+                    () ->
+                        builder.syncAggregate(
+                            syncAggregateSchema.create(
+                                syncAggregateSchema
+                                    .getSyncCommitteeBitsSchema()
+                                    .fromBytes(syncAggregate.syncCommitteeBits)
+                                    .getAllSetBits(),
+                                syncAggregate.syncCommitteeSignature.asInternalBLSSignature())))));
   }
 }

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/bellatrix/BlindedBeaconBlockBodyBellatrix.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/bellatrix/BlindedBeaconBlockBodyBellatrix.java
@@ -102,10 +102,11 @@ public class BlindedBeaconBlockBodyBellatrix extends BeaconBlockBodyAltair {
 
     return super.asInternalBeaconBlockBody(
         spec,
-        (builder) ->
-            builder.executionPayloadHeader(
-                SafeFuture.completedFuture(
-                    executionPayloadHeader.asInternalExecutionPayloadHeader(
-                        executionPayloadHeaderSchema))));
+        builder -> {
+          builder.executionPayloadHeader(
+              executionPayloadHeader.asInternalExecutionPayloadHeader(
+                  executionPayloadHeaderSchema));
+          return SafeFuture.COMPLETE;
+        });
   }
 }

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/capella/BeaconBlockBodyCapella.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/capella/BeaconBlockBodyCapella.java
@@ -98,13 +98,13 @@ public class BeaconBlockBodyCapella extends BeaconBlockBodyAltair {
 
     return super.asInternalBeaconBlockBody(
         spec,
-        (builder) -> {
-          builder.executionPayload(
-              SafeFuture.completedFuture(executionPayload.asInternalExecutionPayload(spec)));
+        builder -> {
+          builder.executionPayload(executionPayload.asInternalExecutionPayload(spec));
           builder.blsToExecutionChanges(
               this.blsToExecutionChanges.stream()
                   .map(b -> b.asInternalSignedBlsToExecutionChange(spec))
                   .collect(blsToExecutionChangesSchema.collector()));
+          return SafeFuture.COMPLETE;
         });
   }
 }

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/capella/BlindedBeaconBlockBodyCapella.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/capella/BlindedBeaconBlockBodyCapella.java
@@ -110,15 +110,15 @@ public class BlindedBeaconBlockBodyCapella extends BeaconBlockBodyAltair {
 
     return super.asInternalBeaconBlockBody(
         spec,
-        (builder) -> {
+        builder -> {
           builder.executionPayloadHeader(
-              SafeFuture.completedFuture(
-                  executionPayloadHeader.asInternalExecutionPayloadHeader(
-                      executionPayloadHeaderSchema)));
+              executionPayloadHeader.asInternalExecutionPayloadHeader(
+                  executionPayloadHeaderSchema));
           builder.blsToExecutionChanges(
               this.blsToExecutionChanges.stream()
                   .map(b -> b.asInternalSignedBlsToExecutionChange(spec))
                   .collect(blsToExecutionChangesSchema.collector()));
+          return SafeFuture.COMPLETE;
         });
   }
 }

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/deneb/BeaconBlockBodyDeneb.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/deneb/BeaconBlockBodyDeneb.java
@@ -115,19 +115,18 @@ public class BeaconBlockBodyDeneb extends BeaconBlockBodyAltair {
         getBeaconBlockBodySchema(spec).getBlobKzgCommitmentsSchema();
     return super.asInternalBeaconBlockBody(
         spec,
-        (builder) -> {
-          builder.executionPayload(
-              SafeFuture.completedFuture(executionPayload.asInternalExecutionPayload(spec)));
+        builder -> {
+          builder.executionPayload(executionPayload.asInternalExecutionPayload(spec));
           builder.blsToExecutionChanges(
               this.blsToExecutionChanges.stream()
                   .map(b -> b.asInternalSignedBlsToExecutionChange(spec))
                   .collect(blsToExecutionChangesSchema.collector()));
           builder.blobKzgCommitments(
-              SafeFuture.completedFuture(
-                  this.blobKZGCommitments.stream()
-                      .map(KZGCommitment::asInternalKZGCommitment)
-                      .map(SszKZGCommitment::new)
-                      .collect(blobKZGCommitmentsSchema.collector())));
+              this.blobKZGCommitments.stream()
+                  .map(KZGCommitment::asInternalKZGCommitment)
+                  .map(SszKZGCommitment::new)
+                  .collect(blobKZGCommitmentsSchema.collector()));
+          return SafeFuture.COMPLETE;
         });
   }
 }

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/deneb/BlindedBeaconBlockBodyDeneb.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/deneb/BlindedBeaconBlockBodyDeneb.java
@@ -127,21 +127,20 @@ public class BlindedBeaconBlockBodyDeneb extends BeaconBlockBodyAltair {
 
     return super.asInternalBeaconBlockBody(
         spec,
-        (builder) -> {
+        builder -> {
           builder.executionPayloadHeader(
-              SafeFuture.completedFuture(
-                  executionPayloadHeader.asInternalExecutionPayloadHeader(
-                      executionPayloadHeaderSchema)));
+              executionPayloadHeader.asInternalExecutionPayloadHeader(
+                  executionPayloadHeaderSchema));
           builder.blsToExecutionChanges(
               this.blsToExecutionChanges.stream()
                   .map(b -> b.asInternalSignedBlsToExecutionChange(spec))
                   .collect(blsToExecutionChangesSchema.collector()));
           builder.blobKzgCommitments(
-              SafeFuture.completedFuture(
-                  this.blobKZGCommitments.stream()
-                      .map(KZGCommitment::asInternalKZGCommitment)
-                      .map(SszKZGCommitment::new)
-                      .collect(blobKZGCommitmentsSchema.collector())));
+              this.blobKZGCommitments.stream()
+                  .map(KZGCommitment::asInternalKZGCommitment)
+                  .map(SszKZGCommitment::new)
+                  .collect(blobKZGCommitmentsSchema.collector()));
+          return SafeFuture.COMPLETE;
         });
   }
 }

--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/ssz/SszBeaconBlockBodyBenchmark.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/ssz/SszBeaconBlockBodyBenchmark.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.benchmarks.ssz;
 
 import org.openjdk.jmh.infra.Blackhole;
 import tech.pegasys.teku.benchmarks.util.CustomRunner;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszSchema;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
@@ -33,16 +34,18 @@ public class SszBeaconBlockBodyBenchmark extends SszAbstractContainerBenchmark<B
         .getSchemaDefinitions()
         .getBeaconBlockBodySchema()
         .createBlockBody(
-            builder ->
-                builder
-                    .randaoReveal(beaconBlockBody.getRandaoReveal())
-                    .eth1Data(beaconBlockBody.getEth1Data())
-                    .graffiti(beaconBlockBody.getGraffiti())
-                    .attestations(beaconBlockBody.getAttestations())
-                    .proposerSlashings(beaconBlockBody.getProposerSlashings())
-                    .attesterSlashings(beaconBlockBody.getAttesterSlashings())
-                    .deposits(beaconBlockBody.getDeposits())
-                    .voluntaryExits(beaconBlockBody.getVoluntaryExits()))
+            builder -> {
+              builder
+                  .randaoReveal(beaconBlockBody.getRandaoReveal())
+                  .eth1Data(beaconBlockBody.getEth1Data())
+                  .graffiti(beaconBlockBody.getGraffiti())
+                  .attestations(beaconBlockBody.getAttestations())
+                  .proposerSlashings(beaconBlockBody.getProposerSlashings())
+                  .attesterSlashings(beaconBlockBody.getAttesterSlashings())
+                  .deposits(beaconBlockBody.getDeposits())
+                  .voluntaryExits(beaconBlockBody.getVoluntaryExits());
+              return SafeFuture.COMPLETE;
+            })
         .join();
   }
 

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerStub.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerStub.java
@@ -59,8 +59,6 @@ public class ExecutionLayerManagerStub extends ExecutionLayerChannelStub
       final BlockProductionPerformance blockProductionPerformance) {
     boolean builderCircuitBreakerEngaged = builderCircuitBreaker.isEngaged(state);
     LOG.info("Builder Circuit Breaker isEngaged: " + builderCircuitBreakerEngaged);
-    super.builderGetHeader(
-        executionPayloadContext, state, payloadValueResult, blockProductionPerformance);
 
     return super.builderGetHeader(
             executionPayloadContext, state, payloadValueResult, blockProductionPerformance)

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerStub.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerStub.java
@@ -24,6 +24,8 @@ import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
+import tech.pegasys.teku.spec.datastructures.execution.FallbackData;
+import tech.pegasys.teku.spec.datastructures.execution.FallbackReason;
 import tech.pegasys.teku.spec.datastructures.execution.HeaderWithFallbackData;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannelStub;
@@ -55,8 +57,31 @@ public class ExecutionLayerManagerStub extends ExecutionLayerChannelStub
       final BeaconState state,
       final SafeFuture<UInt256> payloadValueResult,
       final BlockProductionPerformance blockProductionPerformance) {
-    LOG.info("Builder Circuit Breaker isEngaged: " + builderCircuitBreaker.isEngaged(state));
-    return super.builderGetHeader(
+    boolean builderCircuitBreakerEngaged = builderCircuitBreaker.isEngaged(state);
+    LOG.info("Builder Circuit Breaker isEngaged: " + builderCircuitBreakerEngaged);
+    super.builderGetHeader(
         executionPayloadContext, state, payloadValueResult, blockProductionPerformance);
+
+    return super.builderGetHeader(
+            executionPayloadContext, state, payloadValueResult, blockProductionPerformance)
+        .thenCompose(
+            headerWithFallbackData -> {
+              if (builderCircuitBreakerEngaged) {
+                return engineGetPayload(
+                        executionPayloadContext,
+                        executionPayloadContext.getPayloadBuildingAttributes().getProposalSlot())
+                    .thenApply(
+                        payload ->
+                            HeaderWithFallbackData.create(
+                                headerWithFallbackData.getExecutionPayloadHeader(),
+                                headerWithFallbackData.getBlobKzgCommitments(),
+                                new FallbackData(
+                                    payload.getExecutionPayload(),
+                                    payload.getBlobsBundle(),
+                                    FallbackReason.CIRCUIT_BREAKER_ENGAGED)));
+              } else {
+                return SafeFuture.completedFuture(headerWithFallbackData);
+              }
+            });
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -30,6 +30,7 @@ import java.util.NavigableMap;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import javax.annotation.CheckReturnValue;
 import org.apache.tuweni.bytes.Bytes;
@@ -699,7 +700,7 @@ public class Spec {
       final int proposerIndex,
       final BeaconState blockSlotState,
       final Bytes32 parentBlockSigningRoot,
-      final Consumer<BeaconBlockBodyBuilder> bodyBuilder,
+      final Function<BeaconBlockBodyBuilder, SafeFuture<Void>> bodyBuilder,
       final BlockProductionPerformance blockProductionPerformance) {
     return atSlot(newSlot)
         .getBlockProposalUtil()

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/BeaconBlockBodyBuilder.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/BeaconBlockBodyBuilder.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.spec.datastructures.blocks.blockbody;
 
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.bls.BLSSignature;
-import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.spec.datastructures.blocks.Eth1Data;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregate;
@@ -57,10 +56,9 @@ public interface BeaconBlockBodyBuilder {
     return false;
   }
 
-  BeaconBlockBodyBuilder executionPayload(SafeFuture<ExecutionPayload> executionPayload);
+  BeaconBlockBodyBuilder executionPayload(ExecutionPayload executionPayload);
 
-  BeaconBlockBodyBuilder executionPayloadHeader(
-      SafeFuture<ExecutionPayloadHeader> executionPayloadHeader);
+  BeaconBlockBodyBuilder executionPayloadHeader(ExecutionPayloadHeader executionPayloadHeader);
 
   default Boolean supportsBlsToExecutionChanges() {
     return false;
@@ -73,8 +71,7 @@ public interface BeaconBlockBodyBuilder {
     return false;
   }
 
-  BeaconBlockBodyBuilder blobKzgCommitments(
-      SafeFuture<SszList<SszKZGCommitment>> blobKzgCommitments);
+  BeaconBlockBodyBuilder blobKzgCommitments(SszList<SszKZGCommitment> blobKzgCommitments);
 
-  SafeFuture<? extends BeaconBlockBody> build();
+  BeaconBlockBody build();
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/BeaconBlockBodySchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/BeaconBlockBodySchema.java
@@ -15,7 +15,7 @@ package tech.pegasys.teku.spec.datastructures.blocks.blockbody;
 
 import it.unimi.dsi.fastutil.longs.LongList;
 import java.util.Optional;
-import java.util.function.Consumer;
+import java.util.function.Function;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszContainerSchema;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszListSchema;
@@ -32,7 +32,7 @@ import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
 
 public interface BeaconBlockBodySchema<T extends BeaconBlockBody> extends SszContainerSchema<T> {
   SafeFuture<? extends BeaconBlockBody> createBlockBody(
-      Consumer<BeaconBlockBodyBuilder> bodyBuilder);
+      final Function<BeaconBlockBodyBuilder, SafeFuture<Void>> bodyBuilder);
 
   BeaconBlockBody createEmpty();
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/BeaconBlockBodySchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/BeaconBlockBodySchema.java
@@ -32,7 +32,7 @@ import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
 
 public interface BeaconBlockBodySchema<T extends BeaconBlockBody> extends SszContainerSchema<T> {
   SafeFuture<? extends BeaconBlockBody> createBlockBody(
-      final Function<BeaconBlockBodyBuilder, SafeFuture<Void>> bodyBuilder);
+      Function<BeaconBlockBodyBuilder, SafeFuture<Void>> bodyBuilder);
 
   BeaconBlockBody createEmpty();
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/altair/BeaconBlockBodyBuilderAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/altair/BeaconBlockBodyBuilderAltair.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszBytes32;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodyBuilder;
@@ -49,22 +48,21 @@ public class BeaconBlockBodyBuilderAltair extends BeaconBlockBodyBuilderPhase0 {
   }
 
   @Override
-  public SafeFuture<BeaconBlockBody> build() {
+  public BeaconBlockBody build() {
     validate();
     final BeaconBlockBodySchemaAltairImpl schema =
         getAndValidateSchema(false, BeaconBlockBodySchemaAltairImpl.class);
 
-    return SafeFuture.completedFuture(
-        new BeaconBlockBodyAltairImpl(
-            schema,
-            new SszSignature(randaoReveal),
-            eth1Data,
-            SszBytes32.of(graffiti),
-            proposerSlashings,
-            attesterSlashings,
-            attestations,
-            deposits,
-            voluntaryExits,
-            syncAggregate));
+    return new BeaconBlockBodyAltairImpl(
+        schema,
+        new SszSignature(randaoReveal),
+        eth1Data,
+        SszBytes32.of(graffiti),
+        proposerSlashings,
+        attesterSlashings,
+        attestations,
+        deposits,
+        voluntaryExits,
+        syncAggregate);
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/altair/BeaconBlockBodySchemaAltairImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/altair/BeaconBlockBodySchemaAltairImpl.java
@@ -14,7 +14,7 @@
 package tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair;
 
 import it.unimi.dsi.fastutil.longs.LongList;
-import java.util.function.Consumer;
+import java.util.function.Function;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema9;
@@ -110,10 +110,9 @@ public class BeaconBlockBodySchemaAltairImpl
 
   @Override
   public SafeFuture<BeaconBlockBody> createBlockBody(
-      final Consumer<BeaconBlockBodyBuilder> builderConsumer) {
+      final Function<BeaconBlockBodyBuilder, SafeFuture<Void>> bodyBuilder) {
     final BeaconBlockBodyBuilderAltair builder = new BeaconBlockBodyBuilderAltair(this);
-    builderConsumer.accept(builder);
-    return builder.build();
+    return bodyBuilder.apply(builder).thenApply(__ -> builder.build());
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BeaconBlockBodyBuilderBellatrix.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BeaconBlockBodyBuilderBellatrix.java
@@ -17,7 +17,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
-import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszBytes32;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodyBuilder;
@@ -28,8 +27,8 @@ import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
 import tech.pegasys.teku.spec.datastructures.type.SszSignature;
 
 public class BeaconBlockBodyBuilderBellatrix extends BeaconBlockBodyBuilderAltair {
-  protected SafeFuture<ExecutionPayload> executionPayload;
-  protected SafeFuture<ExecutionPayloadHeader> executionPayloadHeader;
+  protected ExecutionPayload executionPayload;
+  protected ExecutionPayloadHeader executionPayloadHeader;
   protected final BeaconBlockBodySchema<? extends BlindedBeaconBlockBodyBellatrix> blindedSchema;
 
   public BeaconBlockBodyBuilderBellatrix(
@@ -46,15 +45,14 @@ public class BeaconBlockBodyBuilderBellatrix extends BeaconBlockBodyBuilderAltai
   }
 
   @Override
-  public BeaconBlockBodyBuilder executionPayload(
-      final SafeFuture<ExecutionPayload> executionPayload) {
+  public BeaconBlockBodyBuilder executionPayload(final ExecutionPayload executionPayload) {
     this.executionPayload = executionPayload;
     return this;
   }
 
   @Override
   public BeaconBlockBodyBuilder executionPayloadHeader(
-      final SafeFuture<ExecutionPayloadHeader> executionPayloadHeader) {
+      final ExecutionPayloadHeader executionPayloadHeader) {
     this.executionPayloadHeader = executionPayloadHeader;
     return this;
   }
@@ -91,42 +89,38 @@ public class BeaconBlockBodyBuilderBellatrix extends BeaconBlockBodyBuilderAltai
   }
 
   @Override
-  public SafeFuture<BeaconBlockBody> build() {
+  public BeaconBlockBody build() {
     validate();
     if (isBlinded()) {
       final BlindedBeaconBlockBodySchemaBellatrixImpl schema =
           getAndValidateSchema(true, BlindedBeaconBlockBodySchemaBellatrixImpl.class);
-      return executionPayloadHeader.thenApply(
-          header ->
-              new BlindedBeaconBlockBodyBellatrixImpl(
-                  schema,
-                  new SszSignature(randaoReveal),
-                  eth1Data,
-                  SszBytes32.of(graffiti),
-                  proposerSlashings,
-                  attesterSlashings,
-                  attestations,
-                  deposits,
-                  voluntaryExits,
-                  syncAggregate,
-                  header.toVersionBellatrix().orElseThrow()));
+      return new BlindedBeaconBlockBodyBellatrixImpl(
+          schema,
+          new SszSignature(randaoReveal),
+          eth1Data,
+          SszBytes32.of(graffiti),
+          proposerSlashings,
+          attesterSlashings,
+          attestations,
+          deposits,
+          voluntaryExits,
+          syncAggregate,
+          executionPayloadHeader.toVersionBellatrix().orElseThrow());
     }
 
     final BeaconBlockBodySchemaBellatrixImpl schema =
         getAndValidateSchema(false, BeaconBlockBodySchemaBellatrixImpl.class);
-    return executionPayload.thenApply(
-        payload ->
-            new BeaconBlockBodyBellatrixImpl(
-                schema,
-                new SszSignature(randaoReveal),
-                eth1Data,
-                SszBytes32.of(graffiti),
-                proposerSlashings,
-                attesterSlashings,
-                attestations,
-                deposits,
-                voluntaryExits,
-                syncAggregate,
-                payload.toVersionBellatrix().orElseThrow()));
+    return new BeaconBlockBodyBellatrixImpl(
+        schema,
+        new SszSignature(randaoReveal),
+        eth1Data,
+        SszBytes32.of(graffiti),
+        proposerSlashings,
+        attesterSlashings,
+        attestations,
+        deposits,
+        voluntaryExits,
+        syncAggregate,
+        executionPayload.toVersionBellatrix().orElseThrow());
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BeaconBlockBodySchemaBellatrixImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BeaconBlockBodySchemaBellatrixImpl.java
@@ -14,7 +14,7 @@
 package tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.bellatrix;
 
 import it.unimi.dsi.fastutil.longs.LongList;
-import java.util.function.Consumer;
+import java.util.function.Function;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema10;
@@ -121,10 +121,9 @@ public class BeaconBlockBodySchemaBellatrixImpl
 
   @Override
   public SafeFuture<BeaconBlockBody> createBlockBody(
-      final Consumer<BeaconBlockBodyBuilder> builderConsumer) {
+      final Function<BeaconBlockBodyBuilder, SafeFuture<Void>> bodyBuilder) {
     final BeaconBlockBodyBuilderBellatrix builder = new BeaconBlockBodyBuilderBellatrix(this, null);
-    builderConsumer.accept(builder);
-    return builder.build();
+    return bodyBuilder.apply(builder).thenApply(__ -> builder.build());
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BlindedBeaconBlockBodySchemaBellatrixImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BlindedBeaconBlockBodySchemaBellatrixImpl.java
@@ -14,7 +14,7 @@
 package tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.bellatrix;
 
 import it.unimi.dsi.fastutil.longs.LongList;
-import java.util.function.Consumer;
+import java.util.function.Function;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema10;
@@ -119,10 +119,9 @@ public class BlindedBeaconBlockBodySchemaBellatrixImpl
 
   @Override
   public SafeFuture<BeaconBlockBody> createBlockBody(
-      final Consumer<BeaconBlockBodyBuilder> builderConsumer) {
+      final Function<BeaconBlockBodyBuilder, SafeFuture<Void>> bodyBuilder) {
     final BeaconBlockBodyBuilderBellatrix builder = new BeaconBlockBodyBuilderBellatrix(null, this);
-    builderConsumer.accept(builder);
-    return builder.build();
+    return bodyBuilder.apply(builder).thenApply(__ -> builder.build());
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/capella/BeaconBlockBodyBuilderCapella.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/capella/BeaconBlockBodyBuilderCapella.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.capella;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszBytes32;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
@@ -60,44 +59,41 @@ public class BeaconBlockBodyBuilderCapella extends BeaconBlockBodyBuilderBellatr
   }
 
   @Override
-  public SafeFuture<BeaconBlockBody> build() {
+  public BeaconBlockBody build() {
     validate();
     if (isBlinded()) {
       final BlindedBeaconBlockBodySchemaCapellaImpl schema =
           getAndValidateSchema(true, BlindedBeaconBlockBodySchemaCapellaImpl.class);
-      return executionPayloadHeader.thenApply(
-          header ->
-              new BlindedBeaconBlockBodyCapellaImpl(
-                  schema,
-                  new SszSignature(randaoReveal),
-                  eth1Data,
-                  SszBytes32.of(graffiti),
-                  proposerSlashings,
-                  attesterSlashings,
-                  attestations,
-                  deposits,
-                  voluntaryExits,
-                  syncAggregate,
-                  (ExecutionPayloadHeaderCapellaImpl) header.toVersionCapella().orElseThrow(),
-                  blsToExecutionChanges));
+      return new BlindedBeaconBlockBodyCapellaImpl(
+          schema,
+          new SszSignature(randaoReveal),
+          eth1Data,
+          SszBytes32.of(graffiti),
+          proposerSlashings,
+          attesterSlashings,
+          attestations,
+          deposits,
+          voluntaryExits,
+          syncAggregate,
+          (ExecutionPayloadHeaderCapellaImpl)
+              executionPayloadHeader.toVersionCapella().orElseThrow(),
+          blsToExecutionChanges);
     }
 
     final BeaconBlockBodySchemaCapellaImpl schema =
         getAndValidateSchema(false, BeaconBlockBodySchemaCapellaImpl.class);
-    return executionPayload.thenApply(
-        payload ->
-            new BeaconBlockBodyCapellaImpl(
-                schema,
-                new SszSignature(randaoReveal),
-                eth1Data,
-                SszBytes32.of(graffiti),
-                proposerSlashings,
-                attesterSlashings,
-                attestations,
-                deposits,
-                voluntaryExits,
-                syncAggregate,
-                (ExecutionPayloadCapellaImpl) payload.toVersionCapella().orElseThrow(),
-                blsToExecutionChanges));
+    return new BeaconBlockBodyCapellaImpl(
+        schema,
+        new SszSignature(randaoReveal),
+        eth1Data,
+        SszBytes32.of(graffiti),
+        proposerSlashings,
+        attesterSlashings,
+        attestations,
+        deposits,
+        voluntaryExits,
+        syncAggregate,
+        (ExecutionPayloadCapellaImpl) executionPayload.toVersionCapella().orElseThrow(),
+        blsToExecutionChanges);
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/capella/BeaconBlockBodySchemaCapellaImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/capella/BeaconBlockBodySchemaCapellaImpl.java
@@ -14,7 +14,7 @@
 package tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.capella;
 
 import it.unimi.dsi.fastutil.longs.LongList;
-import java.util.function.Consumer;
+import java.util.function.Function;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema11;
@@ -130,10 +130,9 @@ public class BeaconBlockBodySchemaCapellaImpl
 
   @Override
   public SafeFuture<? extends BeaconBlockBody> createBlockBody(
-      final Consumer<BeaconBlockBodyBuilder> builderConsumer) {
+      final Function<BeaconBlockBodyBuilder, SafeFuture<Void>> bodyBuilder) {
     final BeaconBlockBodyBuilderCapella builder = new BeaconBlockBodyBuilderCapella(this, null);
-    builderConsumer.accept(builder);
-    return builder.build();
+    return bodyBuilder.apply(builder).thenApply(__ -> builder.build());
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/capella/BlindedBeaconBlockBodySchemaCapellaImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/capella/BlindedBeaconBlockBodySchemaCapellaImpl.java
@@ -14,7 +14,7 @@
 package tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.capella;
 
 import it.unimi.dsi.fastutil.longs.LongList;
-import java.util.function.Consumer;
+import java.util.function.Function;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema11;
@@ -130,10 +130,9 @@ public class BlindedBeaconBlockBodySchemaCapellaImpl
 
   @Override
   public SafeFuture<BeaconBlockBody> createBlockBody(
-      final Consumer<BeaconBlockBodyBuilder> builderConsumer) {
+      final Function<BeaconBlockBodyBuilder, SafeFuture<Void>> bodyBuilder) {
     final BeaconBlockBodyBuilderCapella builder = new BeaconBlockBodyBuilderCapella(null, this);
-    builderConsumer.accept(builder);
-    return builder.build();
+    return bodyBuilder.apply(builder).thenApply(__ -> builder.build());
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/deneb/BeaconBlockBodyBuilderDeneb.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/deneb/BeaconBlockBodyBuilderDeneb.java
@@ -15,8 +15,6 @@ package tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.deneb;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import org.apache.commons.lang3.tuple.Pair;
-import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszBytes32;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
@@ -30,7 +28,7 @@ import tech.pegasys.teku.spec.datastructures.type.SszSignature;
 
 public class BeaconBlockBodyBuilderDeneb extends BeaconBlockBodyBuilderCapella {
 
-  private SafeFuture<SszList<SszKZGCommitment>> blobKzgCommitments;
+  private SszList<SszKZGCommitment> blobKzgCommitments;
 
   public BeaconBlockBodyBuilderDeneb(
       final BeaconBlockBodySchema<? extends BeaconBlockBodyDeneb> schema,
@@ -45,7 +43,7 @@ public class BeaconBlockBodyBuilderDeneb extends BeaconBlockBodyBuilderCapella {
 
   @Override
   public BeaconBlockBodyBuilder blobKzgCommitments(
-      final SafeFuture<SszList<SszKZGCommitment>> blobKzgCommitments) {
+      final SszList<SszKZGCommitment> blobKzgCommitments) {
     this.blobKzgCommitments = blobKzgCommitments;
     return this;
   }
@@ -57,54 +55,42 @@ public class BeaconBlockBodyBuilderDeneb extends BeaconBlockBodyBuilderCapella {
   }
 
   @Override
-  public SafeFuture<BeaconBlockBody> build() {
+  public BeaconBlockBody build() {
     validate();
     if (isBlinded()) {
       final BlindedBeaconBlockBodySchemaDenebImpl schema =
           getAndValidateSchema(true, BlindedBeaconBlockBodySchemaDenebImpl.class);
-      return executionPayloadHeader
-          .thenCompose(
-              header -> blobKzgCommitments.thenApply(commitments -> Pair.of(header, commitments)))
-          .thenApply(
-              headerWithCommitments ->
-                  new BlindedBeaconBlockBodyDenebImpl(
-                      schema,
-                      new SszSignature(randaoReveal),
-                      eth1Data,
-                      SszBytes32.of(graffiti),
-                      proposerSlashings,
-                      attesterSlashings,
-                      attestations,
-                      deposits,
-                      voluntaryExits,
-                      syncAggregate,
-                      (ExecutionPayloadHeaderDenebImpl)
-                          headerWithCommitments.getLeft().toVersionDeneb().orElseThrow(),
-                      getBlsToExecutionChanges(),
-                      headerWithCommitments.getRight()));
+      return new BlindedBeaconBlockBodyDenebImpl(
+          schema,
+          new SszSignature(randaoReveal),
+          eth1Data,
+          SszBytes32.of(graffiti),
+          proposerSlashings,
+          attesterSlashings,
+          attestations,
+          deposits,
+          voluntaryExits,
+          syncAggregate,
+          (ExecutionPayloadHeaderDenebImpl) executionPayloadHeader.toVersionDeneb().orElseThrow(),
+          getBlsToExecutionChanges(),
+          blobKzgCommitments);
     }
 
     final BeaconBlockBodySchemaDenebImpl schema =
         getAndValidateSchema(false, BeaconBlockBodySchemaDenebImpl.class);
-    return executionPayload
-        .thenCompose(
-            payload -> blobKzgCommitments.thenApply(commitments -> Pair.of(payload, commitments)))
-        .thenApply(
-            payloadWithCommitments ->
-                new BeaconBlockBodyDenebImpl(
-                    schema,
-                    new SszSignature(randaoReveal),
-                    eth1Data,
-                    SszBytes32.of(graffiti),
-                    proposerSlashings,
-                    attesterSlashings,
-                    attestations,
-                    deposits,
-                    voluntaryExits,
-                    syncAggregate,
-                    (ExecutionPayloadDenebImpl)
-                        payloadWithCommitments.getLeft().toVersionDeneb().orElseThrow(),
-                    getBlsToExecutionChanges(),
-                    payloadWithCommitments.getRight()));
+    return new BeaconBlockBodyDenebImpl(
+        schema,
+        new SszSignature(randaoReveal),
+        eth1Data,
+        SszBytes32.of(graffiti),
+        proposerSlashings,
+        attesterSlashings,
+        attestations,
+        deposits,
+        voluntaryExits,
+        syncAggregate,
+        (ExecutionPayloadDenebImpl) executionPayload.toVersionDeneb().orElseThrow(),
+        getBlsToExecutionChanges(),
+        blobKzgCommitments);
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/deneb/BeaconBlockBodySchemaDenebImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/deneb/BeaconBlockBodySchemaDenebImpl.java
@@ -14,7 +14,7 @@
 package tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.deneb;
 
 import it.unimi.dsi.fastutil.longs.LongList;
-import java.util.function.Consumer;
+import java.util.function.Function;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema12;
@@ -136,10 +136,9 @@ public class BeaconBlockBodySchemaDenebImpl
 
   @Override
   public SafeFuture<? extends BeaconBlockBody> createBlockBody(
-      final Consumer<BeaconBlockBodyBuilder> builderConsumer) {
+      final Function<BeaconBlockBodyBuilder, SafeFuture<Void>> bodyBuilder) {
     final BeaconBlockBodyBuilderDeneb builder = new BeaconBlockBodyBuilderDeneb(this, null);
-    builderConsumer.accept(builder);
-    return builder.build();
+    return bodyBuilder.apply(builder).thenApply(__ -> builder.build());
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/deneb/BlindedBeaconBlockBodySchemaDenebImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/deneb/BlindedBeaconBlockBodySchemaDenebImpl.java
@@ -14,7 +14,7 @@
 package tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.deneb;
 
 import it.unimi.dsi.fastutil.longs.LongList;
-import java.util.function.Consumer;
+import java.util.function.Function;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema12;
@@ -137,10 +137,9 @@ public class BlindedBeaconBlockBodySchemaDenebImpl
 
   @Override
   public SafeFuture<BeaconBlockBody> createBlockBody(
-      final Consumer<BeaconBlockBodyBuilder> builderConsumer) {
+      final Function<BeaconBlockBodyBuilder, SafeFuture<Void>> bodyBuilder) {
     final BeaconBlockBodyBuilderDeneb builder = new BeaconBlockBodyBuilderDeneb(null, this);
-    builderConsumer.accept(builder);
-    return builder.build();
+    return bodyBuilder.apply(builder).thenApply(__ -> builder.build());
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/phase0/BeaconBlockBodyBuilderPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/phase0/BeaconBlockBodyBuilderPhase0.java
@@ -18,7 +18,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.bls.BLSSignature;
-import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszBytes32;
 import tech.pegasys.teku.spec.datastructures.blocks.Eth1Data;
@@ -110,14 +109,14 @@ public class BeaconBlockBodyBuilderPhase0 implements BeaconBlockBodyBuilder {
   }
 
   @Override
-  public BeaconBlockBodyBuilder executionPayload(SafeFuture<ExecutionPayload> executionPayload) {
+  public BeaconBlockBodyBuilder executionPayload(ExecutionPayload executionPayload) {
     // No execution payload in phase 0
     return this;
   }
 
   @Override
   public BeaconBlockBodyBuilder executionPayloadHeader(
-      SafeFuture<ExecutionPayloadHeader> executionPayloadHeader) {
+      ExecutionPayloadHeader executionPayloadHeader) {
     // No execution payload in phase 0
     return this;
   }
@@ -131,7 +130,7 @@ public class BeaconBlockBodyBuilderPhase0 implements BeaconBlockBodyBuilder {
 
   @Override
   public BeaconBlockBodyBuilder blobKzgCommitments(
-      final SafeFuture<SszList<SszKZGCommitment>> blobKzgCommitments) {
+      final SszList<SszKZGCommitment> blobKzgCommitments) {
     // No BlobKzgCommitments in phase 0
     return this;
   }
@@ -157,20 +156,19 @@ public class BeaconBlockBodyBuilderPhase0 implements BeaconBlockBodyBuilder {
   }
 
   @Override
-  public SafeFuture<BeaconBlockBody> build() {
+  public BeaconBlockBody build() {
     validate();
     final BeaconBlockBodySchemaPhase0 schema =
         getAndValidateSchema(false, BeaconBlockBodySchemaPhase0.class);
-    return SafeFuture.completedFuture(
-        new BeaconBlockBodyPhase0(
-            schema,
-            new SszSignature(randaoReveal),
-            eth1Data,
-            SszBytes32.of(graffiti),
-            proposerSlashings,
-            attesterSlashings,
-            attestations,
-            deposits,
-            voluntaryExits));
+    return new BeaconBlockBodyPhase0(
+        schema,
+        new SszSignature(randaoReveal),
+        eth1Data,
+        SszBytes32.of(graffiti),
+        proposerSlashings,
+        attesterSlashings,
+        attestations,
+        deposits,
+        voluntaryExits);
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/phase0/BeaconBlockBodyBuilderPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/phase0/BeaconBlockBodyBuilderPhase0.java
@@ -109,14 +109,14 @@ public class BeaconBlockBodyBuilderPhase0 implements BeaconBlockBodyBuilder {
   }
 
   @Override
-  public BeaconBlockBodyBuilder executionPayload(ExecutionPayload executionPayload) {
+  public BeaconBlockBodyBuilder executionPayload(final ExecutionPayload executionPayload) {
     // No execution payload in phase 0
     return this;
   }
 
   @Override
   public BeaconBlockBodyBuilder executionPayloadHeader(
-      ExecutionPayloadHeader executionPayloadHeader) {
+      final ExecutionPayloadHeader executionPayloadHeader) {
     // No execution payload in phase 0
     return this;
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/phase0/BeaconBlockBodySchemaPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/phase0/BeaconBlockBodySchemaPhase0.java
@@ -14,7 +14,7 @@
 package tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.phase0;
 
 import it.unimi.dsi.fastutil.longs.LongList;
-import java.util.function.Consumer;
+import java.util.function.Function;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema8;
@@ -104,10 +104,9 @@ public class BeaconBlockBodySchemaPhase0
 
   @Override
   public SafeFuture<BeaconBlockBody> createBlockBody(
-      final Consumer<BeaconBlockBodyBuilder> builderConsumer) {
+      final Function<BeaconBlockBodyBuilder, SafeFuture<Void>> bodyBuilder) {
     final BeaconBlockBodyBuilderPhase0 builder = new BeaconBlockBodyBuilderPhase0(this);
-    builderConsumer.accept(builder);
-    return builder.build();
+    return bodyBuilder.apply(builder).thenApply(__ -> builder.build());
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadContext.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadContext.java
@@ -50,6 +50,10 @@ public class ExecutionPayloadContext {
     return forkChoiceState.getHeadExecutionBlockHash();
   }
 
+  public boolean isValidatorRegistrationPresent() {
+    return payloadBuildingAttributes.getValidatorRegistration().isPresent();
+  }
+
   @Override
   public boolean equals(final Object o) {
     if (this == o) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadResult.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ExecutionPayloadResult.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.teku.spec.datastructures.execution;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.google.common.base.MoreObjects;
 import java.util.Objects;
 import java.util.Optional;
@@ -33,6 +35,9 @@ public class ExecutionPayloadResult {
       final Optional<SafeFuture<Optional<BlobsBundle>>> blobsBundleFuture,
       final Optional<SafeFuture<HeaderWithFallbackData>> headerWithFallbackDataFuture,
       final Optional<SafeFuture<UInt256>> executionPayloadValueFuture) {
+    checkArgument(
+        executionPayloadFuture.isPresent() != headerWithFallbackDataFuture.isPresent(),
+        "Either executionPayloadFuture or headerWithFallbackDataFuture must be present");
     this.executionPayloadContext = executionPayloadContext;
     this.executionPayloadFuture = executionPayloadFuture;
     this.blobsBundleFuture = blobsBundleFuture;

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/BlockProposalUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/BlockProposalUtil.java
@@ -16,7 +16,7 @@ package tech.pegasys.teku.spec.logic.common.util;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import java.util.Optional;
-import java.util.function.Consumer;
+import java.util.function.Function;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.ethereum.performance.trackers.BlockProductionPerformance;
@@ -51,7 +51,7 @@ public class BlockProposalUtil {
       final int proposerIndex,
       final BeaconState blockSlotState,
       final Bytes32 parentBlockSigningRoot,
-      final Consumer<BeaconBlockBodyBuilder> bodyBuilder,
+      final Function<BeaconBlockBodyBuilder, SafeFuture<Void>> bodyBuilder,
       final BlockProductionPerformance blockProductionPerformance) {
     checkArgument(
         blockSlotState.getSlot().equals(newSlot),
@@ -113,9 +113,8 @@ public class BlockProposalUtil {
   }
 
   private SafeFuture<? extends BeaconBlockBody> createBlockBody(
-      final Consumer<BeaconBlockBodyBuilder> builderConsumer) {
+      final Function<BeaconBlockBodyBuilder, SafeFuture<Void>> bodyBuilder) {
     final BeaconBlockBodyBuilder builder = schemaDefinitions.createBeaconBlockBodyBuilder();
-    builderConsumer.accept(builder);
-    return builder.build();
+    return bodyBuilder.apply(builder).thenApply(__ -> builder.build());
   }
 }

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/altair/BeaconBlockBodyAltairTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/altair/BeaconBlockBodyAltairTest.java
@@ -14,12 +14,10 @@
 package tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair;
 
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 
 import java.util.function.Consumer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodyBuilder;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.common.AbstractBeaconBlockBodyTest;
@@ -38,28 +36,28 @@ class BeaconBlockBodyAltairTest extends AbstractBeaconBlockBodyTest<BeaconBlockB
   @Test
   void equalsReturnsFalseWhenSyncAggregateIsDifferent() {
     syncAggregate = dataStructureUtil.randomSyncAggregate();
-    BeaconBlockBodyAltair testBeaconBlockBody = safeJoin(createBlockBody());
+    final BeaconBlockBodyAltair testBeaconBlockBody = createBlockBody();
 
     assertNotEquals(defaultBlockBody, testBeaconBlockBody);
   }
 
   @Override
-  protected SafeFuture<BeaconBlockBodyAltair> createBlockBody(
+  protected BeaconBlockBodyAltair createBlockBody(
       final Consumer<BeaconBlockBodyBuilder> contentProvider) {
     final BeaconBlockBodyBuilder bodyBuilder = createBeaconBlockBodyBuilder();
     contentProvider.accept(bodyBuilder);
-    return bodyBuilder.build().thenApply(body -> body.toVersionAltair().orElseThrow());
+    return bodyBuilder.build().toVersionAltair().orElseThrow();
   }
 
   @Override
-  protected SafeFuture<BlindedBeaconBlockBodyBellatrix> createBlindedBlockBody(
-      Consumer<BeaconBlockBodyBuilder> contentProvider) {
-    return SafeFuture.completedFuture(null);
+  protected BlindedBeaconBlockBodyBellatrix createBlindedBlockBody(
+      final Consumer<BeaconBlockBodyBuilder> contentProvider) {
+    return null;
   }
 
   @Override
-  protected SafeFuture<BlindedBeaconBlockBodyBellatrix> createDefaultBlindedBlockBody() {
-    return SafeFuture.completedFuture(null);
+  protected BlindedBeaconBlockBodyBellatrix createDefaultBlindedBlockBody() {
+    return null;
   }
 
   @Override

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BeaconBlockBodyBellatrixTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/bellatrix/BeaconBlockBodyBellatrixTest.java
@@ -17,14 +17,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
-import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 
 import java.util.function.Consumer;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.bls.BLSSignature;
-import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.blocks.Eth1Data;
@@ -55,7 +53,7 @@ class BeaconBlockBodyBellatrixTest extends AbstractBeaconBlockBodyTest<BeaconBlo
   @Test
   void equalsReturnsFalseWhenExecutionPayloadIsDifferent() {
     executionPayload = dataStructureUtil.randomExecutionPayload();
-    BeaconBlockBodyBellatrix testBeaconBlockBody = safeJoin(createBlockBody());
+    final BeaconBlockBodyBellatrix testBeaconBlockBody = createBlockBody();
 
     assertNotEquals(defaultBlockBody, testBeaconBlockBody);
   }
@@ -63,8 +61,7 @@ class BeaconBlockBodyBellatrixTest extends AbstractBeaconBlockBodyTest<BeaconBlo
   @Test
   void equalsReturnsFalseWhenExecutionPayloadHeaderIsDifferent() {
     executionPayloadHeader = dataStructureUtil.randomExecutionPayloadHeader();
-    final BlindedBeaconBlockBodyBellatrix testBlindedBeaconBlockBody =
-        safeJoin(createBlindedBlockBody());
+    final BlindedBeaconBlockBodyBellatrix testBlindedBeaconBlockBody = createBlindedBlockBody();
 
     assertNotEquals(defaultBlindedBlockBody, testBlindedBeaconBlockBody);
   }
@@ -96,7 +93,7 @@ class BeaconBlockBodyBellatrixTest extends AbstractBeaconBlockBodyTest<BeaconBlo
                             b ->
                                 // payload header is already set because we requested a blinded
                                 // content
-                                b.executionPayload(SafeFuture.completedFuture(executionPayload)))));
+                                b.executionPayload(executionPayload))));
     assertEquals(
         exception.getMessage(),
         "Exactly one of 'executionPayload' or 'executionPayloadHeader' must be set");
@@ -120,7 +117,7 @@ class BeaconBlockBodyBellatrixTest extends AbstractBeaconBlockBodyTest<BeaconBlo
                     .attesterSlashings(mock(SszList.class))
                     .deposits(mock(SszList.class))
                     .voluntaryExits(mock(SszList.class))
-                    .executionPayload(mock(SafeFuture.class))
+                    .executionPayload(mock(ExecutionPayload.class))
                     .syncAggregate(mock(SyncAggregate.class))
                     .build());
     assertEquals(exception.getMessage(), "Schema must be specified");
@@ -145,26 +142,26 @@ class BeaconBlockBodyBellatrixTest extends AbstractBeaconBlockBodyTest<BeaconBlo
                     .attesterSlashings(mock(SszList.class))
                     .deposits(mock(SszList.class))
                     .voluntaryExits(mock(SszList.class))
-                    .executionPayloadHeader(mock(SafeFuture.class))
+                    .executionPayloadHeader(mock(ExecutionPayloadHeader.class))
                     .syncAggregate(mock(SyncAggregate.class))
                     .build());
     assertEquals(exception.getMessage(), "Blinded schema must be specified");
   }
 
   @Override
-  protected SafeFuture<BeaconBlockBodyBellatrix> createBlockBody(
+  protected BeaconBlockBodyBellatrix createBlockBody(
       final Consumer<BeaconBlockBodyBuilder> contentProvider) {
     final BeaconBlockBodyBuilder bodyBuilder = createBeaconBlockBodyBuilder();
     contentProvider.accept(bodyBuilder);
-    return bodyBuilder.build().thenApply(body -> body.toVersionBellatrix().orElseThrow());
+    return bodyBuilder.build().toVersionBellatrix().orElseThrow();
   }
 
   @Override
-  protected SafeFuture<BlindedBeaconBlockBodyBellatrix> createBlindedBlockBody(
+  protected BlindedBeaconBlockBodyBellatrix createBlindedBlockBody(
       final Consumer<BeaconBlockBodyBuilder> contentProvider) {
     final BeaconBlockBodyBuilder bodyBuilder = createBeaconBlockBodyBuilder();
     contentProvider.accept(bodyBuilder);
-    return bodyBuilder.build().thenApply(body -> body.toBlindedVersionBellatrix().orElseThrow());
+    return bodyBuilder.build().toBlindedVersionBellatrix().orElseThrow();
   }
 
   @Override
@@ -174,9 +171,9 @@ class BeaconBlockBodyBellatrixTest extends AbstractBeaconBlockBodyTest<BeaconBlo
             builder -> {
               builder.syncAggregate(syncAggregate);
               if (blinded) {
-                builder.executionPayloadHeader(SafeFuture.completedFuture(executionPayloadHeader));
+                builder.executionPayloadHeader(executionPayloadHeader);
               } else {
-                builder.executionPayload(SafeFuture.completedFuture(executionPayload));
+                builder.executionPayload(executionPayload);
               }
             });
   }

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/capella/BeaconBlockBodyCapellaTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/capella/BeaconBlockBodyCapellaTest.java
@@ -14,12 +14,10 @@
 package tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.capella;
 
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 
 import java.util.function.Consumer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodyBuilder;
@@ -53,25 +51,25 @@ class BeaconBlockBodyCapellaTest extends AbstractBeaconBlockBodyTest<BeaconBlock
   @Test
   void equalsReturnsFalseWhenBlsToExecutionChangesIsDifferent() {
     blsToExecutionChanges = dataStructureUtil.randomSignedBlsToExecutionChangesList();
-    BeaconBlockBodyAltair testBeaconBlockBody = safeJoin(createBlockBody());
+    final BeaconBlockBodyAltair testBeaconBlockBody = createBlockBody();
 
     assertNotEquals(defaultBlockBody, testBeaconBlockBody);
   }
 
   @Override
-  protected SafeFuture<BeaconBlockBodyCapella> createBlockBody(
+  protected BeaconBlockBodyCapella createBlockBody(
       final Consumer<BeaconBlockBodyBuilder> contentProvider) {
     final BeaconBlockBodyBuilder bodyBuilder = createBeaconBlockBodyBuilder();
     contentProvider.accept(bodyBuilder);
-    return bodyBuilder.build().thenApply(body -> body.toVersionCapella().orElseThrow());
+    return bodyBuilder.build().toVersionCapella().orElseThrow();
   }
 
   @Override
-  protected SafeFuture<BlindedBeaconBlockBodyBellatrix> createBlindedBlockBody(
+  protected BlindedBeaconBlockBodyBellatrix createBlindedBlockBody(
       Consumer<BeaconBlockBodyBuilder> contentProvider) {
     final BeaconBlockBodyBuilder bodyBuilder = createBeaconBlockBodyBuilder();
     contentProvider.accept(bodyBuilder);
-    return bodyBuilder.build().thenApply(body -> body.toBlindedVersionCapella().orElseThrow());
+    return bodyBuilder.build().toBlindedVersionCapella().orElseThrow();
   }
 
   @Override
@@ -81,9 +79,9 @@ class BeaconBlockBodyCapellaTest extends AbstractBeaconBlockBodyTest<BeaconBlock
             builder -> {
               builder.syncAggregate(syncAggregate).blsToExecutionChanges(blsToExecutionChanges);
               if (blinded) {
-                builder.executionPayloadHeader(SafeFuture.completedFuture(executionPayloadHeader));
+                builder.executionPayloadHeader(executionPayloadHeader);
               } else {
-                builder.executionPayload(SafeFuture.completedFuture(executionPayload));
+                builder.executionPayload(executionPayload);
               }
             });
   }

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/deneb/BeaconBlockBodyDenebTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/deneb/BeaconBlockBodyDenebTest.java
@@ -14,12 +14,10 @@
 package tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.deneb;
 
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 
 import java.util.function.Consumer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodyBuilder;
@@ -56,25 +54,25 @@ class BeaconBlockBodyDenebTest extends AbstractBeaconBlockBodyTest<BeaconBlockBo
   @Test
   void equalsReturnsFalseWhenBlobKzgCommitmentsIsDifferent() {
     blobKzgCommitments = dataStructureUtil.randomBlobKzgCommitments();
-    BeaconBlockBodyAltair testBeaconBlockBody = safeJoin(createBlockBody());
+    final BeaconBlockBodyAltair testBeaconBlockBody = createBlockBody();
 
     assertNotEquals(defaultBlockBody, testBeaconBlockBody);
   }
 
   @Override
-  protected SafeFuture<BeaconBlockBodyDeneb> createBlockBody(
+  protected BeaconBlockBodyDeneb createBlockBody(
       final Consumer<BeaconBlockBodyBuilder> contentProvider) {
     final BeaconBlockBodyBuilder bodyBuilder = createBeaconBlockBodyBuilder();
     contentProvider.accept(bodyBuilder);
-    return bodyBuilder.build().thenApply(body -> body.toVersionDeneb().orElseThrow());
+    return bodyBuilder.build().toVersionDeneb().orElseThrow();
   }
 
   @Override
-  protected SafeFuture<BlindedBeaconBlockBodyBellatrix> createBlindedBlockBody(
+  protected BlindedBeaconBlockBodyBellatrix createBlindedBlockBody(
       Consumer<BeaconBlockBodyBuilder> contentProvider) {
     final BeaconBlockBodyBuilder bodyBuilder = createBeaconBlockBodyBuilder();
     contentProvider.accept(bodyBuilder);
-    return bodyBuilder.build().thenApply(body -> body.toBlindedVersionDeneb().orElseThrow());
+    return bodyBuilder.build().toBlindedVersionDeneb().orElseThrow();
   }
 
   @Override
@@ -85,11 +83,11 @@ class BeaconBlockBodyDenebTest extends AbstractBeaconBlockBodyTest<BeaconBlockBo
               builder
                   .syncAggregate(syncAggregate)
                   .blsToExecutionChanges(blsToExecutionChanges)
-                  .blobKzgCommitments(SafeFuture.completedFuture(blobKzgCommitments));
+                  .blobKzgCommitments(blobKzgCommitments);
               if (blinded) {
-                builder.executionPayloadHeader(SafeFuture.completedFuture(executionPayloadHeader));
+                builder.executionPayloadHeader(executionPayloadHeader);
               } else {
-                builder.executionPayload(SafeFuture.completedFuture(executionPayload));
+                builder.executionPayload(executionPayload);
               }
             });
   }

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/phase0/BeaconBlockBodyPhase0Test.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/versions/phase0/BeaconBlockBodyPhase0Test.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.phase0;
 
 import java.util.function.Consumer;
 import org.junit.jupiter.api.BeforeEach;
-import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodyBuilder;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.common.AbstractBeaconBlockBodyTest;
@@ -29,16 +28,16 @@ public class BeaconBlockBodyPhase0Test extends AbstractBeaconBlockBodyTest<Beaco
   }
 
   @Override
-  protected SafeFuture<BeaconBlockBodyPhase0> createBlockBody(
+  protected BeaconBlockBodyPhase0 createBlockBody(
       final Consumer<BeaconBlockBodyBuilder> contentProvider) {
     final BeaconBlockBodyBuilder bodyBuilder = createBeaconBlockBodyBuilder();
     contentProvider.accept(bodyBuilder);
-    return bodyBuilder.build().thenApply(body -> (BeaconBlockBodyPhase0) body);
+    return (BeaconBlockBodyPhase0) bodyBuilder.build();
   }
 
   @Override
-  protected SafeFuture<BlindedBeaconBlockBodyBellatrix> createBlindedBlockBody(
+  protected BlindedBeaconBlockBodyBellatrix createBlindedBlockBody(
       Consumer<BeaconBlockBodyBuilder> contentProvider) {
-    return SafeFuture.completedFuture(null);
+    return null;
   }
 }

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/BlockProposalTestUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/generator/BlockProposalTestUtil.java
@@ -116,11 +116,10 @@ public class BlockProposalTestUtil {
               }
               if (builder.supportsExecutionPayload()) {
                 builder.executionPayload(
-                    SafeFuture.completedFuture(
-                        executionPayload.orElseGet(
-                            () ->
-                                createExecutionPayload(
-                                    newSlot, blockSlotState, transactions, terminalBlock))));
+                    executionPayload.orElseGet(
+                        () ->
+                            createExecutionPayload(
+                                newSlot, blockSlotState, transactions, terminalBlock)));
               }
               if (builder.supportsBlsToExecutionChanges()) {
                 builder.blsToExecutionChanges(
@@ -129,9 +128,9 @@ public class BlockProposalTestUtil {
               }
               if (builder.supportsKzgCommitments()) {
                 builder.blobKzgCommitments(
-                    SafeFuture.completedFuture(
-                        kzgCommitments.orElseGet(dataStructureUtil::emptyBlobKzgCommitments)));
+                    kzgCommitments.orElseGet(dataStructureUtil::emptyBlobKzgCommitments));
               }
+              return SafeFuture.COMPLETE;
             },
             BlockProductionPerformance.NOOP)
         .thenApply(
@@ -192,11 +191,8 @@ public class BlockProposalTestUtil {
               }
               if (builder.supportsExecutionPayload()) {
                 builder.executionPayload(
-                    SafeFuture.completedFuture(
-                        executionPayload.orElseGet(
-                            () ->
-                                createExecutionPayload(
-                                    newSlot, state, transactions, terminalBlock))));
+                    executionPayload.orElseGet(
+                        () -> createExecutionPayload(newSlot, state, transactions, terminalBlock)));
               }
               if (builder.supportsBlsToExecutionChanges()) {
                 builder.blsToExecutionChanges(
@@ -205,9 +201,9 @@ public class BlockProposalTestUtil {
               }
               if (builder.supportsKzgCommitments()) {
                 builder.blobKzgCommitments(
-                    SafeFuture.completedFuture(
-                        kzgCommitments.orElseGet(dataStructureUtil::emptyBlobKzgCommitments)));
+                    kzgCommitments.orElseGet(dataStructureUtil::emptyBlobKzgCommitments));
               }
+              return SafeFuture.COMPLETE;
             })
         .thenApply(
             blockBody -> {

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/BeaconBlockBuilder.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/BeaconBlockBuilder.java
@@ -122,11 +122,12 @@ public class BeaconBlockBuilder {
                 builder.syncAggregate(syncAggregate);
               }
               if (builder.supportsExecutionPayload()) {
-                builder.executionPayload(SafeFuture.completedFuture(executionPayload));
+                builder.executionPayload(executionPayload);
               }
               if (builder.supportsBlsToExecutionChanges()) {
                 builder.blsToExecutionChanges(blsToExecutionChanges);
               }
+              return SafeFuture.COMPLETE;
             })
         .thenApply(
             blockBody ->

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -1235,15 +1235,15 @@ public final class DataStructureUtil {
                 builder.syncAggregate(randomSyncAggregateIfRequiredBySchema(schema));
               }
               if (builder.supportsExecutionPayload()) {
-                builder.executionPayloadHeader(
-                    SafeFuture.completedFuture(randomExecutionPayloadHeader(spec.atSlot(slot))));
+                builder.executionPayloadHeader(randomExecutionPayloadHeader(spec.atSlot(slot)));
               }
               if (builder.supportsBlsToExecutionChanges()) {
                 builder.blsToExecutionChanges(randomSignedBlsToExecutionChangesList());
               }
               if (builder.supportsKzgCommitments()) {
-                builder.blobKzgCommitments(SafeFuture.completedFuture(commitments));
+                builder.blobKzgCommitments(commitments);
               }
+              return SafeFuture.COMPLETE;
             })
         .join();
   }
@@ -1276,15 +1276,15 @@ public final class DataStructureUtil {
                 builder.syncAggregate(randomSyncAggregateIfRequiredBySchema(schema));
               }
               if (builder.supportsExecutionPayload()) {
-                builder.executionPayloadHeader(
-                    SafeFuture.completedFuture(randomExecutionPayloadHeader(spec.atSlot(slotNum))));
+                builder.executionPayloadHeader(randomExecutionPayloadHeader(spec.atSlot(slotNum)));
               }
               if (builder.supportsBlsToExecutionChanges()) {
                 builder.blsToExecutionChanges(randomSignedBlsToExecutionChangesList());
               }
               if (builder.supportsKzgCommitments()) {
-                builder.blobKzgCommitments(SafeFuture.completedFuture(randomBlobKzgCommitments()));
+                builder.blobKzgCommitments(randomBlobKzgCommitments());
               }
+              return SafeFuture.COMPLETE;
             })
         .join();
   }
@@ -1317,15 +1317,15 @@ public final class DataStructureUtil {
                 builder.syncAggregate(randomSyncAggregateIfRequiredBySchema(schema));
               }
               if (builder.supportsExecutionPayload()) {
-                builder.executionPayload(
-                    SafeFuture.completedFuture(randomExecutionPayload(slotNum)));
+                builder.executionPayload(randomExecutionPayload(slotNum));
               }
               if (builder.supportsBlsToExecutionChanges()) {
                 builder.blsToExecutionChanges(randomSignedBlsToExecutionChangesList());
               }
               if (builder.supportsKzgCommitments()) {
-                builder.blobKzgCommitments(SafeFuture.completedFuture(randomBlobKzgCommitments()));
+                builder.blobKzgCommitments(randomBlobKzgCommitments());
               }
+              return SafeFuture.COMPLETE;
             })
         .join();
   }
@@ -1357,14 +1357,15 @@ public final class DataStructureUtil {
                 builder.syncAggregate(randomSyncAggregateIfRequiredBySchema(schema));
               }
               if (builder.supportsExecutionPayload()) {
-                builder.executionPayload(SafeFuture.completedFuture(randomExecutionPayload()));
+                builder.executionPayload(randomExecutionPayload());
               }
               if (builder.supportsBlsToExecutionChanges()) {
                 builder.blsToExecutionChanges(randomSignedBlsToExecutionChangesList());
               }
               if (builder.supportsKzgCommitments()) {
-                builder.blobKzgCommitments(SafeFuture.completedFuture(randomBlobKzgCommitments()));
+                builder.blobKzgCommitments(randomBlobKzgCommitments());
               }
+              return SafeFuture.COMPLETE;
             })
         .join();
   }
@@ -1406,15 +1407,15 @@ public final class DataStructureUtil {
                 builder.syncAggregate(randomSyncAggregateIfRequiredBySchema(schema));
               }
               if (builder.supportsExecutionPayload()) {
-                builder.executionPayload(
-                    SafeFuture.completedFuture(randomExecutionPayload(proposalSlot)));
+                builder.executionPayload(randomExecutionPayload(proposalSlot));
               }
               if (builder.supportsBlsToExecutionChanges()) {
                 builder.blsToExecutionChanges(randomSignedBlsToExecutionChangesList());
               }
               if (builder.supportsKzgCommitments()) {
-                builder.blobKzgCommitments(SafeFuture.completedFuture(randomBlobKzgCommitments()));
+                builder.blobKzgCommitments(randomBlobKzgCommitments());
               }
+              return SafeFuture.COMPLETE;
             })
         .join();
   }
@@ -1424,29 +1425,30 @@ public final class DataStructureUtil {
         spec.getGenesisSpec().getSchemaDefinitions().getBeaconBlockBodySchema();
     return schema
         .createBlockBody(
-            builder ->
-                builder
-                    .randaoReveal(randomSignature())
-                    .eth1Data(randomEth1Data())
-                    .graffiti(Bytes32.ZERO)
-                    .proposerSlashings(
-                        randomSszList(
-                            schema.getProposerSlashingsSchema(), this::randomProposerSlashing, 1))
-                    .attesterSlashings(
-                        randomSszList(
-                            schema.getAttesterSlashingsSchema(), this::randomAttesterSlashing, 1))
-                    .attestations(
-                        randomSszList(schema.getAttestationsSchema(), this::randomAttestation, 3))
-                    .deposits(
-                        randomSszList(
-                            schema.getDepositsSchema(), this::randomDepositWithoutIndex, 1))
-                    .voluntaryExits(
-                        randomSszList(
-                            schema.getVoluntaryExitsSchema(), this::randomSignedVoluntaryExit, 1))
-                    .syncAggregate(randomSyncAggregateIfRequiredBySchema(schema))
-                    .executionPayload(SafeFuture.completedFuture(randomExecutionPayload()))
-                    .blsToExecutionChanges(randomSignedBlsToExecutionChangesList())
-                    .blobKzgCommitments(SafeFuture.completedFuture(emptyBlobKzgCommitments())))
+            builder -> {
+              builder
+                  .randaoReveal(randomSignature())
+                  .eth1Data(randomEth1Data())
+                  .graffiti(Bytes32.ZERO)
+                  .proposerSlashings(
+                      randomSszList(
+                          schema.getProposerSlashingsSchema(), this::randomProposerSlashing, 1))
+                  .attesterSlashings(
+                      randomSszList(
+                          schema.getAttesterSlashingsSchema(), this::randomAttesterSlashing, 1))
+                  .attestations(
+                      randomSszList(schema.getAttestationsSchema(), this::randomAttestation, 3))
+                  .deposits(
+                      randomSszList(schema.getDepositsSchema(), this::randomDepositWithoutIndex, 1))
+                  .voluntaryExits(
+                      randomSszList(
+                          schema.getVoluntaryExitsSchema(), this::randomSignedVoluntaryExit, 1))
+                  .syncAggregate(randomSyncAggregateIfRequiredBySchema(schema))
+                  .executionPayload(randomExecutionPayload())
+                  .blsToExecutionChanges(randomSignedBlsToExecutionChangesList())
+                  .blobKzgCommitments(emptyBlobKzgCommitments());
+              return SafeFuture.COMPLETE;
+            })
         .join();
   }
 
@@ -1460,29 +1462,30 @@ public final class DataStructureUtil {
         spec.getGenesisSpec().getSchemaDefinitions().getBeaconBlockBodySchema();
     return schema
         .createBlockBody(
-            builder ->
-                builder
-                    .randaoReveal(randomSignature())
-                    .eth1Data(randomEth1Data())
-                    .graffiti(Bytes32.ZERO)
-                    .proposerSlashings(
-                        randomSszList(
-                            schema.getProposerSlashingsSchema(), this::randomProposerSlashing, 1))
-                    .attesterSlashings(
-                        randomSszList(
-                            schema.getAttesterSlashingsSchema(), this::randomAttesterSlashing, 1))
-                    .attestations(
-                        randomSszList(schema.getAttestationsSchema(), this::randomAttestation, 3))
-                    .deposits(
-                        randomSszList(
-                            schema.getDepositsSchema(), this::randomDepositWithoutIndex, 1))
-                    .voluntaryExits(
-                        randomSszList(
-                            schema.getVoluntaryExitsSchema(), this::randomSignedVoluntaryExit, 1))
-                    .syncAggregate(randomSyncAggregateIfRequiredBySchema(schema))
-                    .executionPayload(SafeFuture.completedFuture(randomExecutionPayload()))
-                    .blsToExecutionChanges(randomSignedBlsToExecutionChangesList())
-                    .blobKzgCommitments(SafeFuture.completedFuture(commitments)))
+            builder -> {
+              builder
+                  .randaoReveal(randomSignature())
+                  .eth1Data(randomEth1Data())
+                  .graffiti(Bytes32.ZERO)
+                  .proposerSlashings(
+                      randomSszList(
+                          schema.getProposerSlashingsSchema(), this::randomProposerSlashing, 1))
+                  .attesterSlashings(
+                      randomSszList(
+                          schema.getAttesterSlashingsSchema(), this::randomAttesterSlashing, 1))
+                  .attestations(
+                      randomSszList(schema.getAttestationsSchema(), this::randomAttestation, 3))
+                  .deposits(
+                      randomSszList(schema.getDepositsSchema(), this::randomDepositWithoutIndex, 1))
+                  .voluntaryExits(
+                      randomSszList(
+                          schema.getVoluntaryExitsSchema(), this::randomSignedVoluntaryExit, 1))
+                  .syncAggregate(randomSyncAggregateIfRequiredBySchema(schema))
+                  .executionPayload(randomExecutionPayload())
+                  .blsToExecutionChanges(randomSignedBlsToExecutionChangesList())
+                  .blobKzgCommitments(commitments);
+              return SafeFuture.COMPLETE;
+            })
         .join();
   }
 
@@ -1514,14 +1517,15 @@ public final class DataStructureUtil {
                 builder.syncAggregate(randomSyncAggregateIfRequiredBySchema(schema));
               }
               if (builder.supportsExecutionPayload()) {
-                builder.executionPayload(SafeFuture.completedFuture(randomExecutionPayload()));
+                builder.executionPayload(randomExecutionPayload());
               }
               if (builder.supportsBlsToExecutionChanges()) {
                 builder.blsToExecutionChanges(randomSignedBlsToExecutionChangesList());
               }
               if (builder.supportsKzgCommitments()) {
-                builder.blobKzgCommitments(SafeFuture.completedFuture(randomBlobKzgCommitments()));
+                builder.blobKzgCommitments(randomBlobKzgCommitments());
               }
+              return SafeFuture.COMPLETE;
             })
         .join();
   }


### PR DESCRIPTION
This PR makes async the block creation selector created by `BlockOperationSelectorFacotry`.
This means that it can support async flow when providing values to the BlockBuilder. This feature enables deferring the decision to pass full payload or payloadHeader after the interaction with the builder.
This way we can completely remove `SafeFuture`(s) from BlockBuilders so they are now fully synchronous.


fixes #7889
fixes #7881

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
