### PR TITLE
Default to currentEpoch in findEarliestExitEpoch

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/electra/ExecutionPayloadElectraImpl.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/versions/electra/ExecutionPayloadElectraImpl.java
@@ -103,7 +103,7 @@ public class ExecutionPayloadElectraImpl
       final SszUInt64 blobGasUsed,
       final SszUInt64 excessBlobGas,
       final SszList<DepositReceipt> depositReceipts,
-      final SszList<ExecutionLayerWithdrawalRequest> exits) {
+      final SszList<ExecutionLayerWithdrawalRequest> withdrawalRequests) {
     super(
         schema,
         parentHash,
@@ -124,7 +124,7 @@ public class ExecutionPayloadElectraImpl
         blobGasUsed,
         excessBlobGas,
         depositReceipts,
-        exits);
+        withdrawalRequests);
   }
 
   @Override

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/forktransition/ElectraStateUpgrade.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/forktransition/ElectraStateUpgrade.java
@@ -119,7 +119,7 @@ public class ElectraStateUpgrade implements StateUpgrade<BeaconStateDeneb> {
               state.setDepositBalanceToConsume(UInt64.ZERO);
               state.setExitBalanceToConsume(
                   beaconStateAccessors.getActivationExitChurnLimit(state));
-              state.setEarliestExitEpoch(findEarliestExitEpoch(state));
+              state.setEarliestExitEpoch(findEarliestExitEpoch(state, epoch));
               state.setConsolidationBalanceToConsume(
                   beaconStateAccessors.getConsolidationChurnLimit(state));
               state.setEarliestConsolidationEpoch(
@@ -151,14 +151,12 @@ public class ElectraStateUpgrade implements StateUpgrade<BeaconStateDeneb> {
             });
   }
 
