### PR TITLE
Block Production\Publishing Performance threshold based on flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ the [releases page](https://github.com/Consensys/teku/releases).
 ## Unreleased Changes
 
 ### Breaking Changes
-- Removed support for Goerli test network `--network=goerli`.
+- Removed support for the Goerli network `--network=goerli`.
 
 ### Additions and Improvements
 - Increased the executor queue default maximum size to 40_000 (previously 20_000), and other queues to 10_000 (previously 5_000). If you have custom settings for these queues, check to ensure they're still required.
@@ -19,7 +19,7 @@ the [releases page](https://github.com/Consensys/teku/releases).
 - Added hidden option `--Xdeposit-contract-logs-syncing-enabled` to allow disabling the syncing of the deposit contract logs from the EL. This is useful when running a non-validating node. It is advisable to be used alongside with `--Xeth1-missing-deposits-event-logging-enabled=false` to avoid unnecessary logging of missing deposits.
 - Updated the bootnodes for Chiado and Gnosis networks.
 - Added hidden option `--Xp2p-dumps-to-file-enabled` to enable saving p2p dumps to file.
-- Appends consensus layer (CL) and execution layer (EL) clients' information to the validator graffiti. Check [documentation](https://docs.teku.consensys.io/development/reference/cli#validators-graffiti-client-append-format) for available configuration options.
+- Consensus layer (CL) and execution layer (EL) clients' information will be appended to the validator graffiti. Check [documentation](https://docs.teku.consensys.io/development/reference/cli#validators-graffiti-client-append-format) for the available configuration options.
 - Added support for [Graffiti management](https://ethereum.github.io/keymanager-APIs/?urls.primaryName=dev#/Graffiti) in the Key Manager API.
 
 ### Bug Fixes

--- a/beacon/validator/src/integrationTest/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerIntegrationTest.java
+++ b/beacon/validator/src/integrationTest/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerIntegrationTest.java
@@ -21,6 +21,7 @@ import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThat
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -122,7 +123,7 @@ public class ValidatorApiHandlerIntegrationTest {
           syncCommitteeContributionPool,
           syncCommitteeSubscriptionManager,
           new BlockProductionAndPublishingPerformanceFactory(
-              new SystemTimeProvider(), __ -> UInt64.ZERO, true, 0, 0));
+              new SystemTimeProvider(), __ -> UInt64.ZERO, true, List.of(0, 0), List.of(0, 0)));
 
   @BeforeEach
   public void setup() {

--- a/beacon/validator/src/integrationTest/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerIntegrationTest.java
+++ b/beacon/validator/src/integrationTest/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerIntegrationTest.java
@@ -21,7 +21,6 @@ import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.assertThat
 import static tech.pegasys.teku.infrastructure.async.SafeFutureAssert.safeJoin;
 import static tech.pegasys.teku.infrastructure.unsigned.UInt64.ONE;
 
-import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -123,7 +122,7 @@ public class ValidatorApiHandlerIntegrationTest {
           syncCommitteeContributionPool,
           syncCommitteeSubscriptionManager,
           new BlockProductionAndPublishingPerformanceFactory(
-              new SystemTimeProvider(), __ -> UInt64.ZERO, true, List.of(0, 0), List.of(0, 0)));
+              new SystemTimeProvider(), __ -> UInt64.ZERO, true, 0, 0, 0, 0));
 
   @BeforeEach
   public void setup() {

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
@@ -187,6 +187,8 @@ public class BlockOperationSelectorFactory {
       }
 
       final SafeFuture<Void> blockProductionComplete;
+
+      // In `setExecutionData` the following fields are set:
       // Post-Bellatrix: Execution Payload / Execution Payload Header
       // Post-Deneb: KZG Commitments
       if (bodyBuilder.supportsExecutionPayload()) {

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
@@ -162,13 +162,13 @@ public class BlockOperationSelectorFactory {
 
       // Optional fields introduced in later forks
 
-      // Sync aggregate
+      // Post-Altair: Sync aggregate
       if (bodyBuilder.supportsSyncAggregate()) {
         bodyBuilder.syncAggregate(
             contributionPool.createSyncAggregateForBlock(blockSlotState.getSlot(), parentRoot));
       }
 
-      // BLS to Execution changes
+      // Post-Capella: BLS to Execution changes
       if (bodyBuilder.supportsBlsToExecutionChanges()) {
         bodyBuilder.blsToExecutionChanges(
             blsToExecutionChangePool.getItemsForBlock(blockSlotState));
@@ -177,16 +177,17 @@ public class BlockOperationSelectorFactory {
       final SchemaDefinitions schemaDefinitions =
           spec.atSlot(blockSlotState.getSlot()).getSchemaDefinitions();
 
-      // Post-electra: consolidations supported
+      // Post-Electra: Consolidations
       if (bodyBuilder.supportsConsolidations()) {
-        // devnet0 blocks are empty of consolidations, so just default their list.
+        // devnet-0 blocks are empty of consolidations, so just default their list.
         bodyBuilder.consolidations(
             SchemaDefinitionsElectra.required(schemaDefinitions)
                 .getConsolidationsSchema()
                 .createFromElements(List.of()));
       }
 
-      // Execution Payload / Execution Payload Header / KZG Commitments
+      // Post-Bellatrix: Execution Payload / Execution Payload Header
+      // Post-Deneb: KZG Commitments
       final SafeFuture<Void> blockProductionComplete;
       if (bodyBuilder.supportsExecutionPayload()) {
         blockProductionComplete =

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/BlockOperationSelectorFactory.java
@@ -186,9 +186,9 @@ public class BlockOperationSelectorFactory {
                 .createFromElements(List.of()));
       }
 
+      final SafeFuture<Void> blockProductionComplete;
       // Post-Bellatrix: Execution Payload / Execution Payload Header
       // Post-Deneb: KZG Commitments
-      final SafeFuture<Void> blockProductionComplete;
       if (bodyBuilder.supportsExecutionPayload()) {
         blockProductionComplete =
             forkChoiceNotifier

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -175,7 +175,7 @@ class ValidatorApiHandlerTest {
 
   private final BlockProductionAndPublishingPerformanceFactory blockProductionPerformanceFactory =
       new BlockProductionAndPublishingPerformanceFactory(
-          StubTimeProvider.withTimeInMillis(0), __ -> ZERO, false, 0, 0);
+          StubTimeProvider.withTimeInMillis(0), __ -> ZERO, false, List.of(0, 0), List.of(0, 0));
 
   private Spec spec;
   private UInt64 epochStartSlot;

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/ValidatorApiHandlerTest.java
@@ -175,7 +175,7 @@ class ValidatorApiHandlerTest {
 
   private final BlockProductionAndPublishingPerformanceFactory blockProductionPerformanceFactory =
       new BlockProductionAndPublishingPerformanceFactory(
-          StubTimeProvider.withTimeInMillis(0), __ -> ZERO, false, List.of(0, 0), List.of(0, 0));
+          StubTimeProvider.withTimeInMillis(0), __ -> ZERO, false, 0, 0, 0, 0);
 
   private Spec spec;
   private UInt64 epochStartSlot;

--- a/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerBlockProductionManagerImpl.java
+++ b/ethereum/executionlayer/src/main/java/tech/pegasys/teku/ethereum/executionlayer/ExecutionLayerBlockProductionManagerImpl.java
@@ -91,10 +91,9 @@ public class ExecutionLayerBlockProductionManagerImpl
     return executionLayerChannel
         .builderGetPayload(signedBeaconBlock, this::getCachedPayloadResult)
         .thenPeek(
-            builderPayloadOrFallbackData -> {
-              builderResultCache.put(signedBeaconBlock.getSlot(), builderPayloadOrFallbackData);
-              blockPublishingPerformance.builderGetPayload();
-            });
+            builderPayloadOrFallbackData ->
+                builderResultCache.put(signedBeaconBlock.getSlot(), builderPayloadOrFallbackData))
+        .alwaysRun(blockPublishingPerformance::builderGetPayload);
   }
 
   @Override
@@ -109,7 +108,7 @@ public class ExecutionLayerBlockProductionManagerImpl
     final SafeFuture<GetPayloadResponse> getPayloadResponseFuture =
         executionLayerChannel
             .engineGetPayload(context, blockSlotState)
-            .thenPeek(__ -> blockProductionPerformance.engineGetPayload());
+            .alwaysRun(blockProductionPerformance::engineGetPayload);
 
     return ExecutionPayloadResult.createForLocalFlow(context, getPayloadResponseFuture);
   }

--- a/ethereum/performance-trackers/src/main/java/tech/pegasys/teku/ethereum/performance/trackers/BlockProductionAndPublishingPerformanceFactory.java
+++ b/ethereum/performance-trackers/src/main/java/tech/pegasys/teku/ethereum/performance/trackers/BlockProductionAndPublishingPerformanceFactory.java
@@ -13,28 +13,31 @@
 
 package tech.pegasys.teku.ethereum.performance.trackers;
 
+import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 public class BlockProductionAndPublishingPerformanceFactory {
+
   private final TimeProvider timeProvider;
-  private final boolean enabled;
-  private final int lateProductionEventThreshold;
-  private final int latePublishingEventThreshold;
   private final Function<UInt64, UInt64> slotTimeCalculator;
+  private final boolean enabled;
+  private final Map<Flow, Integer> lateProductionEventThreshold;
+  private final Map<Flow, Integer> latePublishingEventThreshold;
 
   public BlockProductionAndPublishingPerformanceFactory(
       final TimeProvider timeProvider,
       final Function<UInt64, UInt64> slotTimeCalculator,
       final boolean enabled,
-      final int lateProductionEventThreshold,
-      final int latePublishingEventThreshold) {
+      final List<Integer> lateProductionEventThreshold,
+      final List<Integer> latePublishingEventThreshold) {
     this.timeProvider = timeProvider;
     this.slotTimeCalculator = slotTimeCalculator;
     this.enabled = enabled;
-    this.lateProductionEventThreshold = lateProductionEventThreshold;
-    this.latePublishingEventThreshold = latePublishingEventThreshold;
+    this.lateProductionEventThreshold = convertToMap(lateProductionEventThreshold);
+    this.latePublishingEventThreshold = convertToMap(latePublishingEventThreshold);
   }
 
   public BlockProductionPerformance createForProduction(final UInt64 slot) {
@@ -53,5 +56,13 @@ public class BlockProductionAndPublishingPerformanceFactory {
     } else {
       return BlockPublishingPerformance.NOOP;
     }
+  }
+
+  /**
+   * @param lateThreshold the first element in the list will be the LOCAL late threshold. The second
+   *     element will be the BUILDER late threshold
+   */
+  private Map<Flow, Integer> convertToMap(final List<Integer> lateThreshold) {
+    return Map.of(Flow.LOCAL, lateThreshold.get(0), Flow.BUILDER, lateThreshold.get(1));
   }
 }

--- a/ethereum/performance-trackers/src/main/java/tech/pegasys/teku/ethereum/performance/trackers/BlockProductionPerformanceImpl.java
+++ b/ethereum/performance-trackers/src/main/java/tech/pegasys/teku/ethereum/performance/trackers/BlockProductionPerformanceImpl.java
@@ -26,7 +26,7 @@ public class BlockProductionPerformanceImpl implements BlockProductionPerformanc
   private final UInt64 slotTime;
   private final Map<Flow, Integer> lateThresholds;
 
-  private Flow flow = Flow.LOCAL;
+  private volatile Flow flow = Flow.LOCAL;
 
   BlockProductionPerformanceImpl(
       final TimeProvider timeProvider,

--- a/ethereum/performance-trackers/src/main/java/tech/pegasys/teku/ethereum/performance/trackers/BlockProductionPerformanceImpl.java
+++ b/ethereum/performance-trackers/src/main/java/tech/pegasys/teku/ethereum/performance/trackers/BlockProductionPerformanceImpl.java
@@ -24,7 +24,7 @@ public class BlockProductionPerformanceImpl implements BlockProductionPerformanc
   private final PerformanceTracker performanceTracker;
   private final UInt64 slot;
   private final UInt64 slotTime;
-  private final Map<Flow, Integer> lateThreshold;
+  private final Map<Flow, Integer> lateThresholds;
 
   private Flow flow = Flow.LOCAL;
 
@@ -32,9 +32,9 @@ public class BlockProductionPerformanceImpl implements BlockProductionPerformanc
       final TimeProvider timeProvider,
       final UInt64 slot,
       final UInt64 slotTime,
-      final Map<Flow, Integer> lateThreshold) {
+      final Map<Flow, Integer> lateThresholds) {
     this.performanceTracker = new PerformanceTracker(timeProvider);
-    this.lateThreshold = lateThreshold;
+    this.lateThresholds = lateThresholds;
     this.slot = slot;
     this.slotTime = slotTime;
     performanceTracker.addEvent("start");
@@ -44,7 +44,7 @@ public class BlockProductionPerformanceImpl implements BlockProductionPerformanc
   public void complete() {
     final UInt64 completionTime = performanceTracker.addEvent(COMPLETE_LABEL);
     final boolean isLateEvent =
-        completionTime.minusMinZero(slotTime).isGreaterThan(lateThreshold.get(flow));
+        completionTime.minusMinZero(slotTime).isGreaterThan(lateThresholds.get(flow));
     performanceTracker.report(
         slotTime,
         isLateEvent,

--- a/ethereum/performance-trackers/src/main/java/tech/pegasys/teku/ethereum/performance/trackers/BlockProductionPerformanceImpl.java
+++ b/ethereum/performance-trackers/src/main/java/tech/pegasys/teku/ethereum/performance/trackers/BlockProductionPerformanceImpl.java
@@ -13,22 +13,26 @@
 
 package tech.pegasys.teku.ethereum.performance.trackers;
 
+import java.util.Map;
 import tech.pegasys.teku.infrastructure.logging.EventLogger;
 import tech.pegasys.teku.infrastructure.time.PerformanceTracker;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 public class BlockProductionPerformanceImpl implements BlockProductionPerformance {
+
   private final PerformanceTracker performanceTracker;
   private final UInt64 slot;
   private final UInt64 slotTime;
-  private final int lateThreshold;
+  private final Map<Flow, Integer> lateThreshold;
+
+  private Flow flow = Flow.LOCAL;
 
   BlockProductionPerformanceImpl(
       final TimeProvider timeProvider,
       final UInt64 slot,
       final UInt64 slotTime,
-      final int lateThreshold) {
+      final Map<Flow, Integer> lateThreshold) {
     this.performanceTracker = new PerformanceTracker(timeProvider);
     this.lateThreshold = lateThreshold;
     this.slot = slot;
@@ -39,7 +43,8 @@ public class BlockProductionPerformanceImpl implements BlockProductionPerformanc
   @Override
   public void complete() {
     final UInt64 completionTime = performanceTracker.addEvent(COMPLETE_LABEL);
-    final boolean isLateEvent = completionTime.minusMinZero(slotTime).isGreaterThan(lateThreshold);
+    final boolean isLateEvent =
+        completionTime.minusMinZero(slotTime).isGreaterThan(lateThreshold.get(flow));
     performanceTracker.report(
         slotTime,
         isLateEvent,
@@ -82,6 +87,8 @@ public class BlockProductionPerformanceImpl implements BlockProductionPerformanc
   @Override
   public void builderGetHeader() {
     performanceTracker.addEvent("builder_get_header");
+    // set the flow to BUILDER when builderGetHeader has been called
+    flow = Flow.BUILDER;
   }
 
   @Override

--- a/ethereum/performance-trackers/src/main/java/tech/pegasys/teku/ethereum/performance/trackers/BlockPublishingPerformanceImpl.java
+++ b/ethereum/performance-trackers/src/main/java/tech/pegasys/teku/ethereum/performance/trackers/BlockPublishingPerformanceImpl.java
@@ -24,7 +24,7 @@ public class BlockPublishingPerformanceImpl implements BlockPublishingPerformanc
   private final PerformanceTracker performanceTracker;
   private final UInt64 slot;
   private final UInt64 slotTime;
-  private final Map<Flow, Integer> lateThreshold;
+  private final Map<Flow, Integer> lateThresholds;
 
   private Flow flow = Flow.LOCAL;
 
@@ -32,9 +32,9 @@ public class BlockPublishingPerformanceImpl implements BlockPublishingPerformanc
       final TimeProvider timeProvider,
       final UInt64 slot,
       final UInt64 slotTime,
-      final Map<Flow, Integer> lateThreshold) {
+      final Map<Flow, Integer> lateThresholds) {
     this.performanceTracker = new PerformanceTracker(timeProvider);
-    this.lateThreshold = lateThreshold;
+    this.lateThresholds = lateThresholds;
     this.slot = slot;
     this.slotTime = slotTime;
     performanceTracker.addEvent("start");
@@ -44,7 +44,7 @@ public class BlockPublishingPerformanceImpl implements BlockPublishingPerformanc
   public void complete() {
     final UInt64 completionTime = performanceTracker.addEvent(COMPLETE_LABEL);
     final boolean isLateEvent =
-        completionTime.minusMinZero(slotTime).isGreaterThan(lateThreshold.get(flow));
+        completionTime.minusMinZero(slotTime).isGreaterThan(lateThresholds.get(flow));
     performanceTracker.report(
         slotTime,
         isLateEvent,

--- a/ethereum/performance-trackers/src/main/java/tech/pegasys/teku/ethereum/performance/trackers/BlockPublishingPerformanceImpl.java
+++ b/ethereum/performance-trackers/src/main/java/tech/pegasys/teku/ethereum/performance/trackers/BlockPublishingPerformanceImpl.java
@@ -13,22 +13,26 @@
 
 package tech.pegasys.teku.ethereum.performance.trackers;
 
+import java.util.Map;
 import tech.pegasys.teku.infrastructure.logging.EventLogger;
 import tech.pegasys.teku.infrastructure.time.PerformanceTracker;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
 public class BlockPublishingPerformanceImpl implements BlockPublishingPerformance {
+
   private final PerformanceTracker performanceTracker;
   private final UInt64 slot;
   private final UInt64 slotTime;
-  private final int lateThreshold;
+  private final Map<Flow, Integer> lateThreshold;
+
+  private Flow flow = Flow.LOCAL;
 
   BlockPublishingPerformanceImpl(
       final TimeProvider timeProvider,
       final UInt64 slot,
       final UInt64 slotTime,
-      final int lateThreshold) {
+      final Map<Flow, Integer> lateThreshold) {
     this.performanceTracker = new PerformanceTracker(timeProvider);
     this.lateThreshold = lateThreshold;
     this.slot = slot;
@@ -39,7 +43,8 @@ public class BlockPublishingPerformanceImpl implements BlockPublishingPerformanc
   @Override
   public void complete() {
     final UInt64 completionTime = performanceTracker.addEvent(COMPLETE_LABEL);
-    final boolean isLateEvent = completionTime.minusMinZero(slotTime).isGreaterThan(lateThreshold);
+    final boolean isLateEvent =
+        completionTime.minusMinZero(slotTime).isGreaterThan(lateThreshold.get(flow));
     performanceTracker.report(
         slotTime,
         isLateEvent,
@@ -52,6 +57,8 @@ public class BlockPublishingPerformanceImpl implements BlockPublishingPerformanc
   @Override
   public void builderGetPayload() {
     performanceTracker.addEvent("builder_get_payload");
+    // set the flow to BUILDER when builderGetPayload has been called
+    flow = Flow.BUILDER;
   }
 
   @Override

--- a/ethereum/performance-trackers/src/main/java/tech/pegasys/teku/ethereum/performance/trackers/BlockPublishingPerformanceImpl.java
+++ b/ethereum/performance-trackers/src/main/java/tech/pegasys/teku/ethereum/performance/trackers/BlockPublishingPerformanceImpl.java
@@ -26,7 +26,7 @@ public class BlockPublishingPerformanceImpl implements BlockPublishingPerformanc
   private final UInt64 slotTime;
   private final Map<Flow, Integer> lateThresholds;
 
-  private Flow flow = Flow.LOCAL;
+  private volatile Flow flow = Flow.LOCAL;
 
   BlockPublishingPerformanceImpl(
       final TimeProvider timeProvider,

--- a/ethereum/performance-trackers/src/main/java/tech/pegasys/teku/ethereum/performance/trackers/Flow.java
+++ b/ethereum/performance-trackers/src/main/java/tech/pegasys/teku/ethereum/performance/trackers/Flow.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.ethereum.performance.trackers;
+
+public enum Flow {
+  LOCAL,
+  BUILDER
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/executionlayer/ExecutionLayerChannelStub.java
@@ -372,7 +372,7 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
         SchemaDefinitionsBellatrix.required(spec.atSlot(slot).getSchemaDefinitions());
 
     return engineGetPayload(executionPayloadContext, state)
-        .thenPeek(__ -> blockProductionPerformance.engineGetPayload())
+        .alwaysRun(blockProductionPerformance::engineGetPayload)
         .thenApply(
             getPayloadResponse -> {
               final ExecutionPayload executionPayload = getPayloadResponse.getExecutionPayload();
@@ -415,7 +415,7 @@ public class ExecutionLayerChannelStub implements ExecutionLayerChannel {
                           });
               return BuilderBidOrFallbackData.create(builderBid);
             })
-        .thenPeek(__ -> blockProductionPerformance.builderGetHeader());
+        .alwaysRun(blockProductionPerformance::builderGetHeader);
   }
 
   @Override

--- a/infrastructure/metrics/src/main/java/tech/pegasys/teku/infrastructure/metrics/MetricsConfig.java
+++ b/infrastructure/metrics/src/main/java/tech/pegasys/teku/infrastructure/metrics/MetricsConfig.java
@@ -40,11 +40,13 @@ public class MetricsConfig {
   public static final int DEFAULT_METRICS_PUBLICATION_INTERVAL = 60;
   public static final boolean DEFAULT_BLOCK_PERFORMANCE_ENABLED = true;
   public static final boolean DEFAULT_TICK_PERFORMANCE_ENABLED = false;
+
   public static final boolean DEFAULT_BLOCK_PRODUCTION_AND_PUBLISHING_PERFORMANCE_ENABLED = true;
-  public static final List<Integer> DEFAULT_BLOCK_PRODUCTION_PERFORMANCE_WARNING_THRESHOLD =
-      List.of(300, 750);
-  public static final List<Integer> DEFAULT_BLOCK_PUBLISHING_PERFORMANCE_WARNING_THRESHOLD =
-      List.of(1000, 1500);
+  public static final int DEFAULT_BLOCK_PRODUCTION_PERFORMANCE_WARNING_LOCAL_THRESHOLD = 600;
+  public static final int DEFAULT_BLOCK_PRODUCTION_PERFORMANCE_WARNING_BUILDER_THRESHOLD = 1000;
+  public static final int DEFAULT_BLOCK_PUBLISHING_PERFORMANCE_WARNING_LOCAL_THRESHOLD = 750;
+  public static final int DEFAULT_BLOCK_PUBLISHING_PERFORMANCE_WARNING_BUILDER_THRESHOLD = 1500;
+
   public static final boolean DEFAULT_BLOB_SIDECARS_STORAGE_COUNTERS_ENABLED = false;
 
   private final boolean metricsEnabled;
@@ -59,8 +61,10 @@ public class MetricsConfig {
   private final boolean tickPerformanceEnabled;
   private final boolean blobSidecarsStorageCountersEnabled;
   private final boolean blockProductionAndPublishingPerformanceEnabled;
-  private final List<Integer> blockProductionPerformanceWarningThreshold;
-  private final List<Integer> blockPublishingPerformanceWarningThreshold;
+  private final int blockProductionPerformanceWarningLocalThreshold;
+  private final int blockProductionPerformanceWarningBuilderThreshold;
+  private final int blockPublishingPerformanceWarningLocalThreshold;
+  private final int blockPublishingPerformanceWarningBuilderThreshold;
 
   private MetricsConfig(
       final boolean metricsEnabled,
@@ -75,8 +79,10 @@ public class MetricsConfig {
       final boolean tickPerformanceEnabled,
       final boolean blobSidecarsStorageCountersEnabled,
       final boolean blockProductionAndPublishingPerformanceEnabled,
-      final List<Integer> blockProductionPerformanceWarningThreshold,
-      final List<Integer> blockPublishingPerformanceWarningThreshold) {
+      final int blockProductionPerformanceWarningLocalThreshold,
+      final int blockProductionPerformanceWarningBuilderThreshold,
+      final int blockPublishingPerformanceWarningLocalThreshold,
+      final int blockPublishingPerformanceWarningBuilderThreshold) {
     this.metricsEnabled = metricsEnabled;
     this.metricsPort = metricsPort;
     this.metricsInterface = metricsInterface;
@@ -90,8 +96,14 @@ public class MetricsConfig {
     this.blobSidecarsStorageCountersEnabled = blobSidecarsStorageCountersEnabled;
     this.blockProductionAndPublishingPerformanceEnabled =
         blockProductionAndPublishingPerformanceEnabled;
-    this.blockProductionPerformanceWarningThreshold = blockProductionPerformanceWarningThreshold;
-    this.blockPublishingPerformanceWarningThreshold = blockPublishingPerformanceWarningThreshold;
+    this.blockProductionPerformanceWarningLocalThreshold =
+        blockProductionPerformanceWarningLocalThreshold;
+    this.blockProductionPerformanceWarningBuilderThreshold =
+        blockProductionPerformanceWarningBuilderThreshold;
+    this.blockPublishingPerformanceWarningLocalThreshold =
+        blockPublishingPerformanceWarningLocalThreshold;
+    this.blockPublishingPerformanceWarningBuilderThreshold =
+        blockPublishingPerformanceWarningBuilderThreshold;
   }
 
   public static MetricsConfigBuilder builder() {
@@ -138,12 +150,20 @@ public class MetricsConfig {
     return blockProductionAndPublishingPerformanceEnabled;
   }
 
-  public List<Integer> getBlockProductionPerformanceWarningThreshold() {
-    return blockProductionPerformanceWarningThreshold;
+  public int getBlockProductionPerformanceWarningLocalThreshold() {
+    return blockProductionPerformanceWarningLocalThreshold;
   }
 
-  public List<Integer> getBlockPublishingPerformanceWarningThreshold() {
-    return blockPublishingPerformanceWarningThreshold;
+  public int getBlockProductionPerformanceWarningBuilderThreshold() {
+    return blockProductionPerformanceWarningBuilderThreshold;
+  }
+
+  public int getBlockPublishingPerformanceWarningLocalThreshold() {
+    return blockPublishingPerformanceWarningLocalThreshold;
+  }
+
+  public int getBlockPublishingPerformanceWarningBuilderThreshold() {
+    return blockPublishingPerformanceWarningBuilderThreshold;
   }
 
   public boolean isTickPerformanceEnabled() {
@@ -167,10 +187,14 @@ public class MetricsConfig {
     private boolean blockPerformanceEnabled = DEFAULT_BLOCK_PERFORMANCE_ENABLED;
     private boolean blockProductionAndPublishingPerformanceEnabled =
         DEFAULT_BLOCK_PRODUCTION_AND_PUBLISHING_PERFORMANCE_ENABLED;
-    private List<Integer> blockProductionPerformanceWarningThreshold =
-        DEFAULT_BLOCK_PRODUCTION_PERFORMANCE_WARNING_THRESHOLD;
-    private List<Integer> blockPublishingPerformanceWarningThreshold =
-        DEFAULT_BLOCK_PUBLISHING_PERFORMANCE_WARNING_THRESHOLD;
+    private int blockProductionPerformanceWarningLocalThreshold =
+        DEFAULT_BLOCK_PRODUCTION_PERFORMANCE_WARNING_LOCAL_THRESHOLD;
+    private int blockProductionPerformanceWarningBuilderThreshold =
+        DEFAULT_BLOCK_PRODUCTION_PERFORMANCE_WARNING_BUILDER_THRESHOLD;
+    private int blockPublishingPerformanceWarningLocalThreshold =
+        DEFAULT_BLOCK_PUBLISHING_PERFORMANCE_WARNING_LOCAL_THRESHOLD;
+    private int blockPublishingPerformanceWarningBuilderThreshold =
+        DEFAULT_BLOCK_PUBLISHING_PERFORMANCE_WARNING_BUILDER_THRESHOLD;
     private boolean tickPerformanceEnabled = DEFAULT_TICK_PERFORMANCE_ENABLED;
     private boolean blobSidecarsStorageCountersEnabled =
         DEFAULT_BLOB_SIDECARS_STORAGE_COUNTERS_ENABLED;
@@ -241,29 +265,32 @@ public class MetricsConfig {
       return this;
     }
 
-    public MetricsConfigBuilder blockProductionPerformanceWarningThreshold(
-        final List<Integer> blockProductionPerformanceWarningThreshold) {
-      validateWarningThreshold(
-          blockProductionPerformanceWarningThreshold, "blockProductionPerformanceWarningThreshold");
-      this.blockProductionPerformanceWarningThreshold = blockProductionPerformanceWarningThreshold;
+    public MetricsConfigBuilder blockProductionPerformanceWarningLocalThreshold(
+        final int blockProductionPerformanceWarningLocalThreshold) {
+      this.blockProductionPerformanceWarningLocalThreshold =
+          blockProductionPerformanceWarningLocalThreshold;
       return this;
     }
 
-    public MetricsConfigBuilder blockPublishingPerformanceWarningThreshold(
-        final List<Integer> blockPublishingPerformanceWarningThreshold) {
-      validateWarningThreshold(
-          blockPublishingPerformanceWarningThreshold, "blockPublishingPerformanceWarningThreshold");
-      this.blockPublishingPerformanceWarningThreshold = blockPublishingPerformanceWarningThreshold;
+    public MetricsConfigBuilder blockProductionPerformanceWarningBuilderThreshold(
+        final int blockProductionPerformanceWarningBuilderThreshold) {
+      this.blockProductionPerformanceWarningBuilderThreshold =
+          blockProductionPerformanceWarningBuilderThreshold;
       return this;
     }
 
-    private void validateWarningThreshold(final List<Integer> threshold, final String name) {
-      if (threshold.size() != 2) {
-        throw new InvalidConfigurationException(
-            String.format(
-                "Invalid %s: %s. Expected size of 2, but it was %d",
-                name, threshold, threshold.size()));
-      }
+    public MetricsConfigBuilder blockPublishingPerformanceWarningLocalThreshold(
+        final int blockPublishingPerformanceWarningLocalThreshold) {
+      this.blockPublishingPerformanceWarningLocalThreshold =
+          blockPublishingPerformanceWarningLocalThreshold;
+      return this;
+    }
+
+    public MetricsConfigBuilder blockPublishingPerformanceWarningBuilderThreshold(
+        final int blockPublishingPerformanceWarningBuilderThreshold) {
+      this.blockPublishingPerformanceWarningBuilderThreshold =
+          blockPublishingPerformanceWarningBuilderThreshold;
+      return this;
     }
 
     public MetricsConfigBuilder tickPerformanceEnabled(final boolean tickPerformanceEnabled) {
@@ -291,8 +318,10 @@ public class MetricsConfig {
           tickPerformanceEnabled,
           blobSidecarsStorageCountersEnabled,
           blockProductionAndPublishingPerformanceEnabled,
-          blockProductionPerformanceWarningThreshold,
-          blockPublishingPerformanceWarningThreshold);
+          blockProductionPerformanceWarningLocalThreshold,
+          blockProductionPerformanceWarningBuilderThreshold,
+          blockPublishingPerformanceWarningLocalThreshold,
+          blockPublishingPerformanceWarningBuilderThreshold);
     }
   }
 }

--- a/infrastructure/metrics/src/main/java/tech/pegasys/teku/infrastructure/metrics/MetricsConfig.java
+++ b/infrastructure/metrics/src/main/java/tech/pegasys/teku/infrastructure/metrics/MetricsConfig.java
@@ -41,8 +41,10 @@ public class MetricsConfig {
   public static final boolean DEFAULT_BLOCK_PERFORMANCE_ENABLED = true;
   public static final boolean DEFAULT_TICK_PERFORMANCE_ENABLED = false;
   public static final boolean DEFAULT_BLOCK_PRODUCTION_AND_PUBLISHING_PERFORMANCE_ENABLED = true;
-  public static final int DEFAULT_BLOCK_PRODUCTION_PERFORMANCE_WARNING_THRESHOLD = 300;
-  public static final int DEFAULT_BLOCK_PUBLISHING_PERFORMANCE_WARNING_THRESHOLD = 1000;
+  public static final List<Integer> DEFAULT_BLOCK_PRODUCTION_PERFORMANCE_WARNING_THRESHOLD =
+      List.of(300, 750);
+  public static final List<Integer> DEFAULT_BLOCK_PUBLISHING_PERFORMANCE_WARNING_THRESHOLD =
+      List.of(1000, 1500);
   public static final boolean DEFAULT_BLOB_SIDECARS_STORAGE_COUNTERS_ENABLED = false;
 
   private final boolean metricsEnabled;
@@ -57,8 +59,8 @@ public class MetricsConfig {
   private final boolean tickPerformanceEnabled;
   private final boolean blobSidecarsStorageCountersEnabled;
   private final boolean blockProductionAndPublishingPerformanceEnabled;
-  private final int blockProductionPerformanceWarningThreshold;
-  private final int blockPublishingPerformanceWarningThreshold;
+  private final List<Integer> blockProductionPerformanceWarningThreshold;
+  private final List<Integer> blockPublishingPerformanceWarningThreshold;
 
   private MetricsConfig(
       final boolean metricsEnabled,
@@ -73,8 +75,8 @@ public class MetricsConfig {
       final boolean tickPerformanceEnabled,
       final boolean blobSidecarsStorageCountersEnabled,
       final boolean blockProductionAndPublishingPerformanceEnabled,
-      final int blockProductionPerformanceWarningThreshold,
-      final int blockPublishingPerformanceWarningThreshold) {
+      final List<Integer> blockProductionPerformanceWarningThreshold,
+      final List<Integer> blockPublishingPerformanceWarningThreshold) {
     this.metricsEnabled = metricsEnabled;
     this.metricsPort = metricsPort;
     this.metricsInterface = metricsInterface;
@@ -136,11 +138,11 @@ public class MetricsConfig {
     return blockProductionAndPublishingPerformanceEnabled;
   }
 
-  public int getBlockProductionPerformanceWarningThreshold() {
+  public List<Integer> getBlockProductionPerformanceWarningThreshold() {
     return blockProductionPerformanceWarningThreshold;
   }
 
-  public int getBlockPublishingPerformanceWarningThreshold() {
+  public List<Integer> getBlockPublishingPerformanceWarningThreshold() {
     return blockPublishingPerformanceWarningThreshold;
   }
 
@@ -165,9 +167,9 @@ public class MetricsConfig {
     private boolean blockPerformanceEnabled = DEFAULT_BLOCK_PERFORMANCE_ENABLED;
     private boolean blockProductionAndPublishingPerformanceEnabled =
         DEFAULT_BLOCK_PRODUCTION_AND_PUBLISHING_PERFORMANCE_ENABLED;
-    private int blockProductionPerformanceWarningThreshold =
+    private List<Integer> blockProductionPerformanceWarningThreshold =
         DEFAULT_BLOCK_PRODUCTION_PERFORMANCE_WARNING_THRESHOLD;
-    private int blockPublishingPerformanceWarningThreshold =
+    private List<Integer> blockPublishingPerformanceWarningThreshold =
         DEFAULT_BLOCK_PUBLISHING_PERFORMANCE_WARNING_THRESHOLD;
     private boolean tickPerformanceEnabled = DEFAULT_TICK_PERFORMANCE_ENABLED;
     private boolean blobSidecarsStorageCountersEnabled =
@@ -240,15 +242,28 @@ public class MetricsConfig {
     }
 
     public MetricsConfigBuilder blockProductionPerformanceWarningThreshold(
-        final int blockProductionPerformanceWarningThreshold) {
+        final List<Integer> blockProductionPerformanceWarningThreshold) {
+      validateWarningThreshold(
+          blockProductionPerformanceWarningThreshold, "blockProductionPerformanceWarningThreshold");
       this.blockProductionPerformanceWarningThreshold = blockProductionPerformanceWarningThreshold;
       return this;
     }
 
     public MetricsConfigBuilder blockPublishingPerformanceWarningThreshold(
-        final int blockPublishingPerformanceWarningThreshold) {
+        final List<Integer> blockPublishingPerformanceWarningThreshold) {
+      validateWarningThreshold(
+          blockPublishingPerformanceWarningThreshold, "blockPublishingPerformanceWarningThreshold");
       this.blockPublishingPerformanceWarningThreshold = blockPublishingPerformanceWarningThreshold;
       return this;
+    }
+
+    private void validateWarningThreshold(final List<Integer> threshold, final String name) {
+      if (threshold.size() != 2) {
+        throw new InvalidConfigurationException(
+            String.format(
+                "Invalid %s: %s. Expected size of 2, but it was %d",
+                name, threshold, threshold.size()));
+      }
     }
 
     public MetricsConfigBuilder tickPerformanceEnabled(final boolean tickPerformanceEnabled) {

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -821,6 +821,11 @@ public class BeaconChainController extends Service implements BeaconChainControl
         .subscribe(ChainHeadChannel.class, syncCommitteeMetrics);
   }
 
+  protected void initEth1DataCache() {
+    LOG.debug("BeaconChainController.initEth1DataCache");
+    eth1DataCache = new Eth1DataCache(spec, metricsSystem, new Eth1VotingPeriod(spec));
+  }
+
   public void initDepositProvider() {
     LOG.debug("BeaconChainController.initDepositProvider()");
     depositProvider =
@@ -837,11 +842,6 @@ public class BeaconChainController extends Service implements BeaconChainControl
         .subscribe(Eth1EventsChannel.class, depositProvider)
         .subscribe(FinalizedCheckpointChannel.class, depositProvider)
         .subscribe(SlotEventsChannel.class, depositProvider);
-  }
-
-  protected void initEth1DataCache() {
-    LOG.debug("BeaconChainController.initEth1DataCache");
-    eth1DataCache = new Eth1DataCache(spec, metricsSystem, new Eth1VotingPeriod(spec));
   }
 
   protected void initAttestationTopicSubscriber() {
@@ -939,8 +939,10 @@ public class BeaconChainController extends Service implements BeaconChainControl
             timeProvider,
             (slot) -> secondsToMillis(recentChainData.computeTimeAtSlot(slot)),
             beaconConfig.getMetricsConfig().isBlockProductionAndPublishingPerformanceEnabled(),
-            beaconConfig.getMetricsConfig().getBlockProductionPerformanceWarningThreshold(),
-            beaconConfig.getMetricsConfig().getBlockPublishingPerformanceWarningThreshold());
+            beaconConfig.getMetricsConfig().getBlockProductionPerformanceWarningLocalThreshold(),
+            beaconConfig.getMetricsConfig().getBlockProductionPerformanceWarningBuilderThreshold(),
+            beaconConfig.getMetricsConfig().getBlockPublishingPerformanceWarningLocalThreshold(),
+            beaconConfig.getMetricsConfig().getBlockPublishingPerformanceWarningBuilderThreshold());
 
     final ValidatorApiHandler validatorApiHandler =
         new ValidatorApiHandler(

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/MetricsOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/MetricsOptions.java
@@ -126,7 +126,8 @@ public class MetricsOptions {
       showDefaultValue = Visibility.ALWAYS,
       paramLabel = "<INTEGER>",
       description =
-          "The time (in ms) at which block production using a local flow is to be considered 'slow'. If set to 100, block production taking at least 100ms would raise a warning.",
+          "The time (in ms) taken from the beginning of the slot at which block production using a local flow is to be considered 'slow'. "
+              + "If set to 100, block production taking at least 100ms into the slot would raise a warning.",
       arity = "1")
   private int blockProductionPerformanceWarningLocalThreshold =
       MetricsConfig.DEFAULT_BLOCK_PRODUCTION_PERFORMANCE_WARNING_LOCAL_THRESHOLD;
@@ -137,7 +138,8 @@ public class MetricsOptions {
       showDefaultValue = Visibility.ALWAYS,
       paramLabel = "<INTEGER>",
       description =
-          "The time (in ms) at which block production using a builder flow is to be considered 'slow'. If set to 100, block production taking at least 100ms would raise a warning.",
+          "The time (in ms) taken from the beginning of the slot at which block production using a builder flow is to be considered 'slow'. "
+              + "If set to 100, block production taking at least 100ms into the slot would raise a warning.",
       arity = "1")
   private int blockProductionPerformanceWarningBuilderThreshold =
       MetricsConfig.DEFAULT_BLOCK_PRODUCTION_PERFORMANCE_WARNING_BUILDER_THRESHOLD;
@@ -148,7 +150,8 @@ public class MetricsOptions {
       showDefaultValue = Visibility.ALWAYS,
       paramLabel = "<INTEGER>",
       description =
-          "The time (in ms) at which block publishing using a local flow is to be considered 'slow'. If set to 100, block publishing taking at least 100ms would raise a warning.",
+          "The time (in ms) taken from the beginning of the slot at which block publishing using a local flow is to be considered 'slow'. "
+              + "If set to 100, block publishing taking at least 100ms into the slot would raise a warning.",
       arity = "1")
   private int blockPublishingPerformanceWarningLocalThreshold =
       MetricsConfig.DEFAULT_BLOCK_PUBLISHING_PERFORMANCE_WARNING_LOCAL_THRESHOLD;
@@ -159,7 +162,8 @@ public class MetricsOptions {
       showDefaultValue = Visibility.ALWAYS,
       paramLabel = "<INTEGER>",
       description =
-          "The time (in ms) at which block publishing using a builder flow is to be considered 'slow'. If set to 100, block publishing taking at least 100ms would raise a warning.",
+          "The time (in ms) taken from the beginning of the slot at which block publishing using a builder flow is to be considered 'slow'. "
+              + "If set to 100, block publishing taking at least 100ms into the slot would raise a warning.",
       arity = "1")
   private int blockPublishingPerformanceWarningBuilderThreshold =
       MetricsConfig.DEFAULT_BLOCK_PUBLISHING_PERFORMANCE_WARNING_BUILDER_THRESHOLD;

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/MetricsOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/MetricsOptions.java
@@ -124,19 +124,29 @@ public class MetricsOptions {
       names = {"--Xmetrics-block-production-timing-tracking-warning-local-threshold"},
       hidden = true,
       showDefaultValue = Visibility.ALWAYS,
-      paramLabel = "<localFlowThreshold,builderFlowThreshold>",
+      paramLabel = "<INTEGER>",
       description =
-          "The times (in ms) at which block production is to be considered 'slow' for a local and builder flow (comma-separated). If set to \"100,200\", block production taking at least 100ms would raise a warning. "
-              + "Same would apply for a builder flow taking at least 200ms.",
-      split = ",")
-  private List<Integer> blockProductionPerformanceWarningThreshold =
-      MetricsConfig.DEFAULT_BLOCK_PRODUCTION_PERFORMANCE_WARNING_THRESHOLD;
+          "The time (in ms) at which block production using a local flow is to be considered 'slow'. If set to 100, block production taking at least 100ms would raise a warning.",
+      arity = "1")
+  private int blockProductionPerformanceWarningLocalThreshold =
+      MetricsConfig.DEFAULT_BLOCK_PRODUCTION_PERFORMANCE_WARNING_LOCAL_THRESHOLD;
+
+  @Option(
+      names = {"--Xmetrics-block-production-timing-tracking-warning-builder-threshold"},
+      hidden = true,
+      showDefaultValue = Visibility.ALWAYS,
+      paramLabel = "<INTEGER>",
+      description =
+          "The time (in ms) at which block production using a builder flow is to be considered 'slow'. If set to 100, block production taking at least 100ms would raise a warning.",
+      arity = "1")
+  private int blockProductionPerformanceWarningBuilderThreshold =
+      MetricsConfig.DEFAULT_BLOCK_PRODUCTION_PERFORMANCE_WARNING_BUILDER_THRESHOLD;
 
   @Option(
       names = {"--Xmetrics-block-publishing-timing-tracking-warning-local-threshold"},
       hidden = true,
       showDefaultValue = Visibility.ALWAYS,
-      paramLabel = "<localFlowThreshold,builderFlowThreshold>",
+      paramLabel = "<INTEGER>",
       description =
           "The time (in ms) at which block publishing using a local flow is to be considered 'slow'. If set to 100, block publishing taking at least 100ms would raise a warning.",
       arity = "1")

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/MetricsOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/MetricsOptions.java
@@ -126,8 +126,9 @@ public class MetricsOptions {
       showDefaultValue = Visibility.ALWAYS,
       paramLabel = "<INTEGER>",
       description =
-          "The time (in ms) taken from the beginning of the slot at which block production using a local flow is to be considered 'slow'. "
-              + "If set to 100, block production taking at least 100ms into the slot would raise a warning.",
+          """
+              The time (in ms) taken from the beginning of the slot at which block production using a local flow is to be considered 'slow'.
+              If set to 100, block production taking at least 100ms into the slot would raise a warning.""",
       arity = "1")
   private int blockProductionPerformanceWarningLocalThreshold =
       MetricsConfig.DEFAULT_BLOCK_PRODUCTION_PERFORMANCE_WARNING_LOCAL_THRESHOLD;
@@ -138,8 +139,9 @@ public class MetricsOptions {
       showDefaultValue = Visibility.ALWAYS,
       paramLabel = "<INTEGER>",
       description =
-          "The time (in ms) taken from the beginning of the slot at which block production using a builder flow is to be considered 'slow'. "
-              + "If set to 100, block production taking at least 100ms into the slot would raise a warning.",
+          """
+              The time (in ms) taken from the beginning of the slot at which block production using a builder flow is to be considered 'slow'.
+              If set to 100, block production taking at least 100ms into the slot would raise a warning.""",
       arity = "1")
   private int blockProductionPerformanceWarningBuilderThreshold =
       MetricsConfig.DEFAULT_BLOCK_PRODUCTION_PERFORMANCE_WARNING_BUILDER_THRESHOLD;
@@ -150,8 +152,9 @@ public class MetricsOptions {
       showDefaultValue = Visibility.ALWAYS,
       paramLabel = "<INTEGER>",
       description =
-          "The time (in ms) taken from the beginning of the slot at which block publishing using a local flow is to be considered 'slow'. "
-              + "If set to 100, block publishing taking at least 100ms into the slot would raise a warning.",
+          """
+              The time (in ms) taken from the beginning of the slot at which block publishing using a local flow is to be considered 'slow'.
+              If set to 100, block publishing taking at least 100ms into the slot would raise a warning.""",
       arity = "1")
   private int blockPublishingPerformanceWarningLocalThreshold =
       MetricsConfig.DEFAULT_BLOCK_PUBLISHING_PERFORMANCE_WARNING_LOCAL_THRESHOLD;
@@ -162,8 +165,9 @@ public class MetricsOptions {
       showDefaultValue = Visibility.ALWAYS,
       paramLabel = "<INTEGER>",
       description =
-          "The time (in ms) taken from the beginning of the slot at which block publishing using a builder flow is to be considered 'slow'. "
-              + "If set to 100, block publishing taking at least 100ms into the slot would raise a warning.",
+          """
+              The time (in ms) taken from the beginning of the slot at which block publishing using a builder flow is to be considered 'slow'.
+              If set to 100, block publishing taking at least 100ms into the slot would raise a warning.""",
       arity = "1")
   private int blockPublishingPerformanceWarningBuilderThreshold =
       MetricsConfig.DEFAULT_BLOCK_PUBLISHING_PERFORMANCE_WARNING_BUILDER_THRESHOLD;

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/MetricsOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/MetricsOptions.java
@@ -124,24 +124,24 @@ public class MetricsOptions {
       names = {"--Xmetrics-block-production-timing-tracking-warning-threshold"},
       hidden = true,
       showDefaultValue = Visibility.ALWAYS,
-      paramLabel = "<INTEGER>",
+      paramLabel = "<localFlowThreshold,builderFlowThreshold>",
       description =
-          "The time (in ms) at which block production is to be considered 'slow'. If set to 100, block production taking at least 100ms would raise a warning.",
-      fallbackValue = "true",
-      arity = "0..1")
-  private int blockProductionPerformanceWarningThreshold =
+          "The times (in ms) at which block production is to be considered 'slow' for a local and builder flow (comma-separated). If set to \"100,200\", block production taking at least 100ms would raise a warning. "
+              + "Same would apply for a builder flow taking at least 200ms.",
+      split = ",")
+  private List<Integer> blockProductionPerformanceWarningThreshold =
       MetricsConfig.DEFAULT_BLOCK_PRODUCTION_PERFORMANCE_WARNING_THRESHOLD;
 
   @Option(
       names = {"--Xmetrics-block-publishing-timing-tracking-warning-threshold"},
       hidden = true,
       showDefaultValue = Visibility.ALWAYS,
-      paramLabel = "<INTEGER>",
+      paramLabel = "<localFlowThreshold,builderFlowThreshold>",
       description =
-          "The time (in ms) at which block publishing is to be considered 'slow'. If set to 100, block publishing taking at least 100ms would raise a warning.",
-      fallbackValue = "true",
-      arity = "0..1")
-  private int blockPublishingPerformanceWarningThreshold =
+          "The times (in ms) at which block publishing is to be considered 'slow' for a local and builder flow (comma-separated). If set to \"100,200\", block publishing for a local flow taking at least 100ms would raise a warning. "
+              + "Same would apply for a builder flow taking at least 200ms.",
+      split = ",")
+  private List<Integer> blockPublishingPerformanceWarningThreshold =
       MetricsConfig.DEFAULT_BLOCK_PUBLISHING_PERFORMANCE_WARNING_THRESHOLD;
 
   @Option(

--- a/teku/src/main/java/tech/pegasys/teku/cli/options/MetricsOptions.java
+++ b/teku/src/main/java/tech/pegasys/teku/cli/options/MetricsOptions.java
@@ -121,7 +121,7 @@ public class MetricsOptions {
       MetricsConfig.DEFAULT_BLOCK_PRODUCTION_AND_PUBLISHING_PERFORMANCE_ENABLED;
 
   @Option(
-      names = {"--Xmetrics-block-production-timing-tracking-warning-threshold"},
+      names = {"--Xmetrics-block-production-timing-tracking-warning-local-threshold"},
       hidden = true,
       showDefaultValue = Visibility.ALWAYS,
       paramLabel = "<localFlowThreshold,builderFlowThreshold>",
@@ -133,16 +133,26 @@ public class MetricsOptions {
       MetricsConfig.DEFAULT_BLOCK_PRODUCTION_PERFORMANCE_WARNING_THRESHOLD;
 
   @Option(
-      names = {"--Xmetrics-block-publishing-timing-tracking-warning-threshold"},
+      names = {"--Xmetrics-block-publishing-timing-tracking-warning-local-threshold"},
       hidden = true,
       showDefaultValue = Visibility.ALWAYS,
       paramLabel = "<localFlowThreshold,builderFlowThreshold>",
       description =
-          "The times (in ms) at which block publishing is to be considered 'slow' for a local and builder flow (comma-separated). If set to \"100,200\", block publishing for a local flow taking at least 100ms would raise a warning. "
-              + "Same would apply for a builder flow taking at least 200ms.",
-      split = ",")
-  private List<Integer> blockPublishingPerformanceWarningThreshold =
-      MetricsConfig.DEFAULT_BLOCK_PUBLISHING_PERFORMANCE_WARNING_THRESHOLD;
+          "The time (in ms) at which block publishing using a local flow is to be considered 'slow'. If set to 100, block publishing taking at least 100ms would raise a warning.",
+      arity = "1")
+  private int blockPublishingPerformanceWarningLocalThreshold =
+      MetricsConfig.DEFAULT_BLOCK_PUBLISHING_PERFORMANCE_WARNING_LOCAL_THRESHOLD;
+
+  @Option(
+      names = {"--Xmetrics-block-publishing-timing-tracking-warning-builder-threshold"},
+      hidden = true,
+      showDefaultValue = Visibility.ALWAYS,
+      paramLabel = "<INTEGER>",
+      description =
+          "The time (in ms) at which block publishing using a builder flow is to be considered 'slow'. If set to 100, block publishing taking at least 100ms would raise a warning.",
+      arity = "1")
+  private int blockPublishingPerformanceWarningBuilderThreshold =
+      MetricsConfig.DEFAULT_BLOCK_PUBLISHING_PERFORMANCE_WARNING_BUILDER_THRESHOLD;
 
   @Option(
       names = {"--Xmetrics-blob-sidecars-storage-enabled"},
@@ -171,10 +181,14 @@ public class MetricsOptions {
                 .blobSidecarsStorageCountersEnabled(blobSidecarsStorageCountersEnabled)
                 .blockProductionAndPublishingPerformanceEnabled(
                     blockProductionAndPublishingPerformanceEnabled)
-                .blockProductionPerformanceWarningThreshold(
-                    blockProductionPerformanceWarningThreshold)
-                .blockPublishingPerformanceWarningThreshold(
-                    blockPublishingPerformanceWarningThreshold));
+                .blockProductionPerformanceWarningLocalThreshold(
+                    blockProductionPerformanceWarningLocalThreshold)
+                .blockProductionPerformanceWarningBuilderThreshold(
+                    blockProductionPerformanceWarningBuilderThreshold)
+                .blockPublishingPerformanceWarningLocalThreshold(
+                    blockPublishingPerformanceWarningLocalThreshold)
+                .blockPublishingPerformanceWarningBuilderThreshold(
+                    blockPublishingPerformanceWarningBuilderThreshold));
   }
 
   private URL parseMetricsEndpointUrl() {

--- a/teku/src/test/java/tech/pegasys/teku/cli/options/MetricsOptionsTest.java
+++ b/teku/src/test/java/tech/pegasys/teku/cli/options/MetricsOptionsTest.java
@@ -16,12 +16,10 @@ package tech.pegasys.teku.cli.options;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hyperledger.besu.metrics.StandardMetricCategory.JVM;
 import static org.hyperledger.besu.metrics.StandardMetricCategory.PROCESS;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory.EVENTBUS;
 import static tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory.LIBP2P;
 import static tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory.NETWORK;
 
-import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -122,62 +120,32 @@ public class MetricsOptionsTest extends AbstractBeaconNodeCommandTest {
         .containsOnly("localhost", "127.0.0.1");
   }
 
-  @ParameterizedTest
-  @MethodSource("provideArgumentsForWarningThresholdShouldAcceptTwoThresholds")
-  public void warningThresholds_shouldAcceptTwoThresholds(
-      final String option,
-      final String value,
-      final Function<MetricsConfig, List<Integer>> configValue,
-      final List<Integer> expectedValue) {
-    final TekuConfiguration tekuConfiguration = getTekuConfigurationFromArguments(option, value);
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("provideArgumentsForShouldSetWarningThresholds")
+  public void shouldSetWarningThresholds(
+      final String option, final Function<MetricsConfig, Integer> configValueFunction) {
+    final TekuConfiguration tekuConfiguration = getTekuConfigurationFromArguments(option, "100");
     final MetricsConfig config = tekuConfiguration.metricsConfig();
-    assertThat(configValue.apply(config)).isEqualTo(expectedValue);
+    assertThat(configValueFunction.apply(config)).isEqualTo(100);
   }
 
-  @ParameterizedTest
-  @MethodSource("provideArgumentsForWarningThresholdShouldFailIfNotTwoThresholds")
-  public void warningThresholds_shouldFailIfNotTwoThresholds(
-      final String option, final String value, final String expectedErrorMessage) {
-    assertThrows(
-        Throwable.class,
-        () -> getTekuConfigurationFromArguments(option, value),
-        expectedErrorMessage);
-  }
-
-  private static Stream<Arguments> provideArgumentsForWarningThresholdShouldAcceptTwoThresholds() {
+  private static Stream<Arguments> provideArgumentsForShouldSetWarningThresholds() {
     return Stream.of(
         Arguments.of(
-            "--Xmetrics-block-production-timing-tracking-warning-threshold",
-            "100,200",
-            (Function<MetricsConfig, List<Integer>>)
-                MetricsConfig::getBlockProductionPerformanceWarningThreshold,
-            List.of(100, 200)),
+            "--Xmetrics-block-production-timing-tracking-warning-local-threshold",
+            (Function<MetricsConfig, Integer>)
+                MetricsConfig::getBlockProductionPerformanceWarningLocalThreshold),
         Arguments.of(
-            "--Xmetrics-block-publishing-timing-tracking-warning-threshold",
-            "100,200",
-            (Function<MetricsConfig, List<Integer>>)
-                MetricsConfig::getBlockPublishingPerformanceWarningThreshold,
-            List.of(100, 200)));
-  }
-
-  private static Stream<Arguments>
-      provideArgumentsForWarningThresholdShouldFailIfNotTwoThresholds() {
-    return Stream.of(
+            "--Xmetrics-block-production-timing-tracking-warning-builder-threshold",
+            (Function<MetricsConfig, Integer>)
+                MetricsConfig::getBlockProductionPerformanceWarningBuilderThreshold),
         Arguments.of(
-            "--Xmetrics-block-production-timing-tracking-warning-threshold",
-            "100",
-            "Invalid blockProductionPerformanceWarningThreshold: [100]. Expected size of 2, but it was 1"),
+            "--Xmetrics-block-publishing-timing-tracking-warning-local-threshold",
+            (Function<MetricsConfig, Integer>)
+                MetricsConfig::getBlockPublishingPerformanceWarningLocalThreshold),
         Arguments.of(
-            "--Xmetrics-block-publishing-timing-tracking-warning-threshold",
-            "100",
-            "Invalid blockPublishingPerformanceWarningThreshold: [100]. Expected size of 2, but it was 1"),
-        Arguments.of(
-            "--Xmetrics-block-production-timing-tracking-warning-threshold",
-            "100,200,300",
-            "Invalid blockProductionPerformanceWarningThreshold: [100,200,300]. Expected size of 2, but it was 3"),
-        Arguments.of(
-            "--Xmetrics-block-publishing-timing-tracking-warning-threshold",
-            "100,200,300",
-            "Invalid blockPublishingPerformanceWarningThreshold: [100,200,300]. Expected size of 2, but it was 3"));
+            "--Xmetrics-block-publishing-timing-tracking-warning-builder-threshold",
+            (Function<MetricsConfig, Integer>)
+                MetricsConfig::getBlockPublishingPerformanceWarningBuilderThreshold));
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
After a discussion:
- Default to 600 (local) and 1000 (builder) for block production
- Default to 750 (local) and 1500 (builder) for block publishing

In total 4 hidden options:

- `--Xmetrics-block-production-timing-tracking-warning-local-threshold`
- `--Xmetrics-block-production-timing-tracking-warning-builder-threshold`
- `--Xmetrics-block-publishing-timing-tracking-warning-local-threshold`
- `--Xmetrics-block-publishing-timing-tracking-warning-builder-threshold`

## Fixed Issue(s)
fixes #8182 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
