### PR TITLE
Add engine_getClientVersionV1 interface + ability to get commit hash

### DIFF
--- a/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JExecutionEngineClientTest.java
+++ b/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JExecutionEngineClientTest.java
@@ -210,8 +210,7 @@ public class Web3JExecutionEngineClientTest {
   @TestTemplate
   public void getClientVersionV1_shouldBuildRequestAndResponseSuccessfully() throws Exception {
     final ClientVersionV1 consensusClientVersion =
-        new ClientVersionV1(
-            ClientVersionV1.TEKU_CLIENT_CODE, "teku", "1.0.0", Bytes4.fromHexString("87fa8ca7"));
+        new ClientVersionV1("TK", "teku", "1.0.0", Bytes4.fromHexString("87fa8ca7"));
     final ClientVersionV1 executionClientVersion =
         new ClientVersionV1("BU", "besu", "1.0.0", Bytes4.fromHexString("8dba2981"));
 
@@ -231,7 +230,7 @@ public class Web3JExecutionEngineClientTest {
         .hasSize(1)
         .first()
         .asInstanceOf(MAP)
-        .containsEntry("code", ClientVersionV1.TEKU_CLIENT_CODE)
+        .containsEntry("code", "TK")
         .containsEntry("name", "teku")
         .containsEntry("version", "1.0.0")
         .containsEntry("commit", "0x87fa8ca7");

--- a/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JExecutionEngineClientTest.java
+++ b/ethereum/executionclient/src/integration-test/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JExecutionEngineClientTest.java
@@ -230,6 +230,7 @@ public class Web3JExecutionEngineClientTest {
         .hasSize(1)
         .first()
         .asInstanceOf(MAP)
+        .hasSize(4)
         .containsEntry("code", "TK")
         .containsEntry("name", "teku")
         .containsEntry("version", "1.0.0")

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ExecutionEngineClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ExecutionEngineClient.java
@@ -16,6 +16,7 @@ package tech.pegasys.teku.ethereum.executionclient;
 import java.util.List;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.ethereum.executionclient.schema.ClientVersionV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV2;
 import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV3;
@@ -65,4 +66,6 @@ public interface ExecutionEngineClient {
       ForkChoiceStateV1 forkChoiceState, Optional<PayloadAttributesV3> payloadAttributes);
 
   SafeFuture<Response<List<String>>> exchangeCapabilities(List<String> capabilities);
+
+  SafeFuture<Response<List<ClientVersionV1>>> getClientVersionV1(ClientVersionV1 clientVersion);
 }

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ThrottlingExecutionEngineClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ThrottlingExecutionEngineClient.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
+import tech.pegasys.teku.ethereum.executionclient.schema.ClientVersionV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV2;
 import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV3;
@@ -126,5 +127,11 @@ public class ThrottlingExecutionEngineClient implements ExecutionEngineClient {
   @Override
   public SafeFuture<Response<List<String>>> exchangeCapabilities(final List<String> capabilities) {
     return taskQueue.queueTask(() -> delegate.exchangeCapabilities(capabilities));
+  }
+
+  @Override
+  public SafeFuture<Response<List<ClientVersionV1>>> getClientVersionV1(
+      final ClientVersionV1 clientVersion) {
+    return taskQueue.queueTask(() -> delegate.getClientVersionV1(clientVersion));
   }
 }

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/metrics/MetricRecordingExecutionEngineClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/metrics/MetricRecordingExecutionEngineClient.java
@@ -61,7 +61,7 @@ public class MetricRecordingExecutionEngineClient extends MetricRecordingAbstrac
   public static final String GET_PAYLOAD_V3_METHOD = "get_payloadV3";
   public static final String NEW_PAYLOAD_V3_METHOD = "new_payloadV3";
   public static final String EXCHANGE_CAPABILITIES_METHOD = "exchange_capabilities";
-  public static final String GET_CLIENT_VERSION_METHOD = "get_client_version";
+  public static final String GET_CLIENT_VERSION_V1_METHOD = "get_clientVersionV1";
 
   private final ExecutionEngineClient delegate;
 
@@ -171,6 +171,6 @@ public class MetricRecordingExecutionEngineClient extends MetricRecordingAbstrac
   public SafeFuture<Response<List<ClientVersionV1>>> getClientVersionV1(
       final ClientVersionV1 clientVersion) {
     return countRequest(
-        () -> delegate.getClientVersionV1(clientVersion), GET_CLIENT_VERSION_METHOD);
+        () -> delegate.getClientVersionV1(clientVersion), GET_CLIENT_VERSION_V1_METHOD);
   }
 }

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/metrics/MetricRecordingExecutionEngineClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/metrics/MetricRecordingExecutionEngineClient.java
@@ -61,7 +61,7 @@ public class MetricRecordingExecutionEngineClient extends MetricRecordingAbstrac
   public static final String GET_PAYLOAD_V3_METHOD = "get_payloadV3";
   public static final String NEW_PAYLOAD_V3_METHOD = "new_payloadV3";
   public static final String EXCHANGE_CAPABILITIES_METHOD = "exchange_capabilities";
-  public static final String GET_CLIENT_VERSION_V1_METHOD = "get_clientVersionV1";
+  public static final String GET_CLIENT_VERSION_V1_METHOD = "get_client_versionV1";
 
   private final ExecutionEngineClient delegate;
 

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/metrics/MetricRecordingExecutionEngineClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/metrics/MetricRecordingExecutionEngineClient.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.ethereum.executionclient.ExecutionEngineClient;
+import tech.pegasys.teku.ethereum.executionclient.schema.ClientVersionV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV2;
 import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV3;
@@ -59,6 +60,8 @@ public class MetricRecordingExecutionEngineClient extends MetricRecordingAbstrac
       "forkchoice_updated_with_attributesV3";
   public static final String GET_PAYLOAD_V3_METHOD = "get_payloadV3";
   public static final String NEW_PAYLOAD_V3_METHOD = "new_payloadV3";
+  public static final String EXCHANGE_CAPABILITIES_METHOD = "exchange_capabilities";
+  public static final String GET_CLIENT_VERSION_METHOD = "get_client_version";
 
   private final ExecutionEngineClient delegate;
 
@@ -160,6 +163,14 @@ public class MetricRecordingExecutionEngineClient extends MetricRecordingAbstrac
 
   @Override
   public SafeFuture<Response<List<String>>> exchangeCapabilities(final List<String> capabilities) {
-    return delegate.exchangeCapabilities(capabilities);
+    return countRequest(
+        () -> delegate.exchangeCapabilities(capabilities), EXCHANGE_CAPABILITIES_METHOD);
+  }
+
+  @Override
+  public SafeFuture<Response<List<ClientVersionV1>>> getClientVersionV1(
+      final ClientVersionV1 clientVersion) {
+    return countRequest(
+        () -> delegate.getClientVersionV1(clientVersion), GET_CLIENT_VERSION_METHOD);
   }
 }

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/ClientVersionV1.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/ClientVersionV1.java
@@ -23,10 +23,9 @@ import java.util.Objects;
 import tech.pegasys.teku.ethereum.executionclient.serialization.Bytes4Deserializer;
 import tech.pegasys.teku.ethereum.executionclient.serialization.Bytes4Serializer;
 import tech.pegasys.teku.infrastructure.bytes.Bytes4;
