### PR TITLE
Invert validatorActiveLongEnough check to be more clear

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/block/BlockProcessorElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/block/BlockProcessorElectra.java
@@ -158,7 +158,7 @@ public class BlockProcessorElectra extends BlockProcessorDeneb {
           final Validator validator = state.getValidators().get(validatorIndex);
 
           // Check if validator has eth1 credentials
-          boolean isExecutionAddress = predicates.hasEth1WithdrawalCredential(validator);
+          final boolean isExecutionAddress = predicates.hasEth1WithdrawalCredential(validator);
           if (!isExecutionAddress) {
             return;
           }
@@ -166,7 +166,7 @@ public class BlockProcessorElectra extends BlockProcessorDeneb {
           // Check exit source_address matches validator eth1 withdrawal credentials
           final Bytes20 executionAddress =
               new Bytes20(validator.getWithdrawalCredentials().slice(12));
-          boolean isCorrectSourceAddress = executionAddress.equals(exit.getSourceAddress());
+          final boolean isCorrectSourceAddress = executionAddress.equals(exit.getSourceAddress());
           if (!isCorrectSourceAddress) {
             return;
           }
@@ -178,16 +178,16 @@ public class BlockProcessorElectra extends BlockProcessorDeneb {
           }
 
           // Check if validator has already initiated exit
-          boolean hasInitiatedExit = !validator.getExitEpoch().equals(FAR_FUTURE_EPOCH);
+          final boolean hasInitiatedExit = !validator.getExitEpoch().equals(FAR_FUTURE_EPOCH);
           if (hasInitiatedExit) {
             return;
           }
 
           // Check if validator has been active long enough
           final boolean validatorActiveLongEnough =
-              currentEpoch.isLessThan(
+              currentEpoch.isGreaterThanOrEqualTo(
                   validator.getActivationEpoch().plus(specConfig.getShardCommitteePeriod()));
-          if (validatorActiveLongEnough) {
+          if (!validatorActiveLongEnough) {
             return;
           }
 


### PR DESCRIPTION
## PR Description

There was a hint of confusion when reading this check. The variable name (`validatorActiveLongEnough`) doesn't quite match what it represents. I was reading it as: "if the validator is active long enough, reject this" which is wrong.

https://github.com/Consensys/teku/blob/c862af719a68b93d3394d957196486fe5dfced42/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/block/BlockProcessorElectra.java#L186-L192

Also add a few `final` specifiers which I know we like.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
