### PR TITLE
Update endpoints tags, operationId and summary according to the spec

### DIFF
--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_beacon_pool_attestations.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_beacon_pool_attestations.json
@@ -1,8 +1,8 @@
 {
   "get" : {
     "tags" : [ "Beacon" ],
-    "operationId" : "getAttestations",
-    "summary" : "Get attestations",
+    "operationId" : "getPoolAttestations",
+    "summary" : "Get Attestations from operations pool",
     "description" : "Retrieves attestations known by the node but not necessarily incorporated into any block.",
     "parameters" : [ {
       "name" : "slot",
@@ -58,8 +58,8 @@
   },
   "post" : {
     "tags" : [ "Beacon", "Validator Required Api" ],
-    "operationId" : "postAttestation",
-    "summary" : "Submit signed attestations",
+    "operationId" : "submitPoolAttestations",
+    "summary" : "Submit Attestation objects to node",
     "description" : "Submit signed attestations to the beacon node to be validated and submitted if valid.\n\nThis endpoint does not protected against slashing.",
     "requestBody" : {
       "content" : {

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_beacon_pool_attester_slashings.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_beacon_pool_attester_slashings.json
@@ -1,8 +1,8 @@
 {
   "get" : {
     "tags" : [ "Beacon" ],
-    "operationId" : "getAttesterSlashings",
-    "summary" : "Get Attester Slashings",
+    "operationId" : "getPoolAttesterSlashings",
+    "summary" : "Get AttesterSlashings from operations pool",
     "description" : "Retrieves attester slashings known by the node but not necessarily incorporated into any block.",
     "responses" : {
       "200" : {
@@ -39,8 +39,8 @@
   },
   "post" : {
     "tags" : [ "Beacon" ],
-    "operationId" : "postAttesterSlashing",
-    "summary" : "Submit attester slashing object",
+    "operationId" : "submitPoolAttesterSlashings",
+    "summary" : "Submit AttesterSlashing object to node's pool",
     "description" : "Submits attester slashing object to node's pool and if passes validation node MUST broadcast it to network.",
     "requestBody" : {
       "content" : {

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_beacon_pool_bls_to_execution_changes.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_beacon_pool_bls_to_execution_changes.json
@@ -1,7 +1,7 @@
 {
   "post" : {
     "tags" : [ "Beacon" ],
-    "operationId" : "postBlsToExecutionChange",
+    "operationId" : "submitPoolBLSToExecutionChange",
     "summary" : "Submit SignedBLSToExecutionChange object to node's pool",
     "description" : "Submits SignedBLSToExecutionChange object to node's pool and if passes validation node MUST broadcast it to network.",
     "requestBody" : {
@@ -45,7 +45,7 @@
   },
   "get" : {
     "tags" : [ "Beacon" ],
-    "operationId" : "getBlsToExecutionChanges",
+    "operationId" : "getPoolBLSToExecutionChanges",
     "summary" : "Get SignedBLSToExecutionChange from operations pool",
     "description" : "Retrieves BLS to execution changes known by the node but not necessarily incorporated into any block",
     "parameters" : [ {

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_beacon_pool_proposer_slashings.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_beacon_pool_proposer_slashings.json
@@ -1,8 +1,8 @@
 {
   "get" : {
     "tags" : [ "Beacon" ],
-    "operationId" : "getProposerSlashings",
-    "summary" : "Get proposer slashings",
+    "operationId" : "getPoolProposerSlashings",
+    "summary" : "Get ProposerSlashings from operations pool",
     "description" : "Retrieves proposer slashings known by the node but not necessarily incorporated into any block.",
     "responses" : {
       "200" : {
@@ -39,8 +39,8 @@
   },
   "post" : {
     "tags" : [ "Beacon" ],
-    "operationId" : "postProposerSlashing",
-    "summary" : "Submit proposer slashing object",
+    "operationId" : "submitPoolProposerSlashings",
+    "summary" : "Submit ProposerSlashing object to node's pool",
     "description" : "Submits proposer slashing object to node's pool and, if it passes validation, the node MUST broadcast it to network.",
     "requestBody" : {
       "content" : {

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_beacon_pool_sync_committees.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_beacon_pool_sync_committees.json
@@ -1,8 +1,8 @@
 {
   "post" : {
     "tags" : [ "Beacon", "Validator Required Api" ],
-    "operationId" : "postSyncCommittees",
-    "summary" : "Submit sync committee messages to node",
+    "operationId" : "submitPoolSyncCommitteeSignatures",
+    "summary" : "Submit sync committee signatures to node",
     "description" : "Submits sync committee message objects to the node.\n\nSync committee messages are not present in phase0, but are required for Altair networks.\n\nIf a sync committee message is validated successfully the node MUST publish that sync committee message on all applicable subnets.\n\nIf one or more sync committee messages fail validation the node MUST return a 400 error with details of which sync committee messages have failed, and why.",
     "requestBody" : {
       "content" : {

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_beacon_pool_voluntary_exits.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_beacon_pool_voluntary_exits.json
@@ -1,8 +1,8 @@
 {
   "get" : {
     "tags" : [ "Beacon" ],
-    "operationId" : "getVoluntaryExits",
-    "summary" : "Get signed voluntary exits",
+    "operationId" : "getPoolVoluntaryExits",
+    "summary" : "Get SignedVoluntaryExit from operations pool",
     "description" : "Retrieves voluntary exits known by the node but not necessarily incorporated into any block.",
     "responses" : {
       "200" : {
@@ -39,8 +39,8 @@
   },
   "post" : {
     "tags" : [ "Beacon" ],
-    "operationId" : "postVoluntaryExit",
-    "summary" : "Submit signed voluntary exit",
+    "operationId" : "submitPoolVoluntaryExit",
+    "summary" : "Submit SignedVoluntaryExit object to node's pool",
     "description" : "Submits signed voluntary exit object to node's pool and if it passes validation node MUST broadcast it to network.",
     "requestBody" : {
       "content" : {

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_beacon_rewards_attestations_{epoch}.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_beacon_rewards_attestations_{epoch}.json
@@ -5,7 +5,7 @@
       "Rewards"
     ],
     "operationId": "getAttestationsRewards",
-    "summary": "Get Attestations Rewards",
+    "summary": "Get attestations rewards",
     "description": "Retrieve attestation reward info for validators specified by array of public keys or validator index. If no array is provided, return reward info for every validator.",
     "parameters": [
       {

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_beacon_rewards_blocks_{block_id}.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_beacon_rewards_blocks_{block_id}.json
@@ -2,7 +2,7 @@
   "get" : {
     "tags" : [ "Beacon", "Rewards"],
     "operationId" : "getBlockRewards",
-    "summary" : "Get Block Rewards",
+    "summary" : "Get block rewards",
     "description" : "Retrieve block reward info for a single block.",
     "parameters" : [ {
       "name" : "block_id",

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_beacon_rewards_sync_committee_{block_id}.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_beacon_rewards_sync_committee_{block_id}.json
@@ -2,7 +2,7 @@
   "post" : {
     "tags" : [ "Beacon", "Rewards" ],
     "operationId" : "getSyncCommitteeRewards",
-    "summary" : "Get Sync Committee Rewards",
+    "summary" : "Get sync committee rewards",
     "description" : "Retrieves rewards info for sync committee members specified by array of public keys or validator index. If no array is provided, return reward info for every committee member.",
     "parameters" : [ {
       "name" : "block_id",

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_beacon_states_{state_id}_committees.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_beacon_states_{state_id}_committees.json
@@ -1,8 +1,8 @@
 {
   "get" : {
     "tags" : [ "Beacon" ],
-    "operationId" : "getStateCommittees",
-    "summary" : "Get committees at state",
+    "operationId" : "getEpochCommittees",
+    "summary" : "Get all committees for a state.",
     "description" : "Retrieves the committees for the given state.",
     "parameters" : [ {
       "name" : "state_id",

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_beacon_states_{state_id}_fork.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_beacon_states_{state_id}_fork.json
@@ -1,8 +1,8 @@
 {
   "get" : {
     "tags" : [ "Beacon", "Validator Required Api" ],
-    "operationId" : "getSateFork",
-    "summary" : "Get state fork",
+    "operationId" : "getStateFork",
+    "summary" : "Get Fork object for requested state",
     "description" : "Returns Fork object for state with given 'state_id'.",
     "parameters" : [ {
       "name" : "state_id",

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_beacon_states_{state_id}_randao.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_beacon_states_{state_id}_randao.json
@@ -2,7 +2,7 @@
   "get" : {
     "tags" : [ "Beacon" ],
     "operationId" : "getStateRandao",
-    "summary" : "Get state RANDAO",
+    "summary" : "Get the RANDAO mix for some epoch in a specified state.",
     "description" : "Fetch the RANDAO mix for the requested epoch from the state identified by `state_id`.\n\nIf an epoch is not specified then the RANDAO mix for the state's current epoch will be returned.\n\nBy adjusting the `state_id` parameter you can query for any historic value of the RANDAO mix. Ordinarily states from the same epoch will mutate the RANDAO mix for that epoch as blocks are applied.",
     "parameters" : [ {
       "name" : "state_id",

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_beacon_states_{state_id}_root.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_beacon_states_{state_id}_root.json
@@ -2,7 +2,7 @@
   "get" : {
     "tags" : [ "Beacon" ],
     "operationId" : "getStateRoot",
-    "summary" : "Get state root",
+    "summary" : "Get state SSZ HashTreeRoot",
     "description" : "Calculates HashTreeRoot for state with given 'state_id'. If stateId is root, same value will be returned.",
     "parameters" : [ {
       "name" : "state_id",

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_beacon_states_{state_id}_sync_committees.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_beacon_states_{state_id}_sync_committees.json
@@ -1,8 +1,8 @@
 {
   "get" : {
-    "tags" : [ "Beacon", "Validator Required Api" ],
-    "operationId" : "getStateSyncCommittees",
-    "summary" : "Get sync committees",
+    "tags" : [ "Beacon" ],
+    "operationId" : "getEpochSyncCommittees",
+    "summary" : "Get sync committees for a state.",
     "description" : "Retrieves the sync committees for the given state.",
     "parameters" : [ {
       "name" : "state_id",

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_beacon_states_{state_id}_validators_{validator_id}.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_beacon_states_{state_id}_validators_{validator_id}.json
@@ -2,7 +2,7 @@
   "get" : {
     "tags" : [ "Beacon", "Validator Required Api" ],
     "operationId" : "getStateValidator",
-    "summary" : "Get validator from state",
+    "summary" : "Get validator from state by id",
     "description" : "Retrieves data about the given peer.",
     "parameters" : [ {
       "name" : "state_id",

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_builder_states_{state_id}_expected_withdrawals.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_builder_states_{state_id}_expected_withdrawals.json
@@ -1,8 +1,8 @@
 {
   "get" : {
     "tags" : [ "Builder" ],
-    "operationId" : "GetExpectedWithdrawals",
-    "summary" : "Get Expected Withdrawals",
+    "operationId" : "getNextWithdrawals",
+    "summary" : "Get the withdrawals that are to be included for the block built on the specified state.",
     "description" : "Get the withdrawals computed from the specified state, that will be included in the block \n    that gets built on the specified state.",
     "parameters" : [ {
       "name" : "state_id",

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_config_deposit_contract.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_config_deposit_contract.json
@@ -1,7 +1,7 @@
 {
   "get" : {
     "tags" : [ "Config" ],
-    "operationId" : "getDepositContractAddress",
+    "operationId" : "getDepositContract",
     "summary" : "Get deposit contract address",
     "description" : "Retrieve deposit contract address and genesis fork version.",
     "responses" : {

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_config_fork_schedule.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_config_fork_schedule.json
@@ -1,8 +1,8 @@
 {
   "get" : {
     "tags" : [ "Config" ],
-    "operationId" : "getScheduledForks",
-    "summary" : "Get scheduled forks",
+    "operationId" : "getForkSchedule",
+    "summary" : "Get scheduled upcoming forks.",
     "description" : "Retrieve all scheduled upcoming forks this node is aware of.",
     "responses" : {
       "200" : {

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_config_spec.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_config_spec.json
@@ -2,7 +2,7 @@
   "get" : {
     "tags" : [ "Config", "Validator Required Api" ],
     "operationId" : "getSpec",
-    "summary" : "Get spec params",
+    "summary" : "Get spec params.",
     "description" : "Retrieve specification configuration used on this node.",
     "responses" : {
       "200" : {

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_node_health.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_node_health.json
@@ -1,8 +1,8 @@
 {
   "get" : {
     "tags" : [ "Node" ],
-    "operationId" : "GetNodeHealth",
-    "summary" : "Get node health",
+    "operationId" : "getHealth",
+    "summary" : "Get health check",
     "description" : "Returns node health status in http status codes. Useful for load balancers.",
     "parameters" : [ {
       "name" : "syncing_status",

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_node_peers.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_node_peers.json
@@ -1,8 +1,8 @@
 {
   "get" : {
     "tags" : [ "Node" ],
-    "operationId" : "getNodePeers",
-    "summary" : "Get node peers",
+    "operationId" : "getPeers",
+    "summary" : "Get node network peers",
     "description" : "Retrieves data about the node's network peers.",
     "responses" : {
       "200" : {

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_node_peers_{peer_id}.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_node_peers_{peer_id}.json
@@ -1,7 +1,7 @@
 {
   "get" : {
     "tags" : [ "Node" ],
-    "operationId" : "getNodePeer",
+    "operationId" : "getPeer",
     "summary" : "Get node peer",
     "description" : "Retrieves data about the given peer.",
     "parameters" : [ {

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_node_syncing.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_node_syncing.json
@@ -1,7 +1,7 @@
 {
   "get" : {
     "tags" : [ "Node", "Validator Required Api" ],
-    "operationId" : "getNodeSyncingStatus",
+    "operationId" : "getSyncingStatus",
     "summary" : "Get node syncing status",
     "description" : "Requests the beacon node to describe if it's currently syncing or not, and if it is, what block it is up to.",
     "responses" : {

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_node_version.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_node_version.json
@@ -2,7 +2,7 @@
   "get" : {
     "tags" : [ "Node" ],
     "operationId" : "getNodeVersion",
-    "summary" : "Get node version",
+    "summary" : "Get version string of the running beacon node.",
     "description" : "similar to [HTTP User-Agent](https://tools.ietf.org/html/rfc7231#section-5.5.3).",
     "responses" : {
       "200" : {

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_validator_aggregate_and_proofs.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_validator_aggregate_and_proofs.json
@@ -1,8 +1,8 @@
 {
   "post" : {
     "tags" : [ "Validator", "Validator Required Api" ],
-    "operationId" : "postAggregateAndProofs",
-    "summary" : "Publish aggregate and proofs",
+    "operationId" : "publishAggregateAndProofs",
+    "summary" : "Publish multiple aggregate and proofs",
     "description" : "Verifies given aggregate and proofs and publishes it on appropriate gossipsub topic.",
     "requestBody" : {
       "content" : {

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_validator_aggregate_attestation.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_validator_aggregate_attestation.json
@@ -1,8 +1,8 @@
 {
   "get" : {
     "tags" : [ "Validator", "Validator Required Api" ],
-    "operationId" : "getAggregateAttestation",
-    "summary" : "Get aggregated attestations",
+    "operationId" : "getAggregatedAttestation",
+    "summary" : "Get aggregated attestation",
     "description" : "Aggregates all attestations matching given attestation data root and slot.",
     "parameters" : [ {
       "name" : "attestation_data_root",

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_validator_attestation_data.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_validator_attestation_data.json
@@ -1,7 +1,7 @@
 {
   "get" : {
     "tags" : [ "Validator", "Validator Required Api" ],
-    "operationId" : "getAttestationData",
+    "operationId" : "produceAttestationData",
     "summary" : "Produce an AttestationData",
     "description" : "Requests that the beacon node produce an AttestationData.",
     "parameters" : [ {

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_validator_beacon_committee_subscriptions.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_validator_beacon_committee_subscriptions.json
@@ -1,8 +1,8 @@
 {
   "post" : {
     "tags" : [ "Validator", "Validator Required Api" ],
-    "operationId" : "postSubscribeToBeaconCommitteeSubnet",
-    "summary" : "Subscribe to a committee subnet",
+    "operationId" : "prepareBeaconCommitteeSubnet",
+    "summary" : "Signal beacon node to prepare for a committee subnet",
     "description" : "After Beacon node receives this request, search using discv5 for peers related to this subnet and replace current peers with those ones if necessary If validator is_aggregator, beacon node must:\n- announce subnet topic subscription on gossipsub\n- aggregate attestations received on that subnet\n",
     "requestBody" : {
       "content" : {

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_validator_blinded_blocks_{slot}.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_validator_blinded_blocks_{slot}.json
@@ -1,7 +1,7 @@
 {
   "get" : {
     "tags" : [ "Validator", "Validator Required Api"],
-    "operationId" : "getNewBlindedBlock",
+    "operationId" : "produceBlindedBlock",
     "summary" : "Produce unsigned blinded block",
     "description" : "Requests a beacon node to produce a valid blinded block, which can then be signed by a validator. A blinded block is a block with only a transactions root, rather than a full transactions list.\n\nMetadata in the response indicates the type of block produced, and the supported types of block will be added to as forks progress.\n\nPre-Bellatrix, this endpoint will return a `BeaconBlock`.",
     "parameters" : [ {

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_validator_contribution_and_proofs.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_validator_contribution_and_proofs.json
@@ -1,8 +1,8 @@
 {
   "post" : {
     "tags" : [ "Validator", "Validator Required Api" ],
-    "operationId" : "postContributionAndProofs",
-    "summary" : "Publish contribution and proofs",
+    "operationId" : "publishContributionAndProofs",
+    "summary" : "Publish multiple contribution and proofs",
     "description" : "Verifies given sync committee contribution and proofs and publishes on appropriate gossipsub topics.",
     "requestBody" : {
       "content" : {

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_validator_duties_attester_{epoch}.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_validator_duties_attester_{epoch}.json
@@ -1,7 +1,7 @@
 {
   "post" : {
     "tags" : [ "Validator", "Validator Required Api" ],
-    "operationId" : "postAttesterDuties",
+    "operationId" : "getAttesterDuties",
     "summary" : "Get attester duties",
     "description" : "Requests the beacon node to provide a set of attestation duties, which should be performed by validators, for a particular epoch. Duties should only need to be checked once per epoch, however a chain reorganization (of > MIN_SEED_LOOKAHEAD epochs) could occur, resulting in a change of duties. For full safety, you should monitor head events and confirm the dependent root in this response matches:\n- event.previous_duty_dependent_root when `compute_epoch_at_slot(event.slot) == epoch`\n- event.current_duty_dependent_root when `compute_epoch_at_slot(event.slot) + 1 == epoch`\n- event.block otherwise\n\nThe dependent_root value is `get_block_root_at_slot(state, compute_start_slot_at_epoch(epoch - 1) - 1)` or the genesis block root in the case of underflow.",
     "parameters" : [ {

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_validator_duties_proposer_{epoch}.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_validator_duties_proposer_{epoch}.json
@@ -2,7 +2,7 @@
   "get" : {
     "tags" : [ "Validator", "Validator Required Api" ],
     "operationId" : "getProposerDuties",
-    "summary" : "Get proposer duties",
+    "summary" : "Get block proposers duties",
     "description" : "Request beacon node to provide all validators that are scheduled to propose a block in the given epoch.\n\nDuties should only need to be checked once per epoch, however a chain reorganization could occur that results in a change of duties. For full safety, you should monitor head events and confirm the dependent root in this response matches:\n- event.current_duty_dependent_root when `compute_epoch_at_slot(event.slot) == epoch`\n- event.block otherwise\n\nThe dependent_root value is `get_block_root_at_slot(state, compute_start_slot_at_epoch(epoch) - 1)` or the genesis block root in the case of underflow.",
     "parameters" : [ {
       "name" : "epoch",

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_validator_duties_sync_{epoch}.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_validator_duties_sync_{epoch}.json
@@ -1,7 +1,7 @@
 {
   "post" : {
     "tags" : [ "Validator", "Validator Required Api" ],
-    "operationId" : "postSyncDuties",
+    "operationId" : "getSyncCommitteeDuties",
     "summary" : "Get sync committee duties",
     "description" : "Requests the beacon node to provide a set of sync committee duties",
     "parameters" : [ {

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_validator_liveness_{epoch}.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_validator_liveness_{epoch}.json
@@ -1,8 +1,8 @@
 {
   "post" : {
     "tags" : [ "Validator" ],
-    "operationId" : "postValidatorLiveness",
-    "summary" : "Get Validator Liveness",
+    "operationId" : "getLiveness",
+    "summary" : "Indicates if a validator has been observed on the network",
     "description" : "Requests the beacon node to indicate if a validator has been observed to be live in a given epoch. The beacon node might detect liveness by observing messages from the validator on the network, in the beacon chain, from its API or from any other source. It is important to note that the values returned by the beacon node are not canonical; they are best-effort and based upon a subjective view of the network.",
     "parameters" : [ {
       "name" : "epoch",

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_validator_prepare_beacon_proposer.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_validator_prepare_beacon_proposer.json
@@ -2,7 +2,7 @@
   "post" : {
     "tags" : [ "Validator", "Validator Required Api" ],
     "operationId" : "prepareBeaconProposer",
-    "summary" : "Prepare Beacon Proposers",
+    "summary" : "Provide beacon node with proposals for the given validators.",
     "description" : "Prepares the beacon node for potential proposers by supplying information required when proposing blocks for the given validators. The information supplied for each validator index is considered persistent until overwritten by new information for the given validator index, or until the beacon node restarts.\n\nNote that because the information is not persistent across beacon node restarts it is recommended that either the beacon node is monitored for restarts or this information is refreshed by resending this request periodically (for example, each epoch).\n\nAlso note that requests containing currently inactive or unknown validator indices will be accepted, as they may become active at a later epoch.",
     "requestBody" : {
       "content" : {

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_validator_register_validator.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_validator_register_validator.json
@@ -1,8 +1,8 @@
 {
   "post" : {
-    "tags" : [ "Validator", "Validator Required Api" ],
+    "tags" : [ "Validator" ],
     "operationId" : "registerValidator",
-    "summary" : "Register validators with builder",
+    "summary" : "Provide beacon node with registrations for the given validators to the external builder network.",
     "description" : "Prepares the beacon node for engaging with external builders. The information must be sent by the beacon node to the builder network. It is expected that the validator client will send this information periodically to ensure the beacon node has correct and timely registration information to provide to builders. The validator client should not sign blinded beacon blocks that do not adhere to their latest fee recipient and gas limit preferences.",
     "requestBody" : {
       "content" : {

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_validator_sync_committee_contribution.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_validator_sync_committee_contribution.json
@@ -1,7 +1,7 @@
 {
   "get" : {
     "tags" : [ "Validator", "Validator Required Api" ],
-    "operationId" : "getSyncCommitteeContribution",
+    "operationId" : "produceSyncCommitteeContribution",
     "summary" : "Produce a sync committee contribution",
     "description" : "Returns a `SyncCommitteeContribution` that is the aggregate of `SyncCommitteeMessage` values known to this node matching the specified slot, subcommittee index and beacon block root.",
     "parameters" : [ {

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_validator_sync_committee_subscriptions.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v1_validator_sync_committee_subscriptions.json
@@ -1,8 +1,8 @@
 {
   "post" : {
     "tags" : [ "Validator", "Validator Required Api" ],
-    "operationId" : "postSyncCommitteeSubscriptions",
-    "summary" : "Subscribe to a Sync committee subnet",
+    "operationId" : "prepareSyncCommitteeSubnets",
+    "summary" : "Subscribe to sync committee subnets",
     "description" : "Subscribe to a number of sync committee subnets\n\nSync committees are not present in phase0, but are required for Altair networks.\n\nSubscribing to sync committee subnets is an action performed by VC to enable network participation in Altair networks, and only required if the VC has an active validator in an active sync committee.",
     "requestBody" : {
       "content" : {

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v2_validator_blocks_{slot}.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v2_validator_blocks_{slot}.json
@@ -1,8 +1,8 @@
 {
   "get" : {
     "tags" : [ "Validator", "Validator Required Api" ],
-    "operationId" : "getNewBlock",
-    "summary" : "Produce unsigned block",
+    "operationId" : "produceBlockV2",
+    "summary" : "Produce a new block, without signature.",
     "description" : "Requests a beacon node to produce a valid block, which can then be signed by a validator.\nMetadata in the response indicates the type of block produced, and the supported types of block will be added to as forks progress.",
     "parameters" : [ {
       "name" : "slot",

--- a/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v3_validator_blocks_{slot}.json
+++ b/data/beaconrestapi/src/integration-test/resources/tech/pegasys/teku/beaconrestapi/beacon/paths/_eth_v3_validator_blocks_{slot}.json
@@ -2,7 +2,7 @@
   "get" : {
     "tags" : [ "Validator", "Validator Required Api" ],
     "operationId" : "produceBlockV3",
-    "summary" : "Produce a new block, without signature",
+    "summary" : "Produce a new block, without signature.",
     "description" : "Requests a beacon node to produce a valid block, which can then be signed by a validator. The\nreturned block may be blinded or unblinded, depending on the current state of the network as\ndecided by the execution and beacon nodes.\nThe beacon node must return an unblinded block if it obtains the execution payload from its\npaired execution node. It must only return a blinded block if it obtains the execution payload\nheader from an MEV relay.\nMetadata in the response indicates the type of block produced, and the supported types of block\nwill be added to as forks progress.",
     "parameters" : [ {
       "name" : "slot",

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetAttestations.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetAttestations.java
@@ -48,8 +48,8 @@ public class GetAttestations extends RestApiEndpoint {
   public GetAttestations(final NodeDataProvider nodeDataProvider, final Spec spec) {
     super(
         EndpointMetadata.get(ROUTE)
-            .operationId("getAttestations")
-            .summary("Get attestations")
+            .operationId("getPoolAttestations")
+            .summary("Get Attestations from operations pool")
             .description(
                 "Retrieves attestations known by the node but not necessarily incorporated into any block.")
             .tags(TAG_BEACON)

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetAttesterSlashings.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetAttesterSlashings.java
@@ -43,8 +43,8 @@ public class GetAttesterSlashings extends RestApiEndpoint {
   GetAttesterSlashings(final NodeDataProvider provider, Spec spec) {
     super(
         EndpointMetadata.get(ROUTE)
-            .operationId("getAttesterSlashings")
-            .summary("Get Attester Slashings")
+            .operationId("getPoolAttesterSlashings")
+            .summary("Get AttesterSlashings from operations pool")
             .description(
                 "Retrieves attester slashings known by the node but not necessarily incorporated into any block.")
             .tags(TAG_BEACON)

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetBlsToExecutionChanges.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetBlsToExecutionChanges.java
@@ -75,7 +75,7 @@ public class GetBlsToExecutionChanges extends RestApiEndpoint {
             .build();
 
     return EndpointMetadata.get(ROUTE)
-        .operationId("getBlsToExecutionChanges")
+        .operationId("getPoolBLSToExecutionChanges")
         .summary("Get SignedBLSToExecutionChange from operations pool")
         .description(
             "Retrieves BLS to execution changes known by the node but not necessarily incorporated into any block")

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetProposerSlashings.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetProposerSlashings.java
@@ -50,8 +50,8 @@ public class GetProposerSlashings extends RestApiEndpoint {
   GetProposerSlashings(final NodeDataProvider provider) {
     super(
         EndpointMetadata.get(ROUTE)
-            .operationId("getProposerSlashings")
-            .summary("Get proposer slashings")
+            .operationId("getPoolProposerSlashings")
+            .summary("Get ProposerSlashings from operations pool")
             .description(
                 "Retrieves proposer slashings known by the node but not necessarily incorporated into any block.")
             .tags(TAG_BEACON)

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateCommittees.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateCommittees.java
@@ -74,8 +74,8 @@ public class GetStateCommittees extends RestApiEndpoint {
   GetStateCommittees(final ChainDataProvider chainDataProvider) {
     super(
         EndpointMetadata.get(ROUTE)
-            .operationId("getStateCommittees")
-            .summary("Get committees at state")
+            .operationId("getEpochCommittees")
+            .summary("Get all committees for a state.")
             .description("Retrieves the committees for the given state.")
             .pathParam(PARAMETER_STATE_ID)
             .queryParam(EPOCH_PARAMETER)

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateFork.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateFork.java
@@ -52,8 +52,8 @@ public class GetStateFork extends AbstractGetSimpleDataFromState {
   GetStateFork(final ChainDataProvider chainDataProvider) {
     super(
         EndpointMetadata.get(ROUTE)
-            .operationId("getSateFork")
-            .summary("Get state fork")
+            .operationId("getStateFork")
+            .summary("Get Fork object for requested state")
             .description("Returns Fork object for state with given 'state_id'.")
             .tags(TAG_BEACON, TAG_VALIDATOR_REQUIRED)
             .pathParam(PARAMETER_STATE_ID)

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateRandao.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateRandao.java
@@ -69,7 +69,7 @@ public class GetStateRandao extends RestApiEndpoint {
             .build();
     return EndpointMetadata.get(ROUTE)
         .operationId("getStateRandao")
-        .summary("Get state RANDAO")
+        .summary("Get the RANDAO mix for some epoch in a specified state.")
         .description(
             "Fetch the RANDAO mix for the requested epoch from the state identified by `state_id`.\n\n"
                 + "If an epoch is not specified then the RANDAO mix for the state's current epoch will be returned.\n\n"

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateRoot.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateRoot.java
@@ -48,7 +48,7 @@ public class GetStateRoot extends AbstractGetSimpleDataFromState {
     super(
         EndpointMetadata.get(ROUTE)
             .operationId("getStateRoot")
-            .summary("Get state root")
+            .summary("Get state SSZ HashTreeRoot")
             .description(
                 "Calculates HashTreeRoot for state with given 'state_id'. If stateId is root, same value will be returned.")
             .tags(TAG_BEACON)

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateSyncCommittees.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateSyncCommittees.java
@@ -20,7 +20,6 @@ import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_BAD_REQUE
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.EXECUTION_OPTIMISTIC;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.FINALIZED;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.TAG_BEACON;
-import static tech.pegasys.teku.infrastructure.http.RestApiConstants.TAG_VALIDATOR_REQUIRED;
 import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.BOOLEAN_TYPE;
 import static tech.pegasys.teku.infrastructure.json.types.CoreTypes.UINT64_TYPE;
 import static tech.pegasys.teku.infrastructure.json.types.SerializableTypeDefinition.listOf;
@@ -71,10 +70,10 @@ public class GetStateSyncCommittees extends RestApiEndpoint {
   public GetStateSyncCommittees(final ChainDataProvider chainDataProvider) {
     super(
         EndpointMetadata.get(ROUTE)
-            .operationId("getStateSyncCommittees")
-            .summary("Get sync committees")
+            .operationId("getEpochSyncCommittees")
+            .summary("Get sync committees for a state.")
             .description("Retrieves the sync committees for the given state.")
-            .tags(TAG_BEACON, TAG_VALIDATOR_REQUIRED)
+            .tags(TAG_BEACON)
             .pathParam(PARAMETER_STATE_ID)
             .queryParam(EPOCH_PARAMETER)
             .response(HttpStatusCodes.SC_OK, "Request successful", RESPONSE_TYPE)

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateValidator.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetStateValidator.java
@@ -60,7 +60,7 @@ public class GetStateValidator extends RestApiEndpoint {
     super(
         EndpointMetadata.get(ROUTE)
             .operationId("getStateValidator")
-            .summary("Get validator from state")
+            .summary("Get validator from state by id")
             .description("Retrieves data about the given peer.")
             .pathParam(PARAMETER_STATE_ID)
             .pathParam(PARAMETER_VALIDATOR_ID)

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetVoluntaryExits.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/GetVoluntaryExits.java
@@ -51,8 +51,8 @@ public class GetVoluntaryExits extends RestApiEndpoint {
   GetVoluntaryExits(final NodeDataProvider provider) {
     super(
         EndpointMetadata.get(ROUTE)
-            .operationId("getVoluntaryExits")
-            .summary("Get signed voluntary exits")
+            .operationId("getPoolVoluntaryExits")
+            .summary("Get SignedVoluntaryExit from operations pool")
             .description(
                 "Retrieves voluntary exits known by the node but not necessarily incorporated into any block.")
             .tags(TAG_BEACON)

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostAttestation.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostAttestation.java
@@ -48,8 +48,8 @@ public class PostAttestation extends RestApiEndpoint {
       final ValidatorDataProvider provider, final SchemaDefinitionCache schemaDefinitionCache) {
     super(
         EndpointMetadata.post(ROUTE)
-            .operationId("postAttestation")
-            .summary("Submit signed attestations")
+            .operationId("submitPoolAttestations")
+            .summary("Submit Attestation objects to node")
             .description(
                 "Submit signed attestations to the beacon node to be validated and submitted if valid.\n\n"
                     + "This endpoint does not protected against slashing.")

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostAttesterSlashing.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostAttesterSlashing.java
@@ -44,8 +44,8 @@ public class PostAttesterSlashing extends RestApiEndpoint {
   public PostAttesterSlashing(final NodeDataProvider provider, final Spec spec) {
     super(
         EndpointMetadata.post(ROUTE)
-            .operationId("postAttesterSlashing")
-            .summary("Submit attester slashing object")
+            .operationId("submitPoolAttesterSlashings")
+            .summary("Submit AttesterSlashing object to node's pool")
             .description(
                 "Submits attester slashing object to node's pool and if passes validation node MUST broadcast it to network.")
             .tags(TAG_BEACON)

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostBlsToExecutionChanges.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostBlsToExecutionChanges.java
@@ -52,7 +52,7 @@ public class PostBlsToExecutionChanges extends RestApiEndpoint {
 
   private static EndpointMetadata createEndpointMetadata(final SchemaDefinitionCache schemaCache) {
     return EndpointMetadata.post(ROUTE)
-        .operationId("postBlsToExecutionChange")
+        .operationId("submitPoolBLSToExecutionChange")
         .summary("Submit SignedBLSToExecutionChange object to node's pool")
         .description(
             "Submits SignedBLSToExecutionChange object to node's pool and if passes validation node MUST broadcast it"

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostProposerSlashing.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostProposerSlashing.java
@@ -41,8 +41,8 @@ public class PostProposerSlashing extends RestApiEndpoint {
   public PostProposerSlashing(final NodeDataProvider provider) {
     super(
         EndpointMetadata.post(ROUTE)
-            .operationId("postProposerSlashing")
-            .summary("Submit proposer slashing object")
+            .operationId("submitPoolProposerSlashings")
+            .summary("Submit ProposerSlashing object to node's pool")
             .description(
                 "Submits proposer slashing object to node's pool and, if it passes validation, the node MUST broadcast it to network.")
             .tags(TAG_BEACON)

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostSyncCommittees.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostSyncCommittees.java
@@ -49,8 +49,8 @@ public class PostSyncCommittees extends RestApiEndpoint {
   public PostSyncCommittees(final ValidatorDataProvider provider) {
     super(
         EndpointMetadata.post(ROUTE)
-            .operationId("postSyncCommittees")
-            .summary("Submit sync committee messages to node")
+            .operationId("submitPoolSyncCommitteeSignatures")
+            .summary("Submit sync committee signatures to node")
             .description(
                 "Submits sync committee message objects to the node.\n\n"
                     + "Sync committee messages are not present in phase0, but are required for Altair networks.\n\n"

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostVoluntaryExit.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/beacon/PostVoluntaryExit.java
@@ -43,8 +43,8 @@ public class PostVoluntaryExit extends RestApiEndpoint {
   public PostVoluntaryExit(final NodeDataProvider provider) {
     super(
         EndpointMetadata.post(ROUTE)
-            .operationId("postVoluntaryExit")
-            .summary("Submit signed voluntary exit")
+            .operationId("submitPoolVoluntaryExit")
+            .summary("Submit SignedVoluntaryExit object to node's pool")
             .description(
                 "Submits signed voluntary exit object to node's pool and if it passes validation node MUST broadcast it to network.")
             .tags(TAG_BEACON)

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/builder/GetExpectedWithdrawals.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/builder/GetExpectedWithdrawals.java
@@ -62,8 +62,9 @@ public class GetExpectedWithdrawals extends RestApiEndpoint {
       final SchemaDefinitionCache schemaDefinitionCache) {
     super(
         EndpointMetadata.get(ROUTE)
-            .operationId("GetExpectedWithdrawals")
-            .summary("Get Expected Withdrawals")
+            .operationId("getNextWithdrawals")
+            .summary(
+                "Get the withdrawals that are to be included for the block built on the specified state.")
             .description(
                 "Get the withdrawals computed from the specified state, that will be included in the block \n"
                     + "    that gets built on the specified state.")

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/config/GetDepositContract.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/config/GetDepositContract.java
@@ -53,7 +53,7 @@ public class GetDepositContract extends RestApiEndpoint {
       final Eth1Address depositContractAddress, final ConfigProvider configProvider) {
     super(
         EndpointMetadata.get(ROUTE)
-            .operationId("getDepositContractAddress")
+            .operationId("getDepositContract")
             .summary("Get deposit contract address")
             .description("Retrieve deposit contract address and genesis fork version.")
             .tags(TAG_CONFIG)

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/config/GetForkSchedule.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/config/GetForkSchedule.java
@@ -46,8 +46,8 @@ public class GetForkSchedule extends RestApiEndpoint {
   GetForkSchedule(final ConfigProvider configProvider) {
     super(
         EndpointMetadata.get(ROUTE)
-            .operationId("getScheduledForks")
-            .summary("Get scheduled forks")
+            .operationId("getForkSchedule")
+            .summary("Get scheduled upcoming forks.")
             .description("Retrieve all scheduled upcoming forks this node is aware of.")
             .tags(TAG_CONFIG)
             .response(SC_OK, "Success", FORK_SCHEDULE_RESPONSE_TYPE)

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/config/GetSpec.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/config/GetSpec.java
@@ -42,7 +42,7 @@ public class GetSpec extends RestApiEndpoint {
     super(
         EndpointMetadata.get(ROUTE)
             .operationId("getSpec")
-            .summary("Get spec params")
+            .summary("Get spec params.")
             .description("Retrieve specification configuration used on this node.")
             .tags(TAG_CONFIG, TAG_VALIDATOR_REQUIRED)
             .response(SC_OK, "Success", GET_SPEC_RESPONSE_TYPE)

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetHealth.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetHealth.java
@@ -44,8 +44,8 @@ public class GetHealth extends RestApiEndpoint {
   GetHealth(final SyncDataProvider syncProvider, final ChainDataProvider chainDataProvider) {
     super(
         EndpointMetadata.get(ROUTE)
-            .operationId("GetNodeHealth")
-            .summary("Get node health")
+            .operationId("getHealth")
+            .summary("Get health check")
             .description(
                 "Returns node health status in http status codes. Useful for load balancers.")
             .queryParam(SYNCING_PARAMETER)

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetPeerById.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetPeerById.java
@@ -50,7 +50,7 @@ public class GetPeerById extends RestApiEndpoint {
   GetPeerById(final NetworkDataProvider network) {
     super(
         EndpointMetadata.get(ROUTE)
-            .operationId("getNodePeer")
+            .operationId("getPeer")
             .summary("Get node peer")
             .description("Retrieves data about the given peer.")
             .pathParam(PEER_ID_PARAMETER)

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetPeers.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetPeers.java
@@ -107,8 +107,8 @@ public class GetPeers extends RestApiEndpoint {
   GetPeers(final NetworkDataProvider network) {
     super(
         EndpointMetadata.get(ROUTE)
-            .operationId("getNodePeers")
-            .summary("Get node peers")
+            .operationId("getPeers")
+            .summary("Get node network peers")
             .description("Retrieves data about the node's network peers.")
             .tags(TAG_NODE)
             .response(SC_OK, "Request successful", PEERS_RESPONSE_TYPE)

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetSyncing.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetSyncing.java
@@ -67,7 +67,7 @@ public class GetSyncing extends RestApiEndpoint {
       final ExecutionClientDataProvider executionClientDataProvider) {
     super(
         EndpointMetadata.get(ROUTE)
-            .operationId("getNodeSyncingStatus")
+            .operationId("getSyncingStatus")
             .summary("Get node syncing status")
             .description(
                 "Requests the beacon node to describe if it's currently syncing or not, "

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetVersion.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/node/GetVersion.java
@@ -45,7 +45,7 @@ public class GetVersion extends RestApiEndpoint {
     super(
         EndpointMetadata.get(ROUTE)
             .operationId("getNodeVersion")
-            .summary("Get node version")
+            .summary("Get version string of the running beacon node.")
             .description(
                 "similar to [HTTP User-Agent](https://tools.ietf.org/html/rfc7231#section-5.5.3).")
             .tags(TAG_NODE)

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/rewards/GetAttestationRewards.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/rewards/GetAttestationRewards.java
@@ -95,7 +95,7 @@ public class GetAttestationRewards extends RestApiEndpoint {
     super(
         EndpointMetadata.post(ROUTE)
             .operationId("getAttestationsRewards")
-            .summary("Get Attestations Rewards")
+            .summary("Get attestations rewards")
             .description(
                 "Retrieve attestation reward info for validators specified by array of public keys or validator index"
                     + ". If no array is provided, return reward info for every validator.")

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/rewards/GetBlockRewards.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/rewards/GetBlockRewards.java
@@ -66,7 +66,7 @@ public class GetBlockRewards extends RestApiEndpoint {
     super(
         EndpointMetadata.get(ROUTE)
             .operationId("getBlockRewards")
-            .summary("Get Block Rewards")
+            .summary("Get block rewards")
             .description("Retrieve block reward info for a single block.")
             .tags(TAG_BEACON, TAG_REWARDS)
             .pathParam(PARAMETER_BLOCK_ID)

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/rewards/GetSyncCommitteeRewards.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/rewards/GetSyncCommitteeRewards.java
@@ -75,7 +75,7 @@ public class GetSyncCommitteeRewards extends RestApiEndpoint {
     super(
         EndpointMetadata.post(ROUTE)
             .operationId("getSyncCommitteeRewards")
-            .summary("Get Sync Committee Rewards")
+            .summary("Get sync committee rewards")
             .description(
                 "Retrieves rewards info for sync committee members specified by array of public keys "
                     + "or validator index. If no array is provided, return reward info for every committee member.")

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetAggregateAttestation.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetAggregateAttestation.java
@@ -52,8 +52,8 @@ public class GetAggregateAttestation extends RestApiEndpoint {
   public GetAggregateAttestation(final ValidatorDataProvider provider, final Spec spec) {
     super(
         EndpointMetadata.get(ROUTE)
-            .operationId("getAggregateAttestation")
-            .summary("Get aggregated attestations")
+            .operationId("getAggregatedAttestation")
+            .summary("Get aggregated attestation")
             .description(
                 "Aggregates all attestations matching given attestation data root and slot.")
             .tags(TAG_VALIDATOR, TAG_VALIDATOR_REQUIRED)

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetAttestationData.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetAttestationData.java
@@ -58,7 +58,7 @@ public class GetAttestationData extends RestApiEndpoint {
   public GetAttestationData(final ValidatorDataProvider provider) {
     super(
         EndpointMetadata.get(ROUTE)
-            .operationId("getAttestationData")
+            .operationId("produceAttestationData")
             .summary("Produce an AttestationData")
             .description("Requests that the beacon node produce an AttestationData.")
             .tags(TAG_VALIDATOR, TAG_VALIDATOR_REQUIRED)

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetNewBlindedBlock.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetNewBlindedBlock.java
@@ -68,7 +68,7 @@ public class GetNewBlindedBlock extends RestApiEndpoint {
   private static EndpointMetadata getEndpointMetaData(
       final Spec spec, final SchemaDefinitionCache schemaDefinitionCache) {
     return EndpointMetadata.get(ROUTE)
-        .operationId("getNewBlindedBlock")
+        .operationId("produceBlindedBlock")
         .summary("Produce unsigned blinded block")
         .description(
             "Requests a beacon node to produce a valid blinded block, which can then be signed by a validator. "

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetProposerDuties.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetProposerDuties.java
@@ -50,7 +50,7 @@ public class GetProposerDuties extends RestApiEndpoint {
     super(
         EndpointMetadata.get(ROUTE)
             .operationId("getProposerDuties")
-            .summary("Get proposer duties")
+            .summary("Get block proposers duties")
             .description(
                 "Request beacon node to provide all validators that are scheduled to propose a block in the given epoch.\n\n"
                     + "Duties should only need to be checked once per epoch, "

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetSyncCommitteeContribution.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/GetSyncCommitteeContribution.java
@@ -55,7 +55,7 @@ public class GetSyncCommitteeContribution extends RestApiEndpoint {
       final SchemaDefinitionCache schemaDefinitionCache) {
     super(
         EndpointMetadata.get(ROUTE)
-            .operationId("getSyncCommitteeContribution")
+            .operationId("produceSyncCommitteeContribution")
             .summary("Produce a sync committee contribution")
             .description(
                 "Returns a `SyncCommitteeContribution` that is the aggregate of `SyncCommitteeMessage` "

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostAggregateAndProofs.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostAggregateAndProofs.java
@@ -46,8 +46,8 @@ public class PostAggregateAndProofs extends RestApiEndpoint {
       final ValidatorDataProvider provider, final SchemaDefinitions schemaDefinitions) {
     super(
         EndpointMetadata.post(ROUTE)
-            .operationId("postAggregateAndProofs")
-            .summary("Publish aggregate and proofs")
+            .operationId("publishAggregateAndProofs")
+            .summary("Publish multiple aggregate and proofs")
             .description(
                 "Verifies given aggregate and proofs and publishes it on appropriate gossipsub topic.")
             .tags(TAG_VALIDATOR, TAG_VALIDATOR_REQUIRED)

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostAttesterDuties.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostAttesterDuties.java
@@ -51,7 +51,7 @@ public class PostAttesterDuties extends RestApiEndpoint {
       final SyncDataProvider syncDataProvider, final ValidatorDataProvider validatorDataProvider) {
     super(
         EndpointMetadata.post(ROUTE)
-            .operationId("postAttesterDuties")
+            .operationId("getAttesterDuties")
             .summary("Get attester duties")
             .description(
                 "Requests the beacon node to provide a set of attestation duties, "

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostContributionAndProofs.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostContributionAndProofs.java
@@ -45,8 +45,8 @@ public class PostContributionAndProofs extends RestApiEndpoint {
       final ValidatorDataProvider provider, final SchemaDefinitionCache schemaDefinitionCache) {
     super(
         EndpointMetadata.post(ROUTE)
-            .operationId("postContributionAndProofs")
-            .summary("Publish contribution and proofs")
+            .operationId("publishContributionAndProofs")
+            .summary("Publish multiple contribution and proofs")
             .description(
                 "Verifies given sync committee contribution and proofs and publishes on appropriate gossipsub topics.")
             .tags(TAG_VALIDATOR, TAG_VALIDATOR_REQUIRED)

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostPrepareBeaconProposer.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostPrepareBeaconProposer.java
@@ -91,7 +91,7 @@ public class PostPrepareBeaconProposer extends RestApiEndpoint {
   private static EndpointMetadata createMetadata() {
     return EndpointMetadata.post(ROUTE)
         .operationId("prepareBeaconProposer")
-        .summary("Prepare Beacon Proposers")
+        .summary("Provide beacon node with proposals for the given validators.")
         .description(
             "Prepares the beacon node for potential proposers by supplying information required when proposing blocks for the given validators. The information supplied for each validator index is considered persistent until overwritten by new information for the given validator index, or until the beacon node restarts.\n\n"
                 + "Note that because the information is not persistent across beacon node restarts it is recommended that either the beacon node is monitored for restarts or this information is refreshed by resending this request periodically (for example, each epoch).\n\n"

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostRegisterValidator.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostRegisterValidator.java
@@ -16,7 +16,6 @@ package tech.pegasys.teku.beaconrestapi.handlers.v1.validator;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_INTERNAL_SERVER_ERROR;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.TAG_VALIDATOR;
-import static tech.pegasys.teku.infrastructure.http.RestApiConstants.TAG_VALIDATOR_REQUIRED;
 import static tech.pegasys.teku.spec.schemas.ApiSchemas.SIGNED_VALIDATOR_REGISTRATIONS_SCHEMA;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -41,7 +40,8 @@ public class PostRegisterValidator extends RestApiEndpoint {
     super(
         EndpointMetadata.post(ROUTE)
             .operationId("registerValidator")
-            .summary("Register validators with builder")
+            .summary(
+                "Provide beacon node with registrations for the given validators to the external builder network.")
             .description(
                 "Prepares the beacon node for engaging with external builders."
                     + " The information must be sent by the beacon node to the builder network."
@@ -49,7 +49,7 @@ public class PostRegisterValidator extends RestApiEndpoint {
                     + " to ensure the beacon node has correct and timely registration information"
                     + " to provide to builders. The validator client should not sign blinded beacon"
                     + " blocks that do not adhere to their latest fee recipient and gas limit preferences.")
-            .tags(TAG_VALIDATOR, TAG_VALIDATOR_REQUIRED)
+            .tags(TAG_VALIDATOR)
             .requestBodyType(
                 SIGNED_VALIDATOR_REGISTRATIONS_SCHEMA.getJsonTypeDefinition(),
                 SIGNED_VALIDATOR_REGISTRATIONS_SCHEMA::sszDeserialize)

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostSubscribeToBeaconCommitteeSubnet.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostSubscribeToBeaconCommitteeSubnet.java
@@ -76,8 +76,8 @@ public class PostSubscribeToBeaconCommitteeSubnet extends RestApiEndpoint {
   public PostSubscribeToBeaconCommitteeSubnet(final ValidatorDataProvider provider) {
     super(
         EndpointMetadata.post(ROUTE)
-            .operationId("postSubscribeToBeaconCommitteeSubnet")
-            .summary("Subscribe to a committee subnet")
+            .operationId("prepareBeaconCommitteeSubnet")
+            .summary("Signal beacon node to prepare for a committee subnet")
             .description(
                 "After Beacon node receives this request, search using discv5 for peers related to this subnet and replace current peers with those ones if necessary If validator is_aggregator, beacon node must:\n"
                     + "- announce subnet topic subscription on gossipsub\n"

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostSyncCommitteeSubscriptions.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostSyncCommitteeSubscriptions.java
@@ -67,8 +67,8 @@ public class PostSyncCommitteeSubscriptions extends RestApiEndpoint {
   public PostSyncCommitteeSubscriptions(final ValidatorDataProvider validatorDataProvider) {
     super(
         EndpointMetadata.post(ROUTE)
-            .operationId("postSyncCommitteeSubscriptions")
-            .summary("Subscribe to a Sync committee subnet")
+            .operationId("prepareSyncCommitteeSubnets")
+            .summary("Subscribe to sync committee subnets")
             .description(
                 "Subscribe to a number of sync committee subnets\n\n"
                     + "Sync committees are not present in phase0, but are required for Altair networks.\n\n"

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostSyncDuties.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostSyncDuties.java
@@ -52,7 +52,7 @@ public class PostSyncDuties extends RestApiEndpoint {
       final SyncDataProvider syncDataProvider, final ValidatorDataProvider validatorDataProvider) {
     super(
         EndpointMetadata.post(ROUTE)
-            .operationId("postSyncDuties")
+            .operationId("getSyncCommitteeDuties")
             .summary("Get sync committee duties")
             .description("Requests the beacon node to provide a set of sync committee duties")
             .tags(TAG_VALIDATOR, TAG_VALIDATOR_REQUIRED)

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostValidatorLiveness.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/validator/PostValidatorLiveness.java
@@ -65,8 +65,8 @@ public class PostValidatorLiveness extends RestApiEndpoint {
       final SyncDataProvider syncDataProvider) {
     super(
         EndpointMetadata.post(ROUTE)
-            .operationId("postValidatorLiveness")
-            .summary("Get Validator Liveness")
+            .operationId("getLiveness")
+            .summary("Indicates if a validator has been observed on the network")
             .description(
                 "Requests the beacon node to indicate if a validator has been"
                     + " observed to be live in a given epoch. The beacon node might detect liveness by"

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v2/validator/GetNewBlock.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v2/validator/GetNewBlock.java
@@ -68,8 +68,8 @@ public class GetNewBlock extends RestApiEndpoint {
   private static EndpointMetadata getEndpointMetaData(
       final Spec spec, final SchemaDefinitionCache schemaDefinitionCache) {
     return EndpointMetadata.get(ROUTE)
-        .operationId("getNewBlock")
-        .summary("Produce unsigned block")
+        .operationId("produceBlockV2")
+        .summary("Produce a new block, without signature.")
         .description(
             "Requests a beacon node to produce a valid block, which can then be signed by a validator.\n"
                 + "Metadata in the response indicates the type of block produced, and the supported types of block "

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v3/validator/GetNewBlockV3.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v3/validator/GetNewBlockV3.java
@@ -81,7 +81,7 @@ public class GetNewBlockV3 extends RestApiEndpoint {
       final SchemaDefinitionCache schemaDefinitionCache) {
     return EndpointMetadata.get(ROUTE)
         .operationId("produceBlockV3")
-        .summary("Produce a new block, without signature")
+        .summary("Produce a new block, without signature.")
         .description(
             "Requests a beacon node to produce a valid block, which can then be signed by a validator. The\n"
                 + "returned block may be blinded or unblinded, depending on the current state of the network as\n"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

Updated several fields for all Beacon API endpoints to reduce the gap between our implementation and the spec. All `tags`, `operationId` and `summaries` were verified to match the spec.

**Tags:**
- `getEpochSyncCommittees` - Validator required tag removed [like in the spec](https://github.com/ethereum/beacon-APIs/blob/master/apis/beacon/states/sync_committees.yaml#L5-L6) and I don't see validator API is calling this.
- `registerValidator` - Validator required tag removed [like in the spec](https://github.com/ethereum/beacon-APIs/blob/master/apis/validator/register_validator.yaml#L15-L16), I think the message is that `mev-builder` is not required to propose blocks :)


**OperationId:**
All was modified to be the same as in the spec, so the correct endpoint could be easily found when changes are needed.

**Summmary:**
Updated most by taking summaries from the spec because it's usually more descriptive, skipped only few, like blinded block where it's less descriptive in the spec.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
