### PR TITLE
DVT integration for attestation aggregation

### DIFF
--- a/ethereum/json-types/src/main/java/tech/pegasys/teku/ethereum/json/types/validator/BeaconCommitteeSelectionProof.java
+++ b/ethereum/json-types/src/main/java/tech/pegasys/teku/ethereum/json/types/validator/BeaconCommitteeSelectionProof.java
@@ -14,6 +14,8 @@
 package tech.pegasys.teku.ethereum.json.types.validator;
 
 import java.util.Objects;
+import org.apache.tuweni.bytes.Bytes;
+import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.json.types.CoreTypes;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -65,6 +67,10 @@ public class BeaconCommitteeSelectionProof {
 
   public String getSelectionProof() {
     return selectionProof;
+  }
+
+  public BLSSignature getSelectionProofSignature() {
+    return BLSSignature.fromBytesCompressed(Bytes.fromHexString(getSelectionProof()));
   }
 
   public static BeaconCommitteeSelectionProof.Builder builder() {

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorClientOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorClientOptions.java
@@ -80,6 +80,7 @@ public class ValidatorClientOptions {
       description =
           "Use DVT endpoints to determine if a distributed validator has aggregation duties.",
       arity = "0..1",
+      showDefaultValue = CommandLine.Help.Visibility.ALWAYS,
       hidden = true,
       fallbackValue = "true")
   private boolean dvtSelectionsEndpointEnabled =

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorClientOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorClientOptions.java
@@ -13,8 +13,6 @@
 
 package tech.pegasys.teku.cli.options;
 
-import static tech.pegasys.teku.validator.api.ValidatorConfig.DEFAULT_VALIDATOR_CLIENT_SSZ_BLOCKS_ENABLED;
-
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
@@ -62,7 +60,8 @@ public class ValidatorClientOptions {
       showDefaultValue = CommandLine.Help.Visibility.ALWAYS,
       arity = "0..1",
       fallbackValue = "true")
-  private boolean validatorClientSszBlocksEnabled = DEFAULT_VALIDATOR_CLIENT_SSZ_BLOCKS_ENABLED;
+  private boolean validatorClientSszBlocksEnabled =
+      ValidatorConfig.DEFAULT_VALIDATOR_CLIENT_SSZ_BLOCKS_ENABLED;
 
   @CommandLine.Option(
       names = {"--Xuse-post-validators-endpoint-enabled"},
@@ -74,6 +73,17 @@ public class ValidatorClientOptions {
       fallbackValue = "true")
   private boolean validatorClientUsePostValidatorsEndpointEnabled =
       ValidatorConfig.DEFAULT_VALIDATOR_CLIENT_USE_POST_VALIDATORS_ENDPOINT_ENABLED;
+
+  @Option(
+      names = {"--Xdvt-integration-enabled"},
+      paramLabel = "<BOOLEAN>",
+      description =
+          "Use DVT endpoints to determine if a distributed validator has aggregation duties.",
+      arity = "0..1",
+      hidden = true,
+      fallbackValue = "true")
+  private boolean dvtSelectionsEndpointEnabled =
+      ValidatorConfig.DEFAULT_DVT_SELECTIONS_ENDPOINT_ENABLED;
 
   public void configure(TekuConfiguration.Builder builder) {
     configureBeaconNodeApiEndpoints();
@@ -87,7 +97,8 @@ public class ValidatorClientOptions {
                     validatorClientUsePostValidatorsEndpointEnabled)
                 .failoversSendSubnetSubscriptionsEnabled(failoversSendSubnetSubscriptionsEnabled)
                 .failoversPublishSignedDutiesEnabled(failoversPublishSignedDutiesEnabled)
-                .sentryNodeConfigurationFile(exclusiveParams.sentryConfigFile));
+                .sentryNodeConfigurationFile(exclusiveParams.sentryConfigFile)
+                .dvtSelectionsEndpointEnabled(dvtSelectionsEndpointEnabled));
   }
 
   private void configureBeaconNodeApiEndpoints() {

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.cli.options;
 
 import static tech.pegasys.teku.networks.Eth2NetworkConfiguration.DEFAULT_VALIDATOR_EXECUTOR_THREADS;
 import static tech.pegasys.teku.validator.api.ValidatorConfig.DEFAULT_DOPPELGANGER_DETECTION_ENABLED;
+import static tech.pegasys.teku.validator.api.ValidatorConfig.DEFAULT_DVT_SELECTIONS_ENDPOINT_ENABLED;
 import static tech.pegasys.teku.validator.api.ValidatorConfig.DEFAULT_SHUTDOWN_WHEN_VALIDATOR_SLASHED_ENABLED;
 import static tech.pegasys.teku.validator.api.ValidatorConfig.DEFAULT_VALIDATOR_IS_LOCAL_SLASHING_PROTECTION_SYNCHRONIZED_ENABLED;
 
@@ -164,6 +165,16 @@ public class ValidatorOptions {
       fallbackValue = "true")
   private boolean shutdownWhenValidatorSlashed = DEFAULT_SHUTDOWN_WHEN_VALIDATOR_SLASHED_ENABLED;
 
+  @Option(
+      names = {"--Xdvt-selections-endpoints-enabled"},
+      paramLabel = "<BOOLEAN>",
+      description =
+          "Use DVT endpoints to determine if a distributed validator has aggregation duties.",
+      arity = "0..1",
+      hidden = true,
+      fallbackValue = "true")
+  private boolean dvtSelectionsEndpointEnabled = DEFAULT_DVT_SELECTIONS_ENDPOINT_ENABLED;
+
   public void configure(TekuConfiguration.Builder builder) {
     builder.validator(
         config ->
@@ -183,7 +194,8 @@ public class ValidatorOptions {
                 .executorThreads(executorThreads)
                 .blockV3enabled(blockV3Enabled)
                 .exitWhenNoValidatorKeysEnabled(exitWhenNoValidatorKeysEnabled)
-                .shutdownWhenValidatorSlashedEnabled(shutdownWhenValidatorSlashed));
+                .shutdownWhenValidatorSlashedEnabled(shutdownWhenValidatorSlashed)
+                .dvtSelectionsEndpointEnabled(dvtSelectionsEndpointEnabled));
     validatorProposerOptions.configure(builder);
     validatorKeysOptions.configure(builder);
   }

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.cli.options;
 
 import static tech.pegasys.teku.networks.Eth2NetworkConfiguration.DEFAULT_VALIDATOR_EXECUTOR_THREADS;
 import static tech.pegasys.teku.validator.api.ValidatorConfig.DEFAULT_DOPPELGANGER_DETECTION_ENABLED;
-import static tech.pegasys.teku.validator.api.ValidatorConfig.DEFAULT_DVT_SELECTIONS_ENDPOINT_ENABLED;
 import static tech.pegasys.teku.validator.api.ValidatorConfig.DEFAULT_SHUTDOWN_WHEN_VALIDATOR_SLASHED_ENABLED;
 import static tech.pegasys.teku.validator.api.ValidatorConfig.DEFAULT_VALIDATOR_IS_LOCAL_SLASHING_PROTECTION_SYNCHRONIZED_ENABLED;
 
@@ -165,16 +164,6 @@ public class ValidatorOptions {
       fallbackValue = "true")
   private boolean shutdownWhenValidatorSlashed = DEFAULT_SHUTDOWN_WHEN_VALIDATOR_SLASHED_ENABLED;
 
-  @Option(
-      names = {"--Xdvt-selections-endpoints-enabled"},
-      paramLabel = "<BOOLEAN>",
-      description =
-          "Use DVT endpoints to determine if a distributed validator has aggregation duties.",
-      arity = "0..1",
-      hidden = true,
-      fallbackValue = "true")
-  private boolean dvtSelectionsEndpointEnabled = DEFAULT_DVT_SELECTIONS_ENDPOINT_ENABLED;
-
   public void configure(TekuConfiguration.Builder builder) {
     builder.validator(
         config ->
@@ -194,8 +183,7 @@ public class ValidatorOptions {
                 .executorThreads(executorThreads)
                 .blockV3enabled(blockV3Enabled)
                 .exitWhenNoValidatorKeysEnabled(exitWhenNoValidatorKeysEnabled)
-                .shutdownWhenValidatorSlashedEnabled(shutdownWhenValidatorSlashed)
-                .dvtSelectionsEndpointEnabled(dvtSelectionsEndpointEnabled));
+                .shutdownWhenValidatorSlashedEnabled(shutdownWhenValidatorSlashed));
     validatorProposerOptions.configure(builder);
     validatorKeysOptions.configure(builder);
   }

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/ValidatorOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/ValidatorOptionsTest.java
@@ -234,4 +234,20 @@ public class ValidatorOptionsTest extends AbstractBeaconNodeCommandTest {
             .getValidatorConfig();
     assertThat(config.isShutdownWhenValidatorSlashedEnabled()).isTrue();
   }
+
+  @Test
+  public void shouldNotUseDvtSelectionsEndpointByDefault() {
+    final String[] args = {};
+    final TekuConfiguration config = getTekuConfigurationFromArguments(args);
+    assertThat(config.validatorClient().getValidatorConfig().isDvtSelectionsEndpointEnabled())
+        .isFalse();
+  }
+
+  @Test
+  public void shouldSetUseDvtSelectionsEndpoint() {
+    final String[] args = {"--Xdvt-selections-endpoints-enabled"};
+    final TekuConfiguration config = getTekuConfigurationFromArguments(args);
+    assertThat(config.validatorClient().getValidatorConfig().isDvtSelectionsEndpointEnabled())
+        .isTrue();
+  }
 }

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/ValidatorOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/ValidatorOptionsTest.java
@@ -242,12 +242,4 @@ public class ValidatorOptionsTest extends AbstractBeaconNodeCommandTest {
     assertThat(config.validatorClient().getValidatorConfig().isDvtSelectionsEndpointEnabled())
         .isFalse();
   }
-
-  @Test
-  public void shouldSetUseDvtSelectionsEndpoint() {
-    final String[] args = {"--Xdvt-selections-endpoints-enabled"};
-    final TekuConfiguration config = getTekuConfigurationFromArguments(args);
-    assertThat(config.validatorClient().getValidatorConfig().isDvtSelectionsEndpointEnabled())
-        .isTrue();
-  }
 }

