### PR TITLE
Run engine capabilities monitoring only on startup/restart

### DIFF
--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/events/ExecutionClientEventsChannel.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/events/ExecutionClientEventsChannel.java
@@ -17,5 +17,6 @@ import tech.pegasys.teku.infrastructure.events.VoidReturningChannelInterface;
 
 public interface ExecutionClientEventsChannel extends VoidReturningChannelInterface {
 
+  /** `true` on startup or on a successful request after an error, `false` on an error */
   void onAvailabilityUpdated(boolean isAvailable);
 }

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/EngineCapabilitiesMonitor.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/EngineCapabilitiesMonitor.java
@@ -16,38 +16,27 @@ package tech.pegasys.teku.ethereum.executionlayer;
 import com.google.common.base.Suppliers;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import tech.pegasys.teku.ethereum.events.SlotEventsChannel;
 import tech.pegasys.teku.ethereum.executionclient.ExecutionEngineClient;
+import tech.pegasys.teku.ethereum.executionclient.events.ExecutionClientEventsChannel;
 import tech.pegasys.teku.ethereum.executionclient.response.ResponseUnwrapper;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.logging.EventLogger;
-import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.Spec;
 
-public class EngineCapabilitiesMonitor implements SlotEventsChannel {
+public class EngineCapabilitiesMonitor implements ExecutionClientEventsChannel {
 
   private static final Logger LOG = LogManager.getLogger();
 
-  private static final int EPOCHS_PER_MONITORING = 10;
-  static final UInt64 SLOT_IN_THE_EPOCH_TO_RUN_MONITORING = UInt64.valueOf(3);
-
-  private final AtomicReference<UInt64> lastRunEpoch = new AtomicReference<>();
-
-  private final Spec spec;
   private final EventLogger eventLogger;
   private final Supplier<List<String>> capabilitiesSupplier;
   private final ExecutionEngineClient executionEngineClient;
 
   public EngineCapabilitiesMonitor(
-      final Spec spec,
       final EventLogger eventLogger,
       final EngineJsonRpcMethodsResolver engineMethodsResolver,
       final ExecutionEngineClient executionEngineClient) {
-    this.spec = spec;
     this.eventLogger = eventLogger;
     this.capabilitiesSupplier =
         Suppliers.memoize(() -> new ArrayList<>(engineMethodsResolver.getCapabilities()));
@@ -55,26 +44,11 @@ public class EngineCapabilitiesMonitor implements SlotEventsChannel {
   }
 
   @Override
-  public void onSlot(final UInt64 slot) {
-    final UInt64 currentEpoch = spec.computeEpochAtSlot(slot);
-    if (hasNeverRun() || (epochIsApplicable(currentEpoch) && slotIsApplicable(slot))) {
+  public void onAvailabilityUpdated(final boolean isAvailable) {
+    if (isAvailable) {
       monitor()
-          .handleException(ex -> LOG.error("Exception exchanging Engine API capabilities", ex))
-          .always(() -> lastRunEpoch.set(currentEpoch));
+          .handleException(ex -> LOG.error("Exception exchanging Engine API capabilities", ex));
     }
-  }
-
-  private boolean hasNeverRun() {
-    return lastRunEpoch.get() == null;
-  }
-
-  private boolean epochIsApplicable(final UInt64 epoch) {
-    return epoch.minusMinZero(lastRunEpoch.get()).isGreaterThanOrEqualTo(EPOCHS_PER_MONITORING);
-  }
-
-  private boolean slotIsApplicable(final UInt64 slot) {
-    return slot.mod(spec.getSlotsPerEpoch(slot))
-        .equals(SLOT_IN_THE_EPOCH_TO_RUN_MONITORING.minusMinZero(1));
   }
 
   private SafeFuture<Void> monitor() {

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/EngineCapabilitiesMonitor.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/EngineCapabilitiesMonitor.java
@@ -46,8 +46,7 @@ public class EngineCapabilitiesMonitor implements ExecutionClientEventsChannel {
   @Override
   public void onAvailabilityUpdated(final boolean isAvailable) {
     if (isAvailable) {
-      monitor()
-          .handleException(ex -> LOG.error("Exception exchanging Engine API capabilities", ex));
+      monitor().finish(error -> LOG.error("Exception exchanging Engine API capabilities", error));
     }
   }
 

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/EngineCapabilitiesMonitorTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/EngineCapabilitiesMonitorTest.java
@@ -13,15 +13,10 @@
 
 package tech.pegasys.teku.ethereum.executionlayer;
 
-import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
-import static tech.pegasys.teku.ethereum.executionlayer.EngineCapabilitiesMonitor.SLOT_IN_THE_EPOCH_TO_RUN_MONITORING;
 
 import java.util.HashSet;
 import java.util.List;
@@ -31,13 +26,9 @@ import tech.pegasys.teku.ethereum.executionclient.ExecutionEngineClient;
 import tech.pegasys.teku.ethereum.executionclient.schema.Response;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.logging.EventLogger;
-import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.TestSpecFactory;
 
 public class EngineCapabilitiesMonitorTest {
 
-  private final Spec spec = TestSpecFactory.createDefault();
   private final EventLogger eventLogger = mock(EventLogger.class);
   private final EngineJsonRpcMethodsResolver engineMethodsResolver =
       mock(EngineJsonRpcMethodsResolver.class);
@@ -52,8 +43,7 @@ public class EngineCapabilitiesMonitorTest {
     when(engineMethodsResolver.getCapabilities()).thenReturn(new HashSet<>(capabilities));
     mockEngineCapabilitiesResponse(capabilities);
     engineCapabilitiesMonitor =
-        new EngineCapabilitiesMonitor(
-            spec, eventLogger, engineMethodsResolver, executionEngineClient);
+        new EngineCapabilitiesMonitor(eventLogger, engineMethodsResolver, executionEngineClient);
   }
 
   @Test
@@ -61,80 +51,28 @@ public class EngineCapabilitiesMonitorTest {
     // engine only supports one of the methods
     mockEngineCapabilitiesResponse(List.of("method1"));
 
-    // 3rd slot in epoch
-    engineCapabilitiesMonitor.onSlot(UInt64.valueOf(2));
+    engineCapabilitiesMonitor.onAvailabilityUpdated(true);
 
     verify(eventLogger).missingEngineApiCapabilities(List.of("method2"));
   }
 
   @Test
   public void doesNotLogWarningIfEngineSupportsAllRequiredCapabilities() {
-    // 3rd slot in epoch
-    engineCapabilitiesMonitor.onSlot(UInt64.valueOf(2));
+    engineCapabilitiesMonitor.onAvailabilityUpdated(true);
 
     verifyNoInteractions(eventLogger);
   }
 
   @Test
-  public void doesNotRunMonitoringIfNotAtRequiredEpoch() {
-    // one run at epoch 0
-    engineCapabilitiesMonitor.onSlot(UInt64.valueOf(2));
-    verify(executionEngineClient, times(1)).exchangeCapabilities(anyList());
+  public void doesNotRunMonitoringIfExecutionClientIsNotAvailable() {
+    engineCapabilitiesMonitor.onAvailabilityUpdated(false);
 
-    clearInvocations(executionEngineClient);
-
-    // should not run next epoch
-    engineCapabilitiesMonitor.onSlot(computeApplicableSlotForEpoch(UInt64.ONE));
-    verify(executionEngineClient, never()).exchangeCapabilities(anyList());
-
-    // should not run at epoch 9
-    engineCapabilitiesMonitor.onSlot(computeApplicableSlotForEpoch(UInt64.valueOf(9)));
-    verify(executionEngineClient, never()).exchangeCapabilities(anyList());
-
-    // should run again at epoch 10
-    engineCapabilitiesMonitor.onSlot(computeApplicableSlotForEpoch(UInt64.valueOf(10)));
-    verify(executionEngineClient, times(1)).exchangeCapabilities(anyList());
-
-    clearInvocations(executionEngineClient);
-
-    // should not run at epoch 12
-    engineCapabilitiesMonitor.onSlot(computeApplicableSlotForEpoch(UInt64.valueOf(12)));
-    verify(executionEngineClient, never()).exchangeCapabilities(anyList());
-  }
-
-  @Test
-  public void runsMonitoringFirstTimeRegardlessOfSlot() {
-    engineCapabilitiesMonitor.onSlot(UInt64.ZERO);
-    verify(executionEngineClient).exchangeCapabilities(anyList());
-  }
-
-  @Test
-  public void doesNotRunMonitoringIfNotAtRequiredSlot() {
-    // run once to bypass hasNeverRun()
-    engineCapabilitiesMonitor.onSlot(UInt64.ZERO);
-    verify(executionEngineClient).exchangeCapabilities(anyList());
-
-    clearInvocations(executionEngineClient);
-
-    // should not run monitoring on not applicable slots
-    final UInt64 nextApplicableSlot = computeApplicableSlotForEpoch(UInt64.valueOf(10));
-    engineCapabilitiesMonitor.onSlot(nextApplicableSlot.minus(1));
-    engineCapabilitiesMonitor.onSlot(nextApplicableSlot.plus(1));
-    engineCapabilitiesMonitor.onSlot(nextApplicableSlot.plus(2));
     verifyNoInteractions(executionEngineClient);
-
-    // should run on applicable slot
-    engineCapabilitiesMonitor.onSlot(nextApplicableSlot);
-    verify(executionEngineClient).exchangeCapabilities(anyList());
+    verifyNoInteractions(eventLogger);
   }
 
   private void mockEngineCapabilitiesResponse(final List<String> engineCapabilities) {
     when(executionEngineClient.exchangeCapabilities(capabilities))
         .thenReturn(SafeFuture.completedFuture(new Response<>(engineCapabilities)));
-  }
-
-  private UInt64 computeApplicableSlotForEpoch(final UInt64 epoch) {
-    return spec.computeStartSlotAtEpoch(epoch)
-        .plus(SLOT_IN_THE_EPOCH_TO_RUN_MONITORING.minusMinZero(1));
   }
 }

--- a/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerService.java
+++ b/services/executionlayer/src/main/java/tech/pegasys/teku/services/executionlayer/ExecutionLayerService.java
@@ -180,11 +180,10 @@ public class ExecutionLayerService extends Service {
 
     if (config.isExchangeCapabilitiesMonitoringEnabled()) {
       final EngineCapabilitiesMonitor engineCapabilitiesMonitor =
-          new EngineCapabilitiesMonitor(
-              config.getSpec(), EVENT_LOG, engineMethodsResolver, executionEngineClient);
+          new EngineCapabilitiesMonitor(EVENT_LOG, engineMethodsResolver, executionEngineClient);
       serviceConfig
           .getEventChannels()
-          .subscribe(SlotEventsChannel.class, engineCapabilitiesMonitor);
+          .subscribe(ExecutionClientEventsChannel.class, engineCapabilitiesMonitor);
     }
 
     final Optional<BuilderClient> builderClient =

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ExecutionLayerOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ExecutionLayerOptions.java
@@ -139,7 +139,7 @@ public class ExecutionLayerOptions {
       names = {"--exchange-capabilities-monitoring-enabled"},
       paramLabel = "<BOOLEAN>",
       description =
-          "Enables querying EL for the Engine API methods it supports on startup/restart. If incompatibility is detected, there will be a warning raised in the logs.",
+          "Enables querying EL for the Engine API methods it supports. If incompatibility is detected, there will be a warning raised in the logs.",
       arity = "0..1",
       showDefaultValue = Visibility.ALWAYS,
       fallbackValue = "true")

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ExecutionLayerOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ExecutionLayerOptions.java
@@ -139,7 +139,7 @@ public class ExecutionLayerOptions {
       names = {"--exchange-capabilities-monitoring-enabled"},
       paramLabel = "<BOOLEAN>",
       description =
-          "Enables querying EL periodically for the Engine API methods it supports. If incompatibility is detected, there will be a warning raised in the logs.",
+          "Enables querying EL for the Engine API methods it supports on startup/restart. If incompatibility is detected, there will be a warning raised in the logs.",
       arity = "0..1",
       showDefaultValue = Visibility.ALWAYS,
       fallbackValue = "true")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Change current logic of running engine capabilities monitoring every 10 epochs to only running it on EL startup/restart using the `ExecutionClientEventsChannel`.

The negative is that the warning would only be raised once on startup or restart of EL instead of every 10 epochs as right now.

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
