### PR TITLE
Fixing error on compute_consolidation_epoch_and_update_churn implementation

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/helpers/BeaconStateMutatorsElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/helpers/BeaconStateMutatorsElectra.java
@@ -151,7 +151,7 @@ public class BeaconStateMutatorsElectra extends BeaconStateMutatorsBellatrix {
       final UInt64 balanceToProcess =
           consolidationBalance.minusMinZero(consolidationBalanceToConsume);
       final UInt64 additionalEpochs =
-          balanceToProcess.decrement().dividedBy(perEpochConsolidationChurn.increment());
+          balanceToProcess.decrement().dividedBy(perEpochConsolidationChurn).increment();
       stateElectra.setConsolidationBalanceToConsume(
           consolidationBalanceToConsume.plus(
               additionalEpochs


### PR DESCRIPTION
We were evaluating operations in the wrong order. From spec:
```
additional_epochs = (balance_to_process - 1) // per_epoch_consolidation_churn + 1
```

Division must happen before the increment.