### PR TITLE
tiny refactors for late block reorg

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -360,7 +360,8 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
       return SafeFuture.completedFuture(Optional.empty());
     }
     final BeaconState blockSlotState = maybeBlockSlotState.get();
-    final Bytes32 parentRoot = spec.getBlockRootAtSlot(blockSlotState, slot.minus(1));
+    final Bytes32 parentRoot = spec.getBlockRootAtSlot(blockSlotState, slot.decrement());
+    LOG.debug("parent block {}:({})", parentRoot, slot);
     if (combinedChainDataClient.isOptimisticBlock(parentRoot)) {
       LOG.warn(
           "Unable to produce block at slot {} because parent has optimistically validated payload",

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -696,16 +696,16 @@ public class Spec {
 
   // Block Proposal
   public SafeFuture<BeaconBlockAndState> createNewUnsignedBlock(
-      final UInt64 newSlot,
+      final UInt64 proposalSlot,
       final int proposerIndex,
       final BeaconState blockSlotState,
       final Bytes32 parentBlockSigningRoot,
       final Function<BeaconBlockBodyBuilder, SafeFuture<Void>> bodyBuilder,
       final BlockProductionPerformance blockProductionPerformance) {
-    return atSlot(newSlot)
+    return atSlot(proposalSlot)
         .getBlockProposalUtil()
         .createNewUnsignedBlock(
-            newSlot,
+            proposalSlot,
             proposerIndex,
             blockSlotState,
             parentBlockSigningRoot,

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/BlockProposalUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/BlockProposalUtil.java
@@ -47,16 +47,16 @@ public class BlockProposalUtil {
   }
 
   public SafeFuture<BeaconBlockAndState> createNewUnsignedBlock(
-      final UInt64 newSlot,
+      final UInt64 proposalSlot,
       final int proposerIndex,
       final BeaconState blockSlotState,
       final Bytes32 parentBlockSigningRoot,
       final Function<BeaconBlockBodyBuilder, SafeFuture<Void>> bodyBuilder,
       final BlockProductionPerformance blockProductionPerformance) {
     checkArgument(
-        blockSlotState.getSlot().equals(newSlot),
+        blockSlotState.getSlot().equals(proposalSlot),
         "Block slot state from incorrect slot. Expected %s but got %s",
-        newSlot,
+        proposalSlot,
         blockSlotState.getSlot());
 
     // Create block body
@@ -72,7 +72,7 @@ public class BlockProposalUtil {
                       ? schemaDefinitions.getBlindedBeaconBlockSchema()
                       : schemaDefinitions.getBeaconBlockSchema();
               return beaconBlockSchema.create(
-                  newSlot,
+                  proposalSlot,
                   UInt64.valueOf(proposerIndex),
                   parentBlockSigningRoot,
                   tmpStateRoot,

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -175,6 +175,7 @@ import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 import tech.pegasys.teku.storage.client.EarliestAvailableBlockSlot;
 import tech.pegasys.teku.storage.client.RecentChainData;
 import tech.pegasys.teku.storage.client.StorageBackedRecentChainData;
+import tech.pegasys.teku.storage.client.ValidatorIsConnectedProvider;
 import tech.pegasys.teku.storage.store.FileKeyValueStore;
 import tech.pegasys.teku.storage.store.KeyValueStore;
 import tech.pegasys.teku.storage.store.StoreConfig;
@@ -397,6 +398,9 @@ public class BeaconChainController extends Service implements BeaconChainControl
     storageQueryChannel = combinedStorageChannel;
     storageUpdateChannel = combinedStorageChannel;
     final VoteUpdateChannel voteUpdateChannel = eventChannels.getPublisher(VoteUpdateChannel.class);
+
+    final ValidatorIsConnectedProvider validatorIsConnectedProvider =
+        new ValidatorIsConnectedProviderImpl(() -> forkChoiceNotifier);
     // Init other services
     return initWeakSubjectivity(storageQueryChannel, storageUpdateChannel)
         .thenCompose(
@@ -414,7 +418,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
                     voteUpdateChannel,
                     eventChannels.getPublisher(FinalizedCheckpointChannel.class, beaconAsyncRunner),
                     coalescingChainHeadChannel,
-                    new ValidatorIsConnectedProviderImpl(forkChoiceNotifier),
+                    validatorIsConnectedProvider,
                     spec))
         .thenCompose(
             client -> {

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/ValidatorIsConnectedProviderImpl.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/ValidatorIsConnectedProviderImpl.java
@@ -13,19 +13,20 @@
 
 package tech.pegasys.teku.services.beaconchain;
 
+import java.util.function.Supplier;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.statetransition.forkchoice.ForkChoiceNotifier;
 import tech.pegasys.teku.storage.client.ValidatorIsConnectedProvider;
 
 public class ValidatorIsConnectedProviderImpl implements ValidatorIsConnectedProvider {
-  private final ForkChoiceNotifier forkChoiceNotifier;
+  private final Supplier<ForkChoiceNotifier> forkChoiceNotifier;
 
-  public ValidatorIsConnectedProviderImpl(ForkChoiceNotifier forkChoiceNotifier) {
+  public ValidatorIsConnectedProviderImpl(Supplier<ForkChoiceNotifier> forkChoiceNotifier) {
     this.forkChoiceNotifier = forkChoiceNotifier;
   }
 
   @Override
   public boolean isValidatorConnected(int validatorId, UInt64 slot) {
-    return forkChoiceNotifier.validatorIsConnected(UInt64.valueOf(validatorId), slot);
+    return forkChoiceNotifier.get().validatorIsConnected(UInt64.valueOf(validatorId), slot);
   }
 }


### PR DESCRIPTION
ForkChoiceNotifier needed to be supplier because it wasn't intiialised from BeaconChainController.

Also renamed `newSlot` to `proposalSlot` in line with a previous change.

adjunct to #6595

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
