### PR TITLE
Prune pending pools content and Blobsidecar trackers every epoch

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/AbstractIgnoringFutureHistoricalSlot.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/AbstractIgnoringFutureHistoricalSlot.java
@@ -32,11 +32,13 @@ import tech.pegasys.teku.storage.api.FinalizedCheckpointChannel;
  */
 abstract class AbstractIgnoringFutureHistoricalSlot
     implements SlotEventsChannel, FinalizedCheckpointChannel {
+  public static final UInt64 PRUNE_SLOT = UInt64.ONE;
   private final Spec spec;
 
   // Define the range of slots we care about
   private final UInt64 futureSlotTolerance;
   private final UInt64 historicalSlotTolerance;
+  private final UInt64 slotsInEpoch;
 
   private volatile UInt64 currentSlot = UInt64.ZERO;
   private volatile UInt64 latestFinalizedSlot = GENESIS_SLOT;
@@ -46,12 +48,13 @@ abstract class AbstractIgnoringFutureHistoricalSlot
     this.spec = spec;
     this.futureSlotTolerance = futureSlotTolerance;
     this.historicalSlotTolerance = historicalSlotTolerance;
+    this.slotsInEpoch = UInt64.valueOf(spec.getGenesisSpec().getSlotsPerEpoch());
   }
 
   @Override
   public void onSlot(final UInt64 slot) {
     currentSlot = slot;
-    if (currentSlot.mod(historicalSlotTolerance).equals(UInt64.ZERO)) {
+    if (currentSlot.mod(slotsInEpoch).equals(PRUNE_SLOT)) {
       // Purge old items
       prune();
     }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Current behavior is to prune every 10 epochs, so in normal finalization we have 8 extra epochs of stuff we don't need, which is not only memory, but could cause issues with blobSidecarTrackers, because they are active items (see `BlockBlobSidecarsTrackersPoolImpl`). Plus removing little number of items more often is always more comfortable for GC.
Some notes:
- I don't want to query slots per epoch every slot, because actually SLOTS_PER_EPOCH is constant for all milestones, even if this is changed, nothing will be broken
- I think it's good to offset something from near epoch transition so moved it to the first slot (or maybe I'm too paranoid)


## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
