### PR TITLE
Fix PendingPartialWithdrawal deserialization mistake

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/versions/electra/PendingPartialWithdrawal.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/state/versions/electra/PendingPartialWithdrawal.java
@@ -22,6 +22,18 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 public class PendingPartialWithdrawal
     extends Container3<PendingPartialWithdrawal, SszUInt64, SszUInt64, SszUInt64> {
+  protected PendingPartialWithdrawal(
+      ContainerSchema3<PendingPartialWithdrawal, SszUInt64, SszUInt64, SszUInt64> schema) {
+    super(schema);
+  }
+
+  public PendingPartialWithdrawal(
+      final PendingPartialWithdrawalSchema pendingPartialWithdrawalSchema,
+      final SszUInt64 index,
+      final SszUInt64 amount,
+      final SszUInt64 withdrawableEpoch) {
+    super(pendingPartialWithdrawalSchema, index, amount, withdrawableEpoch);
+  }
 
   public static class PendingPartialWithdrawalSchema
       extends ContainerSchema3<PendingPartialWithdrawal, SszUInt64, SszUInt64, SszUInt64> {
@@ -52,16 +64,13 @@ public class PendingPartialWithdrawal
 
     @Override
     public PendingPartialWithdrawal createFromBackingNode(TreeNode node) {
-      return null;
+      return new PendingPartialWithdrawal(this, node);
     }
   }
 
   private PendingPartialWithdrawal(
-      PendingPartialWithdrawal.PendingPartialWithdrawalSchema type,
-      final SszUInt64 index,
-      final SszUInt64 amount,
-      final SszUInt64 withdrawableEpoch) {
-    super(type, index, amount, withdrawableEpoch);
+      PendingPartialWithdrawal.PendingPartialWithdrawalSchema type, final TreeNode backingNode) {
+    super(type, backingNode);
   }
 
   public int getIndex() {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsAltair.java
@@ -79,7 +79,7 @@ public class SchemaDefinitionsAltair extends AbstractSchemaDefinitions {
   public static SchemaDefinitionsAltair required(final SchemaDefinitions schemaDefinitions) {
     Preconditions.checkArgument(
         schemaDefinitions instanceof SchemaDefinitionsAltair,
-        "Expected definitions of type %s by got %s",
+        "Expected definitions of type %s but got %s",
         SchemaDefinitionsAltair.class,
         schemaDefinitions.getClass());
     return (SchemaDefinitionsAltair) schemaDefinitions;

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsBellatrix.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsBellatrix.java
@@ -81,7 +81,7 @@ public class SchemaDefinitionsBellatrix extends SchemaDefinitionsAltair {
   public static SchemaDefinitionsBellatrix required(final SchemaDefinitions schemaDefinitions) {
     checkArgument(
         schemaDefinitions instanceof SchemaDefinitionsBellatrix,
-        "Expected definitions of type %s by got %s",
+        "Expected definitions of type %s but got %s",
         SchemaDefinitionsBellatrix.class,
         schemaDefinitions.getClass());
     return (SchemaDefinitionsBellatrix) schemaDefinitions;

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsCapella.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsCapella.java
@@ -109,7 +109,7 @@ public class SchemaDefinitionsCapella extends SchemaDefinitionsBellatrix {
   public static SchemaDefinitionsCapella required(final SchemaDefinitions schemaDefinitions) {
     checkArgument(
         schemaDefinitions instanceof SchemaDefinitionsCapella,
-        "Expected definitions of type %s by got %s",
+        "Expected definitions of type %s but got %s",
         SchemaDefinitionsCapella.class,
         schemaDefinitions.getClass());
     return (SchemaDefinitionsCapella) schemaDefinitions;

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsDeneb.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsDeneb.java
@@ -140,7 +140,7 @@ public class SchemaDefinitionsDeneb extends SchemaDefinitionsCapella {
   public static SchemaDefinitionsDeneb required(final SchemaDefinitions schemaDefinitions) {
     checkArgument(
         schemaDefinitions instanceof SchemaDefinitionsDeneb,
-        "Expected definitions of type %s by got %s",
+        "Expected definitions of type %s but got %s",
         SchemaDefinitionsDeneb.class,
         schemaDefinitions.getClass());
     return (SchemaDefinitionsDeneb) schemaDefinitions;

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsElectra.java
@@ -144,7 +144,7 @@ public class SchemaDefinitionsElectra extends SchemaDefinitionsDeneb {
   public static SchemaDefinitionsElectra required(final SchemaDefinitions schemaDefinitions) {
     checkArgument(
         schemaDefinitions instanceof SchemaDefinitionsElectra,
-        "Expected definitions of type %s by got %s",
+        "Expected definitions of type %s but got %s",
         SchemaDefinitionsElectra.class,
         schemaDefinitions.getClass());
     return (SchemaDefinitionsElectra) schemaDefinitions;

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/state/PendingBalanceDepositPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/state/PendingBalanceDepositPropertyTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.state;
+
+import static tech.pegasys.teku.spec.propertytest.util.PropertyTestHelper.assertDeserializeMutatedThrowsExpected;
+import static tech.pegasys.teku.spec.propertytest.util.PropertyTestHelper.assertRoundTrip;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import tech.pegasys.teku.spec.datastructures.state.versions.electra.PendingBalanceDeposit;
+import tech.pegasys.teku.spec.propertytest.suppliers.state.PendingBalanceDepositSupplier;
+
+public class PendingBalanceDepositPropertyTest {
+  @Property
+  void roundTrip(
+      @ForAll(supplier = PendingBalanceDepositSupplier.class)
+          final PendingBalanceDeposit pendingBalanceDeposit)
+      throws JsonProcessingException {
+    assertRoundTrip(pendingBalanceDeposit);
+  }
+
+  @Property
+  void deserializeMutated(
+      @ForAll(supplier = PendingBalanceDepositSupplier.class)
+          final PendingBalanceDeposit pendingBalanceDeposit,
+      @ForAll final int seed) {
+    assertDeserializeMutatedThrowsExpected(pendingBalanceDeposit, seed);
+  }
+}

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/state/PendingConsolidationPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/state/PendingConsolidationPropertyTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.state;
+
+import static tech.pegasys.teku.spec.propertytest.util.PropertyTestHelper.assertDeserializeMutatedThrowsExpected;
+import static tech.pegasys.teku.spec.propertytest.util.PropertyTestHelper.assertRoundTrip;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import tech.pegasys.teku.spec.datastructures.state.versions.electra.PendingConsolidation;
+import tech.pegasys.teku.spec.propertytest.suppliers.state.PendingConsolidationSupplier;
+
+public class PendingConsolidationPropertyTest {
+  @Property
+  void roundTrip(
+      @ForAll(supplier = PendingConsolidationSupplier.class)
+          final PendingConsolidation pendingConsolidation)
+      throws JsonProcessingException {
+    assertRoundTrip(pendingConsolidation);
+  }
+
+  @Property
+  void deserializeMutated(
+      @ForAll(supplier = PendingConsolidationSupplier.class)
+          final PendingConsolidation pendingConsolidation,
+      @ForAll final int seed) {
+    assertDeserializeMutatedThrowsExpected(pendingConsolidation, seed);
+  }
+}

--- a/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/state/PendingPartialWithdrawalPropertyTest.java
+++ b/ethereum/spec/src/property-test/java/tech/pegasys/teku/spec/datastructures/state/PendingPartialWithdrawalPropertyTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.state;
+
+import static tech.pegasys.teku.spec.propertytest.util.PropertyTestHelper.assertDeserializeMutatedThrowsExpected;
+import static tech.pegasys.teku.spec.propertytest.util.PropertyTestHelper.assertRoundTrip;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import tech.pegasys.teku.spec.datastructures.state.versions.electra.PendingPartialWithdrawal;
+import tech.pegasys.teku.spec.propertytest.suppliers.state.PendingPartialWithdrawalSupplier;
+
+public class PendingPartialWithdrawalPropertyTest {
+  @Property
+  void roundTrip(
+      @ForAll(supplier = PendingPartialWithdrawalSupplier.class)
+          final PendingPartialWithdrawal pendingPartialWithdrawal)
+      throws JsonProcessingException {
+    assertRoundTrip(pendingPartialWithdrawal);
+  }
+
+  @Property
+  void deserializeMutated(
+      @ForAll(supplier = PendingPartialWithdrawalSupplier.class)
+          final PendingPartialWithdrawal pendingPartialWithdrawal,
+      @ForAll final int seed) {
+    assertDeserializeMutatedThrowsExpected(pendingPartialWithdrawal, seed);
+  }
+}

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/propertytest/suppliers/state/PendingBalanceDepositSupplier.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/propertytest/suppliers/state/PendingBalanceDepositSupplier.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.propertytest.suppliers.state;
+
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.datastructures.state.versions.electra.PendingBalanceDeposit;
+import tech.pegasys.teku.spec.propertytest.suppliers.DataStructureUtilSupplier;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class PendingBalanceDepositSupplier
+    extends DataStructureUtilSupplier<PendingBalanceDeposit> {
+  public PendingBalanceDepositSupplier() {
+    super(DataStructureUtil::randomPendingBalanceDeposit, SpecMilestone.ELECTRA);
+  }
+}

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/propertytest/suppliers/state/PendingConsolidationSupplier.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/propertytest/suppliers/state/PendingConsolidationSupplier.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.propertytest.suppliers.state;
+
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.datastructures.state.versions.electra.PendingConsolidation;
+import tech.pegasys.teku.spec.propertytest.suppliers.DataStructureUtilSupplier;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class PendingConsolidationSupplier extends DataStructureUtilSupplier<PendingConsolidation> {
+  public PendingConsolidationSupplier() {
+    super(DataStructureUtil::randomPendingConsolidation, SpecMilestone.ELECTRA);
+  }
+}

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/propertytest/suppliers/state/PendingPartialWithdrawalSupplier.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/propertytest/suppliers/state/PendingPartialWithdrawalSupplier.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.propertytest.suppliers.state;
+
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.datastructures.state.versions.electra.PendingPartialWithdrawal;
+import tech.pegasys.teku.spec.propertytest.suppliers.DataStructureUtilSupplier;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+public class PendingPartialWithdrawalSupplier
+    extends DataStructureUtilSupplier<PendingPartialWithdrawal> {
+  public PendingPartialWithdrawalSupplier() {
+    super(DataStructureUtil::randomPendingPartialWithdrawal, SpecMilestone.ELECTRA);
+  }
+}

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -175,6 +175,9 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconStat
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.altair.BeaconStateSchemaAltair;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.phase0.BeaconStateSchemaPhase0;
 import tech.pegasys.teku.spec.datastructures.state.versions.capella.HistoricalSummary;
+import tech.pegasys.teku.spec.datastructures.state.versions.electra.PendingBalanceDeposit;
+import tech.pegasys.teku.spec.datastructures.state.versions.electra.PendingConsolidation;
+import tech.pegasys.teku.spec.datastructures.state.versions.electra.PendingPartialWithdrawal;
 import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.spec.datastructures.type.SszKZGProof;
 import tech.pegasys.teku.spec.datastructures.type.SszPublicKey;
@@ -2452,6 +2455,27 @@ public final class DataStructureUtil {
     return getElectraSchemaDefinitions(randomSlot())
         .getExecutionLayerExitSchema()
         .create(executionAddress, validator.getPublicKey());
+  }
+
+  public PendingBalanceDeposit randomPendingBalanceDeposit() {
+    return getElectraSchemaDefinitions(randomSlot())
+        .getPendingBalanceDepositSchema()
+        .create(SszUInt64.of(randomUInt64()), SszUInt64.of(randomUInt64()));
+  }
+
+  public PendingConsolidation randomPendingConsolidation() {
+    return getElectraSchemaDefinitions(randomSlot())
+        .getPendingConsolidationSchema()
+        .create(SszUInt64.of(randomUInt64()), SszUInt64.of(randomUInt64()));
+  }
+
+  public PendingPartialWithdrawal randomPendingPartialWithdrawal() {
+    return getElectraSchemaDefinitions(randomSlot())
+        .getPendingPartialWithdrawalSchema()
+        .create(
+            SszUInt64.of(randomUInt64()),
+            SszUInt64.of(randomUInt64()),
+            SszUInt64.of(randomUInt64()));
   }
 
   public UInt64 randomBlobSidecarIndex() {


### PR DESCRIPTION
## PR Description

This PR adds property tests for the three new "pending*" structures. While doing this, I noticed that `createFromBackingNode` was returning `null` which meant `sszDeserialize` would return `null` too. The property tests for this structure were failing because of it.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
