### PR TITLE
Refactor `StorageUpdateChannel`

### DIFF
--- a/storage/api/src/main/java/tech/pegasys/teku/storage/api/StorageUpdateChannel.java
+++ b/storage/api/src/main/java/tech/pegasys/teku/storage/api/StorageUpdateChannel.java
@@ -37,8 +37,6 @@ public interface StorageUpdateChannel extends ChannelInterface {
       Map<SlotAndBlockRoot, List<BlobSidecar>> blobSidecarsBySlot,
       Optional<UInt64> maybeEarliestBlobSidecarSlot);
 
-  SafeFuture<Void> onFinalizedState(BeaconState finalizedState, Bytes32 blockRoot);
-
   SafeFuture<Void> onReconstructedFinalizedState(BeaconState finalizedState, Bytes32 blockRoot);
 
   SafeFuture<Void> onWeakSubjectivityUpdate(WeakSubjectivityUpdate weakSubjectivityUpdate);

--- a/storage/src/integration-test/java/tech/pegasys/teku/storage/server/kvstore/DatabaseTest.java
+++ b/storage/src/integration-test/java/tech/pegasys/teku/storage/server/kvstore/DatabaseTest.java
@@ -544,7 +544,7 @@ public class DatabaseTest {
             .streamValidAttestationsForBlockAtSlot(targetSlot)
             .map(attestation -> BlockOptions.create().addAttestation(attestation))
             .limit(2)
-            .collect(toList());
+            .toList();
 
     // Create several different blocks at the same slot
     final SignedBlockAndState blockA =
@@ -628,7 +628,7 @@ public class DatabaseTest {
             .streamValidAttestationsForBlockAtSlot(divergingSlot)
             .map(attestation -> BlockOptions.create().addAttestation(attestation))
             .limit(2)
-            .collect(toList());
+            .toList();
 
     // Create several different blocks at the same slot
     final SignedBlockAndState blockA =
@@ -859,7 +859,7 @@ public class DatabaseTest {
         chainBuilder
             .streamBlocksAndStates(
                 checkpoint1BlockAndState.getSlot(), checkpoint2BlockAndState.getSlot())
-            .collect(toList());
+            .toList();
 
     final UpdatableStore result = recreateStore();
     // Historical blocks should not be in the new store
@@ -1004,9 +1004,7 @@ public class DatabaseTest {
     final SignedBlockAndState transitionBlock =
         generateChainWithFinalizableTransitionBlock(context);
     final List<SignedBlockAndState> newBlocks =
-        chainBuilder
-            .streamBlocksAndStates(genesisBlockAndState.getSlot().intValue())
-            .collect(toList());
+        chainBuilder.streamBlocksAndStates(genesisBlockAndState.getSlot().intValue()).toList();
     // Save all blocks and states in separate transactions
     for (SignedBlockAndState newBlock : newBlocks) {
       add(List.of(newBlock));
@@ -2093,18 +2091,20 @@ public class DatabaseTest {
   }
 
   @TestTemplate
-  public void shouldStoreFinalizedState(final DatabaseContext context) throws IOException {
+  public void shouldStoreReconstructedFinalizedState(final DatabaseContext context)
+      throws IOException {
     createStorageSystem(context, StateStorageMode.ARCHIVE, StoreConfig.createDefault(), false);
     assertThat(database.getLatestAvailableFinalizedState(ONE)).isEmpty();
 
     final BeaconState beaconState = dataStructureUtil.randomBeaconState(ONE);
-    database.storeFinalizedState(beaconState, dataStructureUtil.randomBytes32());
+    database.storeReconstructedFinalizedState(beaconState, dataStructureUtil.randomBytes32());
 
     assertThat(database.getLatestAvailableFinalizedState(ONE)).contains(beaconState);
   }
 
   @TestTemplate
-  public void shouldStoreFinalizedStateAndRoots(final DatabaseContext context) throws IOException {
+  public void shouldStoreReconstructedFinalizedStateAndRoots(final DatabaseContext context)
+      throws IOException {
     createStorageSystem(context, StateStorageMode.ARCHIVE, StoreConfig.createDefault(), false);
 
     final BeaconState state1 = dataStructureUtil.randomBeaconState(ONE);
@@ -2114,8 +2114,8 @@ public class DatabaseTest {
     final Bytes32 blockRoot2 = dataStructureUtil.randomBytes32();
 
     assertThat(database.getLatestAvailableFinalizedState(UInt64.valueOf(2))).isEmpty();
-    database.storeFinalizedState(state1, blockRoot1);
-    database.storeFinalizedState(state2, blockRoot2);
+    database.storeReconstructedFinalizedState(state1, blockRoot1);
+    database.storeReconstructedFinalizedState(state2, blockRoot2);
 
     assertThat(database.getLatestAvailableFinalizedState(ONE)).contains(state1);
     assertThat(database.getLatestAvailableFinalizedState(UInt64.valueOf(2))).contains(state2);
@@ -2486,7 +2486,7 @@ public class DatabaseTest {
           block,
           blobSidecars.stream()
               .filter(blobSidecar -> blobSidecar.getBlockRoot().equals(block.getRoot()))
-              .collect(Collectors.toUnmodifiableList()),
+              .toList(),
           spec.calculateBlockCheckpoints(block.getState()));
     }
     commit(transaction);
@@ -2517,7 +2517,7 @@ public class DatabaseTest {
                         .filter(
                             blobSidecar ->
                                 blobSidecar.getBlockRoot().equals(blockAndState.getRoot()))
-                        .collect(Collectors.toUnmodifiableList()),
+                        .toList(),
                     spec.calculateBlockCheckpoints(blockAndState.getState())));
   }
 
@@ -2630,7 +2630,7 @@ public class DatabaseTest {
   }
 
   private void assertBlobSidecars(final Map<UInt64, List<BlobSidecar>> blobSidecars) {
-    final List<UInt64> slots = blobSidecars.keySet().stream().sorted().collect(toList());
+    final List<UInt64> slots = blobSidecars.keySet().stream().sorted().toList();
     if (slots.isEmpty()) {
       return;
     }
@@ -2652,7 +2652,7 @@ public class DatabaseTest {
   }
 
   private void assertNonCanonicalBlobSidecars(final Map<UInt64, List<BlobSidecar>> blobSidecars) {
-    final List<UInt64> slots = blobSidecars.keySet().stream().sorted().collect(toList());
+    final List<UInt64> slots = blobSidecars.keySet().stream().sorted().toList();
     if (slots.isEmpty()) {
       return;
     }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/ChainStorage.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/ChainStorage.java
@@ -127,11 +127,6 @@ public class ChainStorage
   }
 
   @Override
-  public SafeFuture<Void> onFinalizedState(BeaconState finalizedState, Bytes32 blockRoot) {
-    return SafeFuture.fromRunnable(() -> database.storeFinalizedState(finalizedState, blockRoot));
-  }
-
-  @Override
   public SafeFuture<Void> onReconstructedFinalizedState(
       BeaconState finalizedState, Bytes32 blockRoot) {
     return SafeFuture.fromRunnable(

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/CombinedStorageChannelSplitter.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/CombinedStorageChannelSplitter.java
@@ -78,12 +78,6 @@ public class CombinedStorageChannelSplitter implements CombinedStorageChannel {
   }
 
   @Override
-  public SafeFuture<Void> onFinalizedState(
-      final BeaconState finalizedState, final Bytes32 blockRoot) {
-    return updateDelegate.onFinalizedState(finalizedState, blockRoot);
-  }
-
-  @Override
   public SafeFuture<Void> onReconstructedFinalizedState(
       BeaconState finalizedState, Bytes32 blockRoot) {
     return updateDelegate.onReconstructedFinalizedState(finalizedState, blockRoot);

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
@@ -52,8 +52,6 @@ public interface Database extends AutoCloseable {
       Map<SlotAndBlockRoot, List<BlobSidecar>> blobSidecarsBySlot,
       Optional<UInt64> maybeEarliestBlobSidecarSlot);
 
-  void storeFinalizedState(BeaconState state, Bytes32 blockRoot);
-
   void storeReconstructedFinalizedState(BeaconState state, Bytes32 blockRoot);
 
   void updateWeakSubjectivityState(WeakSubjectivityUpdate weakSubjectivityUpdate);
@@ -65,8 +63,6 @@ public interface Database extends AutoCloseable {
   Optional<BlobSidecar> getBlobSidecar(SlotAndBlockRootAndBlobIndex key);
 
   Optional<BlobSidecar> getNonCanonicalBlobSidecar(SlotAndBlockRootAndBlobIndex key);
-
-  void removeBlobSidecars(SlotAndBlockRoot slotAndBlockRoot);
 
   /**
    * This prune method will delete BlobSidecars starting from the oldest BlobSidecars (by slot) up

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/RetryingStorageUpdateChannel.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/RetryingStorageUpdateChannel.java
@@ -98,12 +98,6 @@ public class RetryingStorageUpdateChannel implements StorageUpdateChannel {
   }
 
   @Override
-  public SafeFuture<Void> onFinalizedState(
-      final BeaconState finalizedState, final Bytes32 blockRoot) {
-    return this.retry(() -> delegate.onFinalizedState(finalizedState, blockRoot));
-  }
-
-  @Override
   public SafeFuture<Void> onReconstructedFinalizedState(
       final BeaconState finalizedState, final Bytes32 blockRoot) {
     return this.retry(() -> delegate.onReconstructedFinalizedState(finalizedState, blockRoot));

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
@@ -576,14 +576,6 @@ public class KvStoreDatabase implements Database {
   }
 
   @Override
-  public void storeFinalizedState(BeaconState state, Bytes32 blockRoot) {
-    try (final FinalizedUpdater updater = finalizedUpdater()) {
-      updater.addFinalizedState(blockRoot, state);
-      handleAddFinalizedStateRoot(state, updater);
-    }
-  }
-
-  @Override
   public void storeReconstructedFinalizedState(BeaconState state, Bytes32 blockRoot) {
     try (final FinalizedUpdater updater = finalizedUpdater()) {
       updater.addReconstructedFinalizedState(blockRoot, state);
@@ -804,14 +796,6 @@ public class KvStoreDatabase implements Database {
   public Optional<BlobSidecar> getNonCanonicalBlobSidecar(final SlotAndBlockRootAndBlobIndex key) {
     final Optional<Bytes> maybePayload = dao.getNonCanonicalBlobSidecar(key);
     return maybePayload.map(payload -> spec.deserializeBlobSidecar(payload, key.getSlot()));
-  }
-
-  @Override
-  public void removeBlobSidecars(final SlotAndBlockRoot slotAndBlockRoot) {
-    try (final FinalizedUpdater updater = finalizedUpdater()) {
-      getBlobSidecarKeys(slotAndBlockRoot).forEach(updater::removeBlobSidecar);
-      updater.commit();
-    }
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
@@ -62,13 +62,10 @@ public class NoOpDatabase implements Database {
       final Optional<UInt64> maybeEarliestBlobSidecarSlot) {}
 
   @Override
-  public void storeFinalizedState(BeaconState state, Bytes32 blockRoot) {}
+  public void storeReconstructedFinalizedState(final BeaconState state, final Bytes32 blockRoot) {}
 
   @Override
-  public void storeReconstructedFinalizedState(BeaconState state, Bytes32 blockRoot) {}
-
-  @Override
-  public void updateWeakSubjectivityState(WeakSubjectivityUpdate weakSubjectivityUpdate) {}
+  public void updateWeakSubjectivityState(final WeakSubjectivityUpdate weakSubjectivityUpdate) {}
 
   @Override
   public Optional<OnDiskStoreData> createMemoryStore() {
@@ -290,9 +287,6 @@ public class NoOpDatabase implements Database {
   public Optional<BlobSidecar> getNonCanonicalBlobSidecar(final SlotAndBlockRootAndBlobIndex key) {
     return Optional.empty();
   }
-
-  @Override
-  public void removeBlobSidecars(final SlotAndBlockRoot slotAndBlockRoot) {}
 
   @Override
   public Stream<SlotAndBlockRootAndBlobIndex> streamBlobSidecarKeys(

--- a/storage/src/test/java/tech/pegasys/teku/storage/server/RetryingStorageUpdateChannelTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/server/RetryingStorageUpdateChannelTest.java
@@ -30,7 +30,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
-import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.exceptions.FatalServiceFailureException;
@@ -39,7 +38,6 @@ import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
-import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.storage.api.StorageUpdate;
 import tech.pegasys.teku.storage.api.StorageUpdateChannel;
 import tech.pegasys.teku.storage.api.UpdateResult;
@@ -79,20 +77,6 @@ class RetryingStorageUpdateChannelTest {
 
     assertThat(result).isCompleted();
     verify(delegate, times(3)).onFinalizedBlocks(blocks, blobSidecarsBySlot, Optional.empty());
-  }
-
-  @Test
-  void onFinalizedState_shouldRetryUntilSuccess() {
-    final BeaconState state = mock(BeaconState.class);
-    when(delegate.onFinalizedState(state, Bytes32.ZERO))
-        .thenReturn(SafeFuture.failedFuture(new RuntimeException("Failed 1")))
-        .thenReturn(SafeFuture.failedFuture(new RuntimeException("Failed 2")))
-        .thenReturn(SafeFuture.completedFuture(null));
-
-    final SafeFuture<Void> result = retryingChannel.onFinalizedState(state, Bytes32.ZERO);
-
-    assertThat(result).isCompleted();
-    verify(delegate, times(3)).onFinalizedState(state, Bytes32.ZERO);
   }
 
   @Test

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageUpdateChannel.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageUpdateChannel.java
@@ -43,12 +43,6 @@ public class StubStorageUpdateChannel implements StorageUpdateChannel {
   }
 
   @Override
-  public SafeFuture<Void> onFinalizedState(
-      final BeaconState finalizedState, final Bytes32 blockRoot) {
-    return SafeFuture.COMPLETE;
-  }
-
-  @Override
   public SafeFuture<Void> onReconstructedFinalizedState(
       final BeaconState finalizedState, final Bytes32 blockRoot) {
     return SafeFuture.COMPLETE;

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageUpdateChannelWithDelays.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubStorageUpdateChannelWithDelays.java
@@ -49,12 +49,6 @@ public class StubStorageUpdateChannelWithDelays implements StorageUpdateChannel 
   }
 
   @Override
-  public SafeFuture<Void> onFinalizedState(
-      final BeaconState finalizedState, final Bytes32 blockRoot) {
-    return asyncRunner.runAsync(() -> SafeFuture.COMPLETE);
-  }
-
-  @Override
   public SafeFuture<Void> onReconstructedFinalizedState(
       final BeaconState finalizedState, final Bytes32 blockRoot) {
     return asyncRunner.runAsync(() -> SafeFuture.COMPLETE);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
`onFinalizedState` is not triggered anywhere, so having in the channel is wrong. `onStorageUpdate` can be used instead. So removing this method along with `storeFinalizedState`. Changed tests to use `storeReconstructedFinalizedState` which is an used method.

Also remove unused `removeBlobSidecars`

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
