### PR TITLE
Add support for slashing interchange format tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -297,10 +297,13 @@ allprojects {
 
 def refTestVersion = 'v1.4.0' // Arbitrary change to refresh cache number: 1
 def blsRefTestVersion = 'v0.1.2'
+def slashingProtectionRefTestVersion = 'v5.3.0'
 def refTestBaseUrl = 'https://github.com/ethereum/consensus-spec-tests/releases/download'
 def blsRefTestBaseUrl = 'https://github.com/ethereum/bls12-381-tests/releases/download'
+def slashingProtectionRefTestBaseUrl = 'https://github.com/eth-clients/slashing-protection-interchange-tests/archive/refs/tags'
 def refTestDownloadDir = "${buildDir}/refTests/${refTestVersion}"
 def blsRefTestDownloadDir = "${buildDir}/blsRefTests/${blsRefTestVersion}"
+def slashingProtectionRefTestDownloadDir = "${buildDir}/slashingProtectionRefTests/${slashingProtectionRefTestVersion}"
 def refTestExpandDir = "${project.rootDir}/eth-reference-tests/src/referenceTest/resources/consensus-spec-tests/"
 
 task downloadEthRefTests(type: Download) {
@@ -321,7 +324,15 @@ task downloadBlsRefTests(type: Download) {
   overwrite false
 }
 
-task downloadRefTests(dependsOn: [downloadEthRefTests, downloadBlsRefTests])
+task downloadSlashingProtectionRefTests(type: Download) {
+  src([
+      "${slashingProtectionRefTestBaseUrl}/${slashingProtectionRefTestVersion}.tar.gz"
+  ])
+  dest "${slashingProtectionRefTestDownloadDir}/slashing-protection-interchange-tests.tar.gz"
+  overwrite false
+}
+
+task downloadRefTests(dependsOn: [downloadEthRefTests, downloadBlsRefTests, downloadSlashingProtectionRefTests])
 
 task cleanRefTestsGeneral(type: Delete) {
   delete "${refTestExpandDir}/tests/general"
@@ -359,8 +370,25 @@ task expandRefTestsBls(type: Copy, dependsOn: [cleanRefTestsBls, downloadBlsRefT
   into "${refTestExpandDir}/tests/bls"
 }
 
-task expandRefTests(dependsOn: [expandRefTestsGeneral, expandRefTestsMainnet, expandRefTestsMinimal, expandRefTestsBls])
-task cleanRefTests(dependsOn: [cleanRefTestsGeneral, cleanRefTestsMainnet, cleanRefTestsMinimal, cleanRefTestsBls])
+task cleanRefTestsSlashingProtection(type: Delete) {
+  delete "${refTestExpandDir}/tests/slashing-protection-interchange"
+}
+
+task expandRefTestsSlashingProtection(type: Copy, dependsOn: [cleanRefTestsSlashingProtection, downloadSlashingProtectionRefTests]) {
+  into "${refTestExpandDir}/tests/slashing-protection-interchange"
+  from {
+    tarTree("${slashingProtectionRefTestDownloadDir}/slashing-protection-interchange-tests.tar.gz").matching {
+      include "**/tests/generated/*.json"
+      // flatten the directory structure
+      eachFile { FileCopyDetails fcp ->
+          fcp.path = fcp.name
+      }
+    }
+  }
+}
+
+task expandRefTests(dependsOn: [expandRefTestsGeneral, expandRefTestsMainnet, expandRefTestsMinimal, expandRefTestsBls, expandRefTestsSlashingProtection])
+task cleanRefTests(dependsOn: [cleanRefTestsGeneral, cleanRefTestsMainnet, cleanRefTestsMinimal, cleanRefTestsBls, cleanRefTestsSlashingProtection])
 
 task deploy() {}
 

--- a/build.gradle
+++ b/build.gradle
@@ -297,13 +297,13 @@ allprojects {
 
 def refTestVersion = 'v1.4.0' // Arbitrary change to refresh cache number: 1
 def blsRefTestVersion = 'v0.1.2'
-def slashingProtectionRefTestVersion = 'v5.3.0'
+def slashingProtectionInterchangeRefTestVersion = 'v5.3.0'
 def refTestBaseUrl = 'https://github.com/ethereum/consensus-spec-tests/releases/download'
 def blsRefTestBaseUrl = 'https://github.com/ethereum/bls12-381-tests/releases/download'
-def slashingProtectionRefTestBaseUrl = 'https://github.com/eth-clients/slashing-protection-interchange-tests/archive/refs/tags'
+def slashingProtectionInterchangeRefTestBaseUrl = 'https://github.com/eth-clients/slashing-protection-interchange-tests/archive/refs/tags'
 def refTestDownloadDir = "${buildDir}/refTests/${refTestVersion}"
 def blsRefTestDownloadDir = "${buildDir}/blsRefTests/${blsRefTestVersion}"
-def slashingProtectionRefTestDownloadDir = "${buildDir}/slashingProtectionRefTests/${slashingProtectionRefTestVersion}"
+def slashingProtectionInterchangeRefTestDownloadDir = "${buildDir}/slashingProtectionInterchangeRefTests/${slashingProtectionInterchangeRefTestVersion}"
 def refTestExpandDir = "${project.rootDir}/eth-reference-tests/src/referenceTest/resources/consensus-spec-tests/"
 
 task downloadEthRefTests(type: Download) {
@@ -324,15 +324,15 @@ task downloadBlsRefTests(type: Download) {
   overwrite false
 }
 
-task downloadSlashingProtectionRefTests(type: Download) {
+task downloadSlashingProtectionInterchangeRefTests(type: Download) {
   src([
-      "${slashingProtectionRefTestBaseUrl}/${slashingProtectionRefTestVersion}.tar.gz"
+      "${slashingProtectionInterchangeRefTestBaseUrl}/${slashingProtectionInterchangeRefTestVersion}.tar.gz"
   ])
-  dest "${slashingProtectionRefTestDownloadDir}/slashing-protection-interchange-tests.tar.gz"
+  dest "${slashingProtectionInterchangeRefTestDownloadDir}/slashing-protection-interchange-tests.tar.gz"
   overwrite false
 }
 
-task downloadRefTests(dependsOn: [downloadEthRefTests, downloadBlsRefTests, downloadSlashingProtectionRefTests])
+task downloadRefTests(dependsOn: [downloadEthRefTests, downloadBlsRefTests, downloadSlashingProtectionInterchangeRefTests])
 
 task cleanRefTestsGeneral(type: Delete) {
   delete "${refTestExpandDir}/tests/general"
@@ -370,25 +370,25 @@ task expandRefTestsBls(type: Copy, dependsOn: [cleanRefTestsBls, downloadBlsRefT
   into "${refTestExpandDir}/tests/bls"
 }
 
-task cleanRefTestsSlashingProtection(type: Delete) {
+task cleanRefTestsSlashingProtectionInterchange(type: Delete) {
   delete "${refTestExpandDir}/tests/slashing-protection-interchange"
 }
 
-task expandRefTestsSlashingProtection(type: Copy, dependsOn: [cleanRefTestsSlashingProtection, downloadSlashingProtectionRefTests]) {
-  into "${refTestExpandDir}/tests/slashing-protection-interchange"
+task expandRefTestsSlashingProtectionInterchange(type: Copy, dependsOn: [cleanRefTestsSlashingProtectionInterchange, downloadSlashingProtectionInterchangeRefTests]) {
   from {
-    tarTree("${slashingProtectionRefTestDownloadDir}/slashing-protection-interchange-tests.tar.gz").matching {
+    tarTree("${slashingProtectionInterchangeRefTestDownloadDir}/slashing-protection-interchange-tests.tar.gz").matching {
       include "**/tests/generated/*.json"
-      // flatten the directory structure
+      // flatten
       eachFile { FileCopyDetails fcp ->
-          fcp.path = fcp.name
+        fcp.path = fcp.name
       }
     }
   }
+  into "${refTestExpandDir}/tests/slashing-protection-interchange"
 }
 
-task expandRefTests(dependsOn: [expandRefTestsGeneral, expandRefTestsMainnet, expandRefTestsMinimal, expandRefTestsBls, expandRefTestsSlashingProtection])
-task cleanRefTests(dependsOn: [cleanRefTestsGeneral, cleanRefTestsMainnet, cleanRefTestsMinimal, cleanRefTestsBls, cleanRefTestsSlashingProtection])
+task expandRefTests(dependsOn: [expandRefTestsGeneral, expandRefTestsMainnet, expandRefTestsMinimal, expandRefTestsBls, expandRefTestsSlashingProtectionInterchange])
+task cleanRefTests(dependsOn: [cleanRefTestsGeneral, cleanRefTestsMainnet, cleanRefTestsMinimal, cleanRefTestsBls, cleanRefTestsSlashingProtectionInterchange])
 
 task deploy() {}
 

--- a/data/dataexchange/src/test/resources/format2_minimal_different_genesis_validators_root.json
+++ b/data/dataexchange/src/test/resources/format2_minimal_different_genesis_validators_root.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "interchange_format_version": "5",
-    "genesis_validators_root": "0x0000000000000000000000000000000000000000000000000000000000123456"
+    "genesis_validators_root": "0x0000000000000000000000000000000000000000000000000000000000123457"
   },
   "data": [
     {

--- a/eth-reference-tests/build.gradle
+++ b/eth-reference-tests/build.gradle
@@ -15,9 +15,12 @@ dependencies {
   referenceTestImplementation project(':storage')
   referenceTestImplementation testFixtures(project(':storage'))
   referenceTestImplementation project(':infrastructure:async')
+  referenceTestImplementation project(':infrastructure:io')
   referenceTestImplementation testFixtures(project(':infrastructure:async'))
   referenceTestImplementation testFixtures(project(':infrastructure:metrics'))
   referenceTestImplementation project(':infrastructure:time')
+  referenceTestImplementation project(':data:dataexchange')
+  referenceTestImplementation project(':data:serializer')
 
   referenceTestImplementation 'org.hyperledger.besu:plugin-api'
   referenceTestImplementation 'com.fasterxml.jackson.core:jackson-databind'

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/Eth2ReferenceTestCase.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/Eth2ReferenceTestCase.java
@@ -31,6 +31,7 @@ import tech.pegasys.teku.reference.phase0.kzg.KzgTests;
 import tech.pegasys.teku.reference.phase0.rewards.RewardsTestExecutorPhase0;
 import tech.pegasys.teku.reference.phase0.sanity.SanityTests;
 import tech.pegasys.teku.reference.phase0.shuffling.ShufflingTestExecutor;
+import tech.pegasys.teku.reference.phase0.slashing_protection_interchange.SlashingProtectionInterchangeTestExecutor;
 import tech.pegasys.teku.reference.phase0.ssz_generic.SszGenericTests;
 import tech.pegasys.teku.reference.phase0.ssz_static.SszTestExecutor;
 
@@ -48,6 +49,7 @@ public abstract class Eth2ReferenceTestCase {
           .putAll(SszGenericTests.SSZ_GENERIC_TEST_TYPES)
           .putAll(OperationsTestExecutor.OPERATIONS_TEST_TYPES)
           .putAll(SanityTests.SANITY_TEST_TYPES)
+          .put("slashing-protection-interchange", new SlashingProtectionInterchangeTestExecutor())
           .put("light_client/single_merkle_proof", TestExecutor.IGNORE_TESTS)
           .put("light_client/sync", TestExecutor.IGNORE_TESTS)
           .put("light_client/update_ranking", TestExecutor.IGNORE_TESTS)

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/ManualReferenceTestRunner.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/ManualReferenceTestRunner.java
@@ -42,7 +42,7 @@ public class ManualReferenceTestRunner extends Eth2ReferenceTestCase {
    *
    * <p>May be overridden by the ENV_TEST_TYPE environment variable.
    */
-  private static final String TEST_TYPE = "fork_choice";
+  private static final String TEST_TYPE = "";
 
   /**
    * Filter test to run to those from the specified spec. One of general, minimal or mainnet

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/TestDataUtils.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/TestDataUtils.java
@@ -13,6 +13,8 @@
 
 package tech.pegasys.teku.reference;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.dataformat.yaml.YAMLParser;
@@ -29,11 +31,13 @@ import tech.pegasys.teku.ethtests.finder.TestDefinition;
 import tech.pegasys.teku.infrastructure.json.types.DeserializableTypeDefinition;
 import tech.pegasys.teku.infrastructure.ssz.SszData;
 import tech.pegasys.teku.infrastructure.ssz.schema.SszSchema;
+import tech.pegasys.teku.provider.JsonProvider;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 
 public class TestDataUtils {
 
   private static final YAMLFactory YAML_FACTORY;
+  private static final JsonProvider JSON_PROVIDER;
 
   static {
     final LoaderOptions loaderOptions = new LoaderOptions();
@@ -41,6 +45,7 @@ public class TestDataUtils {
     // https://github.com/FasterXML/jackson-dataformats-text/tree/2.15/yaml#maximum-input-yaml-document-size-3-mb
     loaderOptions.setCodePointLimit(1024 * 1024 * 100);
     YAML_FACTORY = YAMLFactory.builder().loaderOptions(loaderOptions).build();
+    JSON_PROVIDER = new JsonProvider();
   }
 
   public static <T extends SszData> T loadSsz(
@@ -99,5 +104,16 @@ public class TestDataUtils {
       in.nextToken();
       return type.deserialize(in);
     }
+  }
+
+  public static JsonNode loadJson(final TestDefinition testDefinition, final String fileName)
+      throws IOException {
+    final Path path = testDefinition.getTestDirectory().resolve(fileName);
+    return JSON_PROVIDER.getObjectMapper().readTree(Files.newInputStream(path));
+  }
+
+  public static <T> T jsonToObject(final String json, final Class<T> type)
+      throws JsonProcessingException {
+    return JSON_PROVIDER.jsonToObject(json, type);
   }
 }

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/TestDataUtils.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/TestDataUtils.java
@@ -13,14 +13,13 @@
 
 package tech.pegasys.teku.reference;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.dataformat.yaml.YAMLParser;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.function.Function;
@@ -90,7 +89,7 @@ public class TestDataUtils {
       throws IOException {
     final Path path = testDefinition.getTestDirectory().resolve(fileName);
     try (final InputStream in = Files.newInputStream(path)) {
-      return new ObjectMapper(YAML_FACTORY).readerFor(type).readValue(in);
+      return new ObjectMapper(YAML_FACTORY).readValue(in, type);
     }
   }
 
@@ -106,14 +105,17 @@ public class TestDataUtils {
     }
   }
 
-  public static JsonNode loadJson(final TestDefinition testDefinition, final String fileName)
+  public static <T> T loadJson(
+      final TestDefinition testDefinition, final String fileName, final Class<T> type)
       throws IOException {
     final Path path = testDefinition.getTestDirectory().resolve(fileName);
-    return JSON_PROVIDER.getObjectMapper().readTree(Files.newInputStream(path));
+    try (final InputStream in = Files.newInputStream(path)) {
+      return JSON_PROVIDER.getObjectMapper().readValue(in, type);
+    }
   }
 
-  public static <T> T jsonToObject(final String json, final Class<T> type)
-      throws JsonProcessingException {
-    return JSON_PROVIDER.jsonToObject(json, type);
+  public static <T> void writeJsonToFile(final T object, final Path file) throws IOException {
+    final String json = JSON_PROVIDER.getObjectMapper().writeValueAsString(object);
+    Files.writeString(file, json, StandardCharsets.UTF_8);
   }
 }

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/slashing_protection_interchange/SlashingProtectionInterchangeTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/slashing_protection_interchange/SlashingProtectionInterchangeTestExecutor.java
@@ -106,7 +106,7 @@ public class SlashingProtectionInterchangeTestExecutor implements TestExecutor {
       final SlashingProtectionImporter importer,
       final SlashingProtectionInterchangeFormat interchange) {
     try {
-      final Path importFile = Files.createTempFile("import", ".yml");
+      final Path importFile = Files.createTempFile("import", ".json");
       TestDataUtils.writeJsonToFile(interchange, importFile);
       final Optional<String> initialiseError = importer.initialise(importFile.toFile());
       assertThat(initialiseError).isEmpty();

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/slashing_protection_interchange/SlashingProtectionInterchangeTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/slashing_protection_interchange/SlashingProtectionInterchangeTestExecutor.java
@@ -48,7 +48,7 @@ public class SlashingProtectionInterchangeTestExecutor implements TestExecutor {
 
     // our implementation fails when importing one of the keys in an interchange, which is already
     // in our slashprotection directory with a different genesis validators root. However, the test
-    // does not import any keys
+    // does not import any keys.
     if (testData.name.startsWith("wrong_genesis_validators_root")) {
       LOG.info("Skipping {}", testData.name);
       return;

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/slashing_protection_interchange/SlashingProtectionInterchangeTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/slashing_protection_interchange/SlashingProtectionInterchangeTestExecutor.java
@@ -76,15 +76,7 @@ public class SlashingProtectionInterchangeTestExecutor implements TestExecutor {
       final Bytes32 genesisValidatorsRoot,
       final SlashingProtectionImporter importer,
       final LocalSlashingProtector slashingProtector) {
-    try {
-      final Path importFile = Files.createTempFile("import", ".yml");
-      TestDataUtils.writeJsonToFile(step.interchange, importFile);
-      importer.initialise(importFile.toFile());
-      // cleanup
-      Files.delete(importFile);
-    } catch (IOException ex) {
-      throw new UncheckedIOException(ex);
-    }
+    importInterchange(importer, step.interchange);
     final Map<BLSPublicKey, String> importErrors =
         importer.updateLocalRecords(status -> LOG.info("Import status: " + status));
     if (step.shouldSucceed) {
@@ -106,6 +98,20 @@ public class SlashingProtectionInterchangeTestExecutor implements TestExecutor {
                         attestation.sourceEpoch,
                         attestation.targetEpoch))
                 .isCompletedWithValue(attestation.shouldSucceed));
+  }
+
+  private void importInterchange(
+      final SlashingProtectionImporter importer,
+      final SlashingProtectionInterchangeFormat interchange) {
+    try {
+      final Path importFile = Files.createTempFile("import", ".yml");
+      TestDataUtils.writeJsonToFile(interchange, importFile);
+      importer.initialise(importFile.toFile());
+      // cleanup
+      Files.delete(importFile);
+    } catch (IOException ex) {
+      throw new UncheckedIOException(ex);
+    }
   }
 
   private void deleteDirectory(final Path dir) {
@@ -137,15 +143,13 @@ public class SlashingProtectionInterchangeTestExecutor implements TestExecutor {
         BLSPublicKey pubkey,
         UInt64 slot,
         @JsonProperty("signing_root") Bytes32 signingRoot,
-        @JsonProperty("should_succeed") boolean shouldSucceed,
-        @JsonProperty("should_succeed_complete") boolean shouldSucceedComplete) {}
+        @JsonProperty("should_succeed") boolean shouldSucceed) {}
 
     public record Attestation(
         BLSPublicKey pubkey,
         @JsonProperty("source_epoch") UInt64 sourceEpoch,
         @JsonProperty("target_epoch") UInt64 targetEpoch,
         @JsonProperty("signing_root") Bytes32 signingRoot,
-        @JsonProperty("should_succeed") boolean shouldSucceed,
-        @JsonProperty("should_succeed_complete") boolean shouldSucceedComplete) {}
+        @JsonProperty("should_succeed") boolean shouldSucceed) {}
   }
 }

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/slashing_protection_interchange/SlashingProtectionInterchangeTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/slashing_protection_interchange/SlashingProtectionInterchangeTestExecutor.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.reference.phase0.slashing_protection_interchange;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.bls.BLSPublicKey;
+import tech.pegasys.teku.data.SlashingProtectionImporter;
+import tech.pegasys.teku.ethtests.finder.TestDefinition;
+import tech.pegasys.teku.infrastructure.io.SyncDataAccessor;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.reference.TestDataUtils;
+import tech.pegasys.teku.reference.TestExecutor;
+import tech.pegasys.teku.spec.signatures.LocalSlashingProtector;
+
+public class SlashingProtectionInterchangeTestExecutor implements TestExecutor {
+
+  private static final Logger LOG = LogManager.getLogger();
+
+  //TODO: implement the logic
+  @Override
+  public void runTest(final TestDefinition testDefinition) throws Throwable {
+    final JsonNode testNode = TestDataUtils.loadJson(testDefinition, testDefinition.getTestName());
+
+    final String testName = testNode.get("name").asText();
+    final Bytes32 genesisValidatorsRoot =
+        Bytes32.fromHexString(testNode.get("genesis_validators_root").asText());
+
+    LOG.info("Running {}", testName);
+
+    final Path tempDir = Files.createTempDirectory(testName);
+
+    final Path slashProtectionPath = tempDir.resolve("slashprotection");
+
+    final Path slashProtectionImportFile = tempDir.resolve("import.yml");
+
+    Files.writeString(
+        slashProtectionImportFile,
+        testNode.get("steps").get(0).get("interchange").toString(),
+        StandardCharsets.UTF_8);
+
+    final BLSPublicKey pubkey =
+        BLSPublicKey.fromHexString(
+            "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c");
+
+    Files.createDirectories(slashProtectionPath);
+    SlashingProtectionImporter importer = new SlashingProtectionImporter(slashProtectionPath);
+    importer.initialise(slashProtectionImportFile.toFile());
+    final Map<BLSPublicKey, String> errors = importer.updateLocalRecords((__) -> {});
+
+    assertThat(errors).isEmpty();
+
+    LocalSlashingProtector localSlashingProtector =
+        new LocalSlashingProtector(
+            SyncDataAccessor.create(slashProtectionPath), slashProtectionPath);
+    assertThat(
+            localSlashingProtector.maySignBlock(pubkey, genesisValidatorsRoot, UInt64.valueOf(10)))
+        .isCompletedWithValue(false);
+    assertThat(
+            localSlashingProtector.maySignBlock(pubkey, genesisValidatorsRoot, UInt64.valueOf(13)))
+        .isCompletedWithValue(false);
+    assertThat(
+            localSlashingProtector.maySignBlock(pubkey, genesisValidatorsRoot, UInt64.valueOf(14)))
+        .isCompletedWithValue(true);
+    assertThat(
+            localSlashingProtector.maySignAttestation(
+                pubkey, genesisValidatorsRoot, UInt64.valueOf(0), UInt64.valueOf(2)))
+        .isCompletedWithValue(false);
+    assertThat(
+            localSlashingProtector.maySignAttestation(
+                pubkey, genesisValidatorsRoot, UInt64.valueOf(1), UInt64.valueOf(3)))
+        .isCompletedWithValue(false);
+  }
+}

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/slashing_protection_interchange/SlashingProtectionInterchangeTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/slashing_protection_interchange/SlashingProtectionInterchangeTestExecutor.java
@@ -49,7 +49,7 @@ public class SlashingProtectionInterchangeTestExecutor implements TestExecutor {
     // our implementation does not fail importing when the GVR in the interchange mismatches the one
     // from the spec
     if (testData.name.startsWith("wrong_genesis_validators_root")) {
-      LOG.info("Not going to run {}", testData.name);
+      LOG.info("Skipping {}", testData.name);
       return;
     }
 

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/slashing_protection_interchange/SlashingProtectionInterchangeTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/slashing_protection_interchange/SlashingProtectionInterchangeTestExecutor.java
@@ -49,7 +49,8 @@ public class SlashingProtectionInterchangeTestExecutor implements TestExecutor {
 
     // our implementation fails when importing one of the keys in an interchange, which is already
     // in our slashprotection directory with a different genesis validators root. However, the test
-    // does not import any keys.
+    // does not import any keys. This case is covered by
+    // SlashingProtectionImporterTest#shouldFailImportingIfValidatorExistingRecordHasDifferentGenesisValidatorsRoot()
     if (testData.name.startsWith("wrong_genesis_validators_root")) {
       LOG.info("Skipping {}", testData.name);
       return;
@@ -137,6 +138,8 @@ public class SlashingProtectionInterchangeTestExecutor implements TestExecutor {
 
     public record Step(
         @JsonProperty("should_succeed") boolean shouldSucceed,
+        // we don't fail importing when the interchange contains slashable data, so can safely
+        // ignore this field in the tests
         @JsonProperty("contains_slashable_data") boolean containsSlashableData,
         SlashingProtectionInterchangeFormat interchange,
         List<Block> blocks,

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/slashing_protection_interchange/SlashingProtectionInterchangeTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/slashing_protection_interchange/SlashingProtectionInterchangeTestExecutor.java
@@ -23,6 +23,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
@@ -106,7 +107,8 @@ public class SlashingProtectionInterchangeTestExecutor implements TestExecutor {
     try {
       final Path importFile = Files.createTempFile("import", ".yml");
       TestDataUtils.writeJsonToFile(interchange, importFile);
-      importer.initialise(importFile.toFile());
+      final Optional<String> initialiseError = importer.initialise(importFile.toFile());
+      assertThat(initialiseError).isEmpty();
       // cleanup
       Files.delete(importFile);
     } catch (IOException ex) {

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/slashing_protection_interchange/SlashingProtectionInterchangeTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/slashing_protection_interchange/SlashingProtectionInterchangeTestExecutor.java
@@ -36,7 +36,7 @@ public class SlashingProtectionInterchangeTestExecutor implements TestExecutor {
 
   private static final Logger LOG = LogManager.getLogger();
 
-  //TODO: implement the logic
+  // TODO: implement the logic
   @Override
   public void runTest(final TestDefinition testDefinition) throws Throwable {
     final JsonNode testNode = TestDataUtils.loadJson(testDefinition, testDefinition.getTestName());

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/slashing_protection_interchange/SlashingProtectionInterchangeTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/slashing_protection_interchange/SlashingProtectionInterchangeTestExecutor.java
@@ -84,18 +84,18 @@ public class SlashingProtectionInterchangeTestExecutor implements TestExecutor {
     } else {
       assertThat(importErrors).isNotEmpty();
     }
+    final Bytes32 genesisValidatorsRoot = step.interchange.metadata.genesisValidatorsRoot;
     step.blocks.forEach(
         block ->
             assertThat(
-                    slashingProtector.maySignBlock(
-                        block.pubkey, step.interchange.metadata.genesisValidatorsRoot, block.slot))
+                    slashingProtector.maySignBlock(block.pubkey, genesisValidatorsRoot, block.slot))
                 .isCompletedWithValue(block.shouldSucceed));
     step.attestations.forEach(
         attestation ->
             assertThat(
                     slashingProtector.maySignAttestation(
                         attestation.pubkey,
-                        step.interchange.metadata.genesisValidatorsRoot,
+                        genesisValidatorsRoot,
                         attestation.sourceEpoch,
                         attestation.targetEpoch))
                 .isCompletedWithValue(attestation.shouldSucceed));

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/slashing_protection_interchange/SlashingProtectionInterchangeTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/slashing_protection_interchange/SlashingProtectionInterchangeTestExecutor.java
@@ -68,18 +68,16 @@ public class SlashingProtectionInterchangeTestExecutor implements TestExecutor {
     final LocalSlashingProtector slashingProtector =
         new LocalSlashingProtector(SyncDataAccessor.create(tempDir), tempDir);
     testData.steps.forEach(
-        step ->
-            runStep(step, testData.genesisValidatorsRoot, importer, slashingProtector, tempDir));
+        step -> runStep(step, testData.genesisValidatorsRoot, importer, slashingProtector));
   }
 
   private void runStep(
       final Step step,
       final Bytes32 genesisValidatorsRoot,
       final SlashingProtectionImporter importer,
-      final LocalSlashingProtector slashingProtector,
-      final Path tempDir) {
-    final Path importFile = tempDir.resolve("import.yml");
+      final LocalSlashingProtector slashingProtector) {
     try {
+      final Path importFile = Files.createTempFile("import", ".yml");
       TestDataUtils.writeJsonToFile(step.interchange, importFile);
       importer.initialise(importFile.toFile());
       // cleanup

--- a/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/BlsRefTestFinder.java
+++ b/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/BlsRefTestFinder.java
@@ -26,19 +26,19 @@ public class BlsRefTestFinder implements TestFinder {
 
   @Override
   @MustBeClosed
-  public Stream<TestDefinition> findTests(final String fork, final String spec, final Path testRoot)
-      throws IOException {
-    if (!spec.equals("bls")) {
+  public Stream<TestDefinition> findTests(
+      final String fork, final String config, final Path testRoot) throws IOException {
+    if (!config.equals("bls")) {
       return Stream.empty();
     }
     return Files.list(testRoot)
         .filter(path -> path.toFile().isDirectory())
-        .flatMap(unchecked(path -> findBlsTests(spec, testRoot, path)));
+        .flatMap(unchecked(path -> findBlsTests(config, testRoot, path)));
   }
 
   @MustBeClosed
   private Stream<TestDefinition> findBlsTests(
-      final String spec, final Path testRoot, final Path testCategoryDir) throws IOException {
+      final String config, final Path testRoot, final Path testCategoryDir) throws IOException {
     final String testType = "bls/" + testRoot.relativize(testCategoryDir);
     return Files.list(testCategoryDir)
         .filter(file -> file.toFile().getName().endsWith(".yaml"))
@@ -46,7 +46,7 @@ public class BlsRefTestFinder implements TestFinder {
             testFile ->
                 new TestDefinition(
                     "",
-                    spec,
+                    config,
                     testType,
                     testFile.toFile().getName(),
                     testRoot.relativize(testCategoryDir)));

--- a/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/ReferenceTestFinder.java
+++ b/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/ReferenceTestFinder.java
@@ -50,7 +50,7 @@ public class ReferenceTestFinder {
       return new BlsRefTestFinder().findTests("", spec, specDirectory);
     }
     if (spec.equals("slashing-protection-interchange")) {
-      return new SlashingProtectionInterchangeTestFinder().findTests("", spec, specDirectory);
+      return new SlashingProtectionInterchangeRefTestFinder().findTests("", spec, specDirectory);
     }
     return SUPPORTED_FORKS.stream()
         .flatMap(

--- a/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/ReferenceTestFinder.java
+++ b/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/ReferenceTestFinder.java
@@ -47,7 +47,10 @@ public class ReferenceTestFinder {
   private static Stream<TestDefinition> findTestTypes(final Path specDirectory) throws IOException {
     final String spec = specDirectory.getFileName().toString();
     if (spec.equals("bls")) {
-      return new BlsRefTestFinder().findTests(TestFork.PHASE0, spec, specDirectory);
+      return new BlsRefTestFinder().findTests("", spec, specDirectory);
+    }
+    if (spec.equals("slashing-protection-interchange")) {
+      return new SlashingProtectionInterchangeTestFinder().findTests("", spec, specDirectory);
     }
     return SUPPORTED_FORKS.stream()
         .flatMap(
@@ -60,7 +63,6 @@ public class ReferenceTestFinder {
               return Stream.of(
                       new BlsTestFinder(),
                       new KzgTestFinder(),
-                      new BlsRefTestFinder(),
                       new SszTestFinder("ssz_generic"),
                       new SszTestFinder("ssz_static"),
                       new ShufflingTestFinder(),

--- a/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/SlashingProtectionInterchangeRefTestFinder.java
+++ b/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/SlashingProtectionInterchangeRefTestFinder.java
@@ -19,13 +19,13 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.stream.Stream;
 
-public class SlashingProtectionInterchangeTestFinder implements TestFinder {
+public class SlashingProtectionInterchangeRefTestFinder implements TestFinder {
 
   @Override
   @MustBeClosed
-  public Stream<TestDefinition> findTests(final String fork, final String spec, final Path testRoot)
-      throws IOException {
-    if (!spec.equals("slashing-protection-interchange")) {
+  public Stream<TestDefinition> findTests(
+      final String fork, final String config, final Path testRoot) throws IOException {
+    if (!config.equals("slashing-protection-interchange")) {
       return Stream.empty();
     }
     return Files.list(testRoot)
@@ -34,8 +34,8 @@ public class SlashingProtectionInterchangeTestFinder implements TestFinder {
             testFile ->
                 new TestDefinition(
                     fork,
-                    spec,
-                    spec,
+                    config,
+                    config,
                     testFile.toFile().getName(),
                     testRoot.relativize(testFile.getParent())));
   }

--- a/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/SlashingProtectionInterchangeTestFinder.java
+++ b/eth-tests/src/main/java/tech/pegasys/teku/ethtests/finder/SlashingProtectionInterchangeTestFinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Consensys Software Inc., 2022
+ * Copyright Consensys Software Inc., 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -13,42 +13,30 @@
 
 package tech.pegasys.teku.ethtests.finder;
 
-import static tech.pegasys.teku.ethtests.finder.ReferenceTestFinder.unchecked;
-
 import com.google.errorprone.annotations.MustBeClosed;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.stream.Stream;
 
-@SuppressWarnings("MustBeClosedChecker")
-public class BlsRefTestFinder implements TestFinder {
+public class SlashingProtectionInterchangeTestFinder implements TestFinder {
 
   @Override
   @MustBeClosed
   public Stream<TestDefinition> findTests(final String fork, final String spec, final Path testRoot)
       throws IOException {
-    if (!spec.equals("bls")) {
+    if (!spec.equals("slashing-protection-interchange")) {
       return Stream.empty();
     }
     return Files.list(testRoot)
-        .filter(path -> path.toFile().isDirectory())
-        .flatMap(unchecked(path -> findBlsTests(spec, testRoot, path)));
-  }
-
-  @MustBeClosed
-  private Stream<TestDefinition> findBlsTests(
-      final String spec, final Path testRoot, final Path testCategoryDir) throws IOException {
-    final String testType = "bls/" + testRoot.relativize(testCategoryDir);
-    return Files.list(testCategoryDir)
-        .filter(file -> file.toFile().getName().endsWith(".yaml"))
+        .filter(file -> file.toFile().getName().endsWith(".json"))
         .map(
             testFile ->
                 new TestDefinition(
-                    "",
+                    fork,
                     spec,
-                    testType,
+                    spec,
                     testFile.toFile().getName(),
-                    testRoot.relativize(testCategoryDir)));
+                    testRoot.relativize(testFile.getParent())));
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
![image](https://github.com/Consensys/teku/assets/14827647/8be455da-bcfe-416d-9906-c8913e8365fa)

As per https://github.com/eth-clients/slashing-protection-interchange-tests

**Things to note:**

- Our implementation is minimal, so ignoring `should_succeed_complete`
- There is a test https://github.com/eth-clients/slashing-protection-interchange-tests/blob/master/tests/generated/wrong_genesis_validators_root.json which basically asserts that import should fail if there is a GVR mismatch. Added a comment to explain why we ignore this test.
- I have ignored `containsSlashableData`. Seems we have no problems importing anyways.

## Fixed Issue(s)
fixes #7784 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
