### PR TITLE
Configuration options to improve testing UX

### DIFF
--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuBeaconNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuBeaconNode.java
@@ -113,9 +113,13 @@ public class TekuBeaconNode extends TekuNode {
     super(network, TEKU_DOCKER_IMAGE_NAME, version, LOG);
     this.config = tekuNodeConfig;
     this.spec = SpecFactory.create(config.getNetworkName(), config.getSpecConfigModifier());
+    if (config.getConfigMap().containsKey("validator-api-enabled")) {
+      container.addExposedPort(VALIDATOR_API_PORT);
+    }
+
+    container.addExposedPorts(METRICS_PORT, REST_API_PORT);
     container
         .withWorkingDirectory(WORKING_DIRECTORY)
-        .withExposedPorts(REST_API_PORT, METRICS_PORT)
         .waitingFor(
             new HttpWaitStrategy()
                 .forPort(REST_API_PORT)

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNode.java
@@ -31,6 +31,7 @@ import org.testcontainers.utility.MountableFile;
 import tech.pegasys.teku.api.response.v1.EventType;
 
 public abstract class TekuNode extends Node {
+  public static final int VALIDATOR_API_PORT = 9052;
   private static final Logger LOG = LogManager.getLogger();
   protected boolean started = false;
 
@@ -145,5 +146,16 @@ public abstract class TekuNode extends Node {
 
   protected URI getRestApiUrl() {
     return URI.create("http://127.0.0.1:" + container.getMappedPort(REST_API_PORT));
+  }
+
+  public URI getValidatorApiUrl() {
+    final boolean isUseSsl =
+        (boolean) getConfig().getConfigMap().getOrDefault("Xvalidator-api-ssl-enabled", true);
+    final String prefix = isUseSsl ? "https" : "http";
+
+    final URI uri =
+        URI.create(prefix + "://127.0.0.1:" + container.getMappedPort(VALIDATOR_API_PORT));
+    LOG.debug("Validator URL: {}", uri);
+    return uri;
   }
 }

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNodeConfigBuilder.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuNodeConfigBuilder.java
@@ -25,9 +25,9 @@ import static tech.pegasys.teku.test.acceptance.dsl.Node.REST_API_PORT;
 import static tech.pegasys.teku.test.acceptance.dsl.Node.SENTRY_NODE_CONFIG_FILE_PATH;
 import static tech.pegasys.teku.test.acceptance.dsl.Node.WORKING_DIRECTORY;
 import static tech.pegasys.teku.test.acceptance.dsl.Node.copyToTmpFile;
+import static tech.pegasys.teku.test.acceptance.dsl.TekuNode.VALIDATOR_API_PORT;
 import static tech.pegasys.teku.test.acceptance.dsl.TekuNodeConfig.DEFAULT_VALIDATOR_COUNT;
 import static tech.pegasys.teku.test.acceptance.dsl.TekuNodeConfig.INITIAL_STATE_FILE;
-import static tech.pegasys.teku.test.acceptance.dsl.TekuValidatorNode.VALIDATOR_API_PORT;
 
 import com.google.common.io.Resources;
 import io.libp2p.core.PeerId;
@@ -297,6 +297,27 @@ public class TekuNodeConfigBuilder {
     } catch (Exception e) {
       LOG.error("Could not generate self signed cert", e);
     }
+    return this;
+  }
+
+  public TekuNodeConfigBuilder withValidatorApiNoSsl(final boolean ignoreSslInterface) {
+    LOG.debug("Validator api enabled, no SSL, ignoreInterface={}", ignoreSslInterface);
+    configMap.put("validator-api-enabled", true);
+    configMap.put("Xvalidator-api-ssl-enabled", false);
+    configMap.put("validator-api-port", VALIDATOR_API_PORT);
+    configMap.put("validator-api-host-allowlist", "*");
+    configMap.put("Xvalidator-api-unsafe-hosts-enabled", ignoreSslInterface);
+    return this;
+  }
+
+  public TekuNodeConfigBuilder withSpecifiedBearerToken(final String password) throws IOException {
+    final String bearerPath = "/bearer.txt";
+    LOG.debug("Setting bearer password, and mapping to file {}}", bearerPath);
+    configMap.put("validator-api-bearer-file", bearerPath);
+    final File bearerFile = File.createTempFile("bearer", ".txt");
+    Files.writeString(bearerFile.toPath(), password, UTF_8);
+    bearerFile.deleteOnExit();
+    configFileMap.put(bearerFile, bearerPath);
     return this;
   }
 

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuValidatorNode.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/teku/test/acceptance/dsl/TekuValidatorNode.java
@@ -17,7 +17,6 @@ import static tech.pegasys.teku.test.acceptance.dsl.metrics.MetricConditions.wit
 import static tech.pegasys.teku.test.acceptance.dsl.metrics.MetricConditions.withNameEqualsTo;
 import static tech.pegasys.teku.test.acceptance.dsl.metrics.MetricConditions.withValueGreaterThan;
 
-import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import org.apache.logging.log4j.LogManager;
@@ -29,7 +28,6 @@ import tech.pegasys.teku.test.acceptance.dsl.tools.ValidatorKeysApi;
 public class TekuValidatorNode extends TekuNode {
 
   private static final Logger LOG = LogManager.getLogger();
-  public static final int VALIDATOR_API_PORT = 9052;
   protected static final String VALIDATOR_PATH = DATA_PATH + "validator/";
 
   private final TekuNodeConfig config;
@@ -99,10 +97,6 @@ public class TekuValidatorNode extends TekuNode {
                 "method", "publish_block",
                 "outcome", "success")),
         withValueGreaterThan(0));
-  }
-
-  private URI getValidatorApiUrl() {
-    return URI.create("https://127.0.0.1:" + container.getMappedPort(VALIDATOR_API_PORT));
   }
 
   private String getApiPassword() {

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorRestApiOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorRestApiOptions.java
@@ -13,8 +13,10 @@
 
 package tech.pegasys.teku.cli.options;
 
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import picocli.CommandLine;
 import tech.pegasys.teku.config.TekuConfiguration;
 import tech.pegasys.teku.validator.client.restapi.ValidatorRestApiConfig;
@@ -49,6 +51,17 @@ public class ValidatorRestApiOptions {
   private boolean restApiSslEnabled = true;
 
   @CommandLine.Option(
+      names = {"--Xvalidator-api-unsafe-hosts-enabled"},
+      paramLabel = "<BOOLEAN>",
+      showDefaultValue = CommandLine.Help.Visibility.ALWAYS,
+      description =
+          "Disable the sanity check on localhost only for non ssl connections. Very unsafe to send bearer on unencrypted connection on a network! Should only be used for testing.",
+      hidden = true,
+      fallbackValue = "true",
+      arity = "0..1")
+  private boolean validatorApiDisableSslHostRestrictionEnabled = false;
+
+  @CommandLine.Option(
       names = {"--validator-api-enabled"},
       paramLabel = "<BOOLEAN>",
       showDefaultValue = CommandLine.Help.Visibility.ALWAYS,
@@ -63,6 +76,13 @@ public class ValidatorRestApiOptions {
       description = "Interface of Validator Rest API",
       arity = "1")
   private String restApiInterface = ValidatorRestApiConfig.DEFAULT_REST_API_INTERFACE;
+
+  @CommandLine.Option(
+      names = {"--validator-api-bearer-file"},
+      paramLabel = "<FILENAME>",
+      description = "Use the specified file as the bearer token for the validator Rest API",
+      arity = "1")
+  private Path validatorApiBearerFile = null;
 
   @CommandLine.Option(
       names = {"--validator-api-host-allowlist"},
@@ -107,6 +127,9 @@ public class ValidatorRestApiOptions {
                 .restApiCorsAllowedOrigins(restApiCorsAllowedOrigins)
                 .validatorApiKeystoreFile(keystoreFile)
                 .validatorApiKeystorePasswordFile(keystorePasswordFile)
+                .validatorApiBearerFile(Optional.ofNullable(validatorApiBearerFile))
+                .validatorApiDisableSslHostRestrictionEnabled(
+                    validatorApiDisableSslHostRestrictionEnabled)
                 .restApiHostAllowlist(restApiHostAllowlist));
   }
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/ValidatorRestApi.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/restapi/ValidatorRestApi.java
@@ -74,6 +74,12 @@ public class ValidatorRestApi {
             spec, keyManager, validatorApiChannel, genesisDataProvider, timeProvider);
     final Path slashingProtectionPath =
         ValidatorClientService.getSlashingProtectionPath(dataDirLayout);
+    final Path validatorApiBearerFile =
+        config
+            .getMaybeValidatorApiBearerFile()
+            .orElse(
+                ValidatorClientService.getKeyManagerPath(dataDirLayout)
+                    .resolve("validator-api-bearer"));
     return new RestApiBuilder()
         .openApiInfo(
             openApi ->
@@ -123,8 +129,7 @@ public class ValidatorRestApi {
         .endpoint(new DeleteGasLimit(proposerConfigManager))
         .endpoint(new PostVoluntaryExit(voluntaryExitDataProvider))
         .sslCertificate(config.getRestApiKeystoreFile(), config.getRestApiKeystorePasswordFile())
-        .passwordFilePath(
-            ValidatorClientService.getKeyManagerPath(dataDirLayout).resolve("validator-api-bearer"))
+        .passwordFilePath(validatorApiBearerFile)
         .build();
   }
 }


### PR DESCRIPTION
With this PR, it is possible to

 - change bearer token to a configured path rather than the generated default, by using `validator-api-bearer-file`. This is a supported option and will be added to documentation.
 - disable our ssl check whenever not using localhost interface. This was always the only secure and sane default, but to improve testing UX it can be beneficial to disable. This will remain undocumented and raise a warning if it's been set.

 As a tester, you would now be able to use
 ```
--validator-api-enabled=true \
--Xvalidator-api-ssl-enabled=false \
--validator-api-interface=0.0.0.0 \
--Xvalidator-api-unsafe-hosts-enabled=true \
--validator-api-host-allowlist="*"
 ```
 and your node will then allow connections on the validator-api (standard keymanager interface) via non ssl from any host.
 Just to re-iterate, this is not a production configuration, as it would give OPEN access to your keys. Please don't ever use this configuration on mainnet, like... ever... It is very bad to have open access to these keys, but it can make sense in some testing scenarios where there are other factors limiting access to the api.

 The development flags won't be documented, so I've given a more complete definition here. There's also an acceptance test making use of the flags.

fixes #8057

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
