### PR TITLE
Add an option to disable syncing the deposit contract logs for non-validator nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ the [releases page](https://github.com/Consensys/teku/releases).
 
 ### Additions and Improvements
 - Increased the executor queue default maximum size to 40_000 (previously 20_000), and other queues to 10_000 (previously 5_000). If you have custom settings for these queues, check to ensure they're still required.
-- Added `peers_direction_current` LIBP2P metric for the number of peers by direction including inbound and outbound.
+- Added `peers_direction_current` metric to track the number of peers by direction (inbound and outbound).
+- Deposit tree snapshots will be loaded from database as a default unless custom snapshot has been provided.
+- Added hidden option `--Xdeposit-contract-logs-syncing-enabled` to allow disabling the syncing of the deposit contract logs from the EL. This is useful when running a non-validating node.
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,6 @@ the [releases page](https://github.com/Consensys/teku/releases).
 - Increased the executor queue default maximum size to 40_000 (previously 20_000), and other queues to 10_000 (previously 5_000). If you have custom settings for these queues, check to ensure they're still required.
 - Added `peers_direction_current` libp2p metric to track the number of peers by direction (inbound and outbound).
 - Deposit tree snapshots will be loaded from database as a default unless custom snapshot has been provided.
-- Added hidden option `--Xdeposit-contract-logs-syncing-enabled` to allow disabling the syncing of the deposit contract logs from the EL. This is useful when running a non-validating node.
+- Added hidden option `--Xdeposit-contract-logs-syncing-enabled` to allow disabling the syncing of the deposit contract logs from the EL. This is useful when running a non-validating node. It is advisable to be used alongside with `--Xeth1-missing-deposits-event-logging-enabled=false` to avoid unnecessary logging of missing deposits.
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ the [releases page](https://github.com/Consensys/teku/releases).
 
 ### Additions and Improvements
 - Increased the executor queue default maximum size to 40_000 (previously 20_000), and other queues to 10_000 (previously 5_000). If you have custom settings for these queues, check to ensure they're still required.
-- Added `peers_direction_current` metric to track the number of peers by direction (inbound and outbound).
+- Added `peers_direction_current` libp2p metric to track the number of peers by direction (inbound and outbound).
 - Deposit tree snapshots will be loaded from database as a default unless custom snapshot has been provided.
 - Added hidden option `--Xdeposit-contract-logs-syncing-enabled` to allow disabling the syncing of the deposit contract logs from the EL. This is useful when running a non-validating node.
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/block/BlockProcessorElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/block/BlockProcessorElectra.java
@@ -90,7 +90,7 @@ public class BlockProcessorElectra extends BlockProcessorDeneb {
     safelyProcess(
         () ->
             processDepositReceipts(
-                MutableBeaconStateElectra.required(state),
+                state,
                 body.getOptionalExecutionPayload()
                     .flatMap(ExecutionPayload::toVersionElectra)
                     .map(ExecutionPayloadElectra::getDepositReceipts)

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/electra/block/BlockProcessorElectraTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/electra/block/BlockProcessorElectraTest.java
@@ -129,7 +129,7 @@ class BlockProcessorElectraTest extends BlockProcessorDenebTest {
                         UInt64.valueOf(firstElectraDepositReceiptIndex + i)))
             .toList();
 
-    final BeaconState state =
+    final BeaconStateElectra state =
         BeaconStateElectra.required(
             preState.updated(
                 mutableState ->
@@ -139,7 +139,7 @@ class BlockProcessorElectraTest extends BlockProcessorDenebTest {
                             depositReceiptsSchema.createFromElements(depositReceipts))));
 
     // verify deposit_receipts_start_index has been set
-    assertThat(BeaconStateElectra.required(state).getDepositReceiptsStartIndex())
+    assertThat(state.getDepositReceiptsStartIndex())
         .isEqualTo(UInt64.valueOf(firstElectraDepositReceiptIndex));
     // verify validators have been added to the state
     assertThat(state.getValidators().size())

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/ColorConsolePrinter.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/ColorConsolePrinter.java
@@ -33,25 +33,15 @@ public class ColorConsolePrinter {
   }
 
   private static String colorCode(final Color color) {
-    switch (color) {
-      case BLACK:
-        return "\u001b[30m";
-      case RED:
-        return "\u001b[31m";
-      case GREEN:
-        return "\u001b[32m";
-      case YELLOW:
-        return "\u001b[33m";
-      case BLUE:
-        return "\u001b[34m";
-      case PURPLE:
-        return "\u001b[35m";
-      case CYAN:
-        return "\u001b[36m";
-      case WHITE:
-        return "\u001b[37m";
-      default:
-        return "";
-    }
+    return switch (color) {
+      case BLACK -> "\u001b[30m";
+      case RED -> "\u001b[31m";
+      case GREEN -> "\u001b[32m";
+      case YELLOW -> "\u001b[33m";
+      case BLUE -> "\u001b[34m";
+      case PURPLE -> "\u001b[35m";
+      case CYAN -> "\u001b[36m";
+      case WHITE -> "\u001b[37m";
+    };
   }
 }

--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/EventLogger.java
@@ -309,6 +309,12 @@ public class EventLogger {
         Color.RED);
   }
 
+  public void depositContractLogsSyncingDisabled() {
+    warn(
+        "Deposit contract logs syncing from the Execution Client has been disabled! You WILL not be able to produce blocks.",
+        Color.YELLOW);
+  }
+
   public void builderBidNotHonouringGasLimit(
       final UInt64 parentGasLimit, final UInt64 proposedGasLimit, final UInt64 preferredGasLimit) {
     String reorgEventLog =

--- a/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/PowchainConfiguration.java
+++ b/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/PowchainConfiguration.java
@@ -31,6 +31,7 @@ public class PowchainConfiguration {
   public static final int DEFAULT_ETH1_LOGS_MAX_BLOCK_RANGE = 10_000;
   public static final boolean DEFAULT_USE_MISSING_DEPOSIT_EVENT_LOGGING = false;
   public static final boolean DEFAULT_DEPOSIT_SNAPSHOT_ENABLED = true;
+  public static final boolean DEFAULT_DEPOSIT_CONTRACT_LOGS_SYNCING_ENABLED = true;
   public static final String DEPOSIT_SNAPSHOT_URL_PATH = "/eth/v1/beacon/deposit_snapshot";
 
   private final Spec spec;
@@ -40,6 +41,7 @@ public class PowchainConfiguration {
   private final DepositTreeSnapshotConfiguration depositTreeSnapshotConfiguration;
   private final int eth1LogsMaxBlockRange;
   private final boolean useMissingDepositEventLogging;
+  private final boolean depositContractLogsSyncingEnabled;
 
   private PowchainConfiguration(
       final Spec spec,
@@ -48,7 +50,8 @@ public class PowchainConfiguration {
       final Optional<UInt64> depositContractDeployBlock,
       final DepositTreeSnapshotConfiguration depositTreeSnapshotConfiguration,
       final int eth1LogsMaxBlockRange,
-      final boolean useMissingDepositEventLogging) {
+      final boolean useMissingDepositEventLogging,
+      final boolean depositContractLogsSyncingEnabled) {
     this.spec = spec;
     this.eth1Endpoints = eth1Endpoints;
     this.depositContract = depositContract;
@@ -56,6 +59,7 @@ public class PowchainConfiguration {
     this.depositTreeSnapshotConfiguration = depositTreeSnapshotConfiguration;
     this.eth1LogsMaxBlockRange = eth1LogsMaxBlockRange;
     this.useMissingDepositEventLogging = useMissingDepositEventLogging;
+    this.depositContractLogsSyncingEnabled = depositContractLogsSyncingEnabled;
   }
 
   public static Builder builder() {
@@ -94,6 +98,10 @@ public class PowchainConfiguration {
     return useMissingDepositEventLogging;
   }
 
+  public boolean depositContractLogsSyncingEnabled() {
+    return depositContractLogsSyncingEnabled;
+  }
+
   public static class Builder {
     private Spec spec;
     private List<String> eth1Endpoints = new ArrayList<>();
@@ -105,6 +113,8 @@ public class PowchainConfiguration {
     private int eth1LogsMaxBlockRange = DEFAULT_ETH1_LOGS_MAX_BLOCK_RANGE;
     private boolean useMissingDepositEventLogging = DEFAULT_USE_MISSING_DEPOSIT_EVENT_LOGGING;
     private boolean depositSnapshotEnabled = DEFAULT_DEPOSIT_SNAPSHOT_ENABLED;
+    private boolean depositContractLogsSyncingEnabled =
+        DEFAULT_DEPOSIT_CONTRACT_LOGS_SYNCING_ENABLED;
 
     private Builder() {}
 
@@ -125,7 +135,8 @@ public class PowchainConfiguration {
               bundledDepositSnapshotPath,
               isBundledSnapshotEnabled),
           eth1LogsMaxBlockRange,
-          useMissingDepositEventLogging);
+          useMissingDepositEventLogging,
+          depositContractLogsSyncingEnabled);
     }
 
     private void validate() {
@@ -208,6 +219,12 @@ public class PowchainConfiguration {
 
     public Builder depositSnapshotEnabled(final boolean depositSnapshotEnabled) {
       this.depositSnapshotEnabled = depositSnapshotEnabled;
+      return this;
+    }
+
+    public Builder depositContractLogsSyncingEnabled(
+        final boolean depositContractLogsSyncingEnabled) {
+      this.depositContractLogsSyncingEnabled = depositContractLogsSyncingEnabled;
       return this;
     }
 

--- a/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/PowchainConfiguration.java
+++ b/services/powchain/src/main/java/tech/pegasys/teku/services/powchain/PowchainConfiguration.java
@@ -98,7 +98,7 @@ public class PowchainConfiguration {
     return useMissingDepositEventLogging;
   }
 
-  public boolean depositContractLogsSyncingEnabled() {
+  public boolean isDepositContractLogsSyncingEnabled() {
     return depositContractLogsSyncingEnabled;
   }
 

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/DepositOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/DepositOptions.java
@@ -72,7 +72,7 @@ public class DepositOptions {
       names = {"--Xdeposit-contract-logs-syncing-enabled"},
       paramLabel = "<BOOLEAN>",
       description =
-          "Enable syncing of deposit contract logs from the EL. This is required for block production.",
+          "Enable syncing of deposit contract logs from the Execution Engine node. This is required for block production.",
       hidden = true,
       showDefaultValue = Visibility.ALWAYS,
       arity = "0..1",

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/DepositOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/DepositOptions.java
@@ -68,6 +68,17 @@ public class DepositOptions {
       fallbackValue = "true")
   private boolean depositSnapshotEnabled = PowchainConfiguration.DEFAULT_DEPOSIT_SNAPSHOT_ENABLED;
 
+  @Option(
+      names = {"--Xdeposit-contract-logs-syncing-enabled"},
+      paramLabel = "<BOOLEAN>",
+      description =
+          "Enable syncing of deposit contract logs from the EL. This is required for block production.",
+      showDefaultValue = Visibility.ALWAYS,
+      arity = "0..1",
+      fallbackValue = "true")
+  private boolean depositContractLogsSyncingEnabled =
+      PowchainConfiguration.DEFAULT_DEPOSIT_CONTRACT_LOGS_SYNCING_ENABLED;
+
   public void configure(final TekuConfiguration.Builder builder) {
     builder.powchain(
         b -> {
@@ -76,6 +87,7 @@ public class DepositOptions {
           b.useMissingDepositEventLogging(useMissingDepositEventLogging);
           b.customDepositSnapshotPath(depositSnapshotPath);
           b.depositSnapshotEnabled(depositSnapshotEnabled);
+          b.depositContractLogsSyncingEnabled(depositContractLogsSyncingEnabled);
         });
   }
 }

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/DepositOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/DepositOptions.java
@@ -73,6 +73,7 @@ public class DepositOptions {
       paramLabel = "<BOOLEAN>",
       description =
           "Enable syncing of deposit contract logs from the EL. This is required for block production.",
+      hidden = true,
       showDefaultValue = Visibility.ALWAYS,
       arity = "0..1",
       fallbackValue = "true")

--- a/teku/src/main/java/tech/pegasys/teku/services/BeaconNodeServiceController.java
+++ b/teku/src/main/java/tech/pegasys/teku/services/BeaconNodeServiceController.java
@@ -100,7 +100,7 @@ public class BeaconNodeServiceController extends ServiceController {
         || (!tekuConfig.powchain().isEnabled() && maybeExecutionWeb3jClientProvider.isEmpty())) {
       return Optional.empty();
     }
-    if (!tekuConfig.powchain().depositContractLogsSyncingEnabled()) {
+    if (!tekuConfig.powchain().isDepositContractLogsSyncingEnabled()) {
       // PowchainService is only used for deposit contract logs syncing, so no need to initialize it
       // if disabled
       EVENT_LOG.depositContractLogsSyncingDisabled();

--- a/teku/src/main/java/tech/pegasys/teku/services/BeaconNodeServiceController.java
+++ b/teku/src/main/java/tech/pegasys/teku/services/BeaconNodeServiceController.java
@@ -101,6 +101,8 @@ public class BeaconNodeServiceController extends ServiceController {
       return Optional.empty();
     }
     if (!tekuConfig.powchain().depositContractLogsSyncingEnabled()) {
+      // PowchainService is only used for deposit contract logs syncing, so no need to initialize it
+      // if disabled
       EVENT_LOG.depositContractLogsSyncingDisabled();
       return Optional.empty();
     }

--- a/teku/src/main/java/tech/pegasys/teku/services/BeaconNodeServiceController.java
+++ b/teku/src/main/java/tech/pegasys/teku/services/BeaconNodeServiceController.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.teku.services;
 
+import static tech.pegasys.teku.infrastructure.logging.EventLogger.EVENT_LOG;
+
 import java.util.Optional;
 import java.util.function.Supplier;
 import tech.pegasys.teku.config.TekuConfiguration;
@@ -96,6 +98,10 @@ public class BeaconNodeServiceController extends ServiceController {
       final Supplier<Optional<BeaconState>> finalizedStateSupplier) {
     if (tekuConfig.beaconChain().interopConfig().isInteropEnabled()
         || (!tekuConfig.powchain().isEnabled() && maybeExecutionWeb3jClientProvider.isEmpty())) {
+      return Optional.empty();
+    }
+    if (!tekuConfig.powchain().depositContractLogsSyncingEnabled()) {
+      EVENT_LOG.depositContractLogsSyncingDisabled();
       return Optional.empty();
     }
     final PowchainService powchainService =

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/DepositOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/DepositOptionsTest.java
@@ -183,4 +183,11 @@ public class DepositOptionsTest extends AbstractBeaconNodeCommandTest {
     assertThat(depositTreeSnapshotConfiguration.getCustomDepositSnapshotPath())
         .hasValue("/foo/bar");
   }
+
+  @Test
+  public void shouldHaveDepositContractLogsSyncingEnabledByDefault() {
+    final String[] args = {};
+    final TekuConfiguration config = getTekuConfigurationFromArguments(args);
+    assertThat(config.powchain().isDepositContractLogsSyncingEnabled()).isTrue();
+  }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

- Introduce `--Xdeposit-contract-logs-syncing-enabled` which is true by default
- Added a CHANGELOG, which was deleted as part of the cleanup, but will be part of the next release

## Fixed Issue(s)
fixes #7240 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
