### PR TITLE
Add block_gossip SSE event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ the [releases page](https://github.com/Consensys/teku/releases).
 
 - The CLI options `--beacon-events-block-notify-when-validated-enabled` and
   `--beacon-events-block-notify-when-imported-enabled` have been removed. This change was made due
-  to redundancy, as the functionality of these options is now covered by the new `block_gossip` SSE event.
+  to redundancy, as the functionality of these options is now covered by the new `block_gossip` and
+  the existing `block` SSE events.
 
 ### Additions and Improvements
 - Improved compatibility with `/eth/v3/validator/blocks/{slot}` experimental beacon API for block production. It can now respond with blinded and unblinded content based on the block production flow. It also supports the `builder_boost_factor` parameter.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,13 @@ the [releases page](https://github.com/Consensys/teku/releases).
 
 ### Breaking Changes
 
+- The CLI options `--beacon-events-block-notify-when-validated-enabled` and
+  `--beacon-events-block-notify-when-imported-enabled` have been removed. This change was made due
+  to redundancy, as the functionality of these options is now covered by the new `block_gossip` SSE event.
+
 ### Additions and Improvements
 - Improved compatibility with `/eth/v3/validator/blocks/{slot}` experimental beacon API for block production. It can now respond with blinded and unblinded content based on the block production flow. It also supports the `builder_boost_factor` parameter.
+
+- Add `block_gossip` SSE event as per https://github.com/ethereum/beacon-APIs/pull/405
 
 ### Bug Fixes

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApiConfig.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/BeaconRestApiConfig.java
@@ -25,8 +25,6 @@ import tech.pegasys.teku.infrastructure.exceptions.InvalidConfigurationException
 import tech.pegasys.teku.infrastructure.io.PortAvailability;
 
 public class BeaconRestApiConfig {
-  public static final Boolean DEFAULT_BEACON_EVENTS_BLOCK_NOTIFY_WHEN_VALIDATED_ENABLED = false;
-  public static final Boolean DEFAULT_BEACON_EVENTS_BLOCK_NOTIFY_WHEN_IMPORTED_ENABLED = true;
   private static final Logger LOG = LogManager.getLogger();
 
   public static final int DEFAULT_REST_API_PORT = 5051;
@@ -52,8 +50,6 @@ public class BeaconRestApiConfig {
   private final int maxUrlLength;
   private final int maxPendingEvents;
   private final Optional<Integer> validatorThreads;
-  private final boolean beaconEventsBlockNotifyWhenValidatedEnabled;
-  private final boolean beaconEventsBlockNotifyWhenImportedEnabled;
 
   private BeaconRestApiConfig(
       final int restApiPort,
@@ -67,9 +63,7 @@ public class BeaconRestApiConfig {
       final int maxUrlLength,
       final int maxPendingEvents,
       final Optional<Integer> validatorThreads,
-      final boolean beaconLivenessTrackingEnabled,
-      final boolean beaconEventsBlockNotifyWhenValidatedEnabled,
-      final boolean beaconEventsBlockNotifyWhenImportedEnabled) {
+      final boolean beaconLivenessTrackingEnabled) {
     this.restApiPort = restApiPort;
     this.restApiDocsEnabled = restApiDocsEnabled;
     this.restApiEnabled = restApiEnabled;
@@ -82,8 +76,6 @@ public class BeaconRestApiConfig {
     this.maxPendingEvents = maxPendingEvents;
     this.validatorThreads = validatorThreads;
     this.beaconLivenessTrackingEnabled = beaconLivenessTrackingEnabled;
-    this.beaconEventsBlockNotifyWhenValidatedEnabled = beaconEventsBlockNotifyWhenValidatedEnabled;
-    this.beaconEventsBlockNotifyWhenImportedEnabled = beaconEventsBlockNotifyWhenImportedEnabled;
   }
 
   public int getRestApiPort() {
@@ -104,14 +96,6 @@ public class BeaconRestApiConfig {
 
   public boolean isBeaconLivenessTrackingEnabled() {
     return beaconLivenessTrackingEnabled;
-  }
-
-  public boolean isBeaconEventsBlockNotifyWhenValidatedEnabled() {
-    return beaconEventsBlockNotifyWhenValidatedEnabled;
-  }
-
-  public boolean isBeaconEventsBlockNotifyWhenImportedEnabled() {
-    return beaconEventsBlockNotifyWhenImportedEnabled;
   }
 
   public String getRestApiInterface() {
@@ -171,10 +155,6 @@ public class BeaconRestApiConfig {
     private int maxUrlLength = DEFAULT_MAX_URL_LENGTH;
     private Optional<Integer> validatorThreads = Optional.empty();
     private Eth1Address eth1DepositContractAddress;
-    private boolean beaconEventsBlockNotifyWhenValidatedEnabled =
-        DEFAULT_BEACON_EVENTS_BLOCK_NOTIFY_WHEN_VALIDATED_ENABLED;
-    private boolean defaultBeaconEventsBlockNotifyWhenImportedEnabled =
-        DEFAULT_BEACON_EVENTS_BLOCK_NOTIFY_WHEN_IMPORTED_ENABLED;
 
     private BeaconRestApiConfigBuilder() {}
 
@@ -281,27 +261,11 @@ public class BeaconRestApiConfig {
           maxUrlLength,
           maxPendingEvents,
           validatorThreads,
-          beaconLivenessTrackingEnabled,
-          beaconEventsBlockNotifyWhenValidatedEnabled,
-          defaultBeaconEventsBlockNotifyWhenImportedEnabled);
+          beaconLivenessTrackingEnabled);
     }
 
     public BeaconRestApiConfigBuilder maxUrlLength(final int maxUrlLength) {
       this.maxUrlLength = maxUrlLength;
-      return this;
-    }
-
-    public BeaconRestApiConfigBuilder beaconEventsBlockNotifyWhenValidatedEnabled(
-        final boolean beaconEventsBlockNotifyWhenValidatedEnabled) {
-      this.beaconEventsBlockNotifyWhenValidatedEnabled =
-          beaconEventsBlockNotifyWhenValidatedEnabled;
-      return this;
-    }
-
-    public BeaconRestApiConfigBuilder beaconEventsBlockNotifyWhenImportedEnabled(
-        final boolean defaultBeaconEventsBlockNotifyWhenImportedEnabled) {
-      this.defaultBeaconEventsBlockNotifyWhenImportedEnabled =
-          defaultBeaconEventsBlockNotifyWhenImportedEnabled;
       return this;
     }
   }

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/BlockGossipEvent.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/BlockGossipEvent.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.beaconrestapi.handlers.v1.events;
+
+import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.BYTES32_TYPE;
+import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.UINT64_TYPE;
+
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.infrastructure.json.types.SerializableTypeDefinition;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+
+public class BlockGossipEvent extends Event<BlockGossipEvent.BlockData> {
+
+  private static final SerializableTypeDefinition<BlockGossipEvent.BlockData>
+      BLOCK_GOSSIP_EVENT_TYPE =
+          SerializableTypeDefinition.object(BlockGossipEvent.BlockData.class)
+              .name("BlockGossipEvent")
+              .withField("slot", UINT64_TYPE, BlockGossipEvent.BlockData::slot)
+              .withField("block", BYTES32_TYPE, BlockGossipEvent.BlockData::block)
+              .build();
+
+  BlockGossipEvent(final SignedBeaconBlock block) {
+    super(BLOCK_GOSSIP_EVENT_TYPE, new BlockData(block.getSlot(), block.getRoot()));
+  }
+
+  public record BlockData(UInt64 slot, Bytes32 block) {}
+}

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManagerTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManagerTest.java
@@ -259,6 +259,15 @@ public class EventSubscriptionManagerTest {
   }
 
   @Test
+  void shouldPropagateBlockGossip() throws IOException {
+    when(req.getQueryString()).thenReturn("&topics=block_gossip");
+    manager.registerClient(client1);
+
+    triggerBlockGossipEvent();
+    checkEvent("block_gossip", new BlockGossipEvent(sampleBlock.asInternalSignedBeaconBlock(spec)));
+  }
+
+  @Test
   void shouldPropagateBlobSidecar() throws IOException {
     when(req.getQueryString()).thenReturn("&topics=blob_sidecar");
     manager.registerClient(client1);
@@ -441,6 +450,11 @@ public class EventSubscriptionManagerTest {
 
   private void triggerBlockEvent() {
     manager.onNewBlock(sampleBlock.asInternalSignedBeaconBlock(spec), false);
+    asyncRunner.executeQueuedActions();
+  }
+
+  private void triggerBlockGossipEvent() {
+    manager.onNewBlockGossip(sampleBlock.asInternalSignedBeaconBlock(spec));
     asyncRunner.executeQueuedActions();
   }
 

--- a/data/provider/src/main/java/tech/pegasys/teku/api/NodeDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/NodeDataProvider.java
@@ -27,7 +27,7 @@ import tech.pegasys.teku.api.migrated.ValidatorLivenessAtEpoch;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.attestation.ProcessedAttestationListener;
-import tech.pegasys.teku.spec.datastructures.blocks.ImportedBlockListener;
+import tech.pegasys.teku.spec.datastructures.blocks.ReceivedBlockListener;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
@@ -168,7 +168,7 @@ public class NodeDataProvider {
             });
   }
 
-  public void subscribeToReceivedBlocks(ImportedBlockListener listener) {
+  public void subscribeToReceivedBlocks(ReceivedBlockListener listener) {
     blockManager.subscribeToReceivedBlocks(listener);
   }
 

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/EventType.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/response/v1/EventType.java
@@ -29,7 +29,8 @@ public enum EventType {
   blob_sidecar,
   attester_slashing,
   proposer_slashing,
-  payload_attributes;
+  payload_attributes,
+  block_gossip;
 
   public static List<EventType> getTopics(List<String> topics) {
     return topics.stream().map(EventType::valueOf).toList();

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/ReceivedBlockListener.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blocks/ReceivedBlockListener.java
@@ -13,7 +13,8 @@
 
 package tech.pegasys.teku.spec.datastructures.blocks;
 
-@FunctionalInterface
-public interface ImportedBlockListener {
+public interface ReceivedBlockListener {
+  void onBlockValidated(SignedBeaconBlock block);
+
   void onBlockImported(SignedBeaconBlock block, boolean executionOptimistic);
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AttestationManager.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AttestationManager.java
@@ -214,9 +214,6 @@ public class AttestationManager extends Service
             });
   }
 
-  @Override
-  public void onBlockValidated(SignedBeaconBlock block) {}
-
   public SafeFuture<AttestationProcessingResult> onAttestation(
       final ValidatableAttestation attestation) {
     if (pendingAttestations.contains(attestation)) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/BlockImportNotifications.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/BlockImportNotifications.java
@@ -16,8 +16,7 @@ package tech.pegasys.teku.statetransition.block;
 import tech.pegasys.teku.infrastructure.events.VoidReturningChannelInterface;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 
+@FunctionalInterface
 public interface BlockImportNotifications extends VoidReturningChannelInterface {
   void onBlockImported(SignedBeaconBlock block);
-
-  void onBlockValidated(SignedBeaconBlock block);
 }

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/BeaconRestApiOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/BeaconRestApiOptions.java
@@ -124,28 +124,6 @@ public class BeaconRestApiOptions {
       BeaconRestApiConfig.DEFAULT_BEACON_LIVENESS_TRACKING_ENABLED;
 
   @Option(
-      names = {"--beacon-events-block-notify-when-validated-enabled"},
-      paramLabel = "<BOOLEAN>",
-      showDefaultValue = Visibility.ALWAYS,
-      description =
-          "Block notification events will be sent once the block has been validated, prior to attempting to import the block. The optimistic flag will be determined based on if chain head is optimistic.",
-      arity = "0..1",
-      fallbackValue = "true")
-  private Boolean beaconEventsBlockNotifyWhenValidated =
-      BeaconRestApiConfig.DEFAULT_BEACON_EVENTS_BLOCK_NOTIFY_WHEN_VALIDATED_ENABLED;
-
-  @Option(
-      names = {"--beacon-events-block-notify-when-imported-enabled"},
-      paramLabel = "<BOOLEAN>",
-      showDefaultValue = Visibility.ALWAYS,
-      description =
-          "Block notification events will be sent once the block has been imported, at which point we can accurately set the optimistic flag.",
-      arity = "0..1",
-      fallbackValue = "true")
-  private Boolean beaconEventsBlockNotifyWhenImported =
-      BeaconRestApiConfig.DEFAULT_BEACON_EVENTS_BLOCK_NOTIFY_WHEN_IMPORTED_ENABLED;
-
-  @Option(
       names = {"--Xrest-api-validator-threads"},
       description = "Set the number of threads used to handle validator api requests",
       paramLabel = "<INTEGER>",
@@ -175,8 +153,6 @@ public class BeaconRestApiOptions {
                 .restApiCorsAllowedOrigins(restApiCorsAllowedOrigins)
                 .maxUrlLength(maxUrlLength)
                 .beaconLivenessTrackingEnabled(beaconLivenessTrackingEnabled)
-                .beaconEventsBlockNotifyWhenValidatedEnabled(beaconEventsBlockNotifyWhenValidated)
-                .beaconEventsBlockNotifyWhenImportedEnabled(beaconEventsBlockNotifyWhenImported)
                 .maxPendingEvents(maxPendingEvents)
                 .validatorThreads(Optional.ofNullable(validatorThreads)));
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

- Add new `block_gossip` event when block is validated.
- Rename `ImportedBlockListener` to `ReceivedBlockListener` and add `onValidated` method
- Remove redundant CLI options: `--beacon-events-block-notify-when-validated-enabled` and `--beacon-events-block-notify-when-imported-enabled` since now we have two SSE events

**TODO:**
I still find `BlockImportNotifications` and `ReceivedBlockListener` bit redundant.

## Fixed Issue(s)
fixes #7513 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
