### PR TITLE
Add builder boost factor part2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,5 +12,6 @@ the [releases page](https://github.com/Consensys/teku/releases).
 ### Breaking Changes
 
 ### Additions and Improvements
+- Improved compatibility with `/eth/v3/validator/blocks/{slot}` experimental beacon API for block production. It can now respond with blinded and unblinded content based on the block production flow. It also supports the `builder_boost_factor` parameter.
 
 ### Bug Fixes

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -313,7 +313,8 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
       final UInt64 slot,
       final BLSSignature randaoReveal,
       final Optional<Bytes32> graffiti,
-      final Optional<Boolean> requestedBlinded) {
+      final Optional<Boolean> requestedBlinded,
+      final Optional<UInt64> requestedBuilderBoostFactor) {
     LOG.info("Creating unsigned block for slot {}", slot);
     performanceTracker.reportBlockProductionAttempt(spec.computeEpochAtSlot(slot));
     if (isSyncActive()) {

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -340,7 +340,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
                     randaoReveal,
                     graffiti,
                     requestedBlinded,
-                    Optional.empty(),
+                    requestedBuilderBoostFactor,
                     blockSlotState,
                     blockProductionPerformance))
         .alwaysRun(blockProductionPerformance::complete);

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -490,7 +490,11 @@ class ValidatorApiHandlerTest {
     nodeIsSyncing();
     final SafeFuture<Optional<BlockContainer>> result =
         validatorApiHandler.createUnsignedBlock(
-            ONE, dataStructureUtil.randomSignature(), Optional.empty(), Optional.of(false));
+            ONE,
+            dataStructureUtil.randomSignature(),
+            Optional.empty(),
+            Optional.of(false),
+            Optional.of(ONE));
 
     assertThat(result).isCompletedExceptionally();
     assertThatThrownBy(result::get).hasRootCauseInstanceOf(NodeSyncingException.class);
@@ -507,7 +511,11 @@ class ValidatorApiHandlerTest {
 
     final SafeFuture<Optional<BlockContainer>> result =
         validatorApiHandler.createUnsignedBlock(
-            newSlot, dataStructureUtil.randomSignature(), Optional.empty(), Optional.of(false));
+            newSlot,
+            dataStructureUtil.randomSignature(),
+            Optional.empty(),
+            Optional.of(false),
+            Optional.of(ONE));
 
     assertThat(result).isCompletedExceptionally();
     assertThatThrownBy(result::get).hasRootCauseInstanceOf(NodeSyncingException.class);
@@ -535,7 +543,7 @@ class ValidatorApiHandlerTest {
 
     final SafeFuture<Optional<BlockContainer>> result =
         validatorApiHandler.createUnsignedBlock(
-            newSlot, randaoReveal, Optional.empty(), Optional.of(false));
+            newSlot, randaoReveal, Optional.empty(), Optional.of(false), Optional.of(ONE));
 
     verify(blockFactory)
         .createUnsignedBlock(

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -537,10 +537,13 @@ class ValidatorApiHandlerTest {
             randaoReveal,
             Optional.empty(),
             Optional.of(false),
-            Optional.empty(),
+            Optional.of(ONE),
             BlockProductionPerformance.NOOP))
         .thenReturn(SafeFuture.completedFuture(createdBlock));
 
+    // even if passing a non-empty reqestedBlinded and requestedBuilderBoostFactor isn't a valid
+    // combination,
+    // we still want to check that all parameters are passed down the line to the block factory
     final SafeFuture<Optional<BlockContainer>> result =
         validatorApiHandler.createUnsignedBlock(
             newSlot, randaoReveal, Optional.empty(), Optional.of(false), Optional.of(ONE));
@@ -552,7 +555,7 @@ class ValidatorApiHandlerTest {
             randaoReveal,
             Optional.empty(),
             Optional.of(false),
-            Optional.empty(),
+            Optional.of(ONE),
             BlockProductionPerformance.NOOP);
     assertThat(result).isCompletedWithValue(Optional.of(createdBlock));
   }

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/validator/GetNewBlockIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/validator/GetNewBlockIntegrationTest.java
@@ -72,7 +72,7 @@ public class GetNewBlockIntegrationTest extends AbstractDataBackedRestAPIIntegra
   void shouldGetUnsignedBlock_asJson(final String route, final boolean isBlindedBlock)
       throws IOException {
     when(validatorApiChannel.createUnsignedBlock(
-            eq(UInt64.ONE), eq(signature), any(), eq(Optional.of(isBlindedBlock))))
+            eq(UInt64.ONE), eq(signature), any(), eq(Optional.of(isBlindedBlock)), any()))
         .thenReturn(SafeFuture.completedFuture(Optional.of(randomBlock)));
     Response response = get(route, signature, ContentTypes.JSON);
     assertThat(response.code()).isEqualTo(SC_OK);
@@ -88,7 +88,7 @@ public class GetNewBlockIntegrationTest extends AbstractDataBackedRestAPIIntegra
   void shouldGetUnsignedBlock_asOctet(final String route, final boolean isBlindedBlock)
       throws IOException {
     when(validatorApiChannel.createUnsignedBlock(
-            eq(UInt64.ONE), eq(signature), any(), eq(Optional.of(isBlindedBlock))))
+            eq(UInt64.ONE), eq(signature), any(), eq(Optional.of(isBlindedBlock)), any()))
         .thenReturn(SafeFuture.completedFuture(Optional.of(randomBlock)));
     Response response = get(route, signature, ContentTypes.OCTET_STREAM);
     assertThat(response.code()).isEqualTo(SC_OK);
@@ -100,7 +100,7 @@ public class GetNewBlockIntegrationTest extends AbstractDataBackedRestAPIIntegra
   @MethodSource("getNewBlockCases")
   void shouldShowNoContent(final String route, final boolean isBlindedBlock) throws IOException {
     when(validatorApiChannel.createUnsignedBlock(
-            eq(UInt64.ONE), eq(signature), any(), eq(Optional.of(isBlindedBlock))))
+            eq(UInt64.ONE), eq(signature), any(), eq(Optional.of(isBlindedBlock)), any()))
         .thenReturn(SafeFuture.failedFuture(new ChainDataUnavailableException()));
     Response response = get(route, signature, ContentTypes.OCTET_STREAM);
     assertThat(response.code()).isEqualTo(SC_NO_CONTENT);
@@ -111,7 +111,7 @@ public class GetNewBlockIntegrationTest extends AbstractDataBackedRestAPIIntegra
   @MethodSource("getNewBlockCases")
   void shouldShowUnavailable(final String route, final boolean isBlindedBlock) throws IOException {
     when(validatorApiChannel.createUnsignedBlock(
-            eq(UInt64.ONE), eq(signature), any(), eq(Optional.of(isBlindedBlock))))
+            eq(UInt64.ONE), eq(signature), any(), eq(Optional.of(isBlindedBlock)), any()))
         .thenReturn(SafeFuture.failedFuture(new ServiceUnavailableException()));
     Response response = get(route, signature, ContentTypes.OCTET_STREAM);
     assertThat(response.code()).isEqualTo(SC_SERVICE_UNAVAILABLE);
@@ -125,7 +125,7 @@ public class GetNewBlockIntegrationTest extends AbstractDataBackedRestAPIIntegra
   void shouldNotStackTraceForMissingDeposits(final String route, final boolean isBlindedBlock)
       throws IOException {
     when(validatorApiChannel.createUnsignedBlock(
-            eq(UInt64.ONE), eq(signature), any(), eq(Optional.of(isBlindedBlock))))
+            eq(UInt64.ONE), eq(signature), any(), eq(Optional.of(isBlindedBlock)), any()))
         .thenReturn(
             SafeFuture.failedFuture(
                 MissingDepositsException.missingRange(UInt64.valueOf(1), UInt64.valueOf(10))));

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v3/GetNewBlockV3IntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v3/GetNewBlockV3IntegrationTest.java
@@ -95,7 +95,8 @@ public class GetNewBlockV3IntegrationTest extends AbstractDataBackedRestAPIInteg
     assumeThat(specMilestone).isLessThan(DENEB);
     final BeaconBlock beaconBlock = dataStructureUtil.randomBeaconBlock(ONE);
     final BLSSignature signature = beaconBlock.getBlock().getBody().getRandaoReveal();
-    when(validatorApiChannel.createUnsignedBlock(eq(UInt64.ONE), eq(signature), any(), any()))
+    when(validatorApiChannel.createUnsignedBlock(
+            eq(UInt64.ONE), eq(signature), any(), any(), any()))
         .thenReturn(SafeFuture.completedFuture(Optional.of(beaconBlock)));
     Response response = get(signature, ContentTypes.JSON);
     assertResponseWithHeaders(response, false);
@@ -108,7 +109,8 @@ public class GetNewBlockV3IntegrationTest extends AbstractDataBackedRestAPIInteg
     assumeThat(specMilestone).isLessThan(DENEB);
     final BeaconBlock beaconBlock = dataStructureUtil.randomBeaconBlock(ONE);
     final BLSSignature signature = beaconBlock.getBlock().getBody().getRandaoReveal();
-    when(validatorApiChannel.createUnsignedBlock(eq(UInt64.ONE), eq(signature), any(), any()))
+    when(validatorApiChannel.createUnsignedBlock(
+            eq(UInt64.ONE), eq(signature), any(), any(), any()))
         .thenReturn(SafeFuture.completedFuture(Optional.of(beaconBlock)));
     Response response = get(signature, ContentTypes.OCTET_STREAM);
     assertResponseWithHeaders(response, false);
@@ -124,7 +126,8 @@ public class GetNewBlockV3IntegrationTest extends AbstractDataBackedRestAPIInteg
     assumeThat(specMilestone).isGreaterThanOrEqualTo(BELLATRIX);
     final BeaconBlock blindedBeaconBlock = dataStructureUtil.randomBlindedBeaconBlock(ONE);
     final BLSSignature signature = blindedBeaconBlock.getBlock().getBody().getRandaoReveal();
