### PR TITLE
Removing recursiion asserts from Eth2P2PNetworkOptionTest

### DIFF
--- a/teku/src/test/java/tech/pegasys/teku/cli/options/Eth2P2PNetworkOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/Eth2P2PNetworkOptionsTest.java
@@ -29,7 +29,6 @@ import tech.pegasys.teku.ethereum.execution.types.Eth1Address;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.P2PConfig;
 import tech.pegasys.teku.networks.Eth2NetworkConfiguration;
-import tech.pegasys.teku.spec.networks.Eth2Network;
 
 public class Eth2P2PNetworkOptionsTest extends AbstractBeaconNodeCommandTest {
 
@@ -52,9 +51,7 @@ public class Eth2P2PNetworkOptionsTest extends AbstractBeaconNodeCommandTest {
     final TekuConfiguration tekuConfig = getResultingTekuConfiguration();
 
     // eth2Config
-    assertThat(tekuConfig.eth2NetworkConfiguration())
-        .usingRecursiveComparison()
-        .isEqualTo(eth2NetworkConfig);
+    assertThat(tekuConfig.eth2NetworkConfiguration()).isEqualTo(eth2NetworkConfig);
 
     // Storage config
     assertThat(tekuConfig.storageConfiguration().getEth1DepositContract())
@@ -77,13 +74,6 @@ public class Eth2P2PNetworkOptionsTest extends AbstractBeaconNodeCommandTest {
         .isEqualTo(eth2NetworkConfig.getEth1DepositContractAddress());
     assertThat(tekuConfig.powchain().getDepositContractDeployBlock())
         .isEqualTo(eth2NetworkConfig.getEth1DepositContractDeployBlock());
-
-    assertThat(
-            createConfigBuilder()
-                .eth2NetworkConfig(b -> b.applyNetworkDefaults(networkName))
-                .build())
-        .usingRecursiveComparison()
-        .isEqualTo(tekuConfig);
   }
 
   @Test
@@ -96,21 +86,11 @@ public class Eth2P2PNetworkOptionsTest extends AbstractBeaconNodeCommandTest {
           "0xFE3B557E8Fb62b89F4916B721be55cEb828dBd73"
         });
 
-    TekuConfiguration tekuConfiguration = getResultingTekuConfiguration();
-    Eth2NetworkConfiguration configuration = tekuConfiguration.eth2NetworkConfiguration();
-    final Eth1Address configuredDepositContract = configuration.getEth1DepositContractAddress();
+    final TekuConfiguration tekuConfiguration = getResultingTekuConfiguration();
+    final Eth1Address configuredDepositContract =
+        tekuConfiguration.eth2NetworkConfiguration().getEth1DepositContractAddress();
     assertThat(configuredDepositContract)
         .isEqualTo(Eth1Address.fromHexString("0xFE3B557E8Fb62b89F4916B721be55cEb828dBd73"));
-    assertThat(
-            createConfigBuilder()
-                .eth2NetworkConfig(
-                    b -> {
-                      b.applyNetworkDefaults(Eth2Network.MAINNET);
-                      b.eth1DepositContractAddress("0xFE3B557E8Fb62b89F4916B721be55cEb828dBd73");
-                    })
-                .build())
-        .usingRecursiveComparison()
-        .isEqualTo(tekuConfiguration);
   }
 
   @Test
@@ -121,20 +101,11 @@ public class Eth2P2PNetworkOptionsTest extends AbstractBeaconNodeCommandTest {
         });
 
     final TekuConfiguration tekuConfiguration = getResultingTekuConfiguration();
-    final Eth2NetworkConfiguration configuration = tekuConfiguration.eth2NetworkConfiguration();
+    final Eth2NetworkConfiguration eth2NetworkConfiguration =
+        tekuConfiguration.eth2NetworkConfiguration();
     final Optional<UInt64> configuredDepositContractDeployBlock =
-        configuration.getEth1DepositContractDeployBlock();
+        eth2NetworkConfiguration.getEth1DepositContractDeployBlock();
     assertThat(configuredDepositContractDeployBlock).isEqualTo(Optional.of(UInt64.valueOf(345L)));
-    assertThat(
-            createConfigBuilder()
-                .eth2NetworkConfig(
-                    b -> {
-                      b.applyNetworkDefaults(Eth2Network.MAINNET);
-                      b.eth1DepositContractDeployBlock(345L);
-                    })
-                .build())
-        .usingRecursiveComparison()
-        .isEqualTo(tekuConfiguration);
   }
 
   @Test
