### PR TITLE
DepositWithIndex: replace inheritance with composition

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/DepositProvider.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/DepositProvider.java
@@ -103,13 +103,13 @@ public class DepositProvider
     event.getDeposits().stream()
         .map(depositUtil::convertDepositEventToOperationDeposit)
         .forEach(
-            deposit -> {
+            depositWithIndex -> {
               if (!recentChainData.isPreGenesis()) {
-                LOG.debug("About to process deposit: {}", deposit.index());
+                LOG.debug("About to process deposit: {}", depositWithIndex.index());
               }
 
-              depositNavigableMap.put(deposit.index(), deposit);
-              depositMerkleTree.pushLeaf(deposit.deposit().getData().hashTreeRoot());
+              depositNavigableMap.put(depositWithIndex.index(), depositWithIndex);
+              depositMerkleTree.pushLeaf(depositWithIndex.deposit().getData().hashTreeRoot());
             });
     depositCounter.inc(event.getDeposits().size());
     eth1DataCache.onBlockWithDeposit(

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/DepositProvider.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/DepositProvider.java
@@ -105,11 +105,11 @@ public class DepositProvider
         .forEach(
             deposit -> {
               if (!recentChainData.isPreGenesis()) {
-                LOG.debug("About to process deposit: {}", deposit.getIndex());
+                LOG.debug("About to process deposit: {}", deposit.index());
               }
 
-              depositNavigableMap.put(deposit.getIndex(), deposit);
-              depositMerkleTree.pushLeaf(deposit.getDeposit().getData().hashTreeRoot());
+              depositNavigableMap.put(deposit.index(), deposit);
+              depositMerkleTree.pushLeaf(deposit.deposit().getData().hashTreeRoot());
             });
     depositCounter.inc(event.getDeposits().size());
     eth1DataCache.onBlockWithDeposit(
@@ -212,7 +212,7 @@ public class DepositProvider
     final long maxDeposits = spec.getMaxDeposits(state);
     final SszListSchema<Deposit, ?> depositsSchema = depositsSchemaCache.get(maxDeposits);
     return getDepositsWithIndex(state, eth1Data).stream()
-        .map(DepositWithIndex::getDeposit)
+        .map(DepositWithIndex::deposit)
         .collect(depositsSchema.collector());
   }
 
@@ -307,15 +307,15 @@ public class DepositProvider
         .stream()
         .map(
             deposit -> {
-              if (!deposit.getIndex().equals(expectedDepositIndex.get())) {
+              if (!deposit.index().equals(expectedDepositIndex.get())) {
                 throw MissingDepositsException.missingRange(
-                    expectedDepositIndex.get(), deposit.getIndex());
+                    expectedDepositIndex.get(), deposit.index());
               }
-              expectedDepositIndex.set(deposit.getIndex().plus(ONE));
+              expectedDepositIndex.set(deposit.index().plus(ONE));
               SszBytes32Vector proof =
-                  depositProofSchema.of(merkleTree.getProof(deposit.getIndex().intValue()));
+                  depositProofSchema.of(merkleTree.getProof(deposit.index().intValue()));
               return new DepositWithIndex(
-                  new Deposit(proof, deposit.getDeposit().getData()), deposit.getIndex());
+                  new Deposit(proof, deposit.deposit().getData()), deposit.index());
             })
         .toList();
   }

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/DepositProvider.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/DepositProvider.java
@@ -306,16 +306,17 @@ public class DepositProvider
         .values()
         .stream()
         .map(
-            deposit -> {
-              if (!deposit.index().equals(expectedDepositIndex.get())) {
+            depositWithIndex -> {
+              if (!depositWithIndex.index().equals(expectedDepositIndex.get())) {
                 throw MissingDepositsException.missingRange(
-                    expectedDepositIndex.get(), deposit.index());
+                    expectedDepositIndex.get(), depositWithIndex.index());
               }
-              expectedDepositIndex.set(deposit.index().plus(ONE));
+              expectedDepositIndex.set(depositWithIndex.index().plus(ONE));
               SszBytes32Vector proof =
-                  depositProofSchema.of(merkleTree.getProof(deposit.index().intValue()));
+                  depositProofSchema.of(merkleTree.getProof(depositWithIndex.index().intValue()));
               return new DepositWithIndex(
-                  new Deposit(proof, deposit.deposit().getData()), deposit.index());
+                  new Deposit(proof, depositWithIndex.deposit().getData()),
+                  depositWithIndex.index());
             })
         .toList();
   }

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/DepositProviderTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/DepositProviderTest.java
@@ -157,7 +157,7 @@ public class DepositProviderTest {
     List<DepositWithIndex> deposits = depositProvider.getDepositsWithIndex(state, newEth1Data);
     assertThat(deposits).hasSize(25);
     checkThatDepositProofIsValid(deposits);
-    assertThat(deposits.stream().map(DepositWithIndex::getDeposit))
+    assertThat(deposits.stream().map(DepositWithIndex::deposit))
         .containsExactlyElementsOf(depositProvider.getDeposits(state, newEth1Data));
   }
 
