### PR TITLE
EIP-7251: Implementing process_consolidation block processing function

### DIFF
--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/operations/DefaultOperationProcessor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/operations/DefaultOperationProcessor.java
@@ -24,6 +24,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBodySch
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregate;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.capella.BeaconBlockBodySchemaCapella;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.electra.BeaconBlockBodySchemaElectra;
+import tech.pegasys.teku.spec.datastructures.consolidations.SignedConsolidation;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSummary;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.DepositReceipt;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionLayerWithdrawalRequest;
@@ -170,5 +171,17 @@ public class DefaultOperationProcessor implements OperationProcessor {
     spec.getBlockProcessor(state.getSlot())
         .processExecutionLayerWithdrawalRequests(
             state, withdrawalRequests, validatorExitContextSupplier);
+  }
+
+  @Override
+  public void processConsolidation(
+      final MutableBeaconState state, final SignedConsolidation consolidation)
+      throws BlockProcessingException {
+    final SszList<SignedConsolidation> consolidations =
+        BeaconBlockBodySchemaElectra.required(beaconBlockBodySchema)
+            .getConsolidationsSchema()
+            .of(consolidation);
+
+    spec.getBlockProcessor(state.getSlot()).processConsolidations(state, consolidations);
   }
 }

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/operations/OperationProcessor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/operations/OperationProcessor.java
@@ -17,6 +17,7 @@ import java.util.Optional;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregate;
+import tech.pegasys.teku.spec.datastructures.consolidations.SignedConsolidation;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSummary;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.DepositReceipt;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionLayerWithdrawalRequest;
@@ -70,5 +71,8 @@ public interface OperationProcessor {
 
   void processExecutionLayerWithdrawalRequest(
       MutableBeaconState state, ExecutionLayerWithdrawalRequest executionLayerWithdrawalRequest)
+      throws BlockProcessingException;
+
+  void processConsolidation(MutableBeaconState state, SignedConsolidation consolidation)
       throws BlockProcessingException;
 }

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/operations/OperationsTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/common/operations/OperationsTestExecutor.java
@@ -33,6 +33,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.BeaconBlockBodySchemaAltair;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregate;
+import tech.pegasys.teku.spec.datastructures.consolidations.SignedConsolidation;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.DepositReceipt;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionLayerWithdrawalRequest;
@@ -75,7 +76,8 @@ public class OperationsTestExecutor<T extends SszData> implements TestExecutor {
     BLS_TO_EXECUTION_CHANGE,
     WITHDRAWAL,
     DEPOSIT_RECEIPT,
-    EXECUTION_LAYER_WITHDRAWAL_REQUEST
+    EXECUTION_LAYER_WITHDRAWAL_REQUEST,
+    CONSOLIDATION
   }
 
   public static final ImmutableMap<String, TestExecutor> OPERATIONS_TEST_TYPES =
@@ -124,6 +126,9 @@ public class OperationsTestExecutor<T extends SszData> implements TestExecutor {
               new OperationsTestExecutor<>(
                   "execution_layer_withdrawal_request.ssz_snappy",
                   Operation.EXECUTION_LAYER_WITHDRAWAL_REQUEST))
+          .put(
+              "operations/consolidation",
+              new OperationsTestExecutor<>("consolidation.ssz_snappy", Operation.CONSOLIDATION))
           .build();
 
   private final String dataFileName;
@@ -313,6 +318,7 @@ public class OperationsTestExecutor<T extends SszData> implements TestExecutor {
       case DEPOSIT_RECEIPT -> processDepositReceipt(testDefinition, state, processor);
       case EXECUTION_LAYER_WITHDRAWAL_REQUEST -> processExecutionLayerWithdrawalRequest(
           testDefinition, state, processor);
+      case CONSOLIDATION -> processConsolidation(testDefinition, state, processor);
       default -> throw new UnsupportedOperationException(
           "Operation " + operation + " not implemented in OperationTestExecutor");
     }
