### PR TITLE
increased the time to keep attestations cached

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/attestation/AggregatingAttestationPool.java
@@ -104,7 +104,7 @@ public class AggregatingAttestationPool implements SlotEventsChannel {
       updateSize(1);
     }
     // Always keep the latest slot attestations so we don't discard everything
-    long currentSize = getSize();
+    int currentSize = getSize();
     while (dataHashBySlot.size() > 1 && currentSize > maximumAttestationCount) {
       LOG.trace("Attestation cache at {} exceeds {}, ", currentSize, maximumAttestationCount);
       final UInt64 firstSlotToKeep = dataHashBySlot.firstKey().plus(1);


### PR DESCRIPTION
Also added a small amount of logging at trace level, it'll likely be noisy if we have to turn it on.

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
