### PR TITLE
Refactor `GraffitiBuilder`

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/GraffitiBuilder.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/GraffitiBuilder.java
@@ -139,7 +139,7 @@ public class GraffitiBuilder implements ExecutionClientVersionChannel {
   @VisibleForTesting
   protected String formatClientsInfo(final int length) {
     final String consensusCode = consensusClientVersion.code();
-    final String executionCode = getExecutionCode();
+    final String executionCode = getExecutionCodeSafely();
     // LH1be52536BU0f91a674
     if (length >= 20) {
       return String.format(
@@ -175,7 +175,7 @@ public class GraffitiBuilder implements ExecutionClientVersionChannel {
     return "";
   }
 
-  private String getExecutionCode() {
+  private String getExecutionCodeSafely() {
     return executionClientVersion
         .map(
             clientVersion -> {

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/GraffitiBuilder.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/GraffitiBuilder.java
@@ -118,8 +118,9 @@ public class GraffitiBuilder implements ExecutionClientVersionChannel {
   @VisibleForTesting
   protected String extractGraffiti(final Optional<Bytes32> graffiti, final int length) {
     return graffiti
-        .map(bytes -> bytes.slice(0, length))
-        .map(bytes -> new String(bytes.toArrayUnsafe(), StandardCharsets.UTF_8))
+        .map(Bytes::toArray)
+        .map(bytes -> Arrays.copyOf(bytes, length))
+        .map(bytes -> new String(bytes, StandardCharsets.UTF_8))
         .orElse("");
   }
 

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/GraffitiBuilder.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/GraffitiBuilder.java
@@ -118,9 +118,8 @@ public class GraffitiBuilder implements ExecutionClientVersionChannel {
   @VisibleForTesting
   protected String extractGraffiti(final Optional<Bytes32> graffiti, final int length) {
     return graffiti
-        .map(Bytes::toArrayUnsafe)
-        .map(bytes -> Arrays.copyOf(bytes, length))
-        .map(bytes -> new String(bytes, StandardCharsets.UTF_8))
+        .map(bytes -> bytes.slice(0, length))
+        .map(bytes -> new String(bytes.toArrayUnsafe(), StandardCharsets.UTF_8))
         .orElse("");
   }
 

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/GraffitiBuilder.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/GraffitiBuilder.java
@@ -73,6 +73,15 @@ public class GraffitiBuilder implements ExecutionClientVersionChannel {
   @Override
   public void onExecutionClientVersion(final ClientVersion executionClientVersion) {
     this.executionClientVersion = Optional.of(executionClientVersion);
+    logDefaultGraffiti();
+  }
+
+  @Override
+  public void onExecutionClientVersionNotAvailable() {
+    logDefaultGraffiti();
+  }
+
+  private void logDefaultGraffiti() {
     final Optional<Bytes32> defaultGraffiti = Optional.of(buildGraffiti(defaultUserGraffiti));
     EVENT_LOG.logDefaultGraffiti(
         extractGraffiti(defaultGraffiti, calculateGraffitiLength(defaultGraffiti)));

--- a/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/GraffitiBuilderTest.java
+++ b/beacon/validator/src/test/java/tech/pegasys/teku/validator/coordinator/GraffitiBuilderTest.java
@@ -109,7 +109,6 @@ public class GraffitiBuilderTest {
     final Bytes32 userGraffiti = Bytes32Parser.toBytes32(ASCII_GRAFFITI_20);
     final Bytes32 expectedGraffiti = Bytes32Parser.toBytes32(ASCII_GRAFFITI_20 + " TK");
     this.graffitiBuilder = new GraffitiBuilder(CLIENT_CODES, Optional.of(defaultGraffiti));
-    graffitiBuilder.onExecutionClientVersion(ClientVersion.UNKNOWN);
     assertThat(graffitiBuilder.buildGraffiti(Optional.of(userGraffiti)))
         .isEqualTo(expectedGraffiti);
   }
@@ -142,7 +141,6 @@ public class GraffitiBuilderTest {
       final Optional<String> maybeUserGraffiti,
       final String expectedGraffiti) {
     this.graffitiBuilder = new GraffitiBuilder(clientGraffitiAppendFormat, userGraffiti);
-    graffitiBuilder.onExecutionClientVersion(ClientVersion.UNKNOWN);
     final Bytes32 expectedGraffitiBytes = Bytes32Parser.toBytes32(expectedGraffiti);
     assertThat(
             new String(
@@ -341,8 +339,6 @@ public class GraffitiBuilderTest {
 
   @Test
   public void formatClientInfo_shouldRenderClClientNameAndFullCommit_whenElInfoNotAvailable() {
-    graffitiBuilder.onExecutionClientVersion(ClientVersion.UNKNOWN);
-
     // 20: LH1be52536BU0f91a674
     assertThat(graffitiBuilder.formatClientsInfo(30))
         .isEqualTo(
@@ -356,8 +352,6 @@ public class GraffitiBuilderTest {
 
   @Test
   public void formatClientInfo_shouldRenderClClientNameAndHalfCommit_whenElInfoNotAvailable() {
-    graffitiBuilder.onExecutionClientVersion(ClientVersion.UNKNOWN);
-
     // 12: LH1be5BU0f91
     assertThat(graffitiBuilder.formatClientsInfo(19))
         .isEqualTo(
@@ -373,8 +367,6 @@ public class GraffitiBuilderTest {
 
   @Test
   public void formatClientInfo_shouldRenderClClientNameAnd1stCommitByte_whenElInfoNotAvailable() {
-    graffitiBuilder.onExecutionClientVersion(ClientVersion.UNKNOWN);
-
     // 8: LH1bBU0f
     assertThat(graffitiBuilder.formatClientsInfo(11))
         .isEqualTo(
@@ -390,8 +382,6 @@ public class GraffitiBuilderTest {
 
   @Test
   public void formatClientInfo_shouldRenderClClientName_whenElInfoNotAvailable() {
-    graffitiBuilder.onExecutionClientVersion(ClientVersion.UNKNOWN);
-
     // 4: LHBU
     assertThat(graffitiBuilder.formatClientsInfo(7))
         .isEqualTo(TEKU_CLIENT_VERSION.code())
@@ -403,8 +393,6 @@ public class GraffitiBuilderTest {
 
   @Test
   public void formatClientInfo_shouldSkipClientsInfo_whenNotEnoughSpaceAndElInfoNotAvailable() {
-    graffitiBuilder.onExecutionClientVersion(ClientVersion.UNKNOWN);
-
     // Empty
     assertThat(graffitiBuilder.formatClientsInfo(3))
         .isEqualTo("")

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ExecutionClientVersionChannel.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ExecutionClientVersionChannel.java
@@ -25,6 +25,6 @@ public interface ExecutionClientVersionChannel extends VoidReturningChannelInter
    */
   void onExecutionClientVersion(ClientVersion executionClientVersion);
 
-  /** Called when engine_getClientVersion method is not available or has failed */
+  /** Called when engine_getClientVersion method is not available or has failed on startup */
   void onExecutionClientVersionNotAvailable();
 }

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ExecutionClientVersionChannel.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ExecutionClientVersionChannel.java
@@ -18,5 +18,12 @@ import tech.pegasys.teku.spec.datastructures.execution.ClientVersion;
 
 public interface ExecutionClientVersionChannel extends VoidReturningChannelInterface {
 
+  /**
+   * provides an execution {@link ClientVersion} based on <a
+   * href="https://github.com/ethereum/execution-apis/blob/main/src/engine/identification.md#engine_getclientversionv1">engine_getClientVersion</a>
+   */
   void onExecutionClientVersion(ClientVersion executionClientVersion);
+
+  /** called when engine_getClientVersion method is not available or has failed */
+  void onExecutionClientVersionNotAvailable();
 }

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ExecutionClientVersionChannel.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ExecutionClientVersionChannel.java
@@ -19,11 +19,12 @@ import tech.pegasys.teku.spec.datastructures.execution.ClientVersion;
 public interface ExecutionClientVersionChannel extends VoidReturningChannelInterface {
 
   /**
-   * provides an execution {@link ClientVersion} based on <a
-   * href="https://github.com/ethereum/execution-apis/blob/main/src/engine/identification.md#engine_getclientversionv1">engine_getClientVersion</a>
+   * Provides an execution {@link ClientVersion} based on <a
+   * href="https://github.com/ethereum/execution-apis/blob/main/src/engine/identification.md#engine_getclientversionv1">engine_getClientVersion</a>.
+   * This method will be called on startup and every time the {@link ClientVersion} changes.
    */
   void onExecutionClientVersion(ClientVersion executionClientVersion);
 
-  /** called when engine_getClientVersion method is not available or has failed */
+  /** Called when engine_getClientVersion method is not available or has failed */
   void onExecutionClientVersionNotAvailable();
 }

--- a/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ExecutionClientVersionProvider.java
+++ b/ethereum/executionclient/src/main/java/tech/pegasys/teku/ethereum/executionclient/ExecutionClientVersionProvider.java
@@ -36,11 +36,11 @@ public class ExecutionClientVersionProvider implements ExecutionClientEventsChan
 
   private final AtomicBoolean lastExecutionClientAvailability = new AtomicBoolean(true);
 
+  private final AtomicReference<ClientVersion> executionClientVersion = new AtomicReference<>();
+
   private final ExecutionLayerChannel executionLayerChannel;
   private final ExecutionClientVersionChannel executionClientVersionChannel;
   private final ClientVersion consensusClientVersion;
-
-  private final AtomicReference<ClientVersion> executionClientVersion = new AtomicReference<>();
 
   public ExecutionClientVersionProvider(
       final ExecutionLayerChannel executionLayerChannel,

--- a/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/ExecutionClientVersionProviderTest.java
+++ b/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/ExecutionClientVersionProviderTest.java
@@ -52,12 +52,8 @@ public class ExecutionClientVersionProviderTest {
     when(executionLayerChannel.engineGetClientVersion(any()))
         .thenReturn(SafeFuture.failedFuture(new IllegalStateException("oopsy")));
 
-    final ExecutionClientVersionProvider executionClientVersionProvider =
-        new ExecutionClientVersionProvider(
-            executionLayerChannel, publishChannel, consensusClientVersion);
-
-    executionClientVersionProvider.onAvailabilityUpdated(false);
-    executionClientVersionProvider.onAvailabilityUpdated(true);
+    new ExecutionClientVersionProvider(
+        executionLayerChannel, publishChannel, consensusClientVersion);
 
     // only called once (on initialization)
     verify(publishChannel).onExecutionClientVersionNotAvailable();
@@ -127,7 +123,7 @@ public class ExecutionClientVersionProviderTest {
     verify(executionLayerChannel, times(2)).engineGetClientVersion(consensusClientVersion);
     // no version is pushed in the channel
     verify(publishChannel, never()).onExecutionClientVersion(any());
-    // non-availability has not been called in the middle
+    // non-availability has not been called if EL has been available on initialization
     verify(publishChannel, never()).onExecutionClientVersionNotAvailable();
 
     // EL is back

--- a/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/ExecutionClientVersionProviderTest.java
+++ b/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/ExecutionClientVersionProviderTest.java
@@ -127,7 +127,8 @@ public class ExecutionClientVersionProviderTest {
     verify(executionLayerChannel, times(2)).engineGetClientVersion(consensusClientVersion);
     // no version is pushed in the channel
     verify(publishChannel, never()).onExecutionClientVersion(any());
-    verify(publishChannel).onExecutionClientVersionNotAvailable();
+    // non-availability has not been called in the middle
+    verify(publishChannel, never()).onExecutionClientVersionNotAvailable();
 
     // EL is back
     when(executionLayerChannel.engineGetClientVersion(any()))
@@ -139,7 +140,5 @@ public class ExecutionClientVersionProviderTest {
     verify(executionLayerChannel, times(3)).engineGetClientVersion(consensusClientVersion);
     // Version is the same, not pushed in the channel
     verify(publishChannel, never()).onExecutionClientVersion(any());
-    // non-availability has been called only once
-    verify(publishChannel).onExecutionClientVersionNotAvailable();
   }
 }

--- a/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/ExecutionClientVersionProviderTest.java
+++ b/ethereum/executionclient/src/test/java/tech/pegasys/teku/ethereum/executionclient/ExecutionClientVersionProviderTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
@@ -60,6 +61,7 @@ public class ExecutionClientVersionProviderTest {
 
     // only called once (on initialization)
     verify(publishChannel).onExecutionClientVersionNotAvailable();
+    verifyNoMoreInteractions(publishChannel);
   }
 
   @Test
@@ -106,7 +108,7 @@ public class ExecutionClientVersionProviderTest {
   }
 
   @Test
-  public void doesNotPushUnknownVersionInChannel_whenELIsDownInTheMiddle() {
+  public void doesNotPushExecutionClientVersionInChannel_whenELIsDownInTheMiddle() {
     final ExecutionClientVersionProvider executionClientVersionProvider =
         new ExecutionClientVersionProvider(
             executionLayerChannel, publishChannel, consensusClientVersion);
@@ -123,8 +125,9 @@ public class ExecutionClientVersionProviderTest {
     executionClientVersionProvider.onAvailabilityUpdated(true);
     // EL called two times
     verify(executionLayerChannel, times(2)).engineGetClientVersion(consensusClientVersion);
-    // UNKNOWN version is not pushed in the channel
+    // no version is pushed in the channel
     verify(publishChannel, never()).onExecutionClientVersion(any());
+    verify(publishChannel).onExecutionClientVersionNotAvailable();
 
     // EL is back
     when(executionLayerChannel.engineGetClientVersion(any()))
@@ -136,5 +139,7 @@ public class ExecutionClientVersionProviderTest {
     verify(executionLayerChannel, times(3)).engineGetClientVersion(consensusClientVersion);
     // Version is the same, not pushed in the channel
     verify(publishChannel, never()).onExecutionClientVersion(any());
+    // non-availability has been called only once
+    verify(publishChannel).onExecutionClientVersionNotAvailable();
   }
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ClientVersion.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/execution/ClientVersion.java
@@ -18,6 +18,5 @@ import tech.pegasys.teku.infrastructure.bytes.Bytes4;
 public record ClientVersion(String code, String name, String version, Bytes4 commit) {
 
   public static final String TEKU_CLIENT_CODE = "TK";
-
-  public static final ClientVersion UNKNOWN = new ClientVersion("NA", "", "", Bytes4.ZERO);
+  public static final String UNKNOWN_CLIENT_CODE = "NA";
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Didn't change the `GraffitiBuilder` tests to not modify the current behaviour, but thought the code could be refactored a bit.

I don't see value in `ClientVersion.UNKNOWN`, can just rely on volatile `Optional`. This also simplifies `ExecutionClientVersionProvider` while keeping the same functionality. Also don't see value in `safeConsensusCode` since we set it explictily.

Added `void onExecutionClientVersionNotAvailable()` to `ExecutionClientVersionChannel` in order to print graffiti in cases where `engine_getClientVersion` is not available.


## Fixed Issue(s)
N/A

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
