### PR TITLE
Remove point-at-infinity for proofs/commitments

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/versions/deneb/BlobSidecar.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/versions/deneb/BlobSidecar.java
@@ -135,7 +135,7 @@ public class BlobSidecar
         getBlockRoot(),
         getIndex(),
         getBlob().toBriefString(),
-        getKZGCommitment().toHexString(),
+        getKZGCommitment().toAbbreviatedString(),
         getKZGProof().toAbbreviatedString());
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/networking/libp2p/rpc/BlobSidecarsByRootRequestMessageSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/networking/libp2p/rpc/BlobSidecarsByRootRequestMessageSchema.java
@@ -21,7 +21,7 @@ public class BlobSidecarsByRootRequestMessageSchema
     extends AbstractSszListSchema<BlobIdentifier, BlobSidecarsByRootRequestMessage> {
 
   // Size validation according to the spec (MAX_REQUEST_BLOCKS_DENEB * MAX_BLOBS_PER_BLOCK) is
-  // done in the RPC handler.
+  // done in the RPC handler
   public BlobSidecarsByRootRequestMessageSchema(final SpecConfigDeneb specConfigDeneb) {
     super(
         BlobIdentifier.SSZ_SCHEMA,

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/networking/libp2p/rpc/BlobSidecarsByRootRequestMessageSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/networking/libp2p/rpc/BlobSidecarsByRootRequestMessageSchema.java
@@ -20,8 +20,8 @@ import tech.pegasys.teku.spec.config.SpecConfigDeneb;
 public class BlobSidecarsByRootRequestMessageSchema
     extends AbstractSszListSchema<BlobIdentifier, BlobSidecarsByRootRequestMessage> {
 
-  // Size validation according to the spec (MAX_REQUEST_BLOCKS_DENEB *
-  // MAX_BLOB_COMMITMENTS_PER_BLOCK) is done in the RPC handler.
+  // Size validation according to the spec (MAX_REQUEST_BLOCKS_DENEB * MAX_BLOBS_PER_BLOCK) is
+  // done in the RPC handler.
   public BlobSidecarsByRootRequestMessageSchema(final SpecConfigDeneb specConfigDeneb) {
     super(
         BlobIdentifier.SSZ_SCHEMA,

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/networking/libp2p/rpc/BlobSidecarsByRootRequestMessageSchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/networking/libp2p/rpc/BlobSidecarsByRootRequestMessageSchema.java
@@ -20,8 +20,8 @@ import tech.pegasys.teku.spec.config.SpecConfigDeneb;
 public class BlobSidecarsByRootRequestMessageSchema
     extends AbstractSszListSchema<BlobIdentifier, BlobSidecarsByRootRequestMessage> {
 
-  // Size validation according to the spec (MAX_REQUEST_BLOCKS_DENEB * MAX_BLOBS_PER_BLOCK) is
-  // done in the RPC handler
+  // Size validation according to the spec (MAX_REQUEST_BLOCKS_DENEB *
+  // MAX_BLOB_COMMITMENTS_PER_BLOCK) is done in the RPC handler.
   public BlobSidecarsByRootRequestMessageSchema(final SpecConfigDeneb specConfigDeneb) {
     super(
         BlobIdentifier.SSZ_SCHEMA,

--- a/infrastructure/kzg/src/main/java/tech/pegasys/teku/kzg/KZG.java
+++ b/infrastructure/kzg/src/main/java/tech/pegasys/teku/kzg/KZG.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.kzg;
 
 import java.util.List;
 import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes48;
 
 /**
  * This interface specifies all the KZG functions needed for the Deneb specification and is the
@@ -53,13 +54,13 @@ public interface KZG {
 
         @Override
         public KZGCommitment blobToKzgCommitment(final Bytes blob) throws KZGException {
-          return KZGCommitment.INFINITY;
+          return KZGCommitment.fromBytesCompressed(Bytes48.ZERO);
         }
 
         @Override
         public KZGProof computeBlobKzgProof(final Bytes blob, final KZGCommitment kzgCommitment)
             throws KZGException {
-          return KZGProof.INFINITY;
+          return KZGProof.fromBytesCompressed(Bytes48.ZERO);
         }
       };
 

--- a/infrastructure/kzg/src/main/java/tech/pegasys/teku/kzg/KZG.java
+++ b/infrastructure/kzg/src/main/java/tech/pegasys/teku/kzg/KZG.java
@@ -53,7 +53,7 @@ public interface KZG {
 
         @Override
         public KZGCommitment blobToKzgCommitment(final Bytes blob) throws KZGException {
-          return KZGCommitment.infinity();
+          return KZGCommitment.INFINITY;
         }
 
         @Override

--- a/infrastructure/kzg/src/main/java/tech/pegasys/teku/kzg/KZGCommitment.java
+++ b/infrastructure/kzg/src/main/java/tech/pegasys/teku/kzg/KZGCommitment.java
@@ -23,14 +23,11 @@ import org.apache.tuweni.ssz.SSZ;
 
 public final class KZGCommitment {
 
-  /**
-   * Creates 0x00..00 for point-at-infinity
-   *
-   * @return point-at-infinity as per the Eth2 spec
-   */
-  public static KZGCommitment infinity() {
-    return KZGCommitment.fromBytesCompressed(Bytes48.ZERO);
-  }
+  /** The KZGCommitment which represents the point-at-infinity. */
+  public static final KZGCommitment INFINITY =
+      KZGCommitment.fromBytesCompressed(
+          Bytes48.fromHexString(
+              "0xc00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"));
 
   public static KZGCommitment fromHexString(final String hexString) {
     return KZGCommitment.fromBytesCompressed(Bytes48.fromHexString(hexString));

--- a/infrastructure/kzg/src/main/java/tech/pegasys/teku/kzg/KZGCommitment.java
+++ b/infrastructure/kzg/src/main/java/tech/pegasys/teku/kzg/KZGCommitment.java
@@ -23,12 +23,6 @@ import org.apache.tuweni.ssz.SSZ;
 
 public final class KZGCommitment {
 
-  /** The KZGCommitment which represents the point-at-infinity. */
-  public static final KZGCommitment INFINITY =
-      KZGCommitment.fromBytesCompressed(
-          Bytes48.fromHexString(
-              "0xc00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"));
-
   public static KZGCommitment fromHexString(final String hexString) {
     return KZGCommitment.fromBytesCompressed(Bytes48.fromHexString(hexString));
   }

--- a/infrastructure/kzg/src/main/java/tech/pegasys/teku/kzg/KZGProof.java
+++ b/infrastructure/kzg/src/main/java/tech/pegasys/teku/kzg/KZGProof.java
@@ -23,8 +23,11 @@ import org.apache.tuweni.ssz.SSZ;
 
 public final class KZGProof {
 
-  /** Creates 0x00..00 for point-at-infinity */
-  public static final KZGProof INFINITY = KZGProof.fromBytesCompressed(Bytes48.ZERO);
+  /** The KZGProof which represents the point-at-infinity. */
+  public static final KZGProof INFINITY =
+      KZGProof.fromBytesCompressed(
+          Bytes48.fromHexString(
+              "0xc00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"));
 
   public static KZGProof fromHexString(final String hexString) {
     return KZGProof.fromBytesCompressed(Bytes48.fromHexString(hexString));

--- a/infrastructure/kzg/src/main/java/tech/pegasys/teku/kzg/KZGProof.java
+++ b/infrastructure/kzg/src/main/java/tech/pegasys/teku/kzg/KZGProof.java
@@ -23,12 +23,6 @@ import org.apache.tuweni.ssz.SSZ;
 
 public final class KZGProof {
 
-  /** The KZGProof which represents the point-at-infinity. */
-  public static final KZGProof INFINITY =
-      KZGProof.fromBytesCompressed(
-          Bytes48.fromHexString(
-              "0xc00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"));
-
   public static KZGProof fromHexString(final String hexString) {
     return KZGProof.fromBytesCompressed(Bytes48.fromHexString(hexString));
   }

--- a/infrastructure/kzg/src/test/java/tech/pegasys/teku/kzg/CKZG4844Test.java
+++ b/infrastructure/kzg/src/test/java/tech/pegasys/teku/kzg/CKZG4844Test.java
@@ -86,12 +86,12 @@ public final class CKZG4844Test {
                 () ->
                     CKZG.verifyBlobKzgProofBatch(
                         List.of(Bytes.fromHexString("0x", BYTES_PER_BLOB)),
-                        List.of(KZGCommitment.INFINITY),
-                        List.of(KZGProof.INFINITY))),
+                        List.of(getSampleCommitment()),
+                        List.of(getSampleProof()))),
             assertThrows(KZGException.class, () -> CKZG.blobToKzgCommitment(Bytes.EMPTY)),
             assertThrows(
                 KZGException.class,
-                () -> CKZG.computeBlobKzgProof(Bytes.EMPTY, KZGCommitment.INFINITY)));
+                () -> CKZG.computeBlobKzgProof(Bytes.EMPTY, getSampleCommitment())));
 
     assertThat(exceptions)
         .allSatisfy(
@@ -291,6 +291,10 @@ public final class CKZG4844Test {
 
   private KZGCommitment getSampleCommitment() {
     return CKZG.blobToKzgCommitment(getSampleBlob());
+  }
+
+  private KZGProof getSampleProof() {
+    return CKZG.computeBlobKzgProof(getSampleBlob(), getSampleCommitment());
   }
 
   private UInt256 randomBLSFieldElement() {

--- a/infrastructure/kzg/src/test/java/tech/pegasys/teku/kzg/CKZG4844Test.java
+++ b/infrastructure/kzg/src/test/java/tech/pegasys/teku/kzg/CKZG4844Test.java
@@ -86,12 +86,12 @@ public final class CKZG4844Test {
                 () ->
                     CKZG.verifyBlobKzgProofBatch(
                         List.of(Bytes.fromHexString("0x", BYTES_PER_BLOB)),
-                        List.of(KZGCommitment.infinity()),
+                        List.of(KZGCommitment.INFINITY),
                         List.of(KZGProof.INFINITY))),
             assertThrows(KZGException.class, () -> CKZG.blobToKzgCommitment(Bytes.EMPTY)),
             assertThrows(
                 KZGException.class,
-                () -> CKZG.computeBlobKzgProof(Bytes.EMPTY, KZGCommitment.infinity())));
+                () -> CKZG.computeBlobKzgProof(Bytes.EMPTY, KZGCommitment.INFINITY)));
 
     assertThat(exceptions)
         .allSatisfy(


### PR DESCRIPTION
## PR Description

I noticed that `KZGProof` and `KZGCommitment` were using the wrong point-at-infinity bytes. It was 48 zero bytes and it should have been `0xc0` followed by 47 zero bytes. See the `G1_POINT_AT_INFINITY` constant here:

https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/polynomial-commitments.md#constants

I've made this mistake several times myself. It's the uncompressed bytes which are all zero; the compressed bytes include the "infinity" flag. This only appears to have been used in test code, so no worries.

* Additionally, the two classes were providing this value differently.
  * I like the static variable style, so I switched the other one to that style.
* I believe `BlobSidecar#toLogString` should print the abbreviated commitment.
  * I will revert this change if this was intentional.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
