### PR TITLE
Move block rewards calculation to dedicated spec util

### DIFF
--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/rewards/GetBlockRewardsIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/rewards/GetBlockRewardsIntegrationTest.java
@@ -31,6 +31,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregate;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.generator.ChainBuilder;
+import tech.pegasys.teku.spec.logic.common.util.BlockRewardCalculatorUtil;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class GetBlockRewardsIntegrationTest extends AbstractDataBackedRestAPIIntegrationTest {
@@ -38,7 +39,7 @@ public class GetBlockRewardsIntegrationTest extends AbstractDataBackedRestAPIInt
   @BeforeEach
   public void setup() {
     spec = TestSpecFactory.createMinimalAltair();
-    rewardCalculator = new RewardCalculator(spec);
+    rewardCalculator = new RewardCalculator(spec, new BlockRewardCalculatorUtil(spec));
     final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
     startRestAPIAtGenesis(SpecMilestone.ALTAIR);
     chainBuilder.generateBlocksUpToSlot(10);

--- a/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/rewards/GetSyncCommitteeRewardsIntegrationTest.java
+++ b/data/beaconrestapi/src/integration-test/java/tech/pegasys/teku/beaconrestapi/v1/rewards/GetSyncCommitteeRewardsIntegrationTest.java
@@ -39,6 +39,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregate;
 import tech.pegasys.teku.spec.datastructures.type.SszPublicKey;
 import tech.pegasys.teku.spec.generator.ChainBuilder;
+import tech.pegasys.teku.spec.logic.common.util.BlockRewardCalculatorUtil;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class GetSyncCommitteeRewardsIntegrationTest
@@ -47,7 +48,7 @@ public class GetSyncCommitteeRewardsIntegrationTest
   @BeforeEach
   public void setup() {
     spec = TestSpecFactory.createMinimalAltair();
-    rewardCalculator = new RewardCalculator(spec);
+    rewardCalculator = new RewardCalculator(spec, new BlockRewardCalculatorUtil(spec));
     final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
     startRestAPIAtGenesis(SpecMilestone.ALTAIR);
     final SyncAggregate syncAggregate =

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/rewards/GetBlockRewards.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/rewards/GetBlockRewards.java
@@ -40,12 +40,12 @@ public class GetBlockRewards extends RestApiEndpoint {
 
   private static final SerializableTypeDefinition<BlockRewardData> DATA_TYPE =
       SerializableTypeDefinition.object(BlockRewardData.class)
-          .withField("proposer_index", UINT64_TYPE, BlockRewardData::getProposerIndex)
+          .withField("proposer_index", UINT64_TYPE, BlockRewardData::proposerIndex)
           .withField("total", LONG_TYPE, BlockRewardData::getTotal)
-          .withField("attestations", LONG_TYPE, BlockRewardData::getAttestations)
-          .withField("sync_aggregate", LONG_TYPE, BlockRewardData::getSyncAggregate)
-          .withField("proposer_slashings", LONG_TYPE, BlockRewardData::getProposerSlashings)
-          .withField("attester_slashings", LONG_TYPE, BlockRewardData::getAttesterSlashings)
+          .withField("attestations", LONG_TYPE, BlockRewardData::attestations)
+          .withField("sync_aggregate", LONG_TYPE, BlockRewardData::syncAggregate)
+          .withField("proposer_slashings", LONG_TYPE, BlockRewardData::proposerSlashings)
+          .withField("attester_slashings", LONG_TYPE, BlockRewardData::attesterSlashings)
           .build();
 
   private static final SerializableTypeDefinition<ObjectAndMetaData<BlockRewardData>>

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/AbstractMigratedBeaconHandlerWithChainDataProviderTest.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/AbstractMigratedBeaconHandlerWithChainDataProviderTest.java
@@ -21,6 +21,7 @@ import tech.pegasys.teku.bls.BLSKeyPair;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.generator.ChainBuilder;
+import tech.pegasys.teku.spec.logic.common.util.BlockRewardCalculatorUtil;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.validatorcache.ActiveValidatorCache;
 import tech.pegasys.teku.statetransition.validatorcache.ActiveValidatorChannel;
@@ -71,6 +72,9 @@ public class AbstractMigratedBeaconHandlerWithChainDataProviderTest
     chainUpdater = new ChainUpdater(recentChainData, chainBuilder, spec);
     chainDataProvider =
         new ChainDataProvider(
-            spec, recentChainData, combinedChainDataClient, new RewardCalculator(spec));
+            spec,
+            recentChainData,
+            combinedChainDataClient,
+            new RewardCalculator(spec, new BlockRewardCalculatorUtil(spec)));
   }
 }

--- a/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v3/validator/GetNewBlockV3Test.java
+++ b/data/beaconrestapi/src/test/java/tech/pegasys/teku/beaconrestapi/handlers/v3/validator/GetNewBlockV3Test.java
@@ -61,6 +61,7 @@ import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadResult;
 import tech.pegasys.teku.spec.datastructures.metadata.BlockContainerAndMetaData;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.executionlayer.ExecutionLayerBlockProductionManager;
+import tech.pegasys.teku.spec.logic.common.util.BlockRewardCalculatorUtil;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 import tech.pegasys.teku.validator.api.ValidatorApiChannel;
@@ -378,7 +379,8 @@ public class GetNewBlockV3Test extends AbstractMigratedBeaconHandlerTest {
         .thenReturn(Optional.of(SafeFuture.completedFuture(executionPayloadValue)));
     when(executionLayerBlockProductionManagerMock.getCachedPayloadResult(any()))
         .thenReturn(Optional.of(executionPayloadResultMock));
-    final RewardCalculator rewardCalculatorMock = new RewardCalculator(spec);
+    final RewardCalculator rewardCalculatorMock =
+        new RewardCalculator(spec, new BlockRewardCalculatorUtil(spec));
 
     validatorDataProvider =
         new ValidatorDataProvider(

--- a/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java
@@ -600,7 +600,8 @@ public class ChainDataProvider {
                       maybeState ->
                           maybeState.map(
                               state ->
-                                  rewardCalculator.getBlockRewardData(blockAndMetaData, state)));
+                                  rewardCalculator.getBlockRewardDataAndMetaData(
+                                      blockAndMetaData, state)));
             });
   }
 

--- a/data/provider/src/main/java/tech/pegasys/teku/api/RewardCalculator.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/RewardCalculator.java
@@ -13,11 +13,7 @@
 
 package tech.pegasys.teku.api;
 