@@ -358,6 +364,16 @@ public class OperationsTestExecutor<T extends SszData> implements TestExecutor {
     final ExecutionLayerWithdrawalRequest executionLayerWithdrawalRequest =
         loadSsz(testDefinition, dataFileName, ExecutionLayerWithdrawalRequest.SSZ_SCHEMA);
     processor.processExecutionLayerWithdrawalRequest(state, executionLayerWithdrawalRequest);
+  }
+
+  private void processConsolidation(
+      final TestDefinition testDefinition,
+      final MutableBeaconState state,
+      final OperationProcessor processor)
+      throws BlockProcessingException {
+    final SignedConsolidation consolidation =
+        loadSsz(testDefinition, dataFileName, SignedConsolidation.SSZ_SCHEMA);
+    processor.processConsolidation(state, consolidation);
   }
 
   private SignedVoluntaryExit loadVoluntaryExit(final TestDefinition testDefinition) {
@@ -424,7 +440,8 @@ public class OperationsTestExecutor<T extends SszData> implements TestExecutor {
           EXECUTION_PAYLOAD,
           WITHDRAWAL,
           DEPOSIT_RECEIPT,
-          EXECUTION_LAYER_WITHDRAWAL_REQUEST -> {}
+          EXECUTION_LAYER_WITHDRAWAL_REQUEST,
+          CONSOLIDATION -> {}
     }
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/Domain.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/constants/Domain.java
@@ -33,4 +33,7 @@ public class Domain {
 
   // Capella
   public static final Bytes4 DOMAIN_BLS_TO_EXECUTION_CHANGE = Bytes4.fromHexString("0x0A000000");
+
+  // Electra
+  public static final Bytes4 DOMAIN_CONSOLIDATION = Bytes4.fromHexString("0x0B000000");
 }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/AbstractBlockProcessor.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/AbstractBlockProcessor.java
@@ -46,6 +46,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSummary;
 import tech.pegasys.teku.spec.datastructures.blocks.Eth1Data;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
+import tech.pegasys.teku.spec.datastructures.consolidations.SignedConsolidation;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayload;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.DepositReceipt;
 import tech.pegasys.teku.spec.datastructures.execution.versions.electra.ExecutionLayerWithdrawalRequest;
@@ -920,6 +921,13 @@ public abstract class AbstractBlockProcessor implements BlockProcessor {
     // No ExecutionLayerWithdrawalRequests until Electra
   }
 
+  @Override
+  public void processConsolidations(
+      final MutableBeaconState state, final SszList<SignedConsolidation> consolidations)
+      throws BlockProcessingException {
+    // No Consolidations until Electra
+  }
+
   // Catch generic errors and wrap them in a BlockProcessingException
   protected void safelyProcess(final BlockProcessingAction action) throws BlockProcessingException {
     try {
@@ -927,6 +935,13 @@ public abstract class AbstractBlockProcessor implements BlockProcessor {
     } catch (ArithmeticException | IllegalArgumentException | IndexOutOfBoundsException e) {
       LOG.warn("Failed to process block", e);
       throw new BlockProcessingException(e);
+    }
+  }
+
+  protected void assertCondition(final boolean condition, final String errorMessage)
+      throws BlockProcessingException {
+    if (!condition) {
+      throw new BlockProcessingException(errorMessage);
     }
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/BlockProcessor.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/BlockProcessor.java
@@ -53,8 +53,7 @@ import tech.pegasys.teku.spec.logic.versions.bellatrix.block.OptimisticExecution
 
 public interface BlockProcessor {
 
-  Optional<OperationInvalidReason> validateAttestation(
-      final BeaconState state, final AttestationData data);
+  Optional<OperationInvalidReason> validateAttestation(BeaconState state, AttestationData data);
 
   BeaconState processAndValidateBlock(
       SignedBeaconBlock signedBlock,
@@ -124,10 +123,10 @@ public interface BlockProcessor {
       throws BlockProcessingException;
 
   void processDepositWithoutCheckingMerkleProof(
-      final MutableBeaconState state,
-      final Deposit deposit,
-      final Optional<Object2IntMap<BLSPublicKey>> maybePubkeyToIndexMap,
-      final boolean signatureAlreadyVerified);
+      MutableBeaconState state,
+      Deposit deposit,
+      Optional<Object2IntMap<BLSPublicKey>> maybePubkeyToIndexMap,
+      boolean signatureAlreadyVerified);
 
   void processVoluntaryExits(
       MutableBeaconState state,
@@ -139,7 +138,7 @@ public interface BlockProcessor {
       MutableBeaconState state, SyncAggregate syncAggregate, BLSSignatureVerifier signatureVerifier)
       throws BlockProcessingException;
 
-  UInt64 computeParticipantReward(final BeaconStateAltair state);
+  UInt64 computeParticipantReward(BeaconStateAltair state);
 
   void processExecutionPayload(
       MutableBeaconState state,
@@ -169,18 +168,16 @@ public interface BlockProcessor {
   void processWithdrawals(MutableBeaconState state, ExecutionPayloadSummary payloadSummary)
       throws BlockProcessingException;
 
-  void processDepositReceipts(
-      final MutableBeaconState state, final SszList<DepositReceipt> depositReceipts)
+  void processDepositReceipts(MutableBeaconState state, SszList<DepositReceipt> depositReceipts)
       throws BlockProcessingException;
 
   void processExecutionLayerWithdrawalRequests(
-      final MutableBeaconState state,
-      final SszList<ExecutionLayerWithdrawalRequest> exits,
-      final Supplier<ValidatorExitContext> validatorExitContextSupplier)
+      MutableBeaconState state,
+      SszList<ExecutionLayerWithdrawalRequest> exits,
+      Supplier<ValidatorExitContext> validatorExitContextSupplier)
       throws BlockProcessingException;
 
-  void processConsolidations(
-      MutableBeaconState state, final SszList<SignedConsolidation> consolidations)
+  void processConsolidations(MutableBeaconState state, SszList<SignedConsolidation> consolidations)
       throws BlockProcessingException;
 
   ExpectedWithdrawals getExpectedWithdrawals(BeaconState preState);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/BlockProcessor.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/block/BlockProcessor.java
@@ -27,6 +27,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.Eth1Data;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.versions.altair.SyncAggregate;
+import tech.pegasys.teku.spec.datastructures.consolidations.SignedConsolidation;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadHeader;
 import tech.pegasys.teku.spec.datastructures.execution.ExecutionPayloadSummary;
 import tech.pegasys.teku.spec.datastructures.execution.ExpectedWithdrawals;
@@ -51,6 +52,7 @@ import tech.pegasys.teku.spec.logic.versions.altair.block.BlockProcessorAltair;
 import tech.pegasys.teku.spec.logic.versions.bellatrix.block.OptimisticExecutionPayloadExecutor;
 
 public interface BlockProcessor {
+
   Optional<OperationInvalidReason> validateAttestation(
       final BeaconState state, final AttestationData data);
 
@@ -175,6 +177,10 @@ public interface BlockProcessor {
       final MutableBeaconState state,
       final SszList<ExecutionLayerWithdrawalRequest> exits,
       final Supplier<ValidatorExitContext> validatorExitContextSupplier)
+      throws BlockProcessingException;
+
+  void processConsolidations(
+      MutableBeaconState state, final SszList<SignedConsolidation> consolidations)
       throws BlockProcessingException;
 
   ExpectedWithdrawals getExpectedWithdrawals(BeaconState preState);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/Predicates.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/helpers/Predicates.java
@@ -18,6 +18,7 @@ import static tech.pegasys.teku.spec.constants.WithdrawalPrefixes.ETH1_ADDRESS_W
 
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
+import tech.pegasys.teku.ethereum.execution.types.Eth1Address;
 import tech.pegasys.teku.infrastructure.crypto.Sha256;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszBytes32Vector;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
@@ -96,6 +97,21 @@ public class Predicates {
 
   public static boolean isEth1WithdrawalCredential(final Bytes32 withdrawalCredentials) {
     return withdrawalCredentials.get(0) == ETH1_ADDRESS_WITHDRAWAL_BYTE;
+  }
+
+  /**
+   * Get the execution address from a validator's withdrawal credentials. This method does not check
+   * if the validator has the correct type of withdrawal credentials (e.g. prefixes 0x01 and 0x02).
+   *
+   * <p>This method can be used in conjunction with {@link
+   * PredicatesElectra#hasExecutionWithdrawalCredential(Validator)} to ensure a correct execution
+   * address will be returned.
+   *
+   * @param withdrawalCredentials the 32 bytes withdrawal credentials field of a validator
+   * @return the last 20 bytes of the input withdrawal credentials, wrapped as {@link Eth1Address}.
+   */
+  public static Eth1Address getExecutionAddressUnchecked(final Bytes32 withdrawalCredentials) {
+    return Eth1Address.fromBytes(withdrawalCredentials.slice(12));
   }
 
   /**

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/operations/OperationSignatureVerifier.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/operations/OperationSignatureVerifier.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.spec.logic.common.operations;
 
+import java.util.List;
 import java.util.Optional;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -24,6 +25,8 @@ import tech.pegasys.teku.bls.BLSSignatureVerifier;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.spec.constants.Domain;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockHeader;
+import tech.pegasys.teku.spec.datastructures.consolidations.Consolidation;
+import tech.pegasys.teku.spec.datastructures.consolidations.SignedConsolidation;
 import tech.pegasys.teku.spec.datastructures.operations.BlsToExecutionChange;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.SignedBlsToExecutionChange;
@@ -136,6 +139,25 @@ public class OperationSignatureVerifier {
     final BLSSignature signature = signedBlsToExecutionChange.getSignature();
 
     return signatureVerifier.verify(publicKey, signingRoot, signature);
+  }
+
+  /* Signature verification for process_consolidation */
+  public boolean verifyConsolidationSignature(
+      final BeaconState state,
+      final SignedConsolidation signedConsolidation,
+      final BLSSignatureVerifier signatureVerifier) {
+    final Bytes32 domain =
+        miscHelpers.computeDomain(Domain.DOMAIN_CONSOLIDATION, state.getGenesisValidatorsRoot());
+    final Consolidation consolidation = signedConsolidation.getMessage();
+    final Bytes signingRoot = miscHelpers.computeSigningRoot(consolidation, domain);
+
+    final BLSPublicKey sourcePublicKey =
+        state.getValidators().get(consolidation.getSourceIndex()).getPublicKey();
+    final BLSPublicKey targetPublicKey =
+        state.getValidators().get(consolidation.getTargetIndex()).getPublicKey();
+
+    return signatureVerifier.verify(
+        List.of(sourcePublicKey, targetPublicKey), signingRoot, signedConsolidation.getSignature());
   }
 
   private Bytes calculateBlsToExecutionChangeSigningRoot(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/block/BlockProcessorElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/block/BlockProcessorElectra.java
@@ -414,6 +414,9 @@ public class BlockProcessorElectra extends BlockProcessorDeneb {
           "Source and Target validators in consolidation must have the same withdrawal credentials");
 
       // Verify consolidation is signed by the source and the target
+      // Note: we are not concerned about batch verifying these signatures at this point. It is
+      // likely that SignedConsolidation will disappear in favour of EL-triggered consolidation
+      // operations.
       assertCondition(
           operationSignatureVerifier.verifyConsolidationSignature(
               electraState, signedConsolidation, BLSSignatureVerifier.SIMPLE),

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/block/BlockProcessorElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/block/BlockProcessorElectra.java
@@ -27,6 +27,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.bls.BLSSignatureVerifier;
+import tech.pegasys.teku.ethereum.execution.types.Eth1Address;
 import tech.pegasys.teku.infrastructure.bytes.Bytes20;
 import tech.pegasys.teku.infrastructure.ssz.SszList;
 import tech.pegasys.teku.infrastructure.ssz.SszMutableList;
@@ -397,7 +398,7 @@ public class BlockProcessorElectra extends BlockProcessorDeneb {
       // Consolidations must specify an epoch when they become valid; they are not valid before then
       assertCondition(
           currentEpoch.isGreaterThanOrEqualTo(consolidation.getEpoch()),
-          "Consolidation must have activation epoch in the future");
+          "Consolidation must have an activation epoch no greater than current epoch");
 
       // Verify the source and the target have Execution layer withdrawal credentials
       assertCondition(
@@ -407,10 +408,12 @@ public class BlockProcessorElectra extends BlockProcessorDeneb {
           predicatesElectra.hasExecutionWithdrawalCredential(targetValidator),
           "Target validator in consolidation must have execution withdrawal credentials");
       // Verify the same withdrawal address
+      final Eth1Address sourceValidatorExecutionAddress =
+          Predicates.getExecutionAddressUnchecked(sourceValidator.getWithdrawalCredentials());
+      final Eth1Address targetValidatorExecutionAddress =
+          Predicates.getExecutionAddressUnchecked(targetValidator.getWithdrawalCredentials());
       assertCondition(
-          sourceValidator
-              .getWithdrawalCredentials()
-              .equals(targetValidator.getWithdrawalCredentials()),
+          sourceValidatorExecutionAddress.equals(targetValidatorExecutionAddress),
           "Source and Target validators in consolidation must have the same withdrawal credentials");
 
       // Verify consolidation is signed by the source and the target

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/helpers/PredicatesTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/common/helpers/PredicatesTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import tech.pegasys.teku.ethereum.execution.types.Eth1Address;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
@@ -31,6 +32,7 @@ import tech.pegasys.teku.spec.datastructures.state.Validator;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class PredicatesTest {
+
   private Predicates predicates;
   private static final Spec SPEC = TestSpecFactory.createMainnet(SpecMilestone.CAPELLA);
   private static final SpecConfigCapella SPEC_CONFIG_CAPELLA =
@@ -44,6 +46,38 @@ public class PredicatesTest {
   @BeforeEach
   public void before() {
     this.predicates = new Predicates(SPEC_CONFIG_CAPELLA);
+  }
+
+  @ParameterizedTest
+  @MethodSource("getExecutionAddressUncheckedArgs")
+  public void getExecutionAddressUnchecked(final Validator validator) {
+    final Eth1Address executionAddress =
+        Predicates.getExecutionAddressUnchecked(validator.getWithdrawalCredentials());
+    assertThat(executionAddress)
+        .isEqualTo(Eth1Address.fromBytes(validator.getWithdrawalCredentials().slice(12)));
+  }
+
+  private static Stream<Arguments> getExecutionAddressUncheckedArgs() {
+    final Bytes32 eth1WithdrawalCredentials = DATA_STRUCTURE_UTIL.randomEth1WithdrawalCredentials();
+    final Bytes32 compoundingWithdrawalCredentials =
+        DATA_STRUCTURE_UTIL.randomCompoundingWithdrawalCredentials();
+    // Even though it does not make sense to extract Eth1 address from blsWithdrawalCredentials, the
+    // method does not check for it so it will return the last 20 bytes of "anything".
+    final Bytes32 blsWithdrawalCredentials = DATA_STRUCTURE_UTIL.randomBlsWithdrawalCredentials();
+
+    return Stream.of(
+        Arguments.of(
+            DATA_STRUCTURE_UTIL
+                .randomValidator()
+                .withWithdrawalCredentials(eth1WithdrawalCredentials)),
+        Arguments.of(
+            DATA_STRUCTURE_UTIL
+                .randomValidator()
+                .withWithdrawalCredentials(compoundingWithdrawalCredentials)),
+        Arguments.of(
+            DATA_STRUCTURE_UTIL
+                .randomValidator()
+                .withWithdrawalCredentials(blsWithdrawalCredentials)));
   }
 
   @Test


### PR DESCRIPTION
## PR Description
Spec reference: https://github.com/ethereum/consensus-specs/blob/dev/specs/electra/beacon-chain.md#new-process_consolidation

Summary:
- Implemented `process_consolidation` function on `BlockProcessorCapella`
- Created method `assertCondition(..)` to make it easier to write assertions as their python spec `assert` counterpart.
- Updated reference-tests OperationTestExecution to include consolidation operations
- Verified `process_consolidation` operations with reference tests for minimal (mainnet tests seem to have an [issue](https://github.com/ethereum/consensus-specs/issues/3739))

## Fixed Issue(s)
fixes #8150

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
