### PR TITLE
Put blob sidecar valid seen validation to the top

### DIFF
--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/BlobSidecarGossipValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/BlobSidecarGossipValidatorTest.java
@@ -278,6 +278,31 @@ public class BlobSidecarGossipValidatorTest {
   }
 
   @TestTemplate
+  void shouldIgnoreImmediatelyWhenBlobFromValidInfoSet() {
+    SafeFutureAssert.assertThatSafeFuture(blobSidecarValidator.validate(blobSidecar))
+        .isCompletedWithValueMatching(InternalValidationResult::isAccept);
+
+    verify(miscHelpersDeneb).verifyBlobSidecarMerkleProof(blobSidecar);
+    verify(miscHelpersDeneb).verifyBlobKzgProof(kzg, blobSidecar);
+    verify(gossipValidationHelper).getParentStateInBlockEpoch(any(), any(), any());
+    verify(gossipValidationHelper).isProposerTheExpectedProposer(any(), any(), any());
+    verify(gossipValidationHelper)
+        .isSignatureValidWithRespectToProposerIndex(any(), any(), any(), any());
+    clearInvocations(gossipValidationHelper);
+    clearInvocations(miscHelpersDeneb);
+
+    SafeFutureAssert.assertThatSafeFuture(blobSidecarValidator.validate(blobSidecar))
+        .isCompletedWithValueMatching(InternalValidationResult::isIgnore);
+
+    verify(miscHelpersDeneb, never()).verifyBlobSidecarMerkleProof(blobSidecar);
+    verify(miscHelpersDeneb, never()).verifyBlobKzgProof(kzg, blobSidecar);
+    verify(gossipValidationHelper, never()).getParentStateInBlockEpoch(any(), any(), any());
+    verify(gossipValidationHelper, never()).isProposerTheExpectedProposer(any(), any(), any());
+    verify(gossipValidationHelper, never())
+        .isSignatureValidWithRespectToProposerIndex(any(), any(), any(), any());
+  }
+
+  @TestTemplate
   void shouldNotVerifyKnownValidSignedHeader() {
     SafeFutureAssert.assertThatSafeFuture(blobSidecarValidator.validate(blobSidecar))
         .isCompletedWithValueMatching(InternalValidationResult::isAccept);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Motivation:
- such check in block gossip validation is at top, just after `finalized` 
- it's the cheapest check possible, current check is after kzg verification which is the most expensive
- we probably observed network behavior exploiting current order
- there is always similar check in the end for concurrent validation

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
