### PR TITLE
update block v3 deserialisation based on headers

### DIFF
--- a/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/JsonUtil.java
+++ b/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/JsonUtil.java
@@ -122,6 +122,14 @@ public class JsonUtil {
     }
   }
 
+  public static <T> T parseBasedOnHeader(
+      final String header, final String json, final DeserializableOneOfTypeDefinition<T> oneOfType)
+      throws JsonProcessingException {
+    final DeserializableTypeDefinition<? extends T> typeDefinition =
+        oneOfType.getMatchingType(header);
+    return parse(json, typeDefinition);
+  }
+
   public static <T> Optional<T> getAttribute(
       final String json, final DeserializableTypeDefinition<T> type, final String... path)
       throws JsonProcessingException {

--- a/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/DeserializableOneOfTypeDefinition.java
+++ b/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/DeserializableOneOfTypeDefinition.java
@@ -44,16 +44,16 @@ public class DeserializableOneOfTypeDefinition<TObject>
     return new DeserializableOneOfTypeDefinitionBuilder<>();
   }
 
-  public DeserializableTypeDefinition<? extends TObject> getMatchingType(String json) {
+  public DeserializableTypeDefinition<? extends TObject> getMatchingType(String content) {
     DeserializableTypeDefinition<? extends TObject> typeDefinition = null;
     for (Predicate<String> predicate : parserTypes.keySet()) {
-      if (predicate.test(json)) {
+      if (predicate.test(content)) {
         typeDefinition = parserTypes.get(predicate);
         break;
       }
     }
 
-    checkArgument(typeDefinition != null, "No class deserialization method found: %s", json);
+    checkArgument(typeDefinition != null, "No class deserialization method found: %s", content);
     return typeDefinition;
   }
 }

--- a/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/DeserializableOneOfTypeDefinition.java
+++ b/infrastructure/json/src/main/java/tech/pegasys/teku/infrastructure/json/types/DeserializableOneOfTypeDefinition.java
@@ -44,7 +44,7 @@ public class DeserializableOneOfTypeDefinition<TObject>
     return new DeserializableOneOfTypeDefinitionBuilder<>();
   }
 
-  public DeserializableTypeDefinition<? extends TObject> getMatchingType(String content) {
+  public DeserializableTypeDefinition<? extends TObject> getMatchingType(final String content) {
     DeserializableTypeDefinition<? extends TObject> typeDefinition = null;
     for (Predicate<String> predicate : parserTypes.keySet()) {
       if (predicate.test(content)) {

--- a/validator/remote/src/integration-test/java/tech/pegasys/teku/validator/remote/typedef/handlers/ProduceBlockRequestTest.java
+++ b/validator/remote/src/integration-test/java/tech/pegasys/teku/validator/remote/typedef/handlers/ProduceBlockRequestTest.java
@@ -70,7 +70,11 @@ public class ProduceBlockRequestTest extends AbstractTypeDefRequestTestBase {
 
     final String mockResponse = readExpectedJsonResource(specMilestone, false, false);
 
-    mockWebServer.enqueue(new MockResponse().setResponseCode(SC_OK).setBody(mockResponse));
+    mockWebServer.enqueue(
+        new MockResponse()
+            .setResponseCode(SC_OK)
+            .setBody(mockResponse)
+            .setHeader(HEADER_EXECUTION_PAYLOAD_BLINDED, "false"));
 
     final BLSSignature signature = beaconBlock.getBlock().getBody().getRandaoReveal();
 
@@ -120,7 +124,11 @@ public class ProduceBlockRequestTest extends AbstractTypeDefRequestTestBase {
 
     final String mockResponse = readExpectedJsonResource(specMilestone, true, false);
 
-    mockWebServer.enqueue(new MockResponse().setResponseCode(SC_OK).setBody(mockResponse));
+    mockWebServer.enqueue(
+        new MockResponse()
+            .setResponseCode(SC_OK)
+            .setBody(mockResponse)
+            .setHeader(HEADER_EXECUTION_PAYLOAD_BLINDED, "true"));
 
     final BLSSignature signature = blindedBeaconBlock.getBlock().getBody().getRandaoReveal();
 
@@ -168,7 +176,11 @@ public class ProduceBlockRequestTest extends AbstractTypeDefRequestTestBase {
 
     final String mockResponse = readExpectedJsonResource(specMilestone, false, true);
 
-    mockWebServer.enqueue(new MockResponse().setResponseCode(SC_OK).setBody(mockResponse));
+    mockWebServer.enqueue(
+        new MockResponse()
+            .setResponseCode(SC_OK)
+            .setBody(mockResponse)
+            .setHeader(HEADER_EXECUTION_PAYLOAD_BLINDED, "false"));
 
     final BLSSignature signature = blockContents.getBlock().getBody().getRandaoReveal();
 

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/handlers/ProduceBlockRequest.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/handlers/ProduceBlockRequest.java
@@ -85,12 +85,10 @@ public class ProduceBlockRequest extends AbstractTypeDefRequest {
         DeserializableOneOfTypeDefinition.object(ProduceBlockResponse.class)
             .withType(
                 x -> true,
-                executionPayloadBlindedHeader -> executionPayloadBlindedHeader.equals("false"),
+                executionPayloadBlindedHeader ->
+                    !Boolean.parseBoolean(executionPayloadBlindedHeader),
                 produceBlockResponseDefinition)
-            .withType(
-                x -> true,
-                executionPayloadBlindedHeader -> executionPayloadBlindedHeader.equals("true"),
-                produceBlindedBlockResponseDefinition)
+            .withType(x -> true, Boolean::parseBoolean, produceBlindedBlockResponseDefinition)
             .build();
 
     this.responseHandler =

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/handlers/ProduceBlockRequest.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/handlers/ProduceBlockRequest.java
@@ -85,11 +85,11 @@ public class ProduceBlockRequest extends AbstractTypeDefRequest {
         DeserializableOneOfTypeDefinition.object(ProduceBlockResponse.class)
             .withType(
                 x -> true,
-                s -> s.matches(".*\"execution_payload_blinded\" *: *false.*"),
+                executionPayloadBlindedHeader -> executionPayloadBlindedHeader.equals("false"),
                 produceBlockResponseDefinition)
             .withType(
                 x -> true,
-                s -> s.matches(".*\"execution_payload_blinded\" *: *true.*"),
+                executionPayloadBlindedHeader -> executionPayloadBlindedHeader.equals("true"),
                 produceBlindedBlockResponseDefinition)
             .build();
 
@@ -145,7 +145,11 @@ public class ProduceBlockRequest extends AbstractTypeDefRequest {
                   this.blockContainerSchema.sszDeserialize(Bytes.of(response.body().bytes()))));
         }
       } else {
-        return Optional.of(JsonUtil.parse(response.body().string(), produceBlockTypeDefinition));
+        return Optional.of(
+            JsonUtil.parseBasedOnHeader(
+                response.header(HEADER_EXECUTION_PAYLOAD_BLINDED),
+                response.body().string(),
+                produceBlockTypeDefinition));
       }
     } catch (final IOException ex) {
       LOG.trace("Failed to parse response object creating block", ex);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Select the block V3 json response deserialiser based on the `Eth-Execution-Payload-Blinded` instead of the json response body to avoid parsing the whole json content

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
fixes #7988 


## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
