### PR TITLE
Disable requirement for EIP-7251 configuration in Electra config

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/builder/ElectraBuilder.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/config/builder/ElectraBuilder.java
@@ -30,8 +30,10 @@ public class ElectraBuilder implements ForkConfigBuilder<SpecConfigDeneb, SpecCo
 
   private Bytes4 electraForkVersion;
   private UInt64 electraForkEpoch;
-  private UInt64 minPerEpochChurnLimitElectra;
-  private UInt64 maxPerEpochActivationExitChurnLimit;
+  // TODO: remove default when EIP-7251 become part of the Electra
+  private UInt64 minPerEpochChurnLimitElectra = UInt64.ZERO;
+  // TODO: remove default when EIP-7251 become part of the Electra
+  private UInt64 maxPerEpochActivationExitChurnLimit = UInt64.ZERO;
   private Integer maxDepositReceiptsPerPayload;
   private Integer maxExecutionLayerExits;
   private UInt64 minActivationBalance;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Adding defaults to EIP-7251 constants because they are not yet part of the official Electra config, they have [separate EIP-7251 fork](https://github.com/ethereum/consensus-specs/blob/dev/configs/mainnet.yaml#L56-L58), so some other tools (Kurtosis) are not expecting that we require these constants for Electra config.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
