### PR TITLE
Only cache finalized indices in (pubkey, index) cache

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorIndexCacheTracker.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorIndexCacheTracker.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.coordinator;
+
+import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateCache;
+import tech.pegasys.teku.storage.api.FinalizedCheckpointChannel;
+import tech.pegasys.teku.storage.client.RecentChainData;
+
+public class ValidatorIndexCacheTracker implements FinalizedCheckpointChannel {
+
+  private final RecentChainData recentChainData;
+
+  public ValidatorIndexCacheTracker(final RecentChainData recentChainData) {
+    this.recentChainData = recentChainData;
+  }
+
+  @Override
+  public void onNewFinalizedCheckpoint(
+      final Checkpoint checkpoint, final boolean fromOptimisticBlock) {
+    final BeaconState finalizedState = recentChainData.getStore().getLatestFinalized().getState();
+    BeaconStateCache.getTransitionCaches(finalizedState)
+        .getValidatorIndexCache()
+        .updateLatestFinalizedIndex(finalizedState);
+  }
+}

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorIndexCacheTrackerTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorIndexCacheTrackerTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.coordinator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
+import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateCache;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.storage.client.RecentChainData;
+import tech.pegasys.teku.storage.store.UpdatableStore;
+
+class ValidatorIndexCacheTrackerTest {
+
+  private final RecentChainData recentChainData = mock(RecentChainData.class);
+
+  private final Spec spec = TestSpecFactory.createDefault();
+
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+
+  private final AnchorPoint anchorPoint = dataStructureUtil.randomAnchorPoint(UInt64.ZERO);
+
+  private final ValidatorIndexCacheTracker validatorIndexCacheTracker =
+      new ValidatorIndexCacheTracker(recentChainData);
+
+  @BeforeEach
+  public void setup() {
+    final UpdatableStore store = mock(UpdatableStore.class);
+    when(recentChainData.getStore()).thenReturn(store);
+    when(store.getLatestFinalized()).thenReturn(anchorPoint);
+  }
+
+  @Test
+  public void updatesCacheLatestFinalizedIndex() {
+    assertThat(getCacheLatestFinalizedIndex(anchorPoint.getState())).isEqualTo(-1);
+
+    validatorIndexCacheTracker.onNewFinalizedCheckpoint(mock(Checkpoint.class), false);
+
+    assertThat(getCacheLatestFinalizedIndex(anchorPoint.getState()))
+        .isNotEqualTo(-1)
+        .isEqualTo(anchorPoint.getState().getValidators().size() - 1);
+  }
+
+  private int getCacheLatestFinalizedIndex(final BeaconState state) {
+    return BeaconStateCache.getTransitionCaches(state)
+        .getValidatorIndexCache()
+        .getLatestFinalizedIndex();
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/TransitionCaches.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/TransitionCaches.java
@@ -179,9 +179,10 @@ public class TransitionCaches {
   /**
    * (validator pub key) -> (validator index) cache
    *
-   * <p>WARNING: May contain mappings for public keys of validators that are not yet registered in
-   * this state (but when registered are guaranteed to be at that index). Check index {@literal < }
-   * total validator count before looking up the cache
+   * <p>WARNING: Only contains mappings for public keys of validators whose indices are part of a
+   * finalized state. Otherwise, the mapping will be retrieved from the state. Look at
+   * https://eips.ethereum.org/EIPS/eip-6110#validator-index-invariant for more information. Check
+   * index {@literal < } total validator count before looking up the cache.
    */
   public ValidatorIndexCache getValidatorIndexCache() {
     return validatorIndexCache;

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/ValidatorIndexCache.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/ValidatorIndexCache.java
@@ -25,71 +25,105 @@ import tech.pegasys.teku.spec.datastructures.state.Validator;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 
 public class ValidatorIndexCache {
-  private final Cache<BLSPublicKey, Integer> validatorIndices;
-  private final AtomicInteger lastIndex;
 
   private static final int INDEX_NONE = -1;
+
   static final ValidatorIndexCache NO_OP_INSTANCE =
-      new ValidatorIndexCache(NoOpCache.getNoOpCache(), INDEX_NONE);
+      new ValidatorIndexCache(NoOpCache.getNoOpCache(), INDEX_NONE, INDEX_NONE);
+
+  private final Cache<BLSPublicKey, Integer> validatorIndices;
+
+  private final AtomicInteger latestFinalizedIndex;
+  private final AtomicInteger lastCachedIndex;
 
   @VisibleForTesting
-  ValidatorIndexCache(final Cache<BLSPublicKey, Integer> validatorIndices, final int lastIndex) {
+  ValidatorIndexCache(
+      final Cache<BLSPublicKey, Integer> validatorIndices,
+      final int latestFinalizedIndex,
+      final int lastCachedIndex) {
     this.validatorIndices = validatorIndices;
-    this.lastIndex = new AtomicInteger(lastIndex);
+    this.latestFinalizedIndex = new AtomicInteger(latestFinalizedIndex);
+    this.lastCachedIndex = new AtomicInteger(lastCachedIndex);
   }
 
   public ValidatorIndexCache() {
-    this.validatorIndices = LRUCache.create(Integer.MAX_VALUE - 1);
-    this.lastIndex = new AtomicInteger(INDEX_NONE);
+    this(LRUCache.create(Integer.MAX_VALUE - 1), INDEX_NONE, INDEX_NONE);
   }
 
   public Optional<Integer> getValidatorIndex(
       final BeaconState state, final BLSPublicKey publicKey) {
-    // Store lastIndex here in case we need to scan keys from the state.
+    // Store latestFinalizedIndex here in case we need to scan keys from the state.
     // This ensures we're adding from a point that we're confident the cache is at
     // when we scan for more keys through the state later.
-    final int lastIndexSnapshot = lastIndex.get();
-
-    final Optional<Integer> validatorIndex = validatorIndices.getCached(publicKey);
-    if (validatorIndex.isPresent()) {
-      return validatorIndex.filter(index -> index < state.getValidators().size());
-    }
-
-    return findIndexFromState(state.getValidators(), publicKey, lastIndexSnapshot);
+    final int latestFinalizedIndexSnapshot = latestFinalizedIndex.get();
+    final SszList<Validator> validators = state.getValidators();
+    return validatorIndices
+        .getCached(publicKey)
+        .or(() -> findIndexFromFinalizedState(validators, publicKey, latestFinalizedIndexSnapshot))
+        .or(
+            () ->
+                findIndexFromNonFinalizedState(
+                    validators, publicKey, latestFinalizedIndexSnapshot));
   }
 
-  private Optional<Integer> findIndexFromState(
-      final SszList<Validator> validatorList,
+  private Optional<Integer> findIndexFromFinalizedState(
+      final SszList<Validator> validators,
       final BLSPublicKey publicKey,
-      final int lastIndexSnapshot) {
-    for (int i = Math.max(lastIndexSnapshot, 0); i < validatorList.size(); i++) {
-      BLSPublicKey pubKey = validatorList.get(i).getPublicKey();
+      final int latestFinalizedIndex) {
+    for (int i = lastCachedIndex.get() + 1; i <= latestFinalizedIndex; i++) {
+      final BLSPublicKey pubKey = validators.get(i).getPublicKey();
+      // cache finalized mapping
       validatorIndices.invalidateWithNewValue(pubKey, i);
+      updateLastCachedIndex(i);
       if (pubKey.equals(publicKey)) {
-        updateLastIndex(i);
         return Optional.of(i);
       }
     }
-
-    updateLastIndex(validatorList.size());
     return Optional.empty();
   }
 
-  private void updateLastIndex(final int i) {
-    lastIndex.updateAndGet(curr -> Math.max(curr, i));
+  private void updateLastCachedIndex(final int updatedIndex) {
+    lastCachedIndex.updateAndGet(curr -> Math.max(curr, updatedIndex));
+  }
+
+  private Optional<Integer> findIndexFromNonFinalizedState(
+      final SszList<Validator> validators,
+      final BLSPublicKey publicKey,
+      final int latestFinalizedIndex) {
+    for (int i = latestFinalizedIndex + 1; i < validators.size(); i++) {
+      final BLSPublicKey pubKey = validators.get(i).getPublicKey();
+      if (pubKey.equals(publicKey)) {
+        return Optional.of(i);
+      }
+    }
+    return Optional.empty();
+  }
+
+  public void updateLatestFinalizedIndex(final BeaconState finalizedState) {
+    latestFinalizedIndex.updateAndGet(
+        curr -> Math.max(curr, finalizedState.getValidators().size() - 1));
   }
 
   public void invalidateWithNewValue(final BLSPublicKey pubKey, final int updatedIndex) {
+    if (updatedIndex > latestFinalizedIndex.get()) {
+      // do not cache if index is not finalized
+      return;
+    }
     validatorIndices.invalidateWithNewValue(pubKey, updatedIndex);
-  }
-
-  @VisibleForTesting
-  int getLastIndex() {
-    return lastIndex.get();
   }
 
   @VisibleForTesting
   Cache<BLSPublicKey, Integer> getValidatorIndices() {
     return validatorIndices;
+  }
+
+  @VisibleForTesting
+  int getLatestFinalizedIndex() {
+    return latestFinalizedIndex.get();
+  }
+
+  @VisibleForTesting
+  int getLastCachedIndex() {
+    return lastCachedIndex.get();
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/ValidatorIndexCache.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/ValidatorIndexCache.java
@@ -70,7 +70,9 @@ public class ValidatorIndexCache {
       final SszList<Validator> validators,
       final BLSPublicKey publicKey,
       final int latestFinalizedIndex) {
-    for (int i = lastCachedIndex.get() + 1; i <= latestFinalizedIndex; i++) {
+    for (int i = lastCachedIndex.get() + 1;
+        i <= Math.min(latestFinalizedIndex, validators.size() - 1);
+        i++) {
       final BLSPublicKey pubKey = validators.get(i).getPublicKey();
       // cache finalized mapping
       validatorIndices.invalidateWithNewValue(pubKey, i);
@@ -99,10 +101,14 @@ public class ValidatorIndexCache {
     return Optional.empty();
   }
 
-  // TODO: call this method also on startup when the chain is initialized with an anchor point
   public void updateLatestFinalizedIndex(final BeaconState finalizedState) {
     latestFinalizedIndex.updateAndGet(
         curr -> Math.max(curr, finalizedState.getValidators().size() - 1));
+  }
+
+  @VisibleForTesting
+  public int getLatestFinalizedIndex() {
+    return latestFinalizedIndex.get();
   }
 
   public void invalidateWithNewValue(final BLSPublicKey pubKey, final int updatedIndex) {
@@ -116,11 +122,6 @@ public class ValidatorIndexCache {
   @VisibleForTesting
   Cache<BLSPublicKey, Integer> getValidatorIndices() {
     return validatorIndices;
-  }
-
-  @VisibleForTesting
-  int getLatestFinalizedIndex() {
-    return latestFinalizedIndex.get();
   }
 
   @VisibleForTesting

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/ValidatorIndexCache.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/ValidatorIndexCache.java
@@ -77,7 +77,11 @@ public class ValidatorIndexCache {
       final SszList<Validator> validators,
       final BLSPublicKey publicKey,
       final int latestFinalizedIndex) {
-    LOG.info("Scanning for {} in finalized state", publicKey);
+    LOG.info(
+        "Scanning for {} in finalized state from {} to {}",
+        publicKey,
+        lastCachedIndex.get() + 1,
+        Math.min(latestFinalizedIndex, validators.size() - 1));
     for (int i = lastCachedIndex.get() + 1;
         i <= Math.min(latestFinalizedIndex, validators.size() - 1);
         i++) {
@@ -101,7 +105,11 @@ public class ValidatorIndexCache {
       final SszList<Validator> validators,
       final BLSPublicKey publicKey,
       final int latestFinalizedIndex) {
-    LOG.info("Scanning for {} in non-finalized state", publicKey);
+    LOG.info(
+        "Scanning for {} in non-finalized state from {} to {}",
+        publicKey,
+        latestFinalizedIndex + 1,
+        validators.size() - 1);
     for (int i = latestFinalizedIndex + 1; i < validators.size(); i++) {
       final BLSPublicKey pubKey = validators.get(i).getPublicKey();
       if (pubKey.equals(publicKey)) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/ValidatorIndexCache.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/ValidatorIndexCache.java
@@ -32,7 +32,6 @@ public class ValidatorIndexCache {
       new ValidatorIndexCache(NoOpCache.getNoOpCache(), INDEX_NONE, INDEX_NONE);
 
   private final Cache<BLSPublicKey, Integer> validatorIndices;
-
   private final AtomicInteger latestFinalizedIndex;
   private final AtomicInteger lastCachedIndex;
 
@@ -47,7 +46,9 @@ public class ValidatorIndexCache {
   }
 
   public ValidatorIndexCache() {
-    this(LRUCache.create(Integer.MAX_VALUE - 1), INDEX_NONE, INDEX_NONE);
+    validatorIndices = LRUCache.create(Integer.MAX_VALUE - 1);
+    latestFinalizedIndex = new AtomicInteger(INDEX_NONE);
+    lastCachedIndex = new AtomicInteger(INDEX_NONE);
   }
 
   public Optional<Integer> getValidatorIndex(
@@ -106,17 +107,17 @@ public class ValidatorIndexCache {
         curr -> Math.max(curr, finalizedState.getValidators().size() - 1));
   }
 
-  @VisibleForTesting
-  public int getLatestFinalizedIndex() {
-    return latestFinalizedIndex.get();
-  }
-
   public void invalidateWithNewValue(final BLSPublicKey pubKey, final int updatedIndex) {
     if (updatedIndex > latestFinalizedIndex.get()) {
       // do not cache if index is not finalized
       return;
     }
     validatorIndices.invalidateWithNewValue(pubKey, updatedIndex);
+  }
+
+  @VisibleForTesting
+  public int getLatestFinalizedIndex() {
+    return latestFinalizedIndex.get();
   }
 
   @VisibleForTesting

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/ValidatorIndexCache.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/ValidatorIndexCache.java
@@ -99,6 +99,7 @@ public class ValidatorIndexCache {
     return Optional.empty();
   }
 
+  // TODO: call this method also on startup when the chain is initialized with an anchor point
   public void updateLatestFinalizedIndex(final BeaconState finalizedState) {
     latestFinalizedIndex.updateAndGet(
         curr -> Math.max(curr, finalizedState.getValidators().size() - 1));

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/ValidatorIndexCache.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/ValidatorIndexCache.java
@@ -59,12 +59,9 @@ public class ValidatorIndexCache {
     // Store latestFinalizedIndex here in case we need to scan keys from the state.
     // This ensures we're adding from a point that we're confident the cache is at
     // when we scan for more keys through the state later.
-    LOG.info("Searching for {} in the cache", publicKey);
     final int latestFinalizedIndexSnapshot = latestFinalizedIndex.get();
-    LOG.info("Latest finalized index is: {}", latestFinalizedIndexSnapshot);
     final SszList<Validator> validators = state.getValidators();
     Optional<Integer> cached = validatorIndices.getCached(publicKey);
-    cached.ifPresent(i -> LOG.info("Cache hit for {} (index: {})", publicKey, i));
     return cached
         .or(() -> findIndexFromFinalizedState(validators, publicKey, latestFinalizedIndexSnapshot))
         .or(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/ValidatorIndexCache.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/ValidatorIndexCache.java
@@ -77,14 +77,10 @@ public class ValidatorIndexCache {
       final SszList<Validator> validators,
       final BLSPublicKey publicKey,
       final int latestFinalizedIndex) {
-    LOG.info(
-        "Scanning for {} in finalized state from {} to {}",
-        publicKey,
-        lastCachedIndex.get() + 1,
-        Math.min(latestFinalizedIndex, validators.size() - 1));
-    for (int i = lastCachedIndex.get() + 1;
-        i <= Math.min(latestFinalizedIndex, validators.size() - 1);
-        i++) {
+    int to = Math.min(latestFinalizedIndex, validators.size() - 1);
+    int from = lastCachedIndex.get() + 1;
+    LOG.info("Scanning for {} in finalized state from {} to {}", publicKey, from, to);
+    for (int i = from; i <= to; i++) {
       final BLSPublicKey pubKey = validators.get(i).getPublicKey();
       // cache finalized mapping
       validatorIndices.invalidateWithNewValue(pubKey, i);

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -197,6 +197,7 @@ import tech.pegasys.teku.validator.coordinator.Eth1VotingPeriod;
 import tech.pegasys.teku.validator.coordinator.GraffitiBuilder;
 import tech.pegasys.teku.validator.coordinator.MilestoneBasedBlockFactory;
 import tech.pegasys.teku.validator.coordinator.ValidatorApiHandler;
+import tech.pegasys.teku.validator.coordinator.ValidatorIndexCacheTracker;
 import tech.pegasys.teku.validator.coordinator.performance.DefaultPerformanceTracker;
 import tech.pegasys.teku.validator.coordinator.performance.NoOpPerformanceTracker;
 import tech.pegasys.teku.validator.coordinator.performance.PerformanceTracker;
@@ -518,6 +519,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
     initValidatorApiHandler();
     initRestAPI();
     initOperationsReOrgManager();
+    initValidatorIndexCacheTracker();
   }
 
   private void initKeyValueStore() {
@@ -1300,6 +1302,13 @@ public class BeaconChainController extends Service implements BeaconChainControl
             blsToExecutionChangePool,
             recentChainData);
     eventChannels.subscribe(ChainHeadChannel.class, operationsReOrgManager);
+  }
+
+  protected void initValidatorIndexCacheTracker() {
+    LOG.debug("BeaconChainController.initValidatorIndexCacheTracker()");
+    final ValidatorIndexCacheTracker validatorIndexCacheTracker =
+        new ValidatorIndexCacheTracker(recentChainData);
+    eventChannels.subscribe(FinalizedCheckpointChannel.class, validatorIndexCacheTracker);
   }
 
   protected void initForkChoiceStateProvider() {

--- a/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/client/RecentChainData.java
@@ -57,6 +57,7 @@ import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateCache;
 import tech.pegasys.teku.spec.logic.common.util.BeaconStateUtil;
 import tech.pegasys.teku.storage.api.ChainHeadChannel;
 import tech.pegasys.teku.storage.api.FinalizedCheckpointChannel;
@@ -239,6 +240,11 @@ public abstract class RecentChainData implements StoreUpdateHandler {
               this.forkDigestToMilestone.put(forkDigest, forkAndMilestone.getSpecMilestone());
               this.milestoneToForkDigest.put(forkAndMilestone.getSpecMilestone(), forkDigest);
             });
+
+    // Update the ValidatorIndexCache latest finalized index to the anchor state
+    BeaconStateCache.getTransitionCaches(anchorState)
+        .getValidatorIndexCache()
+        .updateLatestFinalizedIndex(anchorState);
 
     storeInitializedFuture.complete(null);
     return true;

--- a/storage/src/test/java/tech/pegasys/teku/storage/client/RecentChainDataTest.java
+++ b/storage/src/test/java/tech/pegasys/teku/storage/client/RecentChainDataTest.java
@@ -48,6 +48,7 @@ import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyForkChoiceStrate
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconStateCache;
 import tech.pegasys.teku.spec.generator.ChainBuilder;
 import tech.pegasys.teku.spec.generator.ChainBuilder.BlockOptions;
 import tech.pegasys.teku.spec.generator.ChainProperties;
@@ -160,6 +161,13 @@ class RecentChainDataTest {
         anchorPoint.getBlockSlot().times(genesisSpecConfig.getSecondsPerSlot()).plus(genesisTime);
     recentChainData.initializeFromAnchorPoint(anchorPoint, UInt64.valueOf(100));
     assertThat(recentChainData.getStore().getTimeSeconds()).isEqualTo(anchorBlockTime);
+    // make sure the ValidatorIndexCache latest finalized index is updated
+    assertThat(
+            BeaconStateCache.getTransitionCaches(anchor.getState())
+                .getValidatorIndexCache()
+                .getLatestFinalizedIndex())
+        .isNotEqualTo(-1)
+        .isEqualTo(anchor.getState().getValidators().size() - 1);
   }
 
   @Test


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
This PR changes the `ValidatorIndexCache` such that only finalized validator indices are cached. This is accomplished by creating a `ValidatorIndexCacheTracker` which is subscribed to finalized checkpoint events which in turn updates the finalized index of the `ValidatorIndexCache`. This is the assumption as per https://eips.ethereum.org/EIPS/eip-6110#validator-index-invariant .

So from this PR onwards, when looking for an index for a public key, the steps are:

1. Look for an index in the cache
2. Scan within the finalized validator indices for an index and cache whilst going. If found, return it. Next iterations will start from the last cached one.
3. If not found withing the finalized validator indices, search within the non finalized ones, but do not cache.

Also on store initialization (either from initial state or disk), the cache finalized index is populated. That is required because `onNewFinalizedCheckpoint` is triggered only on finalizations after the store is initialized.

**Things to consider:**

- Performance issues when scanning for a lot of non finalized pub keys. How often does that happen? How slow it could be?
- Maybe could make the logic fork specific or do we need to? It could become more complex.

## Fixed Issue(s)
fixes #7898

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
