### PR TITLE
Removing yet more recursion on tests!

### DIFF
--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/LoggingConfig.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/LoggingConfig.java
@@ -106,18 +106,29 @@ public class LoggingConfig {
       return false;
     }
     final LoggingConfig that = (LoggingConfig) o;
-    return colorEnabled == that.colorEnabled && includeEventsEnabled == that.includeEventsEnabled
+    return colorEnabled == that.colorEnabled
+        && includeEventsEnabled == that.includeEventsEnabled
         && includeValidatorDutiesEnabled == that.includeValidatorDutiesEnabled
         && includeP2pWarningsEnabled == that.includeP2pWarningsEnabled
-        && dbOpAlertThresholdMillis == that.dbOpAlertThresholdMillis && Objects.equals(logLevel, that.logLevel)
-        && destination == that.destination && Objects.equals(logFile, that.logFile) && Objects.equals(
-        logFileNamePattern, that.logFileNamePattern);
+        && dbOpAlertThresholdMillis == that.dbOpAlertThresholdMillis
+        && Objects.equals(logLevel, that.logLevel)
+        && destination == that.destination
+        && Objects.equals(logFile, that.logFile)
+        && Objects.equals(logFileNamePattern, that.logFileNamePattern);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(logLevel, colorEnabled, includeEventsEnabled, includeValidatorDutiesEnabled,
-        includeP2pWarningsEnabled, destination, logFile, logFileNamePattern, dbOpAlertThresholdMillis);
+    return Objects.hash(
+        logLevel,
+        colorEnabled,
+        includeEventsEnabled,
+        includeValidatorDutiesEnabled,
+        includeP2pWarningsEnabled,
+        destination,
+        logFile,
+        logFileNamePattern,
+        dbOpAlertThresholdMillis);
   }
 
   public static final class LoggingConfigBuilder {

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/LoggingConfig.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/LoggingConfig.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.infrastructure.logging;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import java.util.Objects;
 import java.util.Optional;
 import org.apache.logging.log4j.Level;
 
@@ -94,6 +95,29 @@ public class LoggingConfig {
 
   public int getDbOpAlertThresholdMillis() {
     return dbOpAlertThresholdMillis;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final LoggingConfig that = (LoggingConfig) o;
+    return colorEnabled == that.colorEnabled && includeEventsEnabled == that.includeEventsEnabled
+        && includeValidatorDutiesEnabled == that.includeValidatorDutiesEnabled
+        && includeP2pWarningsEnabled == that.includeP2pWarningsEnabled
+        && dbOpAlertThresholdMillis == that.dbOpAlertThresholdMillis && Objects.equals(logLevel, that.logLevel)
+        && destination == that.destination && Objects.equals(logFile, that.logFile) && Objects.equals(
+        logFileNamePattern, that.logFileNamePattern);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(logLevel, colorEnabled, includeEventsEnabled, includeValidatorDutiesEnabled,
+        includeP2pWarningsEnabled, destination, logFile, logFileNamePattern, dbOpAlertThresholdMillis);
   }
 
   public static final class LoggingConfigBuilder {

--- a/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/WeakSubjectivityInitializerTest.java
+++ b/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/WeakSubjectivityInitializerTest.java
@@ -73,7 +73,7 @@ public class WeakSubjectivityInitializerTest {
     assertThat(result).isCompleted();
     verify(queryChannel).getWeakSubjectivityState();
     verify(updateChannel, never()).onWeakSubjectivityUpdate(any());
-    assertThat(safeJoin(result)).usingRecursiveComparison().isEqualTo(defaultConfig);
+    assertThat(safeJoin(result)).isEqualTo(defaultConfig);
   }
 
   @Test
@@ -98,7 +98,7 @@ public class WeakSubjectivityInitializerTest {
     verify(updateChannel)
         .onWeakSubjectivityUpdate(
             WeakSubjectivityUpdate.setWeakSubjectivityCheckpoint(cliCheckpoint));
-    assertThat(safeJoin(result)).usingRecursiveComparison().isEqualTo(cliConfig);
+    assertThat(safeJoin(result)).isEqualTo(cliConfig);
   }
 
   @Test
@@ -119,7 +119,6 @@ public class WeakSubjectivityInitializerTest {
     verify(queryChannel).getWeakSubjectivityState();
     verify(updateChannel, never()).onWeakSubjectivityUpdate(any());
     assertThat(safeJoin(result))
-        .usingRecursiveComparison()
         .isEqualTo(WeakSubjectivityConfig.builder(storedState).specProvider(spec).build());
   }
 
@@ -150,7 +149,7 @@ public class WeakSubjectivityInitializerTest {
     verify(updateChannel)
         .onWeakSubjectivityUpdate(
             WeakSubjectivityUpdate.setWeakSubjectivityCheckpoint(cliCheckpoint));
-    assertThat(safeJoin(result)).usingRecursiveComparison().isEqualTo(cliConfig);
+    assertThat(safeJoin(result)).isEqualTo(cliConfig);
   }
 
   @Test
@@ -175,7 +174,7 @@ public class WeakSubjectivityInitializerTest {
     assertThat(result).isCompleted();
     verify(queryChannel).getWeakSubjectivityState();
     verify(updateChannel, never()).onWeakSubjectivityUpdate(any());
-    assertThat(safeJoin(result)).usingRecursiveComparison().isEqualTo(cliConfig);
+    assertThat(safeJoin(result)).isEqualTo(cliConfig);
   }
 
   @Test

--- a/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/BeaconNodeCommandTest.java
@@ -68,6 +68,7 @@ import tech.pegasys.teku.infrastructure.logging.LoggingConfig;
 import tech.pegasys.teku.infrastructure.logging.LoggingConfig.LoggingConfigBuilder;
 import tech.pegasys.teku.networking.nat.NatMethod;
 import tech.pegasys.teku.networks.Eth2NetworkConfiguration;
+import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.config.SpecConfigDeneb;
 import tech.pegasys.teku.storage.server.DatabaseStorageException;
@@ -717,12 +718,21 @@ public class BeaconNodeCommandTest extends AbstractBeaconNodeCommandTest {
       final TekuConfiguration expected, final LoggingConfig expectedLogging) {
     assertTekuConfiguration(expected);
     final LoggingConfig actualLogging = getResultingLoggingConfiguration();
-    assertThat(actualLogging).usingRecursiveComparison().isEqualTo(expectedLogging);
+    assertThat(actualLogging).isEqualTo(expectedLogging);
   }
 
   private void assertTekuConfiguration(final TekuConfiguration expected) {
     final TekuConfiguration actual = getResultingTekuConfiguration();
-    assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
+
+    // Assert Spec object separately to avoid recursion issues
+    assertThat(actual.eth2NetworkConfiguration().getSpec())
+        .isEqualTo(expected.eth2NetworkConfiguration().getSpec());
+
+    // Ignore any Spec assertion on recursion
+    assertThat(actual)
+        .usingRecursiveComparison()
+        .ignoringFieldsOfTypes(Spec.class)
+        .isEqualTo(expected);
   }
 
   private Path createTempFile(final byte[] contents) throws IOException {

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/BeaconNodeDataOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/BeaconNodeDataOptionsTest.java
@@ -52,9 +52,6 @@ public class BeaconNodeDataOptionsTest extends AbstractBeaconNodeCommandTest {
         getTekuConfigurationFromArguments("--data-storage-mode", "prune");
     final StorageConfiguration config = tekuConfiguration.storageConfiguration();
     assertThat(config.getDataStorageMode()).isEqualTo(PRUNE);
-    assertThat(createConfigBuilder().storageConfiguration(b -> b.dataStorageMode(PRUNE)).build())
-        .usingRecursiveComparison()
-        .isEqualTo(tekuConfiguration);
   }
 
   @Test
@@ -63,9 +60,6 @@ public class BeaconNodeDataOptionsTest extends AbstractBeaconNodeCommandTest {
         getTekuConfigurationFromArguments("--data-storage-mode", "archive");
     final StorageConfiguration config = tekuConfiguration.storageConfiguration();
     assertThat(config.getDataStorageMode()).isEqualTo(ARCHIVE);
-    assertThat(createConfigBuilder().storageConfiguration(b -> b.dataStorageMode(ARCHIVE)).build())
-        .usingRecursiveComparison()
-        .isEqualTo(tekuConfiguration);
   }
 
   @Test
@@ -73,9 +67,6 @@ public class BeaconNodeDataOptionsTest extends AbstractBeaconNodeCommandTest {
     final TekuConfiguration config =
         getTekuConfigurationFromArguments("--data-path", TEST_PATH.toString());
     assertThat(config.dataConfig().getDataBasePath()).isEqualTo(TEST_PATH);
-    assertThat(createConfigBuilder().data(b -> b.dataBasePath(TEST_PATH)).build())
-        .usingRecursiveComparison()
-        .isEqualTo(config);
   }
 
   @Test
@@ -90,12 +81,6 @@ public class BeaconNodeDataOptionsTest extends AbstractBeaconNodeCommandTest {
         getTekuConfigurationFromArguments("--data-storage-archive-frequency", "1024000");
     final StorageConfiguration config = tekuConfiguration.storageConfiguration();
     assertThat(config.getDataStorageFrequency()).isEqualTo(1024000L);
-    assertThat(
-            createConfigBuilder()
-                .storageConfiguration(b -> b.dataStorageFrequency(1024000L))
-                .build())
-        .usingRecursiveComparison()
-        .isEqualTo(tekuConfiguration);
   }
 
   @Test
@@ -126,12 +111,6 @@ public class BeaconNodeDataOptionsTest extends AbstractBeaconNodeCommandTest {
         getTekuConfigurationFromArguments("--Xdata-storage-create-db-version", "noop");
     final StorageConfiguration config = tekuConfiguration.storageConfiguration();
     assertThat(config.getDataStorageCreateDbVersion()).isEqualTo(DatabaseVersion.NOOP);
-    assertThat(
-            createConfigBuilder()
-                .storageConfiguration(b -> b.dataStorageCreateDbVersion(DatabaseVersion.NOOP))
-                .build())
-        .usingRecursiveComparison()
-        .isEqualTo(tekuConfiguration);
   }
 
   @Test
@@ -145,14 +124,6 @@ public class BeaconNodeDataOptionsTest extends AbstractBeaconNodeCommandTest {
             "--reconstruct-historic-states",
             "true");
     assertThat(tekuConfiguration.sync().isReconstructHistoricStatesEnabled()).isEqualTo(true);
-    assertThat(
-            createConfigBuilder()
-                .eth2NetworkConfig(b -> b.customGenesisState(GENESIS_STATE))
-                .storageConfiguration(b -> b.dataStorageMode(ARCHIVE))
-                .sync(b -> b.reconstructHistoricStatesEnabled(true))
-                .build())
-        .usingRecursiveComparison()
-        .isEqualTo(tekuConfiguration);
   }
 
   @Test
@@ -180,14 +151,6 @@ public class BeaconNodeDataOptionsTest extends AbstractBeaconNodeCommandTest {
             "true");
 
     assertThat(tekuConfiguration.sync().isReconstructHistoricStatesEnabled()).isEqualTo(true);
-    assertThat(
-            createConfigBuilder()
-                .eth2NetworkConfig(b -> b.applyNetworkDefaults(Eth2Network.MAINNET))
-                .storageConfiguration(b -> b.dataStorageMode(ARCHIVE))
-                .sync(b -> b.reconstructHistoricStatesEnabled(true))
-                .build())
-        .usingRecursiveComparison()
-        .isEqualTo(tekuConfiguration);
   }
 
   @Test
@@ -213,17 +176,7 @@ public class BeaconNodeDataOptionsTest extends AbstractBeaconNodeCommandTest {
     assertThat(config.storageConfiguration().getDataStorageMode()).isEqualTo(MINIMAL);
     assertThat(config.storageConfiguration().getBlockPruningInterval())
         .isEqualTo(Duration.ofSeconds(150));
-    assertThat(
-            createConfigBuilder()
-                .storageConfiguration(
-                    b ->
-                        b.dataStorageMode(MINIMAL)
-                            .blockPruningInterval(Duration.ofSeconds(150))
-                            .blockPruningLimit(50))
-                .sync(b -> b.fetchAllHistoricBlocks(false))
-                .build())
-        .usingRecursiveComparison()
-        .isEqualTo(config);
+    assertThat(config.storageConfiguration().getBlockPruningLimit()).isEqualTo(50);
   }
 
   @Test
@@ -234,13 +187,6 @@ public class BeaconNodeDataOptionsTest extends AbstractBeaconNodeCommandTest {
     assertThat(config.storageConfiguration().getBlobsPruningInterval())
         .isEqualTo(Duration.ofSeconds(55));
     assertThat(config.storageConfiguration().getBlobsPruningLimit()).isEqualTo(10);
-    assertThat(
-            createConfigBuilder()
-                .storageConfiguration(
-                    b -> b.blobsPruningInterval(Duration.ofSeconds(55)).blobsPruningLimit(10))
-                .build())
-        .usingRecursiveComparison()
-        .isEqualTo(config);
   }
 
   @Test

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/DepositOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/DepositOptionsTest.java
@@ -17,7 +17,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static tech.pegasys.teku.beacon.pow.DepositSnapshotFileLoader.DEFAULT_SNAPSHOT_RESOURCE_PATHS;
 import static tech.pegasys.teku.services.powchain.PowchainConfiguration.DEPOSIT_SNAPSHOT_URL_PATH;
 
-import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/DepositOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/DepositOptionsTest.java
@@ -43,12 +43,6 @@ public class DepositOptionsTest extends AbstractBeaconNodeCommandTest {
     final String[] args = {"--eth1-endpoint", "http://example.com:1234/path/"};
     final TekuConfiguration config = getTekuConfigurationFromArguments(args);
     assertThat(config.powchain().isEnabled()).isTrue();
-    assertThat(
-            createConfigBuilder()
-                .powchain(b -> b.eth1Endpoints(List.of("http://example.com:1234/path/")))
-                .build())
-        .usingRecursiveComparison()
-        .isEqualTo(config);
   }
 
   @Test
@@ -62,9 +56,6 @@ public class DepositOptionsTest extends AbstractBeaconNodeCommandTest {
     final String[] args = {"--eth1-endpoint", "   "};
     final TekuConfiguration config = getTekuConfigurationFromArguments(args);
     assertThat(config.powchain().isEnabled()).isFalse();
-    assertThat(createConfigBuilder().powchain(b -> b.eth1Endpoints(List.of())).build())
-        .usingRecursiveComparison()
-        .isEqualTo(config);
   }
 
   @Test
@@ -81,18 +72,6 @@ public class DepositOptionsTest extends AbstractBeaconNodeCommandTest {
             "http://example-2.com:1234/path/",
             "http://example-3.com:1234/path/");
     assertThat(config.powchain().isEnabled()).isTrue();
-    assertThat(
-            createConfigBuilder()
-                .powchain(
-                    b ->
-                        b.eth1Endpoints(
-                            List.of(
-                                "http://example.com:1234/path/",
-                                "http://example-2.com:1234/path/",
-                                "http://example-3.com:1234/path/")))
-                .build())
-        .usingRecursiveComparison()
-        .isEqualTo(config);
   }
 
   @Test

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/Eth2NetworkOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/Eth2NetworkOptionsTest.java
@@ -50,12 +50,6 @@ class Eth2NetworkOptionsTest extends AbstractBeaconNodeCommandTest {
         .isEqualTo(SpecMilestone.PHASE0);
     assertThat(spec.getForkSchedule().getSpecMilestoneAtEpoch(UInt64.valueOf(64)))
         .isEqualTo(SpecMilestone.ALTAIR);
-    assertThat(
-            createConfigBuilder()
-                .eth2NetworkConfig(b -> b.altairForkEpoch(UInt64.valueOf(64)))
-                .build())
-        .usingRecursiveComparison()
-        .isEqualTo(config);
   }
 
   @Test
@@ -64,9 +58,6 @@ class Eth2NetworkOptionsTest extends AbstractBeaconNodeCommandTest {
         getTekuConfigurationFromArguments("--Xtrusted-setup", "/test.txt");
     final Optional<String> trustedSetup = config.eth2NetworkConfiguration().getTrustedSetup();
     assertThat(trustedSetup).isEqualTo(Optional.of("/test.txt"));
-    assertThat(createConfigBuilder().eth2NetworkConfig(b -> b.trustedSetup("/test.txt")).build())
-        .usingRecursiveComparison()
-        .isEqualTo(config);
   }
 
   @Test
@@ -75,7 +66,6 @@ class Eth2NetworkOptionsTest extends AbstractBeaconNodeCommandTest {
     final Optional<String> trustedSetup = config.eth2NetworkConfiguration().getTrustedSetup();
     assertThat(trustedSetup)
         .matches(ts -> ts.map(path -> path.endsWith("mainnet-trusted-setup.txt")).orElse(false));
-    assertThat(createConfigBuilder().build()).usingRecursiveComparison().isEqualTo(config);
   }
 
   @Test
@@ -88,13 +78,6 @@ class Eth2NetworkOptionsTest extends AbstractBeaconNodeCommandTest {
         .isEqualTo(SpecMilestone.ALTAIR);
     assertThat(spec.getForkSchedule().getSpecMilestoneAtEpoch(UInt64.valueOf(120000)))
         .isEqualTo(SpecMilestone.BELLATRIX);
-    assertThat(
-            createConfigBuilder()
-                .executionLayer(b -> b.engineEndpoint("someEndpoint"))
-                .eth2NetworkConfig(b -> b.bellatrixForkEpoch(UInt64.valueOf(120000)))
-                .build())
-        .usingRecursiveComparison()
-        .isEqualTo(config);
   }
 
   @Test
@@ -166,15 +149,6 @@ class Eth2NetworkOptionsTest extends AbstractBeaconNodeCommandTest {
             "--Xnetwork-total-terminal-difficulty-override", "123456789012345678901");
     assertThat(config.eth2NetworkConfiguration().getTotalTerminalDifficultyOverride())
         .isEqualTo(Optional.of(UInt256.valueOf(new BigInteger("123456789012345678901"))));
-    assertThat(
-            createConfigBuilder()
-                .eth2NetworkConfig(
-                    b ->
-                        b.totalTerminalDifficultyOverride(
-                            UInt256.valueOf(new BigInteger("123456789012345678901"))))
-                .build())
-        .usingRecursiveComparison()
-        .isEqualTo(config);
   }
 
   @Test
