### PR TITLE
Refactoring sync committee selection proof signing logic into SyncAggregatorSelectionProofProvider

### DIFF
--- a/ethereum/json-types/src/main/java/tech/pegasys/teku/ethereum/json/types/validator/SyncCommitteeSelectionProof.java
+++ b/ethereum/json-types/src/main/java/tech/pegasys/teku/ethereum/json/types/validator/SyncCommitteeSelectionProof.java
@@ -14,6 +14,8 @@
 package tech.pegasys.teku.ethereum.json.types.validator;
 
 import java.util.Objects;
+import org.apache.tuweni.bytes.Bytes;
+import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.json.types.CoreTypes;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -79,6 +81,10 @@ public class SyncCommitteeSelectionProof {
 
   public String getSelectionProof() {
     return selectionProof;
+  }
+
+  public BLSSignature getSelectionProofSignature() {
+    return BLSSignature.fromBytesCompressed(Bytes.fromHexString(getSelectionProof()));
   }
 
   public static SyncCommitteeSelectionProof.Builder builder() {

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncAggregatorSelectionProofProvider.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncAggregatorSelectionProofProvider.java
@@ -55,7 +55,7 @@ public class SyncAggregatorSelectionProofProvider {
               });
         });
 
-    return SafeFuture.completedFuture(null);
+    return SafeFuture.COMPLETE;
   }
 
   protected SafeFuture<BLSSignature> createAndSignSelectionData(

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncAggregatorSelectionProofProvider.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncAggregatorSelectionProofProvider.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.client.duties.synccommittee;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.IntStream;
+import org.apache.commons.lang3.tuple.Pair;
+import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncAggregatorSelectionData;
+import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
+import tech.pegasys.teku.spec.logic.common.util.SyncCommitteeUtil;
+import tech.pegasys.teku.validator.client.Validator;
+
+public class SyncAggregatorSelectionProofProvider {
+
+  protected final Map<Pair<Integer, Integer>, SafeFuture<BLSSignature>> selectionProofFutures =
+      new ConcurrentHashMap<>();
+
+  public SyncAggregatorSelectionProofProvider() {}
+
+  public SafeFuture<Void> prepareSelectionProofForSlot(
+      final UInt64 slot,
+      final Collection<ValidatorAndCommitteeIndices> assignments,
+      final SyncCommitteeUtil syncCommitteeUtil,
+      final ForkInfo forkInfo) {
+    assignments.forEach(
+        assignment -> {
+          final IntStream syncSubCommitteeIndexes =
+              syncCommitteeUtil.getSyncSubcommittees(assignment.getCommitteeIndices()).intStream();
+
+          syncSubCommitteeIndexes.forEach(
+              subcommitteeIndex -> {
+                final SafeFuture<BLSSignature> signedProofFuture =
+                    createAndSignSelectionData(
+                        slot, syncCommitteeUtil, forkInfo, assignment, subcommitteeIndex);
+
+                selectionProofFutures.put(
+                    Pair.of(assignment.getValidatorIndex(), subcommitteeIndex), signedProofFuture);
+              });
+        });
+
+    return SafeFuture.completedFuture(null);
+  }
+
+  protected SafeFuture<BLSSignature> createAndSignSelectionData(
+      final UInt64 slot,
+      final SyncCommitteeUtil syncCommitteeUtil,
+      final ForkInfo forkInfo,
+      final ValidatorAndCommitteeIndices assignment,
+      final int subcommitteeIndex) {
+    final SyncAggregatorSelectionData selectionData =
+        syncCommitteeUtil.createSyncAggregatorSelectionData(
+            slot, UInt64.valueOf(subcommitteeIndex));
+
+    final Validator validator = assignment.getValidator();
+    return validator.getSigner().signSyncCommitteeSelectionProof(selectionData, forkInfo);
+  }
+
+  public Optional<SafeFuture<BLSSignature>> getSelectionProofFuture(
+      int validatorIndex, int subcommitteeIndex) {
+    return Optional.ofNullable(
+        selectionProofFutures.get(Pair.of(validatorIndex, subcommitteeIndex)));
+  }
+}

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeScheduledDuties.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeScheduledDuties.java
@@ -224,7 +224,12 @@ public class SyncCommitteeScheduledDuties implements ScheduledDuties {
               spec, forkProvider, validatorApiChannel, assignments.values());
       final SyncCommitteeAggregationDuty aggregationDuty =
           new SyncCommitteeAggregationDuty(
-              spec, forkProvider, validatorApiChannel, validatorLogger, assignments.values());
+              spec,
+              forkProvider,
+              validatorApiChannel,
+              validatorLogger,
+              assignments.values(),
+              new SyncAggregatorSelectionProofProvider());
       return new SyncCommitteeScheduledDuties(
           productionDuty,
           aggregationDuty,

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncAggregatorSelectionProofProviderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncAggregatorSelectionProofProviderTest.java
@@ -38,6 +38,7 @@ import tech.pegasys.teku.spec.signatures.Signer;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.validator.client.Validator;
 
+@SuppressWarnings("FutureReturnValueIgnored")
 class SyncAggregatorSelectionProofProviderTest {
 
   final Spec spec = TestSpecFactory.createMinimalAltair();
@@ -120,18 +121,18 @@ class SyncAggregatorSelectionProofProviderTest {
   @Test
   public void failedSignatureHandling() {
     // Signature for subcommittee index 0 will fail
-    final SyncAggregatorSelectionData syncAggregatorSelectionData_SubCommitteeZero =
+    final SyncAggregatorSelectionData syncAggregatorSelectionDataSubCommitteeZero =
         syncCommitteeUtil.createSyncAggregatorSelectionData(slot, UInt64.ZERO);
     doReturn(SafeFuture.failedFuture(new RuntimeException("Boom")))
         .when(validator1.getSigner())
-        .signSyncCommitteeSelectionProof(eq(syncAggregatorSelectionData_SubCommitteeZero), any());
+        .signSyncCommitteeSelectionProof(eq(syncAggregatorSelectionDataSubCommitteeZero), any());
 
     // Signature for subcommittee index 1 will succeed
-    final SyncAggregatorSelectionData syncAggregatorSelectionData_SubCommitteeOne =
+    final SyncAggregatorSelectionData syncAggregatorSelectionDataSubCommitteeOne =
         syncCommitteeUtil.createSyncAggregatorSelectionData(slot, UInt64.ONE);
     doReturn(SafeFuture.completedFuture(dataStructureUtil.randomSignature()))
         .when(validator1.getSigner())
-        .signSyncCommitteeSelectionProof(eq(syncAggregatorSelectionData_SubCommitteeOne), any());
+        .signSyncCommitteeSelectionProof(eq(syncAggregatorSelectionDataSubCommitteeOne), any());
 
     final Collection<ValidatorAndCommitteeIndices> assignments =
         List.of(committeeAssignment(validator1, 1, 0, 1));
@@ -172,7 +173,7 @@ class SyncAggregatorSelectionProofProviderTest {
   }
 
   private ValidatorAndCommitteeIndices committeeAssignment(
-      final tech.pegasys.teku.validator.client.Validator validator,
+      final Validator validator,
       final int validatorIndex,
       final int... committeeIndices) {
     final ValidatorAndCommitteeIndices assignment =

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncAggregatorSelectionProofProviderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncAggregatorSelectionProofProviderTest.java
@@ -173,9 +173,7 @@ class SyncAggregatorSelectionProofProviderTest {
   }
 
   private ValidatorAndCommitteeIndices committeeAssignment(
-      final Validator validator,
-      final int validatorIndex,
-      final int... committeeIndices) {
+      final Validator validator, final int validatorIndex, final int... committeeIndices) {
     final ValidatorAndCommitteeIndices assignment =
         new ValidatorAndCommitteeIndices(validator, validatorIndex);
     assignment.addCommitteeIndices(IntList.of(committeeIndices));

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncAggregatorSelectionProofProviderTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncAggregatorSelectionProofProviderTest.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.client.duties.synccommittee;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import it.unimi.dsi.fastutil.ints.IntList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncAggregatorSelectionData;
+import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
+import tech.pegasys.teku.spec.logic.common.util.SyncCommitteeUtil;
+import tech.pegasys.teku.spec.signatures.Signer;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.validator.client.Validator;
+
+class SyncAggregatorSelectionProofProviderTest {
+
+  final Spec spec = TestSpecFactory.createMinimalAltair();
+  final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+  final SyncCommitteeUtil syncCommitteeUtil = spec.getSyncCommitteeUtilRequired(UInt64.ONE);
+  final ForkInfo forkInfo = dataStructureUtil.randomForkInfo();
+  final UInt64 slot = UInt64.ONE;
+  final Validator validator1 =
+      new Validator(dataStructureUtil.randomPublicKey(), mock(Signer.class), Optional::empty);
+  final Validator validator2 =
+      new Validator(dataStructureUtil.randomPublicKey(), mock(Signer.class), Optional::empty);
+  SyncAggregatorSelectionProofProvider syncAggregatorSelectionProofProvider;
+
+  @BeforeEach
+  public void setUp() {
+    syncAggregatorSelectionProofProvider = new SyncAggregatorSelectionProofProvider();
+  }
+
+  @Test
+  public void singleValidatorInSingleSyncSubcommittee() {
+    final BLSSignature expectedSignature =
+        mockValidatorSignerForSyncCommitteeSelectionProofSigning(validator1);
+
+    final Collection<ValidatorAndCommitteeIndices> assignments =
+        List.of(committeeAssignment(validator1, 1, 0));
+
+    syncAggregatorSelectionProofProvider
+        .prepareSelectionProofForSlot(slot, assignments, syncCommitteeUtil, forkInfo)
+        .thenAccept(
+            __ -> {
+              // Expected signature for validator with assignment for subcommittee
+              assertSignedSelectionProofWasCreated(1, 0, expectedSignature);
+              // Empty when querying non-assigned subcommittee index
+              assertThat(syncAggregatorSelectionProofProvider.getSelectionProofFuture(1, 999))
+                  .isEmpty();
+              // Empty when querying validator without duty assignments
+              assertThat(syncAggregatorSelectionProofProvider.getSelectionProofFuture(2, 111))
+                  .isEmpty();
+            });
+  }
+
+  @Test
+  public void singleValidatorInMultipleSyncSubcommittee() {
+    final BLSSignature expectedSignature =
+        mockValidatorSignerForSyncCommitteeSelectionProofSigning(validator1);
+
+    final Collection<ValidatorAndCommitteeIndices> assignments =
+        List.of(committeeAssignment(validator1, 1, 0, 1));
+
+    syncAggregatorSelectionProofProvider
+        .prepareSelectionProofForSlot(slot, assignments, syncCommitteeUtil, forkInfo)
+        .thenAccept(
+            __ -> {
+              assertSignedSelectionProofWasCreated(1, 0, expectedSignature);
+              assertSignedSelectionProofWasCreated(1, 1, expectedSignature);
+            });
+  }
+
+  @Test
+  public void multipleValidatorsInMultipleSyncSubcommittee() {
+    final BLSSignature expectedSignatureValidator1 =
+        mockValidatorSignerForSyncCommitteeSelectionProofSigning(validator1);
+    final BLSSignature expectedSignatureValidator2 =
+        mockValidatorSignerForSyncCommitteeSelectionProofSigning(validator2);
+
+    final Collection<ValidatorAndCommitteeIndices> assignments =
+        List.of(committeeAssignment(validator1, 1, 0, 1), committeeAssignment(validator2, 2, 1, 2));
+
+    syncAggregatorSelectionProofProvider
+        .prepareSelectionProofForSlot(slot, assignments, syncCommitteeUtil, forkInfo)
+        .thenAccept(
+            __ -> {
+              assertSignedSelectionProofWasCreated(1, 0, expectedSignatureValidator1);
+              assertSignedSelectionProofWasCreated(1, 1, expectedSignatureValidator1);
+              assertSignedSelectionProofWasCreated(2, 1, expectedSignatureValidator2);
+              assertSignedSelectionProofWasCreated(2, 2, expectedSignatureValidator2);
+            });
+  }
+
+  @Test
+  public void failedSignatureHandling() {
+    // Signature for subcommittee index 0 will fail
+    final SyncAggregatorSelectionData syncAggregatorSelectionData_SubCommitteeZero =
+        syncCommitteeUtil.createSyncAggregatorSelectionData(slot, UInt64.ZERO);
+    doReturn(SafeFuture.failedFuture(new RuntimeException("Boom")))
+        .when(validator1.getSigner())
+        .signSyncCommitteeSelectionProof(eq(syncAggregatorSelectionData_SubCommitteeZero), any());
+
+    // Signature for subcommittee index 1 will succeed
+    final SyncAggregatorSelectionData syncAggregatorSelectionData_SubCommitteeOne =
+        syncCommitteeUtil.createSyncAggregatorSelectionData(slot, UInt64.ONE);
+    doReturn(SafeFuture.completedFuture(dataStructureUtil.randomSignature()))
+        .when(validator1.getSigner())
+        .signSyncCommitteeSelectionProof(eq(syncAggregatorSelectionData_SubCommitteeOne), any());
+
+    final Collection<ValidatorAndCommitteeIndices> assignments =
+        List.of(committeeAssignment(validator1, 1, 0, 1));
+
+    syncAggregatorSelectionProofProvider
+        .prepareSelectionProofForSlot(slot, assignments, syncCommitteeUtil, forkInfo)
+        .thenAccept(
+            __ -> {
+              // Checking that future for subcommittee index 0 failed
+              final Optional<SafeFuture<BLSSignature>> selectionProofFuture0 =
+                  syncAggregatorSelectionProofProvider.getSelectionProofFuture(1, 0);
+              assertThat(selectionProofFuture0).isPresent();
+              assertThat(selectionProofFuture0.get()).isCompletedExceptionally();
+
+              // Checking that future for subcommittee index 1 succeeded
+              final Optional<SafeFuture<BLSSignature>> selectionProofFuture1 =
+                  syncAggregatorSelectionProofProvider.getSelectionProofFuture(1, 0);
+              assertThat(selectionProofFuture1).isPresent();
+              assertThat(selectionProofFuture1.get()).isCompleted();
+            });
+  }
+
+  private void assertSignedSelectionProofWasCreated(
+      final int validatorIndex, final int subcommitteeIndex, final BLSSignature expectedSignature) {
+    final Optional<SafeFuture<BLSSignature>> selectionProofFuture =
+        syncAggregatorSelectionProofProvider.getSelectionProofFuture(
+            validatorIndex, subcommitteeIndex);
+    assertThat(selectionProofFuture).isPresent();
+    assertThat(selectionProofFuture.get()).isCompletedWithValue(expectedSignature);
+  }
+
+  private BLSSignature mockValidatorSignerForSyncCommitteeSelectionProofSigning(
+      final Validator validator) {
+    final BLSSignature signature = dataStructureUtil.randomSignature();
+    when(validator.getSigner().signSyncCommitteeSelectionProof(any(), any()))
+        .thenReturn(SafeFuture.completedFuture(signature));
+    return signature;
+  }
+
+  private ValidatorAndCommitteeIndices committeeAssignment(
+      final tech.pegasys.teku.validator.client.Validator validator,
+      final int validatorIndex,
+      final int... committeeIndices) {
+    final ValidatorAndCommitteeIndices assignment =
+        new ValidatorAndCommitteeIndices(validator, validatorIndex);
+    assignment.addCommitteeIndices(IntList.of(committeeIndices));
+    return assignment;
+  }
+}


### PR DESCRIPTION
This is a PR laying the work that will enable our Obol DVT integration for sync committee selections.

The core logic is moving the logic of signing selection proofs out of the validator/subcommittee loop and into its own step, with all logic encapsulated on `SyncAggregatorSelectionProofProvider`.

All selection proof signing operations are submitted to the provider, and later on can be queried individually, each one having its own future.

For a peek on how this will be used, check this draft PR: https://github.com/Consensys/teku/pull/8054