### PR TITLE
EIP7251 - voluntary exits operation validation

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/SpecLogicAltair.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/altair/SpecLogicAltair.java
@@ -38,6 +38,7 @@ import tech.pegasys.teku.spec.logic.versions.altair.statetransition.epoch.Valida
 import tech.pegasys.teku.spec.logic.versions.bellatrix.helpers.BellatrixTransitionHelpers;
 import tech.pegasys.teku.spec.logic.versions.phase0.operations.validation.AttestationDataValidatorPhase0;
 import tech.pegasys.teku.spec.logic.versions.phase0.operations.validation.OperationValidatorPhase0;
+import tech.pegasys.teku.spec.logic.versions.phase0.operations.validation.VoluntaryExitValidator;
 import tech.pegasys.teku.spec.logic.versions.phase0.util.AttestationUtilPhase0;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsAltair;
 
@@ -110,9 +111,15 @@ public class SpecLogicAltair extends AbstractSpecLogic {
     // execution change
     final AttestationDataValidator attestationDataValidator =
         new AttestationDataValidatorPhase0(config, miscHelpers, beaconStateAccessors);
+    final VoluntaryExitValidator voluntaryExitValidator =
+        new VoluntaryExitValidator(config, predicates, beaconStateAccessors);
     final OperationValidator operationValidator =
         new OperationValidatorPhase0(
-            config, predicates, beaconStateAccessors, attestationDataValidator, attestationUtil);
+            predicates,
+            beaconStateAccessors,
+            attestationDataValidator,
+            attestationUtil,
+            voluntaryExitValidator);
     final ValidatorStatusFactoryAltair validatorStatusFactory =
         new ValidatorStatusFactoryAltair(
             config,

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/bellatrix/SpecLogicBellatrix.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/bellatrix/SpecLogicBellatrix.java
@@ -39,6 +39,7 @@ import tech.pegasys.teku.spec.logic.versions.bellatrix.statetransition.epoch.Epo
 import tech.pegasys.teku.spec.logic.versions.bellatrix.util.BlindBlockUtilBellatrix;
 import tech.pegasys.teku.spec.logic.versions.phase0.operations.validation.AttestationDataValidatorPhase0;
 import tech.pegasys.teku.spec.logic.versions.phase0.operations.validation.OperationValidatorPhase0;
+import tech.pegasys.teku.spec.logic.versions.phase0.operations.validation.VoluntaryExitValidator;
 import tech.pegasys.teku.spec.logic.versions.phase0.util.AttestationUtilPhase0;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsBellatrix;
 
@@ -114,9 +115,15 @@ public class SpecLogicBellatrix extends AbstractSpecLogic {
         new AttestationUtilPhase0(config, schemaDefinitions, beaconStateAccessors, miscHelpers);
     final AttestationDataValidator attestationDataValidator =
         new AttestationDataValidatorPhase0(config, miscHelpers, beaconStateAccessors);
+    final VoluntaryExitValidator voluntaryExitValidator =
+        new VoluntaryExitValidator(config, predicates, beaconStateAccessors);
     final OperationValidator operationValidator =
         new OperationValidatorPhase0(
-            config, predicates, beaconStateAccessors, attestationDataValidator, attestationUtil);
+            predicates,
+            beaconStateAccessors,
+            attestationDataValidator,
+            attestationUtil,
+            voluntaryExitValidator);
     final ValidatorStatusFactoryAltair validatorStatusFactory =
         new ValidatorStatusFactoryAltair(
             config,

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/SpecLogicCapella.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/SpecLogicCapella.java
@@ -40,6 +40,7 @@ import tech.pegasys.teku.spec.logic.versions.capella.helpers.MiscHelpersCapella;
 import tech.pegasys.teku.spec.logic.versions.capella.operations.validation.OperationValidatorCapella;
 import tech.pegasys.teku.spec.logic.versions.capella.statetransition.epoch.EpochProcessorCapella;
 import tech.pegasys.teku.spec.logic.versions.phase0.operations.validation.AttestationDataValidatorPhase0;
+import tech.pegasys.teku.spec.logic.versions.phase0.operations.validation.VoluntaryExitValidator;
 import tech.pegasys.teku.spec.logic.versions.phase0.util.AttestationUtilPhase0;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsCapella;
 
@@ -114,9 +115,15 @@ public class SpecLogicCapella extends AbstractSpecLogic {
         new AttestationUtilPhase0(config, schemaDefinitions, beaconStateAccessors, miscHelpers);
     final AttestationDataValidator attestationDataValidator =
         new AttestationDataValidatorPhase0(config, miscHelpers, beaconStateAccessors);
+    final VoluntaryExitValidator voluntaryExitValidator =
+        new VoluntaryExitValidator(config, predicates, beaconStateAccessors);
     final OperationValidator operationValidator =
         new OperationValidatorCapella(
-            config, predicates, beaconStateAccessors, attestationDataValidator, attestationUtil);
+            predicates,
+            beaconStateAccessors,
+            attestationDataValidator,
+            attestationUtil,
+            voluntaryExitValidator);
     final ValidatorStatusFactoryAltair validatorStatusFactory =
         new ValidatorStatusFactoryAltair(
             config,

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/operations/validation/OperationValidatorCapella.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/capella/operations/validation/OperationValidatorCapella.java
@@ -14,7 +14,6 @@
 package tech.pegasys.teku.spec.logic.versions.capella.operations.validation;
 
 import java.util.Optional;
-import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.datastructures.operations.BlsToExecutionChange;
 import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
@@ -24,6 +23,7 @@ import tech.pegasys.teku.spec.logic.common.operations.validation.AttestationData
 import tech.pegasys.teku.spec.logic.common.operations.validation.OperationInvalidReason;
 import tech.pegasys.teku.spec.logic.common.util.AttestationUtil;
 import tech.pegasys.teku.spec.logic.versions.phase0.operations.validation.OperationValidatorPhase0;
+import tech.pegasys.teku.spec.logic.versions.phase0.operations.validation.VoluntaryExitValidator;
 
 public class OperationValidatorCapella extends OperationValidatorPhase0 {
 
@@ -31,12 +31,17 @@ public class OperationValidatorCapella extends OperationValidatorPhase0 {
       new BlsToExecutionChangesValidator();
 
   public OperationValidatorCapella(
-      final SpecConfig specConfig,
       final Predicates predicates,
       final BeaconStateAccessors beaconStateAccessors,
       final AttestationDataValidator attestationDataValidator,
-      final AttestationUtil attestationUtil) {
-    super(specConfig, predicates, beaconStateAccessors, attestationDataValidator, attestationUtil);
+      final AttestationUtil attestationUtil,
+      final VoluntaryExitValidator voluntaryExitValidator) {
+    super(
+        predicates,
+        beaconStateAccessors,
+        attestationDataValidator,
+        attestationUtil,
+        voluntaryExitValidator);
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/SpecLogicDeneb.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/deneb/SpecLogicDeneb.java
@@ -43,6 +43,7 @@ import tech.pegasys.teku.spec.logic.versions.deneb.helpers.MiscHelpersDeneb;
 import tech.pegasys.teku.spec.logic.versions.deneb.operations.validation.AttestationDataValidatorDeneb;
 import tech.pegasys.teku.spec.logic.versions.deneb.util.AttestationUtilDeneb;
 import tech.pegasys.teku.spec.logic.versions.deneb.util.ForkChoiceUtilDeneb;
+import tech.pegasys.teku.spec.logic.versions.phase0.operations.validation.VoluntaryExitValidator;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsDeneb;
 
 public class SpecLogicDeneb extends AbstractSpecLogic {
@@ -114,9 +115,15 @@ public class SpecLogicDeneb extends AbstractSpecLogic {
         new AttestationUtilDeneb(config, schemaDefinitions, beaconStateAccessors, miscHelpers);
     final AttestationDataValidator attestationDataValidator =
         new AttestationDataValidatorDeneb(config, miscHelpers, beaconStateAccessors);
+    final VoluntaryExitValidator voluntaryExitValidator =
+        new VoluntaryExitValidator(config, predicates, beaconStateAccessors);
     final OperationValidator operationValidator =
         new OperationValidatorCapella(
-            config, predicates, beaconStateAccessors, attestationDataValidator, attestationUtil);
+            predicates,
+            beaconStateAccessors,
+            attestationDataValidator,
+            attestationUtil,
+            voluntaryExitValidator);
     final ValidatorStatusFactoryAltair validatorStatusFactory =
         new ValidatorStatusFactoryAltair(
             config,

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/SpecLogicElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/SpecLogicElectra.java
@@ -44,6 +44,7 @@ import tech.pegasys.teku.spec.logic.versions.electra.helpers.BeaconStateAccessor
 import tech.pegasys.teku.spec.logic.versions.electra.helpers.BeaconStateMutatorsElectra;
 import tech.pegasys.teku.spec.logic.versions.electra.helpers.MiscHelpersElectra;
 import tech.pegasys.teku.spec.logic.versions.electra.helpers.PredicatesElectra;
+import tech.pegasys.teku.spec.logic.versions.electra.operations.validation.VoluntaryExitValidatorElectra;
 import tech.pegasys.teku.spec.logic.versions.electra.statetransition.epoch.EpochProcessorElectra;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsElectra;
 
@@ -116,9 +117,15 @@ public class SpecLogicElectra extends AbstractSpecLogic {
         new AttestationUtilDeneb(config, schemaDefinitions, beaconStateAccessors, miscHelpers);
     final AttestationDataValidator attestationDataValidator =
         new AttestationDataValidatorDeneb(config, miscHelpers, beaconStateAccessors);
+    final VoluntaryExitValidatorElectra voluntaryExitValidatorElectra =
+        new VoluntaryExitValidatorElectra(config, predicates, beaconStateAccessors);
     final OperationValidator operationValidator =
         new OperationValidatorCapella(
-            config, predicates, beaconStateAccessors, attestationDataValidator, attestationUtil);
+            predicates,
+            beaconStateAccessors,
+            attestationDataValidator,
+            attestationUtil,
+            voluntaryExitValidatorElectra);
     final ValidatorStatusFactoryAltair validatorStatusFactory =
         new ValidatorStatusFactoryAltair(
             config,

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/operations/validation/VoluntaryExitValidatorElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/operations/validation/VoluntaryExitValidatorElectra.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.logic.versions.electra.operations.validation;
+
+import static tech.pegasys.teku.spec.logic.common.operations.validation.OperationInvalidReason.check;
+import static tech.pegasys.teku.spec.logic.common.operations.validation.OperationInvalidReason.firstOf;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.util.Optional;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.config.SpecConfig;
+import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
+import tech.pegasys.teku.spec.datastructures.state.Fork;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.electra.BeaconStateElectra;
+import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
+import tech.pegasys.teku.spec.logic.common.helpers.Predicates;
+import tech.pegasys.teku.spec.logic.common.operations.validation.OperationInvalidReason;
+import tech.pegasys.teku.spec.logic.versions.electra.helpers.BeaconStateAccessorsElectra;
+import tech.pegasys.teku.spec.logic.versions.phase0.operations.validation.VoluntaryExitValidator;
+
+public class VoluntaryExitValidatorElectra extends VoluntaryExitValidator {
+  private final BeaconStateAccessorsElectra stateAccessorsElectra;
+
+  public VoluntaryExitValidatorElectra(
+      final SpecConfig specConfig,
+      final Predicates predicates,
+      final BeaconStateAccessors beaconStateAccessors) {
+    super(specConfig, predicates, beaconStateAccessors);
+    this.stateAccessorsElectra = BeaconStateAccessorsElectra.required(beaconStateAccessors);
+  }
+
+  @Override
+  public Optional<OperationInvalidReason> validate(
+      final Fork fork, final BeaconState state, final SignedVoluntaryExit signedExit) {
+    final BeaconStateElectra stateElectra = BeaconStateElectra.required(state);
+    return firstOf(
+        () -> super.validate(fork, state, signedExit),
+        () -> validateElectraConditions(stateElectra, signedExit));
+  }
+
+  @VisibleForTesting
+  Optional<OperationInvalidReason> validateElectraConditions(
+      final BeaconStateElectra stateElectra, final SignedVoluntaryExit exit) {
+    final int validatorId = exit.getValidatorId();
+    return check(
+        stateAccessorsElectra
+            .getPendingBalanceToWithdraw(stateElectra, validatorId)
+            .equals(UInt64.ZERO),
+        VoluntaryExitValidator.ExitInvalidReason.pendingWithdrawalsInQueue());
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/SpecLogicPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/SpecLogicPhase0.java
@@ -35,6 +35,7 @@ import tech.pegasys.teku.spec.logic.versions.phase0.block.BlockProcessorPhase0;
 import tech.pegasys.teku.spec.logic.versions.phase0.helpers.BeaconStateAccessorsPhase0;
 import tech.pegasys.teku.spec.logic.versions.phase0.operations.validation.AttestationDataValidatorPhase0;
 import tech.pegasys.teku.spec.logic.versions.phase0.operations.validation.OperationValidatorPhase0;
+import tech.pegasys.teku.spec.logic.versions.phase0.operations.validation.VoluntaryExitValidator;
 import tech.pegasys.teku.spec.logic.versions.phase0.statetransition.epoch.EpochProcessorPhase0;
 import tech.pegasys.teku.spec.logic.versions.phase0.statetransition.epoch.ValidatorStatusFactoryPhase0;
 import tech.pegasys.teku.spec.logic.versions.phase0.util.AttestationUtilPhase0;
@@ -100,9 +101,15 @@ public class SpecLogicPhase0 extends AbstractSpecLogic {
         new AttestationUtilPhase0(config, schemaDefinitions, beaconStateAccessors, miscHelpers);
     final AttestationDataValidator attestationDataValidator =
         new AttestationDataValidatorPhase0(config, miscHelpers, beaconStateAccessors);
+    final VoluntaryExitValidator voluntaryExitValidator =
+        new VoluntaryExitValidator(config, predicates, beaconStateAccessors);
     final OperationValidator operationValidator =
         new OperationValidatorPhase0(
-            config, predicates, beaconStateAccessors, attestationDataValidator, attestationUtil);
+            predicates,
+            beaconStateAccessors,
+            attestationDataValidator,
+            attestationUtil,
+            voluntaryExitValidator);
     final ValidatorStatusFactoryPhase0 validatorStatusFactory =
         new ValidatorStatusFactoryPhase0(
             config, beaconStateUtil, attestationUtil, beaconStateAccessors, predicates);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/operations/validation/OperationValidatorPhase0.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/operations/validation/OperationValidatorPhase0.java
@@ -14,7 +14,6 @@
 package tech.pegasys.teku.spec.logic.versions.phase0.operations.validation;
 
 import java.util.Optional;
-import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.BlsToExecutionChange;
@@ -38,18 +37,17 @@ public class OperationValidatorPhase0 implements OperationValidator {
   private final VoluntaryExitValidator voluntaryExitValidator;
 
   public OperationValidatorPhase0(
-      final SpecConfig specConfig,
       final Predicates predicates,
       final BeaconStateAccessors beaconStateAccessors,
       final AttestationDataValidator attestationDataValidator,
-      final AttestationUtil attestationUtil) {
+      final AttestationUtil attestationUtil,
+      final VoluntaryExitValidator voluntaryExitValidator) {
     this.attestationDataValidator = attestationDataValidator;
     this.attesterSlashingValidator =
         new AttesterSlashingValidator(predicates, beaconStateAccessors, attestationUtil);
     this.proposerSlashingValidator =
         new ProposerSlashingValidator(predicates, beaconStateAccessors);
-    this.voluntaryExitValidator =
-        new VoluntaryExitValidator(specConfig, predicates, beaconStateAccessors);
+    this.voluntaryExitValidator = voluntaryExitValidator;
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/operations/validation/VoluntaryExitValidator.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/phase0/operations/validation/VoluntaryExitValidator.java
@@ -37,7 +37,7 @@ public class VoluntaryExitValidator
   private final Predicates predicates;
   private final BeaconStateAccessors beaconStateAccessors;
 
-  VoluntaryExitValidator(
+  public VoluntaryExitValidator(
       final SpecConfig specConfig,
       final Predicates predicates,
       final BeaconStateAccessors beaconStateAccessors) {
@@ -49,7 +49,7 @@ public class VoluntaryExitValidator
   @Override
   public Optional<OperationInvalidReason> validate(
       final Fork fork, final BeaconState state, final SignedVoluntaryExit signedExit) {
-    VoluntaryExit exit = signedExit.getMessage();
+    final VoluntaryExit exit = signedExit.getMessage();
     return firstOf(
         () ->
             check(
@@ -108,6 +108,11 @@ public class VoluntaryExitValidator
 
     public static OperationInvalidReason invalidSignature() {
       return () -> "Signature is invalid";
+    }
+
+    public static OperationInvalidReason pendingWithdrawalsInQueue() {
+      return () ->
+          "Validator cannot be exited while there are pending withdrawals in the withdrawal queue";
     }
   }
 }

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/electra/operations/validation/VoluntaryExitValidatorElectraTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/electra/operations/validation/VoluntaryExitValidatorElectraTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.logic.versions.electra.operations.validation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.bls.BLSKeyPair;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.interop.MockStartValidatorKeyPairFactory;
+import tech.pegasys.teku.spec.datastructures.operations.SignedVoluntaryExit;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.electra.BeaconStateElectra;
+import tech.pegasys.teku.spec.logic.versions.electra.helpers.BeaconStateAccessorsElectra;
+import tech.pegasys.teku.spec.logic.versions.electra.helpers.PredicatesElectra;
+import tech.pegasys.teku.spec.logic.versions.phase0.operations.validation.VoluntaryExitValidator;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.statetransition.BeaconChainUtil;
+import tech.pegasys.teku.storage.client.MemoryOnlyRecentChainData;
+import tech.pegasys.teku.storage.client.RecentChainData;
+
+class VoluntaryExitValidatorElectraTest {
+  private static final List<BLSKeyPair> VALIDATOR_KEYS =
+      new MockStartValidatorKeyPairFactory().generateKeyPairs(0, 25);
+
+  private RecentChainData recentChainData;
+  private final Spec spec = TestSpecFactory.createMinimalElectra();
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+
+  private VoluntaryExitValidatorElectra validatorElectra;
+
+  private final PredicatesElectra predicates = new PredicatesElectra(spec.getGenesisSpecConfig());
+  private final BeaconStateAccessorsElectra stateAccessors =
+      mock(BeaconStateAccessorsElectra.class);
+
+  @BeforeEach
+  void setup() throws Exception {
+    recentChainData = MemoryOnlyRecentChainData.create(spec);
+    final BeaconChainUtil beaconChainUtil =
+        BeaconChainUtil.create(spec, recentChainData, VALIDATOR_KEYS, true);
+    validatorElectra =
+        new VoluntaryExitValidatorElectra(spec.getGenesisSpecConfig(), predicates, stateAccessors);
+
+    beaconChainUtil.initializeStorage();
+    beaconChainUtil.createAndImportBlockAtSlot(6);
+  }
+
+  @Test
+  public void shouldAcceptValidVoluntaryExit() throws Exception {
+    when(stateAccessors.getPendingBalanceToWithdraw(any(), anyInt())).thenReturn(UInt64.ZERO);
+
+    final SignedVoluntaryExit exit =
+        dataStructureUtil.randomSignedVoluntaryExit(dataStructureUtil.randomUInt64(24));
+    final BeaconStateElectra stateElectra =
+        BeaconStateElectra.required(recentChainData.getBestState().orElseThrow().get());
+    assertThat(validatorElectra.validateElectraConditions(stateElectra, exit)).isEmpty();
+  }
+
+  @Test
+  public void shouldRejectValidVoluntaryExitWithPendingWithdrawals() throws Exception {
+    when(stateAccessors.getPendingBalanceToWithdraw(any(), anyInt())).thenReturn(UInt64.ONE);
+
+    final SignedVoluntaryExit exit =
+        dataStructureUtil.randomSignedVoluntaryExit(dataStructureUtil.randomUInt64(24));
+    final BeaconStateElectra stateElectra =
+        BeaconStateElectra.required(recentChainData.getBestState().orElseThrow().get());
+    assertThat(validatorElectra.validateElectraConditions(stateElectra, exit))
+        .contains(VoluntaryExitValidator.ExitInvalidReason.pendingWithdrawalsInQueue());
+  }
+}

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/phase0/operations/validation/OperationValidatorPhase0Test.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/phase0/operations/validation/OperationValidatorPhase0Test.java
@@ -18,7 +18,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoInteractions;
 
 import org.junit.jupiter.api.Test;
-import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.datastructures.operations.BlsToExecutionChange;
 import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
@@ -33,27 +32,27 @@ public class OperationValidatorPhase0Test {
 
   @Test
   void shouldRejectBlsOperationsPhase0() {
-    final SpecConfig specConfig = mock(SpecConfig.class);
     final Predicates predicates = mock(Predicates.class);
     final BeaconStateAccessors beaconStateAccessors = mock(BeaconStateAccessors.class);
     final AttestationDataValidator attestationDataValidator = mock(AttestationDataValidator.class);
     final AttestationUtil attestationUtil = mock(AttestationUtil.class);
+    final VoluntaryExitValidator voluntaryExitValidator = mock(VoluntaryExitValidator.class);
     final OperationValidator operationValidator =
         new OperationValidatorPhase0(
-            specConfig,
             predicates,
             beaconStateAccessors,
             attestationDataValidator,
-            attestationUtil);
+            attestationUtil,
+            voluntaryExitValidator);
 
     assertThat(
             operationValidator.validateBlsToExecutionChange(
                 mock(Fork.class), mock(BeaconState.class), mock(BlsToExecutionChange.class)))
         .containsInstanceOf(OperationInvalidReason.class);
-    verifyNoInteractions(specConfig);
     verifyNoInteractions(predicates);
     verifyNoInteractions(beaconStateAccessors);
     verifyNoInteractions(attestationDataValidator);
     verifyNoInteractions(attestationUtil);
+    verifyNoInteractions(voluntaryExitValidator);
   }
 }


### PR DESCRIPTION
Extended the voluntary exits validation for electra, where voluntary exits can't be processed if there are pending withdrawals in the queue.

Structured this validation to be individually tested but didn't refactor the rest. also looks like a lot of the specLogic classes have heavily duplicated code but this is not really new, so I left it.

partially addresses #8149

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