@@ -188,16 +162,6 @@ class Eth2NetworkOptionsTest extends AbstractBeaconNodeCommandTest {
             Optional.of(
                 Bytes32.fromHexStringStrict(
                     "0x7562f205a2d14e80a3a67da9df0b769b0ba0111a8e81034606f8f27f51f4dd8e")));
-    assertThat(
-            createConfigBuilder()
-                .eth2NetworkConfig(
-                    b ->
-                        b.terminalBlockHashOverride(
-                            Bytes32.fromHexStringStrict(
-                                "0x7562f205a2d14e80a3a67da9df0b769b0ba0111a8e81034606f8f27f51f4dd8e")))
-                .build())
-        .usingRecursiveComparison()
-        .isEqualTo(config);
   }
 
   @Test
@@ -207,12 +171,6 @@ class Eth2NetworkOptionsTest extends AbstractBeaconNodeCommandTest {
             "--Xnetwork-terminal-block-hash-epoch-override", "120000");
     assertThat(config.eth2NetworkConfiguration().getTerminalBlockHashEpochOverride())
         .isEqualTo(Optional.of(UInt64.valueOf(120000)));
-    assertThat(
-            createConfigBuilder()
-                .eth2NetworkConfig(b -> b.terminalBlockHashEpochOverride(UInt64.valueOf(120000)))
-                .build())
-        .usingRecursiveComparison()
-        .isEqualTo(config);
   }
 
   @Test
