### PR TITLE
Log execution client version if available

### DIFF
--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ExecutionClientVersionChannel.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ExecutionClientVersionChannel.java
@@ -13,12 +13,10 @@
 
 package tech.pegasys.teku.ethereum.executionclient;
 
-import tech.pegasys.teku.ethereum.events.ExecutionClientEventsChannel;
+import tech.pegasys.teku.infrastructure.events.VoidReturningChannelInterface;
 import tech.pegasys.teku.spec.datastructures.execution.ClientVersion;
 
-public interface ExecutionClientVersionChannel extends ExecutionClientEventsChannel {
-  void onExecutionClientVersion(ClientVersion executionClientVersion);
+public interface ExecutionClientVersionChannel extends VoidReturningChannelInterface {
 
-  @Override
-  default void onAvailabilityUpdated(boolean isAvailable) {}
+  void onExecutionClientVersion(ClientVersion executionClientVersion);
 }

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ExecutionClientVersionProvider.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ExecutionClientVersionProvider.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.teku.ethereum.executionclient;
 
+import static tech.pegasys.teku.infrastructure.logging.EventLogger.EVENT_LOG;
+
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.logging.log4j.LogManager;
@@ -36,6 +38,7 @@ public class ExecutionClientVersionProvider implements ExecutionClientEventsChan
   private final ExecutionLayerChannel executionLayerChannel;
   private final ExecutionClientVersionChannel executionClientVersionChannel;
   private final ClientVersion consensusClientVersion;
+
   private final AtomicReference<ClientVersion> executionClientVersion = new AtomicReference<>(null);
 
   public ExecutionClientVersionProvider(
@@ -74,7 +77,8 @@ public class ExecutionClientVersionProvider implements ExecutionClientEventsChan
     if (executionClientVersion.equals(this.executionClientVersion.get())) {
       return;
     }
-
+    EVENT_LOG.logExecutionClientVersion(
+        executionClientVersion.name(), executionClientVersion.version());
     this.executionClientVersion.set(executionClientVersion);
     executionClientVersionChannel.onExecutionClientVersion(executionClientVersion);
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

- This logging seems to have been removed and I think could be useful.
- Also `ExecutionClientVersionChannel` can just extend `VoidReturningChannelInterface`

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
