### PR TITLE
Don't encode ids array comma separators in getStateValidator request

### DIFF
--- a/validator/remote/src/integration-test/java/tech/pegasys/teku/validator/remote/typedef/OkHttpValidatorTypeDefClientTest.java
+++ b/validator/remote/src/integration-test/java/tech/pegasys/teku/validator/remote/typedef/OkHttpValidatorTypeDefClientTest.java
@@ -367,6 +367,21 @@ class OkHttpValidatorTypeDefClientTest extends AbstractTypeDefRequestTestBase {
   }
 
   @TestTemplate
+  void getStateValidators_MakesExpectedRequest() throws Exception {
+    mockWebServer.enqueue(new MockResponse().setResponseCode(SC_NO_CONTENT));
+
+    okHttpValidatorTypeDefClient.getStateValidators(List.of("1", "0x1234"));
+
+    final RecordedRequest request = mockWebServer.takeRequest();
+    assertThat(request.getMethod()).isEqualTo("GET");
+
+    assertThat(request.getPath()).contains(ValidatorApiMethod.GET_VALIDATORS.getPath(emptyMap()));
+    // comma-separated GET query array parameters shouldn't be encoded
+    // and must pass AS IS as per RFC-3986
+    assertThat(request.getPath()).contains("?id=1,0x1234");
+  }
+
+  @TestTemplate
   public void postValidators_WhenNoContent_ReturnsEmpty() {
     mockWebServer.enqueue(new MockResponse().setResponseCode(SC_NO_CONTENT));
 

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/handlers/AbstractTypeDefRequest.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/handlers/AbstractTypeDefRequest.java
@@ -84,18 +84,27 @@ public abstract class AbstractTypeDefRequest {
       final Map<String, String> urlParams,
       final Map<String, String> queryParams,
       final ResponseHandler<T> responseHandler) {
-    return get(apiMethod, urlParams, queryParams, Map.of(), responseHandler);
+    return get(apiMethod, urlParams, queryParams, emptyMap(), emptyMap(), responseHandler);
   }
 
   protected <T> Optional<T> get(
       final ValidatorApiMethod apiMethod,
       final Map<String, String> urlParams,
       final Map<String, String> queryParams,
+      final Map<String, String> encodedQueryParams,
       final Map<String, String> headers,
       final ResponseHandler<T> responseHandler) {
     final HttpUrl.Builder httpUrlBuilder = urlBuilder(apiMethod, urlParams);
     if (queryParams != null && !queryParams.isEmpty()) {
       queryParams.forEach(httpUrlBuilder::addQueryParameter);
+    }
+
+    // The encodedQueryParams are considered to be encoded already
+    // and should not be encoded again. This is useful to prevent
+    // the comma in an array of values (e.g. id=1,2,3) from being
+    // encoded.
+    if (encodedQueryParams != null && !encodedQueryParams.isEmpty()) {
+      encodedQueryParams.forEach(httpUrlBuilder::addEncodedQueryParameter);
     }
 
     final Request.Builder builder = requestBuilder().url(httpUrlBuilder.build());

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/handlers/CreateBlockRequest.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/handlers/CreateBlockRequest.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.validator.remote.typedef.handlers;
 
+import static java.util.Collections.emptyMap;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_NOT_FOUND;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_UNSIGNED_BLINDED_BLOCK;
@@ -109,7 +110,13 @@ public class CreateBlockRequest extends AbstractTypeDefRequest {
       // application/octet-stream is preferred, but will accept application/json
       headers.put("Accept", "application/octet-stream;q=0.9, application/json;q=0.4");
     }
-    return get(apiMethod, Map.of("slot", slot.toString()), queryParams, headers, responseHandler)
+    return get(
+            apiMethod,
+            Map.of("slot", slot.toString()),
+            queryParams,
+            emptyMap(),
+            headers,
+            responseHandler)
         .map(
             response ->
                 new BlockContainerAndMetaData(

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/handlers/GetStateValidatorsRequest.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/handlers/GetStateValidatorsRequest.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.validator.remote.typedef.handlers;
 
+import static java.util.Collections.emptyMap;
 import static tech.pegasys.teku.ethereum.json.types.beacon.StateValidatorDataBuilder.STATE_VALIDATORS_RESPONSE_TYPE;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.PARAM_ID;
 import static tech.pegasys.teku.validator.remote.apiclient.ValidatorApiMethod.GET_VALIDATORS;
@@ -35,8 +36,10 @@ public class GetStateValidatorsRequest extends AbstractTypeDefRequest {
       final List<String> validatorIds) {
     return get(
         GET_VALIDATORS,
-        Map.of(),
+        emptyMap(),
+        emptyMap(),
         Map.of(PARAM_ID, String.join(",", validatorIds)),
+        emptyMap(),
         new ResponseHandler<>(STATE_VALIDATORS_RESPONSE_TYPE));
   }
 }

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/handlers/ProduceBlockRequest.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/typedef/handlers/ProduceBlockRequest.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.validator.remote.typedef.handlers;
 
+import static java.util.Collections.emptyMap;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_NOT_FOUND;
 import static tech.pegasys.teku.infrastructure.http.HttpStatusCodes.SC_OK;
 import static tech.pegasys.teku.infrastructure.http.RestApiConstants.BUILDER_BOOST_FACTOR;
@@ -126,6 +127,7 @@ public class ProduceBlockRequest extends AbstractTypeDefRequest {
             GET_UNSIGNED_BLOCK_V3,
             Map.of("slot", slot.toString()),
             queryParams,
+            emptyMap(),
             headers,
             this.responseHandler)
         .map(


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
- fixed validator states were queried with GET ids list encoded, but shouldn't, check old rationale for this in #7757
- added test for this
- clarified that we are not required to call any other BN API with array in query parameter

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