@@ -242,12 +200,6 @@ class Eth2NetworkOptionsTest extends AbstractBeaconNodeCommandTest {
         getTekuConfigurationFromArguments("--genesis-state", genesisState);
     assertThat(config.eth2NetworkConfiguration().getNetworkBoostrapConfig().getGenesisState())
         .isEqualTo(Optional.of(genesisState));
-    assertThat(
-            createConfigBuilder()
-                .eth2NetworkConfig(b -> b.customGenesisState(genesisState))
-                .build())
-        .usingRecursiveComparison()
-        .isEqualTo(config);
   }
 
   @ParameterizedTest

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/ExecutionLayerOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/ExecutionLayerOptionsTest.java
@@ -50,15 +50,7 @@ public class ExecutionLayerOptionsTest extends AbstractBeaconNodeCommandTest {
     };
     final TekuConfiguration config = getTekuConfigurationFromArguments(args);
     assertThat(config.executionLayer().isEnabled()).isTrue();
-
-    assertThat(
-            createConfigBuilder()
-                .eth2NetworkConfig(
-                    b -> b.altairForkEpoch(UInt64.ZERO).bellatrixForkEpoch(UInt64.ONE))
-                .executionLayer(b -> b.engineEndpoint("http://example.com:1234/path/"))
-                .build())
-        .usingRecursiveComparison()
-        .isEqualTo(config);
+    assertThat(config.executionLayer().getEngineEndpoint()).isEqualTo("http://example.com:1234/path/");
   }
 
   @Test
@@ -75,18 +67,8 @@ public class ExecutionLayerOptionsTest extends AbstractBeaconNodeCommandTest {
     };
     final TekuConfiguration config = getTekuConfigurationFromArguments(args);
     assertThat(config.executionLayer().isEnabled()).isTrue();
