### PR TITLE
add manual docker hub with commit hash publishing circleci step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,12 +143,16 @@ commands:
 
   docker_publish_images:
     description: "Upload the docker images"
+    parameters:
+      include_commit_hash:
+        type: Boolean
+        default: false
     steps:
       - run:
           name: "Publish Docker Images"
           command: |
             docker login --username "${DOCKER_USER_RW}" --password "${DOCKER_PASSWORD_RW}"
-            ./gradlew --no-daemon --parallel "-Pbranch=${CIRCLE_BRANCH}" uploadDocker
+            ./gradlew --no-daemon --parallel "-Pbranch=${CIRCLE_BRANCH} -PincludeCommitHash=<< parameters.include_commit_hash >>" uploadDocker
 
   notify:
     description: "Notify Slack"
@@ -431,23 +435,33 @@ jobs:
       - notify
 
   publishDockerAmd64:
+    parameters:
+      include_commit_hash:
+        type: Boolean
+        default: false
     executor: machine_executor_amd64
     steps:
       - prepare
       - attach_workspace:
           at: ~/project
       - docker_trust_sign
-      - docker_publish_images
+      - docker_publish_images:
+          include_commit_hash: << parameters.commit_hash >>
       - notify
 
   publishDockerArm64:
+    parameters:
+      include_commit_hash:
+        type: Boolean
+        default: false
     executor: machine_executor_arm64
     steps:
       - prepare
       - attach_workspace:
           at: ~/project
       - docker_trust_sign
-      - docker_publish_images
+      - docker_publish_images:
+          include_commit_hash: << parameters.commit_hash >>
       - notify
 
   manifestDocker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -446,7 +446,7 @@ jobs:
           at: ~/project
       - docker_trust_sign
       - docker_publish_images:
-          include_commit_hash: << parameters.commit_hash >>
+          include_commit_hash: << parameters.include_commit_hash >>
       - notify
 
   publishDockerArm64:
@@ -461,7 +461,7 @@ jobs:
           at: ~/project
       - docker_trust_sign
       - docker_publish_images:
-          include_commit_hash: << parameters.commit_hash >>
+          include_commit_hash: << parameters.include_commit_hash >>
       - notify
 
   manifestDocker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,7 +145,7 @@ commands:
     description: "Upload the docker images"
     parameters:
       include_commit_hash:
-        type: Boolean
+        type: boolean
         default: false
     steps:
       - run:
@@ -437,7 +437,7 @@ jobs:
   publishDockerAmd64:
     parameters:
       include_commit_hash:
-        type: Boolean
+        type: boolean
         default: false
     executor: machine_executor_amd64
     steps:
@@ -452,7 +452,7 @@ jobs:
   publishDockerArm64:
     parameters:
       include_commit_hash:
-        type: Boolean
+        type: boolean
         default: false
     executor: machine_executor_arm64
     steps:

--- a/build.gradle
+++ b/build.gradle
@@ -539,7 +539,7 @@ task distDocker  {
       commandLine 'git', 'rev-parse', '--short', 'HEAD'
       standardOutput = commitHash
     }
-    dockerBuildVersion = "master-" + commitHash
+    dockerBuildVersion += '-' + commitHash
   }
 
   doLast {

--- a/build.gradle
+++ b/build.gradle
@@ -532,6 +532,16 @@ def executableAndArg = System.getProperty('os.name').toLowerCase().contains('win
 task distDocker  {
   dependsOn dockerDistUntar
   def dockerBuildVersion = 'develop'
+
+  if (project.hasProperty('includeCommitHash') && project.property('includeCommitHash').toBoolean()) {
+    def commitHash = new ByteArrayOutputStream()
+    exec {
+      commandLine 'git', 'rev-parse', '--short', 'HEAD'
+      standardOutput = commitHash
+    }
+    dockerBuildVersion = "master-" + commitHash
+  }
+
   doLast {
     for (def variant in dockerJdkVariants) {
       copy {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Add a Circle CI parameter to publish docker hub images with the commit hash in the tag:
In order to publish a docker image with the commit hash included in the tag (`master-abcd1234`), the master branch circle CI workflow must be relaunched manually from the circle CI app:

<img width="1051" alt="Screenshot 2024-04-17 at 11 48 59" src="https://github.com/Consensys/teku/assets/1208687/e3e35d23-a219-4cac-9447-6a3ad4eeac5a">

And the parameter `include_commit_hash` must be set to `true`:

<img width="748" alt="Screenshot 2024-04-17 at 11 51 27" src="https://github.com/Consensys/teku/assets/1208687/8052acbc-3180-46fb-9b1d-86c539c4bb36">

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
fixes https://github.com/Consensys/teku-internal/issues/110

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
