### PR TITLE
Skip EL part of graffiti when EL info not available

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/GraffitiBuilder.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/GraffitiBuilder.java
@@ -128,8 +128,10 @@ public class GraffitiBuilder implements ExecutionClientVersionChannel {
 
   @VisibleForTesting
   protected String formatClientsInfo(final int length) {
+    final boolean isElInfoAvailable = !ClientVersion.UNKNOWN.equals(executionClientVersion.get());
     final String safeConsensusCode = extractClientCodeSafely(consensusClientVersion);
-    final String safeExecutionCode = extractClientCodeSafely(executionClientVersion.get());
+    final String safeExecutionCode =
+        isElInfoAvailable ? extractClientCodeSafely(executionClientVersion.get()) : "";
     // LH1be52536BU0f91a674
     if (length >= 20) {
       return String.format(
@@ -137,7 +139,7 @@ public class GraffitiBuilder implements ExecutionClientVersionChannel {
           safeConsensusCode,
           consensusClientVersion.commit().toUnprefixedHexString(),
           safeExecutionCode,
-          executionClientVersion.get().commit().toUnprefixedHexString());
+          isElInfoAvailable ? executionClientVersion.get().commit().toUnprefixedHexString() : "");
     }
     // LH1be5BU0f91
     if (length >= 12) {
@@ -146,7 +148,9 @@ public class GraffitiBuilder implements ExecutionClientVersionChannel {
           safeConsensusCode,
           consensusClientVersion.commit().toUnprefixedHexString().substring(0, 4),
           safeExecutionCode,
-          executionClientVersion.get().commit().toUnprefixedHexString().substring(0, 4));
+          isElInfoAvailable
+              ? executionClientVersion.get().commit().toUnprefixedHexString().substring(0, 4)
+              : "");
     }
     // LH1bBU0f
     if (length >= 8) {
@@ -155,11 +159,13 @@ public class GraffitiBuilder implements ExecutionClientVersionChannel {
           safeConsensusCode,
           consensusClientVersion.commit().toUnprefixedHexString().substring(0, 2),
           safeExecutionCode,
-          executionClientVersion.get().commit().toUnprefixedHexString().substring(0, 2));
+          isElInfoAvailable
+              ? executionClientVersion.get().commit().toUnprefixedHexString().substring(0, 2)
+              : "");
     }
     // LHBU
     if (length >= 4) {
-      return String.format("%s%s", safeConsensusCode, safeExecutionCode);
+      return String.format("%s%s", safeConsensusCode, isElInfoAvailable ? safeExecutionCode : "");
     }
 
     return "";

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/GraffitiBuilderTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/GraffitiBuilderTest.java
@@ -122,6 +122,26 @@ public class GraffitiBuilderTest {
         .isEqualTo(expectedGraffitiBytes);
   }
 