-
-    assertThat(
-            createConfigBuilder()
-                .eth2NetworkConfig(
-                    b -> b.altairForkEpoch(UInt64.ZERO).bellatrixForkEpoch(UInt64.ONE))
-                .executionLayer(
-                    b ->
-                        b.engineEndpoint("http://example.com:1234/path/")
-                            .builderEndpoint("http://example2.com:1234/path2/"))
-                .build())
-        .usingRecursiveComparison()
-        .isEqualTo(config);
+    assertThat(config.executionLayer().getEngineEndpoint()).isEqualTo("http://example.com:1234/path/");
+    assertThat(config.executionLayer().getBuilderEndpoint()).contains("http://example2.com:1234/path2/");
   }
 
   @Test

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/ExecutionLayerOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/ExecutionLayerOptionsTest.java
@@ -24,7 +24,6 @@ import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.cli.AbstractBeaconNodeCommandTest;
 import tech.pegasys.teku.config.TekuConfiguration;
 import tech.pegasys.teku.infrastructure.exceptions.InvalidConfigurationException;
-import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 public class ExecutionLayerOptionsTest extends AbstractBeaconNodeCommandTest {
 
@@ -50,7 +49,8 @@ public class ExecutionLayerOptionsTest extends AbstractBeaconNodeCommandTest {
     };
     final TekuConfiguration config = getTekuConfigurationFromArguments(args);
     assertThat(config.executionLayer().isEnabled()).isTrue();
-    assertThat(config.executionLayer().getEngineEndpoint()).isEqualTo("http://example.com:1234/path/");
+    assertThat(config.executionLayer().getEngineEndpoint())
+        .isEqualTo("http://example.com:1234/path/");
   }
 
   @Test
@@ -67,8 +67,10 @@ public class ExecutionLayerOptionsTest extends AbstractBeaconNodeCommandTest {
     };
     final TekuConfiguration config = getTekuConfigurationFromArguments(args);
     assertThat(config.executionLayer().isEnabled()).isTrue();
-    assertThat(config.executionLayer().getEngineEndpoint()).isEqualTo("http://example.com:1234/path/");
-    assertThat(config.executionLayer().getBuilderEndpoint()).contains("http://example2.com:1234/path2/");
+    assertThat(config.executionLayer().getEngineEndpoint())
+        .isEqualTo("http://example.com:1234/path/");
+    assertThat(config.executionLayer().getBuilderEndpoint())
+        .contains("http://example2.com:1234/path2/");
   }
 
   @Test

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/InteropOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/InteropOptionsTest.java
@@ -31,21 +31,5 @@ public class InteropOptionsTest extends AbstractBeaconNodeCommandTest {
         tekuConfiguration.validatorClient().getInteropConfig().getInteropGenesisTime();
     assertThat(interopGenesisTime)
         .isGreaterThanOrEqualTo((int) (System.currentTimeMillis() / 1000));
-
-    assertThat(
-            createConfigBuilder()
-                .interop(b -> b.interopEnabled(true))
-                .build()
-                .validatorClient()
-                .getInteropConfig()
-                .getInteropGenesisTime())
-        .isGreaterThanOrEqualTo((int) (System.currentTimeMillis() / 1000));
-
-    assertThat(
-            createConfigBuilder()
-                .interop(b -> b.interopEnabled(true).interopGenesisTime(interopGenesisTime))
-                .build())
-        .usingRecursiveComparison()
-        .isEqualTo(tekuConfiguration);
   }
 }

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/LoggingOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/LoggingOptionsTest.java
@@ -75,7 +75,6 @@ public class LoggingOptionsTest extends AbstractBeaconNodeCommandTest {
     final LoggingConfig config = getLoggingConfigurationFromArguments("--log-destination", "file");
     assertThat(config.getDestination()).isEqualTo(LoggingDestination.FILE);
     assertThat(createLoggingConfigBuilder().destination(LoggingDestination.FILE).build())
-        .usingRecursiveComparison()
         .isEqualTo(config);
   }
 
@@ -84,9 +83,6 @@ public class LoggingOptionsTest extends AbstractBeaconNodeCommandTest {
     final LoggingConfig config =
         getLoggingConfigurationFromArguments("--log-include-events-enabled");
     assertThat(config.isIncludeEventsEnabled()).isTrue();
-    assertThat(createLoggingConfigBuilder().includeEventsEnabled(true).build())
-        .usingRecursiveComparison()
-        .isEqualTo(config);
   }
 
   @Test
