### PR TITLE
Trigger primary BN readiness check when failover has issues

### DIFF
--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessManager.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/BeaconNodeReadinessManager.java
@@ -77,6 +77,10 @@ public class BeaconNodeReadinessManager extends Service implements ValidatorTimi
         .iterator();
   }
 
+  public SafeFuture<Void> performPrimaryReadinessCheck() {
+    return performReadinessCheck(primaryBeaconNodeApi, true);
+  }
+
   @Override
   protected SafeFuture<?> doStart() {
     return performReadinessCheckAgainstAllNodes();
@@ -134,10 +138,6 @@ public class BeaconNodeReadinessManager extends Service implements ValidatorTimi
     final Stream<SafeFuture<?>> failoverReadinessChecks =
         failoverBeaconNodeApis.stream().map(this::performFailoverReadinessCheck);
     return SafeFuture.allOf(primaryReadinessCheck, SafeFuture.allOf(failoverReadinessChecks));
-  }
-
-  private SafeFuture<Void> performPrimaryReadinessCheck() {
-    return performReadinessCheck(primaryBeaconNodeApi, true);
   }
 
   private SafeFuture<Void> performFailoverReadinessCheck(final RemoteValidatorApiChannel failover) {

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/eventsource/EventSourceBeaconChainEventAdapter.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/eventsource/EventSourceBeaconChainEventAdapter.java
@@ -55,7 +55,7 @@ public class EventSourceBeaconChainEventAdapter
   private final CountDownLatch runningLatch = new CountDownLatch(1);
 
   private volatile BackgroundEventSource eventSource;
-  private volatile RemoteValidatorApiChannel currentBeaconNodeUsedForEventStreaming;
+  @VisibleForTesting volatile RemoteValidatorApiChannel currentBeaconNodeUsedForEventStreaming;
 
   private final BeaconNodeReadinessManager beaconNodeReadinessManager;
   private final RemoteValidatorApiChannel primaryBeaconNodeApi;

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/eventsource/EventSourceBeaconChainEventAdapter.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/eventsource/EventSourceBeaconChainEventAdapter.java
@@ -177,6 +177,7 @@ public class EventSourceBeaconChainEventAdapter
     findReadyFailoverAndSwitch();
   }
 
+  @SuppressWarnings("FutureReturnValueIgnored")
   private void findReadyFailoverAndSwitch() {
     failoverBeaconNodeApis.stream()
         .filter(beaconNodeReadinessManager::isReady)

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/eventsource/EventSourceBeaconChainEventAdapter.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/eventsource/EventSourceBeaconChainEventAdapter.java
@@ -124,8 +124,7 @@ public class EventSourceBeaconChainEventAdapter
   @SuppressWarnings("FutureReturnValueIgnored")
   public void onFailoverNodeNotReady(final RemoteValidatorApiChannel failoverNotInSync) {
     if (currentEventStreamHasSameEndpoint(failoverNotInSync)) {
-      final boolean switched = switchToFailoverEventStreamIfAvailable();
-      if (!switched) {
+      if (failoverBeaconNodeApis.size() == 1 || !switchToFailoverEventStreamIfAvailable()) {
         // No failover switching is available, and we are currently connected to a failover node
         // with issues, so trigger the readiness check against the primary BN immediately
         beaconNodeReadinessManager.performPrimaryReadinessCheck();

--- a/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/eventsource/EventSourceBeaconChainEventAdapter.java
+++ b/validator/remote/src/main/java/tech/pegasys/teku/validator/remote/eventsource/EventSourceBeaconChainEventAdapter.java
@@ -121,6 +121,7 @@ public class EventSourceBeaconChainEventAdapter
   }
 
   @Override
+  @SuppressWarnings("FutureReturnValueIgnored")
   public void onFailoverNodeNotReady(final RemoteValidatorApiChannel failoverNotInSync) {
     if (currentEventStreamHasSameEndpoint(failoverNotInSync)) {
       final boolean switched = switchToFailoverEventStreamIfAvailable();
@@ -183,7 +184,6 @@ public class EventSourceBeaconChainEventAdapter
     return findReadyFailoverAndSwitch();
   }
 
-  @SuppressWarnings("FutureReturnValueIgnored")
   private boolean findReadyFailoverAndSwitch() {
     final Optional<? extends RemoteValidatorApiChannel> readyFailover =
         failoverBeaconNodeApis.stream()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Currently we wait `onAttestationAggregationDue` to trigger the readiness check for beacon nodes, which in turn trigger event streaming failing over/returning to primary. However, if there is a failover issue and there are no other failovers available, in some edge cases VC has to wait around a slot time before the `onPrimaryNodeBackReady` callback is called and the failover to primary can happen.

The edge case is  `onAttestationAggregationDue` happens. Both primary and failover are in a bad state. We are still connected to a failover, so we try switching but nothing is available. In the meantime, primary has recovered. However, we still have to wait until the next `onAttestationAggregationDue` before reconnecting.

## Fixed Issue(s)
related to #8180 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
