### PR TITLE
Add Holesky to DepositSnapshot infura test

### DIFF
--- a/services/powchain/src/test/java/tech/pegasys/teku/services/powchain/DepositSnapshotsBundleTest.java
+++ b/services/powchain/src/test/java/tech/pegasys/teku/services/powchain/DepositSnapshotsBundleTest.java
@@ -151,6 +151,7 @@ public class DepositSnapshotsBundleTest {
     return Stream.of(
         Arguments.of(Eth2Network.GNOSIS, "https://rpc.ankr.com/gnosis"),
         Arguments.of(Eth2Network.MAINNET, "https://mainnet.infura.io/v3/%INFURA_KEY%"),
-        Arguments.of(Eth2Network.SEPOLIA, "https://sepolia.infura.io/v3/%INFURA_KEY%"));
+        Arguments.of(Eth2Network.SEPOLIA, "https://sepolia.infura.io/v3/%INFURA_KEY%"),
+        Arguments.of(Eth2Network.HOLESKY, "https://holesky.infura.io/v3/%INFURA_KEY%"));
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Infura finally added Holesky to their endpoints, so turning it on for snapshots test.
You will need to login to Infura first and turn on Holesky endpoint for your key to make it work.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