@@ -94,18 +90,12 @@ public class LoggingOptionsTest extends AbstractBeaconNodeCommandTest {
     final LoggingConfig config =
         getLoggingConfigurationFromArguments("--log-destination", "console");
     assertThat(config.getDestination()).isEqualTo(LoggingDestination.CONSOLE);
-    assertThat(createLoggingConfigBuilder().destination(LoggingDestination.CONSOLE).build())
-        .usingRecursiveComparison()
-        .isEqualTo(config);
   }
 
   @Test
   public void logDestination_shouldAcceptBothAsDestination() {
     final LoggingConfig config = getLoggingConfigurationFromArguments("--log-destination", "both");
     assertThat(config.getDestination()).isEqualTo(LoggingDestination.BOTH);
-    assertThat(createLoggingConfigBuilder().destination(LoggingDestination.BOTH).build())
-        .usingRecursiveComparison()
-        .isEqualTo(config);
   }
 
   @Test

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/MetricsOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/MetricsOptionsTest.java
@@ -34,8 +34,6 @@ import tech.pegasys.teku.infrastructure.metrics.MetricsConfig;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 
 public class MetricsOptionsTest extends AbstractBeaconNodeCommandTest {
-  private static final Comparator<Set<?>> SET_COMPARATOR = (o1, o2) -> o1.equals(o2) ? 0 : 1;
-  private static final String[] SET_FIELDS = new String[] {"metricsConfig.metricsCategories"};
 
   @Test
   public void shouldReadFromConfigurationFile() {
@@ -55,10 +53,6 @@ public class MetricsOptionsTest extends AbstractBeaconNodeCommandTest {
         getTekuConfigurationFromArguments("--metrics-categories", category.toString());
     final MetricsConfig config = tekuConfiguration.metricsConfig();
     assertThat(config.getMetricsCategories()).isEqualTo(Set.of(category));
-    assertThat(createConfigBuilder().metrics(b -> b.metricsCategories(Set.of(category))).build())
-        .usingRecursiveComparison()
-        .withComparatorForFields(SET_COMPARATOR, SET_FIELDS)
-        .isEqualTo(tekuConfiguration);
   }
 
   @ParameterizedTest(name = "{0}")
@@ -68,10 +62,6 @@ public class MetricsOptionsTest extends AbstractBeaconNodeCommandTest {
         getTekuConfigurationFromArguments("--metrics-categories", category.toString());
     final MetricsConfig config = tekuConfiguration.metricsConfig();
     assertThat(config.getMetricsCategories()).isEqualTo(Set.of(category));
-    assertThat(createConfigBuilder().metrics(b -> b.metricsCategories(Set.of(category))).build())
-        .usingRecursiveComparison()
-        .withComparatorForFields(SET_COMPARATOR, SET_FIELDS)
-        .isEqualTo(tekuConfiguration);
   }
 
   @Test
@@ -81,13 +71,6 @@ public class MetricsOptionsTest extends AbstractBeaconNodeCommandTest {
             "--metrics-categories", "LIBP2P,NETWORK,EVENTBUS,PROCESS");
     final MetricsConfig config = tekuConfiguration.metricsConfig();
     assertThat(config.getMetricsCategories()).isEqualTo(Set.of(LIBP2P, NETWORK, EVENTBUS, PROCESS));
-    assertThat(
-            createConfigBuilder()
-                .metrics(b -> b.metricsCategories(Set.of(LIBP2P, NETWORK, EVENTBUS, PROCESS)))
-                .build())
-        .usingRecursiveComparison()
-        .withComparatorForFields(SET_COMPARATOR, SET_FIELDS)
-        .isEqualTo(tekuConfiguration);
   }
 
   @Test
@@ -103,9 +86,6 @@ public class MetricsOptionsTest extends AbstractBeaconNodeCommandTest {
     TekuConfiguration tekuConfiguration = getTekuConfigurationFromArguments("--metrics-enabled");
     final MetricsConfig config = tekuConfiguration.metricsConfig();
     assertThat(config.isMetricsEnabled()).isTrue();
-    assertThat(createConfigBuilder().metrics(b -> b.metricsEnabled(true)).build())
-        .usingRecursiveComparison()
-        .isEqualTo(tekuConfiguration);
   }
 
   @Test
@@ -114,9 +94,6 @@ public class MetricsOptionsTest extends AbstractBeaconNodeCommandTest {
         getTekuConfigurationFromArguments("--metrics-host-allowlist");
     final MetricsConfig config = tekuConfiguration.metricsConfig();
     assertThat(config.getMetricsHostAllowlist()).isEmpty();
-    assertThat(createConfigBuilder().metrics(b -> b.metricsHostAllowlist(List.of())).build())
-        .usingRecursiveComparison()
-        .isEqualTo(tekuConfiguration);
   }
 
   @Test
@@ -125,12 +102,6 @@ public class MetricsOptionsTest extends AbstractBeaconNodeCommandTest {
         getTekuConfigurationFromArguments("--metrics-host-allowlist", "my.host,their.host");
     final MetricsConfig config = tekuConfiguration.metricsConfig();
     assertThat(config.getMetricsHostAllowlist()).containsOnly("my.host", "their.host");
-    assertThat(
-            createConfigBuilder()
-                .metrics(b -> b.metricsHostAllowlist(List.of("my.host", "their.host")))
-                .build())
-        .usingRecursiveComparison()
-        .isEqualTo(tekuConfiguration);
   }
 
   @Test
@@ -139,9 +110,6 @@ public class MetricsOptionsTest extends AbstractBeaconNodeCommandTest {
         getTekuConfigurationFromArguments("--metrics-host-allowlist", "*");
     final MetricsConfig config = tekuConfiguration.metricsConfig();
     assertThat(config.getMetricsHostAllowlist()).containsOnly("*");
-    assertThat(createConfigBuilder().metrics(b -> b.metricsHostAllowlist(List.of("*"))).build())
-        .usingRecursiveComparison()
-        .isEqualTo(tekuConfiguration);
   }
 
   @Test

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/MetricsOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/MetricsOptionsTest.java
@@ -20,8 +20,6 @@ import static tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory.EVENTB
 import static tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory.LIBP2P;
 import static tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory.NETWORK;
 
-import java.util.Comparator;
-import java.util.List;
 import java.util.Set;
 import org.hyperledger.besu.metrics.StandardMetricCategory;
 import org.hyperledger.besu.plugin.services.metrics.MetricCategory;

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/P2POptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/P2POptionsTest.java
@@ -17,8 +17,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
-import java.util.Optional;
-import java.util.OptionalInt;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.beacon.sync.SyncConfig;
 import tech.pegasys.teku.cli.AbstractBeaconNodeCommandTest;
@@ -68,9 +66,6 @@ public class P2POptionsTest extends AbstractBeaconNodeCommandTest {
     final TekuConfiguration config = getTekuConfigurationFromArguments("--p2p-enabled");
     assertThat(config.network().isEnabled()).isTrue();
     assertThat(config.sync().isSyncEnabled()).isTrue();
-    assertThat(createConfigBuilder().network(b -> b.isEnabled(true)).build())
-        .usingRecursiveComparison()
-        .isEqualTo(config);
   }
 
   @Test
@@ -78,9 +73,6 @@ public class P2POptionsTest extends AbstractBeaconNodeCommandTest {
     final TekuConfiguration config = getTekuConfigurationFromArguments("--p2p-enabled=false");
     assertThat(config.network().isEnabled()).isFalse();
     assertThat(config.sync().isSyncEnabled()).isFalse();
-    assertThat(createConfigBuilder().network(b -> b.isEnabled(false)).build())
-        .usingRecursiveComparison()
-        .isEqualTo(config);
   }
 
   @Test
@@ -89,9 +81,6 @@ public class P2POptionsTest extends AbstractBeaconNodeCommandTest {
         getTekuConfigurationFromArguments("--p2p-discovery-enabled");
     final DiscoveryConfig config = tekuConfiguration.discovery();
     assertThat(config.isDiscoveryEnabled()).isTrue();
-    assertThat(createConfigBuilder().discovery(b -> b.isDiscoveryEnabled(true)).build())
-        .usingRecursiveComparison()
-        .isEqualTo(tekuConfiguration);
   }
 
   @Test
@@ -107,9 +96,6 @@ public class P2POptionsTest extends AbstractBeaconNodeCommandTest {
     assertThat(tekuConfig.discovery().getListenUdpPort())
         .isEqualTo(tekuConfig.network().getListenPort());
     assertThat(tekuConfig.discovery().getListenUdpPort()).isEqualTo(9999);
-    assertThat(createConfigBuilder().network(b -> b.listenPort(9999)).build())
-        .usingRecursiveComparison()
-        .isEqualTo(tekuConfig);
   }
 
   @Test
@@ -118,13 +104,6 @@ public class P2POptionsTest extends AbstractBeaconNodeCommandTest {
         getTekuConfigurationFromArguments("--p2p-udp-port=9888", "--p2p-port=9999");
     assertThat(tekuConfig.discovery().getListenUdpPort()).isEqualTo(9888);
     assertThat(tekuConfig.network().getListenPort()).isEqualTo(9999);
-    assertThat(
-            createConfigBuilder()
-                .network(b -> b.listenPort(9999))
-                .discovery(b -> b.listenUdpPort(9888))
-                .build())
-        .usingRecursiveComparison()
-        .isEqualTo(tekuConfig);
   }
 
   @Test
@@ -139,9 +118,6 @@ public class P2POptionsTest extends AbstractBeaconNodeCommandTest {
     TekuConfiguration tekuConfiguration =
         getTekuConfigurationFromArguments("--p2p-advertised-ip", ip);
     assertThat(tekuConfiguration.network().getAdvertisedIp()).contains(ip);
-    assertThat(createConfigBuilder().network(b -> b.advertisedIp(Optional.of(ip))).build())
-        .usingRecursiveComparison()
-        .isEqualTo(tekuConfiguration);
   }
 
   @Test
@@ -154,9 +130,6 @@ public class P2POptionsTest extends AbstractBeaconNodeCommandTest {
     TekuConfiguration tekuConfiguration =
         getTekuConfigurationFromArguments("--p2p-advertised-port", "8056");
     assertThat(tekuConfiguration.network().getAdvertisedPort()).isEqualTo(8056);
-    assertThat(createConfigBuilder().network(b -> b.advertisedPort(OptionalInt.of(8056))).build())
-        .usingRecursiveComparison()
-        .isEqualTo(tekuConfiguration);
   }
 
   @Test
@@ -172,9 +145,6 @@ public class P2POptionsTest extends AbstractBeaconNodeCommandTest {
     assertThat(tekuConfiguration.discovery().getAdvertisedUdpPort()).isEqualTo(8000);
     assertThat(tekuConfiguration.discovery().getAdvertisedUdpPort())
         .isEqualTo(tekuConfiguration.network().getAdvertisedPort());
-    assertThat(createConfigBuilder().network(b -> b.listenPort(8000)).build())
-        .usingRecursiveComparison()
-        .isEqualTo(tekuConfiguration);
   }
 
   @Test
@@ -184,13 +154,6 @@ public class P2POptionsTest extends AbstractBeaconNodeCommandTest {
     assertThat(tekuConfig.discovery().getAdvertisedUdpPort()).isEqualTo(7000);
     assertThat(tekuConfig.discovery().getAdvertisedUdpPort())
         .isEqualTo(tekuConfig.network().getAdvertisedPort());
-    assertThat(
-            createConfigBuilder()
-                .network(b -> b.advertisedPort(OptionalInt.of(7000)))
-                .network(b -> b.listenPort(8000))
-                .build())
-        .usingRecursiveComparison()
-        .isEqualTo(tekuConfig);
   }
 
   @Test
@@ -201,14 +164,6 @@ public class P2POptionsTest extends AbstractBeaconNodeCommandTest {
     assertThat(tekuConfig.discovery().getAdvertisedUdpPort()).isEqualTo(6000);
     assertThat(tekuConfig.network().getAdvertisedPort()).isEqualTo(7000);
     assertThat(tekuConfig.network().getListenPort()).isEqualTo(8000);
-    assertThat(
-            createConfigBuilder()
-                .discovery(b -> b.advertisedUdpPort(OptionalInt.of(6000)))
-                .network(b -> b.listenPort(8000))
-                .network(b -> b.advertisedPort(OptionalInt.of(7000)))
-                .build())
-        .usingRecursiveComparison()
-        .isEqualTo(tekuConfig);
   }
 
   @Test
@@ -218,9 +173,6 @@ public class P2POptionsTest extends AbstractBeaconNodeCommandTest {
             "--p2p-peer-lower-bound", "100",
             "--p2p-peer-upper-bound", "110");
     assertThat(tekuConfiguration.discovery().getMinRandomlySelectedPeers()).isEqualTo(20);
-    assertThat(createConfigBuilder().discovery(b -> b.minPeers(100).maxPeers(110)).build())
-        .usingRecursiveComparison()
-        .isEqualTo(tekuConfiguration);
   }
 
   @Test
