### PR TITLE
[EIP-6110] Add config as per spec

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigElectra.java
@@ -19,6 +19,8 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 public interface SpecConfigElectra extends SpecConfigDeneb {
 
+  UInt64 UNSET_DEPOSIT_RECEIPTS_START_INDEX = UInt64.MAX_VALUE;
+
   static SpecConfigElectra required(final SpecConfig specConfig) {
     return specConfig
         .toVersionElectra()
@@ -32,6 +34,8 @@ public interface SpecConfigElectra extends SpecConfigDeneb {
   Bytes4 getElectraForkVersion();
 
   UInt64 getElectraForkEpoch();
+
+  int getMaxDepositReceiptsPerPayload();
 
   @Override
   Optional<SpecConfigElectra> toVersionElectra();

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigElectraImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigElectraImpl.java
@@ -23,13 +23,17 @@ public class SpecConfigElectraImpl extends DelegatingSpecConfigDeneb implements 
   private final Bytes4 electraForkVersion;
   private final UInt64 electraForkEpoch;
 
+  private final int maxDepositReceiptsPerPayload;
+
   public SpecConfigElectraImpl(
       final SpecConfigDeneb specConfig,
       final Bytes4 electraForkVersion,
-      final UInt64 electraForkEpoch) {
+      final UInt64 electraForkEpoch,
+      final int maxDepositReceiptsPerPayload) {
     super(specConfig);
     this.electraForkVersion = electraForkVersion;
     this.electraForkEpoch = electraForkEpoch;
+    this.maxDepositReceiptsPerPayload = maxDepositReceiptsPerPayload;
   }
 
   @Override
@@ -40,6 +44,11 @@ public class SpecConfigElectraImpl extends DelegatingSpecConfigDeneb implements 
   @Override
   public UInt64 getElectraForkEpoch() {
     return electraForkEpoch;
+  }
+
+  @Override
+  public int getMaxDepositReceiptsPerPayload() {
+    return maxDepositReceiptsPerPayload;
   }
 
   @Override
@@ -58,11 +67,13 @@ public class SpecConfigElectraImpl extends DelegatingSpecConfigDeneb implements 
     final SpecConfigElectraImpl that = (SpecConfigElectraImpl) o;
     return Objects.equals(specConfig, that.specConfig)
         && Objects.equals(electraForkVersion, that.electraForkVersion)
-        && Objects.equals(electraForkEpoch, that.electraForkEpoch);
+        && Objects.equals(electraForkEpoch, that.electraForkEpoch)
+        && maxDepositReceiptsPerPayload == that.maxDepositReceiptsPerPayload;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(specConfig, electraForkVersion, electraForkEpoch);
+    return Objects.hash(
+        specConfig, electraForkVersion, electraForkEpoch, maxDepositReceiptsPerPayload);
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigLoader.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/SpecConfigLoader.java
@@ -32,7 +32,7 @@ import tech.pegasys.teku.spec.networks.Eth2Presets;
 public class SpecConfigLoader {
   private static final Logger LOG = LogManager.getLogger();
   private static final List<String> AVAILABLE_PRESETS =
-      List.of("phase0", "altair", "bellatrix", "capella", "deneb");
+      List.of("phase0", "altair", "bellatrix", "capella", "deneb", "electra");
   private static final String CONFIG_PATH = "configs/";
   private static final String PRESET_PATH = "presets/";
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/builder/ElectraBuilder.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/builder/ElectraBuilder.java
@@ -31,11 +31,14 @@ public class ElectraBuilder implements ForkConfigBuilder<SpecConfigDeneb, SpecCo
   private Bytes4 electraForkVersion;
   private UInt64 electraForkEpoch;
 
+  private Integer maxDepositReceiptsPerPayload;
+
   ElectraBuilder() {}
 
   @Override
   public SpecConfigElectra build(final SpecConfigDeneb specConfig) {
-    return new SpecConfigElectraImpl(specConfig, electraForkVersion, electraForkEpoch);
+    return new SpecConfigElectraImpl(
+        specConfig, electraForkVersion, electraForkEpoch, maxDepositReceiptsPerPayload);
   }
 
   public ElectraBuilder electraForkEpoch(final UInt64 electraForkEpoch) {
@@ -47,6 +50,12 @@ public class ElectraBuilder implements ForkConfigBuilder<SpecConfigDeneb, SpecCo
   public ElectraBuilder electraForkVersion(final Bytes4 electraForkVersion) {
     checkNotNull(electraForkVersion);
     this.electraForkVersion = electraForkVersion;
+    return this;
+  }
+
+  public ElectraBuilder maxDepositReceiptsPerPayload(final Integer maxDepositReceiptsPerPayload) {
+    checkNotNull(maxDepositReceiptsPerPayload);
+    this.maxDepositReceiptsPerPayload = maxDepositReceiptsPerPayload;
     return this;
   }
 
@@ -71,6 +80,7 @@ public class ElectraBuilder implements ForkConfigBuilder<SpecConfigDeneb, SpecCo
 
     constants.put("electraForkEpoch", electraForkEpoch);
     constants.put("electraForkVersion", electraForkVersion);
+    constants.put("maxDepositReceiptsPerPayload", maxDepositReceiptsPerPayload);
 
     return constants;
   }

--- a/ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/electra.yaml
+++ b/ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/mainnet/electra.yaml
@@ -1,1 +1,6 @@
 # Mainnet preset - Electra
+
+# Execution
+# ---------------------------------------------------------------
+# 2**13 (= 8192) receipts
+MAX_DEPOSIT_RECEIPTS_PER_PAYLOAD: 8192

--- a/ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/minimal/electra.yaml
+++ b/ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/minimal/electra.yaml
@@ -1,1 +1,6 @@
 # Minimal preset - Electra
+
+# Execution
+# ---------------------------------------------------------------
+# [customized]
+MAX_DEPOSIT_RECEIPTS_PER_PAYLOAD: 4

--- a/ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/swift/electra.yaml
+++ b/ethereum/spec/src/main/resources/tech/pegasys/teku/spec/config/presets/swift/electra.yaml
@@ -1,1 +1,6 @@
 # Minimal preset - Electra
+
+# Execution
+# ---------------------------------------------------------------
+# [customized]
+MAX_DEPOSIT_RECEIPTS_PER_PAYLOAD: 4

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/config/SpecConfigAssertions.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/config/SpecConfigAssertions.java
@@ -23,10 +23,6 @@ import java.util.stream.Collectors;
 
 public class SpecConfigAssertions {
 
-  static void assertAllPhase0FieldsSet(final SpecConfig config) throws Exception {
-    assertAllFieldsSet(config, SpecConfigPhase0.class);
-  }
-
   static void assertAllAltairFieldsSet(final SpecConfig config) throws Exception {
     assertAllFieldsSet(config, SpecConfigAltair.class);
   }

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/config/SpecConfigBuilderTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/config/SpecConfigBuilderTest.java
@@ -32,6 +32,7 @@ import tech.pegasys.teku.spec.config.builder.AltairBuilder;
 import tech.pegasys.teku.spec.config.builder.BellatrixBuilder;
 import tech.pegasys.teku.spec.config.builder.CapellaBuilder;
 import tech.pegasys.teku.spec.config.builder.DenebBuilder;
+import tech.pegasys.teku.spec.config.builder.ElectraBuilder;
 import tech.pegasys.teku.spec.config.builder.SpecConfigBuilder;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
@@ -45,7 +46,8 @@ class SpecConfigBuilderTest {
           AltairBuilder.class,
           BellatrixBuilder.class,
           CapellaBuilder.class,
-          DenebBuilder.class);
+          DenebBuilder.class,
+          ElectraBuilder.class);
 
   /**
    * Ensures Builders have actually non-primitive setters, because primitive setters are silently

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/config/SpecConfigElectraTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/config/SpecConfigElectraTest.java
@@ -25,9 +25,9 @@ public class SpecConfigElectraTest {
 
   @Test
   public void equals_mainnet() {
-    SpecConfigElectra configA =
+    final SpecConfigElectra configA =
         SpecConfigLoader.loadConfig("mainnet").toVersionElectra().orElseThrow();
-    SpecConfigElectra configB =
+    final SpecConfigElectra configB =
         SpecConfigLoader.loadConfig("mainnet").toVersionElectra().orElseThrow();
 
     assertThat(configA).isEqualTo(configB);
@@ -36,10 +36,10 @@ public class SpecConfigElectraTest {
 
   @Test
   public void equals_sameRandomValues() {
-    SpecConfigDeneb specConfigDeneb =
+    final SpecConfigDeneb specConfigDeneb =
         SpecConfigLoader.loadConfig("mainnet").toVersionDeneb().orElseThrow();
-    SpecConfigElectra configA = createRandomElectraConfig(specConfigDeneb, 1);
-    SpecConfigElectra configB = createRandomElectraConfig(specConfigDeneb, 1);
+    final SpecConfigElectra configA = createRandomElectraConfig(specConfigDeneb, 1);
+    final SpecConfigElectra configB = createRandomElectraConfig(specConfigDeneb, 1);
 
     assertThat(configA).isEqualTo(configB);
     assertThat(configA.hashCode()).isEqualTo(configB.hashCode());
@@ -47,10 +47,10 @@ public class SpecConfigElectraTest {
 
   @Test
   public void equals_differentRandomValues() {
-    SpecConfigDeneb specConfigDeneb =
+    final SpecConfigDeneb specConfigDeneb =
         SpecConfigLoader.loadConfig("mainnet").toVersionDeneb().orElseThrow();
-    SpecConfigElectra configA = createRandomElectraConfig(specConfigDeneb, 1);
-    SpecConfigElectra configB = createRandomElectraConfig(specConfigDeneb, 2);
+    final SpecConfigElectra configA = createRandomElectraConfig(specConfigDeneb, 1);
+    final SpecConfigElectra configB = createRandomElectraConfig(specConfigDeneb, 2);
 
     assertThat(configA).isNotEqualTo(configB);
     assertThat(configA.hashCode()).isNotEqualTo(configB.hashCode());
@@ -58,16 +58,17 @@ public class SpecConfigElectraTest {
 
   @Test
   public void equals_denebConfigDiffer() {
-    SpecConfigDeneb denebA = SpecConfigLoader.loadConfig("mainnet").toVersionDeneb().orElseThrow();
-    SpecConfigDeneb denebB =
+    final SpecConfigDeneb denebA =
+        SpecConfigLoader.loadConfig("mainnet").toVersionDeneb().orElseThrow();
+    final SpecConfigDeneb denebB =
         SpecConfigLoader.loadConfig(
                 "mainnet",
                 b -> b.denebBuilder(db -> db.maxBlobsPerBlock(denebA.getMaxBlobsPerBlock() + 4)))
             .toVersionDeneb()
             .orElseThrow();
 
-    SpecConfigElectra configA = createRandomElectraConfig(denebA, 1);
-    SpecConfigElectra configB = createRandomElectraConfig(denebB, 1);
+    final SpecConfigElectra configA = createRandomElectraConfig(denebA, 1);
+    final SpecConfigElectra configB = createRandomElectraConfig(denebB, 1);
 
     assertThat(configA).isNotEqualTo(configB);
     assertThat(configA.hashCode()).isNotEqualTo(configB.hashCode());

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/config/SpecConfigElectraTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/config/SpecConfigElectraTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Consensys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class SpecConfigElectraTest {
+  private final Spec spec = TestSpecFactory.createMinimalDeneb();
+
+  @Test
+  public void equals_mainnet() {
+    SpecConfigElectra configA =
+        SpecConfigLoader.loadConfig("mainnet").toVersionElectra().orElseThrow();
+    SpecConfigElectra configB =
+        SpecConfigLoader.loadConfig("mainnet").toVersionElectra().orElseThrow();
+
+    assertThat(configA).isEqualTo(configB);
+    assertThat(configA.hashCode()).isEqualTo(configB.hashCode());
+  }
+
+  @Test
+  public void equals_sameRandomValues() {
+    SpecConfigDeneb specConfigDeneb =
+        SpecConfigLoader.loadConfig("mainnet").toVersionDeneb().orElseThrow();
+    SpecConfigElectra configA = createRandomElectraConfig(specConfigDeneb, 1);
+    SpecConfigElectra configB = createRandomElectraConfig(specConfigDeneb, 1);
+
+    assertThat(configA).isEqualTo(configB);
+    assertThat(configA.hashCode()).isEqualTo(configB.hashCode());
+  }
+
+  @Test
+  public void equals_differentRandomValues() {
+    SpecConfigDeneb specConfigDeneb =
+        SpecConfigLoader.loadConfig("mainnet").toVersionDeneb().orElseThrow();
+    SpecConfigElectra configA = createRandomElectraConfig(specConfigDeneb, 1);
+    SpecConfigElectra configB = createRandomElectraConfig(specConfigDeneb, 2);
+
+    assertThat(configA).isNotEqualTo(configB);
+    assertThat(configA.hashCode()).isNotEqualTo(configB.hashCode());
+  }
+
+  @Test
+  public void equals_denebConfigDiffer() {
+    SpecConfigDeneb denebA = SpecConfigLoader.loadConfig("mainnet").toVersionDeneb().orElseThrow();
+    SpecConfigDeneb denebB =
+        SpecConfigLoader.loadConfig(
+                "mainnet",
+                b -> b.denebBuilder(db -> db.maxBlobsPerBlock(denebA.getMaxBlobsPerBlock() + 4)))
+            .toVersionDeneb()
+            .orElseThrow();
+
+    SpecConfigElectra configA = createRandomElectraConfig(denebA, 1);
+    SpecConfigElectra configB = createRandomElectraConfig(denebB, 1);
+
+    assertThat(configA).isNotEqualTo(configB);
+    assertThat(configA.hashCode()).isNotEqualTo(configB.hashCode());
+  }
+
+  private SpecConfigElectra createRandomElectraConfig(
+      final SpecConfigDeneb denebConfig, final int seed) {
+    final DataStructureUtil dataStructureUtil = new DataStructureUtil(seed, spec);
+
+    return new SpecConfigElectraImpl(
+        denebConfig,
+        dataStructureUtil.randomBytes4(),
+        dataStructureUtil.randomUInt64(),
+        dataStructureUtil.randomPositiveInt()) {};
+  }
+}

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/config/SpecConfigLoaderTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/config/SpecConfigLoaderTest.java
@@ -27,28 +27,23 @@ import java.io.OutputStream;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import tech.pegasys.teku.spec.networks.Eth2Network;
 
 public class SpecConfigLoaderTest {
 
   @ParameterizedTest(name = "{0}")
-  @MethodSource("knownNetworks")
-  public void shouldLoadAllKnownNetworks(final String name, final Class<?> configType)
-      throws Exception {
-    final SpecConfig config = SpecConfigLoader.loadConfigStrict(name);
-    assertAllFieldsSet(config, configType);
+  @EnumSource(Eth2Network.class)
+  public void shouldLoadAllKnownNetworks(final Eth2Network network) throws Exception {
+    final SpecConfig config = SpecConfigLoader.loadConfigStrict(network.configName());
+    // testing latest SpecConfig ensures all fields will be asserted on
+    assertAllFieldsSet(config, SpecConfigElectra.class);
   }
 
   /**
@@ -141,24 +136,6 @@ public class SpecConfigLoaderTest {
     final SpecConfig config = SpecConfigLoader.loadConfig(configUrl.toString(), false, __ -> {});
     assertThat(config).isNotNull();
     assertThat(config.getMaxCommitteesPerSlot()).isEqualTo(12); // Mainnet preset is 64.
-  }
-
-  @Test
-  public void shouldTestAllKnownNetworks() {
-    final List<String> testedNetworks =
-        knownNetworks().map(args -> (String) args.get()[0]).sorted().collect(Collectors.toList());
-    final List<String> allKnownNetworks =
-        Arrays.stream(Eth2Network.values())
-            .map(Eth2Network::configName)
-            .sorted()
-            .collect(Collectors.toList());
-
-    assertThat(testedNetworks).isEqualTo(allKnownNetworks);
-  }
-
-  static Stream<Arguments> knownNetworks() {
-    return Stream.of(Eth2Network.values())
-        .map(network -> Arguments.of(network.configName(), SpecConfigBellatrix.class));
   }
 
   private void writeStreamToFile(final InputStream inputStream, final Path filePath)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

- Added Constants and Preset as per https://github.com/ethereum/consensus-specs/blob/dev/specs/_features/eip6110/beacon-chain.md
- Fixed issue where the preset was not picked up (changed `SpecConfigLoader` )
- Added missing test which existed for previous forks
- Refactored a bit `SpecConfigLoaderTest`. Also made it use `SpecConfigElectra`, so that all fields are tested

## Fixed Issue(s)
solves one of the tasks in #7898 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
