### PR TITLE
EIP-6110 Stop Eth1 data polling

### DIFF
--- a/beacon/validator/src/jmh/java/tech/pegasys/teku/validator/coordinator/DepositProviderBenchmark.java
+++ b/beacon/validator/src/jmh/java/tech/pegasys/teku/validator/coordinator/DepositProviderBenchmark.java
@@ -17,7 +17,6 @@ import static org.mockito.Mockito.mock;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.apache.tuweni.bytes.Bytes32;
@@ -47,7 +46,7 @@ public class DepositProviderBenchmark {
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
   private final int depositEventCount = 1000;
 
-  private List<DepositsFromBlockEvent> events =
+  private final List<DepositsFromBlockEvent> events =
       IntStream.range(0, depositEventCount)
           .mapToObj(
               index ->
@@ -62,14 +61,14 @@ public class DepositProviderBenchmark {
                               dataStructureUtil.randomSignature(),
                               spec.getGenesisSpecConfig().getMaxEffectiveBalance(),
                               UInt64.valueOf(index)))))
-          .collect(Collectors.toList());
+          .toList();
 
   private final NoOpMetricsSystem metricsSystem = new NoOpMetricsSystem();
   private final DepositProvider depositProvider =
       new DepositProvider(
           metricsSystem,
           mock(RecentChainData.class),
-          new Eth1DataCache(metricsSystem, new Eth1VotingPeriod(spec)),
+          new Eth1DataCache(spec, metricsSystem, new Eth1VotingPeriod(spec)),
           mock(StorageUpdateChannel.class),
           mock(Eth1DepositStorageChannel.class),
           spec,

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/DepositProvider.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/DepositProvider.java
@@ -138,7 +138,7 @@ public class DepositProvider
                 .getEth1DataAndHeight(finalizedState.getEth1Data())
                 .map(Eth1DataCache.Eth1DataAndHeight::getBlockHeight);
         if (heightOptional.isEmpty()) {
-          LOG.debug("Eth1Data height not found in cache. Skipping DepositTree pruning");
+          LOG.debug("Eth1Data height not found in cache. Skipping DepositTree finalization");
           return;
         }
         depositMerkleTree.finalize(finalizedState.getEth1Data(), heightOptional.get());
@@ -179,14 +179,16 @@ public class DepositProvider
       return;
     }
 
