### PR TITLE
Move fallback log and some renaming

### DIFF
--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionBuilderModule.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionBuilderModule.java
@@ -469,6 +469,9 @@ public class ExecutionBuilderModule {
             return getPayloadFromBuilder(signedBlindedBeaconBlock);
           } else {
             final FallbackData fallbackData = headerWithFallbackData.getFallbackData().get();
+            LOG.debug(
+                "Using FallbackData to provide unblinded execution data (FallbackReason: {})",
+                fallbackData.getReason());
             final BuilderPayload builderPayload =
                 fallbackData
                     .getBlobsBundle()

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionBuilderModule.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionBuilderModule.java
@@ -93,7 +93,7 @@ public class ExecutionBuilderModule {
     this.useShouldOverrideBuilderFlag = useShouldOverrideBuilderFlag;
   }
 
-  private Optional<SafeFuture<HeaderWithFallbackData>> checkIfBuilderGetHeaderIsViable(
+  private Optional<SafeFuture<HeaderWithFallbackData>> isBuilderFlowViable(
       final ExecutionPayloadContext executionPayloadContext,
       final BeaconState state,
       final SafeFuture<GetPayloadResponse> localGetPayloadResponse,
@@ -140,11 +140,11 @@ public class ExecutionBuilderModule {
             .engineGetPayloadForFallback(executionPayloadContext, state.getSlot())
             .thenPeek(__ -> blockProductionPerformance.engineGetPayload());
 
-    final Optional<SafeFuture<HeaderWithFallbackData>> nonViabilityReason =
-        checkIfBuilderGetHeaderIsViable(
+    final Optional<SafeFuture<HeaderWithFallbackData>> maybeFallback =
+        isBuilderFlowViable(
             executionPayloadContext, state, localGetPayloadResponse, payloadValueResult);
-    if (nonViabilityReason.isPresent()) {
-      return nonViabilityReason
+    if (maybeFallback.isPresent()) {
+      return maybeFallback
           .get()
           .thenPeek(
               headerWithFallbackData ->


### PR DESCRIPTION
Main thing is moving logging and recording of fallback when we make the decision (during block creation) and not during unblinding.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
