### PR TITLE
Filter out indices in the caches which are larger than the validators in the state

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/ValidatorIndexCache.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/ValidatorIndexCache.java
@@ -58,8 +58,8 @@ public class ValidatorIndexCache {
     if (validatorIndex.isPresent()) {
       return validatorIndex.filter(index -> index < validators.size());
     }
-    // Making sure to use the same latestFinalizedIndex when scanning through
-    // the finalized and the non-finalized states
+    // Using the same latestFinalizedIndex when scanning through
+    // the finalized and the non-finalized states ensures consistency
     final int latestFinalizedIndexSnapshot = latestFinalizedIndex.get();
     return findIndexFromFinalizedState(validators, publicKey, latestFinalizedIndexSnapshot)
         .or(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/ValidatorIndexCache.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/ValidatorIndexCache.java
@@ -53,14 +53,15 @@ public class ValidatorIndexCache {
 
   public Optional<Integer> getValidatorIndex(
       final BeaconState state, final BLSPublicKey publicKey) {
-    // Store latestFinalizedIndex here in case we need to scan keys from the state.
-    // This ensures we're adding from a point that we're confident the cache is at
-    // when we scan for more keys through the state later.
-    final int latestFinalizedIndexSnapshot = latestFinalizedIndex.get();
     final SszList<Validator> validators = state.getValidators();
-    return validatorIndices
-        .getCached(publicKey)
-        .or(() -> findIndexFromFinalizedState(validators, publicKey, latestFinalizedIndexSnapshot))
+    final Optional<Integer> validatorIndex = validatorIndices.getCached(publicKey);
+    if (validatorIndex.isPresent()) {
+      return validatorIndex.filter(index -> index < validators.size());
+    }
+    // Making sure to use the same latestFinalizedIndex when scanning through
+    // the finalized and the non-finalized states
+    final int latestFinalizedIndexSnapshot = latestFinalizedIndex.get();
+    return findIndexFromFinalizedState(validators, publicKey, latestFinalizedIndexSnapshot)
         .or(
             () ->
                 findIndexFromNonFinalizedState(

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/ValidatorIndexCacheTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/state/beaconstate/common/ValidatorIndexCacheTest.java
@@ -44,6 +44,23 @@ public class ValidatorIndexCacheTest {
   final Cache<BLSPublicKey, Integer> cache = mock(Cache.class);
 
   @Test
+  public void shouldReturnEmptyIfValidatorIndexIsNotConsistentWithNumberOfValidatorsInState() {
+    final SszList<Validator> validators = state.getValidators();
+    final int latestFinalizedIndex = NUMBER_OF_VALIDATORS - 1;
+    final ValidatorIndexCache validatorIndexCache = new ValidatorIndexCache();
+    validatorIndexCache.updateLatestFinalizedIndex(state);
+
+    final BLSPublicKey publicKey = validators.get(latestFinalizedIndex).getPublicKey();
+    // cache eagerly the last validator public key
+    validatorIndexCache.invalidateWithNewValue(publicKey, latestFinalizedIndex);
+
+    // state with one less validator
+    final BeaconState state = dataStructureUtil.randomBeaconState(NUMBER_OF_VALIDATORS - 1);
+
+    assertThat(validatorIndexCache.getValidatorIndex(state, publicKey)).isEmpty();
+  }
+
+  @Test
   public void shouldScanFinalizedStateAndCache() {
     final SszList<Validator> validators = state.getValidators();
     final int latestFinalizedIndex = NUMBER_OF_VALIDATORS - 1;


### PR DESCRIPTION
## PR Description
This was the logic before and got removed by mistake in https://github.com/Consensys/teku/pull/8165

```java
final Optional<Integer> validatorIndex = validatorIndices.getCached(publicKey);
if (validatorIndex.isPresent()) {
   return validatorIndex.filter(index -> index < state.getValidators().size());
}
```

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