-    // We want to verify our Beacon Node view of the eth1 deposits.
-    // So we want to check if it has the necessary deposit data to propose a block
-
     recentChainData
         .getBestState()
         .get()
         .thenAccept(
             state -> {
+              if (spec.isFormerDepositMechanismDisabled(state)) {
+                return;
+              }
+              // We want to verify our Beacon Node view of the eth1 deposits.
+              // So we want to check if it has the necessary deposit data to propose a block
               final UInt64 eth1DepositCount = state.getEth1Data().getDepositCount();
 
               final UInt64 lastAvailableDepositIndex =

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/Eth1DataCache.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/Eth1DataCache.java
@@ -28,6 +28,7 @@ import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.infrastructure.metrics.SettableGauge;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.Eth1Data;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 
@@ -39,8 +40,9 @@ public class Eth1DataCache {
   static final String VOTES_CURRENT_METRIC_NAME = "eth1_current_period_votes_current";
   static final String VOTES_BEST_METRIC_NAME = "eth1_current_period_votes_best";
 
-  private final UInt64 cacheDuration;
+  private final Spec spec;
   private final Eth1VotingPeriod eth1VotingPeriod;
+  private final UInt64 cacheDuration;
 
   private final NavigableMap<UInt64, Eth1DataAndHeight> eth1ChainCache =
       new ConcurrentSkipListMap<>();
@@ -50,7 +52,9 @@ public class Eth1DataCache {
   private final SettableGauge currentPeriodVotesBest;
   private final SettableGauge currentPeriodVotesMax;
 
-  public Eth1DataCache(final MetricsSystem metricsSystem, final Eth1VotingPeriod eth1VotingPeriod) {
+  public Eth1DataCache(
+      final Spec spec, final MetricsSystem metricsSystem, final Eth1VotingPeriod eth1VotingPeriod) {
+    this.spec = spec;
     this.eth1VotingPeriod = eth1VotingPeriod;
     cacheDuration = eth1VotingPeriod.getCacheDurationInSeconds();
     metricsSystem.createIntegerGauge(
@@ -110,17 +114,21 @@ public class Eth1DataCache {
     prune(blockTimestamp);
   }
 
-  public Eth1Data getEth1Vote(BeaconState state) {
-    NavigableMap<UInt64, Eth1Data> votesToConsider =
+  public Eth1Data getEth1Vote(final BeaconState state) {
+    if (spec.isFormerDepositMechanismDisabled(state)) {
+      // no need for a real vote when Eth1 polling has been disabled
+      return state.getEth1Data();
+    }
+    final NavigableMap<UInt64, Eth1Data> votesToConsider =
         getVotesToConsider(state.getSlot(), state.getGenesisTime(), state.getEth1Data());
     // Avoid using .values() directly as it has O(n) lookup which gets expensive fast
     final Set<Eth1Data> validBlocks = new HashSet<>(votesToConsider.values());
     final Map<Eth1Data, Eth1Vote> votes = countVotes(state);
 
-    Eth1Data defaultVote =
+    final Eth1Data defaultVote =
         votesToConsider.isEmpty() ? state.getEth1Data() : votesToConsider.lastEntry().getValue();
 
-    Optional<Eth1Data> vote =
+    final Optional<Eth1Data> vote =
         votes.entrySet().stream()
             .filter(entry -> validBlocks.contains(entry.getKey()))
             .max(Map.Entry.comparingByValue())
@@ -134,12 +142,16 @@ public class Eth1DataCache {
   }
 
   public void updateMetrics(final BeaconState state) {
+    if (spec.isFormerDepositMechanismDisabled(state)) {
+      // no need to update metrics when Eth1 polling has been disabled
+      return;
+    }
     final Eth1Data currentEth1Data = state.getEth1Data();
     // Avoid using .values() directly as it has O(n) lookup which gets expensive fast
     final Set<Eth1Data> knownBlocks =
         new HashSet<>(
             getVotesToConsider(state.getSlot(), state.getGenesisTime(), currentEth1Data).values());
-    Map<Eth1Data, Eth1Vote> votes = countVotes(state);
+    final Map<Eth1Data, Eth1Vote> votes = countVotes(state);
 
     currentPeriodVotesMax.set(eth1VotingPeriod.getTotalSlotsInVotingPeriod(state.getSlot()));
     currentPeriodVotesTotal.set(state.getEth1DataVotes().size());
@@ -156,7 +168,7 @@ public class Eth1DataCache {
   }
 
   protected Map<Eth1Data, Eth1Vote> countVotes(final BeaconState state) {
-    Map<Eth1Data, Eth1Vote> votes = new HashMap<>();
+    final Map<Eth1Data, Eth1Vote> votes = new HashMap<>();
     int i = 0;
     for (Eth1Data eth1Data : state.getEth1DataVotes()) {
       final int currentIndex = i;

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/DepositProviderTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/DepositProviderTest.java
@@ -306,6 +306,21 @@ public class DepositProviderTest {
   }
 
   @Test
+  void
+      shouldNotLogAnEventOnSlotIfFormerDepositMechanismIsDisabled_EvenIfAllDepositsRequiredForStateNotAvailable() {
+    setup(1, SpecMilestone.ELECTRA);
+    mockDepositsFromEth1Block(0, 8);
+    updateStateEth1DepositIndex(5);
+    updateStateDepositReceiptsStartIndex(5);
+    updateStateEth1DataDepositCount(10);
+    when(recentChainData.getBestState()).thenReturn(Optional.of(SafeFuture.completedFuture(state)));
+
+    depositProvider.onSlot(UInt64.ONE);
+
+    verifyNoInteractions(eventLogger);
+  }
+
+  @Test
   void shouldNotLogAnEventOnSlotWhenAllDepositsRequiredForStateAvailable() {
     setup(1);
     // To generate a valid proof we need the deposits up to state deposit count

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/Eth1DataProviderTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/Eth1DataProviderTest.java
@@ -70,7 +70,7 @@ public class Eth1DataProviderTest {
     assertThat(slotsInVotingPeriod).isEqualTo(SLOTS_IN_VOTING_PERIOD_ASSERTION);
 
     final Eth1VotingPeriod eth1VotingPeriod = new Eth1VotingPeriod(spec);
-    final Eth1DataCache eth1DataCache = new Eth1DataCache(metricsSystem, eth1VotingPeriod);
+    final Eth1DataCache eth1DataCache = new Eth1DataCache(spec, metricsSystem, eth1VotingPeriod);
     final DepositProvider depositProvider =
         new DepositProvider(
             new StubMetricsSystem(),

--- a/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/runloop/AsyncRunLoopTest.java
+++ b/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/runloop/AsyncRunLoopTest.java
@@ -103,11 +103,11 @@ class AsyncRunLoopTest {
     verify(logic, never()).advance();
 
     advanceTime(firstAdvanceDelay);
-    verify(logic, times(1)).advance();
+    verify(logic).advance();
 
     // Shouldn't use same delay for second advance so this won't wait long enough
     advanceTime(firstAdvanceDelay);
-    verify(logic, times(1)).advance();
+    verify(logic).advance();
 
     // Advance remaining time until second advance is due and confirm it is invoked
     advanceTime(secondAdvanceDelay.minus(firstAdvanceDelay));
@@ -128,13 +128,13 @@ class AsyncRunLoopTest {
     verify(logic, never()).advance();
 
     advanceTime(advanceDelay);
-    verify(logic, times(1)).advance();
+    verify(logic).advance();
 
     runLoop.stop();
     advanceTime(advanceDelay);
 
     // advance should have been invoked only once
-    verify(logic, times(1)).advance();
+    verify(logic).advance();
   }
 
   @Test

--- a/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/runloop/AsyncRunLoopTest.java
+++ b/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/runloop/AsyncRunLoopTest.java
@@ -118,6 +118,26 @@ class AsyncRunLoopTest {
   }
 
   @Test
+  void shouldNotAdvanceIfStopped() {
+    final Duration advanceDelay = Duration.ofSeconds(2);
+    when(logic.advance()).thenReturn(SafeFuture.COMPLETE);
+    when(logic.getDelayUntilNextAdvance()).thenReturn(advanceDelay);
+
+    runLoop.start();
+    verify(logic).init();
+    verify(logic, never()).advance();
+
+    advanceTime(advanceDelay);
+    verify(logic, times(1)).advance();
+
+    runLoop.stop();
+    advanceTime(advanceDelay);
+
+    // advance should have been invoked only once
+    verify(logic, times(1)).advance();
+  }
+
+  @Test
   void shouldRetryAfterDelayWhenAdvanceFails() {
     final Duration advanceDelay = Duration.ofSeconds(5);
     final Throwable error = new RuntimeException("Computer says no");

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
@@ -134,8 +134,8 @@ public class StatusLogger {
         batchSize);
   }
 
-  public void eth1PollingHasBeenDisabled(final UInt64 epoch) {
-    log.info("Eth1 polling has been disabled at epoch {}", epoch);
+  public void eth1PollingHasBeenDisabled() {
+    log.info("Eth1 polling has been disabled ");
   }
 
   public void unexpectedFailure(final String description, final Throwable cause) {

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
@@ -135,7 +135,7 @@ public class StatusLogger {
   }
 
   public void eth1PollingHasBeenDisabled() {
-    log.info("Eth1 polling has been disabled ");
+    log.info("Eth1 polling has been disabled");
   }
 
   public void unexpectedFailure(final String description, final Throwable cause) {

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
@@ -515,6 +515,13 @@ public class StatusLogger {
         executionBlockHash);
   }
 
+  public void warnFlagDeprecation(final String oldFlag, final String newFlag) {
+    logWithColorIfLevelGreaterThanInfo(
+        Level.WARN,
+        String.format("Flag `%s` is deprecated, use `%s` instead", oldFlag, newFlag),
+        Color.YELLOW);
+  }
+
   public void warnIgnoringWeakSubjectivityPeriod() {
     log.warn(
         print(

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/StatusLogger.java
@@ -134,6 +134,10 @@ public class StatusLogger {
         batchSize);
   }
 
+  public void eth1PollingHasBeenDisabled(final UInt64 epoch) {
+    log.info("Eth1 polling has been disabled at epoch {}", epoch);
+  }
+
   public void unexpectedFailure(final String description, final Throwable cause) {
     log.error("PLEASE FIX OR REPORT | Unexpected exception thrown for {}", description, cause);
   }
@@ -148,18 +152,6 @@ public class StatusLogger {
 
   public void listeningForDiscv5(final String enr) {
     log.info("Local ENR: {}", enr);
-  }
-
-  public void blockCreationFailure(final Exception cause) {
-    log.error("Error during block creation", cause);
-  }
-
-  public void attestationFailure(final Throwable cause) {
-    log.error("Error during attestation creation", cause);
-  }
-
-  public void validatorDepositYamlKeyWriterFailure(final Path file) {
-    log.error("Error writing keys to {}", file.toString());
   }
 
   public void validatorDepositEncryptedKeystoreWriterFailure(
@@ -387,12 +379,6 @@ public class StatusLogger {
     log.info("ETH1 block satisfying minimum genesis time found");
   }
 
-  public void migratingDataDirectory(final Path dataPath) {
-    log.info(
-        "Migrating data directory layout under {} to separate beacon node and validator data",
-        dataPath.toAbsolutePath());
-  }
-
   public void beaconDataPathSet(final Path dataPath) {
     log.info("Storing beacon chain data in: {}", dataPath.toAbsolutePath());
   }
@@ -527,13 +513,6 @@ public class StatusLogger {
         "Loaded deposits tree state from snapshot with {} deposits and {} execution block hash.",
         deposits,
         executionBlockHash);
-  }
-
-  public void warnFlagDeprecation(final String oldFlag, final String newFlag) {
-    logWithColorIfLevelGreaterThanInfo(
-        Level.WARN,
-        String.format("Flag `%s` is deprecated, use `%s` instead", oldFlag, newFlag),
-        Color.YELLOW);
   }
 
   public void warnIgnoringWeakSubjectivityPeriod() {

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -830,7 +830,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
 
   protected void initEth1DataCache() {
     LOG.debug("BeaconChainController.initEth1DataCache");
-    eth1DataCache = new Eth1DataCache(metricsSystem, new Eth1VotingPeriod(spec));
+    eth1DataCache = new Eth1DataCache(spec, metricsSystem, new Eth1VotingPeriod(spec));
   }
 
   protected void initAttestationTopicSubscriber() {

--- a/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/PowchainService.java
+++ b/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/PowchainService.java
@@ -73,7 +73,7 @@ public class PowchainService extends Service implements FinalizedCheckpointChann
   private final ServiceConfig serviceConfig;
   private final PowchainConfiguration powConfig;
   private final Optional<ExecutionWeb3jClientProvider> maybeExecutionWeb3jClientProvider;
-  private final Supplier<Optional<BeaconState>> latestFinalizedState;
+  private final Supplier<Optional<BeaconState>> finalizedStateSupplier;
 
   private List<Web3j> web3js;
   private Eth1Providers eth1Providers;
@@ -84,12 +84,12 @@ public class PowchainService extends Service implements FinalizedCheckpointChann
       final ServiceConfig serviceConfig,
       final PowchainConfiguration powConfig,
       final Optional<ExecutionWeb3jClientProvider> maybeExecutionWeb3jClientProvider,
-      final Supplier<Optional<BeaconState>> latestFinalizedState) {
+      final Supplier<Optional<BeaconState>> finalizedStateSupplier) {
     checkArgument(powConfig.isEnabled() || maybeExecutionWeb3jClientProvider.isPresent());
     this.serviceConfig = serviceConfig;
     this.powConfig = powConfig;
     this.maybeExecutionWeb3jClientProvider = maybeExecutionWeb3jClientProvider;
-    this.latestFinalizedState = latestFinalizedState;
+    this.finalizedStateSupplier = finalizedStateSupplier;
   }
 
   @Override
@@ -129,7 +129,7 @@ public class PowchainService extends Service implements FinalizedCheckpointChann
       return;
     }
     if (isFormerDepositMechanismDisabled()) {
-      // stop Eth1 polling
+      //  stop Eth1 polling
       stop()
           .finish(
               () -> {
@@ -143,7 +143,7 @@ public class PowchainService extends Service implements FinalizedCheckpointChann
   }
 
   private boolean isFormerDepositMechanismDisabled() {
-    return latestFinalizedState
+    return finalizedStateSupplier
         .get()
         .map(powConfig.getSpec()::isFormerDepositMechanismDisabled)
         .orElse(false);

--- a/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/PowchainService.java
+++ b/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/PowchainService.java
@@ -149,7 +149,8 @@ public class PowchainService extends Service implements FinalizedCheckpointChann
         .orElse(false);
   }
 
-  private void initialize() {
+  @VisibleForTesting
+  void initialize() {
     final AsyncRunner asyncRunner = serviceConfig.createAsyncRunner("powchain");
 
     final SpecConfig config = powConfig.getSpec().getGenesisSpecConfig();

--- a/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/PowchainService.java
+++ b/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/PowchainService.java
@@ -279,16 +279,9 @@ public class PowchainService extends Service implements FinalizedCheckpointChann
     if (!isRunning()) {
       return;
     }
-    final BeaconState finalizedState = latestFinalizedState.get();
-    if (spec.isFormerDepositMechanismDisabled(finalizedState)) {
+    if (spec.isFormerDepositMechanismDisabled(latestFinalizedState.get())) {
       // stop Eth1 polling
-      stop()
-          .finish(
-              () -> {
-                final UInt64 epoch = spec.computeEpochAtSlot(finalizedState.getSlot());
-                STATUS_LOG.eth1PollingHasBeenDisabled(epoch);
-              },
-              LOG::error);
+      stop().finish(STATUS_LOG::eth1PollingHasBeenDisabled, LOG::error);
     }
   }
 

--- a/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/PowchainService.java
+++ b/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/PowchainService.java
@@ -282,7 +282,7 @@ public class PowchainService extends Service implements FinalizedCheckpointChann
     final BeaconState finalizedState = latestFinalizedState.get();
     if (spec.isFormerDepositMechanismDisabled(finalizedState)) {
       // stop Eth1 polling
-      doStop()
+      stop()
           .finish(
               () -> {
                 final UInt64 epoch = spec.computeEpochAtSlot(finalizedState.getSlot());

--- a/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/PowchainService.java
+++ b/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/PowchainService.java
@@ -149,8 +149,7 @@ public class PowchainService extends Service implements FinalizedCheckpointChann
         .orElse(false);
   }
 
-  @VisibleForTesting
-  void initialize() {
+  private void initialize() {
     final AsyncRunner asyncRunner = serviceConfig.createAsyncRunner("powchain");
 
     final SpecConfig config = powConfig.getSpec().getGenesisSpecConfig();

--- a/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/PowchainService.java
+++ b/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/PowchainService.java
@@ -74,7 +74,7 @@ public class PowchainService extends Service {
       final Optional<ExecutionWeb3jClientProvider> maybeExecutionWeb3jClientProvider) {
     checkArgument(powConfig.isEnabled() || maybeExecutionWeb3jClientProvider.isPresent());
 
-    AsyncRunner asyncRunner = serviceConfig.createAsyncRunner("powchain");
+    final AsyncRunner asyncRunner = serviceConfig.createAsyncRunner("powchain");
 
     this.okHttpClient = createOkHttpClient();
     final SpecConfig config = powConfig.getSpec().getGenesisSpecConfig();
@@ -128,7 +128,7 @@ public class PowchainService extends Service {
 
     final Eth1Provider eth1Provider = eth1Providers.getEth1Provider();
     final String depositContract = powConfig.getDepositContract().toHexString();
-    DepositEventsAccessor depositEventsAccessor =
+    final DepositEventsAccessor depositEventsAccessor =
         new DepositEventsAccessor(eth1Provider, depositContract);
 
     final ValidatingEth1EventsPublisher eth1EventsPublisher =

--- a/services/powchain/src/test/java/tech/pegasys/teku/services/powchain/PowchainServiceTest.java
+++ b/services/powchain/src/test/java/tech/pegasys/teku/services/powchain/PowchainServiceTest.java
@@ -46,7 +46,7 @@ import tech.pegasys.teku.storage.api.Eth1DepositStorageChannel;
 public class PowchainServiceTest {
   private final ServiceConfig serviceConfig = mock(ServiceConfig.class);
   private final PowchainConfiguration powConfig = mock(PowchainConfiguration.class);
-  private final Supplier<BeaconState> latestFinalizedState = () -> mock(BeaconState.class);
+  private final Supplier<Optional<BeaconState>> latestFinalizedState = Optional::empty;
   private final DepositTreeSnapshotConfiguration depositTreeSnapshotConfiguration =
       mock(DepositTreeSnapshotConfiguration.class);
   private final ExecutionWeb3jClientProvider engineWeb3jClientProvider =

--- a/services/powchain/src/test/java/tech/pegasys/teku/services/powchain/PowchainServiceTest.java
+++ b/services/powchain/src/test/java/tech/pegasys/teku/services/powchain/PowchainServiceTest.java
@@ -142,7 +142,7 @@ public class PowchainServiceTest {
     when(depositTreeSnapshotConfiguration.isBundledDepositSnapshotEnabled()).thenReturn(false);
 
     final PowchainService powchainService =
-        new PowchainService(serviceConfig, powConfig, Optional.of(engineWeb3jClientProvider));
+        createAndInitializePowchainService(Optional.of(engineWeb3jClientProvider));
 
     verifyExpectedOrderOfDepositSnapshotPathResources(powchainService, List.of());
   }
@@ -178,7 +178,7 @@ public class PowchainServiceTest {
     when(depositTreeSnapshotConfiguration.isBundledDepositSnapshotEnabled()).thenReturn(false);
 
     final PowchainService powchainService =
-        new PowchainService(serviceConfig, powConfig, Optional.of(engineWeb3jClientProvider));
+        createAndInitializePowchainService(Optional.of(engineWeb3jClientProvider));
 
     verifyExpectedOrderOfDepositSnapshotPathResources(powchainService, List.of());
   }

--- a/services/powchain/src/test/java/tech/pegasys/teku/services/powchain/PowchainServiceTest.java
+++ b/services/powchain/src/test/java/tech/pegasys/teku/services/powchain/PowchainServiceTest.java
@@ -252,6 +252,8 @@ public class PowchainServiceTest {
 
     powchainService.start().join();
 
+    assertThat(powchainService.isRunning()).isTrue();
+
     powchainService.onNewFinalizedCheckpoint(mock(Checkpoint.class), false);
 
     assertThat(powchainService.isRunning()).isFalse();

--- a/services/powchain/src/test/java/tech/pegasys/teku/services/powchain/PowchainServiceTest.java
+++ b/services/powchain/src/test/java/tech/pegasys/teku/services/powchain/PowchainServiceTest.java
@@ -75,10 +75,7 @@ public class PowchainServiceTest {
 
   @Test
   public void shouldFail_WhenNeitherEth1NorExecutionEndpoint() {
-    assertThatThrownBy(
-            () ->
-                new PowchainService(
-                    serviceConfig, powConfig, Optional.empty(), latestFinalizedState))
+    assertThatThrownBy(() -> createAndInitializePowchainService(Optional.empty()))
         .isInstanceOf(IllegalArgumentException.class);
   }
 
@@ -86,12 +83,7 @@ public class PowchainServiceTest {
   public void shouldFail_WhenNoEth1EndpointButWebsocketsExecutionEndpoint() {
     when(web3JClient.isWebsocketsClient()).thenReturn(true);
     assertThatThrownBy(
-            () ->
-                new PowchainService(
-                    serviceConfig,
-                    powConfig,
-                    Optional.of(engineWeb3jClientProvider),
-                    latestFinalizedState))
+            () -> createAndInitializePowchainService(Optional.of(engineWeb3jClientProvider)))
         .hasMessageContaining("not compatible with Websockets");
   }
 
@@ -109,12 +101,7 @@ public class PowchainServiceTest {
     when(serviceConfig.getEventChannels()).thenReturn(eventChannels);
     assertThatNoException()
         .isThrownBy(
-            () ->
-                new PowchainService(
-                    serviceConfig,
-                    powConfig,
-                    Optional.of(engineWeb3jClientProvider),
-                    latestFinalizedState));
+            () -> createAndInitializePowchainService(Optional.of(engineWeb3jClientProvider)));
   }
 
   @Test
@@ -125,8 +112,7 @@ public class PowchainServiceTest {
         .thenReturn(Optional.of("/foo/bundled"));
 
     final PowchainService powchainService =
-        new PowchainService(
-            serviceConfig, powConfig, Optional.of(engineWeb3jClientProvider), latestFinalizedState);
+        createAndInitializePowchainService(Optional.of(engineWeb3jClientProvider));
 
     verifyExpectedOrderOfDepositSnapshotPathResources(
         powchainService, List.of(new DepositSnapshotResource("/foo/custom", true)));
@@ -141,8 +127,7 @@ public class PowchainServiceTest {
     when(depositTreeSnapshotConfiguration.isBundledDepositSnapshotEnabled()).thenReturn(true);
 
     final PowchainService powchainService =
-        new PowchainService(
-            serviceConfig, powConfig, Optional.of(engineWeb3jClientProvider), latestFinalizedState);
+        createAndInitializePowchainService(Optional.of(engineWeb3jClientProvider));
 
     verifyExpectedOrderOfDepositSnapshotPathResources(
         powchainService, List.of(new DepositSnapshotResource("/foo/bundled", true)));
@@ -173,8 +158,7 @@ public class PowchainServiceTest {
     when(depositTreeSnapshotConfiguration.isBundledDepositSnapshotEnabled()).thenReturn(true);
 
     final PowchainService powchainService =
-        new PowchainService(
-            serviceConfig, powConfig, Optional.of(engineWeb3jClientProvider), latestFinalizedState);
+        createAndInitializePowchainService(Optional.of(engineWeb3jClientProvider));
 
     verifyExpectedOrderOfDepositSnapshotPathResources(
         powchainService,
@@ -207,8 +191,7 @@ public class PowchainServiceTest {
         .thenReturn(Optional.of("/foo/checkpoint"));
 
     final PowchainService powchainService =
-        new PowchainService(
-            serviceConfig, powConfig, Optional.of(engineWeb3jClientProvider), latestFinalizedState);
+        createAndInitializePowchainService(Optional.of(engineWeb3jClientProvider));
 
     verifyExpectedOrderOfDepositSnapshotPathResources(
         powchainService, List.of(new DepositSnapshotResource("/foo/custom", true)));
@@ -222,8 +205,7 @@ public class PowchainServiceTest {
         .thenReturn(Optional.empty());
 
     final PowchainService powchainService =
-        new PowchainService(
-            serviceConfig, powConfig, Optional.of(engineWeb3jClientProvider), latestFinalizedState);
+        createAndInitializePowchainService(Optional.of(engineWeb3jClientProvider));
 
     assertThat(
             powchainService
@@ -231,6 +213,15 @@ public class PowchainServiceTest {
                 .getDepositSnapshotFileLoader()
                 .getDepositSnapshotResources())
         .isEmpty();
+  }
+
+  private PowchainService createAndInitializePowchainService(
+      final Optional<ExecutionWeb3jClientProvider> maybeExecutionWeb3jClientProvider) {
+    final PowchainService powchainService =
+        new PowchainService(
+            serviceConfig, powConfig, maybeExecutionWeb3jClientProvider, latestFinalizedState);
+    powchainService.initialize();
+    return powchainService;
   }
 
   private void verifyExpectedOrderOfDepositSnapshotPathResources(

--- a/teku/src/main/java/tech/pegasys/teku/services/BeaconNodeServiceController.java
+++ b/teku/src/main/java/tech/pegasys/teku/services/BeaconNodeServiceController.java
@@ -62,7 +62,7 @@ public class BeaconNodeServiceController extends ServiceController {
             tekuConfig.network().getListenPort(),
             tekuConfig.discovery().isDiscoveryEnabled()));
     // making it a Supplier ensures that BeaconChainService has been started and RecentChainData has
-    // been initialized
+    // been initialized when `get()` is called
     final Supplier<Optional<BeaconState>> latestFinalizedState =
         () -> {
           final RecentChainData recentChainData =

--- a/teku/src/main/java/tech/pegasys/teku/services/BeaconNodeServiceController.java
+++ b/teku/src/main/java/tech/pegasys/teku/services/BeaconNodeServiceController.java
@@ -63,7 +63,7 @@ public class BeaconNodeServiceController extends ServiceController {
             tekuConfig.discovery().isDiscoveryEnabled()));
     // making it a Supplier ensures that BeaconChainService has been started and RecentChainData has
     // been initialized when `get()` is called
-    final Supplier<Optional<BeaconState>> latestFinalizedState =
+    final Supplier<Optional<BeaconState>> finalizedStateSupplier =
         () -> {
           final RecentChainData recentChainData =
               beaconChainService.getBeaconChainController().getRecentChainData();
@@ -73,7 +73,7 @@ public class BeaconNodeServiceController extends ServiceController {
           return Optional.of(recentChainData.getStore().getLatestFinalized().getState());
         };
     powchainService(
-            tekuConfig, serviceConfig, maybeExecutionWeb3jClientProvider, latestFinalizedState)
+            tekuConfig, serviceConfig, maybeExecutionWeb3jClientProvider, finalizedStateSupplier)
         .ifPresent(services::add);
 
     final Optional<SlashingRiskAction> maybeValidatorSlashedAction =
@@ -93,7 +93,7 @@ public class BeaconNodeServiceController extends ServiceController {
       final TekuConfiguration tekuConfig,
       final ServiceConfig serviceConfig,
       final Optional<ExecutionWeb3jClientProvider> maybeExecutionWeb3jClientProvider,
-      final Supplier<Optional<BeaconState>> latestFinalizedState) {
+      final Supplier<Optional<BeaconState>> finalizedStateSupplier) {
     if (tekuConfig.beaconChain().interopConfig().isInteropEnabled()
         || (!tekuConfig.powchain().isEnabled() && maybeExecutionWeb3jClientProvider.isEmpty())) {
       return Optional.empty();
@@ -103,7 +103,7 @@ public class BeaconNodeServiceController extends ServiceController {
             serviceConfig,
             tekuConfig.powchain(),
             maybeExecutionWeb3jClientProvider,
-            latestFinalizedState);
+            finalizedStateSupplier);
     serviceConfig.getEventChannels().subscribe(FinalizedCheckpointChannel.class, powchainService);
     return Optional.of(powchainService);
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
If we have already transitioned to the new deposit mechanism:

- Don't log missing deposit data 
- Don't do actual `Eth1Data` vote, just return the one from the state
- Don't update `Eth1Data` metrics
- Don't initialize and start `PowchainService` services
- Implement stop for `AsyncRunLoop` because `TimeBasedEth1HeadTracker` was running in loop and `stop` was not implemented

Also attached `FinalizedCheckpointChannel` to `PowchainService` to stop Eth1 polling when transitioned on the fly. I am not 100 % sure of the cleanest way to pass a state to `PowchainService` because `RecentChainData` is initialized after starting of the services, so passing it before that will be in null. That's why chose to pass a `Supplier` (along with some comments) but happy for suggestions.

**Update:**
Refactored `PowchainService` to initialize when starting. This has couple of benefits. No initialization needed when we have already finalized the transition to the new deposit mechanism. This allows thing like using the websockets web3j client after Electra instead of relying on http, so no more of this error:

```java
if (executionWeb3jClientProvider.getWeb3JClient().isWebsocketsClient()) {
   throw new InvalidConfigurationException("Eth1 endpoint fallback is not compatible with Websockets execution engine endpoint");
 }
```
It also allows to log the eth1 polling disabling only in case it has been enabled before.

## Fixed Issue(s)
will solve one of the tasks under #7898 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
