### PR TITLE
Added electra ref tests for deposit_receipt and execution_layer_exit

### DIFF
--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/operations/DefaultOperationProcessor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/operations/DefaultOperationProcessor.java
@@ -14,14 +14,19 @@
 package tech.pegasys.teku.reference.common.operations;
 
 import java.util.Optional;
+import java.util.function.Supplier;
 import tech.pegasys.teku.bls.BLSSignatureVerifier;
+import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodySchema;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregate;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.capella.BeaconBlockBodySchemaCapella;
+import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.electra.BeaconBlockBodySchemaElectra;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSummary;
+import tech.pegasys.teku.spec.datastructures.execution.versions.electra.DepositReceipt;
+import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionLayerExit;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.Deposit;
@@ -29,10 +34,12 @@ import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.SignedBlsToExecutionChange;
 import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
+import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateMutators.ValidatorExitContext;
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.BlockProcessingException;
 import tech.pegasys.teku.spec.logic.versions.bellatrix.block.OptimisticExecutionPayloadExecutor;
 
 public class DefaultOperationProcessor implements OperationProcessor {
+
   private final Spec spec;
   private final BeaconBlockBodySchema<?> beaconBlockBodySchema;
 
@@ -131,5 +138,35 @@ public class DefaultOperationProcessor implements OperationProcessor {
       final MutableBeaconState state, final ExecutionPayloadSummary payloadSummary)
       throws BlockProcessingException {
     spec.getBlockProcessor(state.getSlot()).processWithdrawals(state, payloadSummary);
+  }
+
+  @Override
+  public void processDepositReceipt(
+      final MutableBeaconState state, final DepositReceipt depositReceipt)
+      throws BlockProcessingException {
+    final SszList<DepositReceipt> depositReceiptList =
+        BeaconBlockBodySchemaElectra.required(beaconBlockBodySchema)
+            .getExecutionPayloadSchema()
+            .getDepositReceiptsSchemaRequired()
+            .of(depositReceipt);
+
+    spec.getBlockProcessor(state.getSlot()).processDepositReceipts(state, depositReceiptList);
+  }
+
+  @Override
+  public void processExecutionLayerExit(
+      final MutableBeaconState state, final ExecutionLayerExit executionLayerExit)
+      throws BlockProcessingException {
+    final SszList<ExecutionLayerExit> exits =
+        BeaconBlockBodySchemaElectra.required(beaconBlockBodySchema)
+            .getExecutionPayloadSchema()
+            .getExecutionLayerExitsSchemaRequired()
+            .of(executionLayerExit);
+    final Supplier<ValidatorExitContext> validatorExitContextSupplier =
+        spec.atSlot(state.getSlot())
+            .beaconStateMutators()
+            .createValidatorExitContextSupplier(state);
+    spec.getBlockProcessor(state.getSlot())
+        .processExecutionLayerExits(state, exits, validatorExitContextSupplier);
   }
 }

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/operations/OperationProcessor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/operations/OperationProcessor.java
@@ -18,6 +18,8 @@ import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregate;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSummary;
+import tech.pegasys.teku.spec.datastructures.execution.versions.electra.DepositReceipt;
+import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionLayerExit;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.Deposit;
@@ -61,5 +63,11 @@ public interface OperationProcessor {
       throws BlockProcessingException;
 
   void processWithdrawals(MutableBeaconState state, ExecutionPayloadSummary payloadSummary)
+      throws BlockProcessingException;
+
+  void processDepositReceipt(final MutableBeaconState state, final DepositReceipt depositReceipt)
+      throws BlockProcessingException;
+
+  void processExecutionLayerExit(MutableBeaconState state, ExecutionLayerExit executionLayerExit)
       throws BlockProcessingException;
 }

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/operations/OperationsTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/operations/OperationsTestExecutor.java
@@ -420,7 +420,9 @@ public class OperationsTestExecutor<T extends SszData> implements TestExecutor {
           ATTESTATION,
           SYNC_AGGREGATE,
           EXECUTION_PAYLOAD,
-          WITHDRAWAL -> {}
+          WITHDRAWAL,
+          DEPOSIT_RECEIPT,
+          EXECUTION_LAYER_EXIT -> {}
     }
   }
 

--- a/eth-tests/src/main/java/tech/pegasys/teku/ethtests/TestFork.java
+++ b/eth-tests/src/main/java/tech/pegasys/teku/ethtests/TestFork.java
@@ -19,4 +19,5 @@ public class TestFork {
   public static final String BELLATRIX = "bellatrix";
   public static final String CAPELLA = "capella";
   public static final String DENEB = "deneb";
+  public static final String ELECTRA = "electra";
 }