-import static tech.pegasys.teku.spec.constants.IncentivizationWeights.PROPOSER_WEIGHT;
-import static tech.pegasys.teku.spec.constants.IncentivizationWeights.WEIGHT_DENOMINATOR;
-
 import com.google.common.annotations.VisibleForTesting;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -26,76 +22,50 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.api.exceptions.BadRequestException;
 import tech.pegasys.teku.api.migrated.BlockRewardData;
 import tech.pegasys.teku.api.migrated.SyncCommitteeRewardData;
 import tech.pegasys.teku.bls.BLSPublicKey;
-import tech.pegasys.teku.infrastructure.ssz.SszList;
-import tech.pegasys.teku.infrastructure.ssz.collections.SszBitvector;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.SpecVersion;
-import tech.pegasys.teku.spec.cache.IndexedAttestationCache;
-import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockContainer;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregate;
 import tech.pegasys.teku.spec.datastructures.metadata.BlockAndMetaData;
 import tech.pegasys.teku.spec.datastructures.metadata.ObjectAndMetaData;
-import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
-import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.datastructures.state.SyncCommittee;
-import tech.pegasys.teku.spec.datastructures.state.Validator;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.altair.BeaconStateAltair;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.altair.MutableBeaconStateAltair;
 import tech.pegasys.teku.spec.datastructures.type.SszPublicKey;
