### PR TITLE
Remove EL_OFFLINE from SyncState enum

### DIFF
--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/DefaultSyncServiceFactory.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/DefaultSyncServiceFactory.java
@@ -29,7 +29,6 @@ import tech.pegasys.teku.beacon.sync.forward.singlepeer.SinglePeerSyncServiceFac
 import tech.pegasys.teku.beacon.sync.gossip.blobs.RecentBlobSidecarsFetcher;
 import tech.pegasys.teku.beacon.sync.gossip.blocks.RecentBlocksFetchService;
 import tech.pegasys.teku.beacon.sync.historical.HistoricalBlockSyncService;
-import tech.pegasys.teku.ethereum.executionclient.events.ExecutionClientEventsChannel;
 import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.infrastructure.async.AsyncRunnerFactory;
 import tech.pegasys.teku.infrastructure.events.EventChannels;
@@ -135,8 +134,6 @@ public class DefaultSyncServiceFactory implements SyncServiceFactory {
             spec, asyncRunner, blockBlobSidecarsTrackersPool, forwardSyncService, fetchTaskFactory);
 
     final SyncStateTracker syncStateTracker = createSyncStateTracker(forwardSyncService);
-
-    eventChannels.subscribe(ExecutionClientEventsChannel.class, syncStateTracker);
 
     final HistoricalBlockSyncService historicalBlockSyncService =
         createHistoricalSyncService(syncStateTracker);

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/events/SyncState.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/events/SyncState.java
@@ -18,19 +18,10 @@ public enum SyncState {
   SYNCING,
   OPTIMISTIC_SYNCING,
   AWAITING_EL, // Beacon chain has completed optimistic sync but waiting for the EL
-  EL_OFFLINE,
   IN_SYNC;
 
   public boolean isInSync() {
     return this == IN_SYNC;
-  }
-
-  public boolean isElOffline() {
-    return this == EL_OFFLINE;
-  }
-
-  public boolean isStartingUp() {
-    return this == START_UP;
   }
 
   public boolean isSyncing() {

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/AbstractDataBackedRestAPIIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/AbstractDataBackedRestAPIIntegrationTest.java
@@ -40,7 +40,6 @@ import okhttp3.RequestBody;
 import okhttp3.Response;
 import org.junit.jupiter.api.AfterEach;
 import tech.pegasys.teku.api.DataProvider;
-import tech.pegasys.teku.api.ExecutionClientDataProvider;
 import tech.pegasys.teku.api.RewardCalculator;
 import tech.pegasys.teku.beacon.sync.SyncService;
 import tech.pegasys.teku.bls.BLSKeyGenerator;
@@ -150,9 +149,6 @@ public abstract class AbstractDataBackedRestAPIIntegrationTest {
   protected final ForkChoiceNotifier forkChoiceNotifier = mock(ForkChoiceNotifier.class);
   protected final Eth1DataProvider eth1DataProvider = mock(Eth1DataProvider.class);
 
-  protected final ExecutionClientDataProvider executionClientDataProvider =
-      mock(ExecutionClientDataProvider.class);
-
   private StorageSystem storageSystem;
 
   protected RecentChainData recentChainData;
@@ -258,7 +254,6 @@ public abstract class AbstractDataBackedRestAPIIntegrationTest {
             eventChannels,
             asyncRunner,
             StubTimeProvider.withTimeInMillis(1000),
-            executionClientDataProvider,
             spec);
     assertThat(beaconRestApi.start()).isCompleted();
     client = new OkHttpClient.Builder().readTimeout(0, TimeUnit.SECONDS).build();

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/node/GetSyncingIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/node/GetSyncingIntegrationTest.java
@@ -49,7 +49,6 @@ public class GetSyncingIntegrationTest extends AbstractDataBackedRestAPIIntegrat
     startRestAPIAtGenesis();
     when(syncService.getSyncStatus()).thenReturn(getSyncStatus(false, 6, 11, 16));
     when(syncService.getCurrentSyncState()).thenReturn(SyncState.IN_SYNC);
-    when(executionClientDataProvider.isExecutionClientAvailable()).thenReturn(true);
 
     final Response response = get();
     assertThat(response.code()).isEqualTo(SC_OK);
@@ -64,7 +63,9 @@ public class GetSyncingIntegrationTest extends AbstractDataBackedRestAPIIntegrat
   public void shouldGetSyncStatusWhenElOffline() throws IOException {
     startRestAPIAtGenesis();
     when(syncService.getSyncStatus()).thenReturn(getSyncStatus(false, 1, 10, 15));
-    when(syncService.getCurrentSyncState()).thenReturn(SyncState.EL_OFFLINE);
+    when(syncService.getCurrentSyncState()).thenReturn(SyncState.SYNCING);
+    // update EL availability
+    dataProvider.getExecutionClientDataProvider().onAvailabilityUpdated(false);
 
     final Response response = get();
     assertThat(response.code()).isEqualTo(SC_OK);

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/JsonTypeDefinitionBeaconRestApi.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/JsonTypeDefinitionBeaconRestApi.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import java.util.List;
 import org.apache.commons.lang3.StringUtils;
 import tech.pegasys.teku.api.DataProvider;
-import tech.pegasys.teku.api.ExecutionClientDataProvider;
 import tech.pegasys.teku.api.exceptions.BadRequestException;
 import tech.pegasys.teku.api.exceptions.ServiceUnavailableException;
 import tech.pegasys.teku.beaconrestapi.addon.CapellaRestApiBuilderAddon;
@@ -133,18 +132,10 @@ public class JsonTypeDefinitionBeaconRestApi implements BeaconRestApi {
       final EventChannels eventChannels,
       final AsyncRunner asyncRunner,
       final TimeProvider timeProvider,
-      final ExecutionClientDataProvider executionClientDataProvider,
       final Spec spec) {
     restApi =
         create(
-            config,
-            dataProvider,
-            eth1DataProvider,
-            eventChannels,
-            asyncRunner,
-            timeProvider,
-            executionClientDataProvider,
-            spec);
+            config, dataProvider, eth1DataProvider, eventChannels, asyncRunner, timeProvider, spec);
   }
 
   @Override
@@ -169,7 +160,6 @@ public class JsonTypeDefinitionBeaconRestApi implements BeaconRestApi {
       final EventChannels eventChannels,
       final AsyncRunner asyncRunner,
       final TimeProvider timeProvider,
-      final ExecutionClientDataProvider executionClientDataProvider,
       final Spec spec) {
     final SchemaDefinitionCache schemaCache = new SchemaDefinitionCache(spec);
     RestApiBuilder builder =
@@ -299,7 +289,7 @@ public class JsonTypeDefinitionBeaconRestApi implements BeaconRestApi {
             .endpoint(new PutLogLevel())
             .endpoint(new GetStateByBlockRoot(dataProvider, spec))
             .endpoint(new Liveness(dataProvider))
-            .endpoint(new Readiness(dataProvider, executionClientDataProvider))
+            .endpoint(new Readiness(dataProvider))
             .endpoint(new GetAllBlocksAtSlot(dataProvider, schemaCache))
             .endpoint(new GetPeersScore(dataProvider))
             .endpoint(new GetProposersData(dataProvider))

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/admin/Readiness.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/admin/Readiness.java
@@ -42,14 +42,13 @@ public class Readiness extends RestApiEndpoint {
 
   private final ExecutionClientDataProvider executionClientDataProvider;
 
-  public Readiness(
-      final DataProvider provider, final ExecutionClientDataProvider executionClientDataProvider) {
+  public Readiness(final DataProvider provider) {
     this(
         provider.getSyncDataProvider(),
         provider.getChainDataProvider(),
         provider.getNetworkDataProvider(),
         provider.getNodeDataProvider(),
-        executionClientDataProvider);
+        provider.getExecutionClientDataProvider());
   }
 
   Readiness(

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetSyncing.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetSyncing.java
@@ -27,6 +27,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 import tech.pegasys.teku.api.DataProvider;
+import tech.pegasys.teku.api.ExecutionClientDataProvider;
 import tech.pegasys.teku.api.SyncDataProvider;
 import tech.pegasys.teku.beacon.sync.events.SyncState;
 import tech.pegasys.teku.beacon.sync.events.SyncingStatus;
@@ -55,12 +56,15 @@ public class GetSyncing extends RestApiEndpoint {
           .build();
 
   private final SyncDataProvider syncProvider;
+  private final ExecutionClientDataProvider executionClientDataProvider;
 
   public GetSyncing(final DataProvider provider) {
-    this(provider.getSyncDataProvider());
+    this(provider.getSyncDataProvider(), provider.getExecutionClientDataProvider());
   }
 
-  GetSyncing(final SyncDataProvider syncProvider) {
+  GetSyncing(
+      final SyncDataProvider syncProvider,
+      final ExecutionClientDataProvider executionClientDataProvider) {
     super(
         EndpointMetadata.get(ROUTE)
             .operationId("getNodeSyncingStatus")
@@ -72,12 +76,13 @@ public class GetSyncing extends RestApiEndpoint {
             .response(SC_OK, "Request successful", SYNCING_RESPONSE_TYPE)
             .build());
     this.syncProvider = syncProvider;
+    this.executionClientDataProvider = executionClientDataProvider;
   }
 
   @Override
   public void handleRequest(RestApiRequest request) throws JsonProcessingException {
     request.header(Header.CACHE_CONTROL, CACHE_NONE);
-    request.respondOk(new SyncStatusData(syncProvider));
+    request.respondOk(new SyncStatusData(syncProvider, executionClientDataProvider));
   }
 
   static class SyncStatusData {
@@ -87,11 +92,13 @@ public class GetSyncing extends RestApiEndpoint {
     private final UInt64 currentSlot;
     private final UInt64 slotsBehind;
 
-    public SyncStatusData(final SyncDataProvider syncProvider) {
+    public SyncStatusData(
+        final SyncDataProvider syncProvider,
+        final ExecutionClientDataProvider executionClientDataProvider) {
       final SyncingStatus status = syncProvider.getSyncingStatus();
       final SyncState syncState = syncProvider.getCurrentSyncState();
       this.isSyncing = !syncState.isInSync();
-      this.elOffline = Optional.of(syncState.isElOffline());
+      this.elOffline = Optional.of(!executionClientDataProvider.isExecutionClientAvailable());
       this.isOptimistic = Optional.of(syncState.isOptimistic());
       this.currentSlot = status.getCurrentSlot();
       // do this last, after isSyncing is calculated

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetSyncingTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetSyncingTest.java
@@ -31,7 +31,8 @@ public class GetSyncingTest extends AbstractMigratedBeaconHandlerTest {
 
   @BeforeEach
   void setUp() {
-    setHandler(new GetSyncing(syncDataProvider));
+    setHandler(new GetSyncing(syncDataProvider, executionClientDataProvider));
+    when(executionClientDataProvider.isExecutionClientAvailable()).thenReturn(true);
   }
 
   @Test
@@ -57,14 +58,15 @@ public class GetSyncingTest extends AbstractMigratedBeaconHandlerTest {
   }
 
   @Test
-  public void shouldGetSyncStatusElOffline() throws Exception {
-    when(syncService.getSyncStatus()).thenReturn(getSyncStatus(true, 1, 10, 11));
-    when(syncService.getCurrentSyncState()).thenReturn(SyncState.EL_OFFLINE);
+  public void shouldGetElOffline() throws Exception {
+    when(syncService.getSyncStatus()).thenReturn(getSyncStatus(false, 1, 10, 11));
+    when(syncService.getCurrentSyncState()).thenReturn(SyncState.IN_SYNC);
+    when(executionClientDataProvider.isExecutionClientAvailable()).thenReturn(false);
 
     handler.handleRequest(request);
     assertThat(request.getResponseCode()).isEqualTo(SC_OK);
     assertThat(request.getResponseBody())
-        .isEqualTo(new GetSyncing.SyncStatusData(true, false, true, 10, 1));
+        .isEqualTo(new GetSyncing.SyncStatusData(false, false, true, 10, 0));
   }
 
   @Test

--- a/data/provider/src/main/java/tech/pegasys/teku/api/DataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/DataProvider.java
@@ -45,6 +45,7 @@ public class DataProvider {
   private final ValidatorDataProvider validatorDataProvider;
   private final NodeDataProvider nodeDataProvider;
   private final ConfigProvider configProvider;
+  private final ExecutionClientDataProvider executionClientDataProvider;
 
   private DataProvider(
       final ConfigProvider configProvider,
@@ -52,13 +53,15 @@ public class DataProvider {
       final NodeDataProvider nodeDataProvider,
       final ChainDataProvider chainDataProvider,
       final SyncDataProvider syncDataProvider,
-      final ValidatorDataProvider validatorDataProvider) {
+      final ValidatorDataProvider validatorDataProvider,
+      final ExecutionClientDataProvider executionClientDataProvider) {
     this.configProvider = configProvider;
     this.networkDataProvider = networkDataProvider;
     this.nodeDataProvider = nodeDataProvider;
     this.chainDataProvider = chainDataProvider;
     this.syncDataProvider = syncDataProvider;
     this.validatorDataProvider = validatorDataProvider;
+    this.executionClientDataProvider = executionClientDataProvider;
   }
 
   public ConfigProvider getConfigProvider() {
@@ -83,6 +86,10 @@ public class DataProvider {
 
   public NodeDataProvider getNodeDataProvider() {
     return nodeDataProvider;
+  }
+
+  public ExecutionClientDataProvider getExecutionClientDataProvider() {
+    return executionClientDataProvider;
   }
 
   public static DataProvider.Builder builder() {
@@ -254,19 +261,23 @@ public class DataProvider {
               combinedChainDataClient,
               executionLayerBlockProductionManager,
               rewardCalculator);
+      final ExecutionClientDataProvider executionClientDataProvider =
+          new ExecutionClientDataProvider();
 
       checkNotNull(configProvider, "Expect config Provider");
       checkNotNull(networkDataProvider, "Expect Network Data Provider");
       checkNotNull(chainDataProvider, "Expect Chain Data Provider");
       checkNotNull(syncDataProvider, "Expect Sync Data Provider");
       checkNotNull(validatorDataProvider, "Expect Validator Data Provider");
+      checkNotNull(executionClientDataProvider, "Expect Execution Client Data Provider");
       return new DataProvider(
           configProvider,
           networkDataProvider,
           nodeDataProvider,
           chainDataProvider,
           syncDataProvider,
-          validatorDataProvider);
+          validatorDataProvider,
+          executionClientDataProvider);
     }
 
     public Builder rejectedExecutionSupplier(final IntSupplier rejectedExecutionCountSupplier) {

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -1113,7 +1113,8 @@ public class BeaconChainController extends Service implements BeaconChainControl
     final Eth1DataProvider eth1DataProvider = new Eth1DataProvider(eth1DataCache, depositProvider);
 
     final ExecutionClientDataProvider executionClientDataProvider =
-        new ExecutionClientDataProvider();
+        dataProvider.getExecutionClientDataProvider();
+
     eventChannels.subscribe(ExecutionClientEventsChannel.class, executionClientDataProvider);
 
     beaconRestAPI =

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -1126,7 +1126,6 @@ public class BeaconChainController extends Service implements BeaconChainControl
                 eventChannels,
                 eventAsyncRunner,
                 timeProvider,
-                executionClientDataProvider,
                 spec));
 
     if (getLivenessTrackingEnabled(beaconConfig)) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

- Remove `EL_OFFLINE` from `SyncState` and use the existing `ExecutionClientDataProvider` to get the information.

This will fix cases where the `SyncState` can be misinterpreted. Chain could still be in sync even if EL has timed out or errored for a single request. It's better to let `onTick()` control the `SyncState` entirely.

 For example, the following issue happened to one of our users:

- Block building was initiated using the builder flow and local EL `getPayload` was called. 
- The request timed out and `SyncState` was changed to `EL_OFFLINE` so `SyncState.isInSync()` was returning false
- Remote `VC` gets 503 (still syncing) when publishing the block and it fails.

Also `onTick()` could be triggered at the same time which checks `SyncState.isInSync()` and since it can be returning false, it can start syncing process wrongly.

We only introduced EL_OFFLINE for `/eth/v1/node/syncing` endpoint and think it doesn't belong in the syncing process.

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
