### PR TITLE
Reject aggregate attestation from gossip if there are no participants

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AggregateAttestationValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AggregateAttestationValidator.java
@@ -145,7 +145,6 @@ public class AggregateAttestationValidator {
               final IntList attestingIndices =
                   spec.getAttestingIndices(
                       state, aggregate.getData(), aggregate.getAggregationBits());
-
               if (attestingIndices.isEmpty()) {
                 return SafeFuture.completedFuture(
                     reject(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AggregateAttestationValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AggregateAttestationValidator.java
@@ -141,6 +141,17 @@ public class AggregateAttestationValidator {
 
               final BeaconState state = maybeState.get();
 
+              // [REJECT] The aggregate attestation has participants
+              final IntList attestingIndices =
+                  spec.getAttestingIndices(
+                      state, aggregate.getData(), aggregate.getAggregationBits());
+
+              if (attestingIndices.isEmpty()) {
+                return SafeFuture.completedFuture(
+                    reject(
+                        "Rejecting aggregate attestation because it does not have participants"));
+              }
+
               final Optional<BLSPublicKey> aggregatorPublicKey =
                   spec.getValidatorPubKey(state, aggregateAndProof.getIndex());
               if (aggregatorPublicKey.isEmpty()) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AttestationValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AttestationValidator.java
@@ -105,12 +105,10 @@ public class AttestationValidator {
             .performSlotInclusionGossipValidation(attestation, genesisTime, currentTimeMillis);
 
     if (slotInclusionGossipValidationResult.isPresent()) {
-      switch (slotInclusionGossipValidationResult.get()) {
-        case IGNORE:
-          return completedFuture(InternalValidationResultWithState.ignore());
-        case SAVE_FOR_FUTURE:
-          return completedFuture(InternalValidationResultWithState.saveForFuture());
-      }
+      return switch (slotInclusionGossipValidationResult.get()) {
+        case IGNORE -> completedFuture(InternalValidationResultWithState.ignore());
+        case SAVE_FOR_FUTURE -> completedFuture(InternalValidationResultWithState.saveForFuture());
+      };
     }
 
     // The block being voted for (attestation.data.beacon_block_root) passes validation.
@@ -151,9 +149,7 @@ public class AttestationValidator {
                         attestation.getData().getIndex(), receivedOnSubnetId.getAsInt()));
               }
 
-              // The check below is not specified in the Eth2 networking spec, yet an attestation
-              // with aggregation bits size greater/less than the committee size is invalid. So we
-              // reject those attestations at the networking layer.
+              // [REJECT] The number of aggregation bits matches the committee size
               final IntList committee =
                   spec.getBeaconCommittee(state, data.getSlot(), data.getIndex());
               if (committee.size() != attestation.getAggregationBits().size()) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Add a missing REJECT validation for aggregate attestations as part of https://github.com/ethereum/consensus-specs/pull/3552:

_[REJECT]_ The aggregate attestation has participants -- that is, `len(get_attesting_indices(state, aggregate.data, aggregate.aggregation_bits)) >= 1`.

## Fixed Issue(s)
fixes #7904 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