+import tech.pegasys.teku.spec.datastructures.execution.ClientVersion;
 
 public class ClientVersionV1 {
-
-  public static final String TEKU_CLIENT_CODE = "TK";
 
   public final String code;
   public final String name;
@@ -49,6 +48,22 @@ public class ClientVersionV1 {
     this.name = name;
     this.version = version;
     this.commit = commit;
+  }
+
+  public static ClientVersionV1 fromInternalClientVersion(final ClientVersion clientVersion) {
+    return new ClientVersionV1(
+        clientVersion.code(),
+        clientVersion.name(),
+        clientVersion.version(),
+        clientVersion.commit());
+  }
+
+  public static ClientVersion asInternalClientVersion(final ClientVersionV1 clientVersionV1) {
+    return new ClientVersion(
+        clientVersionV1.code,
+        clientVersionV1.name,
+        clientVersionV1.version,
+        clientVersionV1.commit);
   }
 
   @Override

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/ClientVersionV1.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/schema/ClientVersionV1.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionclient.schema;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.common.base.MoreObjects;
+import java.util.Objects;
+import tech.pegasys.teku.ethereum.executionclient.serialization.Bytes4Deserializer;
+import tech.pegasys.teku.ethereum.executionclient.serialization.Bytes4Serializer;
+import tech.pegasys.teku.infrastructure.bytes.Bytes4;
+
+public class ClientVersionV1 {
+
+  public static final String TEKU_CLIENT_CODE = "TK";
+
+  public final String code;
+  public final String name;
+  public final String version;
+
+  @JsonSerialize(using = Bytes4Serializer.class)
+  @JsonDeserialize(using = Bytes4Deserializer.class)
+  public final Bytes4 commit;
+
+  public ClientVersionV1(
+      @JsonProperty("code") String code,
+      @JsonProperty("name") String name,
+      @JsonProperty("version") String version,
+      @JsonProperty("commit") Bytes4 commit) {
+    checkNotNull(code, "code");
+    checkNotNull(name, "name");
+    checkNotNull(version, "version");
+    checkNotNull(commit, "commit");
+    this.code = code;
+    this.name = name;
+    this.version = version;
+    this.commit = commit;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ClientVersionV1 that = (ClientVersionV1) o;
+    return Objects.equals(code, that.code)
+        && Objects.equals(name, that.name)
+        && Objects.equals(version, that.version)
+        && Objects.equals(commit, that.commit);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(code, name, version, commit);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("code", code)
+        .add("name", name)
+        .add("version", version)
+        .add("commit", commit)
+        .toString();
+  }
+}

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/serialization/Bytes4Deserializer.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/serialization/Bytes4Deserializer.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Consensys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionclient.serialization;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import java.io.IOException;
+import tech.pegasys.teku.infrastructure.bytes.Bytes4;
+
+public class Bytes4Deserializer extends JsonDeserializer<Bytes4> {
+
+  @Override
+  public Bytes4 deserialize(final JsonParser p, final DeserializationContext ctxt)
+      throws IOException {
+    return Bytes4.fromHexString(p.getValueAsString());
+  }
+}

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/serialization/Bytes4Serializer.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/serialization/Bytes4Serializer.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Consensys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.executionclient.serialization;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import java.io.IOException;
+import java.util.Locale;
+import tech.pegasys.teku.infrastructure.bytes.Bytes4;
+
+public class Bytes4Serializer extends JsonSerializer<Bytes4> {
+  @Override
+  public void serialize(
+      final Bytes4 value, final JsonGenerator gen, final SerializerProvider serializers)
+      throws IOException {
+    gen.writeString(value.toHexString().toLowerCase(Locale.ROOT));
+  }
+}

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/DefaultExecutionWeb3jClientProvider.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/DefaultExecutionWeb3jClientProvider.java
@@ -58,7 +58,7 @@ public class DefaultExecutionWeb3jClientProvider implements ExecutionWeb3jClient
             .jwtConfigOpt(jwtConfig)
             .timeProvider(timeProvider)
             .executionClientEventsPublisher(executionClientEventsPublisher)
-            .nonCriticalMethods("engine_exchangeCapabilities")
+            .nonCriticalMethods("engine_exchangeCapabilities", "engine_getClientVersionV1")
             .build();
     this.alreadyBuilt = true;
   }

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JExecutionEngineClient.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3JExecutionEngineClient.java
@@ -27,6 +27,7 @@ import org.web3j.protocol.core.DefaultBlockParameterName;
 import org.web3j.protocol.core.Request;
 import org.web3j.protocol.core.methods.response.EthBlock;
 import tech.pegasys.teku.ethereum.executionclient.ExecutionEngineClient;
