### PR TITLE
Removing recursive comparison from Eth2NetworkConfigurationTest

### DIFF
--- a/ethereum/networks/src/main/java/tech/pegasys/teku/networks/Eth2NetworkConfiguration.java
+++ b/ethereum/networks/src/main/java/tech/pegasys/teku/networks/Eth2NetworkConfiguration.java
@@ -32,6 +32,7 @@ import static tech.pegasys.teku.spec.networks.Eth2Network.SWIFT;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
@@ -264,6 +265,71 @@ public class Eth2NetworkConfiguration {
   @Override
   public String toString() {
     return constants;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final Eth2NetworkConfiguration that = (Eth2NetworkConfiguration) o;
+    return startupTargetPeerCount == that.startupTargetPeerCount
+        && startupTimeoutSeconds == that.startupTimeoutSeconds
+        && asyncP2pMaxThreads == that.asyncP2pMaxThreads
+        && asyncBeaconChainMaxThreads == that.asyncBeaconChainMaxThreads
+        && asyncBeaconChainMaxQueue == that.asyncBeaconChainMaxQueue
+        && asyncP2pMaxQueue == that.asyncP2pMaxQueue
+        && forkChoiceLateBlockReorgEnabled == that.forkChoiceLateBlockReorgEnabled
+        && forkChoiceUpdatedAlwaysSendPayloadAttributes
+            == that.forkChoiceUpdatedAlwaysSendPayloadAttributes
+        && Objects.equals(spec, that.spec)
+        && Objects.equals(constants, that.constants)
+        && Objects.equals(stateBoostrapConfig, that.stateBoostrapConfig)
+        && Objects.equals(discoveryBootnodes, that.discoveryBootnodes)
+        && Objects.equals(altairForkEpoch, that.altairForkEpoch)
+        && Objects.equals(bellatrixForkEpoch, that.bellatrixForkEpoch)
+        && Objects.equals(capellaForkEpoch, that.capellaForkEpoch)
+        && Objects.equals(denebForkEpoch, that.denebForkEpoch)
+        && Objects.equals(eth1DepositContractAddress, that.eth1DepositContractAddress)
+        && Objects.equals(eth1DepositContractDeployBlock, that.eth1DepositContractDeployBlock)
+        && Objects.equals(trustedSetup, that.trustedSetup)
+        && Objects.equals(terminalBlockHashOverride, that.terminalBlockHashOverride)
+        && Objects.equals(totalTerminalDifficultyOverride, that.totalTerminalDifficultyOverride)
+        && Objects.equals(terminalBlockHashEpochOverride, that.terminalBlockHashEpochOverride)
+        && Objects.equals(eth2Network, that.eth2Network)
+        && Objects.equals(epochsStoreBlobs, that.epochsStoreBlobs);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        spec,
+        constants,
+        stateBoostrapConfig,
+        startupTargetPeerCount,
+        startupTimeoutSeconds,
+        discoveryBootnodes,
+        altairForkEpoch,
+        bellatrixForkEpoch,
+        capellaForkEpoch,
+        denebForkEpoch,
+        eth1DepositContractAddress,
+        eth1DepositContractDeployBlock,
+        trustedSetup,
+        terminalBlockHashOverride,
+        totalTerminalDifficultyOverride,
+        terminalBlockHashEpochOverride,
+        eth2Network,
+        epochsStoreBlobs,
+        asyncP2pMaxThreads,
+        asyncBeaconChainMaxThreads,
+        asyncBeaconChainMaxQueue,
+        asyncP2pMaxQueue,
+        forkChoiceLateBlockReorgEnabled,
+        forkChoiceUpdatedAlwaysSendPayloadAttributes);
   }
 
   public static class Builder {

--- a/ethereum/networks/src/main/java/tech/pegasys/teku/networks/StateBoostrapConfig.java
+++ b/ethereum/networks/src/main/java/tech/pegasys/teku/networks/StateBoostrapConfig.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.networks;
 
+import java.util.Objects;
 import java.util.Optional;
 
 public class StateBoostrapConfig {
@@ -57,5 +58,31 @@ public class StateBoostrapConfig {
 
   public boolean isAllowSyncOutsideWeakSubjectivityPeriod() {
     return allowSyncOutsideWeakSubjectivityPeriod;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final StateBoostrapConfig that = (StateBoostrapConfig) o;
+    return isUsingCustomInitialState == that.isUsingCustomInitialState
+        && allowSyncOutsideWeakSubjectivityPeriod == that.allowSyncOutsideWeakSubjectivityPeriod
+        && Objects.equals(genesisState, that.genesisState)
+        && Objects.equals(initialState, that.initialState)
+        && Objects.equals(checkpointSyncUrl, that.checkpointSyncUrl);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        genesisState,
+        initialState,
+        checkpointSyncUrl,
+        isUsingCustomInitialState,
+        allowSyncOutsideWeakSubjectivityPeriod);
   }
 }

--- a/ethereum/networks/src/test/java/tech/pegasys/teku/networks/Eth2NetworkConfigurationTest.java
+++ b/ethereum/networks/src/test/java/tech/pegasys/teku/networks/Eth2NetworkConfigurationTest.java
@@ -42,7 +42,7 @@ public class Eth2NetworkConfigurationTest {
     networkDefinition.configure(networkConfigBuilder);
 
     assertThat(networkConfig.getConstants()).isEqualTo(network.configName());
-    assertThat(networkConfigBuilder.build()).usingRecursiveComparison().isEqualTo(networkConfig);
+    assertThat(networkConfigBuilder.build()).isEqualTo(networkConfig);
     assertThat(networkConfig.getNetworkBoostrapConfig().isUsingCustomInitialState()).isFalse();
   }
 
@@ -52,7 +52,7 @@ public class Eth2NetworkConfigurationTest {
         Eth2NetworkConfiguration.builder("goerli").build();
     final Eth2NetworkConfiguration praterConfig =
         Eth2NetworkConfiguration.builder("prater").build();
-    assertThat(goerliConfig).usingRecursiveComparison().isEqualTo(praterConfig);
+    assertThat(goerliConfig).isEqualTo(praterConfig);
   }
 
   @Test
@@ -77,7 +77,7 @@ public class Eth2NetworkConfigurationTest {
 
   @Test
   public void applyNetworkDefaults_shouldOverwritePreviouslySetValues() {
-    List<Arguments> definedNetworks = getDefinedNetworks().collect(Collectors.toList());
+    List<Arguments> definedNetworks = getDefinedNetworks().toList();
 
     for (Arguments networkA : definedNetworks) {
       for (Arguments networkB : definedNetworks) {
@@ -88,16 +88,15 @@ public class Eth2NetworkConfigurationTest {
         builder.applyNetworkDefaults(networkAName);
         builder.applyNetworkDefaults(networkBName);
 
-        assertThat(builder)
-            .usingRecursiveComparison()
-            .isEqualTo(Eth2NetworkConfiguration.builder(networkBName));
+        assertThat(builder.build())
+            .isEqualTo(Eth2NetworkConfiguration.builder(networkBName).build());
       }
     }
   }
 
   @Test
   public void applyNamedNetworkDefaults_shouldOverwritePreviouslySetValues() {
-    List<Arguments> definedNetworks = getDefinedNetworks().collect(Collectors.toList());
+    List<Arguments> definedNetworks = getDefinedNetworks().toList();
 
     for (Arguments networkA : definedNetworks) {
       for (Arguments networkB : definedNetworks) {
@@ -109,9 +108,8 @@ public class Eth2NetworkConfigurationTest {
         networkBDef.configure(builder);
 
         final Eth2Network networkBName = ((Eth2Network) networkB.get()[0]);
-        assertThat(builder)
-            .usingRecursiveComparison()
-            .isEqualTo(Eth2NetworkConfiguration.builder(networkBName));
+        assertThat(builder.build())
+            .isEqualTo(Eth2NetworkConfiguration.builder(networkBName).build());
       }
     }
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
This recursive comparison is the cause of the tests being slow on CircleCI.

This is part 1/2 of the required changes.