### PR TITLE
[Spike] New block rewards cache

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactory.java
@@ -21,14 +21,14 @@ import tech.pegasys.teku.ethereum.performance.trackers.BlockProductionPerformanc
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
-import tech.pegasys.teku.spec.datastructures.blocks.BlockContainer;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
+import tech.pegasys.teku.spec.datastructures.metadata.BlockContainerAndMetaData;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 
 public interface BlockFactory {
 
-  SafeFuture<BlockContainer> createUnsignedBlock(
+  SafeFuture<BlockContainerAndMetaData> createUnsignedBlock(
       BeaconState blockSlotState,
       UInt64 proposalSlot,
       BLSSignature randaoReveal,

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactoryDeneb.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactoryDeneb.java
@@ -23,11 +23,9 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
-import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
-import tech.pegasys.teku.spec.datastructures.blocks.BlockContainer;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
-import tech.pegasys.teku.spec.datastructures.blocks.versions.deneb.BlockContents;
 import tech.pegasys.teku.spec.datastructures.execution.BlobsBundle;
+import tech.pegasys.teku.spec.datastructures.metadata.BlockContainerAndMetaData;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsDeneb;
 
@@ -43,7 +41,7 @@ public class BlockFactoryDeneb extends BlockFactoryPhase0 {
   }
 
   @Override
-  public SafeFuture<BlockContainer> createUnsignedBlock(
+  public SafeFuture<BlockContainerAndMetaData> createUnsignedBlock(
       final BeaconState blockSlotState,
       final UInt64 proposalSlot,
       final BLSSignature randaoReveal,
@@ -59,17 +57,17 @@ public class BlockFactoryDeneb extends BlockFactoryPhase0 {
             requestedBlinded,
             requestedBuilderBoostFactor,
             blockProductionPerformance)
-        .thenApply(BlockContainer::getBlock)
         .thenCompose(
-            block -> {
-              if (block.isBlinded()) {
-                return SafeFuture.completedFuture(block);
+            blockContainerAndMetaData -> {
+              if (blockContainerAndMetaData.blockContainer().isBlinded()) {
+                return SafeFuture.completedFuture(blockContainerAndMetaData);
               }
               // The execution BlobsBundle has been cached as part of the block creation
               return operationSelector
                   .createBlobsBundleSelector()
-                  .apply(block)
-                  .thenApply(blobsBundle -> createBlockContents(block, blobsBundle));
+                  .apply(blockContainerAndMetaData.blockContainer().getBlock())
+                  .thenApply(
+                      blobsBundle -> createBlockContents(blockContainerAndMetaData, blobsBundle));
             });
   }
 
@@ -78,10 +76,14 @@ public class BlockFactoryDeneb extends BlockFactoryPhase0 {
     return operationSelector.createBlobSidecarsSelector().apply(blockContainer);
   }
 
-  private BlockContents createBlockContents(
-      final BeaconBlock block, final BlobsBundle blobsBundle) {
-    return schemaDefinitionsDeneb
-        .getBlockContentsSchema()
-        .create(block, blobsBundle.getProofs(), blobsBundle.getBlobs());
+  private BlockContainerAndMetaData createBlockContents(
+      final BlockContainerAndMetaData blockContainerAndMetaData, final BlobsBundle blobsBundle) {
+    return blockContainerAndMetaData.withBlockContainer(
+        schemaDefinitionsDeneb
+            .getBlockContentsSchema()
+            .create(
+                blockContainerAndMetaData.blockContainer().getBlock(),
+                blobsBundle.getProofs(),
+                blobsBundle.getBlobs()));
   }
 }

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactoryPhase0.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactoryPhase0.java
@@ -24,12 +24,14 @@ import tech.pegasys.teku.ethereum.performance.trackers.BlockProductionPerformanc
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.constants.EthConstants;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockContainer;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateCache;
 
 public class BlockFactoryPhase0 implements BlockFactory {
 
@@ -76,6 +78,15 @@ public class BlockFactoryPhase0 implements BlockFactory {
                 requestedBuilderBoostFactor,
                 blockProductionPerformance),
             blockProductionPerformance)
+        .thenPeek(
+            beaconBlockAndState ->
+                System.out.println(
+                    "block rewards: "
+                        + EthConstants.GWEI_TO_WEI.multiply(
+                            BeaconStateCache.getStateTransitionCaches(
+                                    beaconBlockAndState.getState())
+                                .getLastBlockRewards()
+                                .longValue())))
         .thenApply(BeaconBlockAndState::getBlock);
   }
 

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactoryPhase0.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactoryPhase0.java
@@ -24,14 +24,11 @@ import tech.pegasys.teku.ethereum.performance.trackers.BlockProductionPerformanc
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.constants.EthConstants;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
-import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockAndState;
-import tech.pegasys.teku.spec.datastructures.blocks.BlockContainer;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
+import tech.pegasys.teku.spec.datastructures.metadata.BlockContainerAndMetaData;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateCache;
 
 public class BlockFactoryPhase0 implements BlockFactory {
 
@@ -45,7 +42,7 @@ public class BlockFactoryPhase0 implements BlockFactory {
   }
 
   @Override
-  public SafeFuture<BlockContainer> createUnsignedBlock(
+  public SafeFuture<BlockContainerAndMetaData> createUnsignedBlock(
       final BeaconState blockSlotState,
       final UInt64 proposalSlot,
       final BLSSignature randaoReveal,
@@ -78,16 +75,9 @@ public class BlockFactoryPhase0 implements BlockFactory {
                 requestedBuilderBoostFactor,
                 blockProductionPerformance),
             blockProductionPerformance)
-        .thenPeek(
-            beaconBlockAndState ->
-                System.out.println(
-                    "block rewards: "
-                        + EthConstants.GWEI_TO_WEI.multiply(
-                            BeaconStateCache.getStateTransitionCaches(
-                                    beaconBlockAndState.getState())
-                                .getLastBlockRewards()
-                                .longValue())))
-        .thenApply(BeaconBlockAndState::getBlock);
+        .thenApply(
+            blockAndState ->
+                BlockContainerAndMetaData.fromBeaconBlockAndState(blockAndState, spec));
   }
 
   @Override

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
@@ -48,6 +48,7 @@ import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.SignedBlsToExecutionChange;
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateCache;
 import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.spec.datastructures.type.SszKZGProof;
 import tech.pegasys.teku.spec.executionlayer.ExecutionLayerBlockProductionManager;
@@ -255,6 +256,15 @@ public class BlockOperationSelectorFactory {
             blockProductionPerformance);
 
     return SafeFuture.allOf(
+        executionPayloadResult
+            .getExecutionPayloadValueFuture()
+            .map(
+                futureValue ->
+                    futureValue.thenAccept(
+                        value ->
+                            BeaconStateCache.getStateTransitionCaches(blockSlotState)
+                                .setLastBlockExecutionValue(value)))
+            .orElse(SafeFuture.COMPLETE),
         builderSetPayloadPostMerge(
             bodyBuilder, setUnblindedContentIfBuilderFallbacks, executionPayloadResult),
         builderSetKzgCommitments(

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/MilestoneBasedBlockFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/MilestoneBasedBlockFactory.java
@@ -27,9 +27,9 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
-import tech.pegasys.teku.spec.datastructures.blocks.BlockContainer;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
+import tech.pegasys.teku.spec.datastructures.metadata.BlockContainerAndMetaData;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 
 public class MilestoneBasedBlockFactory implements BlockFactory {
@@ -61,7 +61,7 @@ public class MilestoneBasedBlockFactory implements BlockFactory {
   }
 
   @Override
-  public SafeFuture<BlockContainer> createUnsignedBlock(
+  public SafeFuture<BlockContainerAndMetaData> createUnsignedBlock(
       final BeaconState blockSlotState,
       final UInt64 proposalSlot,
       final BLSSignature randaoReveal,

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -62,11 +62,11 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecVersion;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
-import tech.pegasys.teku.spec.datastructures.blocks.BlockContainer;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
 import tech.pegasys.teku.spec.datastructures.builder.SignedValidatorRegistration;
 import tech.pegasys.teku.spec.datastructures.genesis.GenesisData;
+import tech.pegasys.teku.spec.datastructures.metadata.BlockContainerAndMetaData;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.SignedAggregateAndProof;
@@ -309,7 +309,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
   }
 
   @Override
-  public SafeFuture<Optional<BlockContainer>> createUnsignedBlock(
+  public SafeFuture<Optional<BlockContainerAndMetaData>> createUnsignedBlock(
       final UInt64 slot,
       final BLSSignature randaoReveal,
       final Optional<Bytes32> graffiti,
@@ -349,7 +349,7 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
         .alwaysRun(blockProductionPerformance::complete);
   }
 
-  private SafeFuture<Optional<BlockContainer>> createBlock(
+  private SafeFuture<Optional<BlockContainerAndMetaData>> createBlock(
       final UInt64 slot,
       final BLSSignature randaoReveal,
       final Optional<Bytes32> graffiti,

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v3/validator/GetNewBlockV3.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v3/validator/GetNewBlockV3.java
@@ -112,7 +112,7 @@ public class GetNewBlockV3 extends RestApiEndpoint {
     final Optional<Bytes32> graffiti = request.getOptionalQueryParameter(GRAFFITI_PARAMETER);
     final Optional<UInt64> requestedBuilderBoostFactor =
         request.getOptionalQueryParameter(BUILDER_BOOST_FACTOR_PARAMETER);
-    final SafeFuture<Optional<BlockContainerAndMetaData<BlockContainer>>> result =
+    final SafeFuture<Optional<BlockContainerAndMetaData>> result =
         validatorDataProvider.produceBlock(slot, randao, graffiti, requestedBuilderBoostFactor);
     request.respondAsync(
         result.thenApply(
@@ -145,8 +145,8 @@ public class GetNewBlockV3 extends RestApiEndpoint {
                                 SC_INTERNAL_SERVER_ERROR, "Unable to produce a block"))));
   }
 
-  private static SerializableTypeDefinition<BlockContainerAndMetaData<BlockContainer>>
-      getResponseType(final SchemaDefinitionCache schemaDefinitionCache) {
+  private static SerializableTypeDefinition<BlockContainerAndMetaData> getResponseType(
+      final SchemaDefinitionCache schemaDefinitionCache) {
 
     final List<MilestoneDependentTypesUtil.ConditionalSchemaGetter<BlockContainer>> schemaGetters =
         generateBlockContainerSchemaGetters(schemaDefinitionCache);
@@ -154,7 +154,7 @@ public class GetNewBlockV3 extends RestApiEndpoint {
     final SerializableTypeDefinition<BlockContainer> blockContainerType =
         getMultipleSchemaDefinitionFromMilestone(schemaDefinitionCache, "Block", schemaGetters);
 
-    return SerializableTypeDefinition.<BlockContainerAndMetaData<BlockContainer>>object()
+    return SerializableTypeDefinition.<BlockContainerAndMetaData>object()
         .name("ProduceBlockV3Response")
         .withField("version", MILESTONE_TYPE, BlockContainerAndMetaData::specMilestone)
         .withField(

--- a/data/provider/src/main/java/tech/pegasys/teku/api/DataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/DataProvider.java
@@ -23,7 +23,6 @@ import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.SignedBlsToExecutionChange;
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
-import tech.pegasys.teku.spec.executionlayer.ExecutionLayerBlockProductionManager;
 import tech.pegasys.teku.statetransition.OperationPool;
 import tech.pegasys.teku.statetransition.attestation.AggregatingAttestationPool;
 import tech.pegasys.teku.statetransition.attestation.AttestationManager;
@@ -101,7 +100,6 @@ public class DataProvider {
     private Spec spec;
     private RecentChainData recentChainData;
     private CombinedChainDataClient combinedChainDataClient;
-    private ExecutionLayerBlockProductionManager executionLayerBlockProductionManager;
     private RewardCalculator rewardCalculator;
     private Eth2P2PNetwork p2pNetwork;
     private SyncService syncService;
@@ -128,12 +126,6 @@ public class DataProvider {
 
     public Builder combinedChainDataClient(final CombinedChainDataClient combinedChainDataClient) {
       this.combinedChainDataClient = combinedChainDataClient;
-      return this;
-    }
-
-    public Builder executionLayerBlockProductionManager(
-        final ExecutionLayerBlockProductionManager executionLayerBlockProductionManager) {
-      this.executionLayerBlockProductionManager = executionLayerBlockProductionManager;
       return this;
     }
 
@@ -255,12 +247,7 @@ public class DataProvider {
       final SyncDataProvider syncDataProvider =
           new SyncDataProvider(syncService, rejectedExecutionSupplier);
       final ValidatorDataProvider validatorDataProvider =
-          new ValidatorDataProvider(
-              spec,
-              validatorApiChannel,
-              combinedChainDataClient,
-              executionLayerBlockProductionManager,
-              rewardCalculator);
+          new ValidatorDataProvider(spec, validatorApiChannel, combinedChainDataClient);
       final ExecutionClientDataProvider executionClientDataProvider =
           new ExecutionClientDataProvider();
 

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
@@ -23,10 +23,7 @@ import it.unimi.dsi.fastutil.ints.IntList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
-import org.apache.tuweni.units.bigints.UInt256;
 import tech.pegasys.teku.api.exceptions.BadRequestException;
 import tech.pegasys.teku.api.schema.SignedBeaconBlock;
 import tech.pegasys.teku.api.schema.ValidatorBlockResult;
@@ -46,11 +43,9 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.provider.JsonProvider;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.constants.EthConstants;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockContainer;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
 import tech.pegasys.teku.spec.datastructures.builder.SignedValidatorRegistration;
-import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadResult;
 import tech.pegasys.teku.spec.datastructures.metadata.BlockContainerAndMetaData;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
@@ -60,7 +55,6 @@ import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncComm
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeMessage;
 import tech.pegasys.teku.spec.datastructures.operations.versions.bellatrix.BeaconPreparableProposer;
 import tech.pegasys.teku.spec.datastructures.validator.BroadcastValidationLevel;
-import tech.pegasys.teku.spec.executionlayer.ExecutionLayerBlockProductionManager;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult.FailureReason;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsAltair;
 import tech.pegasys.teku.storage.client.ChainDataUnavailableException;
@@ -75,7 +69,6 @@ import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 
 public class ValidatorDataProvider {
 
-  private static final Logger LOG = LogManager.getLogger();
   public static final String CANNOT_PRODUCE_HISTORIC_BLOCK =
       "Cannot produce a block for a historic slot.";
   public static final String NO_SLOT_PROVIDED = "No slot was provided.";
@@ -90,20 +83,13 @@ public class ValidatorDataProvider {
   private static final int SC_OK = 200;
   private final Spec spec;
 
-  private final ExecutionLayerBlockProductionManager executionLayerBlockProductionManager;
-  private final RewardCalculator rewardCalculator;
-
   public ValidatorDataProvider(
       final Spec spec,
       final ValidatorApiChannel validatorApiChannel,
-      final CombinedChainDataClient combinedChainDataClient,
-      final ExecutionLayerBlockProductionManager executionLayerBlockProductionManager,
-      final RewardCalculator rewardCalculator) {
+      final CombinedChainDataClient combinedChainDataClient) {
     this.validatorApiChannel = validatorApiChannel;
     this.combinedChainDataClient = combinedChainDataClient;
-    this.executionLayerBlockProductionManager = executionLayerBlockProductionManager;
     this.spec = spec;
-    this.rewardCalculator = rewardCalculator;
   }
 
   public boolean isStoreAvailable() {
@@ -119,98 +105,22 @@ public class ValidatorDataProvider {
       final boolean isBlinded,
       final Optional<UInt64> requestedBuilderBoostFactor) {
     checkBlockProducingParameters(slot, randao);
-    return validatorApiChannel.createUnsignedBlock(
-        slot, randao, graffiti, Optional.of(isBlinded), requestedBuilderBoostFactor);
+    return validatorApiChannel
+        .createUnsignedBlock(
+            slot, randao, graffiti, Optional.of(isBlinded), requestedBuilderBoostFactor)
+        .thenApply(
+            blockContainerAndMetaData ->
+                blockContainerAndMetaData.map(BlockContainerAndMetaData::blockContainer));
   }
 
-  public SafeFuture<Optional<BlockContainerAndMetaData<BlockContainer>>> produceBlock(
+  public SafeFuture<Optional<BlockContainerAndMetaData>> produceBlock(
       final UInt64 slot,
       final BLSSignature randao,
       final Optional<Bytes32> graffiti,
       final Optional<UInt64> requestedBuilderBoostFactor) {
     checkBlockProducingParameters(slot, randao);
-    return validatorApiChannel
-        .createUnsignedBlock(slot, randao, graffiti, Optional.empty(), requestedBuilderBoostFactor)
-        .thenCompose(this::lookUpBlockValues);
-  }
-
-  private SafeFuture<Optional<BlockContainerAndMetaData<BlockContainer>>> lookUpBlockValues(
-      final Optional<BlockContainer> maybeBlockContainer) {
-    return maybeBlockContainer
-        .map(
-            blockContainer ->
-                retrieveExecutionPayloadValue(maybeBlockContainer.get().getSlot())
-                    .thenCombine(
-                        retrieveConsensusBlockRewards(maybeBlockContainer.get()),
-                        (executionPayloadValue, consensusBlockValue) ->
-                            addMetaData(
-                                maybeBlockContainer, executionPayloadValue, consensusBlockValue)))
-        .orElse(SafeFuture.completedFuture(Optional.empty()));
-  }
-
-  private Optional<BlockContainerAndMetaData<BlockContainer>> addMetaData(
-      final Optional<BlockContainer> maybeBlockContainer,
-      final UInt256 executionPayloadValue,
-      final UInt256 consensusBlockValue) {
-    System.out.println("block rewards: " + consensusBlockValue);
-    return maybeBlockContainer.map(
-        blockContainer ->
-            new BlockContainerAndMetaData<>(
-                blockContainer,
-                spec.atSlot(blockContainer.getSlot()).getMilestone(),
-                executionPayloadValue,
-                consensusBlockValue));
-  }
-
-  private SafeFuture<UInt256> retrieveExecutionPayloadValue(final UInt64 slot) {
-    final Optional<ExecutionPayloadResult> cachedPayloadResult =
-        executionLayerBlockProductionManager.getCachedPayloadResult(slot);
-    if (cachedPayloadResult.isEmpty()) {
-      LOG.warn(
-          "Unable to get cached payload result for slot {}. Setting execution payload value to 0",
-          slot.intValue());
-      return SafeFuture.completedFuture(UInt256.ZERO);
-    }
-    final Optional<SafeFuture<UInt256>> executionPayloadValueFuture =
-        cachedPayloadResult.get().getExecutionPayloadValueFuture();
-    if (executionPayloadValueFuture.isEmpty()) {
-      LOG.warn(
-          "No execution payload value available for slot {}. Setting value to 0", slot.intValue());
-      return SafeFuture.completedFuture(UInt256.ZERO);
-    }
-    return executionPayloadValueFuture.get();
-  }
-
-  private SafeFuture<UInt256> retrieveConsensusBlockRewards(final BlockContainer blockContainer) {
-    final String rewardCalculationError =
-        String.format(
-            "Unable to calculate block rewards for slot %d. Setting value to 0",
-            blockContainer.getSlot().intValue());
-    return combinedChainDataClient
-        .getStateAtSlotExact(blockContainer.getBlock().getSlot().decrement())
-        .thenApply(
-            maybeParentState ->
-                maybeParentState.map(
-                    parentState ->
-                        rewardCalculator.getBlockRewardData(blockContainer, parentState)))
-        .thenApply(
-            blockRewardData ->
-                blockRewardData.map(
-                    rewardData -> EthConstants.GWEI_TO_WEI.multiply(rewardData.getTotal())))
-        .thenApply(
-            maybeTotalRewards -> {
-              if (maybeTotalRewards.isEmpty()) {
-                LOG.warn(rewardCalculationError);
-                return UInt256.ZERO;
-              } else {
-                return maybeTotalRewards.get();
-              }
-            })
-        .exceptionally(
-            throwable -> {
-              LOG.warn(rewardCalculationError, throwable);
-              return UInt256.ZERO;
-            });
+    return validatorApiChannel.createUnsignedBlock(
+        slot, randao, graffiti, Optional.empty(), requestedBuilderBoostFactor);
   }
 
   private void checkBlockProducingParameters(final UInt64 slot, final BLSSignature randao) {

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ValidatorDataProvider.java
@@ -152,6 +152,7 @@ public class ValidatorDataProvider {
       final Optional<BlockContainer> maybeBlockContainer,
       final UInt256 executionPayloadValue,
       final UInt256 consensusBlockValue) {
+    System.out.println("block rewards: " + consensusBlockValue);
     return maybeBlockContainer.map(
         blockContainer ->
             new BlockContainerAndMetaData<>(

--- a/data/provider/src/test/java/tech/pegasys/teku/api/ValidatorDataProviderTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/ValidatorDataProviderTest.java
@@ -253,7 +253,7 @@ public class ValidatorDataProviderTest {
             ONE, signatureInternal, Optional.empty(), Optional.empty(), Optional.of(ONE)))
         .thenReturn(completedFuture(Optional.of(blockInternal)));
 
-    SafeFuture<? extends Optional<? extends BlockContainerAndMetaData<? extends SszData>>> data =
+    SafeFuture<? extends Optional<? extends BlockContainerAndMetaData>> data =
         provider.produceBlock(ONE, signatureInternal, Optional.empty(), Optional.of(ONE));
 
     verify(validatorApiChannel)

--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/TransitionCachesBenchmark.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/teku/benchmarks/TransitionCachesBenchmark.java
@@ -33,7 +33,7 @@ import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.infrastructure.collections.TekuPair;
 import tech.pegasys.teku.infrastructure.collections.cache.Cache;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.TransitionCaches;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.EpochTransitionCaches;
 
 @Fork(1)
 @State(Scope.Thread)
@@ -48,7 +48,7 @@ public class TransitionCachesBenchmark {
 
   long counter;
 
-  private final TransitionCaches fullCache = TransitionCaches.createNewEmpty();
+  private final EpochTransitionCaches fullCache = EpochTransitionCaches.createNewEmpty();
 
   @Setup(Level.Trial)
   public void init() {

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/operations/OperationsTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/operations/OperationsTestExecutor.java
@@ -190,7 +190,7 @@ public class OperationsTestExecutor<T extends SszData> implements TestExecutor {
 
   private void assertTotalBalances(final Spec spec, final BeaconState state) {
     final Optional<TotalBalances> maybeProgressiveBalances =
-        BeaconStateCache.getTransitionCaches(state)
+        BeaconStateCache.getEpochTransitionCaches(state)
             .getProgressiveTotalBalances()
             .getTotalBalances(spec.getSpecConfig(state.getSlot()));
     assertThat(maybeProgressiveBalances).isPresent();

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionBuilderModule.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionBuilderModule.java
@@ -50,7 +50,6 @@ import tech.pegasys.teku.spec.datastructures.execution.FallbackReason;
 import tech.pegasys.teku.spec.datastructures.execution.GetPayloadResponse;
 import tech.pegasys.teku.spec.datastructures.execution.HeaderWithFallbackData;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateCache;
 import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsDeneb;
@@ -218,18 +217,12 @@ public class ExecutionBuilderModule {
                         requestedBuilderBoostFactor, localBlockValue, builderBidValue);
 
                 if (localPayloadValueWon) {
-                  BeaconStateCache.getStateTransitionCaches(state)
-                      .setLastBlockExecutionValue(localBlockValue);
-
                   return getResultFromLocalGetPayloadResponse(
                       localGetPayloadResponse,
                       slot,
                       FallbackReason.LOCAL_BLOCK_VALUE_WON,
                       payloadValueResult);
                 }
-
-                BeaconStateCache.getStateTransitionCaches(state)
-                    .setLastBlockExecutionValue(builderBidValue);
 
                 final Optional<ExecutionPayload> localExecutionPayload =
                     maybeLocalGetPayloadResponse.map(GetPayloadResponse::getExecutionPayload);

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionBuilderModule.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionBuilderModule.java
@@ -50,6 +50,7 @@ import tech.pegasys.teku.spec.datastructures.execution.FallbackReason;
 import tech.pegasys.teku.spec.datastructures.execution.GetPayloadResponse;
 import tech.pegasys.teku.spec.datastructures.execution.HeaderWithFallbackData;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateCache;
 import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsDeneb;
@@ -217,12 +218,18 @@ public class ExecutionBuilderModule {
                         requestedBuilderBoostFactor, localBlockValue, builderBidValue);
 
                 if (localPayloadValueWon) {
+                  BeaconStateCache.getStateTransitionCaches(state)
+                      .setLastBlockExecutionValue(localBlockValue);
+
                   return getResultFromLocalGetPayloadResponse(
                       localGetPayloadResponse,
                       slot,
                       FallbackReason.LOCAL_BLOCK_VALUE_WON,
                       payloadValueResult);
                 }
+
+                BeaconStateCache.getStateTransitionCaches(state)
+                    .setLastBlockExecutionValue(builderBidValue);
 
                 final Optional<ExecutionPayload> localExecutionPayload =
                     maybeLocalGetPayloadResponse.map(GetPayloadResponse::getExecutionPayload);

--- a/ethereum/json-types/src/main/java/tech/pegasys/teku/ethereum/json/types/EthereumTypes.java
+++ b/ethereum/json-types/src/main/java/tech/pegasys/teku/ethereum/json/types/EthereumTypes.java
@@ -31,7 +31,6 @@ import tech.pegasys.teku.infrastructure.restapi.openapi.response.ResponseContent
 import tech.pegasys.teku.infrastructure.ssz.SszData;
 import tech.pegasys.teku.kzg.KZGCommitment;
 import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.datastructures.blocks.BlockContainer;
 import tech.pegasys.teku.spec.datastructures.metadata.BlockContainerAndMetaData;
 import tech.pegasys.teku.spec.datastructures.metadata.ObjectAndMetaData;
 import tech.pegasys.teku.spec.logic.versions.deneb.types.VersionedHash;
@@ -103,7 +102,7 @@ public class EthereumTypes {
         value -> getSszHeaders(__ -> value.getMilestone(), value.getData()));
   }
 
-  public static ResponseContentTypeDefinition<BlockContainerAndMetaData<BlockContainer>>
+  public static ResponseContentTypeDefinition<BlockContainerAndMetaData>
       blockContainerAndMetaDataSszResponseType() {
     return new OctetStreamResponseContentTypeDefinition<>(
         (data, out) -> data.blockContainer().sszSerialize(out),

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/BeaconStateCache.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/BeaconStateCache.java
@@ -13,15 +13,24 @@
 
 package tech.pegasys.teku.spec.datastructures.state.beaconstate;
 
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.TransitionCaches;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.EpochTransitionCaches;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.StateTransitionCaches;
 
 public interface BeaconStateCache {
 
-  static TransitionCaches getTransitionCaches(BeaconState state) {
+  static EpochTransitionCaches getEpochTransitionCaches(BeaconState state) {
     return state instanceof BeaconStateCache
-        ? ((BeaconStateCache) state).getTransitionCaches()
-        : TransitionCaches.getNoOp();
+        ? ((BeaconStateCache) state).getEpochTransitionCaches()
+        : EpochTransitionCaches.getNoOp();
   }
 
-  TransitionCaches getTransitionCaches();
+  static StateTransitionCaches getStateTransitionCaches(BeaconState state) {
+    return state instanceof BeaconStateCache
+        ? ((BeaconStateCache) state).getStateTransitionCaches()
+        : StateTransitionCaches.getNoOp();
+  }
+
+  EpochTransitionCaches getEpochTransitionCaches();
+
+  StateTransitionCaches getStateTransitionCaches();
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/AbstractBeaconState.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/AbstractBeaconState.java
@@ -30,26 +30,31 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconStat
 public abstract class AbstractBeaconState<TMutable extends MutableBeaconState>
     extends SszContainerImpl implements BeaconState, BeaconStateCache {
 
-  private final TransitionCaches transitionCaches;
+  private final EpochTransitionCaches epochTransitionCaches;
+  private final StateTransitionCaches stateTransitionCaches;
 
   protected AbstractBeaconState(final BeaconStateSchema<?, ?> schema) {
     super(schema);
-    transitionCaches = TransitionCaches.createNewEmpty();
+    epochTransitionCaches = EpochTransitionCaches.createNewEmpty();
+    stateTransitionCaches = StateTransitionCaches.createNewEmpty();
   }
 
   protected AbstractBeaconState(
-      SszCompositeSchema<?> type,
-      TreeNode backingNode,
-      IntCache<SszData> cache,
-      TransitionCaches transitionCaches) {
+      final SszCompositeSchema<?> type,
+      final TreeNode backingNode,
+      final IntCache<SszData> cache,
+      final EpochTransitionCaches epochTransitionCaches,
+      final StateTransitionCaches stateTransitionCaches) {
     super(type, backingNode, cache);
-    this.transitionCaches = transitionCaches;
+    this.epochTransitionCaches = epochTransitionCaches;
+    this.stateTransitionCaches = stateTransitionCaches;
   }
 
   protected AbstractBeaconState(
       AbstractSszContainerSchema<? extends SszContainer> type, TreeNode backingNode) {
     super(type, backingNode);
-    transitionCaches = TransitionCaches.createNewEmpty();
+    epochTransitionCaches = EpochTransitionCaches.createNewEmpty();
+    stateTransitionCaches = StateTransitionCaches.createNewEmpty();
   }
 
   @Override
@@ -76,8 +81,13 @@ public abstract class AbstractBeaconState<TMutable extends MutableBeaconState>
   }
 
   @Override
-  public TransitionCaches getTransitionCaches() {
-    return transitionCaches;
+  public EpochTransitionCaches getEpochTransitionCaches() {
+    return epochTransitionCaches;
+  }
+
+  @Override
+  public StateTransitionCaches getStateTransitionCaches() {
+    return stateTransitionCaches;
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/AbstractMutableBeaconState.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/AbstractMutableBeaconState.java
@@ -29,7 +29,8 @@ public abstract class AbstractMutableBeaconState<
         T extends SszContainerImpl & BeaconState & BeaconStateCache>
     extends SszMutableContainerImpl implements MutableBeaconState, BeaconStateCache {
 
-  private final TransitionCaches transitionCaches;
+  private final EpochTransitionCaches epochTransitionCaches;
+  private final StateTransitionCaches stateTransitionCaches;
   private final boolean builder;
 
   protected AbstractMutableBeaconState(T backingImmutableView) {
@@ -38,8 +39,12 @@ public abstract class AbstractMutableBeaconState<
 
   protected AbstractMutableBeaconState(T backingImmutableView, boolean builder) {
     super(backingImmutableView);
-    this.transitionCaches =
-        builder ? TransitionCaches.getNoOp() : backingImmutableView.getTransitionCaches().copy();
+    this.epochTransitionCaches =
+        builder
+            ? EpochTransitionCaches.getNoOp()
+            : backingImmutableView.getEpochTransitionCaches().copy();
+    this.stateTransitionCaches =
+        builder ? StateTransitionCaches.getNoOp() : StateTransitionCaches.createNewEmpty();
     this.builder = builder;
   }
 
@@ -51,15 +56,26 @@ public abstract class AbstractMutableBeaconState<
   @Override
   protected T createImmutableSszComposite(TreeNode backingNode, IntCache<SszData> viewCache) {
     return createImmutableBeaconState(
-        backingNode, viewCache, builder ? TransitionCaches.createNewEmpty() : transitionCaches);
+        backingNode,
+        viewCache,
+        builder ? EpochTransitionCaches.createNewEmpty() : epochTransitionCaches,
+        builder ? StateTransitionCaches.getNoOp() : stateTransitionCaches);
   }
 
   protected abstract T createImmutableBeaconState(
-      TreeNode backingNode, IntCache<SszData> viewCache, TransitionCaches transitionCache);
+      TreeNode backingNode,
+      IntCache<SszData> viewCache,
+      EpochTransitionCaches epochTransitionCaches,
+      StateTransitionCaches stateTransitionCaches);
 
   @Override
-  public TransitionCaches getTransitionCaches() {
-    return transitionCaches;
+  public EpochTransitionCaches getEpochTransitionCaches() {
+    return epochTransitionCaches;
+  }
+
+  @Override
+  public StateTransitionCaches getStateTransitionCaches() {
+    return stateTransitionCaches;
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/AbstractMutableBeaconState.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/AbstractMutableBeaconState.java
@@ -44,7 +44,9 @@ public abstract class AbstractMutableBeaconState<
             ? EpochTransitionCaches.getNoOp()
             : backingImmutableView.getEpochTransitionCaches().copy();
     this.stateTransitionCaches =
-        builder ? StateTransitionCaches.getNoOp() : StateTransitionCaches.createNewEmpty();
+        builder
+            ? StateTransitionCaches.getNoOp()
+            : backingImmutableView.getStateTransitionCaches().copy();
     this.builder = builder;
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/EpochTransitionCaches.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/EpochTransitionCaches.java
@@ -29,7 +29,7 @@ import tech.pegasys.teku.spec.logic.common.statetransition.epoch.status.Progress
 import tech.pegasys.teku.spec.logic.common.statetransition.epoch.status.TotalBalances;
 
 /** The container class for all transition caches. */
-public class TransitionCaches {
+public class EpochTransitionCaches {
 
   private static final int MAX_ACTIVE_VALIDATORS_CACHE = 8;
   private static final int MAX_BEACON_PROPOSER_INDEX_CACHE = 1;
@@ -40,8 +40,8 @@ public class TransitionCaches {
   private static final int MAX_SYNC_COMMITTEE_CACHE = 2;
   public static final int MAX_BASE_REWARD_PER_INCREMENT_CACHE = 1;
 
-  private static final TransitionCaches NO_OP_INSTANCE =
-      new TransitionCaches(
+  private static final EpochTransitionCaches NO_OP_INSTANCE =
+      new EpochTransitionCaches(
           NoOpCache.getNoOpCache(),
           NoOpCache.getNoOpCache(),
           NoOpCache.getNoOpCache(),
@@ -56,18 +56,18 @@ public class TransitionCaches {
           ProgressiveTotalBalancesUpdates.NOOP) {
 
         @Override
-        public TransitionCaches copy() {
+        public EpochTransitionCaches copy() {
           return this;
         }
       };
 
   /** Creates new instance with clean caches */
-  public static TransitionCaches createNewEmpty() {
-    return new TransitionCaches();
+  public static EpochTransitionCaches createNewEmpty() {
+    return new EpochTransitionCaches();
   }
 
   /** Returns the instance which doesn't cache anything */
-  public static TransitionCaches getNoOp() {
+  public static EpochTransitionCaches getNoOp() {
     return NO_OP_INSTANCE;
   }
 
@@ -87,7 +87,7 @@ public class TransitionCaches {
   private volatile Optional<TotalBalances> latestTotalBalances = Optional.empty();
   private volatile ProgressiveTotalBalancesUpdates progressiveTotalBalances;
 
-  private TransitionCaches() {
+  private EpochTransitionCaches() {
     activeValidators = LRUCache.create(MAX_ACTIVE_VALIDATORS_CACHE);
     beaconProposerIndex = LRUCache.create(MAX_BEACON_PROPOSER_INDEX_CACHE);
     beaconCommittee = LRUCache.create(MAX_BEACON_COMMITTEE_CACHE);
@@ -102,7 +102,7 @@ public class TransitionCaches {
     progressiveTotalBalances = ProgressiveTotalBalancesUpdates.NOOP;
   }
 
-  private TransitionCaches(
+  private EpochTransitionCaches(
       Cache<UInt64, IntList> activeValidators,
       Cache<UInt64, Integer> beaconProposerIndex,
       Cache<TekuPair<UInt64, UInt64>, IntList> beaconCommittee,
@@ -215,8 +215,8 @@ public class TransitionCaches {
    * Makes an independent copy which contains all the data in this instance Modifications to
    * returned caches shouldn't affect caches from this instance
    */
-  public TransitionCaches copy() {
-    return new TransitionCaches(
+  public EpochTransitionCaches copy() {
+    return new EpochTransitionCaches(
         activeValidators.copy(),
         beaconProposerIndex.copy(),
         beaconCommittee.copy(),

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/StateTransitionCaches.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/StateTransitionCaches.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.state.beaconstate.common;
+
+import org.apache.tuweni.units.bigints.UInt256;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+public class StateTransitionCaches {
+  private volatile UInt64 lastBlockRewards = UInt64.ZERO;
+  private volatile UInt256 lastBlockExecutionValue = UInt256.ZERO;
+
+  private static final StateTransitionCaches NO_OP_INSTANCE =
+      new StateTransitionCaches() {
+        @Override
+        public StateTransitionCaches copy() {
+          return this;
+        }
+      };
+
+  private StateTransitionCaches(
+      final UInt64 lastBlockRewards, final UInt256 lastBlockExecutionValue) {
+    this.lastBlockRewards = lastBlockRewards;
+    this.lastBlockExecutionValue = lastBlockExecutionValue;
+  }
+
+  private StateTransitionCaches() {}
+
+  /** Creates new instance with clean caches */
+  public static StateTransitionCaches createNewEmpty() {
+    return new StateTransitionCaches();
+  }
+
+  /** Returns the instance which doesn't cache anything */
+  public static StateTransitionCaches getNoOp() {
+    return NO_OP_INSTANCE;
+  }
+
+  public UInt64 getLastBlockRewards() {
+    return lastBlockRewards;
+  }
+
+  public UInt256 getLastBlockExecutionValue() {
+    return lastBlockExecutionValue;
+  }
+
+  public void increaseLastBlockRewards(final UInt64 delta) {
+    // state transition is single threaded, so no need to do an atomic update
+    this.lastBlockRewards = this.lastBlockRewards.plus(delta);
+  }
+
+  public void setLastBlockExecutionValue(final UInt256 lastBlockExecutionValue) {
+    this.lastBlockExecutionValue = lastBlockExecutionValue;
+  }
+
+  public StateTransitionCaches copy() {
+    return new StateTransitionCaches(lastBlockRewards, lastBlockExecutionValue);
+  }
+
+  // Called at the end of every slot transition (processSlot)
+  // Note: this is always called before the block is processed (if block is proposed)
+  public void onSlotProcessed() {
+    this.lastBlockRewards = UInt64.ZERO;
+    this.lastBlockExecutionValue = UInt256.ZERO;
+  }
+
+  // Called at the end of every slot transition (processBlock)
+  // this can be used to free cached data that are only used during the state transition and can be
+  // garbage collected
+  public void onBlockProcessed() {}
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/altair/BeaconStateAltairImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/altair/BeaconStateAltairImpl.java
@@ -23,7 +23,8 @@ import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateCache;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchema;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.AbstractBeaconState;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.TransitionCaches;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.EpochTransitionCaches;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.StateTransitionCaches;
 
 class BeaconStateAltairImpl extends AbstractBeaconState<MutableBeaconStateAltair>
     implements BeaconStateAltair, BeaconStateCache, ValidatorStatsAltair {
@@ -37,8 +38,9 @@ class BeaconStateAltairImpl extends AbstractBeaconState<MutableBeaconStateAltair
       SszCompositeSchema<?> type,
       TreeNode backingNode,
       IntCache<SszData> cache,
-      TransitionCaches transitionCaches) {
-    super(type, backingNode, cache, transitionCaches);
+      EpochTransitionCaches epochTransitionCaches,
+      StateTransitionCaches stateTransitionCaches) {
+    super(type, backingNode, cache, epochTransitionCaches, stateTransitionCaches);
   }
 
   BeaconStateAltairImpl(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/altair/MutableBeaconStateAltairImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/altair/MutableBeaconStateAltairImpl.java
@@ -19,7 +19,8 @@ import tech.pegasys.teku.infrastructure.ssz.cache.IntCache;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateCache;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.AbstractMutableBeaconState;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.TransitionCaches;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.EpochTransitionCaches;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.StateTransitionCaches;
 
 class MutableBeaconStateAltairImpl extends AbstractMutableBeaconState<BeaconStateAltairImpl>
     implements MutableBeaconStateAltair, BeaconStateCache, ValidatorStatsAltair {
@@ -39,8 +40,12 @@ class MutableBeaconStateAltairImpl extends AbstractMutableBeaconState<BeaconStat
 
   @Override
   protected BeaconStateAltairImpl createImmutableBeaconState(
-      TreeNode backingNode, IntCache<SszData> viewCache, TransitionCaches transitionCache) {
-    return new BeaconStateAltairImpl(getSchema(), backingNode, viewCache, transitionCache);
+      TreeNode backingNode,
+      IntCache<SszData> viewCache,
+      EpochTransitionCaches epochTransitionCaches,
+      StateTransitionCaches stateTransitionCaches) {
+    return new BeaconStateAltairImpl(
+        getSchema(), backingNode, viewCache, epochTransitionCaches, stateTransitionCaches);
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/bellatrix/BeaconStateBellatrixImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/bellatrix/BeaconStateBellatrixImpl.java
@@ -23,7 +23,8 @@ import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateCache;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchema;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.AbstractBeaconState;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.TransitionCaches;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.EpochTransitionCaches;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.StateTransitionCaches;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.altair.ValidatorStatsAltair;
 
 class BeaconStateBellatrixImpl extends AbstractBeaconState<MutableBeaconStateBellatrix>
@@ -38,8 +39,9 @@ class BeaconStateBellatrixImpl extends AbstractBeaconState<MutableBeaconStateBel
       SszCompositeSchema<?> type,
       TreeNode backingNode,
       IntCache<SszData> cache,
-      TransitionCaches transitionCaches) {
-    super(type, backingNode, cache, transitionCaches);
+      EpochTransitionCaches transitionCaches,
+      StateTransitionCaches stateTransitionCaches) {
+    super(type, backingNode, cache, transitionCaches, stateTransitionCaches);
   }
 
   BeaconStateBellatrixImpl(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/bellatrix/MutableBeaconStateBellatrixImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/bellatrix/MutableBeaconStateBellatrixImpl.java
@@ -21,7 +21,8 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateCache;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.AbstractMutableBeaconState;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.TransitionCaches;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.EpochTransitionCaches;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.StateTransitionCaches;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.altair.ValidatorStatsAltair;
 
 class MutableBeaconStateBellatrixImpl extends AbstractMutableBeaconState<BeaconStateBellatrixImpl>
@@ -42,8 +43,12 @@ class MutableBeaconStateBellatrixImpl extends AbstractMutableBeaconState<BeaconS
 
   @Override
   protected BeaconStateBellatrixImpl createImmutableBeaconState(
-      TreeNode backingNode, IntCache<SszData> viewCache, TransitionCaches transitionCache) {
-    return new BeaconStateBellatrixImpl(getSchema(), backingNode, viewCache, transitionCache);
+      TreeNode backingNode,
+      IntCache<SszData> viewCache,
+      EpochTransitionCaches epochTransitionCaches,
+      StateTransitionCaches stateTransitionCaches) {
+    return new BeaconStateBellatrixImpl(
+        getSchema(), backingNode, viewCache, epochTransitionCaches, stateTransitionCaches);
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/capella/BeaconStateCapellaImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/capella/BeaconStateCapellaImpl.java
@@ -23,7 +23,8 @@ import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateCache;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchema;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.AbstractBeaconState;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.TransitionCaches;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.EpochTransitionCaches;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.StateTransitionCaches;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.altair.ValidatorStatsAltair;
 
 public class BeaconStateCapellaImpl extends AbstractBeaconState<MutableBeaconStateCapella>
@@ -38,8 +39,9 @@ public class BeaconStateCapellaImpl extends AbstractBeaconState<MutableBeaconSta
       SszCompositeSchema<?> type,
       TreeNode backingNode,
       IntCache<SszData> cache,
-      TransitionCaches transitionCaches) {
-    super(type, backingNode, cache, transitionCaches);
+      EpochTransitionCaches transitionCaches,
+      StateTransitionCaches stateTransitionCaches) {
+    super(type, backingNode, cache, transitionCaches, stateTransitionCaches);
   }
 
   BeaconStateCapellaImpl(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/capella/MutableBeaconStateCapellaImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/capella/MutableBeaconStateCapellaImpl.java
@@ -19,7 +19,8 @@ import tech.pegasys.teku.infrastructure.ssz.cache.IntCache;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateCache;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.AbstractMutableBeaconState;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.TransitionCaches;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.EpochTransitionCaches;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.StateTransitionCaches;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.altair.ValidatorStatsAltair;
 
 public class MutableBeaconStateCapellaImpl
@@ -38,8 +39,10 @@ public class MutableBeaconStateCapellaImpl
   protected BeaconStateCapellaImpl createImmutableBeaconState(
       final TreeNode backingNode,
       final IntCache<SszData> viewCache,
-      final TransitionCaches transitionCache) {
-    return new BeaconStateCapellaImpl(getSchema(), backingNode, viewCache, transitionCache);
+      final EpochTransitionCaches epochTransitionCaches,
+      final StateTransitionCaches stateTransitionCaches) {
+    return new BeaconStateCapellaImpl(
+        getSchema(), backingNode, viewCache, epochTransitionCaches, stateTransitionCaches);
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/deneb/BeaconStateDenebImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/deneb/BeaconStateDenebImpl.java
@@ -23,7 +23,8 @@ import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateCache;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchema;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.AbstractBeaconState;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.TransitionCaches;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.EpochTransitionCaches;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.StateTransitionCaches;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.altair.ValidatorStatsAltair;
 
 public class BeaconStateDenebImpl extends AbstractBeaconState<MutableBeaconStateDeneb>
@@ -37,8 +38,9 @@ public class BeaconStateDenebImpl extends AbstractBeaconState<MutableBeaconState
       final SszCompositeSchema<?> type,
       final TreeNode backingNode,
       final IntCache<SszData> cache,
-      final TransitionCaches transitionCaches) {
-    super(type, backingNode, cache, transitionCaches);
+      final EpochTransitionCaches transitionCaches,
+      final StateTransitionCaches stateTransitionCaches) {
+    super(type, backingNode, cache, transitionCaches, stateTransitionCaches);
   }
 
   BeaconStateDenebImpl(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/deneb/MutableBeaconStateDenebImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/deneb/MutableBeaconStateDenebImpl.java
@@ -19,7 +19,8 @@ import tech.pegasys.teku.infrastructure.ssz.cache.IntCache;
 import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateCache;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.AbstractMutableBeaconState;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.TransitionCaches;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.EpochTransitionCaches;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.StateTransitionCaches;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.altair.ValidatorStatsAltair;
 
 public class MutableBeaconStateDenebImpl extends AbstractMutableBeaconState<BeaconStateDenebImpl>
@@ -38,8 +39,10 @@ public class MutableBeaconStateDenebImpl extends AbstractMutableBeaconState<Beac
   protected BeaconStateDenebImpl createImmutableBeaconState(
       final TreeNode backingNode,
       final IntCache<SszData> viewCache,
-      final TransitionCaches transitionCache) {
-    return new BeaconStateDenebImpl(getSchema(), backingNode, viewCache, transitionCache);
+      final EpochTransitionCaches epochTransitionCaches,
+      final StateTransitionCaches stateTransitionCaches) {
+    return new BeaconStateDenebImpl(
+        getSchema(), backingNode, viewCache, epochTransitionCaches, stateTransitionCaches);
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/phase0/BeaconStatePhase0Impl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/phase0/BeaconStatePhase0Impl.java
@@ -23,7 +23,8 @@ import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateCache;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateSchema;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.AbstractBeaconState;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.TransitionCaches;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.EpochTransitionCaches;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.StateTransitionCaches;
 
 class BeaconStatePhase0Impl extends AbstractBeaconState<MutableBeaconStatePhase0>
     implements BeaconStatePhase0, BeaconStateCache, ValidatorStatsPhase0 {
@@ -37,8 +38,9 @@ class BeaconStatePhase0Impl extends AbstractBeaconState<MutableBeaconStatePhase0
       SszCompositeSchema<?> type,
       TreeNode backingNode,
       IntCache<SszData> cache,
-      TransitionCaches transitionCaches) {
-    super(type, backingNode, cache, transitionCaches);
+      EpochTransitionCaches transitionCaches,
+      StateTransitionCaches stateTransitionCaches) {
+    super(type, backingNode, cache, transitionCaches, stateTransitionCaches);
   }
 
   BeaconStatePhase0Impl(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/phase0/MutableBeaconStatePhase0Impl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/versions/phase0/MutableBeaconStatePhase0Impl.java
@@ -21,7 +21,8 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateCache;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.AbstractMutableBeaconState;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.TransitionCaches;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.EpochTransitionCaches;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.StateTransitionCaches;
 
 class MutableBeaconStatePhase0Impl extends AbstractMutableBeaconState<BeaconStatePhase0Impl>
     implements MutableBeaconStatePhase0, BeaconStateCache, ValidatorStatsPhase0 {
@@ -41,8 +42,12 @@ class MutableBeaconStatePhase0Impl extends AbstractMutableBeaconState<BeaconStat
 
   @Override
   protected BeaconStatePhase0Impl createImmutableBeaconState(
-      TreeNode backingNode, IntCache<SszData> viewCache, TransitionCaches transitionCache) {
-    return new BeaconStatePhase0Impl(getSchema(), backingNode, viewCache, transitionCache);
+      TreeNode backingNode,
+      IntCache<SszData> viewCache,
+      EpochTransitionCaches epochTransitionCaches,
+      StateTransitionCaches stateTransitionCaches) {
+    return new BeaconStatePhase0Impl(
+        getSchema(), backingNode, viewCache, epochTransitionCaches, stateTransitionCaches);
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
@@ -290,9 +290,10 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
             .map(
                 blobsBundle -> {
                   LOG.info("getPayload: blobsBundle: {}", blobsBundle.toBriefString());
-                  return new GetPayloadResponse(executionPayload, UInt256.ZERO, blobsBundle, false);
+                  return new GetPayloadResponse(
+                      executionPayload, UInt256.valueOf(42), blobsBundle, false);
                 })
-            .orElse(new GetPayloadResponse(executionPayload));
+            .orElse(new GetPayloadResponse(executionPayload, UInt256.valueOf(43)));
 
     return SafeFuture.completedFuture(getPayloadResponse);
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/StateTransition.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/StateTransition.java
@@ -22,6 +22,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.SpecVersion;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockHeader;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateCache;
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.EpochProcessingException;
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.SlotProcessingException;
 
@@ -102,6 +103,7 @@ public class StateTransition {
                     previousStateRoot,
                     latestBlockHeader.getBodyRoot());
             state.setLatestBlockHeader(latestBlockHeaderNew);
+            BeaconStateCache.getStateTransitionCaches(state).onSlotProcessed();
           }
 
           // Cache block root

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/AbstractBlockProcessor.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/AbstractBlockProcessor.java
@@ -59,6 +59,7 @@ import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.state.Validator;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateCache;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
 import tech.pegasys.teku.spec.datastructures.util.AttestationProcessingResult;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
@@ -319,9 +320,10 @@ public abstract class AbstractBlockProcessor implements BlockProcessor {
       final Optional<? extends OptimisticExecutionPayloadExecutor> payloadExecutor)
       throws BlockProcessingException {
     return preState.updated(
-        state ->
-            processBlock(
-                state, block, indexedAttestationCache, signatureVerifier, payloadExecutor));
+        state -> {
+          processBlock(state, block, indexedAttestationCache, signatureVerifier, payloadExecutor);
+          BeaconStateCache.getStateTransitionCaches(state).onBlockProcessed();
+        });
   }
 
   protected void processBlock(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateAccessors.java
@@ -79,7 +79,7 @@ public abstract class BeaconStateAccessors {
       return Optional.empty();
     }
     return Optional.of(
-        BeaconStateCache.getTransitionCaches(state)
+        BeaconStateCache.getEpochTransitionCaches(state)
             .getValidatorsPubKeys()
             .get(
                 validatorIndex,
@@ -87,7 +87,7 @@ public abstract class BeaconStateAccessors {
                   BLSPublicKey pubKey = state.getValidators().get(i.intValue()).getPublicKey();
 
                   // eagerly pre-cache pubKey => validatorIndex mapping
-                  BeaconStateCache.getTransitionCaches(state)
+                  BeaconStateCache.getEpochTransitionCaches(state)
                       .getValidatorIndexCache()
                       .invalidateWithNewValue(pubKey, i.intValue());
                   return pubKey;
@@ -109,7 +109,7 @@ public abstract class BeaconStateAccessors {
         "Cannot get active validator indices from an epoch beyond the seed lookahead period. Requested epoch %s from state in epoch %s",
         epoch,
         stateEpoch);
-    return BeaconStateCache.getTransitionCaches(state)
+    return BeaconStateCache.getEpochTransitionCaches(state)
         .getActiveValidators()
         .get(
             epoch,
@@ -140,7 +140,7 @@ public abstract class BeaconStateAccessors {
   }
 
   public UInt64 getTotalActiveBalance(BeaconState state) {
-    return BeaconStateCache.getTransitionCaches(state)
+    return BeaconStateCache.getEpochTransitionCaches(state)
         .getTotalActiveBalance()
         .get(
             getCurrentEpoch(state),
@@ -210,7 +210,7 @@ public abstract class BeaconStateAccessors {
 
   public int getBeaconProposerIndex(BeaconState state, UInt64 requestedSlot) {
     validateStateCanCalculateProposerIndexAtSlot(state, requestedSlot);
-    return BeaconStateCache.getTransitionCaches(state)
+    return BeaconStateCache.getEpochTransitionCaches(state)
         .getBeaconProposerIndex()
         .get(
             requestedSlot,
@@ -288,7 +288,7 @@ public abstract class BeaconStateAccessors {
     // Make sure state is within range of the slot being queried
     validateStateForCommitteeQuery(state, slot);
 
-    return BeaconStateCache.getTransitionCaches(state)
+    return BeaconStateCache.getEpochTransitionCaches(state)
         .getBeaconCommittee()
         .get(
             TekuPair.of(slot, index),

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateMutators.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/BeaconStateMutators.java
@@ -23,6 +23,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.datastructures.state.Validator;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateCache;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
 
 public class BeaconStateMutators {
@@ -37,6 +38,19 @@ public class BeaconStateMutators {
     this.specConfig = specConfig;
     this.miscHelpers = miscHelpers;
     this.beaconStateAccessors = beaconStateAccessors;
+  }
+
+  /**
+   * this is the same as {@link #increaseBalance(MutableBeaconState, int, UInt64)} but in addition
+   * it updates the lastBlockRewardCache to keep track of the total rewards for the last block
+   *
+   * @param state
+   * @param proposerIndex
+   * @param delta
+   */
+  public void increaseProposerBalance(MutableBeaconState state, int proposerIndex, UInt64 delta) {
+    increaseBalance(state, proposerIndex, delta);
+    BeaconStateCache.getStateTransitionCaches(state).increaseLastBlockRewards(delta);
   }
 
   /**
@@ -229,7 +243,7 @@ public class BeaconStateMutators {
     UInt64 whistleblowerReward =
         validator.getEffectiveBalance().dividedBy(specConfig.getWhistleblowerRewardQuotient());
     UInt64 proposerReward = calculateProposerReward(whistleblowerReward);
-    increaseBalance(state, proposerIndex, proposerReward);
+    increaseProposerBalance(state, proposerIndex, proposerReward);
     increaseBalance(state, whistleblowerIndex, whistleblowerReward.minus(proposerReward));
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/MiscHelpers.java
@@ -185,7 +185,7 @@ public class MiscHelpers {
       checkArgument(fromIndex < indexCount, "CommitteeUtil.getShuffledIndex1");
       checkArgument(toIndex <= indexCount, "CommitteeUtil.getShuffledIndex1");
     }
-    return BeaconStateCache.getTransitionCaches(state)
+    return BeaconStateCache.getEpochTransitionCaches(state)
         .getCommitteeShuffle()
         .get(seed, s -> shuffleList(indices, s))
         .subList(fromIndex, toIndex);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/AbstractEpochProcessor.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/AbstractEpochProcessor.java
@@ -37,7 +37,7 @@ import tech.pegasys.teku.spec.datastructures.state.Validator;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateCache;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.TransitionCaches;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.EpochTransitionCaches;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateMutators;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateMutators.ValidatorExitContext;
@@ -106,7 +106,7 @@ public abstract class AbstractEpochProcessor implements EpochProcessor {
 
     updateTransitionCaches(state, currentEpoch, totalBalances);
 
-    final TransitionCaches transitionCaches = BeaconStateCache.getTransitionCaches(state);
+    final EpochTransitionCaches transitionCaches = BeaconStateCache.getEpochTransitionCaches(state);
     final ProgressiveTotalBalancesUpdates progressiveTotalBalances =
         transitionCaches.getProgressiveTotalBalances();
     progressiveTotalBalances.onEpochTransition(validatorStatuses.getStatuses());
@@ -133,7 +133,7 @@ public abstract class AbstractEpochProcessor implements EpochProcessor {
       final MutableBeaconState state,
       final UInt64 currentEpoch,
       final TotalBalances totalBalances) {
-    final TransitionCaches transitionCaches = BeaconStateCache.getTransitionCaches(state);
+    final EpochTransitionCaches transitionCaches = BeaconStateCache.getEpochTransitionCaches(state);
     transitionCaches.setLatestTotalBalances(totalBalances);
     transitionCaches
         .getTotalActiveBalance()
@@ -155,7 +155,7 @@ public abstract class AbstractEpochProcessor implements EpochProcessor {
     }
 
     final TotalBalances totalBalances =
-        BeaconStateCache.getTransitionCaches(preState)
+        BeaconStateCache.getEpochTransitionCaches(preState)
             .getProgressiveTotalBalances()
             .getTotalBalances(specConfig)
             .orElseGet(
@@ -455,7 +455,7 @@ public abstract class AbstractEpochProcessor implements EpochProcessor {
         final Validator validator = validators.get(index);
         final UInt64 newEffectiveBalance =
             balance.minus(balance.mod(effectiveBalanceIncrement)).min(maxEffectiveBalance);
-        BeaconStateCache.getTransitionCaches(state)
+        BeaconStateCache.getEpochTransitionCaches(state)
             .getProgressiveTotalBalances()
             .onEffectiveBalanceChange(status, newEffectiveBalance);
         validators.set(index, validator.withEffectiveBalance(newEffectiveBalance));

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/status/AbstractValidatorStatusFactory.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/epoch/status/AbstractValidatorStatusFactory.java
@@ -23,7 +23,7 @@ import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.datastructures.state.Validator;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateCache;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.TransitionCaches;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.EpochTransitionCaches;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
 import tech.pegasys.teku.spec.logic.common.helpers.Predicates;
 import tech.pegasys.teku.spec.logic.common.util.AttestationUtil;
@@ -72,7 +72,7 @@ public abstract class AbstractValidatorStatusFactory implements ValidatorStatusF
 
   private TotalBalances createTotalBalances(
       final BeaconState state, final List<ValidatorStatus> statuses) {
-    final TransitionCaches transitionCaches = BeaconStateCache.getTransitionCaches(state);
+    final EpochTransitionCaches transitionCaches = BeaconStateCache.getEpochTransitionCaches(state);
     final ProgressiveTotalBalancesUpdates progressiveTotalBalances =
         transitionCaches.getProgressiveTotalBalances();
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/BeaconStateUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/BeaconStateUtil.java
@@ -138,7 +138,7 @@ public class BeaconStateUtil {
   }
 
   public List<UInt64> getEffectiveActiveUnslashedBalances(final BeaconState state) {
-    return BeaconStateCache.getTransitionCaches(state)
+    return BeaconStateCache.getEpochTransitionCaches(state)
         .getEffectiveBalances()
         .get(
             beaconStateAccessors.getCurrentEpoch(state),
@@ -163,7 +163,7 @@ public class BeaconStateUtil {
 
   public UInt64 getAttestersTotalEffectiveBalance(final BeaconState state, final UInt64 slot) {
     beaconStateAccessors.validateStateForCommitteeQuery(state, slot);
-    return BeaconStateCache.getTransitionCaches(state)
+    return BeaconStateCache.getEpochTransitionCaches(state)
         .getAttestersTotalBalance()
         .get(
             slot,

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/SyncCommitteeUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/SyncCommitteeUtil.java
@@ -105,7 +105,7 @@ public class SyncCommitteeUtil {
         epoch,
         state.getSlot());
     final BeaconStateAltair altairState = BeaconStateAltair.required(state);
-    return BeaconStateCache.getTransitionCaches(altairState)
+    return BeaconStateCache.getEpochTransitionCaches(altairState)
         .getSyncCommitteeCache()
         .get(
             syncCommitteePeriod,

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ValidatorsUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/ValidatorsUtil.java
@@ -53,7 +53,7 @@ public class ValidatorsUtil {
   }
 
   public Optional<Integer> getValidatorIndex(BeaconState state, BLSPublicKey publicKey) {
-    return BeaconStateCache.getTransitionCaches(state)
+    return BeaconStateCache.getEpochTransitionCaches(state)
         .getValidatorIndexCache()
         .getValidatorIndex(state, publicKey);
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/block/BlockProcessorAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/block/BlockProcessorAltair.java
@@ -142,7 +142,7 @@ public class BlockProcessorAltair extends AbstractBlockProcessor {
     maybeProposerReward.ifPresent(
         proposerReward -> {
           final int proposerIndex = beaconStateAccessors.getBeaconProposerIndex(state);
-          beaconStateMutators.increaseBalance(state, proposerIndex, proposerReward);
+          beaconStateMutators.increaseProposerBalance(state, proposerIndex, proposerReward);
         });
   }
 
@@ -190,7 +190,7 @@ public class BlockProcessorAltair extends AbstractBlockProcessor {
             SszByte.of(
                 miscHelpersAltair.addFlags(previousParticipationFlags, newParticipationFlags)));
 
-        BeaconStateCache.getTransitionCaches(state)
+        BeaconStateCache.getEpochTransitionCaches(state)
             .getProgressiveTotalBalances()
             .onAttestation(
                 state.getValidators().get(index),
@@ -254,7 +254,7 @@ public class BlockProcessorAltair extends AbstractBlockProcessor {
       if (aggregate.getSyncCommitteeBits().getBit(i)) {
         participantPubkeys.add(publicKey);
         beaconStateMutators.increaseBalance(state, validatorIndex, participantReward);
-        beaconStateMutators.increaseBalance(state, proposerIndex, proposerReward);
+        beaconStateMutators.increaseProposerBalance(state, proposerIndex, proposerReward);
       } else {
         beaconStateMutators.decreaseBalance(state, validatorIndex, participantReward);
       }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/helpers/BeaconStateAccessorsAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/helpers/BeaconStateAccessorsAltair.java
@@ -55,7 +55,7 @@ public class BeaconStateAccessorsAltair extends BeaconStateAccessors {
   }
 
   public UInt64 getBaseRewardPerIncrement(final BeaconState state) {
-    return BeaconStateCache.getTransitionCaches(state)
+    return BeaconStateCache.getEpochTransitionCaches(state)
         .getBaseRewardPerIncrement()
         .get(
             getCurrentEpoch(state),

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/helpers/BeaconStateMutatorsAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/helpers/BeaconStateMutatorsAltair.java
@@ -52,7 +52,7 @@ public class BeaconStateMutatorsAltair extends BeaconStateMutators {
       final int slashedIndex,
       final Supplier<ValidatorExitContext> validatorExitContextSupplier) {
     super.slashValidator(state, slashedIndex, validatorExitContextSupplier);
-    BeaconStateCache.getTransitionCaches(state)
+    BeaconStateCache.getEpochTransitionCaches(state)
         .getProgressiveTotalBalances()
         .onSlashing(state, slashedIndex);
   }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/statetransition/epoch/EpochProcessorAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/statetransition/epoch/EpochProcessorAltair.java
@@ -26,7 +26,7 @@ import tech.pegasys.teku.spec.config.SpecConfigAltair;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateCache;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.TransitionCaches;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.common.EpochTransitionCaches;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.altair.BeaconStateAltair;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.altair.MutableBeaconStateAltair;
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateMutators;
@@ -137,7 +137,7 @@ public class EpochProcessorAltair extends AbstractEpochProcessor {
   @Override
   public void initProgressiveTotalBalancesIfRequired(
       final BeaconState state, final TotalBalances totalBalances) {
-    final TransitionCaches transitionCaches = BeaconStateCache.getTransitionCaches(state);
+    final EpochTransitionCaches transitionCaches = BeaconStateCache.getEpochTransitionCaches(state);
     if (!(transitionCaches.getProgressiveTotalBalances()
         instanceof ProgressiveTotalBalancesAltair)) {
       transitionCaches.setProgressiveTotalBalances(

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -698,7 +698,6 @@ public class BeaconChainController extends Service implements BeaconChainControl
             .spec(spec)
             .recentChainData(recentChainData)
             .combinedChainDataClient(combinedChainDataClient)
-            .executionLayerBlockProductionManager(executionLayerBlockProductionManager)
             .rewardCalculator(rewardCalculator)
             .p2pNetwork(p2pNetwork)
             .syncService(syncService)

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainMetrics.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainMetrics.java
@@ -227,7 +227,7 @@ public class BeaconChainMetrics implements SlotEventsChannel {
 
   private void updateMetrics(final StateAndBlockSummary head) {
     final BeaconState state = head.getState();
-    BeaconStateCache.getTransitionCaches(state)
+    BeaconStateCache.getEpochTransitionCaches(state)
         .getLatestTotalBalances()
         .ifPresent(
             totalBalances -> {

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorApiChannel.java
@@ -29,10 +29,10 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.events.ChannelInterface;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.datastructures.blocks.BlockContainer;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
 import tech.pegasys.teku.spec.datastructures.builder.SignedValidatorRegistration;
 import tech.pegasys.teku.spec.datastructures.genesis.GenesisData;
+import tech.pegasys.teku.spec.datastructures.metadata.BlockContainerAndMetaData;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.SignedAggregateAndProof;
@@ -81,7 +81,7 @@ public interface ValidatorApiChannel extends ChannelInterface {
         }
 
         @Override
-        public SafeFuture<Optional<BlockContainer>> createUnsignedBlock(
+        public SafeFuture<Optional<BlockContainerAndMetaData>> createUnsignedBlock(
             UInt64 slot,
             BLSSignature randaoReveal,
             Optional<Bytes32> graffiti,
@@ -197,7 +197,7 @@ public interface ValidatorApiChannel extends ChannelInterface {
    * @param requestedBlinded can be removed once block creation V2 APIs are removed in favour of V3
    *     only
    */
-  SafeFuture<Optional<BlockContainer>> createUnsignedBlock(
+  SafeFuture<Optional<BlockContainerAndMetaData>> createUnsignedBlock(
       UInt64 slot,
       BLSSignature randaoReveal,
       Optional<Bytes32> graffiti,

--- a/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
+++ b/validator/beaconnode/src/main/java/tech/pegasys/teku/validator/beaconnode/metrics/MetricRecordingValidatorApiChannel.java
@@ -38,10 +38,10 @@ import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.metrics.Validator.ValidatorDutyMetricUtils;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.datastructures.blocks.BlockContainer;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
 import tech.pegasys.teku.spec.datastructures.builder.SignedValidatorRegistration;
 import tech.pegasys.teku.spec.datastructures.genesis.GenesisData;
+import tech.pegasys.teku.spec.datastructures.metadata.BlockContainerAndMetaData;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.SignedAggregateAndProof;
@@ -126,7 +126,7 @@ public class MetricRecordingValidatorApiChannel implements ValidatorApiChannel {
   }
 
   @Override
-  public SafeFuture<Optional<BlockContainer>> createUnsignedBlock(
+  public SafeFuture<Optional<BlockContainerAndMetaData>> createUnsignedBlock(
       final UInt64 slot,
       final BLSSignature randaoReveal,
       final Optional<Bytes32> graffiti,

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/BlockProductionDuty.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/BlockProductionDuty.java
@@ -32,6 +32,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.BlockContainer;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSummary;
+import tech.pegasys.teku.spec.datastructures.metadata.BlockContainerAndMetaData;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
 import tech.pegasys.teku.spec.datastructures.validator.BroadcastValidationLevel;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
@@ -91,6 +92,9 @@ public class BlockProductionDuty implements Duty {
             signature ->
                 validatorDutyMetrics.record(
                     () -> createUnsignedBlock(signature), this, ValidatorDutyMetricsSteps.CREATE))
+        .thenApply(
+            blockContainerAndMetaData ->
+                blockContainerAndMetaData.map(BlockContainerAndMetaData::blockContainer))
         .thenCompose(this::validateBlock)
         .thenCompose(
             blockContainer ->
@@ -109,7 +113,7 @@ public class BlockProductionDuty implements Duty {
     return validator.getSigner().createRandaoReveal(spec.computeEpochAtSlot(slot), forkInfo);
   }
 
-  private SafeFuture<Optional<BlockContainer>> createUnsignedBlock(
+  private SafeFuture<Optional<BlockContainerAndMetaData>> createUnsignedBlock(
       final BLSSignature randaoReveal) {
     if (blockV3Enabled) {
       return validatorApiChannel.createUnsignedBlock(

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/FailoverValidatorApiHandler.java
@@ -43,6 +43,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.BlockContainer;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
 import tech.pegasys.teku.spec.datastructures.builder.SignedValidatorRegistration;
 import tech.pegasys.teku.spec.datastructures.genesis.GenesisData;
+import tech.pegasys.teku.spec.datastructures.metadata.BlockContainerAndMetaData;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.SignedAggregateAndProof;
@@ -146,13 +147,13 @@ public class FailoverValidatorApiHandler implements ValidatorApiChannel {
   }
 
   @Override
-  public SafeFuture<Optional<BlockContainer>> createUnsignedBlock(
+  public SafeFuture<Optional<BlockContainerAndMetaData>> createUnsignedBlock(
       final UInt64 slot,
       final BLSSignature randaoReveal,
       final Optional<Bytes32> graffiti,
       final Optional<Boolean> requestedBlinded,
       final Optional<UInt64> requestedBuilderBoostFactor) {
-    final ValidatorApiChannelRequest<Optional<BlockContainer>> request =
+    final ValidatorApiChannelRequest<Optional<BlockContainerAndMetaData>> request =
         apiChannel ->
             apiChannel
                 .createUnsignedBlock(
@@ -160,7 +161,10 @@ public class FailoverValidatorApiHandler implements ValidatorApiChannel {
                 .thenPeek(
                     blockContainer -> {
                       if (!failoverDelegates.isEmpty()
-                          && blockContainer.map(BlockContainer::isBlinded).orElse(false)) {
+                          && blockContainer
+                              .map(BlockContainerAndMetaData::blockContainer)
+                              .map(BlockContainer::isBlinded)
+                              .orElse(false)) {
                         blindedBlockCreatorCache.put(slot, apiChannel);
                       }
                     });

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/RemoteValidatorApiHandler.java
@@ -53,10 +53,10 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.datastructures.blocks.BlockContainer;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
 import tech.pegasys.teku.spec.datastructures.builder.SignedValidatorRegistration;
 import tech.pegasys.teku.spec.datastructures.genesis.GenesisData;
+import tech.pegasys.teku.spec.datastructures.metadata.BlockContainerAndMetaData;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.SignedAggregateAndProof;
@@ -273,7 +273,7 @@ public class RemoteValidatorApiHandler implements RemoteValidatorApiChannel {
   }
 
   @Override
-  public SafeFuture<Optional<BlockContainer>> createUnsignedBlock(
+  public SafeFuture<Optional<BlockContainerAndMetaData>> createUnsignedBlock(
       final UInt64 slot,
       final BLSSignature randaoReveal,
       final Optional<Bytes32> graffiti,

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/sentry/SentryValidatorApiChannel.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/sentry/SentryValidatorApiChannel.java
@@ -28,10 +28,10 @@ import tech.pegasys.teku.ethereum.json.types.validator.ProposerDuties;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.datastructures.blocks.BlockContainer;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
 import tech.pegasys.teku.spec.datastructures.builder.SignedValidatorRegistration;
 import tech.pegasys.teku.spec.datastructures.genesis.GenesisData;
+import tech.pegasys.teku.spec.datastructures.metadata.BlockContainerAndMetaData;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.SignedAggregateAndProof;
@@ -99,7 +99,7 @@ public class SentryValidatorApiChannel implements ValidatorApiChannel {
   }
 
   @Override
-  public SafeFuture<Optional<BlockContainer>> createUnsignedBlock(
+  public SafeFuture<Optional<BlockContainerAndMetaData>> createUnsignedBlock(
       final UInt64 slot,
       final BLSSignature randaoReveal,
       final Optional<Bytes32> graffiti,

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/OkHttpValidatorTypeDefClient.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/OkHttpValidatorTypeDefClient.java
@@ -24,10 +24,10 @@ import tech.pegasys.teku.ethereum.json.types.validator.ProposerDuties;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.datastructures.blocks.BlockContainer;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
 import tech.pegasys.teku.spec.datastructures.builder.SignedValidatorRegistration;
 import tech.pegasys.teku.spec.datastructures.genesis.GenesisData;
+import tech.pegasys.teku.spec.datastructures.metadata.BlockContainerAndMetaData;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.validator.api.SendSignedBlockResult;
 import tech.pegasys.teku.validator.api.required.SyncingStatus;
@@ -97,7 +97,7 @@ public class OkHttpValidatorTypeDefClient {
   }
 
   @Deprecated
-  public Optional<BlockContainer> createUnsignedBlock(
+  public Optional<BlockContainerAndMetaData> createUnsignedBlock(
       final UInt64 slot,
       final BLSSignature randaoReveal,
       final Optional<Bytes32> graffiti,
@@ -115,7 +115,7 @@ public class OkHttpValidatorTypeDefClient {
     }
   }
 
-  public Optional<BlockContainer> createUnsignedBlock(
+  public Optional<BlockContainerAndMetaData> createUnsignedBlock(
       final UInt64 slot,
       final BLSSignature randaoReveal,
       final Optional<Bytes32> graffiti,
@@ -123,8 +123,9 @@ public class OkHttpValidatorTypeDefClient {
     final ProduceBlockRequest produceBlockRequest =
         new ProduceBlockRequest(baseEndpoint, okHttpClient, spec, slot, preferSszBlockEncoding);
     try {
-      return produceBlockRequest.createUnsignedBlock(
-          randaoReveal, graffiti, requestedBuilderBoostFactor);
+      return produceBlockRequest
+          .createUnsignedBlock(randaoReveal, graffiti, requestedBuilderBoostFactor)
+          .map(container -> BlockContainerAndMetaData.fromBlockContainer(container, spec));
     } catch (final BlockProductionV3FailedException ex) {
       LOG.warn("Produce Block V3 request failed at slot {}. Retrying with Block V2", slot);
 

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/handlers/CreateBlockRequest.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/handlers/CreateBlockRequest.java
@@ -39,6 +39,7 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockContainer;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockContainerSchema;
+import tech.pegasys.teku.spec.datastructures.metadata.BlockContainerAndMetaData;
 import tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod;
 import tech.pegasys.teku.validator.remote.typedef.BlindedBlockEndpointNotAvailableException;
 import tech.pegasys.teku.validator.remote.typedef.ResponseHandler;
@@ -96,7 +97,7 @@ public class CreateBlockRequest extends AbstractTypeDefRequest {
             : responseHandler;
   }
 
-  public Optional<BlockContainer> createUnsignedBlock(
+  public Optional<BlockContainerAndMetaData> createUnsignedBlock(
       final BLSSignature randaoReveal, final Optional<Bytes32> graffiti) {
     final Map<String, String> queryParams = new HashMap<>();
     queryParams.put("randao_reveal", randaoReveal.toString());
@@ -108,7 +109,10 @@ public class CreateBlockRequest extends AbstractTypeDefRequest {
       headers.put("Accept", "application/octet-stream;q=0.9, application/json;q=0.4");
     }
     return get(apiMethod, Map.of("slot", slot.toString()), queryParams, headers, responseHandler)
-        .map(GetBlockResponse::getData);
+        .map(
+            getBlockResponse ->
+                BlockContainerAndMetaData.fromBlockContainer(
+                    getBlockResponse.getData(), getBlockResponse.getSpecMilestone()));
   }
 
   private Optional<GetBlockResponse> handleBlockContainerResult(


### PR DESCRIPTION
fixes: #7942 


- introduces a new cache (`StateTransitionCaches`) attached to the state that can be used to
  - store temporary intermediate data to help speeding up the state transition (atm not used)
  - store calculated data coming from state transition and block processing in general (including execution payload related stuff). I use here to cache block rewards (consensus) and payload execution value

- updated state transition functions to:
  - update block rewards in cache
  - call callback events (`onSlotProcessed` and `onBlockProcessed`)

- renamed `TransitionCaches` to `EpochTransitionCaches`

- it also makes `BlockContainerAndMetaData` be the data structure of the `ValidatorAPIChannel`. Not everything has been implemented here but the idea is that we can make the typeDef client "restore" it including all the metadata from the header variables.


## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
