### PR TITLE
Fix sync committee when syncing

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandler.java
@@ -490,6 +490,9 @@ public class ValidatorApiHandler implements ValidatorApiChannel {
   @Override
   public SafeFuture<Optional<SyncCommitteeContribution>> createSyncCommitteeContribution(
       final UInt64 slot, final int subcommitteeIndex, final Bytes32 beaconBlockRoot) {
+    if (isSyncActive()) {
+      return NodeSyncingException.failedFuture();
+    }
     return SafeFuture.completedFuture(
         syncCommitteeMessagePool.createContribution(slot, beaconBlockRoot, subcommitteeIndex));
   }

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -101,6 +101,7 @@ import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.SignedAggregateAndProof;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SignedContributionAndProof;
+import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeContribution;
 import tech.pegasys.teku.spec.datastructures.operations.versions.altair.SyncCommitteeMessage;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.state.CheckpointState;
@@ -691,6 +692,17 @@ class ValidatorApiHandlerTest {
     final SafeFuture<Optional<Attestation>> result =
         validatorApiHandler.createAggregate(
             ONE, dataStructureUtil.randomAttestationData().hashTreeRoot());
+
+    assertThat(result).isCompletedExceptionally();
+    assertThatThrownBy(result::get).hasRootCauseInstanceOf(NodeSyncingException.class);
+  }
+
+  @Test
+  public void createSyncCommitteeContribution() {
+    nodeIsSyncing();
+    final SafeFuture<Optional<SyncCommitteeContribution>> result =
+        validatorApiHandler.createSyncCommitteeContribution(
+            ONE, 0, dataStructureUtil.randomBytes32());
 
     assertThat(result).isCompletedExceptionally();
     assertThatThrownBy(result::get).hasRootCauseInstanceOf(NodeSyncingException.class);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
@@ -149,9 +149,7 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
 
   @Override
   public SafeFuture<Optional<PowBlock>> eth1GetPowBlock(final Bytes32 blockHash) {
-    if (!online) {
-      return SafeFuture.failedFuture(new RuntimeException("stub is offline"));
-    }
+    offlineCheck();
 
     if (!transitionEmulationEnabled) {
       requestedPowBlocks.add(blockHash);
@@ -178,9 +176,7 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
 
   @Override
   public SafeFuture<PowBlock> eth1GetPowChainHead() {
-    if (!online) {
-      return SafeFuture.failedFuture(new RuntimeException("stub is offline"));
-    }
+    offlineCheck();
 
     if (!transitionEmulationEnabled) {
       return SafeFuture.failedFuture(
@@ -205,9 +201,7 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
   public SafeFuture<ForkChoiceUpdatedResult> engineForkChoiceUpdated(
       final ForkChoiceState forkChoiceState,
       final Optional<PayloadBuildingAttributes> payloadBuildingAttributes) {
-    if (!online) {
-      return SafeFuture.failedFuture(new RuntimeException("stub is offline"));
-    }
+    offlineCheck();
 
     if (!bellatrixActivationDetected) {
       LOG.info(
@@ -243,9 +237,7 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
   @Override
   public SafeFuture<GetPayloadResponse> engineGetPayload(
       final ExecutionPayloadContext executionPayloadContext, final BeaconState state) {
-    if (!online) {
-      return SafeFuture.failedFuture(new RuntimeException("stub is offline"));
-    }
+    offlineCheck();
 
     if (!bellatrixActivationDetected) {
       LOG.info(
@@ -330,9 +322,7 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
 
   @Override
   public SafeFuture<PayloadStatus> engineNewPayload(final NewPayloadRequest newPayloadRequest) {
-    if (!online) {
-      return SafeFuture.failedFuture(new RuntimeException("stub is offline"));
-    }
+    offlineCheck();
 
     final ExecutionPayload executionPayload = newPayloadRequest.getExecutionPayload();
     final PayloadStatus returnedStatus =
@@ -349,9 +339,7 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
 
   @Override
   public SafeFuture<List<ClientVersion>> engineGetClientVersion(final ClientVersion clientVersion) {
-    if (!online) {
-      return SafeFuture.failedFuture(new RuntimeException("stub is offline"));
-    }
+    offlineCheck();
 
     return SafeFuture.completedFuture(List.of(STUB_CLIENT_VERSION));
   }
@@ -359,9 +347,7 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
   @Override
   public SafeFuture<Void> builderRegisterValidators(
       final SszList<SignedValidatorRegistration> signedValidatorRegistrations, final UInt64 slot) {
-    if (!online) {
-      return SafeFuture.failedFuture(new RuntimeException("stub is offline"));
-    }
+    offlineCheck();
     return SafeFuture.COMPLETE;
   }
 
@@ -372,9 +358,7 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
       final SafeFuture<UInt256> payloadValueResult,
       final Optional<UInt64> requestedBuilderBoostFactor,
       final BlockProductionPerformance blockProductionPerformance) {
-    if (!online) {
-      return SafeFuture.failedFuture(new RuntimeException("stub is offline"));
-    }
+    offlineCheck();
 
     final UInt64 slot = state.getSlot();
     LOG.info(
@@ -425,9 +409,7 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
   public SafeFuture<BuilderPayload> builderGetPayload(
       final SignedBeaconBlock signedBeaconBlock,
       final Function<UInt64, Optional<ExecutionPayloadResult>> getCachedPayloadResultFunction) {
-    if (!online) {
-      return SafeFuture.failedFuture(new RuntimeException("stub is offline"));
-    }
+    offlineCheck();
 
     final UInt64 slot = signedBeaconBlock.getSlot();
     final SchemaDefinitions schemaDefinitions = spec.atSlot(slot).getSchemaDefinitions();
@@ -514,6 +496,12 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
     private HeadAndAttributes(final Bytes32 head, final PayloadBuildingAttributes attributes) {
       this.head = head;
       this.attributes = attributes;
+    }
+  }
+
+  private void offlineCheck() {
+    if (!online) {
+      throw new RuntimeException("stub is offline");
     }
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
@@ -108,6 +108,8 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
       lastBuilderBlobsBundle = Optional.empty();
   private Optional<PowBlock> lastValidBlock = Optional.empty();
 
+  private boolean el_online =  true;
+
   public ExecutionLayerChannelStub(
       final Spec spec,
       final TimeProvider timeProvider,
@@ -147,6 +149,10 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
 
   @Override
   public SafeFuture<Optional<PowBlock>> eth1GetPowBlock(final Bytes32 blockHash) {
+    if(!el_online) {
+      return SafeFuture.failedFuture(new RuntimeException("stub is offline"));
+    }
+
     if (!transitionEmulationEnabled) {
       requestedPowBlocks.add(blockHash);
       return SafeFuture.completedFuture(Optional.ofNullable(knownBlocks.get(blockHash)));
@@ -172,6 +178,10 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
 
   @Override
   public SafeFuture<PowBlock> eth1GetPowChainHead() {
+    if(!el_online) {
+      return SafeFuture.failedFuture(new RuntimeException("stub is offline"));
+    }
+
     if (!transitionEmulationEnabled) {
       return SafeFuture.failedFuture(
           new UnsupportedOperationException("getPowChainHead not supported"));
@@ -195,6 +205,10 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
   public SafeFuture<ForkChoiceUpdatedResult> engineForkChoiceUpdated(
       final ForkChoiceState forkChoiceState,
       final Optional<PayloadBuildingAttributes> payloadBuildingAttributes) {
+    if(!el_online) {
+      return SafeFuture.failedFuture(new RuntimeException("stub is offline"));
+    }
+
     if (!bellatrixActivationDetected) {
       LOG.info(
           "forkChoiceUpdated received before terminalBlock has been sent. Assuming transition already happened");
@@ -229,6 +243,10 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
   @Override
   public SafeFuture<GetPayloadResponse> engineGetPayload(
       final ExecutionPayloadContext executionPayloadContext, final BeaconState state) {
+    if(!el_online) {
+      return SafeFuture.failedFuture(new RuntimeException("stub is offline"));
+    }
+
     if (!bellatrixActivationDetected) {
       LOG.info(
           "getPayload received before terminalBlock has been sent. Assuming transition already happened");
@@ -312,6 +330,10 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
 
   @Override
   public SafeFuture<PayloadStatus> engineNewPayload(final NewPayloadRequest newPayloadRequest) {
+    if(!el_online) {
+      return SafeFuture.failedFuture(new RuntimeException("stub is offline"));
+    }
+
     final ExecutionPayload executionPayload = newPayloadRequest.getExecutionPayload();
     final PayloadStatus returnedStatus =
         Optional.ofNullable(knownPosBlocks.get(executionPayload.getBlockHash()))
@@ -327,12 +349,19 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
 
   @Override
   public SafeFuture<List<ClientVersion>> engineGetClientVersion(final ClientVersion clientVersion) {
+    if(!el_online) {
+      return SafeFuture.failedFuture(new RuntimeException("stub is offline"));
+    }
+
     return SafeFuture.completedFuture(List.of(STUB_CLIENT_VERSION));
   }
 
   @Override
   public SafeFuture<Void> builderRegisterValidators(
       final SszList<SignedValidatorRegistration> signedValidatorRegistrations, final UInt64 slot) {
+    if(!el_online) {
+      return SafeFuture.failedFuture(new RuntimeException("stub is offline"));
+    }
     return SafeFuture.COMPLETE;
   }
 
@@ -343,6 +372,10 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
       final SafeFuture<UInt256> payloadValueResult,
       final Optional<UInt64> requestedBuilderBoostFactor,
       final BlockProductionPerformance blockProductionPerformance) {
+    if(!el_online) {
+      return SafeFuture.failedFuture(new RuntimeException("stub is offline"));
+    }
+
     final UInt64 slot = state.getSlot();
     LOG.info(
         "getPayloadHeader: payloadId: {} slot: {} ... delegating to getPayload ...",
@@ -392,6 +425,10 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
   public SafeFuture<BuilderPayload> builderGetPayload(
       final SignedBeaconBlock signedBeaconBlock,
       final Function<UInt64, Optional<ExecutionPayloadResult>> getCachedPayloadResultFunction) {
+    if(!el_online) {
+      return SafeFuture.failedFuture(new RuntimeException("stub is offline"));
+    }
+
     final UInt64 slot = signedBeaconBlock.getSlot();
     final SchemaDefinitions schemaDefinitions = spec.atSlot(slot).getSchemaDefinitions();
     final Optional<SchemaDefinitionsBellatrix> schemaDefinitionsBellatrix =

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
@@ -108,7 +108,7 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
       lastBuilderBlobsBundle = Optional.empty();
   private Optional<PowBlock> lastValidBlock = Optional.empty();
 
-  private boolean el_online =  true;
+  private boolean online = true;
 
   public ExecutionLayerChannelStub(
       final Spec spec,
@@ -149,7 +149,7 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
 
   @Override
   public SafeFuture<Optional<PowBlock>> eth1GetPowBlock(final Bytes32 blockHash) {
-    if(!el_online) {
+    if (!online) {
       return SafeFuture.failedFuture(new RuntimeException("stub is offline"));
     }
 
@@ -178,7 +178,7 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
 
   @Override
   public SafeFuture<PowBlock> eth1GetPowChainHead() {
-    if(!el_online) {
+    if (!online) {
       return SafeFuture.failedFuture(new RuntimeException("stub is offline"));
     }
 
@@ -205,7 +205,7 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
   public SafeFuture<ForkChoiceUpdatedResult> engineForkChoiceUpdated(
       final ForkChoiceState forkChoiceState,
       final Optional<PayloadBuildingAttributes> payloadBuildingAttributes) {
-    if(!el_online) {
+    if (!online) {
       return SafeFuture.failedFuture(new RuntimeException("stub is offline"));
     }
 
@@ -243,7 +243,7 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
   @Override
   public SafeFuture<GetPayloadResponse> engineGetPayload(
       final ExecutionPayloadContext executionPayloadContext, final BeaconState state) {
-    if(!el_online) {
+    if (!online) {
       return SafeFuture.failedFuture(new RuntimeException("stub is offline"));
     }
 
@@ -330,7 +330,7 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
 
   @Override
   public SafeFuture<PayloadStatus> engineNewPayload(final NewPayloadRequest newPayloadRequest) {
-    if(!el_online) {
+    if (!online) {
       return SafeFuture.failedFuture(new RuntimeException("stub is offline"));
     }
 
@@ -349,7 +349,7 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
 
   @Override
   public SafeFuture<List<ClientVersion>> engineGetClientVersion(final ClientVersion clientVersion) {
-    if(!el_online) {
+    if (!online) {
       return SafeFuture.failedFuture(new RuntimeException("stub is offline"));
     }
 
@@ -359,7 +359,7 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
   @Override
   public SafeFuture<Void> builderRegisterValidators(
       final SszList<SignedValidatorRegistration> signedValidatorRegistrations, final UInt64 slot) {
-    if(!el_online) {
+    if (!online) {
       return SafeFuture.failedFuture(new RuntimeException("stub is offline"));
     }
     return SafeFuture.COMPLETE;
@@ -372,7 +372,7 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
       final SafeFuture<UInt256> payloadValueResult,
       final Optional<UInt64> requestedBuilderBoostFactor,
       final BlockProductionPerformance blockProductionPerformance) {
-    if(!el_online) {
+    if (!online) {
       return SafeFuture.failedFuture(new RuntimeException("stub is offline"));
     }
 
@@ -425,7 +425,7 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
   public SafeFuture<BuilderPayload> builderGetPayload(
       final SignedBeaconBlock signedBeaconBlock,
       final Function<UInt64, Optional<ExecutionPayloadResult>> getCachedPayloadResultFunction) {
-    if(!el_online) {
+    if (!online) {
       return SafeFuture.failedFuture(new RuntimeException("stub is offline"));
     }
 
@@ -498,6 +498,10 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
 
   public Set<Bytes32> getRequestedPowBlocks() {
     return requestedPowBlocks;
+  }
+
+  public void setOnline(final boolean online) {
+    this.online = online;
   }
 
   @SuppressWarnings("unused")

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/synccommittee/ChainHeadTooHoldException.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/synccommittee/ChainHeadTooHoldException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Consensys Software Inc., 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.validator.client.duties.synccommittee;
+
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+
+public class ChainHeadTooHoldException extends RuntimeException {
+
+  public ChainHeadTooHoldException(final UInt64 headSlot, final UInt64 slot) {
+    super("Chain head too old. Head slot: " + headSlot + ", requested slot: " + slot);
+  }
+}

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/synccommittee/ChainHeadTooOldException.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/synccommittee/ChainHeadTooOldException.java
@@ -15,9 +15,9 @@ package tech.pegasys.teku.validator.client.duties.synccommittee;
 
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
-public class ChainHeadTooHoldException extends RuntimeException {
+public class ChainHeadTooOldException extends RuntimeException {
 
-  public ChainHeadTooHoldException(final UInt64 headSlot, final UInt64 slot) {
+  public ChainHeadTooOldException(final UInt64 headSlot, final UInt64 slot) {
     super("Chain head too old. Head slot: " + headSlot + ", requested slot: " + slot);
   }
 }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/synccommittee/ChainHeadTracker.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/synccommittee/ChainHeadTracker.java
@@ -36,7 +36,7 @@ public class ChainHeadTracker implements ValidatorTimingChannel {
     }
     if (headBlockRoot.isPresent()
         && atSlot.minusMinZero(headBlockSlot).isGreaterThan(HEAD_TOO_OLD_THRESHOLD)) {
-      throw new ChainHeadTooHoldException(headBlockSlot, atSlot);
+      throw new ChainHeadTooOldException(headBlockSlot, atSlot);
     }
     return headBlockRoot;
   }

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/synccommittee/ChainHeadTracker.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/synccommittee/ChainHeadTracker.java
@@ -24,7 +24,9 @@ import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.validator.api.ValidatorTimingChannel;
 
 public class ChainHeadTracker implements ValidatorTimingChannel {
+  public static final int HEAD_TOO_OLD_THRESHOLD = 32;
 
+  private UInt64 currentSlot = UInt64.ZERO;
   private UInt64 headBlockSlot = UInt64.ZERO;
   private Optional<Bytes32> headBlockRoot = Optional.empty();
 
@@ -34,6 +36,10 @@ public class ChainHeadTracker implements ValidatorTimingChannel {
       throw new ChainHeadBeyondSlotException(atSlot);
     }
     return headBlockRoot;
+  }
+
+  public boolean isHeadTooOld() {
+    return currentSlot.minusMinZero(headBlockSlot).isGreaterThan(HEAD_TOO_OLD_THRESHOLD);
   }
 
   @Override
@@ -47,7 +53,9 @@ public class ChainHeadTracker implements ValidatorTimingChannel {
   }
 
   @Override
-  public void onSlot(final UInt64 slot) {}
+  public void onSlot(final UInt64 slot) {
+    currentSlot = slot;
+  }
 
   @Override
   public void onPossibleMissedEvents() {}

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/synccommittee/ChainHeadTracker.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/synccommittee/ChainHeadTracker.java
@@ -26,7 +26,6 @@ import tech.pegasys.teku.validator.api.ValidatorTimingChannel;
 public class ChainHeadTracker implements ValidatorTimingChannel {
   public static final int HEAD_TOO_OLD_THRESHOLD = 32;
 
-  private UInt64 currentSlot = UInt64.ZERO;
   private UInt64 headBlockSlot = UInt64.ZERO;
   private Optional<Bytes32> headBlockRoot = Optional.empty();
 
@@ -35,11 +34,10 @@ public class ChainHeadTracker implements ValidatorTimingChannel {
       // We've moved on and no longer have a reference to what the head block was at that slot
       throw new ChainHeadBeyondSlotException(atSlot);
     }
+    if (atSlot.minusMinZero(headBlockSlot).isGreaterThan(HEAD_TOO_OLD_THRESHOLD)) {
+      throw new ChainHeadTooHoldException(headBlockSlot, atSlot);
+    }
     return headBlockRoot;
-  }
-
-  public boolean isHeadTooOld() {
-    return currentSlot.minusMinZero(headBlockSlot).isGreaterThan(HEAD_TOO_OLD_THRESHOLD);
   }
 
   @Override
@@ -53,9 +51,7 @@ public class ChainHeadTracker implements ValidatorTimingChannel {
   }
 
   @Override
-  public void onSlot(final UInt64 slot) {
-    currentSlot = slot;
-  }
+  public void onSlot(final UInt64 slot) {}
 
   @Override
   public void onPossibleMissedEvents() {}

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/synccommittee/ChainHeadTracker.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/synccommittee/ChainHeadTracker.java
@@ -34,7 +34,8 @@ public class ChainHeadTracker implements ValidatorTimingChannel {
       // We've moved on and no longer have a reference to what the head block was at that slot
       throw new ChainHeadBeyondSlotException(atSlot);
     }
-    if (atSlot.minusMinZero(headBlockSlot).isGreaterThan(HEAD_TOO_OLD_THRESHOLD)) {
+    if (headBlockRoot.isPresent()
+        && atSlot.minusMinZero(headBlockSlot).isGreaterThan(HEAD_TOO_OLD_THRESHOLD)) {
       throw new ChainHeadTooHoldException(headBlockSlot, atSlot);
     }
     return headBlockRoot;

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeScheduledDuties.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeScheduledDuties.java
@@ -88,7 +88,7 @@ public class SyncCommitteeScheduledDuties implements ScheduledDuties {
     }
     try {
       lastSignatureBlockRoot = chainHeadTracker.getCurrentChainHead(slot);
-    } catch (final ChainHeadBeyondSlotException | ChainHeadTooHoldException ex) {
+    } catch (final ChainHeadBeyondSlotException | ChainHeadTooOldException ex) {
       return chainHeadSlotCheckFailure(ex);
     }
     lastSignatureSlot = Optional.of(slot);

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeScheduledDuties.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeScheduledDuties.java
@@ -86,13 +86,10 @@ public class SyncCommitteeScheduledDuties implements ScheduledDuties {
     if (assignments.isEmpty()) {
       return SafeFuture.completedFuture(DutyResult.NO_OP);
     }
-    if (chainHeadTracker.isHeadTooOld()) {
-      return SafeFuture.completedFuture(DutyResult.NODE_SYNCING);
-    }
     try {
       lastSignatureBlockRoot = chainHeadTracker.getCurrentChainHead(slot);
-    } catch (ChainHeadBeyondSlotException ex) {
-      return chainHeadBeyondSlotFailure(ex);
+    } catch (final ChainHeadBeyondSlotException | ChainHeadTooHoldException ex) {
+      return chainHeadSlotCheckFailure(ex);
     }
     lastSignatureSlot = Optional.of(slot);
     return lastSignatureBlockRoot
@@ -100,7 +97,7 @@ public class SyncCommitteeScheduledDuties implements ScheduledDuties {
         .orElse(SafeFuture.completedFuture(DutyResult.NODE_SYNCING));
   }
 
-  private SafeFuture<DutyResult> chainHeadBeyondSlotFailure(final ChainHeadBeyondSlotException ex) {
+  private SafeFuture<DutyResult> chainHeadSlotCheckFailure(final RuntimeException ex) {
     return SafeFuture.completedFuture(DutyResult.forError(getAllValidatorKeys(), ex));
   }
 

--- a/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeScheduledDuties.java
+++ b/validator/client/src/main/java/tech/pegasys/teku/validator/client/duties/synccommittee/SyncCommitteeScheduledDuties.java
@@ -86,6 +86,9 @@ public class SyncCommitteeScheduledDuties implements ScheduledDuties {
     if (assignments.isEmpty()) {
       return SafeFuture.completedFuture(DutyResult.NO_OP);
     }
+    if (chainHeadTracker.isHeadTooOld()) {
+      return SafeFuture.completedFuture(DutyResult.NODE_SYNCING);
+    }
     try {
       lastSignatureBlockRoot = chainHeadTracker.getCurrentChainHead(slot);
     } catch (ChainHeadBeyondSlotException ex) {

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/ChainHeadTrackerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/ChainHeadTrackerTest.java
@@ -23,7 +23,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.validator.client.duties.synccommittee.ChainHeadBeyondSlotException;
-import tech.pegasys.teku.validator.client.duties.synccommittee.ChainHeadTooHoldException;
+import tech.pegasys.teku.validator.client.duties.synccommittee.ChainHeadTooOldException;
 import tech.pegasys.teku.validator.client.duties.synccommittee.ChainHeadTracker;
 
 class ChainHeadTrackerTest {
@@ -69,7 +69,7 @@ class ChainHeadTrackerTest {
     updateHead(slot, headBlockRoot);
 
     assertThrows(
-        ChainHeadTooHoldException.class,
+        ChainHeadTooOldException.class,
         () -> tracker.getCurrentChainHead(slot.plus(HEAD_TOO_OLD_THRESHOLD + 1)));
   }
 

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/ChainHeadTrackerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/ChainHeadTrackerTest.java
@@ -23,6 +23,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.validator.client.duties.synccommittee.ChainHeadBeyondSlotException;
+import tech.pegasys.teku.validator.client.duties.synccommittee.ChainHeadTooHoldException;
 import tech.pegasys.teku.validator.client.duties.synccommittee.ChainHeadTracker;
 
 class ChainHeadTrackerTest {
@@ -62,20 +63,14 @@ class ChainHeadTrackerTest {
   }
 
   @Test
-  void isHeadTooOldShouldReturnFalseWhenHeadSlotIsInThreshold() {
-    final UInt64 currentSlot = UInt64.valueOf(HEAD_TOO_OLD_THRESHOLD + 1);
-    tracker.onSlot(currentSlot);
-    updateHead(currentSlot.minus(HEAD_TOO_OLD_THRESHOLD), dataStructureUtil.randomBytes32());
-    assertThat(tracker.isHeadTooOld()).isFalse();
-  }
+  void shouldThrowCustomExceptionWhenHeadSlotIsTooOld() {
+    final UInt64 slot = dataStructureUtil.randomUInt64();
+    final Bytes32 headBlockRoot = dataStructureUtil.randomBytes32();
+    updateHead(slot, headBlockRoot);
 
-  @Test
-  void isHeadTooOldShouldReturnTrueWhenHeadSlotIsInThreshold() {
-    final UInt64 currentSlot = UInt64.valueOf(HEAD_TOO_OLD_THRESHOLD + 1);
-    tracker.onSlot(currentSlot);
-    updateHead(
-        currentSlot.minus(HEAD_TOO_OLD_THRESHOLD).decrement(), dataStructureUtil.randomBytes32());
-    assertThat(tracker.isHeadTooOld()).isTrue();
+    assertThrows(
+        ChainHeadTooHoldException.class,
+        () -> tracker.getCurrentChainHead(slot.plus(HEAD_TOO_OLD_THRESHOLD + 1)));
   }
 
   private void updateHead(final UInt64 slot, final Bytes32 headBlockRoot) {

--- a/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/ChainHeadTrackerTest.java
+++ b/validator/client/src/test/java/tech/pegasys/teku/validator/client/duties/ChainHeadTrackerTest.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.validator.client.duties;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static tech.pegasys.teku.validator.client.duties.synccommittee.ChainHeadTracker.HEAD_TOO_OLD_THRESHOLD;
 
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
@@ -58,6 +59,23 @@ class ChainHeadTrackerTest {
 
     assertThrows(
         ChainHeadBeyondSlotException.class, () -> tracker.getCurrentChainHead(slot.minus(1)));
+  }
+
+  @Test
+  void isHeadTooOldShouldReturnFalseWhenHeadSlotIsInThreshold() {
+    final UInt64 currentSlot = UInt64.valueOf(HEAD_TOO_OLD_THRESHOLD + 1);
+    tracker.onSlot(currentSlot);
+    updateHead(currentSlot.minus(HEAD_TOO_OLD_THRESHOLD), dataStructureUtil.randomBytes32());
+    assertThat(tracker.isHeadTooOld()).isFalse();
+  }
+
+  @Test
+  void isHeadTooOldShouldReturnTrueWhenHeadSlotIsInThreshold() {
+    final UInt64 currentSlot = UInt64.valueOf(HEAD_TOO_OLD_THRESHOLD + 1);
+    tracker.onSlot(currentSlot);
+    updateHead(
+        currentSlot.minus(HEAD_TOO_OLD_THRESHOLD).decrement(), dataStructureUtil.randomBytes32());
+    assertThat(tracker.isHeadTooOld()).isTrue();
   }
 
   private void updateHead(final UInt64 slot, final Bytes32 headBlockRoot) {


### PR DESCRIPTION
fixes #8005

The aggregation fix is non-controversial while the sync message is not that clean, but it is the easiest implementation I came up with so far.


Essentially we will stop producing sync committee message if the head we have is older than 32 slot, which means:
1- we are connected to a BN which is falling out of sync.
2- the chain is not production a block for more than entire epoch, we have bigger problems.



## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
