### PR TITLE
Configure CLI after adding subcommand

### DIFF
--- a/teku/src/main/java/tech/pegasys/teku/cli/BeaconNodeCommand.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/BeaconNodeCommand.java
@@ -212,7 +212,7 @@ public class BeaconNodeCommand implements Callable<Integer> {
   }
 
   private CommandLine getCommandLine() {
-    return configureCommandLine(new CommandLine(this)).addSubcommand(validatorClientSubcommand);
+    return configureCommandLine(new CommandLine(this).addSubcommand(validatorClientSubcommand));
   }
 
   public int parse(final String[] args) {


### PR DESCRIPTION
If you want to specify metrics category (ie `--metrics-categories=VALIDATOR_DUTY`) in standalone VC you get:

```
No TypeConverter registered for org.hyperledger.besu.plugin.services.metrics.MetricCategory of field java.util.Set<org.hyperledger.besu.plugin.services.metrics.MetricCategory> tech.pegasys.teku.cli.options.MetricsOptions.metricsCategories

To display full help:
teku [COMMAND] --help
```

This PR fixes this.