### PR TITLE
Add error log on non-completed trackers

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/BlockBlobSidecarsTrackersPoolImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/BlockBlobSidecarsTrackersPoolImpl.java
@@ -272,6 +272,13 @@ public class BlockBlobSidecarsTrackersPoolImpl extends AbstractIgnoringFutureHis
     totalBlobSidecars += (int) addedBlobs;
     sizeGauge.set(totalBlobSidecars, GAUGE_BLOB_SIDECARS_LABEL);
 
+    if (!blobSidecarsTracker.isCompleted()) {
+      LOG.error(
+          "Tracker for block {} is supposed to be completed but it is not. Missing blob sidecars: {}",
+          block.toLogString(),
+          blobSidecarsTracker.getMissingBlobSidecars().count());
+    }
+
     if (orderedBlobSidecarsTrackers.add(slotAndBlockRoot)) {
       sizeGauge.set(orderedBlobSidecarsTrackers.size(), GAUGE_BLOB_SIDECARS_TRACKERS_LABEL);
     }


### PR DESCRIPTION
In some flows we supply block and blobs to tracker, and it is supposed to be immediately completed.

I added an error log if it isn't the case.

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
