### PR TITLE
fixed exception reporting duties

### DIFF
--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/AbstractDutyScheduler.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/AbstractDutyScheduler.java
@@ -15,7 +15,7 @@ package tech.pegasys.teku.validator.client;
 
 import java.util.NavigableMap;
 import java.util.Optional;
-import java.util.TreeMap;
+import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.function.BiConsumer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -35,7 +35,7 @@ public abstract class AbstractDutyScheduler implements ValidatorTimingChannel {
 
   private UInt64 lastProductionSlot;
 
-  protected final NavigableMap<UInt64, PendingDuties> dutiesByEpoch = new TreeMap<>();
+  protected final NavigableMap<UInt64, PendingDuties> dutiesByEpoch = new ConcurrentSkipListMap<>();
   private Optional<UInt64> currentEpoch = Optional.empty();
 
   protected AbstractDutyScheduler(


### PR DESCRIPTION
while metrics function runs, it would occasionally report a concurrent modification exception.


## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