+  @ParameterizedTest(name = "format={0}, userGraffiti={1}")
+  @MethodSource("getBuildGraffitiFixturesElInfoNa")
+  public void buildGraffiti_shouldProvideCorrectOutput_whenElInfoNa(
+      final ClientGraffitiAppendFormat clientGraffitiAppendFormat,
+      final Optional<String> maybeUserGraffiti,
+      final String expectedGraffiti) {
+    this.graffitiBuilder = new GraffitiBuilder(clientGraffitiAppendFormat, userGraffiti);
+    final Bytes32 expectedGraffitiBytes = Bytes32Parser.toBytes32(expectedGraffiti);
+    assertThat(
+            new String(
+                Arrays.copyOfRange(
+                    expectedGraffitiBytes.toArray(),
+                    0,
+                    32 - expectedGraffitiBytes.numberOfTrailingZeroBytes()),
+                StandardCharsets.UTF_8))
+        .isEqualTo(expectedGraffiti);
+    assertThat(graffitiBuilder.buildGraffiti(maybeUserGraffiti.map(Bytes32Parser::toBytes32)))
+        .isEqualTo(expectedGraffitiBytes);
+  }
+
   @Test
   public void extractGraffiti_shouldReturnEmptyString() {
     assertThat(graffitiBuilder.extractGraffiti(Optional.empty(), 0)).isEqualTo("");
@@ -290,9 +310,77 @@ public class GraffitiBuilderTest {
   }
 
   @Test
-  public void formatClientInfo_shouldSkipClientsInfoWhenNotEnoughSpace() {
+  public void formatClientInfo_shouldSkipClientsInfo_whenNotEnoughSpace() {
     graffitiBuilder.onExecutionClientVersion(BESU_CLIENT_VERSION);
 
+    // Empty
+    assertThat(graffitiBuilder.formatClientsInfo(3))
+        .isEqualTo("")
+        .satisfies(s -> assertThat(s.getBytes(StandardCharsets.UTF_8).length).isEqualTo(0));
+    assertThat(graffitiBuilder.formatClientsInfo(0))
+        .isEqualTo("")
+        .satisfies(s -> assertThat(s.getBytes(StandardCharsets.UTF_8).length).isEqualTo(0));
+    assertThat(graffitiBuilder.formatClientsInfo(-1))
+        .isEqualTo("")
+        .satisfies(s -> assertThat(s.getBytes(StandardCharsets.UTF_8).length).isEqualTo(0));
+  }
+
+  @Test
+  public void formatClientInfo_shouldRenderClClientNameAndFullCommit_whenElInfoNotAvailable() {
+    // 20: LH1be52536BU0f91a674
+    assertThat(graffitiBuilder.formatClientsInfo(30))
+        .isEqualTo(
+            TEKU_CLIENT_VERSION.code() + TEKU_CLIENT_VERSION.commit().toUnprefixedHexString())
+        .satisfies(s -> assertThat(s.getBytes(StandardCharsets.UTF_8).length).isLessThan(20));
+    assertThat(graffitiBuilder.formatClientsInfo(20))
+        .isEqualTo(
+            TEKU_CLIENT_VERSION.code() + TEKU_CLIENT_VERSION.commit().toUnprefixedHexString())
+        .satisfies(s -> assertThat(s.getBytes(StandardCharsets.UTF_8).length).isLessThan(20));
+  }
+
+  @Test
+  public void formatClientInfo_shouldRenderClClientNameAndHalfCommit_whenElInfoNotAvailable() {
+    // 12: LH1be5BU0f91
+    assertThat(graffitiBuilder.formatClientsInfo(19))
+        .isEqualTo(
+            TEKU_CLIENT_VERSION.code()
+                + TEKU_CLIENT_VERSION.commit().toUnprefixedHexString().substring(0, 4))
+        .satisfies(s -> assertThat(s.getBytes(StandardCharsets.UTF_8).length).isLessThan(12));
+    assertThat(graffitiBuilder.formatClientsInfo(12))
+        .isEqualTo(
+            TEKU_CLIENT_VERSION.code()
+                + TEKU_CLIENT_VERSION.commit().toUnprefixedHexString().substring(0, 4))
+        .satisfies(s -> assertThat(s.getBytes(StandardCharsets.UTF_8).length).isLessThan(12));
+  }
+
+  @Test
+  public void formatClientInfo_shouldRenderClClientNameAnd1stCommitByte_whenElInfoNotAvailable() {
+    // 8: LH1bBU0f
+    assertThat(graffitiBuilder.formatClientsInfo(11))
+        .isEqualTo(
+            TEKU_CLIENT_VERSION.code()
+                + TEKU_CLIENT_VERSION.commit().toUnprefixedHexString().substring(0, 2))
+        .satisfies(s -> assertThat(s.getBytes(StandardCharsets.UTF_8).length).isLessThan(8));
+    assertThat(graffitiBuilder.formatClientsInfo(8))
+        .isEqualTo(
+            TEKU_CLIENT_VERSION.code()
+                + TEKU_CLIENT_VERSION.commit().toUnprefixedHexString().substring(0, 2))
+        .satisfies(s -> assertThat(s.getBytes(StandardCharsets.UTF_8).length).isLessThan(8));
+  }
+
+  @Test
+  public void formatClientInfo_shouldRenderClClientName_whenElInfoNotAvailable() {
+    // 4: LHBU
+    assertThat(graffitiBuilder.formatClientsInfo(7))
+        .isEqualTo(TEKU_CLIENT_VERSION.code())
+        .satisfies(s -> assertThat(s.getBytes(StandardCharsets.UTF_8).length).isLessThan(4));
+    assertThat(graffitiBuilder.formatClientsInfo(4))
+        .isEqualTo(TEKU_CLIENT_VERSION.code())
+        .satisfies(s -> assertThat(s.getBytes(StandardCharsets.UTF_8).length).isLessThan(4));
+  }
+
+  @Test
+  public void formatClientInfo_shouldSkipClientsInfo_whenNotEnoughSpaceAndElInfoNotAvailable() {
     // Empty
     assertThat(graffitiBuilder.formatClientsInfo(3))
         .isEqualTo("")
@@ -447,6 +535,48 @@ public class GraffitiBuilderTest {
             CLIENT_CODES,
             Optional.of(ASCII_GRAFFITI_20),
             ASCII_GRAFFITI_20 + " " + TEKU_CLIENT_VERSION.code() + BESU_CLIENT_VERSION.code()),
+        Arguments.of(DISABLED, Optional.empty(), ""),
+        Arguments.of(DISABLED, Optional.of("small"), "small"),
+        Arguments.of(DISABLED, Optional.of(UTF_8_GRAFFITI_4), UTF_8_GRAFFITI_4),
+        Arguments.of(DISABLED, Optional.of(ASCII_GRAFFITI_20), ASCII_GRAFFITI_20));
+  }
+
+  private static Stream<Arguments> getBuildGraffitiFixturesElInfoNa() {
+    return Stream.of(
+        Arguments.of(
+            AUTO,
+            Optional.empty(),
+            TEKU_CLIENT_VERSION.code() + TEKU_CLIENT_VERSION.commit().toUnprefixedHexString()),
+        Arguments.of(
+            AUTO,
+            Optional.of("small"),
+            "small "
+                + TEKU_CLIENT_VERSION.code()
+                + TEKU_CLIENT_VERSION.commit().toUnprefixedHexString()),
+        Arguments.of(
+            AUTO,
+            Optional.of(UTF_8_GRAFFITI_4),
+            UTF_8_GRAFFITI_4
+                + " "
+                + TEKU_CLIENT_VERSION.code()
+                + TEKU_CLIENT_VERSION.commit().toUnprefixedHexString()),
+        Arguments.of(
+            AUTO,
+            Optional.of(ASCII_GRAFFITI_20),
+            ASCII_GRAFFITI_20
+                + " "
+                + TEKU_CLIENT_VERSION.code()
+                + TEKU_CLIENT_VERSION.commit().toUnprefixedHexString().substring(0, 2)),
+        Arguments.of(CLIENT_CODES, Optional.empty(), TEKU_CLIENT_VERSION.code()),
+        Arguments.of(CLIENT_CODES, Optional.of("small"), "small " + TEKU_CLIENT_VERSION.code()),
+        Arguments.of(
+            CLIENT_CODES,
+            Optional.of(UTF_8_GRAFFITI_4),
+            UTF_8_GRAFFITI_4 + " " + TEKU_CLIENT_VERSION.code()),
+        Arguments.of(
+            CLIENT_CODES,
+            Optional.of(ASCII_GRAFFITI_20),
+            ASCII_GRAFFITI_20 + " " + TEKU_CLIENT_VERSION.code()),
         Arguments.of(DISABLED, Optional.empty(), ""),
         Arguments.of(DISABLED, Optional.of("small"), "small"),
         Arguments.of(DISABLED, Optional.of(UTF_8_GRAFFITI_4), UTF_8_GRAFFITI_4),

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/GraffitiBuilderTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/GraffitiBuilderTest.java
@@ -101,6 +101,17 @@ public class GraffitiBuilderTest {
     assertThat(graffitiBuilder.buildGraffiti(Optional.of(graffiti))).isEqualTo(graffiti);
   }
 
+  @Test
+  public void buildGraffiti_shouldPreferCallInput() {
+    final Bytes32 defaultGraffiti = Bytes32Parser.toBytes32(asciiGraffiti32);
+    final Bytes32 userGraffiti = Bytes32Parser.toBytes32(ASCII_GRAFFITI_20);
+    final Bytes32 expectedGraffiti = Bytes32Parser.toBytes32(ASCII_GRAFFITI_20 + " TK");
+    this.graffitiBuilder = new GraffitiBuilder(CLIENT_CODES, Optional.of(defaultGraffiti));
+    graffitiBuilder.onExecutionClientVersion(ClientVersion.UNKNOWN);
+    assertThat(graffitiBuilder.buildGraffiti(Optional.of(userGraffiti)))
+        .isEqualTo(expectedGraffiti);
+  }
+
   @ParameterizedTest(name = "format={0}, userGraffiti={1}")
   @MethodSource("getBuildGraffitiFixtures")
   public void buildGraffiti_shouldProvideCorrectOutput(
@@ -129,6 +140,7 @@ public class GraffitiBuilderTest {
       final Optional<String> maybeUserGraffiti,
       final String expectedGraffiti) {
     this.graffitiBuilder = new GraffitiBuilder(clientGraffitiAppendFormat, userGraffiti);
+    graffitiBuilder.onExecutionClientVersion(ClientVersion.UNKNOWN);
     final Bytes32 expectedGraffitiBytes = Bytes32Parser.toBytes32(expectedGraffiti);
     assertThat(
             new String(
@@ -327,6 +339,8 @@ public class GraffitiBuilderTest {
 
   @Test
   public void formatClientInfo_shouldRenderClClientNameAndFullCommit_whenElInfoNotAvailable() {
+    graffitiBuilder.onExecutionClientVersion(ClientVersion.UNKNOWN);
+
     // 20: LH1be52536BU0f91a674
     assertThat(graffitiBuilder.formatClientsInfo(30))
         .isEqualTo(
@@ -340,6 +354,8 @@ public class GraffitiBuilderTest {
 
   @Test
   public void formatClientInfo_shouldRenderClClientNameAndHalfCommit_whenElInfoNotAvailable() {
+    graffitiBuilder.onExecutionClientVersion(ClientVersion.UNKNOWN);
+
     // 12: LH1be5BU0f91
     assertThat(graffitiBuilder.formatClientsInfo(19))
         .isEqualTo(
@@ -355,6 +371,8 @@ public class GraffitiBuilderTest {
 
   @Test
   public void formatClientInfo_shouldRenderClClientNameAnd1stCommitByte_whenElInfoNotAvailable() {
+    graffitiBuilder.onExecutionClientVersion(ClientVersion.UNKNOWN);
+
     // 8: LH1bBU0f
     assertThat(graffitiBuilder.formatClientsInfo(11))
         .isEqualTo(
@@ -370,6 +388,8 @@ public class GraffitiBuilderTest {
 
   @Test
   public void formatClientInfo_shouldRenderClClientName_whenElInfoNotAvailable() {
+    graffitiBuilder.onExecutionClientVersion(ClientVersion.UNKNOWN);
+
     // 4: LHBU
     assertThat(graffitiBuilder.formatClientsInfo(7))
         .isEqualTo(TEKU_CLIENT_VERSION.code())
@@ -381,6 +401,8 @@ public class GraffitiBuilderTest {
 
   @Test
   public void formatClientInfo_shouldSkipClientsInfo_whenNotEnoughSpaceAndElInfoNotAvailable() {
+    graffitiBuilder.onExecutionClientVersion(ClientVersion.UNKNOWN);
+
     // Empty
     assertThat(graffitiBuilder.formatClientsInfo(3))
         .isEqualTo("")


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
We are currently filling it with something like `NA0000`, which is not beautiful, so we decided to skip it at all in this case.
Also behavior was updated to push UNKNOWN version in channel when it's not known due to failure or whatever, but do it only once per client start. So we could have normal log line with expected graffiti on start when execution client is not supporting the new API and it will be not noisy if there are issues with EL.

PS: I don't try to put more CL info in graffiti when EL version is unknown to make it simpler.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