--- a/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/ReferenceTestFinder.java
+++ b/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/ReferenceTestFinder.java
@@ -31,7 +31,12 @@ public class ReferenceTestFinder {
       Path.of("src", "referenceTest", "resources", "consensus-spec-tests", "tests");
   private static final List<String> SUPPORTED_FORKS =
       List.of(
-          TestFork.PHASE0, TestFork.ALTAIR, TestFork.BELLATRIX, TestFork.CAPELLA, TestFork.DENEB);
+          TestFork.PHASE0,
+          TestFork.ALTAIR,
+          TestFork.BELLATRIX,
+          TestFork.CAPELLA,
+          TestFork.DENEB,
+          TestFork.ELECTRA);
 
   @MustBeClosed
   public static Stream<TestDefinition> findReferenceTests() throws IOException {

--- a/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/TestDefinition.java
+++ b/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/TestDefinition.java
@@ -72,6 +72,7 @@ public class TestDefinition {
           case TestFork.BELLATRIX -> SpecMilestone.BELLATRIX;
           case TestFork.CAPELLA -> SpecMilestone.CAPELLA;
           case TestFork.DENEB -> SpecMilestone.DENEB;
+          case TestFork.ELECTRA -> SpecMilestone.ELECTRA;
           default -> throw new IllegalArgumentException("Unknown fork: " + fork);
         };
     spec = TestSpecFactory.create(milestone, network);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/AbstractBlockProcessor.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/AbstractBlockProcessor.java
@@ -47,6 +47,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.Eth1Data;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
+import tech.pegasys.teku.spec.datastructures.execution.versions.electra.DepositReceipt;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionLayerExit;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
@@ -885,10 +886,18 @@ public abstract class AbstractBlockProcessor implements BlockProcessor {
   }
 
   @Override
+  public void processDepositReceipts(
+      final MutableBeaconState state, final SszList<DepositReceipt> depositReceipts)
+      throws BlockProcessingException {
+    // No DepositReceipts until Electra
+  }
+
+  @Override
   public void processExecutionLayerExits(
       final MutableBeaconState state,
       final SszList<ExecutionLayerExit> exits,
-      final Supplier<ValidatorExitContext> validatorExitContextSupplier) {
+      final Supplier<ValidatorExitContext> validatorExitContextSupplier)
+      throws BlockProcessingException {
     // No ExecutionLayer exits until Electra
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/BlockProcessor.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/BlockProcessor.java
@@ -32,6 +32,7 @@ import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSummary;
 import tech.pegasys.teku.spec.datastructures.execution.NewPayloadRequest;
 import tech.pegasys.teku.spec.datastructures.execution.versions.capella.Withdrawal;
+import tech.pegasys.teku.spec.datastructures.execution.versions.electra.DepositReceipt;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionLayerExit;
 import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
@@ -167,10 +168,15 @@ public interface BlockProcessor {
   void processWithdrawals(MutableBeaconState state, ExecutionPayloadSummary payloadSummary)
       throws BlockProcessingException;
 
+  void processDepositReceipts(
+      final MutableBeaconState state, final SszList<DepositReceipt> depositReceipts)
+      throws BlockProcessingException;
+
   void processExecutionLayerExits(
       final MutableBeaconState state,
       final SszList<ExecutionLayerExit> exits,
-      final Supplier<ValidatorExitContext> validatorExitContextSupplier);
+      final Supplier<ValidatorExitContext> validatorExitContextSupplier)
+      throws BlockProcessingException;
 
   Optional<List<Withdrawal>> getExpectedWithdrawals(BeaconState preState);
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/block/BlockProcessorElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/block/BlockProcessorElectra.java
@@ -142,7 +142,8 @@ public class BlockProcessorElectra extends BlockProcessorDeneb {
   public void processExecutionLayerExits(
       final MutableBeaconState state,
       final SszList<ExecutionLayerExit> exits,
-      final Supplier<ValidatorExitContext> validatorExitContextSupplier) {
+      final Supplier<ValidatorExitContext> validatorExitContextSupplier)
+      throws BlockProcessingException {
     final UInt64 currentEpoch = miscHelpers.computeEpochAtSlot(state.getSlot());
 
     exits.forEach(
@@ -210,14 +211,17 @@ public class BlockProcessorElectra extends BlockProcessorDeneb {
   /*
    Implements process_deposit_receipt from consensus-specs (EIP-6110)
   */
+  @Override
   public void processDepositReceipts(
-      final MutableBeaconStateElectra state, final SszList<DepositReceipt> depositReceipts) {
+      final MutableBeaconState state, final SszList<DepositReceipt> depositReceipts)
+      throws BlockProcessingException {
+    final MutableBeaconStateElectra electraState = MutableBeaconStateElectra.required(state);
     for (DepositReceipt depositReceipt : depositReceipts) {
       // process_deposit_receipt
-      if (state
+      if (electraState
           .getDepositReceiptsStartIndex()
           .equals(SpecConfigElectra.UNSET_DEPOSIT_RECEIPTS_START_INDEX)) {
-        state.setDepositReceiptsStartIndex(depositReceipt.getIndex());
+        electraState.setDepositReceiptsStartIndex(depositReceipt.getIndex());
       }
       applyDeposit(
           state,

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/electra/block/BlockProcessorElectraTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/electra/block/BlockProcessorElectraTest.java
@@ -105,7 +105,7 @@ class BlockProcessorElectraTest extends BlockProcessorDenebTest {
   }
 
   @Test
-  public void processesDepositReceipts() {
+  public void processesDepositReceipts() throws BlockProcessingException {
     final BeaconStateElectra preState =
         BeaconStateElectra.required(
             createBeaconState()
@@ -129,7 +129,7 @@ class BlockProcessorElectraTest extends BlockProcessorDenebTest {
                         UInt64.valueOf(firstElectraDepositReceiptIndex + i)))
             .toList();
 
-    final BeaconStateElectra state =
+    final BeaconState state =
         BeaconStateElectra.required(
             preState.updated(
                 mutableState ->
@@ -139,7 +139,7 @@ class BlockProcessorElectraTest extends BlockProcessorDenebTest {
                             depositReceiptsSchema.createFromElements(depositReceipts))));
 
     // verify deposit_receipts_start_index has been set
-    assertThat(state.getDepositReceiptsStartIndex())
+    assertThat(BeaconStateElectra.required(state).getDepositReceiptsStartIndex())
         .isEqualTo(UInt64.valueOf(firstElectraDepositReceiptIndex));
     // verify validators have been added to the state
     assertThat(state.getValidators().size())


### PR DESCRIPTION
## PR Description
Enabling new Electra ref tests for deposits_receipt and execution_layer_exit. Those tests are being included as part of this spec PR: https://github.com/ethereum/consensus-specs/pull/3615

## Fixed Issue(s)
N/A

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
