### PR TITLE
Express `seen_ttl` in consensus params

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/P2PConfig.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/P2PConfig.java
@@ -193,7 +193,6 @@ public class P2PConfig {
       networkConfig.gossipConfig(
           builder -> {
             gossipConfigurator.configure(builder, eth2Context);
-            // https://github.com/ethereum/consensus-specs/pull/3627
             builder.seenTTL(
                 Duration.ofSeconds(
                     (long) specConfig.getSecondsPerSlot() * specConfig.getSlotsPerEpoch() * 2));

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/P2PConfig.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/P2PConfig.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.networking.eth2;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import java.time.Duration;
 import java.util.OptionalInt;
 import java.util.function.Consumer;
 import tech.pegasys.teku.infrastructure.exceptions.InvalidConfigurationException;
@@ -25,6 +26,7 @@ import tech.pegasys.teku.networking.p2p.discovery.DiscoveryConfig;
 import tech.pegasys.teku.networking.p2p.network.config.NetworkConfig;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.config.NetworkingSpecConfig;
+import tech.pegasys.teku.spec.config.SpecConfig;
 
 public class P2PConfig {
 
@@ -182,14 +184,22 @@ public class P2PConfig {
           isGossipScoringEnabled
               ? GossipConfigurator.scoringEnabled(spec)
               : GossipConfigurator.NOOP;
+      final SpecConfig specConfig = spec.getGenesisSpecConfig();
       final Eth2Context eth2Context =
           Eth2Context.builder()
-              .activeValidatorCount(spec.getGenesisSpecConfig().getMinGenesisActiveValidatorCount())
+              .activeValidatorCount(specConfig.getMinGenesisActiveValidatorCount())
               .gossipEncoding(gossipEncoding)
               .build();
-      networkConfig.gossipConfig(c -> gossipConfigurator.configure(c, eth2Context));
+      networkConfig.gossipConfig(
+          builder -> {
+            gossipConfigurator.configure(builder, eth2Context);
+            // https://github.com/ethereum/consensus-specs/pull/3627
+            builder.seenTTL(
+                Duration.ofSeconds(
+                    (long) specConfig.getSecondsPerSlot() * specConfig.getSlotsPerEpoch() * 2));
+          });
 
-      NetworkConfig networkConfig = this.networkConfig.build();
+      final NetworkConfig networkConfig = this.networkConfig.build();
       discoveryConfig.listenUdpPortDefault(networkConfig.getListenPort());
       discoveryConfig.advertisedUdpPortDefault(OptionalInt.of(networkConfig.getAdvertisedPort()));
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
As per https://github.com/ethereum/consensus-specs/pull/3627

I think more consistent to set with consensus params values to align with networks like `Gnosis`, etc rather than the hardcoded value we have at the moment:

```
static final Duration DEFAULT_HEARTBEAT_INTERVAL = Duration.ofMillis(700);
static final Duration DEFAULT_SEEN_TTL = DEFAULT_HEARTBEAT_INTERVAL.multipliedBy(1115);
```

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
