### PR TITLE
Fix `toWithdraw` calculation in `processExecutionLayerWithdrawalRequests`

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/block/BlockProcessorElectra.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/electra/block/BlockProcessorElectra.java
@@ -174,8 +174,7 @@ public class BlockProcessorElectra extends BlockProcessorDeneb {
   public void processExecutionLayerWithdrawalRequests(
       final MutableBeaconState state,
       final SszList<ExecutionLayerWithdrawalRequest> withdrawalRequests,
-      final Supplier<ValidatorExitContext> validatorExitContextSupplier)
-      throws BlockProcessingException {
+      final Supplier<ValidatorExitContext> validatorExitContextSupplier) {
     final UInt64 currentEpoch = miscHelpers.computeEpochAtSlot(state.getSlot());
 
     withdrawalRequests.forEach(
@@ -260,7 +259,7 @@ public class BlockProcessorElectra extends BlockProcessorDeneb {
               && hasExcessBalance) {
             final UInt64 toWithdraw =
                 validatorBalance
-                    .min(minActivationBalance)
+                    .minus(minActivationBalance)
                     .minus(pendingBalanceToWithdraw)
                     .min(withdrawalRequest.getAmount());
             final UInt64 exitQueueEpoch =


### PR DESCRIPTION
## PR Description

Reviewed `processExecutionLayerWithdrawalRequests` and noticed a mistake that I made. My bad.

The calculation for `toWithdraw` used `min` when it should have used `minus`. See the spec:

```python
to_withdraw = min(
    state.balances[index] - MIN_ACTIVATION_BALANCE - pending_balance_to_withdraw,
    amount
)
```

Also, the `throws BlockProcessingException` is unnecessary.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
