### PR TITLE
Make DataUnavailablePool always accept new blocks

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blobs/DataUnavailableBlockPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blobs/DataUnavailableBlockPool.java
@@ -38,7 +38,7 @@ import tech.pegasys.teku.storage.api.FinalizedCheckpointChannel;
  * with UNKNOWN_BLOCK and will be tracked in the block pendingPool.
  */
 public class DataUnavailableBlockPool implements FinalizedCheckpointChannel {
-  public static final int MAX_CAPACITY = 50;
+  public static final int MAX_CAPACITY = 10;
   private static final Logger LOG = LogManager.getLogger();
 
   private static final Duration WAIT_BEFORE_RETRY = Duration.ofSeconds(1);

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blobs/DataUnavailableBlockPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blobs/DataUnavailableBlockPool.java
@@ -38,7 +38,7 @@ import tech.pegasys.teku.storage.api.FinalizedCheckpointChannel;
  * with UNKNOWN_BLOCK and will be tracked in the block pendingPool.
  */
 public class DataUnavailableBlockPool implements FinalizedCheckpointChannel {
-  public static final int MAX_CAPACITY = 10;
+  public static final int MAX_CAPACITY = 50;
   private static final Logger LOG = LogManager.getLogger();
 
   private static final Duration WAIT_BEFORE_RETRY = Duration.ofSeconds(1);

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blobs/DataUnavailableBlockPool.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/blobs/DataUnavailableBlockPool.java
@@ -38,7 +38,7 @@ import tech.pegasys.teku.storage.api.FinalizedCheckpointChannel;
  * with UNKNOWN_BLOCK and will be tracked in the block pendingPool.
  */
 public class DataUnavailableBlockPool implements FinalizedCheckpointChannel {
-  public static int MAX_CAPACITY = 10;
+  public static final int MAX_CAPACITY = 10;
   private static final Logger LOG = LogManager.getLogger();
 
   private static final Duration WAIT_BEFORE_RETRY = Duration.ofSeconds(1);


### PR DESCRIPTION
We always make room for latest block, so we guarantee to retry the latest.

The scenario to fix is:
- several block with missing blobs fill the pool. None of this blocks have been imported by any node (blobs not seen by anyone)
- a new block arrives and is discarded. But his block has been imported by others and become canonical (blobs seen by magority of the validators).
- Next proposer builds on top of that. And we don't have any retry in place.

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