@@ -144,17 +115,6 @@ public class Eth2P2PNetworkOptionsTest extends AbstractBeaconNodeCommandTest {
     TekuConfiguration tekuConfiguration = getResultingTekuConfiguration();
     final List<String> bootnodes = tekuConfiguration.discovery().getBootnodes();
     assertThat(bootnodes).isEmpty();
-
-    assertThat(
-            createConfigBuilder()
-                .eth2NetworkConfig(
-                    b -> {
-                      b.applyNetworkDefaults(Eth2Network.PRATER);
-                    })
-                .discovery(b -> b.bootnodes(List.of()))
-                .build())
-        .usingRecursiveComparison()
-        .isEqualTo(tekuConfiguration);
   }
 
   @Test
@@ -162,20 +122,9 @@ public class Eth2P2PNetworkOptionsTest extends AbstractBeaconNodeCommandTest {
     final URL url =
         getClass().getClassLoader().getResource("tech/pegasys/teku/cli/options/constants.yaml");
     beaconNodeCommand.parse(new String[] {"--network", url.toString()});
-
     final TekuConfiguration config = getResultingTekuConfiguration();
     assertThat(config.eth2NetworkConfiguration().getConstants().toLowerCase(Locale.ROOT))
         .isEqualToIgnoringWhitespace(url.toString().toLowerCase(Locale.ROOT));
-    assertThat(
-            createConfigBuilder()
-                .eth2NetworkConfig(
-                    b -> {
-                      b.applyNetworkDefaults(url.toString());
-                      b.discoveryBootnodes();
-                    })
-                .build())
-        .usingRecursiveComparison()
-        .isEqualTo(config);
   }
 
   @Test
@@ -184,9 +133,6 @@ public class Eth2P2PNetworkOptionsTest extends AbstractBeaconNodeCommandTest {
         getTekuConfigurationFromArguments("--Xpeer-rate-limit", "10");
     final P2PConfig config = tekuConfiguration.beaconChain().p2pConfig();
     assertThat(config.getPeerRateLimit()).isEqualTo(10);
-    assertThat(createConfigBuilder().p2p(b -> b.peerRateLimit(10)).build())
-        .usingRecursiveComparison()
-        .isEqualTo(tekuConfiguration);
   }
 
   @Test
@@ -195,15 +141,11 @@ public class Eth2P2PNetworkOptionsTest extends AbstractBeaconNodeCommandTest {
         getTekuConfigurationFromArguments("--Xpeer-request-limit", "10");
     final P2PConfig config = tekuConfiguration.beaconChain().p2pConfig();
     assertThat(config.getPeerRequestLimit()).isEqualTo(10);
-    assertThat(createConfigBuilder().p2p(b -> b.peerRequestLimit(10)).build())
-        .usingRecursiveComparison()
-        .isEqualTo(tekuConfiguration);
   }
 
   @Test
   public void helpDisplaysDefaultNetwork() {
     beaconNodeCommand.parse(new String[] {"--help"});
-
     final String output = getCommandLineOutput();
     assertThat(output)
         .contains(
@@ -218,9 +160,6 @@ public class Eth2P2PNetworkOptionsTest extends AbstractBeaconNodeCommandTest {
     final TekuConfiguration config = getTekuConfigurationFromArguments("--initial-state", state);
     assertThat(config.eth2NetworkConfiguration().getNetworkBoostrapConfig().getInitialState())
         .contains(state);
-    assertThat(createConfigBuilder().eth2NetworkConfig(b -> b.customInitialState(state)).build())
-        .usingRecursiveComparison()
-        .isEqualTo(config);
   }
 
   @Test
@@ -259,16 +198,6 @@ public class Eth2P2PNetworkOptionsTest extends AbstractBeaconNodeCommandTest {
                 .getNetworkBoostrapConfig()
                 .isUsingCustomInitialState())
         .isTrue();
-    assertThat(
-            createConfigBuilder()
-                .eth2NetworkConfig(
-                    b -> {
-                      b.applyNetworkDefaults(network);
-                      b.customInitialState(state);
-                    })
-                .build())
-        .usingRecursiveComparison()
-        .isEqualTo(config);
   }
 
   @Test


### PR DESCRIPTION
## PR Description

Removing some unnecessary assertions on `TekuConfig` object in favour of targeted assertions on the expected values being overwritten in the config.