### PR TITLE
Make Validator loading error logs more visible

### DIFF
--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
@@ -110,6 +110,14 @@ public class StatusLogger {
             Color.RED));
   }
 
+  public void validatorLoadError(final String causeMessage) {
+    log.error("Error was encountered during validator client service start up. {}", causeMessage);
+  }
+
+  public void warnNoValidatorsLoaded() {
+    log.warn("Loaded 0 validators from provided key sources.");
+  }
+
   public void fatalError(final String description, final Throwable cause) {
     log.fatal("Exiting due to fatal error in {}", description, cause);
   }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
@@ -275,7 +275,6 @@ public class ValidatorClientService extends Service {
                   ExceptionUtil.getCause(error, InvalidConfigurationException.class);
               if (maybeCause.isPresent()) {
                 STATUS_LOG.validatorLoadError(maybeCause.get().getMessage());
-                LOG.error(maybeCause.get());
               } else {
                 STATUS_LOG.validatorLoadError(error.getMessage());
                 LOG.error(error);

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
@@ -274,11 +274,17 @@ public class ValidatorClientService extends Service {
               final Optional<Throwable> maybeCause =
                   ExceptionUtil.getCause(error, InvalidConfigurationException.class);
               if (maybeCause.isPresent()) {
-                LOG.warn(maybeCause.get().getMessage());
+                STATUS_LOG.validatorLoadError(maybeCause.get().getMessage());
+                LOG.error(maybeCause.get());
               } else {
-                LOG.error("Error was encountered during validator client service start up.", error);
+                STATUS_LOG.validatorLoadError(error.getMessage());
+                LOG.error(error);
               }
               checkNoKeysLoaded(validatorConfig, validatorLoader);
+              if (validatorLoader.hasValidatorSources()
+                  && validatorLoader.getOwnedValidators().hasNoValidators()) {
+                STATUS_LOG.warnNoValidatorsLoaded();
+              }
               return null;
             })
         .always(() -> LOG.trace("Finished starting validator client service."));

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/ValidatorLoader.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/loader/ValidatorLoader.java
@@ -213,6 +213,10 @@ public class ValidatorLoader {
     return ownedValidators;
   }
 
+  public boolean hasValidatorSources() {
+    return !validatorSources.isEmpty();
+  }
+
   public static ValidatorLoader create(
       final Spec spec,
       final ValidatorConfig config,

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/MultithreadedValidatorLoaderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/loader/MultithreadedValidatorLoaderTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.client.loader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.signatures.Signer;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.validator.api.GraffitiProvider;
+import tech.pegasys.teku.validator.client.loader.ValidatorSource.ValidatorProvider;
+
+public class MultithreadedValidatorLoaderTest {
+  private final Spec spec = TestSpecFactory.createMinimalPhase0();
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+  private final BLSPublicKey key1 = dataStructureUtil.randomPublicKey();
+  private final BLSPublicKey key2 = dataStructureUtil.randomPublicKey();
+  private final BLSPublicKey key3 = dataStructureUtil.randomPublicKey();
+  private final GraffitiProvider graffitiProvider = Optional::empty;
+  private final Signer signer1 = mock(Signer.class);
+  private final Signer signer2 = mock(Signer.class);
+  private final Signer signer3 = mock(Signer.class);
+  private final ValidatorProvider validatorProvider1 = mock(ValidatorProvider.class);
+  private final ValidatorProvider validatorProvider2 = mock(ValidatorProvider.class);
+  private final ValidatorProvider validatorProvider3 = mock(ValidatorProvider.class);
+  private final Map<BLSPublicKey, ValidatorProvider> sources =
+      Map.of(key1, validatorProvider1, key2, validatorProvider2, key3, validatorProvider3);
+  private OwnedValidators ownedValidators;
+
+  @BeforeEach
+  public void setup() {
+    this.ownedValidators = new OwnedValidators();
+    when(validatorProvider1.getPublicKey()).thenReturn(key1);
+    when(validatorProvider1.createSigner()).thenReturn(signer1);
+    when(validatorProvider2.getPublicKey()).thenReturn(key2);
+    when(validatorProvider2.createSigner()).thenReturn(signer2);
+    when(validatorProvider3.getPublicKey()).thenReturn(key3);
+    when(validatorProvider3.createSigner()).thenReturn(signer3);
+  }
+
+  @Test
+  public void shouldLoadValidators() {
+    MultithreadedValidatorLoader.loadValidators(ownedValidators, sources, graffitiProvider);
+    assertThat(ownedValidators.getPublicKeys()).contains(key1, key2, key3);
+  }
+
+  @Test
+  public void shouldThrowIfValidatorIsNotLoaded() {
+    when(validatorProvider3.createSigner()).thenThrow(new RuntimeException("123"));
+    assertThatThrownBy(
+            () ->
+                MultithreadedValidatorLoader.loadValidators(
+                    ownedValidators, sources, graffitiProvider))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage("123");
+    assertThat(ownedValidators.getPublicKeys()).isEmpty();
+  }
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

Current behavior:
- errors during validator loading doesn't come to the console
- if, say, 64 validators are loaded and error happens on №32, no validators are loaded at all (with no message to console)
- application is not shutdown without flag "exit-when-no-validator-keys-enabled"

This change addresses visibility of errors during validators loading

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