@@ -233,9 +185,6 @@ public class P2POptionsTest extends AbstractBeaconNodeCommandTest {
             ((FilePrivateKeySource) tekuConfiguration.network().getPrivateKeySource().get())
                 .getFileName())
         .isEqualTo("/some/file");
-    assertThat(createConfigBuilder().network(b -> b.privateKeyFile("/some/file")).build())
-        .usingRecursiveComparison()
-        .isEqualTo(tekuConfiguration);
   }
 
   @Test
@@ -255,12 +204,6 @@ public class P2POptionsTest extends AbstractBeaconNodeCommandTest {
             "--p2p-peer-upper-bound", "110",
             "--Xp2p-minimum-randomly-selected-peer-count", "40");
     assertThat(tekuConfiguration.discovery().getMinRandomlySelectedPeers()).isEqualTo(40);
-    assertThat(
-            createConfigBuilder()
-                .discovery(b -> b.minPeers(100).maxPeers(110).minRandomlySelectedPeers(40))
-                .build())
-        .usingRecursiveComparison()
-        .isEqualTo(tekuConfiguration);
   }
 
   @Test
@@ -270,9 +213,6 @@ public class P2POptionsTest extends AbstractBeaconNodeCommandTest {
             "--p2p-peer-lower-bound", "0",
             "--p2p-peer-upper-bound", "0");
     assertThat(tekuConfiguration.discovery().getMinRandomlySelectedPeers()).isEqualTo(0);
-    assertThat(createConfigBuilder().discovery(b -> b.minPeers(0).maxPeers(0)).build())
-        .usingRecursiveComparison()
-        .isEqualTo(tekuConfiguration);
   }
 
   @Test
@@ -280,9 +220,6 @@ public class P2POptionsTest extends AbstractBeaconNodeCommandTest {
     TekuConfiguration tekuConfiguration =
         getTekuConfigurationFromArguments("--Xp2p-historical-sync-batch-size", "10");
     assertThat(tekuConfiguration.sync().getHistoricalSyncBatchSize()).isEqualTo(10);
-    assertThat(createConfigBuilder().sync(s -> s.historicalSyncBatchSize(10)).build())
-        .usingRecursiveComparison()
-        .isEqualTo(tekuConfiguration);
   }
 
   @Test
@@ -290,9 +227,6 @@ public class P2POptionsTest extends AbstractBeaconNodeCommandTest {
     TekuConfiguration tekuConfiguration =
         getTekuConfigurationFromArguments("--Xp2p-sync-batch-size", "10");
     assertThat(tekuConfiguration.sync().getForwardSyncBatchSize()).isEqualTo(10);
-    assertThat(createConfigBuilder().sync(s -> s.forwardSyncBatchSize(10)).build())
-        .usingRecursiveComparison()
-        .isEqualTo(tekuConfiguration);
   }
 
   @Test
@@ -300,9 +234,6 @@ public class P2POptionsTest extends AbstractBeaconNodeCommandTest {
     TekuConfiguration tekuConfiguration =
         getTekuConfigurationFromArguments("--Xp2p-sync-max-pending-batches", "10");
     assertThat(tekuConfiguration.sync().getForwardSyncMaxPendingBatches()).isEqualTo(10);
-    assertThat(createConfigBuilder().sync(s -> s.forwardSyncMaxPendingBatches(10)).build())
-        .usingRecursiveComparison()
-        .isEqualTo(tekuConfiguration);
   }
 
   @Test
