### PR TITLE
Use correct end index for subList calls

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/statetransition/epoch/EpochProcessorElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/statetransition/epoch/EpochProcessorElectra.java
@@ -165,8 +165,7 @@ public class EpochProcessorElectra extends EpochProcessorBellatrix {
 
     final SszList<PendingBalanceDeposit> pendingBalanceDeposits =
         stateElectra.getPendingBalanceDeposits();
-    for (int i = 0; i < pendingBalanceDeposits.size(); i++) {
-      final PendingBalanceDeposit deposit = pendingBalanceDeposits.get(i);
+    for (final PendingBalanceDeposit deposit : pendingBalanceDeposits) {
       if (processedAmount.plus(deposit.getAmount()).isGreaterThan(availableForProcessing)) {
         break;
       }
@@ -183,7 +182,7 @@ public class EpochProcessorElectra extends EpochProcessorBellatrix {
       final List<PendingBalanceDeposit> newList =
           pendingBalanceDeposits
               .asList()
-              .subList(nextDepositIndex, pendingBalanceDeposits.size() - 1);
+              .subList(nextDepositIndex, pendingBalanceDeposits.size());
       stateElectra.setPendingBalanceDeposits(
           schemaDefinitionsElectra.getPendingBalanceDepositsSchema().createFromElements(newList));
       stateElectra.setDepositBalanceToConsume(availableForProcessing.minusMinZero(processedAmount));
@@ -204,8 +203,7 @@ public class EpochProcessorElectra extends EpochProcessorBellatrix {
         stateElectra.getPendingConsolidations();
     final UInt64 currentEpoch = stateAccessorsElectra.getCurrentEpoch(state);
 
-    for (int i = 0; i < pendingConsolidations.size(); i++) {
-      final PendingConsolidation pendingConsolidation = pendingConsolidations.get(i);
+    for (final PendingConsolidation pendingConsolidation : pendingConsolidations) {
       final Validator sourceValidator =
           state.getValidators().get(pendingConsolidation.getSourceIndex());
       if (sourceValidator.isSlashed()) {
@@ -234,7 +232,7 @@ public class EpochProcessorElectra extends EpochProcessorBellatrix {
       final List<PendingConsolidation> newList =
           pendingConsolidations
               .asList()
-              .subList(nextPendingBalanceConsolidation, pendingConsolidations.size() - 1);
+              .subList(nextPendingBalanceConsolidation, pendingConsolidations.size());
       stateElectra.setPendingConsolidations(
           schemaDefinitionsElectra.getPendingConsolidationsSchema().createFromElements(newList));
     }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/statetransition/epoch/EpochProcessorElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/statetransition/epoch/EpochProcessorElectra.java
@@ -180,9 +180,7 @@ public class EpochProcessorElectra extends EpochProcessorBellatrix {
       stateElectra.setDepositBalanceToConsume(UInt64.ZERO);
     } else {
       final List<PendingBalanceDeposit> newList =
-          pendingBalanceDeposits
-              .asList()
-              .subList(nextDepositIndex, pendingBalanceDeposits.size());
+          pendingBalanceDeposits.asList().subList(nextDepositIndex, pendingBalanceDeposits.size());
       stateElectra.setPendingBalanceDeposits(
           schemaDefinitionsElectra.getPendingBalanceDepositsSchema().createFromElements(newList));
       stateElectra.setDepositBalanceToConsume(availableForProcessing.minusMinZero(processedAmount));


### PR DESCRIPTION
## PR Description

Noticed another little mistake. The `toIndex` value for these `List.subList` calls are wrong. The end is exclusive.

> Returns a view of the portion of this list between the specified fromIndex, inclusive, and toIndex, exclusive.

https://docs.oracle.com/javase/8/docs/api/java/util/List.html#subList-int-int-

<img width="613" alt="image" src="https://github.com/Consensys/teku/assets/95511699/374f6f03-a96c-4013-ac8e-9485d4cff078">

I'm aware all of this code is a work in progress 😄 I know there will be problems.

Also, I replaced the two loops with more java-esque for-each patterns. This was just a nit.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
