### PR TITLE
Added header to builder call

### DIFF
--- a/ethereum/executionclient/build.gradle
+++ b/ethereum/executionclient/build.gradle
@@ -8,6 +8,7 @@ dependencies {
   implementation project(':infrastructure:events')
   implementation project(':infrastructure:version')
   implementation project(':ethereum:execution-types')
+  implementation project(':infrastructure:http')
   implementation project(':ethereum:spec')
   implementation project(':ethereum:json-types')
 

--- a/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/rest/OkHttpRestClientTest.java
+++ b/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/rest/OkHttpRestClientTest.java
@@ -180,7 +180,7 @@ class OkHttpRestClientTest {
     final TestObject2 requestBodyObject = new TestObject2(TEST_BLOCK_HASH);
     final SafeFuture<Response<TestObject>> responseFuture =
         underTest.postAsync(
-            TEST_PATH, requestBodyObject, requestTypeDefinition, responseTypeDefinition);
+            TEST_PATH, Map.of(), requestBodyObject, requestTypeDefinition, responseTypeDefinition);
 
     assertThat(responseFuture)
         .succeedsWithin(Duration.ofSeconds(1))
@@ -206,7 +206,11 @@ class OkHttpRestClientTest {
     final TestObject2 requestBodyObject = new TestObject2(TEST_BLOCK_HASH);
     final SafeFuture<Response<TestObject>> responseFuture =
         underTest.postAsync(
-            TEST_PATH, requestBodyObject, failingRequestTypeDefinition, responseTypeDefinition);
+            TEST_PATH,
+            Map.of(),
+            requestBodyObject,
+            failingRequestTypeDefinition,
+            responseTypeDefinition);
 
     // this will fail if there are uncaught exceptions in other threads
     Waiter.waitFor(() -> assertThat(responseFuture).isDone(), 30, TimeUnit.SECONDS, false);

--- a/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/rest/RestBuilderClientTest.java
+++ b/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/rest/RestBuilderClientTest.java
@@ -388,8 +388,15 @@ class RestBuilderClientTest {
               final BuilderPayload builderPayload = response.getPayload();
               verifyBuilderPayloadResponse(builderPayload);
             });
-
-    verifyPostRequest("/eth/v1/builder/blinded_blocks", signedBlindedBeaconBlockRequest);
+    final Consumer<RecordedRequest> containsConsensusVersionHeader =
+        req ->
+            assertThat(req.getHeader("Eth-Consensus-Version"))
+                .isEqualTo(milestone.name().toLowerCase(Locale.ROOT));
+    verifyRequest(
+        "POST",
+        "/eth/v1/builder/blinded_blocks",
+        Optional.of(signedBlindedBeaconBlockRequest),
+        Optional.of(containsConsensusVersionHeader));
   }
 
   @TestTemplate

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/OkHttpRestClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/OkHttpRestClient.java
@@ -69,7 +69,7 @@ public class OkHttpRestClient implements RestClient {
       final S requestBodyObject,
       final SerializableTypeDefinition<S> requestTypeDefinition) {
     return postAsyncInternal(
-        apiPath, Map.of(), requestBodyObject, requestTypeDefinition, Optional.empty());
+        apiPath, NO_HEADERS, requestBodyObject, requestTypeDefinition, Optional.empty());
   }
 
   @Override

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/OkHttpRestClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/OkHttpRestClient.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.ethereum.executionclient.rest;
 import static java.util.Objects.requireNonNull;
 
 import java.io.IOException;
+import java.net.URL;
 import java.util.Map;
 import java.util.Optional;
 import okhttp3.Call;