@@ -173,7 +173,7 @@ public class DepositProviderTest {
     List<DepositWithIndex> deposits = depositProvider.getDepositsWithIndex(state, randomEth1Data);
     assertThat(deposits).hasSize(10);
     checkThatDepositProofIsValid(deposits);
-    assertThat(deposits.stream().map(DepositWithIndex::getDeposit))
+    assertThat(deposits.stream().map(DepositWithIndex::deposit))
         .containsExactlyElementsOf(depositProvider.getDeposits(state, randomEth1Data));
   }
 
@@ -207,7 +207,7 @@ public class DepositProviderTest {
     // expected size
     assertThat(deposits).hasSize(11);
     checkThatDepositProofIsValid(deposits);
-    assertThat(deposits.stream().map(DepositWithIndex::getDeposit))
+    assertThat(deposits.stream().map(DepositWithIndex::deposit))
         .containsExactlyElementsOf(depositProvider.getDeposits(state, randomEth1Data));
   }
 
@@ -257,7 +257,7 @@ public class DepositProviderTest {
     depositMerkleTree.add(
         depositUtil
             .convertDepositEventToOperationDeposit(deposit)
-            .getDeposit()
+            .deposit()
             .getData()
             .hashTreeRoot());
     verify(eth1DataCache)
@@ -500,10 +500,10 @@ public class DepositProviderTest {
                     genesisSpec
                         .predicates()
                         .isValidMerkleBranch(
-                            depositWithIndex.getDeposit().getData().hashTreeRoot(),
-                            depositWithIndex.getDeposit().getProof(),
+                            depositWithIndex.deposit().getData().hashTreeRoot(),
+                            depositWithIndex.deposit().getProof(),
                             genesisSpec.getConfig().getDepositContractTreeDepth() + 1,
-                            depositWithIndex.getIndex().intValue(),
+                            depositWithIndex.index().intValue(),
                             depositMerkleTree.getRoot()))
                 .withFailMessage("Expected proof to be valid but was not")
                 .isTrue());