@@ -310,9 +241,6 @@ public class P2POptionsTest extends AbstractBeaconNodeCommandTest {
     TekuConfiguration tekuConfiguration =
         getTekuConfigurationFromArguments("--Xp2p-sync-rate-limit", "10");
     assertThat(tekuConfiguration.sync().getForwardSyncMaxBlocksPerMinute()).isEqualTo(10);
-    assertThat(createConfigBuilder().sync(s -> s.forwardSyncMaxBlocksPerMinute(10)).build())
-        .usingRecursiveComparison()
-        .isEqualTo(tekuConfiguration);
   }
 
   @Test

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/ReflectionBasedBeaconRestApiOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/ReflectionBasedBeaconRestApiOptionsTest.java
@@ -25,7 +25,6 @@ import tech.pegasys.teku.cli.AbstractBeaconNodeCommandTest;
 import tech.pegasys.teku.config.TekuConfiguration;
 
 public class ReflectionBasedBeaconRestApiOptionsTest extends AbstractBeaconNodeCommandTest {
-  //TODO-lucas fix
 
   private BeaconRestApiConfig getConfig(final TekuConfiguration tekuConfiguration) {
     return tekuConfiguration.beaconChain().beaconRestApiConfig();

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/ReflectionBasedBeaconRestApiOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/ReflectionBasedBeaconRestApiOptionsTest.java
@@ -15,9 +15,6 @@ package tech.pegasys.teku.cli.options;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -28,6 +25,7 @@ import tech.pegasys.teku.cli.AbstractBeaconNodeCommandTest;
 import tech.pegasys.teku.config.TekuConfiguration;
 
 public class ReflectionBasedBeaconRestApiOptionsTest extends AbstractBeaconNodeCommandTest {
+  //TODO-lucas fix
 
   private BeaconRestApiConfig getConfig(final TekuConfiguration tekuConfiguration) {
     return tekuConfiguration.beaconChain().beaconRestApiConfig();
@@ -55,9 +53,6 @@ public class ReflectionBasedBeaconRestApiOptionsTest extends AbstractBeaconNodeC
         getTekuConfigurationFromArguments("--rest-api-docs-enabled");
     final BeaconRestApiConfig config = getConfig(tekuConfiguration);
     assertThat(config.isRestApiDocsEnabled()).isTrue();
-    assertThat(createConfigBuilder().restApi(b -> b.restApiDocsEnabled(true)).build())
-        .usingRecursiveComparison()
-        .isEqualTo(tekuConfiguration);
   }
 
   @Test
@@ -65,9 +60,6 @@ public class ReflectionBasedBeaconRestApiOptionsTest extends AbstractBeaconNodeC
     TekuConfiguration tekuConfiguration = getTekuConfigurationFromArguments("--rest-api-enabled");
     final BeaconRestApiConfig config = getConfig(tekuConfiguration);
     assertThat(config.isRestApiEnabled()).isTrue();
-    assertThat(createConfigBuilder().restApi(b -> b.restApiEnabled(true)).build())
-        .usingRecursiveComparison()
-        .isEqualTo(tekuConfiguration);
   }
 
   @ParameterizedTest
@@ -78,13 +70,6 @@ public class ReflectionBasedBeaconRestApiOptionsTest extends AbstractBeaconNodeC
     final BeaconRestApiConfig config = getConfig(tekuConfiguration);
     assertThat(config.isRestApiEnabled()).isEqualTo(expectedRestApiEnabled);
     assertThat(config.getRestApiPort()).isEqualTo(expectedRestApiPort);
-    assertThat(
-            createConfigBuilder()
-                .restApi(
-                    b -> b.restApiEnabled(expectedRestApiEnabled).restApiPort(expectedRestApiPort))
-                .build())
-        .usingRecursiveComparison()
-        .isEqualTo(tekuConfiguration);
   }
 
   public static Stream<Arguments> getRestApiOptionParams() {
@@ -103,9 +88,6 @@ public class ReflectionBasedBeaconRestApiOptionsTest extends AbstractBeaconNodeC
         getTekuConfigurationFromArguments("--Xrest-api-light-client-enabled");
     final BeaconRestApiConfig config = getConfig(tekuConfiguration);
     assertThat(config.isRestApiLightClientEnabled()).isTrue();
-    assertThat(createConfigBuilder().restApi(b -> b.restApiLightClientEnabled(true)).build())
-        .usingRecursiveComparison()
-        .isEqualTo(tekuConfiguration);
   }
 
   @Test
@@ -114,12 +96,6 @@ public class ReflectionBasedBeaconRestApiOptionsTest extends AbstractBeaconNodeC
         getTekuConfigurationFromArguments("--rest-api-host-allowlist");
     final BeaconRestApiConfig config = getConfig(tekuConfiguration);
     assertThat(config.getRestApiHostAllowlist()).isEmpty();
-    assertThat(
-            createConfigBuilder()
-                .restApi(b -> b.restApiHostAllowlist(Collections.emptyList()))
-                .build())
-        .usingRecursiveComparison()
-        .isEqualTo(tekuConfiguration);
   }
 
   @Test
@@ -128,12 +104,6 @@ public class ReflectionBasedBeaconRestApiOptionsTest extends AbstractBeaconNodeC
         getTekuConfigurationFromArguments("--rest-api-host-allowlist", "my.host,their.host");
     final BeaconRestApiConfig config = getConfig(tekuConfiguration);
     assertThat(config.getRestApiHostAllowlist()).containsOnly("my.host", "their.host");
-    assertThat(
-            createConfigBuilder()
-                .restApi(b -> b.restApiHostAllowlist(List.of("my.host", "their.host")))
-                .build())
-        .usingRecursiveComparison()
-        .isEqualTo(tekuConfiguration);
   }
 
   @Test
@@ -142,9 +112,6 @@ public class ReflectionBasedBeaconRestApiOptionsTest extends AbstractBeaconNodeC
         getTekuConfigurationFromArguments("--rest-api-host-allowlist", "*");
     final BeaconRestApiConfig config = getConfig(tekuConfiguration);
     assertThat(config.getRestApiHostAllowlist()).containsOnly("*");
-    assertThat(createConfigBuilder().restApi(b -> b.restApiHostAllowlist(List.of("*"))).build())
-        .usingRecursiveComparison()
-        .isEqualTo(tekuConfiguration);
   }
 
   @Test
@@ -152,9 +119,6 @@ public class ReflectionBasedBeaconRestApiOptionsTest extends AbstractBeaconNodeC
     TekuConfiguration tekuConfiguration = getTekuConfigurationFromArguments();
     final BeaconRestApiConfig config = getConfig(tekuConfiguration);
     assertThat(config.getRestApiHostAllowlist()).containsOnly("localhost", "127.0.0.1");
-    assertThat(createConfigBuilder().build())
-        .usingRecursiveComparison()
-        .isEqualTo(tekuConfiguration);
   }
 
   @Test
@@ -163,12 +127,6 @@ public class ReflectionBasedBeaconRestApiOptionsTest extends AbstractBeaconNodeC
         getTekuConfigurationFromArguments("--rest-api-cors-origins");
     final BeaconRestApiConfig config = getConfig(tekuConfiguration);
     assertThat(config.getRestApiCorsAllowedOrigins()).isEmpty();
-    assertThat(
-            createConfigBuilder()
-                .restApi(b -> b.restApiCorsAllowedOrigins(Collections.emptyList()))
-                .build())
-        .usingRecursiveComparison()
-        .isEqualTo(tekuConfiguration);
   }
 
   @Test
@@ -177,12 +135,6 @@ public class ReflectionBasedBeaconRestApiOptionsTest extends AbstractBeaconNodeC
         getTekuConfigurationFromArguments("--rest-api-cors-origins", "my.host,their.host");
     final BeaconRestApiConfig config = getConfig(tekuConfiguration);
     assertThat(config.getRestApiCorsAllowedOrigins()).containsOnly("my.host", "their.host");
-    assertThat(
-            createConfigBuilder()
-                .restApi(b -> b.restApiCorsAllowedOrigins(List.of("my.host", "their.host")))
-                .build())
-        .usingRecursiveComparison()
-        .isEqualTo(tekuConfiguration);
   }
 
   @Test
