### PR TITLE
Ability to add deposit receipts in the stub

### DIFF
--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerBlockProductionManagerImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerBlockProductionManagerImpl.java
@@ -78,7 +78,7 @@ public class ExecutionLayerBlockProductionManagerImpl
     if (!isBlind) {
       final SafeFuture<GetPayloadResponse> getPayloadResponseFuture =
           executionLayerChannel
-              .engineGetPayload(context, blockSlotState.getSlot())
+              .engineGetPayload(context, blockSlotState)
               .thenPeek(__ -> blockProductionPerformance.engineGetPayload());
       final SafeFuture<ExecutionPayload> executionPayloadFuture =
           getPayloadResponseFuture.thenApply(GetPayloadResponse::getExecutionPayload);
@@ -111,7 +111,7 @@ public class ExecutionLayerBlockProductionManagerImpl
     if (!isBlind) {
       final SafeFuture<GetPayloadResponse> getPayloadResponseFuture =
           executionLayerChannel
-              .engineGetPayload(context, blockSlotState.getSlot())
+              .engineGetPayload(context, blockSlotState)
               .thenPeek(__ -> blockProductionPerformance.engineGetPayload());
       final SafeFuture<ExecutionPayload> executionPayloadFuture =
           getPayloadResponseFuture.thenApply(GetPayloadResponse::getExecutionPayload);

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
@@ -195,8 +195,8 @@ public class ExecutionLayerManagerImpl implements ExecutionLayerManager {
 
   @Override
   public SafeFuture<GetPayloadResponse> engineGetPayload(
-      final ExecutionPayloadContext executionPayloadContext, final UInt64 slot) {
-    return engineGetPayload(executionPayloadContext, slot, false)
+      final ExecutionPayloadContext executionPayloadContext, final BeaconState state) {
+    return engineGetPayload(executionPayloadContext, state.getSlot(), false)
         .thenPeek(__ -> recordExecutionPayloadFallbackSource(Source.LOCAL_EL, FallbackReason.NONE));
   }
 

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerStub.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerStub.java
@@ -37,9 +37,9 @@ public class ExecutionLayerManagerStub extends ExecutionLayerChannelStub
   private final BuilderCircuitBreaker builderCircuitBreaker;
 
   public ExecutionLayerManagerStub(
-      Spec spec,
-      TimeProvider timeProvider,
-      boolean enableTransitionEmulation,
+      final Spec spec,
+      final TimeProvider timeProvider,
+      final boolean enableTransitionEmulation,
       final Optional<Bytes32> terminalBlockHashInTTDMode,
       final BuilderCircuitBreaker builderCircuitBreaker) {
     super(spec, timeProvider, enableTransitionEmulation, terminalBlockHashInTTDMode);
@@ -58,7 +58,7 @@ public class ExecutionLayerManagerStub extends ExecutionLayerChannelStub
       final SafeFuture<UInt256> payloadValueResult,
       final Optional<UInt64> requestedBuilderBoostFactor,
       final BlockProductionPerformance blockProductionPerformance) {
-    boolean builderCircuitBreakerEngaged = builderCircuitBreaker.isEngaged(state);
+    final boolean builderCircuitBreakerEngaged = builderCircuitBreaker.isEngaged(state);
     LOG.info("Builder Circuit Breaker isEngaged: " + builderCircuitBreakerEngaged);
 
     return super.builderGetHeader(
@@ -70,9 +70,7 @@ public class ExecutionLayerManagerStub extends ExecutionLayerChannelStub
         .thenCompose(
             headerWithFallbackData -> {
               if (builderCircuitBreakerEngaged) {
-                return engineGetPayload(
-                        executionPayloadContext,
-                        executionPayloadContext.getPayloadBuildingAttributes().getProposalSlot())
+                return engineGetPayload(executionPayloadContext, state)
                     .thenApply(
                         payload ->
                             HeaderWithFallbackData.create(

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImplTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImplTest.java
@@ -166,11 +166,12 @@ class ExecutionLayerManagerImplTest {
     final ExecutionPayloadContext executionPayloadContext =
         dataStructureUtil.randomPayloadExecutionContext(false, true);
     final UInt64 slot = executionPayloadContext.getForkChoiceState().getHeadBlockSlot();
+    final BeaconState state = dataStructureUtil.randomBeaconState(slot);
 
     final GetPayloadResponse getPayloadResponse =
         prepareEngineGetPayloadResponse(executionPayloadContext, localExecutionPayloadValue, slot);
 
-    assertThat(executionLayerManager.engineGetPayload(executionPayloadContext, slot))
+    assertThat(executionLayerManager.engineGetPayload(executionPayloadContext, state))
         .isCompletedWithValue(getPayloadResponse);
 
     // we expect no calls to builder
@@ -187,11 +188,12 @@ class ExecutionLayerManagerImplTest {
         dataStructureUtil.randomPayloadExecutionContext(false, true);
     executionLayerManager = createExecutionLayerChannelImpl(false, false);
     final UInt64 slot = executionPayloadContext.getForkChoiceState().getHeadBlockSlot();
+    final BeaconState state = dataStructureUtil.randomBeaconState(slot);
 
     final GetPayloadResponse getPayloadResponse =
         prepareEngineGetPayloadResponse(executionPayloadContext, localExecutionPayloadValue, slot);
 
-    assertThat(executionLayerManager.engineGetPayload(executionPayloadContext, slot))
+    assertThat(executionLayerManager.engineGetPayload(executionPayloadContext, state))
         .isCompletedWithValue(getPayloadResponse);
 
     // we expect no calls to builder

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/util/DepositReceiptsUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/util/DepositReceiptsUtil.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.util;
+
+import java.security.SecureRandom;
+import java.util.List;
+import java.util.stream.IntStream;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.bls.BLS;
+import tech.pegasys.teku.bls.BLSKeyPair;
+import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.bls.BLSSignature;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.constants.Domain;
+import tech.pegasys.teku.spec.datastructures.execution.versions.electra.DepositReceipt;
+import tech.pegasys.teku.spec.datastructures.operations.DepositMessage;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsElectra;
+
+public class DepositReceiptsUtil {
+
+  private static final int MAX_NUMBER_OF_DEPOSITS_PER_BLOCK = 3;
+
+  private final Spec spec;
+
+  @SuppressWarnings("DoNotCreateSecureRandomDirectly")
+  private final SecureRandom random = new SecureRandom();
+
+  public DepositReceiptsUtil(final Spec spec) {
+    this.spec = spec;
+  }
+
+  public List<DepositReceipt> generateDepositReceipts(final BeaconState state) {
+    final UInt64 nextDepositReceiptIndex = UInt64.valueOf(state.getValidators().size());
+    return IntStream.range(0, getNumberOfDepositReceiptsToGenerate())
+        .mapToObj(i -> createDepositReceipt(state.getSlot(), nextDepositReceiptIndex.plus(i)))
+        .toList();
+  }
+
+  private int getNumberOfDepositReceiptsToGenerate() {
+    return random.nextInt(MAX_NUMBER_OF_DEPOSITS_PER_BLOCK + 1);
+  }
+
+  private DepositReceipt createDepositReceipt(final UInt64 slot, final UInt64 index) {
+    final BLSKeyPair validatorKeyPair = BLSKeyPair.random(random);
+    final BLSPublicKey publicKey = validatorKeyPair.getPublicKey();
+    final UInt64 depositAmount = UInt64.THIRTY_TWO_ETH;
+    final DepositMessage depositMessage =
+        new DepositMessage(publicKey, Bytes32.ZERO, depositAmount);
+    final MiscHelpers miscHelpers = spec.atSlot(slot).miscHelpers();
+    final Bytes32 depositDomain = miscHelpers.computeDomain(Domain.DEPOSIT);
+    final BLSSignature signature =
+        BLS.sign(
+            validatorKeyPair.getSecretKey(),
+            miscHelpers.computeSigningRoot(depositMessage, depositDomain));
+    return SchemaDefinitionsElectra.required(spec.atSlot(slot).getSchemaDefinitions())
+        .getDepositReceiptSchema()
+        .create(publicKey, Bytes32.ZERO, depositAmount, signature, index);
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannel.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannel.java
@@ -60,7 +60,7 @@ public interface ExecutionLayerChannel extends ChannelInterface {
 
         @Override
         public SafeFuture<GetPayloadResponse> engineGetPayload(
-            final ExecutionPayloadContext executionPayloadContext, final UInt64 slot) {
+            final ExecutionPayloadContext executionPayloadContext, final BeaconState state) {
           return SafeFuture.completedFuture(null);
         }
 
@@ -123,7 +123,7 @@ public interface ExecutionLayerChannel extends ChannelInterface {
    * BeaconState, boolean, Optional, BlockProductionPerformance)} instead
    */
   SafeFuture<GetPayloadResponse> engineGetPayload(
-      ExecutionPayloadContext executionPayloadContext, UInt64 slot);
+      ExecutionPayloadContext executionPayloadContext, BeaconState state);
 
   // builder namespace
   SafeFuture<Void> builderRegisterValidators(


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Configured by a static constant `GENERATE_DEPOSIT_RECEIPTS`. Defaulting to `false` since we don't want random deposit receipts in the stub and end up in an inactivity leak.

Also changed `engineGetPayload` to pass a state instead of slot. This could be useful in the future as well if we need more information.

## Fixed Issue(s)
related to #7898 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