--- a/teku/src/test/java/tech/pegasys/teku/cli/subcommand/ValidatorClientCommandTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/subcommand/ValidatorClientCommandTest.java
@@ -210,6 +210,23 @@ public class ValidatorClientCommandTest extends AbstractBeaconNodeCommandTest {
             "--Xvalidator-client-executor-threads must be greater than 0 and less than 5000.");
   }
 
+  @Test
+  public void shouldSetUseDvtSelectionsEndpoint() {
+    final String[] args = {"vc", "--network", "minimal", "--Xdvt-integration-enabled"};
+    final TekuConfiguration config = getTekuConfigurationFromArguments(args);
+
+    assertThat(config.validatorClient().getValidatorConfig().isDvtSelectionsEndpointEnabled())
+        .isTrue();
+  }
+
+  @Test
+  public void shouldNotUseDvtSelectionsEndpointByDefault() {
+    final String[] args = {"vc", "--network", "minimal"};
+    final TekuConfiguration config = getTekuConfigurationFromArguments(args);
+    assertThat(config.validatorClient().getValidatorConfig().isDvtSelectionsEndpointEnabled())
+        .isFalse();
+  }
+
   private String pathFor(final String filename) {
     return Resources.getResource(ValidatorClientCommandTest.class, filename).toString();
   }

