### PR TITLE
Changed development flag to be unhidden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ the [releases page](https://github.com/Consensys/teku/releases).
 ## Unreleased Changes
 
 ### Breaking Changes
+ - The development command line argument `--Xvalidator-is-local-slashing-protection-synchronized-enabled` has become a supported and documented argument `--validator-is-local-slashing-protection-synchronized-enabled`.
 
 ### Additions and Improvements
 - Introduced [Validator Slashing Prevention feature](https://docs.teku.consensys.io/how-to/prevent-slashing/detect-slashing).

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/ValidatorOptions.java
@@ -143,12 +143,11 @@ public class ValidatorOptions {
       ValidatorConfig.DEFAULT_EXIT_WHEN_NO_VALIDATOR_KEYS_ENABLED;
 
   @Option(
-      names = {"--Xvalidator-is-local-slashing-protection-synchronized-enabled"},
+      names = {"--validator-is-local-slashing-protection-synchronized-enabled"},
       paramLabel = "<BOOLEAN>",
       description = "Restrict local signing to a single operation at a time.",
       showDefaultValue = CommandLine.Help.Visibility.ALWAYS,
       arity = "0..1",
-      hidden = true,
       fallbackValue = "true")
   private boolean isLocalSlashingProtectionSynchronizedEnabled =
       DEFAULT_VALIDATOR_IS_LOCAL_SLASHING_PROTECTION_SYNCHRONIZED_ENABLED;


### PR DESCRIPTION
Unhiding local slashing protection synchronized flag, leaving the default the same.

This will be added to documentation.

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
