### PR TITLE
unhide shut-down-when-validator-slashed-enabled option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,5 +12,6 @@ the [releases page](https://github.com/Consensys/teku/releases).
 ### Breaking Changes
 
 ### Additions and Improvements
+- Introduced [Validator Slashing Prevention feature](https://docs.teku.consensys.io/how-to/prevent-slashing/detect-slashing).
 
 ### Bug Fixes

--- a/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/validatorslashing/ValidatorSlashingDetectionAcceptanceTest.java
+++ b/acceptance-tests/src/acceptance-test/java/tech/pegasys/teku/test/acceptance/validatorslashing/ValidatorSlashingDetectionAcceptanceTest.java
@@ -45,7 +45,8 @@ public class ValidatorSlashingDetectionAcceptanceTest extends AcceptanceTestBase
   final SystemTimeProvider timeProvider = new SystemTimeProvider();
   final String network = "swift";
   final String slashingActionLog =
-      "Validator(s) with public key(s) %s got slashed. Shutting down...";
+      "Validator slashing detection is enabled and validator(s) with public key(s) %s detected as slashed. "
+          + "Shutting down...";
   final int shutdownWaitingSeconds = 60;
 
   enum SlashingEventType {

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNodeConfigBuilder.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNodeConfigBuilder.java
@@ -411,8 +411,8 @@ public class TekuNodeConfigBuilder {
   }
 
   public TekuNodeConfigBuilder withStopVcWhenValidatorSlashedEnabled() {
-    LOG.debug("Xshut-down-when-validator-slashed-enabled={}", true);
-    configMap.put("Xshut-down-when-validator-slashed-enabled", true);
+    LOG.debug("shut-down-when-validator-slashed-enabled={}", true);
+    configMap.put("shut-down-when-validator-slashed-enabled", true);
     return this;
   }
 

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
@@ -251,7 +251,8 @@ public class StatusLogger {
 
   public void validatorSlashedAlert(final Set<String> slashedValidatorPublicKeys) {
     log.fatal(
-        "Validator(s) with public key(s) {} got slashed. Shutting down...",
+        "Validator slashing detection is enabled and validator(s) with public key(s) {} detected as slashed. "
+            + "Shutting down...",
         String.join(", ", slashedValidatorPublicKeys));
   }
 

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
@@ -154,7 +154,7 @@ public class ValidatorOptions {
       DEFAULT_VALIDATOR_IS_LOCAL_SLASHING_PROTECTION_SYNCHRONIZED_ENABLED;
 
   @Option(
-      names = {"--Xshut-down-when-validator-slashed-enabled"},
+      names = {"--shut-down-when-validator-slashed-enabled"},
       paramLabel = "<BOOLEAN>",
       description =
           "If an owned validator key is detected as slashed, the node should terminate with exit code 2. In this case, the service should not be restarted.",

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
@@ -160,7 +160,6 @@ public class ValidatorOptions {
           "If an owned validator key is detected as slashed, the node should terminate with exit code 2. In this case, the service should not be restarted.",
       showDefaultValue = CommandLine.Help.Visibility.ALWAYS,
       arity = "0..1",
-      hidden = true,
       fallbackValue = "true")
   private boolean shutdownWhenValidatorSlashed = DEFAULT_SHUTDOWN_WHEN_VALIDATOR_SLASHED_ENABLED;
 

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
@@ -157,7 +157,7 @@ public class ValidatorOptions {
       names = {"--shut-down-when-validator-slashed-enabled"},
       paramLabel = "<BOOLEAN>",
       description =
-          "If an owned validator key is detected as slashed, the node should terminate with exit code 2. In this case, the service should not be restarted.",
+          "If enabled and an owned validator key is detected as slashed, the node will terminate. In this case, the service should not be restarted.",
       showDefaultValue = CommandLine.Help.Visibility.ALWAYS,
       arity = "0..1",
       fallbackValue = "true")

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/ValidatorOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/ValidatorOptionsTest.java
@@ -229,7 +229,7 @@ public class ValidatorOptionsTest extends AbstractBeaconNodeCommandTest {
   @Test
   public void shouldSetShutdownWhenValidatorSlashedEnabled() {
     final ValidatorConfig config =
-        getTekuConfigurationFromArguments("--Xshut-down-when-validator-slashed-enabled=true")
+        getTekuConfigurationFromArguments("--shut-down-when-validator-slashed-enabled=true")
             .validatorClient()
             .getValidatorConfig();
     assertThat(config.isShutdownWhenValidatorSlashedEnabled()).isTrue();


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Unhide the `shut-down-when-validator-slashed-enabled` option.
The validator slashing detection feature has been tested on goerli. The slashed validators were detected successfully in few seconds and Teku shut down as expected in both scenarios:
1. Single process VC/BN, the whole Teku node shut down
2. Separate VC and BN, the VC running the slashed validator shut down as expected

A [documentation PR](https://github.com/Consensys/doc.teku/pull/526) is open and will be merged once this PR has been merged.
The link to the new documentation section in the changelog will be working once the new documentation is released (the current link is pointing to the latest version)

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
fixes #7707 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