-    when(validatorApiChannel.createUnsignedBlock(eq(UInt64.ONE), eq(signature), any(), any()))
+    when(validatorApiChannel.createUnsignedBlock(
+            eq(UInt64.ONE), eq(signature), any(), any(), any()))
         .thenReturn(SafeFuture.completedFuture(Optional.of(blindedBeaconBlock)));
     Response response = get(signature, ContentTypes.JSON);
     assertResponseWithHeaders(response, true);
@@ -137,7 +140,8 @@ public class GetNewBlockV3IntegrationTest extends AbstractDataBackedRestAPIInteg
     assumeThat(specMilestone).isGreaterThanOrEqualTo(BELLATRIX);
     final BeaconBlock blindedBeaconBlock = dataStructureUtil.randomBlindedBeaconBlock(ONE);
     final BLSSignature signature = blindedBeaconBlock.getBlock().getBody().getRandaoReveal();
-    when(validatorApiChannel.createUnsignedBlock(eq(UInt64.ONE), eq(signature), any(), any()))
+    when(validatorApiChannel.createUnsignedBlock(
+            eq(UInt64.ONE), eq(signature), any(), any(), any()))
         .thenReturn(SafeFuture.completedFuture(Optional.of(blindedBeaconBlock)));
     Response response = get(signature, ContentTypes.OCTET_STREAM);
     assertResponseWithHeaders(response, true);
@@ -153,7 +157,8 @@ public class GetNewBlockV3IntegrationTest extends AbstractDataBackedRestAPIInteg
     assumeThat(specMilestone).isEqualTo(DENEB);
     final BlockContents blockContents = dataStructureUtil.randomBlockContents(ONE);
     final BLSSignature signature = blockContents.getBlock().getBody().getRandaoReveal();
-    when(validatorApiChannel.createUnsignedBlock(eq(UInt64.ONE), eq(signature), any(), any()))
+    when(validatorApiChannel.createUnsignedBlock(
+            eq(UInt64.ONE), eq(signature), any(), any(), any()))
         .thenReturn(SafeFuture.completedFuture(Optional.of(blockContents)));
     Response response = get(signature, ContentTypes.JSON);
     assertResponseWithHeaders(response, false);
@@ -166,7 +171,8 @@ public class GetNewBlockV3IntegrationTest extends AbstractDataBackedRestAPIInteg
     assumeThat(specMilestone).isEqualTo(DENEB);
     final BlockContents blockContents = dataStructureUtil.randomBlockContents(ONE);
     final BLSSignature signature = blockContents.getBlock().getBody().getRandaoReveal();
-    when(validatorApiChannel.createUnsignedBlock(eq(UInt64.ONE), eq(signature), any(), any()))
+    when(validatorApiChannel.createUnsignedBlock(
+            eq(UInt64.ONE), eq(signature), any(), any(), any()))
         .thenReturn(SafeFuture.completedFuture(Optional.of(blockContents)));
     Response response = get(signature, ContentTypes.OCTET_STREAM);
     assertResponseWithHeaders(response, false);
@@ -182,7 +188,8 @@ public class GetNewBlockV3IntegrationTest extends AbstractDataBackedRestAPIInteg
   void shouldFailWhenNoBlockProduced() throws IOException {
     final BeaconBlock beaconBlock = dataStructureUtil.randomBeaconBlock(ONE);
     final BLSSignature signature = beaconBlock.getBlock().getBody().getRandaoReveal();
-    when(validatorApiChannel.createUnsignedBlock(eq(UInt64.ONE), eq(signature), any(), any()))
+    when(validatorApiChannel.createUnsignedBlock(
+            eq(UInt64.ONE), eq(signature), any(), any(), any()))
         .thenReturn(SafeFuture.completedFuture(Optional.empty()));
     Response response = get(signature, ContentTypes.JSON);
     assertThat(response.code()).isEqualTo(SC_INTERNAL_SERVER_ERROR);

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v3_validator_blocks_{slot}.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v3_validator_blocks_{slot}.json
@@ -40,6 +40,15 @@
         "type" : "boolean",
         "description" : "Skip verification of the `randao_reveal` value. If this flag is set then the\n `randao_reveal` must be set to the point at infinity (`0xc0..00`). This query parameter\n  is a flag and does not take a value"
       }