-  private UInt64 findEarliestExitEpoch(final BeaconState state) {
-    UInt64 lastExitEpoch = UInt64.ZERO;
-    for (final Validator validator : state.getValidators()) {
-      final UInt64 exitEpoch = validator.getExitEpoch();
-      if (!exitEpoch.equals(FAR_FUTURE_EPOCH)) {
-        lastExitEpoch = lastExitEpoch.max(exitEpoch);
-      }
-    }
-    return lastExitEpoch.increment();
+  private UInt64 findEarliestExitEpoch(final BeaconState state, final UInt64 currentEpoch) {
+    return state.getValidators().stream()
+        .map(Validator::getExitEpoch)
+        .filter(exitEpoch -> !exitEpoch.equals(FAR_FUTURE_EPOCH))
+        .max(UInt64::compareTo)
+        .orElse(currentEpoch)
+        .increment();
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/forktransition/ElectraStateUpgrade.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/forktransition/ElectraStateUpgrade.java
@@ -18,7 +18,6 @@ import static tech.pegasys.teku.spec.config.SpecConfig.FAR_FUTURE_EPOCH;
 import java.util.Comparator;
 import java.util.stream.IntStream;
 import org.apache.tuweni.bytes.Bytes32;
-import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.ssz.SszMutableList;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.config.SpecConfigElectra;
@@ -153,11 +152,10 @@ public class ElectraStateUpgrade implements StateUpgrade<BeaconStateDeneb> {
   }
 
   private UInt64 findEarliestExitEpoch(final BeaconState state) {
-    final SszList<Validator> validators = state.getValidators();
     UInt64 lastExitEpoch = UInt64.ZERO;
-    for (int i = 0; i < validators.size(); i++) {
-      final UInt64 exitEpoch = validators.get(i).getExitEpoch();
-      if (exitEpoch.isLessThan(UInt64.MAX_VALUE)) {
+    for (final Validator validator : state.getValidators()) {
+      final UInt64 exitEpoch = validator.getExitEpoch();
+      if (!exitEpoch.equals(FAR_FUTURE_EPOCH)) {
         lastExitEpoch = lastExitEpoch.max(exitEpoch);
       }
     }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/helpers/BeaconStateAccessorsElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/helpers/BeaconStateAccessorsElectra.java
@@ -79,7 +79,7 @@ public class BeaconStateAccessorsElectra extends BeaconStateAccessorsDeneb {
         state.getPendingPartialWithdrawals().asList();
     return partialWithdrawals.stream()
         .filter(z -> z.getIndex() == validatorIndex)
-        .map(z -> z.getAmount())
+        .map(PendingPartialWithdrawal::getAmount)
         .reduce(UInt64.ZERO, UInt64::plus);
   }
 

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/electra/forktransition/ElectraStateUpgradeTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/electra/forktransition/ElectraStateUpgradeTest.java
@@ -57,12 +57,10 @@ class ElectraStateUpgradeTest {
 
   @Test
   void canUpgradeFromDeneb() {
+    final UInt64 slot = UInt64.valueOf(80_000L);
     final BeaconStateDeneb pre =
         BeaconStateDeneb.required(
-            dataStructureUtil
-                .stateBuilder(SpecMilestone.DENEB, 0, 0)
-                .slot(UInt64.valueOf(80_000L))
-                .build());
+            dataStructureUtil.stateBuilder(SpecMilestone.DENEB, 0, 0).slot(slot).build());
 
     final ElectraStateUpgrade upgrade =
         new ElectraStateUpgrade(
@@ -78,7 +76,7 @@ class ElectraStateUpgradeTest {
     // = (64 *10^9) - (64 *10^9) MOD 10^9
     // = (64 *10^9) - 0
     assertThat(post.getExitBalanceToConsume()).isEqualTo(UInt64.valueOf(64_000_000_000L));
-    assertThat(post.getEarliestExitEpoch()).isEqualTo(UInt64.valueOf(10_001));
+    assertThat(post.getEarliestExitEpoch()).isEqualTo(slot.dividedBy(8).increment());
     assertThat(post.getConsolidationBalanceToConsume()).isEqualTo(UInt64.ZERO);
     // 80_000/8 (slots -> epochs) + max_seed_lookahead + 1
     assertThat(post.getEarliestConsolidationEpoch()).isEqualTo(UInt64.valueOf(10005));
@@ -168,6 +166,7 @@ class ElectraStateUpgradeTest {
         BeaconStateDeneb.required(
             dataStructureUtil
                 .stateBuilder(SpecMilestone.DENEB, 4, 0)
+                .slot(UInt64.valueOf(100_000))
                 .validators(validator1, validator2)
                 // All validators have their balance = maxEffectiveBalance
                 .balances(

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/electra/forktransition/ElectraStateUpgradeTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/electra/forktransition/ElectraStateUpgradeTest.java
@@ -78,7 +78,7 @@ class ElectraStateUpgradeTest {
     // = (64 *10^9) - (64 *10^9) MOD 10^9
     // = (64 *10^9) - 0
     assertThat(post.getExitBalanceToConsume()).isEqualTo(UInt64.valueOf(64_000_000_000L));
-    assertThat(post.getEarliestExitEpoch()).isEqualTo(UInt64.ONE);
+    assertThat(post.getEarliestExitEpoch()).isEqualTo(UInt64.valueOf(10_001));
     assertThat(post.getConsolidationBalanceToConsume()).isEqualTo(UInt64.ZERO);
     // 80_000/8 (slots -> epochs) + max_seed_lookahead + 1
     assertThat(post.getEarliestConsolidationEpoch()).isEqualTo(UInt64.valueOf(10005));


### PR DESCRIPTION
## PR Description

Noticed another little problem. In `findEarliestExitEpoch`, if none of the validators have an exit epoch set, `lastExitEpoch` should be the current epoch (plus one), not zero (plus one). Right?

```python
exit_epochs = [v.exit_epoch for v in pre.validators if v.exit_epoch != FAR_FUTURE_EPOCH]
if not exit_epochs:
    exit_epochs = [get_current_epoch(pre)]
earliest_exit_epoch = max(exit_epochs) + 1
```

Primarily:

* Update `findEarliestExitEpoch` to be a little closer to the spec.
  * Replace for loop with stream, map, ...
  * Use `FAR_FUTURE_EPOCH` instead of `UInt64::MAX_VALUE`.
  * Replace `isLessThan` with `!equals`, like the spec.
 
Also:

* Rename `exits` to `withdrawalRequests`. I missed this when renaming variables.
* Use lambda operation in `getPendingBalanceToWithdraw` (just a nit).

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
