### PR TITLE
Updating Linux images for executors in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ executors:
 
   machine_executor_amd64:
     machine:
-      image: ubuntu-2204:2023.07.2 # https://circleci.com/developer/machine/image/ubuntu-2204
+      image: ubuntu-2204:2024.01.1 # https://circleci.com/developer/machine/image/ubuntu-2204
       docker_layer_caching: true
     working_directory: ~/project
     environment:
@@ -70,7 +70,7 @@ executors:
 
   machine_executor_arm64:
     machine:
-      image: ubuntu-2204:2023.07.2 # https://circleci.com/developer/machine/image/ubuntu-2204
+      image: ubuntu-2204:2024.01.1 # https://circleci.com/developer/machine/image/ubuntu-2204
     resource_class: arm.medium
     environment:
       architecture: "arm64"


### PR DESCRIPTION
## PR Description

The images we were using have been deprecated. I have updated them to a newer version.