+    }, {
+      "name" : "builder_boost_factor",
+      "in" : "query",
+      "schema" : {
+        "type" : "string",
+        "description" : "Percentage multiplier to apply to the builder's payload value when choosing between a\nbuilder payload header and payload from the paired execution node. This parameter is only\nrelevant if the beacon node is connected to a builder, deems it safe to produce a builder\npayload, and receives valid responses from both the builder endpoint _and_ the paired\nexecution node. When these preconditions are met, the server MUST act as follows:\n\n* if `exec_node_payload_value >= builder_boost_factor * (builder_payload_value // 100)`,\n  then return a full (unblinded) block containing the execution node payload.\n* otherwise, return a blinded block containing the builder payload header.\n\nServers must support the following values of the boost factor which encode common\npreferences:\n\n* `builder_boost_factor=0`: prefer the execution node payload unless an error makes it\n  unviable.\n* `builder_boost_factor=100`: default profit maximization mode; choose whichever\n  payload pays more.\n* `builder_boost_factor=2**64 - 1`: prefer the builder payload unless an error or\n  beacon node health check makes it unviable.\n\nServers should use saturating arithmetic or another technique to ensure that large values of\nthe `builder_boost_factor` do not trigger overflows or errors. If this parameter is\nprovided and the beacon node is not configured with a builder then the beacon node MUST\nrespond with a full block, which the caller can choose to reject if it wishes. If this\nparameter is **not** provided then it should be treated as having the default value of 100.\nIf the value is provided but out of range for a 64-bit unsigned integer, then an error\nresponse with status code 400 MUST be returned.",
+        "example" : "1",
+        "format" : "uint64"
+      }
     } ],
     "responses" : {
       "200" : {

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApiTypes.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApiTypes.java
@@ -17,6 +17,7 @@ import static tech.pegasys.teku.ethereum.json.types.EthereumTypes.SIGNATURE_TYPE
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.ATTESTATION_DATA_ROOT;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.BEACON_BLOCK_ROOT;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.BLOCK_ROOT;
+import static tech.pegasys.teku.infrastructure.http.RestApiConstants.BUILDER_BOOST_FACTOR_DESCRIPTION;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.COMMITTEE_INDEX;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.COMMITTEE_INDEX_QUERY_DESCRIPTION;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.COUNT;
@@ -56,6 +57,7 @@ import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.BYTES32_TYPE
 import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.INTEGER_TYPE;
 import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.RAW_INTEGER_TYPE;
 import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.STRING_TYPE;
+import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.UINT64_TYPE;
 
 import java.util.Locale;
 import java.util.function.Function;
@@ -140,6 +142,11 @@ public class BeaconRestApiTypes {
       new ParameterMetadata<>(
           RestApiConstants.SKIP_RANDAO_VERIFICATION,
           BOOLEAN_TYPE.withDescription(SKIP_RANDAO_VERIFICATION_PARAM_DESCRIPTION));
+
+  public static final ParameterMetadata<UInt64> BUILDER_BOOST_FACTOR_PARAMETER =
+      new ParameterMetadata<>(
+          RestApiConstants.BUILDER_BOOST_FACTOR,
+          UINT64_TYPE.withDescription(BUILDER_BOOST_FACTOR_DESCRIPTION));
 
   public static final ParameterMetadata<Bytes32> GRAFFITI_PARAMETER =
       new ParameterMetadata<>(

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetNewBlindedBlock.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetNewBlindedBlock.java
@@ -114,7 +114,7 @@ public class GetNewBlindedBlock extends RestApiEndpoint {
     final BLSSignature randao = request.getQueryParameter(RANDAO_PARAMETER);
     final Optional<Bytes32> graffiti = request.getOptionalQueryParameter(GRAFFITI_PARAMETER);
     final SafeFuture<Optional<BlockContainer>> result =
-        provider.getUnsignedBeaconBlockAtSlot(slot, randao, graffiti, true);
+        provider.getUnsignedBeaconBlockAtSlot(slot, randao, graffiti, true, Optional.empty());
     request.respondAsync(
         result.thenApplyChecked(
             maybeBlock ->

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v2/validator/GetNewBlock.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v2/validator/GetNewBlock.java
@@ -112,7 +112,7 @@ public class GetNewBlock extends RestApiEndpoint {
     final BLSSignature randao = request.getQueryParameter(RANDAO_PARAMETER);
     final Optional<Bytes32> graffiti = request.getOptionalQueryParameter(GRAFFITI_PARAMETER);
     final SafeFuture<Optional<BlockContainer>> result =
-        provider.getUnsignedBeaconBlockAtSlot(slot, randao, graffiti, false);
+        provider.getUnsignedBeaconBlockAtSlot(slot, randao, graffiti, false, Optional.empty());
     request.respondAsync(
         result.thenApply(
             maybeBlock ->

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v3/validator/GetNewBlockV3.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v3/validator/GetNewBlockV3.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.beaconrestapi.handlers.v3.validator;
 
+import static tech.pegasys.teku.beaconrestapi.BeaconRestApiTypes.BUILDER_BOOST_FACTOR_PARAMETER;
 import static tech.pegasys.teku.beaconrestapi.BeaconRestApiTypes.GRAFFITI_PARAMETER;
 import static tech.pegasys.teku.beaconrestapi.BeaconRestApiTypes.RANDAO_PARAMETER;
 import static tech.pegasys.teku.beaconrestapi.BeaconRestApiTypes.SKIP_RANDAO_VERIFICATION_PARAMETER;
@@ -94,6 +95,7 @@ public class GetNewBlockV3 extends RestApiEndpoint {
         .queryParamRequired(RANDAO_PARAMETER)
         .queryParam(GRAFFITI_PARAMETER)
         .queryParam(SKIP_RANDAO_VERIFICATION_PARAMETER)
+        .queryParam(BUILDER_BOOST_FACTOR_PARAMETER)
         .response(
             SC_OK,
             "Request successful",
@@ -108,8 +110,10 @@ public class GetNewBlockV3 extends RestApiEndpoint {
         request.getPathParameter(SLOT_PARAMETER.withDescription(SLOT_PATH_DESCRIPTION));
     final BLSSignature randao = request.getQueryParameter(RANDAO_PARAMETER);
     final Optional<Bytes32> graffiti = request.getOptionalQueryParameter(GRAFFITI_PARAMETER);
+    final Optional<UInt64> requestedBuilderBoostFactor =
+        request.getOptionalQueryParameter(BUILDER_BOOST_FACTOR_PARAMETER);
     final SafeFuture<Optional<BlockContainerAndMetaData<BlockContainer>>> result =
-        validatorDataProvider.produceBlock(slot, randao, graffiti);
+        validatorDataProvider.produceBlock(slot, randao, graffiti, requestedBuilderBoostFactor);
     request.respondAsync(
         result.thenApply(
             maybeBlock ->

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/AbstractGetNewBlockTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/AbstractGetNewBlockTest.java
@@ -54,7 +54,8 @@ public abstract class AbstractGetNewBlockTest extends AbstractMigratedBeaconHand
     final BeaconBlock randomBeaconBlock = dataStructureUtil.randomBeaconBlock(ONE);
     doReturn(SafeFuture.completedFuture(Optional.of(randomBeaconBlock)))
         .when(validatorDataProvider)
-        .getUnsignedBeaconBlockAtSlot(ONE, signature, Optional.empty(), isBlindedBlocks());
+        .getUnsignedBeaconBlockAtSlot(
+            ONE, signature, Optional.empty(), isBlindedBlocks(), Optional.empty());
 
     handler.handleRequest(request);
 
@@ -73,7 +74,8 @@ public abstract class AbstractGetNewBlockTest extends AbstractMigratedBeaconHand
     final BeaconBlock blindedBeaconBLock = dataStructureUtil.randomBlindedBeaconBlock(ONE);
     doReturn(SafeFuture.completedFuture(Optional.of(blindedBeaconBLock)))
         .when(validatorDataProvider)
-        .getUnsignedBeaconBlockAtSlot(ONE, signature, Optional.empty(), isBlindedBlocks());
+        .getUnsignedBeaconBlockAtSlot(
+            ONE, signature, Optional.empty(), isBlindedBlocks(), Optional.empty());
 
     handler.handleRequest(request);
 
@@ -87,7 +89,8 @@ public abstract class AbstractGetNewBlockTest extends AbstractMigratedBeaconHand
     final BlockContents blockContents = dataStructureUtil.randomBlockContents(ONE);
     doReturn(SafeFuture.completedFuture(Optional.of(blockContents)))
         .when(validatorDataProvider)
-        .getUnsignedBeaconBlockAtSlot(ONE, signature, Optional.empty(), isBlindedBlocks());
+        .getUnsignedBeaconBlockAtSlot(
+            ONE, signature, Optional.empty(), isBlindedBlocks(), Optional.empty());
 
     handler.handleRequest(request);
 
@@ -99,7 +102,8 @@ public abstract class AbstractGetNewBlockTest extends AbstractMigratedBeaconHand
 
     doReturn(SafeFuture.completedFuture(Optional.empty()))
         .when(validatorDataProvider)
-        .getUnsignedBeaconBlockAtSlot(ONE, signature, Optional.empty(), isBlindedBlocks());
+        .getUnsignedBeaconBlockAtSlot(
+            ONE, signature, Optional.empty(), isBlindedBlocks(), Optional.empty());
 
     handler.handleRequest(request);
     assertThat(request.getResponseError()).containsInstanceOf(ChainDataUnavailableException.class);

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v3/validator/GetNewBlockV3Test.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v3/validator/GetNewBlockV3Test.java
@@ -98,7 +98,7 @@ public class GetNewBlockV3Test extends AbstractMigratedBeaconHandlerTest {
             consensusBlockValue);
     doReturn(SafeFuture.completedFuture(Optional.of(blockContainerAndMetaData)))
         .when(validatorDataProvider)
-        .produceBlock(ONE, signature, Optional.empty());
+        .produceBlock(ONE, signature, Optional.empty(), Optional.empty());
 
     handler.handleRequest(request);
 
@@ -126,7 +126,7 @@ public class GetNewBlockV3Test extends AbstractMigratedBeaconHandlerTest {
             consensusBlockValue);
     doReturn(SafeFuture.completedFuture(Optional.of(blockContainerAndMetaData)))
         .when(validatorDataProvider)
-        .produceBlock(ONE, signature, Optional.empty());
+        .produceBlock(ONE, signature, Optional.empty(), Optional.empty());
 
     handler.handleRequest(request);
 
@@ -154,7 +154,7 @@ public class GetNewBlockV3Test extends AbstractMigratedBeaconHandlerTest {
             consensusBlockValue);
     doReturn(SafeFuture.completedFuture(Optional.of(blockContainerAndMetaData)))
         .when(validatorDataProvider)
-        .produceBlock(ONE, signature, Optional.empty());
+        .produceBlock(ONE, signature, Optional.empty(), Optional.empty());
 
     handler.handleRequest(request);
 
@@ -173,7 +173,7 @@ public class GetNewBlockV3Test extends AbstractMigratedBeaconHandlerTest {
   void shouldThrowExceptionWhenEmptyBlock() throws Exception {
     doReturn(SafeFuture.completedFuture(Optional.empty()))
         .when(validatorDataProvider)
-        .produceBlock(ONE, signature, Optional.empty());
+        .produceBlock(ONE, signature, Optional.empty(), Optional.empty());
 
     handler.handleRequest(request);
     assertThat(request.getResponseCode()).isEqualTo(SC_INTERNAL_SERVER_ERROR);
@@ -190,7 +190,7 @@ public class GetNewBlockV3Test extends AbstractMigratedBeaconHandlerTest {
       blockContainer = dataStructureUtil.randomBeaconBlock(ONE);
     }
     final ValidatorApiChannel validatorApiChannelMock = mock(ValidatorApiChannel.class);
-    when(validatorApiChannelMock.createUnsignedBlock(any(), any(), any(), any()))
+    when(validatorApiChannelMock.createUnsignedBlock(any(), any(), any(), any(), any()))
         .thenReturn(SafeFuture.completedFuture(Optional.of(blockContainer)));
     final CombinedChainDataClient combinedChainDataClientMock = mock(CombinedChainDataClient.class);
     when(combinedChainDataClientMock.getCurrentSlot()).thenReturn(ZERO);
@@ -251,7 +251,7 @@ public class GetNewBlockV3Test extends AbstractMigratedBeaconHandlerTest {
       blockContainer = dataStructureUtil.randomBeaconBlock(ONE);
     }
     final ValidatorApiChannel validatorApiChannelMock = mock(ValidatorApiChannel.class);
-    when(validatorApiChannelMock.createUnsignedBlock(any(), any(), any(), any()))
+    when(validatorApiChannelMock.createUnsignedBlock(any(), any(), any(), any(), any()))
         .thenReturn(SafeFuture.completedFuture(Optional.of(blockContainer)));
     final CombinedChainDataClient combinedChainDataClientMock = mock(CombinedChainDataClient.class);
     when(combinedChainDataClientMock.getCurrentSlot()).thenReturn(ZERO);
@@ -312,7 +312,7 @@ public class GetNewBlockV3Test extends AbstractMigratedBeaconHandlerTest {
       blockContainer = dataStructureUtil.randomBeaconBlock(ONE);
     }
     final ValidatorApiChannel validatorApiChannelMock = mock(ValidatorApiChannel.class);
-    when(validatorApiChannelMock.createUnsignedBlock(any(), any(), any(), any()))
+    when(validatorApiChannelMock.createUnsignedBlock(any(), any(), any(), any(), any()))
         .thenReturn(SafeFuture.completedFuture(Optional.of(blockContainer)));
     final CombinedChainDataClient combinedChainDataClientMock = mock(CombinedChainDataClient.class);
     when(combinedChainDataClientMock.getCurrentSlot()).thenReturn(ZERO);
@@ -364,7 +364,7 @@ public class GetNewBlockV3Test extends AbstractMigratedBeaconHandlerTest {
     assumeThat(specMilestone).isLessThan(ALTAIR);
     final BlockContainer blockContainer = dataStructureUtil.randomBeaconBlock(ONE);
     final ValidatorApiChannel validatorApiChannelMock = mock(ValidatorApiChannel.class);
-    when(validatorApiChannelMock.createUnsignedBlock(any(), any(), any(), any()))
+    when(validatorApiChannelMock.createUnsignedBlock(any(), any(), any(), any(), any()))
         .thenReturn(SafeFuture.completedFuture(Optional.of(blockContainer)));
     final BeaconState parentStateMock = mock(BeaconState.class);
     final CombinedChainDataClient combinedChainDataClientMock = mock(CombinedChainDataClient.class);

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
@@ -229,19 +229,6 @@ public class ValidatorDataProvider {
     }
   }
 
-  public SafeFuture<Optional<BlockContainer>> getUnsignedBeaconBlockAtSlot(
-      UInt64 slot, BLSSignature randao, Optional<Bytes32> graffiti) {
-    if (randao == null) {
-      throw new IllegalArgumentException(NO_RANDAO_PROVIDED);
-    }
-    return getUnsignedBeaconBlockAtSlot(
-        slot,
-        BLSSignature.fromBytesCompressed(randao.toSSZBytes()),
-        graffiti,
-        false,
-        Optional.empty());
-  }
-
   public SpecMilestone getMilestoneAtSlot(final UInt64 slot) {
     return spec.atSlot(slot).getMilestone();
   }

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
@@ -115,16 +115,21 @@ public class ValidatorDataProvider {
       final UInt64 slot,
       final BLSSignature randao,
       final Optional<Bytes32> graffiti,
-      final boolean isBlinded) {
+      final boolean isBlinded,
+      final Optional<UInt64> requestedBuilderBoostFactor) {
     checkBlockProducingParameters(slot, randao);
-    return validatorApiChannel.createUnsignedBlock(slot, randao, graffiti, Optional.of(isBlinded));
+    return validatorApiChannel.createUnsignedBlock(
+        slot, randao, graffiti, Optional.of(isBlinded), requestedBuilderBoostFactor);
   }
 
   public SafeFuture<Optional<BlockContainerAndMetaData<BlockContainer>>> produceBlock(
-      final UInt64 slot, final BLSSignature randao, final Optional<Bytes32> graffiti) {
+      final UInt64 slot,
+      final BLSSignature randao,
+      final Optional<Bytes32> graffiti,
+      final Optional<UInt64> requestedBuilderBoostFactor) {
     checkBlockProducingParameters(slot, randao);
     return validatorApiChannel
-        .createUnsignedBlock(slot, randao, graffiti, Optional.empty())
+        .createUnsignedBlock(slot, randao, graffiti, Optional.empty(), requestedBuilderBoostFactor)
         .thenCompose(this::lookUpBlockValues);
   }
 
@@ -230,7 +235,11 @@ public class ValidatorDataProvider {
       throw new IllegalArgumentException(NO_RANDAO_PROVIDED);
     }
     return getUnsignedBeaconBlockAtSlot(
-        slot, BLSSignature.fromBytesCompressed(randao.toSSZBytes()), graffiti, false);
+        slot,
+        BLSSignature.fromBytesCompressed(randao.toSSZBytes()),
+        graffiti,
+        false,
+        Optional.empty());
   }
 
   public SpecMilestone getMilestoneAtSlot(final UInt64 slot) {

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
@@ -110,7 +110,8 @@ public class ValidatorDataProvider {
     return combinedChainDataClient.isStoreAvailable();
   }
 
-  @Deprecated
+  @Deprecated // This method is used within the blockV1 and blockV2 flow. It will be deprecated in
+  // the future.
   public SafeFuture<Optional<BlockContainer>> getUnsignedBeaconBlockAtSlot(
       final UInt64 slot,
       final BLSSignature randao,

--- a/data/provider/src/test/java/tech/pegasys/teku/api/ValidatorDataProviderTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/ValidatorDataProviderTest.java
@@ -163,14 +163,15 @@ public class ValidatorDataProviderTest {
     assumeThat(specMilestone).isLessThan(SpecMilestone.DENEB);
     when(combinedChainDataClient.getCurrentSlot()).thenReturn(ZERO);
     when(validatorApiChannel.createUnsignedBlock(
-            ONE, signatureInternal, Optional.empty(), Optional.of(false)))
+            ONE, signatureInternal, Optional.empty(), Optional.of(false), Optional.empty()))
         .thenReturn(completedFuture(Optional.of(blockInternal)));
 
     SafeFuture<? extends Optional<? extends SszData>> data =
         provider.getUnsignedBeaconBlockAtSlot(ONE, signatureInternal, Optional.empty());
 
     verify(validatorApiChannel)
-        .createUnsignedBlock(ONE, signatureInternal, Optional.empty(), Optional.of(false));
+        .createUnsignedBlock(
+            ONE, signatureInternal, Optional.empty(), Optional.of(false), Optional.empty());
 
     assertThat(data).isCompleted();
 
@@ -183,14 +184,15 @@ public class ValidatorDataProviderTest {
     when(combinedChainDataClient.getCurrentSlot()).thenReturn(ZERO);
     blockContents = dataStructureUtil.randomBlockContents();
     when(validatorApiChannel.createUnsignedBlock(
-            ONE, signatureInternal, Optional.empty(), Optional.of(false)))
+            ONE, signatureInternal, Optional.empty(), Optional.of(false), Optional.of(ONE)))
         .thenReturn(completedFuture(Optional.of(blockContents)));
 
     SafeFuture<? extends Optional<? extends SszData>> data =
         provider.getUnsignedBeaconBlockAtSlot(ONE, signatureInternal, Optional.empty());
 
     verify(validatorApiChannel)
-        .createUnsignedBlock(ONE, signatureInternal, Optional.empty(), Optional.of(false));
+        .createUnsignedBlock(
+            ONE, signatureInternal, Optional.empty(), Optional.of(false), Optional.of(ONE));
 
     assertThat(data).isCompleted();
 

--- a/data/provider/src/test/java/tech/pegasys/teku/api/ValidatorDataProviderTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/ValidatorDataProviderTest.java
@@ -46,6 +46,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.units.bigints.UInt256;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.mockito.ArgumentCaptor;
@@ -74,6 +75,8 @@ import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.versions.deneb.BlockContents;
 import tech.pegasys.teku.spec.datastructures.builder.SignedValidatorRegistration;
+import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadResult;
+import tech.pegasys.teku.spec.datastructures.metadata.BlockContainerAndMetaData;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.validator.BroadcastValidationLevel;
@@ -129,13 +132,19 @@ public class ValidatorDataProviderTest {
   @TestTemplate
   void getUnsignedBeaconBlockAtSlot_throwsWithoutSlotDefined() {
     assertThatExceptionOfType(IllegalArgumentException.class)
-        .isThrownBy(() -> provider.getUnsignedBeaconBlockAtSlot(null, null, Optional.empty()));
+        .isThrownBy(
+            () ->
+                provider.getUnsignedBeaconBlockAtSlot(
+                    null, null, Optional.empty(), false, Optional.empty()));
   }
 
   @TestTemplate
   void getUnsignedBeaconBlockAtSlot_shouldThrowWithoutRandaoDefined() {
     assertThatExceptionOfType(IllegalArgumentException.class)
-        .isThrownBy(() -> provider.getUnsignedBeaconBlockAtSlot(ONE, null, Optional.empty()));
+        .isThrownBy(
+            () ->
+                provider.getUnsignedBeaconBlockAtSlot(
+                    ONE, null, Optional.empty(), false, Optional.empty()));
   }
 
   @TestTemplate
@@ -144,7 +153,9 @@ public class ValidatorDataProviderTest {
 
     assertThatExceptionOfType(IllegalArgumentException.class)
         .isThrownBy(
-            () -> provider.getUnsignedBeaconBlockAtSlot(ZERO, signatureInternal, Optional.empty()));
+            () ->
+                provider.getUnsignedBeaconBlockAtSlot(
+                    ZERO, signatureInternal, Optional.empty(), false, Optional.empty()));
   }
 
   @TestTemplate
@@ -155,7 +166,11 @@ public class ValidatorDataProviderTest {
         .isThrownBy(
             () ->
                 provider.getUnsignedBeaconBlockAtSlot(
-                    UInt64.valueOf(10L), signatureInternal, Optional.empty()));
+                    UInt64.valueOf(10L),
+                    signatureInternal,
+                    Optional.empty(),
+                    false,
+                    Optional.empty()));
   }
 
   @TestTemplate
@@ -167,7 +182,8 @@ public class ValidatorDataProviderTest {
         .thenReturn(completedFuture(Optional.of(blockInternal)));
 
     SafeFuture<? extends Optional<? extends SszData>> data =
-        provider.getUnsignedBeaconBlockAtSlot(ONE, signatureInternal, Optional.empty());
+        provider.getUnsignedBeaconBlockAtSlot(
+            ONE, signatureInternal, Optional.empty(), false, Optional.empty());
 
     verify(validatorApiChannel)
         .createUnsignedBlock(
@@ -179,24 +195,78 @@ public class ValidatorDataProviderTest {
   }
 
   @TestTemplate
-  void getUnsignedBlockContentsAtSlot_PostDeneb_shouldCreateAnUnsignedBlockContents() {
-    assumeThat(specMilestone).isGreaterThanOrEqualTo(SpecMilestone.DENEB);
-    when(combinedChainDataClient.getCurrentSlot()).thenReturn(ZERO);
-    blockContents = dataStructureUtil.randomBlockContents();
-    when(validatorApiChannel.createUnsignedBlock(
-            ONE, signatureInternal, Optional.empty(), Optional.of(false), Optional.of(ONE)))
-        .thenReturn(completedFuture(Optional.of(blockContents)));
+  void produceBlock_throwsWithoutSlotDefined() {
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> provider.produceBlock(null, null, Optional.empty(), Optional.empty()));
+  }
 
-    SafeFuture<? extends Optional<? extends SszData>> data =
-        provider.getUnsignedBeaconBlockAtSlot(ONE, signatureInternal, Optional.empty());
+  @TestTemplate
+  void produceBlock_shouldThrowWithoutRandaoDefined() {
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> provider.produceBlock(ONE, null, Optional.empty(), Optional.empty()));
+  }
+
+  @TestTemplate
+  void produceBlock_shouldThrowIfHistoricSlotRequested() {
+    when(combinedChainDataClient.getCurrentSlot()).thenReturn(ONE);
+
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(
+            () ->
+                provider.produceBlock(ZERO, signatureInternal, Optional.empty(), Optional.empty()));
+  }
+
+  @TestTemplate
+  void produceBlock_shouldThrowIfFarFutureSlotRequested() {
+    when(combinedChainDataClient.getCurrentSlot()).thenReturn(ONE);
+
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(
+            () ->
+                provider.produceBlock(
+                    UInt64.valueOf(10L), signatureInternal, Optional.empty(), Optional.empty()));
+  }
+
+  @TestTemplate
+  void produceBlock_shouldCreateAnUnsignedBlock() {
+    when(combinedChainDataClient.getCurrentSlot()).thenReturn(ONE);
+    when(combinedChainDataClient.getStateAtSlotExact(blockInternal.getSlot().decrement()))
+        .thenReturn(completedFuture(Optional.of(dataStructureUtil.randomBeaconState())));
+
+    final Optional<ExecutionPayloadResult> executionPayloadResult;
+
+    if (specMilestone.isGreaterThanOrEqualTo(SpecMilestone.BELLATRIX)) {
+      executionPayloadResult =
+          Optional.of(
+              new ExecutionPayloadResult(
+                  dataStructureUtil.randomPayloadExecutionContext(ONE, false),
+                  Optional.of(completedFuture(dataStructureUtil.randomExecutionPayload())),
+                  Optional.empty(),
+                  Optional.empty(),
+                  Optional.of(completedFuture(UInt256.ONE))));
+    } else {
+      executionPayloadResult = Optional.empty();
+    }
+
+    when(executionLayerBlockProductionManager.getCachedPayloadResult(ZERO))
+        .thenReturn(executionPayloadResult);
+
+    when(validatorApiChannel.createUnsignedBlock(
+            ONE, signatureInternal, Optional.empty(), Optional.empty(), Optional.of(ONE)))
+        .thenReturn(completedFuture(Optional.of(blockInternal)));
+
+    SafeFuture<? extends Optional<? extends BlockContainerAndMetaData<? extends SszData>>> data =
+        provider.produceBlock(ONE, signatureInternal, Optional.empty(), Optional.of(ONE));
 
     verify(validatorApiChannel)
         .createUnsignedBlock(
-            ONE, signatureInternal, Optional.empty(), Optional.of(false), Optional.of(ONE));
+            ONE, signatureInternal, Optional.empty(), Optional.empty(), Optional.of(ONE));
 
     assertThat(data).isCompleted();
 
-    assertThat(data.getNow(null).orElseThrow()).usingRecursiveComparison().isEqualTo(blockContents);
+    assertThat(data.getNow(null).orElseThrow().blockContainer())
+        .usingRecursiveComparison()
+        .isEqualTo(blockInternal);
   }
 
   @TestTemplate

--- a/data/provider/src/test/java/tech/pegasys/teku/api/ValidatorDataProviderTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/ValidatorDataProviderTest.java
@@ -73,7 +73,6 @@ import tech.pegasys.teku.spec.TestSpecContext;
 import tech.pegasys.teku.spec.TestSpecInvocationContextProvider.SpecContext;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
-import tech.pegasys.teku.spec.datastructures.blocks.versions.deneb.BlockContents;
 import tech.pegasys.teku.spec.datastructures.builder.SignedValidatorRegistration;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadResult;
 import tech.pegasys.teku.spec.datastructures.metadata.BlockContainerAndMetaData;
@@ -110,7 +109,6 @@ public class ValidatorDataProviderTest {
   private final ValidatorApiChannel validatorApiChannel = mock(ValidatorApiChannel.class);
   private ValidatorDataProvider provider;
   private BeaconBlock blockInternal;
-  private BlockContents blockContents;
   private final BLSSignature signatureInternal = BLSTestUtil.randomSignature(1234);
 
   @BeforeEach

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ValidatorsUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ValidatorsUtil.java
@@ -34,8 +34,6 @@ import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
 import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
 
 public class ValidatorsUtil {
-
-  public static final boolean DEFAULT_PRODUCE_BLINDED_BLOCK = true;
   private final SpecConfig specConfig;
   private final MiscHelpers miscHelpers;
   private final BeaconStateAccessors beaconStateAccessors;

--- a/infrastructure/http/src/main/java/tech/pegasys/teku/infrastructure/http/RestApiConstants.java
+++ b/infrastructure/http/src/main/java/tech/pegasys/teku/infrastructure/http/RestApiConstants.java
@@ -187,6 +187,37 @@ public class RestApiConstants {
           + " `randao_reveal` must be set to the point at infinity (`0xc0..00`). This query parameter\n"
           + "  is a flag and does not take a value";
 
+  public static final String BUILDER_BOOST_FACTOR = "builder_boost_factor";
+  public static final String BUILDER_BOOST_FACTOR_DESCRIPTION =
+      """
+          Percentage multiplier to apply to the builder's payload value when choosing between a
+          builder payload header and payload from the paired execution node. This parameter is only
+          relevant if the beacon node is connected to a builder, deems it safe to produce a builder
+          payload, and receives valid responses from both the builder endpoint _and_ the paired
+          execution node. When these preconditions are met, the server MUST act as follows:
+
+          * if `exec_node_payload_value >= builder_boost_factor * (builder_payload_value // 100)`,
+            then return a full (unblinded) block containing the execution node payload.
+          * otherwise, return a blinded block containing the builder payload header.
+
+          Servers must support the following values of the boost factor which encode common
+          preferences:
+
+          * `builder_boost_factor=0`: prefer the execution node payload unless an error makes it
+            unviable.
+          * `builder_boost_factor=100`: default profit maximization mode; choose whichever
+            payload pays more.
+          * `builder_boost_factor=2**64 - 1`: prefer the builder payload unless an error or
+            beacon node health check makes it unviable.
+
+          Servers should use saturating arithmetic or another technique to ensure that large values of
+          the `builder_boost_factor` do not trigger overflows or errors. If this parameter is
+          provided and the beacon node is not configured with a builder then the beacon node MUST
+          respond with a full block, which the caller can choose to reject if it wishes. If this
+          parameter is **not** provided then it should be treated as having the default value of 100.
+          If the value is provided but out of range for a 64-bit unsigned integer, then an error
+          response with status code 400 MUST be returned.""";
+
   public static final String HEADER_ACCEPT = "Accept";
 
   public static final String HEADER_CONSENSUS_VERSION = "Eth-Consensus-Version";

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
@@ -85,7 +85,8 @@ public interface ValidatorApiChannel extends ChannelInterface {
             UInt64 slot,
             BLSSignature randaoReveal,
             Optional<Bytes32> graffiti,
-            Optional<Boolean> requestedBlinded) {
+            Optional<Boolean> requestedBlinded,
+            Optional<UInt64> requestedBuilderBoostFactor) {
           return SafeFuture.completedFuture(Optional.empty());
         }
 
@@ -200,7 +201,8 @@ public interface ValidatorApiChannel extends ChannelInterface {
       UInt64 slot,
       BLSSignature randaoReveal,
       Optional<Bytes32> graffiti,
-      Optional<Boolean> requestedBlinded);
+      Optional<Boolean> requestedBlinded,
+      Optional<UInt64> requestedBuilderBoostFactor);
 
   SafeFuture<Optional<AttestationData>> createAttestationData(UInt64 slot, int committeeIndex);
 

--- a/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
+++ b/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
@@ -129,10 +129,12 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
   public SafeFuture<Optional<BlockContainer>> createUnsignedBlock(
       final UInt64 slot,
       final BLSSignature randaoReveal,
-      Optional<Bytes32> graffiti,
-      final Optional<Boolean> requestedBlinded) {
+      final Optional<Bytes32> graffiti,
+      final Optional<Boolean> requestedBlinded,
+      final Optional<UInt64> requestedBuilderBoostFactor) {
     return countOptionalDataRequest(
-        delegate.createUnsignedBlock(slot, randaoReveal, graffiti, requestedBlinded),
+        delegate.createUnsignedBlock(
+            slot, randaoReveal, graffiti, requestedBlinded, requestedBuilderBoostFactor),
         BeaconNodeRequestLabels.CREATE_UNSIGNED_BLOCK_METHOD);
   }
 

--- a/validator/beaconnode/src/test/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannelTest.java
+++ b/validator/beaconnode/src/test/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannelTest.java
@@ -193,7 +193,8 @@ class MetricRecordingValidatorApiChannelTest {
         requestDataTest(
             "createUnsignedBlock",
             channel ->
-                channel.createUnsignedBlock(slot, signature, Optional.empty(), Optional.of(false)),
+                channel.createUnsignedBlock(
+                    slot, signature, Optional.empty(), Optional.of(false), Optional.empty()),
             BeaconNodeRequestLabels.CREATE_UNSIGNED_BLOCK_METHOD,
             dataStructureUtil.randomBeaconBlock(slot)),
         requestDataTest(

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/BlockProductionDuty.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/BlockProductionDuty.java
@@ -113,10 +113,14 @@ public class BlockProductionDuty implements Duty {
       final BLSSignature randaoReveal) {
     if (blockV3Enabled) {
       return validatorApiChannel.createUnsignedBlock(
-          slot, randaoReveal, validator.getGraffiti(), Optional.empty());
+          slot, randaoReveal, validator.getGraffiti(), Optional.empty(), Optional.empty());
     } else {
       return validatorApiChannel.createUnsignedBlock(
-          slot, randaoReveal, validator.getGraffiti(), Optional.of(useBlindedBlock));
+          slot,
+          randaoReveal,
+          validator.getGraffiti(),
+          Optional.of(useBlindedBlock),
+          Optional.empty());
     }
   }
 

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/BlockProductionDutyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/BlockProductionDutyTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.async.SafeFuture.completedFuture;
 import static tech.pegasys.teku.infrastructure.async.SafeFuture.failedFuture;
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
+import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 
 import java.util.List;
@@ -137,7 +138,11 @@ class BlockProductionDutyTest {
     when(signer.createRandaoReveal(spec.computeEpochAtSlot(CAPELLA_SLOT), fork))
         .thenReturn(completedFuture(randaoReveal));
     when(validatorApiChannel.createUnsignedBlock(
-            CAPELLA_SLOT, randaoReveal, Optional.of(graffiti), Optional.of(isBlindedBlocksEnabled)))
+            CAPELLA_SLOT,
+            randaoReveal,
+            Optional.of(graffiti),
+            Optional.of(isBlindedBlocksEnabled),
+            Optional.empty()))
         .thenReturn(completedFuture(Optional.of(unsignedBlock)));
     when(signer.signBlock(unsignedBlock, fork)).thenReturn(completedFuture(blockSignature));
     final SignedBeaconBlock signedBlock =
@@ -193,7 +198,7 @@ class BlockProductionDutyTest {
     when(signer.signBlock(unsignedBlockContents.getBlock(), fork))
         .thenReturn(completedFuture(blockSignature));
     when(validatorApiChannel.createUnsignedBlock(
-            denebSlot, randaoReveal, Optional.of(graffiti), Optional.of(false)))
+            denebSlot, randaoReveal, Optional.of(graffiti), Optional.of(false), Optional.empty()))
         .thenReturn(completedFuture(Optional.of(unsignedBlockContents)));
     when(validatorApiChannel.sendSignedBlock(any(), any()))
         .thenReturn(completedFuture(SendSignedBlockResult.success(unsignedBlock.getRoot())));
@@ -275,7 +280,7 @@ class BlockProductionDutyTest {
     when(signer.signBlock(unsignedBlindedBlock.getBlock(), fork))
         .thenReturn(completedFuture(blockSignature));
     when(validatorApiChannel.createUnsignedBlock(
-            denebSlot, randaoReveal, Optional.of(graffiti), Optional.of(true)))
+            denebSlot, randaoReveal, Optional.of(graffiti), Optional.of(true), Optional.empty()))
         .thenReturn(completedFuture(Optional.of(unsignedBlindedBlock)));
     when(validatorApiChannel.sendSignedBlock(any(), any()))
         .thenReturn(completedFuture(SendSignedBlockResult.success(unsignedBlindedBlock.getRoot())));
@@ -343,7 +348,7 @@ class BlockProductionDutyTest {
     when(signer.signBlock(unsignedBlockContentsMock.getBlock(), fork))
         .thenReturn(completedFuture(blockSignature));
     when(validatorApiChannel.createUnsignedBlock(
-            denebSlot, randaoReveal, Optional.of(graffiti), Optional.of(false)))
+            denebSlot, randaoReveal, Optional.of(graffiti), Optional.of(false), Optional.empty()))
         .thenReturn(completedFuture(Optional.of(unsignedBlockContentsMock)));
     when(validatorApiChannel.sendSignedBlock(any(), any()))
         .thenReturn(completedFuture(SendSignedBlockResult.success(blockRoot)));
@@ -386,7 +391,7 @@ class BlockProductionDutyTest {
     when(signer.signBlock(unsignedBlockContentsMock.getBlock(), fork))
         .thenReturn(completedFuture(blockSignature));
     when(validatorApiChannel.createUnsignedBlock(
-            denebSlot, randaoReveal, Optional.of(graffiti), Optional.of(false)))
+            denebSlot, randaoReveal, Optional.of(graffiti), Optional.of(false), Optional.empty()))
         .thenReturn(completedFuture(Optional.of(unsignedBlockContentsMock)));
     when(validatorApiChannel.sendSignedBlock(any(), any()))
         .thenReturn(completedFuture(SendSignedBlockResult.success(blockRoot)));
@@ -441,7 +446,11 @@ class BlockProductionDutyTest {
     when(signer.createRandaoReveal(spec.computeEpochAtSlot(CAPELLA_SLOT), fork))
         .thenReturn(completedFuture(randaoReveal));
     when(validatorApiChannel.createUnsignedBlock(
-            CAPELLA_SLOT, randaoReveal, Optional.of(graffiti), Optional.of(false)))
+            CAPELLA_SLOT,
+            randaoReveal,
+            Optional.of(graffiti),
+            Optional.of(false),
+            Optional.empty()))
         .thenReturn(failedFuture(error));
 
     assertDutyFails(error);
@@ -457,7 +466,11 @@ class BlockProductionDutyTest {
     when(signer.createRandaoReveal(spec.computeEpochAtSlot(CAPELLA_SLOT), fork))
         .thenReturn(completedFuture(randaoReveal));
     when(validatorApiChannel.createUnsignedBlock(
-            CAPELLA_SLOT, randaoReveal, Optional.of(graffiti), Optional.of(false)))
+            CAPELLA_SLOT,
+            randaoReveal,
+            Optional.of(graffiti),
+            Optional.of(false),
+            Optional.empty()))
         .thenReturn(completedFuture(Optional.empty()));
 
     performAndReportDuty();
@@ -483,7 +496,11 @@ class BlockProductionDutyTest {
     when(signer.createRandaoReveal(spec.computeEpochAtSlot(CAPELLA_SLOT), fork))
         .thenReturn(completedFuture(randaoReveal));
     when(validatorApiChannel.createUnsignedBlock(
-            CAPELLA_SLOT, randaoReveal, Optional.of(graffiti), Optional.of(false)))
+            CAPELLA_SLOT,
+            randaoReveal,
+            Optional.of(graffiti),
+            Optional.of(false),
+            Optional.empty()))
         .thenReturn(completedFuture(Optional.of(unsignedBlock)));
     when(signer.signBlock(unsignedBlock, fork)).thenReturn(failedFuture(error));
 
@@ -523,7 +540,7 @@ class BlockProductionDutyTest {
     when(signer.createRandaoReveal(spec.computeEpochAtSlot(CAPELLA_SLOT), fork))
         .thenReturn(completedFuture(randaoReveal));
     when(validatorApiChannel.createUnsignedBlock(
-            CAPELLA_SLOT, randaoReveal, Optional.of(graffiti), Optional.empty()))
+            CAPELLA_SLOT, randaoReveal, Optional.of(graffiti), Optional.empty(), Optional.of(ONE)))
         .thenReturn(completedFuture(Optional.of(unsignedBlock)));
     when(signer.signBlock(unsignedBlock, fork)).thenReturn(completedFuture(blockSignature));
     final SignedBeaconBlock signedBlock =
@@ -533,7 +550,8 @@ class BlockProductionDutyTest {
 
     performAndReportDuty();
     verify(validatorApiChannel)
-        .createUnsignedBlock(CAPELLA_SLOT, randaoReveal, Optional.of(graffiti), Optional.empty());
+        .createUnsignedBlock(
+            CAPELLA_SLOT, randaoReveal, Optional.of(graffiti), Optional.empty(), Optional.of(ONE));
 
     verify(validatorApiChannel).sendSignedBlock(signedBlock, BroadcastValidationLevel.NOT_REQUIRED);
     verify(validatorLogger)
@@ -582,7 +600,7 @@ class BlockProductionDutyTest {
     when(signer.signBlock(unsignedBlockContents.getBlock(), fork))
         .thenReturn(completedFuture(blockSignature));
     when(validatorApiChannel.createUnsignedBlock(
-            denebSlot, randaoReveal, Optional.of(graffiti), Optional.empty()))
+            denebSlot, randaoReveal, Optional.of(graffiti), Optional.empty(), Optional.empty()))
         .thenReturn(completedFuture(Optional.of(unsignedBlockContents)));
     when(validatorApiChannel.sendSignedBlock(any(), any()))
         .thenReturn(completedFuture(SendSignedBlockResult.success(unsignedBlock.getRoot())));
@@ -590,7 +608,8 @@ class BlockProductionDutyTest {
     performAndReportDuty(denebSlot);
 
     verify(validatorApiChannel)
-        .createUnsignedBlock(denebSlot, randaoReveal, Optional.of(graffiti), Optional.empty());
+        .createUnsignedBlock(
+            denebSlot, randaoReveal, Optional.of(graffiti), Optional.empty(), Optional.empty());
 
     final ArgumentCaptor<SignedBlockContents> signedBlockContentsArgumentCaptor =
         ArgumentCaptor.forClass(SignedBlockContents.class);

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/BlockProductionDutyTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/BlockProductionDutyTest.java
@@ -25,7 +25,6 @@ import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.infrastructure.async.SafeFuture.completedFuture;
 import static tech.pegasys.teku.infrastructure.async.SafeFuture.failedFuture;
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
-import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ZERO;
 
 import java.util.List;
@@ -540,7 +539,7 @@ class BlockProductionDutyTest {
     when(signer.createRandaoReveal(spec.computeEpochAtSlot(CAPELLA_SLOT), fork))
         .thenReturn(completedFuture(randaoReveal));
     when(validatorApiChannel.createUnsignedBlock(
-            CAPELLA_SLOT, randaoReveal, Optional.of(graffiti), Optional.empty(), Optional.of(ONE)))
+            CAPELLA_SLOT, randaoReveal, Optional.of(graffiti), Optional.empty(), Optional.empty()))
         .thenReturn(completedFuture(Optional.of(unsignedBlock)));
     when(signer.signBlock(unsignedBlock, fork)).thenReturn(completedFuture(blockSignature));
     final SignedBeaconBlock signedBlock =
@@ -551,7 +550,7 @@ class BlockProductionDutyTest {
     performAndReportDuty();
     verify(validatorApiChannel)
         .createUnsignedBlock(
-            CAPELLA_SLOT, randaoReveal, Optional.of(graffiti), Optional.empty(), Optional.of(ONE));
+            CAPELLA_SLOT, randaoReveal, Optional.of(graffiti), Optional.empty(), Optional.empty());
 
     verify(validatorApiChannel).sendSignedBlock(signedBlock, BroadcastValidationLevel.NOT_REQUIRED);
     verify(validatorLogger)

--- a/validator/remote/src/integration-test/java/tech/pegasys/teku/validator/remote/typedef/OkHttpValidatorTypeDefClientTest.java
+++ b/validator/remote/src/integration-test/java/tech/pegasys/teku/validator/remote/typedef/OkHttpValidatorTypeDefClientTest.java
@@ -307,6 +307,7 @@ class OkHttpValidatorTypeDefClientTest extends AbstractTypeDefRequestTestBase {
         okHttpValidatorTypeDefClient.createUnsignedBlock(
             dataStructureUtil.randomUInt64(),
             dataStructureUtil.randomSignature(),
+            Optional.empty(),
             Optional.empty());
 
     assertThat(producedBlock).hasValue(blockContainer);

--- a/validator/remote/src/integration-test/java/tech/pegasys/teku/validator/remote/typedef/handlers/ProduceBlockRequestTest.java
+++ b/validator/remote/src/integration-test/java/tech/pegasys/teku/validator/remote/typedef/handlers/ProduceBlockRequestTest.java
@@ -214,13 +214,18 @@ public class ProduceBlockRequestTest extends AbstractTypeDefRequestTestBase {
     final BLSSignature signature = dataStructureUtil.randomSignature();
     RecordedRequest recordedRequest;
 
+    // here we are testing that the request is sent with the correct parameters, so we don't bother
+    // creating an actual block. We just return a 404 which will cause the request to throw
+
     mockWebServer.enqueue(new MockResponse().setResponseCode(SC_NOT_FOUND));
 
+    // no optional parameters
     assertThatThrownBy(
         () -> request.createUnsignedBlock(signature, Optional.empty(), Optional.empty()));
 
     recordedRequest = mockWebServer.takeRequest();
 
+    // the request should not contain any optional parameters
     assertThat(recordedRequest.getRequestUrl().queryParameterNames())
         .doesNotContain("graffiti", "builder_boost_factor");
     assertThat(recordedRequest.getRequestUrl().queryParameter("randao_reveal"))
@@ -228,6 +233,7 @@ public class ProduceBlockRequestTest extends AbstractTypeDefRequestTestBase {
 
     mockWebServer.enqueue(new MockResponse().setResponseCode(SC_NOT_FOUND));
 
+    // with all parameters
     assertThatThrownBy(
         () ->
             request.createUnsignedBlock(
@@ -235,6 +241,7 @@ public class ProduceBlockRequestTest extends AbstractTypeDefRequestTestBase {
 
     recordedRequest = mockWebServer.takeRequest();
 
+    // the request should contain all optional parameters
     assertThat(recordedRequest.getRequestUrl().queryParameter("randao_reveal"))
         .isEqualTo(signature.toString());
     assertThat(recordedRequest.getRequestUrl().queryParameter("graffiti"))

--- a/validator/remote/src/integration-test/java/tech/pegasys/teku/validator/remote/typedef/handlers/ProduceBlockRequestTest.java
+++ b/validator/remote/src/integration-test/java/tech/pegasys/teku/validator/remote/typedef/handlers/ProduceBlockRequestTest.java
@@ -14,7 +14,9 @@
 package tech.pegasys.teku.validator.remote.typedef.handlers;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assumptions.assumeThat;
+import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_NOT_FOUND;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.HEADER_EXECUTION_PAYLOAD_BLINDED;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
@@ -24,7 +26,9 @@ import static tech.pegasys.teku.spec.SpecMilestone.DENEB;
 import com.google.common.net.MediaType;
 import java.util.Optional;
 import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.RecordedRequest;
 import okio.Buffer;
+import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
@@ -71,7 +75,7 @@ public class ProduceBlockRequestTest extends AbstractTypeDefRequestTestBase {
     final BLSSignature signature = beaconBlock.getBlock().getBody().getRandaoReveal();
 
     final Optional<BlockContainer> maybeBlockContainer =
-        request.createUnsignedBlock(signature, Optional.empty());
+        request.createUnsignedBlock(signature, Optional.empty(), Optional.empty());
 
     assertThat(maybeBlockContainer).isPresent();
 
@@ -100,7 +104,7 @@ public class ProduceBlockRequestTest extends AbstractTypeDefRequestTestBase {
     final BLSSignature signature = beaconBlock.getBlock().getBody().getRandaoReveal();
 
     final Optional<BlockContainer> maybeBlockContainer =
-        request.createUnsignedBlock(signature, Optional.empty());
+        request.createUnsignedBlock(signature, Optional.empty(), Optional.empty());
 
     assertThat(maybeBlockContainer).isPresent();
 
@@ -121,7 +125,7 @@ public class ProduceBlockRequestTest extends AbstractTypeDefRequestTestBase {
     final BLSSignature signature = blindedBeaconBlock.getBlock().getBody().getRandaoReveal();
 
     final Optional<BlockContainer> maybeBlockContainer =
-        request.createUnsignedBlock(signature, Optional.empty());
+        request.createUnsignedBlock(signature, Optional.empty(), Optional.empty());
 
     assertThat(maybeBlockContainer).hasValue(blockResponse.getData());
   }
@@ -148,7 +152,7 @@ public class ProduceBlockRequestTest extends AbstractTypeDefRequestTestBase {
     final BLSSignature signature = blindedBeaconBlock.getBlock().getBody().getRandaoReveal();
 
     final Optional<BlockContainer> maybeBlockContainer =
-        request.createUnsignedBlock(signature, Optional.empty());
+        request.createUnsignedBlock(signature, Optional.empty(), Optional.empty());
 
     assertThat(maybeBlockContainer).isPresent();
 
@@ -169,7 +173,7 @@ public class ProduceBlockRequestTest extends AbstractTypeDefRequestTestBase {
     final BLSSignature signature = blockContents.getBlock().getBody().getRandaoReveal();
 
     final Optional<BlockContainer> maybeBlockContainer =
-        request.createUnsignedBlock(signature, Optional.empty());
+        request.createUnsignedBlock(signature, Optional.empty(), Optional.empty());
 
     assertThat(maybeBlockContainer).isPresent();
 
@@ -198,11 +202,45 @@ public class ProduceBlockRequestTest extends AbstractTypeDefRequestTestBase {
     final BLSSignature signature = blockContents.getBlock().getBody().getRandaoReveal();
 
     final Optional<BlockContainer> maybeBlockContainer =
-        request.createUnsignedBlock(signature, Optional.empty());
+        request.createUnsignedBlock(signature, Optional.empty(), Optional.empty());
 
     assertThat(maybeBlockContainer).isPresent();
 
     assertThat(maybeBlockContainer.get()).isEqualTo(blockResponse.getData());
+  }
+
+  @TestTemplate
+  public void shouldPassUrlParameters() throws InterruptedException {
+    final BLSSignature signature = dataStructureUtil.randomSignature();
+    RecordedRequest recordedRequest;
+
+    mockWebServer.enqueue(new MockResponse().setResponseCode(SC_NOT_FOUND));
+
+    assertThatThrownBy(
+        () -> request.createUnsignedBlock(signature, Optional.empty(), Optional.empty()));
+
+    recordedRequest = mockWebServer.takeRequest();
+
+    assertThat(recordedRequest.getRequestUrl().queryParameterNames())
+        .doesNotContain("graffiti", "builder_boost_factor");
+    assertThat(recordedRequest.getRequestUrl().queryParameter("randao_reveal"))
+        .isEqualTo(signature.toString());
+
+    mockWebServer.enqueue(new MockResponse().setResponseCode(SC_NOT_FOUND));
+
+    assertThatThrownBy(
+        () ->
+            request.createUnsignedBlock(
+                signature, Optional.of(Bytes32.ZERO), Optional.of(UInt64.valueOf(48))));
+
+    recordedRequest = mockWebServer.takeRequest();
+
+    assertThat(recordedRequest.getRequestUrl().queryParameter("randao_reveal"))
+        .isEqualTo(signature.toString());
+    assertThat(recordedRequest.getRequestUrl().queryParameter("graffiti"))
+        .isEqualTo("0x0000000000000000000000000000000000000000000000000000000000000000");
+    assertThat(recordedRequest.getRequestUrl().queryParameter("builder_boost_factor"))
+        .isEqualTo("48");
   }
 
   private String readExpectedJsonResource(

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandler.java
@@ -150,11 +150,13 @@ public class FailoverValidatorApiHandler implements ValidatorApiChannel {
       final UInt64 slot,
       final BLSSignature randaoReveal,
       final Optional<Bytes32> graffiti,
-      final Optional<Boolean> requestedBlinded) {
+      final Optional<Boolean> requestedBlinded,
+      final Optional<UInt64> requestedBuilderBoostFactor) {
     final ValidatorApiChannelRequest<Optional<BlockContainer>> request =
         apiChannel ->
             apiChannel
-                .createUnsignedBlock(slot, randaoReveal, graffiti, requestedBlinded)
+                .createUnsignedBlock(
+                    slot, randaoReveal, graffiti, requestedBlinded, requestedBuilderBoostFactor)
                 .thenPeek(
                     blockContainer -> {
                       if (!failoverDelegates.isEmpty()

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
@@ -277,14 +277,18 @@ public class RemoteValidatorApiHandler implements RemoteValidatorApiChannel {
       final UInt64 slot,
       final BLSSignature randaoReveal,
       final Optional<Bytes32> graffiti,
-      final Optional<Boolean> requestedBlinded) {
+      final Optional<Boolean> requestedBlinded,
+      final Optional<UInt64> requestedBuilderBoostFactor) {
     if (requestedBlinded.isPresent()) {
       return sendRequest(
           () ->
               typeDefClient.createUnsignedBlock(
                   slot, randaoReveal, graffiti, requestedBlinded.get()));
     }
-    return sendRequest(() -> typeDefClient.createUnsignedBlock(slot, randaoReveal, graffiti));
+    return sendRequest(
+        () ->
+            typeDefClient.createUnsignedBlock(
+                slot, randaoReveal, graffiti, requestedBuilderBoostFactor));
   }
 
   @Override

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/sentry/SentryValidatorApiChannel.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/sentry/SentryValidatorApiChannel.java
@@ -103,10 +103,12 @@ public class SentryValidatorApiChannel implements ValidatorApiChannel {
       final UInt64 slot,
       final BLSSignature randaoReveal,
       final Optional<Bytes32> graffiti,
-      final Optional<Boolean> requestedBlinded) {
+      final Optional<Boolean> requestedBlinded,
+      final Optional<UInt64> requestedBuilderBoostFactor) {
     return blockHandlerChannel
         .orElse(dutiesProviderChannel)
-        .createUnsignedBlock(slot, randaoReveal, graffiti, requestedBlinded);
+        .createUnsignedBlock(
+            slot, randaoReveal, graffiti, requestedBlinded, requestedBuilderBoostFactor);
   }
 
   @Override

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/OkHttpValidatorTypeDefClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/OkHttpValidatorTypeDefClient.java
@@ -29,7 +29,6 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
 import tech.pegasys.teku.spec.datastructures.builder.SignedValidatorRegistration;
 import tech.pegasys.teku.spec.datastructures.genesis.GenesisData;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
-import tech.pegasys.teku.spec.logic.common.util.ValidatorsUtil;
 import tech.pegasys.teku.validator.api.SendSignedBlockResult;
 import tech.pegasys.teku.validator.api.required.SyncingStatus;
 import tech.pegasys.teku.validator.remote.typedef.handlers.CreateAttestationDataRequest;
@@ -108,7 +107,7 @@ public class OkHttpValidatorTypeDefClient {
             baseEndpoint, okHttpClient, spec, slot, blinded, preferSszBlockEncoding);
     try {
       return createBlockRequest.createUnsignedBlock(randaoReveal, graffiti);
-    } catch (BlindedBlockEndpointNotAvailableException ex) {
+    } catch (final BlindedBlockEndpointNotAvailableException ex) {
       LOG.warn(
           "Beacon Node {} does not support blinded block production. Falling back to normal block production.",
           baseEndpoint);
@@ -117,15 +116,21 @@ public class OkHttpValidatorTypeDefClient {
   }
 
   public Optional<BlockContainer> createUnsignedBlock(
-      final UInt64 slot, final BLSSignature randaoReveal, final Optional<Bytes32> graffiti) {
+      final UInt64 slot,
+      final BLSSignature randaoReveal,
+      final Optional<Bytes32> graffiti,
+      final Optional<UInt64> requestedBuilderBoostFactor) {
     final ProduceBlockRequest produceBlockRequest =
         new ProduceBlockRequest(baseEndpoint, okHttpClient, spec, slot, preferSszBlockEncoding);
     try {
-      return produceBlockRequest.createUnsignedBlock(randaoReveal, graffiti);
+      return produceBlockRequest.createUnsignedBlock(
+          randaoReveal, graffiti, requestedBuilderBoostFactor);
     } catch (final BlockProductionV3FailedException ex) {
       LOG.warn("Produce Block V3 request failed at slot {}. Retrying with Block V2", slot);
-      return createUnsignedBlock(
-          slot, randaoReveal, graffiti, ValidatorsUtil.DEFAULT_PRODUCE_BLINDED_BLOCK);
+
+      // Falling back to V2, we have to request a blinded block to be able to support both local and
+      // builder flow.
+      return createUnsignedBlock(slot, randaoReveal, graffiti, true);
     }
   }
 

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/handlers/ProduceBlockRequest.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/handlers/ProduceBlockRequest.java
@@ -15,10 +15,13 @@ package tech.pegasys.teku.validator.remote.typedef.handlers;
 
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_NOT_FOUND;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
+import static tech.pegasys.teku.infrastructure.http.RestApiConstants.BUILDER_BOOST_FACTOR;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.CONSENSUS_BLOCK_VALUE;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.EXECUTION_PAYLOAD_BLINDED;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.EXECUTION_PAYLOAD_VALUE;
+import static tech.pegasys.teku.infrastructure.http.RestApiConstants.GRAFFITI;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.HEADER_EXECUTION_PAYLOAD_BLINDED;
+import static tech.pegasys.teku.infrastructure.http.RestApiConstants.RANDAO_REVEAL;
 import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.BOOLEAN_TYPE;
 import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.UINT256_TYPE;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_UNSIGNED_BLOCK_V3;
@@ -101,11 +104,15 @@ public class ProduceBlockRequest extends AbstractTypeDefRequest {
   }
 
   public Optional<BlockContainer> createUnsignedBlock(
-      final BLSSignature randaoReveal, final Optional<Bytes32> graffiti) {
+      final BLSSignature randaoReveal,
+      final Optional<Bytes32> graffiti,
+      final Optional<UInt64> requestedBuilderBoostFactor) {
     final Map<String, String> queryParams = new HashMap<>();
-    queryParams.put("randao_reveal", randaoReveal.toString());
+    queryParams.put(RANDAO_REVEAL, randaoReveal.toString());
     final Map<String, String> headers = new HashMap<>();
-    graffiti.ifPresent(bytes32 -> queryParams.put("graffiti", bytes32.toHexString()));
+    graffiti.ifPresent(bytes32 -> queryParams.put(GRAFFITI, bytes32.toHexString()));
+    requestedBuilderBoostFactor.ifPresent(
+        builderBoostFactor -> queryParams.put(BUILDER_BOOST_FACTOR, builderBoostFactor.toString()));
 
     if (this.preferSszBlockEncoding) {
       // application/octet-stream is preferred, but will accept application/json

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandlerTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandlerTest.java
@@ -584,7 +584,8 @@ class FailoverValidatorApiHandlerTest {
 
     final ValidatorApiChannelRequest<Optional<BlockContainer>> creationRequest =
         apiChannel ->
-            apiChannel.createUnsignedBlock(slot, randaoReveal, Optional.empty(), Optional.of(true));
+            apiChannel.createUnsignedBlock(
+                slot, randaoReveal, Optional.empty(), Optional.of(true), Optional.empty());
 
     setupFailures(creationRequest, primaryApiChannel);
     setupSuccesses(creationRequest, Optional.of(blindedBlock), failoverApiChannel1);
@@ -686,7 +687,7 @@ class FailoverValidatorApiHandlerTest {
             "createUnsignedBlock",
             apiChannel ->
                 apiChannel.createUnsignedBlock(
-                    slot, randaoReveal, Optional.empty(), Optional.of(false)),
+                    slot, randaoReveal, Optional.empty(), Optional.of(false), Optional.empty()),
             BeaconNodeRequestLabels.CREATE_UNSIGNED_BLOCK_METHOD,
             Optional.of(mock(BeaconBlock.class))),
         getArguments(

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandlerTest.java
@@ -447,7 +447,11 @@ class RemoteValidatorApiHandlerTest {
 
     SafeFuture<Optional<BlockContainer>> future =
         apiHandler.createUnsignedBlock(
-            UInt64.ONE, blsSignature, Optional.of(Bytes32.random()), Optional.of(false));
+            UInt64.ONE,
+            blsSignature,
+            Optional.of(Bytes32.random()),
+            Optional.of(false),
+            Optional.empty());
 
     assertThat(unwrapToOptional(future)).isEmpty();
   }
@@ -463,7 +467,27 @@ class RemoteValidatorApiHandlerTest {
         .thenReturn(Optional.of(beaconBlock));
 
     SafeFuture<Optional<BlockContainer>> future =
-        apiHandler.createUnsignedBlock(UInt64.ONE, blsSignature, graffiti, Optional.of(false));
+        apiHandler.createUnsignedBlock(
+            UInt64.ONE, blsSignature, graffiti, Optional.of(false), Optional.empty());
+
+    assertThatSszData(unwrapToValue(future)).isEqualByAllMeansTo(beaconBlock);
+  }
+
+  @Test
+  public void createUnsignedBlock_viaBlockV3_WhenFound_ReturnsBlock() {
+    final BeaconBlock beaconBlock = dataStructureUtil.randomBeaconBlock(UInt64.ONE);
+    final BLSSignature blsSignature = dataStructureUtil.randomSignature();
+    final Optional<Bytes32> graffiti = Optional.of(Bytes32.random());
+
+    // we expect new block API to be called (with proposer boost factor parameter instead of blinded
+    // parameter)
+    when(typeDefClient.createUnsignedBlock(
+            eq(beaconBlock.getSlot()), eq(blsSignature), eq(graffiti), eq(Optional.of(UInt64.ONE))))
+        .thenReturn(Optional.of(beaconBlock));
+
+    SafeFuture<Optional<BlockContainer>> future =
+        apiHandler.createUnsignedBlock(
+            UInt64.ONE, blsSignature, graffiti, Optional.empty(), Optional.of(UInt64.ONE));
 
     assertThatSszData(unwrapToValue(future)).isEqualByAllMeansTo(beaconBlock);
   }
@@ -482,7 +506,8 @@ class RemoteValidatorApiHandlerTest {
         .thenReturn(Optional.of(blockContents));
 
     SafeFuture<Optional<BlockContainer>> future =
-        apiHandler.createUnsignedBlock(UInt64.ONE, blsSignature, graffiti, Optional.of(false));
+        apiHandler.createUnsignedBlock(
+            UInt64.ONE, blsSignature, graffiti, Optional.of(false), Optional.empty());
 
     assertThatSszData(unwrapToValue(future)).isEqualByAllMeansTo(blockContents);
   }

--- a/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/sentry/SentryValidatorApiChannelTest.java
+++ b/validator/remote/src/test/java/tech/pegasys/teku/validator/remote/sentry/SentryValidatorApiChannelTest.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import java.util.Collections;
@@ -123,14 +124,15 @@ class SentryValidatorApiChannelTest {
   @Test
   void createUnsignedBlockShouldUseBlockHandlerChannelWhenAvailable() {
     sentryValidatorApiChannel.createUnsignedBlock(
-        UInt64.ZERO, BLSSignature.empty(), Optional.empty(), Optional.of(false));
+        UInt64.ZERO, BLSSignature.empty(), Optional.empty(), Optional.of(false), Optional.of(ONE));
 
     verify(blockHandlerChannel)
         .createUnsignedBlock(
             eq(UInt64.ZERO),
             eq(BLSSignature.empty()),
             eq(Optional.empty()),
-            eq(Optional.of(false)));
+            eq(Optional.of(false)),
+            eq(Optional.of(ONE)));
     verifyNoInteractions(dutiesProviderChannel);
     verifyNoInteractions(attestationPublisherChannel);
   }
@@ -142,14 +144,15 @@ class SentryValidatorApiChannelTest {
             dutiesProviderChannel, Optional.empty(), Optional.of(attestationPublisherChannel));
 
     sentryValidatorApiChannel.createUnsignedBlock(
-        UInt64.ZERO, BLSSignature.empty(), Optional.empty(), Optional.of(false));
+        UInt64.ZERO, BLSSignature.empty(), Optional.empty(), Optional.of(false), Optional.of(ONE));
 
     verify(dutiesProviderChannel)
         .createUnsignedBlock(
             eq(UInt64.ZERO),
             eq(BLSSignature.empty()),
             eq(Optional.empty()),
-            eq(Optional.of(false)));
+            eq(Optional.of(false)),
+            eq(Optional.of(ONE)));
     verifyNoInteractions(blockHandlerChannel);
     verifyNoInteractions(attestationPublisherChannel);
   }


### PR DESCRIPTION
Introduces new `requestedBuilderBoostFactor` in
- `ValidatorApiHandler::createUnsignedBlock`
- API definition (`GetNewBlockV3`)
- typedef client  (`ProduceBlockRequest`)

In `ValidatorDataProviderTest` removes some unit tests on no-more-used method and add missing for new `produceBlock` method

fixes #7851 

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