+import tech.pegasys.teku.ethereum.executionclient.schema.ClientVersionV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV1;
 import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV2;
 import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV3;
@@ -47,7 +48,8 @@ import tech.pegasys.teku.spec.logic.versions.deneb.types.VersionedHash;
 
 public class Web3JExecutionEngineClient implements ExecutionEngineClient {
 
-  private static final Duration EXCHANGE_CAPABILITIES_TIMEOUT = Duration.ofSeconds(8);
+  private static final Duration EXCHANGE_CAPABILITIES_TIMEOUT = Duration.ofSeconds(1);
+  private static final Duration GET_CLIENT_VERSION_TIMEOUT = Duration.ofSeconds(1);
 
   private final Web3JClient web3JClient;
 
@@ -87,7 +89,7 @@ public class Web3JExecutionEngineClient implements ExecutionEngineClient {
 
   @Override
   public SafeFuture<Response<ExecutionPayloadV1>> getPayloadV1(Bytes8 payloadId) {
-    Request<?, ExecutionPayloadV1Web3jResponse> web3jRequest =
+    final Request<?, ExecutionPayloadV1Web3jResponse> web3jRequest =
         new Request<>(
             "engine_getPayloadV1",
             Collections.singletonList(payloadId.toHexString()),
@@ -98,7 +100,7 @@ public class Web3JExecutionEngineClient implements ExecutionEngineClient {
 
   @Override
   public SafeFuture<Response<GetPayloadV2Response>> getPayloadV2(final Bytes8 payloadId) {
-    Request<?, GetPayloadV2Web3jResponse> web3jRequest =
+    final Request<?, GetPayloadV2Web3jResponse> web3jRequest =
         new Request<>(
             "engine_getPayloadV2",
             Collections.singletonList(payloadId.toHexString()),
@@ -120,7 +122,7 @@ public class Web3JExecutionEngineClient implements ExecutionEngineClient {
 
   @Override
   public SafeFuture<Response<PayloadStatusV1>> newPayloadV1(ExecutionPayloadV1 executionPayload) {
-    Request<?, PayloadStatusV1Web3jResponse> web3jRequest =
+    final Request<?, PayloadStatusV1Web3jResponse> web3jRequest =
         new Request<>(
             "engine_newPayloadV1",
             Collections.singletonList(executionPayload),
@@ -132,7 +134,7 @@ public class Web3JExecutionEngineClient implements ExecutionEngineClient {
   @Override
   public SafeFuture<Response<PayloadStatusV1>> newPayloadV2(
       final ExecutionPayloadV2 executionPayload) {
-    Request<?, PayloadStatusV1Web3jResponse> web3jRequest =
+    final Request<?, PayloadStatusV1Web3jResponse> web3jRequest =
         new Request<>(
             "engine_newPayloadV2",
             Collections.singletonList(executionPayload),
@@ -161,7 +163,7 @@ public class Web3JExecutionEngineClient implements ExecutionEngineClient {
   @Override
   public SafeFuture<Response<ForkChoiceUpdatedResult>> forkChoiceUpdatedV1(
       ForkChoiceStateV1 forkChoiceState, Optional<PayloadAttributesV1> payloadAttributes) {
-    Request<?, ForkChoiceUpdatedResultWeb3jResponse> web3jRequest =
+    final Request<?, ForkChoiceUpdatedResultWeb3jResponse> web3jRequest =
         new Request<>(
             "engine_forkchoiceUpdatedV1",
             list(forkChoiceState, payloadAttributes.orElse(null)),
@@ -174,7 +176,7 @@ public class Web3JExecutionEngineClient implements ExecutionEngineClient {
   public SafeFuture<Response<ForkChoiceUpdatedResult>> forkChoiceUpdatedV2(
       final ForkChoiceStateV1 forkChoiceState,
       final Optional<PayloadAttributesV2> payloadAttributes) {
-    Request<?, ForkChoiceUpdatedResultWeb3jResponse> web3jRequest =
+    final Request<?, ForkChoiceUpdatedResultWeb3jResponse> web3jRequest =
         new Request<>(
             "engine_forkchoiceUpdatedV2",
             list(forkChoiceState, payloadAttributes.orElse(null)),
@@ -187,7 +189,7 @@ public class Web3JExecutionEngineClient implements ExecutionEngineClient {
   public SafeFuture<Response<ForkChoiceUpdatedResult>> forkChoiceUpdatedV3(
       final ForkChoiceStateV1 forkChoiceState,
       final Optional<PayloadAttributesV3> payloadAttributes) {
-    Request<?, ForkChoiceUpdatedResultWeb3jResponse> web3jRequest =
+    final Request<?, ForkChoiceUpdatedResultWeb3jResponse> web3jRequest =
         new Request<>(
             "engine_forkchoiceUpdatedV3",
             list(forkChoiceState, payloadAttributes.orElse(null)),
@@ -198,13 +200,25 @@ public class Web3JExecutionEngineClient implements ExecutionEngineClient {
 
   @Override
   public SafeFuture<Response<List<String>>> exchangeCapabilities(final List<String> capabilities) {
-    Request<?, ExchangeCapabilitiesWeb3jResponse> web3jRequest =
+    final Request<?, ExchangeCapabilitiesWeb3jResponse> web3jRequest =
         new Request<>(
             "engine_exchangeCapabilities",
             Collections.singletonList(capabilities),
             web3JClient.getWeb3jService(),
             ExchangeCapabilitiesWeb3jResponse.class);
     return web3JClient.doRequest(web3jRequest, EXCHANGE_CAPABILITIES_TIMEOUT);
+  }
+
+  @Override
+  public SafeFuture<Response<List<ClientVersionV1>>> getClientVersionV1(
+      final ClientVersionV1 clientVersion) {
+    final Request<?, GetClientVersionV1Web3jResponse> web3jRequest =
+        new Request<>(
+            "engine_getClientVersionV1",
+            Collections.singletonList(clientVersion),
+            web3JClient.getWeb3jService(),
+            GetClientVersionV1Web3jResponse.class);
+    return web3JClient.doRequest(web3jRequest, GET_CLIENT_VERSION_TIMEOUT);
   }
 
   static class ExecutionPayloadV1Web3jResponse
@@ -224,6 +238,9 @@ public class Web3JExecutionEngineClient implements ExecutionEngineClient {
 
   static class ExchangeCapabilitiesWeb3jResponse
       extends org.web3j.protocol.core.Response<List<String>> {}
+
+  static class GetClientVersionV1Web3jResponse
+      extends org.web3j.protocol.core.Response<List<ClientVersionV1>> {}
 
   /**
    * Returns a list that supports null items.

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3jClientBuilder.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/web3j/Web3jClientBuilder.java
@@ -85,37 +85,31 @@ public class Web3jClientBuilder {
     checkNotNull(endpoint);
     checkNotNull(timeout);
     requireNonNull(endpoint.getScheme(), () -> prepareInvalidSchemeMessage(endpoint));
-    switch (endpoint.getScheme()) {
-      case "http":
-      case "https":
-        return new Web3jHttpClient(
-            EVENT_LOG,
-            endpoint,
-            timeProvider,
-            timeout,
-            jwtConfigOpt,
-            executionClientEventsPublisher,
-            nonCriticalMethods);
-      case "ws":
-      case "wss":
-        return new Web3jWebsocketClient(
-            EVENT_LOG,
-            endpoint,
-            timeProvider,
-            jwtConfigOpt,
-            executionClientEventsPublisher,
-            nonCriticalMethods);
-      case "file":
-        return new Web3jIpcClient(
-            EVENT_LOG,
-            endpoint,
-            timeProvider,
-            jwtConfigOpt,
-            executionClientEventsPublisher,
-            nonCriticalMethods);
-      default:
-        throw new InvalidConfigurationException(prepareInvalidSchemeMessage(endpoint));
-    }
+    return switch (endpoint.getScheme()) {
+      case "http", "https" -> new Web3jHttpClient(
+          EVENT_LOG,
+          endpoint,
+          timeProvider,
+          timeout,
+          jwtConfigOpt,
+          executionClientEventsPublisher,
+          nonCriticalMethods);
+      case "ws", "wss" -> new Web3jWebsocketClient(
+          EVENT_LOG,
+          endpoint,
+          timeProvider,
+          jwtConfigOpt,
+          executionClientEventsPublisher,
+          nonCriticalMethods);
+      case "file" -> new Web3jIpcClient(
+          EVENT_LOG,
+          endpoint,
+          timeProvider,
+          jwtConfigOpt,
+          executionClientEventsPublisher,
+          nonCriticalMethods);
+      default -> throw new InvalidConfigurationException(prepareInvalidSchemeMessage(endpoint));
+    };
   }
 
   private String prepareInvalidSchemeMessage(final URI endpoint) {

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionClientHandler.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionClientHandler.java
@@ -13,10 +13,12 @@
 
 package tech.pegasys.teku.ethereum.executionlayer;
 
+import java.util.List;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.execution.ClientVersion;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
 import tech.pegasys.teku.spec.datastructures.execution.GetPayloadResponse;
 import tech.pegasys.teku.spec.datastructures.execution.NewPayloadRequest;
@@ -40,4 +42,6 @@ public interface ExecutionClientHandler {
       ExecutionPayloadContext executionPayloadContext, UInt64 slot);
 
   SafeFuture<PayloadStatus> engineNewPayload(NewPayloadRequest newPayloadRequest);
+
+  SafeFuture<List<ClientVersion>> engineGetClientVersion(ClientVersion clientVersion);
 }

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionClientHandlerImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionClientHandlerImpl.java
@@ -13,14 +13,18 @@
 
 package tech.pegasys.teku.ethereum.executionlayer;
 
+import java.util.List;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.ethereum.executionclient.ExecutionEngineClient;
 import tech.pegasys.teku.ethereum.executionclient.methods.EngineApiMethod;
 import tech.pegasys.teku.ethereum.executionclient.methods.JsonRpcRequestParams;
+import tech.pegasys.teku.ethereum.executionclient.response.ResponseUnwrapper;
+import tech.pegasys.teku.ethereum.executionclient.schema.ClientVersionV1;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.datastructures.execution.ClientVersion;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
 import tech.pegasys.teku.spec.datastructures.execution.GetPayloadResponse;
@@ -108,5 +112,15 @@ public class ExecutionClientHandlerImpl implements ExecutionClientHandler {
         .getMethod(
             EngineApiMethod.ENGINE_NEW_PAYLOAD, executionPayload::getMilestone, PayloadStatus.class)
         .execute(paramsBuilder.build());
+  }
+
+  @Override
+  public SafeFuture<List<ClientVersion>> engineGetClientVersion(final ClientVersion clientVersion) {
+    return executionEngineClient
+        .getClientVersionV1(ClientVersionV1.fromInternalClientVersion(clientVersion))
+        .thenApply(ResponseUnwrapper::unwrapExecutionClientResponseOrThrow)
+        .thenApply(
+            clientVersions ->
+                clientVersions.stream().map(ClientVersionV1::asInternalClientVersion).toList());
   }
 }

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
@@ -18,6 +18,7 @@ import static tech.pegasys.teku.spec.config.Constants.MAXIMUM_CONCURRENT_EE_REQU
 
 import com.google.common.annotations.VisibleForTesting;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 import org.apache.logging.log4j.LogManager;
@@ -49,6 +50,7 @@ import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.builder.BuilderPayload;
 import tech.pegasys.teku.spec.datastructures.builder.SignedValidatorRegistration;
+import tech.pegasys.teku.spec.datastructures.execution.ClientVersion;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadResult;
 import tech.pegasys.teku.spec.datastructures.execution.FallbackReason;
@@ -223,6 +225,12 @@ public class ExecutionLayerManagerImpl implements ExecutionLayerManager {
   public SafeFuture<PayloadStatus> engineNewPayload(final NewPayloadRequest newPayloadRequest) {
     LOG.trace("calling engineNewPayload(newPayloadRequest={})", newPayloadRequest);
     return executionClientHandler.engineNewPayload(newPayloadRequest);
+  }
+
+  @Override
+  public SafeFuture<List<ClientVersion>> engineGetClientVersion(final ClientVersion clientVersion) {
+    LOG.trace("calling engineGetClientVersion(clientVersion={})", clientVersion);
+    return executionClientHandler.engineGetClientVersion(clientVersion);
   }
 
   @Override

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionHandlerClientTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionHandlerClientTest.java
@@ -17,12 +17,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.ethereum.executionclient.ExecutionEngineClient;
+import tech.pegasys.teku.ethereum.executionclient.schema.ClientVersionV1;
+import tech.pegasys.teku.ethereum.executionclient.schema.Response;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.datastructures.execution.ClientVersion;
 import tech.pegasys.teku.spec.datastructures.execution.PowBlock;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
@@ -64,6 +68,34 @@ public abstract class ExecutionHandlerClientTest {
 
     final SafeFuture<PowBlock> result = handler.eth1GetPowChainHead();
     assertThat(result).isCompletedWithValue(block);
+  }
+
+  @Test
+  void engineGetClientVersion_shouldCallEngineGetClientVersionV1() {
+    final ExecutionClientHandler handler = getHandler();
+
+    final ClientVersion consensusClientVersion = createClientVersion();
+    final ClientVersion executionClientVersion = createClientVersion();
+
+    when(executionEngineClient.getClientVersionV1(
+            ClientVersionV1.fromInternalClientVersion(consensusClientVersion)))
+        .thenReturn(
+            SafeFuture.completedFuture(
+                new Response<>(
+                    List.of(ClientVersionV1.fromInternalClientVersion(executionClientVersion)))));
+
+    final SafeFuture<List<ClientVersion>> result =
+        handler.engineGetClientVersion(consensusClientVersion);
+
+    assertThat(result).isCompletedWithValue(List.of(executionClientVersion));
+  }
+
+  private ClientVersion createClientVersion() {
+    return new ClientVersion(
+        dataStructureUtil.randomString(2),
+        dataStructureUtil.randomString(10),
+        dataStructureUtil.randomString(10),
+        dataStructureUtil.randomBytes4());
   }
 
   final ExecutionClientHandler getHandler() {

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionHandlerClientTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionHandlerClientTest.java
@@ -74,8 +74,8 @@ public abstract class ExecutionHandlerClientTest {
   void engineGetClientVersion_shouldCallEngineGetClientVersionV1() {
     final ExecutionClientHandler handler = getHandler();
 
-    final ClientVersion consensusClientVersion = createClientVersion();
-    final ClientVersion executionClientVersion = createClientVersion();
+    final ClientVersion consensusClientVersion = dataStructureUtil.randomClientVersion();
+    final ClientVersion executionClientVersion = dataStructureUtil.randomClientVersion();
 
     when(executionEngineClient.getClientVersionV1(
             ClientVersionV1.fromInternalClientVersion(consensusClientVersion)))
@@ -88,14 +88,6 @@ public abstract class ExecutionHandlerClientTest {
         handler.engineGetClientVersion(consensusClientVersion);
 
     assertThat(result).isCompletedWithValue(List.of(executionClientVersion));
-  }
-
-  private ClientVersion createClientVersion() {
-    return new ClientVersion(
-        dataStructureUtil.randomString(2),
-        dataStructureUtil.randomString(10),
-        dataStructureUtil.randomString(10),
-        dataStructureUtil.randomBytes4());
   }
 
   final ExecutionClientHandler getHandler() {

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImplTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImplTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.when;
 import static tech.pegasys.teku.ethereum.executionlayer.ExecutionBuilderModule.BUILDER_BOOST_FACTOR_MAX_PROFIT;
 import static tech.pegasys.teku.ethereum.executionlayer.ExecutionBuilderModule.BUILDER_BOOST_FACTOR_PREFER_BUILDER;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.stream.IntStream;
 import org.apache.tuweni.bytes.Bytes32;
@@ -49,6 +50,7 @@ import tech.pegasys.teku.spec.datastructures.builder.BuilderBid;
 import tech.pegasys.teku.spec.datastructures.builder.BuilderPayload;
 import tech.pegasys.teku.spec.datastructures.builder.SignedBuilderBid;
 import tech.pegasys.teku.spec.datastructures.execution.BlobsBundle;
+import tech.pegasys.teku.spec.datastructures.execution.ClientVersion;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
@@ -196,6 +198,18 @@ class ExecutionLayerManagerImplTest {
     verifyNoInteractions(builderClient);
 
     verifySourceCounter(Source.LOCAL_EL, FallbackReason.NONE);
+  }
+
+  @Test
+  public void engineGetClientVersion_shouldReturnClientVersionViaEngine() {
+    final ClientVersion consensusClientVersion = dataStructureUtil.randomClientVersion();
+    final List<ClientVersion> engineResponse = List.of(dataStructureUtil.randomClientVersion());
+
+    when(executionClientHandler.engineGetClientVersion(consensusClientVersion))
+        .thenReturn(SafeFuture.completedFuture(engineResponse));
+
+    assertThat(executionLayerManager.engineGetClientVersion(consensusClientVersion))
+        .isCompletedWithValue(engineResponse);
   }
 
   @Test

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ClientVersion.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ClientVersion.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.execution;
+
+import tech.pegasys.teku.infrastructure.bytes.Bytes4;
+
+public record ClientVersion(String code, String name, String version, Bytes4 commit) {}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannel.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannel.java
@@ -73,7 +73,7 @@ public interface ExecutionLayerChannel extends ChannelInterface {
         @Override
         public SafeFuture<List<ClientVersion>> engineGetClientVersion(
             final ClientVersion clientVersion) {
-          return SafeFuture.completedFuture(null);
+          return SafeFuture.completedFuture(List.of());
         }
 
         @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannel.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannel.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.executionlayer;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 import org.apache.tuweni.bytes.Bytes32;
@@ -25,6 +26,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.builder.BuilderPayload;
 import tech.pegasys.teku.spec.datastructures.builder.SignedValidatorRegistration;
+import tech.pegasys.teku.spec.datastructures.execution.ClientVersion;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadResult;
 import tech.pegasys.teku.spec.datastructures.execution.GetPayloadResponse;
@@ -69,6 +71,12 @@ public interface ExecutionLayerChannel extends ChannelInterface {
         }
 
         @Override
+        public SafeFuture<List<ClientVersion>> engineGetClientVersion(
+            final ClientVersion clientVersion) {
+          return SafeFuture.completedFuture(null);
+        }
+
+        @Override
         public SafeFuture<Void> builderRegisterValidators(
             final SszList<SignedValidatorRegistration> signedValidatorRegistrations,
             final UInt64 slot) {
@@ -106,6 +114,8 @@ public interface ExecutionLayerChannel extends ChannelInterface {
       Optional<PayloadBuildingAttributes> payloadBuildingAttributes);
 
   SafeFuture<PayloadStatus> engineNewPayload(NewPayloadRequest newPayloadRequest);
+
+  SafeFuture<List<ClientVersion>> engineGetClientVersion(ClientVersion clientVersion);
 
   /**
    * This is low level method, use {@link

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
@@ -33,6 +33,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
 import tech.pegasys.teku.ethereum.performance.trackers.BlockProductionPerformance;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.bytes.Bytes4;
 import tech.pegasys.teku.infrastructure.bytes.Bytes8;
 import tech.pegasys.teku.infrastructure.collections.cache.LRUCache;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
@@ -51,6 +52,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.builder.BuilderPayload;
 import tech.pegasys.teku.spec.datastructures.builder.SignedValidatorRegistration;
 import tech.pegasys.teku.spec.datastructures.execution.BlobsBundle;
+import tech.pegasys.teku.spec.datastructures.execution.ClientVersion;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
@@ -68,6 +70,9 @@ import tech.pegasys.teku.spec.schemas.SchemaDefinitionsDeneb;
 
 public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
   private static final Logger LOG = LogManager.getLogger();
+  private static final ClientVersion STUB_CLIENT_VERSION =
+      new ClientVersion("SB", ExecutionLayerChannel.STUB_ENDPOINT_PREFIX, "0.0.0", Bytes4.ZERO);
+
   private final TimeProvider timeProvider;
   private final Map<Bytes32, PowBlock> knownBlocks = new ConcurrentHashMap<>();
   private final Map<Bytes32, PayloadStatus> knownPosBlocks = new ConcurrentHashMap<>();
@@ -311,6 +316,11 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
         newPayloadRequest.getParentBeaconBlockRoot(),
         returnedStatus);
     return SafeFuture.completedFuture(returnedStatus);
+  }
+
+  @Override
+  public SafeFuture<List<ClientVersion>> engineGetClientVersion(final ClientVersion clientVersion) {
+    return SafeFuture.completedFuture(List.of(STUB_CLIENT_VERSION));
   }
 
   @Override

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -114,6 +114,7 @@ import tech.pegasys.teku.spec.datastructures.builder.SignedBuilderBid;
 import tech.pegasys.teku.spec.datastructures.builder.SignedValidatorRegistration;
 import tech.pegasys.teku.spec.datastructures.builder.ValidatorRegistration;
 import tech.pegasys.teku.spec.datastructures.execution.BlobsBundle;
+import tech.pegasys.teku.spec.datastructures.execution.ClientVersion;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadBuilder;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
@@ -1850,6 +1851,14 @@ public final class DataStructureUtil {
             : Optional.empty(),
         randomWithdrawalList(),
         randomBytes32());
+  }
+
+  public ClientVersion randomClientVersion() {
+    return new ClientVersion(
+        randomString(2),
+        randomString(randomInt(1, 10)),
+        randomString(randomInt(1, 10)),
+        randomBytes4());
   }
 
   public BeaconPreparableProposer randomBeaconPreparableProposer() {

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -24,6 +24,7 @@ import static tech.pegasys.teku.spec.schemas.ApiSchemas.VALIDATOR_REGISTRATION_S
 
 import com.google.common.base.Preconditions;
 import it.unimi.dsi.fastutil.ints.IntList;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -280,6 +281,10 @@ public final class DataStructureUtil {
     final byte[] result = new byte[length];
     random.nextBytes(result);
     return Bytes.wrap(result);
+  }
+
+  public String randomString(final int length) {
+    return new String(randomBytes(length).toArrayUnsafe(), StandardCharsets.UTF_8);
   }
 
   public BLSSignature randomSignature() {

--- a/infrastructure/bytes/src/main/java/tech/pegasys/teku/infrastructure/bytes/Bytes4.java
+++ b/infrastructure/bytes/src/main/java/tech/pegasys/teku/infrastructure/bytes/Bytes4.java
@@ -22,6 +22,7 @@ import org.apache.tuweni.bytes.MutableBytes;
 
 public class Bytes4 {
   public static final int SIZE = 4;
+  public static final Bytes4 ZERO = new Bytes4(Bytes.wrap(new byte[SIZE]));
 
   private final Bytes bytes;
 

--- a/infrastructure/version/build.gradle
+++ b/infrastructure/version/build.gradle
@@ -1,3 +1,20 @@
+task generateGitProperties {
+  if (!grgit) {
+    logger.warn("Not building from a git checkout, skipping git.properties generation")
+    return
+  }
+  def outputFile = layout.buildDirectory.file("resources/main/git.properties").get().asFile
+  outputs.file(outputFile)
+  doLast {
+    outputFile.text = "git.commit.id=${grgit.head().id}"
+  }
+}
+
+tasks.withType(JavaCompile).configureEach {
+  dependsOn generateGitProperties
+}
+
+
 dependencies {
   implementation 'org.apache.commons:commons-lang3'
   implementation 'org.apache.tuweni:tuweni-bytes'

--- a/infrastructure/version/src/main/java/tech/pegasys/teku/infrastructure/version/VersionProvider.java
+++ b/infrastructure/version/src/main/java/tech/pegasys/teku/infrastructure/version/VersionProvider.java
@@ -68,12 +68,17 @@ public class VersionProvider {
   }
 
   private static Optional<String> getCommitHash() {
-    try (InputStream is =
-        VersionProvider.class.getClassLoader().getResourceAsStream("git.properties")) {
+    return getCommitHash(
+        VersionProvider.class.getClassLoader().getResourceAsStream("git.properties"));
+  }
+
+  static Optional<String> getCommitHash(final InputStream gitPropertiesStream) {
+    try (InputStream is = gitPropertiesStream) {
       if (is != null) {
         final Properties properties = new Properties();
         properties.load(is);
-        return Optional.ofNullable(properties.getProperty("git.commit.id"));
+        return Optional.ofNullable(properties.getProperty("git.commit.id"))
+            .filter(commitHash -> commitHash.length() == 40);
       } else {
         return Optional.empty();
       }

--- a/infrastructure/version/src/main/java/tech/pegasys/teku/infrastructure/version/VersionProvider.java
+++ b/infrastructure/version/src/main/java/tech/pegasys/teku/infrastructure/version/VersionProvider.java
@@ -45,10 +45,10 @@ public class VersionProvider {
   }
 
   public static Optional<String> getCommitHash() {
-    final Properties properties = new Properties();
     try (InputStream is =
         VersionProvider.class.getClassLoader().getResourceAsStream("git.properties")) {
       if (is != null) {
+        final Properties properties = new Properties();
         properties.load(is);
         return Optional.ofNullable(properties.getProperty("git.commit.id"));
       } else {

--- a/infrastructure/version/src/main/java/tech/pegasys/teku/infrastructure/version/VersionProvider.java
+++ b/infrastructure/version/src/main/java/tech/pegasys/teku/infrastructure/version/VersionProvider.java
@@ -77,8 +77,7 @@ public class VersionProvider {
       if (is != null) {
         final Properties properties = new Properties();
         properties.load(is);
-        return Optional.ofNullable(properties.getProperty("git.commit.id"))
-            .filter(commitHash -> commitHash.length() == 40);
+        return Optional.ofNullable(properties.getProperty("git.commit.id"));
       } else {
         return Optional.empty();
       }

--- a/infrastructure/version/src/main/java/tech/pegasys/teku/infrastructure/version/VersionProvider.java
+++ b/infrastructure/version/src/main/java/tech/pegasys/teku/infrastructure/version/VersionProvider.java
@@ -33,6 +33,7 @@ public class VersionProvider {
   public static final String IMPLEMENTATION_VERSION = "v" + getImplementationVersion();
   public static final String VERSION =
       CLIENT_IDENTITY + "/" + IMPLEMENTATION_VERSION + "/" + detectOS() + "/" + detectJvm();
+  public static final Optional<String> COMMIT_HASH = getCommitHash();
 
   public static Bytes32 getDefaultGraffiti() {
     final String graffitiVersionString = CLIENT_IDENTITY + "/" + IMPLEMENTATION_VERSION;
@@ -41,21 +42,6 @@ public class VersionProvider {
       return Bytes32.rightPad(versionBytes);
     } else {
       return Bytes32.wrap(versionBytes.slice(0, Bytes32.SIZE));
-    }
-  }
-
-  public static Optional<String> getCommitHash() {
-    try (InputStream is =
-        VersionProvider.class.getClassLoader().getResourceAsStream("git.properties")) {
-      if (is != null) {
-        final Properties properties = new Properties();
-        properties.load(is);
-        return Optional.ofNullable(properties.getProperty("git.commit.id"));
-      } else {
-        return Optional.empty();
-      }
-    } catch (IOException ex) {
-      throw new UncheckedIOException(ex);
     }
   }
 
@@ -79,6 +65,21 @@ public class VersionProvider {
     final String detectedVM = normalizeVM(normalize("java.vendor"), normalize("java.vm.name"));
     final String detectedJavaVersion = System.getProperty("java.specification.version");
     return detectedVM + "-java-" + detectedJavaVersion;
+  }
+
+  private static Optional<String> getCommitHash() {
+    try (InputStream is =
+        VersionProvider.class.getClassLoader().getResourceAsStream("git.properties")) {
+      if (is != null) {
+        final Properties properties = new Properties();
+        properties.load(is);
+        return Optional.ofNullable(properties.getProperty("git.commit.id"));
+      } else {
+        return Optional.empty();
+      }
+    } catch (IOException ex) {
+      throw new UncheckedIOException(ex);
+    }
   }
 
   static String defaultStoragePathForNormalizedOS(

--- a/infrastructure/version/src/test/java/tech/pegasys/teku/infrastructure/version/VersionProviderTest.java
+++ b/infrastructure/version/src/test/java/tech/pegasys/teku/infrastructure/version/VersionProviderTest.java
@@ -26,8 +26,8 @@ class VersionProviderTest {
   private static final String TEKU = "/teku";
 
   @Test
-  void getCommitHash_retrievesValidCommitHash() {
-    assertThat(VersionProvider.getCommitHash())
+  void commitHashConstant_isValidCommitHash() {
+    assertThat(VersionProvider.COMMIT_HASH)
         .hasValueSatisfying(
             commitHash -> assertThat(commitHash).hasSize(40).matches("[0-9a-fA-F]+"));
   }

--- a/infrastructure/version/src/test/java/tech/pegasys/teku/infrastructure/version/VersionProviderTest.java
+++ b/infrastructure/version/src/test/java/tech/pegasys/teku/infrastructure/version/VersionProviderTest.java
@@ -26,6 +26,13 @@ class VersionProviderTest {
   private static final String TEKU = "/teku";
 
   @Test
+  void getCommitHash_retrievesValidCommitHash() {
+    assertThat(VersionProvider.getCommitHash())
+        .hasValueSatisfying(
+            commitHash -> assertThat(commitHash).hasSize(40).matches("[0-9a-fA-F]+"));
+  }
+
+  @Test
   void defaultStoragePath_shouldHandleWindowsPath() {
     final String homeFolder = "c:\\users\\myUser\\AppData\\local";
     final Map<String, String> env = Map.of(ENV_LOCALAPPDATA, homeFolder);

--- a/infrastructure/version/src/test/java/tech/pegasys/teku/infrastructure/version/VersionProviderTest.java
+++ b/infrastructure/version/src/test/java/tech/pegasys/teku/infrastructure/version/VersionProviderTest.java
@@ -18,9 +18,14 @@ import static tech.pegasys.teku.infrastructure.version.VersionProvider.ENV_HOME;
 import static tech.pegasys.teku.infrastructure.version.VersionProvider.ENV_LOCALAPPDATA;
 import static tech.pegasys.teku.infrastructure.version.VersionProvider.ENV_XDG_DATA_HOME;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Map;
 import org.apache.logging.log4j.util.Strings;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 class VersionProviderTest {
   private static final String TEKU = "/teku";
@@ -30,6 +35,33 @@ class VersionProviderTest {
     assertThat(VersionProvider.COMMIT_HASH)
         .hasValueSatisfying(
             commitHash -> assertThat(commitHash).hasSize(40).matches("[0-9a-fA-F]+"));
+  }
+
+  @Test
+  void getCommitHashIsEmpty_whenGitPropertiesFileDoesNotExist() {
+    final InputStream notExistingFile =
+        VersionProviderTest.class.getClassLoader().getResourceAsStream("foo.properties");
+    assertThat(VersionProvider.getCommitHash(notExistingFile)).isEmpty();
+  }
+
+  @Test
+  void getCommitHashIsEmpty_whenGitCommitIdPropertyDoesNotExist(@TempDir Path tempDir)
+      throws IOException {
+    final Path gitPropertiesFile = tempDir.resolve("git.properties");
+
+    Files.writeString(gitPropertiesFile, "git.commit.foo=3824d24e9fee209d2335780643dac7f2dc4986e1");
+
+    assertThat(VersionProvider.getCommitHash(Files.newInputStream(gitPropertiesFile))).isEmpty();
+  }
+
+  @Test
+  void getCommitHashIsEmpty_whenGitCommitIdIsNot40Characters(@TempDir Path tempDir)
+      throws IOException {
+    final Path gitPropertiesFile = tempDir.resolve("git.properties");
+
+    Files.writeString(gitPropertiesFile, "git.commit.id=3824d24e9");
+
+    assertThat(VersionProvider.getCommitHash(Files.newInputStream(gitPropertiesFile))).isEmpty();
   }
 
   @Test

--- a/infrastructure/version/src/test/java/tech/pegasys/teku/infrastructure/version/VersionProviderTest.java
+++ b/infrastructure/version/src/test/java/tech/pegasys/teku/infrastructure/version/VersionProviderTest.java
@@ -55,16 +55,6 @@ class VersionProviderTest {
   }
 
   @Test
-  void getCommitHashIsEmpty_whenGitCommitIdIsNot40Characters(@TempDir Path tempDir)
-      throws IOException {
-    final Path gitPropertiesFile = tempDir.resolve("git.properties");
-
-    Files.writeString(gitPropertiesFile, "git.commit.id=3824d24e9");
-
-    assertThat(VersionProvider.getCommitHash(Files.newInputStream(gitPropertiesFile))).isEmpty();
-  }
-
-  @Test
   void defaultStoragePath_shouldHandleWindowsPath() {
     final String homeFolder = "c:\\users\\myUser\\AppData\\local";
     final Map<String, String> env = Map.of(ENV_LOCALAPPDATA, homeFolder);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

- Add `getClientVersionV1` in `ExecutionEngineClient`
- Add `engineGetClientVersion` in `ExecutionLayerChannel`
- Add gradle task `generateGitProperties` to create a `git.properties` file in runtime/JAR which is used by `VersionProvider` to be able to retrieve the git commit hash (will be used in future PRs)


## Fixed Issue(s)
related to #7930 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
