### PR TITLE
Use isGreaterThanOrEqualTo when checking committee index

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/block/BlockProcessorElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/block/BlockProcessorElectra.java
@@ -385,8 +385,6 @@ public class BlockProcessorElectra extends BlockProcessorDeneb {
     final UInt64 committeeCountPerSlot =
         beaconStateAccessors.getCommitteeCountPerSlot(
             state, attestation.getData().getTarget().getEpoch());
-    beaconStateAccessors.getCommitteeCountPerSlot(
-        state, attestation.getData().getTarget().getEpoch());
     final SszBitlist aggregationBits = attestation.getAggregationBits();
     final Optional<OperationInvalidReason> committeeCheckResult =
         checkCommittees(
@@ -408,7 +406,7 @@ public class BlockProcessorElectra extends BlockProcessorDeneb {
       final SszBitlist aggregationBits) {
     int participantsCount = 0;
     for (final UInt64 committeeIndex : committeeIndices) {
-      if (committeeIndex.isGreaterThan(committeeCountPerSlot)) {
+      if (committeeIndex.isGreaterThanOrEqualTo(committeeCountPerSlot)) {
         return Optional.of(AttestationInvalidReason.COMMITTEE_INDEX_TOO_HIGH);
       }
       final IntList committee =


### PR DESCRIPTION
## PR Description

Noticed what I believe to be two minor accidents.

* A duplicate statement which had no effect.
* An incorrect `committeeIndex` check.

For the second one, since it's an index, the max value is `committeeCountPerSlot - 1`, right?

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
