### PR TITLE
Change comment (getting finalized checkpoint from store rather than state

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlobSidecarGossipValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/BlobSidecarGossipValidator.java
@@ -136,7 +136,7 @@ public class BlobSidecarGossipValidator {
 
     /*
      * [IGNORE] The sidecar is from a slot greater than the latest finalized slot -- i.e. validate that
-     * `block_header.slot > compute_start_slot_at_epoch(state.finalized_checkpoint.epoch)`
+     * `block_header.slot > compute_start_slot_at_epoch(store.finalized_checkpoint.epoch)`
      */
     if (gossipValidationHelper.isSlotFinalized(blockHeader.getSlot())) {
       LOG.trace("BlobSidecar is too old (slot already finalized)");


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
We already get the finalizedCheckpoint from the store when constructing P2P Status message and for block and blob sidecars gossip validation, so just changed a comment.

![image](https://github.com/Consensys/teku/assets/14827647/377192e9-d41a-438a-a66d-b4938b80d210)

![image](https://github.com/Consensys/teku/assets/14827647/02e561a1-463b-41c4-b25c-03309b11a844)


## Fixed Issue(s)
fixes #7905 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