-import tech.pegasys.teku.spec.logic.common.block.AbstractBlockProcessor;
-import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.EpochProcessingException;
-import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.SlotProcessingException;
-import tech.pegasys.teku.spec.logic.versions.altair.block.BlockProcessorAltair;
+import tech.pegasys.teku.spec.logic.common.util.BlockRewardCalculatorUtil;
 
 public class RewardCalculator {
   private final Spec spec;
-  private static final Logger LOG = LogManager.getLogger();
+  private final BlockRewardCalculatorUtil blockRewardCalculatorUtil;
 
-  public RewardCalculator(Spec spec) {
+  public RewardCalculator(
+      final Spec spec, final BlockRewardCalculatorUtil blockRewardCalculatorUtil) {
     this.spec = spec;
+    this.blockRewardCalculatorUtil = blockRewardCalculatorUtil;
   }
 
-  ObjectAndMetaData<BlockRewardData> getBlockRewardData(
+  public ObjectAndMetaData<BlockRewardData> getBlockRewardDataAndMetaData(
       final BlockAndMetaData blockAndMetaData, final BeaconState parentState) {
     return blockAndMetaData.map(
-        __ -> getBlockRewardData(blockAndMetaData.getData().getMessage(), parentState));
+        __ ->
+            BlockRewardData.fromInternal(
+                blockRewardCalculatorUtil.getBlockRewardData(
+                    blockAndMetaData.getData().getMessage(), parentState)));
   }
 
   public BlockRewardData getBlockRewardData(
       final BlockContainer blockContainer, final BeaconState parentState) {
-    final BeaconBlock block = blockContainer.getBlock();
-    if (!spec.atSlot(block.getSlot()).getMilestone().isGreaterThanOrEqualTo(SpecMilestone.ALTAIR)) {
-      throw new BadRequestException(
-          "Slot "
-              + block.getSlot()
-              + " is pre altair, and no sync committee information is available");
+    try {
+      return BlockRewardData.fromInternal(
+          blockRewardCalculatorUtil.getBlockRewardData(blockContainer, parentState));
+    } catch (IllegalArgumentException e) {
+      throw new BadRequestException(e.getMessage());
     }
-
-    final BeaconState preState = getPreState(block.getSlot(), parentState);
-
-    final SpecVersion specVersion = spec.atSlot(preState.getSlot());
-    return calculateBlockRewards(
-        block, BlockProcessorAltair.required(specVersion.getBlockProcessor()), preState);
-  }
-
-  @VisibleForTesting
-  long getProposerReward(final BeaconState state) {
-    final UInt64 participantReward = spec.getSyncCommitteeParticipantReward(state);
-    return participantReward
-        .times(PROPOSER_WEIGHT)
-        .dividedBy(WEIGHT_DENOMINATOR.minus(PROPOSER_WEIGHT))
-        .longValue();
   }
 
   @VisibleForTesting
@@ -130,8 +100,7 @@ public class RewardCalculator {
     return output;
   }
 
-  @VisibleForTesting
-  SyncCommitteeRewardData getSyncCommitteeRewardData(
+  public SyncCommitteeRewardData getSyncCommitteeRewardData(
       Set<String> validators, BlockAndMetaData blockAndMetadata, BeaconState state) {
     final BeaconBlock block = blockAndMetadata.getData().getMessage();
     if (!spec.atSlot(block.getSlot()).getMilestone().isGreaterThanOrEqualTo(SpecMilestone.ALTAIR)) {
@@ -161,75 +130,6 @@ public class RewardCalculator {
   }
 
   @VisibleForTesting
-  BlockRewardData calculateBlockRewards(
-      final BeaconBlock block,
-      final BlockProcessorAltair blockProcessorAltair,
-      final BeaconState preState) {
-    final long proposerReward = getProposerReward(preState);
-    final SyncAggregate aggregate = block.getBody().getOptionalSyncAggregate().orElseThrow();
-    final UInt64 proposerIndex = block.getProposerIndex();
-    final long attestationsBlockRewards =
-        calculateAttestationRewards(block, blockProcessorAltair, preState);
-    final long syncAggregateBlockRewards =
-        calculateProposerSyncAggregateBlockRewards(proposerReward, aggregate);
-    final long proposerSlashingsBlockRewards = calculateProposerSlashingsRewards(block, preState);
-    final long attesterSlashingsBlockRewards = calculateAttesterSlashingsRewards(block, preState);
-
-    return new BlockRewardData(
-        proposerIndex,
-        attestationsBlockRewards,
-        syncAggregateBlockRewards,
-        proposerSlashingsBlockRewards,
-        attesterSlashingsBlockRewards);
-  }
-
-  @VisibleForTesting
-  long calculateProposerSyncAggregateBlockRewards(long proposerReward, SyncAggregate aggregate) {
-    final SszBitvector syncCommitteeBits = aggregate.getSyncCommitteeBits();
-    return proposerReward * syncCommitteeBits.getBitCount();
-  }
-
-  @VisibleForTesting
-  long calculateProposerSlashingsRewards(
-      final BeaconBlock beaconBlock, final BeaconState preState) {
-    final SszList<ProposerSlashing> proposerSlashings =
-        beaconBlock.getBody().getProposerSlashings();
-
-    final UInt64 epoch = spec.computeEpochAtSlot(preState.getSlot());
-    final SpecConfig specConfig = spec.getSpecConfig(epoch);
-
-    long proposerSlashingsRewards = 0;
-    for (ProposerSlashing slashing : proposerSlashings) {
-      final int slashedIndex = slashing.getHeader1().getMessage().getProposerIndex().intValue();
-      proposerSlashingsRewards =
-          calculateSlashingRewards(specConfig, preState, slashedIndex, proposerSlashingsRewards);
-    }
-
-    return proposerSlashingsRewards;
-  }
-
-  @VisibleForTesting
-  long calculateAttesterSlashingsRewards(
-      final BeaconBlock beaconBlock, final BeaconState preState) {
-    final SszList<AttesterSlashing> attesterSlashings =
-        beaconBlock.getBody().getAttesterSlashings();
-
-    final UInt64 epoch = spec.computeEpochAtSlot(preState.getSlot());
-    final SpecConfig specConfig = spec.getSpecConfig(epoch);
-
-    long attesterSlashingsRewards = 0;
-    for (AttesterSlashing slashing : attesterSlashings) {
-      for (final UInt64 index : slashing.getIntersectingValidatorIndices()) {
-        attesterSlashingsRewards =
-            calculateSlashingRewards(
-                specConfig, preState, index.intValue(), attesterSlashingsRewards);
-      }
-    }
-
-    return attesterSlashingsRewards;
-  }
-
-  @VisibleForTesting
   SyncCommitteeRewardData calculateSyncCommitteeRewards(
       final Map<Integer, Integer> committeeIndices,
       final long participantReward,
@@ -255,82 +155,31 @@ public class RewardCalculator {
 
   @VisibleForTesting
   void checkValidatorsList(
-      List<BLSPublicKey> committeeKeys, int validatorSetSize, Set<String> validators) {
-    for (String v : validators) {
-      if (v.startsWith("0x")) {
-        if (!committeeKeys.contains(BLSPublicKey.fromHexString(v))) {
-          throw new BadRequestException(String.format("'%s' was not found in the committee", v));
+      final List<BLSPublicKey> committeeKeys,
+      final int validatorSetSize,
+      final Set<String> validators) {
+    for (final String validator : validators) {
+      if (validator.startsWith("0x")) {
+        if (!committeeKeys.contains(BLSPublicKey.fromHexString(validator))) {
+          throw new BadRequestException(
+              String.format("'%s' was not found in the committee", validator));
         }
       } else {
         try {
-          final int index = Integer.parseInt(v);
+          final int index = Integer.parseInt(validator);
           if (index < 0 || index >= validatorSetSize) {
             throw new BadRequestException(
                 String.format(
                     "index '%s' is not in the expected validator index range 0 - %d",
-                    v, validatorSetSize));
+                    validator, validatorSetSize));
           }
         } catch (NumberFormatException e) {
           throw new BadRequestException(
               String.format(
                   "'%s' was expected to be a committee index but could not be read as a number",
-                  v));
+                  validator));
         }
       }
     }
-  }
-
-  private long calculateAttestationRewards(
-      final BeaconBlock block,
-      final BlockProcessorAltair blockProcessor,
-      final BeaconState preState) {
-    final List<Optional<UInt64>> rewards = new ArrayList<>();
-    final MutableBeaconStateAltair mutableBeaconStateAltair =
-        BeaconStateAltair.required(preState).createWritableCopy();
-    final AbstractBlockProcessor.IndexedAttestationProvider indexedAttestationProvider =
-        blockProcessor.createIndexedAttestationProvider(
-            mutableBeaconStateAltair, IndexedAttestationCache.capturing());
-    block
-        .getBody()
-        .getAttestations()
-        .forEach(
-            attestation ->
-                rewards.add(
-                    blockProcessor.processAttestationProposerReward(
-                        mutableBeaconStateAltair, attestation, indexedAttestationProvider)));
-
-    return rewards.stream()
-        .filter(Optional::isPresent)
-        .map(Optional::get)
-        .map(UInt64::longValue)
-        .reduce(0L, Long::sum);
-  }
-
-  private long calculateSlashingRewards(
-      final SpecConfig specConfig,
-      final BeaconState state,
-      final int slashedIndex,
-      final long currentRewards) {
-    final Validator validator = state.getValidators().get(slashedIndex);
-    final UInt64 whistleblowerReward =
-        validator.getEffectiveBalance().dividedBy(specConfig.getWhistleblowerRewardQuotient());
-    final UInt64 proposerReward =
-        whistleblowerReward.dividedBy(specConfig.getProposerRewardQuotient());
-    final UInt64 rewardsAdditions = proposerReward.plus(whistleblowerReward.minus(proposerReward));
-    return currentRewards + rewardsAdditions.longValue();
-  }
-
-  private BeaconState getPreState(final UInt64 slot, final BeaconState parentState) {
-    final BeaconState preState;
-    try {
-      preState = spec.processSlots(parentState, slot);
-    } catch (SlotProcessingException | EpochProcessingException e) {
-      LOG.debug("Failed to fetch preState for slot {}", slot, e);
-      throw new IllegalArgumentException(
-          "Failed to calculate block rewards, as could not generate the pre-state of the block at slot "
-              + slot,
-          e);
-    }
-    return preState;
   }
 }

--- a/data/provider/src/main/java/tech/pegasys/teku/api/RewardCalculator.java
+++ b/data/provider/src/main/java/tech/pegasys/teku/api/RewardCalculator.java
@@ -52,10 +52,7 @@ public class RewardCalculator {
   public ObjectAndMetaData<BlockRewardData> getBlockRewardDataAndMetaData(
       final BlockAndMetaData blockAndMetaData, final BeaconState parentState) {
     return blockAndMetaData.map(
-        __ ->
-            BlockRewardData.fromInternal(
-                blockRewardCalculatorUtil.getBlockRewardData(
-                    blockAndMetaData.getData().getMessage(), parentState)));
+        __ -> getBlockRewardData(blockAndMetaData.getData().getMessage(), parentState));
   }
 
   public BlockRewardData getBlockRewardData(

--- a/data/provider/src/test/java/tech/pegasys/teku/api/ChainDataProviderTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/ChainDataProviderTest.java
@@ -412,7 +412,8 @@ public class ChainDataProviderTest extends AbstractChainDataProviderTest {
     assertThat(blockAndMetadata).isNotEmpty();
     verify(mockCombinedChainDataClient, times(1))
         .getStateAtSlotExact(blockAndMetadata.get().getData().getSlot().decrement());
-    verify(rewardCalculatorMock, times(1)).getBlockRewardData(eq(blockAndMetadata.get()), any());
+    verify(rewardCalculatorMock, times(1))
+        .getBlockRewardDataAndMetaData(eq(blockAndMetadata.get()), any());
     assertThat(future).isCompleted();
   }
 

--- a/data/provider/src/test/java/tech/pegasys/teku/api/ChainDataProviderTestPhase0.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/ChainDataProviderTestPhase0.java
@@ -67,6 +67,7 @@ import tech.pegasys.teku.spec.datastructures.metadata.ObjectAndMetaData;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.generator.AttestationGenerator;
 import tech.pegasys.teku.spec.generator.ChainBuilder;
+import tech.pegasys.teku.spec.logic.common.util.BlockRewardCalculatorUtil;
 import tech.pegasys.teku.storage.client.ChainDataUnavailableException;
 import tech.pegasys.teku.storage.client.RecentChainData;
 
@@ -322,7 +323,10 @@ public class ChainDataProviderTestPhase0 extends AbstractChainDataProviderTest {
   public void getSyncCommitteeRewardsFromBlockId_slotIsPreAltair() {
     final ChainDataProvider provider =
         new ChainDataProvider(
-            spec, recentChainData, combinedChainDataClient, new RewardCalculator(spec));
+            spec,
+            recentChainData,
+            combinedChainDataClient,
+            new RewardCalculator(spec, new BlockRewardCalculatorUtil(spec)));
     final SafeFuture<Optional<SyncCommitteeRewardData>> future =
         provider.getSyncCommitteeRewardsFromBlockId("head", Set.of());
     assertThat(future).isCompletedExceptionally();

--- a/data/provider/src/test/java/tech/pegasys/teku/api/RewardCalculatorTest.java
+++ b/data/provider/src/test/java/tech/pegasys/teku/api/RewardCalculatorTest.java
@@ -13,17 +13,12 @@
 
 package tech.pegasys.teku.api;
 
-import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
-import static tech.pegasys.teku.spec.constants.IncentivizationWeights.PROPOSER_WEIGHT;
-import static tech.pegasys.teku.spec.constants.IncentivizationWeights.WEIGHT_DENOMINATOR;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -42,36 +37,44 @@ import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
-import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
-import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockContainer;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockAndState;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregate;
 import tech.pegasys.teku.spec.datastructures.metadata.BlockAndMetaData;
 import tech.pegasys.teku.spec.datastructures.state.Validator;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
-import tech.pegasys.teku.spec.logic.common.block.AbstractBlockProcessor;
-import tech.pegasys.teku.spec.logic.versions.altair.block.BlockProcessorAltair;
+import tech.pegasys.teku.spec.logic.common.util.BlockRewardCalculatorUtil;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class RewardCalculatorTest {
   private final Spec spec = TestSpecFactory.createMinimalCapella();
   private final DataStructureUtil data = new DataStructureUtil(spec);
-
-  private RewardCalculator calculator = new RewardCalculator(spec);
+  private final BlockRewardCalculatorUtil blockRewardCalculatorUtil =
+      mock(BlockRewardCalculatorUtil.class);
+  private final RewardCalculator calculator = new RewardCalculator(spec, blockRewardCalculatorUtil);
 
   private final BLSPublicKey publicKey = data.randomPublicKey();
 
-  private final BlockProcessorAltair blockProcessorAltair = mock(BlockProcessorAltair.class);
-
-  private static final long SINGLE_SLASHING_REWARD = 62500000L;
+  @Test
+  void getBlockRewardData_shouldCallBlockRewardCalculatorUtil() {
+    when(blockRewardCalculatorUtil.getBlockRewardData(any(), any()))
+        .thenReturn(new BlockRewardCalculatorUtil.BlockRewardData(UInt64.ONE, 2, 3, 4, 5));
+    final BlockRewardData result =
+        calculator.getBlockRewardData(mock(BlockContainer.class), mock(BeaconState.class));
+    assertThat(result.proposerIndex()).isEqualTo(UInt64.ONE);
+    assertThat(result.attestations()).isEqualTo(2);
+    assertThat(result.syncAggregate()).isEqualTo(3);
+    assertThat(result.proposerSlashings()).isEqualTo(4);
+    assertThat(result.attesterSlashings()).isEqualTo(5);
+    assertThat(result.getTotal()).isEqualTo(14);
+  }
 
   @Test
   void getCommitteeIndices_withSpecifiedValidators() {
     final BeaconState state = data.randomBeaconState(32);
 
     final List<BLSPublicKey> stateValidators =
-        state.getValidators().stream().map(Validator::getPublicKey).collect(toList());
+        state.getValidators().stream().map(Validator::getPublicKey).toList();
     final List<BLSPublicKey> committeeKeys =
         List.of(
             stateValidators.get(1),
@@ -94,7 +97,7 @@ public class RewardCalculatorTest {
     final BeaconState state = data.randomBeaconState(32);
 
     final List<BLSPublicKey> stateValidators =
-        state.getValidators().stream().map(Validator::getPublicKey).collect(toList());
+        state.getValidators().stream().map(Validator::getPublicKey).toList();
     final List<BLSPublicKey> committeeKeys =
         List.of(
             stateValidators.get(1),
@@ -116,7 +119,7 @@ public class RewardCalculatorTest {
     final BeaconState state = data.randomBeaconState(32);
 
     final List<BLSPublicKey> stateValidators =
-        state.getValidators().stream().map(Validator::getPublicKey).collect(toList());
+        state.getValidators().stream().map(Validator::getPublicKey).toList();
     final List<BLSPublicKey> committeeKeys =
         List.of(
             stateValidators.get(1),
@@ -138,23 +141,20 @@ public class RewardCalculatorTest {
   }
 
   @Test
-  void getBlockRewardData_shouldRejectPreAltair() {
-    final RewardCalculator rewardCalculator =
-        new RewardCalculator(TestSpecFactory.createMinimalPhase0());
-    final DataStructureUtil dataStructureUtil =
-        new DataStructureUtil(TestSpecFactory.createMinimalPhase0());
-    final BlockContainer blockContainer = mock(BlockContainer.class);
-    when(blockContainer.getBlock()).thenReturn(dataStructureUtil.randomBeaconBlock());
+  void getBlockRewardData_shouldRejectWithBadRequestExceptionWhenBlockRewardCalculatorThrows() {
+    when(blockRewardCalculatorUtil.getBlockRewardData(any(), any()))
+        .thenThrow(new IllegalArgumentException("error"));
     assertThatThrownBy(
-            () -> rewardCalculator.getBlockRewardData(blockContainer, mock(BeaconState.class)))
+            () ->
+                calculator.getBlockRewardData(mock(BlockContainer.class), mock(BeaconState.class)))
         .isInstanceOf(BadRequestException.class)
-        .hasMessageContaining("is pre altair,");
+        .hasMessage("error");
   }
 
   @Test
   void getSyncCommitteeRewardsFromBlockId_shouldRejectPreAltair() {
     final RewardCalculator rewardCalculator =
-        new RewardCalculator(TestSpecFactory.createMinimalPhase0());
+        new RewardCalculator(TestSpecFactory.createMinimalPhase0(), blockRewardCalculatorUtil);
     final DataStructureUtil dataStructureUtil =
         new DataStructureUtil(TestSpecFactory.createMinimalPhase0());
     final BlockAndMetaData blockAndMetaData =
@@ -170,134 +170,6 @@ public class RewardCalculatorTest {
                     Set.of(), blockAndMetaData, mock(BeaconState.class)))
         .isInstanceOf(BadRequestException.class)
         .hasMessageContaining("is pre altair,");
-  }
-
-  @Test
-  void getBlockRewardData_shouldOutputAttesterSlashings() {
-    final BeaconState preState = data.randomBeaconState();
-    final BeaconBlock block =
-        data.blockBuilder(preState.getSlot().increment().longValue())
-            .attesterSlashings(data.randomAttesterSlashings(1, 100))
-            .build()
-            .getImmediately();
-    final BlockRewardData reward =
-        calculator.calculateBlockRewards(block, blockProcessorAltair, preState);
-    assertThat(reward.getAttesterSlashings()).isEqualTo(SINGLE_SLASHING_REWARD);
-  }
-
-  @Test
-  void getBlockRewardData_shouldOutputProposerSlashings() {
-    final BeaconState preState = data.randomBeaconState();
-    final BeaconBlock block =
-        data.blockBuilder(preState.getSlot().increment().longValue())
-            .proposerSlashings(data.randomProposerSlashings(1, 100))
-            .build()
-            .getImmediately();
-    final BlockRewardData reward =
-        calculator.calculateBlockRewards(block, blockProcessorAltair, preState);
-    assertThat(reward.getProposerSlashings()).isEqualTo(SINGLE_SLASHING_REWARD);
-  }
-
-  @Test
-  void getBlockRewardData_shouldOutputSyncAggregate() {
-    final BeaconState preState = data.randomBeaconState();
-    final BeaconBlock block =
-        data.blockBuilder(preState.getSlot().increment().longValue())
-            .syncAggregate(data.randomSyncAggregate(1, 2, 3, 4))
-            .build()
-            .getImmediately();
-    final BlockRewardData reward =
-        calculator.calculateBlockRewards(block, blockProcessorAltair, preState);
-    assertThat(reward.getSyncAggregate()).isEqualTo(140L);
-  }
-
-  @Test
-  void getBlockRewardData_shouldOutputAttestations() {
-    // these values are invalid, but basically count each attestation as 1, so the attestation
-    // reward equals the number of attestations
-    when(blockProcessorAltair.createIndexedAttestationProvider(any(), any()))
-        .thenReturn(mock(AbstractBlockProcessor.IndexedAttestationProvider.class));
-    when(blockProcessorAltair.processAttestationProposerReward(any(), any(), any()))
-        .thenReturn(Optional.of(UInt64.ONE));
-    final BeaconState preState = data.randomBeaconState();
-    final BeaconBlock block =
-        data.blockBuilder(preState.getSlot().increment().longValue())
-            .attestations(data.randomAttestations(10, preState.getSlot().decrement()))
-            .build()
-            .getImmediately();
-    final BlockRewardData reward =
-        calculator.calculateBlockRewards(block, blockProcessorAltair, preState);
-    assertThat(reward.getAttestations()).isEqualTo(10L);
-    verify(blockProcessorAltair, times(10)).processAttestationProposerReward(any(), any(), any());
-  }
-
-  @Test
-  void getBlockRewardData_shouldOutputRewardData() {
-    when(blockProcessorAltair.createIndexedAttestationProvider(any(), any()))
-        .thenReturn(mock(AbstractBlockProcessor.IndexedAttestationProvider.class));
-    when(blockProcessorAltair.processAttestationProposerReward(any(), any(), any()))
-        .thenReturn(Optional.of(UInt64.ONE));
-    final BeaconState preState = data.randomBeaconState();
-    final BeaconBlock block =
-        data.blockBuilder(preState.getSlot().increment().longValue())
-            .executionPayload(data.randomExecutionPayload())
-            .proposerSlashings(data.randomProposerSlashings(3, 100))
-            .attesterSlashings(data.randomAttesterSlashings(2, 100))
-            .attestations(data.randomAttestations(10, preState.getSlot().decrement()))
-            .syncAggregate(data.randomSyncAggregate(1, 2, 3, 4))
-            .build()
-            .getImmediately();
-    final BlockRewardData reward =
-        calculator.calculateBlockRewards(block, blockProcessorAltair, preState);
-    assertThat(reward)
-        .isEqualTo(
-            new BlockRewardData(
-                block.getProposerIndex(),
-                10L,
-                140L,
-                3 * SINGLE_SLASHING_REWARD,
-                2 * SINGLE_SLASHING_REWARD));
-    verify(blockProcessorAltair, times(10)).processAttestationProposerReward(any(), any(), any());
-  }
-
-  @Test
-  void test_getProposerReward() {
-    final BeaconState state = data.randomBeaconState();
-    final long participantReward = spec.getSyncCommitteeParticipantReward(state).longValue();
-    final long proposerWeight = PROPOSER_WEIGHT.longValue();
-    final long weightDenominator = WEIGHT_DENOMINATOR.longValue();
-    final long expected = participantReward * proposerWeight / (weightDenominator - proposerWeight);
-
-    assertThat(calculator.getProposerReward(state)).isEqualTo(expected);
-  }
-
-  @Test
-  void calculateProposerSlashingsRewards_shouldCalculateRewards() {
-    final BeaconBlockAndState blockAndState = data.randomBlockAndStateWithValidatorLogic(16);
-    final long result =
-        calculator.calculateProposerSlashingsRewards(
-            blockAndState.getBlock(), blockAndState.getState());
-    assertThat(result).isEqualTo(SINGLE_SLASHING_REWARD);
-  }
-
-  @Test
-  void calculateAttesterSlashingsRewards_shouldCalculateRewards() {
-    final BeaconBlockAndState blockAndState = data.randomBlockAndStateWithValidatorLogic(100);
-    final long result =
-        calculator.calculateAttesterSlashingsRewards(
-            blockAndState.getBlock(), blockAndState.getState());
-    assertThat(result).isEqualTo(SINGLE_SLASHING_REWARD);
-  }
-
-  @Test
-  void calculateProposerSyncAggregateBlockRewards_manySyncAggregateIndices() {
-    final long reward = 1234L;
-    final int[] participantIndices = new int[] {0, 3, 4, 7, 16, 17, 20, 23, 25, 26, 29, 30};
-    final SyncAggregate syncAggregate = data.randomSyncAggregate(participantIndices);
-
-    final long syncAggregateBlockRewards =
-        calculator.calculateProposerSyncAggregateBlockRewards(reward, syncAggregate);
-    assertThat(syncAggregateBlockRewards).isEqualTo(reward * participantIndices.length);
   }
 
   @Test

--- a/data/serializer/src/main/java/tech/pegasys/teku/api/migrated/BlockRewardData.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/migrated/BlockRewardData.java
@@ -13,89 +13,28 @@
 
 package tech.pegasys.teku.api.migrated;
 
-import java.util.Objects;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 /** Represents the block rewards in GWei and the block proposer index */
-public class BlockRewardData {
-  private UInt64 proposerIndex;
-  private final long attestations;
-  private final long syncAggregate;
-  private final long proposerSlashings;
-  private final long attesterSlashings;
+public record BlockRewardData(
+    UInt64 proposerIndex,
+    long attestations,
+    long syncAggregate,
+    long proposerSlashings,
+    long attesterSlashings) {
 
-  public BlockRewardData(
-      final UInt64 proposerIndex,
-      final long attestations,
-      final long syncAggregate,
-      final long proposerSlashings,
-      final long attesterSlashings) {
-    this.proposerIndex = proposerIndex;
-    this.attestations = attestations;
-    this.syncAggregate = syncAggregate;
-    this.proposerSlashings = proposerSlashings;
-    this.attesterSlashings = attesterSlashings;
-  }
-
-  public UInt64 getProposerIndex() {
-    return proposerIndex;
+  public static BlockRewardData fromInternal(
+      final tech.pegasys.teku.spec.logic.common.util.BlockRewardCalculatorUtil.BlockRewardData
+          internal) {
+    return new BlockRewardData(
+        internal.proposerIndex(),
+        internal.attestations(),
+        internal.syncAggregate(),
+        internal.proposerSlashings(),
+        internal.attesterSlashings());
   }
 
   public long getTotal() {
     return attestations + syncAggregate + proposerSlashings + attesterSlashings;
-  }
-
-  public long getAttestations() {
-    return attestations;
-  }
-
-  public long getSyncAggregate() {
-    return syncAggregate;
-  }
-
-  public long getProposerSlashings() {
-    return proposerSlashings;
-  }
-
-  public long getAttesterSlashings() {
-    return attesterSlashings;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    BlockRewardData that = (BlockRewardData) o;
-    return attestations == that.attestations
-        && syncAggregate == that.syncAggregate
-        && proposerSlashings == that.proposerSlashings
-        && attesterSlashings == that.attesterSlashings
-        && Objects.equals(proposerIndex, that.proposerIndex);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(
-        proposerIndex, attestations, syncAggregate, proposerSlashings, attesterSlashings);
-  }
-
-  @Override
-  public String toString() {
-    return "BlockRewardData{"
-        + "proposerIndex="
-        + proposerIndex
-        + ", attestations="
-        + attestations
-        + ", syncAggregate="
-        + syncAggregate
-        + ", proposerSlashings="
-        + proposerSlashings
-        + ", attesterSlashings="
-        + attesterSlashings
-        + '}';
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/BlockRewardCalculatorUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/util/BlockRewardCalculatorUtil.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.logic.common.util;
+
+import static tech.pegasys.teku.spec.constants.IncentivizationWeights.PROPOSER_WEIGHT;
+import static tech.pegasys.teku.spec.constants.IncentivizationWeights.WEIGHT_DENOMINATOR;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszBitvector;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.SpecVersion;
+import tech.pegasys.teku.spec.cache.IndexedAttestationCache;
+import tech.pegasys.teku.spec.config.SpecConfig;
+import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
+import tech.pegasys.teku.spec.datastructures.blocks.BlockContainer;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregate;
+import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
+import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
+import tech.pegasys.teku.spec.datastructures.state.Validator;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.altair.BeaconStateAltair;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.altair.MutableBeaconStateAltair;
+import tech.pegasys.teku.spec.logic.common.block.AbstractBlockProcessor;
+import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.EpochProcessingException;
+import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.SlotProcessingException;
+import tech.pegasys.teku.spec.logic.versions.altair.block.BlockProcessorAltair;
+
+public class BlockRewardCalculatorUtil {
+  private final Spec spec;
+  private static final Logger LOG = LogManager.getLogger();
+
+  public BlockRewardCalculatorUtil(Spec spec) {
+    this.spec = spec;
+  }
+
+  public BlockRewardData getBlockRewardData(
+      final BlockContainer blockContainer, final BeaconState parentState) {
+    final BeaconBlock block = blockContainer.getBlock();
+    if (!spec.atSlot(block.getSlot()).getMilestone().isGreaterThanOrEqualTo(SpecMilestone.ALTAIR)) {
+      throw new IllegalArgumentException(
+          "Slot "
+              + block.getSlot()
+              + " is pre altair, and no sync committee information is available");
+    }
+
+    final BeaconState preState = getPreState(block.getSlot(), parentState);
+
+    final SpecVersion specVersion = spec.atSlot(preState.getSlot());
+    return calculateBlockRewards(
+        block, BlockProcessorAltair.required(specVersion.getBlockProcessor()), preState);
+  }
+
+  @VisibleForTesting
+  long getProposerReward(final BeaconState state) {
+    final UInt64 participantReward = spec.getSyncCommitteeParticipantReward(state);
+    return participantReward
+        .times(PROPOSER_WEIGHT)
+        .dividedBy(WEIGHT_DENOMINATOR.minus(PROPOSER_WEIGHT))
+        .longValue();
+  }
+
+  @VisibleForTesting
+  BlockRewardData calculateBlockRewards(
+      final BeaconBlock block,
+      final BlockProcessorAltair blockProcessorAltair,
+      final BeaconState preState) {
+    final long proposerReward = getProposerReward(preState);
+    final SyncAggregate aggregate = block.getBody().getOptionalSyncAggregate().orElseThrow();
+    final UInt64 proposerIndex = block.getProposerIndex();
+    final long attestationsBlockRewards =
+        calculateAttestationRewards(block, blockProcessorAltair, preState);
+    final long syncAggregateBlockRewards =
+        calculateProposerSyncAggregateBlockRewards(proposerReward, aggregate);
+    final long proposerSlashingsBlockRewards = calculateProposerSlashingsRewards(block, preState);
+    final long attesterSlashingsBlockRewards = calculateAttesterSlashingsRewards(block, preState);
+
+    return new BlockRewardData(
+        proposerIndex,
+        attestationsBlockRewards,
+        syncAggregateBlockRewards,
+        proposerSlashingsBlockRewards,
+        attesterSlashingsBlockRewards);
+  }
+
+  @VisibleForTesting
+  long calculateAttesterSlashingsRewards(
+      final BeaconBlock beaconBlock, final BeaconState preState) {
+    final SszList<AttesterSlashing> attesterSlashings =
+        beaconBlock.getBody().getAttesterSlashings();
+
+    final UInt64 epoch = spec.computeEpochAtSlot(preState.getSlot());
+    final SpecConfig specConfig = spec.getSpecConfig(epoch);
+
+    long attesterSlashingsRewards = 0;
+    for (AttesterSlashing slashing : attesterSlashings) {
+      for (final UInt64 index : slashing.getIntersectingValidatorIndices()) {
+        attesterSlashingsRewards =
+            calculateSlashingRewards(
+                specConfig, preState, index.intValue(), attesterSlashingsRewards);
+      }
+    }
+
+    return attesterSlashingsRewards;
+  }
+
+  @VisibleForTesting
+  long calculateProposerSyncAggregateBlockRewards(long proposerReward, SyncAggregate aggregate) {
+    final SszBitvector syncCommitteeBits = aggregate.getSyncCommitteeBits();
+    return proposerReward * syncCommitteeBits.getBitCount();
+  }
+
+  @VisibleForTesting
+  long calculateProposerSlashingsRewards(
+      final BeaconBlock beaconBlock, final BeaconState preState) {
+    final SszList<ProposerSlashing> proposerSlashings =
+        beaconBlock.getBody().getProposerSlashings();
+
+    final UInt64 epoch = spec.computeEpochAtSlot(preState.getSlot());
+    final SpecConfig specConfig = spec.getSpecConfig(epoch);
+
+    long proposerSlashingsRewards = 0;
+    for (ProposerSlashing slashing : proposerSlashings) {
+      final int slashedIndex = slashing.getHeader1().getMessage().getProposerIndex().intValue();
+      proposerSlashingsRewards =
+          calculateSlashingRewards(specConfig, preState, slashedIndex, proposerSlashingsRewards);
+    }
+
+    return proposerSlashingsRewards;
+  }
+
+  private long calculateAttestationRewards(
+      final BeaconBlock block,
+      final BlockProcessorAltair blockProcessor,
+      final BeaconState preState) {
+    final List<Optional<UInt64>> rewards = new ArrayList<>();
+    final MutableBeaconStateAltair mutableBeaconStateAltair =
+        BeaconStateAltair.required(preState).createWritableCopy();
+    final AbstractBlockProcessor.IndexedAttestationProvider indexedAttestationProvider =
+        blockProcessor.createIndexedAttestationProvider(
+            mutableBeaconStateAltair, IndexedAttestationCache.capturing());
+    block
+        .getBody()
+        .getAttestations()
+        .forEach(
+            attestation ->
+                rewards.add(
+                    blockProcessor.processAttestationProposerReward(
+                        mutableBeaconStateAltair, attestation, indexedAttestationProvider)));
+
+    return rewards.stream()
+        .filter(Optional::isPresent)
+        .map(Optional::get)
+        .map(UInt64::longValue)
+        .reduce(0L, Long::sum);
+  }
+
+  private long calculateSlashingRewards(
+      final SpecConfig specConfig,
+      final BeaconState state,
+      final int slashedIndex,
+      final long currentRewards) {
+    final Validator validator = state.getValidators().get(slashedIndex);
+    final UInt64 whistleblowerReward =
+        validator.getEffectiveBalance().dividedBy(specConfig.getWhistleblowerRewardQuotient());
+    final UInt64 proposerReward =
+        whistleblowerReward.dividedBy(specConfig.getProposerRewardQuotient());
+    final UInt64 rewardsAdditions = proposerReward.plus(whistleblowerReward.minus(proposerReward));
+    return currentRewards + rewardsAdditions.longValue();
+  }
+
+  private BeaconState getPreState(final UInt64 slot, final BeaconState parentState) {
+    final BeaconState preState;
+    try {
+      preState = spec.processSlots(parentState, slot);
+    } catch (SlotProcessingException | EpochProcessingException e) {
+      LOG.debug("Failed to fetch preState for slot {}", slot, e);
+      throw new IllegalArgumentException(
+          "Failed to calculate block rewards, as could not generate the pre-state of the block at slot "
+              + slot,
+          e);
+    }
+    return preState;
+  }
+
+  /** Represents the block rewards in GWei and the block proposer index */
+  public record BlockRewardData(
+      UInt64 proposerIndex,
+      long attestations,
+      long syncAggregate,
+      long proposerSlashings,
+      long attesterSlashings) {
+    public long getTotal() {
+      return attestations + syncAggregate + proposerSlashings + attesterSlashings;
+    }
+  }
+}

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/BlockRewardCalculatorUtilTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/util/BlockRewardCalculatorUtilTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.logic.common.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static tech.pegasys.teku.spec.constants.IncentivizationWeights.PROPOSER_WEIGHT;
+import static tech.pegasys.teku.spec.constants.IncentivizationWeights.WEIGHT_DENOMINATOR;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
+import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockAndState;
+import tech.pegasys.teku.spec.datastructures.blocks.BlockContainer;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregate;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.logic.common.block.AbstractBlockProcessor;
+import tech.pegasys.teku.spec.logic.common.util.BlockRewardCalculatorUtil.BlockRewardData;
+import tech.pegasys.teku.spec.logic.versions.altair.block.BlockProcessorAltair;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class BlockRewardCalculatorUtilTest {
+  private final Spec spec = TestSpecFactory.createMinimalCapella();
+  private final DataStructureUtil data = new DataStructureUtil(spec);
+
+  private final BlockRewardCalculatorUtil calculator = new BlockRewardCalculatorUtil(spec);
+
+  private final BlockProcessorAltair blockProcessorAltair = mock(BlockProcessorAltair.class);
+
+  private static final long SINGLE_SLASHING_REWARD = 62500000L;
+
+  @Test
+  void getBlockRewardData_shouldOutputAttesterSlashings() {
+    final BeaconState preState = data.randomBeaconState();
+    final BeaconBlock block =
+        data.blockBuilder(preState.getSlot().increment().longValue())
+            .attesterSlashings(data.randomAttesterSlashings(1, 100))
+            .build()
+            .getImmediately();
+    final BlockRewardData reward =
+        calculator.calculateBlockRewards(block, blockProcessorAltair, preState);
+    assertThat(reward.attesterSlashings()).isEqualTo(SINGLE_SLASHING_REWARD);
+  }
+
+  @Test
+  void getBlockRewardData_shouldOutputProposerSlashings() {
+    final BeaconState preState = data.randomBeaconState();
+    final BeaconBlock block =
+        data.blockBuilder(preState.getSlot().increment().longValue())
+            .proposerSlashings(data.randomProposerSlashings(1, 100))
+            .build()
+            .getImmediately();
+    final BlockRewardData reward =
+        calculator.calculateBlockRewards(block, blockProcessorAltair, preState);
+    assertThat(reward.proposerSlashings()).isEqualTo(SINGLE_SLASHING_REWARD);
+  }
+
+  @Test
+  void getBlockRewardData_shouldOutputSyncAggregate() {
+    final BeaconState preState = data.randomBeaconState();
+    final BeaconBlock block =
+        data.blockBuilder(preState.getSlot().increment().longValue())
+            .syncAggregate(data.randomSyncAggregate(1, 2, 3, 4))
+            .build()
+            .getImmediately();
+    final BlockRewardData reward =
+        calculator.calculateBlockRewards(block, blockProcessorAltair, preState);
+    assertThat(reward.syncAggregate()).isEqualTo(140L);
+  }
+
+  @Test
+  void getBlockRewardData_shouldOutputAttestations() {
+    // these values are invalid, but basically count each attestation as 1, so the attestation
+    // reward equals the number of attestations
+    when(blockProcessorAltair.createIndexedAttestationProvider(any(), any()))
+        .thenReturn(mock(AbstractBlockProcessor.IndexedAttestationProvider.class));
+    when(blockProcessorAltair.processAttestationProposerReward(any(), any(), any()))
+        .thenReturn(Optional.of(UInt64.ONE));
+    final BeaconState preState = data.randomBeaconState();
+    final BeaconBlock block =
+        data.blockBuilder(preState.getSlot().increment().longValue())
+            .attestations(data.randomAttestations(10, preState.getSlot().decrement()))
+            .build()
+            .getImmediately();
+    final BlockRewardData reward =
+        calculator.calculateBlockRewards(block, blockProcessorAltair, preState);
+    assertThat(reward.attestations()).isEqualTo(10L);
+    verify(blockProcessorAltair, times(10)).processAttestationProposerReward(any(), any(), any());
+  }
+
+  @Test
+  void getBlockRewardData_shouldOutputRewardData() {
+    when(blockProcessorAltair.createIndexedAttestationProvider(any(), any()))
+        .thenReturn(mock(AbstractBlockProcessor.IndexedAttestationProvider.class));
+    when(blockProcessorAltair.processAttestationProposerReward(any(), any(), any()))
+        .thenReturn(Optional.of(UInt64.ONE));
+    final BeaconState preState = data.randomBeaconState();
+    final BeaconBlock block =
+        data.blockBuilder(preState.getSlot().increment().longValue())
+            .executionPayload(data.randomExecutionPayload())
+            .proposerSlashings(data.randomProposerSlashings(3, 100))
+            .attesterSlashings(data.randomAttesterSlashings(2, 100))
+            .attestations(data.randomAttestations(10, preState.getSlot().decrement()))
+            .syncAggregate(data.randomSyncAggregate(1, 2, 3, 4))
+            .build()
+            .getImmediately();
+    final BlockRewardData reward =
+        calculator.calculateBlockRewards(block, blockProcessorAltair, preState);
+    assertThat(reward)
+        .isEqualTo(
+            new BlockRewardData(
+                block.getProposerIndex(),
+                10L,
+                140L,
+                3 * SINGLE_SLASHING_REWARD,
+                2 * SINGLE_SLASHING_REWARD));
+    verify(blockProcessorAltair, times(10)).processAttestationProposerReward(any(), any(), any());
+  }
+
+  @Test
+  void test_getProposerReward() {
+    final BeaconState state = data.randomBeaconState();
+    final long participantReward = spec.getSyncCommitteeParticipantReward(state).longValue();
+    final long proposerWeight = PROPOSER_WEIGHT.longValue();
+    final long weightDenominator = WEIGHT_DENOMINATOR.longValue();
+    final long expected = participantReward * proposerWeight / (weightDenominator - proposerWeight);
+
+    assertThat(calculator.getProposerReward(state)).isEqualTo(expected);
+  }
+
+  @Test
+  void calculateProposerSlashingsRewards_shouldCalculateRewards() {
+    final BeaconBlockAndState blockAndState = data.randomBlockAndStateWithValidatorLogic(16);
+    final long result =
+        calculator.calculateProposerSlashingsRewards(
+            blockAndState.getBlock(), blockAndState.getState());
+    assertThat(result).isEqualTo(SINGLE_SLASHING_REWARD);
+  }
+
+  @Test
+  void calculateAttesterSlashingsRewards_shouldCalculateRewards() {
+    final BeaconBlockAndState blockAndState = data.randomBlockAndStateWithValidatorLogic(100);
+    final long result =
+        calculator.calculateAttesterSlashingsRewards(
+            blockAndState.getBlock(), blockAndState.getState());
+    assertThat(result).isEqualTo(SINGLE_SLASHING_REWARD);
+  }
+
+  @Test
+  void calculateProposerSyncAggregateBlockRewards_manySyncAggregateIndices() {
+    final long reward = 1234L;
+    final int[] participantIndices = new int[] {0, 3, 4, 7, 16, 17, 20, 23, 25, 26, 29, 30};
+    final SyncAggregate syncAggregate = data.randomSyncAggregate(participantIndices);
+
+    final long syncAggregateBlockRewards =
+        calculator.calculateProposerSyncAggregateBlockRewards(reward, syncAggregate);
+    assertThat(syncAggregateBlockRewards).isEqualTo(reward * participantIndices.length);
+  }
+
+  @Test
+  void getBlockRewardData_shouldRejectPreAltair() {
+    final BlockRewardCalculatorUtil rewardCalculator =
+        new BlockRewardCalculatorUtil(TestSpecFactory.createMinimalPhase0());
+    final DataStructureUtil dataStructureUtil =
+        new DataStructureUtil(TestSpecFactory.createMinimalPhase0());
+    final BlockContainer blockContainer = mock(BlockContainer.class);
+    when(blockContainer.getBlock()).thenReturn(dataStructureUtil.randomBeaconBlock());
+    assertThatThrownBy(
+            () -> rewardCalculator.getBlockRewardData(blockContainer, mock(BeaconState.class)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("is pre altair,");
+  }
+}

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -109,6 +109,7 @@ import tech.pegasys.teku.spec.datastructures.validator.BroadcastValidationLevel;
 import tech.pegasys.teku.spec.executionlayer.ExecutionLayerBlockProductionManager;
 import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannel;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
+import tech.pegasys.teku.spec.logic.common.util.BlockRewardCalculatorUtil;
 import tech.pegasys.teku.spec.logic.versions.deneb.helpers.MiscHelpersDeneb;
 import tech.pegasys.teku.statetransition.EpochCachePrimer;
 import tech.pegasys.teku.statetransition.LocalOperationAcceptedFilter;
@@ -872,7 +873,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
 
   public void initRewardCalculator() {
     LOG.debug("BeaconChainController.initRewardCalculator()");
-    rewardCalculator = new RewardCalculator(spec);
+    rewardCalculator = new RewardCalculator(spec, new BlockRewardCalculatorUtil(spec));
   }
 
   public void initValidatorApiHandler() {


### PR DESCRIPTION
The reason is because we can use the block rewards calculation for other purpose

I left non-block rewards calculation in original class.