--- a/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
+++ b/validator/api/src/main/java/tech/pegasys/teku/validator/api/ValidatorConfig.java
@@ -65,6 +65,7 @@ public class ValidatorConfig {
   public static final boolean DEFAULT_VALIDATOR_BLINDED_BLOCKS_ENABLED = false;
   public static final int DEFAULT_VALIDATOR_REGISTRATION_SENDING_BATCH_SIZE = 100;
   public static final UInt64 DEFAULT_BUILDER_REGISTRATION_GAS_LIMIT = UInt64.valueOf(30_000_000);
+  public static final boolean DEFAULT_DVT_SELECTIONS_ENDPOINT_ENABLED = false;
 
   private final List<String> validatorKeys;
   private final List<String> validatorExternalSignerPublicKeySources;
@@ -105,6 +106,7 @@ public class ValidatorConfig {
   private final int executorThreads;
 
   private final boolean isLocalSlashingProtectionSynchronizedModeEnabled;
+  private final boolean dvtSelectionsEndpointEnabled;
 
   private ValidatorConfig(
       final List<String> validatorKeys,
@@ -143,7 +145,8 @@ public class ValidatorConfig {
       final int executorMaxQueueSize,
       final int executorThreads,
       final Optional<String> sentryNodeConfigurationFile,
-      boolean isLocalSlashingProtectionSynchronizedModeEnabled) {
+      boolean isLocalSlashingProtectionSynchronizedModeEnabled,
+      boolean dvtSelectionsEndpointEnabled) {
     this.validatorKeys = validatorKeys;
     this.validatorExternalSignerPublicKeySources = validatorExternalSignerPublicKeySources;
     this.validatorExternalSignerUrl = validatorExternalSignerUrl;
@@ -186,6 +189,7 @@ public class ValidatorConfig {
     this.sentryNodeConfigurationFile = sentryNodeConfigurationFile;
     this.isLocalSlashingProtectionSynchronizedModeEnabled =
         isLocalSlashingProtectionSynchronizedModeEnabled;
+    this.dvtSelectionsEndpointEnabled = dvtSelectionsEndpointEnabled;
   }
 
   public static Builder builder() {
@@ -348,6 +352,10 @@ public class ValidatorConfig {
     return isLocalSlashingProtectionSynchronizedModeEnabled;
   }
 
+  public boolean isDvtSelectionsEndpointEnabled() {
+    return dvtSelectionsEndpointEnabled;
+  }
+
   public static final class Builder {
     private List<String> validatorKeys = new ArrayList<>();
     private List<String> validatorExternalSignerPublicKeySources = new ArrayList<>();
@@ -395,11 +403,10 @@ public class ValidatorConfig {
     private Optional<BLSPublicKey> builderRegistrationPublicKeyOverride = Optional.empty();
     private int executorMaxQueueSize = DEFAULT_EXECUTOR_MAX_QUEUE_SIZE;
     private Optional<String> sentryNodeConfigurationFile = Optional.empty();
-
     private int executorThreads = DEFAULT_VALIDATOR_EXECUTOR_THREADS;
-
     private boolean isLocalSlashingProtectionSynchronizedModeEnabled =
         DEFAULT_VALIDATOR_IS_LOCAL_SLASHING_PROTECTION_SYNCHRONIZED_ENABLED;
+    private boolean dvtSelectionsEndpointEnabled = DEFAULT_DVT_SELECTIONS_ENDPOINT_ENABLED;
 
     private Builder() {}
 
@@ -640,6 +647,11 @@ public class ValidatorConfig {
       return this;
     }
 
+    public Builder dvtSelectionsEndpointEnabled(final boolean dvtSelectionsEndpointEnabled) {
+      this.dvtSelectionsEndpointEnabled = dvtSelectionsEndpointEnabled;
+      return this;
+    }
+
     public ValidatorConfig build() {
       validateExternalSignerUrlAndPublicKeys();
       validateExternalSignerKeystoreAndPasswordFileConfig();
@@ -683,7 +695,8 @@ public class ValidatorConfig {
           executorMaxQueueSize,
           executorThreads,
           sentryNodeConfigurationFile,
-          isLocalSlashingProtectionSynchronizedModeEnabled);
+          isLocalSlashingProtectionSynchronizedModeEnabled,
+          dvtSelectionsEndpointEnabled);
     }
 
     private void validateExternalSignerUrlAndPublicKeys() {

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyLoader.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyLoader.java
@@ -45,6 +45,7 @@ public class AttestationDutyLoader
       scheduledDutiesFactory;
   private final BeaconCommitteeSubscriptions beaconCommitteeSubscriptions;
   private final Spec spec;
+  private final boolean useDvtEndpoint;
 
   public AttestationDutyLoader(
       final ValidatorApiChannel validatorApiChannel,
@@ -54,13 +55,15 @@ public class AttestationDutyLoader
       final OwnedValidators validators,
       final ValidatorIndexProvider validatorIndexProvider,
       final BeaconCommitteeSubscriptions beaconCommitteeSubscriptions,
-      final Spec spec) {
+      final Spec spec,
+      final boolean useDvtEndpoint) {
     super(validators, validatorIndexProvider);
     this.validatorApiChannel = validatorApiChannel;
     this.forkProvider = forkProvider;
     this.scheduledDutiesFactory = scheduledDutiesFactory;
     this.beaconCommitteeSubscriptions = beaconCommitteeSubscriptions;
     this.spec = spec;
+    this.useDvtEndpoint = useDvtEndpoint;
   }
 
   @Override
@@ -77,9 +80,18 @@ public class AttestationDutyLoader
       final UInt64 epoch, final AttesterDuties duties) {
     final SlotBasedScheduledDuties<AttestationProductionDuty, AggregationDuty> scheduledDuties =
         scheduledDutiesFactory.apply(duties.getDependentRoot());
+
+    final Optional<DvtAttestationAggregations> dvtAttestationAggregationsForEpoch =
+        useDvtEndpoint
+            ? Optional.of(
+                new DvtAttestationAggregations(validatorApiChannel, duties.getDuties().size()))
+            : Optional.empty();
+
     return SafeFuture.allOf(
             duties.getDuties().stream()
-                .map(duty -> scheduleDuties(scheduledDuties, duty))
+                .map(
+                    duty ->
+                        scheduleDuties(scheduledDuties, duty, dvtAttestationAggregationsForEpoch))
                 .toArray(SafeFuture[]::new))
         .<SlotBasedScheduledDuties<?, ?>>thenApply(__ -> scheduledDuties)
         .alwaysRun(beaconCommitteeSubscriptions::sendRequests);
@@ -87,7 +99,8 @@ public class AttestationDutyLoader
 
   private SafeFuture<Void> scheduleDuties(
       final SlotBasedScheduledDuties<AttestationProductionDuty, AggregationDuty> scheduledDuties,
-      final AttesterDuty duty) {
+      final AttesterDuty duty,
+      final Optional<DvtAttestationAggregations> dvtAttestationAggregationLoader) {
     final Optional<Validator> maybeValidator = validators.getValidator(duty.getPublicKey());
     if (maybeValidator.isEmpty()) {
       return SafeFuture.COMPLETE;
@@ -116,7 +129,8 @@ public class AttestationDutyLoader
         validator,
         duty.getSlot(),
         aggregatorModulo,
-        unsignedAttestationFuture);
+        unsignedAttestationFuture,
+        dvtAttestationAggregationLoader);
   }
 
   private SafeFuture<Optional<AttestationData>> scheduleAttestationProduction(
@@ -147,10 +161,18 @@ public class AttestationDutyLoader
       final Validator validator,
       final UInt64 slot,
       final int aggregatorModulo,
-      final SafeFuture<Optional<AttestationData>> unsignedAttestationFuture) {
+      final SafeFuture<Optional<AttestationData>> unsignedAttestationFuture,
+      final Optional<DvtAttestationAggregations> dvtAttestationAggregation) {
     return forkProvider
         .getForkInfo(slot)
         .thenCompose(forkInfo -> validator.getSigner().signAggregationSlot(slot, forkInfo))
+        .thenCompose(
+            blsSignature ->
+                dvtAttestationAggregation
+                    .map(
+                        dvt ->
+                            dvt.getCombinedSelectionProofFuture(validatorIndex, slot, blsSignature))
+                    .orElse(SafeFuture.completedFuture(blsSignature)))
         .thenAccept(
             slotSignature -> {
               final SpecVersion specVersion = spec.atSlot(slot);

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyLoader.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyLoader.java
@@ -167,12 +167,12 @@ public class AttestationDutyLoader
         .getForkInfo(slot)
         .thenCompose(forkInfo -> validator.getSigner().signAggregationSlot(slot, forkInfo))
         .thenCompose(
-            blsSignature ->
+            slotSignature ->
                 dvtAttestationAggregation
                     .map(
                         dvt ->
-                            dvt.getCombinedSelectionProofFuture(validatorIndex, slot, blsSignature))
-                    .orElse(SafeFuture.completedFuture(blsSignature)))
+                            dvt.getCombinedSelectionProofFuture(validatorIndex, slot, slotSignature))
+                    .orElse(SafeFuture.completedFuture(slotSignature)))
         .thenAccept(
             slotSignature -> {
               final SpecVersion specVersion = spec.atSlot(slot);

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyLoader.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AttestationDutyLoader.java
@@ -171,7 +171,8 @@ public class AttestationDutyLoader
                 dvtAttestationAggregation
                     .map(
                         dvt ->
-                            dvt.getCombinedSelectionProofFuture(validatorIndex, slot, slotSignature))
+                            dvt.getCombinedSelectionProofFuture(
+                                validatorIndex, slot, slotSignature))
                     .orElse(SafeFuture.completedFuture(slotSignature)))
         .thenAccept(
             slotSignature -> {

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/DvtAttestationAggregations.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/DvtAttestationAggregations.java
@@ -28,6 +28,7 @@ public class DvtAttestationAggregations {
 
   // TODO-lucas add a limit on the number of entries in batch request
 
+  @SuppressWarnings("unused")
   private static final Logger LOG = LogManager.getLogger();
 
   private final ValidatorApiChannel validatorApiChannel;

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/DvtAttestationAggregations.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/DvtAttestationAggregations.java
@@ -28,8 +28,6 @@ import tech.pegasys.teku.validator.api.ValidatorApiChannel;
 
 public class DvtAttestationAggregations {
 
-  // TODO-lucas add a limit on the number of entries in batch request
-
   private static final Logger LOG = LogManager.getLogger();
 
   private final ValidatorApiChannel validatorApiChannel;

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/DvtAttestationAggregations.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/DvtAttestationAggregations.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.client;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.ethereum.json.types.validator.BeaconCommitteeSelectionProof;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.validator.api.ValidatorApiChannel;
+
+public class DvtAttestationAggregations {
+
+  // TODO-lucas add a limit on the number of entries in batch request
+
+  private static final Logger LOG = LogManager.getLogger();
+
+  private final ValidatorApiChannel validatorApiChannel;
+
+  private final Map<BeaconCommitteeSelectionProof, SafeFuture<BLSSignature>> pendingRequests =
+      new ConcurrentHashMap<>();
+
+  private final int expectedCount;
+
+  public DvtAttestationAggregations(
+      final ValidatorApiChannel validatorApiChannel, int expectedDutiesCount) {
+    this.validatorApiChannel = validatorApiChannel;
+    this.expectedCount = expectedDutiesCount;
+  }
+
+  public SafeFuture<BLSSignature> getCombinedSelectionProofFuture(
+      final int validatorIndex, final UInt64 slot, final BLSSignature partialProof) {
+
+    final BeaconCommitteeSelectionProof request =
+        new BeaconCommitteeSelectionProof.Builder()
+            .validatorIndex(validatorIndex)
+            .slot(slot)
+            .selectionProof(partialProof.toBytesCompressed().toHexString())
+            .build();
+
+    final SafeFuture<BLSSignature> future = new SafeFuture<>();
+    pendingRequests.put(request, future);
+
+    if (pendingRequests.size() >= expectedCount) {
+      submitBatchRequests();
+    }
+
+    return future;
+  }
+
+  private void submitBatchRequests() {
+    validatorApiChannel
+        .getBeaconCommitteeSelectionProof(pendingRequests.keySet().stream().toList())
+        .thenAccept(
+            beaconCommitteeSelectionProofs -> {
+              if (beaconCommitteeSelectionProofs.isPresent()) {
+                pendingRequests.forEach(
+                    (request, future) -> {
+                      final Optional<BeaconCommitteeSelectionProof> response =
+                          beaconCommitteeSelectionProofs.get().stream()
+                              .filter(
+                                  p ->
+                                      request.getValidatorIndex() == p.getValidatorIndex()
+                                          && request.getSlot().equals(p.getSlot()))
+                              .findFirst();
+                      response.ifPresentOrElse(
+                          resp -> future.complete(resp.getSelectionProofSignature()),
+                          () -> future.completeExceptionally(new RuntimeException("Error")));
+                    });
+              } else {
+                pendingRequests
+                    .values()
+                    .forEach(future -> future.completeExceptionally(new RuntimeException("Error")));
+              }
+            })
+        .ifExceptionGetsHereRaiseABug();
+  }
+}

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/ValidatorClientService.java
@@ -464,7 +464,8 @@ public class ValidatorClientService extends Service {
                 validators,
                 validatorIndexProvider,
                 beaconCommitteeSubscriptions,
-                spec));
+                spec,
+                config.getValidatorConfig().isDvtSelectionsEndpointEnabled()));
     final DutyLoader<?> blockDutyLoader =
         new RetryingDutyLoader<>(
             asyncRunner,

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutyLoaderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutyLoaderTest.java
@@ -76,7 +76,8 @@ class AttestationDutyLoaderTest {
           new OwnedValidators(validators),
           validatorIndexProvider,
           beaconCommitteeSubscriptions,
-          spec);
+          spec,
+          false);
 
   @BeforeEach
   void setUp() {

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutySchedulerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/AttestationDutySchedulerTest.java
@@ -753,7 +753,8 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
             new OwnedValidators(Map.of(VALIDATOR1_KEY, validator1, VALIDATOR2_KEY, validator2)),
             validatorIndexProvider,
             beaconCommitteeSubscriptions,
-            spec);
+            spec,
+            false);
     dutyScheduler =
         new AttestationDutyScheduler(
             metricsSystem, new RetryingDutyLoader<>(asyncRunner, attestationDutyLoader), spec);
@@ -768,7 +769,8 @@ public class AttestationDutySchedulerTest extends AbstractDutySchedulerTest {
             new OwnedValidators(Map.of(VALIDATOR1_KEY, validator1, VALIDATOR2_KEY, validator2)),
             validatorIndexProvider,
             beaconCommitteeSubscriptions,
-            spec);
+            spec,
+            false);
     dutyScheduler =
         new AttestationDutyScheduler(
             metricsSystem2, new RetryingDutyLoader<>(asyncRunner, attestationDutyLoader), spec);

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/DvtAttestationAggregationsTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/DvtAttestationAggregationsTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.ethereum.json.types.validator.BeaconCommitteeSelectionProof;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.validator.api.ValidatorApiChannel;
+
+class DvtAttestationAggregationsTest {
+
+  private final DataStructureUtil dataStructureUtil =
+      new DataStructureUtil(TestSpecFactory.createDefault());
+  private DvtAttestationAggregations loader;
+  private ValidatorApiChannel validatorApiChannel;
+
+  @BeforeEach
+  public void setUp() {
+    validatorApiChannel = mock(ValidatorApiChannel.class);
+  }
+
+  @Test
+  public void completesAllFuturesWhenMiddlewareReturnsAllCombinedSelectionProofs() {
+    when(validatorApiChannel.getBeaconCommitteeSelectionProof(any()))
+        .thenReturn(
+            SafeFuture.completedFuture(Optional.of(List.of(combinedProof(1), combinedProof(2)))));
+
+    loader = new DvtAttestationAggregations(validatorApiChannel, 2);
+
+    final SafeFuture<BLSSignature> futureSelectionProofValidator1 =
+        loader.getCombinedSelectionProofFuture(1, UInt64.ONE, dataStructureUtil.randomSignature());
+    final SafeFuture<BLSSignature> futureSelectionProofValidator2 =
+        loader.getCombinedSelectionProofFuture(2, UInt64.ONE, dataStructureUtil.randomSignature());
+
+    assertThat(futureSelectionProofValidator1).isCompleted();
+    assertThat(futureSelectionProofValidator2).isCompleted();
+  }
+
+  @Test
+  public void partiallyCompleteFuturesWhenMiddlewareOnlyReturnsSomeCombinedSelectionProofs() {
+    when(validatorApiChannel.getBeaconCommitteeSelectionProof(any()))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(List.of(combinedProof(1)))));
+
+    loader = new DvtAttestationAggregations(validatorApiChannel, 2);
+
+    final SafeFuture<BLSSignature> futureSelectionProofValidator1 =
+        loader.getCombinedSelectionProofFuture(1, UInt64.ONE, dataStructureUtil.randomSignature());
+    final SafeFuture<BLSSignature> futureSelectionProofValidator2 =
+        loader.getCombinedSelectionProofFuture(2, UInt64.ONE, dataStructureUtil.randomSignature());
+
+    assertThat(futureSelectionProofValidator1).isCompleted();
+    assertThat(futureSelectionProofValidator2).isCompletedExceptionally();
+  }
+
+  @Test
+  public void failAllFuturesIfMiddlewareDoesNotReturnAnyValue() {
+    when(validatorApiChannel.getBeaconCommitteeSelectionProof(any()))
+        .thenReturn(SafeFuture.completedFuture(Optional.empty()));
+
+    loader = new DvtAttestationAggregations(validatorApiChannel, 3);
+
+    final SafeFuture<BLSSignature> futureSelectionProofValidator1 =
+        loader.getCombinedSelectionProofFuture(1, UInt64.ONE, dataStructureUtil.randomSignature());
+    final SafeFuture<BLSSignature> futureSelectionProofValidator2 =
+        loader.getCombinedSelectionProofFuture(2, UInt64.ONE, dataStructureUtil.randomSignature());
+    final SafeFuture<BLSSignature> futureSelectionProofValidator3 =
+        loader.getCombinedSelectionProofFuture(3, UInt64.ONE, dataStructureUtil.randomSignature());
+
+    assertThat(futureSelectionProofValidator1).isCompletedExceptionally();
+    assertThat(futureSelectionProofValidator2).isCompletedExceptionally();
+    assertThat(futureSelectionProofValidator3).isCompletedExceptionally();
+  }
+
+  @Test
+  public void handleSameValidatorAggregatingInDifferentSlots() {
+    when(validatorApiChannel.getBeaconCommitteeSelectionProof(any()))
+        .thenReturn(
+            SafeFuture.completedFuture(
+                Optional.of(List.of(combinedProofForSlot(1, 1), combinedProofForSlot(1, 2)))));
+
+    loader = new DvtAttestationAggregations(validatorApiChannel, 2);
+
+    final SafeFuture<BLSSignature> futureSelectionProofValidatorAtSlot1 =
+        loader.getCombinedSelectionProofFuture(1, UInt64.ONE, dataStructureUtil.randomSignature());
+    final SafeFuture<BLSSignature> futureSelectionProofValidatorAtSlot2 =
+        loader.getCombinedSelectionProofFuture(
+            1, UInt64.valueOf(2), dataStructureUtil.randomSignature());
+
+    assertThat(futureSelectionProofValidatorAtSlot1).isCompleted();
+    assertThat(futureSelectionProofValidatorAtSlot2).isCompleted();
+  }
+
+  private BeaconCommitteeSelectionProof combinedProof(final int validatorIndex) {
+    return new BeaconCommitteeSelectionProof.Builder()
+        .validatorIndex(validatorIndex)
+        .slot(UInt64.ONE)
+        .selectionProof(dataStructureUtil.randomSignature().toBytesCompressed().toHexString())
+        .build();
+  }
+
+  private BeaconCommitteeSelectionProof combinedProofForSlot(
+      final int validatorIndex, final int slot) {
+    return new BeaconCommitteeSelectionProof.Builder()
+        .validatorIndex(validatorIndex)
+        .slot(UInt64.valueOf(slot))
+        .selectionProof(dataStructureUtil.randomSignature().toBytesCompressed().toHexString())
+        .build();
+  }
+}

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/DvtAttestationAggregationsTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/DvtAttestationAggregationsTest.java
@@ -16,10 +16,13 @@ package tech.pegasys.teku.validator.client;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.bls.BLSSignature;
@@ -43,7 +46,7 @@ class DvtAttestationAggregationsTest {
   }
 
   @Test
-  public void completesAllFuturesWhenMiddlewareReturnsAllCombinedSelectionProofs() {
+  public void completesAllFuturesWhenMiddlewareReturnsAllSelectionProofs() {
     when(validatorApiChannel.getBeaconCommitteeSelectionProof(any()))
         .thenReturn(
             SafeFuture.completedFuture(Optional.of(List.of(combinedProof(1), combinedProof(2)))));
@@ -60,7 +63,7 @@ class DvtAttestationAggregationsTest {
   }
 
   @Test
-  public void partiallyCompleteFuturesWhenMiddlewareOnlyReturnsSomeCombinedSelectionProofs() {
+  public void partiallyCompleteFuturesWhenMiddlewareOnlyReturnsSomeSelectionProofs() {
     when(validatorApiChannel.getBeaconCommitteeSelectionProof(any()))
         .thenReturn(SafeFuture.completedFuture(Optional.of(List.of(combinedProof(1)))));
 
@@ -85,13 +88,42 @@ class DvtAttestationAggregationsTest {
     final SafeFuture<BLSSignature> futureSelectionProofValidator1 =
         loader.getCombinedSelectionProofFuture(1, UInt64.ONE, dataStructureUtil.randomSignature());
     final SafeFuture<BLSSignature> futureSelectionProofValidator2 =
-        loader.getCombinedSelectionProofFuture(2, UInt64.ONE, dataStructureUtil.randomSignature());
+        loader.getCombinedSelectionProofFuture(
+            2, UInt64.valueOf(2), dataStructureUtil.randomSignature());
     final SafeFuture<BLSSignature> futureSelectionProofValidator3 =
-        loader.getCombinedSelectionProofFuture(3, UInt64.ONE, dataStructureUtil.randomSignature());
+        loader.getCombinedSelectionProofFuture(
+            3, UInt64.valueOf(3), dataStructureUtil.randomSignature());
 
     assertThat(futureSelectionProofValidator1).isCompletedExceptionally();
     assertThat(futureSelectionProofValidator2).isCompletedExceptionally();
     assertThat(futureSelectionProofValidator3).isCompletedExceptionally();
+  }
+
+  @Test
+  public void handleDifferentValidatorAggregatingInSameSlot() {
+    when(validatorApiChannel.getBeaconCommitteeSelectionProof(any()))
+        .thenReturn(
+            SafeFuture.completedFuture(
+                Optional.of(
+                    List.of(
+                        combinedProofForSlot(1, 1),
+                        combinedProofForSlot(2, 1),
+                        combinedProofForSlot(3, 1)))));
+
+    loader = new DvtAttestationAggregations(validatorApiChannel, 3);
+
+    final SafeFuture<BLSSignature> futureSelectionProofValidator1 =
+        loader.getCombinedSelectionProofFuture(1, UInt64.ONE, dataStructureUtil.randomSignature());
+    final SafeFuture<BLSSignature> futureSelectionProofValidator2 =
+        loader.getCombinedSelectionProofFuture(2, UInt64.ONE, dataStructureUtil.randomSignature());
+    final SafeFuture<BLSSignature> futureSelectionProofValidator3 =
+        loader.getCombinedSelectionProofFuture(3, UInt64.ONE, dataStructureUtil.randomSignature());
+
+    assertThat(futureSelectionProofValidator1).isCompleted();
+    assertThat(futureSelectionProofValidator2).isCompleted();
+    assertThat(futureSelectionProofValidator3).isCompleted();
+
+    // TODO-lucas assert response values map to futures
   }
 
   @Test
@@ -111,6 +143,51 @@ class DvtAttestationAggregationsTest {
 
     assertThat(futureSelectionProofValidatorAtSlot1).isCompleted();
     assertThat(futureSelectionProofValidatorAtSlot2).isCompleted();
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void
+      unexpectedErrorHandlingResponseMustCompleteExceptionallyPendingRequestsWithUnderlyingCause() {
+    final List<BeaconCommitteeSelectionProof> mockList = mock(List.class);
+    // Forcing an unexpected error when handling response
+    when(mockList.stream()).thenThrow(new RuntimeException("Unexpected error"));
+    when(validatorApiChannel.getBeaconCommitteeSelectionProof(any()))
+        .thenReturn(SafeFuture.completedFuture(Optional.of(mockList)));
+
+    loader = new DvtAttestationAggregations(validatorApiChannel, 1);
+
+    final SafeFuture<BLSSignature> futureSelectionProofValidator1 =
+        loader.getCombinedSelectionProofFuture(1, UInt64.ONE, dataStructureUtil.randomSignature());
+
+    assertThat(futureSelectionProofValidator1)
+        .isCompletedExceptionally()
+        .failsWithin(1, TimeUnit.SECONDS)
+        .withThrowableOfType(ExecutionException.class)
+        .withCauseInstanceOf(RuntimeException.class)
+        .withMessageContaining("Error getting DVT attestation aggregation complete proof");
+  }
+
+  @Test
+  public void unexpectedErrorHandlingResponseMustCompleteExceptionallyAllNonCompletedRequests() {
+    final BeaconCommitteeSelectionProof proofValidator1 = combinedProofForSlot(1, 1);
+    final BeaconCommitteeSelectionProof proofValidator2 = spy(combinedProofForSlot(2, 1));
+    // Forcing an unexpected error while handling the second proof
+    when(proofValidator2.getValidatorIndex()).thenThrow(new RuntimeException("Unexpected error"));
+    when(validatorApiChannel.getBeaconCommitteeSelectionProof(any()))
+        .thenReturn(
+            SafeFuture.completedFuture(Optional.of(List.of(proofValidator1, proofValidator2))));
+
+    loader = new DvtAttestationAggregations(validatorApiChannel, 1);
+
+    final SafeFuture<BLSSignature> futureProofValidator1 =
+        loader.getCombinedSelectionProofFuture(1, UInt64.ONE, dataStructureUtil.randomSignature());
+    final SafeFuture<BLSSignature> futureProofValidator2 =
+        loader.getCombinedSelectionProofFuture(
+            2, UInt64.valueOf(2), dataStructureUtil.randomSignature());
+
+    assertThat(futureProofValidator1).isCompleted();
+    assertThat(futureProofValidator2).isCompletedExceptionally();
   }
 
   private BeaconCommitteeSelectionProof combinedProof(final int validatorIndex) {

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/DvtAttestationAggregationsTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/DvtAttestationAggregationsTest.java
@@ -16,6 +16,8 @@ package tech.pegasys.teku.validator.client;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
@@ -57,6 +59,8 @@ class DvtAttestationAggregationsTest {
 
     assertThat(futureSelectionProofValidator1).isCompleted();
     assertThat(futureSelectionProofValidator2).isCompleted();
+
+    verify(validatorApiChannel, times(1)).getBeaconCommitteeSelectionProof(any());
   }
 
   @Test

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/DvtAttestationAggregationsTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/DvtAttestationAggregationsTest.java
@@ -16,8 +16,6 @@ package tech.pegasys.teku.validator.client;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
@@ -59,8 +57,6 @@ class DvtAttestationAggregationsTest {
 
     assertThat(futureSelectionProofValidator1).isCompleted();
     assertThat(futureSelectionProofValidator2).isCompleted();
-
-    verify(validatorApiChannel, times(1)).getBeaconCommitteeSelectionProof(any());
   }
 
   @Test


### PR DESCRIPTION
## PR Description
This PR adds a flag `--Xdvt-integration-enabled` to enable DVT integration.

For each attestation duty, we need to use the partial proof for a validator and use the DVT endpoints to retrieve a combined proof, used to check if that validator is an aggregator.

Requests are batched into a single call to `/beacon_committee_selections`.

## Fixed Issue(s)
related to #6851

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
