### PR TITLE
Use slot-based SchemaDefinitions when creating/singing block for Deneb

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactoryDeneb.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockFactoryDeneb.java
@@ -21,11 +21,11 @@ import tech.pegasys.teku.ethereum.performance.trackers.BlockProductionPerformanc
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
 import tech.pegasys.teku.spec.datastructures.blocks.versions.deneb.BlockContents;
+import tech.pegasys.teku.spec.datastructures.blocks.versions.deneb.BlockContentsSchema;
 import tech.pegasys.teku.spec.datastructures.execution.BlobsBundle;
 import tech.pegasys.teku.spec.datastructures.metadata.BlockContainerAndMetaData;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
@@ -33,13 +33,8 @@ import tech.pegasys.teku.spec.schemas.SchemaDefinitionsDeneb;
 
 public class BlockFactoryDeneb extends BlockFactoryPhase0 {
 
-  private final SchemaDefinitionsDeneb schemaDefinitionsDeneb;
-
   public BlockFactoryDeneb(final Spec spec, final BlockOperationSelectorFactory operationSelector) {
     super(spec, operationSelector);
-    this.schemaDefinitionsDeneb =
-        SchemaDefinitionsDeneb.required(
-            spec.forMilestone(SpecMilestone.DENEB).getSchemaDefinitions());
   }
 
   @Override
@@ -81,8 +76,12 @@ public class BlockFactoryDeneb extends BlockFactoryPhase0 {
 
   private BlockContents createBlockContents(
       final BeaconBlock block, final BlobsBundle blobsBundle) {
-    return schemaDefinitionsDeneb
-        .getBlockContentsSchema()
+    return getBlockContentsSchema(block.getSlot())
         .create(block, blobsBundle.getProofs(), blobsBundle.getBlobs());
+  }
+
+  private BlockContentsSchema getBlockContentsSchema(final UInt64 slot) {
+    return SchemaDefinitionsDeneb.required(spec.atSlot(slot).getSchemaDefinitions())
+        .getBlockContentsSchema();
   }
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/signer/MilestoneBasedBlockContainerSigner.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/signer/MilestoneBasedBlockContainerSigner.java
@@ -23,7 +23,6 @@ import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockContainer;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
-import tech.pegasys.teku.spec.schemas.SchemaDefinitionsDeneb;
 import tech.pegasys.teku.validator.client.Validator;
 
 public class MilestoneBasedBlockContainerSigner implements BlockContainerSigner {
@@ -39,13 +38,7 @@ public class MilestoneBasedBlockContainerSigner implements BlockContainerSigner 
 
     // Not needed for all milestones
     final Supplier<BlockContainerSignerDeneb> blockContainerSignerDeneb =
-        Suppliers.memoize(
-            () -> {
-              final SchemaDefinitionsDeneb schemaDefinitions =
-                  SchemaDefinitionsDeneb.required(
-                      spec.forMilestone(SpecMilestone.DENEB).getSchemaDefinitions());
-              return new BlockContainerSignerDeneb(spec, schemaDefinitions);
-            });
+        Suppliers.memoize(() -> new BlockContainerSignerDeneb(spec));
 
     // Populate forks signers
     spec.getEnabledMilestones()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
We are specifically getting `SchemaDefinitionsDeneb` for milestone DENEB when creating/signing block

```
spec.forMilestone(SpecMilestone.DENEB).getSchemaDefinitions())
```

This breaks if we need to propose a block for later milestones where the block structure has changed. (e.g. Electra)

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
