### PR TITLE
Add builder boost factor part1

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactory.java
@@ -34,6 +34,7 @@ public interface BlockFactory {
       BLSSignature randaoReveal,
       Optional<Bytes32> optionalGraffiti,
       Optional<Boolean> requestedBlinded,
+      Optional<UInt64> requestedProposerBoostFactor,
       BlockProductionPerformance blockProductionPerformance);
 
   SafeFuture<SignedBeaconBlock> unblindSignedBlockIfBlinded(SignedBeaconBlock maybeBlindedBlock);

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactory.java
@@ -34,7 +34,7 @@ public interface BlockFactory {
       BLSSignature randaoReveal,
       Optional<Bytes32> optionalGraffiti,
       Optional<Boolean> requestedBlinded,
-      Optional<UInt64> requestedProposerBoostFactor,
+      Optional<UInt64> requestedBuilderBoostFactor,
       BlockProductionPerformance blockProductionPerformance);
 
   SafeFuture<SignedBeaconBlock> unblindSignedBlockIfBlinded(SignedBeaconBlock maybeBlindedBlock);

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactoryDeneb.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactoryDeneb.java
@@ -49,6 +49,7 @@ public class BlockFactoryDeneb extends BlockFactoryPhase0 {
       final BLSSignature randaoReveal,
       final Optional<Bytes32> optionalGraffiti,
       final Optional<Boolean> requestedBlinded,
+      final Optional<UInt64> requestedProposerBoostFactor,
       final BlockProductionPerformance blockProductionPerformance) {
     return super.createUnsignedBlock(
             blockSlotState,
@@ -56,6 +57,7 @@ public class BlockFactoryDeneb extends BlockFactoryPhase0 {
             randaoReveal,
             optionalGraffiti,
             requestedBlinded,
+            requestedProposerBoostFactor,
             blockProductionPerformance)
         .thenApply(BlockContainer::getBlock)
         .thenCompose(

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactoryDeneb.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactoryDeneb.java
@@ -49,7 +49,7 @@ public class BlockFactoryDeneb extends BlockFactoryPhase0 {
       final BLSSignature randaoReveal,
       final Optional<Bytes32> optionalGraffiti,
       final Optional<Boolean> requestedBlinded,
-      final Optional<UInt64> requestedProposerBoostFactor,
+      final Optional<UInt64> requestedBuilderBoostFactor,
       final BlockProductionPerformance blockProductionPerformance) {
     return super.createUnsignedBlock(
             blockSlotState,
@@ -57,7 +57,7 @@ public class BlockFactoryDeneb extends BlockFactoryPhase0 {
             randaoReveal,
             optionalGraffiti,
             requestedBlinded,
-            requestedProposerBoostFactor,
+            requestedBuilderBoostFactor,
             blockProductionPerformance)
         .thenApply(BlockContainer::getBlock)
         .thenCompose(

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactoryPhase0.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactoryPhase0.java
@@ -49,6 +49,7 @@ public class BlockFactoryPhase0 implements BlockFactory {
       final BLSSignature randaoReveal,
       final Optional<Bytes32> optionalGraffiti,
       final Optional<Boolean> requestedBlinded,
+      final Optional<UInt64> requestedProposerBoostFactor,
       final BlockProductionPerformance blockProductionPerformance) {
     checkArgument(
         blockSlotState.getSlot().equals(proposalSlot),
@@ -72,6 +73,7 @@ public class BlockFactoryPhase0 implements BlockFactory {
                 randaoReveal,
                 optionalGraffiti,
                 requestedBlinded,
+                requestedProposerBoostFactor,
                 blockProductionPerformance),
             blockProductionPerformance)
         .thenApply(BeaconBlockAndState::getBlock);

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactoryPhase0.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactoryPhase0.java
@@ -49,7 +49,7 @@ public class BlockFactoryPhase0 implements BlockFactory {
       final BLSSignature randaoReveal,
       final Optional<Bytes32> optionalGraffiti,
       final Optional<Boolean> requestedBlinded,
-      final Optional<UInt64> requestedProposerBoostFactor,
+      final Optional<UInt64> requestedBuilderBoostFactor,
       final BlockProductionPerformance blockProductionPerformance) {
     checkArgument(
         blockSlotState.getSlot().equals(proposalSlot),
@@ -73,7 +73,7 @@ public class BlockFactoryPhase0 implements BlockFactory {
                 randaoReveal,
                 optionalGraffiti,
                 requestedBlinded,
-                requestedProposerBoostFactor,
+                requestedBuilderBoostFactor,
                 blockProductionPerformance),
             blockProductionPerformance)
         .thenApply(BeaconBlockAndState::getBlock);

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
@@ -108,7 +108,7 @@ public class BlockOperationSelectorFactory {
       final BLSSignature randaoReveal,
       final Optional<Bytes32> optionalGraffiti,
       final Optional<Boolean> requestedBlinded,
-      final Optional<UInt64> requestedProposerBoostFactor,
+      final Optional<UInt64> requestedBuilderBoostFactor,
       final BlockProductionPerformance blockProductionPerformance) {
 
     return bodyBuilder -> {
@@ -182,7 +182,7 @@ public class BlockOperationSelectorFactory {
                             executionPayloadContext,
                             bodyBuilder,
                             requestedBlinded,
-                            requestedProposerBoostFactor,
+                            requestedBuilderBoostFactor,
                             schemaDefinitions,
                             blockSlotState,
                             blockProductionPerformance));
@@ -200,7 +200,7 @@ public class BlockOperationSelectorFactory {
       final Optional<ExecutionPayloadContext> executionPayloadContext,
       final BeaconBlockBodyBuilder bodyBuilder,
       final Optional<Boolean> requestedBlinded,
-      final Optional<UInt64> requestedProposerBoostFactor,
+      final Optional<UInt64> requestedBuilderBoostFactor,
       final SchemaDefinitions schemaDefinitions,
       final BeaconState blockSlotState,
       final BlockProductionPerformance blockProductionPerformance) {
@@ -230,7 +230,7 @@ public class BlockOperationSelectorFactory {
             schemaDefinitions,
             blockSlotState,
             executionPayloadContext,
-            requestedProposerBoostFactor,
+            requestedBuilderBoostFactor,
             blockProductionPerformance);
       } else {
         return builderSetPayload(
@@ -251,7 +251,7 @@ public class BlockOperationSelectorFactory {
                 () -> new IllegalStateException("Cannot provide kzg commitments before The Merge")),
             blockSlotState,
             shouldTryBuilderFlow,
-            requestedProposerBoostFactor,
+            requestedBuilderBoostFactor,
             blockProductionPerformance);
 
     return SafeFuture.allOf(
@@ -326,7 +326,7 @@ public class BlockOperationSelectorFactory {
       final SchemaDefinitions schemaDefinitions,
       final BeaconState blockSlotState,
       final Optional<ExecutionPayloadContext> executionPayloadContext,
-      final Optional<UInt64> requestedProposerBoostFactor,
+      final Optional<UInt64> requestedBuilderBoostFactor,
       final BlockProductionPerformance blockProductionPerformance) {
     if (executionPayloadContext.isEmpty()) {
       // preMergePayloadHeader
@@ -342,7 +342,7 @@ public class BlockOperationSelectorFactory {
             executionPayloadContext.get(),
             blockSlotState,
             true,
-            requestedProposerBoostFactor,
+            requestedBuilderBoostFactor,
             blockProductionPerformance)
         .getHeaderWithFallbackDataFuture()
         .orElseThrow()

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
@@ -108,6 +108,7 @@ public class BlockOperationSelectorFactory {
       final BLSSignature randaoReveal,
       final Optional<Bytes32> optionalGraffiti,
       final Optional<Boolean> requestedBlinded,
+      final Optional<UInt64> requestedProposerBoostFactor,
       final BlockProductionPerformance blockProductionPerformance) {
 
     return bodyBuilder -> {
@@ -181,6 +182,7 @@ public class BlockOperationSelectorFactory {
                             executionPayloadContext,
                             bodyBuilder,
                             requestedBlinded,
+                            requestedProposerBoostFactor,
                             schemaDefinitions,
                             blockSlotState,
                             blockProductionPerformance));
@@ -198,6 +200,7 @@ public class BlockOperationSelectorFactory {
       final Optional<ExecutionPayloadContext> executionPayloadContext,
       final BeaconBlockBodyBuilder bodyBuilder,
       final Optional<Boolean> requestedBlinded,
+      final Optional<UInt64> requestedProposerBoostFactor,
       final SchemaDefinitions schemaDefinitions,
       final BeaconState blockSlotState,
       final BlockProductionPerformance blockProductionPerformance) {
@@ -227,6 +230,7 @@ public class BlockOperationSelectorFactory {
             schemaDefinitions,
             blockSlotState,
             executionPayloadContext,
+            requestedProposerBoostFactor,
             blockProductionPerformance);
       } else {
         return builderSetPayload(
@@ -247,6 +251,7 @@ public class BlockOperationSelectorFactory {
                 () -> new IllegalStateException("Cannot provide kzg commitments before The Merge")),
             blockSlotState,
             shouldTryBuilderFlow,
+            requestedProposerBoostFactor,
             blockProductionPerformance);
 
     return SafeFuture.allOf(
@@ -305,7 +310,11 @@ public class BlockOperationSelectorFactory {
     }
     return executionLayerBlockProductionManager
         .initiateBlockProduction(
-            executionPayloadContext.get(), blockSlotState, false, blockProductionPerformance)
+            executionPayloadContext.get(),
+            blockSlotState,
+            false,
+            Optional.empty(),
+            blockProductionPerformance)
         .getExecutionPayloadFuture()
         .orElseThrow()
         .thenAccept(bodyBuilder::executionPayload);
@@ -317,6 +326,7 @@ public class BlockOperationSelectorFactory {
       final SchemaDefinitions schemaDefinitions,
       final BeaconState blockSlotState,
       final Optional<ExecutionPayloadContext> executionPayloadContext,
+      final Optional<UInt64> requestedProposerBoostFactor,
       final BlockProductionPerformance blockProductionPerformance) {
     if (executionPayloadContext.isEmpty()) {
       // preMergePayloadHeader
@@ -329,7 +339,11 @@ public class BlockOperationSelectorFactory {
 
     return executionLayerBlockProductionManager
         .initiateBlockProduction(
-            executionPayloadContext.get(), blockSlotState, true, blockProductionPerformance)
+            executionPayloadContext.get(),
+            blockSlotState,
+            true,
+            requestedProposerBoostFactor,
+            blockProductionPerformance)
         .getHeaderWithFallbackDataFuture()
         .orElseThrow()
         .thenAccept(

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/MilestoneBasedBlockFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/MilestoneBasedBlockFactory.java
@@ -67,7 +67,7 @@ public class MilestoneBasedBlockFactory implements BlockFactory {
       final BLSSignature randaoReveal,
       final Optional<Bytes32> optionalGraffiti,
       final Optional<Boolean> requestedBlinded,
-      final Optional<UInt64> requestedProposerBoostFactor,
+      final Optional<UInt64> requestedBuilderBoostFactor,
       final BlockProductionPerformance blockProductionPerformance) {
     final SpecMilestone milestone = getMilestone(proposalSlot);
     return registeredFactories
@@ -78,7 +78,7 @@ public class MilestoneBasedBlockFactory implements BlockFactory {
             randaoReveal,
             optionalGraffiti,
             requestedBlinded,
-            requestedProposerBoostFactor,
+            requestedBuilderBoostFactor,
             blockProductionPerformance);
   }
 

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/MilestoneBasedBlockFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/MilestoneBasedBlockFactory.java
@@ -67,6 +67,7 @@ public class MilestoneBasedBlockFactory implements BlockFactory {
       final BLSSignature randaoReveal,
       final Optional<Bytes32> optionalGraffiti,
       final Optional<Boolean> requestedBlinded,
+      final Optional<UInt64> requestedProposerBoostFactor,
       final BlockProductionPerformance blockProductionPerformance) {
     final SpecMilestone milestone = getMilestone(proposalSlot);
     return registeredFactories
@@ -77,6 +78,7 @@ public class MilestoneBasedBlockFactory implements BlockFactory {
             randaoReveal,
             optionalGraffiti,
             requestedBlinded,
+            requestedProposerBoostFactor,
             blockProductionPerformance);
   }
 

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -350,7 +350,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
       final BLSSignature randaoReveal,
       final Optional<Bytes32> graffiti,
       final Optional<Boolean> requestedBlinded,
-      final Optional<UInt64> requestedProposerBoostFactor,
+      final Optional<UInt64> requestedBuilderBoostFactor,
       final Optional<BeaconState> maybeBlockSlotState,
       final BlockProductionPerformance blockProductionPerformance) {
     if (maybeBlockSlotState.isEmpty()) {
@@ -371,7 +371,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
             randaoReveal,
             graffiti,
             requestedBlinded,
-            requestedProposerBoostFactor,
+            requestedBuilderBoostFactor,
             blockProductionPerformance)
         .thenApply(Optional::of);
   }

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -313,7 +313,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
       final UInt64 slot,
       final BLSSignature randaoReveal,
       final Optional<Bytes32> graffiti,
-      final Optional<Boolean> blinded) {
+      final Optional<Boolean> requestedBlinded) {
     LOG.info("Creating unsigned block for slot {}", slot);
     performanceTracker.reportBlockProductionAttempt(spec.computeEpochAtSlot(slot));
     if (isSyncActive()) {
@@ -338,7 +338,8 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
                     slot,
                     randaoReveal,
                     graffiti,
-                    blinded,
+                    requestedBlinded,
+                    Optional.empty(),
                     blockSlotState,
                     blockProductionPerformance))
         .alwaysRun(blockProductionPerformance::complete);
@@ -348,7 +349,8 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
       final UInt64 slot,
       final BLSSignature randaoReveal,
       final Optional<Bytes32> graffiti,
-      final Optional<Boolean> blinded,
+      final Optional<Boolean> requestedBlinded,
+      final Optional<UInt64> requestedProposerBoostFactor,
       final Optional<BeaconState> maybeBlockSlotState,
       final BlockProductionPerformance blockProductionPerformance) {
     if (maybeBlockSlotState.isEmpty()) {
@@ -364,7 +366,13 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
     }
     return blockFactory
         .createUnsignedBlock(
-            blockSlotState, slot, randaoReveal, graffiti, blinded, blockProductionPerformance)
+            blockSlotState,
+            slot,
+            randaoReveal,
+            graffiti,
+            requestedBlinded,
+            requestedProposerBoostFactor,
+            blockProductionPerformance)
         .thenApply(Optional::of);
   }
 

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/AbstractBlockFactoryTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/AbstractBlockFactoryTest.java
@@ -210,6 +210,7 @@ public abstract class AbstractBlockFactoryTest {
                 randaoReveal,
                 Optional.empty(),
                 Optional.of(blinded),
+                Optional.empty(),
                 BlockProductionPerformance.NOOP));
 
     final BeaconBlock block = blockContainer.getBlock();
@@ -414,7 +415,7 @@ public abstract class AbstractBlockFactoryTest {
 
   private void setupExecutionLayerBlockAndBlobsProduction() {
     // pre Deneb
-    when(executionLayer.initiateBlockProduction(any(), any(), eq(false), any()))
+    when(executionLayer.initiateBlockProduction(any(), any(), eq(false), any(), any()))
         .thenAnswer(
             args -> {
               final ExecutionPayloadResult executionPayloadResult =
@@ -427,7 +428,7 @@ public abstract class AbstractBlockFactoryTest {
               cachedExecutionPayloadResult = executionPayloadResult;
               return executionPayloadResult;
             });
-    when(executionLayer.initiateBlockProduction(any(), any(), eq(true), any()))
+    when(executionLayer.initiateBlockProduction(any(), any(), eq(true), any(), any()))
         .thenAnswer(
             args -> {
               final ExecutionPayloadResult executionPayloadResult =
@@ -443,7 +444,7 @@ public abstract class AbstractBlockFactoryTest {
               return executionPayloadResult;
             });
     // post Deneb
-    when(executionLayer.initiateBlockAndBlobsProduction(any(), any(), eq(false), any()))
+    when(executionLayer.initiateBlockAndBlobsProduction(any(), any(), eq(false), any(), any()))
         .thenAnswer(
             args -> {
               final ExecutionPayloadResult executionPayloadResult =
@@ -456,7 +457,7 @@ public abstract class AbstractBlockFactoryTest {
               cachedExecutionPayloadResult = executionPayloadResult;
               return executionPayloadResult;
             });
-    when(executionLayer.initiateBlockAndBlobsProduction(any(), any(), eq(true), any()))
+    when(executionLayer.initiateBlockAndBlobsProduction(any(), any(), eq(true), any(), any()))
         .thenAnswer(
             args -> {
               final ExecutionPayloadResult executionPayloadResult =

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryTest.java
@@ -216,6 +216,7 @@ class BlockOperationSelectorFactoryTest {
                 dataStructureUtil.randomSignature(),
                 Optional.empty(),
                 Optional.empty(),
+                Optional.empty(),
                 BlockProductionPerformance.NOOP)
             .apply(bodyBuilder));
 
@@ -251,6 +252,7 @@ class BlockOperationSelectorFactoryTest {
                 parentRoot,
                 blockSlotState,
                 randaoReveal,
+                Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
                 BlockProductionPerformance.NOOP)
@@ -332,6 +334,7 @@ class BlockOperationSelectorFactoryTest {
                 randaoReveal,
                 Optional.empty(),
                 Optional.empty(),
+                Optional.empty(),
                 BlockProductionPerformance.NOOP)
             .apply(bodyBuilder));
 
@@ -360,6 +363,7 @@ class BlockOperationSelectorFactoryTest {
                 dataStructureUtil.randomSignature(),
                 Optional.empty(),
                 Optional.of(false),
+                Optional.empty(),
                 BlockProductionPerformance.NOOP)
             .apply(bodyBuilder));
     assertThat(bodyBuilder.executionPayload).isEqualTo(defaultExecutionPayload);
@@ -377,6 +381,7 @@ class BlockOperationSelectorFactoryTest {
                 dataStructureUtil.randomSignature(),
                 Optional.empty(),
                 Optional.of(true),
+                Optional.empty(),
                 BlockProductionPerformance.NOOP)
             .apply(bodyBuilder));
     assertThat(bodyBuilder.executionPayloadHeader)
@@ -405,6 +410,7 @@ class BlockOperationSelectorFactoryTest {
                 dataStructureUtil.randomSignature(),
                 Optional.empty(),
                 Optional.of(false),
+                Optional.empty(),
                 BlockProductionPerformance.NOOP)
             .apply(bodyBuilder));
 
@@ -434,6 +440,7 @@ class BlockOperationSelectorFactoryTest {
                 dataStructureUtil.randomSignature(),
                 Optional.empty(),
                 Optional.of(true),
+                Optional.empty(),
                 BlockProductionPerformance.NOOP)
             .apply(bodyBuilder));
 
@@ -462,6 +469,7 @@ class BlockOperationSelectorFactoryTest {
                 dataStructureUtil.randomSignature(),
                 Optional.empty(),
                 Optional.of(false),
+                Optional.empty(),
                 BlockProductionPerformance.NOOP)
             .apply(bodyBuilder));
 
@@ -490,6 +498,7 @@ class BlockOperationSelectorFactoryTest {
                 dataStructureUtil.randomSignature(),
                 Optional.empty(),
                 Optional.empty(),
+                Optional.empty(),
                 BlockProductionPerformance.NOOP)
             .apply(bodyBuilder));
 
@@ -516,6 +525,7 @@ class BlockOperationSelectorFactoryTest {
                 parentRoot,
                 blockSlotState,
                 dataStructureUtil.randomSignature(),
+                Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
                 BlockProductionPerformance.NOOP)
@@ -548,6 +558,7 @@ class BlockOperationSelectorFactoryTest {
                 parentRoot,
                 blockSlotState,
                 dataStructureUtil.randomSignature(),
+                Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
                 BlockProductionPerformance.NOOP)
@@ -600,6 +611,7 @@ class BlockOperationSelectorFactoryTest {
                 dataStructureUtil.randomSignature(),
                 Optional.empty(),
                 Optional.of(false),
+                Optional.empty(),
                 BlockProductionPerformance.NOOP)
             .apply(bodyBuilder));
 
@@ -636,6 +648,7 @@ class BlockOperationSelectorFactoryTest {
                 dataStructureUtil.randomSignature(),
                 Optional.empty(),
                 Optional.of(true),
+                Optional.empty(),
                 BlockProductionPerformance.NOOP)
             .apply(bodyBuilder));
 
@@ -789,7 +802,11 @@ class BlockOperationSelectorFactoryTest {
       final ExecutionPayloadContext executionPayloadContext,
       final BeaconState blockSlotState) {
     when(executionLayer.initiateBlockProduction(
-            executionPayloadContext, blockSlotState, false, BlockProductionPerformance.NOOP))
+            executionPayloadContext,
+            blockSlotState,
+            false,
+            Optional.empty(),
+            BlockProductionPerformance.NOOP))
         .thenReturn(
             new ExecutionPayloadResult(
                 executionPayloadContext,
@@ -804,7 +821,11 @@ class BlockOperationSelectorFactoryTest {
       final ExecutionPayloadContext executionPayloadContext,
       final BeaconState blockSlotState) {
     when(executionLayer.initiateBlockProduction(
-            executionPayloadContext, blockSlotState, true, BlockProductionPerformance.NOOP))
+            executionPayloadContext,
+            blockSlotState,
+            true,
+            Optional.empty(),
+            BlockProductionPerformance.NOOP))
         .thenReturn(
             new ExecutionPayloadResult(
                 executionPayloadContext,
@@ -830,7 +851,11 @@ class BlockOperationSelectorFactoryTest {
                 FallbackReason.SHOULD_OVERRIDE_BUILDER_FLAG_IS_TRUE));
 
     when(executionLayer.initiateBlockProduction(
-            executionPayloadContext, blockSlotState, true, BlockProductionPerformance.NOOP))
+            executionPayloadContext,
+            blockSlotState,
+            true,
+            Optional.empty(),
+            BlockProductionPerformance.NOOP))
         .thenReturn(
             new ExecutionPayloadResult(
                 executionPayloadContext,
@@ -846,7 +871,11 @@ class BlockOperationSelectorFactoryTest {
       final BeaconState blockSlotState,
       final BlobsBundle blobsBundle) {
     when(executionLayer.initiateBlockAndBlobsProduction(
-            executionPayloadContext, blockSlotState, false, BlockProductionPerformance.NOOP))
+            executionPayloadContext,
+            blockSlotState,
+            false,
+            Optional.empty(),
+            BlockProductionPerformance.NOOP))
         .thenReturn(
             new ExecutionPayloadResult(
                 executionPayloadContext,
@@ -864,7 +893,11 @@ class BlockOperationSelectorFactoryTest {
     final HeaderWithFallbackData headerWithFallbackData =
         HeaderWithFallbackData.create(executionPayloadHeader, Optional.of(blobKzgCommitments));
     when(executionLayer.initiateBlockAndBlobsProduction(
-            executionPayloadContext, blockSlotState, true, BlockProductionPerformance.NOOP))
+            executionPayloadContext,
+            blockSlotState,
+            true,
+            Optional.empty(),
+            BlockProductionPerformance.NOOP))
         .thenReturn(
             new ExecutionPayloadResult(
                 executionPayloadContext,
@@ -889,7 +922,11 @@ class BlockOperationSelectorFactoryTest {
                 FallbackReason.SHOULD_OVERRIDE_BUILDER_FLAG_IS_TRUE));
 
     when(executionLayer.initiateBlockAndBlobsProduction(
-            executionPayloadContext, blockSlotState, true, BlockProductionPerformance.NOOP))
+            executionPayloadContext,
+            blockSlotState,
+            true,
+            Optional.empty(),
+            BlockProductionPerformance.NOOP))
         .thenReturn(
             new ExecutionPayloadResult(
                 executionPayloadContext,

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -529,6 +529,7 @@ class ValidatorApiHandlerTest {
             randaoReveal,
             Optional.empty(),
             Optional.of(false),
+            Optional.empty(),
             BlockProductionPerformance.NOOP))
         .thenReturn(SafeFuture.completedFuture(createdBlock));
 
@@ -543,6 +544,7 @@ class ValidatorApiHandlerTest {
             randaoReveal,
             Optional.empty(),
             Optional.of(false),
+            Optional.empty(),
             BlockProductionPerformance.NOOP);
     assertThat(result).isCompletedWithValue(Optional.of(createdBlock));
   }

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionBuilderModule.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionBuilderModule.java
@@ -576,7 +576,9 @@ public class ExecutionBuilderModule {
     final String actualComparisonFactorString;
     final String comparisonFactorSource = isRequestedBuilderBoostFactor ? "VC" : "BN";
 
-    if (actualBuilderBoostFactor.equals(BUILDER_BOOST_FACTOR_PREFER_EXECUTION)) {
+    if (actualBuilderBoostFactor.equals(BUILDER_BOOST_FACTOR_MAX_PROFIT)) {
+      actualComparisonFactorString = "MAX_PROFIT";
+    } else if (actualBuilderBoostFactor.equals(BUILDER_BOOST_FACTOR_PREFER_EXECUTION)) {
       actualComparisonFactorString = "PREFER_EXECUTION";
     } else if (actualBuilderBoostFactor.equals(BUILDER_BOOST_FACTOR_PREFER_BUILDER)) {
       actualComparisonFactorString = "PREFER_BUILDER";

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionBuilderModule.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionBuilderModule.java
@@ -553,7 +553,7 @@ public class ExecutionBuilderModule {
 
     if (requestedBuilderBoostFactor.isPresent()) {
       // If the requestedBuilderBoostFactor is set,
-      // we always use it to determine whether the local payload wins
+      // we always use it over builderBidCompareFactor to determine whether the local payload wins
       isDefaultComparisonVC =
           requestedBuilderBoostFactor.get().equals(UInt64.valueOf(HUNDRED_PERCENT));
       actualComparisonFactor = requestedBuilderBoostFactor;

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionBuilderModule.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionBuilderModule.java
@@ -547,28 +547,28 @@ public class ExecutionBuilderModule {
       final UInt256 builderBidValue,
       final UInt256 localPayloadValue,
       final Optional<UInt64> requestedBuilderBoostFactor) {
-    final boolean isDefaultComparisonVC;
+    final boolean isDefaultComparison;
     final Optional<?> actualComparisonFactor;
     final Optional<String> comparisonFactorSource;
 
     if (requestedBuilderBoostFactor.isPresent()) {
       // If the requestedBuilderBoostFactor is set,
       // we always use it over builderBidCompareFactor to determine whether the local payload wins
-      isDefaultComparisonVC =
+      isDefaultComparison =
           requestedBuilderBoostFactor.get().equals(UInt64.valueOf(HUNDRED_PERCENT));
       actualComparisonFactor = requestedBuilderBoostFactor;
       comparisonFactorSource = Optional.of("VC");
     } else if (builderBidCompareFactor.isPresent()) {
-      isDefaultComparisonVC = builderBidCompareFactor.get() == HUNDRED_PERCENT;
+      isDefaultComparison = builderBidCompareFactor.get() == HUNDRED_PERCENT;
       actualComparisonFactor = builderBidCompareFactor;
       comparisonFactorSource = Optional.of("BN");
     } else {
-      isDefaultComparisonVC = true;
+      isDefaultComparison = true;
       actualComparisonFactor = Optional.empty();
       comparisonFactorSource = Optional.empty();
     }
 
-    if (isDefaultComparisonVC) {
+    if (isDefaultComparison) {
       LOG.info(
           "Local execution payload ({} ETH) is chosen over builder bid ({} ETH).",
           weiToEth(localPayloadValue),

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionBuilderModule.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionBuilderModule.java
@@ -549,7 +549,7 @@ public class ExecutionBuilderModule {
       final Optional<UInt64> requestedBuilderBoostFactor) {
     final boolean isDefaultComparison;
     final Optional<?> actualComparisonFactor;
-    final Optional<String> comparisonFactorSource;
+    final String comparisonFactorSource;
 
     if (requestedBuilderBoostFactor.isPresent()) {
       // If the requestedBuilderBoostFactor is set,
@@ -557,29 +557,30 @@ public class ExecutionBuilderModule {
       isDefaultComparison =
           requestedBuilderBoostFactor.get().equals(UInt64.valueOf(HUNDRED_PERCENT));
       actualComparisonFactor = requestedBuilderBoostFactor;
-      comparisonFactorSource = Optional.of("VC");
+      comparisonFactorSource = "VC";
     } else if (builderBidCompareFactor.isPresent()) {
       isDefaultComparison = builderBidCompareFactor.get() == HUNDRED_PERCENT;
       actualComparisonFactor = builderBidCompareFactor;
-      comparisonFactorSource = Optional.of("BN");
+      comparisonFactorSource = "BN";
     } else {
       isDefaultComparison = true;
       actualComparisonFactor = Optional.empty();
-      comparisonFactorSource = Optional.empty();
+      comparisonFactorSource = "DEFAULT";
     }
 
     if (isDefaultComparison) {
       LOG.info(
-          "Local execution payload ({} ETH) is chosen over builder bid ({} ETH).",
+          "Local execution payload ({} ETH) is chosen over builder bid ({} ETH, compare factor MAX_PROFIT, compare factor source {}).",
           weiToEth(localPayloadValue),
-          weiToEth(builderBidValue));
+          weiToEth(builderBidValue),
+          comparisonFactorSource);
     } else {
       LOG.info(
           "Local execution payload ({} ETH) is chosen over builder bid ({} ETH, compare factor {}%, compare factor source {}).",
           weiToEth(localPayloadValue),
           weiToEth(builderBidValue),
           actualComparisonFactor.get(),
-          comparisonFactorSource.get());
+          comparisonFactorSource);
     }
   }
 }

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionBuilderModule.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionBuilderModule.java
@@ -131,7 +131,7 @@ public class ExecutionBuilderModule {
       final ExecutionPayloadContext executionPayloadContext,
       final BeaconState state,
       final SafeFuture<UInt256> payloadValueResult,
-      final Optional<UInt64> requestedProposerBoostFactor,
+      final Optional<UInt64> requestedBuilderBoostFactor,
       final BlockProductionPerformance blockProductionPerformance) {
 
     final SafeFuture<GetPayloadResponse> localGetPayloadResponse =
@@ -212,9 +212,8 @@ public class ExecutionBuilderModule {
                 logReceivedBuilderBid(signedBuilderBid.getMessage());
 
                 if (isLocalPayloadValueWinning(
-                    builderBidValue, localBlockValue, requestedProposerBoostFactor)) {
-                  logLocalPayloadWin(
-                      builderBidValue, localBlockValue, requestedProposerBoostFactor);
+                    builderBidValue, localBlockValue, requestedBuilderBoostFactor)) {
+                  logLocalPayloadWin(builderBidValue, localBlockValue, requestedBuilderBoostFactor);
                   return getResultFromLocalGetPayloadResponse(
                       localGetPayloadResponse,
                       slot,
@@ -247,22 +246,22 @@ public class ExecutionBuilderModule {
   private boolean isLocalPayloadValueWinning(
       final UInt256 builderBidValue,
       final UInt256 localPayloadValue,
-      final Optional<UInt64> requestedProposerBoostFactor) {
-    if (requestedProposerBoostFactor.isPresent()) {
-      final UInt64 proposerBoostFactor = requestedProposerBoostFactor.get();
+      final Optional<UInt64> requestedBuilderBoostFactor) {
+    if (requestedBuilderBoostFactor.isPresent()) {
+      final UInt64 builderBoostFactor = requestedBuilderBoostFactor.get();
 
-      LOG.debug("Using requestedProposerBoostFactor " + proposerBoostFactor);
+      LOG.debug("Using requestedBuilderBoostFactor " + builderBoostFactor);
 
-      if (proposerBoostFactor.equals(VC_BUILDER_BOOST_FACTOR_PREFER_EXECUTION)) {
+      if (builderBoostFactor.equals(VC_BUILDER_BOOST_FACTOR_PREFER_EXECUTION)) {
         return true;
       }
 
-      if (proposerBoostFactor.equals(VC_BUILDER_BOOST_FACTOR_PREFER_BUILDER)) {
+      if (builderBoostFactor.equals(VC_BUILDER_BOOST_FACTOR_PREFER_BUILDER)) {
         return false;
       }
 
       return builderBidValue
-          .multiply(UInt256.valueOf(proposerBoostFactor.longValue()))
+          .multiply(UInt256.valueOf(builderBoostFactor.longValue()))
           .lessOrEqualThan(localPayloadValue.multiply(HUNDRED_PERCENT));
     }
 
@@ -547,17 +546,17 @@ public class ExecutionBuilderModule {
   private void logLocalPayloadWin(
       final UInt256 builderBidValue,
       final UInt256 localPayloadValue,
-      final Optional<UInt64> requestedProposerBoostFactor) {
+      final Optional<UInt64> requestedBuilderBoostFactor) {
     final boolean isDefaultComparisonVC;
     final Optional<?> actualComparisonFactor;
     final Optional<String> comparisonFactorSource;
 
-    if (requestedProposerBoostFactor.isPresent()) {
-      // If the requestedProposerBoostFactor is set, we always use it to determine whether the local
-      // payload wins
+    if (requestedBuilderBoostFactor.isPresent()) {
+      // If the requestedBuilderBoostFactor is set,
+      // we always use it to determine whether the local payload wins
       isDefaultComparisonVC =
-          requestedProposerBoostFactor.get().equals(UInt64.valueOf(HUNDRED_PERCENT));
-      actualComparisonFactor = requestedProposerBoostFactor;
+          requestedBuilderBoostFactor.get().equals(UInt64.valueOf(HUNDRED_PERCENT));
+      actualComparisonFactor = requestedBuilderBoostFactor;
       comparisonFactorSource = Optional.of("VC");
     } else if (builderBidCompareFactor.isPresent()) {
       isDefaultComparisonVC = builderBidCompareFactor.get() == HUNDRED_PERCENT;

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerBlockProductionManagerImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerBlockProductionManagerImpl.java
@@ -72,7 +72,7 @@ public class ExecutionLayerBlockProductionManagerImpl
       final ExecutionPayloadContext context,
       final BeaconState blockSlotState,
       final boolean isBlind,
-      final Optional<UInt64> requestedProposerBoostFactor,
+      final Optional<UInt64> requestedBuilderBoostFactor,
       final BlockProductionPerformance blockProductionPerformance) {
     final ExecutionPayloadResult result;
     if (!isBlind) {
@@ -94,7 +94,7 @@ public class ExecutionLayerBlockProductionManagerImpl
     } else {
       result =
           builderGetHeader(
-              context, blockSlotState, requestedProposerBoostFactor, blockProductionPerformance);
+              context, blockSlotState, requestedBuilderBoostFactor, blockProductionPerformance);
     }
     executionResultCache.put(blockSlotState.getSlot(), result);
     return result;
@@ -105,7 +105,7 @@ public class ExecutionLayerBlockProductionManagerImpl
       final ExecutionPayloadContext context,
       final BeaconState blockSlotState,
       final boolean isBlind,
-      final Optional<UInt64> requestedProposerBoostFactor,
+      final Optional<UInt64> requestedBuilderBoostFactor,
       final BlockProductionPerformance blockProductionPerformance) {
     final ExecutionPayloadResult result;
     if (!isBlind) {
@@ -129,7 +129,7 @@ public class ExecutionLayerBlockProductionManagerImpl
     } else {
       result =
           builderGetHeader(
-              context, blockSlotState, requestedProposerBoostFactor, blockProductionPerformance);
+              context, blockSlotState, requestedBuilderBoostFactor, blockProductionPerformance);
     }
     executionResultCache.put(blockSlotState.getSlot(), result);
     return result;
@@ -151,7 +151,7 @@ public class ExecutionLayerBlockProductionManagerImpl
   private ExecutionPayloadResult builderGetHeader(
       final ExecutionPayloadContext executionPayloadContext,
       final BeaconState state,
-      final Optional<UInt64> requestedProposerBoostFactor,
+      final Optional<UInt64> requestedBuilderBoostFactor,
       final BlockProductionPerformance blockProductionPerformance) {
 
     final SafeFuture<UInt256> executionPayloadValueFuture = new SafeFuture<>();
@@ -162,7 +162,7 @@ public class ExecutionLayerBlockProductionManagerImpl
                 executionPayloadContext,
                 state,
                 executionPayloadValueFuture,
-                requestedProposerBoostFactor,
+                requestedBuilderBoostFactor,
                 blockProductionPerformance)
             .whenException(executionPayloadValueFuture::completeExceptionally);
 

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerBlockProductionManagerImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerBlockProductionManagerImpl.java
@@ -72,6 +72,7 @@ public class ExecutionLayerBlockProductionManagerImpl
       final ExecutionPayloadContext context,
       final BeaconState blockSlotState,
       final boolean isBlind,
+      final Optional<UInt64> requestedProposerBoostFactor,
       final BlockProductionPerformance blockProductionPerformance) {
     final ExecutionPayloadResult result;
     if (!isBlind) {
@@ -91,7 +92,9 @@ public class ExecutionLayerBlockProductionManagerImpl
               Optional.empty(),
               Optional.of(executionPayloadValueFuture));
     } else {
-      result = builderGetHeader(context, blockSlotState, blockProductionPerformance);
+      result =
+          builderGetHeader(
+              context, blockSlotState, requestedProposerBoostFactor, blockProductionPerformance);
     }
     executionResultCache.put(blockSlotState.getSlot(), result);
     return result;
@@ -102,6 +105,7 @@ public class ExecutionLayerBlockProductionManagerImpl
       final ExecutionPayloadContext context,
       final BeaconState blockSlotState,
       final boolean isBlind,
+      final Optional<UInt64> requestedProposerBoostFactor,
       final BlockProductionPerformance blockProductionPerformance) {
     final ExecutionPayloadResult result;
     if (!isBlind) {
@@ -123,7 +127,9 @@ public class ExecutionLayerBlockProductionManagerImpl
               Optional.empty(),
               Optional.of(executionPayloadValueFuture));
     } else {
-      result = builderGetHeader(context, blockSlotState, blockProductionPerformance);
+      result =
+          builderGetHeader(
+              context, blockSlotState, requestedProposerBoostFactor, blockProductionPerformance);
     }
     executionResultCache.put(blockSlotState.getSlot(), result);
     return result;
@@ -145,6 +151,7 @@ public class ExecutionLayerBlockProductionManagerImpl
   private ExecutionPayloadResult builderGetHeader(
       final ExecutionPayloadContext executionPayloadContext,
       final BeaconState state,
+      final Optional<UInt64> requestedProposerBoostFactor,
       final BlockProductionPerformance blockProductionPerformance) {
 
     final SafeFuture<UInt256> executionPayloadValueFuture = new SafeFuture<>();
@@ -155,6 +162,7 @@ public class ExecutionLayerBlockProductionManagerImpl
                 executionPayloadContext,
                 state,
                 executionPayloadValueFuture,
+                requestedProposerBoostFactor,
                 blockProductionPerformance)
             .whenException(executionPayloadValueFuture::completeExceptionally);
 

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
@@ -79,7 +79,7 @@ public class ExecutionLayerManagerImpl implements ExecutionLayerManager {
       final MetricsSystem metricsSystem,
       final BuilderBidValidator builderBidValidator,
       final BuilderCircuitBreaker builderCircuitBreaker,
-      final Optional<Integer> builderBidCompareFactor,
+      final UInt64 builderBidCompareFactor,
       final boolean useShouldOverrideBuilderFlag) {
     final LabelledMetric<Counter> executionPayloadSourceCounter =
         metricsSystem.createLabelledCounter(
@@ -146,7 +146,7 @@ public class ExecutionLayerManagerImpl implements ExecutionLayerManager {
       final BuilderBidValidator builderBidValidator,
       final BuilderCircuitBreaker builderCircuitBreaker,
       final LabelledMetric<Counter> executionPayloadSourceCounter,
-      final Optional<Integer> builderBidCompareFactor,
+      final UInt64 builderBidCompareFactor,
       final boolean useShouldOverrideBuilderFlag) {
     this.executionClientHandler = executionClientHandler;
     this.spec = spec;

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
@@ -244,13 +244,13 @@ public class ExecutionLayerManagerImpl implements ExecutionLayerManager {
       final ExecutionPayloadContext executionPayloadContext,
       final BeaconState state,
       final SafeFuture<UInt256> payloadValueResult,
-      final Optional<UInt64> requestedProposerBoostFactor,
+      final Optional<UInt64> requestedBuilderBoostFactor,
       final BlockProductionPerformance blockProductionPerformance) {
     return executionBuilderModule.builderGetHeader(
         executionPayloadContext,
         state,
         payloadValueResult,
-        requestedProposerBoostFactor,
+        requestedBuilderBoostFactor,
         blockProductionPerformance);
   }
 

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
@@ -244,9 +244,14 @@ public class ExecutionLayerManagerImpl implements ExecutionLayerManager {
       final ExecutionPayloadContext executionPayloadContext,
       final BeaconState state,
       final SafeFuture<UInt256> payloadValueResult,
+      final Optional<UInt64> requestedProposerBoostFactor,
       final BlockProductionPerformance blockProductionPerformance) {
     return executionBuilderModule.builderGetHeader(
-        executionPayloadContext, state, payloadValueResult, blockProductionPerformance);
+        executionPayloadContext,
+        state,
+        payloadValueResult,
+        requestedProposerBoostFactor,
+        blockProductionPerformance);
   }
 
   @VisibleForTesting

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerStub.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerStub.java
@@ -56,7 +56,7 @@ public class ExecutionLayerManagerStub extends ExecutionLayerChannelStub
       final ExecutionPayloadContext executionPayloadContext,
       final BeaconState state,
       final SafeFuture<UInt256> payloadValueResult,
-      final Optional<UInt64> requestedProposerBoostFactor,
+      final Optional<UInt64> requestedBuilderBoostFactor,
       final BlockProductionPerformance blockProductionPerformance) {
     boolean builderCircuitBreakerEngaged = builderCircuitBreaker.isEngaged(state);
     LOG.info("Builder Circuit Breaker isEngaged: " + builderCircuitBreakerEngaged);
@@ -65,7 +65,7 @@ public class ExecutionLayerManagerStub extends ExecutionLayerChannelStub
             executionPayloadContext,
             state,
             payloadValueResult,
-            requestedProposerBoostFactor,
+            requestedBuilderBoostFactor,
             blockProductionPerformance)
         .thenCompose(
             headerWithFallbackData -> {

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerStub.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerStub.java
@@ -56,12 +56,17 @@ public class ExecutionLayerManagerStub extends ExecutionLayerChannelStub
       final ExecutionPayloadContext executionPayloadContext,
       final BeaconState state,
       final SafeFuture<UInt256> payloadValueResult,
+      final Optional<UInt64> requestedProposerBoostFactor,
       final BlockProductionPerformance blockProductionPerformance) {
     boolean builderCircuitBreakerEngaged = builderCircuitBreaker.isEngaged(state);
     LOG.info("Builder Circuit Breaker isEngaged: " + builderCircuitBreakerEngaged);
 
     return super.builderGetHeader(
-            executionPayloadContext, state, payloadValueResult, blockProductionPerformance)
+            executionPayloadContext,
+            state,
+            payloadValueResult,
+            requestedProposerBoostFactor,
+            blockProductionPerformance)
         .thenCompose(
             headerWithFallbackData -> {
               if (builderCircuitBreakerEngaged) {

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerBlockProductionManagerImplTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerBlockProductionManagerImplTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.ethereum.executionlayer.ExecutionBuilderModule.BUILDER_BOOST_FACTOR_MAX_PROFIT;
 
 import java.util.Optional;
 import org.apache.tuweni.units.bigints.UInt256;
@@ -558,7 +559,7 @@ class ExecutionLayerBlockProductionManagerImplTest {
             ? new BuilderBidValidatorImpl(spec, eventLogger)
             : BuilderBidValidator.NOOP,
         builderCircuitBreaker,
-        Optional.of(100),
+            BUILDER_BOOST_FACTOR_MAX_PROFIT,
         true);
   }
 

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerBlockProductionManagerImplTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerBlockProductionManagerImplTest.java
@@ -559,7 +559,7 @@ class ExecutionLayerBlockProductionManagerImplTest {
             ? new BuilderBidValidatorImpl(spec, eventLogger)
             : BuilderBidValidator.NOOP,
         builderCircuitBreaker,
-            BUILDER_BOOST_FACTOR_MAX_PROFIT,
+        BUILDER_BOOST_FACTOR_MAX_PROFIT,
         true);
   }
 

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerBlockProductionManagerImplTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerBlockProductionManagerImplTest.java
@@ -110,7 +110,11 @@ class ExecutionLayerBlockProductionManagerImplTest {
 
     final ExecutionPayloadResult executionPayloadResult =
         blockProductionManager.initiateBlockProduction(
-            executionPayloadContext, state, true, BlockProductionPerformance.NOOP);
+            executionPayloadContext,
+            state,
+            true,
+            Optional.empty(),
+            BlockProductionPerformance.NOOP);
     assertThat(executionPayloadResult.getExecutionPayloadContext())
         .isEqualTo(executionPayloadContext);
     assertThat(executionPayloadResult.getExecutionPayloadFuture()).isEmpty();
@@ -164,7 +168,11 @@ class ExecutionLayerBlockProductionManagerImplTest {
 
     final ExecutionPayloadResult executionPayloadResult =
         blockProductionManager.initiateBlockProduction(
-            executionPayloadContext, state, true, BlockProductionPerformance.NOOP);
+            executionPayloadContext,
+            state,
+            true,
+            Optional.empty(),
+            BlockProductionPerformance.NOOP);
     assertThat(executionPayloadResult.getExecutionPayloadContext())
         .isEqualTo(executionPayloadContext);
     assertThat(executionPayloadResult.getExecutionPayloadFuture()).isEmpty();
@@ -209,7 +217,11 @@ class ExecutionLayerBlockProductionManagerImplTest {
 
     final ExecutionPayloadResult executionPayloadResult =
         blockProductionManager.initiateBlockProduction(
-            executionPayloadContext, state, false, BlockProductionPerformance.NOOP);
+            executionPayloadContext,
+            state,
+            false,
+            Optional.empty(),
+            BlockProductionPerformance.NOOP);
     assertThat(executionPayloadResult.getExecutionPayloadContext())
         .isEqualTo(executionPayloadContext);
     assertThat(executionPayloadResult.getHeaderWithFallbackDataFuture()).isEmpty();
@@ -260,7 +272,11 @@ class ExecutionLayerBlockProductionManagerImplTest {
 
     final ExecutionPayloadResult executionPayloadResult =
         blockProductionManager.initiateBlockAndBlobsProduction(
-            executionPayloadContext, state, true, BlockProductionPerformance.NOOP);
+            executionPayloadContext,
+            state,
+            true,
+            Optional.empty(),
+            BlockProductionPerformance.NOOP);
     assertThat(executionPayloadResult.getExecutionPayloadContext())
         .isEqualTo(executionPayloadContext);
     assertThat(executionPayloadResult.getExecutionPayloadFuture()).isEmpty();
@@ -314,7 +330,11 @@ class ExecutionLayerBlockProductionManagerImplTest {
 
     final ExecutionPayloadResult executionPayloadResult =
         blockProductionManager.initiateBlockAndBlobsProduction(
-            executionPayloadContext, state, true, BlockProductionPerformance.NOOP);
+            executionPayloadContext,
+            state,
+            true,
+            Optional.empty(),
+            BlockProductionPerformance.NOOP);
     assertThat(executionPayloadResult.getExecutionPayloadContext())
         .isEqualTo(executionPayloadContext);
     assertThat(executionPayloadResult.getExecutionPayloadFuture()).isEmpty();
@@ -360,7 +380,11 @@ class ExecutionLayerBlockProductionManagerImplTest {
 
     final ExecutionPayloadResult executionPayloadResult =
         blockProductionManager.initiateBlockAndBlobsProduction(
-            executionPayloadContext, state, false, BlockProductionPerformance.NOOP);
+            executionPayloadContext,
+            state,
+            false,
+            Optional.empty(),
+            BlockProductionPerformance.NOOP);
     assertThat(executionPayloadResult.getExecutionPayloadContext())
         .isEqualTo(executionPayloadContext);
     assertThat(executionPayloadResult.getHeaderWithFallbackDataFuture()).isEmpty();

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImplTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImplTest.java
@@ -22,6 +22,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.ethereum.executionlayer.ExecutionBuilderModule.BUILDER_BOOST_FACTOR_MAX_PROFIT;
+import static tech.pegasys.teku.ethereum.executionlayer.ExecutionBuilderModule.BUILDER_BOOST_FACTOR_PREFER_BUILDER;
 
 import java.util.Optional;
 import java.util.stream.IntStream;
@@ -345,7 +347,7 @@ class ExecutionLayerManagerImplTest {
   public void
       builderGetHeaderGetPayload_shouldReturnEnginePayloadWhenValueLowerButBetterWithFactor() {
     // Setup requires local payload to have at lest 50% value of builder's to win
-    executionLayerManager = createExecutionLayerChannelImpl(true, false, Optional.of(50));
+    executionLayerManager = createExecutionLayerChannelImpl(true, false, UInt64.valueOf(50));
     setBuilderOnline();
 
     final ExecutionPayloadContext executionPayloadContext =
@@ -392,7 +394,7 @@ class ExecutionLayerManagerImplTest {
   @Test
   public void builderGetHeaderGetPayload_shouldReturnBuilderPayloadWhenBuilderWonLocal() {
     // Setup requires local payload to have at lest 50% value of builder's to win
-    executionLayerManager = createExecutionLayerChannelImpl(true, false, Optional.of(50));
+    executionLayerManager = createExecutionLayerChannelImpl(true, false, UInt64.valueOf(50));
     setBuilderOnline();
 
     final ExecutionPayloadContext executionPayloadContext =
@@ -424,7 +426,7 @@ class ExecutionLayerManagerImplTest {
   @Test
   public void builderGetHeaderGetPayload_shouldGivePriorityToRequestedBuilderBoostFactor() {
     // Beacon node setup requires local payload to have at lest 50% value of builder's to win
-    executionLayerManager = createExecutionLayerChannelImpl(true, false, Optional.of(50));
+    executionLayerManager = createExecutionLayerChannelImpl(true, false, UInt64.valueOf(50));
     setBuilderOnline();
 
     final ExecutionPayloadContext executionPayloadContext =
@@ -474,7 +476,8 @@ class ExecutionLayerManagerImplTest {
   public void
       builderGetHeaderGetPayload_shouldReturnBuilderPayloadWhenBuilderFactorIsAlwaysBuilder() {
     // Setup will always ignore local payload in favor of Builder bid
-    executionLayerManager = createExecutionLayerChannelImpl(true, false, Optional.empty());
+    executionLayerManager =
+        createExecutionLayerChannelImpl(true, false, BUILDER_BOOST_FACTOR_PREFER_BUILDER);
     setBuilderOnline();
 
     final ExecutionPayloadContext executionPayloadContext =
@@ -508,7 +511,8 @@ class ExecutionLayerManagerImplTest {
   public void
       builderGetHeaderGetPayload_shouldReturnLocalPayloadWhenBuilderFactorIsAlwaysBuilderAndBidValidationFails() {
     // Setup will always ignore local payload in favor of Builder bid
-    executionLayerManager = createExecutionLayerChannelImpl(true, true, Optional.empty());
+    executionLayerManager =
+        createExecutionLayerChannelImpl(true, true, BUILDER_BOOST_FACTOR_PREFER_BUILDER);
     setBuilderOnline();
 
     final ExecutionPayloadContext executionPayloadContext =
@@ -1157,13 +1161,13 @@ class ExecutionLayerManagerImplTest {
   private ExecutionLayerManagerImpl createExecutionLayerChannelImpl(
       final boolean builderEnabled, final boolean builderValidatorEnabled) {
     return createExecutionLayerChannelImpl(
-        builderEnabled, builderValidatorEnabled, Optional.of(100));
+        builderEnabled, builderValidatorEnabled, BUILDER_BOOST_FACTOR_MAX_PROFIT);
   }
 
   private ExecutionLayerManagerImpl createExecutionLayerChannelImpl(
       final boolean builderEnabled,
       final boolean builderValidatorEnabled,
-      final Optional<Integer> builderBidCompareFactor) {
+      final UInt64 builderBidCompareFactor) {
     when(builderCircuitBreaker.isEngaged(any())).thenReturn(false);
     return ExecutionLayerManagerImpl.create(
         eventLogger,

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImplTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImplTest.java
@@ -422,7 +422,7 @@ class ExecutionLayerManagerImplTest {
   }
 
   @Test
-  public void builderGetHeaderGetPayload_shouldGivePriorityToRequestedProposerBoostFactor() {
+  public void builderGetHeaderGetPayload_shouldGivePriorityToRequestedBuilderBoostFactor() {
     // Beacon node setup requires local payload to have at lest 50% value of builder's to win
     executionLayerManager = createExecutionLayerChannelImpl(true, false, Optional.of(50));
     setBuilderOnline();
@@ -457,7 +457,7 @@ class ExecutionLayerManagerImplTest {
             expectedHeader,
             new FallbackData(localExecutionPayload, FallbackReason.LOCAL_BLOCK_VALUE_WON));
     final SafeFuture<UInt256> blockValueResult = new SafeFuture<>();
-    // we set the requestedProposerBoostFactor to 48% so that the local value will win
+    // we set the requestedBuilderBoostFactor to 48% so that the local value will win
     assertThat(
             executionLayerManager.builderGetHeader(
                 executionPayloadContext,

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImplTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImplTest.java
@@ -216,7 +216,11 @@ class ExecutionLayerManagerImplTest {
     // we expect result from the builder
     assertThat(
             executionLayerManager.builderGetHeader(
-                executionPayloadContext, state, blockValueResult, BlockProductionPerformance.NOOP))
+                executionPayloadContext,
+                state,
+                blockValueResult,
+                Optional.empty(),
+                BlockProductionPerformance.NOOP))
         .isCompletedWithValue(HeaderWithFallbackData.create(header));
     assertThat(blockValueResult).isCompletedWithValue(builderExecutionPayloadValue);
 
@@ -262,7 +266,11 @@ class ExecutionLayerManagerImplTest {
     // we expect result from the builder
     assertThat(
             executionLayerManager.builderGetHeader(
-                executionPayloadContext, state, blockValueResult, BlockProductionPerformance.NOOP))
+                executionPayloadContext,
+                state,
+                blockValueResult,
+                Optional.empty(),
+                BlockProductionPerformance.NOOP))
         .isCompletedWithValue(HeaderWithFallbackData.create(header));
     assertThat(blockValueResult).isCompletedWithValue(builderExecutionPayloadValue);
 
@@ -323,7 +331,11 @@ class ExecutionLayerManagerImplTest {
     final SafeFuture<UInt256> blockValueResult = new SafeFuture<>();
     assertThat(
             executionLayerManager.builderGetHeader(
-                executionPayloadContext, state, blockValueResult, BlockProductionPerformance.NOOP))
+                executionPayloadContext,
+                state,
+                blockValueResult,
+                Optional.empty(),
+                BlockProductionPerformance.NOOP))
         .isCompletedWithValue(expectedResult);
     assertThat(blockValueResult).isCompletedWithValue(localValueOverride);
     verifyFallbackToLocalEL(slot, executionPayloadContext, expectedResult);
@@ -367,7 +379,11 @@ class ExecutionLayerManagerImplTest {
     final SafeFuture<UInt256> blockValueResult = new SafeFuture<>();
     assertThat(
             executionLayerManager.builderGetHeader(
-                executionPayloadContext, state, blockValueResult, BlockProductionPerformance.NOOP))
+                executionPayloadContext,
+                state,
+                blockValueResult,
+                Optional.empty(),
+                BlockProductionPerformance.NOOP))
         .isCompletedWithValue(expectedResult);
     assertThat(blockValueResult).isCompletedWithValue(localValueOverride);
     verifyFallbackToLocalEL(slot, executionPayloadContext, expectedResult);
@@ -396,7 +412,11 @@ class ExecutionLayerManagerImplTest {
     final SafeFuture<UInt256> blockValueResult = new SafeFuture<>();
     assertThat(
             executionLayerManager.builderGetHeader(
-                executionPayloadContext, state, blockValueResult, BlockProductionPerformance.NOOP))
+                executionPayloadContext,
+                state,
+                blockValueResult,
+                Optional.empty(),
+                BlockProductionPerformance.NOOP))
         .isCompletedWithValue(expectedResult);
     assertThat(blockValueResult).isCompletedWithValue(builderExecutionPayloadValue);
   }
@@ -426,7 +446,11 @@ class ExecutionLayerManagerImplTest {
     final SafeFuture<UInt256> blockValueResult = new SafeFuture<>();
     assertThat(
             executionLayerManager.builderGetHeader(
-                executionPayloadContext, state, blockValueResult, BlockProductionPerformance.NOOP))
+                executionPayloadContext,
+                state,
+                blockValueResult,
+                Optional.empty(),
+                BlockProductionPerformance.NOOP))
         .isCompletedWithValue(expectedResult);
     assertThat(blockValueResult).isCompletedWithValue(builderExecutionPayloadValue);
   }
@@ -463,7 +487,11 @@ class ExecutionLayerManagerImplTest {
     final SafeFuture<UInt256> blockValueResult = new SafeFuture<>();
     assertThat(
             executionLayerManager.builderGetHeader(
-                executionPayloadContext, state, blockValueResult, BlockProductionPerformance.NOOP))
+                executionPayloadContext,
+                state,
+                blockValueResult,
+                Optional.empty(),
+                BlockProductionPerformance.NOOP))
         .isCompletedWithValue(expectedResult);
     assertThat(blockValueResult).isCompletedWithValue(localExecutionPayloadValue);
 
@@ -499,7 +527,11 @@ class ExecutionLayerManagerImplTest {
     final SafeFuture<UInt256> blockValueResult = new SafeFuture<>();
     assertThat(
             executionLayerManager.builderGetHeader(
-                executionPayloadContext, state, blockValueResult, BlockProductionPerformance.NOOP))
+                executionPayloadContext,
+                state,
+                blockValueResult,
+                Optional.empty(),
+                BlockProductionPerformance.NOOP))
         .isCompletedWithValue(expectedResult);
     assertThat(blockValueResult).isCompletedWithValue(localExecutionPayloadValue);
 
@@ -577,7 +609,11 @@ class ExecutionLayerManagerImplTest {
     final SafeFuture<UInt256> blockValueResult = new SafeFuture<>();
     assertThat(
             executionLayerManager.builderGetHeader(
-                executionPayloadContext, state, blockValueResult, BlockProductionPerformance.NOOP))
+                executionPayloadContext,
+                state,
+                blockValueResult,
+                Optional.empty(),
+                BlockProductionPerformance.NOOP))
         .isCompletedWithValue(expectedResult);
     assertThat(blockValueResult).isCompletedWithValue(localExecutionPayloadValue);
     verifyFallbackToLocalEL(slot, executionPayloadContext, expectedResult);
@@ -614,7 +650,11 @@ class ExecutionLayerManagerImplTest {
     final SafeFuture<UInt256> blockValueResult = new SafeFuture<>();
     assertThat(
             executionLayerManager.builderGetHeader(
-                executionPayloadContext, state, blockValueResult, BlockProductionPerformance.NOOP))
+                executionPayloadContext,
+                state,
+                blockValueResult,
+                Optional.empty(),
+                BlockProductionPerformance.NOOP))
         .isCompletedWithValue(expectedResult);
     assertThat(blockValueResult).isCompletedWithValue(localExecutionPayloadValue);
 
@@ -649,7 +689,11 @@ class ExecutionLayerManagerImplTest {
     final SafeFuture<UInt256> blockValueResult = new SafeFuture<>();
     assertThat(
             executionLayerManager.builderGetHeader(
-                executionPayloadContext, state, blockValueResult, BlockProductionPerformance.NOOP))
+                executionPayloadContext,
+                state,
+                blockValueResult,
+                Optional.empty(),
+                BlockProductionPerformance.NOOP))
         .isCompletedWithValue(expectedResult);
     assertThat(blockValueResult).isCompletedWithValue(localExecutionPayloadValue);
 
@@ -687,7 +731,11 @@ class ExecutionLayerManagerImplTest {
     final SafeFuture<UInt256> blockValueResult = new SafeFuture<>();
     assertThat(
             executionLayerManager.builderGetHeader(
-                executionPayloadContext, state, blockValueResult, BlockProductionPerformance.NOOP))
+                executionPayloadContext,
+                state,
+                blockValueResult,
+                Optional.empty(),
+                BlockProductionPerformance.NOOP))
         .isCompletedWithValue(expectedResult);
     assertThat(blockValueResult).isCompletedWithValue(localExecutionPayloadValue);
 
@@ -723,7 +771,11 @@ class ExecutionLayerManagerImplTest {
     final SafeFuture<UInt256> blockValueResult = new SafeFuture<>();
     assertThat(
             executionLayerManager.builderGetHeader(
-                executionPayloadContext, state, blockValueResult, BlockProductionPerformance.NOOP))
+                executionPayloadContext,
+                state,
+                blockValueResult,
+                Optional.empty(),
+                BlockProductionPerformance.NOOP))
         .isCompletedWithValue(expectedResult);
     assertThat(blockValueResult).isCompletedWithValue(localExecutionPayloadValue);
 
@@ -761,7 +813,11 @@ class ExecutionLayerManagerImplTest {
     final SafeFuture<UInt256> blockValueResult = new SafeFuture<>();
     assertThat(
             executionLayerManager.builderGetHeader(
-                executionPayloadContext, state, blockValueResult, BlockProductionPerformance.NOOP))
+                executionPayloadContext,
+                state,
+                blockValueResult,
+                Optional.empty(),
+                BlockProductionPerformance.NOOP))
         .isCompletedWithValue(expectedResult);
     assertThat(blockValueResult).isCompletedWithValue(localExecutionPayloadValue);
 
@@ -799,7 +855,11 @@ class ExecutionLayerManagerImplTest {
     final SafeFuture<UInt256> blockValueResult = new SafeFuture<>();
     assertThat(
             executionLayerManager.builderGetHeader(
-                executionPayloadContext, state, blockValueResult, BlockProductionPerformance.NOOP))
+                executionPayloadContext,
+                state,
+                blockValueResult,
+                Optional.empty(),
+                BlockProductionPerformance.NOOP))
         .isCompletedWithValue(expectedResult);
     assertThat(blockValueResult).isCompletedWithValue(localExecutionPayloadValue);
 
@@ -835,7 +895,11 @@ class ExecutionLayerManagerImplTest {
     final SafeFuture<UInt256> blockValueResult = new SafeFuture<>();
     assertThat(
             executionLayerManager.builderGetHeader(
-                executionPayloadContext, state, blockValueResult, BlockProductionPerformance.NOOP))
+                executionPayloadContext,
+                state,
+                blockValueResult,
+                Optional.empty(),
+                BlockProductionPerformance.NOOP))
         .isCompletedWithValue(expectedResult);
     assertThat(blockValueResult).isCompletedWithValue(localExecutionPayloadValue);
 
@@ -860,6 +924,7 @@ class ExecutionLayerManagerImplTest {
                           executionPayloadContext,
                           state,
                           SafeFuture.completedFuture(localExecutionPayloadValue),
+                          Optional.empty(),
                           BlockProductionPerformance.NOOP))
                   .isCompleted();
             });

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerBlockProductionManager.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerBlockProductionManager.java
@@ -42,6 +42,7 @@ public interface ExecutionLayerBlockProductionManager {
             final ExecutionPayloadContext context,
             final BeaconState blockSlotState,
             final boolean isBlind,
+            final Optional<UInt64> requestedProposerBoostFactor,
             final BlockProductionPerformance blockProductionPerformance) {
           return null;
         }
@@ -51,6 +52,7 @@ public interface ExecutionLayerBlockProductionManager {
             final ExecutionPayloadContext context,
             final BeaconState blockSlotState,
             final boolean isBlind,
+            final Optional<UInt64> requestedProposerBoostFactor,
             final BlockProductionPerformance blockProductionPerformance) {
           return null;
         }
@@ -73,6 +75,7 @@ public interface ExecutionLayerBlockProductionManager {
    * @param context Payload context
    * @param blockSlotState pre state
    * @param isBlind Block type. Use blind for builder building
+   * @param requestedProposerBoostFactor The proposer boost factor requested by vc
    * @param blockProductionPerformance Block production performance tracker
    * @return Container with filled Payload or Payload Header futures
    */
@@ -80,6 +83,7 @@ public interface ExecutionLayerBlockProductionManager {
       ExecutionPayloadContext context,
       BeaconState blockSlotState,
       boolean isBlind,
+      Optional<UInt64> requestedProposerBoostFactor,
       BlockProductionPerformance blockProductionPerformance);
 
   /**
@@ -89,6 +93,7 @@ public interface ExecutionLayerBlockProductionManager {
    * @param context Payload context
    * @param blockSlotState pre state
    * @param isBlind Block type. Use blind for builder building
+   * @param requestedProposerBoostFactor The proposer boost factor requested by vc
    * @param blockProductionPerformance Block production performance tracker
    * @return Container with filled Payload or Payload Header futures
    */
@@ -96,12 +101,13 @@ public interface ExecutionLayerBlockProductionManager {
       ExecutionPayloadContext context,
       BeaconState blockSlotState,
       boolean isBlind,
+      Optional<UInt64> requestedProposerBoostFactor,
       BlockProductionPerformance blockProductionPerformance);
 
   /**
    * Required {@link #initiateBlockProduction(ExecutionPayloadContext, BeaconState, boolean,
-   * BlockProductionPerformance)} or {@link
-   * #initiateBlockAndBlobsProduction(ExecutionPayloadContext, BeaconState, boolean,
+   * Optional, BlockProductionPerformance)} or {@link
+   * #initiateBlockAndBlobsProduction(ExecutionPayloadContext, BeaconState, boolean, Optional,
    * BlockProductionPerformance)} to have been called first in order for a value to be present
    */
   Optional<ExecutionPayloadResult> getCachedPayloadResult(UInt64 slot);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerBlockProductionManager.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerBlockProductionManager.java
@@ -42,7 +42,7 @@ public interface ExecutionLayerBlockProductionManager {
             final ExecutionPayloadContext context,
             final BeaconState blockSlotState,
             final boolean isBlind,
-            final Optional<UInt64> requestedProposerBoostFactor,
+            final Optional<UInt64> requestedBuilderBoostFactor,
             final BlockProductionPerformance blockProductionPerformance) {
           return null;
         }
@@ -52,7 +52,7 @@ public interface ExecutionLayerBlockProductionManager {
             final ExecutionPayloadContext context,
             final BeaconState blockSlotState,
             final boolean isBlind,
-            final Optional<UInt64> requestedProposerBoostFactor,
+            final Optional<UInt64> requestedBuilderBoostFactor,
             final BlockProductionPerformance blockProductionPerformance) {
           return null;
         }
@@ -75,7 +75,7 @@ public interface ExecutionLayerBlockProductionManager {
    * @param context Payload context
    * @param blockSlotState pre state
    * @param isBlind Block type. Use blind for builder building
-   * @param requestedProposerBoostFactor The proposer boost factor requested by vc
+   * @param requestedBuilderBoostFactor The proposer boost factor requested by vc
    * @param blockProductionPerformance Block production performance tracker
    * @return Container with filled Payload or Payload Header futures
    */
@@ -83,7 +83,7 @@ public interface ExecutionLayerBlockProductionManager {
       ExecutionPayloadContext context,
       BeaconState blockSlotState,
       boolean isBlind,
-      Optional<UInt64> requestedProposerBoostFactor,
+      Optional<UInt64> requestedBuilderBoostFactor,
       BlockProductionPerformance blockProductionPerformance);
 
   /**
@@ -93,7 +93,7 @@ public interface ExecutionLayerBlockProductionManager {
    * @param context Payload context
    * @param blockSlotState pre state
    * @param isBlind Block type. Use blind for builder building
-   * @param requestedProposerBoostFactor The proposer boost factor requested by vc
+   * @param requestedBuilderBoostFactor The proposer boost factor requested by vc
    * @param blockProductionPerformance Block production performance tracker
    * @return Container with filled Payload or Payload Header futures
    */
@@ -101,7 +101,7 @@ public interface ExecutionLayerBlockProductionManager {
       ExecutionPayloadContext context,
       BeaconState blockSlotState,
       boolean isBlind,
-      Optional<UInt64> requestedProposerBoostFactor,
+      Optional<UInt64> requestedBuilderBoostFactor,
       BlockProductionPerformance blockProductionPerformance);
 
   /**

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannel.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannel.java
@@ -88,6 +88,7 @@ public interface ExecutionLayerChannel extends ChannelInterface {
             final ExecutionPayloadContext executionPayloadContext,
             final BeaconState state,
             final SafeFuture<UInt256> payloadValueResult,
+            final Optional<UInt64> requestedProposerBoostFactor,
             final BlockProductionPerformance blockProductionPerformance) {
           payloadValueResult.complete(null);
           return SafeFuture.completedFuture(null);
@@ -109,7 +110,7 @@ public interface ExecutionLayerChannel extends ChannelInterface {
   /**
    * This is low level method, use {@link
    * ExecutionLayerBlockProductionManager#initiateBlockProduction(ExecutionPayloadContext,
-   * BeaconState, boolean, BlockProductionPerformance)} instead
+   * BeaconState, boolean, Optional, BlockProductionPerformance)} instead
    */
   SafeFuture<GetPayloadResponse> engineGetPayload(
       ExecutionPayloadContext executionPayloadContext, UInt64 slot);
@@ -129,7 +130,7 @@ public interface ExecutionLayerChannel extends ChannelInterface {
   /**
    * This is low level method, use {@link
    * ExecutionLayerBlockProductionManager#initiateBlockProduction(ExecutionPayloadContext,
-   * BeaconState, boolean, BlockProductionPerformance)} instead
+   * BeaconState, boolean, Optional, BlockProductionPerformance)} instead
    *
    * @param executionPayloadContext The execution payload context
    * @param state The beacon state
@@ -141,5 +142,6 @@ public interface ExecutionLayerChannel extends ChannelInterface {
       ExecutionPayloadContext executionPayloadContext,
       BeaconState state,
       SafeFuture<UInt256> payloadValueResult,
+      Optional<UInt64> requestedProposerBoostFactor,
       BlockProductionPerformance blockProductionPerformance);
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannel.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannel.java
@@ -88,7 +88,7 @@ public interface ExecutionLayerChannel extends ChannelInterface {
             final ExecutionPayloadContext executionPayloadContext,
             final BeaconState state,
             final SafeFuture<UInt256> payloadValueResult,
-            final Optional<UInt64> requestedProposerBoostFactor,
+            final Optional<UInt64> requestedBuilderBoostFactor,
             final BlockProductionPerformance blockProductionPerformance) {
           payloadValueResult.complete(null);
           return SafeFuture.completedFuture(null);
@@ -142,6 +142,6 @@ public interface ExecutionLayerChannel extends ChannelInterface {
       ExecutionPayloadContext executionPayloadContext,
       BeaconState state,
       SafeFuture<UInt256> payloadValueResult,
-      Optional<UInt64> requestedProposerBoostFactor,
+      Optional<UInt64> requestedBuilderBoostFactor,
       BlockProductionPerformance blockProductionPerformance);
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
@@ -323,7 +323,7 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
       final ExecutionPayloadContext executionPayloadContext,
       final BeaconState state,
       final SafeFuture<UInt256> payloadValueResult,
-      final Optional<UInt64> requestedProposerBoostFactor,
+      final Optional<UInt64> requestedBuilderBoostFactor,
       final BlockProductionPerformance blockProductionPerformance) {
     final UInt64 slot = state.getSlot();
     LOG.info(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
@@ -323,6 +323,7 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
       final ExecutionPayloadContext executionPayloadContext,
       final BeaconState state,
       final SafeFuture<UInt256> payloadValueResult,
+      final Optional<UInt64> requestedProposerBoostFactor,
       final BlockProductionPerformance blockProductionPerformance) {
     final UInt64 slot = state.getSlot();
     LOG.info(

--- a/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerConfiguration.java
+++ b/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerConfiguration.java
@@ -302,7 +302,7 @@ public class ExecutionLayerConfiguration {
       }
       final UInt64 builderBidCompareFactorUint64;
       try {
-        builderBidCompareFactorUint64 = UInt64.valueOf(Integer.parseInt(builderBidCompareFactor));
+        builderBidCompareFactorUint64 = UInt64.valueOf(builderBidCompareFactor);
       } catch (final IllegalArgumentException ex) {
         throw new InvalidConfigurationException(
             "Expecting a number >= 0, percentage or "

--- a/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerConfiguration.java
+++ b/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerConfiguration.java
@@ -303,7 +303,7 @@ public class ExecutionLayerConfiguration {
       final UInt64 builderBidCompareFactorUint64;
       try {
         builderBidCompareFactorUint64 = UInt64.valueOf(Integer.parseInt(builderBidCompareFactor));
-      } catch (final NumberFormatException | ArithmeticException ex) {
+      } catch (final IllegalArgumentException ex) {
         throw new InvalidConfigurationException(
             "Expecting a number >= 0, percentage or "
                 + BUILDER_ALWAYS_KEYWORD

--- a/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerConfiguration.java
+++ b/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerConfiguration.java
@@ -35,8 +35,7 @@ public class ExecutionLayerConfiguration {
   public static final int DEFAULT_BUILDER_CIRCUIT_BREAKER_ALLOWED_FAULTS = 5;
   public static final int DEFAULT_BUILDER_CIRCUIT_BREAKER_ALLOWED_CONSECUTIVE_FAULTS = 3;
   public static final int BUILDER_CIRCUIT_BREAKER_WINDOW_HARD_CAP = 64;
-  public static final UInt64 DEFAULT_BUILDER_BID_COMPARE_FACTOR =
-          BUILDER_BOOST_FACTOR_MAX_PROFIT;
+  public static final UInt64 DEFAULT_BUILDER_BID_COMPARE_FACTOR = BUILDER_BOOST_FACTOR_MAX_PROFIT;
   public static final boolean DEFAULT_BUILDER_SET_USER_AGENT_HEADER = true;
   public static final boolean DEFAULT_USE_SHOULD_OVERRIDE_BUILDER_FLAG = true;
   public static final boolean DEFAULT_EXCHANGE_CAPABILITIES_MONITORING_ENABLED = true;

--- a/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerConfiguration.java
+++ b/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerConfiguration.java
@@ -13,8 +13,9 @@
 
 package tech.pegasys.teku.services.executionlayer;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+import static tech.pegasys.teku.ethereum.executionlayer.ExecutionBuilderModule.BUILDER_BOOST_FACTOR_MAX_PROFIT;
+import static tech.pegasys.teku.ethereum.executionlayer.ExecutionBuilderModule.BUILDER_BOOST_FACTOR_PREFER_BUILDER;
 import static tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannel.STUB_ENDPOINT_PREFIX;
 
 import java.util.Optional;
@@ -22,6 +23,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.infrastructure.exceptions.InvalidConfigurationException;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 
@@ -33,7 +35,8 @@ public class ExecutionLayerConfiguration {
   public static final int DEFAULT_BUILDER_CIRCUIT_BREAKER_ALLOWED_FAULTS = 5;
   public static final int DEFAULT_BUILDER_CIRCUIT_BREAKER_ALLOWED_CONSECUTIVE_FAULTS = 3;
   public static final int BUILDER_CIRCUIT_BREAKER_WINDOW_HARD_CAP = 64;
-  public static final int DEFAULT_BUILDER_BID_COMPARE_FACTOR = 100;
+  public static final UInt64 DEFAULT_BUILDER_BID_COMPARE_FACTOR =
+          BUILDER_BOOST_FACTOR_MAX_PROFIT;
   public static final boolean DEFAULT_BUILDER_SET_USER_AGENT_HEADER = true;
   public static final boolean DEFAULT_USE_SHOULD_OVERRIDE_BUILDER_FLAG = true;
   public static final boolean DEFAULT_EXCHANGE_CAPABILITIES_MONITORING_ENABLED = true;
@@ -48,7 +51,7 @@ public class ExecutionLayerConfiguration {
   private final int builderCircuitBreakerWindow;
   private final int builderCircuitBreakerAllowedFaults;
   private final int builderCircuitBreakerAllowedConsecutiveFaults;
-  private final Optional<Integer> builderBidCompareFactor;
+  private final UInt64 builderBidCompareFactor;
   private final boolean builderSetUserAgentHeader;
   private final boolean useShouldOverrideBuilderFlag;
   private final boolean exchangeCapabilitiesMonitoringEnabled;
@@ -63,7 +66,7 @@ public class ExecutionLayerConfiguration {
       final int builderCircuitBreakerWindow,
       final int builderCircuitBreakerAllowedFaults,
       final int builderCircuitBreakerAllowedConsecutiveFaults,
-      final Optional<Integer> builderBidCompareFactor,
+      final UInt64 builderBidCompareFactor,
       final boolean builderSetUserAgentHeader,
       final boolean useShouldOverrideBuilderFlag,
       final boolean exchangeCapabilitiesMonitoringEnabled) {
@@ -130,7 +133,7 @@ public class ExecutionLayerConfiguration {
     return builderCircuitBreakerAllowedConsecutiveFaults;
   }
 
-  public Optional<Integer> getBuilderBidCompareFactor() {
+  public UInt64 getBuilderBidCompareFactor() {
     return builderBidCompareFactor;
   }
 
@@ -157,7 +160,7 @@ public class ExecutionLayerConfiguration {
     private int builderCircuitBreakerAllowedFaults = DEFAULT_BUILDER_CIRCUIT_BREAKER_ALLOWED_FAULTS;
     private int builderCircuitBreakerAllowedConsecutiveFaults =
         DEFAULT_BUILDER_CIRCUIT_BREAKER_ALLOWED_CONSECUTIVE_FAULTS;
-    private String builderBidCompareFactor = Integer.toString(DEFAULT_BUILDER_BID_COMPARE_FACTOR);
+    private String builderBidCompareFactor = DEFAULT_BUILDER_BID_COMPARE_FACTOR.toString();
     private boolean builderSetUserAgentHeader = DEFAULT_BUILDER_SET_USER_AGENT_HEADER;
     private boolean useShouldOverrideBuilderFlag = DEFAULT_USE_SHOULD_OVERRIDE_BUILDER_FLAG;
     private boolean exchangeCapabilitiesMonitoringEnabled =
@@ -168,21 +171,21 @@ public class ExecutionLayerConfiguration {
     public ExecutionLayerConfiguration build() {
       validateStubEndpoints();
       validateBuilderCircuitBreaker();
-      final Optional<Integer> builderBidCompareFactor = validateAndParseBuilderBidCompareFactor();
+      final UInt64 builderBidCompareFactor = validateAndParseBuilderBidCompareFactor();
 
       if (builderEndpoint.isPresent()) {
-        if (builderBidCompareFactor.isEmpty()) {
+        if (builderBidCompareFactor.equals(BUILDER_BOOST_FACTOR_PREFER_BUILDER)) {
           LOG.info(
               "During block production, a valid builder bid will always be chosen over locally produced payload.");
         } else {
           final String additionalHint =
-              builderBidCompareFactor.get() == DEFAULT_BUILDER_BID_COMPARE_FACTOR
+              builderBidCompareFactor.equals(DEFAULT_BUILDER_BID_COMPARE_FACTOR)
                   ? " Can be configured via --builder-bid-compare-factor"
                   : "";
           LOG.info(
               "During block production, locally produced payload will be chosen when its value is equal or greater than {}% of the builder bid value."
                   + additionalHint,
-              builderBidCompareFactor.get());
+              builderBidCompareFactor);
         }
       }
 
@@ -290,26 +293,24 @@ public class ExecutionLayerConfiguration {
       }
     }
 
-    private Optional<Integer> validateAndParseBuilderBidCompareFactor() {
+    private UInt64 validateAndParseBuilderBidCompareFactor() {
       if (builderBidCompareFactor.equalsIgnoreCase(BUILDER_ALWAYS_KEYWORD)) {
-        return Optional.empty();
+        return BUILDER_BOOST_FACTOR_PREFER_BUILDER;
       }
       if (builderBidCompareFactor.endsWith("%")) {
         builderBidCompareFactor =
             builderBidCompareFactor.substring(0, builderBidCompareFactor.length() - 1);
       }
-      final int builderBidCompareFactorInt;
+      final UInt64 builderBidCompareFactorUint64;
       try {
-        builderBidCompareFactorInt = Integer.parseInt(builderBidCompareFactor);
-      } catch (final NumberFormatException ex) {
+        builderBidCompareFactorUint64 = UInt64.valueOf(Integer.parseInt(builderBidCompareFactor));
+      } catch (final NumberFormatException | ArithmeticException ex) {
         throw new InvalidConfigurationException(
-            "Expecting number, percentage or "
+            "Expecting a number >= 0, percentage or "
                 + BUILDER_ALWAYS_KEYWORD
                 + " keyword for Builder bid compare factor");
       }
-      checkArgument(
-          builderBidCompareFactorInt >= 0, "Builder bid compare factor percentage should be >= 0");
-      return Optional.of(builderBidCompareFactorInt);
+      return builderBidCompareFactorUint64;
     }
   }
 }

--- a/services/executionlayer/src/test/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerConfigurationTest.java
+++ b/services/executionlayer/src/test/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerConfigurationTest.java
@@ -16,10 +16,12 @@ package tech.pegasys.teku.services.executionlayer;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
+import static tech.pegasys.teku.ethereum.executionlayer.ExecutionBuilderModule.BUILDER_BOOST_FACTOR_PREFER_BUILDER;
 import static tech.pegasys.teku.services.executionlayer.ExecutionLayerConfiguration.BUILDER_ALWAYS_KEYWORD;
 
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.exceptions.InvalidConfigurationException;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 
@@ -65,19 +67,23 @@ public class ExecutionLayerConfigurationTest {
   public void shouldParseBuilderBidCompareFactor() {
     final ExecutionLayerConfiguration.Builder builder1 =
         configBuilder.specProvider(bellatrixSpec).builderBidCompareFactor("50");
-    assertThat(builder1.build().getBuilderBidCompareFactor()).contains(50);
+    assertThat(builder1.build().getBuilderBidCompareFactor())
+        .isEqualByComparingTo(UInt64.valueOf(50));
     final ExecutionLayerConfiguration.Builder builder2 =
         configBuilder.specProvider(bellatrixSpec).builderBidCompareFactor("50%");
-    assertThat(builder2.build().getBuilderBidCompareFactor()).contains(50);
+    assertThat(builder2.build().getBuilderBidCompareFactor())
+        .isEqualByComparingTo(UInt64.valueOf(50));
     final ExecutionLayerConfiguration.Builder builder3 =
         configBuilder.specProvider(bellatrixSpec).builderBidCompareFactor("Builder_ALWAYS");
-    assertThat(builder3.build().getBuilderBidCompareFactor()).isEmpty();
+    assertThat(builder3.build().getBuilderBidCompareFactor())
+        .isEqualByComparingTo(BUILDER_BOOST_FACTOR_PREFER_BUILDER);
   }
 
   @Test
   public void shouldHaveCorrectDefaultBuilderBidCompareFactor() {
     final ExecutionLayerConfiguration.Builder builder1 = configBuilder.specProvider(bellatrixSpec);
-    assertThat(builder1.build().getBuilderBidCompareFactor()).contains(100);
+    assertThat(builder1.build().getBuilderBidCompareFactor())
+        .isEqualByComparingTo(UInt64.valueOf(50));
   }
 
   @Test

--- a/services/executionlayer/src/test/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerConfigurationTest.java
+++ b/services/executionlayer/src/test/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerConfigurationTest.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.services.executionlayer;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
+import static tech.pegasys.teku.ethereum.executionlayer.ExecutionBuilderModule.BUILDER_BOOST_FACTOR_MAX_PROFIT;
 import static tech.pegasys.teku.ethereum.executionlayer.ExecutionBuilderModule.BUILDER_BOOST_FACTOR_PREFER_BUILDER;
 import static tech.pegasys.teku.services.executionlayer.ExecutionLayerConfiguration.BUILDER_ALWAYS_KEYWORD;
 
@@ -45,9 +46,12 @@ public class ExecutionLayerConfigurationTest {
     final ExecutionLayerConfiguration.Builder builder =
         configBuilder.specProvider(bellatrixSpec).builderBidCompareFactor("-100");
 
-    assertThatExceptionOfType(IllegalArgumentException.class)
+    assertThatExceptionOfType(InvalidConfigurationException.class)
         .isThrownBy(builder::build)
-        .withMessageContaining("Builder bid compare factor percentage should be >= 0");
+        .withMessageContaining(
+            "Expecting a number >= 0, percentage or "
+                + BUILDER_ALWAYS_KEYWORD
+                + " keyword for Builder bid compare factor");
   }
 
   @Test
@@ -58,7 +62,7 @@ public class ExecutionLayerConfigurationTest {
     assertThatExceptionOfType(InvalidConfigurationException.class)
         .isThrownBy(builder::build)
         .withMessageContaining(
-            "Expecting number, percentage or "
+            "Expecting a number >= 0, percentage or "
                 + BUILDER_ALWAYS_KEYWORD
                 + " keyword for Builder bid compare factor");
   }
@@ -83,7 +87,7 @@ public class ExecutionLayerConfigurationTest {
   public void shouldHaveCorrectDefaultBuilderBidCompareFactor() {
     final ExecutionLayerConfiguration.Builder builder1 = configBuilder.specProvider(bellatrixSpec);
     assertThat(builder1.build().getBuilderBidCompareFactor())
-        .isEqualByComparingTo(UInt64.valueOf(50));
+        .isEqualByComparingTo(BUILDER_BOOST_FACTOR_MAX_PROFIT);
   }
 
   @Test

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ExecutionLayerOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ExecutionLayerOptions.java
@@ -112,7 +112,7 @@ public class ExecutionLayerOptions {
               + BUILDER_ALWAYS_KEYWORD
               + "' to always use builder bid. In this configuration locally produced payload will be used only when the bid is invalid.",
       arity = "1")
-  private String builderBidCompareFactor = Integer.toString(DEFAULT_BUILDER_BID_COMPARE_FACTOR);
+  private String builderBidCompareFactor = DEFAULT_BUILDER_BID_COMPARE_FACTOR.toString();
 
   @Option(
       names = {"--builder-set-user-agent-header"},

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
@@ -85,7 +85,7 @@ public interface ValidatorApiChannel extends ChannelInterface {
             UInt64 slot,
             BLSSignature randaoReveal,
             Optional<Bytes32> graffiti,
-            Optional<Boolean> blinded) {
+            Optional<Boolean> requestedBlinded) {
           return SafeFuture.completedFuture(Optional.empty());
         }
 
@@ -193,13 +193,14 @@ public interface ValidatorApiChannel extends ChannelInterface {
   SafeFuture<Optional<ProposerDuties>> getProposerDuties(UInt64 epoch);
 
   /**
-   * @param blinded can be removed once block creation V2 APIs are removed in favour of V3 only
+   * @param requestedBlinded can be removed once block creation V2 APIs are removed in favour of V3
+   *     only
    */
   SafeFuture<Optional<BlockContainer>> createUnsignedBlock(
       UInt64 slot,
       BLSSignature randaoReveal,
       Optional<Bytes32> graffiti,
-      Optional<Boolean> blinded);
+      Optional<Boolean> requestedBlinded);
 
   SafeFuture<Optional<AttestationData>> createAttestationData(UInt64 slot, int committeeIndex);
 

--- a/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
+++ b/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
@@ -130,9 +130,9 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
       final UInt64 slot,
       final BLSSignature randaoReveal,
       Optional<Bytes32> graffiti,
-      final Optional<Boolean> blinded) {
+      final Optional<Boolean> requestedBlinded) {
     return countOptionalDataRequest(
-        delegate.createUnsignedBlock(slot, randaoReveal, graffiti, blinded),
+        delegate.createUnsignedBlock(slot, randaoReveal, graffiti, requestedBlinded),
         BeaconNodeRequestLabels.CREATE_UNSIGNED_BLOCK_METHOD);
   }
 

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandler.java
@@ -150,11 +150,11 @@ public class FailoverValidatorApiHandler implements ValidatorApiChannel {
       final UInt64 slot,
       final BLSSignature randaoReveal,
       final Optional<Bytes32> graffiti,
-      final Optional<Boolean> blinded) {
+      final Optional<Boolean> requestedBlinded) {
     final ValidatorApiChannelRequest<Optional<BlockContainer>> request =
         apiChannel ->
             apiChannel
-                .createUnsignedBlock(slot, randaoReveal, graffiti, blinded)
+                .createUnsignedBlock(slot, randaoReveal, graffiti, requestedBlinded)
                 .thenPeek(
                     blockContainer -> {
                       if (!failoverDelegates.isEmpty()

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
@@ -295,10 +295,12 @@ public class RemoteValidatorApiHandler implements RemoteValidatorApiChannel {
       final UInt64 slot,
       final BLSSignature randaoReveal,
       final Optional<Bytes32> graffiti,
-      final Optional<Boolean> blinded) {
-    if (blinded.isPresent()) {
+      final Optional<Boolean> requestedBlinded) {
+    if (requestedBlinded.isPresent()) {
       return sendRequest(
-          () -> typeDefClient.createUnsignedBlock(slot, randaoReveal, graffiti, blinded.get()));
+          () ->
+              typeDefClient.createUnsignedBlock(
+                  slot, randaoReveal, graffiti, requestedBlinded.get()));
     }
     return sendRequest(() -> typeDefClient.createUnsignedBlock(slot, randaoReveal, graffiti));
   }

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/sentry/SentryValidatorApiChannel.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/sentry/SentryValidatorApiChannel.java
@@ -103,10 +103,10 @@ public class SentryValidatorApiChannel implements ValidatorApiChannel {
       final UInt64 slot,
       final BLSSignature randaoReveal,
       final Optional<Bytes32> graffiti,
-      final Optional<Boolean> blinded) {
+      final Optional<Boolean> requestedBlinded) {
     return blockHandlerChannel
         .orElse(dutiesProviderChannel)
-        .createUnsignedBlock(slot, randaoReveal, graffiti, blinded);
+        .createUnsignedBlock(slot, randaoReveal, graffiti, requestedBlinded);
   }
 
   @Override


### PR DESCRIPTION
- Adds `requestedBuilderBoostFactor` eventually coming from BlockV3
- The `requestedBuilderBoostFactor` will always override the eventual comparison factor configured on BN side.
- Uniforms our internal `builderComparisonFactor` representation to the new param (from `Optional<Integer>` to `Uint64`) so the handling is simplified

In our CLI we could support `PREFER_BUILDER` as an alias to `BUILDER_ALWAYS` and start advertising the new maintaining backward compatibility (separate PR)

related to #7851 

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
