### PR TITLE
Explicit Peering Agreement implementation

### DIFF
--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/gossip/config/GossipConfig.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/gossip/config/GossipConfig.java
@@ -18,6 +18,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.time.Duration;
 import java.util.function.Consumer;
 import tech.pegasys.teku.infrastructure.exceptions.InvalidConfigurationException;
+import tech.pegasys.teku.networking.p2p.gossip.config.GossipPeerScoringConfig.DirectPeerManager;
 
 /**
  * Gossip options
@@ -32,8 +33,8 @@ public class GossipConfig {
   private static final int DEFAULT_ADVERTISE = 3;
   private static final int DEFAULT_HISTORY = 6;
   static final Duration DEFAULT_HEARTBEAT_INTERVAL = Duration.ofMillis(700);
-  // After EIP-7045, attestations are valid for up to 2 full epochs, so TTL is 65 slots
-  // 1115 * HEARTBEAT = 1115 * 0.7 / 12 = 65.125
+  // After EIP-7045, attestations are valid for up to 2 full epochs, so TTL is 65
+  // slots 1115 * HEARTBEAT = 1115 * 0.7 / 12 = 65.125
   static final Duration DEFAULT_SEEN_TTL = DEFAULT_HEARTBEAT_INTERVAL.multipliedBy(1115);
 
   private final int d;
@@ -213,6 +214,12 @@ public class GossipConfig {
         throw new InvalidConfigurationException(String.format("Invalid seenTTL: %s", seenTTL));
       }
       this.seenTTL = seenTTL;
+      return this;
+    }
+
+    public Builder directPeerManager(final DirectPeerManager directPeerManager) {
+      checkNotNull(directPeerManager);
+      this.scoringConfigBuilder.directPeerManager(directPeerManager);
       return this;
     }
   }

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/gossip/config/GossipScoringConfig.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/gossip/config/GossipScoringConfig.java
@@ -16,7 +16,9 @@ package tech.pegasys.teku.networking.p2p.gossip.config;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Consumer;
+import tech.pegasys.teku.networking.p2p.gossip.config.GossipPeerScoringConfig.DirectPeerManager;
 
 /** Gossip scoring config. Contains peer scoring and topic scoring configs. */
 public class GossipScoringConfig {
@@ -161,6 +163,13 @@ public class GossipScoringConfig {
     public Builder opportunisticGraftThreshold(final Double opportunisticGraftThreshold) {
       checkNotNull(opportunisticGraftThreshold);
       this.opportunisticGraftThreshold = opportunisticGraftThreshold;
+      return this;
+    }
+
+    public Builder directPeerManager(final DirectPeerManager directPeerManager) {
+      checkNotNull(directPeerManager);
+
+      this.peerScoringConfigBuilder.directPeerManager(Optional.of(directPeerManager));
       return this;
     }
   }

--- a/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/config/NetworkConfig.java
+++ b/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/network/config/NetworkConfig.java
@@ -21,6 +21,7 @@ import java.net.NetworkInterface;
 import java.net.SocketException;
 import java.net.UnknownHostException;
 import java.util.Enumeration;
+import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.function.Consumer;
@@ -29,6 +30,8 @@ import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.infrastructure.exceptions.InvalidConfigurationException;
 import tech.pegasys.teku.infrastructure.io.PortAvailability;
 import tech.pegasys.teku.networking.p2p.gossip.config.GossipConfig;
+import tech.pegasys.teku.networking.p2p.gossip.config.GossipPeerScoringConfig.DirectPeerManager;
+import tech.pegasys.teku.networking.p2p.peer.NodeId;
 
 public class NetworkConfig {
 
@@ -259,6 +262,13 @@ public class NetworkConfig {
 
     public Builder yamuxEnabled(final boolean yamuxEnabled) {
       this.yamuxEnabled = yamuxEnabled;
+      return this;
+    }
+
+    public Builder directPeers(final List<NodeId> directPeers) {
+      checkNotNull(directPeers);
+      final DirectPeerManager directPeerManager = directPeers::contains;
+      this.gossipConfigBuilder.directPeerManager(directPeerManager);
       return this;
     }
   }

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
@@ -334,6 +334,9 @@ public class P2POptions {
   }
 
   public void configure(final TekuConfiguration.Builder builder) {
+    // From a discovery configuration perspective, direct peers are static peers
+    p2pStaticPeers.addAll(p2pDirectPeers);
+
     builder
         .p2p(
             b ->

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
@@ -26,6 +26,7 @@ import tech.pegasys.teku.beacon.sync.SyncConfig;
 import tech.pegasys.teku.config.TekuConfiguration;
 import tech.pegasys.teku.networking.eth2.P2PConfig;
 import tech.pegasys.teku.networking.p2p.discovery.DiscoveryConfig;
+import tech.pegasys.teku.networking.p2p.libp2p.MultiaddrPeerAddress;
 import tech.pegasys.teku.networking.p2p.network.config.NetworkConfig;
 
 public class P2POptions {
@@ -373,6 +374,13 @@ public class P2POptions {
               }
               if (p2pAdvertisedPort != null) {
                 n.advertisedPort(OptionalInt.of(p2pAdvertisedPort));
+              }
+              if (!p2pDirectPeers.isEmpty()) {
+                n.directPeers(
+                    p2pDirectPeers.stream()
+                        .map(MultiaddrPeerAddress::fromAddress)
+                        .map(MultiaddrPeerAddress::getId)
+                        .toList());
               }
               n.networkInterface(p2pInterface)
                   .isEnabled(p2pEnabled)

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/P2POptions.java
@@ -143,10 +143,22 @@ public class P2POptions {
   @Option(
       names = {"--p2p-static-peers"},
       paramLabel = "<PEER_ADDRESSES>",
-      description = "Static peers",
+      description =
+          "Specifies a list of 'static' peers with which to establish and maintain connections",
       split = ",",
       arity = "0..*")
   private List<String> p2pStaticPeers = new ArrayList<>();
+
+  @Option(
+      names = {"--p2p-direct-peers"},
+      paramLabel = "<PEER_ADDRESSES>",
+      description =
+          "Specifies a list of 'direct' peers with which to establish and maintain connections.\n"
+              + "Direct peers are static peers with which this node will always exchange full messages, regardless of peer scoring mechanisms.\n"
+              + "Such peers will also need to enable you as direct in order to work.",
+      split = ",",
+      arity = "0..*")
+  private List<String> p2pDirectPeers = new ArrayList<>();
 
   @Option(
       names = {"--Xp2p-multipeer-sync-enabled"},


### PR DESCRIPTION
## PR Description

Implements [Gossipsub v1.1 "Explicit Peering Agreement"](https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.1.md#explicit-peering-agreements) by introducing a new CLI flag `--direct-peers` ("direct" is used instead of "explicit" to follow [jvm-libp2p](https://github.com/libp2p/jvm-libp2p) convention). 
As such, documentation on https://github.com/Consensys/doc.teku should be updated as well to reflect this change (I can do it if you wish!).

### Implementation

From a discovering configuration perspective, direct peers are treated as static peers, as we want to connect with them immediately on startup and persist the connection with them without being kicked out by the reputation system. 
In order to do that, the list of static peers is extended with the direct peers provided in the CLI option.

Lastly, a function that determines whether a peer is direct or not is passed downstream to `jvm-libp2p` to enable the direct peer functionality on gossipsub.

## Fixed Issue(s)
Closes #8004.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
