### PR TITLE
Refactor block production flow (part 2)

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
@@ -39,10 +39,12 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlockUnblinder;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodyBuilder;
+import tech.pegasys.teku.spec.datastructures.blocks.versions.deneb.BlockContentsSchema;
 import tech.pegasys.teku.spec.datastructures.builder.BuilderBid;
 import tech.pegasys.teku.spec.datastructures.builder.BuilderPayload;
 import tech.pegasys.teku.spec.datastructures.execution.BlobsBundle;
 import tech.pegasys.teku.spec.datastructures.execution.BuilderBidOrFallbackData;
+import tech.pegasys.teku.spec.datastructures.execution.BuilderPayloadOrFallbackData;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
@@ -244,23 +246,11 @@ public class BlockOperationSelectorFactory {
             requestedBuilderBoostFactor,
             blockProductionPerformance);
 
-    // we should try to return unblinded content only if no explicit "blindness" has been requested
-    // and builder flow fallbacks to local
-    final Function<BuilderBidOrFallbackData, Boolean> setUnblindedContentIfBuilderFallbacks =
-        builderBidOrFallbackData ->
-            builderBidOrFallbackData.getFallbackData().isPresent() && requestedBlinded.isEmpty();
-
     return SafeFuture.allOf(
         cacheExecutionPayloadValue(executionPayloadResult, blockSlotState),
-        // Execution Payload / Execution Payload Header
         setPayloadOrPayloadHeader(
-            bodyBuilder,
-            schemaDefinitions,
-            setUnblindedContentIfBuilderFallbacks,
-            executionPayloadResult),
-        // KZG Commitments
-        setKzgCommitments(
-            bodyBuilder, schemaDefinitions, executionPayloadResult, blockSlotState.getSlot()));
+            bodyBuilder, schemaDefinitions, requestedBlinded, executionPayloadResult),
+        setKzgCommitments(bodyBuilder, schemaDefinitions, executionPayloadResult));
   }
 
   private SafeFuture<Void> cacheExecutionPayloadValue(
@@ -276,7 +266,7 @@ public class BlockOperationSelectorFactory {
   private SafeFuture<Void> setPayloadOrPayloadHeader(
       final BeaconBlockBodyBuilder bodyBuilder,
       final SchemaDefinitionsBellatrix schemaDefinitions,
-      final Function<BuilderBidOrFallbackData, Boolean> setUnblindedContentIfBuilderFallbacks,
+      final Optional<Boolean> requestedBlinded,
       final ExecutionPayloadResult executionPayloadResult) {
 
     if (executionPayloadResult.isFromNonBlindedFlow()) {
@@ -286,14 +276,16 @@ public class BlockOperationSelectorFactory {
           .orElseThrow()
           .thenAccept(bodyBuilder::executionPayload);
     }
-
     // blinded flow
     return executionPayloadResult
         .getBuilderBidOrFallbackDataFuture()
         .orElseThrow()
         .thenAccept(
             builderBidOrFallbackData -> {
-              if (setUnblindedContentIfBuilderFallbacks.apply(builderBidOrFallbackData)) {
+              // we should try to return unblinded content only if no explicit "blindness" has been
+              // requested and builder flow fallbacks to local
+              if (requestedBlinded.isEmpty()
+                  && builderBidOrFallbackData.getFallbackData().isPresent()) {
                 bodyBuilder.executionPayload(
                     builderBidOrFallbackData.getFallbackDataRequired().getExecutionPayload());
               } else {
@@ -321,8 +313,7 @@ public class BlockOperationSelectorFactory {
   private SafeFuture<Void> setKzgCommitments(
       final BeaconBlockBodyBuilder bodyBuilder,
       final SchemaDefinitions schemaDefinitions,
-      final ExecutionPayloadResult executionPayloadResult,
-      final UInt64 slot) {
+      final ExecutionPayloadResult executionPayloadResult) {
     if (!bodyBuilder.supportsKzgCommitments()) {
       return SafeFuture.COMPLETE;
     }
@@ -332,7 +323,10 @@ public class BlockOperationSelectorFactory {
     if (executionPayloadResult.isFromNonBlindedFlow()) {
       // non-blinded flow
       blobKzgCommitments =
-          getExecutionBlobsBundleFromNonBlindedFlow(executionPayloadResult, slot)
+          executionPayloadResult
+              .getBlobsBundleFutureFromNonBlindedFlow()
+              .orElseThrow()
+              .thenApply(Optional::orElseThrow)
               .thenApply(blobKzgCommitmentsSchema::createFromBlobsBundle);
     } else {
       // blinded flow
@@ -391,9 +385,20 @@ public class BlockOperationSelectorFactory {
             () ->
                 executionLayerBlockProductionManager
                     .getUnblindedPayload(signedBlindedBlock, blockPublishingPerformance)
-                    .thenApply(BuilderPayload::getExecutionPayload));
+                    .thenApply(this::getExecutionPayloadFromBlindedFlow));
       }
     };
+  }
+
+  private ExecutionPayload getExecutionPayloadFromBlindedFlow(
+      final BuilderPayloadOrFallbackData builderPayloadOrFallbackData) {
+    return builderPayloadOrFallbackData
+        .getBuilderPayload()
+        // from the builder payload
+        .map(BuilderPayload::getExecutionPayload)
+        // from the local fallback
+        .orElseGet(
+            () -> builderPayloadOrFallbackData.getFallbackDataRequired().getExecutionPayload());
   }
 
   public Function<BeaconBlock, SafeFuture<BlobsBundle>> createBlobsBundleSelector() {
@@ -408,20 +413,22 @@ public class BlockOperationSelectorFactory {
                           "ExecutionPayloadResult hasn't been cached for slot " + slot));
 
       if (executionPayloadResult.isFromNonBlindedFlow()) {
-        // we performed a non-blinded flow, so the bundle must be in getPayloadResponseFuture
-        return getExecutionBlobsBundleFromNonBlindedFlow(executionPayloadResult, slot);
+        // we performed a non-blinded flow, so the bundle must be in
+        // getBlobsBundleFutureFromNonBlindedFlow
+        return executionPayloadResult
+            .getBlobsBundleFutureFromNonBlindedFlow()
+            .orElseThrow()
+            .thenApply(Optional::orElseThrow);
       } else {
-        // we performed a blinded flow, so the bundle must be in getbuilderBidOrFallbackDataFuture
+        // we performed a blinded flow, so the bundle must be in the FallbackData in
+        // getBuilderBidOrFallbackDataFuture
         return executionPayloadResult
             .getBuilderBidOrFallbackDataFuture()
             .orElseThrow()
             .thenApply(
                 builderBidOrFallbackData ->
                     builderBidOrFallbackData.getFallbackDataRequired().getBlobsBundle())
-            .thenApply(
-                blobsBundle ->
-                    blobsBundle.orElseThrow(
-                        () -> executionBlobsBundleIsNotAvailableException(slot)));
+            .thenApply(Optional::orElseThrow);
       }
     };
   }
@@ -432,38 +439,53 @@ public class BlockOperationSelectorFactory {
       final UInt64 slot = blockContainer.getSlot();
       final SignedBeaconBlock block = blockContainer.getSignedBlock();
 
-      final MiscHelpersDeneb miscHelpersDeneb =
-          MiscHelpersDeneb.required(spec.atSlot(slot).miscHelpers());
-
       final SszList<Blob> blobs;
       final SszList<SszKZGProof> proofs;
-      final SszList<SszKZGCommitment> blockCommitments =
-          block.getMessage().getBody().getOptionalBlobKzgCommitments().orElseThrow();
 
       if (blockContainer.isBlinded()) {
-        // need to use the builder BlobsBundle for the blinded flow, because the
-        // blobs and the proofs wouldn't be part of the BlockContainer. Keep in mind, the builder
-        // BlobsBundle could also be a local fallback.
-        final tech.pegasys.teku.spec.datastructures.builder.BlobsBundle blobsBundle =
-            getCachedBuilderBlobsBundle(slot);
+        // need to use the builder BlobsBundle or the local fallback for the blinded flow, because
+        // the blobs and the proofs wouldn't be part of the BlockContainer.
+        final BuilderPayloadOrFallbackData builderPayloadOrFallbackData =
+            executionLayerBlockProductionManager
+                .getCachedUnblindedPayload(slot)
+                .orElseThrow(
+                    () ->
+                        new IllegalStateException(
+                            "BuilderPayloadOrFallbackData hasn't been cached for slot " + slot));
 
-        blobs = blobsBundle.getBlobs();
-        proofs = blobsBundle.getProofs();
+        final Optional<BuilderPayload> maybeBuilderPayload =
+            builderPayloadOrFallbackData.getBuilderPayload();
 
-        // consistency check because the BlobsBundle comes from an external source (a builder)
-        checkState(
-            blobsBundle.getCommitments().hashTreeRoot().equals(blockCommitments.hashTreeRoot()),
-            "Commitments in the builder BlobsBundle don't match the commitments in the block");
-        checkState(
-            blockCommitments.size() == proofs.size(),
-            "The number of proofs in the builder BlobsBundle doesn't match the number of commitments in the block");
-        checkState(
-            blockCommitments.size() == blobs.size(),
-            "The number of blobs in the builder BlobsBundle doesn't match the number of commitments in the block");
+        if (maybeBuilderPayload.isPresent()) {
+          // from the builder payload
+          final tech.pegasys.teku.spec.datastructures.builder.BlobsBundle blobsBundle =
+              maybeBuilderPayload.get().getOptionalBlobsBundle().orElseThrow();
+          // consistency checks because the BlobsBundle comes from an external source (a builder)
+          verifyBuilderBlobsBundle(blobsBundle, block);
+          blobs = blobsBundle.getBlobs();
+          proofs = blobsBundle.getProofs();
+        } else {
+          // from the local fallback
+          final BlobsBundle blobsBundle =
+              builderPayloadOrFallbackData.getFallbackDataRequired().getBlobsBundle().orElseThrow();
+          final BlockContentsSchema blockContentsSchema =
+              SchemaDefinitionsDeneb.required(spec.atSlot(slot).getSchemaDefinitions())
+                  .getBlockContentsSchema();
+          blobs = blockContentsSchema.getBlobsSchema().createFromElements(blobsBundle.getBlobs());
+          proofs =
+              blockContentsSchema
+                  .getKzgProofsSchema()
+                  .createFromElements(
+                      blobsBundle.getProofs().stream().map(SszKZGProof::new).toList());
+        }
+
       } else {
         blobs = blockContainer.getBlobs().orElseThrow();
         proofs = blockContainer.getKzgProofs().orElseThrow();
       }
+
+      final MiscHelpersDeneb miscHelpersDeneb =
+          MiscHelpersDeneb.required(spec.atSlot(slot).miscHelpers());
 
       final List<BlobSidecar> blobSidecars =
           IntStream.range(0, blobs.size())
@@ -479,29 +501,19 @@ public class BlockOperationSelectorFactory {
     };
   }
 
-  private SafeFuture<BlobsBundle> getExecutionBlobsBundleFromNonBlindedFlow(
-      final ExecutionPayloadResult executionPayloadResult, final UInt64 slot) {
-    return executionPayloadResult
-        .getBlobsBundleFutureFromNonBlindedFlow()
-        .orElseThrow()
-        .thenApply(
-            blobsBundle ->
-                blobsBundle.orElseThrow(() -> executionBlobsBundleIsNotAvailableException(slot)));
-  }
-
-  private IllegalStateException executionBlobsBundleIsNotAvailableException(final UInt64 slot) {
-    return new IllegalStateException("execution BlobsBundle is not available for slot " + slot);
-  }
-
-  private tech.pegasys.teku.spec.datastructures.builder.BlobsBundle getCachedBuilderBlobsBundle(
-      final UInt64 slot) {
-    return executionLayerBlockProductionManager
-        .getCachedUnblindedPayload(slot)
-        .orElseThrow(
-            () -> new IllegalStateException("BuilderPayload hasn't been cached for slot " + slot))
-        .getOptionalBlobsBundle()
-        .orElseThrow(
-            () ->
-                new IllegalStateException("builder BlobsBundle is not available for slot " + slot));
+  private void verifyBuilderBlobsBundle(
+      final tech.pegasys.teku.spec.datastructures.builder.BlobsBundle blobsBundle,
+      final SignedBeaconBlock block) {
+    final SszList<SszKZGCommitment> blockCommitments =
+        block.getMessage().getBody().getOptionalBlobKzgCommitments().orElseThrow();
+    checkState(
+        blobsBundle.getCommitments().hashTreeRoot().equals(blockCommitments.hashTreeRoot()),
+        "Commitments in the builder BlobsBundle don't match the commitments in the block");
+    checkState(
+        blockCommitments.size() == blobsBundle.getProofs().size(),
+        "The number of proofs in the builder BlobsBundle doesn't match the number of commitments in the block");
+    checkState(
+        blockCommitments.size() == blobsBundle.getBlobs().size(),
+        "The number of blobs in the builder BlobsBundle doesn't match the number of commitments in the block");
   }
 }

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/AbstractBlockFactoryTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/AbstractBlockFactoryTest.java
@@ -58,6 +58,7 @@ import tech.pegasys.teku.spec.datastructures.builder.BuilderBid;
 import tech.pegasys.teku.spec.datastructures.builder.BuilderPayload;
 import tech.pegasys.teku.spec.datastructures.execution.BlobsBundle;
 import tech.pegasys.teku.spec.datastructures.execution.BuilderBidOrFallbackData;
+import tech.pegasys.teku.spec.datastructures.execution.BuilderPayloadOrFallbackData;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadResult;
@@ -293,7 +294,8 @@ public abstract class AbstractBlockFactoryTest {
 
     // no need to prepare blobs bundle when only testing block unblinding
     when(executionLayer.getUnblindedPayload(blindedBlock, BlockPublishingPerformance.NOOP))
-        .thenReturn(SafeFuture.completedFuture(executionPayload));
+        .thenReturn(
+            SafeFuture.completedFuture(BuilderPayloadOrFallbackData.create(executionPayload)));
 
     final SignedBeaconBlock unblindedBlock =
         blockFactory
@@ -367,7 +369,7 @@ public abstract class AbstractBlockFactoryTest {
 
     // simulate caching of the builder payload
     when(executionLayer.getCachedUnblindedPayload(signedBlockContainer.getSlot()))
-        .thenReturn(builderPayload);
+        .thenReturn(builderPayload.map(BuilderPayloadOrFallbackData::create));
 
     final List<BlobSidecar> blobSidecars =
         blockFactory.createBlobSidecars(signedBlockContainer, BlockPublishingPerformance.NOOP);

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactoryTest.java
@@ -33,6 +33,8 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.ethereum.performance.trackers.BlockProductionPerformance;
 import tech.pegasys.teku.ethereum.performance.trackers.BlockPublishingPerformance;
@@ -59,6 +61,7 @@ import tech.pegasys.teku.spec.datastructures.builder.BuilderPayload;
 import tech.pegasys.teku.spec.datastructures.consolidations.SignedConsolidation;
 import tech.pegasys.teku.spec.datastructures.execution.BlobsBundle;
 import tech.pegasys.teku.spec.datastructures.execution.BuilderBidOrFallbackData;
+import tech.pegasys.teku.spec.datastructures.execution.BuilderPayloadOrFallbackData;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
@@ -651,15 +654,25 @@ class BlockOperationSelectorFactoryTest {
         .hasSameElementsAs(blobsBundle.getCommitments());
   }
 
-  @Test
-  void shouldUnblindSignedBlindedBeaconBlock() {
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  void shouldUnblindSignedBlindedBeaconBlock(final boolean useLocalFallback) {
     final ExecutionPayload randomExecutionPayload = dataStructureUtil.randomExecutionPayload();
     final SignedBeaconBlock blindedSignedBlock = dataStructureUtil.randomSignedBlindedBeaconBlock();
     final CapturingBeaconBlockUnblinder blockUnblinder =
         new CapturingBeaconBlockUnblinder(spec.getGenesisSchemaDefinitions(), blindedSignedBlock);
 
+    final BuilderPayloadOrFallbackData builderPayloadOrFallbackData;
+    if (useLocalFallback) {
+      final FallbackData fallbackData =
+          new FallbackData(
+              new GetPayloadResponse(randomExecutionPayload), FallbackReason.BUILDER_ERROR);
+      builderPayloadOrFallbackData = BuilderPayloadOrFallbackData.create(fallbackData);
+    } else {
+      builderPayloadOrFallbackData = BuilderPayloadOrFallbackData.create(randomExecutionPayload);
+    }
     when(executionLayer.getUnblindedPayload(blindedSignedBlock, BlockPublishingPerformance.NOOP))
-        .thenReturn(SafeFuture.completedFuture(randomExecutionPayload));
+        .thenReturn(SafeFuture.completedFuture(builderPayloadOrFallbackData));
 
     factory.createBlockUnblinderSelector(BlockPublishingPerformance.NOOP).accept(blockUnblinder);
 
@@ -831,7 +844,7 @@ class BlockOperationSelectorFactoryTest {
     prepareCachedBuilderPayload(
         signedBlindedBeaconBlock.getSlot(),
         dataStructureUtil.randomExecutionPayload(),
-        Optional.of(blobsBundle));
+        blobsBundle);
 
     assertThatThrownBy(
             () ->
@@ -856,7 +869,7 @@ class BlockOperationSelectorFactoryTest {
     prepareCachedBuilderPayload(
         signedBlindedBeaconBlock.getSlot(),
         dataStructureUtil.randomExecutionPayload(),
-        Optional.of(blobsBundle));
+        blobsBundle);
 
     assertThatThrownBy(
             () ->
@@ -881,7 +894,7 @@ class BlockOperationSelectorFactoryTest {
     prepareCachedBuilderPayload(
         signedBlindedBeaconBlock.getSlot(),
         dataStructureUtil.randomExecutionPayload(),
-        Optional.of(blobsBundle));
+        blobsBundle);
 
     assertThatThrownBy(
             () ->
@@ -893,22 +906,31 @@ class BlockOperationSelectorFactoryTest {
             "The number of proofs in the builder BlobsBundle doesn't match the number of commitments in the block");
   }
 
-  @Test
-  void shouldCreateBlobSidecarsForBlindedBlock() {
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  void shouldCreateBlobSidecarsForBlindedBlock(final boolean useLocalFallback) {
     final SszList<SszKZGCommitment> commitments = dataStructureUtil.randomBlobKzgCommitments(3);
     final SignedBeaconBlock signedBlindedBeaconBlock =
         dataStructureUtil.randomSignedBlindedBeaconBlockWithCommitments(commitments);
+    final UInt64 slot = signedBlindedBeaconBlock.getSlot();
 
-    final MiscHelpersDeneb miscHelpersDeneb =
-        MiscHelpersDeneb.required(spec.atSlot(signedBlindedBeaconBlock.getSlot()).miscHelpers());
-
+    final ExecutionPayload executionPayload = dataStructureUtil.randomExecutionPayload();
     final tech.pegasys.teku.spec.datastructures.builder.BlobsBundle blobsBundle =
         dataStructureUtil.randomBuilderBlobsBundle(commitments);
 
-    prepareCachedBuilderPayload(
-        signedBlindedBeaconBlock.getSlot(),
-        dataStructureUtil.randomExecutionPayload(),
-        Optional.of(blobsBundle));
+    if (useLocalFallback) {
+      final BlobsBundle localFallbackBlobsBundle =
+          new BlobsBundle(
+              blobsBundle.getCommitments().stream()
+                  .map(SszKZGCommitment::getKZGCommitment)
+                  .toList(),
+              blobsBundle.getProofs().stream().map(SszKZGProof::getKZGProof).toList(),
+              blobsBundle.getBlobs().stream().toList());
+      prepareCachedFallbackData(slot, executionPayload, localFallbackBlobsBundle);
+    } else {
+
+      prepareCachedBuilderPayload(slot, executionPayload, blobsBundle);
+    }
 
     final List<BlobSidecar> blobSidecars =
         factory
@@ -924,8 +946,10 @@ class BlockOperationSelectorFactoryTest {
             .getOptionalBlobKzgCommitments()
             .orElseThrow();
 
-    assertThat(blobSidecars).hasSize(expectedBlobs.size());
+    final MiscHelpersDeneb miscHelpersDeneb =
+        MiscHelpersDeneb.required(spec.atSlot(slot).miscHelpers());
 
+    assertThat(blobSidecars).hasSize(expectedBlobs.size());
     IntStream.range(0, blobSidecars.size())
         .forEach(
             index -> {
@@ -1133,17 +1157,24 @@ class BlockOperationSelectorFactoryTest {
   private void prepareCachedBuilderPayload(
       final UInt64 slot,
       final ExecutionPayload executionPayload,
-      final Optional<tech.pegasys.teku.spec.datastructures.builder.BlobsBundle> blobsBundle) {
+      final tech.pegasys.teku.spec.datastructures.builder.BlobsBundle blobsBundle) {
     final BuilderPayload builderPayload =
-        blobsBundle
-            .map(
-                bundle ->
-                    (BuilderPayload)
-                        SchemaDefinitionsDeneb.required(spec.atSlot(slot).getSchemaDefinitions())
-                            .getExecutionPayloadAndBlobsBundleSchema()
-                            .create(executionPayload, bundle))
-            .orElse(executionPayload);
-    when(executionLayer.getCachedUnblindedPayload(slot)).thenReturn(Optional.of(builderPayload));
+        SchemaDefinitionsDeneb.required(spec.atSlot(slot).getSchemaDefinitions())
+            .getExecutionPayloadAndBlobsBundleSchema()
+            .create(executionPayload, blobsBundle);
+    when(executionLayer.getCachedUnblindedPayload(slot))
+        .thenReturn(Optional.of(BuilderPayloadOrFallbackData.create(builderPayload)));
+  }
+
+  private void prepareCachedFallbackData(
+      final UInt64 slot, final ExecutionPayload executionPayload, final BlobsBundle blobsBundle) {
+    when(executionLayer.getCachedUnblindedPayload(slot))
+        .thenReturn(
+            Optional.of(
+                BuilderPayloadOrFallbackData.create(
+                    new FallbackData(
+                        new GetPayloadResponse(executionPayload, UInt256.ZERO, blobsBundle, false),
+                        FallbackReason.BUILDER_ERROR))));
   }
 
   private static class CapturingBeaconBlockBodyBuilder implements BeaconBlockBodyBuilder {

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImpl.java
@@ -47,9 +47,9 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
-import tech.pegasys.teku.spec.datastructures.builder.BuilderPayload;
 import tech.pegasys.teku.spec.datastructures.builder.SignedValidatorRegistration;
 import tech.pegasys.teku.spec.datastructures.execution.BuilderBidOrFallbackData;
+import tech.pegasys.teku.spec.datastructures.execution.BuilderPayloadOrFallbackData;
 import tech.pegasys.teku.spec.datastructures.execution.ClientVersion;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadResult;
@@ -154,7 +154,6 @@ public class ExecutionLayerManagerImpl implements ExecutionLayerManager {
     this.executionPayloadSourceCounter = executionPayloadSourceCounter;
     this.executionBuilderModule =
         new ExecutionBuilderModule(
-            spec,
             this,
             builderBidValidator,
             builderCircuitBreaker,
@@ -239,7 +238,7 @@ public class ExecutionLayerManagerImpl implements ExecutionLayerManager {
   }
 
   @Override
-  public SafeFuture<BuilderPayload> builderGetPayload(
+  public SafeFuture<BuilderPayloadOrFallbackData> builderGetPayload(
       final SignedBeaconBlock signedBeaconBlock,
       final Function<UInt64, Optional<ExecutionPayloadResult>> getCachedPayloadResultFunction) {
     return executionBuilderModule.builderGetPayload(

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionBuilderModuleTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionBuilderModuleTest.java
@@ -217,7 +217,6 @@ public class ExecutionBuilderModuleTest {
 
     executionBuilderModule =
         new ExecutionBuilderModule(
-            spec,
             executionLayerManager,
             builderBidValidator,
             builderCircuitBreaker,

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerBlockProductionManagerImplTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerBlockProductionManagerImplTest.java
@@ -45,11 +45,11 @@ import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBlockContainer;
 import tech.pegasys.teku.spec.datastructures.builder.BuilderBid;
-import tech.pegasys.teku.spec.datastructures.builder.BuilderPayload;
 import tech.pegasys.teku.spec.datastructures.builder.ExecutionPayloadAndBlobsBundle;
 import tech.pegasys.teku.spec.datastructures.builder.SignedBuilderBid;
 import tech.pegasys.teku.spec.datastructures.execution.BlobsBundle;
 import tech.pegasys.teku.spec.datastructures.execution.BuilderBidOrFallbackData;
+import tech.pegasys.teku.spec.datastructures.execution.BuilderPayloadOrFallbackData;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadResult;
@@ -120,7 +120,7 @@ class ExecutionLayerBlockProductionManagerImplTest {
     final SafeFuture<BuilderBidOrFallbackData> builderBidOrFallbackDataFuture =
         executionPayloadResult.getBuilderBidOrFallbackDataFuture().orElseThrow();
     assertThat(builderBidOrFallbackDataFuture.get()).isEqualTo(expectedResult);
-    final BuilderPayload localPayload =
+    final FallbackData localFallback =
         verifyFallbackToLocalEL(slot, executionPayloadContext, expectedResult);
 
     assertThat(blockProductionManager.getCachedPayloadResult(slot))
@@ -128,11 +128,11 @@ class ExecutionLayerBlockProductionManagerImplTest {
     // wrong slot
     assertThat(blockProductionManager.getCachedPayloadResult(slot.plus(1))).isEmpty();
 
-    final SafeFuture<BuilderPayload> unblindedPayload =
+    final SafeFuture<BuilderPayloadOrFallbackData> unblindedPayload =
         blockProductionManager.getUnblindedPayload(
             dataStructureUtil.randomSignedBlindedBeaconBlock(slot),
             BlockPublishingPerformance.NOOP);
-    assertThat(unblindedPayload.get()).isEqualTo(localPayload);
+    assertThat(unblindedPayload.get().getFallbackData()).hasValue(localFallback);
 
     // wrong slot, we will hit builder client by this call
     final SignedBeaconBlock signedBlindedBeaconBlock =
@@ -188,7 +188,7 @@ class ExecutionLayerBlockProductionManagerImplTest {
     assertThat(
             blockProductionManager.getUnblindedPayload(
                 signedBlindedBeaconBlock, BlockPublishingPerformance.NOOP))
-        .isCompletedWithValue(payload);
+        .isCompletedWithValue(BuilderPayloadOrFallbackData.create(payload));
 
     // we expect both builder and local engine have been called
     verify(builderClient).getPayload(signedBlindedBeaconBlock);
@@ -278,17 +278,17 @@ class ExecutionLayerBlockProductionManagerImplTest {
     final SafeFuture<BuilderBidOrFallbackData> builderBidOrFallbackDataFuture =
         executionPayloadResult.getBuilderBidOrFallbackDataFuture().orElseThrow();
     assertThat(builderBidOrFallbackDataFuture.get()).isEqualTo(expectedResult);
-    final BuilderPayload localPayload =
+    final FallbackData localFallback =
         verifyFallbackToLocalEL(slot, executionPayloadContext, expectedResult);
 
     assertThat(blockProductionManager.getCachedPayloadResult(slot))
         .contains(executionPayloadResult);
 
-    final SafeFuture<BuilderPayload> unblindedPayload =
+    final SafeFuture<BuilderPayloadOrFallbackData> unblindedPayload =
         blockProductionManager.getUnblindedPayload(
             dataStructureUtil.randomSignedBlindedBeaconBlock(slot),
             BlockPublishingPerformance.NOOP);
-    assertThat(unblindedPayload.get()).isEqualTo(localPayload);
+    assertThat(unblindedPayload.get().getFallbackData()).hasValue(localFallback);
 
     verifyNoMoreInteractions(builderClient);
     verifyNoMoreInteractions(executionClientHandler);
@@ -340,7 +340,7 @@ class ExecutionLayerBlockProductionManagerImplTest {
     assertThat(
             blockProductionManager.getUnblindedPayload(
                 signedBlindedBeaconBlock, BlockPublishingPerformance.NOOP))
-        .isCompletedWithValue(payloadAndBlobsBundle);
+        .isCompletedWithValue(BuilderPayloadOrFallbackData.create(payloadAndBlobsBundle));
 
     // we expect both builder and local engine have been called
     verify(builderClient).getPayload(signedBlindedBeaconBlock);
@@ -428,7 +428,7 @@ class ExecutionLayerBlockProductionManagerImplTest {
     return signedBuilderBid.getMessage();
   }
 
-  private BuilderPayload verifyFallbackToLocalEL(
+  private FallbackData verifyFallbackToLocalEL(
       final UInt64 slot,
       final ExecutionPayloadContext executionPayloadContext,
       final BuilderBidOrFallbackData builderBidOrFallbackData) {
@@ -448,24 +448,6 @@ class ExecutionLayerBlockProductionManagerImplTest {
     final SignedBeaconBlock signedBlindedBeaconBlock =
         dataStructureUtil.randomSignedBlindedBeaconBlock(slot);
 
-    final BuilderPayload builderPayload =
-        spec.atSlot(slot)
-            .getSchemaDefinitions()
-            .toVersionDeneb()
-            .map(
-                schemaDefinitionsDeneb -> {
-                  final tech.pegasys.teku.spec.datastructures.builder.BlobsBundle blobsBundle =
-                      schemaDefinitionsDeneb
-                          .getBlobsBundleSchema()
-                          .createFromExecutionBlobsBundle(
-                              fallbackData.getBlobsBundle().orElseThrow());
-                  return (BuilderPayload)
-                      schemaDefinitionsDeneb
-                          .getExecutionPayloadAndBlobsBundleSchema()
-                          .create(fallbackData.getExecutionPayload(), blobsBundle);
-                })
-            .orElseGet(fallbackData::getExecutionPayload);
-
     // we expect result from the cached payload
     assertThat(
             executionLayerManager.builderGetPayload(
@@ -475,7 +457,7 @@ class ExecutionLayerBlockProductionManagerImplTest {
                         ExecutionPayloadResult.createForBlindedFlow(
                             executionPayloadContext,
                             SafeFuture.completedFuture(builderBidOrFallbackData)))))
-        .isCompletedWithValue(builderPayload);
+        .isCompletedWithValue(BuilderPayloadOrFallbackData.create(fallbackData));
 
     // we expect no additional calls
     verifyNoMoreInteractions(builderClient);
@@ -483,7 +465,7 @@ class ExecutionLayerBlockProductionManagerImplTest {
 
     verifySourceCounter(Source.BUILDER_LOCAL_EL_FALLBACK, fallbackReason);
 
-    return builderPayload;
+    return fallbackData;
   }
 
   private ExecutionPayload prepareBuilderGetPayloadResponse(

--- a/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImplTest.java
+++ b/ethereum/executionlayer/src/test/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerManagerImplTest.java
@@ -46,10 +46,10 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.builder.BuilderBid;
-import tech.pegasys.teku.spec.datastructures.builder.BuilderPayload;
 import tech.pegasys.teku.spec.datastructures.builder.SignedBuilderBid;
 import tech.pegasys.teku.spec.datastructures.execution.BlobsBundle;
 import tech.pegasys.teku.spec.datastructures.execution.BuilderBidOrFallbackData;
+import tech.pegasys.teku.spec.datastructures.execution.BuilderPayloadOrFallbackData;
 import tech.pegasys.teku.spec.datastructures.execution.ClientVersion;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
@@ -58,7 +58,6 @@ import tech.pegasys.teku.spec.datastructures.execution.FallbackData;
 import tech.pegasys.teku.spec.datastructures.execution.FallbackReason;
 import tech.pegasys.teku.spec.datastructures.execution.GetPayloadResponse;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
-import tech.pegasys.teku.spec.schemas.SchemaDefinitionsDeneb;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 class ExecutionLayerManagerImplTest {
@@ -244,7 +243,7 @@ class ExecutionLayerManagerImplTest {
     assertThat(
             executionLayerManager.builderGetPayload(
                 signedBlindedBeaconBlock, (aSlot) -> Optional.empty()))
-        .isCompletedWithValue(payload);
+        .isCompletedWithValue(BuilderPayloadOrFallbackData.create(payload));
 
     // we expect both builder and local engine have been called
     verify(builderClient).getPayload(signedBlindedBeaconBlock);
@@ -286,7 +285,7 @@ class ExecutionLayerManagerImplTest {
     assertThat(
             executionLayerManager.builderGetPayload(
                 signedBlindedBeaconBlock, (aSlot) -> Optional.empty()))
-        .isCompletedWithValue(payload);
+        .isCompletedWithValue(BuilderPayloadOrFallbackData.create(payload));
 
     // we expect both builder and local engine have been called
     verify(builderClient).getPayload(signedBlindedBeaconBlock);
@@ -366,9 +365,9 @@ class ExecutionLayerManagerImplTest {
         prepareEngineGetPayloadResponse(executionPayloadContext, localExecutionPayloadValue, slot);
 
     // we expect local engine header as result
-    BuilderBidOrFallbackData expectedResult =
-        BuilderBidOrFallbackData.create(
-            new FallbackData(getPayloadResponse, FallbackReason.BUILDER_ERROR));
+    final FallbackData fallbackData =
+        new FallbackData(getPayloadResponse, FallbackReason.BUILDER_ERROR);
+    final BuilderBidOrFallbackData expectedResult = BuilderBidOrFallbackData.create(fallbackData);
     assertThat(
             executionLayerManager.builderGetHeader(
                 executionPayloadContext, state, Optional.empty(), BlockProductionPerformance.NOOP))
@@ -389,7 +388,7 @@ class ExecutionLayerManagerImplTest {
                     Optional.of(
                         ExecutionPayloadResult.createForBlindedFlow(
                             executionPayloadContext, SafeFuture.completedFuture(expectedResult)))))
-        .isCompletedWithValue(getPayloadResponse.getExecutionPayload());
+        .isCompletedWithValue(BuilderPayloadOrFallbackData.create(fallbackData));
 
     // we expect no additional calls
     verifyNoMoreInteractions(builderClient);
@@ -650,7 +649,7 @@ class ExecutionLayerManagerImplTest {
     assertThat(
             executionLayerManager.builderGetPayload(
                 signedBlindedBeaconBlock, (aSlot) -> Optional.empty()))
-        .isCompletedWithValue(payload);
+        .isCompletedWithValue(BuilderPayloadOrFallbackData.create(payload));
 
     // we expect both builder and local engine have been called
     verify(builderClient).getPayload(signedBlindedBeaconBlock);
@@ -710,24 +709,6 @@ class ExecutionLayerManagerImplTest {
     }
     verifyEngineCalled(executionPayloadContext, slot);
 
-    final BuilderPayload builderPayload =
-        fallbackData
-            .getBlobsBundle()
-            .map(
-                executionBlobsBundle -> {
-                  final SchemaDefinitionsDeneb schemaDefinitions =
-                      SchemaDefinitionsDeneb.required(spec.atSlot(slot).getSchemaDefinitions());
-                  final tech.pegasys.teku.spec.datastructures.builder.BlobsBundle blobsBundle =
-                      schemaDefinitions
-                          .getBlobsBundleSchema()
-                          .createFromExecutionBlobsBundle(executionBlobsBundle);
-                  return (BuilderPayload)
-                      schemaDefinitions
-                          .getExecutionPayloadAndBlobsBundleSchema()
-                          .create(fallbackData.getExecutionPayload(), blobsBundle);
-                })
-            .orElse(fallbackData.getExecutionPayload());
-
     final SignedBeaconBlock signedBlindedBeaconBlock =
         dataStructureUtil.randomSignedBlindedBeaconBlock(slot);
 
@@ -740,7 +721,7 @@ class ExecutionLayerManagerImplTest {
                         ExecutionPayloadResult.createForBlindedFlow(
                             executionPayloadContext,
                             SafeFuture.completedFuture(builderBidOrFallbackData)))))
-        .isCompletedWithValue(builderPayload);
+        .isCompletedWithValue(BuilderPayloadOrFallbackData.create(fallbackData));
 
     // we expect no additional calls
     verifyNoMoreInteractions(builderClient);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/BuilderPayloadOrFallbackData.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/BuilderPayloadOrFallbackData.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.execution;
+
+import com.google.common.base.MoreObjects;
+import java.util.Objects;
+import java.util.Optional;
+import tech.pegasys.teku.spec.datastructures.builder.BuilderPayload;
+
+/**
+ * Either {@link #builderPayload} or {@link #fallbackData} would be present, depending on if builder
+ * has been used or there has been a local fallback
+ */
+public class BuilderPayloadOrFallbackData {
+  private final Optional<BuilderPayload> builderPayload;
+  private final Optional<FallbackData> fallbackData;
+
+  private BuilderPayloadOrFallbackData(
+      final Optional<BuilderPayload> builderPayload, final Optional<FallbackData> fallbackData) {
+    this.builderPayload = builderPayload;
+    this.fallbackData = fallbackData;
+  }
+
+  public static BuilderPayloadOrFallbackData create(final BuilderPayload builderPayload) {
+    return new BuilderPayloadOrFallbackData(Optional.ofNullable(builderPayload), Optional.empty());
+  }
+
+  public static BuilderPayloadOrFallbackData create(final FallbackData fallbackData) {
+    return new BuilderPayloadOrFallbackData(Optional.empty(), Optional.ofNullable(fallbackData));
+  }
+
+  public Optional<BuilderPayload> getBuilderPayload() {
+    return builderPayload;
+  }
+
+  public Optional<FallbackData> getFallbackData() {
+    return fallbackData;
+  }
+
+  public FallbackData getFallbackDataRequired() {
+    return fallbackData.orElseThrow(
+        () -> new IllegalStateException("FallbackData is not available in " + this));
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final BuilderPayloadOrFallbackData that = (BuilderPayloadOrFallbackData) o;
+    return Objects.equals(builderPayload, that.builderPayload)
+        && Objects.equals(fallbackData, that.fallbackData);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(builderPayload, fallbackData);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("builderPayload", builderPayload)
+        .add("fallbackData", fallbackData)
+        .toString();
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerBlockProductionManager.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerBlockProductionManager.java
@@ -19,7 +19,7 @@ import tech.pegasys.teku.ethereum.performance.trackers.BlockPublishingPerformanc
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
-import tech.pegasys.teku.spec.datastructures.builder.BuilderPayload;
+import tech.pegasys.teku.spec.datastructures.execution.BuilderPayloadOrFallbackData;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadResult;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
@@ -49,14 +49,14 @@ public interface ExecutionLayerBlockProductionManager {
         }
 
         @Override
-        public SafeFuture<BuilderPayload> getUnblindedPayload(
+        public SafeFuture<BuilderPayloadOrFallbackData> getUnblindedPayload(
             final SignedBeaconBlock signedBeaconBlock,
             final BlockPublishingPerformance blockPublishingPerformance) {
           return SafeFuture.completedFuture(null);
         }
 
         @Override
-        public Optional<BuilderPayload> getCachedUnblindedPayload(final UInt64 slot) {
+        public Optional<BuilderPayloadOrFallbackData> getCachedUnblindedPayload(final UInt64 slot) {
           return Optional.empty();
         }
       };
@@ -86,15 +86,12 @@ public interface ExecutionLayerBlockProductionManager {
    */
   Optional<ExecutionPayloadResult> getCachedPayloadResult(UInt64 slot);
 
-  /**
-   * @return a payload which is either a builder or a local fallback
-   */
-  SafeFuture<BuilderPayload> getUnblindedPayload(
+  SafeFuture<BuilderPayloadOrFallbackData> getUnblindedPayload(
       SignedBeaconBlock signedBeaconBlock, BlockPublishingPerformance blockPublishingPerformance);
 
   /**
    * Requires {@link #getUnblindedPayload(SignedBeaconBlock, BlockPublishingPerformance)} to have
    * been called first in order for a value to be present
    */
-  Optional<BuilderPayload> getCachedUnblindedPayload(UInt64 slot);
+  Optional<BuilderPayloadOrFallbackData> getCachedUnblindedPayload(UInt64 slot);
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannel.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannel.java
@@ -24,9 +24,9 @@ import tech.pegasys.teku.infrastructure.events.ChannelInterface;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
-import tech.pegasys.teku.spec.datastructures.builder.BuilderPayload;
 import tech.pegasys.teku.spec.datastructures.builder.SignedValidatorRegistration;
 import tech.pegasys.teku.spec.datastructures.execution.BuilderBidOrFallbackData;
+import tech.pegasys.teku.spec.datastructures.execution.BuilderPayloadOrFallbackData;
 import tech.pegasys.teku.spec.datastructures.execution.ClientVersion;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadResult;
@@ -84,7 +84,7 @@ public interface ExecutionLayerChannel extends ChannelInterface {
         }
 
         @Override
-        public SafeFuture<BuilderPayload> builderGetPayload(
+        public SafeFuture<BuilderPayloadOrFallbackData> builderGetPayload(
             final SignedBeaconBlock signedBeaconBlock,
             final Function<UInt64, Optional<ExecutionPayloadResult>>
                 getCachedPayloadResultFunction) {
@@ -132,7 +132,7 @@ public interface ExecutionLayerChannel extends ChannelInterface {
    * ExecutionLayerBlockProductionManager#getUnblindedPayload(SignedBeaconBlock,
    * BlockPublishingPerformance)} instead
    */
-  SafeFuture<BuilderPayload> builderGetPayload(
+  SafeFuture<BuilderPayloadOrFallbackData> builderGetPayload(
       SignedBeaconBlock signedBeaconBlock,
       Function<UInt64, Optional<ExecutionPayloadResult>> getCachedPayloadResultFunction);
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
@@ -55,6 +55,7 @@ import tech.pegasys.teku.spec.datastructures.builder.BuilderPayload;
 import tech.pegasys.teku.spec.datastructures.builder.SignedValidatorRegistration;
 import tech.pegasys.teku.spec.datastructures.execution.BlobsBundle;
 import tech.pegasys.teku.spec.datastructures.execution.BuilderBidOrFallbackData;
+import tech.pegasys.teku.spec.datastructures.execution.BuilderPayloadOrFallbackData;
 import tech.pegasys.teku.spec.datastructures.execution.ClientVersion;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadContext;
@@ -418,7 +419,7 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
   }
 
   @Override
-  public SafeFuture<BuilderPayload> builderGetPayload(
+  public SafeFuture<BuilderPayloadOrFallbackData> builderGetPayload(
       final SignedBeaconBlock signedBeaconBlock,
       final Function<UInt64, Optional<ExecutionPayloadResult>> getCachedPayloadResultFunction) {
     offlineCheck();
@@ -478,7 +479,7 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
             // pre Deneb
             .orElse(lastBuilderPayloadToBeUnblinded.get());
 
-    return SafeFuture.completedFuture(builderPayload);
+    return SafeFuture.completedFuture(BuilderPayloadOrFallbackData.create(builderPayload));
   }
 
   public void setPayloadStatus(PayloadStatus payloadStatus) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Further refactor after https://github.com/Consensys/teku/pull/8215

- `builderGetPayload` in `ExecutionLayerChannel` returning `BuilderPayloadOrFallbackData` (no need of mimicking)
- Logic to select if to use the fallback or not is moved to `BlockOperationSelectorFactory`
- Adapted tests
- Feedback from previous PR

## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
