### PR TITLE
Increasing unitTest timeout to 60s

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -256,7 +256,7 @@ jobs:
           at: ~/project
       - run:
           name: UnitTests
-          no_output_timeout: 20m
+          no_output_timeout: 60m
           command: |
             CLASSNAMES=$(circleci tests glob "**/src/test/java/**/*.java" \
               | sed 's@.*/src/test/java/@@' \


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

Temporarily increasing unitTest job timeout to avoid builds failing. I'll keep looking into the root cause but want to try to get stabilize our pipeline while doing so.