@@ -519,7 +519,7 @@ public class DepositProviderTest {
   private void mockDepositsFromEth1Block(int startIndex, int n) {
     allSeenDepositsList.subList(startIndex, n).stream()
         .map(depositUtil::convertDepositEventToOperationDeposit)
-        .map(depositWithIndex -> depositWithIndex.getDeposit().getData().hashTreeRoot())
+        .map(depositWithIndex -> depositWithIndex.deposit().getData().hashTreeRoot())
         .forEachOrdered(depositMerkleTree::add);
 
     DepositsFromBlockEvent depositsFromBlockEvent = mock(DepositsFromBlockEvent.class);

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/DepositProviderTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/DepositProviderTest.java
@@ -46,7 +46,6 @@ import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.config.SpecConfig;
 import tech.pegasys.teku.spec.datastructures.blocks.Eth1Data;
 import tech.pegasys.teku.spec.datastructures.operations.Deposit;
-import tech.pegasys.teku.spec.datastructures.operations.DepositData;
 import tech.pegasys.teku.spec.datastructures.operations.DepositWithIndex;
 import tech.pegasys.teku.spec.datastructures.state.AnchorPoint;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
@@ -130,7 +129,7 @@ public class DepositProviderTest {
     mockDepositsFromEth1Block(0, 10);
     mockDepositsFromEth1Block(10, 20);
 
-    SszList<Deposit> deposits = depositProvider.getDeposits(state, randomEth1Data);
+    List<DepositWithIndex> deposits = depositProvider.getDepositsWithIndex(state, randomEth1Data);
     assertThat(deposits).hasSize(15);
     checkThatDepositProofIsValid(deposits);
   }
@@ -155,9 +154,11 @@ public class DepositProviderTest {
             .collect(SszListSchema.create(Eth1Data.SSZ_SCHEMA, 32).collector());
     state = state.updated(mutableState -> mutableState.setEth1DataVotes(et1hDataVotes));
 
-    SszList<Deposit> deposits = depositProvider.getDeposits(state, newEth1Data);
+    List<DepositWithIndex> deposits = depositProvider.getDepositsWithIndex(state, newEth1Data);
     assertThat(deposits).hasSize(25);
     checkThatDepositProofIsValid(deposits);
+    assertThat(deposits.stream().map(DepositWithIndex::getDeposit))
+        .containsExactlyElementsOf(depositProvider.getDeposits(state, newEth1Data));
   }
 
   @Test
@@ -169,9 +170,11 @@ public class DepositProviderTest {
     mockDepositsFromEth1Block(0, 10);
     mockDepositsFromEth1Block(10, 20);
 
-    SszList<Deposit> deposits = depositProvider.getDeposits(state, randomEth1Data);
+    List<DepositWithIndex> deposits = depositProvider.getDepositsWithIndex(state, randomEth1Data);
     assertThat(deposits).hasSize(10);
     checkThatDepositProofIsValid(deposits);
+    assertThat(deposits.stream().map(DepositWithIndex::getDeposit))
+        .containsExactlyElementsOf(depositProvider.getDeposits(state, randomEth1Data));
   }
 
   @Test
@@ -196,13 +199,16 @@ public class DepositProviderTest {
     mockDepositsFromEth1Block(0, 10);
     mockDepositsFromEth1Block(10, 20);
 
-    final SszList<Deposit> deposits = depositProvider.getDeposits(state, randomEth1Data);
+    final List<DepositWithIndex> deposits =
+        depositProvider.getDepositsWithIndex(state, randomEth1Data);
 
     // the pending Eth1 deposits (deposit_receipt_start_index - eth1_deposit_index)
     // we need to process eth1_deposit_index deposit (5) up to 16 (exclusive) so 11 is the
     // expected size
     assertThat(deposits).hasSize(11);
     checkThatDepositProofIsValid(deposits);
+    assertThat(deposits.stream().map(DepositWithIndex::getDeposit))
+        .containsExactlyElementsOf(depositProvider.getDeposits(state, randomEth1Data));
   }
 
   @Test
@@ -249,7 +255,11 @@ public class DepositProviderTest {
     depositProvider.onDepositsFromBlock(event);
 
     depositMerkleTree.add(
-        depositUtil.convertDepositEventToOperationDeposit(deposit).getData().hashTreeRoot());
+        depositUtil
+            .convertDepositEventToOperationDeposit(deposit)
+            .getDeposit()
+            .getData()
+            .hashTreeRoot());
     verify(eth1DataCache)
         .onBlockWithDeposit(
             event.getBlockNumber(),
@@ -482,18 +492,18 @@ public class DepositProviderTest {
         .isEqualTo(UInt64.valueOf(30));
   }
 
-  private void checkThatDepositProofIsValid(SszList<Deposit> deposits) {
+  private void checkThatDepositProofIsValid(List<DepositWithIndex> depositsWithIndex) {
     final SpecVersion genesisSpec = spec.getGenesisSpec();
-    deposits.forEach(
-        deposit ->
+    depositsWithIndex.forEach(
+        depositWithIndex ->
             assertThat(
                     genesisSpec
                         .predicates()
                         .isValidMerkleBranch(
-                            deposit.getData().hashTreeRoot(),
-                            deposit.getProof(),
+                            depositWithIndex.getDeposit().getData().hashTreeRoot(),
+                            depositWithIndex.getDeposit().getProof(),
                             genesisSpec.getConfig().getDepositContractTreeDepth() + 1,
-                            ((DepositWithIndex) deposit).getIndex().intValue(),
+                            depositWithIndex.getIndex().intValue(),
                             depositMerkleTree.getRoot()))
                 .withFailMessage("Expected proof to be valid but was not")
                 .isTrue());
@@ -509,8 +519,7 @@ public class DepositProviderTest {
   private void mockDepositsFromEth1Block(int startIndex, int n) {
     allSeenDepositsList.subList(startIndex, n).stream()
         .map(depositUtil::convertDepositEventToOperationDeposit)
-        .map(Deposit::getData)
-        .map(DepositData::hashTreeRoot)
+        .map(depositWithIndex -> depositWithIndex.getDeposit().getData().hashTreeRoot())
         .forEachOrdered(depositMerkleTree::add);
 
     DepositsFromBlockEvent depositsFromBlockEvent = mock(DepositsFromBlockEvent.class);

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/beacon/GetDeposits.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/beacon/GetDeposits.java
@@ -35,11 +35,11 @@ public class GetDeposits extends RestApiEndpoint {
 
   private static final SerializableTypeDefinition<DepositWithIndex> DEPOSIT_WITH_INDEX_TYPE =
       SerializableTypeDefinition.object(DepositWithIndex.class)
-          .withField("index", CoreTypes.UINT64_TYPE, DepositWithIndex::getIndex)
+          .withField("index", CoreTypes.UINT64_TYPE, DepositWithIndex::index)
           .withField(
               "data",
               DepositData.SSZ_SCHEMA.getJsonTypeDefinition(),
-              depositWithIndex -> depositWithIndex.getDeposit().getData())
+              depositWithIndex -> depositWithIndex.deposit().getData())
           .build();
 
   public static final SerializableTypeDefinition<List<DepositWithIndex>> DEPOSITS_RESPONSE_TYPE =

--- a/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/beacon/GetDeposits.java
+++ b/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/tekuv1/beacon/GetDeposits.java
@@ -37,7 +37,9 @@ public class GetDeposits extends RestApiEndpoint {
       SerializableTypeDefinition.object(DepositWithIndex.class)
           .withField("index", CoreTypes.UINT64_TYPE, DepositWithIndex::getIndex)
           .withField(
-              "data", DepositData.SSZ_SCHEMA.getJsonTypeDefinition(), DepositWithIndex::getData)
+              "data",
+              DepositData.SSZ_SCHEMA.getJsonTypeDefinition(),
+              depositWithIndex -> depositWithIndex.getDeposit().getData())
           .build();
 
   public static final SerializableTypeDefinition<List<DepositWithIndex>> DEPOSITS_RESPONSE_TYPE =

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/Spec.java
@@ -295,7 +295,7 @@ public class Spec {
   public BeaconState initializeBeaconStateFromEth1(
       final Bytes32 eth1BlockHash,
       final UInt64 eth1Timestamp,
-      final List<? extends Deposit> deposits,
+      final List<Deposit> deposits,
       final Optional<ExecutionPayloadHeader> payloadHeader) {
     final GenesisGenerator genesisGenerator = createGenesisGenerator();
     genesisGenerator.updateCandidateState(eth1BlockHash, eth1Timestamp, deposits);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/DepositWithIndex.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/DepositWithIndex.java
@@ -16,47 +16,11 @@ package tech.pegasys.teku.spec.datastructures.operations;
 import org.jetbrains.annotations.NotNull;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
-import java.util.Objects;
-
-public class DepositWithIndex implements Comparable<DepositWithIndex> {
-
-  private final Deposit deposit;
-  private final UInt64 index;
-
-  public DepositWithIndex(Deposit deposit, UInt64 index) {
-    this.deposit = deposit;
-    this.index = index;
-  }
-
-  public Deposit getDeposit() {
-    return deposit;
-  }
-
-  public UInt64 getIndex() {
-    return index;
-  }
+public record DepositWithIndex(Deposit deposit, UInt64 index) implements Comparable<DepositWithIndex> {
 
   @Override
   public int compareTo(final @NotNull DepositWithIndex o) {
-    return this.getIndex().compareTo(o.getIndex());
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-
-    DepositWithIndex that = (DepositWithIndex) o;
-    return deposit.equals(that.deposit) && index.equals(that.index);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(deposit, index);
+    return this.index().compareTo(o.index());
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/DepositWithIndex.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/DepositWithIndex.java
@@ -16,6 +16,8 @@ package tech.pegasys.teku.spec.datastructures.operations;
 import org.jetbrains.annotations.NotNull;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
+import java.util.Objects;
+
 public class DepositWithIndex implements Comparable<DepositWithIndex> {
 
   private final Deposit deposit;
@@ -54,9 +56,7 @@ public class DepositWithIndex implements Comparable<DepositWithIndex> {
 
   @Override
   public int hashCode() {
-    int result = deposit.hashCode();
-    result = 31 * result + index.hashCode();
-    return result;
+    return Objects.hash(deposit, index);
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/DepositWithIndex.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/DepositWithIndex.java
@@ -16,7 +16,8 @@ package tech.pegasys.teku.spec.datastructures.operations;
 import org.jetbrains.annotations.NotNull;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
-public record DepositWithIndex(Deposit deposit, UInt64 index) implements Comparable<DepositWithIndex> {
+public record DepositWithIndex(Deposit deposit, UInt64 index)
+    implements Comparable<DepositWithIndex> {
 
   @Override
   public int compareTo(final @NotNull DepositWithIndex o) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/DepositWithIndex.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/DepositWithIndex.java
@@ -15,22 +15,20 @@ package tech.pegasys.teku.spec.datastructures.operations;
 
 import java.util.Objects;
 import org.jetbrains.annotations.NotNull;
-import tech.pegasys.teku.infrastructure.ssz.collections.SszBytes32Vector;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
-public class DepositWithIndex extends Deposit implements Comparable<DepositWithIndex> {
+public class DepositWithIndex implements Comparable<DepositWithIndex> {
 
+  private final Deposit deposit;
   private final UInt64 index;
 
-  public DepositWithIndex(
-      final SszBytes32Vector proof, final DepositData data, final UInt64 index) {
-    super(proof, data);
+  public DepositWithIndex(Deposit deposit, UInt64 index) {
+    this.deposit = deposit;
     this.index = index;
   }
 
-  public DepositWithIndex(final DepositData data, final UInt64 index) {
-    super(data);
-    this.index = index;
+  public Deposit getDeposit() {
+    return deposit;
   }
 
   public UInt64 getIndex() {
@@ -43,23 +41,16 @@ public class DepositWithIndex extends Deposit implements Comparable<DepositWithI
   }
 
   @Override
-  public boolean equals(final Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    if (!super.equals(o)) {
-      return false;
-    }
-    final DepositWithIndex that = (DepositWithIndex) o;
-    return index.equals(that.index);
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    DepositWithIndex that = (DepositWithIndex) o;
+    return Objects.equals(index, that.index) && Objects.equals(deposit, that.deposit);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(super.hashCode(), index);
+    return Objects.hash(deposit, index);
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/DepositWithIndex.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/operations/DepositWithIndex.java
@@ -13,7 +13,6 @@
 
 package tech.pegasys.teku.spec.datastructures.operations;
 
-import java.util.Objects;
 import org.jetbrains.annotations.NotNull;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 
@@ -42,15 +41,22 @@ public class DepositWithIndex implements Comparable<DepositWithIndex> {
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
     DepositWithIndex that = (DepositWithIndex) o;
-    return Objects.equals(index, that.index) && Objects.equals(deposit, that.deposit);
+    return deposit.equals(that.deposit) && index.equals(that.index);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(deposit, index);
+    int result = deposit.hashCode();
+    result = 31 * result + index.hashCode();
+    return result;
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/util/DepositUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/util/DepositUtil.java
@@ -37,6 +37,8 @@ public class DepositUtil {
             event.getWithdrawal_credentials(),
             event.getAmount(),
             event.getSignature());
-    return new DepositWithIndex(data, event.getMerkle_tree_index());
+    return new DepositWithIndex(
+        new tech.pegasys.teku.spec.datastructures.operations.Deposit(data),
+        event.getMerkle_tree_index());
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/genesis/GenesisGenerator.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/genesis/GenesisGenerator.java
@@ -79,9 +79,7 @@ public class GenesisGenerator {
   }
 
   public void updateCandidateState(
-      final Bytes32 eth1BlockHash,
-      final UInt64 eth1Timestamp,
-      final List<? extends Deposit> deposits) {
+      final Bytes32 eth1BlockHash, final UInt64 eth1Timestamp, final List<Deposit> deposits) {
     updateGenesisTime(eth1Timestamp);
 
     state.setEth1Data(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/AbstractBlockProcessor.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/AbstractBlockProcessor.java
@@ -655,8 +655,7 @@ public abstract class AbstractBlockProcessor implements BlockProcessor {
   }
 
   @Override
-  public void processDeposits(
-      final MutableBeaconState state, final SszList<? extends Deposit> deposits)
+  public void processDeposits(final MutableBeaconState state, final SszList<Deposit> deposits)
       throws BlockProcessingException {
     safelyProcess(
         () -> {
@@ -667,7 +666,7 @@ public abstract class AbstractBlockProcessor implements BlockProcessor {
         });
   }
 
-  private boolean batchVerifyDepositSignatures(final SszList<? extends Deposit> deposits) {
+  private boolean batchVerifyDepositSignatures(final SszList<Deposit> deposits) {
     try {
       final List<List<BLSPublicKey>> publicKeys = new ArrayList<>();
       final List<Bytes> messages = new ArrayList<>();

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/BlockProcessor.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/BlockProcessor.java
@@ -119,7 +119,7 @@ public interface BlockProcessor {
       BLSSignatureVerifier signatureVerifier)
       throws BlockProcessingException;
 
-  void processDeposits(MutableBeaconState state, SszList<? extends Deposit> deposits)
+  void processDeposits(MutableBeaconState state, SszList<Deposit> deposits)
       throws BlockProcessingException;
 
   void processDepositWithoutCheckingMerkleProof(

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/common/AbstractBeaconBlockBodyTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/common/AbstractBeaconBlockBodyTest.java
@@ -76,7 +76,8 @@ public abstract class AbstractBeaconBlockBodyTest<T extends BeaconBlockBody> {
             dataStructureUtil.randomSignedVoluntaryExit(),
             dataStructureUtil.randomSignedVoluntaryExit());
     deposits =
-        blockBodyLists.createDeposits(dataStructureUtil.randomDeposits(2).toArray(new Deposit[0]));
+        blockBodyLists.createDeposits(
+            dataStructureUtil.randomDepositsWithIndex(2).toArray(new Deposit[0]));
     attestations =
         blockBodyLists.createAttestations(
             dataStructureUtil.randomAttestation(),

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/common/AbstractBeaconBlockBodyTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blocks/blockbody/common/AbstractBeaconBlockBodyTest.java
@@ -76,8 +76,7 @@ public abstract class AbstractBeaconBlockBodyTest<T extends BeaconBlockBody> {
             dataStructureUtil.randomSignedVoluntaryExit(),
             dataStructureUtil.randomSignedVoluntaryExit());
     deposits =
-        blockBodyLists.createDeposits(
-            dataStructureUtil.randomDepositsWithIndex(2).toArray(new Deposit[0]));
+        blockBodyLists.createDeposits(dataStructureUtil.randomDeposits(2).toArray(new Deposit[0]));
     attestations =
         blockBodyLists.createAttestations(
             dataStructureUtil.randomAttestation(),

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/genesis/GenesisGeneratorTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/genesis/GenesisGeneratorTest.java
@@ -22,7 +22,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.IntStream;
 import org.apache.tuweni.bytes.Bytes32;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -58,37 +57,33 @@ class GenesisGeneratorTest {
       new MockStartDepositGenerator(spec, new DepositGenerator(spec, true))
           .createDeposits(VALIDATOR_KEYS);
   private final List<Deposit> initialDeposits =
-      IntStream.range(0, initialDepositData.size())
-          .mapToObj(
-              index -> {
-                final DepositData data = initialDepositData.get(index);
-                return new DepositWithIndex(data, UInt64.valueOf(index));
-              })
-          .collect(toList());
+      initialDepositData.stream().map(Deposit::new).toList();
 
   @Test
   void initializeBeaconStateFromEth1_shouldIgnoreInvalidSignedDeposits() {
-    List<DepositWithIndex> deposits = dataStructureUtil.randomDeposits(3);
-    DepositWithIndex deposit = deposits.get(1);
-    DepositData depositData = deposit.getData();
+    List<DepositWithIndex> depositsWithIndex = dataStructureUtil.randomDepositsWithIndex(3);
+    DepositWithIndex deposit = depositsWithIndex.get(1);
+    DepositData depositData = deposit.getDeposit().getData();
     DepositWithIndex invalidSigDeposit =
         new DepositWithIndex(
-            new DepositData(
-                depositData.getPubkey(),
-                depositData.getWithdrawalCredentials(),
-                depositData.getAmount(),
-                BLSSignature.empty()),
+            new Deposit(
+                new DepositData(
+                    depositData.getPubkey(),
+                    depositData.getWithdrawalCredentials(),
+                    depositData.getAmount(),
+                    BLSSignature.empty())),
             deposit.getIndex());
-    deposits.set(1, invalidSigDeposit);
+    depositsWithIndex.set(1, invalidSigDeposit);
+    List<Deposit> deposits = depositsWithIndex.stream().map(DepositWithIndex::getDeposit).toList();
 
     BeaconState state =
         spec.initializeBeaconStateFromEth1(Bytes32.ZERO, UInt64.ZERO, deposits, Optional.empty());
     assertEquals(2, state.getValidators().size());
     assertEquals(
-        deposits.get(0).getData().getPubkey().toBytesCompressed(),
+        depositsWithIndex.get(0).getDeposit().getData().getPubkey().toBytesCompressed(),
         state.getValidators().get(0).getPubkeyBytes());
     assertEquals(
-        deposits.get(2).getData().getPubkey().toBytesCompressed(),
+        depositsWithIndex.get(2).getDeposit().getData().getPubkey().toBytesCompressed(),
         state.getValidators().get(1).getPubkeyBytes());
   }
 
@@ -145,14 +140,7 @@ class GenesisGeneratorTest {
 
     List<DepositData> initialDepositData = List.of(partialDepositData, topUpDepositData);
 
-    List<Deposit> initialDeposits =
-        IntStream.range(0, initialDepositData.size())
-            .mapToObj(
-                index -> {
-                  final DepositData data = initialDepositData.get(index);
-                  return new DepositWithIndex(data, UInt64.valueOf(index));
-                })
-            .collect(toList());
+    List<Deposit> initialDeposits = initialDepositData.stream().map(Deposit::new).collect(toList());
 
     genesisGenerator.updateCandidateState(Bytes32.ZERO, UInt64.ZERO, initialDeposits);
 

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/genesis/GenesisGeneratorTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/genesis/GenesisGeneratorTest.java
@@ -63,7 +63,7 @@ class GenesisGeneratorTest {
   void initializeBeaconStateFromEth1_shouldIgnoreInvalidSignedDeposits() {
     List<DepositWithIndex> depositsWithIndex = dataStructureUtil.randomDepositsWithIndex(3);
     DepositWithIndex deposit = depositsWithIndex.get(1);
-    DepositData depositData = deposit.getDeposit().getData();
+    DepositData depositData = deposit.deposit().getData();
     DepositWithIndex invalidSigDeposit =
         new DepositWithIndex(
             new Deposit(
@@ -72,18 +72,18 @@ class GenesisGeneratorTest {
                     depositData.getWithdrawalCredentials(),
                     depositData.getAmount(),
                     BLSSignature.empty())),
-            deposit.getIndex());
+            deposit.index());
     depositsWithIndex.set(1, invalidSigDeposit);
-    List<Deposit> deposits = depositsWithIndex.stream().map(DepositWithIndex::getDeposit).toList();
+    List<Deposit> deposits = depositsWithIndex.stream().map(DepositWithIndex::deposit).toList();
 
     BeaconState state =
         spec.initializeBeaconStateFromEth1(Bytes32.ZERO, UInt64.ZERO, deposits, Optional.empty());
     assertEquals(2, state.getValidators().size());
     assertEquals(
-        depositsWithIndex.get(0).getDeposit().getData().getPubkey().toBytesCompressed(),
+        depositsWithIndex.get(0).deposit().getData().getPubkey().toBytesCompressed(),
         state.getValidators().get(0).getPubkeyBytes());
     assertEquals(
-        depositsWithIndex.get(2).getDeposit().getData().getPubkey().toBytesCompressed(),
+        depositsWithIndex.get(2).deposit().getData().getPubkey().toBytesCompressed(),
         state.getValidators().get(1).getPubkeyBytes());
   }
 

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/StateUpgradeTransitionTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/StateUpgradeTransitionTest.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.spec.logic;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -31,8 +30,8 @@ import tech.pegasys.teku.spec.TestSpecFactory;
 import tech.pegasys.teku.spec.TestSpecInvocationContextProvider.SpecContext;
 import tech.pegasys.teku.spec.datastructures.interop.MockStartDepositGenerator;
 import tech.pegasys.teku.spec.datastructures.interop.MockStartValidatorKeyPairFactory;
+import tech.pegasys.teku.spec.datastructures.operations.Deposit;
 import tech.pegasys.teku.spec.datastructures.operations.DepositData;
-import tech.pegasys.teku.spec.datastructures.operations.DepositWithIndex;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.altair.BeaconStateAltair;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.versions.bellatrix.BeaconStateBellatrix;
@@ -135,12 +134,7 @@ public class StateUpgradeTransitionTest {
         new MockStartDepositGenerator(spec, new DepositGenerator(spec, true))
             .createDeposits(VALIDATOR_KEYS, spec.getGenesisSpecConfig().getMaxEffectiveBalance());
 
-    final List<DepositWithIndex> deposits = new ArrayList<>();
-    for (int index = 0; index < initialDepositData.size(); index++) {
-      final DepositData data = initialDepositData.get(index);
-      DepositWithIndex deposit = new DepositWithIndex(data, UInt64.valueOf(index));
-      deposits.add(deposit);
-    }
+    final List<Deposit> deposits = initialDepositData.stream().map(Deposit::new).toList();
     final BeaconState initialState =
         spec.initializeBeaconStateFromEth1(Bytes32.ZERO, UInt64.ZERO, deposits, Optional.empty());
     return initialState.updated(state -> state.setGenesisTime(UInt64.ZERO));

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/block/BlockProcessorTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/block/BlockProcessorTest.java
@@ -37,7 +37,6 @@ import tech.pegasys.teku.spec.datastructures.blocks.Eth1Data;
 import tech.pegasys.teku.spec.datastructures.operations.Deposit;
 import tech.pegasys.teku.spec.datastructures.operations.DepositData;
 import tech.pegasys.teku.spec.datastructures.operations.DepositMessage;
-import tech.pegasys.teku.spec.datastructures.operations.DepositWithIndex;
 import tech.pegasys.teku.spec.datastructures.state.Fork;
 import tech.pegasys.teku.spec.datastructures.state.Validator;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
@@ -259,10 +258,9 @@ public abstract class BlockProcessorTest {
                     new Eth1Data(depositMerkleTree.getRoot(), UInt64.valueOf(1), Bytes32.ZERO)));
 
     SszListSchema<Deposit, ?> schema =
-        SszListSchema.create(DepositWithIndex.SSZ_SCHEMA, specConfig.getMaxDeposits());
+        SszListSchema.create(Deposit.SSZ_SCHEMA, specConfig.getMaxDeposits());
     SszBytes32Vector proof = Deposit.SSZ_SCHEMA.getProofSchema().of(depositMerkleTree.getProof(0));
-    SszList<Deposit> deposits =
-        schema.of(new DepositWithIndex(proof, depositData, UInt64.valueOf(0)));
+    SszList<Deposit> deposits = schema.of(new Deposit(proof, depositData));
 
     // Attempt to process deposit with above data.
     return beaconState.updated(state -> blockProcessor.processDeposits(state, deposits));

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -1621,14 +1621,12 @@ public final class DataStructureUtil {
     return randomDepositEvent(randomUInt64());
   }
 
+  public List<Deposit> randomDeposits(final int num) {
+    return randomDepositsWithIndex(num).stream().map(DepositWithIndex::deposit).toList();
+  }
+
   public List<DepositWithIndex> randomDepositsWithIndex(final int num) {
-    final ArrayList<DepositWithIndex> deposits = new ArrayList<>();
-
-    for (int i = 0; i < num; i++) {
-      deposits.add(randomDepositWithIndex());
-    }
-
-    return deposits;
+    return Stream.generate(this::randomDepositWithIndex).limit(num).toList();
   }
 
   public SszList<Deposit> randomSszDeposits(final int num) {

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -1551,10 +1551,11 @@ public final class DataStructureUtil {
     final Bytes32 randomBytes32 = randomBytes32();
     final SszBytes32VectorSchema<?> proofSchema = Deposit.SSZ_SCHEMA.getProofSchema();
     return new DepositWithIndex(
-        Stream.generate(() -> randomBytes32)
-            .limit(proofSchema.getLength())
-            .collect(proofSchema.collectorUnboxed()),
-        randomDepositData(),
+        new Deposit(
+            Stream.generate(() -> randomBytes32)
+                .limit(proofSchema.getLength())
+                .collect(proofSchema.collectorUnboxed()),
+            randomDepositData()),
         UInt64.valueOf(depositIndex));
   }
 
@@ -1620,7 +1621,7 @@ public final class DataStructureUtil {
     return randomDepositEvent(randomUInt64());
   }
 
-  public List<DepositWithIndex> randomDeposits(final int num) {
+  public List<DepositWithIndex> randomDepositsWithIndex(final int num) {
     final ArrayList<DepositWithIndex> deposits = new ArrayList<>();
 
     for (int i = 0; i < num; i++) {

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/DataStructureUtil.java
@@ -32,6 +32,7 @@ import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.apache.tuweni.bytes.Bytes;
@@ -1626,7 +1627,7 @@ public final class DataStructureUtil {
   }
 
   public List<DepositWithIndex> randomDepositsWithIndex(final int num) {
-    return Stream.generate(this::randomDepositWithIndex).limit(num).toList();
+    return Stream.generate(this::randomDepositWithIndex).limit(num).collect(Collectors.toList());
   }
 
   public SszList<Deposit> randomSszDeposits(final int num) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/genesis/GenesisHandler.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/genesis/GenesisHandler.java
@@ -84,7 +84,7 @@ public class GenesisHandler implements Eth1EventsChannel {
     validateDeposits(depositsWithIndex);
     final int previousValidatorRequirementPercent =
         roundPercent(genesisGenerator.getActiveValidatorCount());
-    List<Deposit> deposits = depositsWithIndex.stream().map(DepositWithIndex::getDeposit).toList();
+    List<Deposit> deposits = depositsWithIndex.stream().map(DepositWithIndex::deposit).toList();
     genesisGenerator.updateCandidateState(blockHash, timestamp, deposits);
 
     final int newActiveValidatorCount = genesisGenerator.getActiveValidatorCount();
@@ -105,9 +105,9 @@ public class GenesisHandler implements Eth1EventsChannel {
 
     final UInt64 expectedIndex = UInt64.valueOf(genesisGenerator.getDepositCount());
     final DepositWithIndex firstDeposit = deposits.get(0);
-    if (!firstDeposit.getIndex().equals(expectedIndex)) {
+    if (!firstDeposit.index().equals(expectedIndex)) {
       throw InvalidDepositEventsException.expectedDepositAtIndex(
-          expectedIndex, firstDeposit.getIndex());
+          expectedIndex, firstDeposit.index());
     }
   }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/genesis/GenesisHandler.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/genesis/GenesisHandler.java
@@ -27,6 +27,7 @@ import tech.pegasys.teku.ethereum.pow.api.MinGenesisTimeBlockEvent;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.datastructures.operations.Deposit;
 import tech.pegasys.teku.spec.datastructures.operations.DepositWithIndex;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.util.DepositUtil;
@@ -77,10 +78,13 @@ public class GenesisHandler implements Eth1EventsChannel {
   }
 
   private void processNewData(
-      final Bytes32 blockHash, final UInt64 timestamp, final List<DepositWithIndex> deposits) {
-    validateDeposits(deposits);
+      final Bytes32 blockHash,
+      final UInt64 timestamp,
+      final List<DepositWithIndex> depositsWithIndex) {
+    validateDeposits(depositsWithIndex);
     final int previousValidatorRequirementPercent =
         roundPercent(genesisGenerator.getActiveValidatorCount());
+    List<Deposit> deposits = depositsWithIndex.stream().map(DepositWithIndex::getDeposit).toList();
     genesisGenerator.updateCandidateState(blockHash, timestamp, deposits);
 
     final int newActiveValidatorCount = genesisGenerator.getActiveValidatorCount();


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

When fixing #8247 got some unexpected `DepositProviderTest` failures. 
It turned out that POJO `DepositWithIndex` is inherited from SSZ `Deposit`, added to an `SszList<Deposit>` and casted back to `DepositWithIndex` in the test. 

This PR 
- Makes an explicit composition in `DepositWithIndex` instead of inheritance 
- Makes explicit methods to get either `SszList<Deposit>` SSZ structure  or plain `List<DepositWithIndex>` from `DepositProvider`

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
