### PR TITLE
7549 Block processing (modified attestation processing)

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/operations/validation/AttestationDataValidator.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/operations/validation/AttestationDataValidator.java
@@ -20,6 +20,8 @@ public interface AttestationDataValidator
 
   enum AttestationInvalidReason implements OperationInvalidReason {
     COMMITTEE_INDEX_TOO_HIGH("CommitteeIndex too high"),
+    COMMITTEE_INDEX_MUST_BE_ZERO("CommitteeIndex must be set to zero"),
+    PARTICIPANTS_COUNT_MISMATCH("Attesting participants count do not match aggregation bits"),
     NOT_FROM_CURRENT_OR_PREVIOUS_EPOCH("Attestation not from current or previous epoch"),
     SLOT_NOT_IN_EPOCH("Attestation slot not in specified epoch"),
     SUBMITTED_TOO_QUICKLY("Attestation submitted too quickly"),

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/SpecLogicElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/SpecLogicElectra.java
@@ -35,8 +35,6 @@ import tech.pegasys.teku.spec.logic.versions.bellatrix.util.BlindBlockUtilBellat
 import tech.pegasys.teku.spec.logic.versions.capella.block.BlockProcessorCapella;
 import tech.pegasys.teku.spec.logic.versions.capella.operations.validation.OperationValidatorCapella;
 import tech.pegasys.teku.spec.logic.versions.deneb.helpers.MiscHelpersDeneb;
-import tech.pegasys.teku.spec.logic.versions.deneb.operations.validation.AttestationDataValidatorDeneb;
-import tech.pegasys.teku.spec.logic.versions.deneb.util.AttestationUtilDeneb;
 import tech.pegasys.teku.spec.logic.versions.deneb.util.ForkChoiceUtilDeneb;
 import tech.pegasys.teku.spec.logic.versions.electra.block.BlockProcessorElectra;
 import tech.pegasys.teku.spec.logic.versions.electra.forktransition.ElectraStateUpgrade;
@@ -44,8 +42,10 @@ import tech.pegasys.teku.spec.logic.versions.electra.helpers.BeaconStateAccessor
 import tech.pegasys.teku.spec.logic.versions.electra.helpers.BeaconStateMutatorsElectra;
 import tech.pegasys.teku.spec.logic.versions.electra.helpers.MiscHelpersElectra;
 import tech.pegasys.teku.spec.logic.versions.electra.helpers.PredicatesElectra;
+import tech.pegasys.teku.spec.logic.versions.electra.operations.validation.AttestationDataValidatorElectra;
 import tech.pegasys.teku.spec.logic.versions.electra.operations.validation.VoluntaryExitValidatorElectra;
 import tech.pegasys.teku.spec.logic.versions.electra.statetransition.epoch.EpochProcessorElectra;
+import tech.pegasys.teku.spec.logic.versions.electra.util.AttestationUtilElectra;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsElectra;
 
 public class SpecLogicElectra extends AbstractSpecLogic {
@@ -114,9 +114,9 @@ public class SpecLogicElectra extends AbstractSpecLogic {
         new BeaconStateUtil(
             config, schemaDefinitions, predicates, miscHelpers, beaconStateAccessors);
     final AttestationUtil attestationUtil =
-        new AttestationUtilDeneb(config, schemaDefinitions, beaconStateAccessors, miscHelpers);
+        new AttestationUtilElectra(config, schemaDefinitions, beaconStateAccessors, miscHelpers);
     final AttestationDataValidator attestationDataValidator =
-        new AttestationDataValidatorDeneb(config, miscHelpers, beaconStateAccessors);
+        new AttestationDataValidatorElectra(config, miscHelpers, beaconStateAccessors);
     final VoluntaryExitValidatorElectra voluntaryExitValidatorElectra =
         new VoluntaryExitValidatorElectra(config, predicates, beaconStateAccessors);
     final OperationValidator operationValidator =

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/block/BlockProcessorElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/block/BlockProcessorElectra.java
@@ -17,6 +17,8 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static tech.pegasys.teku.spec.config.SpecConfig.FAR_FUTURE_EPOCH;
 import static tech.pegasys.teku.spec.config.SpecConfigElectra.FULL_EXIT_REQUEST_AMOUNT;
 
+import it.unimi.dsi.fastutil.ints.IntList;
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
 import org.apache.logging.log4j.LogManager;
@@ -26,6 +28,7 @@ import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.infrastructure.bytes.Bytes20;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.ssz.SszMutableList;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszBitlist;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszByte;
 import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -36,6 +39,7 @@ import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.DepositReceipt;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionLayerWithdrawalRequest;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionPayloadElectra;
+import tech.pegasys.teku.spec.datastructures.operations.Attestation;
 import tech.pegasys.teku.spec.datastructures.state.Validator;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.state.beaconstate.MutableBeaconState;
@@ -46,6 +50,8 @@ import tech.pegasys.teku.spec.datastructures.state.versions.electra.PendingParti
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateMutators.ValidatorExitContext;
 import tech.pegasys.teku.spec.logic.common.helpers.Predicates;
 import tech.pegasys.teku.spec.logic.common.operations.OperationSignatureVerifier;
+import tech.pegasys.teku.spec.logic.common.operations.validation.AttestationDataValidator.AttestationInvalidReason;
+import tech.pegasys.teku.spec.logic.common.operations.validation.OperationInvalidReason;
 import tech.pegasys.teku.spec.logic.common.operations.validation.OperationValidator;
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.BlockProcessingException;
 import tech.pegasys.teku.spec.logic.common.util.AttestationUtil;
@@ -359,6 +365,50 @@ public class BlockProcessorElectra extends BlockProcessorDeneb {
             .getPendingBalanceDepositSchema()
             .create(SszUInt64.of(UInt64.fromLongBits(validatorIndex)), SszUInt64.of(amount)));
     stateElectra.setPendingBalanceDeposits(pendingBalanceDeposits);
+  }
+
+  @Override
+  protected void assertAttestationValid(
+      final MutableBeaconState state, final Attestation attestation) {
+    super.assertAttestationValid(state, attestation);
+    final List<UInt64> committeeIndices = attestation.getCommitteeIndicesRequired();
+    final UInt64 committeeCountPerSlot =
+        beaconStateAccessors.getCommitteeCountPerSlot(
+            state, attestation.getData().getTarget().getEpoch());
+    beaconStateAccessors.getCommitteeCountPerSlot(
+        state, attestation.getData().getTarget().getEpoch());
+    final SszBitlist aggregationBits = attestation.getAggregationBits();
+    final Optional<OperationInvalidReason> committeeCheckResult =
+        checkCommittees(
+            committeeIndices,
+            committeeCountPerSlot,
+            state,
+            attestation.getData().getSlot(),
+            aggregationBits);
+    if (committeeCheckResult.isPresent()) {
+      throw new IllegalArgumentException(committeeCheckResult.get().describe());
+    }
+  }
+
+  private Optional<OperationInvalidReason> checkCommittees(
+      final List<UInt64> committeeIndices,
+      final UInt64 committeeCountPerSlot,
+      final BeaconState state,
+      final UInt64 slot,
+      final SszBitlist aggregationBits) {
+    int participantsCount = 0;
+    for (final UInt64 committeeIndex : committeeIndices) {
+      if (committeeIndex.isGreaterThan(committeeCountPerSlot)) {
+        return Optional.of(AttestationInvalidReason.COMMITTEE_INDEX_TOO_HIGH);
+      }
+      final IntList committee =
+          beaconStateAccessors.getBeaconCommittee(state, slot, committeeIndex);
+      participantsCount += committee.size();
+    }
+    if (participantsCount != aggregationBits.size()) {
+      return Optional.of(AttestationInvalidReason.PARTICIPANTS_COUNT_MISMATCH);
+    }
+    return Optional.empty();
   }
 
   protected Validator getValidatorFromDeposit(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/operations/validation/AttestationDataValidatorElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/operations/validation/AttestationDataValidatorElectra.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.logic.versions.electra.operations.validation;
+
+import static tech.pegasys.teku.spec.logic.common.operations.validation.OperationInvalidReason.check;
+import static tech.pegasys.teku.spec.logic.common.operations.validation.OperationInvalidReason.firstOf;
+
+import java.util.Optional;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.config.SpecConfig;
+import tech.pegasys.teku.spec.datastructures.operations.AttestationData;
+import tech.pegasys.teku.spec.datastructures.state.Fork;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
+import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
+import tech.pegasys.teku.spec.logic.common.operations.validation.AttestationDataValidator;
+import tech.pegasys.teku.spec.logic.common.operations.validation.OperationInvalidReason;
+
+public class AttestationDataValidatorElectra implements AttestationDataValidator {
+
+  private final SpecConfig specConfig;
+  private final MiscHelpers miscHelpers;
+  private final BeaconStateAccessors beaconStateAccessors;
+
+  public AttestationDataValidatorElectra(
+      final SpecConfig specConfig,
+      final MiscHelpers miscHelpers,
+      final BeaconStateAccessors beaconStateAccessors) {
+    this.specConfig = specConfig;
+    this.miscHelpers = miscHelpers;
+    this.beaconStateAccessors = beaconStateAccessors;
+  }
+
+  @Override
+  public Optional<OperationInvalidReason> validate(
+      final Fork fork, final BeaconState state, final AttestationData data) {
+    return firstOf(
+        () ->
+            check(
+                data.getTarget().getEpoch().equals(beaconStateAccessors.getPreviousEpoch(state))
+                    || data.getTarget()
+                        .getEpoch()
+                        .equals(beaconStateAccessors.getCurrentEpoch(state)),
+                AttestationInvalidReason.NOT_FROM_CURRENT_OR_PREVIOUS_EPOCH),
+        () ->
+            check(
+                data.getTarget().getEpoch().equals(miscHelpers.computeEpochAtSlot(data.getSlot())),
+                AttestationInvalidReason.SLOT_NOT_IN_EPOCH),
+        () ->
+            check(
+                data.getSlot()
+                        .plus(specConfig.getMinAttestationInclusionDelay())
+                        .compareTo(state.getSlot())
+                    <= 0,
+                AttestationInvalidReason.SUBMITTED_TOO_QUICKLY),
+        () ->
+            check(
+                data.getIndex().equals(UInt64.ZERO),
+                AttestationInvalidReason.COMMITTEE_INDEX_MUST_BE_ZERO),
+        () -> {
+          if (data.getTarget().getEpoch().equals(beaconStateAccessors.getCurrentEpoch(state))) {
+            return check(
+                data.getSource().equals(state.getCurrentJustifiedCheckpoint()),
+                AttestationInvalidReason.INCORRECT_CURRENT_JUSTIFIED_CHECKPOINT);
+          } else {
+            return check(
+                data.getSource().equals(state.getPreviousJustifiedCheckpoint()),
+                AttestationInvalidReason.INCORRECT_PREVIOUS_JUSTIFIED_CHECKPOINT);
+          }
+        });
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/util/AttestationUtilElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/util/AttestationUtilElectra.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.logic.versions.electra.util;
+
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntList;
+import java.util.List;
+import java.util.stream.IntStream;
+import tech.pegasys.teku.infrastructure.ssz.collections.SszBitlist;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.config.SpecConfig;
+import tech.pegasys.teku.spec.datastructures.operations.Attestation;
+import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
+import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateAccessors;
+import tech.pegasys.teku.spec.logic.common.helpers.MiscHelpers;
+import tech.pegasys.teku.spec.logic.versions.deneb.util.AttestationUtilDeneb;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitions;
+
+public class AttestationUtilElectra extends AttestationUtilDeneb {
+  public AttestationUtilElectra(
+      final SpecConfig specConfig,
+      final SchemaDefinitions schemaDefinitions,
+      final BeaconStateAccessors beaconStateAccessors,
+      final MiscHelpers miscHelpers) {
+    super(specConfig, schemaDefinitions, beaconStateAccessors, miscHelpers);
+  }
+
+  /**
+   * Return the attesting indices corresponding to ``aggregation_bits`` and ``committee_bits``.
+   *
+   * @param state
+   * @param attestation
+   * @return
+   * @throws IllegalArgumentException
+   * @see
+   *     <a>https://github.com/ethereum/consensus-specs/blob/dev/specs/electra/beacon-chain.md#modified-get_attesting_indices</a>
+   */
+  @Override
+  public IntList getAttestingIndices(final BeaconState state, final Attestation attestation) {
+    final List<UInt64> committeeIndices = attestation.getCommitteeIndicesRequired();
+    final SszBitlist aggregationBits = attestation.getAggregationBits();
+    final IntList attestingIndices = new IntArrayList();
+    int committeeOffset = 0;
+    for (final UInt64 committeeIndex : committeeIndices) {
+      final IntList committee =
+          beaconStateAccessors.getBeaconCommittee(
+              state, attestation.getData().getSlot(), committeeIndex);
+      final IntList committeeAttesters =
+          getCommitteeAttesters(committee, aggregationBits, committeeOffset);
+      attestingIndices.addAll(committeeAttesters);
+      committeeOffset += committee.size();
+    }
+    return attestingIndices;
+  }
+
+  public IntList getCommitteeAttesters(
+      final IntList committee, final SszBitlist aggregationBits, final int committeeOffset) {
+    return IntList.of(
+        streamCommitteeAttesters(committee, aggregationBits, committeeOffset).toArray());
+  }
+
+  public IntStream streamCommitteeAttesters(
+      final IntList committee, final SszBitlist aggregationBits, final int committeeOffset) {
+    return IntStream.range(committeeOffset, committeeOffset + committee.size())
+        .filter(aggregationBits::isSet)
+        .map(attesterIndex -> committee.getInt(attesterIndex - committeeOffset));
+  }
+}

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/electra/block/BlockProcessorElectraTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/electra/block/BlockProcessorElectraTest.java
@@ -47,6 +47,7 @@ import tech.pegasys.teku.spec.datastructures.state.versions.electra.PendingParti
 import tech.pegasys.teku.spec.logic.common.helpers.BeaconStateMutators.ValidatorExitContext;
 import tech.pegasys.teku.spec.logic.common.statetransition.exceptions.BlockProcessingException;
 import tech.pegasys.teku.spec.logic.versions.deneb.block.BlockProcessorDenebTest;
+import tech.pegasys.teku.spec.logic.versions.electra.util.AttestationUtilElectra;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsElectra;
 
 class BlockProcessorElectraTest extends BlockProcessorDenebTest {
@@ -582,6 +583,12 @@ class BlockProcessorElectraTest extends BlockProcessorDenebTest {
         .isEqualTo(UInt64.valueOf(123_456_789));
     assertThat(mostRecentPendingPartialWithdrawal.getWithdrawableEpoch())
         .isEqualTo(UInt64.valueOf(1_261));
+  }
+
+  @Test
+  void shouldUseElectraAttestationUtil() {
+    assertThat(spec.getGenesisSpec().getAttestationUtil())
+        .isInstanceOf(AttestationUtilElectra.class);
   }
 
   private Supplier<ValidatorExitContext> validatorExitContextSupplier(final BeaconState state) {


### PR DESCRIPTION
Based on @mehdi-aouadi work (with a couple of big fix)

- avoids inheritance on `AttestationDataValidator` to make rules easier to follow.
- testing relies on ref test: all `operations/attestation` ref tests from `v1.5.0-alpha.1` are passing

<img width="905" alt="image" src="https://github.com/Consensys/teku/assets/15999009/d6e10477-d642-40a5-89f3-552a10ecc4d9">


## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