@@ -191,10 +143,6 @@ public class ReflectionBasedBeaconRestApiOptionsTest extends AbstractBeaconNodeC
         getTekuConfigurationFromArguments("--rest-api-cors-origins", "*");
     final BeaconRestApiConfig config = getConfig(tekuConfiguration);
     assertThat(config.getRestApiCorsAllowedOrigins()).containsOnly("*");
-    assertThat(
-            createConfigBuilder().restApi(b -> b.restApiCorsAllowedOrigins(List.of("*"))).build())
-        .usingRecursiveComparison()
-        .isEqualTo(tekuConfiguration);
   }
 
   @Test
@@ -203,9 +151,6 @@ public class ReflectionBasedBeaconRestApiOptionsTest extends AbstractBeaconNodeC
         getTekuConfigurationFromArguments("--Xrest-api-max-url-length", "4096");
     final BeaconRestApiConfig config = getConfig(tekuConfiguration);
     assertThat(config.getMaxUrlLength()).isEqualTo(4096);
-    assertThat(createConfigBuilder().restApi(b -> b.maxUrlLength(4096)).build())
-        .usingRecursiveComparison()
-        .isEqualTo(tekuConfiguration);
   }
 
   @Test
@@ -214,9 +159,6 @@ public class ReflectionBasedBeaconRestApiOptionsTest extends AbstractBeaconNodeC
         getTekuConfigurationFromArguments("--Xrest-api-max-url-length", "1052672");
     final BeaconRestApiConfig config = getConfig(tekuConfiguration);
     assertThat(config.getMaxUrlLength()).isEqualTo(1052672);
-    assertThat(createConfigBuilder().restApi(b -> b.maxUrlLength(1052672)).build())
-        .usingRecursiveComparison()
-        .isEqualTo(tekuConfiguration);
   }
 
   @Test
@@ -256,8 +198,5 @@ public class ReflectionBasedBeaconRestApiOptionsTest extends AbstractBeaconNodeC
         getTekuConfigurationFromArguments("--Xrest-api-validator-threads=15");
     final int validatorThreads = getConfig(tekuConfiguration).getValidatorThreads();
     assertThat(validatorThreads).isEqualTo(15);
-    assertThat(createConfigBuilder().restApi(b -> b.validatorThreads(Optional.of(15))).build())
-        .usingRecursiveComparison()
-        .isEqualTo(tekuConfiguration);
   }
 }

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/StoreOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/StoreOptionsTest.java
@@ -30,10 +30,6 @@ public class StoreOptionsTest extends AbstractBeaconNodeCommandTest {
     TekuConfiguration tekuConfiguration = getTekuConfigurationFromArguments(args);
     final StoreConfig globalConfiguration = tekuConfiguration.beaconChain().storeConfig();
     assertThat(globalConfiguration.getHotStatePersistenceFrequencyInEpochs()).isEqualTo(99);
-
-    assertThat(createConfigBuilder().store(b -> b.hotStatePersistenceFrequencyInEpochs(99)).build())
-        .usingRecursiveComparison()
-        .isEqualTo(tekuConfiguration);
   }
 
   @Test

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/WeakSubjectivityOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/WeakSubjectivityOptionsTest.java
@@ -56,8 +56,10 @@ public class WeakSubjectivityOptionsTest extends AbstractBeaconNodeCommandTest {
         getResultingTekuConfiguration().weakSubjectivity().getWeakSubjectivityCheckpoint().get();
 
     assertThat(checkpoint.getEpoch()).isEqualTo(UInt64.valueOf(24187));
-    assertThat(checkpoint.getRoot()).isEqualTo(Bytes32.fromHexString(
-        "0x2a6b2528908d5a9ed729417740f54e7267141fd8dca1ec052fc05aa8806e56e3"));
+    assertThat(checkpoint.getRoot())
+        .isEqualTo(
+            Bytes32.fromHexString(
+                "0x2a6b2528908d5a9ed729417740f54e7267141fd8dca1ec052fc05aa8806e56e3"));
   }
 
   @Test

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/WeakSubjectivityOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/WeakSubjectivityOptionsTest.java
@@ -37,13 +37,6 @@ public class WeakSubjectivityOptionsTest extends AbstractBeaconNodeCommandTest {
     final TekuConfiguration config =
         getTekuConfigurationFromArguments("--ws-checkpoint", checkpointParam);
     assertThat(config.weakSubjectivity().getWeakSubjectivityCheckpoint()).contains(checkpoint);
-
-    assertThat(
-            createConfigBuilder()
-                .weakSubjectivity(b -> b.weakSubjectivityCheckpoint(checkpoint))
-                .build())
-        .usingRecursiveComparison()
-        .isEqualTo(config);
   }
 
   @Test
@@ -63,19 +56,8 @@ public class WeakSubjectivityOptionsTest extends AbstractBeaconNodeCommandTest {
         getResultingTekuConfiguration().weakSubjectivity().getWeakSubjectivityCheckpoint().get();
 
     assertThat(checkpoint.getEpoch()).isEqualTo(UInt64.valueOf(24187));
-
-    assertThat(
-            createConfigBuilder()
-                .weakSubjectivity(
-                    b ->
-                        b.weakSubjectivityCheckpoint(
-                            new Checkpoint(
-                                UInt64.valueOf(24187),
-                                Bytes32.fromHexString(
-                                    "0x2a6b2528908d5a9ed729417740f54e7267141fd8dca1ec052fc05aa8806e56e3"))))
-                .build())
-        .usingRecursiveComparison()
-        .isEqualTo(config);
+    assertThat(checkpoint.getRoot()).isEqualTo(Bytes32.fromHexString(
+        "0x2a6b2528908d5a9ed729417740f54e7267141fd8dca1ec052fc05aa8806e56e3"));
   }
 
   @Test
@@ -100,12 +82,6 @@ public class WeakSubjectivityOptionsTest extends AbstractBeaconNodeCommandTest {
         getTekuConfigurationFromArguments("--Xws-suppress-errors-until-epoch", "123");
     assertThat(config.weakSubjectivity().getSuppressWSPeriodChecksUntilEpoch())
         .contains(UInt64.valueOf(123));
-    assertThat(
-            createConfigBuilder()
-                .weakSubjectivity(b -> b.suppressWSPeriodChecksUntilEpoch(UInt64.valueOf(123)))
-                .build())
-        .usingRecursiveComparison()
-        .isEqualTo(config);
   }
 
   @Test


### PR DESCRIPTION
- **Removing recursive comparison from DepositOptionsTest**
- **Removing recursive comparison from P2POptionsTest**
- **Removing recursive comparison from StoreOptionsTest**
- **Removing recursive comparison from ExecutionLayerOptionsTest**
- **Removing recursive comparison from MetricsOptionsTest**
- **Removing recursive comparison from WeakSubjectivityOptionsTest**
- **Removing recursive comparison from InteropOptionsTest**
- **Removing recursive comparison from ReflectionBasedBeaconRestApiOptionsTest**
- **Removing recursive comparison from Eth2NetworkOptionsTest**
- **Removing recursive comparison from LoggingOptionsTest**
- **Removing recursive comparison from WeakSubjectivityInitializerTest**