@@ -67,17 +68,23 @@ public class OkHttpRestClient implements RestClient {
       final String apiPath,
       final S requestBodyObject,
       final SerializableTypeDefinition<S> requestTypeDefinition) {
-    return postAsyncInternal(apiPath, requestBodyObject, requestTypeDefinition, Optional.empty());
+    return postAsyncInternal(
+        apiPath, Map.of(), requestBodyObject, requestTypeDefinition, Optional.empty());
   }
 
   @Override
   public <T, S> SafeFuture<Response<T>> postAsync(
       final String apiPath,
+      final Map<String, String> headers,
       final S requestBodyObject,
       final SerializableTypeDefinition<S> requestTypeDefinition,
       final DeserializableTypeDefinition<T> responseTypeDefinition) {
     return postAsyncInternal(
-        apiPath, requestBodyObject, requestTypeDefinition, Optional.of(responseTypeDefinition));
+        apiPath,
+        headers,
+        requestBodyObject,
+        requestTypeDefinition,
+        Optional.of(responseTypeDefinition));
   }
 
   private <T> SafeFuture<Response<T>> getAsyncInternal(
@@ -90,16 +97,17 @@ public class OkHttpRestClient implements RestClient {
 
   private <T, S> SafeFuture<Response<T>> postAsyncInternal(
       final String apiPath,
+      final Map<String, String> headers,
       final S requestBodyObject,
       final SerializableTypeDefinition<S> requestTypeDefinition,
       final Optional<DeserializableTypeDefinition<T>> responseTypeDefinitionMaybe) {
     final RequestBody requestBody = createRequestBody(requestBodyObject, requestTypeDefinition);
-    final Request request = createPostRequest(apiPath, requestBody);
+    final Request request = createPostRequest(apiPath, requestBody, headers);
     return makeAsyncRequest(request, responseTypeDefinitionMaybe);
   }
 
   private Request createGetRequest(final String apiPath, final Map<String, String> headers) {
-    final HttpUrl httpUrl = createHttpUrl(apiPath);
+    final URL httpUrl = createHttpUrl(apiPath);
     final Request.Builder requestBuilder = new Request.Builder().url(httpUrl);
     headers.forEach(requestBuilder::header);
     return requestBuilder.build();
@@ -122,14 +130,17 @@ public class OkHttpRestClient implements RestClient {
     };
   }
 
-  private Request createPostRequest(final String apiPath, final RequestBody requestBody) {
-    final HttpUrl httpUrl = createHttpUrl(apiPath);
-    return new Request.Builder().url(httpUrl).post(requestBody).build();
+  private Request createPostRequest(
+      final String apiPath, final RequestBody requestBody, final Map<String, String> headers) {
+    final URL httpUrl = createHttpUrl(apiPath);
+    final Request.Builder requestBuilder = new Request.Builder().url(httpUrl).post(requestBody);
+    headers.forEach(requestBuilder::header);
+    return requestBuilder.build();
   }
 
-  private HttpUrl createHttpUrl(final String apiPath) {
+  private URL createHttpUrl(final String apiPath) {
     final HttpUrl.Builder urlBuilder = baseEndpoint.newBuilder(apiPath);
-    return requireNonNull(urlBuilder).build();
+    return requireNonNull(urlBuilder).build().url();
   }
 
   private <T> SafeFuture<Response<T>> makeAsyncRequest(

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/RestBuilderClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/RestBuilderClient.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.ethereum.executionclient.rest;
 
 import static tech.pegasys.teku.ethereum.executionclient.rest.RestClient.NO_HEADERS;
+import static tech.pegasys.teku.infrastructure.http.RestApiConstants.HEADER_CONSENSUS_VERSION;
 import static tech.pegasys.teku.spec.config.Constants.BUILDER_GET_PAYLOAD_TIMEOUT;
 import static tech.pegasys.teku.spec.config.Constants.BUILDER_PROPOSAL_DELAY_TOLERANCE;
 import static tech.pegasys.teku.spec.config.Constants.BUILDER_REGISTER_VALIDATOR_TIMEOUT;
@@ -21,6 +22,7 @@ import static tech.pegasys.teku.spec.config.Constants.BUILDER_STATUS_TIMEOUT;
 import static tech.pegasys.teku.spec.schemas.ApiSchemas.SIGNED_VALIDATOR_REGISTRATIONS_SCHEMA;
 
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -161,6 +163,7 @@ public class RestBuilderClient implements BuilderClient {
     return restClient
         .postAsync(
             BuilderApiMethod.GET_PAYLOAD.getPath(),
+            Map.of(HEADER_CONSENSUS_VERSION, milestone.name().toLowerCase(Locale.ROOT)),
             signedBlindedBeaconBlock,
             requestTypeDefinition,
             responseTypeDefinition)

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/RestClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/rest/RestClient.java
@@ -38,6 +38,7 @@ public interface RestClient {
 
   <T, S> SafeFuture<Response<T>> postAsync(
       final String apiPath,
+      final Map<String, String> headers,
       final S requestBodyObject,
       final SerializableTypeDefinition<S> requestTypeDefinition,
       final DeserializableTypeDefinition<T> responseTypeDefinition);


### PR DESCRIPTION
When calling `/eth/v1/builder/blinded_blocks` we had missed the `Eth-Consensus-Version` header.

I changed the OkHttpRestClient from using HttpUrl as there was a warning on the interface we were using.

We now add the header. I manually lower-cased the milestone string, as the version method we use in schema isn't really what we want in this context, but at some point we probably want to build this logic into SpecMilestone rather than relying on the Schema `Version` object.

fixes #8061.

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
