### PR TITLE
Reduce amount of logs when there are issues fetching deposits from EL

### DIFF
--- a/beacon/pow/src/test/java/tech/pegasys/teku/beacon/pow/DepositsFetcherTest.java
+++ b/beacon/pow/src/test/java/tech/pegasys/teku/beacon/pow/DepositsFetcherTest.java
@@ -44,6 +44,9 @@ import tech.pegasys.teku.ethereum.pow.api.Eth1EventsChannel;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.SafeFutureAssert;
 import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
+import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
+import tech.pegasys.teku.infrastructure.time.TimeProvider;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 public class DepositsFetcherTest {
 
@@ -53,6 +56,7 @@ public class DepositsFetcherTest {
   private final DepositEventsAccessor depositEventsAccessor = mock(DepositEventsAccessor.class);
   private final Eth1BlockFetcher eth1BlockFetcher = mock(Eth1BlockFetcher.class);
   private final StubAsyncRunner asyncRunner = new StubAsyncRunner();
+  private final TimeProvider timeProvider = StubTimeProvider.withTimeInSeconds(UInt64.ZERO);
 
   private final DepositFetcher depositFetcher =
       new DepositFetcher(
@@ -61,7 +65,8 @@ public class DepositsFetcherTest {
           depositEventsAccessor,
           eth1BlockFetcher,
           asyncRunner,
-          MAX_BLOCK_RANGE);
+          MAX_BLOCK_RANGE,
+          timeProvider);
 
   @Test
   void depositsInConsecutiveBlocks() {

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -128,6 +128,7 @@ dependencyManagement {
       entry 'core'
       entry 'abi'
       entry 'crypto'
+      entry 'utils'
     }
 
     dependency 'org.xerial.snappy:snappy-java:1.1.10.5'

--- a/infrastructure/logging/build.gradle
+++ b/infrastructure/logging/build.gradle
@@ -2,7 +2,7 @@ dependencies {
     api 'org.apache.tuweni:tuweni-bytes'
     api 'org.apache.tuweni:tuweni-units'
 
-    implementation 'org.web3j:utils:4.9.8'
+    implementation 'org.web3j:utils'
     implementation 'org.apache.logging.log4j:log4j-core'
     compileOnly 'com.github.oshi:oshi-core'
 

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
@@ -121,8 +121,7 @@ public class StatusLogger {
   public void eth1DepositEventsFailure(final Throwable cause) {
     log.fatal(
         "PLEASE CHECK YOUR ETH1 NODE | Encountered a problem retrieving deposit events from eth1 endpoint: {}",
-        cause.getMessage(),
-        cause);
+        cause.getMessage());
   }
 
   public void eth1FetchDepositsRequiresSmallerRange(final int batchSize) {

--- a/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/PowchainService.java
+++ b/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/PowchainService.java
@@ -65,7 +65,7 @@ public class PowchainService extends Service {
   private final Eth1HeadTracker headTracker;
   private final List<Web3j> web3js;
   private final OkHttpClient okHttpClient;
-  private Eth1Providers eth1Providers;
+  private final Eth1Providers eth1Providers;
 
   public PowchainService(
       final ServiceConfig serviceConfig,
@@ -149,7 +149,8 @@ public class PowchainService extends Service {
             depositEventsAccessor,
             eth1BlockFetcher,
             asyncRunner,
-            powConfig.getEth1LogsMaxBlockRange());
+            powConfig.getEth1LogsMaxBlockRange(),
+            serviceConfig.getTimeProvider());
 
     headTracker =
         new TimeBasedEth1HeadTracker(

--- a/services/powchain/src/test/java/tech/pegasys/teku/services/powchain/DepositRangeReductionTest.java
+++ b/services/powchain/src/test/java/tech/pegasys/teku/services/powchain/DepositRangeReductionTest.java
@@ -263,6 +263,7 @@ public class DepositRangeReductionTest {
         depositEventsAccessor,
         eth1BlockFetcher,
         asyncRunner,
-        MAX_BLOCK_RANGE);
+        MAX_BLOCK_RANGE,
+        timeProvider);
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

- Reduce the logs spamming every 2 seconds in case of issues with fetching deposits to every 30 seconds. 
- Removed the stack trace because the InvalidDepositEventsException message contains all the relevant information.
- Moved hardcoding of `org.web3j:utils` version to `versions.gradle`

## Fixed Issue(s)
fixes #7908 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
