### PR TITLE
Improve logging

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/blobs/BlobSidecarsAndValidationResult.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/blobs/BlobSidecarsAndValidationResult.java
@@ -126,7 +126,7 @@ public class BlobSidecarsAndValidationResult {
 
   public String toLogString() {
     return String.format(
-        "result %s, blob sidecars: %d, cause: %s",
+        "%s, blob sidecars: %d, cause: %s",
         validationResult, blobSidecars.size(), cause.map(ExceptionUtil::getMessageOrSimpleName));
   }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/BlockImportPerformance.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/block/BlockImportPerformance.java
@@ -129,6 +129,10 @@ public class BlockImportPerformance {
                 totalProcessingDuration, TOTAL_PROCESSING_TIME_LABEL, resultMetricLabelValue),
         (totalDuration, timings) ->
             eventLogger.lateBlockImport(
-                block.getRoot(), block.getSlot(), block.getProposerIndex(), timings));
+                block.getRoot(),
+                block.getSlot(),
+                block.getProposerIndex(),
+                timings,
+                resultMetricLabelValue));
   }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/ForkChoice.java
@@ -538,7 +538,7 @@ public class ForkChoice implements ForkChoiceUpdatedResultSubscriber {
       case VALID, NOT_REQUIRED -> LOG.debug(
           "blobSidecars validation result: {}", blobSidecarsAndValidationResult::toLogString);
       case NOT_AVAILABLE -> {
-        LOG.warn(
+        LOG.debug(
             "blobSidecars validation result: {}", blobSidecarsAndValidationResult::toLogString);
         return BlockImportResult.failedDataAvailabilityCheckNotAvailable(
             blobSidecarsAndValidationResult.getCause());

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockManagerTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/block/BlockManagerTest.java
@@ -770,7 +770,8 @@ public class BlockManagerTest {
                 + TRANSACTION_COMMITTED_EVENT_LABEL
                 + " +0ms, "
                 + COMPLETED_EVENT_LABEL
-                + " +0ms");
+                + " +0ms",
+            "success");
   }
 
   @Test

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java
@@ -280,8 +280,8 @@ public class EventLogger {
       final String result) {
     final String slowBlockLog =
         String.format(
-            "Late Block Import *** Block: %s proposer %s - %s - result: %s",
-            LogFormatter.formatBlock(slot, root), proposer, timings, result);
+            "Late Block Import *** Block: %s Proposer: %s Result: %s %s",
+            LogFormatter.formatBlock(slot, root), proposer, result, timings);
     warn(slowBlockLog, Color.YELLOW);
   }
 

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java
@@ -273,11 +273,15 @@ public class EventLogger {
   }
 
   public void lateBlockImport(
-      final Bytes32 root, final UInt64 slot, final UInt64 proposer, final String timings) {
-    String slowBlockLog =
+      final Bytes32 root,
+      final UInt64 slot,
+      final UInt64 proposer,
+      final String timings,
+      final String result) {
+    final String slowBlockLog =
         String.format(
-            "Late Block Import *** Block: %s proposer %s %s",
-            LogFormatter.formatBlock(slot, root), proposer, timings);
+            "Late Block Import *** Block: %s proposer %s - %s - result: %s",
+            LogFormatter.formatBlock(slot, root), proposer, timings, result);
     warn(slowBlockLog, Color.YELLOW);
   }
 


### PR DESCRIPTION
Set log level to `trace` for block import failures for which user can't do much.

Add reason to Late Block Import (to avoid confusion about late blocks that actually fail at the end)

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
