### PR TITLE
Increasing windowsBuild timeout to 60m

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -201,7 +201,7 @@ jobs:
             - deps-{{ checksum "build.gradle" }}-{{ checksum "gradle/versions.gradle" }}
       - run:
           name: Build
-          no_output_timeout: 20m
+          no_output_timeout: 60m
           command: |
             $Env:JAVA_TOOL_OPTIONS = "-Xmx2g"
             $Env:GRADLE_OPTS = "-Dorg.gradle.daemon=false -Dorg.gradle.parallel=true"


### PR DESCRIPTION
## PR Description
Temporarily increasing windowsBuild job timeout to avoid builds failing. I'll keep looking into the root cause but want to try to get stabilize our pipeline while doing so.

